### PR TITLE
[fix](vllm)Protect PhysicalVLLM queries from invalid state and concurrent teardown

### DIFF
--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -131,9 +131,9 @@ class LocalVLLMExecutor(VLLMExecutor):
 
         self.model = model
         self.engine_args = dict(engine_args)
-        self.llm = None
+        self.llm: Any = None
         self.engine_ready = threading.Event()
-        self.engine_error_message = None
+        self.engine_error_message: str | None = None
         self.engine_init_timeout_s = _vllm_engine_init_timeout_s(engine_init_timeout_s)
 
         sampling_params = generate_args.pop("sampling_params", None)
@@ -160,7 +160,7 @@ class LocalVLLMExecutor(VLLMExecutor):
         self.task_count_lock = threading.Lock()
 
         self.completed_tasks: deque[tuple[str | None, pa.Table]] = deque()
-        self.error_message = None
+        self.error_message: str | None = None
         self.error_lock = threading.Lock()
         self.on_error = on_error
 
@@ -275,7 +275,7 @@ class LocalVLLMExecutor(VLLMExecutor):
             if final_output is None or not final_output.outputs:
                 raise RuntimeError("vllm returned no outputs")
 
-            output_text: str = final_output.outputs[0].text  # type: ignore[assignment]
+            output_text: str = final_output.outputs[0].text
             target_deque.append((output_text, row))
             with self._result_cv:
                 self._result_cv.notify_all()
@@ -454,13 +454,15 @@ class LocalVLLMExecutor(VLLMExecutor):
         source_deque = (
             self._per_executor_deques.get(executor_id, self.completed_tasks) if executor_id else self.completed_tasks
         )
-        if executor_id:
-            done = lambda: (
-                executor_id in self._per_executor_finished
-                and self._per_executor_running_task_count.get(executor_id, 0) == 0
-            )
-        else:
-            done = lambda: self._finished_submitting and self.running_task_count == 0
+
+        def done() -> bool:
+            if executor_id:
+                return (
+                    executor_id in self._per_executor_finished
+                    and self._per_executor_running_task_count.get(executor_id, 0) == 0
+                )
+            return self._finished_submitting and self.running_task_count == 0
+
         with self._result_cv:
             self._result_cv.wait_for(lambda: len(source_deque) > 0 or self.error_message is not None or done())
             return len(source_deque) > 0
@@ -477,13 +479,13 @@ class LocalVLLMExecutor(VLLMExecutor):
         with self._result_cv:
             self._result_cv.notify_all()
         loop = getattr(self, "loop", None)
-        loop_thread = getattr(self, "loop_thread", None)
         if loop is not None and loop.is_running():
             loop.call_soon_threadsafe(loop.stop)
 
 
 class RayLocalVLLMExecutor(LocalVLLMExecutor):
-    async def wait_for_result(self, executor_id: str | None = None) -> bool:
+    # Ray actor calls are awaitable, while the in-process executor exposes a blocking method.
+    async def wait_for_result(self, executor_id: str | None = None) -> bool:  # type: ignore[override]
         return await asyncio.to_thread(self._wait_for_result_blocking, executor_id)
 
 

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
+from numbers import Integral, Real
 from typing import Any
 
 import pyarrow as pa
@@ -30,8 +32,8 @@ def _positive_float_env(name: str, default: float | None = None) -> float | None
     if not raw:
         return default
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
     return value
 
 
@@ -57,7 +59,12 @@ def _bounded_query_timeout_s(timeout_s: float | None) -> float | None:
 
 def _vllm_engine_init_timeout_s(value: Any | None = None) -> float | None:
     if value is not None:
-        return max(0.0, float(value))
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError("vllm engine_init_timeout_s must be a finite non-negative number")
+        result = float(value)
+        if not math.isfinite(result) or result < 0.0:
+            raise ValueError("vllm engine_init_timeout_s must be a finite non-negative number")
+        return result
     return _positive_float_env("VANE_VLLM_ENGINE_INIT_TIMEOUT_S")
 
 
@@ -806,7 +813,7 @@ class LLMActors:
         engine_args: dict[str, Any],
         generate_args: dict[str, Any],
         on_error: str,
-        gpus_per_actor: int,
+        gpus_per_actor: int | float,
         concurrency: int,
         load_balance_threshold: int,
         name_prefix: str | None = None,
@@ -860,7 +867,7 @@ class LLMActors:
         engine_args: dict[str, Any],
         generate_args: dict[str, Any],
         on_error: str,
-        gpus_per_actor: int,
+        gpus_per_actor: int | float,
         concurrency: int,
         load_balance_threshold: int,
         name_prefix: str,
@@ -956,11 +963,40 @@ _DEFAULTS: dict[str, Any] = {
 }
 
 
+def _integer_option(name: str, value: Any, *, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"vllm {name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        qualifier = "positive" if minimum == 1 else f">= {minimum}"
+        raise ValueError(f"vllm {name} must be {qualifier}")
+    return result
+
+
+def _fractional_gpu_option(value: Any) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError("vllm gpus_per_actor must be a finite positive number")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError("vllm gpus_per_actor must be a finite positive number")
+    if result >= 1:
+        if not result.is_integer():
+            raise ValueError("vllm gpus_per_actor values >= 1 must be integers")
+        return int(result)
+    return result
+
+
+def _unit_interval_option(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"vllm {name} must be a finite number in [0, 1]")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"vllm {name} must be a finite number in [0, 1]")
+    return result
+
+
 def normalize_options(options: Any | None) -> dict[str, Any]:
     merged = dict(_DEFAULTS)
