### PR TITLE
[fix](ai) Prevent API key exposure through descriptor repr and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 ### Security
 
 - Documented the trust boundaries around Python UDFs, Ray workers, credentials, native parsers, and remote model code.
+- Redacted AI provider credentials from descriptor and provider-option `repr`,
+  logs, exception formatting, and assertion diffs; plaintext is revealed only at
+  provider execution, and SQL continues to reject inline credentials. Option
+  mappings held by AI descriptors now store sensitive values wrapped in an
+  internal secret type, so code that compared those mappings against plain
+  dictionaries must compare revealed values instead.
 
 ## 0.1.0a1
 

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -964,6 +964,7 @@ class TestAnthropicProvider:
 
     def test_provider_get_prompter_splits_call_client_options(self):
         """Anthropic call-level client options go to provider_options only."""
+        from vane.ai._redaction import Secret
         from vane.ai.providers.anthropic import AnthropicProvider
 
         provider = AnthropicProvider(api_key="ctor-key", base_url="https://ctor.example")
@@ -975,8 +976,9 @@ class TestAnthropicProvider:
             temperature=0,
         )
 
+        # Credentials are sealed on the descriptor (vane#105).
         assert desc.provider_options == {
-            "api_key": "call-key",
+            "api_key": Secret("call-key"),
             "base_url": "https://call.example",
             "timeout": 30,
         }
@@ -1083,6 +1085,7 @@ class TestGoogleProvider:
 
     def test_provider_get_prompter_splits_call_client_options(self):
         """Google prompt call-level client options go to provider_options only."""
+        from vane.ai._redaction import Secret
         from vane.ai.providers.google import GoogleProvider
 
         provider = GoogleProvider(api_key="ctor-key")
@@ -1092,7 +1095,8 @@ class TestGoogleProvider:
             temperature=0,
         )
 
-        assert desc.provider_options == {"api_key": "call-key"}
+        # Credentials are sealed on the descriptor (vane#105).
+        assert desc.provider_options == {"api_key": Secret("call-key")}
         assert "api_key" not in desc.prompt_options
         assert desc.prompt_options["max_api_concurrency"] == 7
         assert desc.prompt_options["temperature"] == 0
@@ -1114,6 +1118,7 @@ class TestGoogleProvider:
 
     def test_provider_get_text_embedder_splits_call_client_options(self):
         """Google embedding call-level client options go to provider_options only."""
+        from vane.ai._redaction import Secret
         from vane.ai.providers.google import GoogleProvider
 
         provider = GoogleProvider(api_key="ctor-key")
@@ -1123,7 +1128,8 @@ class TestGoogleProvider:
             on_error="log",
         )
 
-        assert desc.provider_options == {"api_key": "call-key"}
+        # Credentials are sealed on the descriptor (vane#105).
+        assert desc.provider_options == {"api_key": Secret("call-key")}
         assert "api_key" not in desc.embed_options
         assert desc.embed_options["task_type"] == "RETRIEVAL_QUERY"
         assert desc.embed_options["on_error"] == "log"

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -209,6 +209,15 @@ class TestDescriptorReprRedaction:
         assert ORGANIZATION not in repr(descriptor)
         assert ORGANIZATION not in str(descriptor)
 
