### PR TITLE
[fix](execution) Preserve ExecutionBatch payloads across retries

### DIFF
--- a/SOURCE_PROVENANCE.md
+++ b/SOURCE_PROVENANCE.md
@@ -30,7 +30,7 @@ the former `AstroVela/duckdb` commit
 `398033a962719ac09868f4484ec4f97353bb0325`, whose sole parent is the official
 baseline above. Its Vane commit message records both original revisions, so the
 custom source, authorship, and provenance remain available even if that fork is
-retired. The resulting engine tree is described as `v1.5.0-1-g398033a962`.
+retired. The resulting engine tree is described as `v1.5.0-2-ge2d3989890`.
 Source archives do not contain Git metadata, so the same description is passed
 through `OVERRIDE_GIT_DESCRIBE` in `pyproject.toml`. A change to the engine
 source must update both records in the same pull request. Release reviews must

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -136,30 +136,6 @@ static unique_ptr<DataChunk> MakeEmptyExecutionBatchChunk(ClientContext &context
 	return chunk;
 }
 
-static unique_ptr<DataChunk> TakeMaterializedExecutionBatch(ClientContext &context, ExecutionBatch &batch,
-                                                            const vector<LogicalType> &types, const char *reason) {
-	if (batch.kind == ExecutionBatchKind::MATERIALIZED_CHUNK) {
-		if (batch.materialized) {
-			return std::move(batch.materialized);
-		}
-		return MakeEmptyExecutionBatchChunk(context, types);
-	}
-	if (batch.kind == ExecutionBatchKind::LAZY_DATA_CHUNK) {
-		if (!batch.lazy) {
-			return MakeEmptyExecutionBatchChunk(context, types);
-		}
-		auto barrier = MaterializeExternalBlockBarrier(context, *batch.lazy, reason ? string(reason) : string());
-		auto chunk = std::move(barrier.chunk);
-		// Once a lazy batch has been materialized, the returned DataChunk owns the
-		// materialized Arrow buffers. Drop the original descriptors immediately so
-		// their budget tickets do not artificially hold upstream ref-bundle
-		// backpressure while the downstream operator processes the chunk.
-		batch = ExecutionBatch();
-		return chunk;
-	}
-	throw InternalException("unsupported ExecutionBatch kind");
-}
-
 static void StoreMaterializedExecutionBatch(ExecutionBatch &batch, unique_ptr<DataChunk> chunk) {
 	batch = ExecutionBatch();
 	batch.kind = ExecutionBatchKind::MATERIALIZED_CHUNK;
@@ -168,6 +144,40 @@ static void StoreMaterializedExecutionBatch(ExecutionBatch &batch, unique_ptr<Da
 		batch.estimated_bytes = chunk->GetAllocationSize();
 	}
 	batch.materialized = std::move(chunk);
+}
+
+static DataChunk &MaterializeExecutionBatch(ClientContext &context, ExecutionBatch &batch,
+                                            const vector<LogicalType> &types, const char *reason) {
+	if (batch.kind == ExecutionBatchKind::MATERIALIZED_CHUNK) {
+		if (!batch.materialized) {
+			if (batch.rows > 0) {
+				throw InternalException("materialized ExecutionBatch has %llu rows but no payload", batch.rows);
+			}
+			StoreMaterializedExecutionBatch(batch, MakeEmptyExecutionBatchChunk(context, types));
+		}
+		return *batch.materialized;
+	}
+	if (batch.kind == ExecutionBatchKind::LAZY_DATA_CHUNK) {
+		if (!batch.lazy) {
+			if (batch.rows > 0) {
+				throw InternalException("lazy ExecutionBatch has %llu rows but no payload", batch.rows);
+			}
+			StoreMaterializedExecutionBatch(batch, MakeEmptyExecutionBatchChunk(context, types));
+			return *batch.materialized;
+		}
+		auto barrier = MaterializeExternalBlockBarrier(context, *batch.lazy, reason ? string(reason) : string());
+		// Once a lazy batch has been materialized, the returned DataChunk owns the
+		// materialized Arrow buffers. Drop the original descriptors immediately so
+		// their budget tickets do not artificially hold upstream ref-bundle
+		// backpressure while the downstream operator processes the chunk. Keep the
+		// materialized payload in the batch so a BLOCKED operator can retry it.
+		StoreMaterializedExecutionBatch(batch, std::move(barrier.chunk));
+		if (!batch.materialized) {
+			throw InternalException("materializing lazy ExecutionBatch produced no payload");
+		}
+		return *batch.materialized;
+	}
+	throw InternalException("unsupported ExecutionBatch kind");
 }
 
 } // namespace
