### PR TITLE
[fix](ai) chunk_text boundary validation and zero-weight aggregation guard

### DIFF
--- a/tests/ai/test_chunk_text_validation.py
+++ b/tests/ai/test_chunk_text_validation.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vane.ai.functions import _weighted_average_embeddings, chunk_text
+
+
+def test_multi_chunk_content_with_overlap():
+    text = "abcdefghij" * 10  # 100 chars
+    chunks = chunk_text(text, max_chars=40, overlap_chars=10)
+    assert len(chunks) > 1
+    assert all(chunks), "no empty chunks"
+    assert all(len(c) <= 40 for c in chunks)
+    # Consecutive chunks overlap by exactly overlap_chars until the tail.
+    assert chunks[0][-10:] == chunks[1][:10]
+    # Reassembling with the overlap stripped restores the original text.
+    reassembled = chunks[0] + "".join(c[10:] for c in chunks[1:])
+    assert reassembled == text
+
+
+def test_short_text_returns_single_chunk():
+    assert chunk_text("short", max_chars=2000, overlap_chars=200) == ["short"]
+
+
+@pytest.mark.parametrize("max_chars", [0, -1, -2000], ids=["zero", "negative-one", "negative"])
+def test_rejects_non_positive_max_chars(max_chars):
+    with pytest.raises(ValueError, match="max_chars must be a positive integer"):
+        chunk_text("some text", max_chars=max_chars)
+
+
+@pytest.mark.parametrize("max_chars", [2.5, float("nan"), "2000", None, True])
+def test_rejects_non_integer_max_chars(max_chars):
+    with pytest.raises(ValueError):
+        chunk_text("some text", max_chars=max_chars)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "overlap",
+    [-1, 40, 41],
+    ids=["negative", "equal-to-max", "greater-than-max"],
+)
+def test_rejects_out_of_range_overlap(overlap):
+    with pytest.raises(ValueError, match="0 <= overlap_chars < max_chars"):
+        chunk_text("x" * 100, max_chars=40, overlap_chars=overlap)
+
+
+@pytest.mark.parametrize("overlap", [2.5, "10", None, False])
+def test_rejects_non_integer_overlap(overlap):
+    with pytest.raises(ValueError):
+        chunk_text("x" * 100, max_chars=40, overlap_chars=overlap)  # type: ignore[arg-type]
+
+
+def test_zero_overlap_is_valid():
+    chunks = chunk_text("abcdef", max_chars=2, overlap_chars=0)
+    assert chunks == ["ab", "cd", "ef"]
+
+
+def test_weighted_average_survives_zero_weights():
+    embeddings = [[1.0, 0.0], [0.0, 1.0]]
+    result = _weighted_average_embeddings(embeddings, [0.0, 0.0])
+    assert np.all(np.isfinite(result)), "zero weights must not produce NaN"
+    # Falls back to the unweighted mean (then normalized).
+    expected = np.array([0.5, 0.5]) / np.linalg.norm([0.5, 0.5])
+    np.testing.assert_allclose(result, expected.astype(np.float32), rtol=1e-6)
+
+
+def test_weighted_average_normal_path_unchanged():
+    embeddings = [[1.0, 0.0], [0.0, 1.0]]
+    result = _weighted_average_embeddings(embeddings, [3.0, 1.0])
+    assert np.all(np.isfinite(result))
+    assert result[0] > result[1]

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -271,7 +271,21 @@ def chunk_text(
 
     Returns:
         List of text chunks. Returns ``[text]`` if text fits in one chunk.
+
+    Raises:
+        ValueError: If ``max_chars`` is not a positive integer or
+            ``overlap_chars`` is not an integer in ``[0, max_chars)``.
     """
+    # bool is an int subclass; reject it along with everything non-integral.
+    if isinstance(max_chars, bool) or not isinstance(max_chars, int) or max_chars < 1:
+        raise ValueError(f"max_chars must be a positive integer, got {max_chars!r}")
+    if isinstance(overlap_chars, bool) or not isinstance(overlap_chars, int):
+        raise ValueError(f"overlap_chars must be an integer, got {overlap_chars!r}")
+    if not 0 <= overlap_chars < max_chars:
+        raise ValueError(
+            f"overlap_chars must satisfy 0 <= overlap_chars < max_chars, "
+            f"got overlap_chars={overlap_chars} max_chars={max_chars}"
+        )
     if len(text) <= max_chars:
         return [text]
 
@@ -294,7 +308,13 @@ def _weighted_average_embeddings(
     """Compute length-weighted average of embeddings."""
     arr = np.array(embeddings, dtype=np.float64)
     w = np.array(weights, dtype=np.float64)
-    w /= w.sum()
+    total = w.sum()
+    if not np.isfinite(total) or total <= 0:
+        # All-zero (or non-finite) weights would divide by zero and poison the
+        # result with NaN; fall back to an unweighted average instead.
+        w = np.full_like(w, 1.0 / len(w))
+    else:
+        w /= total
     averaged = (arr * w[:, np.newaxis]).sum(axis=0)
     norm = np.linalg.norm(averaged)
     if norm > 0:


### PR DESCRIPTION
## What

Fixes #70, in `vane/ai/functions.py`.

**`chunk_text`** accepted degenerate parameters silently:
- `max_chars <= 0` → now `ValueError: max_chars must be a positive integer`
- `overlap_chars` outside `[0, max_chars)` → `ValueError` naming both values (overlap == max_chars previously still worked only because of the `max(1, …)` step clamp, but produced maximal re-reading; it's rejected as the criteria require)
- non-integer / non-finite inputs (`2.5`, `nan`, strings, `None`, and `bool` — an `int` subclass — for both parameters) → `ValueError`
- `overlap_chars=0` remains valid; the docstring documents the raises

**`_weighted_average_embeddings`** divided by `w.sum()` unconditionally, so an all-zero weight vector produced NaN embeddings. When the total is zero or non-finite it now falls back to the unweighted mean (then normalizes as before); the weighted path is unchanged.

## Tests

`tests/ai/test_chunk_text_validation.py`: a normal multi-chunk test that verifies chunk sizes, the exact overlap, and loss-free reassembly; boundary rejects for both parameters (13 parameterized cases); `overlap=0` accept; and both aggregation paths (zero weights stay finite and equal the normalized unweighted mean; weighted path unchanged).

Local note: no native `_duckdb` build here, so both functions were verified standalone via AST extraction (13/13 scenarios) and `ruff check`/`format` pass; the pytest file imports normally for CI.

Validated against `02389fd`.