+    def test_openai_nested_organization_header_is_redacted(self):
+        from vane.ai.providers.openai import OpenAIProvider
+
+        descriptor = OpenAIProvider(api_key=API_KEY).get_prompter(
+            extra_headers={"OpenAI-Organization": ORGANIZATION},
+        )
+        assert ORGANIZATION not in repr(descriptor)
+        assert isinstance(descriptor.prompt_options["extra_headers"]["OpenAI-Organization"], Secret)
+
     def test_credential_kwarg_landing_in_prompt_options_is_redacted(self):
         from vane.ai.providers.openai import OpenAIProvider
 

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -1,0 +1,491 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider descriptors seal credentials at construction and unseal only at execution.
+
+Covers vane#105: descriptors must never expose API keys through repr, str,
+logging, exception rendering, or pickled copies, while ``instantiate()`` (and
+the OpenAI dimension probe / local engine construction) still hands the real
+plaintext to the SDK client or engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle
+import sys
+import traceback
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from vane.ai._redaction import REDACTED_PLACEHOLDER, Secret
+
+API_KEY = "sk-PLAINTEXT-API-KEY-SENTINEL-0123456789"
+ORGANIZATION = "org-PLAINTEXT-ORG-SENTINEL-0123456789"
+HUB_TOKEN = "hf_PLAINTEXT-HUB-TOKEN-SENTINEL-0123456789"
+ALL_SENTINELS = (API_KEY, ORGANIZATION, HUB_TOKEN)
+
+
+def _assert_no_plaintext(rendered: str) -> None:
+    for sentinel in ALL_SENTINELS:
+        assert sentinel not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Descriptor factories
+# ---------------------------------------------------------------------------
+
+
+def _openai_embedder_descriptor():
+    from vane.ai.providers.openai import OpenAITextEmbedderDescriptor
+
+    return OpenAITextEmbedderDescriptor(
+        provider_options={"api_key": API_KEY, "organization": ORGANIZATION, "base_url": "https://api.example"},
+        model_name="text-embedding-3-small",
+        dimensions=512,
+        embed_options={"batch_size": 32, "auth_token": API_KEY},
+    )
+
+
+def _openai_prompter_descriptor():
+    from vane.ai.providers.openai import OpenAIPrompterDescriptor
+
+    return OpenAIPrompterDescriptor(
+        provider_options={"api_key": API_KEY, "organization": ORGANIZATION},
+        model_name="gpt-4o-mini",
+        prompt_options={"temperature": 0.5, "auth_token": API_KEY},
+    )
+
+
+def _anthropic_prompter_descriptor():
+    from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+    return AnthropicPrompterDescriptor(
+        provider_options={"api_key": API_KEY, "base_url": "https://api.example"},
+        model_name="claude-sonnet-4-20250514",
+        prompt_options={"temperature": 0.2, "auth_token": API_KEY},
+    )
+
+
+def _google_embedder_descriptor():
+    from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+    return GoogleTextEmbedderDescriptor(
+        provider_options={"api_key": API_KEY},
+        model_name="text-embedding-004",
+        embed_options={"task_type": "RETRIEVAL_QUERY", "auth_token": API_KEY},
+    )
+
+
+def _google_prompter_descriptor():
+    from vane.ai.providers.google import GooglePrompterDescriptor
+
+    return GooglePrompterDescriptor(
+        provider_options={"api_key": API_KEY},
+        model_name="gemini-2.0-flash",
+        prompt_options={"temperature": 0.1, "auth_token": API_KEY},
+    )
+
+
+def _vllm_prompter_descriptor():
+    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+
+    return VLLMPrompterDescriptor(
+        model_name="Qwen/Qwen3-1.7B",
+        vllm_options={
+            "engine_args": {"hf_token": HUB_TOKEN, "max_model_len": 2048},
+            "generate_args": {"sampling_params": {"max_tokens": 64}, "api_key": API_KEY},
+            "gpus_per_actor": 1,
+        },
+    )
+
+
+def _transformers_embedder_descriptor():
+    from vane.ai.providers.transformers import TransformersTextEmbedderDescriptor
+
+    return TransformersTextEmbedderDescriptor(
+        model="sentence-transformers/all-MiniLM-L6-v2",
+        embed_options={"batch_size": 8, "revision": "pinned", "token": HUB_TOKEN},
+    )
+
+
+def _transformers_classifier_descriptor():
+    from vane.ai.providers.transformers import TransformersTextClassifierDescriptor
+
+    return TransformersTextClassifierDescriptor(
+        model="facebook/bart-large-mnli",
+        classify_options={"batch_size": 4, "token": HUB_TOKEN},
+    )
+
+
+ALL_DESCRIPTOR_FACTORIES = [
+    pytest.param(_openai_embedder_descriptor, id="openai-embedder"),
+    pytest.param(_openai_prompter_descriptor, id="openai-prompter"),
+    pytest.param(_anthropic_prompter_descriptor, id="anthropic-prompter"),
+    pytest.param(_google_embedder_descriptor, id="google-embedder"),
+    pytest.param(_google_prompter_descriptor, id="google-prompter"),
+    pytest.param(_vllm_prompter_descriptor, id="vllm-prompter"),
+    pytest.param(_transformers_embedder_descriptor, id="transformers-embedder"),
+    pytest.param(_transformers_classifier_descriptor, id="transformers-classifier"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK modules
+# ---------------------------------------------------------------------------
+
+
+class _RecordingClient:
+    """Records constructor kwargs; stands in for any SDK client class."""
+
+    calls: list[dict] = []  # overridden per instance factory
+
+    def __init__(self, **kwargs):
+        type(self).calls.append(kwargs)
+
+
+def _fresh_recording_client():
+    return type("FakeClient", (_RecordingClient,), {"calls": []})
+
+
+def _install_fake_openai(monkeypatch, async_client, sync_client=None):
+    module = SimpleNamespace(
+        AsyncOpenAI=async_client,
+        OpenAI=sync_client or _fresh_recording_client(),
+        OpenAIError=Exception,
+    )
+    monkeypatch.setitem(sys.modules, "openai", module)
+    return module
+
+
+def _install_fake_anthropic(monkeypatch, async_client):
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(AsyncAnthropic=async_client))
+
+
+def _install_fake_google(monkeypatch, client):
+    fake_genai = SimpleNamespace(Client=client)
+    monkeypatch.setitem(sys.modules, "google", SimpleNamespace(genai=fake_genai))
+    monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
+
+
+def _install_fake_vllm_engine(monkeypatch, captured):
+    def fake_build_executor(model, options):
+        captured.append((model, options))
+        return SimpleNamespace()
+
+    vllm_module = types.ModuleType("duckdb.execution.vllm")
+    vllm_module.build_executor = fake_build_executor
+    execution_module = types.ModuleType("duckdb.execution")
+    execution_module.vllm = vllm_module
+    duckdb_module = types.ModuleType("duckdb")
+    duckdb_module.execution = execution_module
+    monkeypatch.setitem(sys.modules, "duckdb", duckdb_module)
+    monkeypatch.setitem(sys.modules, "duckdb.execution", execution_module)
+    monkeypatch.setitem(sys.modules, "duckdb.execution.vllm", vllm_module)
+
+
+# ---------------------------------------------------------------------------
+# repr / str redaction
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptorReprRedaction:
+    @pytest.mark.parametrize("factory", ALL_DESCRIPTOR_FACTORIES)
+    def test_repr_and_str_contain_no_plaintext(self, factory):
+        descriptor = factory()
+        for rendered in (repr(descriptor), str(descriptor), f"{descriptor}", "{!r}".format(descriptor)):
+            _assert_no_plaintext(rendered)
+            assert REDACTED_PLACEHOLDER in rendered
+
+    @pytest.mark.parametrize("factory", ALL_DESCRIPTOR_FACTORIES)
+    def test_repr_keeps_non_sensitive_fields_readable(self, factory):
+        descriptor = factory()
+        assert descriptor.get_model() in repr(descriptor)
+
+    def test_openai_organization_is_redacted(self):
+        descriptor = _openai_prompter_descriptor()
+        assert ORGANIZATION not in repr(descriptor)
+        assert ORGANIZATION not in str(descriptor)
+
+    def test_credential_kwarg_landing_in_prompt_options_is_redacted(self):
+        from vane.ai.providers.openai import OpenAIProvider
+
+        descriptor = OpenAIProvider(api_key=API_KEY).get_prompter(auth_token=API_KEY, temperature=0.3)
+        assert API_KEY not in repr(descriptor)
+        assert isinstance(descriptor.prompt_options["auth_token"], Secret)
+        assert descriptor.prompt_options["temperature"] == 0.3
+
+    def test_credential_kwarg_landing_in_embed_options_is_redacted(self):
+        from vane.ai.providers.google import GoogleProvider
+
+        descriptor = GoogleProvider(api_key=API_KEY).get_text_embedder(auth_token=API_KEY, task_type="RETRIEVAL_QUERY")
+        assert API_KEY not in repr(descriptor)
+        assert isinstance(descriptor.embed_options["auth_token"], Secret)
+        assert descriptor.embed_options["task_type"] == "RETRIEVAL_QUERY"
+
+    def test_vllm_nested_engine_and_generate_args_are_redacted(self):
+        descriptor = _vllm_prompter_descriptor()
+        rendered = repr(descriptor)
+        _assert_no_plaintext(rendered)
+        assert "2048" in rendered  # non-sensitive engine arg stays readable
+        assert isinstance(descriptor.vllm_options["engine_args"]["hf_token"], Secret)
+        assert isinstance(descriptor.vllm_options["generate_args"]["api_key"], Secret)
+
+    def test_transformers_hub_token_is_redacted(self):
+        descriptor = _transformers_embedder_descriptor()
+        assert HUB_TOKEN not in repr(descriptor)
+        assert isinstance(descriptor.embed_options["token"], Secret)
+        assert descriptor.embed_options["revision"] == "pinned"
+
+
+# ---------------------------------------------------------------------------
+# get_options() stays wrapped
+# ---------------------------------------------------------------------------
+
+
+class TestGetOptionsStaysWrapped:
+    @pytest.mark.parametrize("factory", ALL_DESCRIPTOR_FACTORIES)
+    def test_get_options_repr_has_no_plaintext(self, factory):
+        options = factory().get_options()
+        _assert_no_plaintext(repr(options))
+
+    def test_openai_prompter_get_options_holds_secret(self):
+        options = _openai_prompter_descriptor().get_options()
+        assert isinstance(options["auth_token"], Secret)
+        assert options["auth_token"].reveal() == API_KEY
+
+    def test_vllm_get_options_holds_nested_secret(self):
+        options = _vllm_prompter_descriptor().get_options()
+        assert isinstance(options["engine_args"]["hf_token"], Secret)
+        assert options["engine_args"]["hf_token"].reveal() == HUB_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingRedaction:
+    @pytest.mark.parametrize("factory", ALL_DESCRIPTOR_FACTORIES)
+    def test_percent_s_and_percent_r_logging_emit_no_plaintext(self, factory, caplog):
+        descriptor = factory()
+        logger = logging.getLogger("vane.test.descriptor_redaction")
+        with caplog.at_level(logging.INFO, logger=logger.name):
+            logger.info("descriptor is %s", descriptor)
+            logger.info("descriptor is %r", descriptor)
+        assert len(caplog.records) == 2
+        _assert_no_plaintext(caplog.text)
+        assert REDACTED_PLACEHOLDER in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Exceptions during client construction
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionRedaction:
+    def _assert_exception_clean(self, excinfo):
+        assert not any(sentinel in str(excinfo.value) for sentinel in ALL_SENTINELS)
+        rendered = "".join(traceback.format_exception(excinfo.value))
+        _assert_no_plaintext(rendered)
+
+    def test_openai_client_construction_failure_carries_no_plaintext(self, monkeypatch):
+        class ExplodingClient:
+            def __init__(self, **kwargs):
+                raise RuntimeError("client construction failed")
+
+        _install_fake_openai(monkeypatch, ExplodingClient)
+        with pytest.raises(RuntimeError, match="client construction failed") as excinfo:
+            _openai_embedder_descriptor().instantiate()
+        self._assert_exception_clean(excinfo)
+
+    def test_anthropic_client_construction_failure_carries_no_plaintext(self, monkeypatch):
+        class ExplodingClient:
+            def __init__(self, **kwargs):
+                raise RuntimeError("client construction failed")
+
+        _install_fake_anthropic(monkeypatch, ExplodingClient)
+        with pytest.raises(RuntimeError, match="client construction failed") as excinfo:
+            _anthropic_prompter_descriptor().instantiate()
+        self._assert_exception_clean(excinfo)
+
+
+# ---------------------------------------------------------------------------
+# Plaintext restored exactly at the execution boundary
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapAtExecutionBoundary:
+    def test_openai_embedder_client_receives_plaintext(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_openai(monkeypatch, client)
+        _openai_embedder_descriptor().instantiate()
+        assert client.calls == [{"api_key": API_KEY, "organization": ORGANIZATION, "base_url": "https://api.example"}]
+
+    def test_openai_prompter_client_receives_plaintext_and_options_are_unwrapped(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_openai(monkeypatch, client)
+        prompter = _openai_prompter_descriptor().instantiate()
+        assert client.calls == [{"api_key": API_KEY, "organization": ORGANIZATION}]
+        # prompt-time options forwarded to the SDK must be plain again
+        assert prompter._options == {"temperature": 0.5, "auth_token": API_KEY}
+
+    def test_openai_get_dimensions_probe_receives_plaintext(self, monkeypatch):
+        from vane.ai.providers.openai import OpenAITextEmbedderDescriptor
+
+        probe_calls = []
+
+        class FakeProbeClient:
+            def __init__(self, **kwargs):
+                probe_calls.append(kwargs)
+                self.embeddings = SimpleNamespace(
+                    create=lambda **_: SimpleNamespace(data=[SimpleNamespace(embedding=[0.0] * 7)])
+                )
+
+        _install_fake_openai(monkeypatch, _fresh_recording_client(), sync_client=FakeProbeClient)
+        descriptor = OpenAITextEmbedderDescriptor(
+            provider_options={"api_key": API_KEY, "base_url": "https://api.example"},
+            model_name="custom-served-model",
+        )
+        assert descriptor.get_dimensions().size == 7
+        assert probe_calls == [{"api_key": API_KEY, "base_url": "https://api.example"}]
+
+    def test_anthropic_client_receives_plaintext(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_anthropic(monkeypatch, client)
+        _anthropic_prompter_descriptor().instantiate()
+        assert client.calls == [{"api_key": API_KEY, "base_url": "https://api.example"}]
+
+    def test_google_embedder_client_receives_plaintext(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_google(monkeypatch, client)
+        _google_embedder_descriptor().instantiate()
+        assert client.calls == [{"api_key": API_KEY}]
+
+    def test_google_prompter_client_receives_plaintext(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_google(monkeypatch, client)
+        _google_prompter_descriptor().instantiate()
+        assert client.calls == [{"api_key": API_KEY}]
+
+    def test_vllm_engine_receives_plaintext_nested_args(self, monkeypatch):
+        captured = []
+        _install_fake_vllm_engine(monkeypatch, captured)
+        prompter = _vllm_prompter_descriptor().instantiate()
+        prompter._ensure_executor()
+        assert len(captured) == 1
+        model, options = captured[0]
+        assert model == "Qwen/Qwen3-1.7B"
+        assert options["engine_args"] == {"hf_token": HUB_TOKEN, "max_model_len": 2048}
+        assert options["generate_args"]["api_key"] == API_KEY
+        assert options["generate_args"]["sampling_params"] == {"max_tokens": 64}
+        assert options["use_threading"] is True
+
+    def test_transformers_get_dimensions_receives_plaintext_token(self, monkeypatch):
+        auto_config_calls = []
+
+        class FakeAutoConfig:
+            @staticmethod
+            def from_pretrained(model, **options):
+                auto_config_calls.append((model, options))
+                return SimpleNamespace(hidden_size=384)
+
+        monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(AutoConfig=FakeAutoConfig))
+        descriptor = _transformers_embedder_descriptor()
+        assert descriptor.get_dimensions().size == 384
+        assert auto_config_calls == [
+            (
+                "sentence-transformers/all-MiniLM-L6-v2",
+                {"trust_remote_code": False, "revision": "pinned", "token": HUB_TOKEN},
+            )
+        ]
+
+    def test_transformers_embedder_model_receives_plaintext_token(self, monkeypatch):
+        calls = []
+
+        class FakeSentenceTransformer:
+            def __init__(self, model, **options):
+                calls.append((model, options))
+
+            def eval(self):
+                return self
+
+        monkeypatch.setitem(
+            sys.modules, "sentence_transformers", SimpleNamespace(SentenceTransformer=FakeSentenceTransformer)
+        )
+        _transformers_embedder_descriptor().instantiate()
+        assert calls == [
+            (
+                "sentence-transformers/all-MiniLM-L6-v2",
+                {"trust_remote_code": False, "backend": "torch", "revision": "pinned", "token": HUB_TOKEN},
+            )
+        ]
+
+    def test_transformers_classifier_pipeline_receives_plaintext_token(self, monkeypatch):
+        pipeline_calls = []
+
+        def fake_pipeline(task, **options):
+            pipeline_calls.append((task, options))
+            return object()
+
+        monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(pipeline=fake_pipeline))
+        _transformers_classifier_descriptor().instantiate()
+        assert pipeline_calls == [
+            (
+                "zero-shot-classification",
+                {"model": "facebook/bart-large-mnli", "trust_remote_code": False, "token": HUB_TOKEN},
+            )
+        ]
+
+    def test_runtime_classes_accept_plain_dicts_unchanged(self, monkeypatch):
+        """Directly-constructed runtime objects with plain dicts keep working."""
+        from vane.ai.providers.openai import OpenAITextEmbedder
+
+        client = _fresh_recording_client()
+        _install_fake_openai(monkeypatch, client)
+        OpenAITextEmbedder(provider_options={"api_key": "plain-key"}, model="text-embedding-3-small")
+        assert client.calls == [{"api_key": "plain-key"}]
+
+
+# ---------------------------------------------------------------------------
+# Pickle round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestPickleRoundTrip:
+    @pytest.mark.parametrize("factory", ALL_DESCRIPTOR_FACTORIES)
+    def test_repr_stays_redacted_after_pickle(self, factory):
+        restored = pickle.loads(pickle.dumps(factory()))
+        _assert_no_plaintext(repr(restored))
+        assert REDACTED_PLACEHOLDER in repr(restored)
+
+    def test_openai_pickled_descriptor_still_builds_working_client(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_openai(monkeypatch, client)
+        restored = pickle.loads(pickle.dumps(_openai_embedder_descriptor()))
+        restored.instantiate()
+        assert client.calls == [{"api_key": API_KEY, "organization": ORGANIZATION, "base_url": "https://api.example"}]
+
+    def test_anthropic_pickled_descriptor_still_builds_working_client(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_anthropic(monkeypatch, client)
+        restored = pickle.loads(pickle.dumps(_anthropic_prompter_descriptor()))
+        restored.instantiate()
+        assert client.calls == [{"api_key": API_KEY, "base_url": "https://api.example"}]
+
+    def test_google_pickled_descriptor_still_builds_working_client(self, monkeypatch):
+        client = _fresh_recording_client()
+        _install_fake_google(monkeypatch, client)
+        restored = pickle.loads(pickle.dumps(_google_prompter_descriptor()))
+        restored.instantiate()
+        assert client.calls == [{"api_key": API_KEY}]
+
+    def test_vllm_pickled_descriptor_still_builds_engine_with_plaintext(self, monkeypatch):
+        captured = []
+        _install_fake_vllm_engine(monkeypatch, captured)
+        restored = pickle.loads(pickle.dumps(_vllm_prompter_descriptor()))
+        restored.instantiate()._ensure_executor()
+        _model, options = captured[0]
+        assert options["engine_args"]["hf_token"] == HUB_TOKEN

--- a/tests/ai/test_descriptors.py
+++ b/tests/ai/test_descriptors.py
@@ -101,6 +101,7 @@ class TestTransformersDescriptorPickle:
 
 class TestOpenAIDescriptorPickle:
     def test_text_embedder_descriptor_roundtrip(self):
+        from vane.ai._redaction import Secret
         from vane.ai.providers.openai import OpenAITextEmbedderDescriptor
 
         desc = OpenAITextEmbedderDescriptor(
@@ -116,7 +117,9 @@ class TestOpenAIDescriptorPickle:
 
         assert restored.model_name == "text-embedding-3-small"
         assert restored.dimensions == 512
-        assert restored.provider_options == {"api_key": "test-key"}
+        # Credentials stay sealed on the descriptor (vane#105); the round-trip
+        # preserves the real value, comparable only against another Secret.
+        assert restored.provider_options == {"api_key": Secret("test-key")}
         assert restored.get_provider() == "openai"
         assert restored.is_async() is True
 

--- a/tests/fast/test_ai_options_repr.py
+++ b/tests/fast/test_ai_options_repr.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public provider options never leak ``api_key`` through repr, str, or assertion diffs.
+
+Covers vane#105: the three api_key-bearing options dataclasses (OpenAI,
+Anthropic, Google) render a fixed placeholder instead of the plaintext key,
+while construction, ``.api_key`` reads, equality, and the credential-free
+options dataclasses stay untouched.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from vane.ai._redaction import REDACTED_PLACEHOLDER
+from vane.ai.options import (
+    AnthropicPromptOptions,
+    AnthropicProviderOptions,
+    GoogleEmbeddingOptions,
+    GooglePromptOptions,
+    GoogleProviderOptions,
+    OpenAIEmbeddingOptions,
+    OpenAIPromptOptions,
+    OpenAIProviderOptions,
+    VLLMPromptOptions,
+    VLLMProviderOptions,
+)
+
+API_KEY = "sk-PLAINTEXT-OPTIONS-KEY-SENTINEL-0123456789"
+
+API_KEY_OPTIONS_CLASSES = [
+    OpenAIProviderOptions,
+    AnthropicProviderOptions,
+    GoogleProviderOptions,
+]
+
+CREDENTIAL_FREE_OPTIONS_CLASSES = [
+    VLLMProviderOptions,
+    OpenAIPromptOptions,
+    OpenAIEmbeddingOptions,
+    AnthropicPromptOptions,
+    GooglePromptOptions,
+    GoogleEmbeddingOptions,
+    VLLMPromptOptions,
+]
+
+
+def _default_dataclass_repr(instance) -> str:
+    rendered = ", ".join(f"{field.name}={getattr(instance, field.name)!r}" for field in dataclasses.fields(instance))
+    return f"{type(instance).__qualname__}({rendered})"
+
+
+@pytest.mark.parametrize("options_cls", API_KEY_OPTIONS_CLASSES)
+class TestApiKeyOptionsRedaction:
+    def test_repr_and_str_mask_api_key(self, options_cls):
+        options = options_cls(api_key=API_KEY)
+        for rendered in (repr(options), str(options), f"{options}", "{}".format(options)):
+            assert REDACTED_PLACEHOLDER in rendered
+            assert API_KEY not in rendered
+
+    def test_none_api_key_renders_as_none(self, options_cls):
+        options = options_cls(api_key=None)
+        assert "api_key=None" in repr(options)
+        assert REDACTED_PLACEHOLDER not in repr(options)
+
+    def test_repr_keeps_dataclass_shape(self, options_cls):
+        options = options_cls(api_key=API_KEY)
+        rendered = repr(options)
+        assert rendered.startswith(f"{options_cls.__name__}(")
+        assert rendered.endswith(")")
+        for field in dataclasses.fields(options):
+            assert f"{field.name}=" in rendered
+
+    def test_construction_and_read_unchanged(self, options_cls):
+        options = options_cls(api_key=API_KEY)
+        assert options.api_key == API_KEY
+        assert isinstance(options.api_key, str)
+        assert options.to_descriptor_options()["api_key"] == API_KEY
+
+    def test_equality_unchanged(self, options_cls):
+        assert options_cls(api_key=API_KEY) == options_cls(api_key=API_KEY)
+        assert options_cls(api_key=API_KEY) != options_cls(api_key="other")
+        assert options_cls(api_key=None) == options_cls()
+
+    def test_still_frozen(self, options_cls):
+        options = options_cls(api_key=API_KEY)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            options.api_key = "changed"
+
+    def test_field_type_stays_optional_str(self, options_cls):
+        (api_key_field,) = [field for field in dataclasses.fields(options_cls) if field.name == "api_key"]
+        assert api_key_field.type == "str | None"
+
+
+class TestOtherFieldsRenderNormally:
+    def test_openai_full_repr(self):
+        options = OpenAIProviderOptions(
+            base_url="https://api.example",
+            api_key=API_KEY,
+            organization="org-plain",
+            timeout=30.0,
+            concurrency=4,
+            max_api_concurrency=8,
+        )
+        assert repr(options) == (
+            "OpenAIProviderOptions(base_url='https://api.example', "
+            f"api_key={REDACTED_PLACEHOLDER}, organization='org-plain', "
+            "timeout=30.0, concurrency=4, max_api_concurrency=8)"
+        )
+
+    def test_anthropic_full_repr(self):
+        options = AnthropicProviderOptions(
+            api_key=API_KEY,
+            base_url="https://api.example",
+            timeout=15.5,
+            max_retries=3,
+            concurrency=2,
+            max_api_concurrency=6,
+        )
+        assert repr(options) == (
+            f"AnthropicProviderOptions(api_key={REDACTED_PLACEHOLDER}, "
+            "base_url='https://api.example', timeout=15.5, max_retries=3, "
+            "concurrency=2, max_api_concurrency=6)"
+        )
+
+    def test_google_full_repr(self):
+        options = GoogleProviderOptions(api_key=API_KEY, concurrency=3, max_api_concurrency=9)
+        assert repr(options) == (
+            f"GoogleProviderOptions(api_key={REDACTED_PLACEHOLDER}, concurrency=3, max_api_concurrency=9)"
+        )
+
+    def test_all_none_repr_matches_default_dataclass_shape(self):
+        for options_cls in API_KEY_OPTIONS_CLASSES:
+            options = options_cls()
+            assert repr(options) == _default_dataclass_repr(options)
+
+
+class TestCredentialFreeOptionsUntouched:
+    @pytest.mark.parametrize("options_cls", CREDENTIAL_FREE_OPTIONS_CLASSES)
+    def test_keeps_generated_dataclass_repr(self, options_cls):
+        options = options_cls()
+        assert repr(options) == _default_dataclass_repr(options)
+        assert options_cls.__repr__.__qualname__ == f"{options_cls.__qualname__}.__repr__"
+
+    def test_regular_values_render_verbatim(self):
+        options = OpenAIPromptOptions(max_tokens=128, temperature=0.5)
+        assert repr(options) == (
+            "OpenAIPromptOptions(use_chat_completions=None, max_output_tokens=None, "
+            "max_tokens=128, temperature=0.5, on_error=None)"
+        )
+
+
+@pytest.mark.parametrize("options_cls", API_KEY_OPTIONS_CLASSES)
+class TestAssertionDiffDoesNotLeak:
+    def test_failing_comparison_with_equal_keys_hides_key(self, options_cls):
+        left = options_cls(api_key=API_KEY, concurrency=1)
+        right = options_cls(api_key=API_KEY, concurrency=2)
+        with pytest.raises(AssertionError) as excinfo:
+            assert left == right
+        message = str(excinfo.value)
+        assert API_KEY not in message
+        assert "concurrency" in message

--- a/tests/fast/test_ai_options_repr.py
+++ b/tests/fast/test_ai_options_repr.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public provider options never leak ``api_key`` through repr, str, or assertion diffs.
+"""Public provider options never leak credentials through repr, str, or assertion diffs.
 
-Covers vane#105: the three api_key-bearing options dataclasses (OpenAI,
-Anthropic, Google) render a fixed placeholder instead of the plaintext key,
-while construction, ``.api_key`` reads, equality, and the credential-free
-options dataclasses stay untouched.
+Covers vane#105: the api_key-bearing options dataclasses (OpenAI, Anthropic,
+Google) render a fixed placeholder instead of the plaintext key — OpenAI also
+masks ``organization`` — and the vLLM options render mapping fields
+(``engine_args``/``generate_args``) with nested sensitive keys sealed.
+Construction, field reads, equality, and the credential-free options
+dataclasses stay untouched.
 """
 
 from __future__ import annotations
@@ -38,13 +40,11 @@ API_KEY_OPTIONS_CLASSES = [
 ]
 
 CREDENTIAL_FREE_OPTIONS_CLASSES = [
-    VLLMProviderOptions,
     OpenAIPromptOptions,
     OpenAIEmbeddingOptions,
     AnthropicPromptOptions,
     GooglePromptOptions,
     GoogleEmbeddingOptions,
-    VLLMPromptOptions,
 ]
 
 
@@ -107,9 +107,10 @@ class TestOtherFieldsRenderNormally:
         )
         assert repr(options) == (
             "OpenAIProviderOptions(base_url='https://api.example', "
-            f"api_key={REDACTED_PLACEHOLDER}, organization='org-plain', "
+            f"api_key={REDACTED_PLACEHOLDER}, organization={REDACTED_PLACEHOLDER}, "
             "timeout=30.0, concurrency=4, max_api_concurrency=8)"
         )
+        assert "org-plain" not in repr(options)
 
     def test_anthropic_full_repr(self):
         options = AnthropicProviderOptions(
@@ -151,6 +152,65 @@ class TestCredentialFreeOptionsUntouched:
             "OpenAIPromptOptions(use_chat_completions=None, max_output_tokens=None, "
             "max_tokens=128, temperature=0.5, on_error=None)"
         )
+
+
+class TestOpenAIOrganizationRedaction:
+    def test_organization_masked_when_set(self):
+        options = OpenAIProviderOptions(organization="org-PLAINTEXT-SENTINEL")
+        for rendered in (repr(options), str(options)):
+            assert "org-PLAINTEXT-SENTINEL" not in rendered
+            assert f"organization={REDACTED_PLACEHOLDER}" in rendered
+
+    def test_organization_none_renders_as_none(self):
+        assert "organization=None" in repr(OpenAIProviderOptions())
+
+    def test_organization_read_unchanged(self):
+        options = OpenAIProviderOptions(organization="org-PLAINTEXT-SENTINEL")
+        assert options.organization == "org-PLAINTEXT-SENTINEL"
+        assert options.to_descriptor_options()["organization"] == "org-PLAINTEXT-SENTINEL"
+
+
+HF_TOKEN = "hf_PLAINTEXT-ENGINE-TOKEN-SENTINEL"
+
+
+class TestVLLMMappingFieldRedaction:
+    def test_engine_args_nested_credentials_masked(self):
+        options = VLLMProviderOptions(engine_args={"hf_token": HF_TOKEN, "max_model_len": 512})
+        rendered = repr(options)
+        assert HF_TOKEN not in rendered
+        assert REDACTED_PLACEHOLDER in rendered
+        assert "'max_model_len': 512" in rendered
+
+    def test_generate_args_nested_credentials_masked(self):
+        options = VLLMPromptOptions(generate_args={"api_key": API_KEY, "seed": 7})
+        rendered = repr(options)
+        assert API_KEY not in rendered
+        assert REDACTED_PLACEHOLDER in rendered
+        assert "'seed': 7" in rendered
+
+    def test_mapping_fields_unchanged_for_reads(self):
+        options = VLLMProviderOptions(engine_args={"hf_token": HF_TOKEN})
+        assert options.engine_args == {"hf_token": HF_TOKEN}
+        assert options.to_descriptor_options()["engine_args"] == {"hf_token": HF_TOKEN}
+
+    def test_credential_free_mappings_render_verbatim(self):
+        options = VLLMProviderOptions(engine_args={"max_model_len": 512}, concurrency=2)
+        assert (
+            repr(options)
+            == "VLLMProviderOptions(engine_args={'max_model_len': 512}, concurrency=2, gpus_per_actor=None)"
+        )
+
+    def test_none_mapping_renders_as_none(self):
+        assert "engine_args=None" in repr(VLLMProviderOptions())
+
+    def test_assertion_diff_hides_nested_token(self):
+        left = VLLMProviderOptions(engine_args={"hf_token": HF_TOKEN}, concurrency=1)
+        right = VLLMProviderOptions(engine_args={"hf_token": HF_TOKEN}, concurrency=2)
+        with pytest.raises(AssertionError) as excinfo:
+            assert left == right
+        message = str(excinfo.value)
+        assert HF_TOKEN not in message
+        assert "concurrency" in message
 
 
 @pytest.mark.parametrize("options_cls", API_KEY_OPTIONS_CLASSES)

--- a/tests/fast/test_ai_redaction.py
+++ b/tests/fast/test_ai_redaction.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from vane.ai._redaction import (
+    REDACTED_PLACEHOLDER,
+    SENSITIVE_OPTION_KEYS,
+    Secret,
+    is_sensitive_option_key,
+    normalized_option_key,
+    unwrap_sensitive_options,
+    wrap_sensitive_options,
+)
+
+SENTINEL = "sk-INLINE-SECRET-SENTINEL-0123456789"
+
+
+class TestSecret:
+    def test_repr_and_str_are_fixed_placeholder(self):
+        for value in ("x", SENTINEL, "a-much-longer-credential-value-" * 8):
+            secret = Secret(value)
+            assert repr(secret) == REDACTED_PLACEHOLDER
+            assert str(secret) == REDACTED_PLACEHOLDER
+            assert f"{secret}" == REDACTED_PLACEHOLDER
+            assert "{}".format(secret) == REDACTED_PLACEHOLDER
+            assert value not in repr(secret)
+            assert value not in str(secret)
+
+    def test_placeholder_is_length_hiding(self):
+        short = Secret("x")
+        long = Secret("y" * 500)
+        assert len(repr(short)) == len(repr(long))
+        assert repr(short) == repr(long)
+
+    def test_reveal_returns_original_value(self):
+        assert Secret(SENTINEL).reveal() == SENTINEL
+
+    def test_reveal_after_pickle_round_trip(self):
+        secret = Secret(SENTINEL)
+        restored = pickle.loads(pickle.dumps(secret))
+        assert isinstance(restored, Secret)
+        assert restored.reveal() == SENTINEL
+        assert repr(restored) == REDACTED_PLACEHOLDER
+        assert SENTINEL not in repr(restored)
+        assert SENTINEL not in str(restored)
+
+    def test_equality_between_secrets_compares_real_values(self):
+        assert Secret(SENTINEL) == Secret(SENTINEL)
+        assert Secret(SENTINEL) != Secret("other")
+
+    def test_equality_with_bare_str_is_always_false(self):
+        secret = Secret(SENTINEL)
+        assert not (secret == SENTINEL)
+        assert not (SENTINEL == secret)
+        assert secret != SENTINEL
+        assert SENTINEL != secret
+
+    def test_hash_is_consistent_with_equality(self):
+        assert hash(Secret(SENTINEL)) == hash(Secret(SENTINEL))
+        assert len({Secret(SENTINEL), Secret(SENTINEL)}) == 1
+        assert {Secret(SENTINEL): "hit"}[Secret(SENTINEL)] == "hit"
+
+    def test_wrapping_a_secret_keeps_a_single_secret(self):
+        double = Secret(Secret(SENTINEL))
+        assert isinstance(double, Secret)
+        assert not isinstance(double.reveal(), Secret)
+        assert double.reveal() == SENTINEL
+
+    def test_non_str_values_are_supported(self):
+        secret = Secret(1234)
+        assert secret.reveal() == 1234
+        assert repr(secret) == REDACTED_PLACEHOLDER
+
+    def test_empty_string_is_still_redacted(self):
+        secret = Secret("")
+        assert secret.reveal() == ""
+        assert repr(secret) == REDACTED_PLACEHOLDER
+
+
+class TestSensitiveKeyMatching:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "api_key",
+            "API-Key",
+            "apiKey",
+            "openai_api_key",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "azure_client_secret_value",
+            "client-secret",
+            "google-api-token",
+            "Proxy-Authorization",
+            "access_token",
+            "password",
+            "credentials",
+        ],
+    )
+    def test_sensitive_keys_match(self, key):
+        assert is_sensitive_option_key(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "token_budget",
+            "max_tokens",
+            "max_output_tokens",
+            "model",
+            "provider",
+            "temperature",
+            "secretary",
+            "passwordless_mode",
+        ],
+    )
+    def test_near_miss_keys_do_not_match(self, key):
+        assert not is_sensitive_option_key(key)
+
+    def test_normalization_casefolds_and_strips_non_alphanumerics(self):
+        assert normalized_option_key("Proxy-Authorization") == "proxyauthorization"
+        assert normalized_option_key("API_KEY") == "apikey"
+        assert normalized_option_key(123) == "123"
+
+    def test_key_table_is_normalized(self):
+        for key in SENSITIVE_OPTION_KEYS:
+            assert key == normalized_option_key(key)
+
+
+class TestWrapSensitiveOptions:
+    def test_wraps_sensitive_keys_at_any_depth(self):
+        options = {
+            "model": "gpt-4o",
+            "api_key": SENTINEL,
+            "provider_options": {
+                "aws_secret_access_key": SENTINEL,
+                "region": "us-east-1",
+                "endpoints": [{"authorization": SENTINEL, "url": "https://example.com"}],
+            },
+            "headers": ({"proxy_authorization": SENTINEL},),
+            "token_budget": 42,
+        }
+        wrapped = wrap_sensitive_options(options)
+
+        assert isinstance(wrapped["api_key"], Secret)
+        assert wrapped["api_key"].reveal() == SENTINEL
+        assert isinstance(wrapped["provider_options"]["aws_secret_access_key"], Secret)
+        assert isinstance(wrapped["provider_options"]["endpoints"][0]["authorization"], Secret)
+        assert isinstance(wrapped["headers"], tuple)
+        assert isinstance(wrapped["headers"][0]["proxy_authorization"], Secret)
+        assert SENTINEL not in repr(wrapped)
+        assert SENTINEL not in str(wrapped)
+
+    def test_non_sensitive_and_near_miss_keys_are_untouched(self):
+        options = {
+            "model": "gpt-4o",
+            "token_budget": 42,
+            "max_tokens": 128,
+            "provider_options": {"region": "us-east-1"},
+        }
+        wrapped = wrap_sensitive_options(options)
+        assert wrapped == options
+        assert wrapped["model"] == "gpt-4o"
+        assert wrapped["token_budget"] == 42
+        assert wrapped["max_tokens"] == 128
+        assert wrapped["provider_options"] == {"region": "us-east-1"}
+
+    def test_input_mapping_is_not_mutated(self):
+        options = {"api_key": SENTINEL, "provider_options": {"access_token": SENTINEL}}
+        wrap_sensitive_options(options)
+        assert options["api_key"] == SENTINEL
+        assert options["provider_options"]["access_token"] == SENTINEL
+
+    def test_wrap_is_idempotent(self):
+        options = {"api_key": SENTINEL, "provider_options": {"access_token": SENTINEL}}
+        rewrapped = wrap_sensitive_options(wrap_sensitive_options(options))
+        assert isinstance(rewrapped["api_key"], Secret)
+        assert not isinstance(rewrapped["api_key"].reveal(), Secret)
+        assert rewrapped["api_key"].reveal() == SENTINEL
+        inner = rewrapped["provider_options"]["access_token"]
+        assert isinstance(inner, Secret)
+        assert inner.reveal() == SENTINEL
+
+    def test_container_under_sensitive_key_is_sealed_whole(self):
+        options = {"credentials": {"access_token": SENTINEL}}
+        wrapped = wrap_sensitive_options(options)
+        assert isinstance(wrapped["credentials"], Secret)
+        assert wrapped["credentials"].reveal() == {"access_token": SENTINEL}
+        assert SENTINEL not in repr(wrapped)
+
+    def test_none_values_stay_none(self):
+        wrapped = wrap_sensitive_options({"api_key": None, "model": None})
+        assert wrapped["api_key"] is None
+        assert wrapped["model"] is None
+
+    def test_non_str_sensitive_values_are_wrapped(self):
+        wrapped = wrap_sensitive_options({"secret": 1234})
+        assert isinstance(wrapped["secret"], Secret)
+        assert wrapped["secret"].reveal() == 1234
+
+
+class TestUnwrapSensitiveOptions:
+    def test_unwrap_restores_equivalent_plain_mapping(self):
+        options = {
+            "model": "gpt-4o",
+            "api_key": SENTINEL,
+            "provider_options": {
+                "aws_secret_access_key": SENTINEL,
+                "endpoints": [{"authorization": SENTINEL, "url": "https://example.com"}],
+            },
+            "headers": ({"proxy_authorization": SENTINEL},),
+            "credentials": {"access_token": SENTINEL},
+            "token_budget": 42,
+        }
+        assert unwrap_sensitive_options(wrap_sensitive_options(options)) == options
+
+    def test_unwrap_of_plain_mapping_is_a_no_op(self):
+        options = {"model": "gpt-4o", "provider_options": {"region": "us-east-1"}}
+        assert unwrap_sensitive_options(options) == options
+
+
+class TestRedactionInFailureOutput:
+    def test_failing_assertion_diff_contains_no_plaintext(self):
+        wrapped = wrap_sensitive_options({"api_key": SENTINEL, "model": "gpt-4o"})
+        with pytest.raises(AssertionError) as excinfo:
+            assert wrapped == {"api_key": "some-other-value", "model": "gpt-4o"}
+        text = str(excinfo.value)
+        assert SENTINEL not in text
+        assert REDACTED_PLACEHOLDER in text
+
+    def test_exception_message_embedding_a_secret_is_redacted(self):
+        secret = Secret(SENTINEL)
+        error = ValueError(f"bad option: {secret!r} ({secret})")
+        assert SENTINEL not in str(error)
+        assert REDACTED_PLACEHOLDER in str(error)
+
+
+class TestSqlLayerSharesKeyTable:
+    def test_sql_binding_imports_the_shared_matcher(self):
+        from vane.ai import _redaction, _sql
+
+        assert _sql.is_sensitive_option_key is _redaction.is_sensitive_option_key
+
+    def test_sql_rejection_still_uses_shared_matching(self):
+        from vane.ai._sql import _reject_inline_credentials
+
+        _reject_inline_credentials({"model": "gpt-4o", "token_budget": 42})
+        with pytest.raises(ValueError, match="inline credential"):
+            _reject_inline_credentials({"provider_options": {"aws_secret_access_key": SENTINEL}})
+        with pytest.raises(ValueError, match="inline credential"):
+            _reject_inline_credentials({"provider_options": [{"google-api-token": SENTINEL}]})

--- a/vane/ai/_redaction.py
+++ b/vane/ai/_redaction.py
@@ -3,11 +3,22 @@
 
 """Credential redaction shared by the AI SQL binding and provider layers.
 
-Vane defends provider credentials in two layers: the SQL binding rejects
-inline credential options outright (see ``vane.ai._sql``), while the Python
-descriptor path seals credential values in :class:`Secret` so that repr, str,
-logs, exception messages, and assertion diffs never show the plaintext. Both
-layers share the sensitive-key table and matching logic defined here.
+Vane defends provider credentials in two layers, both driven by the
+sensitive-key table and matching logic defined here.
+
+Layer 1 — the SQL binding rejects inline credentials outright.
+``vane.ai._sql._reject_inline_credentials`` raises on any sensitive-keyed
+option at any nesting depth before a provider is ever constructed;
+environment variables are the supported way to configure credentials for
+the SQL surface.
+
+Layer 2 — the Python descriptor path seals credentials. Provider descriptors
+wrap every sensitive-keyed value in their option mappings in :class:`Secret`
+at construction (:func:`wrap_sensitive_options`), so repr, str, logs,
+exception messages, and assertion diffs show only the fixed placeholder —
+including for pickled copies shipped to workers. The plaintext is restored
+solely at provider execution, immediately before SDK client or engine
+construction, via :func:`unwrap_sensitive_options`.
 
 This module is private; :class:`Secret` is intentionally not exported from
 the public ``vane.ai`` namespace.

--- a/vane/ai/_redaction.py
+++ b/vane/ai/_redaction.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Credential redaction shared by the AI SQL binding and provider layers.
+
+Vane defends provider credentials in two layers: the SQL binding rejects
+inline credential options outright (see ``vane.ai._sql``), while the Python
+descriptor path seals credential values in :class:`Secret` so that repr, str,
+logs, exception messages, and assertion diffs never show the plaintext. Both
+layers share the sensitive-key table and matching logic defined here.
+
+This module is private; :class:`Secret` is intentionally not exported from
+the public ``vane.ai`` namespace.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+__all__ = [
+    "REDACTED_PLACEHOLDER",
+    "SENSITIVE_OPTION_KEYS",
+    "Secret",
+    "is_sensitive_option_key",
+    "normalized_option_key",
+    "unwrap_sensitive_options",
+    "wrap_sensitive_options",
+]
+
+REDACTED_PLACEHOLDER = "**********"
+
+# Normalized credential key names. A key matches when its normalized form is
+# equal to, or ends with, one of these entries (see is_sensitive_option_key).
+SENSITIVE_OPTION_KEYS = frozenset(
+    {
+        "accesskey",
+        "accesskeyid",
+        "accesstoken",
+        "apikey",
+        "apikeyid",
+        "apitoken",
+        "authorization",
+        "authtoken",
+        "bearertoken",
+        "clientsecret",
+        "clientsecretvalue",
+        "credential",
+        "credentials",
+        "password",
+        "passwd",
+        "privatekey",
+        "secret",
+        "secretkey",
+        "token",
+    }
+)
+
+
+def normalized_option_key(key: Any) -> str:
+    """Normalize an option key for sensitive-key matching (casefold, strip non-alphanumerics)."""
+    return re.sub(r"[^a-z0-9]", "", str(key).casefold())
+
+
+def is_sensitive_option_key(key: Any) -> bool:
+    """Return True when ``key`` names a credential according to the shared key table."""
+    normalized = normalized_option_key(key)
+    return any(normalized == sensitive or normalized.endswith(sensitive) for sensitive in SENSITIVE_OPTION_KEYS)
+
+
+class Secret:
+    """Opaque wrapper that renders as a fixed placeholder wherever Python stringifies it.
+
+    The wrapped value is only retrievable through an explicit :meth:`reveal`
+    call. Equality compares real values against another ``Secret`` only;
+    comparison with a bare ``str`` (or any non-``Secret``) is always ``False``.
+    Pickling preserves the real value so workers can use it; plaintext inside
+    pickle payloads is an accepted inherent property of that requirement.
+    """
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: Any) -> None:
+        if isinstance(value, Secret):
+            value = value.reveal()
+        self._value = value
+
+    def reveal(self) -> Any:
+        """Return the wrapped plaintext value."""
+        return self._value
+
+    def __repr__(self) -> str:
+        return REDACTED_PLACEHOLDER
+
+    def __str__(self) -> str:
+        return REDACTED_PLACEHOLDER
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Secret):
+            return bool(self._value == other._value)
+        return False
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __reduce__(self) -> tuple[type[Secret], tuple[Any]]:
+        return (Secret, (self._value,))
+
+
+def _seal(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Secret):
+        return value
+    return Secret(value)
+
+
+def _wrap_value(value: Any) -> Any:
+    if isinstance(value, Secret):
+        return value
+    if isinstance(value, Mapping):
+        return {key: _seal(item) if is_sensitive_option_key(key) else _wrap_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_wrap_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_wrap_value(item) for item in value)
+    return value
+
+
+def wrap_sensitive_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``options`` with every sensitive-keyed value sealed in a :class:`Secret`.
+
+    Matching applies at any nesting depth, including mappings inside lists and
+    tuples. A container value under a sensitive key is sealed whole. Values
+    that are already ``Secret`` are kept as-is (wrapping is idempotent), and
+    ``None`` values stay ``None``.
+    """
+    return {key: _seal(value) if is_sensitive_option_key(key) else _wrap_value(value) for key, value in options.items()}
+
+
+def _unwrap_value(value: Any) -> Any:
+    if isinstance(value, Secret):
+        return _unwrap_value(value.reveal())
+    if isinstance(value, Mapping):
+        return {key: _unwrap_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_unwrap_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_unwrap_value(item) for item in value)
+    return value
+
+
+def unwrap_sensitive_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a plain copy of ``options`` with every :class:`Secret` replaced by its real value."""
+    return {key: _unwrap_value(value) for key, value in options.items()}

--- a/vane/ai/_redaction.py
+++ b/vane/ai/_redaction.py
@@ -74,10 +74,20 @@ def normalized_option_key(key: Any) -> str:
     return re.sub(r"[^a-z0-9]", "", str(key).casefold())
 
 
-def is_sensitive_option_key(key: Any) -> bool:
-    """Return True when ``key`` names a credential according to the shared key table."""
+def is_sensitive_option_key(key: Any, extra_keys: frozenset[str] = frozenset()) -> bool:
+    """Return True when ``key`` names a credential according to the shared key table.
+
+    ``extra_keys`` extends the table for one call with additional normalized
+    entries, matched with the same exact-or-suffix rule. Callers with
+    provider-specific sensitive names (e.g. OpenAI's ``organization``) pass
+    them here rather than widening the shared table, which also drives SQL
+    inline-credential rejection.
+    """
     normalized = normalized_option_key(key)
-    return any(normalized == sensitive or normalized.endswith(sensitive) for sensitive in SENSITIVE_OPTION_KEYS)
+    return any(
+        normalized == sensitive or normalized.endswith(sensitive)
+        for sensitive in (SENSITIVE_OPTION_KEYS | extra_keys if extra_keys else SENSITIVE_OPTION_KEYS)
+    )
 
 
 class Secret:
@@ -127,27 +137,34 @@ def _seal(value: Any) -> Any:
     return Secret(value)
 
 
-def _wrap_value(value: Any) -> Any:
+def _wrap_value(value: Any, extra_keys: frozenset[str]) -> Any:
     if isinstance(value, Secret):
         return value
     if isinstance(value, Mapping):
-        return {key: _seal(item) if is_sensitive_option_key(key) else _wrap_value(item) for key, item in value.items()}
+        return {
+            key: _seal(item) if is_sensitive_option_key(key, extra_keys) else _wrap_value(item, extra_keys)
+            for key, item in value.items()
+        }
     if isinstance(value, list):
-        return [_wrap_value(item) for item in value]
+        return [_wrap_value(item, extra_keys) for item in value]
     if isinstance(value, tuple):
-        return tuple(_wrap_value(item) for item in value)
+        return tuple(_wrap_value(item, extra_keys) for item in value)
     return value
 
 
-def wrap_sensitive_options(options: Mapping[str, Any]) -> dict[str, Any]:
+def wrap_sensitive_options(options: Mapping[str, Any], extra_keys: frozenset[str] = frozenset()) -> dict[str, Any]:
     """Return a copy of ``options`` with every sensitive-keyed value sealed in a :class:`Secret`.
 
     Matching applies at any nesting depth, including mappings inside lists and
     tuples. A container value under a sensitive key is sealed whole. Values
     that are already ``Secret`` are kept as-is (wrapping is idempotent), and
-    ``None`` values stay ``None``.
+    ``None`` values stay ``None``. ``extra_keys`` extends the key table for
+    this call only (see :func:`is_sensitive_option_key`).
     """
-    return {key: _seal(value) if is_sensitive_option_key(key) else _wrap_value(value) for key, value in options.items()}
+    return {
+        key: _seal(value) if is_sensitive_option_key(key, extra_keys) else _wrap_value(value, extra_keys)
+        for key, value in options.items()
+    }
 
 
 def _unwrap_value(value: Any) -> Any:

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import Mapping
 from decimal import Decimal
 from typing import Any
 
 import pyarrow as pa
 
+from vane.ai._redaction import is_sensitive_option_key
 from vane.ai.functions import (
     _actor_number_or_one,
     _adapt_batch_wrapper_for_backend,
@@ -48,43 +48,12 @@ _FLOAT_OPTION_NAMES = {
     "top_p",
 }
 
-_INLINE_CREDENTIAL_KEYS = {
-    "accesskey",
-    "accesskeyid",
-    "accesstoken",
-    "apikey",
-    "apikeyid",
-    "apitoken",
-    "authorization",
-    "authtoken",
-    "bearertoken",
-    "clientsecret",
-    "clientsecretvalue",
-    "credential",
-    "credentials",
-    "password",
-    "passwd",
-    "privatekey",
-    "secret",
-    "secretkey",
-    "token",
-}
-
-
-def _normalized_option_key(key: Any) -> str:
-    return re.sub(r"[^a-z0-9]", "", str(key).casefold())
-
-
-def _is_inline_credential_key(key: Any) -> bool:
-    normalized = _normalized_option_key(key)
-    return any(normalized == sensitive or normalized.endswith(sensitive) for sensitive in _INLINE_CREDENTIAL_KEYS)
-
 
 def _reject_inline_credentials(value: Any, path: str = "options") -> None:
     if isinstance(value, Mapping):
         for key, item in value.items():
             key_text = str(key)
-            if _is_inline_credential_key(key_text):
+            if is_sensitive_option_key(key_text):
                 raise ValueError(
                     f"AI SQL options cannot include inline credential field {path}.{key_text}; "
                     "configure provider credentials through environment variables"

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -50,6 +50,14 @@ _FLOAT_OPTION_NAMES = {
 
 
 def _reject_inline_credentials(value: Any, path: str = "options") -> None:
+    """Reject sensitive-keyed options at any nesting depth (defense layer 1).
+
+    SQL options must never carry credentials inline; environment variables are
+    the supported path. Key matching uses the shared sensitive-key table in
+    ``vane.ai._redaction``, which also drives the Python-layer ``Secret``
+    sealing (defense layer 2) — see that module's docstring for the full
+    two-layer design.
+    """
     if isinstance(value, Mapping):
         for key, item in value.items():
             key_text = str(key)

--- a/vane/ai/options.py
+++ b/vane/ai/options.py
@@ -5,13 +5,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, fields
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, ClassVar, Literal
 
-from vane.ai._redaction import REDACTED_PLACEHOLDER
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from vane.ai._redaction import REDACTED_PLACEHOLDER, wrap_sensitive_options
 
 
 def _set_if_not_none(target: dict[str, Any], key: str, value: object) -> None:
@@ -19,28 +17,39 @@ def _set_if_not_none(target: dict[str, Any], key: str, value: object) -> None:
         target[key] = value
 
 
-class _RedactedApiKeyRepr:
-    """Mixin rendering ``api_key`` as a fixed placeholder in the dataclass-style repr.
+class _RedactedOptionsRepr:
+    """Mixin rendering credential-bearing fields redacted in the dataclass-style repr.
 
-    Dataclasses opting in must be declared with ``repr=False`` so the generated
-    repr does not shadow this one. ``None`` still renders as ``None`` — masking
-    an absent key would be misleading.
+    Scalar fields named in ``_REDACTED_FIELDS`` render as a fixed placeholder
+    when set (``None`` still renders as ``None`` — masking an absent key would
+    be misleading). Mapping-valued fields render with sensitive keys sealed at
+    any nesting depth, so nested credentials (e.g. an HF hub token inside
+    ``engine_args``) never reach the repr. Dataclasses opting in must be
+    declared with ``repr=False`` so the generated repr does not shadow this one.
     """
+
+    _REDACTED_FIELDS: ClassVar[frozenset[str]] = frozenset({"api_key"})
 
     def __repr__(self) -> str:
         parts = []
         for field in fields(self):  # type: ignore[arg-type]
             value = getattr(self, field.name)
-            if field.name == "api_key" and value is not None:
+            if field.name in self._REDACTED_FIELDS and value is not None:
                 parts.append(f"{field.name}={REDACTED_PLACEHOLDER}")
+            elif isinstance(value, Mapping):
+                parts.append(f"{field.name}={wrap_sensitive_options(value)!r}")
             else:
                 parts.append(f"{field.name}={value!r}")
         return f"{type(self).__qualname__}({', '.join(parts)})"
 
 
 @dataclass(frozen=True, repr=False)
-class OpenAIProviderOptions(_RedactedApiKeyRepr):
+class OpenAIProviderOptions(_RedactedOptionsRepr):
     """OpenAI-compatible provider options shared by prompt and embedding calls."""
+
+    # ``organization`` identifies the paying account; the OpenAI provider seals
+    # it at the descriptor layer, so the public repr must not leak it either.
+    _REDACTED_FIELDS: ClassVar[frozenset[str]] = frozenset({"api_key", "organization"})
 
     base_url: str | None = None
     api_key: str | None = None
@@ -61,8 +70,8 @@ class OpenAIProviderOptions(_RedactedApiKeyRepr):
         return options
 
 
-@dataclass(frozen=True)
-class VLLMProviderOptions:
+@dataclass(frozen=True, repr=False)
+class VLLMProviderOptions(_RedactedOptionsRepr):
     """vLLM provider options for actor count, GPU allocation, and engine args."""
 
     engine_args: Mapping[str, Any] | None = None
@@ -115,7 +124,7 @@ class OpenAIEmbeddingOptions:
 
 
 @dataclass(frozen=True, repr=False)
-class AnthropicProviderOptions(_RedactedApiKeyRepr):
+class AnthropicProviderOptions(_RedactedOptionsRepr):
     """Anthropic provider options for client configuration and execution limits."""
 
     api_key: str | None = None
@@ -162,7 +171,7 @@ class AnthropicPromptOptions:
 
 
 @dataclass(frozen=True, repr=False)
-class GoogleProviderOptions(_RedactedApiKeyRepr):
+class GoogleProviderOptions(_RedactedOptionsRepr):
     """Google provider options for client configuration and execution limits."""
 
     api_key: str | None = None
@@ -216,8 +225,8 @@ class GoogleEmbeddingOptions:
         return options
 
 
-@dataclass(frozen=True)
-class VLLMPromptOptions:
+@dataclass(frozen=True, repr=False)
+class VLLMPromptOptions(_RedactedOptionsRepr):
     """vLLM prompt generation options."""
 
     generate_args: Mapping[str, Any] | None = None

--- a/vane/ai/options.py
+++ b/vane/ai/options.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, Literal
+
+from vane.ai._redaction import REDACTED_PLACEHOLDER
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -17,8 +19,27 @@ def _set_if_not_none(target: dict[str, Any], key: str, value: object) -> None:
         target[key] = value
 
 
-@dataclass(frozen=True)
-class OpenAIProviderOptions:
+class _RedactedApiKeyRepr:
+    """Mixin rendering ``api_key`` as a fixed placeholder in the dataclass-style repr.
+
+    Dataclasses opting in must be declared with ``repr=False`` so the generated
+    repr does not shadow this one. ``None`` still renders as ``None`` — masking
+    an absent key would be misleading.
+    """
+
+    def __repr__(self) -> str:
+        parts = []
+        for field in fields(self):  # type: ignore[arg-type]
+            value = getattr(self, field.name)
+            if field.name == "api_key" and value is not None:
+                parts.append(f"{field.name}={REDACTED_PLACEHOLDER}")
+            else:
+                parts.append(f"{field.name}={value!r}")
+        return f"{type(self).__qualname__}({', '.join(parts)})"
+
+
+@dataclass(frozen=True, repr=False)
+class OpenAIProviderOptions(_RedactedApiKeyRepr):
     """OpenAI-compatible provider options shared by prompt and embedding calls."""
 
     base_url: str | None = None
@@ -93,8 +114,8 @@ class OpenAIEmbeddingOptions:
         return options
 
 
-@dataclass(frozen=True)
-class AnthropicProviderOptions:
+@dataclass(frozen=True, repr=False)
+class AnthropicProviderOptions(_RedactedApiKeyRepr):
     """Anthropic provider options for client configuration and execution limits."""
 
     api_key: str | None = None
@@ -140,8 +161,8 @@ class AnthropicPromptOptions:
         return options
 
 
-@dataclass(frozen=True)
-class GoogleProviderOptions:
+@dataclass(frozen=True, repr=False)
+class GoogleProviderOptions(_RedactedApiKeyRepr):
     """Google provider options for client configuration and execution limits."""
 
     api_key: str | None = None

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -18,6 +18,7 @@ import base64
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import UDFOptions
@@ -93,6 +94,10 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
     return_format: Any | None = None
     prompt_options: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.provider_options = wrap_sensitive_options(self.provider_options)
+        self.prompt_options = wrap_sensitive_options(self.prompt_options)
+
     def get_provider(self) -> str:
         return self.provider_name
 
@@ -141,6 +146,10 @@ class AnthropicPrompter:
     ):
         from anthropic import AsyncAnthropic
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        provider_options = unwrap_sensitive_options(provider_options)
+        options = unwrap_sensitive_options(options)
         self._model = model
         self._system_message = system_message
         self._return_format = return_format

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
+from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
@@ -156,6 +157,10 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
     dimensions: int | None = None
     embed_options: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.provider_options = wrap_sensitive_options(self.provider_options)
+        self.embed_options = wrap_sensitive_options(self.embed_options)
+
     def get_provider(self) -> str:
         return self.provider_name
 
@@ -203,6 +208,10 @@ class GoogleTextEmbedder:
     ):
         from google import genai
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        provider_options = unwrap_sensitive_options(provider_options)
+        options = unwrap_sensitive_options(options)
         api_key = provider_options.get("api_key")
         self._client = genai.Client(api_key=api_key) if api_key else genai.Client()
         self._model = model
@@ -263,6 +272,10 @@ class GooglePrompterDescriptor(PrompterDescriptor):
     return_format: Any | None = None
     prompt_options: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.provider_options = wrap_sensitive_options(self.provider_options)
+        self.prompt_options = wrap_sensitive_options(self.prompt_options)
+
     def get_provider(self) -> str:
         return self.provider_name
 
@@ -310,6 +323,10 @@ class GooglePrompter:
     ):
         from google import genai
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        provider_options = unwrap_sensitive_options(provider_options)
+        options = unwrap_sensitive_options(options)
         api_key = provider_options.get("api_key")
         self._client = genai.Client(api_key=api_key) if api_key else genai.Client()
         self._model = model

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -20,12 +20,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pyarrow as pa
 
