### PR TITLE
fix: CI runner compatibility and quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,10 @@ jobs:
         run: python -m pip install --force-reinstall dist/*.whl
 
       - name: Verify the base installation Quickstart outside the checkout
+        env:
+          # Keep this distributed smoke test within a standard 16 GB runner.
+          VANE_FTE_TASK_HEAP_BYTES: "1073741824"
+          VANE_UDF_TASK_HEAP_BYTES: "1073741824"
         run: |
           cd "$RUNNER_TEMP"
           env -u VANE_RUNNER python "$GITHUB_WORKSPACE/scripts/verify_base_install.py"

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -107,6 +107,12 @@ jobs:
           head_ref="$(git rev-parse HEAD)"
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             base_ref="$PR_BASE_SHA"
+            pre-commit run \
+              --show-diff-on-failure \
+              --color=always \
+              --from-ref "$base_ref" \
+              --to-ref "$head_ref"
+            exit
           elif [[ -n "$PUSH_BEFORE_SHA" && ! "$PUSH_BEFORE_SHA" =~ ^0+$ ]] && \
                git cat-file -e "$PUSH_BEFORE_SHA^{commit}" 2>/dev/null; then
             base_ref="$PUSH_BEFORE_SHA"
@@ -117,8 +123,18 @@ jobs:
             exit
           fi
 
+          # A force-push can make before and HEAD sibling commits. Compare the
+          # endpoint trees directly so pre-commit does not expand the range
+          # back to their merge base and lint unrelated files.
+          mapfile -d '' changed_files < <(
+            git diff --name-only --diff-filter=ACMRT -z "$base_ref" "$head_ref" --
+          )
+          if ((${#changed_files[@]} == 0)); then
+            echo "No files changed between $base_ref and $head_ref."
+            exit
+          fi
+
           pre-commit run \
             --show-diff-on-failure \
             --color=always \
-            --from-ref "$base_ref" \
-            --to-ref "$head_ref"
+            --files "${changed_files[@]}"

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 # Optional provider, benchmark, compatibility, and external-service suites run
 # separately because they need additional dependencies or infrastructure.
 python -m pytest \
+  --import-mode=importlib \
+  -o pythonpath=tests \
   tests/fast/test_package_metadata.py \
   tests/fast/test_transformers_provider_security.py \
   tests/fast/test_vane_config.py \


### PR DESCRIPTION
## Summary

The Quickstart smoke test used production 2 GiB FTE/UDF task defaults, causing its minimum Ray heap demand to exceed a standard GitHub runner. Push quality checks also used pre-commit's three-dot diff, so a force-push expanded to the common ancestor and linted 593 unrelated historical files. The base release suite additionally exposed `tests/fast/pandas` as a top-level `pandas` namespace when pandas was absent.

This PR applies 1 GiB task limits only to the Quickstart smoke step, compares push endpoint trees directly while preserving PR merge-base behavior, and isolates release-test imports. It does not change product defaults, public APIs, dependencies, C++, or the DuckDB submodule.

## Validation

  - Exact force-push reproduction checked only `README.md`
  - Quickstart passed with 4 CPUs and 9 GiB Ray memory
  - Release suite: 258 passed, 4 skipped
  - `scripts/format root --changed`
  - Full pre-commit range and GitHub Workflow schema checks
  - `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.
