### PR TITLE
[fix](python) Support Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -45,8 +45,12 @@ jobs:
           python scripts/check_release_artifacts.py dist/*.tar.gz
 
   native-fast-tests:
-    name: Native build and fast tests
+    name: Native build and fast tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     env:
       VCPKG_ROOT: ${{ github.workspace }}/.cache/vcpkg
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/.cache/vcpkg-archives
@@ -78,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -100,12 +104,13 @@ jobs:
             build \
             "cmake>=3.29" \
             "ninja>=1.10" \
-            "pybind11[global]>=2.6.0" \
+            "pybind11[global]>=3.0.0" \
             "scikit-build-core>=0.11.4" \
             packaging \
             pytest
 
       - name: Build and run native distributed tests
+        if: matrix.python-version == '3.12'
         run: scripts/run_native_tests.sh "[distributed]"
 
       - name: Build release artifacts
@@ -135,6 +140,6 @@ jobs:
       - name: Upload validated artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ci-python-artifacts
+          name: ci-python-artifacts-${{ matrix.python-version }}
           path: dist/*
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Validate wheels
         run: |
-          test "$(find wheelhouse -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 3
+          test "$(find wheelhouse -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
           python scripts/check_release_artifacts.py wheelhouse/*.whl
 
       - name: Upload wheels
@@ -129,7 +129,7 @@ jobs:
       - name: Validate the complete distribution set
         run: |
           test "$(find packages -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
-          test "$(find packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 3
+          test "$(find packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
           python scripts/check_release_artifacts.py packages/*.tar.gz packages/*.whl
 
       - name: Generate checksums

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -80,7 +80,7 @@ jobs:
           python -m pip install \
             "cmake>=3.29" \
             "ninja>=1.10" \
-            "pybind11[global]>=2.6.0" \
+            "pybind11[global]>=3.0.0" \
             "scikit-build-core>=0.11.4"
 
       - name: Restore vcpkg binary cache

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,7 +5,7 @@ Vane contains Python, pybind11, and a modified DuckDB C++ engine. A native build
 ## Prerequisites
 
 - Linux x86-64 for the currently tested path
-- Python 3.10, 3.11, or 3.12; Python 3.12 is recommended and is the primary development version
+- Python 3.10 through 3.14; Python 3.12 is recommended and is the primary development version
 - Git with `git subtree` support
 - A C++20 compiler, CMake 3.29+, Ninja, and ccache
 - vcpkg at the baseline pinned in `vcpkg.json`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Vane Data is a high-performance, multimodal-native data engine for AI workloads.
 
 ### Installation
 
-Vane supports Python 3.10, 3.11, and 3.12. Python 3.12 is recommended and is the primary development version.
+Vane supports Python 3.10 through 3.14. Python 3.12 is recommended and is the primary development version.
 
 Install the `vane-ai` package from PyPI:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license-files = [
     "external/duckdb/extension/jemalloc/jemalloc/LICENSE",
 ]
 keywords = ["Vane", "DuckDB", "Ray", "Distributed", "Database", "SQL", "OLAP"]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "cloudpickle>=3.1.2,<4",
     "numpy",
@@ -48,6 +48,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: C++",
 ]
 authors = [{name = "Vane contributors"}]
@@ -93,7 +95,7 @@ build-backend = "build_backend"
 backend-path = ["."]
 requires = [
     "scikit-build-core>=0.11.4",
-	"pybind11[global]>=2.6.0",
+	"pybind11[global]>=3.0.0",
 ]
 
 [tool.scikit-build]
@@ -336,20 +338,20 @@ default-groups = ["dev"]
 # build wheels for.
 # See https://docs.astral.sh/uv/concepts/resolution/#universal-resolution
 environments = [ # no need to resolve packages beyond these platforms with uv...
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "python_version >= '3.11' and python_version < '3.13' and sys_platform == 'win32' and platform_machine == 'ARM64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'win32' and platform_machine == 'AMD64'",
+    "python_version >= '3.11' and python_version < '3.15' and sys_platform == 'win32' and platform_machine == 'ARM64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 required-environments = [ # ... but do always resolve for all of them
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'win32' and platform_machine == 'AMD64'",
-    "python_version >= '3.11' and python_version < '3.13' and sys_platform == 'win32' and platform_machine == 'ARM64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'win32' and platform_machine == 'AMD64'",
+    "python_version >= '3.11' and python_version < '3.15' and sys_platform == 'win32' and platform_machine == 'ARM64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "python_version >= '3.10' and python_version < '3.15' and sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
 # We just need pytorch for tests, wihtout GPU acceleration. PyPI doesn't host a cpu-only version for Linux, so we have
@@ -426,7 +428,7 @@ pypi = [ # dependencies used by the pypi cleanup script
 build = [
     "cmake>=3.29.0",
     "ninja>=1.10",
-    "pybind11[global]>=2.6.0",
+    "pybind11[global]>=3.0.0",
     "scikit_build_core>=0.11.4",
     "tomli>=1.1; python_version < '3.11'",
 ]
@@ -578,7 +580,7 @@ indent-style = "space"
 ######################################################################################################
 [tool.cibuildwheel]
 archs = ["x86_64"]
-build = "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64"
+build = "cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64"
 build-frontend = "build[uv]"
 build-verbosity = 1
 manylinux-x86_64-image = "manylinux_2_28"

--- a/scripts/bootstrap_vcpkg.sh
+++ b/scripts/bootstrap_vcpkg.sh
@@ -17,14 +17,14 @@ for candidate in \
   "$(command -v python3 2>/dev/null || true)" \
   "$(command -v python 2>/dev/null || true)"; do
   if [[ -n "$candidate" && -x "$candidate" ]] \
-    && "$candidate" -c 'import sys; raise SystemExit(not ((3, 10) <= sys.version_info < (3, 13)))'; then
+    && "$candidate" -c 'import sys; raise SystemExit(not ((3, 10) <= sys.version_info < (3, 15)))'; then
     python_cmd="$candidate"
     break
   fi
 done
 
 if [[ -z "$python_cmd" ]]; then
-  echo "Python 3.10, 3.11, or 3.12 is required to bootstrap Vane dependencies." >&2
+  echo "Python 3.10 through 3.14 is required to bootstrap Vane dependencies." >&2
   exit 1
 fi
 

--- a/src/duckdb_py/include/duckdb_python/pybind11/gil_wrapper.hpp
+++ b/src/duckdb_py/include/duckdb_python/pybind11/gil_wrapper.hpp
@@ -8,7 +8,25 @@
 
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 
+#if PY_VERSION_HEX < 0x030D0000 && !defined(Py_LIMITED_API)
+extern "C" int _Py_IsFinalizing(void);
+#endif
+
 namespace duckdb {
+
+inline bool PythonIsFinalizing() {
+#if PY_VERSION_HEX >= 0x030D0000
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API + 0 >= 0x030D0000
+	return Py_IsFinalizing();
+#else
+	return false;
+#endif
+#elif !defined(Py_LIMITED_API)
+	return _Py_IsFinalizing();
+#else
+	return false;
+#endif
+}
 
 //! Thread-safe GIL wrapper that keeps a PERSISTENT PyThreadState per thread.
 //!

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -44,10 +44,6 @@
 
 #include <algorithm>
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 namespace duckdb {
 
 DuckDBPyRelation::DuckDBPyRelation(shared_ptr<Relation> rel_p) : rel(std::move(rel_p)) {
@@ -916,11 +912,9 @@ static bool PyRelationRuntimeUsableForTeardown() {
 	if (!Py_IsInitialized()) {
 		return false;
 	}
-#if !defined(Py_LIMITED_API)
-	if (_Py_IsFinalizing()) {
+	if (PythonIsFinalizing()) {
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/src/duckdb_py/python_udf_actor_resources.cpp
+++ b/src/duckdb_py/python_udf_actor_resources.cpp
@@ -20,23 +20,11 @@
 #include <sstream>
 #include <unordered_set>
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 namespace duckdb {
 
 namespace {
 
 namespace py = pybind11;
-
-static inline int DuckdbPyIsFinalizingForUDFActorResources() {
-#ifdef Py_LIMITED_API
-	return 0;
-#else
-	return _Py_IsFinalizing();
-#endif
-}
 
 static shared_ptr<void> WrapPyObjectForUDFActorHandles(const py::object &obj) {
 	if (obj.is_none()) {
@@ -48,7 +36,7 @@ static shared_ptr<void> WrapPyObjectForUDFActorHandles(const py::object &obj) {
 			return;
 		}
 		auto *boxed_obj = static_cast<py::object *>(ptr);
-		if (!Py_IsInitialized() || DuckdbPyIsFinalizingForUDFActorResources()) {
+		if (!Py_IsInitialized() || PythonIsFinalizing()) {
 			boxed_obj->release();
 			delete boxed_obj;
 			return;
@@ -198,7 +186,7 @@ public:
 		if (resources.empty()) {
 			return;
 		}
-		if (!Py_IsInitialized() || DuckdbPyIsFinalizingForUDFActorResources()) {
+		if (!Py_IsInitialized() || PythonIsFinalizing()) {
 			ReleaseResourcesWithoutPython();
 			return;
 		}
@@ -210,7 +198,7 @@ public:
 		if (resources.empty()) {
 			return;
 		}
-		if (!Py_IsInitialized() || DuckdbPyIsFinalizingForUDFActorResources()) {
+		if (!Py_IsInitialized() || PythonIsFinalizing()) {
 			ReleaseResourcesWithoutPython();
 			return;
 		}

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1997,7 +1997,7 @@ struct PyPhysicalPlanWrapperRunner {
 								break;
 							}
 							lock.unlock();
-							if (DuckdbPyIsFinalizing()) {
+							if (PythonIsFinalizing()) {
 								break;
 							}
 							emit_native_progress(false);

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -651,7 +651,7 @@ static duckdb::shared_ptr<void> WrapPyObjectForUDFActorHandles(const py::object 
 			return;
 		}
 		auto *boxed_obj = static_cast<py::object *>(ptr);
-		if (!Py_IsInitialized() || DuckdbPyIsFinalizing()) {
+		if (!Py_IsInitialized() || PythonIsFinalizing()) {
 			boxed_obj->release();
 			delete boxed_obj;
 			return;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -13,6 +13,7 @@
 #include "duckdb_python/python_objects.hpp"
 #include "duckdb_python/arrow/arrow_array_stream.hpp"
 #include "duckdb_python/arrow/arrow_export_utils.hpp"
+#include "duckdb_python/pybind11/gil_wrapper.hpp"
 
 #include <duckdb/execution/distributed/plan/distributed_physical_plan.hpp>
 #include <duckdb/execution/distributed/plan/plan_config.hpp>
@@ -37,18 +38,6 @@
 #include <duckdb/common/local_file_system.hpp>
 #include <duckdb/common/types/uuid.hpp>
 #include <duckdb/optimizer/optimizer.hpp>
-
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
-static inline int DuckdbPyIsFinalizing() {
-#ifdef Py_LIMITED_API
-	return 0;
-#else
-	return _Py_IsFinalizing();
-#endif
-}
 
 static inline int DuckdbGetEnvIntMs(const char *name) {
 	const char *val = std::getenv(name);

--- a/src/duckdb_py/ray/safe_pyobject.hpp
+++ b/src/duckdb_py/ray/safe_pyobject.hpp
@@ -13,19 +13,13 @@ namespace distributed {
 namespace python {
 namespace ray {
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 static inline bool SafePyObjectCanDecRef() {
 	if (!Py_IsInitialized()) {
 		return false;
 	}
-#if !defined(Py_LIMITED_API)
-	if (_Py_IsFinalizing()) {
+	if (PythonIsFinalizing()) {
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -28,19 +28,13 @@ using namespace duckdb::distributed::python::ray;
 
 namespace {
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 bool RayTaskPythonRuntimeUsable() {
 	if (!Py_IsInitialized()) {
 		return false;
 	}
-#if !defined(Py_LIMITED_API)
-	if (_Py_IsFinalizing()) {
+	if (duckdb::PythonIsFinalizing()) {
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -55,19 +55,13 @@ namespace duckdb {
 
 namespace {
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 static bool PythonRuntimeUsableForUDFTeardown() {
 	if (!Py_IsInitialized()) {
 		return false;
 	}
-#if !defined(Py_LIMITED_API)
-	if (_Py_IsFinalizing()) {
+	if (PythonIsFinalizing()) {
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/src/duckdb_py/vane-runners/vane_runners.cpp
+++ b/src/duckdb_py/vane-runners/vane_runners.cpp
@@ -17,19 +17,13 @@
 
 namespace py = pybind11;
 
-#if !defined(Py_LIMITED_API)
-extern "C" int _Py_IsFinalizing(void);
-#endif
-
 static bool VaneRunnerCanDecRefPython() {
 	if (!Py_IsInitialized()) {
 		return false;
 	}
-#if !defined(Py_LIMITED_API)
-	if (_Py_IsFinalizing()) {
+	if (duckdb::PythonIsFinalizing()) {
 		return false;
 	}
-#endif
 	return true;
 }
 

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -55,7 +55,7 @@ def test_distribution_declares_alpha_version_and_apache_license_expression():
 
     assert version("vane-ai") == "0.1.0a1"
     assert package_metadata["License-Expression"] == "Apache-2.0"
-    assert SpecifierSet(package_metadata["Requires-Python"]) == SpecifierSet(">=3.10,<3.13")
+    assert SpecifierSet(package_metadata["Requires-Python"]) == SpecifierSet(">=3.10,<3.15")
 
 
 def test_provider_extras_match_provider_import_errors():


### PR DESCRIPTION
## Summary

close: #13 

Vane hard-coded Python 3.10–3.12 in package metadata, tooling, CI, and release wheels. Teardown paths also duplicated the private `_Py_IsFinalizing()` API instead of using the public API available in Python 3.13+.

This change adds Python 3.13/3.14 support across package metadata, dependency resolution, documentation, bootstrap tooling, CI, and cp313/cp314 manylinux wheels. It upgrades pybind11 to 3.x and centralizes version-aware interpreter finalization detection while preserving behavior on older Python versions.

## Validation

  - All pre-commit formatting, static, YAML/TOML, and GitHub Workflow checks passed.
  - Incremental native build passed.
  - Relevant tests: 11 passed.
  - Base release suite: 265 passed, 4 deselected.
  - CPython 3.13.14 and 3.14.6: wheel build, installation, Ray Quickstart, release tests, and final sdist validation passed.
  - Validated on Linux x86-64; macOS, Windows, and free-threaded builds were not tested.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.