-from vane.ai._redaction import (
-    Secret,
-    normalized_option_key,
-    unwrap_sensitive_options,
-    wrap_sensitive_options,
-)
+from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
@@ -76,17 +71,15 @@ def _chunk_text(text: str, char_size: int) -> list[str]:
 
 # OpenAI-specific keys sealed in addition to the shared sensitive-key table.
 # ``organization`` identifies the paying account and must not leak via repr,
-# but it is not a generic credential, so it stays out of the shared table.
+# but it is not a generic credential, so it stays out of the shared table
+# (which also drives SQL inline-credential rejection). Suffix matching covers
+# nested forms such as an ``OpenAI-Organization`` request header.
 _EXTRA_SENSITIVE_KEYS = frozenset({"organization"})
 
 
 def _wrap_openai_options(options: Mapping[str, Any]) -> dict[str, Any]:
-    """Seal shared sensitive keys plus OpenAI-specific ones (``organization``)."""
-    wrapped = wrap_sensitive_options(options)
-    for key, value in wrapped.items():
-        if normalized_option_key(key) in _EXTRA_SENSITIVE_KEYS and value is not None and not isinstance(value, Secret):
-            wrapped[key] = Secret(value)
-    return wrapped
+    """Seal shared sensitive keys plus OpenAI-specific ones (``organization``) at any depth."""
+    return wrap_sensitive_options(options, extra_keys=_EXTRA_SENSITIVE_KEYS)
 
 
 # ---------------------------------------------------------------------------

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -20,11 +20,19 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pyarrow as pa
 
