### PR TITLE
[fix](ci) Cache only vcpkg binary archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,8 @@ jobs:
       - name: Restore vcpkg binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            .cache/vcpkg
-            .cache/vcpkg-archives
-          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: vcpkg-binary-v1-${{ runner.os }}-${{ runner.arch }}-x64-linux-${{ hashFiles('vcpkg.json') }}
 
       - name: Install pinned native dependencies
         run: bash scripts/bootstrap_vcpkg.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,10 +87,8 @@ jobs:
         if: matrix.language == 'c-cpp'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            .cache/vcpkg
-            .cache/vcpkg-archives
-          key: codeql-vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}
+          path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+          key: codeql-vcpkg-binary-v1-${{ runner.os }}-${{ runner.arch }}-x64-linux-${{ hashFiles('vcpkg.json') }}
 
       - name: Install pinned native dependencies
         if: matrix.language == 'c-cpp'


### PR DESCRIPTION
## Summary

The workflows previously cached the entire vcpkg checkout and build worktree together with the reusable binary archives, producing cache entries of roughly 4.5 GB and wasting cache storage and transfer time.

Cache only `VCPKG_DEFAULT_BINARY_CACHE`. Keep CI and CodeQL under separate versioned keys because their toolchains produce different vcpkg package ABIs.

## Validation

  - `scripts/format root --changed`
  - Pre-commit checks, including GitHub Workflow validation
  - `actionlint`
  - `git diff --check`
  - Verified that the CI Python matrix shares identical vcpkg ABIs while CodeQL remains isolated
  - Python and native tests were not run because this is a workflow-only change

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only changes passed relevant tests.