-    if options is None:
-        return merged
-
     if isinstance(options, str):
         try:
             parsed = json.loads(options)
@@ -969,25 +1005,30 @@ def normalize_options(options: Any | None) -> dict[str, Any]:
         if not isinstance(parsed, dict):
             raise ValueError("vllm options JSON must decode to a dict")
         options = parsed
-    elif not isinstance(options, dict):
+    elif options is not None and not isinstance(options, dict):
         try:
             options = dict(options)
         except Exception as exc:
             raise TypeError("vllm options must be a dict or JSON string") from exc
 
-    if options.get("ray_address") is not None:
+    if options is not None and options.get("ray_address") is not None:
         raise ValueError("vLLM ray_address has been removed; configure RayRunner instead")
 
-    merged.update(options)
-    merged["concurrency"] = max(1, int(merged["concurrency"]))
-    merged["gpus_per_actor"] = max(0, int(merged["gpus_per_actor"]))
-    merged["do_prefix_routing"] = bool(merged["do_prefix_routing"])
-    merged["max_buffer_size"] = max(0, int(merged["max_buffer_size"]))
-    merged["min_bucket_size"] = max(0, int(merged["min_bucket_size"]))
-    merged["prefix_match_threshold"] = float(merged["prefix_match_threshold"])
-    merged["load_balance_threshold"] = max(0, int(merged["load_balance_threshold"]))
-    merged["batch_size"] = int(merged["batch_size"]) if merged["batch_size"] is not None else None
-    merged["inflight_limit"] = max(0, int(merged["inflight_limit"]))
+    if options is not None:
+        merged.update(options)
+    merged["concurrency"] = _integer_option("concurrency", merged["concurrency"], minimum=1)
+    merged["gpus_per_actor"] = _fractional_gpu_option(merged["gpus_per_actor"])
+    if not isinstance(merged["do_prefix_routing"], bool):
+        raise ValueError("vllm do_prefix_routing must be a boolean")
+    merged["max_buffer_size"] = _integer_option("max_buffer_size", merged["max_buffer_size"], minimum=0)
+    merged["min_bucket_size"] = _integer_option("min_bucket_size", merged["min_bucket_size"], minimum=0)
+    merged["prefix_match_threshold"] = _unit_interval_option("prefix_match_threshold", merged["prefix_match_threshold"])
+    merged["load_balance_threshold"] = _integer_option(
+        "load_balance_threshold", merged["load_balance_threshold"], minimum=0
+    )
+    batch_size = merged["batch_size"]
+    merged["batch_size"] = None if batch_size is None else _integer_option("batch_size", batch_size, minimum=1)
+    merged["inflight_limit"] = _integer_option("inflight_limit", merged["inflight_limit"], minimum=0)
     merged["engine_init_timeout_s"] = _vllm_engine_init_timeout_s(merged.get("engine_init_timeout_s"))
     on_error = merged.get("on_error")
     if on_error is None:
@@ -1056,7 +1097,7 @@ def ensure_named_vllm_pools_for_plan(plan: Any, conn: Any = None) -> tuple[list[
         engine_args = _apply_engine_defaults(dict(opts.get("engine_args") or {}))
         generate_args = dict(opts.get("generate_args") or {})
         on_error = str(opts.get("on_error", "raise"))
-        gpus_per_actor = max(1, int(opts.get("gpus_per_actor", 1)))
+        gpus_per_actor = opts["gpus_per_actor"]
         concurrency = max(1, int(opts.get("concurrency", 1)))
         load_balance_threshold = max(0, int(opts.get("load_balance_threshold", 32)))
         engine_init_timeout_s = _vllm_engine_init_timeout_s(opts.get("engine_init_timeout_s"))
@@ -1111,7 +1152,7 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
             raise RuntimeError("Ray vLLM execution requires an initialized RayRunner runtime")
         if pool_name:
             llm_actors = LLMActors.lookup_named(
-                concurrency=int(opts["concurrency"]),
+                concurrency=opts["concurrency"],
                 name_prefix=pool_name,
             )
         else:
@@ -1120,9 +1161,9 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
                 engine_args=engine_args,
                 generate_args=generate_args,
                 on_error=on_error,
-                gpus_per_actor=int(opts["gpus_per_actor"]),
-                concurrency=int(opts["concurrency"]),
-                load_balance_threshold=int(opts["load_balance_threshold"]),
+                gpus_per_actor=opts["gpus_per_actor"],
+                concurrency=opts["concurrency"],
+                load_balance_threshold=opts["load_balance_threshold"],
                 engine_init_timeout_s=opts["engine_init_timeout_s"],
             )
         return RemoteVLLMExecutor(llm_actors, pool_name=pool_name)

--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -10,12 +10,10 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <deque>
 #include <mutex>
 #include <numeric>
 #include <queue>
-#include <thread>
 #include <utility>
 
 namespace duckdb {
@@ -65,6 +63,16 @@ static idx_t CommonPrefixLength(const string &left, const string &right) {
 	return match_len;
 }
 
+static idx_t CompleteUTF8PrefixLength(const string &value, idx_t prefix_len) {
+	if (prefix_len >= value.size()) {
+		return value.size();
+	}
+	while (prefix_len > 0 && (static_cast<unsigned char>(value[prefix_len]) & 0xC0) == 0x80) {
+		prefix_len--;
+	}
+	return prefix_len;
+}
+
 static string ComputeBucketPrefix(const vector<string> &prompts, idx_t start, idx_t end) {
 	if (end <= start) {
 		return string();
@@ -82,14 +90,7 @@ static string ComputeBucketPrefix(const vector<string> &prompts, idx_t start, id
 		}
 	}
 
-	idx_t prefix_len_to_char = 0;
-	for (idx_t i = 0; i < prefix_len; i++) {
-		auto byte = static_cast<unsigned char>(first[i]);
-		if ((byte & 0xC0) != 0x80) {
-			prefix_len_to_char = i;
-		}
-	}
-	return first.substr(0, prefix_len_to_char);
+	return first.substr(0, CompleteUTF8PrefixLength(first, prefix_len));
 }
 
 static unique_ptr<DataChunk> CopyChunk(ClientContext &context, DataChunk &input) {
@@ -168,9 +169,13 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 	std::atomic<int64_t> completed_prompts {0};
 
 	//! Thread coordination for FinalExecute.
-	std::atomic<idx_t> active_threads {0};
+	std::atomic<idx_t> active_threads {1};
 	std::atomic<idx_t> finished_threads {0};
 	std::atomic<bool> global_finished_submitting {false};
+
+	void PipelineMaxThreadsResolved(idx_t max_threads) override {
+		active_threads.store(MaxValue<idx_t>(1, max_threads));
+	}
 
 	int64_t InflightPrompts() const {
 		const auto submitted = submitted_prompts.load();
@@ -202,6 +207,7 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 		if (!exec) {
 			throw InvalidInputException("vllm executor factory did not return an executor");
 		}
+		config.Validate();
 		config_initialized = true;
 		executor = shared_ptr<VLLMExecutor>(std::move(exec));
 	}
@@ -236,11 +242,38 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 		return true;
 	}
 
+	bool WaitForExecutorResult(ClientContext &context) {
+		auto exec = ExecutorRef();
+		if (!exec) {
+			return false;
+		}
+		// This call may block. Keep it outside executor_call_mutex so another
+		// producer can submit the work that eventually wakes this waiter.
+		exec->WaitForResult(context);
+		return true;
+	}
+
+	VLLMWakeupRegistrationResult RegisterWakeup(ExecutionContext &context) {
+		if (!context.interrupt_state) {
+			return VLLMWakeupRegistrationResult::UNSUPPORTED;
+		}
+		// Another finalizer can drain the last result and shut the shared
+		// executor down between this task's readiness check and wakeup
+		// registration. Treat that terminal state as immediately actionable.
+		auto result = VLLMWakeupRegistrationResult::READY;
+		WithExecutorIfPresent([&](VLLMExecutor &exec) { result = exec.RegisterWakeup(*context.interrupt_state); });
+		return result;
+	}
+
 	//! Called by each thread when it finishes submitting. The last thread
 	//! signals the executor that no more prompts will arrive.
 	void ThreadFinishedSubmitting(ClientContext &context) {
 		auto finished = finished_threads.fetch_add(1) + 1;
-		if (finished >= active_threads.load()) {
+		auto expected = active_threads.load();
+		if (finished > expected) {
+			throw InternalException("vllm producer finished more than once");
+		}
+		if (finished == expected) {
 			if (!global_finished_submitting.exchange(true)) {
 				WithExecutorIfPresent([&](VLLMExecutor &exec) { exec.FinishedSubmitting(context); });
 			}
@@ -253,10 +286,14 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 			std::lock_guard<std::mutex> call_lock(executor_call_mutex);
 			{
 				std::lock_guard<std::mutex> lock(executor_mutex);
-				executor_to_shutdown = std::move(executor);
+				executor_to_shutdown = executor;
 			}
 			if (executor_to_shutdown) {
 				executor_to_shutdown->Shutdown();
+				std::lock_guard<std::mutex> lock(executor_mutex);
+				if (executor == executor_to_shutdown) {
+					executor.reset();
+				}
 			}
 		}
 	}
@@ -279,7 +316,6 @@ struct VLLMOperatorState : public OperatorState {
 	idx_t buffer_size = 0;
 	bool finished_submitting = false;
 	std::deque<unique_ptr<DataChunk>> pending_outputs;
-	bool registered = false;
 };
 
 static void TakeReadyResultOnce(ExecutionContext &context, VLLMGlobalOperatorState &gstate, VLLMOperatorState &state,
@@ -292,8 +328,13 @@ static void SubmitPrompts(ExecutionContext &context, VLLMGlobalOperatorState &gs
 	}
 
 	if (!gstate.config.batch_size.IsValid() || prompts.size() <= gstate.config.batch_size.GetIndex()) {
-		gstate.WithExecutor([&](VLLMExecutor &exec) { exec.Submit(prefix, prompts, rows, context.client); });
-		gstate.submitted_prompts.fetch_add(prompts.size());
+		gstate.WithExecutor([&](VLLMExecutor &exec) {
+			exec.Submit(prefix, prompts, rows, context.client);
+			// Publish after Python has installed its reservation and wait state.
+			// executor_call_mutex also prevents a result drain from racing ahead
+			// of this native accounting update.
+			gstate.submitted_prompts.fetch_add(prompts.size());
+		});
 		return;
 	}
 
@@ -308,7 +349,9 @@ static void SubmitPrompts(ExecutionContext &context, VLLMGlobalOperatorState &gs
 				if (gstate.CanSubmitMore()) {
 					break;
 				}
-				gstate.WithExecutor([&](VLLMExecutor &exec) { exec.WaitForResult(context.client); });
+				if (!gstate.WaitForExecutorResult(context.client)) {
+					throw InternalException("vllm executor disappeared during batch backpressure");
+				}
 			}
 		}
 		const idx_t count = MinValue<idx_t>(batch_size, prompts.size() - offset);
@@ -323,9 +366,10 @@ static void SubmitPrompts(ExecutionContext &context, VLLMGlobalOperatorState &gs
 		batch_rows.Slice(rows, sel, count, 0);
 		batch_rows.Flatten();
 
-		gstate.WithExecutor(
-		    [&](VLLMExecutor &exec) { exec.Submit(prefix, std::move(batch_prompts), batch_rows, context.client); });
-		gstate.submitted_prompts.fetch_add(count);
+		gstate.WithExecutor([&](VLLMExecutor &exec) {
+			exec.Submit(prefix, std::move(batch_prompts), batch_rows, context.client);
+			gstate.submitted_prompts.fetch_add(count);
+		});
 	}
 }
 
@@ -423,7 +467,9 @@ static void PopAndSubmitTasks(ExecutionContext &context, VLLMGlobalOperatorState
 			if (gstate.CanSubmitMore()) {
 				break;
 			}
-			gstate.WithExecutor([&](VLLMExecutor &exec) { exec.WaitForResult(context.client); });
+			if (!gstate.WaitForExecutorResult(context.client)) {
+				throw InternalException("vllm executor disappeared during bucket backpressure");
+			}
 		}
 
 		auto bucket = splits.top();
@@ -513,11 +559,6 @@ OperatorResultType PhysicalVLLM::Execute(ExecutionContext &context, DataChunk &i
 	auto &gstate = gstate_p.Cast<VLLMGlobalOperatorState>();
 	auto &state = state_p.Cast<VLLMOperatorState>();
 
-	if (!state.registered) {
-		state.registered = true;
-		gstate.active_threads.fetch_add(1);
-	}
-
 	if (!state.pending_outputs.empty()) {
 		auto output = std::move(state.pending_outputs.front());
 		state.pending_outputs.pop_front();
@@ -538,7 +579,9 @@ OperatorResultType PhysicalVLLM::Execute(ExecutionContext &context, DataChunk &i
 		if (gstate.CanSubmitMore()) {
 			break;
 		}
-		gstate.WithExecutor([&](VLLMExecutor &exec) { exec.WaitForResult(context.client); });
+		if (!gstate.WaitForExecutorResult(context.client)) {
+			throw InternalException("vllm executor disappeared during operator backpressure");
+		}
 	}
 
 	if (gstate.config.do_prefix_routing) {
@@ -579,9 +622,7 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 			PopAndSubmitTasks(context, gstate, state, 0);
 		}
 		state.finished_submitting = true;
-		if (gstate.HasExecutor()) {
-			gstate.ThreadFinishedSubmitting(context.client);
-		}
+		gstate.ThreadFinishedSubmitting(context.client);
 	}
 
 	if (!gstate.HasExecutor()) {
@@ -608,12 +649,18 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 		return OperatorFinalizeResultType::FINISHED;
 	}
 
-	// Event-driven wait — zero CPU, instant wakeup when a result completes.
-	if (!gstate.WithExecutorIfPresent([&](VLLMExecutor &exec) { exec.WaitForResult(context.client); })) {
-		chunk.SetCardinality(0);
-		return OperatorFinalizeResultType::FINISHED;
-	}
+	// Arm before yielding so result, error, cancellation, or a later producer
+	// cannot race between the readiness check above and task suspension.
+	auto wakeup_result = gstate.RegisterWakeup(context);
 	chunk.SetCardinality(0);
+	if (wakeup_result == VLLMWakeupRegistrationResult::ARMED) {
+		return OperatorFinalizeResultType::BLOCKED;
+	}
+	if (wakeup_result == VLLMWakeupRegistrationResult::UNSUPPORTED && gstate.InflightPrompts() > 0) {
+		// Compatibility fallback for legacy executors. Waiting with zero inflight
+		// would deadlock while another producer is still able to submit.
+		gstate.WaitForExecutorResult(context.client);
+	}
 	return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/external/duckdb/src/include/duckdb/execution/vllm_executor.hpp
+++ b/external/duckdb/src/include/duckdb/execution/vllm_executor.hpp
@@ -10,13 +10,18 @@
 
 #pragma once
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/client_context.hpp"
 
+#include <cmath>
+
 namespace duckdb {
+
+class InterruptState;
 
 struct VLLMConfig {
 	bool do_prefix_routing = true;
@@ -26,6 +31,15 @@ struct VLLMConfig {
 	idx_t load_balance_threshold = 32;
 	optional_idx batch_size {128};
 	idx_t inflight_limit = 128;
+
+	void Validate() const {
+		if (!std::isfinite(prefix_match_threshold) || prefix_match_threshold < 0.0 || prefix_match_threshold > 1.0) {
+			throw InvalidInputException("vllm prefix_match_threshold must be finite and between 0 and 1");
+		}
+		if (batch_size.IsValid() && batch_size.GetIndex() == 0) {
+			throw InvalidInputException("vllm batch_size must be at least 1 or NULL");
+		}
+	}
 };
 
 struct VLLMResult {
@@ -34,6 +48,17 @@ struct VLLMResult {
 	unique_ptr<DataChunk> rows;
 };
 
+//! Outcome of asking an executor to wake a blocked native pipeline task.
+enum class VLLMWakeupRegistrationResult {
+	//! The executor cannot register callbacks; the caller may use a blocking fallback.
+	UNSUPPORTED,
+	//! A one-shot callback was registered, so the caller can safely return BLOCKED.
+	ARMED,
+	//! Work or a terminal state is already ready, so the caller must not block.
+	READY
+};
+
+//! Runtime interface used by PhysicalVLLM, implemented by the Python executor bridge.
 class VLLMExecutor {
 public:
 	virtual ~VLLMExecutor() = default;
@@ -44,6 +69,10 @@ public:
 	virtual void FinishedSubmitting(ClientContext &context) = 0;
 	virtual bool AllTasksFinished(ClientContext &context) = 0;
 	virtual void Shutdown() = 0;
+	//! Try to arm a one-shot scheduler wakeup; legacy executors use the unsupported default.
+	virtual VLLMWakeupRegistrationResult RegisterWakeup(InterruptState &) {
+		return VLLMWakeupRegistrationResult::UNSUPPORTED;
+	}
 
 	//! Block until at least one result is available, an error occurred, or all tasks finished.
 	//! Uses event-driven wakeup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,8 +492,12 @@ module = [
     "pandas",
     "polars",
     "pyarrow.*",
+    "ray",
+    "ray.*",
     "torch",
     "tensorflow",
+    "vllm",
+    "vllm.*",
 ]
 ignore_missing_imports = true
 

--- a/src/duckdb_py/vllm_executor.cpp
+++ b/src/duckdb_py/vllm_executor.cpp
@@ -28,10 +28,45 @@
 #include "duckdb_python/python_objects.hpp"
 #include "duckdb/execution/vllm_executor.hpp"
 #include "duckdb/common/types/arrow_aux_data.hpp"
+#include "duckdb/parallel/interrupt.hpp"
+
+#include <cmath>
 
 namespace duckdb {
 
 namespace {
+
+static py::object RequiredNormalizedOption(const py::dict &normalized, const char *name) {
+	auto key = py::str(name);
+	if (!normalized.contains(key)) {
+		throw InvalidInputException("normalized vllm options are missing '%s'", name);
+	}
+	return py::reinterpret_borrow<py::object>(normalized[key]);
+}
+
+static idx_t NormalizedNonNegativeInteger(const py::dict &normalized, const char *name) {
+	auto value = RequiredNormalizedOption(normalized, name);
+	if (py::isinstance<py::bool_>(value) || !py::isinstance<py::int_>(value)) {
+		throw InvalidInputException("vllm %s must be a non-boolean integer", name);
+	}
+	auto number = value.cast<int64_t>();
+	if (number < 0) {
+		throw InvalidInputException("vllm %s must be nonnegative", name);
+	}
+	return static_cast<idx_t>(number);
+}
+
+static double NormalizedUnitInterval(const py::dict &normalized, const char *name) {
+	auto value = RequiredNormalizedOption(normalized, name);
+	if (py::isinstance<py::bool_>(value) || (!py::isinstance<py::int_>(value) && !py::isinstance<py::float_>(value))) {
+		throw InvalidInputException("vllm %s must be a non-boolean number", name);
+	}
+	auto number = value.cast<double>();
+	if (!std::isfinite(number) || number < 0.0 || number > 1.0) {
+		throw InvalidInputException("vllm %s must be finite and between 0 and 1", name);
+	}
+	return number;
+}
 
 static py::list ConvertToSingleBatch(vector<LogicalType> &types, vector<string> &names, DataChunk &input,
                                      ClientProperties &options, ClientContext &context) {
@@ -245,25 +280,48 @@ public:
 		}
 	}
 
+	VLLMWakeupRegistrationResult RegisterWakeup(InterruptState &interrupt_state) override {
+		PythonGILWrapper gil;
+		if (!py::hasattr(executor->obj, "register_wakeup_callback")) {
+			return VLLMWakeupRegistrationResult::UNSUPPORTED;
+		}
+		try {
+			auto callback = py::cpp_function([interrupt_state]() { interrupt_state.Callback(); });
+			auto armed = executor->obj.attr("register_wakeup_callback")(std::move(callback));
+			if (!py::isinstance<py::bool_>(armed)) {
+				throw InvalidInputException("vllm register_wakeup_callback must return a bool");
+			}
+			return armed.cast<bool>() ? VLLMWakeupRegistrationResult::ARMED : VLLMWakeupRegistrationResult::READY;
+		} catch (const py::error_already_set &ex) {
+			throw InvalidInputException("vllm register_wakeup_callback failed: %s", ex.what());
+		}
+	}
+
 	void WaitForResult(ClientContext &context) override {
 		PythonGILWrapper gil;
+		if (!executor) {
+			return;
+		}
+		// Shutdown can clear the registered handle after the caller snapshots
+		// the outer VLLMExecutor. Keep the Python executor alive for the full
+		// blocking call, even if another finalizer shuts the bridge down.
+		auto executor_ref = executor->obj;
 		try {
-			executor->obj.attr("wait_for_result")();
+			executor_ref.attr("wait_for_result")();
 		} catch (const py::error_already_set &ex) {
 			throw InvalidInputException("vllm wait_for_result failed: %s", ex.what());
 		}
 	}
 
 	void Shutdown() override {
+		PythonGILWrapper gil;
 		if (!executor) {
 			return;
 		}
-		PythonGILWrapper gil;
 		try {
 			executor->obj.attr("shutdown")();
 			executor.reset();
 		} catch (const py::error_already_set &ex) {
-			executor.reset();
 			throw InvalidInputException("vllm shutdown failed: %s", ex.what());
 		}
 	}
@@ -298,19 +356,31 @@ static unique_ptr<VLLMExecutor> CreatePythonVLLMExecutor(ClientContext &context,
 	}
 	auto normalized = normalized_obj.cast<py::dict>();
 
-	config.do_prefix_routing = normalized["do_prefix_routing"].cast<bool>();
-	config.max_buffer_size = normalized["max_buffer_size"].cast<idx_t>();
-	config.min_bucket_size = normalized["min_bucket_size"].cast<idx_t>();
-	config.prefix_match_threshold = normalized["prefix_match_threshold"].cast<double>();
-	config.load_balance_threshold = normalized["load_balance_threshold"].cast<idx_t>();
-	config.inflight_limit = normalized["inflight_limit"].cast<idx_t>();
+	auto do_prefix_routing = RequiredNormalizedOption(normalized, "do_prefix_routing");
+	if (!py::isinstance<py::bool_>(do_prefix_routing)) {
+		throw InvalidInputException("vllm do_prefix_routing must be a bool");
+	}
+	config.do_prefix_routing = do_prefix_routing.cast<bool>();
+	config.max_buffer_size = NormalizedNonNegativeInteger(normalized, "max_buffer_size");
+	config.min_bucket_size = NormalizedNonNegativeInteger(normalized, "min_bucket_size");
+	config.prefix_match_threshold = NormalizedUnitInterval(normalized, "prefix_match_threshold");
+	config.load_balance_threshold = NormalizedNonNegativeInteger(normalized, "load_balance_threshold");
+	config.inflight_limit = NormalizedNonNegativeInteger(normalized, "inflight_limit");
 
-	auto batch_size_obj = normalized["batch_size"];
+	auto batch_size_obj = RequiredNormalizedOption(normalized, "batch_size");
 	if (batch_size_obj.is_none()) {
 		config.batch_size = optional_idx();
 	} else {
-		config.batch_size = optional_idx(batch_size_obj.cast<idx_t>());
+		if (py::isinstance<py::bool_>(batch_size_obj) || !py::isinstance<py::int_>(batch_size_obj)) {
+			throw InvalidInputException("vllm batch_size must be a non-boolean integer or NULL");
+		}
+		auto batch_size = batch_size_obj.cast<int64_t>();
+		if (batch_size < 1) {
+			throw InvalidInputException("vllm batch_size must be at least 1 or NULL");
+		}
+		config.batch_size = optional_idx(static_cast<idx_t>(batch_size));
 	}
+	config.Validate();
 
 	try {
 		py::object executor_obj = module.attr("build_executor")(py::str(model), normalized_obj);

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from collections import deque
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+
+class _RecordingExecutor:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str | None, tuple[str, ...]]] = []
+        self.ready = deque()
+        self.finished = False
+        self.finished_count = 0
+        self.invalid_wait = False
+        self.wakeup_callbacks = []
+        self.wakeup_registrations = 0
+
+    def submit(self, prefix, prompts, rows) -> None:
+        prompt_values = tuple(prompts)
+        self.submissions.append((prefix, prompt_values))
+        self.ready.append(([f"generated:{prompt}" for prompt in prompt_values], rows))
+        self._notify_wakeups()
+
+    def take_ready_result(self):
+        try:
+            return self.ready.popleft()
+        except IndexError:
+            return None
+
+    def finished_submitting(self) -> None:
+        self.finished_count += 1
+        self.finished = True
+        self._notify_wakeups()
+
+    def all_tasks_finished(self) -> bool:
+        return self.finished and not self.ready
+
+    def wait_for_result(self) -> None:
+        if not self.ready and not self.finished:
+            self.invalid_wait = True
+            raise AssertionError("wait_for_result called with no inflight work")
+
+    def register_wakeup_callback(self, callback) -> bool:
+        self.wakeup_registrations += 1
+        if self.ready or self.all_tasks_finished():
+            return False
+        self.wakeup_callbacks.append(callback)
+        return True
+
+    def _notify_wakeups(self) -> None:
+        if not self.ready and not self.all_tasks_finished():
+            return
+        callbacks, self.wakeup_callbacks = self.wakeup_callbacks, []
+        for callback in callbacks:
+            callback()
+
+    def shutdown(self) -> None:
+        self.finished = True
+
+
+class _DeferredWakeupExecutor(_RecordingExecutor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pending = deque()
+        self.callback_armed = threading.Event()
+        self.pending_ready = threading.Event()
+        self.callback_invocations = 0
+
+    def submit(self, prefix, prompts, rows) -> None:
+        prompt_values = tuple(prompts)
+        self.submissions.append((prefix, prompt_values))
+        self.pending.append(([f"generated:{prompt}" for prompt in prompt_values], rows))
+        self.pending_ready.set()
+
+    def all_tasks_finished(self) -> bool:
+        return self.finished and not self.pending and not self.ready
+
+    def register_wakeup_callback(self, callback) -> bool:
+        self.wakeup_registrations += 1
+        if self.ready or self.all_tasks_finished():
+            return False
+        self.wakeup_callbacks.append(callback)
+        self.callback_armed.set()
+        return True
+
+    def publish_results(self) -> None:
+        self.ready.extend(self.pending)
+        self.pending.clear()
+        callbacks, self.wakeup_callbacks = self.wakeup_callbacks, []
+        for callback in callbacks:
+            self.callback_invocations += 1
+            callback()
+
+
+def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=1):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    executor = executor or _RecordingExecutor()
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: executor)
+    con = duckdb.connect()
+    try:
+        con.execute(f"PRAGMA threads={threads}")
+        con.register(
+            "vllm_input",
+            pa.table(
+                {
+                    "id": pa.array(range(len(prompts)), type=pa.int64()),
+                    "prompt": pa.array(list(prompts), type=pa.string()),
+                }
+            ),
+        )
+        encoded = json.dumps(options, separators=(",", ":"))
+        rows = con.execute(
+            "SELECT id, prompt, vllm(prompt, 'recording-model', '" + encoded + "') AS generated FROM vllm_input"
+        ).fetchall()
+        return executor, rows
+    finally:
+        con.close()
+
+
+@pytest.mark.parametrize(
+    ("prompts", "expected_prefix"),
+    [
+        (["abc1", "abc2"], "abc"),
+        (["你好甲", "你好乙"], "你好"),
+        (["🙂alpha", "🙂alpine"], "🙂alp"),
+        (["same", "same"], "same"),
+        (["alpha", "zulu"], None),
+        (["", ""], None),
+    ],
+)
+def test_native_bucket_prefix_ends_on_a_complete_utf8_character(monkeypatch, prompts, expected_prefix):
+    executor, rows = _run_recording_sql(
+        monkeypatch,
+        prompts,
+        {
+            "do_prefix_routing": True,
+            "max_buffer_size": 0,
+            "min_bucket_size": 2,
+            "prefix_match_threshold": 0.3,
+            "batch_size": None,
+            "inflight_limit": 0,
+        },
+    )
+
+    assert [submission[0] for submission in executor.submissions] == [expected_prefix]
+    assert {row[0]: row[2] for row in rows} == {index: f"generated:{prompt}" for index, prompt in enumerate(prompts)}
+
+
+def test_native_bridge_rejects_zero_batch_size_even_if_python_normalization_is_bypassed(monkeypatch):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    invalid = vllm.normalize_options({})
+    invalid["batch_size"] = 0
+    monkeypatch.setattr(vllm, "normalize_options", lambda _options: invalid)
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: _RecordingExecutor())
+
+    con = duckdb.connect()
+    try:
+        with pytest.raises(Exception, match="batch_size"):
+            con.execute("SELECT vllm('hello', 'recording-model')").fetchall()
+    finally:
+        con.close()
+
+
+@pytest.mark.timeout(30)
+def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeypatch):
+    executor = _DeferredWakeupExecutor()
+    publisher_errors = []
+
+    def publish_after_arm() -> None:
+        try:
+            assert executor.callback_armed.wait(timeout=20), "native finalizer did not arm a wakeup callback"
+            assert executor.pending_ready.wait(timeout=20), "native producer did not submit a pending result"
+            executor.publish_results()
+        except BaseException as exc:
+            publisher_errors.append(exc)
+
+    publisher = threading.Thread(target=publish_after_arm, name="vllm-test-result-publisher")
+    publisher.start()
+    try:
+        _, rows = _run_recording_sql(
+            monkeypatch,
+            ["prefix-alpha", "prefix-beta"],
+            {
+                "do_prefix_routing": True,
+                "max_buffer_size": 0,
+                "min_bucket_size": 2,
+                "batch_size": None,
+                "inflight_limit": 0,
+            },
+            executor=executor,
+            threads=2,
+        )
+    finally:
+        publisher.join(timeout=5)
+
+    assert not publisher.is_alive()
+    assert publisher_errors == []
+    assert {row[0]: row[2] for row in rows} == {
+        0: "generated:prefix-alpha",
+        1: "generated:prefix-beta",
+    }
+    assert executor.wakeup_registrations >= 1
+    assert executor.callback_invocations >= 1
+    assert executor.finished_count == 1
+    assert not executor.pending
+    assert not executor.invalid_wait
+
+
+_PARALLEL_FINALIZER_SCRIPT = r"""
+import json
+import threading
+from collections import deque
+
+import duckdb
+import duckdb.execution.vllm as vllm
+
+
+class Fake:
+    def __init__(self):
+        self.condition = threading.Condition()
+        self.pending = deque()
+        self.ready = deque()
+        self.finished = False
+        self.finished_count = 0
+        self.shutdown_count = 0
+        self.wait_count = 0
+        self.finished_event = threading.Event()
+        self.waiters_ready = threading.Event()
+        self.submit_threads = set()
+
+    def submit(self, _prefix, prompts, rows):
+        values = tuple(prompts)
+        self.submit_threads.add(threading.get_ident())
+        with self.condition:
+            self.pending.append((["generated:" + value for value in values], rows))
+
+    def take_ready_result(self):
+        with self.condition:
+            return self.ready.popleft() if self.ready else None
+
+    def finished_submitting(self):
+        self.finished_count += 1
+        self.finished = True
+        self.finished_event.set()
+
+    def all_tasks_finished(self):
+        with self.condition:
+            return self.finished and not self.pending and not self.ready
+
+    def wait_for_result(self):
+        with self.condition:
+            self.wait_count += 1
+            wait_for_shutdown = self.wait_count == 1
+            if self.wait_count >= 2:
+                self.waiters_ready.set()
+            predicate = (lambda: self.shutdown_count) if wait_for_shutdown else (lambda: self.ready or self.shutdown_count)
+            ready = self.condition.wait_for(predicate, timeout=20)
+            if not ready:
+                raise AssertionError("legacy finalizer wait was not released")
+
+    def publish_results(self):
+        with self.condition:
+            self.ready.extend(self.pending)
+            self.pending.clear()
+            self.condition.notify_all()
+
+    def shutdown(self):
+        with self.condition:
+            self.shutdown_count += 1
+            self.condition.notify_all()
+
+
+executor = Fake()
+vllm.build_executor = lambda *_args, **_kwargs: executor
+publisher_errors = []
+
+
+def publish_after_legacy_wait():
+    try:
+        assert executor.finished_event.wait(timeout=20), "native producers did not finish"
+        assert executor.waiters_ready.wait(timeout=20), "native finalizers did not enter concurrent legacy waits"
+        executor.publish_results()
+    except BaseException as exc:
+        publisher_errors.append(exc)
+
+
+publisher = threading.Thread(target=publish_after_legacy_wait, name="vllm-legacy-result-publisher")
+publisher.start()
+options = json.dumps(
+    {
+        "do_prefix_routing": True,
+        "max_buffer_size": 0,
+        "min_bucket_size": 1,
+        "batch_size": None,
+        "inflight_limit": 0,
+    },
+    separators=(",", ":"),
+)
+con = duckdb.connect()
+try:
+    con.execute("PRAGMA threads=2")
+    con.execute(
+        "CREATE TABLE parallel_input AS SELECT i::BIGINT id, "
+        "'prefix-' || i::VARCHAR prompt FROM range(300000) t(i)"
+    )
+    count = con.execute(
+        "SELECT count(generated) FROM (SELECT vllm(prompt, 'model', '"
+        + options
+        + "') AS generated FROM parallel_input) q"
+    ).fetchone()[0]
+finally:
+    con.close()
+    publisher.join(timeout=5)
+
+assert count == 300000
+assert not publisher.is_alive()
+assert publisher_errors == []
+assert len(executor.submit_threads) == 2
+assert executor.finished_count == 1
+assert executor.wait_count >= 1
+assert executor.shutdown_count == 1
+"""
+
+
+def test_parallel_legacy_finalizer_wait_survives_shutdown():
+    completed = subprocess.run(
+        [sys.executable, "-c", _PARALLEL_FINALIZER_SCRIPT],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"batch_size": 0}, "batch_size"),
+        ({"batch_size": True}, "batch_size"),
+        ({"batch_size": 1.5}, "batch_size"),
+        ({"prefix_match_threshold": float("nan")}, "prefix_match_threshold"),
+        ({"prefix_match_threshold": float("inf")}, "prefix_match_threshold"),
+        ({"prefix_match_threshold": True}, "prefix_match_threshold"),
+        ({"gpus_per_actor": 0}, "gpus_per_actor"),
+        ({"gpus_per_actor": 1.5}, "gpus_per_actor"),
+        ({"gpus_per_actor": True}, "gpus_per_actor"),
+        ({"concurrency": True}, "concurrency"),
+        ({"do_prefix_routing": "false"}, "do_prefix_routing"),
+    ],
+)
+def test_vllm_numeric_options_are_strict(options, message):
+    from duckdb.execution.vllm import normalize_options
+
+    with pytest.raises(ValueError, match=message):
+        normalize_options(options)
+
+
+def test_vllm_fractional_gpu_option_is_preserved():
+    from duckdb.execution.vllm import normalize_options
+
+    assert normalize_options({"gpus_per_actor": 0.25})["gpus_per_actor"] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
issue #50 

PhysicalVLLM must reject unsafe normalized options before native execution, preserve complete UTF-8 prefix boundaries, and coordinate the exact producer count. Finalizers support an optional one-shot scheduler wakeup while executors without that protocol continue through the blocking fallback.

Blocking waits must remain outside executor_call_mutex so producers can submit work that wakes the waiter. Another finalizer can drain the last result and shut the Python bridge down during that window, so WaitForResult snapshots the inner Python object under the GIL and treats an already-cleared handle as terminal. Shutdown checks and resets the same handle under the GIL.

## Validation

- Built and reinstalled the native extension in Release mode.
  - pytest -q tests/fast/test_vllm_native_regressions.py tests/fast/test_vllm_runtime_fixes.py: 21 passed.
  - pytest -q tests/fast/test_udf_executor_lifecycle.py -k 'vllm and not actor_wait_for_result_finishes_per_executor_before_global_finish': 14 passed.
  - Repeated test_parallel_legacy_finalizer_wait_survives_shutdown 10 times: 10/10 passed.
  - Ruff, clang-format, pre-commit, and git diff --check passed for the changed fix files.
  - CPU-only validation with a synthetic 300,000-row dataset and PRAGMA threads=2; no performance claims. CUDA and real-model inference were not tested.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.