+from vane.ai._redaction import (
+    Secret,
+    normalized_option_key,
+    unwrap_sensitive_options,
+    wrap_sensitive_options,
+)
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from vane.ai.protocols import Prompter, TextEmbedder
     from vane.ai.typing import Embedding, Options
 
@@ -64,6 +72,21 @@ def _get_input_token_limit(model: str) -> int:
 def _chunk_text(text: str, char_size: int) -> list[str]:
     """Split *text* into character-level chunks of at most *char_size*."""
     return [text[i : i + char_size] for i in range(0, len(text), char_size)]
+
+
+# OpenAI-specific keys sealed in addition to the shared sensitive-key table.
+# ``organization`` identifies the paying account and must not leak via repr,
+# but it is not a generic credential, so it stays out of the shared table.
+_EXTRA_SENSITIVE_KEYS = frozenset({"organization"})
+
+
+def _wrap_openai_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Seal shared sensitive keys plus OpenAI-specific ones (``organization``)."""
+    wrapped = wrap_sensitive_options(options)
+    for key, value in wrapped.items():
+        if normalized_option_key(key) in _EXTRA_SENSITIVE_KEYS and value is not None and not isinstance(value, Secret):
+            wrapped[key] = Secret(value)
+    return wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +173,8 @@ class OpenAITextEmbedderDescriptor(TextEmbedderDescriptor):
             and self.model_name not in _DIMENSION_OVERRIDABLE
         ):
             raise ValueError(f"Model {self.model_name!r} does not support custom dimensions")
+        self.provider_options = _wrap_openai_options(self.provider_options)
+        self.embed_options = _wrap_openai_options(self.embed_options)
 
     def get_provider(self) -> str:
         return self.provider_name
@@ -168,7 +193,7 @@ class OpenAITextEmbedderDescriptor(TextEmbedderDescriptor):
         # Unknown model with custom base_url — probe the server
         from openai import OpenAI as OpenAIClient
 
-        client = OpenAIClient(**self.provider_options)
+        client = OpenAIClient(**unwrap_sensitive_options(self.provider_options))
         response = client.embeddings.create(
             input="dimension probe",
             model=self.model_name,
@@ -227,6 +252,9 @@ class OpenAITextEmbedder:
 
         if encoding_format not in {"float", "base64"}:
             raise ValueError("encoding_format must be 'float' or 'base64'")
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        provider_options = unwrap_sensitive_options(provider_options)
         self._model = model
         self._dimensions = dimensions
         self._encoding_format = encoding_format
@@ -339,6 +367,10 @@ class OpenAIPrompterDescriptor(PrompterDescriptor):
     use_chat_completions: bool = True
     prompt_options: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.provider_options = _wrap_openai_options(self.provider_options)
+        self.prompt_options = _wrap_openai_options(self.prompt_options)
+
     def get_provider(self) -> str:
         return self.provider_name
 
@@ -391,6 +423,10 @@ class OpenAIPrompter:
     ):
         from openai import AsyncOpenAI
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        provider_options = unwrap_sensitive_options(provider_options)
+        options = unwrap_sensitive_options(options)
         self._model = model
         self._system_message = system_message
         self._return_format = return_format

--- a/vane/ai/providers/transformers.py
+++ b/vane/ai/providers/transformers.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 
+from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import TextClassifierDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
@@ -78,6 +79,9 @@ class TransformersTextEmbedderDescriptor(TextEmbedderDescriptor):
     dimensions: int | None = None
     embed_options: dict[str, Any] = field(default_factory=lambda: {"batch_size": 64})
 
+    def __post_init__(self) -> None:
+        self.embed_options = wrap_sensitive_options(self.embed_options)
+
     def get_provider(self) -> str:
         return "transformers"
 
@@ -100,6 +104,8 @@ class TransformersTextEmbedderDescriptor(TextEmbedderDescriptor):
                 config_options[name] = self.embed_options[name]
         if "cache_folder" in self.embed_options:
             config_options["cache_dir"] = self.embed_options["cache_folder"]
+        # Hub access is an execution boundary: restore the plaintext token.
+        config_options = unwrap_sensitive_options(config_options)
         hidden = AutoConfig.from_pretrained(self.model, **config_options).hidden_size
         return EmbeddingDimensions(size=hidden, dtype=pa.float32())
 
@@ -140,6 +146,9 @@ class TransformersTextEmbedder:
     ):
         from sentence_transformers import SentenceTransformer
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        model_options = unwrap_sensitive_options(model_options)
         trust_remote_code = model_options.pop("trust_remote_code", False) is True
         self.model = SentenceTransformer(
             model_name_or_path,
@@ -169,6 +178,9 @@ class TransformersTextClassifierDescriptor(TextClassifierDescriptor):
 
     model: str
     classify_options: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.classify_options = wrap_sensitive_options(self.classify_options)
 
     def get_provider(self) -> str:
         return "transformers"
@@ -208,6 +220,9 @@ class TransformersTextClassifier:
     def __init__(self, model_name: str, **options: Any):
         from transformers import pipeline
 
+        # Restore plaintext credentials sealed by the descriptor; plain dicts
+        # from direct callers pass through unchanged.
+        options = unwrap_sensitive_options(options)
         options["trust_remote_code"] = options.get("trust_remote_code") is True
         self.pipeline = pipeline(
             "zero-shot-classification",

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -45,6 +45,7 @@ import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import UDFOptions
@@ -134,6 +135,9 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
     return_format: Any | None = None
     vllm_options: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.vllm_options = wrap_sensitive_options(self.vllm_options)
+
     def get_provider(self) -> str:
         return self.provider_name
 
@@ -180,7 +184,11 @@ class VLLMPrompter:
         self._model = model
         self._system_message = system_message
         self._return_format = return_format
-        self._options = {k: v for k, v in dict(vllm_options or {}).items() if k not in {"actor_number"}}
+        # Deep-unwrap restores plaintext sealed by the descriptor (including
+        # nested engine_args/generate_args) before the engine sees the options;
+        # plain dicts from direct callers pass through unchanged.
+        options = unwrap_sensitive_options(vllm_options or {})
+        self._options = {k: v for k, v in options.items() if k not in {"actor_number"}}
         self._executor = None
 
         # Pre-compute JSON schema if return_format is set, so the executor


### PR DESCRIPTION
Fixes #105

## Design summary

- **`Secret` wrapper, sealed at descriptor construction.** Every provider descriptor (`openai`, `anthropic`, `google`, `transformers`, `vllm`) wraps sensitive-keyed values in all of its option mappings in `Secret` via `__post_init__` — including nested vLLM `engine_args`/`generate_args` and prompt/embed/classify options. `Secret` renders as a fixed placeholder (`**********`) in `repr`, `str`, logs, exception formatting, and assertion diffs; the wrapped value is retrievable only through an explicit `reveal()`.
- **Revealed only at provider execution.** Plaintext is restored via `unwrap_sensitive_options` exactly at the execution boundary: runtime `__init__` immediately before SDK client construction (OpenAI/Anthropic/Google), the OpenAI server-side dimension probe, the transformers hub-config fetch, and vLLM engine construction. Plain dicts from directly constructed runtime objects pass through unchanged.
- **One shared sensitive-key table drives BOTH layers.** The key table plus normalization/suffix matching moved out of `vane.ai._sql` into private `vane.ai._redaction`; the SQL binding's inline-credential rejection (layer 1) and the Python-path `Secret` sealing (layer 2) now share a single source of truth. SQL behavior is unchanged: inline credential fields are still rejected outright, with environment variables as the supported path.
- **Wide scope.** Matching applies at any nesting depth (mappings inside lists/tuples included); a container value under a sensitive key is sealed whole; wrapping is idempotent; `None` stays `None`.
- **Public `*ProviderOptions` repr redaction.** `OpenAIProviderOptions`, `AnthropicProviderOptions`, and `GoogleProviderOptions` render `api_key` as the placeholder via a shared repr mixin; field types, construction, `.api_key` reads, and equality are unchanged.
- **`Secret` is deliberately not exported** from the public `vane.ai` namespace; the module is private.

## Acceptance criteria mapping

| Issue criterion | Implementation | Tests |
| --- | --- | --- |
| Redact sensitive fields from repr, logs, metrics, serialization diagnostics, and user-facing exceptions | `Secret` placeholder rendering + descriptor `__post_init__` sealing in all five providers (`vane/ai/_redaction.py`, `vane/ai/providers/*.py`) | `tests/ai/test_descriptor_secret_redaction.py` (repr/str/logging/exception/pickle-diagnostic cases), `tests/fast/test_ai_redaction.py` |
| Keep the real value available only to the provider execution context | `unwrap_sensitive_options` at runtime `__init__` / dimension probe / hub fetch / engine construction only; `get_options()` keeps values wrapped | `tests/ai/test_descriptor_secret_redaction.py` (instantiate-unwrap cases), `tests/fast/test_transformers_provider_security.py` |
| Add tests for dataclass repr, nested dicts, exception messages, and logging | Dedicated suites covering each surface | `tests/ai/test_descriptor_secret_redaction.py` (64), `tests/fast/test_ai_redaction.py` (46, incl. nested wrap/unwrap) |
| Cover common key names and avoid logging whole provider option mappings | `SENSITIVE_OPTION_KEYS` (19 normalized names, casefold + non-alphanumeric-stripping suffix match); container values under sensitive keys sealed whole; public options repr redacts `api_key` | `tests/fast/test_ai_redaction.py` (key-table cases), `tests/fast/test_ai_options_repr.py` (36) |
| Document that SQL still rejects inline credentials | `vane/ai/_redaction.py` module docstring is the authoritative two-layer-defense description; `vane/ai/_sql.py` `_reject_inline_credentials` docstring cross-references it | Docs commit; SQL rejection behavior covered by existing `tests/ai/test_expression_ai_sql.py` in CI |

## E2E adaptation (owner-approved)

The dev machine cannot build the native engine (no macOS duckdb wheel; `import duckdb` fails), so the `vane.connect()`-based e2e suite cannot run locally. By owner decision (2026-07-21), real-provider verification instead ran at the **descriptor layer** against SiliconFlow's OpenAI-compatible endpoint — which exercises exactly the seal/unwrap path this PR changes: provider → sealed descriptor → pickle round-trip → `instantiate()` → real API calls. The engine-path unit tests run in CI.

Sanitized evidence (key read only from env; every repr/str/f-string was programmatically asserted to contain neither the key nor any 8+-char substring of it before and after pickling):

```
base_url=https://api.siliconflow.cn/v1
[PASS] embedder descriptor: repr/str/f-string contain no key material (full key + all 8-char substrings checked)
[PASS] embedder descriptor (after pickle round-trip): repr/str/f-string contain no key material
[PASS] server-side dimension probe: model=Qwen/Qwen3-Embedding-0.6B dimensions=1024 dtype=float
[PASS] embed_text: 2 embeddings, each shape (1024,), dtype=float32, L2 norms=[1.0, 1.0]
[PASS] prompter descriptor (Qwen/Qwen3.6-27B): repr/str/f-string contain no key material (incl. after pickle)
[PASS] prompt via Qwen/Qwen3.6-27B: response='OK'
== ALL REQUIRED CHECKS PASSED ==
```

- Embedding model `Qwen/Qwen3-Embedding-0.6B` is absent from the local dimension table, so `get_dimensions()` performed the real server-side probe (1024) with credentials unwrapped from a pickled, sealed descriptor.
- Prompt model `Qwen/Qwen3.6-27B` was accepted as-is (no substitution needed); response: `OK`.
- Bonus Anthropic-compatible path (`AnthropicProvider` against `https://api.siliconflow.cn/`): descriptor redaction and pickle round-trip passed, and the real call authenticated and returned a response — confirming the unwrap path — but response parsing failed non-blockingly because the served model emits a leading `ThinkingBlock`, which `AnthropicPrompter`'s text extraction does not handle. Pre-existing compat limitation unrelated to this PR; noted and moved on.

## Known boundaries / residuals (agreed scope)

1. **Provider-server-side echoes.** Keys echoed or truncated by the provider's own servers inside SDK error messages are out of scope; we cannot rewrite what a remote SDK/service embeds in its errors.
2. **Pickle payloads contain the plaintext.** Workers must authenticate, so `Secret` pickles its real value by design — an accepted prerequisite of worker distribution, documented on the class.
3. **pytest dataclass drill-down.** pytest's structural comparison of two dataclasses bypasses custom repr, so comparing two public `*ProviderOptions` objects with *differing* keys will show the raw `api_key` field values in the diff (equal-key comparisons never leak). Documented residual; the structural defense lives in the `Secret`-wrapped descriptor layer, where drill-down still shows only the placeholder.
4. **`organization` is sealed locally in the OpenAI provider.** It identifies the paying account and must not leak via repr, but it is not a generic credential, so it stays out of the shared table — which also drives SQL rejection semantics and must not start rejecting `organization` inline.

## Test summary

- 166 tests green locally under the local import harness (`-p vane_pkg_stub_plugin --noconftest`, needed because the native engine cannot be imported on this machine): `tests/fast/test_ai_redaction.py` 46, `tests/fast/test_ai_options_repr.py` 36, `tests/fast/test_transformers_provider_security.py` 3, `tests/ai/test_descriptor_secret_redaction.py` 64, `tests/ai/test_descriptors.py` 17.
- Full suite deferred to CI (engine-dependent paths).
- Lint/format clean: `ruff check` and `ruff format` pass (enforced by pre-commit on every commit in this branch).

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented (`CHANGELOG.md` `Unreleased > Security`; descriptor option mappings now hold wrapped secret values).
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered (this PR is that consideration; pickle-plaintext boundary documented above).
- [x] Native changes were compiled; Python-only changes passed relevant tests (Python-only; 166 tests locally, engine-dependent paths in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014az5eSZxzP2SBDyivvivCk
