### PR TITLE
build: derive DuckDB SourceID from engine tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Build and validate source package
         run: |
           python -m pip install --upgrade build pip "tomli>=1.1; python_version < '3.11'"
+          python scripts/sync_duckdb_source_id.py --check
           python -m build --sdist --outdir dist
           python scripts/check_release_artifacts.py dist/*.tar.gz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build and validate the source package
         run: |
           python -m pip install --upgrade build pip
+          python scripts/sync_duckdb_source_id.py --check
           python -m build --sdist --outdir dist
           python scripts/check_release_artifacts.py dist/*.tar.gz
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: sync-duckdb-source-id
+        name: sync DuckDB SourceID
+        entry: python scripts/sync_duckdb_source_id.py --staged-if-changed
+        language: system
+        always_run: true
+        pass_filenames: false
       - id: shfmt
         name: shfmt
         entry: shfmt -w -ln=bash -i=2 -ci -bn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ uv pip install . --no-build-isolation
 
 DuckDB and workspace formatting automatically synchronize the content-derived
 `DUCKDB_SOURCE_ID`. The pre-commit hook also repairs it from the staged DuckDB
-tree if formatting was skipped; CI rejects an out-of-date value.
+tree if formatting was skipped; install that hook once per clone with
+`pre-commit install`. CI rejects an out-of-date value.
 
 ## Formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,9 @@ export SKBUILD_CMAKE_BUILD_TYPE=Release
 uv pip install . --no-build-isolation
 ```
 
-After changing `external/duckdb`, synchronize its content-derived SourceID:
-
-```bash
-python scripts/sync_duckdb_source_id.py
-```
+DuckDB and workspace formatting automatically synchronize the content-derived
+`DUCKDB_SOURCE_ID`. The pre-commit hook also repairs it from the staged DuckDB
+tree if formatting was skipped; CI rejects an out-of-date value.
 
 ## Formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ export SKBUILD_CMAKE_BUILD_TYPE=Release
 uv pip install . --no-build-isolation
 ```
 
+After changing `external/duckdb`, synchronize its content-derived SourceID:
+
+```bash
+python scripts/sync_duckdb_source_id.py
+```
+
 ## Formatting
 
 ```bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,9 +82,15 @@ Some tests require network access, model weights, GPUs, credentials, or a local 
 
 ```bash
 python -m pip install pre-commit
+pre-commit install
 scripts/format root --changed
+python scripts/sync_duckdb_source_id.py --check
 pre-commit run --from-ref origin/main --to-ref HEAD
 ```
+
+Run `pre-commit install` once per clone. The installed commit hook repairs
+`DUCKDB_SOURCE_ID` from the staged DuckDB tree; the explicit check above also
+covers clean range-based runs, where the Git index has no staged changes.
 
 The root formatter deliberately excludes `external/duckdb`. Format DuckDB subtree changes with:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,18 +107,23 @@ The subtree metadata records the exact official DuckDB revision in
 under `external/duckdb`; review and resolve them when updating the official
 baseline. When replaying a change formerly maintained in another repository,
 preserve its author and date and record the original commit and upstream parent
-as commit trailers. After any change below `external/duckdb`, synchronize its
-content-derived identity:
+as commit trailers. `scripts/format duckdb` and `scripts/format workspace`
+automatically synchronize the content-derived identity after a successful
+formatter pass. To synchronize or verify it explicitly, run:
 
 ```bash
 python scripts/sync_duckdb_source_id.py
+python scripts/sync_duckdb_source_id.py --check
 ```
 
 The script records the full Git tree object in `DUCKDB_SOURCE_ID`, including
 staged, unstaged, and untracked non-ignored engine files without changing the
-real Git index. CI checks that record before building source packages. Update
-`SOURCE_PROVENANCE.md` and `OVERRIDE_GIT_DESCRIBE` only when the imported
-upstream baseline, DuckDB version line, or historical mapping changes.
+real Git index. If formatting was skipped, pre-commit updates the file from the
+staged DuckDB tree; stage that generated change and retry the commit. CI checks
+the record before building source packages, including commits made with hooks
+disabled. Update `SOURCE_PROVENANCE.md` and `OVERRIDE_GIT_DESCRIBE` only when
+the imported upstream baseline, DuckDB version line, or historical mapping
+changes.
 
 The original upstream history remains in `duckdb/duckdb`. Vane's path history
 begins at the squashed snapshot and includes every later Vane engine commit. To

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,9 +107,18 @@ The subtree metadata records the exact official DuckDB revision in
 under `external/duckdb`; review and resolve them when updating the official
 baseline. When replaying a change formerly maintained in another repository,
 preserve its author and date and record the original commit and upstream parent
-as commit trailers. Update `SOURCE_PROVENANCE.md` and `OVERRIDE_GIT_DESCRIBE` in
-`pyproject.toml` whenever the imported baseline or resulting engine state
-changes.
+as commit trailers. After any change below `external/duckdb`, synchronize its
+content-derived identity:
+
+```bash
+python scripts/sync_duckdb_source_id.py
+```
+
+The script records the full Git tree object in `DUCKDB_SOURCE_ID`, including
+staged, unstaged, and untracked non-ignored engine files without changing the
+real Git index. CI checks that record before building source packages. Update
+`SOURCE_PROVENANCE.md` and `OVERRIDE_GIT_DESCRIBE` only when the imported
+upstream baseline, DuckDB version line, or historical mapping changes.
 
 The original upstream history remains in `duckdb/duckdb`. Vane's path history
 begins at the squashed snapshot and includes every later Vane engine commit. To

--- a/DUCKDB_SOURCE_ID
+++ b/DUCKDB_SOURCE_ID
@@ -1,0 +1,1 @@
+bf72a7b6380d20a8dc45b03d1d016d4f3fecf9d8

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,10 @@ Vane releases are immutable source and binary artifacts derived from a reviewed 
 
 ## Prepare
 
-1. Open a release pull request that sets the PEP 440 version, updates `CHANGELOG.md`, and records the exact `external/duckdb` commit.
-   If the engine source changed, update `OVERRIDE_GIT_DESCRIBE` in
-   `pyproject.toml` and the matching record in `SOURCE_PROVENANCE.md`.
+1. Open a release pull request that sets the PEP 440 version, updates `CHANGELOG.md`, and records the exact `external/duckdb` tree ID from `DUCKDB_SOURCE_ID`.
+   Run `python scripts/sync_duckdb_source_id.py --check`. Update
+   `OVERRIDE_GIT_DESCRIBE` and `SOURCE_PROVENANCE.md` only when the imported
+   upstream baseline, DuckDB version line, or historical mapping changes.
 2. Confirm that every imported dependency has compatible terms and that `SOURCE_PROVENANCE.md`, `THIRD_PARTY.md`, `LICENSE`, and `NOTICE` are current.
 3. Install the pinned vcpkg manifest and run `python scripts/sync_vcpkg_licenses.py --check`.
 4. Run formatting, fast tests, the relevant slow/native tests, and the package-artifact workflow.

--- a/SOURCE_PROVENANCE.md
+++ b/SOURCE_PROVENANCE.md
@@ -32,10 +32,12 @@ snapshot. The former `AstroVela/duckdb` history maps to Vane as follows:
 | `398033a962719ac09868f4484ec4f97353bb0325` | `3a3967aa8190d0a2d1931d4ca4f5d920760030b4` | `57d4e3c166e307c19b28cb1bb2ea7ebd2283a030` |
 | `e2d398989076fa3c6c3859e77310e5e50608b168` | `398033a962719ac09868f4484ec4f97353bb0325` | `74f8d91976c69d8861262944eb61f4b8a05abd42` |
 
-The former fork is not used for builds or engine identity. It must not be
-deleted until a bundle ending at `e2d398989076fa3c6c3859e77310e5e50608b168`
-has been placed in durable storage and its public location and SHA-256 have
-been recorded here.
+The former fork is not used for builds or engine identity. Vane intentionally
+does not retain a bundle or other archive of its Git objects. The identifiers
+above are kept only as a historical mapping; maintained customization history
+is the corresponding Vane commits, and the official baseline history remains
+in `duckdb/duckdb`. The former fork may therefore be deleted without an
+archival prerequisite.
 
 At Vane commit `74f8d91976c69d8861262944eb61f4b8a05abd42`, the
 DuckDB-rooted subtree history is described as `v1.5.0-2-g55abe0cb9e`. That

--- a/SOURCE_PROVENANCE.md
+++ b/SOURCE_PROVENANCE.md
@@ -25,17 +25,36 @@ The current official upstream baseline is commit
 `3a3967aa8190d0a2d1931d4ca4f5d920760030b4`.
 
 Vane's engine customizations are retained as normal commits after that subtree
-snapshot. The initial customization commit reproduces the complete diff from
-the former `AstroVela/duckdb` commit
-`398033a962719ac09868f4484ec4f97353bb0325`, whose sole parent is the official
-baseline above. Its Vane commit message records both original revisions, so the
-custom source, authorship, and provenance remain available even if that fork is
-retired. The resulting engine tree is described as `v1.5.0-2-ge2d3989890`.
-Source archives do not contain Git metadata, so the same description is passed
-through `OVERRIDE_GIT_DESCRIBE` in `pyproject.toml`. A change to the engine
-source must update both records in the same pull request. Release reviews must
-record the imported upstream baseline and inspect subsequent Vane engine
-commits since the previously released state.
+snapshot. The former `AstroVela/duckdb` history maps to Vane as follows:
+
+| Former fork commit | Parent | Corresponding Vane commit |
+| --- | --- | --- |
+| `398033a962719ac09868f4484ec4f97353bb0325` | `3a3967aa8190d0a2d1931d4ca4f5d920760030b4` | `57d4e3c166e307c19b28cb1bb2ea7ebd2283a030` |
+| `e2d398989076fa3c6c3859e77310e5e50608b168` | `398033a962719ac09868f4484ec4f97353bb0325` | `74f8d91976c69d8861262944eb61f4b8a05abd42` |
+
+The former fork is not used for builds or engine identity. It must not be
+deleted until a bundle ending at `e2d398989076fa3c6c3859e77310e5e50608b168`
+has been placed in durable storage and its public location and SHA-256 have
+been recorded here.
+
+At Vane commit `74f8d91976c69d8861262944eb61f4b8a05abd42`, the
+DuckDB-rooted subtree history is described as `v1.5.0-2-g55abe0cb9e`. That
+description is passed through `OVERRIDE_GIT_DESCRIBE` in `pyproject.toml` to
+preserve DuckDB's human-readable version line in source archives without Git
+metadata.
+
+The exact engine identity is content-derived instead. `DUCKDB_SOURCE_ID`
+records the full Git tree object for `external/duckdb`, computed with
+`scripts/sync_duckdb_source_id.py`. The top-level CMake build passes that value
+through its first 10 hexadecimal characters as `GIT_COMMIT_HASH` and DuckDB's
+embedded `SourceID`. The tree object depends on engine paths, modes, and
+contents rather than commit topology, so rebases and squash merges do not
+change the SourceID.
+Ordinary engine changes update only `DUCKDB_SOURCE_ID`; changes to the upstream
+baseline, DuckDB version line, or historical mapping must also update this
+document and `OVERRIDE_GIT_DESCRIBE`. Release reviews must record the full tree
+ID and inspect subsequent Vane engine commits since the previously released
+state.
 
 The statically linked DuckDB HTTPFS extension is fetched separately during the
 native build and pinned to commit

--- a/cmake/duckdb_loader.cmake
+++ b/cmake/duckdb_loader.cmake
@@ -168,6 +168,13 @@ function(_duckdb_resolve_source_id)
       "${PROJECT_SOURCE_DIR}/scripts/sync_duckdb_source_id.py")
   set(_VANE_DUCKDB_DEFAULT_SOURCE_PATH "${PROJECT_SOURCE_DIR}/external/duckdb")
 
+  # DuckDB formatting updates this manifest after engine changes. Make direct
+  # incremental builds reconfigure before reusing the embedded SourceID.
+  set_property(
+    DIRECTORY "${PROJECT_SOURCE_DIR}"
+    APPEND
+    PROPERTY CMAKE_CONFIGURE_DEPENDS "${_VANE_DUCKDB_SOURCE_ID_FILE}")
+
   if(DEFINED VANE_DUCKDB_SOURCE_ID)
     set(_VANE_DUCKDB_SOURCE_ID "${VANE_DUCKDB_SOURCE_ID}")
   elseif(NOT DUCKDB_SOURCE_PATH STREQUAL _VANE_DUCKDB_DEFAULT_SOURCE_PATH)

--- a/cmake/duckdb_loader.cmake
+++ b/cmake/duckdb_loader.cmake
@@ -162,6 +162,63 @@ function(_duckdb_validate_source_path)
   endif()
 endfunction()
 
+function(_duckdb_resolve_source_id)
+  set(_VANE_DUCKDB_SOURCE_ID_FILE "${PROJECT_SOURCE_DIR}/DUCKDB_SOURCE_ID")
+  set(_VANE_DUCKDB_SOURCE_ID_SCRIPT
+      "${PROJECT_SOURCE_DIR}/scripts/sync_duckdb_source_id.py")
+  set(_VANE_DUCKDB_DEFAULT_SOURCE_PATH "${PROJECT_SOURCE_DIR}/external/duckdb")
+
+  if(DEFINED VANE_DUCKDB_SOURCE_ID)
+    set(_VANE_DUCKDB_SOURCE_ID "${VANE_DUCKDB_SOURCE_ID}")
+  elseif(NOT DUCKDB_SOURCE_PATH STREQUAL _VANE_DUCKDB_DEFAULT_SOURCE_PATH)
+    message(FATAL_ERROR "A custom DUCKDB_SOURCE_PATH requires an explicit "
+                        "VANE_DUCKDB_SOURCE_ID.")
+  elseif(EXISTS "${PROJECT_SOURCE_DIR}/.git")
+    if(NOT EXISTS "${_VANE_DUCKDB_SOURCE_ID_SCRIPT}")
+      message(FATAL_ERROR "Missing ${_VANE_DUCKDB_SOURCE_ID_SCRIPT}")
+    endif()
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    execute_process(
+      COMMAND "${Python_EXECUTABLE}" "${_VANE_DUCKDB_SOURCE_ID_SCRIPT}" --print
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+      RESULT_VARIABLE _VANE_DUCKDB_SOURCE_ID_RESULT
+      OUTPUT_VARIABLE _VANE_DUCKDB_SOURCE_ID
+      ERROR_VARIABLE _VANE_DUCKDB_SOURCE_ID_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(_VANE_DUCKDB_SOURCE_ID_RESULT)
+      message(FATAL_ERROR "Unable to compute the DuckDB source tree ID: "
+                          "${_VANE_DUCKDB_SOURCE_ID_ERROR}")
+    endif()
+  elseif(EXISTS "${_VANE_DUCKDB_SOURCE_ID_FILE}")
+    file(READ "${_VANE_DUCKDB_SOURCE_ID_FILE}" _VANE_DUCKDB_SOURCE_ID)
+    string(STRIP "${_VANE_DUCKDB_SOURCE_ID}" _VANE_DUCKDB_SOURCE_ID)
+  else()
+    message(
+      FATAL_ERROR
+        "DUCKDB_SOURCE_ID is unavailable. Provide VANE_DUCKDB_SOURCE_ID or "
+        "build from a source tree containing DUCKDB_SOURCE_ID.")
+  endif()
+
+  string(LENGTH "${_VANE_DUCKDB_SOURCE_ID}" _VANE_DUCKDB_SOURCE_ID_LENGTH)
+  if(NOT _VANE_DUCKDB_SOURCE_ID MATCHES "^[0-9a-f]+$"
+     OR (NOT _VANE_DUCKDB_SOURCE_ID_LENGTH EQUAL 40
+         AND NOT _VANE_DUCKDB_SOURCE_ID_LENGTH EQUAL 64))
+    message(
+      FATAL_ERROR
+        "Invalid DuckDB source tree ID '${_VANE_DUCKDB_SOURCE_ID}'. Expected "
+        "a 40- or 64-character lowercase hexadecimal Git object ID.")
+  endif()
+
+  string(SUBSTRING "${_VANE_DUCKDB_SOURCE_ID}" 0 10
+                   _VANE_DUCKDB_SHORT_SOURCE_ID)
+  set(VANE_DUCKDB_SOURCE_TREE
+      "${_VANE_DUCKDB_SOURCE_ID}"
+      PARENT_SCOPE)
+  set(GIT_COMMIT_HASH
+      "${_VANE_DUCKDB_SHORT_SOURCE_ID}"
+      PARENT_SCOPE)
+endfunction()
+
 function(_duckdb_create_interface_target target_name)
   add_library(${target_name} INTERFACE)
 
@@ -219,6 +276,8 @@ endfunction()
 function(_duckdb_print_summary)
   message(STATUS "DuckDB Configuration:")
   message(STATUS "  Source: ${DUCKDB_SOURCE_PATH}")
+  message(STATUS "  Source tree: ${VANE_DUCKDB_SOURCE_TREE}")
+  message(STATUS "  Source ID: ${GIT_COMMIT_HASH}")
   message(STATUS "  Build Type: ${CMAKE_BUILD_TYPE}")
   message(STATUS "  Native Arch: ${NATIVE_ARCH}")
   message(STATUS "  Unity Build Disabled: ${DISABLE_UNITY}")
@@ -243,6 +302,7 @@ endfunction()
 function(duckdb_add_library target_name)
   _duckdb_validate_source_path()
   _duckdb_validate_jemalloc_config()
+  _duckdb_resolve_source_id()
   _duckdb_print_summary()
 
   # Add DuckDB subdirectory - it will use our variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,9 @@ exclude = [
 
 [tool.scikit-build.cmake.define]
 BUILD_EXTENSIONS = "core_functions;json;parquet;icu;jemalloc;httpfs"
-# Source archives have no Git metadata. Keep DuckDB's embedded version stable
-# and update this value whenever the engine source revision changes.
-OVERRIDE_GIT_DESCRIBE = "v1.5.0-2-ge2d3989890"
+# Source archives have no Git metadata. This preserves DuckDB's human-readable
+# version line; the exact engine SourceID comes from DUCKDB_SOURCE_ID.
+OVERRIDE_GIT_DESCRIBE = "v1.5.0-2-g55abe0cb9e"
 
 # Override: if COVERAGE is set then:
 # - we create a RelWithDebInfo build
@@ -172,6 +172,7 @@ include = [
     "/MAINTAINERS.md",
     "/RELEASE.md",
     "/ROADMAP.md",
+    "/DUCKDB_SOURCE_ID",
 
     # Build configuration
     "/pyproject.toml",
@@ -182,6 +183,7 @@ include = [
     "cmake/**",
     "/scripts/check_release_artifacts.py",
     "/scripts/run_release_tests.sh",
+    "/scripts/sync_duckdb_source_id.py",
     "/scripts/sync_vcpkg_licenses.py",
     "/scripts/verify_base_install.py",
 

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -11,6 +11,7 @@ import base64
 import csv
 import hashlib
 import io
+import re
 import stat
 import tarfile
 import zipfile
@@ -28,6 +29,7 @@ PROJECT_METADATA = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(
 EXPECTED_NAME = str(PROJECT_METADATA["name"])
 EXPECTED_VERSION = str(PROJECT_METADATA["version"])
 MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
+GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 BANNED_PATH_PARTS = (
     "/.git/",
@@ -198,6 +200,7 @@ def _check_wheel_license_files(artifact: WheelArtifact, metadata) -> None:
 def _check_sdist(artifact: SdistArtifact) -> None:
     names = artifact.names()
     required_paths = (
+        "DUCKDB_SOURCE_ID",
         "LICENSE",
         "NOTICE",
         "THIRD_PARTY.md",
@@ -206,10 +209,17 @@ def _check_sdist(artifact: SdistArtifact) -> None:
         "LICENSES/vcpkg-binary-dependencies.txt",
         "external/duckdb/LICENSE",
         "scripts/run_release_tests.sh",
+        "scripts/sync_duckdb_source_id.py",
         "tests/fast/test_package_metadata.py",
     )
     for relative_path in required_paths:
         _require_sdist_path(names, relative_path, artifact.path)
+
+    source_id_name = _require_sdist_path(names, "DUCKDB_SOURCE_ID", artifact.path)
+    source_id = artifact.read(source_id_name).decode("ascii").strip()
+    if GIT_OBJECT_ID.fullmatch(source_id) is None:
+        raise ValueError(f"{artifact.path}: invalid DuckDB source tree ID {source_id!r}")
+
     metadata = _check_metadata(artifact, "/PKG-INFO")
     _check_sdist_license_files(artifact, metadata)
 

--- a/scripts/format
+++ b/scripts/format
@@ -41,6 +41,7 @@ Examples:
 Notes:
   external/duckdb contains C++, Python, CMake, test, and benchmark files.
   Its formatter is intentionally separate from the root repository formatter.
+  Successful duckdb formatting also synchronizes DUCKDB_SOURCE_ID.
   workspace runs root and external/duckdb independently, then reports failures.
   root requires pre-commit on PATH.
   duckdb requires black>=24, clang-format 11.0.1, and cmake-format on PATH.
@@ -232,6 +233,7 @@ run_root_format_with_verify() {
 
 run_duckdb_format() {
   local duckdb_dir="$repo_root/external/duckdb"
+  local format_status
   local temp_dir
 
   if [[ ! -f "$duckdb_dir/scripts/format.py" ]]; then
@@ -248,24 +250,32 @@ run_duckdb_format() {
       cd "$duckdb_dir" || exit 1
       python scripts/format.py --all --fix --noconfirm
     )
-    return $?
+    format_status=$?
+  else
+    # DuckDB's formatter expects paths relative to its source root. Build a
+    # temporary index at the monorepo HEAD and ask git diff to strip the subtree
+    # prefix so both staged and unstaged DuckDB changes are formatted correctly.
+    temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/vane-duckdb-format.XXXXXX")" || return 1
+    if ! GIT_INDEX_FILE="$temp_dir/index" git read-tree HEAD; then
+      rm -rf "$temp_dir"
+      return 1
+    fi
+
+    (
+      trap 'rm -rf "$temp_dir"' EXIT
+      export GIT_INDEX_FILE="$temp_dir/index"
+      cd "$duckdb_dir" || exit 1
+      python scripts/format.py --fix --noconfirm -- "--relative=external/duckdb"
+    )
+    format_status=$?
   fi
 
-  # DuckDB's formatter expects paths relative to its source root. Build a
-  # temporary index at the monorepo HEAD and ask git diff to strip the subtree
-  # prefix so both staged and unstaged DuckDB changes are formatted correctly.
-  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/vane-duckdb-format.XXXXXX")" || return 1
-  if ! GIT_INDEX_FILE="$temp_dir/index" git read-tree HEAD; then
-    rm -rf "$temp_dir"
-    return 1
+  if [[ $format_status -ne 0 ]]; then
+    return "$format_status"
   fi
 
-  (
-    trap 'rm -rf "$temp_dir"' EXIT
-    export GIT_INDEX_FILE="$temp_dir/index"
-    cd "$duckdb_dir" || exit 1
-    python scripts/format.py --fix --noconfirm -- "--relative=external/duckdb"
-  )
+  echo "Synchronizing DUCKDB_SOURCE_ID..."
+  python "$repo_root/scripts/sync_duckdb_source_id.py"
 }
 
 run_workspace_format() {

--- a/scripts/sync_duckdb_source_id.py
+++ b/scripts/sync_duckdb_source_id.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_DIRECTORY = "external/duckdb"
-SOURCE_ID_FILE = REPOSITORY_ROOT / "DUCKDB_SOURCE_ID"
+SOURCE_ID_PATH = "DUCKDB_SOURCE_ID"
+SOURCE_ID_FILE = REPOSITORY_ROOT / SOURCE_ID_PATH
 GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 
@@ -53,14 +54,57 @@ def source_tree_id() -> str:
     return tree_id
 
 
+def staged_source_tree_id() -> str:
+    """Return the DuckDB tree ID represented by the real Git index."""
+    repository_tree = _git("write-tree")
+    tree_id = _git("rev-parse", f"{repository_tree}:{SOURCE_DIRECTORY}")
+
+    if GIT_OBJECT_ID.fullmatch(tree_id) is None:
+        raise RuntimeError(f"Git returned an invalid DuckDB tree ID: {tree_id!r}")
+    return tree_id
+
+
+def staged_source_id_inputs_changed() -> bool:
+    """Return whether staged engine or SourceID content differs from HEAD."""
+    result = subprocess.run(
+        (
+            "git",
+            "diff",
+            "--cached",
+            "--quiet",
+            "--no-ext-diff",
+            "HEAD",
+            "--",
+            SOURCE_DIRECTORY,
+            SOURCE_ID_PATH,
+        ),
+        cwd=REPOSITORY_ROOT,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        result.check_returncode()
+    return result.returncode == 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--check", action="store_true", help="fail instead of rewriting an out-of-date SourceID")
     mode.add_argument("--print", action="store_true", dest="print_only", help="print the current tree ID")
+    mode.add_argument(
+        "--staged-if-changed",
+        action="store_true",
+        help="rewrite from the Git index only when staged engine or SourceID content changed",
+    )
     args = parser.parse_args()
 
-    expected = source_tree_id() + "\n"
+    if args.staged_if_changed:
+        if not staged_source_id_inputs_changed():
+            return 0
+        expected = staged_source_tree_id() + "\n"
+    else:
+        expected = source_tree_id() + "\n"
+
     if args.print_only:
         print(expected, end="")
         return 0
@@ -70,6 +114,10 @@ def main() -> int:
         if actual != expected:
             print(f"{SOURCE_ID_FILE} is missing or out of date")
             return 1
+        print(f"{SOURCE_ID_FILE} is up to date")
+        return 0
+
+    if actual == expected:
         print(f"{SOURCE_ID_FILE} is up to date")
         return 0
 

--- a/scripts/sync_duckdb_source_id.py
+++ b/scripts/sync_duckdb_source_id.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Synchronize DuckDB's recorded SourceID with its Git tree object."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIRECTORY = "external/duckdb"
+SOURCE_ID_FILE = REPOSITORY_ROOT / "DUCKDB_SOURCE_ID"
+GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+
+
+def _git(*args: str, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=REPOSITORY_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def source_tree_id() -> str:
+    """Return the Git tree ID for the current DuckDB working tree."""
+    top_level = Path(_git("rev-parse", "--show-toplevel")).resolve()
+    if top_level != REPOSITORY_ROOT:
+        raise RuntimeError(f"expected Git root {REPOSITORY_ROOT}, found {top_level}")
+
+    # Use a temporary index so staged, unstaged, and untracked non-ignored
+    # DuckDB files all contribute without changing the developer's real index.
+    with tempfile.TemporaryDirectory(prefix="vane-duckdb-source-id-") as temporary_directory:
+        temporary_index = Path(temporary_directory) / "index"
+        environment = os.environ.copy()
+        environment["GIT_INDEX_FILE"] = str(temporary_index)
+        _git("read-tree", "HEAD", env=environment)
+        _git("add", "-A", "--", SOURCE_DIRECTORY, env=environment)
+        repository_tree = _git("write-tree", env=environment)
+        tree_id = _git("rev-parse", f"{repository_tree}:{SOURCE_DIRECTORY}", env=environment)
+
+    if GIT_OBJECT_ID.fullmatch(tree_id) is None:
+        raise RuntimeError(f"Git returned an invalid DuckDB tree ID: {tree_id!r}")
+    return tree_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="fail instead of rewriting an out-of-date SourceID")
+    mode.add_argument("--print", action="store_true", dest="print_only", help="print the current tree ID")
+    args = parser.parse_args()
+
+    expected = source_tree_id() + "\n"
+    if args.print_only:
+        print(expected, end="")
+        return 0
+
+    actual = SOURCE_ID_FILE.read_text(encoding="utf-8") if SOURCE_ID_FILE.exists() else ""
+    if args.check:
+        if actual != expected:
+            print(f"{SOURCE_ID_FILE} is missing or out of date")
+            return 1
+        print(f"{SOURCE_ID_FILE} is up to date")
+        return 0
+
+    SOURCE_ID_FILE.write_text(expected, encoding="utf-8")
+    print(f"wrote {SOURCE_ID_FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from importlib.metadata import distribution, metadata, requires, version
+from pathlib import Path
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
+
+import duckdb
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_base_distribution_installs_expression_runtime_dependencies():
@@ -53,3 +58,11 @@ def test_wheel_or_install_contains_primary_and_third_party_license_files():
     assert any(path.endswith("licenses/duckdb/experimental/spark/LICENSE") for path in files)
     assert any(path.endswith("compression/alp/algorithm/LICENSE") for path in files)
     assert any(path.endswith("compression/alprd/algorithm/LICENSE") for path in files)
+
+
+def test_duckdb_source_id_matches_recorded_source_tree():
+    source_tree_id = (REPOSITORY_ROOT / "DUCKDB_SOURCE_ID").read_text(encoding="ascii").strip()
+    embedded_source_id = duckdb.sql("SELECT source_id FROM pragma_version()").fetchone()[0]
+
+    assert embedded_source_id == source_tree_id[:10]
+    assert duckdb.__git_revision__ == embedded_source_id


### PR DESCRIPTION
## Summary

- derive the embedded DuckDB SourceID from the full Git tree object for `external/duckdb`
- synchronize `DUCKDB_SOURCE_ID` during DuckDB/workspace formatting and repair it from the staged tree in pre-commit
- reject stale identities in CI and release source-package builds
- retain `OVERRIDE_GIT_DESCRIBE` only as the human-readable DuckDB version line
- update provenance to retain the former fork commit mapping and maintained Vane history without retaining a bundle or other fork Git objects

## Behavior

Ordinary DuckDB source changes no longer require manual edits to `pyproject.toml` or `SOURCE_PROVENANCE.md`. They only change the content-derived `DUCKDB_SOURCE_ID`, which formatting and pre-commit synchronize automatically. The provenance document and version override only need updates when the upstream baseline, DuckDB version line, or historical mapping changes.

Git checkouts compute the identity from the current engine worktree. Source archives without `.git` consume the recorded full tree ID, and custom DuckDB source paths must provide an explicit identity. CMake embeds the first 10 hexadecimal characters as DuckDB `SourceID` and watches the manifest so incremental builds reconfigure after it changes.

Current full tree ID:

`bf72a7b6380d20a8dc45b03d1d016d4f3fecf9d8`

## Validation

- `python scripts/sync_duckdb_source_id.py --check`
- pre-commit checks for the complete `origin/main..HEAD` range
- `python -m pytest tests/fast/test_package_metadata.py`: 5 passed
- `scripts/run_release_tests.sh`: 263 passed, 4 skipped because no writable MinIO/S3 endpoint was configured
- incremental CMake reconfiguration probe after changing the manifest
- native incremental release build and embedded SourceID verification
- source package build, artifact validation, and CMake configuration from an extracted sdist without `.git`