@@ -260,10 +270,10 @@ OperatorResultType PhysicalOperator::ExecuteBatch(ExecutionContext &context, Exe
                                                   OperatorState &state) const {
 	auto input_types = children.empty() ? vector<LogicalType>() : children[0].get().GetTypes();
 	auto barrier_reason = GetName();
-	auto input_chunk = TakeMaterializedExecutionBatch(context.client, input, input_types, barrier_reason.c_str());
+	auto &input_chunk = MaterializeExecutionBatch(context.client, input, input_types, barrier_reason.c_str());
 	auto output_chunk = make_uniq<DataChunk>();
 	output_chunk->Initialize(BufferAllocator::Get(context.client), types);
-	auto result = Execute(context, *input_chunk, *output_chunk, gstate, state);
+	auto result = Execute(context, input_chunk, *output_chunk, gstate, state);
 	StoreMaterializedExecutionBatch(output, std::move(output_chunk));
 	return result;
 }
@@ -346,8 +356,8 @@ SinkResultType PhysicalOperator::SinkBatch(ExecutionContext &context, ExecutionB
                                            OperatorSinkInput &input) const {
 	auto input_types = children.empty() ? vector<LogicalType>() : children[0].get().GetTypes();
 	auto barrier_reason = GetName();
-	auto chunk = TakeMaterializedExecutionBatch(context.client, batch, input_types, barrier_reason.c_str());
-	return Sink(context, *chunk, input);
+	auto &chunk = MaterializeExecutionBatch(context.client, batch, input_types, barrier_reason.c_str());
+	return Sink(context, chunk, input);
 }
 
 // LCOV_EXCL_STOP

--- a/external/duckdb/test/execution/CMakeLists.txt
+++ b/external/duckdb/test/execution/CMakeLists.txt
@@ -4,6 +4,9 @@
 
 option(BUILD_DISTRIBUTED "Build the distributed execution tests" ON)
 
+add_library_unity(test_execution OBJECT test_execution_batch.cpp)
+set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_execution>)
+
 if(BUILD_DISTRIBUTED)
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/distributed)
     add_subdirectory(distributed)

