### PR TITLE
[fix](tests) Use explicit ns units in numpy expectations

### DIFF
--- a/tests/fast/test_all_types.py
+++ b/tests/fast/test_all_types.py
@@ -377,9 +377,9 @@ class TestAllTypes:
             ),
             "interval": np.ma.array(
                 [
-                    np.timedelta64(0),
-                    np.timedelta64(2675722599999999000),
-                    np.timedelta64(42),
+                    np.timedelta64(0, "ns"),
+                    np.timedelta64(2675722599999999000, "ns"),
+                    np.timedelta64(42, "ns"),
                 ],
                 mask=[0, 0, 1],
             ),
@@ -387,7 +387,7 @@ class TestAllTypes:
             # such that the conversion yields "Not a Time"
             "timestamp_ns": np.ma.array(
                 [
-                    np.datetime64("NaT"),
+                    np.datetime64("NaT", "ns"),
                     np.datetime64(9223372036854775806, "ns"),
                     np.datetime64("1990-01-01T00:42"),
                 ],


### PR DESCRIPTION
## Problem

NumPy 2.5 emits a `DeprecationWarning` when `np.timedelta64`/`np.datetime64` are constructed with a generic (unitless) unit, and the pytest configuration promotes warnings to errors. All 51 `TestAllTypes::test_fetchnumpy` parameterizations fail while the shared expected value is built, before any type-specific assertion runs.

## Fix

Sync the four constructor changes from upstream duckdb-python, exactly as scoped in #45:

- [b8d15ab2](https://github.com/duckdb/duckdb-python/commit/b8d15ab2b1bf8b06c5accb801e5b9eed0bc35d70) — pass `"ns"` to the three integer `np.timedelta64` interval expectations
- [91c7c49d](https://github.com/duckdb/duckdb-python/commit/91c7c49d99f8f0c83af9354409993a603e0b1b01) — `np.datetime64("NaT")` → `np.datetime64("NaT", "ns")`

No warning filter is added and pytest's warning policy is unchanged. The interval expectations retain nanosecond semantics.

## Tests run

In a `linux/amd64` container (Python 3.12, NumPy 2.5.1, PyArrow 25.0.0, `vane-ai==0.1.0a1` wheel), without `-W ignore`:

- Before: `tests/fast/test_all_types.py` → **51 failed, 154 passed** (matches the issue report)
- After: `tests/fast/test_all_types.py` → **205 passed**
- `scripts/format root --changed` and all pre-commit hooks pass

Untested environment: `scripts/run_release_tests.sh` could not be completed locally — the development host is macOS (outside the supported Linux x86-64 path) and the Ray/e2e suites are unstable under CPU emulation, failing on tests unrelated to this change. Relying on CI for the official release gate; note the change only touches test expectations in a file outside that gate's file list.

## Compatibility / provenance

Test-only change; no runtime, API, license, or dependency impact. The four lines mirror upstream duckdb-python commits referenced above.

This contribution was prepared with AI assistance (Claude Code); the change was reviewed and the tests above were run as described.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtvrDQW9xFHUoPdD5wMMEd