### PR TITLE
[fix](udf) Restore socket timeout unconditionally after the startup handshake

### DIFF
--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -388,17 +388,22 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
 
     def _recv_expected(self, expected: tuple[int, ...], *, timeout_s: float | None = None) -> tuple[int, bytes]:
         sock = self._require_socket()
-        restore_timeout = None
+        # None is a valid previous timeout (blocking mode), so a separate flag
+        # tracks whether we overrode it — restoring must be unconditional or
+        # the temporary startup timeout leaks into normal task communication.
+        timeout_overridden = False
+        restore_timeout: float | None = None
         if timeout_s is not None and hasattr(sock, "settimeout") and hasattr(sock, "gettimeout"):
             restore_timeout = sock.gettimeout()
             sock.settimeout(max(0.0, float(timeout_s)))
+            timeout_overridden = True
         try:
             msg_type, payload = _recv_message(sock)
         except Exception as exc:
             self._mark_broken(f"UDF subprocess communication failed: {exc}", actor_lost=True)
             raise RuntimeError(self._broken_error) from exc
         finally:
-            if restore_timeout is not None:
+            if timeout_overridden:
                 try:
                     sock.settimeout(restore_timeout)
                 except Exception:

--- a/tests/fast/test_udf_socket_timeout_restore.py
+++ b/tests/fast/test_udf_socket_timeout_restore.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from duckdb.execution import udf_subprocess
+from duckdb.execution.udf_subprocess import _SingleSubprocessExecutor
+
+
+class _FakeSocket:
+    """Tracks the timeout like a real socket: None = blocking, 0.0 = non-blocking."""
+
+    def __init__(self, initial: float | None):
+        self.timeout = initial
+        self.settimeout_calls: list[float | None] = []
+
+    def gettimeout(self) -> float | None:
+        return self.timeout
+
+    def settimeout(self, value: float | None) -> None:
+        self.timeout = value
+        self.settimeout_calls.append(value)
+
+
+def _executor_with(sock: _FakeSocket) -> _SingleSubprocessExecutor:
+    executor = object.__new__(_SingleSubprocessExecutor)
+    executor._require_socket = lambda: sock  # type: ignore[method-assign]
+    executor._broken_error = None
+
+    def _mark_broken(error: str, *, actor_lost: bool = False) -> None:
+        executor._broken_error = error
+
+    executor._mark_broken = _mark_broken  # type: ignore[method-assign]
+    return executor
+
+
+# None = blocking mode (the leak in the issue), 5.0 = existing finite timeout,
+# 0.0 = non-blocking mode.
+@pytest.mark.parametrize("initial", [None, 5.0, 0.0], ids=["blocking", "finite", "non-blocking"])
+def test_recv_expected_restores_timeout_after_success(monkeypatch, initial):
+    sock = _FakeSocket(initial)
+    executor = _executor_with(sock)
+    monkeypatch.setattr(udf_subprocess, "_recv_message", lambda _sock: (0x1, b"ok"))
+
+    msg_type, payload = executor._recv_expected((0x1,), timeout_s=2.0)
+
+    assert (msg_type, payload) == (0x1, b"ok")
+    assert sock.timeout == initial
+    # The temporary timeout was actually applied before being restored.
+    assert sock.settimeout_calls[0] == 2.0
+    assert sock.settimeout_calls[-1] == initial
+
+
+@pytest.mark.parametrize("initial", [None, 5.0, 0.0], ids=["blocking", "finite", "non-blocking"])
+def test_recv_expected_restores_timeout_after_failure(monkeypatch, initial):
+    sock = _FakeSocket(initial)
+    executor = _executor_with(sock)
+
+    def _boom(_sock):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(udf_subprocess, "_recv_message", _boom)
+
+    with pytest.raises(RuntimeError):
+        executor._recv_expected((0x1,), timeout_s=2.0)
+
+    assert sock.timeout == initial
+    assert sock.settimeout_calls[-1] == initial
+
+
+def test_recv_expected_without_timeout_never_touches_socket_timeout(monkeypatch):
+    sock = _FakeSocket(None)
+    executor = _executor_with(sock)
+    monkeypatch.setattr(udf_subprocess, "_recv_message", lambda _sock: (0x1, b""))
+
+    executor._recv_expected((0x1,))
+
+    assert sock.settimeout_calls == []


### PR DESCRIPTION
## What

Fixes #65. `_recv_expected` used `restore_timeout = None` both as "we never overrode the timeout" and as the captured previous value — but `None` is exactly what a normal blocking socket's `gettimeout()` returns, so after a handshake that started from blocking mode the temporary timeout was never restored and leaked into all subsequent task communication.

## Fix

A separate `timeout_overridden` flag tracks whether we changed the timeout; the `finally` block restores `previous_timeout` unconditionally when set (`None` is a valid `settimeout` argument), on both the success and failure paths.

## Tests

`tests/fast/test_udf_socket_timeout_restore.py`, parameterized over the three starting modes from the acceptance criteria — blocking (`None`), an existing finite timeout (`5.0`), and non-blocking (`0.0`) — for both a successful and a failing handshake, asserting the original timeout is back and that the temporary timeout was genuinely applied in between. Plus one case pinning that a call without `timeout_s` never touches the socket timeout.

Local note: the native `_duckdb` module isn't buildable on this machine, so I verified the exact scenarios with the module loaded standalone (all 7 pass — blocking mode restores `[2.0 → None]` where the old code left `2.0` in place) and ran `ruff check`/`format --check`. The pytest file uses the normal `tests/fast` imports for CI.

Validated against `02389fd`.