### PR TITLE
[fix](env) Timeout env parsers reject NaN and infinity like the vllm reference

### DIFF
--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -212,8 +213,10 @@ def _positive_float_env(name: str, default: float | None = None) -> float | None
     if not raw:
         return default
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    # NaN compares false against 0.0 and infinity compares true, so both
+    # slipped through a plain sign check (matches the vllm.py reference).
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
     return value
 
 

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import atexit
 import hashlib
+import math
 import os
 import queue
 import socket
@@ -143,8 +144,10 @@ def _positive_float_env(name: str, default: float) -> float:
     if not raw:
         return default
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    # NaN compares false against 0.0 and infinity compares true, so both
+    # slipped through a plain sign check (matches the vllm.py reference).
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
     return value
 
 

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import time
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -20,8 +21,10 @@ def _positive_float_env(name: str) -> float | None:
     if not raw:
         return None
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    # NaN compares false against 0.0 and infinity compares true, so both
+    # slipped through a plain sign check (matches the vllm.py reference).
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
     return value
 
 

--- a/tests/fast/test_positive_float_env_finiteness.py
+++ b/tests/fast/test_positive_float_env_finiteness.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from duckdb.execution.udf_ray_actor_pool import _positive_float_env as _actor_pool_env
+from duckdb.execution.udf_subprocess import _positive_float_env as _subprocess_env
+from duckdb.runners.ray.safe_get import _positive_float_env as _safe_get_env
+
+_ENV = "VANE_TEST_POSITIVE_FLOAT"
+
+
+def _subprocess(monkeypatch, raw):
+    if raw is None:
+        monkeypatch.delenv(_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_ENV, raw)
+    return _subprocess_env(_ENV, 7.5)
+
+
+def _actor_pool(monkeypatch, raw):
+    if raw is None:
+        monkeypatch.delenv(_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_ENV, raw)
+    return _actor_pool_env(_ENV, 7.5)
+
+
+def _safe_get(monkeypatch, raw):
+    if raw is None:
+        monkeypatch.delenv(_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_ENV, raw)
+    return _safe_get_env(_ENV)
+
+
+_CONSUMERS = [_subprocess, _actor_pool, _safe_get]
+_CONSUMER_IDS = ["udf-subprocess", "ray-actor-pool", "ray-safe-get"]
+
+
+@pytest.mark.parametrize("consumer", _CONSUMERS, ids=_CONSUMER_IDS)
+@pytest.mark.parametrize("raw, expected", [("0", 0.0), ("2.5", 2.5), ("30", 30.0)])
+def test_accepts_finite_non_negative(monkeypatch, consumer, raw, expected):
+    assert consumer(monkeypatch, raw) == expected
+
+
+@pytest.mark.parametrize("consumer", _CONSUMERS, ids=_CONSUMER_IDS)
+@pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "Infinity", "-inf", "-1", "-0.5"])
+def test_rejects_nan_infinity_and_negative(monkeypatch, consumer, raw):
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        consumer(monkeypatch, raw)
+
+
+@pytest.mark.parametrize("consumer", _CONSUMERS, ids=_CONSUMER_IDS)
+@pytest.mark.parametrize("raw", ["abc", "1.2.3"])
+def test_rejects_invalid_strings(monkeypatch, consumer, raw):
+    with pytest.raises(ValueError):
+        consumer(monkeypatch, raw)
+
+
+def test_unset_semantics_preserved(monkeypatch):
+    # Documented behavior for an unset variable: defaults for the two
+    # default-taking helpers, None for the safe-get helper.
+    assert _subprocess(monkeypatch, None) == 7.5
+    assert _actor_pool(monkeypatch, None) == 7.5
+    assert _safe_get(monkeypatch, None) is None


### PR DESCRIPTION
## What

Fixes #69. Three `_positive_float_env` helpers — `duckdb/execution/udf_subprocess.py`, `duckdb/execution/udf_ray_actor_pool.py`, and `duckdb/runners/ray/safe_get.py` — only checked `value < 0.0`. `float("nan")` fails every ordering comparison and `float("inf")` passes it, so both were accepted as timeouts.

## How

Each helper now applies exactly the guard the corrected `vllm.py` copy uses, as the issue's consistency reference:

```python
if not math.isfinite(value) or value < 0.0:
    raise ValueError(f"{name} must be finite and non-negative")
```

- rejects NaN, ±infinity, and negatives; invalid strings keep raising from `float()` itself
- unset-variable semantics preserved: the two default-taking helpers return their default, safe-get returns `None`
- zero stays accepted, matching the vllm reference implementation (it rejects only negatives) — happy to tighten to strictly-positive everywhere if that's the intended reading of the criteria

## Tests

`tests/fast/test_positive_float_env_finiteness.py` parameterizes **every consumer** (per the criteria) over accept (`0`/`2.5`/`30`), reject (`nan`/`NaN`/`inf`/`Infinity`/`-inf`/`-1`/`-0.5`), invalid strings, and unset semantics — 33 cases.

Local note: no native `_duckdb` build on this machine, so the helpers were verified standalone via AST extraction (21/21 scenarios) plus `ruff check`/`format`; the pytest file imports normally for CI.

Validated against `02389fd`.