### PR TITLE
[fix](fte) OOM classifier: match error codes and word-bounded text, not substrings

### DIFF
--- a/duckdb/runners/fte/fte_failures.py
+++ b/duckdb/runners/fte/fte_failures.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -114,8 +115,29 @@ def _missing_output_stats_failure(attempt_id: FteTaskAttemptId) -> dict[str, Any
     }
 
 
+# Structured error codes that mean a memory failure, matched exactly after
+# _normalized_error_token() (upper-cased, separators folded to underscores).
+_MEMORY_ERROR_CODES = frozenset(
+    {
+        "OOM",
+        "OUT_OF_MEMORY",
+        "MEMORY_LIMIT_EXCEEDED",
+        "EXCEEDED_LOCAL_MEMORY_LIMIT",
+        "EXCEEDED_GLOBAL_MEMORY_LIMIT",
+        "EXCEEDED_MEMORY_LIMIT",
+    }
+)
+
+# Text fallback with word boundaries: "oom" must stand alone so messages
+# containing bloom/room/zoom are not classified as memory failures, while
+# "OOM", "oom-killed", and "out of memory" still are. The text is lower-cased
+# with -/_ folded to spaces before matching.
+_MEMORY_TEXT_PATTERN = re.compile(r"\b(?:oom|out of memory|memory limit|exceeded local memory)\b")
+
+
 def _is_memory_failure(payload: Any) -> bool:
-    text = _failure_text(payload).lower()
-    return any(
-        token in text for token in ("out_of_memory", "out of memory", "oom", "memory limit", "exceeded_local_memory")
-    )
+    code = _normalized_error_token(_failure_field(payload, "error_code", "errorCode", "code"))
+    if code in _MEMORY_ERROR_CODES:
+        return True
+    text = _failure_text(payload).lower().replace("_", " ").replace("-", " ")
+    return _MEMORY_TEXT_PATTERN.search(text) is not None

--- a/tests/fast/test_fte_memory_failure_classifier.py
+++ b/tests/fast/test_fte_memory_failure_classifier.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from duckdb.runners.fte.fte_failures import _is_memory_failure
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "Query exceeded per-node memory limit"},
+        {"message": "OOM while hashing build side"},
+        {"message": "worker oom-killed by cgroup"},
+        {"message": "OUT_OF_MEMORY on node 3"},
+        {"message": "task failed: out of memory"},
+        "out of memory",
+    ],
+    ids=["memory-limit", "oom-upper", "oom-killed", "out-of-memory-code-in-text", "plain-text", "bare-string"],
+)
+def test_memory_failure_text_positive(payload):
+    assert _is_memory_failure(payload) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"error_code": "OUT_OF_MEMORY"},
+        {"error_code": "EXCEEDED_LOCAL_MEMORY_LIMIT"},
+        {"error_code": "exceeded-local-memory-limit"},
+        {"code": "MEMORY_LIMIT_EXCEEDED"},
+        {"errorCode": "OOM"},
+    ],
+    ids=["out-of-memory", "local-limit", "normalized-separators", "code-key", "camel-key"],
+)
+def test_memory_failure_structured_codes(payload):
+    assert _is_memory_failure(payload) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "bloom filter construction failed"},
+        {"message": "no room left in queue"},
+        {"message": "zoom level invalid"},
+        {"message": "mushroom cloud render failed"},
+        {"error_code": "BLOOM_FILTER_ERROR"},
+        {"message": "boomerang scheduling retry"},
+        None,
+        "",
+    ],
+    ids=["bloom", "room", "zoom", "mushroom", "bloom-code", "boomerang", "none", "empty"],
+)
+def test_memory_failure_negative(payload):
+    assert _is_memory_failure(payload) is False
+
+
+def test_memory_failure_case_insensitive():
+    assert _is_memory_failure({"message": "Out Of Memory"}) is True
+    assert _is_memory_failure({"message": "MEMORY LIMIT reached"}) is True


### PR DESCRIPTION
## What

Fixes #66. `_is_memory_failure` used a raw `"oom" in text` check, so messages containing **bloom**, **room**, or **zoom** were classified as memory failures — e.g. `bloom filter construction failed` returned true and took the memory-specific non-retry path.

## How (per the acceptance criteria)

- **Structured codes first**: `error_code`/`errorCode`/`code` are read through the existing `_failure_field` + `_normalized_error_token` helpers (upper-cased, `-`/space folded to `_`) and matched exactly against a small frozenset (`OOM`, `OUT_OF_MEMORY`, `MEMORY_LIMIT_EXCEEDED`, `EXCEEDED_LOCAL_MEMORY_LIMIT`, `EXCEEDED_GLOBAL_MEMORY_LIMIT`, `EXCEEDED_MEMORY_LIMIT`)
- **Text fallback with boundaries**: the failure text is lower-cased with `-`/`_` folded to spaces, then matched against `\b(?:oom|out of memory|memory limit|exceeded local memory)\b` — so `OOM`, `oom-killed`, `OUT_OF_MEMORY`, and plain `out of memory` still classify while `bloom`/`room`/`zoom`/`mushroom`/`boomerang` do not
- Case-insensitive throughout

## Tests

New `tests/fast/test_fte_memory_failure_classifier.py` with parameterized positive (6 text + 5 structured-code), negative (8, including the three words from the issue plus `mushroom`, `boomerang`, and a `BLOOM_FILTER_ERROR` code), and case-insensitivity cases.

Note on local verification: I can't build the native `_duckdb` module on this machine, so I verified the classifier logic standalone (loading `fte_failures.py` with a stubbed package parent — all 14 behaviour cases pass) and ran `ruff check`/`ruff format --check` on both files. The new test file follows the existing `tests/fast` import pattern and will run under CI's built environment.

Validated against `02389fd` as noted in the issue.