### PR TITLE
test: fix extension require fixture discovery

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,27 +133,24 @@ def require():
         # Paths to search for extensions
 
         build = Path(__file__).parent.parent / "build"
-        extension = "extension/*/*.duckdb_extension"
-
         extension_search_patterns = [
-            build / "release" / extension,
-            build / "debug" / extension,
+            (build / "release", "extension/*/*.duckdb_extension"),
+            (build / "debug", "extension/*/*.duckdb_extension"),
         ]
 
         # DUCKDB_PYTHON_TEST_EXTENSION_PATH can be used to add a path for the extension test to search for extensions
         if "DUCKDB_PYTHON_TEST_EXTENSION_PATH" in os.environ:
-            env_extension_path = os.getenv("DUCKDB_PYTHON_TEST_EXTENSION_PATH")
-            env_extension_path = env_extension_path.rstrip("/")
-            extension_search_patterns.append(env_extension_path + "/*/*.duckdb_extension")
-            extension_search_patterns.append(env_extension_path + "/*.duckdb_extension")
+            env_extension_path = Path(os.environ["DUCKDB_PYTHON_TEST_EXTENSION_PATH"])
+            extension_search_patterns.append((env_extension_path, "*/*.duckdb_extension"))
+            extension_search_patterns.append((env_extension_path, "*.duckdb_extension"))
 
         extension_paths_found = []
-        for pattern in extension_search_patterns:
-            extension_paths_found.extend(list(Path(pattern).resolve().glob("*")))
+        for root, pattern in extension_search_patterns:
+            extension_paths_found.extend(root.resolve().glob(pattern))
 
         for path in extension_paths_found:
             print(path)
-            if path.endswith(extension_name + ".duckdb_extension"):
+            if path.name == extension_name + ".duckdb_extension":
                 conn = duckdb.connect(db_name, config={"allow_unsigned_extensions": "true"})
                 conn.execute(f"LOAD '{path}'")
                 return conn

--- a/tests/fast/test_extension_require_fixture.py
+++ b/tests/fast/test_extension_require_fixture.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import duckdb
+
+
+class RecordingConnection:
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, statement):
+        self.statements.append(statement)
+
+
+def test_require_loads_present_extension(require, tmp_path, monkeypatch):
+    extension_path = tmp_path / "custom" / "fixture_test.duckdb_extension"
+    extension_path.parent.mkdir()
+    extension_path.touch()
+    connection = RecordingConnection()
+    connect_calls = []
+
+    def connect(db_name, config):
+        connect_calls.append((db_name, config))
+        return connection
+
+    monkeypatch.setenv("DUCKDB_PYTHON_TEST_EXTENSION_PATH", str(tmp_path))
+    monkeypatch.setattr(duckdb, "connect", connect)
+
+    assert require("fixture_test", "fixture.db") is connection
+    assert connect_calls == [("fixture.db", {"allow_unsigned_extensions": "true"})]
+    assert connection.statements == [f"LOAD '{extension_path.resolve()}'"]
+
+
+def test_require_skips_only_when_extension_is_absent(require, tmp_path, monkeypatch):
+    unrelated_extension = tmp_path / "unrelated.duckdb_extension"
+    unrelated_extension.touch()
+    monkeypatch.setenv("DUCKDB_PYTHON_TEST_EXTENSION_PATH", str(tmp_path))
+
+    def unexpected_connect(*_args, **_kwargs):
+        pytest.fail("require should not connect without a matching extension")
+
+    monkeypatch.setattr(duckdb, "connect", unexpected_connect)
+
+    with pytest.raises(pytest.skip.Exception, match="could not load missing"):
+        require("missing")


### PR DESCRIPTION
## Summary

The extension `require` fixture builds `Path` objects containing wildcard
segments and then calls `glob("*")` from those paths. As a result, the intended
extension binaries are not discovered. When a path is found, the fixture also
calls the string-only `endswith` method on a `Path` object.

This separates each search directory from its relative glob pattern and expands
the pattern from a resolved directory root. Matching now uses `Path.name` to
select the exact `<extension>.duckdb_extension` binary.

Regression tests use a temporary extension directory to verify that a present
extension is loaded and that only a genuinely absent extension is skipped.

Fixes #71

## Validation

- Isolated fixture behavior check with a stub DuckDB module:
  - a nested temporary extension was discovered and loaded;
  - an unrelated extension did not prevent a missing extension from being
    skipped.
- `scripts/format root --changed`
- `pre-commit run ruff-format --files tests/fast/test_extension_require_fixture.py`
- `pre-commit run ruff-check --files tests/conftest.py tests/fast/test_extension_require_fixture.py`
- `.venv/bin/python -m py_compile tests/conftest.py tests/fast/test_extension_require_fixture.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/fast/test_extension_require_fixture.py`
  was attempted but could not start because the existing local `_duckdb`
  binary has an unrelated undefined C++ symbol. Rebuilding that local
  installation is currently blocked by the missing `bison` build prerequisite.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [ ] Native changes were compiled; Python-only changes passed relevant tests.
