### PR TITLE
docs: fix "Production deployment" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Follow the [Quickstart guide](https://vane.astrovela.ai/docs/data/quickstart/qui
 ### More Resources
 
 - [Examples](https://vane.astrovela.ai/docs/data/examples)
-- [Production deployment](https://vane.astrovela.ai/docs/data/contributing/development)
+- [Production deployment](https://vane.astrovela.ai/docs/data/deploy/deployment)
 
 ---
 


### PR DESCRIPTION
## Summary

The "Production deployment" link in the "More Resources" section of `README.md` pointed to the contributing/development guide (`https://vane.astrovela.ai/docs/data/contributing/development`) instead of the deployment documentation. This updates it to point to `https://vane.astrovela.ai/docs/data/deploy/deployment`.

Fixes #7

## Validation

- Verified the new URL `https://vane.astrovela.ai/docs/data/deploy/deployment` resolves to the production deployment documentation.
- Rendered `README.md` locally and confirmed the link text and target are correct.
- Documentation-only change; no code paths affected.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.