### PR TITLE
[fix](video) Reject zero/negative VANE_MAX_CONCURRENT_DECODES instead of deadlocking

### DIFF
--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -168,8 +168,25 @@ def _emit_reader_timing(
     )
 
 
+def _max_concurrent_decodes_from_env() -> int:
+    """Positive decode concurrency from VANE_MAX_CONCURRENT_DECODES.
+
+    Zero would build Semaphore(0) and block every decode forever, and a
+    negative or non-integer value is equally meaningless, so all of those are
+    rejected loudly at configuration load instead.
+    """
+    raw = os.environ.get("VANE_MAX_CONCURRENT_DECODES", "1")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"VANE_MAX_CONCURRENT_DECODES must be a positive integer (>= 1), got {raw!r}") from None
+    if value < 1:
+        raise ValueError(f"VANE_MAX_CONCURRENT_DECODES must be a positive integer (>= 1), got {raw!r}")
+    return value
+
+
 # Limit concurrent video decodes within a single process.
-_MAX_CONCURRENT_DECODES = int(os.environ.get("VANE_MAX_CONCURRENT_DECODES", "1"))
+_MAX_CONCURRENT_DECODES = _max_concurrent_decodes_from_env()
 _decode_semaphore = threading.Semaphore(_MAX_CONCURRENT_DECODES)
 
 # Memory-based backpressure: block NEW decode tasks (not mid-decode!) when

--- a/tests/fast/test_video_decode_concurrency_env.py
+++ b/tests/fast/test_video_decode_concurrency_env.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from duckdb.datasource.video_reader import _max_concurrent_decodes_from_env
+
+
+@pytest.mark.parametrize("raw, expected", [("1", 1), ("2", 2), ("64", 64)])
+def test_accepts_positive_integers(monkeypatch, raw, expected):
+    monkeypatch.setenv("VANE_MAX_CONCURRENT_DECODES", raw)
+    assert _max_concurrent_decodes_from_env() == expected
+
+
+def test_unset_defaults_to_one(monkeypatch):
+    monkeypatch.delenv("VANE_MAX_CONCURRENT_DECODES", raising=False)
+    assert _max_concurrent_decodes_from_env() == 1
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "-64"], ids=["zero", "negative-one", "negative"])
+def test_rejects_non_positive_values(monkeypatch, raw):
+    # Semaphore(0) blocks every decode forever; fail loudly at load instead.
+    monkeypatch.setenv("VANE_MAX_CONCURRENT_DECODES", raw)
+    with pytest.raises(ValueError, match=r"VANE_MAX_CONCURRENT_DECODES.*>= 1.*" + raw):
+        _max_concurrent_decodes_from_env()
+
+
+@pytest.mark.parametrize("raw", ["", "two", "1.5", "nan"], ids=["empty", "word", "float", "nan"])
+def test_rejects_invalid_values(monkeypatch, raw):
+    monkeypatch.setenv("VANE_MAX_CONCURRENT_DECODES", raw)
+    with pytest.raises(ValueError, match="VANE_MAX_CONCURRENT_DECODES"):
+        _max_concurrent_decodes_from_env()


### PR DESCRIPTION
## What

Fixes #68. `VANE_MAX_CONCURRENT_DECODES` was converted with a bare `int()` — setting it to `0` builds `Semaphore(0)`, so every decode blocks forever with no hint why.

## How

The conversion moves into `_max_concurrent_decodes_from_env()`, which rejects zero, negative, and non-integer values at configuration load with an error naming the variable and the accepted range:

```
ValueError: VANE_MAX_CONCURRENT_DECODES must be a positive integer (>= 1), got '0'
```

`1` and ordinary positive integers are accepted; unset still defaults to `1`.

## Tests

`tests/fast/test_video_decode_concurrency_env.py` — parameterized accept (`1`/`2`/`64`), unset default, non-positive rejects (`0`/`-1`/`-64`), and invalid rejects (empty/word/float/nan), all via `monkeypatch.setenv`/`delenv` so process state is restored per the acceptance criteria.

Local note: the native `_duckdb` build isn't available on this machine, so I verified the helper standalone (8/8 scenarios) and ran `ruff check`/`format`; the pytest file uses the standard `tests/fast` imports for CI.

Validated against `02389fd`.