### PR TITLE
test: make native TIMETZ timezone deterministic

### DIFF
--- a/tests/fast/api/test_native_tz.py
+++ b/tests/fast/api/test_native_tz.py
@@ -49,6 +49,7 @@ class TestNativeTimeZone:
         assert res[0].tzinfo.zone == "UTC"
 
     def test_native_python_time_timezone(self, duckdb_cursor):
+        duckdb_cursor.execute("SET timezone='UTC';")
         res = duckdb_cursor.execute(f"select TimeRecStart::TIMETZ as tz from '{filename}'").fetchone()
         assert res == (datetime.time(21, 52, 27, tzinfo=datetime.timezone.utc),)
 


### PR DESCRIPTION
## Summary

`test_native_python_time_timezone` expects a UTC `TIMETZ` representation, but
the test does not configure the connection timezone. On hosts using a non-UTC
timezone, DuckDB returns the same instant represented in the session timezone,
causing the test to fail.

This makes the test self-contained by setting the `duckdb_cursor` session
timezone to UTC before selecting the `TIMETZ` value. The existing UTC value and
parameter roundtrip assertions remain unchanged. The host and global
test-process timezones are not modified.

Fixes #46

## Validation

- Reproduced the original failure with `TZ=Asia/Shanghai`:
  `05:52:27+08:00` was returned instead of `21:52:27+00:00`.
- Complete native timezone test file with `TZ=Asia/Shanghai`: `6 passed`.
- Complete native timezone test file with `TZ=UTC`: `6 passed`.
- `scripts/format root --changed`
- `git diff --check`
- `scripts/run_release_tests.sh` was attempted but could not complete because
  the local installation is an older Flight-disabled validation build; it
  aborted in unrelated Flight C++ tests.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.