--- a/external/duckdb/test/execution/test_execution_batch.cpp
+++ b/external/duckdb/test/execution/test_execution_batch.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parallel/interrupt.hpp"
+#include "duckdb/parallel/thread_context.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+class RetryBlockingSink : public PhysicalOperator {
+public:
+	explicit RetryBlockingSink(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::RESULT_COLLECTOR, {}, 3) {
+	}
+
+	SinkResultType Sink(ExecutionContext &, DataChunk &chunk, OperatorSinkInput &) const override {
+		sink_calls++;
+		if (sink_calls <= 2) {
+			return SinkResultType::BLOCKED;
+		}
+
+		accepted_calls++;
+		accepted_rows = chunk.size();
+		accepted_values.clear();
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			accepted_values.push_back(chunk.GetValue(0, row).GetValue<int64_t>());
+		}
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	mutable idx_t sink_calls = 0;
+	mutable idx_t accepted_calls = 0;
+	mutable idx_t accepted_rows = 0;
+	mutable vector<int64_t> accepted_values;
+};
+
+class MultiOutputOperator : public PhysicalOperator {
+public:
+	explicit MultiOutputOperator(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::PROJECTION, {LogicalType::BIGINT}, 3) {
+	}
+
+	OperatorResultType Execute(ExecutionContext &, DataChunk &input, DataChunk &output, GlobalOperatorState &,
+	                           OperatorState &) const override {
+		execute_calls++;
+		observed_payloads.push_back(&input);
+		observed_values.emplace_back();
+		for (idx_t row = 0; row < input.size(); row++) {
+			observed_values.back().push_back(input.GetValue(0, row).GetValue<int64_t>());
+		}
+		output.Reference(input);
+
+		if (execute_calls <= 2) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+		consumed_inputs++;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	mutable idx_t execute_calls = 0;
+	mutable idx_t consumed_inputs = 0;
+	mutable vector<const DataChunk *> observed_payloads;
+	mutable vector<vector<int64_t>> observed_values;
+};
+
+static void RequireRetryablePayload(const ExecutionBatch &batch, const DataChunk *expected_payload) {
+	REQUIRE(batch.kind == ExecutionBatchKind::MATERIALIZED_CHUNK);
+	REQUIRE(batch.rows == 3);
+	REQUIRE(batch.materialized);
+	REQUIRE(batch.materialized.get() == expected_payload);
+	REQUIRE(batch.materialized->size() == 3);
+	REQUIRE(batch.materialized->GetValue(0, 0).GetValue<int64_t>() == 11);
+	REQUIRE(batch.materialized->GetValue(0, 1).GetValue<int64_t>() == 22);
+	REQUIRE(batch.materialized->GetValue(0, 2).GetValue<int64_t>() == 33);
+}
+
+static void VerifyStreamingBackpressure(idx_t threads) {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto setting_result = con.Query("SET streaming_buffer_size='32KB'");
+	REQUIRE_FALSE(setting_result->HasError());
+	setting_result = con.Query("SET threads=" + to_string(threads));
+	REQUIRE_FALSE(setting_result->HasError());
+
+	auto result = con.SendQuery(R"(
+		SELECT
+			i,
+			repeat(chr(65 + (i % 26)::INTEGER), 256) || ':' || i::VARCHAR AS payload,
+			CASE WHEN i % 17 = 0 THEN NULL ELSE i * 3 END AS nullable
+		FROM range(20000) t(i)
+	)");
+	REQUIRE_FALSE(result->HasError());
+	REQUIRE(result->type == QueryResultType::STREAM_RESULT);
+
+	idx_t expected_row = 0;
+	while (auto chunk = result->Fetch()) {
+		REQUIRE(chunk->size() > 0);
+		for (idx_t row = 0; row < chunk->size(); row++) {
+			REQUIRE(chunk->GetValue(0, row).GetValue<int64_t>() == NumericCast<int64_t>(expected_row));
+
+			string expected_payload(256, static_cast<char>('A' + expected_row % 26));
+			expected_payload += ":" + to_string(expected_row);
+			REQUIRE(chunk->GetValue(1, row).GetValue<string>() == expected_payload);
+
+			auto nullable = chunk->GetValue(2, row);
+			if (expected_row % 17 == 0) {
+				REQUIRE(nullable.IsNull());
+			} else {
+				REQUIRE(nullable.GetValue<int64_t>() == NumericCast<int64_t>(expected_row * 3));
+			}
+			expected_row++;
+		}
+	}
+
+	REQUIRE_FALSE(result->HasError());
+	REQUIRE(expected_row == 20000);
+}
+
+} // namespace
+
+TEST_CASE("ExecutionBatch payload remains retryable after a sink blocks", "[execution_batch][sink]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	ThreadContext thread(*con.context);
+	ExecutionContext context(*con.context, thread, nullptr);
+	PhysicalPlan physical_plan(Allocator::DefaultAllocator());
+	RetryBlockingSink sink(physical_plan);
+
+	auto payload = make_uniq<DataChunk>();
+	payload->Initialize(Allocator::DefaultAllocator(), {LogicalType::BIGINT});
+	payload->SetCardinality(3);
+	payload->SetValue(0, 0, Value::BIGINT(11));
+	payload->SetValue(0, 1, Value::BIGINT(22));
+	payload->SetValue(0, 2, Value::BIGINT(33));
+	auto payload_ptr = payload.get();
+
+	ExecutionBatch batch;
+	batch.kind = ExecutionBatchKind::MATERIALIZED_CHUNK;
+	batch.rows = payload->size();
+	batch.estimated_bytes = payload->GetAllocationSize();
+	batch.materialized = std::move(payload);
+
+	GlobalSinkState global_state;
+	LocalSinkState local_state;
+	InterruptState interrupt_state;
+	OperatorSinkInput input {global_state, local_state, interrupt_state};
+
+	REQUIRE(sink.SinkBatch(context, batch, input) == SinkResultType::BLOCKED);
+	RequireRetryablePayload(batch, payload_ptr);
+	REQUIRE(sink.accepted_calls == 0);
+
+	REQUIRE(sink.SinkBatch(context, batch, input) == SinkResultType::BLOCKED);
+	RequireRetryablePayload(batch, payload_ptr);
+	REQUIRE(sink.accepted_calls == 0);
+
+	REQUIRE(sink.SinkBatch(context, batch, input) == SinkResultType::NEED_MORE_INPUT);
+	RequireRetryablePayload(batch, payload_ptr);
+	REQUIRE(sink.sink_calls == 3);
+	REQUIRE(sink.accepted_calls == 1);
+	REQUIRE(sink.accepted_rows == 3);
+	REQUIRE(sink.accepted_values == vector<int64_t> {11, 22, 33});
+}
+
+TEST_CASE("ExecutionBatch payload remains stable while an operator has more output", "[execution_batch][operator]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	ThreadContext thread(*con.context);
+	ExecutionContext context(*con.context, thread, nullptr);
+	PhysicalPlan physical_plan(Allocator::DefaultAllocator());
+	MultiOutputOperator multi_output(physical_plan);
+
+	auto payload = make_uniq<DataChunk>();
+	payload->Initialize(Allocator::DefaultAllocator(), {LogicalType::BIGINT});
+	payload->SetCardinality(3);
+	payload->SetValue(0, 0, Value::BIGINT(11));
+	payload->SetValue(0, 1, Value::BIGINT(22));
+	payload->SetValue(0, 2, Value::BIGINT(33));
+	auto payload_ptr = payload.get();
+
+	ExecutionBatch input;
+	input.kind = ExecutionBatchKind::MATERIALIZED_CHUNK;
+	input.rows = payload->size();
+	input.estimated_bytes = payload->GetAllocationSize();
+	input.materialized = std::move(payload);
+
+	ExecutionBatch output;
+	GlobalOperatorState global_state;
+	OperatorState operator_state;
+	for (idx_t call = 0; call < 3; call++) {
+		auto result = multi_output.ExecuteBatch(context, input, output, global_state, operator_state);
+		if (call < 2) {
+			REQUIRE(result == OperatorResultType::HAVE_MORE_OUTPUT);
+		} else {
+			REQUIRE(result == OperatorResultType::NEED_MORE_INPUT);
+		}
+
+		RequireRetryablePayload(input, payload_ptr);
+		REQUIRE(output.kind == ExecutionBatchKind::MATERIALIZED_CHUNK);
+		REQUIRE(output.rows == 3);
+		REQUIRE(output.materialized);
+		REQUIRE(output.materialized->GetValue(0, 0).GetValue<int64_t>() == 11);
+		REQUIRE(output.materialized->GetValue(0, 1).GetValue<int64_t>() == 22);
+		REQUIRE(output.materialized->GetValue(0, 2).GetValue<int64_t>() == 33);
+	}
+
+	REQUIRE(multi_output.execute_calls == 3);
+	REQUIRE(multi_output.consumed_inputs == 1);
+	REQUIRE(multi_output.observed_payloads.size() == 3);
+	REQUIRE(multi_output.observed_values.size() == 3);
+	for (idx_t call = 0; call < 3; call++) {
+		REQUIRE(multi_output.observed_payloads[call] == payload_ptr);
+		REQUIRE(multi_output.observed_values[call] == vector<int64_t> {11, 22, 33});
+	}
+}
+
+TEST_CASE("Native streaming preserves ExecutionBatch payload through backpressure", "[execution_batch][streaming]") {
+	SECTION("single-threaded") {
+		VerifyStreamingBackpressure(1);
+	}
+	SECTION("multi-threaded") {
+		VerifyStreamingBackpressure(4);
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ exclude = [
 BUILD_EXTENSIONS = "core_functions;json;parquet;icu;jemalloc;httpfs"
 # Source archives have no Git metadata. Keep DuckDB's embedded version stable
 # and update this value whenever the engine source revision changes.
-OVERRIDE_GIT_DESCRIBE = "v1.5.0-1-g398033a962"
+OVERRIDE_GIT_DESCRIBE = "v1.5.0-2-ge2d3989890"
 
 # Override: if COVERAGE is set then:
 # - we create a RelWithDebInfo build

--- a/tests/fast/api/test_streaming_result.py
+++ b/tests/fast/api/test_streaming_result.py
@@ -1,9 +1,135 @@
+# SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: MIT AND Apache-2.0
+#
+# Modified by Vane contributors.
+
+import hashlib
+
 import pytest
 
 import duckdb
 
+STREAMING_BACKPRESSURE_ROW_COUNT = 20_000
+STREAMING_DICTIONARY_VALUES = ("alpha", "beta", "gamma", "delta")
+
+
+def _streaming_backpressure_expected_row(index):
+    payload = chr(65 + index % 26) * 256 + f":{index}"
+    nullable = None if index % 17 == 0 else index * 3
+    return index, payload, nullable
+
+
+def _streaming_backpressure_hash(rows):
+    digest = hashlib.sha256()
+    for row in rows:
+        digest.update(repr(row).encode())
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _fetch_streaming_backpressure_rows(cursor, fetch_method, column_names):
+    if fetch_method == "fetchall":
+        return cursor.fetchall()
+    if fetch_method == "fetchmany":
+        rows = []
+        while True:
+            batch = cursor.fetchmany(777)
+            if not batch:
+                return rows
+            rows.extend(batch)
+
+    pytest.importorskip("pyarrow")
+    if fetch_method == "arrow_table":
+        table = cursor.to_arrow_table()
+        return [tuple(row[name] for name in column_names) for row in table.to_pylist()]
+    if fetch_method == "arrow_reader":
+        rows = []
+        for batch in cursor.to_arrow_reader(STREAMING_BACKPRESSURE_ROW_COUNT):
+            rows.extend(tuple(row[name] for name in column_names) for row in batch.to_pylist())
+        return rows
+    raise AssertionError(f"unsupported fetch method: {fetch_method}")
+
+
+def _streaming_dictionary_input():
+    pa = pytest.importorskip("pyarrow")
+    indices = pa.array(
+        [
+            None if index % 19 == 0 else index % len(STREAMING_DICTIONARY_VALUES)
+            for index in range(STREAMING_BACKPRESSURE_ROW_COUNT)
+        ],
+        type=pa.int16(),
+    )
+    dictionary = pa.DictionaryArray.from_arrays(indices, pa.array(STREAMING_DICTIONARY_VALUES))
+    table = pa.table({"i": pa.array(range(STREAMING_BACKPRESSURE_ROW_COUNT)), "category": dictionary})
+    return pa.Table.from_batches(table.to_batches(257))
+
 
 class TestStreamingResult:
+    @pytest.mark.parametrize("threads", [1, 4])
+    @pytest.mark.parametrize("fetch_method", ["fetchall", "fetchmany", "arrow_table", "arrow_reader"])
+    def test_blocked_execution_batch_preserves_payload(self, duckdb_cursor, threads, fetch_method):
+        # Each wide result chunk exceeds the buffer, so consuming all rows forces
+        # the collector to block and retry successive batches more than twice.
+        duckdb_cursor.execute("SET streaming_buffer_size='32KB'")
+        duckdb_cursor.execute(f"SET threads={threads}")
+        cursor = duckdb_cursor.execute(
+            f"""
+            SELECT
+                i,
+                repeat(chr(65 + (i % 26)::INTEGER), 256) || ':' || i::VARCHAR AS payload,
+                CASE WHEN i % 17 = 0 THEN NULL ELSE i * 3 END AS nullable
+            FROM range({STREAMING_BACKPRESSURE_ROW_COUNT}) t(i)
+            """
+        )
+
+        rows = _fetch_streaming_backpressure_rows(cursor, fetch_method, ("i", "payload", "nullable"))
+        expected = [_streaming_backpressure_expected_row(index) for index in range(STREAMING_BACKPRESSURE_ROW_COUNT)]
+
+        assert len(rows) == STREAMING_BACKPRESSURE_ROW_COUNT
+        assert rows[0] == expected[0]
+        assert rows[-1] == expected[-1]
+        assert [row[0] for row in rows] == list(range(STREAMING_BACKPRESSURE_ROW_COUNT))
+        assert [row[0] for row in rows if row[2] is None] == list(range(0, STREAMING_BACKPRESSURE_ROW_COUNT, 17))
+        assert _streaming_backpressure_hash(rows) == _streaming_backpressure_hash(expected)
+
+    @pytest.mark.parametrize("threads", [1, 4])
+    @pytest.mark.parametrize("fetch_method", ["fetchall", "fetchmany", "arrow_table", "arrow_reader"])
+    def test_blocked_execution_batch_preserves_dictionary_input(self, duckdb_cursor, threads, fetch_method):
+        duckdb_cursor.execute("SET streaming_buffer_size='32KB'")
+        duckdb_cursor.execute(f"SET threads={threads}")
+        duckdb_cursor.register("streaming_dictionary_input", _streaming_dictionary_input())
+        cursor = duckdb_cursor.execute(
+            """
+            SELECT
+                i,
+                category,
+                repeat(chr(65 + (i % 26)::INTEGER), 256) || ':' || i::VARCHAR AS payload,
+                CASE WHEN i % 17 = 0 THEN NULL ELSE i * 3 END AS nullable
+            FROM streaming_dictionary_input
+            ORDER BY i
+            """
+        )
+
+        rows = _fetch_streaming_backpressure_rows(cursor, fetch_method, ("i", "category", "payload", "nullable"))
+        expected = [
+            (
+                index,
+                None if index % 19 == 0 else STREAMING_DICTIONARY_VALUES[index % len(STREAMING_DICTIONARY_VALUES)],
+                _streaming_backpressure_expected_row(index)[1],
+                _streaming_backpressure_expected_row(index)[2],
+            )
+            for index in range(STREAMING_BACKPRESSURE_ROW_COUNT)
+        ]
+
+        assert len(rows) == STREAMING_BACKPRESSURE_ROW_COUNT
+        assert rows[0] == expected[0]
+        assert rows[-1] == expected[-1]
+        assert [row[0] for row in rows] == list(range(STREAMING_BACKPRESSURE_ROW_COUNT))
+        assert [row[0] for row in rows if row[1] is None] == list(range(0, STREAMING_BACKPRESSURE_ROW_COUNT, 19))
+        assert [row[0] for row in rows if row[3] is None] == list(range(0, STREAMING_BACKPRESSURE_ROW_COUNT, 17))
+        assert _streaming_backpressure_hash(rows) == _streaming_backpressure_hash(expected)
+
     def test_fetch_one(self, duckdb_cursor):
         # fetch one
         res = duckdb_cursor.sql("SELECT * FROM range(100000)")

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -1,7 +1,25 @@
+from collections import Counter
+from itertools import product
+
 import pytest
 
 import duckdb
 from duckdb import ColumnExpression
+
+STANDARD_VECTOR_SIZE = 2048
+CROSS_JOIN_BOUNDARY_CASES = (
+    (1, 1),
+    (2, 1),
+    (1, 2),
+    (3, 5),
+    (10, 10),
+    (STANDARD_VECTOR_SIZE, 2),
+    (2, STANDARD_VECTOR_SIZE),
+    (STANDARD_VECTOR_SIZE + 1, 2),
+    (2, STANDARD_VECTOR_SIZE + 1),
+    (2 * STANDARD_VECTOR_SIZE + 17, 3),
+    (3, 2 * STANDARD_VECTOR_SIZE + 17),
+)
 
 
 @pytest.fixture
@@ -86,3 +104,34 @@ class TestRAPIJoins:
         rel = a.cross(b)
         res = rel.fetchall()
         assert res == [(1, 1, 1, 4), (2, 1, 1, 4), (3, 2, 1, 4), (1, 1, 3, 5), (2, 1, 3, 5), (3, 2, 3, 5)]
+
+    @pytest.mark.parametrize("threads", [1, 4])
+    @pytest.mark.parametrize("left_count,right_count", CROSS_JOIN_BOUNDARY_CASES)
+    def test_cross_join_vector_boundaries(self, con, threads, left_count, right_count):
+        con.execute(f"SET threads={threads}")
+        left = con.sql(f"SELECT range AS left_value FROM range({left_count})")
+        right = con.sql(f"SELECT range AS right_value FROM range({right_count})")
+
+        rows = left.cross(right).fetchall()
+        expected_count = left_count * right_count
+        expected_rows = Counter(product(range(left_count), range(right_count)))
+
+        assert len(rows) == expected_count
+        assert Counter(rows) == expected_rows
+        assert left.cross(right).aggregate("count(*)").fetchone() == (expected_count,)
+        assert con.execute(
+            f"SELECT count(*) FROM range({left_count}) l CROSS JOIN range({right_count}) r"
+        ).fetchone() == (expected_count,)
+
+    @pytest.mark.parametrize("threads", [1, 4])
+    def test_cross_join_preserves_null_multiset(self, con, threads):
+        con.execute(f"SET threads={threads}")
+        left = con.sql("SELECT * FROM (VALUES (1), (NULL), (1)) AS left_values(value)")
+        right = con.sql("SELECT * FROM (VALUES (10), (NULL)) AS right_values(value)")
+
+        rows = left.cross(right).fetchall()
+        expected_rows = Counter(product((1, None, 1), (10, None)))
+
+        assert len(rows) == 6
+        assert Counter(rows) == expected_rows
+        assert left.cross(right).aggregate("count(*)").fetchone() == (6,)


### PR DESCRIPTION
## Summary

  Fixes #14.

  Preserve materialized `ExecutionBatch` payloads in the owning batch and pass a
  borrowed `DataChunk &` to the legacy `Sink` and `Execute` fallbacks instead of
  moving the payload into call-local storage.

  This preserves input ownership when:

  - a sink returns `BLOCKED` and must retry the same batch;
  - an operator returns `HAVE_MORE_OUTPUT` and must continue producing output
    from the same input.

  The change prevents both streaming-result truncation and silent under-counting
  from multi-output operators such as `PhysicalCrossProduct`. It also raises an
  internal consistency error when a batch reports logical rows without a payload.

  Regression coverage includes:

  - a deterministic sink that returns `BLOCKED` twice before accepting its input;
  - a deterministic operator that returns `HAVE_MORE_OUTPUT` twice and verifies
    the same payload address and contents on every call;
  - small streaming buffers across `fetchall`, `fetchmany`, Arrow tables, and
    Arrow readers;
  - strings, NULLs, dictionary input, ordering, and single-/multi-threaded
    execution;
  - CROSS JOIN detail multisets, row counts, SQL and Relation API aggregation,
    NULLs, both input orientations, and vector/multi-chunk boundaries.

  ## Validation

  - Native `[execution_batch]`: 3 cases, 120,120 assertions passed
  - `pytest tests/fast/api/test_streaming_result.py`: 20 passed
  - `pytest tests/fast/relational_api/test_joins.py`: 31 passed
  - `pytest tests/fast/test_udf_process.py`: 4 passed
  - `scripts/run_release_tests.sh`: 262 passed, 4 skipped
    - skips require an external writable MinIO/S3 endpoint
  - Release incremental build completed successfully
  - `scripts/format workspace --changed`

  ## Checklist

  - [x] The change is focused and includes tests or a reason tests are unnecessary.
  - [x] Public behavior and compatibility impact are documented.
  - [x] New dependencies, copied code, model assets, and datasets have compatible
        licenses and are recorded where required.
  - [x] No credentials, private endpoints, personal paths, generated data, model
        weights, or build artifacts are included.
  - [x] Security implications have been considered.
  - [x] Native changes were compiled; relevant tests passed.
