### PR TITLE
[fix](udf) Skip null DuckDBPyType holders when sanitizing UDF annotations

### DIFF
--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -109,7 +109,9 @@ static string PicklePythonUDFCallable(const py::function &udf) {
 		py::dict sanitized_annotations;
 		for (auto item : py::reinterpret_borrow<py::dict>(original_annotations)) {
 			shared_ptr<DuckDBPyType> pytype;
-			if (py::try_cast<shared_ptr<DuckDBPyType>>(item.second, pytype)) {
+			// A None annotation (e.g. `-> None`) casts to a null shared_ptr; keep it verbatim
+			// instead of dereferencing it below.
+			if (py::try_cast<shared_ptr<DuckDBPyType>>(item.second, pytype) && pytype) {
 				sanitized_annotations[item.first] = py::str(pytype->ToString());
 				annotations_rewritten = true;
 			} else {


### PR DESCRIPTION
A `-> None` return annotation casts to a null shared_ptr<DuckDBPyType> (pybind11 maps None to a null holder while try_cast still returns true), so PicklePythonUDFCallable dereferenced it via pytype->ToString() and create_function raised "Attempted to dereference shared_ptr that is NULL!". Guard the rewrite with a null check so None annotations fall through to the passthrough branch that keeps the original object.

Fixes #37

## Summary

Describe the user-visible or architectural change and why it is needed.

## Validation

List the exact checks you ran. Include relevant hardware, dataset, runner, and
batch settings for performance changes.

## Checklist

- [ ] The change is focused and includes tests or a reason tests are unnecessary.
- [ ] Public behavior and compatibility impact are documented.
- [ ] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [ ] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [ ] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [ ] Native changes were compiled; Python-only changes passed relevant tests.
