### PR TITLE
[fix](vllm) Preserve SQL option intent and shared Ray lifecycle correctness

### DIFF
--- a/duckdb/execution/_vllm_options_protocol.py
+++ b/duckdb/execution/_vllm_options_protocol.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free wire contract for native vLLM option payloads.
+
+The native vLLM path crosses two otherwise separate layers:
+
+* ``vane.ai.providers.vllm`` builds the constant passed to DuckDB's native
+  ``vllm(prompt, model, options)`` expression.
+* ``duckdb.execution.vllm`` decodes that constant immediately before creating
+  a local vLLM executor or a Ray actor pool.
+
+Keeping the field names here gives both layers one protocol definition without
+making the execution layer import Vane's provider/planning classes.
+
+Secret-bearing options use a DuckDB STRUCT with this logical shape::
+
+    {
+        "__vane_vllm_payload_version": 1,
+        "__vane_vllm_public_options_json": '{"engine_args":{"hf_token":{"__vane_vllm_secret_ref":0}}}',
+        "__vane_vllm_secret_payload": b'{"payload_version":1,"values":["..."]}',
+    }
+
+The public JSON preserves the option tree but substitutes each sealed value
+with an integer reference into the secret payload. The secret payload is a BLOB
+so DuckDB does not render its contents as structured plan metadata. It contains
+strict JSON data, never pickle or executable Python objects.
+
+Options without sealed values keep the legacy plain-JSON argument, so this
+envelope does not change existing non-secret plans. During distributed planning,
+C++ may add ``use_ray``, ``ray_worker_only``, and ``ray_actor_pool_name`` beside
+the three envelope fields. Those are separately whitelisted execution-routing
+fields rather than part of the secret-reference protocol.
+
+``opaque`` does not mean encrypted: callers with access to raw serialized plan
+bytes can still recover the payload. This protocol prevents accidental exposure
+through EXPLAIN, repr, and ordinary structured logging; environment-based
+credentials remain the stronger choice when secrets must not enter a plan.
+
+Incompatible envelope or reference changes must increment
+``_NATIVE_OPTIONS_PAYLOAD_VERSION`` and retain an explicit decoder for any older
+version that must remain supported.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Version of both the outer envelope and its secret-values payload.
+_NATIVE_OPTIONS_PAYLOAD_VERSION = 1
+
+# Keys stored in the DuckDB STRUCT that crosses the native plan boundary.
+_NATIVE_OPTIONS_VERSION_KEY = "__vane_vllm_payload_version"
+_NATIVE_OPTIONS_PUBLIC_KEY = "__vane_vllm_public_options_json"
+_NATIVE_OPTIONS_SECRET_KEY = "__vane_vllm_secret_payload"
+
+# Required top-level fields that identify a value as an opaque options
+# envelope. Keeping the set here makes envelope detection and validation use
+# exactly the same schema as the encoder.
+_NATIVE_OPTIONS_ENVELOPE_KEYS = frozenset(
+    {
+        _NATIVE_OPTIONS_VERSION_KEY,
+        _NATIVE_OPTIONS_PUBLIC_KEY,
+        _NATIVE_OPTIONS_SECRET_KEY,
+    }
+)
+
+# Extra top-level fields that C++ distributed-plan collection may inject into
+# an existing envelope. They are non-secret execution-routing metadata. The
+# runtime validates them at the envelope boundary, then overlays them onto the
+# decoded public options before choosing Local versus Ray execution.
+_NATIVE_OPTIONS_DISTRIBUTED_ROUTING_KEYS = frozenset(
+    {
+        "use_ray",
+        "ray_worker_only",
+        "ray_actor_pool_name",
+    }
+)
+
+# Exact one-field marker used inside public JSON in place of a sealed value.
+_NATIVE_SECRET_REF_KEY = "__vane_vllm_secret_ref"
+
+# Required fields inside the strict-JSON secret BLOB. References in public JSON
+# index into the list stored under ``values``; the nested version is checked
+# independently so a future envelope can evolve its secret representation
+# without silently misreading old data.
+_NATIVE_SECRET_PAYLOAD_VERSION_KEY = "payload_version"
+_NATIVE_SECRET_PAYLOAD_VALUES_KEY = "values"
+_NATIVE_SECRET_PAYLOAD_KEYS = frozenset(
+    {
+        _NATIVE_SECRET_PAYLOAD_VERSION_KEY,
+        _NATIVE_SECRET_PAYLOAD_VALUES_KEY,
+    }
+)
+
+# Runtime-only key used after the envelope has been unpacked into normalized
+# options. It carries the still-opaque BLOB through validation and is removed
+# when secrets are restored at executor/actor creation. The encoder reserves
+# this name as well so user options cannot collide with runtime state.
+_NATIVE_OPTIONS_NORMALIZED_SECRET_KEY = "_vane_vllm_secret_payload"
+
+# Names that cannot be supplied as ordinary top-level/public options. This set
+# covers both the on-wire envelope fields and the transient normalized field;
+# secret-reference markers are rejected recursively by the encoder/decoder.
+_NATIVE_OPTIONS_RESERVED_KEYS = _NATIVE_OPTIONS_ENVELOPE_KEYS | {
+    _NATIVE_OPTIONS_NORMALIZED_SECRET_KEY,
+}
+
+
+def _dump_vllm_protocol_json(value: Any) -> str:
+    """Encode protocol data as compact UTF-8-compatible strict JSON.
+
+    ``allow_nan=False`` keeps the encoder consistent with the strict decoder:
+    non-finite values never cross the native plan boundary.
+    """
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _load_vllm_protocol_json(raw: str | bytes, label: str) -> Any:
+    """Decode untrusted protocol JSON without accepting ambiguous values.
+
+    The decoder rejects invalid UTF-8, non-finite numeric constants, and
+    duplicate object keys. ``label`` identifies the envelope component in the
+    stable public error while preserving the parser failure as its cause.
+    """
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"non-finite number {value!r}")
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        return json.loads(
+            text,
+            parse_constant=reject_constant,
+            object_pairs_hook=reject_duplicate_keys,
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"{label} could not be parsed as strict JSON") from exc
+
+
+def _unpack_native_options_envelope(options: dict[str, Any]) -> dict[str, Any]:
+    """Validate and unpack an opaque native-options envelope.
+
+    Secret values remain sealed in the normalized payload returned here. The
+    execution layer restores them only at the executor or actor creation
+    boundary.
+    """
+    if not _NATIVE_OPTIONS_ENVELOPE_KEYS.intersection(options):
+        return dict(options)
+
+    missing = _NATIVE_OPTIONS_ENVELOPE_KEYS.difference(options)
+    if missing:
+        raise ValueError(f"vllm native options envelope is missing fields: {', '.join(sorted(missing))}")
+    unexpected = set(options).difference(_NATIVE_OPTIONS_ENVELOPE_KEYS | _NATIVE_OPTIONS_DISTRIBUTED_ROUTING_KEYS)
+    if unexpected:
+        raise ValueError(f"vllm native options envelope has unexpected fields: {', '.join(sorted(unexpected))}")
+
+    version = options[_NATIVE_OPTIONS_VERSION_KEY]
+    if isinstance(version, bool) or not isinstance(version, int) or version != _NATIVE_OPTIONS_PAYLOAD_VERSION:
+        raise ValueError(f"unsupported vllm native options payload version: {version!r}")
+    public_options_json = options[_NATIVE_OPTIONS_PUBLIC_KEY]
+    if not isinstance(public_options_json, str):
+        raise TypeError("vllm native public options must be a JSON string")
+    secret_payload = options[_NATIVE_OPTIONS_SECRET_KEY]
+    if not isinstance(secret_payload, bytes):
+        raise TypeError("vllm native secret payload must be bytes")
+
+    public_options = _load_vllm_protocol_json(public_options_json, "vllm native public options")
+    if not isinstance(public_options, dict):
+        raise ValueError("vllm native public options JSON must decode to a dict")
+    reserved_public_keys = _NATIVE_OPTIONS_RESERVED_KEYS.intersection(public_options)
+    if reserved_public_keys:
+        raise ValueError("vllm native public options use reserved fields: " + ", ".join(sorted(reserved_public_keys)))
+    for key in _NATIVE_OPTIONS_DISTRIBUTED_ROUTING_KEYS:
+        if key in options:
+            public_options[key] = options[key]
+    public_options[_NATIVE_OPTIONS_NORMALIZED_SECRET_KEY] = secret_payload
+    return public_options

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -443,17 +443,21 @@ class LocalVLLMExecutor(VLLMExecutor):
         if len(prompts) != rows.num_rows:
             raise ValueError("Number of prompts and rows must match")
 
-        # Create per-executor deque on first submit from this executor.
-        if executor_id and executor_id not in self._per_executor_deques:
-            self._per_executor_deques[executor_id] = deque()
-            self._per_executor_request_ids[executor_id] = set()
-            self._per_executor_tasks[executor_id] = set()
-        if executor_id and (
-            executor_id in self._per_executor_finished
-            or executor_id in self._per_executor_aborted
-            or executor_id in self._per_executor_errors
-        ):
-            raise RuntimeError(f"vllm executor {executor_id} is already finished")
+        # Check terminal state before creating any per-executor containers so a
+        # submit that arrives after abort cannot recreate state behind the
+        # tombstone.
+        if executor_id:
+            with self.task_count_lock:
+                if (
+                    executor_id in self._per_executor_finished
+                    or executor_id in self._per_executor_aborted
+                    or executor_id in self._per_executor_errors
+                ):
+                    raise RuntimeError(f"vllm executor {executor_id} is already finished")
+                if executor_id not in self._per_executor_deques:
+                    self._per_executor_deques[executor_id] = deque()
+                    self._per_executor_request_ids[executor_id] = set()
+                    self._per_executor_tasks[executor_id] = set()
 
         if self._ray_actor_mode:
             # Engine is already ready from sync __init__; skip wait.
@@ -480,6 +484,14 @@ class LocalVLLMExecutor(VLLMExecutor):
             # Background-thread mode for non-Ray use.
             if not self.engine_ready.is_set():
                 await self._wait_for_engine_ready_async()
+            if executor_id:
+                with self.task_count_lock:
+                    if (
+                        executor_id in self._per_executor_finished
+                        or executor_id in self._per_executor_aborted
+                        or executor_id in self._per_executor_errors
+                    ):
+                        raise RuntimeError(f"vllm executor {executor_id} is already finished")
             if self.engine_error_message is not None:
                 if self.on_error == "raise":
                     raise RuntimeError(f"vllm engine init failed: {self.engine_error_message}")
@@ -618,8 +630,14 @@ class LocalVLLMExecutor(VLLMExecutor):
 
     async def abort_executor(self, executor_id: str, wait_expected: bool = False) -> None:
         """Abort requests and discard state owned by one remote executor."""
-        request_ids = set(self._per_executor_request_ids.get(executor_id, ()))
-        tasks = set(self._per_executor_tasks.get(executor_id, ()))
+        # Install the terminal tombstone before the first await. Ray async
+        # actors may start another method while this abort is suspended, and a
+        # late submit must be rejected instead of escaping the snapshots below.
+        with self.task_count_lock:
+            self._per_executor_aborted.add(executor_id)
+            self._per_executor_finished.discard(executor_id)
+            request_ids = set(self._per_executor_request_ids.get(executor_id, ()))
+            tasks = set(self._per_executor_tasks.get(executor_id, ()))
         abort = getattr(getattr(self, "llm", None), "abort", None) or getattr(
             getattr(self, "llm", None), "abort_request", None
         )
@@ -658,8 +676,6 @@ class LocalVLLMExecutor(VLLMExecutor):
             self._per_executor_request_ids.pop(executor_id, None)
             self._per_executor_tasks.pop(executor_id, None)
             self._per_executor_errors.pop(executor_id, None)
-            self._per_executor_aborted.add(executor_id)
-            self._per_executor_finished.discard(executor_id)
             if wait_expected:
                 self._per_executor_abort_wait_required.add(executor_id)
                 if self._per_executor_waiters.get(executor_id, 0) == 0:
@@ -1098,11 +1114,9 @@ class RemoteVLLMExecutor(VLLMExecutor):
         try:
             submit_ref.future().add_done_callback(lambda _future, _ref=submit_ref: self._queue_submit_ref_ready(_ref))
         except Exception as exc:
-            self._submit_refs.pop(submit_ref, None)
-            self._rollback_submitted_batch(actor_idx, count, reservation_id)
             self._record_error(TypeError(f"vllm submit ObjectRef does not support completion callbacks: {exc}"))
 
-    def _resolve_submit_ref(self, submit_ref: Any, *, control_rpc: bool = False) -> bool:
+    def _resolve_submit_ref(self, submit_ref: Any, *, control_rpc: bool = False) -> Exception | None:
         with self._result_cv:
             metadata = self._submit_refs.pop(submit_ref, None)
             try:
@@ -1110,7 +1124,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
             except ValueError:
                 pass
         if metadata is None:
-            return True
+            return None
         actor_idx, count, reservation_id = metadata
         resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
         try:
@@ -1120,9 +1134,17 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 self._rollback_submitted_batch(actor_idx, count, reservation_id)
             except Exception as rollback_error:
                 exc = RuntimeError(f"{exc}; reservation rollback failed: {rollback_error}")
-            self._record_error(exc)
-            return False
-        return True
+            return exc
+        return None
+
+    @staticmethod
+    def _submit_acknowledgement_error(errors: list[Exception]) -> Exception:
+        if len(errors) == 1:
+            return errors[0]
+        return RuntimeError(
+            "vllm remote submit acknowledgements failed: "
+            + "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+        )
 
     def _drain_queued_submit_refs(self) -> None:
         while True:
@@ -1130,19 +1152,23 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 if not self._ready_submit_refs:
                     return
                 submit_ref = self._ready_submit_refs.popleft()
-            if not self._resolve_submit_ref(submit_ref):
+            error = self._resolve_submit_ref(submit_ref)
+            if error is not None:
+                self._record_error(error)
                 return
 
-    def _await_pending_submit_refs(self) -> None:
+    def _await_pending_submit_refs(self) -> list[Exception]:
         """Establish actor-side submission order before sending completion."""
+        errors: list[Exception] = []
         while True:
             with self._result_cv:
                 pending = list(self._submit_refs)
             if not pending:
-                return
+                return errors
             for submit_ref in pending:
-                if not self._resolve_submit_ref(submit_ref, control_rpc=True):
-                    raise RuntimeError(f"vllm remote task failed: {self._error_message}")
+                error = self._resolve_submit_ref(submit_ref, control_rpc=True)
+                if error is not None:
+                    errors.append(error)
 
     def _rollback_submitted_batch(self, actor_idx: int, count: int, reservation_id: str) -> None:
         released = self._rollback_reservation(reservation_id, count)
@@ -1261,6 +1287,13 @@ class RemoteVLLMExecutor(VLLMExecutor):
         with self._lifecycle_lock:
             if self._finished and self._error_message is not None:
                 return
+            # A submit acknowledgement is the causal barrier before actor
+            # terminal RPCs. Consume every outstanding acknowledgement with
+            # its own control-RPC timeout, then perform one logical abort.
+            pending_submit_errors = self._await_pending_submit_refs()
+            if pending_submit_errors:
+                pending_error = self._submit_acknowledgement_error(pending_submit_errors)
+                exc = RuntimeError(f"{exc}; additionally, {pending_error}")
             cleanup_errors: list[Exception] = []
             try:
                 self._abort_actor_state()
@@ -1337,7 +1370,15 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 try:
                     decision = resolve_object_refs_blocking(route_once.remote(*args))
                 except Exception:
-                    decision = resolve_object_refs_blocking(route_once.remote(*args))
+                    try:
+                        decision = resolve_object_refs_blocking(route_once.remote(*args))
+                    except Exception as exc:
+                        # The router may have committed the idempotent
+                        # reservation even though both acknowledgements were
+                        # lost. Terminalize this executor so control-RPC
+                        # reconciliation can release any phantom reservation.
+                        self._record_error(exc)
+                        raise
             else:
                 decision = self._router_call("route_and_reserve", prefix, count, self._executor_id)
             if not isinstance(decision, dict):
@@ -1383,7 +1424,11 @@ class RemoteVLLMExecutor(VLLMExecutor):
             # terminal call can therefore overtake an earlier submit. Resolving
             # every submit acknowledgement is the causal barrier that guarantees
             # each actor has registered all work before it sees finished_executor.
-            self._await_pending_submit_refs()
+            submit_errors = self._await_pending_submit_refs()
+            if submit_errors:
+                submit_error = self._submit_acknowledgement_error(submit_errors)
+                self._record_error(submit_error)
+                raise RuntimeError(f"vllm remote task failed: {self._error_message}")
             errors: list[Exception] = []
             for actor_idx, actor in enumerate(self.llm_actors):
                 if actor_idx in self._finished_actor_indices:

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -4,29 +4,25 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import math
 import os
 import threading
 import time
+import uuid
+import warnings
 from abc import ABC, abstractmethod
-from collections import deque
+from collections import OrderedDict, deque
 from collections.abc import Mapping
+from decimal import Decimal
 from numbers import Integral, Real
-from typing import Any
+from typing import Any, Callable, overload
 
 import pyarrow as pa
 
 from duckdb.runners.ray.ray_env import build_session_runtime_env_vars, install_explicit_session_runtime_env
 from duckdb.runners.ray.safe_get import configured_ray_get_timeout_s, resolve_object_refs_blocking
-
-# ---------------------------------------------------------------------------
-# Shared inflight tracking across all RemoteVLLMExecutors on the same worker.
-# Keyed by pool_name so all executors sharing the same vLLM actor pool see the
-# TRUE global inflight per actor (not per-executor approximation).
-# ---------------------------------------------------------------------------
-_shared_inflight_lock = threading.Lock()
-_shared_inflight: dict[str, list[int]] = {}
 
 
 def _positive_float_env(name: str, default: float | None = None) -> float | None:
@@ -61,7 +57,7 @@ def _bounded_query_timeout_s(timeout_s: float | None) -> float | None:
 
 def _vllm_engine_init_timeout_s(value: Any | None = None) -> float | None:
     if value is not None:
-        if isinstance(value, bool) or not isinstance(value, Real):
+        if isinstance(value, bool) or not isinstance(value, (Real, Decimal)):
             raise ValueError("vllm engine_init_timeout_s must be a finite non-negative number")
         result = float(value)
         if not math.isfinite(result) or result < 0.0:
@@ -70,15 +66,87 @@ def _vllm_engine_init_timeout_s(value: Any | None = None) -> float | None:
     return _positive_float_env("VANE_VLLM_ENGINE_INIT_TIMEOUT_S")
 
 
-def _get_shared_inflight(pool_key: str, num_actors: int) -> list[int]:
-    """Return the shared inflight list for a pool, creating if needed."""
-    with _shared_inflight_lock:
-        if pool_key not in _shared_inflight:
-            _shared_inflight[pool_key] = [0] * num_actors
-        return _shared_inflight[pool_key]
+def _vllm_control_rpc_timeout_s() -> float:
+    default_timeout_s = 30.0
+    raw_value = os.getenv("VANE_VLLM_CONTROL_RPC_TIMEOUT_S")
+    if raw_value is None:
+        return default_timeout_s
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return default_timeout_s
+    if not math.isfinite(value) or value <= 0.0:
+        return default_timeout_s
+    return value
+
+
+def _resolve_vllm_control_ref(object_refs: Any) -> Any:
+    """Resolve terminal/control RPCs with a budget independent of the query."""
+    return resolve_object_refs_blocking(
+        object_refs,
+        timeout=_vllm_control_rpc_timeout_s(),
+        honor_query_deadline=False,
+    )
 
 
 class VLLMExecutor(ABC):
+    """Common execution contract shared by local and Ray-backed vLLM executors.
+
+    Besides the submit/result lifecycle, the base class owns a one-shot wakeup
+    protocol used by DuckDB's native scheduler.  A scheduler callback is armed
+    only while no result or terminal state is ready, then consumed by the next
+    relevant state change so a blocked pipeline task can be scheduled again.
+    """
+
+    def _ensure_wakeup_state(self) -> None:
+        """Lazily initialize callback state for subclasses and test doubles."""
+        if not hasattr(self, "_wakeup_lock"):
+            self._wakeup_lock = threading.Lock()
+        if not hasattr(self, "_wakeup_callbacks"):
+            self._wakeup_callbacks: list[Callable[[], None]] = []
+
+    def _wakeup_ready(self) -> bool:
+        """Return whether the native scheduler should resume without arming."""
+        return False
+
+    def register_wakeup_callback(self, callback: Callable[[], None]) -> bool:
+        """Arm a one-shot native wakeup unless work is already actionable.
+
+        True means the callback is stored and the scheduler may safely block;
+        False means it must immediately recheck results or terminal state.
+        """
+        if not callable(callback):
+            raise TypeError("vllm wakeup callback must be callable")
+        self._ensure_wakeup_state()
+        with self._wakeup_lock:
+            if self._wakeup_ready():
+                return False
+            self._wakeup_callbacks.append(callback)
+            return True
+
+    def _notify_state_change(self, *, force: bool = False) -> None:
+        """Wake condition waiters and consume actionable native callbacks.
+
+        Condition waiters are always notified.  Native callbacks are one-shot
+        and run only when `_wakeup_ready()` is true, unless `force` requests an
+        unconditional scheduler recheck after a state transition.
+        """
+        self._ensure_wakeup_state()
+        callbacks: list[Callable[[], None]] = []
+        with self._wakeup_lock:
+            if force or self._wakeup_ready():
+                callbacks = self._wakeup_callbacks
+                self._wakeup_callbacks = []
+        result_cv = getattr(self, "_result_cv", None)
+        if result_cv is not None:
+            with result_cv:
+                result_cv.notify_all()
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception:
+                pass
+
     @abstractmethod
     def submit(self, _prefix: str | None, prompts: list[str], rows: pa.Table) -> None:
         pass
@@ -168,7 +236,8 @@ class LocalVLLMExecutor(VLLMExecutor):
 
         # Condition variable for WaitForResult(): C++ blocks here until a
         # result is available.
-        self._result_cv = threading.Condition(threading.Lock())
+        self._result_cv = threading.Condition(threading.RLock())
+        self._ensure_wakeup_state()
 
         # Dedicated async Ray actors use their actor loop. Synchronous wrappers
         # hosted inside a generic Ray actor need their own background loop.
@@ -188,15 +257,26 @@ class LocalVLLMExecutor(VLLMExecutor):
         self._shutdown_called = False
         # Per-executor result deques: distributed executors submit/read with
         # a unique executor_id so results are never stolen across tasks.
-        self._per_executor_deques: dict[str, deque[tuple[str | None, pa.Table]]] = {}
+        self._per_executor_deques: dict[str, deque[tuple[Any, ...]]] = {}
         self._per_executor_running_task_count: dict[str, int] = {}
         self._per_executor_finished: set[str] = set()
+        self._per_executor_request_ids: dict[str, set[str]] = {}
+        self._per_executor_tasks: dict[str, set[Any]] = {}
+        self._per_executor_errors: dict[str, str] = {}
+        self._per_executor_aborted: set[str] = set()
+        self._per_executor_waiters: dict[str, int] = {}
+        self._per_executor_abort_wait_required: set[str] = set()
+        self._per_executor_terminal_wait_observed: set[str] = set()
+        self._async_waiter_lock = threading.Lock()
+        self._async_waiters: dict[str, list[tuple[Any, asyncio.Event]]] = {}
 
     @staticmethod
     def _detect_ray_actor() -> bool:
         try:
             import ray
 
+            if not ray.is_initialized():
+                return False
             ctx = ray.get_runtime_context()
             return ctx.get_actor_id() is not None
         except Exception:
@@ -253,12 +333,14 @@ class LocalVLLMExecutor(VLLMExecutor):
             self.loop.close()
             asyncio.set_event_loop(None)
 
-    async def _generate(self, prompt: str, row: pa.Table, executor_id: str | None = None) -> None:
-        # Route results to per-executor deque when executor_id is given,
-        # otherwise use the shared completed_tasks deque.
-        target_deque = (
-            self._per_executor_deques.get(executor_id, self.completed_tasks) if executor_id else self.completed_tasks
-        )
+    async def _generate(
+        self,
+        prompt: str,
+        row: pa.Table,
+        executor_id: str | None = None,
+        reservation_id: str | None = None,
+    ) -> None:
+        request_id: str | None = None
         try:
             if not self._ray_actor_mode and not self.engine_ready.is_set():
                 await self._wait_for_engine_ready_async()
@@ -267,52 +349,66 @@ class LocalVLLMExecutor(VLLMExecutor):
             if self.llm is None:
                 raise RuntimeError("vllm engine not initialized")
             with self.counter_lock:
-                request_id = self.counter
+                request_id = str(self.counter)
                 self.counter += 1
+            if executor_id:
+                with self.task_count_lock:
+                    self._per_executor_request_ids.setdefault(executor_id, set()).add(request_id)
 
             final_output = None
-            async for output in self.llm.generate(prompt, self.sampling_params, str(request_id), **self.generate_args):
+            async for output in self.llm.generate(prompt, self.sampling_params, request_id, **self.generate_args):
                 final_output = output
 
             if final_output is None or not final_output.outputs:
                 raise RuntimeError("vllm returned no outputs")
 
             output_text: str = final_output.outputs[0].text
-            target_deque.append((output_text, row))
-            with self._result_cv:
-                self._result_cv.notify_all()
+            if executor_id:
+                self._per_executor_deques.setdefault(executor_id, deque()).append((output_text, row, reservation_id))
+            else:
+                self.completed_tasks.append((output_text, row))
+            self._notify_state_change()
         except Exception as exc:
             if self.on_error == "raise":
-                with self.error_lock:
-                    if self.error_message is None:
-                        self.error_message = f"{type(exc).__name__}: {exc}"
-                with self._result_cv:
-                    self._result_cv.notify_all()
+                error_message = f"{type(exc).__name__}: {exc}"
+                if executor_id:
+                    with self.task_count_lock:
+                        self._per_executor_errors.setdefault(executor_id, error_message)
+                else:
+                    with self.error_lock:
+                        if self.error_message is None:
+                            self.error_message = error_message
+                self._notify_state_change(force=True)
             else:
-                target_deque.append((None, row))
-                with self._result_cv:
-                    self._result_cv.notify_all()
+                if executor_id:
+                    self._per_executor_deques.setdefault(executor_id, deque()).append((None, row, reservation_id))
+                else:
+                    self.completed_tasks.append((None, row))
+                self._notify_state_change()
         finally:
             with self.task_count_lock:
                 self.running_task_count -= 1
                 if executor_id:
+                    if request_id is not None:
+                        self._per_executor_request_ids.get(executor_id, set()).discard(request_id)
                     remaining = self._per_executor_running_task_count.get(executor_id, 0) - 1
                     self._per_executor_running_task_count[executor_id] = max(0, remaining)
-                if (self._finished_submitting and self.running_task_count == 0) or (
-                    executor_id and executor_id in self._per_executor_finished
-                ):
-                    with self._result_cv:
-                        self._result_cv.notify_all()
+            self._notify_state_change()
 
-    def _append_error_rows(self, rows: pa.Table, executor_id: str | None = None) -> None:
+    def _append_error_rows(
+        self,
+        rows: pa.Table,
+        executor_id: str | None = None,
+        reservation_id: str | None = None,
+    ) -> None:
         rows = _ensure_table(rows)
-        target_deque = (
-            self._per_executor_deques.get(executor_id, self.completed_tasks) if executor_id else self.completed_tasks
-        )
         for i in range(rows.num_rows):
-            target_deque.append((None, rows.slice(i, 1)))
-        with self._result_cv:
-            self._result_cv.notify_all()
+            row = rows.slice(i, 1)
+            if executor_id:
+                self._per_executor_deques.setdefault(executor_id, deque()).append((None, row, reservation_id))
+            else:
+                self.completed_tasks.append((None, row))
+        self._notify_state_change()
 
     def submit(self, _prefix: str | None, prompts: list[str], rows: pa.Table) -> None:
         rows = _ensure_table(rows)
@@ -334,8 +430,15 @@ class LocalVLLMExecutor(VLLMExecutor):
         for i, prompt in enumerate(prompts):
             row = rows.slice(i, 1)
             asyncio.run_coroutine_threadsafe(self._generate(prompt, row), self.loop)
+        self._notify_state_change(force=True)
 
-    async def submit_async(self, prompts: list[str], rows: pa.Table, executor_id: str | None = None) -> None:
+    async def submit_async(
+        self,
+        prompts: list[str],
+        rows: pa.Table,
+        executor_id: str | None = None,
+        reservation_id: str | None = None,
+    ) -> None:
         rows = _ensure_table(rows)
         if len(prompts) != rows.num_rows:
             raise ValueError("Number of prompts and rows must match")
@@ -343,7 +446,13 @@ class LocalVLLMExecutor(VLLMExecutor):
         # Create per-executor deque on first submit from this executor.
         if executor_id and executor_id not in self._per_executor_deques:
             self._per_executor_deques[executor_id] = deque()
-        if executor_id and executor_id in self._per_executor_finished:
+            self._per_executor_request_ids[executor_id] = set()
+            self._per_executor_tasks[executor_id] = set()
+        if executor_id and (
+            executor_id in self._per_executor_finished
+            or executor_id in self._per_executor_aborted
+            or executor_id in self._per_executor_errors
+        ):
             raise RuntimeError(f"vllm executor {executor_id} is already finished")
 
         if self._ray_actor_mode:
@@ -351,7 +460,7 @@ class LocalVLLMExecutor(VLLMExecutor):
             if self.engine_error_message is not None:
                 if self.on_error == "raise":
                     raise RuntimeError(f"vllm engine init failed: {self.engine_error_message}")
-                self._append_error_rows(rows, executor_id)
+                self._append_error_rows(rows, executor_id, reservation_id)
                 return
 
             with self.task_count_lock:
@@ -365,7 +474,8 @@ class LocalVLLMExecutor(VLLMExecutor):
                 row = rows.slice(i, 1)
                 # Run _generate on Ray's actor event loop (same loop as
                 # vLLM engine's async IPC — avoids cross-thread scheduling).
-                asyncio.create_task(self._generate(prompt, row, executor_id))
+                asyncio_task = asyncio.create_task(self._generate(prompt, row, executor_id, reservation_id))
+                self._track_executor_task(executor_id, asyncio_task)
         else:
             # Background-thread mode for non-Ray use.
             if not self.engine_ready.is_set():
@@ -373,7 +483,7 @@ class LocalVLLMExecutor(VLLMExecutor):
             if self.engine_error_message is not None:
                 if self.on_error == "raise":
                     raise RuntimeError(f"vllm engine init failed: {self.engine_error_message}")
-                self._append_error_rows(rows, executor_id)
+                self._append_error_rows(rows, executor_id, reservation_id)
                 return
 
             with self.task_count_lock:
@@ -389,26 +499,54 @@ class LocalVLLMExecutor(VLLMExecutor):
                 # current event loop (Ray's).  asyncio.Event is not thread-safe;
                 # _generate() awaits vLLM's internal Events that are set() by the
                 # output_handler running in self.loop.
-                asyncio.run_coroutine_threadsafe(self._generate(prompt, row, executor_id), self.loop)
+                thread_future = asyncio.run_coroutine_threadsafe(
+                    self._generate(prompt, row, executor_id, reservation_id), self.loop
+                )
+                self._track_executor_task(executor_id, thread_future)
+        self._notify_state_change(force=True)
 
-    def take_ready_result(self, executor_id: str | None = None) -> tuple[list[str | None], pa.Table] | None:
-        if self.error_message is not None and self.on_error == "raise":
-            raise RuntimeError(f"vllm task failed: {self.error_message}")
+    def _track_executor_task(self, executor_id: str | None, task: Any) -> None:
+        """Retain an executor task until its completion callback runs."""
+        if not executor_id:
+            return
+        tasks = self._per_executor_tasks.setdefault(executor_id, set())
+        tasks.add(task)
+
+        def discard(done: Any) -> None:
+            tasks.discard(done)
+
+        task.add_done_callback(discard)
+
+    @overload
+    def take_ready_result(self, executor_id: None = None) -> tuple[list[str | None], pa.Table] | None: ...
+
+    @overload
+    def take_ready_result(self, executor_id: str) -> tuple[list[str | None], pa.Table, str] | None: ...
+
+    def take_ready_result(self, executor_id: str | None = None) -> tuple[Any, ...] | None:
+        if self.on_error == "raise":
+            error_message = self._per_executor_errors.get(executor_id) if executor_id else self.error_message
+            if error_message is not None:
+                raise RuntimeError(f"vllm task failed: {error_message}")
 
         source_deque = (
-            self._per_executor_deques.get(executor_id, self.completed_tasks) if executor_id else self.completed_tasks
+            self._per_executor_deques.setdefault(executor_id, deque()) if executor_id else self.completed_tasks
         )
         try:
-            output, row = source_deque.popleft()
+            item = source_deque.popleft()
         except IndexError:
             return None
-
+        output, row, *extra = item
+        self._notify_state_change()
+        if executor_id:
+            if len(extra) != 1 or not isinstance(extra[0], str) or not extra[0]:
+                raise RuntimeError("vllm per-executor result must include a non-empty reservation_id")
+            return [output], row, extra[0]
         return [output], row
 
     def finished_submitting(self) -> None:
         self._finished_submitting = True
-        with self._result_cv:
-            self._result_cv.notify_all()
+        self._notify_state_change(force=True)
 
     def _engine_ready_wait_timeout_s(self) -> float | None:
         return _bounded_query_timeout_s(self.engine_init_timeout_s)
@@ -445,29 +583,137 @@ class LocalVLLMExecutor(VLLMExecutor):
 
     def finished_executor(self, executor_id: str) -> None:
         self._per_executor_finished.add(executor_id)
-        with self._result_cv:
-            self._result_cv.notify_all()
+        self._notify_state_change(force=True)
+
+    def release_executor(self, executor_id: str) -> bool:
+        """Drop terminal state after an executor drained or aborted."""
+        with self.task_count_lock:
+            if self._per_executor_waiters.get(executor_id, 0) > 0:
+                return False
+            if (
+                executor_id in self._per_executor_abort_wait_required
+                and executor_id not in self._per_executor_terminal_wait_observed
+            ):
+                return False
+            if self._per_executor_deques.get(executor_id):
+                return False
+            if self._per_executor_running_task_count.get(executor_id, 0) > 0:
+                return False
+            if self._per_executor_request_ids.get(executor_id):
+                return False
+            if self._per_executor_tasks.get(executor_id):
+                return False
+            self._per_executor_deques.pop(executor_id, None)
+            self._per_executor_running_task_count.pop(executor_id, None)
+            self._per_executor_request_ids.pop(executor_id, None)
+            self._per_executor_tasks.pop(executor_id, None)
+            self._per_executor_errors.pop(executor_id, None)
+            self._per_executor_aborted.discard(executor_id)
+            self._per_executor_waiters.pop(executor_id, None)
+            self._per_executor_abort_wait_required.discard(executor_id)
+            self._per_executor_terminal_wait_observed.discard(executor_id)
+            self._per_executor_finished.discard(executor_id)
+        self._notify_state_change(force=True)
+        return True
+
+    async def abort_executor(self, executor_id: str, wait_expected: bool = False) -> None:
+        """Abort requests and discard state owned by one remote executor."""
+        request_ids = set(self._per_executor_request_ids.get(executor_id, ()))
+        tasks = set(self._per_executor_tasks.get(executor_id, ()))
+        abort = getattr(getattr(self, "llm", None), "abort", None) or getattr(
+            getattr(self, "llm", None), "abort_request", None
+        )
+        errors: list[BaseException] = []
+        if abort is not None:
+            for request_id in request_ids:
+                try:
+                    result = abort(request_id)
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception as exc:
+                    errors.append(exc)
+        for task in tasks:
+            try:
+                task.cancel()
+            except Exception as exc:
+                errors.append(exc)
+        async_tasks = [task for task in tasks if isinstance(task, asyncio.Future)]
+        if async_tasks:
+            results = await asyncio.gather(*async_tasks, return_exceptions=True)
+            errors.extend(
+                result
+                for result in results
+                if isinstance(result, BaseException) and not isinstance(result, asyncio.CancelledError)
+            )
+        if errors:
+            raise RuntimeError(
+                f"vllm executor {executor_id} abort failed: "
+                + "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+            ) from errors[0]
+        with self.task_count_lock:
+            remaining = self._per_executor_running_task_count.pop(executor_id, 0)
+            if remaining:
+                self.running_task_count = max(0, self.running_task_count - remaining)
+            self._per_executor_deques.pop(executor_id, None)
+            self._per_executor_request_ids.pop(executor_id, None)
+            self._per_executor_tasks.pop(executor_id, None)
+            self._per_executor_errors.pop(executor_id, None)
+            self._per_executor_aborted.add(executor_id)
+            self._per_executor_finished.discard(executor_id)
+            if wait_expected:
+                self._per_executor_abort_wait_required.add(executor_id)
+                if self._per_executor_waiters.get(executor_id, 0) == 0:
+                    self._per_executor_terminal_wait_observed.add(executor_id)
+        self._notify_state_change(force=True)
+        if wait_expected:
+            deadline = time.monotonic() + _vllm_control_rpc_timeout_s()
+            while True:
+                with self.task_count_lock:
+                    acknowledged = (
+                        self._per_executor_waiters.get(executor_id, 0) == 0
+                        and executor_id in self._per_executor_terminal_wait_observed
+                    )
+                if acknowledged:
+                    break
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(f"vllm executor {executor_id} abort waiter did not acknowledge termination")
+                await asyncio.sleep(0.01)
 
     def all_tasks_finished(self) -> bool:
         with self.task_count_lock:
             return self._finished_submitting and self.running_task_count == 0 and len(self.completed_tasks) == 0
 
-    def _wait_for_result_blocking(self, executor_id: str | None = None) -> bool:
-        source_deque = (
-            self._per_executor_deques.get(executor_id, self.completed_tasks) if executor_id else self.completed_tasks
-        )
+    def _wakeup_ready(self) -> bool:
+        if self._shutdown_called or self.error_message is not None:
+            return True
+        if self.completed_tasks or any(bool(results) for results in self._per_executor_deques.values()):
+            return True
+        if self._per_executor_errors or self._per_executor_aborted:
+            return True
+        return self._finished_submitting and self.running_task_count == 0
 
-        def done() -> bool:
-            if executor_id:
-                return (
+    def _wait_for_result_blocking(self, executor_id: str | None = None) -> bool:
+        with self._result_cv:
+            self._result_cv.wait_for(lambda: any(self._wait_for_result_state(executor_id)))
+            return self._wait_for_result_state(executor_id)[0]
+
+    def _wait_for_result_state(self, executor_id: str | None) -> tuple[bool, bool]:
+        source_deque = (
+            self._per_executor_deques.setdefault(executor_id, deque()) if executor_id else self.completed_tasks
+        )
+        has_result = bool(source_deque)
+        if executor_id:
+            terminal = (
+                executor_id in self._per_executor_errors
+                or executor_id in self._per_executor_aborted
+                or (
                     executor_id in self._per_executor_finished
                     and self._per_executor_running_task_count.get(executor_id, 0) == 0
                 )
-            return self._finished_submitting and self.running_task_count == 0
-
-        with self._result_cv:
-            self._result_cv.wait_for(lambda: len(source_deque) > 0 or self.error_message is not None or done())
-            return len(source_deque) > 0
+            )
+        else:
+            terminal = self.error_message is not None or (self._finished_submitting and self.running_task_count == 0)
+        return has_result, terminal
 
     def wait_for_result(self, executor_id: str | None = None) -> bool:
         """Block until at least one result is available or all tasks are done."""
@@ -478,8 +724,7 @@ class LocalVLLMExecutor(VLLMExecutor):
             return
         self._shutdown_called = True
         self._finished_submitting = True
-        with self._result_cv:
-            self._result_cv.notify_all()
+        self._notify_state_change(force=True)
         loop = getattr(self, "loop", None)
         if loop is not None and loop.is_running():
             loop.call_soon_threadsafe(loop.stop)
@@ -510,59 +755,224 @@ class RayLocalVLLMExecutor(LocalVLLMExecutor):
             force_background_thread=force_background_thread,
         )
 
+    def _ensure_async_waiter_state(self) -> None:
+        if not hasattr(self, "_async_waiter_lock"):
+            self._async_waiter_lock = threading.Lock()
+        if not hasattr(self, "_async_waiters"):
+            self._async_waiters: dict[str, list[tuple[Any, asyncio.Event]]] = {}
+
+    def _notify_state_change(self, *, force: bool = False) -> None:
+        super()._notify_state_change(force=force)
+        self._ensure_async_waiter_state()
+        with self._async_waiter_lock:
+            waiters = [waiter for executor_waiters in self._async_waiters.values() for waiter in executor_waiters]
+        for loop, event in waiters:
+            try:
+                loop.call_soon_threadsafe(event.set)
+            except RuntimeError:
+                # The waiter removes itself during normal loop shutdown.
+                continue
+
     # Ray actor calls are awaitable, while the in-process executor exposes a blocking method.
     async def wait_for_result(self, executor_id: str | None = None) -> bool:  # type: ignore[override]
-        return await asyncio.to_thread(self._wait_for_result_blocking, executor_id)
+        if executor_id is None:
+            return await asyncio.to_thread(self._wait_for_result_blocking, None)
+        self._ensure_async_waiter_state()
+        loop = asyncio.get_running_loop()
+        state_changed = asyncio.Event()
+        waiter = (loop, state_changed)
+        with self._async_waiter_lock:
+            self._async_waiters.setdefault(executor_id, []).append(waiter)
+        with self.task_count_lock:
+            self._per_executor_waiters[executor_id] = self._per_executor_waiters.get(executor_id, 0) + 1
+        try:
+            while True:
+                has_result, terminal = self._wait_for_result_state(executor_id)
+                if has_result or terminal:
+                    return has_result
+                state_changed.clear()
+                has_result, terminal = self._wait_for_result_state(executor_id)
+                if has_result or terminal:
+                    continue
+                await state_changed.wait()
+        finally:
+            with self._async_waiter_lock:
+                executor_waiters = self._async_waiters.get(executor_id, [])
+                try:
+                    executor_waiters.remove(waiter)
+                except ValueError:
+                    pass
+                if not executor_waiters:
+                    self._async_waiters.pop(executor_id, None)
+            with self.task_count_lock:
+                remaining = self._per_executor_waiters.get(executor_id, 0) - 1
+                if remaining > 0:
+                    self._per_executor_waiters[executor_id] = remaining
+                else:
+                    self._per_executor_waiters.pop(executor_id, None)
+                if executor_id in self._per_executor_aborted:
+                    self._per_executor_terminal_wait_observed.add(executor_id)
+            self._notify_state_change(force=True)
 
 
 class RemoteVLLMExecutor(VLLMExecutor):
+    # Marks the short interval after reserving an actor's wait slot and before
+    # its Ray ObjectRef is installed. This sentinel is shared by all instances.
+    _WAIT_REF_INSTALLING = object()
+
     def __init__(self, llm_actors: LLMActors, pool_name: str | None = None):
+        # Keep the owner, rather than only its handles, so anonymous pools can
+        # release the actors they created while borrowed named pools remain alive.
+        self._actors_owner = llm_actors
         router_actor = llm_actors.router_actor
         if router_actor is None:
-            raise ValueError("RemoteVLLMExecutor requires a router actor")
+            raise ValueError("vllm remote executor requires a PrefixRouter actor")
         self.router_actor = router_actor
-        resolve_object_refs_blocking(self.router_actor.report_start.remote())
+        self.llm_actors = list(llm_actors.llm_actors)
+        if not self.llm_actors:
+            raise ValueError("vllm remote executor requires at least one actor")
 
-        self.llm_actors = llm_actors.llm_actors
-        self._result_cv = threading.Condition(threading.Lock())
+        # The ID is the isolation boundary for router reservations and all
+        # per-executor state stored inside the shared model actors.
+        self._executor_id = str(uuid.uuid4())
+        self._pool_key = pool_name or f"_anon_{id(llm_actors)}"
+        self._result_cv = threading.Condition(threading.RLock())
+        self._ensure_wakeup_state()
+        # Lifecycle operations may acquire the result condition, so callers
+        # must preserve the lifecycle-lock -> result-condition lock order.
+        self._lifecycle_lock = threading.RLock()
+        self._reservation_lock = threading.Lock()
+        # Reservation-mutating router RPCs remain serialized for exact local/
+        # remote accounting, without holding the local state lock over Ray I/O.
+        self._reservation_rpc_lock = threading.Lock()
+        self._inflight_lock = threading.Lock()
         self._finished = False
         self._finished_submitting_flag = False
-        self._submit_per_actor = [0] * len(self.llm_actors)
-        # Shared inflight tracking: all executors for the same pool see the
-        # true global inflight per actor, enabling accurate load-aware routing.
-        self._pool_key = pool_name or f"_anon_{id(llm_actors)}"
-        self._inflight_per_actor = _get_shared_inflight(self._pool_key, len(self.llm_actors))
-        self._inflight_lock = threading.Lock()
-
-        # Unique ID for per-executor result isolation on actors
-        import uuid
-
-        self._executor_id = str(uuid.uuid4())
-
-        self._result_buffer: deque[tuple[list[str | None], pa.Table]] = deque()
-        self._error_message: str | None = None
         self._shutdown_called = False
+        self._shutdown_complete = False
+        self._error_message: str | None = None
+        # Successful queries remain successful when best-effort terminal cleanup
+        # fails. Shutdown retries unfinished cleanup and surfaces persistent errors.
+        self._terminal_cleanup_errors: list[str] = []
+        self._terminal_cleanup_warning_emitted = False
+        # Actor-indexed counters distinguish dispatched prompts, consumed
+        # results, and the executor's local mirror of router reservations.
+        self._submit_per_actor = [0] * len(self.llm_actors)
         self._results_per_actor = [0] * len(self.llm_actors)
+        self._inflight_per_actor = [0] * len(self.llm_actors)
+        self._result_buffer: deque[tuple[list[str | None], pa.Table]] = deque()
+        # At most one wait ref is armed per actor. Completion callbacks only
+        # enqueue refs here; the executor thread resolves and re-arms them.
         self._wait_refs_by_actor: list[Any | None] = [None] * len(self.llm_actors)
-        self._submit_refs: dict[Any, tuple[int, int]] = {}
+        self._ready_wait_refs: deque[Any] = deque()
+        # Submit refs form the acknowledgement barrier before terminal RPCs;
+        # their metadata is also sufficient to roll back a failed submission.
+        self._submit_refs: dict[Any, tuple[int, int, str]] = {}
+        self._ready_submit_refs: deque[Any] = deque()
+        # Reservations track the remaining prompt count for exact release.
+        self._reservations: OrderedDict[str, dict[str, int]] = OrderedDict()
+        # Successful terminal RPCs are recorded so shutdown/error retries do
+        # not repeat actor or router transitions that already completed.
         self._released_outstanding_inflight = False
+        self._aborted_actor_indices: set[int] = set()
+        self._released_actor_indices: set[int] = set()
+        self._finished_actor_indices: set[int] = set()
+        self._router_completion_reported = False
+
+        try:
+            resolve_object_refs_blocking(self.router_actor.report_start.remote(self._executor_id))
+        except Exception:
+            cancel_start = getattr(self.router_actor, "cancel_executor_start", None)
+            if cancel_start is not None:
+                try:
+                    _resolve_vllm_control_ref(cancel_start.remote(self._executor_id))
+                except Exception:
+                    pass
+            raise
+
+    def _router_call(self, method_name: str, *args: Any, control_rpc: bool = False) -> Any:
+        method = getattr(self.router_actor, method_name, None)
+        if method is None:
+            raise TypeError(f"vllm PrefixRouter does not implement {method_name}")
+        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
+        return resolve(method.remote(*args))
+
+    def _router_release(
+        self,
+        method_name: str,
+        expected: int,
+        *args: Any,
+        operation_id: str,
+        allow_reconcile: bool = False,
+        control_rpc: bool = False,
+    ) -> int:
+        once_name = f"{method_name}_once"
+        method = getattr(self.router_actor, once_name, None)
+        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
+        if method is not None:
+            call_args = (*args, operation_id)
+            try:
+                result = resolve(method.remote(*call_args))
+            except Exception:
+                result = resolve(method.remote(*call_args))
+            if not isinstance(result, dict) or result.get("operation_id") != operation_id:
+                raise RuntimeError(f"vllm PrefixRouter.{once_name} returned an invalid operation result")
+            result = result.get("released")
+        else:
+            result = self._router_call(method_name, *args, control_rpc=control_rpc)
+        if isinstance(result, bool) or not isinstance(result, int):
+            raise RuntimeError(f"vllm PrefixRouter.{method_name} must return an integer release count")
+        if (allow_reconcile and result < 0) or (not allow_reconcile and result != expected):
+            raise RuntimeError(f"vllm PrefixRouter.{method_name} released {result} prompts; expected {expected}")
+        return result
 
     def _actor_has_pending_result(self, actor_idx: int) -> bool:
         return self._results_per_actor[actor_idx] < self._submit_per_actor[actor_idx]
 
+    def _queue_wait_ref_ready(self, ready_ref: Any) -> None:
+        with self._result_cv:
+            if self._shutdown_called or self._finished or ready_ref not in self._wait_refs_by_actor:
+                return
+            if ready_ref not in self._ready_wait_refs:
+                self._ready_wait_refs.append(ready_ref)
+        self._notify_state_change(force=True)
+
     def _ensure_wait_ref(self, actor_idx: int) -> None:
-        if self._wait_refs_by_actor[actor_idx] is not None:
-            return
-        if not self._actor_has_pending_result(actor_idx):
-            return
-        actor = self.llm_actors[actor_idx]
-        wait_ref = actor.wait_for_result.remote(self._executor_id)
-        self._wait_refs_by_actor[actor_idx] = wait_ref
+        with self._result_cv:
+            if self._wait_refs_by_actor[actor_idx] is not None or not self._actor_has_pending_result(actor_idx):
+                return
+            self._wait_refs_by_actor[actor_idx] = self._WAIT_REF_INSTALLING
         try:
-            wait_ref.future().add_done_callback(lambda _future, _ref=wait_ref: self._handle_wait_ref_ready(_ref))
+            wait_ref = self.llm_actors[actor_idx].wait_for_result.remote(self._executor_id)
         except Exception as exc:
-            self._wait_refs_by_actor[actor_idx] = None
+            with self._result_cv:
+                self._wait_refs_by_actor[actor_idx] = None
+            self._record_error(exc)
+            return
+        with self._result_cv:
+            if self._shutdown_called or self._finished:
+                install = False
+            else:
+                self._wait_refs_by_actor[actor_idx] = wait_ref
+                install = True
+        if not install:
+            self._cancel_refs([wait_ref])
+            return
+        try:
+            wait_ref.future().add_done_callback(lambda _future, _ref=wait_ref: self._queue_wait_ref_ready(_ref))
+        except Exception as exc:
+            with self._result_cv:
+                if self._wait_refs_by_actor[actor_idx] == wait_ref:
+                    self._wait_refs_by_actor[actor_idx] = None
             self._record_error(TypeError(f"vllm wait ObjectRef does not support completion callbacks: {exc}"))
+
+    def _ensure_remote_wait_refs(self) -> None:
+        for actor_idx in range(len(self.llm_actors)):
+            self._ensure_wait_ref(actor_idx)
+
+    def register_wakeup_callback(self, callback: Callable[[], None]) -> bool:
+        self._ensure_remote_wait_refs()
+        return super().register_wakeup_callback(callback)
 
     def _actor_index_for_wait_ref(self, ready_ref: Any) -> int:
         for actor_idx, ref in enumerate(self._wait_refs_by_actor):
@@ -570,139 +980,206 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 return actor_idx
         raise RuntimeError("vllm remote wait returned an unknown actor ref")
 
-    def _take_ready_wait_ref(self, ready_ref: Any) -> int | None:
-        with self._result_cv:
-            if self._shutdown_called or self._finished:
-                return None
-            actor_idx = self._actor_index_for_wait_ref(ready_ref)
-            return actor_idx
-
-    def _handle_wait_ref_ready(self, ready_ref: Any) -> None:
-        try:
-            actor_idx = self._take_ready_wait_ref(ready_ref)
-            if actor_idx is None:
+    def _drain_queued_wait_refs(self) -> None:
+        while True:
+            with self._result_cv:
+                if not self._ready_wait_refs:
+                    return
+                ready_ref = self._ready_wait_refs.popleft()
+            try:
+                actor_idx = self._actor_index_for_wait_ref(ready_ref)
+                ready = resolve_object_refs_blocking(ready_ref)
+                self._drain_ready_actor(actor_idx, bool(ready), ready_ref)
+            except Exception as exc:
+                self._record_error(exc)
                 return
-            ready = resolve_object_refs_blocking(ready_ref)
-            self._drain_ready_actor(actor_idx, ready, ready_ref)
-        except Exception as exc:
-            self._record_error(exc)
 
     def _drain_ready_actor(self, actor_idx: int, ready: bool, ready_ref: Any) -> None:
-        actor = self.llm_actors[actor_idx]
         if not ready:
-            if self._finished_submitting_flag:
-                if sum(self._results_per_actor) >= sum(self._submit_per_actor):
-                    self._mark_finished()
-                else:
-                    self._record_error(
-                        RuntimeError(
-                            "vllm actor finished without returning all submitted results: "
-                            f"actor_idx={actor_idx} submitted={self._submit_per_actor[actor_idx]} "
-                            f"received={self._results_per_actor[actor_idx]}"
-                        )
-                    )
+            if (
+                self._finished_submitting_flag
+                and self._results_per_actor[actor_idx] >= self._submit_per_actor[actor_idx]
+            ):
+                with self._result_cv:
+                    if self._wait_refs_by_actor[actor_idx] == ready_ref:
+                        self._wait_refs_by_actor[actor_idx] = None
                 return
-            raise RuntimeError("vllm actor wait completed without a result")
-
-        result = resolve_object_refs_blocking(actor.take_ready_result.remote(self._executor_id))
-        if result is None:
-            raise RuntimeError("vllm actor reported readiness but returned no result")
-
-        results_text, _ = result
-        n_results = len(results_text) if results_text else 0
-        with self._inflight_lock:
-            self._inflight_per_actor[actor_idx] -= n_results
-        self._results_per_actor[actor_idx] += n_results
+            raise RuntimeError(
+                "vllm actor finished without returning all submitted results: "
+                f"actor_idx={actor_idx} submitted={self._submit_per_actor[actor_idx]} "
+                f"received={self._results_per_actor[actor_idx]}"
+            )
+        result = resolve_object_refs_blocking(self.llm_actors[actor_idx].take_ready_result.remote(self._executor_id))
+        if not isinstance(result, tuple) or len(result) != 3:
+            raise RuntimeError("vllm actor result must be a 3-item tuple including reservation_id")
+        results_text, rows, reservation_id = result
+        if not isinstance(reservation_id, str) or not reservation_id:
+            raise RuntimeError("vllm actor result must include a non-empty reservation_id")
+        count = len(results_text) if results_text else 0
+        self._complete_reservation(reservation_id, count)
         with self._result_cv:
             if self._wait_refs_by_actor[actor_idx] == ready_ref:
                 self._wait_refs_by_actor[actor_idx] = None
-            self._result_buffer.append(result)
-            self._result_cv.notify_all()
+            self._results_per_actor[actor_idx] += count
+            self._result_buffer.append((results_text, rows))
+        # Actor waits are one-shot. Re-arm immediately after consuming a
+        # result so an already-buffered successor cannot be stranded without
+        # a completion callback while native backpressure is waiting.
+        self._ensure_wait_ref(actor_idx)
+        self._notify_state_change()
 
-    def _ensure_remote_wait_refs(self) -> None:
-        for actor_idx in range(len(self.llm_actors)):
-            self._ensure_wait_ref(actor_idx)
-        if not any(ref is not None for ref in self._wait_refs_by_actor) and self._finished_submitting_flag:
-            if sum(self._results_per_actor) >= sum(self._submit_per_actor):
-                self._mark_finished()
-
-    def _has_pending_wait_ref(self) -> bool:
-        return any(ref is not None for ref in self._wait_refs_by_actor)
-
-    def _rollback_submitted_actor_batch(self, actor_idx: int, prompt_count: int) -> None:
-        with self._inflight_lock:
-            self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - prompt_count)
-        with self._result_cv:
-            self._submit_per_actor[actor_idx] = max(0, self._submit_per_actor[actor_idx] - prompt_count)
-            self._result_cv.notify_all()
-
-    def _release_outstanding_inflight(self) -> None:
-        with self._inflight_lock:
-            if getattr(self, "_released_outstanding_inflight", False):
-                return
-            for actor_idx in range(len(self._inflight_per_actor)):
-                outstanding = max(0, self._submit_per_actor[actor_idx] - self._results_per_actor[actor_idx])
-                if outstanding:
-                    self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - outstanding)
-            self._released_outstanding_inflight = True
-
-    def _take_submit_ref(self, ready_ref: Any) -> tuple[int, int] | None:
-        with self._result_cv:
-            if self._shutdown_called or self._finished:
-                return None
-            return self._submit_refs.pop(ready_ref, None)
-
-    def _handle_submit_ref_ready(self, ready_ref: Any) -> None:
-        submit_meta = self._take_submit_ref(ready_ref)
-        if submit_meta is None:
+    def _complete_reservation(self, reservation_id: str | None, count: int) -> None:
+        if reservation_id is None or count <= 0:
             return
-        actor_idx, prompt_count = submit_meta
-        try:
-            resolve_object_refs_blocking(ready_ref)
-        except Exception as exc:
-            self._rollback_submitted_actor_batch(actor_idx, prompt_count)
-            self._record_error(exc)
+        reservation_id = str(reservation_id)
+        with self._reservation_rpc_lock:
+            with self._reservation_lock:
+                reservation = self._reservations.get(reservation_id)
+                if reservation is None:
+                    raise RuntimeError(f"vllm result references unknown reservation {reservation_id}")
+                released = min(count, reservation["remaining"])
+                remaining_before = reservation["remaining"]
+                actor_idx = reservation["actor_idx"]
+            self._router_release(
+                "complete",
+                released,
+                reservation_id,
+                released,
+                operation_id=f"{self._executor_id}:complete:{reservation_id}:{remaining_before}:{released}",
+            )
+            with self._reservation_lock:
+                current = self._reservations.get(reservation_id)
+                if current is not reservation or current["remaining"] != remaining_before:
+                    raise RuntimeError(f"vllm reservation {reservation_id} changed during completion")
+                reservation["remaining"] -= released
+                if reservation["remaining"] == 0:
+                    self._reservations.pop(reservation_id, None)
+            with self._inflight_lock:
+                self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - released)
 
-    def _track_submit_ref(self, submit_ref: Any, actor_idx: int, prompt_count: int) -> None:
+    def _rollback_reservation(self, reservation_id: str, count: int) -> int:
+        with self._reservation_rpc_lock:
+            with self._reservation_lock:
+                reservation = self._reservations.get(reservation_id)
+                if reservation is None:
+                    return 0
+                released = min(count, reservation["remaining"])
+                remaining_before = reservation["remaining"]
+                actor_idx = reservation["actor_idx"]
+            self._router_release(
+                "rollback",
+                released,
+                reservation_id,
+                released,
+                operation_id=f"{self._executor_id}:rollback:{reservation_id}:{remaining_before}:{released}",
+            )
+            with self._reservation_lock:
+                current = self._reservations.get(reservation_id)
+                if current is not reservation or current["remaining"] != remaining_before:
+                    raise RuntimeError(f"vllm reservation {reservation_id} changed during rollback")
+                reservation["remaining"] -= released
+                if reservation["remaining"] == 0:
+                    self._reservations.pop(reservation_id, None)
+            with self._inflight_lock:
+                self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - released)
+        return released
+
+    def _queue_submit_ref_ready(self, ready_ref: Any) -> None:
         with self._result_cv:
-            if self._shutdown_called or self._finished:
+            if self._shutdown_called or self._finished or ready_ref not in self._submit_refs:
                 return
-            self._submit_refs[submit_ref] = (actor_idx, prompt_count)
+            if ready_ref not in self._ready_submit_refs:
+                self._ready_submit_refs.append(ready_ref)
+        self._notify_state_change(force=True)
+
+    def _track_submit_ref(self, submit_ref: Any, actor_idx: int, count: int, reservation_id: str) -> None:
+        with self._result_cv:
+            self._submit_refs[submit_ref] = (actor_idx, count, reservation_id)
         try:
-            submit_ref.future().add_done_callback(lambda _future, _ref=submit_ref: self._handle_submit_ref_ready(_ref))
+            submit_ref.future().add_done_callback(lambda _future, _ref=submit_ref: self._queue_submit_ref_ready(_ref))
         except Exception as exc:
-            submit_meta = self._take_submit_ref(submit_ref)
-            if submit_meta is not None:
-                rollback_actor_idx, rollback_prompt_count = submit_meta
-                self._rollback_submitted_actor_batch(rollback_actor_idx, rollback_prompt_count)
+            self._submit_refs.pop(submit_ref, None)
+            self._rollback_submitted_batch(actor_idx, count, reservation_id)
             self._record_error(TypeError(f"vllm submit ObjectRef does not support completion callbacks: {exc}"))
 
-    def _record_error(self, exc: Exception) -> None:
-        self._release_outstanding_inflight()
-        self._cancel_remote_refs()
+    def _resolve_submit_ref(self, submit_ref: Any, *, control_rpc: bool = False) -> bool:
         with self._result_cv:
-            if self._error_message is None:
-                self._error_message = f"{type(exc).__name__}: {exc}"
-            self._finished = True
-            self._wait_refs_by_actor = [None] * len(self.llm_actors)
-            self._submit_refs.clear()
-            self._result_cv.notify_all()
+            metadata = self._submit_refs.pop(submit_ref, None)
+            try:
+                self._ready_submit_refs.remove(submit_ref)
+            except ValueError:
+                pass
+        if metadata is None:
+            return True
+        actor_idx, count, reservation_id = metadata
+        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
+        try:
+            resolve(submit_ref)
+        except Exception as exc:
+            try:
+                self._rollback_submitted_batch(actor_idx, count, reservation_id)
+            except Exception as rollback_error:
+                exc = RuntimeError(f"{exc}; reservation rollback failed: {rollback_error}")
+            self._record_error(exc)
+            return False
+        return True
 
-    def _mark_finished(self) -> None:
-        self._release_outstanding_inflight()
+    def _drain_queued_submit_refs(self) -> None:
+        while True:
+            with self._result_cv:
+                if not self._ready_submit_refs:
+                    return
+                submit_ref = self._ready_submit_refs.popleft()
+            if not self._resolve_submit_ref(submit_ref):
+                return
+
+    def _await_pending_submit_refs(self) -> None:
+        """Establish actor-side submission order before sending completion."""
+        while True:
+            with self._result_cv:
+                pending = list(self._submit_refs)
+            if not pending:
+                return
+            for submit_ref in pending:
+                if not self._resolve_submit_ref(submit_ref, control_rpc=True):
+                    raise RuntimeError(f"vllm remote task failed: {self._error_message}")
+
+    def _rollback_submitted_batch(self, actor_idx: int, count: int, reservation_id: str) -> None:
+        released = self._rollback_reservation(reservation_id, count)
         with self._result_cv:
-            self._finished = True
-            self._wait_refs_by_actor = [None] * len(self.llm_actors)
-            self._submit_refs.clear()
-            self._result_cv.notify_all()
+            self._submit_per_actor[actor_idx] = max(0, self._submit_per_actor[actor_idx] - released)
+        self._notify_state_change(force=True)
 
-    def _cancel_remote_refs(self) -> None:
-        refs = list(self._submit_refs)
-        refs.extend(ref for ref in self._wait_refs_by_actor if ref is not None)
+    def _release_outstanding_inflight(self) -> None:
+        with self._reservation_rpc_lock:
+            with self._reservation_lock:
+                if self._released_outstanding_inflight:
+                    return
+                expected = sum(reservation["remaining"] for reservation in self._reservations.values())
+            self._router_release(
+                "release_executor",
+                expected,
+                self._executor_id,
+                operation_id=f"{self._executor_id}:release:{expected}",
+                allow_reconcile=True,
+                control_rpc=True,
+            )
+            with self._reservation_lock:
+                self._reservations.clear()
+                self._released_outstanding_inflight = True
+            with self._inflight_lock:
+                self._inflight_per_actor = [0] * len(self.llm_actors)
+
+    def _cancel_refs(self, refs: list[Any]) -> None:
         if not refs:
             return
         try:
             import ray
+        except Exception:
+            return
+        try:
+            if not ray.is_initialized():
+                return
         except Exception:
             return
         for ref in refs:
@@ -711,139 +1188,544 @@ class RemoteVLLMExecutor(VLLMExecutor):
             except Exception:
                 pass
 
-    def submit(self, _prefix: str | None, prompts: list[str], rows: pa.Table) -> None:
-        if self._shutdown_called:
-            raise RuntimeError("vllm remote executor is shut down")
-        prompt_count = len(prompts)
-        # Route to actor with lowest actual inflight (adapts to processing speed)
-        with self._inflight_lock:
-            route_to = min(range(len(self.llm_actors)), key=lambda i: self._inflight_per_actor[i])
-            self._inflight_per_actor[route_to] += prompt_count
+    def _cancel_remote_refs(self) -> None:
+        refs = list(self._submit_refs)
+        refs.extend(ref for ref in self._wait_refs_by_actor if ref is not None and ref is not self._WAIT_REF_INSTALLING)
+        self._cancel_refs(refs)
 
+    def _abort_actor_state(self) -> None:
+        errors: list[Exception] = []
+        for actor_idx, actor in enumerate(self.llm_actors):
+            if actor_idx in self._aborted_actor_indices:
+                continue
+            method = getattr(actor, "abort_executor", None)
+            if method is None:
+                errors.append(RuntimeError(f"vllm actor {actor_idx} does not implement abort_executor"))
+                continue
+            try:
+                wait_ref = self._wait_refs_by_actor[actor_idx]
+                wait_expected = wait_ref is not None and wait_ref is not self._WAIT_REF_INSTALLING
+                _resolve_vllm_control_ref(method.remote(self._executor_id, wait_expected))
+                self._aborted_actor_indices.add(actor_idx)
+            except Exception as exc:
+                errors.append(RuntimeError(f"actor {actor_idx}: {exc}"))
+        if errors:
+            raise RuntimeError("vllm remote abort failed: " + "; ".join(str(error) for error in errors))
+
+    def _release_actor_state(self) -> None:
+        errors: list[Exception] = []
+        for actor_idx, actor in enumerate(self.llm_actors):
+            if actor_idx in self._released_actor_indices:
+                continue
+            method = getattr(actor, "release_executor", None)
+            if method is None:
+                errors.append(RuntimeError(f"vllm actor {actor_idx} does not implement release_executor"))
+                continue
+            try:
+                if _resolve_vllm_control_ref(method.remote(self._executor_id)) is not True:
+                    raise RuntimeError("release_executor did not confirm release")
+                self._released_actor_indices.add(actor_idx)
+            except Exception as exc:
+                errors.append(RuntimeError(f"actor {actor_idx}: {exc}"))
+        if errors:
+            raise RuntimeError("vllm remote actor-state release failed: " + "; ".join(str(error) for error in errors))
+
+    def _report_router_completion(self) -> None:
+        if self._router_completion_reported:
+            return
+        _resolve_vllm_control_ref(self.router_actor.report_completion.remote(self._executor_id))
+        self._router_completion_reported = True
+
+    def _defer_terminal_cleanup(self, errors: list[str]) -> None:
+        if not errors:
+            return
+        for error in errors:
+            if error not in self._terminal_cleanup_errors:
+                self._terminal_cleanup_errors.append(error)
+        if self._terminal_cleanup_warning_emitted:
+            return
+        self._terminal_cleanup_warning_emitted = True
         try:
-            submit_ref = self.llm_actors[route_to].submit_async.remote(prompts, rows, self._executor_id)
+            warnings.warn(
+                "vllm query completed successfully but terminal cleanup remains incomplete and will be retried: "
+                + "; ".join(errors),
+                RuntimeWarning,
+                stacklevel=3,
+            )
         except Exception:
-            with self._inflight_lock:
-                self._inflight_per_actor[route_to] = max(0, self._inflight_per_actor[route_to] - prompt_count)
-            raise
+            # Warning filters may promote RuntimeWarning to an exception; cleanup
+            # diagnostics must never turn an otherwise successful query into failure.
+            pass
 
-        self._submit_per_actor[route_to] += prompt_count
-        self._track_submit_ref(submit_ref, route_to, prompt_count)
+    def _record_error(self, exc: Exception) -> None:
+        with self._lifecycle_lock:
+            if self._finished and self._error_message is not None:
+                return
+            cleanup_errors: list[Exception] = []
+            try:
+                self._abort_actor_state()
+            except Exception as cleanup_error:
+                cleanup_errors.append(cleanup_error)
+            try:
+                self._report_router_completion()
+            except Exception as cleanup_error:
+                cleanup_errors.append(cleanup_error)
+            try:
+                self._release_outstanding_inflight()
+            except Exception as cleanup_error:
+                cleanup_errors.append(cleanup_error)
+            self._cancel_remote_refs()
+            with self._result_cv:
+                self._error_message = self._error_message or f"{type(exc).__name__}: {exc}"
+                if cleanup_errors:
+                    self._error_message += "; cleanup failed: " + "; ".join(str(error) for error in cleanup_errors)
+                self._finished = True
+                self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._submit_refs.clear()
+                self._ready_wait_refs.clear()
+                self._ready_submit_refs.clear()
+            self._notify_state_change(force=True)
+
+    def _mark_finished(self) -> None:
+        with self._lifecycle_lock:
+            if self._finished:
+                return
+            cleanup_errors: list[str] = []
+            try:
+                self._release_outstanding_inflight()
+            except Exception as exc:
+                cleanup_errors.append(f"router reservation release: {exc}")
+            try:
+                self._release_actor_state()
+            except Exception as exc:
+                cleanup_errors.append(f"actor state release: {exc}")
+            self._defer_terminal_cleanup(cleanup_errors)
+            with self._result_cv:
+                self._finished = True
+                self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._submit_refs.clear()
+                self._ready_wait_refs.clear()
+                self._ready_submit_refs.clear()
+            self._notify_state_change(force=True)
+
+    def _wakeup_ready(self) -> bool:
+        return bool(
+            self._result_buffer
+            or self._ready_wait_refs
+            or self._ready_submit_refs
+            or self._error_message is not None
+            or self._finished
+            or self._shutdown_called
+        )
+
+    def submit(self, prefix: str | None, prompts: list[str], rows: pa.Table) -> None:
+        with self._lifecycle_lock:
+            if self._shutdown_called or self._finished or self._finished_submitting_flag:
+                raise RuntimeError("vllm remote executor no longer accepts submissions")
+            if self._error_message is not None:
+                raise RuntimeError(f"vllm remote task failed: {self._error_message}")
+            rows = _ensure_table(rows)
+            count = len(prompts)
+            if count != rows.num_rows:
+                raise ValueError("Number of prompts and rows must match")
+            if count == 0:
+                return
+            operation_id = f"{self._executor_id}:route:{uuid.uuid4()}"
+            route_once = getattr(self.router_actor, "route_and_reserve_once", None)
+            if route_once is not None:
+                args = (prefix, count, self._executor_id, operation_id)
+                try:
+                    decision = resolve_object_refs_blocking(route_once.remote(*args))
+                except Exception:
+                    decision = resolve_object_refs_blocking(route_once.remote(*args))
+            else:
+                decision = self._router_call("route_and_reserve", prefix, count, self._executor_id)
+            if not isinstance(decision, dict):
+                raise RuntimeError("vllm PrefixRouter.route_and_reserve must return a dict")
+            actor_idx = int(decision.get("actor_idx", -1))
+            reservation_id = str(decision.get("reservation_id") or "")
+            if actor_idx < 0 or actor_idx >= len(self.llm_actors) or not reservation_id:
+                raise RuntimeError("vllm PrefixRouter returned an invalid reservation")
+            with self._reservation_lock:
+                self._reservations[reservation_id] = {"actor_idx": actor_idx, "remaining": count}
+            with self._inflight_lock:
+                self._inflight_per_actor[actor_idx] += count
+            try:
+                submit_ref = self.llm_actors[actor_idx].submit_async.remote(
+                    prompts, rows, self._executor_id, reservation_id
+                )
+            except Exception:
+                self._rollback_reservation(reservation_id, count)
+                raise
+            with self._result_cv:
+                self._submit_per_actor[actor_idx] += count
+            self._track_submit_ref(submit_ref, actor_idx, count, reservation_id)
+            self._ensure_remote_wait_refs()
+            self._notify_state_change(force=True)
 
     def take_ready_result(self) -> tuple[list[str | None], pa.Table] | None:
+        self._drain_queued_submit_refs()
+        self._drain_queued_wait_refs()
         if self._error_message is not None:
             raise RuntimeError(f"vllm remote task failed: {self._error_message}")
         try:
-            return self._result_buffer.popleft()
+            result = self._result_buffer.popleft()
         except IndexError:
             return None
+        self._notify_state_change()
+        return result
 
     def finished_submitting(self) -> None:
-        if self._finished_submitting_flag:
-            return
-        self._finished_submitting_flag = True
-        errors: list[Exception] = []
-        for actor in self.llm_actors:
-            try:
-                resolve_object_refs_blocking(actor.finished_executor.remote(self._executor_id))
-            except Exception as exc:
-                errors.append(exc)
-        try:
-            resolve_object_refs_blocking(self.router_actor.report_completion.remote())
-        except Exception as exc:
-            errors.append(exc)
-        if errors:
-            if len(errors) == 1:
-                raise RuntimeError(f"vllm remote finished_submitting failed: {errors[0]}") from errors[0]
-            message = "; ".join(str(error) for error in errors)
-            raise RuntimeError(f"vllm remote finished_submitting failed: {message}") from errors[0]
+        with self._lifecycle_lock:
+            if self._finished_submitting_flag and self._router_completion_reported:
+                return
+            # Ray async actors do not guarantee actor-call execution order. A
+            # terminal call can therefore overtake an earlier submit. Resolving
+            # every submit acknowledgement is the causal barrier that guarantees
+            # each actor has registered all work before it sees finished_executor.
+            self._await_pending_submit_refs()
+            errors: list[Exception] = []
+            for actor_idx, actor in enumerate(self.llm_actors):
+                if actor_idx in self._finished_actor_indices:
+                    continue
+                try:
+                    _resolve_vllm_control_ref(actor.finished_executor.remote(self._executor_id))
+                    self._finished_actor_indices.add(actor_idx)
+                except Exception as exc:
+                    errors.append(RuntimeError(f"actor {actor_idx}: {exc}"))
+            if not self._router_completion_reported:
+                try:
+                    self._report_router_completion()
+                except Exception as exc:
+                    errors.append(RuntimeError(f"router: {exc}"))
+            if errors:
+                raise RuntimeError(
+                    "vllm remote finished_submitting failed: " + "; ".join(str(error) for error in errors)
+                )
+            self._finished_submitting_flag = True
+            self._notify_state_change(force=True)
 
     def all_tasks_finished(self) -> bool:
+        self._drain_queued_submit_refs()
+        self._drain_queued_wait_refs()
         if self._result_buffer:
             return False
         if self._error_message is not None:
             raise RuntimeError(f"vllm remote task failed: {self._error_message}")
         if not self._finished_submitting_flag:
             return False
-        # Per-task completion: received at least as many results as submitted
-        total_submitted = sum(self._submit_per_actor)
-        total_received = sum(self._results_per_actor)
-        if total_submitted == 0:
-            self._mark_finished()
-            return True
-        if total_submitted > 0 and total_received >= total_submitted:
+        if sum(self._results_per_actor) >= sum(self._submit_per_actor):
             self._mark_finished()
             return True
         return False
 
     def wait_for_result(self) -> None:
-        """Block until a result is available in the buffer."""
         if self._error_message is not None:
             raise RuntimeError(f"vllm remote task failed: {self._error_message}")
-        if self._result_buffer or self._finished:
-            return
         try:
-            self._ensure_remote_wait_refs()
-            with self._result_cv:
-                if (
-                    not self._result_buffer
-                    and self._error_message is None
-                    and not self._finished
-                    and not self._has_pending_wait_ref()
-                ):
-                    raise RuntimeError("vllm remote wait has no pending actor wait refs before completion")
-                timeout_s = configured_ray_get_timeout_s()
-                ready = self._result_cv.wait_for(
-                    lambda: bool(self._result_buffer) or self._error_message is not None or self._finished,
-                    timeout=timeout_s,
-                )
-                if not ready:
-                    raise RuntimeError("vllm remote wait exceeded query deadline")
+            while not self._result_buffer and self._error_message is None and not self._finished:
+                self._drain_queued_submit_refs()
+                self._drain_queued_wait_refs()
+                if self._result_buffer or self._error_message is not None or self._finished:
+                    break
+                self._ensure_remote_wait_refs()
+                should_mark_finished = False
+                with self._result_cv:
+                    pending = any(ref is not None for ref in self._wait_refs_by_actor)
+                    if not pending and self._finished_submitting_flag:
+                        if sum(self._results_per_actor) >= sum(self._submit_per_actor):
+                            should_mark_finished = True
+                        else:
+                            raise RuntimeError("vllm remote wait has no pending actor wait refs before completion")
+                    if not should_mark_finished:
+                        ready = self._result_cv.wait_for(
+                            lambda: (
+                                bool(self._result_buffer)
+                                or bool(self._ready_submit_refs)
+                                or bool(self._ready_wait_refs)
+                                or self._error_message is not None
+                                or self._finished
+                            ),
+                            timeout=configured_ray_get_timeout_s(),
+                        )
+                        if not ready:
+                            raise RuntimeError("vllm remote wait exceeded query deadline")
+                if should_mark_finished:
+                    self._mark_finished()
+                    break
         except Exception as exc:
             self._record_error(exc)
         if self._error_message is not None:
             raise RuntimeError(f"vllm remote task failed: {self._error_message}")
 
     def shutdown(self) -> None:
-        if self._shutdown_called:
-            return
-        self._shutdown_called = True
-        completion_error: Exception | None = None
-        try:
-            if not self._finished_submitting_flag:
-                self.finished_submitting()
-        except Exception as exc:
-            completion_error = exc
-        finally:
-            self._mark_finished()
-        if completion_error is not None:
-            raise completion_error
+        with self._lifecycle_lock:
+            if self._shutdown_complete:
+                return
+            completed_successfully = (
+                self._finished
+                and self._error_message is None
+                and self._finished_submitting_flag
+                and sum(self._results_per_actor) >= sum(self._submit_per_actor)
+            )
+            self._shutdown_called = True
+            errors: list[Exception] = []
+            try:
+                if not self._finished_submitting_flag:
+                    self.finished_submitting()
+            except Exception as exc:
+                errors.append(exc)
+            if sum(self._results_per_actor) < sum(self._submit_per_actor):
+                try:
+                    self._abort_actor_state()
+                except Exception as exc:
+                    errors.append(exc)
+            try:
+                self._report_router_completion()
+            except Exception as exc:
+                errors.append(exc)
+            try:
+                self._release_outstanding_inflight()
+            except Exception as exc:
+                errors.append(exc)
+            try:
+                self._release_actor_state()
+            except Exception as exc:
+                errors.append(exc)
+            self._cancel_remote_refs()
+            with self._result_cv:
+                self._finished = True
+                self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._submit_refs.clear()
+                self._ready_wait_refs.clear()
+                self._ready_submit_refs.clear()
+            try:
+                self._actors_owner.shutdown()
+            except Exception as exc:
+                errors.append(exc)
+            self._shutdown_complete = not errors
+            if errors and completed_successfully:
+                self._defer_terminal_cleanup([f"shutdown cleanup: {error}" for error in errors])
+            self._notify_state_change(force=True)
+            if errors and not completed_successfully:
+                raise RuntimeError("vllm remote shutdown incomplete: " + "; ".join(str(error) for error in errors))
 
 
 class PrefixRouter:
     def __init__(
         self,
         llm_actors: list[Any],
-        _load_balance_threshold: int,
-        _max_recent_prefixes: int = 8,
+        load_balance_threshold: int,
+        max_recent_prefixes: int = 8,
         *,
         _install_session_runtime_env: bool = False,
     ):
         if _install_session_runtime_env:
             install_explicit_session_runtime_env()
+        if not llm_actors:
+            raise ValueError("vllm PrefixRouter requires at least one actor")
         self.llm_actors = llm_actors
-        self.unfinished_actors = 0
+        self.load_balance_threshold = int(load_balance_threshold)
+        self.max_recent_prefixes = max(1, int(max_recent_prefixes))
+        # This is the authoritative cross-executor reserved-prompt count used
+        # for routing; worker-local mirrors must not influence actor selection.
+        self.inflight = [0] * len(llm_actors)
+        # Prefix affinity is a bounded LRU map so sticky routing cannot retain
+        # an unbounded set of prompt prefixes.
+        self._prefix_affinity: OrderedDict[str, int] = OrderedDict()
+        # Each reservation belongs to one executor and actor, and records the
+        # count still requiring completion or rollback.
+        self._reservations: dict[str, dict[str, Any]] = {}
+        self._active_executors: set[str] = set()
+        # Completed IDs are retained as bounded tombstones, making duplicate
+        # completion idempotent while rejecting accidental ID reuse.
+        self._completed_executors: OrderedDict[str, None] = OrderedDict()
+        # Operation-ID caches replay the original result for retried route and
+        # release RPCs, providing exact-once state mutation over at-least-once calls.
+        self._route_operations: OrderedDict[str, tuple[tuple[Any, ...], dict[str, Any]]] = OrderedDict()
+        self._release_operations: OrderedDict[str, tuple[tuple[Any, ...], int]] = OrderedDict()
+        # All routing, reservation, lifecycle, and idempotency state above is
+        # mutated under one lock so decisions observe one coherent snapshot.
+        self._lock = threading.Lock()
 
-    def report_start(self) -> None:
-        self.unfinished_actors += 1
+    @staticmethod
+    def _trim(mapping: OrderedDict[Any, Any], limit: int) -> None:
+        while len(mapping) > limit:
+            mapping.popitem(last=False)
 
-    def report_completion(self) -> None:
-        if self.unfinished_actors <= 0:
-            raise RuntimeError("vllm router received completion without a matching start")
-        self.unfinished_actors -= 1
-        if self.unfinished_actors == 0:
-            for actor in self.llm_actors:
-                resolve_object_refs_blocking(actor.finished_submitting.remote())
+    def report_start(self, executor_id: str) -> bool:
+        executor_id = str(executor_id)
+        with self._lock:
+            if executor_id in self._active_executors:
+                return False
+            if executor_id in self._completed_executors:
+                raise RuntimeError("vllm router executor was already completed")
+            self._active_executors.add(executor_id)
+            return True
+
+    def cancel_executor_start(self, executor_id: str) -> bool:
+        with self._lock:
+            executor_id = str(executor_id)
+            existed = executor_id in self._active_executors
+            self._active_executors.discard(executor_id)
+            return existed
+
+    def report_completion(self, executor_id: str) -> bool:
+        executor_id = str(executor_id)
+        with self._lock:
+            if executor_id in self._completed_executors:
+                self._completed_executors.move_to_end(executor_id)
+                return False
+            if executor_id not in self._active_executors:
+                raise RuntimeError("vllm router received completion without a matching start")
+            self._active_executors.remove(executor_id)
+            self._completed_executors[executor_id] = None
+            self._trim(self._completed_executors, 4096)
+            return True
+
+    def _route_and_reserve_locked(self, prefix: str | None, prompt_count: Any, executor_id: str) -> dict[str, Any]:
+        executor_id = str(executor_id)
+        if executor_id not in self._active_executors:
+            raise RuntimeError("vllm router executor is not active")
+        if isinstance(prompt_count, bool) or not isinstance(prompt_count, Integral) or prompt_count <= 0:
+            raise ValueError("vllm prompt_count must be a positive integer")
+        prefix = None if prefix is None else str(prefix)
+        min_actor = min(range(len(self.inflight)), key=self.inflight.__getitem__)
+        if prefix is None:
+            actor_idx = min_actor
+            reason = "no_prefix"
+        elif prefix not in self._prefix_affinity:
+            actor_idx = min_actor
+            reason = "initial"
+            self._prefix_affinity[prefix] = actor_idx
+        else:
+            actor_idx = self._prefix_affinity[prefix]
+            if self.inflight[actor_idx] <= self.inflight[min_actor] + self.load_balance_threshold:
+                reason = "sticky"
+            else:
+                actor_idx = min_actor
+                reason = "load_balance"
+                self._prefix_affinity[prefix] = actor_idx
+            self._prefix_affinity.move_to_end(prefix)
+        self._trim(self._prefix_affinity, self.max_recent_prefixes)
+        reservation_id = str(uuid.uuid4())
+        count = int(prompt_count)
+        self.inflight[actor_idx] += count
+        self._reservations[reservation_id] = {
+            "actor_idx": actor_idx,
+            "remaining": count,
+            "executor_id": executor_id,
+        }
+        return {
+            "reservation_id": reservation_id,
+            "actor_idx": actor_idx,
+            "route_reason": reason,
+            "prompt_count": count,
+        }
+
+    def route_and_reserve(self, prefix: str | None, prompt_count: int, executor_id: str) -> dict[str, Any]:
+        with self._lock:
+            return self._route_and_reserve_locked(prefix, prompt_count, executor_id)
+
+    def route_and_reserve_once(
+        self,
+        prefix: str | None,
+        prompt_count: int,
+        executor_id: str,
+        operation_id: str,
+    ) -> dict[str, Any]:
+        token = str(operation_id)
+        if not token:
+            raise ValueError("vllm route operation_id must not be empty")
+        signature = (None if prefix is None else str(prefix), int(prompt_count), str(executor_id))
+        with self._lock:
+            previous = self._route_operations.get(token)
+            if previous is not None:
+                if previous[0] != signature:
+                    raise RuntimeError("vllm route operation_id was reused with different arguments")
+                self._route_operations.move_to_end(token)
+                return {**previous[1], "operation_id": token, "replayed": True}
+            decision = self._route_and_reserve_locked(prefix, prompt_count, executor_id)
+            self._route_operations[token] = (signature, dict(decision))
+            self._trim(self._route_operations, 8192)
+            return {**decision, "operation_id": token, "replayed": False}
+
+    def _release_locked(self, reservation_id: str, count: int | None) -> int:
+        reservation = self._reservations.get(str(reservation_id))
+        if reservation is None:
+            return 0
+        remaining = int(reservation["remaining"])
+        release_count = remaining if count is None else min(remaining, max(0, int(count)))
+        if release_count <= 0:
+            return 0
+        actor_idx = int(reservation["actor_idx"])
+        reservation["remaining"] = remaining - release_count
+        self.inflight[actor_idx] = max(0, self.inflight[actor_idx] - release_count)
+        if reservation["remaining"] == 0:
+            self._reservations.pop(str(reservation_id), None)
+        return release_count
+
+    def complete(self, reservation_id: str, count: int) -> int:
+        with self._lock:
+            return self._release_locked(reservation_id, count)
+
+    def rollback(self, reservation_id: str, count: int | None = None) -> int:
+        with self._lock:
+            return self._release_locked(reservation_id, count)
+
+    def _release_once(
+        self,
+        operation_id: str,
+        signature: tuple[Any, ...],
+        release: Callable[[], int],
+    ) -> dict[str, Any]:
+        token = str(operation_id)
+        if not token:
+            raise ValueError("vllm terminal operation_id must not be empty")
+        previous = self._release_operations.get(token)
+        if previous is not None:
+            if previous[0] != signature:
+                raise RuntimeError("vllm terminal operation_id was reused with different arguments")
+            self._release_operations.move_to_end(token)
+            return {"operation_id": token, "released": previous[1], "replayed": True}
+        released = release()
+        self._release_operations[token] = (signature, released)
+        self._trim(self._release_operations, 8192)
+        return {"operation_id": token, "released": released, "replayed": False}
+
+    def complete_once(self, reservation_id: str, count: int, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            signature = ("complete", str(reservation_id), int(count))
+            return self._release_once(operation_id, signature, lambda: self._release_locked(reservation_id, count))
+
+    def rollback_once(self, reservation_id: str, count: int, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            signature = ("rollback", str(reservation_id), int(count))
+            return self._release_once(operation_id, signature, lambda: self._release_locked(reservation_id, count))
+
+    def release_executor(self, executor_id: str) -> int:
+        with self._lock:
+            executor_id = str(executor_id)
+            reservation_ids = [
+                reservation_id
+                for reservation_id, reservation in self._reservations.items()
+                if reservation["executor_id"] == executor_id
+            ]
+            return sum(self._release_locked(reservation_id, None) for reservation_id in reservation_ids)
+
+    def release_executor_once(self, executor_id: str, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            executor_id = str(executor_id)
+
+            def release() -> int:
+                reservation_ids = [
+                    reservation_id
+                    for reservation_id, reservation in self._reservations.items()
+                    if reservation["executor_id"] == executor_id
+                ]
+                return sum(self._release_locked(reservation_id, None) for reservation_id in reservation_ids)
+
+            return self._release_once(operation_id, ("release_executor", executor_id), release)
 
 
 class _OwnedLLMActorPoolsError(RuntimeError):
@@ -877,6 +1759,8 @@ class LLMActors:
     ):
         import ray
 
+        self.owned = True
+        self._shutdown_complete = False
         LocalVLLMExecutorActor = ray.remote(num_gpus=gpus_per_actor, max_restarts=4)(RayLocalVLLMExecutor)
         PrefixRouterActor = ray.remote(PrefixRouter)
         normalized_session_config = (
@@ -936,35 +1820,66 @@ class LLMActors:
                 ) from creation_error
             raise
 
+    @staticmethod
+    def _kill_handles(
+        ray_module: Any,
+        llm_actors: list[Any],
+        router_actor: Any | None,
+    ) -> tuple[list[Any], Any | None, list[str]]:
+        remaining_actors: list[Any] = []
+        remaining_router = router_actor
+        errors: list[str] = []
+        handles = []
+        if router_actor is not None:
+            handles.append(("router", router_actor))
+        handles.extend(("actor", actor) for actor in llm_actors)
+        for kind, handle in handles:
+            try:
+                try:
+                    ray_module.kill(handle, no_restart=True)
+                except TypeError:
+                    ray_module.kill(handle)
+            except Exception as exc:
+                errors.append(f"{kind} kill failed: {type(exc).__name__}: {exc}")
+                if kind == "actor":
+                    remaining_actors.append(handle)
+                else:
+                    remaining_router = handle
+            else:
+                if kind == "router":
+                    remaining_router = None
+        return remaining_actors, remaining_router, errors
+
     @classmethod
-    def _from_handles(cls, llm_actors: list[Any], router_actor: Any) -> LLMActors:
+    def _from_handles(
+        cls,
+        llm_actors: list[Any],
+        router_actor: Any,
+        *,
+        owned: bool = True,
+    ) -> LLMActors:
         instance = cls.__new__(cls)
         instance.llm_actors = llm_actors
         instance.router_actor = router_actor
+        instance.owned = owned
+        instance._shutdown_complete = False
         return instance
 
     def shutdown(self) -> None:
+        """Release actors owned by this handle exactly once."""
+        if self._shutdown_complete:
+            return
+        if not self.owned:
+            self._shutdown_complete = True
+            return
         import ray
 
-        errors: list[str] = []
-        if self.router_actor is not None:
-            try:
-                ray.kill(self.router_actor, no_restart=True)
-            except BaseException as exc:
-                errors.append(f"router: {type(exc).__name__}: {exc}")
-            else:
-                self.router_actor = None
-
-        remaining_llm_actors: list[Any] = []
-        for actor_index, actor in enumerate(self.llm_actors):
-            try:
-                ray.kill(actor, no_restart=True)
-            except BaseException as exc:
-                errors.append(f"llm-{actor_index}: {type(exc).__name__}: {exc}")
-                remaining_llm_actors.append(actor)
-        self.llm_actors = remaining_llm_actors
+        remaining_actors, remaining_router, errors = self._kill_handles(ray, self.llm_actors, self.router_actor)
+        self.llm_actors = remaining_actors
+        self.router_actor = remaining_router
+        self._shutdown_complete = not remaining_actors and remaining_router is None
         if errors:
-            raise RuntimeError("failed to shut down vLLM actor pool: " + "; ".join(errors))
+            raise RuntimeError("vLLM pool shutdown incomplete: " + "; ".join(errors))
 
     @classmethod
     def get_or_create_named(
@@ -1055,7 +1970,7 @@ class LLMActors:
             raise RuntimeError(
                 f"Named vLLM actor pool '{name_prefix}' is incomplete; missing actors: {', '.join(missing)}"
             )
-        return cls._from_handles(llm_actors, router_actor)
+        return cls._from_handles(llm_actors, router_actor, owned=False)
 
 
 _DEFAULTS: dict[str, Any] = {
@@ -1087,8 +2002,14 @@ def _integer_option(name: str, value: Any, *, minimum: int) -> int:
     return result
 
 
+def _boolean_option(name: str, value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"vllm {name} must be a boolean")
+    return value
+
+
 def _fractional_gpu_option(value: Any) -> int | float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, bool) or not isinstance(value, (Real, Decimal)):
         raise ValueError("vllm gpus_per_actor must be a finite positive number")
     result = float(value)
     if not math.isfinite(result) or result <= 0:
@@ -1101,7 +2022,7 @@ def _fractional_gpu_option(value: Any) -> int | float:
 
 
 def _unit_interval_option(name: str, value: Any) -> float:
-    if isinstance(value, bool) or not isinstance(value, Real):
+    if isinstance(value, bool) or not isinstance(value, (Real, Decimal)):
         raise ValueError(f"vllm {name} must be a finite number in [0, 1]")
     result = float(value)
     if not math.isfinite(result) or not 0.0 <= result <= 1.0:
@@ -1132,8 +2053,16 @@ def normalize_options(options: Any | None) -> dict[str, Any]:
         merged.update(options)
     merged["concurrency"] = _integer_option("concurrency", merged["concurrency"], minimum=1)
     merged["gpus_per_actor"] = _fractional_gpu_option(merged["gpus_per_actor"])
-    if not isinstance(merged["do_prefix_routing"], bool):
-        raise ValueError("vllm do_prefix_routing must be a boolean")
+    for name in (
+        "do_prefix_routing",
+        "use_ray",
+        "use_threading",
+        "require_ray_worker",
+        "ray_worker_only",
+        "_force_background_thread",
+    ):
+        if name in merged:
+            merged[name] = _boolean_option(name, merged[name])
     merged["max_buffer_size"] = _integer_option("max_buffer_size", merged["max_buffer_size"], minimum=0)
     merged["min_bucket_size"] = _integer_option("min_bucket_size", merged["min_bucket_size"], minimum=0)
     merged["prefix_match_threshold"] = _unit_interval_option("prefix_match_threshold", merged["prefix_match_threshold"])
@@ -1284,14 +2213,13 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
     generate_args = dict(opts["generate_args"])
     pool_name = opts.get("ray_actor_pool_name")
     on_error = opts.get("on_error", "raise")
-    require_ray_worker = bool(opts.get("require_ray_worker") or opts.get("ray_worker_only"))
+    require_ray_worker = opts.get("require_ray_worker", False) or opts.get("ray_worker_only", False)
     if require_ray_worker and not _is_ray_worker():
         raise RuntimeError("vllm executor must be constructed on a Ray worker when require_ray_worker is set")
 
     # `use_ray` is the only routing switch. Pool/address metadata only
     # configures Ray-backed execution after it has been explicitly selected.
-    use_ray = bool(opts.get("use_ray"))
-    if use_ray:
+    if opts["use_ray"]:
         import ray
 
         if not ray.is_initialized():
@@ -1312,14 +2240,18 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
                 load_balance_threshold=opts["load_balance_threshold"],
                 engine_init_timeout_s=opts["engine_init_timeout_s"],
             )
-        return RemoteVLLMExecutor(llm_actors, pool_name=pool_name)
+        try:
+            return RemoteVLLMExecutor(llm_actors, pool_name=pool_name)
+        except Exception:
+            llm_actors.shutdown()
+            raise
 
     return LocalVLLMExecutor(
         model,
         engine_args,
         generate_args,
         on_error=on_error,
-        use_threading=bool(opts.get("use_threading", True)),
+        use_threading=opts["use_threading"],
         engine_init_timeout_s=opts["engine_init_timeout_s"],
-        force_background_thread=bool(opts.get("_force_background_thread", False)),
+        force_background_thread=opts.get("_force_background_thread", False),
     )

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -99,6 +99,39 @@ def _resolve_vllm_control_ref(object_refs: Any) -> Any:
     )
 
 
+def _attach_vllm_cleanup_failure(
+    primary_error: BaseException,
+    operation: str,
+    cleanup_error: BaseException,
+) -> None:
+    """Expose secondary cleanup evidence without replacing the primary error."""
+    try:
+        detail = f"{operation} failed: {type(cleanup_error).__name__}: {cleanup_error}"
+    except BaseException:
+        detail = f"{operation} failed with an unprintable {type(cleanup_error).__name__}"
+    try:
+        cleanup_failures = getattr(primary_error, "_vane_cleanup_failures", None)
+        if cleanup_failures is None:
+            cleanup_failures = []
+            setattr(primary_error, "_vane_cleanup_failures", cleanup_failures)
+        cleanup_failures.append(detail)
+    except BaseException:
+        pass
+
+    add_note = getattr(primary_error, "add_note", None)
+    if callable(add_note):
+        try:
+            add_note(detail)
+            return
+        except BaseException:
+            pass
+    try:
+        warnings.warn(detail, RuntimeWarning, stacklevel=3)
+    except BaseException:
+        # Warning filters must not replace the primary construction failure.
+        pass
+
+
 class VLLMExecutor(ABC):
     """Common execution contract shared by local and Ray-backed vLLM executors.
 
@@ -275,8 +308,11 @@ class LocalVLLMExecutor(VLLMExecutor):
         self._per_executor_errors: dict[str, str] = {}
         self._per_executor_aborted: set[str] = set()
         self._per_executor_waiters: dict[str, int] = {}
-        self._per_executor_abort_wait_required: set[str] = set()
-        self._per_executor_terminal_wait_observed: set[str] = set()
+        # A Ray async actor may execute abort/release before an earlier wait RPC
+        # starts. Tokens distinguish that not-yet-started wait from a previously
+        # completed wait for the same executor.
+        self._per_executor_wait_tokens_observed: dict[str, str] = {}
+        self._per_executor_abort_wait_tokens: dict[str, str] = {}
         self._async_waiter_lock = threading.Lock()
         self._async_waiters: dict[str, list[tuple[Any, asyncio.Event]]] = {}
 
@@ -612,9 +648,10 @@ class LocalVLLMExecutor(VLLMExecutor):
         with self.task_count_lock:
             if self._per_executor_waiters.get(executor_id, 0) > 0:
                 return False
+            expected_wait_token = self._per_executor_abort_wait_tokens.get(executor_id)
             if (
-                executor_id in self._per_executor_abort_wait_required
-                and executor_id not in self._per_executor_terminal_wait_observed
+                expected_wait_token is not None
+                and self._per_executor_wait_tokens_observed.get(executor_id) != expected_wait_token
             ):
                 return False
             if self._per_executor_deques.get(executor_id):
@@ -632,20 +669,24 @@ class LocalVLLMExecutor(VLLMExecutor):
             self._per_executor_errors.pop(executor_id, None)
             self._per_executor_aborted.discard(executor_id)
             self._per_executor_waiters.pop(executor_id, None)
-            self._per_executor_abort_wait_required.discard(executor_id)
-            self._per_executor_terminal_wait_observed.discard(executor_id)
+            self._per_executor_wait_tokens_observed.pop(executor_id, None)
+            self._per_executor_abort_wait_tokens.pop(executor_id, None)
             self._per_executor_finished.discard(executor_id)
         self._notify_state_change(force=True)
         return True
 
-    async def abort_executor(self, executor_id: str, wait_expected: bool = False) -> None:
+    async def abort_executor(self, executor_id: str, wait_token: str | None = None) -> None:
         """Abort requests and discard state owned by one remote executor."""
+        if wait_token is not None and (not isinstance(wait_token, str) or not wait_token):
+            raise ValueError("vllm abort wait_token must be a non-empty string")
         # Install the terminal tombstone before the first await. Ray async
         # actors may start another method while this abort is suspended, and a
         # late submit must be rejected instead of escaping the snapshots below.
         with self.task_count_lock:
             self._per_executor_aborted.add(executor_id)
             self._per_executor_finished.discard(executor_id)
+            if wait_token is not None:
+                self._per_executor_abort_wait_tokens[executor_id] = wait_token
             request_ids = set(self._per_executor_request_ids.get(executor_id, ()))
             tasks = set(self._per_executor_tasks.get(executor_id, ()))
         abort = getattr(getattr(self, "llm", None), "abort", None) or getattr(
@@ -686,23 +727,21 @@ class LocalVLLMExecutor(VLLMExecutor):
             self._per_executor_request_ids.pop(executor_id, None)
             self._per_executor_tasks.pop(executor_id, None)
             self._per_executor_errors.pop(executor_id, None)
-            if wait_expected:
-                self._per_executor_abort_wait_required.add(executor_id)
-                if self._per_executor_waiters.get(executor_id, 0) == 0:
-                    self._per_executor_terminal_wait_observed.add(executor_id)
         self._notify_state_change(force=True)
-        if wait_expected:
+        if wait_token is not None:
             deadline = time.monotonic() + _vllm_control_rpc_timeout_s()
             while True:
                 with self.task_count_lock:
                     acknowledged = (
                         self._per_executor_waiters.get(executor_id, 0) == 0
-                        and executor_id in self._per_executor_terminal_wait_observed
+                        and self._per_executor_wait_tokens_observed.get(executor_id) == wait_token
                     )
                 if acknowledged:
                     break
                 if time.monotonic() >= deadline:
-                    raise RuntimeError(f"vllm executor {executor_id} abort waiter did not acknowledge termination")
+                    raise RuntimeError(
+                        f"vllm executor {executor_id} abort waiter {wait_token} did not acknowledge termination"
+                    )
                 await asyncio.sleep(0.01)
 
     def all_tasks_finished(self) -> bool:
@@ -800,9 +839,17 @@ class RayLocalVLLMExecutor(LocalVLLMExecutor):
                 continue
 
     # Ray actor calls are awaitable, while the in-process executor exposes a blocking method.
-    async def wait_for_result(self, executor_id: str | None = None) -> bool:  # type: ignore[override]
+    async def wait_for_result(  # type: ignore[override]
+        self,
+        executor_id: str | None = None,
+        wait_token: str | None = None,
+    ) -> bool:
         if executor_id is None:
+            if wait_token is not None:
+                raise ValueError("vllm global wait does not accept a wait_token")
             return await asyncio.to_thread(self._wait_for_result_blocking, None)
+        if wait_token is not None and (not isinstance(wait_token, str) or not wait_token):
+            raise ValueError("vllm wait_token must be a non-empty string")
         self._ensure_async_waiter_state()
         loop = asyncio.get_running_loop()
         state_changed = asyncio.Event()
@@ -836,8 +883,8 @@ class RayLocalVLLMExecutor(LocalVLLMExecutor):
                     self._per_executor_waiters[executor_id] = remaining
                 else:
                     self._per_executor_waiters.pop(executor_id, None)
-                if executor_id in self._per_executor_aborted:
-                    self._per_executor_terminal_wait_observed.add(executor_id)
+                if wait_token is not None:
+                    self._per_executor_wait_tokens_observed[executor_id] = wait_token
             self._notify_state_change(force=True)
 
 
@@ -889,6 +936,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
         # At most one wait ref is armed per actor. Completion callbacks only
         # enqueue refs here; the executor thread resolves and re-arms them.
         self._wait_refs_by_actor: list[Any | None] = [None] * len(self.llm_actors)
+        self._wait_tokens_by_actor: list[str | None] = [None] * len(self.llm_actors)
         self._ready_wait_refs: deque[Any] = deque()
         # Submit refs form the acknowledgement barrier before terminal RPCs;
         # their metadata is also sufficient to roll back a failed submission.
@@ -906,13 +954,17 @@ class RemoteVLLMExecutor(VLLMExecutor):
 
         try:
             resolve_object_refs_blocking(self.router_actor.report_start.remote(self._executor_id))
-        except Exception:
-            cancel_start = getattr(self.router_actor, "cancel_executor_start", None)
-            if cancel_start is not None:
-                try:
+        except BaseException as start_error:
+            try:
+                cancel_start = getattr(self.router_actor, "cancel_executor_start", None)
+                if cancel_start is not None:
                     _resolve_vllm_control_ref(cancel_start.remote(self._executor_id))
-                except Exception:
-                    pass
+            except BaseException as cleanup_error:
+                _attach_vllm_cleanup_failure(
+                    start_error,
+                    "vllm router start rollback",
+                    cleanup_error,
+                )
             raise
 
     def _router_call(
@@ -979,33 +1031,38 @@ class RemoteVLLMExecutor(VLLMExecutor):
         self._notify_state_change(force=True)
 
     def _ensure_wait_ref(self, actor_idx: int) -> None:
-        with self._result_cv:
-            if self._wait_refs_by_actor[actor_idx] is not None or not self._actor_has_pending_result(actor_idx):
-                return
-            self._wait_refs_by_actor[actor_idx] = self._WAIT_REF_INSTALLING
-        try:
-            wait_ref = self.llm_actors[actor_idx].wait_for_result.remote(self._executor_id)
-        except Exception as exc:
+        # Serialize wait submission with terminal lifecycle calls. Once abort
+        # receives a token, the corresponding wait RPC is guaranteed to have
+        # been submitted and can run while abort awaits its acknowledgement.
+        with self._lifecycle_lock:
             with self._result_cv:
-                self._wait_refs_by_actor[actor_idx] = None
-            self._record_error(exc)
-            return
-        with self._result_cv:
-            if self._shutdown_called or self._finished:
-                install = False
-            else:
-                self._wait_refs_by_actor[actor_idx] = wait_ref
-                install = True
-        if not install:
-            self._cancel_refs([wait_ref])
-            return
-        try:
-            wait_ref.future().add_done_callback(lambda _future, _ref=wait_ref: self._queue_wait_ref_ready(_ref))
-        except Exception as exc:
-            with self._result_cv:
-                if self._wait_refs_by_actor[actor_idx] == wait_ref:
+                if (
+                    self._shutdown_called
+                    or self._finished
+                    or self._wait_refs_by_actor[actor_idx] is not None
+                    or not self._actor_has_pending_result(actor_idx)
+                ):
+                    return
+                wait_token = f"{self._executor_id}:wait:{uuid.uuid4()}"
+                self._wait_refs_by_actor[actor_idx] = self._WAIT_REF_INSTALLING
+                self._wait_tokens_by_actor[actor_idx] = wait_token
+            try:
+                wait_ref = self.llm_actors[actor_idx].wait_for_result.remote(self._executor_id, wait_token)
+            except Exception as exc:
+                with self._result_cv:
                     self._wait_refs_by_actor[actor_idx] = None
-            self._record_error(TypeError(f"vllm wait ObjectRef does not support completion callbacks: {exc}"))
+                    self._wait_tokens_by_actor[actor_idx] = None
+                self._record_error(exc)
+                return
+            with self._result_cv:
+                self._wait_refs_by_actor[actor_idx] = wait_ref
+            try:
+                wait_ref.future().add_done_callback(lambda _future, _ref=wait_ref: self._queue_wait_ref_ready(_ref))
+            except Exception as exc:
+                with self._result_cv:
+                    if self._wait_refs_by_actor[actor_idx] == wait_ref:
+                        self._wait_refs_by_actor[actor_idx] = None
+                self._record_error(TypeError(f"vllm wait ObjectRef does not support completion callbacks: {exc}"))
 
     def _ensure_remote_wait_refs(self) -> None:
         for actor_idx in range(len(self.llm_actors)):
@@ -1044,6 +1101,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 with self._result_cv:
                     if self._wait_refs_by_actor[actor_idx] == ready_ref:
                         self._wait_refs_by_actor[actor_idx] = None
+                        self._wait_tokens_by_actor[actor_idx] = None
                 return
             raise RuntimeError(
                 "vllm actor finished without returning all submitted results: "
@@ -1061,6 +1119,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
         with self._result_cv:
             if self._wait_refs_by_actor[actor_idx] == ready_ref:
                 self._wait_refs_by_actor[actor_idx] = None
+                self._wait_tokens_by_actor[actor_idx] = None
             self._results_per_actor[actor_idx] += count
             self._result_buffer.append((results_text, rows))
         # Actor waits are one-shot. Re-arm immediately after consuming a
@@ -1287,9 +1346,8 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 errors.append(RuntimeError(f"vllm actor {actor_idx} does not implement abort_executor"))
                 continue
             try:
-                wait_ref = self._wait_refs_by_actor[actor_idx]
-                wait_expected = wait_ref is not None and wait_ref is not self._WAIT_REF_INSTALLING
-                _resolve_vllm_control_ref(method.remote(self._executor_id, wait_expected))
+                wait_token = self._wait_tokens_by_actor[actor_idx]
+                _resolve_vllm_control_ref(method.remote(self._executor_id, wait_token))
                 self._aborted_actor_indices.add(actor_idx)
             except Exception as exc:
                 errors.append(RuntimeError(f"actor {actor_idx}: {exc}"))
@@ -1372,6 +1430,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
                     self._error_message += "; cleanup failed: " + "; ".join(str(error) for error in cleanup_errors)
                 self._finished = True
                 self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._wait_tokens_by_actor = [None] * len(self.llm_actors)
                 self._submit_refs.clear()
                 self._ready_wait_refs.clear()
                 self._ready_submit_refs.clear()
@@ -1395,6 +1454,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
             with self._result_cv:
                 self._finished = True
                 self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._wait_tokens_by_actor = [None] * len(self.llm_actors)
                 self._submit_refs.clear()
                 self._ready_wait_refs.clear()
                 self._ready_submit_refs.clear()
@@ -1614,6 +1674,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
             with self._result_cv:
                 self._finished = True
                 self._wait_refs_by_actor = [None] * len(self.llm_actors)
+                self._wait_tokens_by_actor = [None] * len(self.llm_actors)
                 self._submit_refs.clear()
                 self._ready_wait_refs.clear()
                 self._ready_submit_refs.clear()
@@ -2442,8 +2503,15 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
             )
         try:
             return RemoteVLLMExecutor(llm_actors, pool_name=pool_name)
-        except Exception:
-            llm_actors.shutdown()
+        except BaseException as construction_error:
+            try:
+                llm_actors.shutdown()
+            except BaseException as cleanup_error:
+                _attach_vllm_cleanup_failure(
+                    construction_error,
+                    "vllm actor pool construction rollback",
+                    cleanup_error,
+                )
             raise
 
     opts = _restore_native_vllm_secrets(opts)

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -21,6 +21,16 @@ from typing import Any, Callable, overload
 
 import pyarrow as pa
 
+from duckdb.execution._vllm_options_protocol import (
+    _NATIVE_OPTIONS_NORMALIZED_SECRET_KEY,
+    _NATIVE_OPTIONS_PAYLOAD_VERSION,
+    _NATIVE_SECRET_PAYLOAD_KEYS,
+    _NATIVE_SECRET_PAYLOAD_VALUES_KEY,
+    _NATIVE_SECRET_PAYLOAD_VERSION_KEY,
+    _NATIVE_SECRET_REF_KEY,
+    _load_vllm_protocol_json,
+    _unpack_native_options_envelope,
+)
 from duckdb.runners.ray.ray_env import build_session_runtime_env_vars, install_explicit_session_runtime_env
 from duckdb.runners.ray.safe_get import configured_ray_get_timeout_s, resolve_object_refs_blocking
 
@@ -1964,7 +1974,7 @@ class LLMActors:
                     ray_module.kill(handle, no_restart=True)
                 except TypeError:
                     ray_module.kill(handle)
-            except Exception as exc:
+            except BaseException as exc:
                 errors.append(f"{kind} kill failed: {type(exc).__name__}: {exc}")
                 if kind == "actor":
                     remaining_actors.append(handle)
@@ -2118,6 +2128,61 @@ _DEFAULTS: dict[str, Any] = {
     "engine_init_timeout_s": None,
 }
 
+_ALLOWED_VLLM_OPTIONS = frozenset(_DEFAULTS) | {
+    "_force_background_thread",
+    _NATIVE_OPTIONS_NORMALIZED_SECRET_KEY,
+    "ray_actor_pool_name",
+    "ray_address",
+    "ray_worker_only",
+    "require_ray_worker",
+}
+
+
+def _restore_native_secret_refs(value: Any, secrets: list[Any], used: set[int], path: str) -> Any:
+    if isinstance(value, dict):
+        if _NATIVE_SECRET_REF_KEY in value:
+            if set(value) != {_NATIVE_SECRET_REF_KEY}:
+                raise ValueError(f"vllm native secret reference at {path} has unexpected fields")
+            index = value[_NATIVE_SECRET_REF_KEY]
+            if isinstance(index, bool) or not isinstance(index, int) or not 0 <= index < len(secrets):
+                raise ValueError(f"vllm native secret reference at {path} has an invalid index")
+            if index in used:
+                raise ValueError(f"vllm native secret reference at {path} reuses index {index}")
+            used.add(index)
+            return secrets[index]
+        return {key: _restore_native_secret_refs(item, secrets, used, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [
+            _restore_native_secret_refs(item, secrets, used, f"{path}[{index}]") for index, item in enumerate(value)
+        ]
+    return value
+
+
+def _restore_native_vllm_secrets(options: dict[str, Any]) -> dict[str, Any]:
+    public_options = dict(options)
+    secret_payload = public_options.pop(_NATIVE_OPTIONS_NORMALIZED_SECRET_KEY, None)
+    if secret_payload is None:
+        return public_options
+    if not isinstance(secret_payload, bytes):
+        raise TypeError("vllm normalized secret payload must be bytes")
+
+    payload = _load_vllm_protocol_json(secret_payload, "vllm native secret payload")
+    if not isinstance(payload, dict) or set(payload) != _NATIVE_SECRET_PAYLOAD_KEYS:
+        raise ValueError("vllm native secret payload must contain only payload_version and values")
+    version = payload[_NATIVE_SECRET_PAYLOAD_VERSION_KEY]
+    if isinstance(version, bool) or not isinstance(version, int) or version != _NATIVE_OPTIONS_PAYLOAD_VERSION:
+        raise ValueError(f"unsupported vllm native secret payload version: {version!r}")
+    secrets = payload[_NATIVE_SECRET_PAYLOAD_VALUES_KEY]
+    if not isinstance(secrets, list):
+        raise ValueError("vllm native secret payload values must be a list")
+
+    used: set[int] = set()
+    restored = _restore_native_secret_refs(public_options, secrets, used, "options")
+    if used != set(range(len(secrets))):
+        raise ValueError("vllm native secret payload contains unreferenced values")
+    assert isinstance(restored, dict)
+    return restored
+
 
 def _integer_option(name: str, value: Any, *, minimum: int) -> int:
     if isinstance(value, bool) or not isinstance(value, Integral):
@@ -2173,10 +2238,18 @@ def normalize_options(options: Any | None) -> dict[str, Any]:
         except Exception as exc:
             raise TypeError("vllm options must be a dict or JSON string") from exc
 
+    if options is not None:
+        options = _unpack_native_options_envelope(options)
+
     if options is not None and options.get("ray_address") is not None:
         raise ValueError("vLLM ray_address has been removed; configure RayRunner instead")
 
     if options is not None:
+        unknown = sorted(
+            str(name) for name in options if not isinstance(name, str) or name not in _ALLOWED_VLLM_OPTIONS
+        )
+        if unknown:
+            raise ValueError(f"unknown vllm option(s): {', '.join(unknown)}")
         merged.update(options)
     merged["concurrency"] = _integer_option("concurrency", merged["concurrency"], minimum=1)
     merged["gpus_per_actor"] = _fractional_gpu_option(merged["gpus_per_actor"])
@@ -2269,7 +2342,7 @@ def ensure_named_vllm_pools_for_plan(
 
             # Parse options through normalize_options to get clean defaults.
             raw_opts = node.get("options")
-            opts = normalize_options(raw_opts)
+            opts = _restore_native_vllm_secrets(normalize_options(raw_opts))
 
             engine_args = _apply_engine_defaults(dict(opts.get("engine_args") or {}))
             generate_args = dict(opts.get("generate_args") or {})
@@ -2336,10 +2409,7 @@ def _apply_engine_defaults(engine_args: dict[str, Any]) -> dict[str, Any]:
 
 def build_executor(model: str, options: Any | None) -> VLLMExecutor:
     opts = normalize_options(options)
-    engine_args = _apply_engine_defaults(dict(opts["engine_args"]))
-    generate_args = dict(opts["generate_args"])
     pool_name = opts.get("ray_actor_pool_name")
-    on_error = opts.get("on_error", "raise")
     require_ray_worker = opts.get("require_ray_worker", False) or opts.get("ray_worker_only", False)
     if require_ray_worker and not _is_ray_worker():
         raise RuntimeError("vllm executor must be constructed on a Ray worker when require_ray_worker is set")
@@ -2357,11 +2427,14 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
                 name_prefix=pool_name,
             )
         else:
+            opts = _restore_native_vllm_secrets(opts)
+            engine_args = _apply_engine_defaults(dict(opts["engine_args"]))
+            generate_args = dict(opts["generate_args"])
             llm_actors = LLMActors(
                 model=model,
                 engine_args=engine_args,
                 generate_args=generate_args,
-                on_error=on_error,
+                on_error=opts.get("on_error", "raise"),
                 gpus_per_actor=opts["gpus_per_actor"],
                 concurrency=opts["concurrency"],
                 load_balance_threshold=opts["load_balance_threshold"],
@@ -2373,11 +2446,14 @@ def build_executor(model: str, options: Any | None) -> VLLMExecutor:
             llm_actors.shutdown()
             raise
 
+    opts = _restore_native_vllm_secrets(opts)
+    engine_args = _apply_engine_defaults(dict(opts["engine_args"]))
+    generate_args = dict(opts["generate_args"])
     return LocalVLLMExecutor(
         model,
         engine_args,
         generate_args,
-        on_error=on_error,
+        on_error=opts.get("on_error", "raise"),
         use_threading=opts["use_threading"],
         engine_init_timeout_s=opts["engine_init_timeout_s"],
         force_background_thread=opts.get("_force_background_thread", False),

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -867,9 +867,8 @@ class RemoteVLLMExecutor(VLLMExecutor):
         self._shutdown_called = False
         self._shutdown_complete = False
         self._error_message: str | None = None
-        # Successful queries remain successful when best-effort terminal cleanup
-        # fails. Shutdown retries unfinished cleanup and surfaces persistent errors.
-        self._terminal_cleanup_errors: list[str] = []
+        # Terminal cleanup is attempted at finish and retried once at shutdown.
+        # Persistent failure warns without changing a successful query result.
         self._terminal_cleanup_warning_emitted = False
         # Actor-indexed counters distinguish dispatched prompts, consumed
         # results, and the executor's local mirror of router reservations.
@@ -906,12 +905,19 @@ class RemoteVLLMExecutor(VLLMExecutor):
                     pass
             raise
 
-    def _router_call(self, method_name: str, *args: Any, control_rpc: bool = False) -> Any:
+    def _router_call(
+        self,
+        method_name: str,
+        *args: Any,
+        control_rpc: bool = False,
+    ) -> Any:
         method = getattr(self.router_actor, method_name, None)
         if method is None:
             raise TypeError(f"vllm PrefixRouter does not implement {method_name}")
-        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
-        return resolve(method.remote(*args))
+        ref = method.remote(*args)
+        if control_rpc:
+            return _resolve_vllm_control_ref(ref)
+        return resolve_object_refs_blocking(ref)
 
     def _router_release(
         self,
@@ -924,7 +930,12 @@ class RemoteVLLMExecutor(VLLMExecutor):
     ) -> int:
         once_name = f"{method_name}_once"
         method = getattr(self.router_actor, once_name, None)
-        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
+
+        def resolve(ref: Any) -> Any:
+            if control_rpc:
+                return _resolve_vllm_control_ref(ref)
+            return resolve_object_refs_blocking(ref)
+
         if method is not None:
             call_args = (*args, operation_id)
             try:
@@ -935,7 +946,11 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 raise RuntimeError(f"vllm PrefixRouter.{once_name} returned an invalid operation result")
             result = result.get("released")
         else:
-            result = self._router_call(method_name, *args, control_rpc=control_rpc)
+            result = self._router_call(
+                method_name,
+                *args,
+                control_rpc=control_rpc,
+            )
         if isinstance(result, bool) or not isinstance(result, int):
             raise RuntimeError(f"vllm PrefixRouter.{method_name} must return an integer release count")
         if (allow_reconcile and result < 0) or (not allow_reconcile and result != expected):
@@ -1073,7 +1088,13 @@ class RemoteVLLMExecutor(VLLMExecutor):
             with self._inflight_lock:
                 self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - released)
 
-    def _rollback_reservation(self, reservation_id: str, count: int) -> int:
+    def _rollback_reservation(
+        self,
+        reservation_id: str,
+        count: int,
+        *,
+        control_rpc: bool = False,
+    ) -> int:
         with self._reservation_rpc_lock:
             with self._reservation_lock:
                 reservation = self._reservations.get(reservation_id)
@@ -1088,6 +1109,7 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 reservation_id,
                 released,
                 operation_id=f"{self._executor_id}:rollback:{reservation_id}:{remaining_before}:{released}",
+                control_rpc=control_rpc,
             )
             with self._reservation_lock:
                 current = self._reservations.get(reservation_id)
@@ -1116,7 +1138,12 @@ class RemoteVLLMExecutor(VLLMExecutor):
         except Exception as exc:
             self._record_error(TypeError(f"vllm submit ObjectRef does not support completion callbacks: {exc}"))
 
-    def _resolve_submit_ref(self, submit_ref: Any, *, control_rpc: bool = False) -> Exception | None:
+    def _resolve_submit_ref(
+        self,
+        submit_ref: Any,
+        *,
+        control_rpc: bool = False,
+    ) -> Exception | None:
         with self._result_cv:
             metadata = self._submit_refs.pop(submit_ref, None)
             try:
@@ -1126,12 +1153,19 @@ class RemoteVLLMExecutor(VLLMExecutor):
         if metadata is None:
             return None
         actor_idx, count, reservation_id = metadata
-        resolve = _resolve_vllm_control_ref if control_rpc else resolve_object_refs_blocking
         try:
-            resolve(submit_ref)
+            if control_rpc:
+                _resolve_vllm_control_ref(submit_ref)
+            else:
+                resolve_object_refs_blocking(submit_ref)
         except Exception as exc:
             try:
-                self._rollback_submitted_batch(actor_idx, count, reservation_id)
+                self._rollback_submitted_batch(
+                    actor_idx,
+                    count,
+                    reservation_id,
+                    control_rpc=control_rpc,
+                )
             except Exception as rollback_error:
                 exc = RuntimeError(f"{exc}; reservation rollback failed: {rollback_error}")
             return exc
@@ -1166,12 +1200,26 @@ class RemoteVLLMExecutor(VLLMExecutor):
             if not pending:
                 return errors
             for submit_ref in pending:
-                error = self._resolve_submit_ref(submit_ref, control_rpc=True)
+                error = self._resolve_submit_ref(
+                    submit_ref,
+                    control_rpc=True,
+                )
                 if error is not None:
                     errors.append(error)
 
-    def _rollback_submitted_batch(self, actor_idx: int, count: int, reservation_id: str) -> None:
-        released = self._rollback_reservation(reservation_id, count)
+    def _rollback_submitted_batch(
+        self,
+        actor_idx: int,
+        count: int,
+        reservation_id: str,
+        *,
+        control_rpc: bool = False,
+    ) -> None:
+        released = self._rollback_reservation(
+            reservation_id,
+            count,
+            control_rpc=control_rpc,
+        )
         with self._result_cv:
             self._submit_per_actor[actor_idx] = max(0, self._submit_per_actor[actor_idx] - released)
         self._notify_state_change(force=True)
@@ -1248,7 +1296,12 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 errors.append(RuntimeError(f"vllm actor {actor_idx} does not implement release_executor"))
                 continue
             try:
-                if _resolve_vllm_control_ref(method.remote(self._executor_id)) is not True:
+                if (
+                    _resolve_vllm_control_ref(
+                        method.remote(self._executor_id),
+                    )
+                    is not True
+                ):
                     raise RuntimeError("release_executor did not confirm release")
                 self._released_actor_indices.add(actor_idx)
             except Exception as exc:
@@ -1262,19 +1315,14 @@ class RemoteVLLMExecutor(VLLMExecutor):
         _resolve_vllm_control_ref(self.router_actor.report_completion.remote(self._executor_id))
         self._router_completion_reported = True
 
-    def _defer_terminal_cleanup(self, errors: list[str]) -> None:
-        if not errors:
-            return
-        for error in errors:
-            if error not in self._terminal_cleanup_errors:
-                self._terminal_cleanup_errors.append(error)
+    def _warn_incomplete_terminal_cleanup(self, errors: list[Exception]) -> None:
         if self._terminal_cleanup_warning_emitted:
             return
         self._terminal_cleanup_warning_emitted = True
         try:
             warnings.warn(
-                "vllm query completed successfully but terminal cleanup remains incomplete and will be retried: "
-                + "; ".join(errors),
+                "vllm query completed successfully but terminal cleanup remains incomplete after the final "
+                "shutdown attempt; no background retry will be attempted: " + "; ".join(str(error) for error in errors),
                 RuntimeWarning,
                 stacklevel=3,
             )
@@ -1323,16 +1371,17 @@ class RemoteVLLMExecutor(VLLMExecutor):
         with self._lifecycle_lock:
             if self._finished:
                 return
-            cleanup_errors: list[str] = []
+            # This is the first best-effort cleanup attempt. shutdown() makes
+            # the final attempt, so a transient failure here should not warn or
+            # turn an otherwise successful query into a failure.
             try:
                 self._release_outstanding_inflight()
-            except Exception as exc:
-                cleanup_errors.append(f"router reservation release: {exc}")
+            except Exception:
+                pass
             try:
                 self._release_actor_state()
-            except Exception as exc:
-                cleanup_errors.append(f"actor state release: {exc}")
-            self._defer_terminal_cleanup(cleanup_errors)
+            except Exception:
+                pass
             with self._result_cv:
                 self._finished = True
                 self._wait_refs_by_actor = [None] * len(self.llm_actors)
@@ -1364,29 +1413,43 @@ class RemoteVLLMExecutor(VLLMExecutor):
             if count == 0:
                 return
             operation_id = f"{self._executor_id}:route:{uuid.uuid4()}"
-            route_once = getattr(self.router_actor, "route_and_reserve_once", None)
-            if route_once is not None:
-                args = (prefix, count, self._executor_id, operation_id)
-                try:
-                    decision = resolve_object_refs_blocking(route_once.remote(*args))
-                except Exception:
+            try:
+                route_once = getattr(self.router_actor, "route_and_reserve_once", None)
+                if route_once is not None:
+                    args = (prefix, count, self._executor_id, operation_id)
                     try:
                         decision = resolve_object_refs_blocking(route_once.remote(*args))
-                    except Exception as exc:
-                        # The router may have committed the idempotent
-                        # reservation even though both acknowledgements were
-                        # lost. Terminalize this executor so control-RPC
-                        # reconciliation can release any phantom reservation.
-                        self._record_error(exc)
-                        raise
-            else:
-                decision = self._router_call("route_and_reserve", prefix, count, self._executor_id)
-            if not isinstance(decision, dict):
-                raise RuntimeError("vllm PrefixRouter.route_and_reserve must return a dict")
-            actor_idx = int(decision.get("actor_idx", -1))
-            reservation_id = str(decision.get("reservation_id") or "")
-            if actor_idx < 0 or actor_idx >= len(self.llm_actors) or not reservation_id:
-                raise RuntimeError("vllm PrefixRouter returned an invalid reservation")
+                    except Exception:
+                        decision = resolve_object_refs_blocking(route_once.remote(*args))
+                else:
+                    decision = self._router_call("route_and_reserve", prefix, count, self._executor_id)
+                if not isinstance(decision, dict):
+                    raise RuntimeError("vllm PrefixRouter.route_and_reserve must return a dict")
+                actor_idx_value = decision.get("actor_idx")
+                prompt_count_value = decision.get("prompt_count")
+                reservation_id_value = decision.get("reservation_id")
+                valid_operation = route_once is None or decision.get("operation_id") == operation_id
+                if (
+                    isinstance(actor_idx_value, bool)
+                    or not isinstance(actor_idx_value, Integral)
+                    or int(actor_idx_value) < 0
+                    or int(actor_idx_value) >= len(self.llm_actors)
+                    or isinstance(prompt_count_value, bool)
+                    or not isinstance(prompt_count_value, Integral)
+                    or int(prompt_count_value) != count
+                    or not isinstance(reservation_id_value, str)
+                    or not reservation_id_value
+                    or not valid_operation
+                ):
+                    raise RuntimeError("vllm PrefixRouter returned an invalid reservation")
+                actor_idx = int(actor_idx_value)
+                reservation_id = reservation_id_value
+            except Exception as exc:
+                # The router may have committed an idempotent reservation even
+                # when the acknowledgement is lost or malformed. Terminalize
+                # through reconciliation so no phantom reservation survives.
+                self._record_error(exc)
+                raise
             with self._reservation_lock:
                 self._reservations[reservation_id] = {"actor_idx": actor_idx, "remaining": count}
             with self._inflight_lock:
@@ -1544,13 +1607,30 @@ class RemoteVLLMExecutor(VLLMExecutor):
                 self._submit_refs.clear()
                 self._ready_wait_refs.clear()
                 self._ready_submit_refs.clear()
+            owner_terminated_pool = False
             try:
-                self._actors_owner.shutdown()
+                # Test doubles and older embedders may provide the same owner
+                # protocol without being an LLMActors instance.
+                actors_owner: Any = self._actors_owner
+                if isinstance(actors_owner, LLMActors):
+                    actors_owner.shutdown()
+                    owner_terminated_pool = (
+                        actors_owner._shutdown_complete
+                        and not actors_owner.llm_actors
+                        and actors_owner.router_actor is None
+                    )
+                else:
+                    actors_owner.shutdown()
             except Exception as exc:
                 errors.append(exc)
+            if owner_terminated_pool:
+                # Once the query-owned infrastructure is gone, earlier terminal
+                # RPC failures cannot leave actor/router state behind, so they
+                # no longer represent incomplete cleanup.
+                errors.clear()
             self._shutdown_complete = not errors
             if errors and completed_successfully:
-                self._defer_terminal_cleanup([f"shutdown cleanup: {error}" for error in errors])
+                self._warn_incomplete_terminal_cleanup(errors)
             self._notify_state_change(force=True)
             if errors and not completed_successfully:
                 raise RuntimeError("vllm remote shutdown incomplete: " + "; ".join(str(error) for error in errors))
@@ -1963,6 +2043,8 @@ class LLMActors:
         found = (1 if router_actor is not None else 0) + len(llm_actors)
         expected = 1 + concurrency
         if found == expected:
+            # TODO(next PR): validate immutable pool configuration and add
+            # explicit plan-owned leases before broadening named-pool reuse.
             return cls._from_handles(llm_actors, router_actor)
         if found:
             creation_error = RuntimeError(

--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -255,7 +255,7 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 
 	VLLMWakeupRegistrationResult RegisterWakeup(ExecutionContext &context) {
 		if (!context.interrupt_state) {
-			return VLLMWakeupRegistrationResult::UNSUPPORTED;
+			throw InternalException("PhysicalVLLM requires an interrupt state for scheduler wakeup registration");
 		}
 		// Another finalizer can drain the last result and shut the shared
 		// executor down between this task's readiness check and wakeup
@@ -655,11 +655,6 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 	chunk.SetCardinality(0);
 	if (wakeup_result == VLLMWakeupRegistrationResult::ARMED) {
 		return OperatorFinalizeResultType::BLOCKED;
-	}
-	if (wakeup_result == VLLMWakeupRegistrationResult::UNSUPPORTED && gstate.InflightPrompts() > 0) {
-		// Compatibility fallback for legacy executors. Waiting with zero inflight
-		// would deadlock while another producer is still able to submit.
-		gstate.WaitForExecutorResult(context.client);
 	}
 	return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 }

--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -32,25 +32,15 @@ struct VLLMBucketCompare {
 	}
 };
 
-static vector<string> GetPrompts(ExpressionExecutor &executor, DataChunk &input) {
-	Vector result(LogicalType::VARCHAR);
-	executor.ExecuteExpression(input, result);
-
-	UnifiedVectorFormat format;
-	result.ToUnifiedFormat(input.size(), format);
-	auto data = reinterpret_cast<string_t *>(format.data);
-
+struct VLLMPromptInput {
 	vector<string> prompts;
-	prompts.reserve(input.size());
-	for (idx_t i = 0; i < input.size(); i++) {
-		auto idx = format.sel->get_index(i);
-		if (!format.validity.RowIsValid(idx)) {
-			throw InvalidInputException("vllm prompt cannot be NULL");
-		}
-		prompts.push_back(data[idx].GetString());
-	}
-	return prompts;
-}
+	unique_ptr<DataChunk> rows;
+};
+
+struct BufferedVLLMInput {
+	unique_ptr<DataChunk> rows;
+	vector<string> prompts;
+};
 
 static idx_t CommonPrefixLength(const string &left, const string &right) {
 	const auto max_len = MinValue<idx_t>(left.size(), right.size());
@@ -93,10 +83,12 @@ static string ComputeBucketPrefix(const vector<string> &prompts, idx_t start, id
 	return first.substr(0, CompleteUTF8PrefixLength(first, prefix_len));
 }
 
-static unique_ptr<DataChunk> CopyChunk(ClientContext &context, DataChunk &input) {
+static unique_ptr<DataChunk> SliceChunk(ClientContext &context, DataChunk &input, const SelectionVector &selection,
+                                        idx_t count) {
 	auto copy = make_uniq<DataChunk>();
-	copy->Initialize(context, input.GetTypes(), input.size());
-	copy->Append(input, true);
+	copy->Initialize(context, input.GetTypes(), count);
+	copy->Slice(input, selection, count, 0);
+	copy->Flatten();
 	return copy;
 }
 
@@ -140,6 +132,45 @@ static unique_ptr<DataChunk> BuildOutputChunk(ExecutionContext &context, DataChu
 	auto output_ptr = make_uniq<DataChunk>();
 	output_ptr->Move(output);
 	return output_ptr;
+}
+
+static VLLMPromptInput EvaluatePrompts(ExecutionContext &context, ExpressionExecutor &executor, DataChunk &input,
+                                       std::deque<unique_ptr<DataChunk>> &pending_outputs) {
+	Vector result(LogicalType::VARCHAR);
+	executor.ExecuteExpression(input, result);
+
+	UnifiedVectorFormat format;
+	result.ToUnifiedFormat(input.size(), format);
+	auto data = reinterpret_cast<string_t *>(format.data);
+
+	SelectionVector valid_selection(input.size());
+	SelectionVector null_selection(input.size());
+	idx_t valid_count = 0;
+	idx_t null_count = 0;
+	vector<string> prompts;
+	prompts.reserve(input.size());
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto idx = format.sel->get_index(i);
+		if (format.validity.RowIsValid(idx)) {
+			valid_selection.set_index(valid_count++, i);
+			prompts.push_back(data[idx].GetString());
+		} else {
+			null_selection.set_index(null_count++, i);
+		}
+	}
+
+	if (null_count > 0) {
+		auto null_rows = SliceChunk(context.client, input, null_selection, null_count);
+		pending_outputs.push_back(
+		    BuildOutputChunk(context, *null_rows, vector<string>(null_count), vector<bool>(null_count, false)));
+	}
+
+	VLLMPromptInput prompt_input;
+	prompt_input.prompts = std::move(prompts);
+	if (valid_count > 0) {
+		prompt_input.rows = SliceChunk(context.client, input, valid_selection, valid_count);
+	}
+	return prompt_input;
 }
 
 struct VLLMGlobalOperatorState : public GlobalOperatorState {
@@ -312,7 +343,7 @@ struct VLLMOperatorState : public OperatorState {
 
 	ExpressionExecutor prompt_executor;
 
-	vector<unique_ptr<DataChunk>> buffer;
+	vector<BufferedVLLMInput> buffer;
 	idx_t buffer_size = 0;
 	bool finished_submitting = false;
 	std::deque<unique_ptr<DataChunk>> pending_outputs;
@@ -405,14 +436,19 @@ static void PopAndSubmitTasks(ExecutionContext &context, VLLMGlobalOperatorState
 		return;
 	}
 
-	auto types = state.buffer[0]->GetTypes();
+	auto types = state.buffer[0].rows->GetTypes();
 	DataChunk concatted;
 	concatted.Initialize(context.client, types, state.buffer_size);
-	for (auto &chunk_ptr : state.buffer) {
-		concatted.Append(*chunk_ptr, true);
+	vector<string> prompts;
+	prompts.reserve(state.buffer_size);
+	for (auto &buffered : state.buffer) {
+		if (buffered.prompts.size() != buffered.rows->size()) {
+			throw InternalException("vllm buffered prompt count does not match buffered row count");
+		}
+		concatted.Append(*buffered.rows, true);
+		prompts.insert(prompts.end(), buffered.prompts.begin(), buffered.prompts.end());
 	}
 
-	auto prompts = GetPrompts(state.prompt_executor, concatted);
 	if (prompts.empty()) {
 		state.buffer.clear();
 		state.buffer_size = 0;
@@ -530,7 +566,8 @@ static void PopAndSubmitTasks(ExecutionContext &context, VLLMGlobalOperatorState
 		state.buffer_size += bucket.length;
 		auto remaining_ptr = make_uniq<DataChunk>();
 		remaining_ptr->Move(remaining);
-		state.buffer.push_back(std::move(remaining_ptr));
+		vector<string> remaining_prompts(sorted_prompts.begin() + bucket.start, sorted_prompts.begin() + bucket.end);
+		state.buffer.push_back({std::move(remaining_ptr), std::move(remaining_prompts)});
 	}
 }
 
@@ -571,29 +608,31 @@ OperatorResultType PhysicalVLLM::Execute(ExecutionContext &context, DataChunk &i
 		return OperatorResultType::NEED_MORE_INPUT;
 	}
 
-	gstate.EnsureExecutor(context);
+	auto prompt_input = EvaluatePrompts(context, state.prompt_executor, input, state.pending_outputs);
+	if (!prompt_input.prompts.empty()) {
+		gstate.EnsureExecutor(context);
 
-	// Backpressure: if inflight is at limit, drain ready results and wait.
-	while (!gstate.CanSubmitMore()) {
+		// Backpressure: if inflight is at limit, drain ready results and wait.
+		while (!gstate.CanSubmitMore()) {
+			TakeReadyResultOnce(context, gstate, state, input.ColumnCount());
+			if (gstate.CanSubmitMore()) {
+				break;
+			}
+			if (!gstate.WaitForExecutorResult(context.client)) {
+				throw InternalException("vllm executor disappeared during operator backpressure");
+			}
+		}
+
+		if (gstate.config.do_prefix_routing) {
+			state.buffer_size += prompt_input.prompts.size();
+			state.buffer.push_back({std::move(prompt_input.rows), std::move(prompt_input.prompts)});
+			PopAndSubmitTasks(context, gstate, state, gstate.config.max_buffer_size);
+		} else {
+			SubmitPrompts(context, gstate, state, nullptr, prompt_input.prompts, *prompt_input.rows);
+		}
+
 		TakeReadyResultOnce(context, gstate, state, input.ColumnCount());
-		if (gstate.CanSubmitMore()) {
-			break;
-		}
-		if (!gstate.WaitForExecutorResult(context.client)) {
-			throw InternalException("vllm executor disappeared during operator backpressure");
-		}
 	}
-
-	if (gstate.config.do_prefix_routing) {
-		state.buffer_size += input.size();
-		state.buffer.push_back(CopyChunk(context.client, input));
-		PopAndSubmitTasks(context, gstate, state, gstate.config.max_buffer_size);
-	} else {
-		auto prompts = GetPrompts(state.prompt_executor, input);
-		SubmitPrompts(context, gstate, state, nullptr, prompts, input);
-	}
-
-	TakeReadyResultOnce(context, gstate, state, input.ColumnCount());
 	if (!state.pending_outputs.empty()) {
 		auto output = std::move(state.pending_outputs.front());
 		state.pending_outputs.pop_front();

--- a/external/duckdb/src/include/duckdb/execution/vllm_executor.hpp
+++ b/external/duckdb/src/include/duckdb/execution/vllm_executor.hpp
@@ -50,8 +50,6 @@ struct VLLMResult {
 
 //! Outcome of asking an executor to wake a blocked native pipeline task.
 enum class VLLMWakeupRegistrationResult {
-	//! The executor cannot register callbacks; the caller may use a blocking fallback.
-	UNSUPPORTED,
 	//! A one-shot callback was registered, so the caller can safely return BLOCKED.
 	ARMED,
 	//! Work or a terminal state is already ready, so the caller must not block.
@@ -69,10 +67,8 @@ public:
 	virtual void FinishedSubmitting(ClientContext &context) = 0;
 	virtual bool AllTasksFinished(ClientContext &context) = 0;
 	virtual void Shutdown() = 0;
-	//! Try to arm a one-shot scheduler wakeup; legacy executors use the unsupported default.
-	virtual VLLMWakeupRegistrationResult RegisterWakeup(InterruptState &) {
-		return VLLMWakeupRegistrationResult::UNSUPPORTED;
-	}
+	//! Arm a one-shot scheduler wakeup or report that work is already ready.
+	virtual VLLMWakeupRegistrationResult RegisterWakeup(InterruptState &) = 0;
 
 	//! Block until at least one result is available, an error occurred, or all tasks finished.
 	//! Uses event-driven wakeup.

--- a/external/duckdb/src/optimizer/vllm_project_rewriter.cpp
+++ b/external/duckdb/src/optimizer/vllm_project_rewriter.cpp
@@ -3,10 +3,8 @@
 
 #include "duckdb/optimizer/vllm_project_rewriter.hpp"
 
-#include "duckdb/common/constants.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/function/scalar/vllm_functions.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -40,6 +38,60 @@ static bool ContainsVLLM(const Expression &expr) {
 	return found;
 }
 
+static bool IsVLLMShortCircuitBoundary(const Expression &expr) {
+	return expr.type == ExpressionType::CASE_EXPR || expr.type == ExpressionType::CONJUNCTION_AND ||
+	       expr.type == ExpressionType::CONJUNCTION_OR || expr.type == ExpressionType::OPERATOR_COALESCE;
+}
+
+struct VLLMExtractionState {
+	VLLMExtractionState(Binder &binder_p, LogicalProjection &projection_p)
+	    : binder(binder_p), projection(projection_p) {
+	}
+
+	Binder &binder;
+	LogicalProjection &projection;
+	unique_ptr<LogicalOperator> current_child;
+};
+
+static void ExtractVLLMExpressions(unique_ptr<Expression> &expr, VLLMExtractionState &state,
+                                   bool inside_short_circuit = false) {
+	if (!expr) {
+		return;
+	}
+	if (inside_short_circuit && ContainsVLLM(*expr)) {
+		throw NotImplementedException(
+		    "vllm expressions are not supported inside CASE, AND/OR, or COALESCE short-circuit expressions");
+	}
+
+	// Extract children first so nested vllm calls are available as bound columns
+	// to the operators that depend on them.
+	const bool child_inside_short_circuit = inside_short_circuit || IsVLLMShortCircuitBoundary(*expr);
+	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+		ExtractVLLMExpressions(child, state, child_inside_short_circuit);
+	});
+
+	if (!IsVLLMFunction(*expr)) {
+		return;
+	}
+	if (!state.current_child) {
+		D_ASSERT(state.projection.children.size() == 1);
+		state.current_child = std::move(state.projection.children[0]);
+	}
+
+	auto vllm_expr = std::move(expr);
+	auto replacement_name = vllm_expr->GetName();
+	auto output_type = vllm_expr->return_type;
+	auto table_index = state.binder.GenerateTableIndex();
+	auto output_name = StringUtil::Format("__vane_vllm_%llu", static_cast<unsigned long long>(table_index));
+	auto output_binding = ColumnBinding(table_index, 0);
+
+	auto vllm_project = make_uniq<LogicalVLLMProject>(table_index, std::move(vllm_expr), output_name);
+	vllm_project->children.push_back(std::move(state.current_child));
+	state.current_child = std::move(vllm_project);
+
+	expr = make_uniq<BoundColumnRefExpression>(replacement_name, output_type, output_binding);
+}
+
 unique_ptr<LogicalOperator> VLLMProjectRewriter::Optimize(unique_ptr<LogicalOperator> op) {
 	return Rewrite(std::move(op));
 }
@@ -57,40 +109,13 @@ unique_ptr<LogicalOperator> VLLMProjectRewriter::Rewrite(unique_ptr<LogicalOpera
 	}
 
 	auto &proj = op->Cast<LogicalProjection>();
-	idx_t vllm_index = DConstants::INVALID_INDEX;
-
-	for (idx_t i = 0; i < proj.expressions.size(); i++) {
-		auto &expr = proj.expressions[i];
-		if (!ContainsVLLM(*expr)) {
-			continue;
-		}
-		if (!IsVLLMFunction(*expr)) {
-			throw NotImplementedException("vllm must be used as a top-level projection expression");
-		}
-		if (vllm_index != DConstants::INVALID_INDEX) {
-			throw NotImplementedException("Only one vllm expression per projection is supported");
-		}
-		vllm_index = i;
+	VLLMExtractionState state(binder, proj);
+	for (auto &expr : proj.expressions) {
+		ExtractVLLMExpressions(expr, state);
 	}
-
-	if (vllm_index == DConstants::INVALID_INDEX) {
-		return op;
+	if (state.current_child) {
+		proj.children[0] = std::move(state.current_child);
 	}
-
-	D_ASSERT(proj.children.size() == 1);
-
-	auto vllm_expr = std::move(proj.expressions[vllm_index]);
-	auto output_name = vllm_expr->GetName();
-	auto output_type = vllm_expr->return_type;
-	auto table_index = binder.GenerateTableIndex();
-
-	auto output_binding = ColumnBinding(table_index, 0);
-
-	auto vllm_project = make_uniq<LogicalVLLMProject>(table_index, std::move(vllm_expr), output_name);
-	vllm_project->children.push_back(std::move(proj.children[0]));
-	proj.children[0] = std::move(vllm_project);
-
-	proj.expressions[vllm_index] = make_uniq<BoundColumnRefExpression>(output_name, output_type, output_binding);
 
 	return op;
 }

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/vllm_functions.hpp"
 #include "duckdb/function/scalar/udf_functions.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
@@ -20,6 +22,12 @@ namespace duckdb {
 namespace {
 
 enum class AISQLKind : uint8_t { PROMPT, EMBED };
+
+struct NativeVLLMSpec {
+	string model;
+	string options_json;
+	Value system_message;
+};
 
 static void ThrowIfNotConstant(const Expression &arg, const string &name) {
 	if (!arg.IsFoldable()) {
@@ -102,14 +110,45 @@ static py::object OptionsToPython(ClientContext &context, vector<unique_ptr<Expr
 	return PythonObject::FromValue(options, options.type(), context.GetClientProperties());
 }
 
-static Value BuildAISQLPayload(ClientContext &context, AISQLKind kind, const py::object &py_options, bool image_input) {
+static py::dict BuildAISQLSpec(AISQLKind kind, const py::object &py_options, bool image_input) {
 	auto sql_module = py::module_::import("vane.ai._sql");
+	auto builder = kind == AISQLKind::PROMPT ? sql_module.attr("build_ai_prompt_sql_spec")
+	                                         : sql_module.attr("build_ai_embed_sql_spec");
+	return py::cast<py::dict>(kind == AISQLKind::PROMPT ? builder(py_options, image_input) : builder(py_options));
+}
+
+static string ParseExecutionKind(const py::dict &spec) {
+	auto execution_kind = DictGetOrNone(spec, "execution_kind");
+	if (execution_kind.is_none()) {
+		return "expression_udf";
+	}
+	if (!py::isinstance<py::str>(execution_kind)) {
+		throw BinderException("ai SQL helper returned invalid execution_kind");
+	}
+	return py::cast<string>(execution_kind);
+}
+
+static NativeVLLMSpec ParseNativeVLLMSpec(const py::dict &spec) {
+	auto model_obj = DictGetOrNone(spec, "model");
+	auto options_obj = DictGetOrNone(spec, "options_json");
+	if (!py::isinstance<py::str>(model_obj) || !py::isinstance<py::str>(options_obj)) {
+		throw BinderException("ai SQL native vLLM helper returned invalid model or options_json");
+	}
+	auto system_message_obj = DictGetOrNone(spec, "system_message");
+	Value system_message;
+	if (!system_message_obj.is_none()) {
+		if (!py::isinstance<py::str>(system_message_obj)) {
+			throw BinderException("ai SQL native vLLM helper returned invalid system_message");
+		}
+		system_message = Value(py::cast<string>(system_message_obj));
+	}
+	return {py::cast<string>(model_obj), py::cast<string>(options_obj), std::move(system_message)};
+}
+
+static Value BuildAISQLPayload(ClientContext &context, const py::dict &spec) {
 	auto expression_helpers = py::module_::import("vane._expression_udf");
 	auto normalize_schema = expression_helpers.attr("_normalize_schema");
 
-	auto builder = kind == AISQLKind::PROMPT ? sql_module.attr("build_ai_prompt_sql_spec")
-	                                         : sql_module.attr("build_ai_embed_sql_spec");
-	auto spec = py::cast<py::dict>(kind == AISQLKind::PROMPT ? builder(py_options, image_input) : builder(py_options));
 	auto name = py::cast<string>(spec[py::str("name")]);
 	auto udf = py::cast<py::function>(spec[py::str("function")]);
 	auto input_names = ParseInputNames(py::reinterpret_borrow<py::object>(spec[py::str("input_names")]));
@@ -127,6 +166,48 @@ static Value BuildAISQLPayload(ClientContext &context, AISQLKind kind, const py:
 	                                                   input_names, batch_size, /*row_preserving=*/true, gpus,
 	                                                   actor_number, /*stateful=*/false);
 	return AddAISQLPayloadMetadata(payload, provider, model, return_type, dimensions);
+}
+
+static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const string &name,
+                                                 vector<unique_ptr<Expression>> children) {
+	FunctionBinder binder(context);
+	ErrorData error;
+	auto result = binder.BindScalarFunction(DEFAULT_SCHEMA, name, std::move(children), error);
+	if (!result) {
+		error.Throw();
+	}
+	return result;
+}
+
+static unique_ptr<Expression> BuildNativeVLLMPromptArgument(ClientContext &context, unique_ptr<Expression> prompt,
+                                                            const Value &system_message) {
+	vector<unique_ptr<Expression>> concat_arguments;
+	if (!system_message.IsNull() && !StringValue::Get(system_message).empty()) {
+		auto prefix = StringValue::Get(system_message) + "\n\n";
+		concat_arguments.push_back(make_uniq<BoundConstantExpression>(Value(std::move(prefix))));
+	}
+	concat_arguments.push_back(std::move(prompt));
+	// concat ignores NULL arguments. The empty suffix preserves non-NULL text
+	// while matching the previous Python batch wrapper's NULL-to-empty policy.
+	concat_arguments.push_back(make_uniq<BoundConstantExpression>(Value("")));
+	return BindScalarFunction(context, "concat", std::move(concat_arguments));
+}
+
+static unique_ptr<Expression> LowerNativeVLLMPrompt(FunctionBindExpressionInput &input) {
+	if (!input.bind_data) {
+		throw BinderException("native vLLM ai_prompt is missing bind data");
+	}
+	auto &data = input.bind_data->Cast<VLLMFunctionData>();
+	if (input.children.size() != 1) {
+		throw BinderException("native vLLM ai_prompt expected one runtime argument");
+	}
+
+	vector<unique_ptr<Expression>> children;
+	children.reserve(3);
+	children.push_back(std::move(input.children[0]));
+	children.push_back(make_uniq<BoundConstantExpression>(Value(data.model)));
+	children.push_back(make_uniq<BoundConstantExpression>(data.options));
+	return BindScalarFunction(input.context, "vllm", std::move(children));
 }
 
 static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction &bound_function,
@@ -150,10 +231,30 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 	}
 
 	Value payload;
+	unique_ptr<NativeVLLMSpec> native_vllm;
 	{
 		PythonGILWrapper acquire;
 		auto py_options = OptionsToPython(context, arguments, options_index);
-		payload = BuildAISQLPayload(context, kind, py_options, image_input);
+		auto spec = BuildAISQLSpec(kind, py_options, image_input);
+		auto execution_kind = ParseExecutionKind(spec);
+		if (execution_kind == "native_vllm") {
+			if (kind != AISQLKind::PROMPT) {
+				throw BinderException("native vLLM execution is only valid for ai_prompt");
+			}
+			native_vllm = make_uniq<NativeVLLMSpec>(ParseNativeVLLMSpec(spec));
+		} else if (execution_kind == "expression_udf") {
+			payload = BuildAISQLPayload(context, spec);
+		} else {
+			throw BinderException("ai SQL helper returned unknown execution_kind '%s'", execution_kind);
+		}
+	}
+
+	if (native_vllm) {
+		arguments[0] = BuildNativeVLLMPromptArgument(context, std::move(arguments[0]), native_vllm->system_message);
+		Function::EraseArgument(bound_function, arguments, options_index);
+		bound_function.SetReturnType(LogicalType::VARCHAR);
+		bound_function.SetBindExpressionCallback(LowerNativeVLLMPrompt);
+		return make_uniq<VLLMFunctionData>(std::move(native_vllm->model), Value(std::move(native_vllm->options_json)));
 	}
 	auto return_type = udf_helpers::ResolvePayloadReturnType(payload);
 	bound_function.SetReturnType(return_type);

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -181,16 +181,15 @@ static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const s
 
 static unique_ptr<Expression> BuildNativeVLLMPromptArgument(ClientContext &context, unique_ptr<Expression> prompt,
                                                             const Value &system_message) {
-	vector<unique_ptr<Expression>> concat_arguments;
-	if (!system_message.IsNull() && !StringValue::Get(system_message).empty()) {
-		auto prefix = StringValue::Get(system_message) + "\n\n";
-		concat_arguments.push_back(make_uniq<BoundConstantExpression>(Value(std::move(prefix))));
+	if (system_message.IsNull() || StringValue::Get(system_message).empty()) {
+		return prompt;
 	}
+
+	vector<unique_ptr<Expression>> concat_arguments;
+	auto prefix = StringValue::Get(system_message) + "\n\n";
+	concat_arguments.push_back(make_uniq<BoundConstantExpression>(Value(std::move(prefix))));
 	concat_arguments.push_back(std::move(prompt));
-	// concat ignores NULL arguments. The empty suffix preserves non-NULL text
-	// while matching the previous Python batch wrapper's NULL-to-empty policy.
-	concat_arguments.push_back(make_uniq<BoundConstantExpression>(Value("")));
-	return BindScalarFunction(context, "concat", std::move(concat_arguments));
+	return BindScalarFunction(context, "||", std::move(concat_arguments));
 }
 
 static unique_ptr<Expression> LowerNativeVLLMPrompt(FunctionBindExpressionInput &input) {

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -872,7 +872,9 @@ struct PyPhysicalPlanWrapper {
 				auto &vllm_op = op.Cast<PhysicalVLLM>();
 				idx_t node_id = vllm_counter++;
 
-				// Build pool name using the same sanitization as VLLMProjectNode.
+				// Keep distributed vLLM pools scoped to one connection session
+				// and query. Cross-query reuse requires immutable configuration
+				// validation and explicit lifecycle ownership.
 				auto safe_session = duckdb::distributed::SanitizePoolComponent(session_id);
 				auto safe_query = duckdb::distributed::SanitizePoolComponent(query_id);
 				auto pool_name = "duckdb_vllm_" + safe_session + "_" + safe_query + "_" + std::to_string(node_id);

--- a/src/duckdb_py/vllm_executor.cpp
+++ b/src/duckdb_py/vllm_executor.cpp
@@ -189,6 +189,9 @@ static unique_ptr<DataChunk> ConvertArrowTableToDataChunk(const py::object &tabl
 class VLLMPythonExecutor : public VLLMExecutor {
 public:
 	explicit VLLMPythonExecutor(py::object executor_p) : executor(make_uniq<RegisteredObject>(std::move(executor_p))) {
+		if (!py::hasattr(executor->obj, "register_wakeup_callback")) {
+			throw InvalidInputException("vllm executor must implement register_wakeup_callback");
+		}
 	}
 
 	~VLLMPythonExecutor() override {
@@ -282,9 +285,6 @@ public:
 
 	VLLMWakeupRegistrationResult RegisterWakeup(InterruptState &interrupt_state) override {
 		PythonGILWrapper gil;
-		if (!py::hasattr(executor->obj, "register_wakeup_callback")) {
-			return VLLMWakeupRegistrationResult::UNSUPPORTED;
-		}
 		try {
 			auto callback = py::cpp_function([interrupt_state]() { interrupt_state.Callback(); });
 			auto armed = executor->obj.attr("register_wakeup_callback")(std::move(callback));

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -328,17 +328,16 @@ class TestVLLMProvider:
         assert descriptor.system_message == "Be concise."
         assert descriptor.vllm_options["engine_args"] == {"max_model_len": 1024}
 
-    def test_direct_prompter_calls_require_native_query_planning(self):
-        import asyncio
+    def test_vllm_prompt_plan_is_not_an_executable_descriptor(self):
+        from vane.ai.protocols import NativePrompterPlan, PrompterDescriptor
+        from vane.ai.providers.vllm import NativeVLLMPromptPlan, VLLMPrompterDescriptor
 
-        from vane.ai.providers.vllm import VLLMPrompterDescriptor
+        plan = VLLMPrompterDescriptor(model_name="test-model")
 
-        prompter = VLLMPrompterDescriptor(model_name="test-model").instantiate()
-
-        with pytest.raises(NotImplementedError, match="PhysicalVLLM"):
-            prompter.prompt_batch(["hello"])
-        with pytest.raises(NotImplementedError, match="PhysicalVLLM"):
-            asyncio.run(prompter.prompt(("hello",)))
+        assert NativeVLLMPromptPlan is VLLMPrompterDescriptor
+        assert isinstance(plan, NativePrompterPlan)
+        assert not isinstance(plan, PrompterDescriptor)
+        assert not hasattr(plan, "instantiate")
 
 
 class TestVLLMStructuredOutput:

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -280,31 +280,25 @@ class TestWrapperPickle:
 
 
 class TestVLLMProvider:
-    """Tests for the vLLM provider and descriptor."""
+    """Tests for native vLLM provider planning metadata."""
 
     def test_provider_loads(self):
-        """Vllm provider is registered and loadable."""
         from vane.ai.provider import PROVIDERS
 
         assert "vllm" in PROVIDERS
 
     def test_descriptor_creates(self):
-        """VLLMPrompterDescriptor can be created with default settings."""
         from vane.ai.providers.vllm import VLLMPrompterDescriptor
 
-        desc = VLLMPrompterDescriptor(
-            model_name="Qwen/Qwen3-1.7B",
-        )
-        assert desc.get_provider() == "vllm"
-        assert desc.get_model() == "Qwen/Qwen3-1.7B"
+        descriptor = VLLMPrompterDescriptor(model_name="Qwen/Qwen3-1.7B")
+
+        assert descriptor.get_provider() == "vllm"
+        assert descriptor.get_model() == "Qwen/Qwen3-1.7B"
 
     def test_descriptor_pickle_roundtrip(self):
-        """VLLMPrompterDescriptor survives pickle (required for Ray)."""
-        import pickle
-
         from vane.ai.providers.vllm import VLLMPrompterDescriptor
 
-        desc = VLLMPrompterDescriptor(
+        descriptor = VLLMPrompterDescriptor(
             model_name="meta-llama/Llama-3.1-8B",
             system_message="You are a helpful assistant.",
             vllm_options={
@@ -313,183 +307,45 @@ class TestVLLMProvider:
                 "gpus_per_actor": 1,
             },
         )
-        restored = pickle.loads(pickle.dumps(desc))
-        assert restored.model_name == desc.model_name
-        assert restored.system_message == desc.system_message
-        assert restored.vllm_options == desc.vllm_options
 
-    def test_udf_options_defaults(self):
-        """VLLMPrompterDescriptor produces correct UDFOptions."""
-        from vane.ai.providers.vllm import VLLMPrompterDescriptor
+        restored = pickle.loads(pickle.dumps(descriptor))
 
-        desc = VLLMPrompterDescriptor(
-            model_name="Qwen/Qwen3-1.7B",
-            vllm_options={"gpus_per_actor": 2},
-        )
-        opts = desc.get_udf_options()
-        assert opts.num_gpus == 2
-        assert opts.on_error == "raise"
+        assert restored.model_name == descriptor.model_name
+        assert restored.system_message == descriptor.system_message
+        assert restored.vllm_options == descriptor.vllm_options
 
     def test_provider_get_prompter(self):
-        """VLLMProvider.get_prompter returns a VLLMPrompterDescriptor."""
         from vane.ai.providers.vllm import VLLMPrompterDescriptor, VLLMProvider
 
-        provider = VLLMProvider()
-        desc = provider.get_prompter(
+        descriptor = VLLMProvider().get_prompter(
             model="Qwen/Qwen3-1.7B",
             system_message="Be concise.",
             engine_args={"max_model_len": 1024},
         )
-        assert isinstance(desc, VLLMPrompterDescriptor)
-        assert desc.model_name == "Qwen/Qwen3-1.7B"
-        assert desc.system_message == "Be concise."
-        assert desc.vllm_options["engine_args"] == {"max_model_len": 1024}
 
-    def test_prompt_batch_uses_batch_api(self):
-        """_PromptBatch detects prompt_batch() method on vLLM prompter."""
-        from unittest.mock import MagicMock, patch
+        assert isinstance(descriptor, VLLMPrompterDescriptor)
+        assert descriptor.model_name == "Qwen/Qwen3-1.7B"
+        assert descriptor.system_message == "Be concise."
+        assert descriptor.vllm_options["engine_args"] == {"max_model_len": 1024}
+
+    def test_direct_prompter_calls_require_native_query_planning(self):
+        import asyncio
 
         from vane.ai.providers.vllm import VLLMPrompterDescriptor
 
-        desc = VLLMPrompterDescriptor(model_name="test-model")
+        prompter = VLLMPrompterDescriptor(model_name="test-model").instantiate()
 
-        # Mock the instantiate to return a fake prompter with prompt_batch
-        mock_prompter = MagicMock()
-        mock_prompter.prompt_batch.return_value = ["Hello!", "World!"]
-
-        with patch.object(desc, "instantiate", return_value=mock_prompter):
-            from vane.ai.functions import _PromptBatch
-
-            batch = _PromptBatch(desc, "text", "response")
-            table = pa.table({"text": ["hi", "hey"]})
-            result = batch(table)
-
-        mock_prompter.prompt_batch.assert_called_once_with(["hi", "hey"])
-        assert result.column("response").to_pylist() == ["Hello!", "World!"]
-
-    def test_prompter_rejects_multimodal_parts(self):
-        """The native vLLM adapter must not silently discard image parts."""
-        import asyncio
-
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        prompter = VLLMPrompter(model="test")
-
-        with pytest.raises(ValueError, match="multimodal prompt parts are not supported"):
-            asyncio.run(prompter.prompt(("Describe this", b"\x89PNG\r\n\x1a\n")))
-
-    def test_system_message_formatting(self):
-        """VLLMPrompter prepends system message to prompts."""
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        prompter = VLLMPrompter(
-            model="test",
-            system_message="Be brief.",
-        )
-        assert prompter._format_prompt("Hello") == "Be brief.\n\nHello"
-
-    def test_no_system_message(self):
-        """VLLMPrompter passes through prompts when no system_message."""
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        prompter = VLLMPrompter(model="test")
-        assert prompter._format_prompt("Hello") == "Hello"
-
-    def test_prompter_uses_background_executor_for_sync_actor_calls(self, monkeypatch):
-        """The synchronous prompter must not reuse the enclosing Ray actor loop."""
-        import duckdb.execution.vllm as vllm_executor
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        captured = {}
-        sentinel = object()
-
-        def fake_build_executor(model, options):
-            captured.update(model=model, options=options)
-            return sentinel
-
-        monkeypatch.setattr(vllm_executor, "build_executor", fake_build_executor)
-        prompter = VLLMPrompter(model="test", vllm_options={"use_threading": False})
-
-        assert prompter._ensure_executor() is sentinel
-        assert captured["model"] == "test"
-        assert captured["options"]["use_threading"] is True
-        assert captured["options"]["_force_background_thread"] is True
-
-    def test_local_executor_can_force_background_loop_inside_ray_actor(self, monkeypatch):
-        """Sync actor wrappers need a loop thread even when Ray reports actor context."""
-        import sys
-        import types
-
-        import duckdb.execution.vllm as vllm_executor
-
-        fake_vllm = types.ModuleType("vllm")
-
-        class SamplingParams:
-            pass
-
-        fake_vllm.SamplingParams = SamplingParams
-        monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
-        monkeypatch.setattr(vllm_executor.LocalVLLMExecutor, "_detect_ray_actor", staticmethod(lambda: True))
-
-        def fake_run_event_loop(executor):
-            executor.loop = object()
-            executor.loop_ready.set()
-
-        monkeypatch.setattr(vllm_executor.LocalVLLMExecutor, "_run_event_loop", fake_run_event_loop)
-
-        executor = vllm_executor.LocalVLLMExecutor(
-            "test-model",
-            {},
-            {},
-            force_background_thread=True,
-        )
-
-        assert executor._ray_actor_mode is False
-        assert executor.loop_ready.is_set()
-
-    def test_prompt_batch_errors_when_wait_returns_without_result(self):
-        """VLLMPrompter treats an empty wait wakeup as an executor contract error."""
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        class EmptyWakeupExecutor:
-            def __init__(self):
-                self.wait_calls = 0
-
-            def submit(self, _prefix, _prompts, _rows):
-                pass
-
-            def finished_submitting(self):
-                pass
-
-            def take_ready_result(self):
-                return None
-
-            def all_tasks_finished(self):
-                return False
-
-            def wait_for_result(self):
-                self.wait_calls += 1
-
-        prompter = VLLMPrompter(model="test")
-        executor = EmptyWakeupExecutor()
-        prompter._executor = executor
-
-        with pytest.raises(RuntimeError, match="wait_for_result returned without a ready result"):
-            prompter.prompt_batch(["a", "b"])
-        assert executor.wait_calls == 1
-
-
-# ---------------------------------------------------------------------------
-# vLLM Structured Output tests
-# ---------------------------------------------------------------------------
+        with pytest.raises(NotImplementedError, match="PhysicalVLLM"):
+            prompter.prompt_batch(["hello"])
+        with pytest.raises(NotImplementedError, match="PhysicalVLLM"):
+            asyncio.run(prompter.prompt(("hello",)))
 
 
 class TestVLLMStructuredOutput:
-    """Tests for vLLM provider structured output via guided decoding."""
+    """Tests for native vLLM structured-output configuration."""
 
     def test_json_schema_from_pydantic(self):
-        """_json_schema_from_return_format extracts schema from Pydantic model."""
-        from pydantic import BaseModel
+        BaseModel = pytest.importorskip("pydantic").BaseModel
 
         from vane.ai.providers.vllm import _json_schema_from_return_format
 
@@ -498,80 +354,32 @@ class TestVLLMStructuredOutput:
             age: int
 
         schema = _json_schema_from_return_format(Person)
+
         assert schema["type"] == "object"
-        assert "name" in schema["properties"]
-        assert "age" in schema["properties"]
+        assert {"name", "age"} <= schema["properties"].keys()
 
     def test_json_schema_from_dict(self):
-        """_json_schema_from_return_format passes dicts through."""
         from vane.ai.providers.vllm import _json_schema_from_return_format
 
         schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+
         assert _json_schema_from_return_format(schema) is schema
 
     def test_json_schema_from_none(self):
-        """_json_schema_from_return_format returns empty dict for None."""
         from vane.ai.providers.vllm import _json_schema_from_return_format
 
         assert _json_schema_from_return_format(None) == {}
 
     def test_json_schema_bad_type(self):
-        """_json_schema_from_return_format raises for unsupported types."""
         from vane.ai.providers.vllm import _json_schema_from_return_format
 
         with pytest.raises(TypeError, match="return_format must be"):
             _json_schema_from_return_format("bad")
 
-    def test_parse_structured_output_pydantic(self):
-        """_parse_structured_output validates JSON into Pydantic model."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import _parse_structured_output
-
-        class Person(BaseModel):
-            name: str
-            age: int
-
-        result = _parse_structured_output('{"name": "Alice", "age": 30}', Person)
-        assert isinstance(result, Person)
-        assert result.name == "Alice"
-        assert result.age == 30
-
-    def test_parse_structured_output_dict_schema(self):
-        """_parse_structured_output returns dict when schema is a dict."""
-        from vane.ai.providers.vllm import _parse_structured_output
-
-        schema = {"type": "object"}
-        result = _parse_structured_output('{"x": 1}', schema)
-        assert result == {"x": 1}
-
-    def test_parse_structured_output_none(self):
-        """_parse_structured_output returns None for None input."""
-        from vane.ai.providers.vllm import _parse_structured_output
-
-        assert _parse_structured_output(None, {"type": "object"}) is None
-
-    def test_descriptor_with_return_format(self):
-        """VLLMPrompterDescriptor stores return_format."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompterDescriptor
-
-        class Item(BaseModel):
-            label: str
-
-        desc = VLLMPrompterDescriptor(
-            model_name="test-model",
-            return_format=Item,
-        )
-        assert desc.return_format is Item
-
-    def test_descriptor_pickle_with_return_format(self):
-        """VLLMPrompterDescriptor with return_format survives pickle."""
-        import pickle
-
+    def test_descriptor_with_return_format_survives_pickle(self):
         import cloudpickle
-        from pydantic import BaseModel
+
+        BaseModel = pytest.importorskip("pydantic").BaseModel
 
         from vane.ai.providers.vllm import VLLMPrompterDescriptor
 
@@ -579,126 +387,31 @@ class TestVLLMStructuredOutput:
             value: float
             label: str
 
-        desc = VLLMPrompterDescriptor(
+        descriptor = VLLMPrompterDescriptor(
             model_name="test-model",
             return_format=Score,
         )
-        restored = pickle.loads(cloudpickle.dumps(desc))
-        assert restored.return_format is not None
+
+        restored = pickle.loads(cloudpickle.dumps(descriptor))
+
         assert restored.model_name == "test-model"
-        # Validate the restored return_format still works
-        obj = restored.return_format(value=1.0, label="test")
-        assert obj.value == 1.0
+        assert restored.return_format(value=1.0, label="test").value == 1.0
 
-    def test_provider_get_prompter_with_return_format(self):
-        """VLLMProvider.get_prompter forwards return_format."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompterDescriptor, VLLMProvider
-
-        class Output(BaseModel):
-            text: str
-
-        provider = VLLMProvider()
-        desc = provider.get_prompter(
-            model="test-model",
-            return_format=Output,
-        )
-        assert isinstance(desc, VLLMPrompterDescriptor)
-        assert desc.return_format is Output
-
-    def test_prompter_injects_structured_output(self):
-        """VLLMPrompter injects structured output config into sampling_params."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        class Entity(BaseModel):
-            name: str
-            kind: str
-
-        prompter = VLLMPrompter(
-            model="test-model",
-            return_format=Entity,
-            vllm_options={"generate_args": {"sampling_params": {"max_tokens": 100}}},
-        )
-        sp = prompter._options["generate_args"]["sampling_params"]
-        schema = sp["structured_outputs"]["value"]
-        assert schema["type"] == "object"
-        assert "name" in schema["properties"]
-        assert "guided_json" not in sp
-        assert sp["max_tokens"] == 100
-
-    def test_prompter_injects_structured_output_empty_options(self):
-        """VLLMPrompter creates generate_args/sampling_params if absent."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        class Tag(BaseModel):
-            value: str
-
-        prompter = VLLMPrompter(
-            model="test-model",
-            return_format=Tag,
-        )
-        sp = prompter._options["generate_args"]["sampling_params"]
-        assert "structured_outputs" in sp
-        assert "guided_json" not in sp
-
-    def test_prompter_no_return_format_no_structured_output(self):
-        """VLLMPrompter without return_format does not inject structured output."""
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        prompter = VLLMPrompter(model="test-model")
-        gen_args = prompter._options.get("generate_args", {})
-        sp = gen_args.get("sampling_params", {})
-        if isinstance(sp, dict):
-            assert "guided_json" not in sp
-            assert "structured_outputs" not in sp
-
-    def test_maybe_parse_with_return_format(self):
-        """_maybe_parse parses JSON when return_format is set."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        class Item(BaseModel):
-            x: int
-
-        prompter = VLLMPrompter(model="test", return_format=Item)
-        result = prompter._maybe_parse('{"x": 42}')
-        assert isinstance(result, Item)
-        assert result.x == 42
-
-    def test_maybe_parse_without_return_format(self):
-        """_maybe_parse returns raw text when no return_format."""
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        prompter = VLLMPrompter(model="test")
-        assert prompter._maybe_parse("hello") == "hello"
-
-    def test_maybe_parse_none(self):
-        """_maybe_parse returns None for None input."""
-        from pydantic import BaseModel
-
-        from vane.ai.providers.vllm import VLLMPrompter
-
-        class Item(BaseModel):
-            x: int
-
-        prompter = VLLMPrompter(model="test", return_format=Item)
-        assert prompter._maybe_parse(None) is None
-
-    def test_dict_schema_structured_output(self):
-        """VLLMPrompter accepts raw dict schema for structured output."""
-        from vane.ai.providers.vllm import VLLMPrompter
+    def test_descriptor_injects_schema_into_native_sampling_params(self):
+        from vane.ai.providers.vllm import VLLMPrompterDescriptor
 
         schema = {"type": "object", "properties": {"n": {"type": "number"}}}
-        prompter = VLLMPrompter(model="test", return_format=schema)
-        sp = prompter._options["generate_args"]["sampling_params"]
-        assert sp["structured_outputs"]["value"] == schema
-        assert "guided_json" not in sp
+        descriptor = VLLMPrompterDescriptor(
+            model_name="test-model",
+            return_format=schema,
+            vllm_options={"generate_args": {"sampling_params": {"max_tokens": 100}}},
+        )
+
+        sampling_params = descriptor.build_physical_vllm_options()["generate_args"]["sampling_params"]
+
+        assert sampling_params["max_tokens"] == 100
+        assert sampling_params["structured_outputs"] == {"type": "json", "value": schema}
+        assert "guided_json" not in sampling_params
 
 
 class TestUDFExecutionOptions:

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -5,8 +5,8 @@
 
 Covers vane#105: descriptors must never expose API keys through repr, str,
 logging, exception rendering, or pickled copies, while ``instantiate()`` (and
-the OpenAI dimension probe / native option materialization) still hands the
-real plaintext to the SDK client or execution boundary.
+the OpenAI dimension probe / native vLLM executor) still hands the real
+plaintext to the SDK client or execution boundary.
 """
 
 from __future__ import annotations
@@ -362,10 +362,13 @@ class TestUnwrapAtExecutionBoundary:
         _google_prompter_descriptor().instantiate()
         assert client.calls == [{"api_key": API_KEY}]
 
-    def test_vllm_native_options_receive_plaintext_nested_args(self):
+    def test_vllm_native_plan_options_keep_nested_args_sealed(self):
         options = _vllm_prompter_descriptor().build_physical_vllm_options()
-        assert options["engine_args"] == {"hf_token": HUB_TOKEN, "max_model_len": 2048}
-        assert options["generate_args"]["api_key"] == API_KEY
+        assert isinstance(options["engine_args"]["hf_token"], Secret)
+        assert options["engine_args"]["hf_token"].reveal() == HUB_TOKEN
+        assert options["engine_args"]["max_model_len"] == 2048
+        assert isinstance(options["generate_args"]["api_key"], Secret)
+        assert options["generate_args"]["api_key"].reveal() == API_KEY
         assert options["generate_args"]["sampling_params"] == {"max_tokens": 64}
         assert options["use_threading"] is True
 
@@ -468,7 +471,8 @@ class TestPickleRoundTrip:
         restored.instantiate()
         assert client.calls == [{"api_key": API_KEY}]
 
-    def test_vllm_pickled_plan_still_builds_native_options_with_plaintext(self):
+    def test_vllm_pickled_plan_still_builds_native_options_with_sealed_secrets(self):
         restored = pickle.loads(pickle.dumps(_vllm_prompter_descriptor()))
         options = restored.build_physical_vllm_options()
-        assert options["engine_args"]["hf_token"] == HUB_TOKEN
+        assert isinstance(options["engine_args"]["hf_token"], Secret)
+        assert options["engine_args"]["hf_token"].reveal() == HUB_TOKEN

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -5,8 +5,8 @@
 
 Covers vane#105: descriptors must never expose API keys through repr, str,
 logging, exception rendering, or pickled copies, while ``instantiate()`` (and
-the OpenAI dimension probe / local engine construction) still hands the real
-plaintext to the SDK client or engine.
+the OpenAI dimension probe / native option materialization) still hands the
+real plaintext to the SDK client or execution boundary.
 """
 
 from __future__ import annotations
@@ -15,7 +15,6 @@ import logging
 import pickle
 import sys
 import traceback
-import types
 from types import SimpleNamespace
 
 import pytest
@@ -168,22 +167,6 @@ def _install_fake_google(monkeypatch, client):
     fake_genai = SimpleNamespace(Client=client)
     monkeypatch.setitem(sys.modules, "google", SimpleNamespace(genai=fake_genai))
     monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
-
-
-def _install_fake_vllm_engine(monkeypatch, captured):
-    def fake_build_executor(model, options):
-        captured.append((model, options))
-        return SimpleNamespace()
-
-    vllm_module = types.ModuleType("duckdb.execution.vllm")
-    vllm_module.build_executor = fake_build_executor
-    execution_module = types.ModuleType("duckdb.execution")
-    execution_module.vllm = vllm_module
-    duckdb_module = types.ModuleType("duckdb")
-    duckdb_module.execution = execution_module
-    monkeypatch.setitem(sys.modules, "duckdb", duckdb_module)
-    monkeypatch.setitem(sys.modules, "duckdb.execution", execution_module)
-    monkeypatch.setitem(sys.modules, "duckdb.execution.vllm", vllm_module)
 
 
 # ---------------------------------------------------------------------------
@@ -379,14 +362,8 @@ class TestUnwrapAtExecutionBoundary:
         _google_prompter_descriptor().instantiate()
         assert client.calls == [{"api_key": API_KEY}]
 
-    def test_vllm_engine_receives_plaintext_nested_args(self, monkeypatch):
-        captured = []
-        _install_fake_vllm_engine(monkeypatch, captured)
-        prompter = _vllm_prompter_descriptor().instantiate()
-        prompter._ensure_executor()
-        assert len(captured) == 1
-        model, options = captured[0]
-        assert model == "Qwen/Qwen3-1.7B"
+    def test_vllm_native_options_receive_plaintext_nested_args(self):
+        options = _vllm_prompter_descriptor().build_physical_vllm_options()
         assert options["engine_args"] == {"hf_token": HUB_TOKEN, "max_model_len": 2048}
         assert options["generate_args"]["api_key"] == API_KEY
         assert options["generate_args"]["sampling_params"] == {"max_tokens": 64}
@@ -491,10 +468,7 @@ class TestPickleRoundTrip:
         restored.instantiate()
         assert client.calls == [{"api_key": API_KEY}]
 
-    def test_vllm_pickled_descriptor_still_builds_engine_with_plaintext(self, monkeypatch):
-        captured = []
-        _install_fake_vllm_engine(monkeypatch, captured)
+    def test_vllm_pickled_plan_still_builds_native_options_with_plaintext(self):
         restored = pickle.loads(pickle.dumps(_vllm_prompter_descriptor()))
-        restored.instantiate()._ensure_executor()
-        _model, options = captured[0]
+        options = restored.build_physical_vllm_options()
         assert options["engine_args"]["hf_token"] == HUB_TOKEN

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -314,6 +314,30 @@ def test_vllm_descriptor_builds_native_options_without_mutating_inputs():
     assert explicit_concurrency["concurrency"] == 7
 
 
+@pytest.mark.parametrize(
+    ("options", "error", "message"),
+    [
+        (
+            {"engine_args": {"dtype": object()}},
+            TypeError,
+            r"engine_args\.dtype.*JSON-compatible.*object",
+        ),
+        (
+            {"generate_args": {"temperature": float("nan")}},
+            ValueError,
+            r"generate_args\.temperature.*finite",
+        ),
+    ],
+)
+def test_vllm_native_options_reject_invalid_json_values_early(options, error, message):
+    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+
+    descriptor = VLLMPrompterDescriptor(model_name="native-model", vllm_options=options)
+
+    with pytest.raises(error, match=message):
+        descriptor.build_physical_vllm_options()
+
+
 def test_ai_prompt_vllm_rejects_udf_retry_policy():
     with pytest.raises(ValueError, match="native vLLM prompting does not support max_retries"):
         vane.ai.prompt(
@@ -343,7 +367,7 @@ def test_ai_prompt_vllm_expression_plans_native_operator():
     assert "ray_actor" not in plan
 
 
-def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_preserves_columns(monkeypatch):
+def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_output(monkeypatch):
     import duckdb.execution.vllm as vllm_executor
     from vane.ai.providers.vllm import VLLMProvider
 
@@ -357,7 +381,9 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_preserves_columns
 
     monkeypatch.setattr(vllm_executor, "build_executor", build_executor)
     conn = vane.connect()
-    rel = conn.sql("select * from (values (1, 'question'::VARCHAR), (2, NULL::VARCHAR)) source(id, question)")
+    rel = conn.sql(
+        "select * from (values (1, 'question'::VARCHAR), (2, NULL::VARCHAR)) source(id, question) order by id"
+    )
     schema = {
         "type": "object",
         "properties": {"answer": {"type": "string"}},
@@ -379,11 +405,11 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_preserves_columns
         },
     )
 
-    assert result.columns == ["id", "question", "answer"]
+    assert result.columns == ["answer"]
     assert "VLLM_PROJECT" in result.explain()
-    assert result.order("id").fetchall() == [
-        (1, "question", "generated:Answer briefly.\n\nquestion"),
-        (2, None, "generated:Answer briefly.\n\n"),
+    assert result.fetchall() == [
+        ("generated:Answer briefly.\n\nquestion",),
+        ("generated:Answer briefly.\n\n",),
     ]
     assert captured["model"] == "native-model"
     options = captured["options"]
@@ -400,6 +426,46 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_preserves_columns
         "Answer briefly.\n\nquestion",
         "Answer briefly.\n\n",
     ]
+
+
+def test_ai_prompt_native_vllm_output_replaces_same_named_input(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+    from vane.ai.providers.vllm import VLLMProvider
+
+    monkeypatch.setattr(
+        vllm_executor,
+        "build_executor",
+        lambda _model, _options: _RecordingNativeVLLMExecutor(),
+    )
+    rel = vane.connect().sql("select 'question'::VARCHAR as question, 'stale'::VARCHAR as answer")
+
+    result = vane.ai.prompt(
+        rel,
+        "question",
+        provider=VLLMProvider(),
+        output_column="answer",
+    )
+
+    assert result.columns == ["answer"]
+    assert result.fetchall() == [("generated:question",)]
+
+
+@pytest.mark.parametrize("execution_backend", ["ray_actor", "subprocess_task", "definitely-invalid"])
+def test_ai_prompt_native_vllm_rejects_explicit_execution_backend(execution_backend):
+    from vane.ai.providers.vllm import VLLMProvider
+
+    rel = vane.connect().sql("select 'question'::VARCHAR as question")
+
+    with pytest.raises(
+        ValueError,
+        match="execution_backend applies only to Python UDF providers; native vLLM routing is derived from the query runner",
+    ):
+        vane.ai.prompt(
+            rel,
+            "question",
+            provider=VLLMProvider(),
+            execution_backend=execution_backend,
+        )
 
 
 def test_ai_prompt_native_vllm_rejects_image_columns():

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+from collections import deque
 from dataclasses import dataclass
 
 import numpy as np
@@ -129,6 +130,45 @@ class MockProvider(Provider):
         )
 
 
+class _RecordingNativeVLLMExecutor:
+    """Minimal executor used to exercise the native PhysicalVLLM bridge."""
+
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str | None, tuple[str, ...]]] = []
+        self.ready = deque()
+        self.finished = False
+        self.finished_count = 0
+        self.shutdown_count = 0
+
+    def submit(self, prefix, prompts, rows) -> None:
+        prompt_values = tuple(prompts)
+        self.submissions.append((prefix, prompt_values))
+        self.ready.append(([f"generated:{prompt}" for prompt in prompt_values], rows))
+
+    def take_ready_result(self):
+        try:
+            return self.ready.popleft()
+        except IndexError:
+            return None
+
+    def finished_submitting(self) -> None:
+        self.finished = True
+        self.finished_count += 1
+
+    def all_tasks_finished(self) -> bool:
+        return self.finished and not self.ready
+
+    def wait_for_result(self) -> None:
+        pass
+
+    def register_wakeup_callback(self, _callback) -> bool:
+        return False
+
+    def shutdown(self) -> None:
+        self.finished = True
+        self.shutdown_count += 1
+
+
 def test_ai_embed_is_public_expression_api():
     assert callable(vane.ai.embed)
 
@@ -221,6 +261,160 @@ def test_ai_prompt_keeps_existing_relation_api():
     result = vane.ai.prompt(rel, "chunk", provider=MockProvider())
 
     assert result.fetchall() == [("topic:search",)]
+
+
+def test_vllm_descriptor_builds_native_options_without_mutating_inputs():
+    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    caller_options = {
+        "actor_number": 4,
+        "on_error": "ignore",
+        "temperature": 0.25,
+        "engine_args": {"max_model_len": 2048},
+        "generate_args": {"sampling_params": '{"max_tokens":32}'},
+    }
+    descriptor = VLLMPrompterDescriptor(
+        model_name="native-model",
+        return_format=schema,
+        vllm_options=caller_options,
+    )
+
+    native_options = descriptor.build_physical_vllm_options()
+
+    assert native_options["concurrency"] == 4
+    assert "actor_number" not in native_options
+    assert native_options["use_threading"] is True
+    assert native_options["_force_background_thread"] is True
+    assert native_options["on_error"] == "null"
+    sampling_params = native_options["generate_args"]["sampling_params"]
+    assert sampling_params["max_tokens"] == 32
+    assert sampling_params["temperature"] == 0.25
+    assert sampling_params["structured_outputs"] == {"type": "json", "value": schema}
+    assert caller_options == {
+        "actor_number": 4,
+        "on_error": "ignore",
+        "temperature": 0.25,
+        "engine_args": {"max_model_len": 2048},
+        "generate_args": {"sampling_params": '{"max_tokens":32}'},
+    }
+
+    sampling_params["max_tokens"] = 1
+    sampling_params["structured_outputs"]["value"]["required"].clear()
+    assert caller_options["generate_args"]["sampling_params"] == '{"max_tokens":32}'
+    assert schema["required"] == ["answer"]
+
+    explicit_concurrency = VLLMPrompterDescriptor(
+        vllm_options={"actor_number": 2, "concurrency": 7}
+    ).build_physical_vllm_options()
+    assert explicit_concurrency["concurrency"] == 7
+
+
+def test_ai_prompt_vllm_rejects_udf_retry_policy():
+    with pytest.raises(ValueError, match="native vLLM prompting does not support max_retries"):
+        vane.ai.prompt(
+            vane.col("chunk"),
+            provider="vllm",
+            prompt_options={"max_retries": 1},
+        )
+
+
+def test_ai_prompt_vllm_expression_plans_native_operator():
+    from vane.ai.providers.vllm import VLLMProvider
+
+    conn = vane.connect()
+    rel = conn.sql("select 'search'::VARCHAR as chunk")
+
+    expr = vane.ai.prompt(
+        vane.col("chunk"),
+        provider=VLLMProvider(),
+        model="native-model",
+        system_message="Answer briefly.",
+    ).alias("answer")
+    plan = rel.select(expr).explain()
+
+    assert "VLLM_PROJECT" in plan
+    assert "native-model" in plan
+    assert "subprocess_actor" not in plan
+    assert "ray_actor" not in plan
+
+
+def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_preserves_columns(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+    from vane.ai.providers.vllm import VLLMProvider
+
+    executor = _RecordingNativeVLLMExecutor()
+    captured: dict[str, object] = {}
+
+    def build_executor(model, options):
+        captured["model"] = model
+        captured["options"] = options
+        return executor
+
+    monkeypatch.setattr(vllm_executor, "build_executor", build_executor)
+    conn = vane.connect()
+    rel = conn.sql("select * from (values (1, 'question'::VARCHAR), (2, NULL::VARCHAR)) source(id, question)")
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+
+    result = vane.ai.prompt(
+        rel,
+        "question",
+        provider=VLLMProvider(),
+        model="native-model",
+        system_message="Answer briefly.",
+        return_format=schema,
+        output_column="answer",
+        provider_options=vane.ai.VLLMProviderOptions(concurrency=2),
+        prompt_options={
+            "do_prefix_routing": False,
+            "generate_args": {"sampling_params": {"max_tokens": 32}},
+        },
+    )
+
+    assert result.columns == ["id", "question", "answer"]
+    assert "VLLM_PROJECT" in result.explain()
+    assert result.order("id").fetchall() == [
+        (1, "question", "generated:Answer briefly.\n\nquestion"),
+        (2, None, "generated:Answer briefly.\n\n"),
+    ]
+    assert captured["model"] == "native-model"
+    options = captured["options"]
+    assert isinstance(options, dict)
+    assert options["concurrency"] == 2
+    assert "actor_number" not in options
+    assert options["generate_args"]["sampling_params"]["structured_outputs"] == {
+        "type": "json",
+        "value": schema,
+    }
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
+    assert [prompt for _prefix, prompts in executor.submissions for prompt in prompts] == [
+        "Answer briefly.\n\nquestion",
+        "Answer briefly.\n\n",
+    ]
+
+
+def test_ai_prompt_native_vllm_rejects_image_columns():
+    from vane.ai.providers.vllm import VLLMProvider
+
+    conn = vane.connect()
+    rel = conn.sql("select 'question'::VARCHAR as question, 'image'::BLOB as image")
+
+    with pytest.raises(ValueError, match="native vLLM prompting does not support image_columns"):
+        vane.ai.prompt(
+            rel,
+            "question",
+            provider=VLLMProvider(),
+            image_columns=["image"],
+        )
 
 
 def test_ai_prompt_rel_keyword_matches_positional_relation_api():
@@ -390,8 +584,9 @@ def test_ai_prompt_expression_rejects_gpu_actor_on_local_runner(monkeypatch):
     rel = conn.sql("select 1 as id, 'search'::VARCHAR as chunk")
 
     with pytest.raises(duckdb.InvalidInputException, match="GPU resources require a Ray UDF backend"):
-        vane.ai.prompt(
+        expr = vane.ai.prompt(
             vane.col("chunk"),
             provider=MockProvider(),
             provider_options=vane.ai.VLLMProviderOptions(concurrency=1, gpus_per_actor=1),
         ).alias("topic")
+        rel.select(expr)

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 from collections import deque
 from dataclasses import dataclass
@@ -338,6 +339,22 @@ def test_vllm_native_options_reject_invalid_json_values_early(options, error, me
         descriptor.build_physical_vllm_options()
 
 
+@pytest.mark.parametrize(
+    "reserved_key",
+    [
+        "__vane_vllm_payload_version",
+        "__vane_vllm_public_options_json",
+        "__vane_vllm_secret_payload",
+        "_vane_vllm_secret_payload",
+    ],
+)
+def test_vllm_native_options_reject_reserved_protocol_fields(reserved_key):
+    from vane.ai.providers.vllm import _build_native_vllm_options_argument
+
+    with pytest.raises(ValueError, match="reserved protocol fields"):
+        _build_native_vllm_options_argument({reserved_key: "user-value"})
+
+
 def test_ai_prompt_vllm_rejects_udf_retry_policy():
     with pytest.raises(ValueError, match="native vLLM prompting does not support max_retries"):
         vane.ai.prompt(
@@ -365,6 +382,56 @@ def test_ai_prompt_vllm_expression_plans_native_operator():
     assert "native-model" in plan
     assert "subprocess_actor" not in plan
     assert "ray_actor" not in plan
+
+
+@pytest.mark.parametrize("api_shape", ["relation", "expression"])
+def test_ai_prompt_vllm_keeps_inline_secrets_out_of_public_plan_options(api_shape):
+    sentinel = "hf-NATIVE-PLAN-SECRET-SENTINEL"
+    sampling_sentinel = "sk-NATIVE-SAMPLING-SECRET-SENTINEL"
+    conn = vane.connect()
+    source = conn.sql("select 'search'::VARCHAR as chunk")
+    prompt_kwargs = {
+        "provider": "vllm",
+        "model": "native-model",
+        "provider_options": {
+            "engine_args": {
+                "hf_token": sentinel,
+                "max_model_len": 2048,
+            },
+            "generate_args": {"sampling_params": json.dumps({"api_key": sampling_sentinel, "max_tokens": 8})},
+        },
+    }
+    if api_shape == "relation":
+        relation = vane.ai.prompt(source, "chunk", **prompt_kwargs)
+    else:
+        expression = vane.ai.prompt(vane.col("chunk"), **prompt_kwargs).alias("response")
+        relation = source.select(expression)
+
+    assert sentinel not in relation.explain()
+    assert sampling_sentinel not in relation.explain()
+    physical = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        f"opaque-secret-{api_shape}",
+    ).to_physical_plan(conn)
+    nodes = physical.collect_vllm_nodes(conn=conn)
+
+    assert len(nodes) == 1
+    envelope = nodes[0]["options"]
+    assert isinstance(envelope, dict)
+    public_options_json = envelope["__vane_vllm_public_options_json"]
+    assert sentinel not in public_options_json
+    assert sampling_sentinel not in public_options_json
+    public_options = json.loads(public_options_json)
+    assert public_options["engine_args"] == {
+        "hf_token": {"__vane_vllm_secret_ref": 0},
+        "max_model_len": 2048,
+    }
+    assert public_options["generate_args"]["sampling_params"] == {
+        "api_key": {"__vane_vllm_secret_ref": 1},
+        "max_tokens": 8,
+    }
+    assert sentinel.encode() in envelope["__vane_vllm_secret_payload"]
+    assert sampling_sentinel.encode() in envelope["__vane_vllm_secret_payload"]
 
 
 def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_output(monkeypatch):
@@ -426,6 +493,56 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_outp
         "Answer briefly.\n\nquestion",
         "Answer briefly.\n\n",
     ]
+
+
+def test_ai_prompt_vllm_relation_restores_opaque_secrets_at_local_executor_creation(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+
+    engine_token = "hf-LOCAL-EXECUTOR-SECRET-SENTINEL"
+    generate_key = "sk-LOCAL-EXECUTOR-SECRET-SENTINEL"
+    executor = _RecordingNativeVLLMExecutor()
+    captured = {}
+
+    def create_local_executor(model, engine_args, generate_args, **kwargs):
+        captured.update(
+            model=model,
+            engine_args=engine_args,
+            generate_args=generate_args,
+            kwargs=kwargs,
+        )
+        return executor
+
+    monkeypatch.setattr(vllm_executor, "LocalVLLMExecutor", create_local_executor)
+    conn = vane.connect()
+    source = conn.sql("select 'question'::VARCHAR as question")
+
+    result = vane.ai.prompt(
+        source,
+        "question",
+        provider="vllm",
+        model="native-secret-model",
+        provider_options={
+            "engine_args": {
+                "hf_token": engine_token,
+                "max_model_len": 1024,
+            }
+        },
+        prompt_options={
+            "generate_args": {
+                "api_key": generate_key,
+                "sampling_params": {"max_tokens": 8},
+            }
+        },
+    )
+
+    assert engine_token not in result.explain()
+    assert generate_key not in result.explain()
+    assert result.fetchall() == [("generated:question",)]
+    assert captured["model"] == "native-secret-model"
+    assert captured["engine_args"]["hf_token"] == engine_token
+    assert captured["engine_args"]["max_model_len"] == 1024
+    assert captured["generate_args"]["api_key"] == generate_key
+    assert captured["generate_args"]["sampling_params"] == {"max_tokens": 8}
 
 
 def test_ai_prompt_native_vllm_output_replaces_same_named_input(monkeypatch):

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import math
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass
 
 import numpy as np
@@ -474,10 +474,12 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_outp
 
     assert result.columns == ["answer"]
     assert "VLLM_PROJECT" in result.explain()
-    assert result.fetchall() == [
-        ("generated:Answer briefly.\n\nquestion",),
-        ("generated:Answer briefly.\n\n",),
-    ]
+    assert Counter(result.fetchall()) == Counter(
+        [
+            ("generated:Answer briefly.\n\nquestion",),
+            (None,),
+        ]
+    )
     assert captured["model"] == "native-model"
     options = captured["options"]
     assert isinstance(options, dict)
@@ -491,7 +493,6 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_outp
     assert executor.shutdown_count == 1
     assert [prompt for _prefix, prompts in executor.submissions for prompt in prompts] == [
         "Answer briefly.\n\nquestion",
-        "Answer briefly.\n\n",
     ]
 
 

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -1023,6 +1023,18 @@ def test_ai_sql_helper_rejects_vllm_udf_retry_policy():
         build_ai_prompt_sql_spec({"provider": "vllm", "max_retries": Decimal(1)})
 
 
+def test_ai_sql_helper_rejects_non_json_vllm_options_with_path():
+    from vane.ai._sql import build_ai_prompt_sql_spec
+
+    with pytest.raises(TypeError, match=r"engine_args\.dtype.*JSON-compatible.*object"):
+        build_ai_prompt_sql_spec(
+            {
+                "provider": "vllm",
+                "engine_args": {"dtype": object()},
+            }
+        )
+
+
 def test_ai_sql_helper_normalizes_decimal_sql_options(monkeypatch):
     from vane.ai._sql import build_ai_prompt_sql_spec
 

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -933,7 +933,7 @@ def test_ai_prompt_sql_vllm_reuses_one_native_executor_across_batches(monkeypatc
 
     assert rows == [
         (1, "native:Answer briefly.\n\nalpha"),
-        (2, "native:Answer briefly.\n\n"),
+        (2, None),
         (3, "native:Answer briefly.\n\nbeta"),
     ]
     assert len(builds) == 1
@@ -944,7 +944,6 @@ def test_ai_prompt_sql_vllm_reuses_one_native_executor_across_batches(monkeypatc
     assert sorted(prompts for _, prompts in executor.submissions) == sorted(
         [
             ("Answer briefly.\n\nalpha",),
-            ("Answer briefly.\n\n",),
             ("Answer briefly.\n\nbeta",),
         ]
     )

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pickle
 import uuid
+from collections import deque
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -124,6 +125,40 @@ class MockProvider(Provider):
             required_env_name=options.get("required_env_name"),
             fail_after_env_check=bool(options.get("fail_after_env_check", False)),
         )
+
+
+class RecordingNativeVLLMExecutor:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[str | None, tuple[str, ...]]] = []
+        self.ready = deque()
+        self.finished_count = 0
+        self.shutdown_count = 0
+
+    def submit(self, prefix, prompts, rows) -> None:
+        prompt_values = tuple(prompts)
+        self.submissions.append((prefix, prompt_values))
+        self.ready.append(([f"native:{prompt}" for prompt in prompt_values], rows))
+
+    def take_ready_result(self):
+        try:
+            return self.ready.popleft()
+        except IndexError:
+            return None
+
+    def finished_submitting(self) -> None:
+        self.finished_count += 1
+
+    def all_tasks_finished(self) -> bool:
+        return self.finished_count == 1 and not self.ready
+
+    def wait_for_result(self) -> None:
+        raise AssertionError("immediate native vLLM results must not block")
+
+    def register_wakeup_callback(self, callback) -> bool:
+        return False
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
 
 
 @pytest.fixture(autouse=True)
@@ -279,6 +314,44 @@ def test_ai_prompt_image_input_survives_plan_round_trip_as_row_data():
     assert payload["input_names"] == ["messages", "images"]
     assert payload["scalar_arg_count"] == 2
     assert image_bytes not in payload["function_pickle"]
+
+
+def test_ai_prompt_vllm_survives_logical_plan_pickle_as_native_operator(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+
+    executor = RecordingNativeVLLMExecutor()
+    builds: list[tuple[str, dict[str, object]]] = []
+
+    def build_executor(model, options):
+        builds.append((model, dict(options)))
+        return executor
+
+    monkeypatch.setattr(vllm_executor, "build_executor", build_executor)
+    source = vane.connect()
+    relation = source.sql("""
+        SELECT ai_prompt(
+            chunk,
+            struct_pack(
+                provider := 'vllm',
+                model := 'round-trip-vllm',
+                batch_size := 1,
+                do_prefix_routing := false
+            )
+        ) AS response
+        FROM (VALUES ('alpha'), ('beta')) AS t(chunk)
+    """)
+
+    _, target, physical, serialized = _round_trip_ai_plan(relation)
+    table = _execute_ai_physical_plan(target, physical)
+
+    assert physical.collect_udf_nodes() == []
+    assert table.column(0).to_pylist() == ["native:alpha", "native:beta"]
+    assert len(builds) == 1
+    assert builds[0][0] == "round-trip-vllm"
+    assert builds[0][1]["batch_size"] == 1
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
+    assert 0 < len(serialized) < 10_000
 
 
 def test_ai_embed_fixed_dimensions_survive_round_trip():
@@ -648,6 +721,19 @@ def test_ai_prompt_literal_null_image_still_validates_provider():
         """).fetchall()
 
 
+def test_ai_prompt_sql_rejects_native_vllm_image_input():
+    conn = vane.connect()
+
+    with pytest.raises(Exception, match="native vLLM ai_prompt does not support image inputs"):
+        conn.sql("""
+            SELECT ai_prompt(
+                'describe',
+                from_hex('89504e47'),
+                struct_pack(provider := 'vllm', model := 'test-model')
+            )
+        """).fetchall()
+
+
 def test_ai_prompt_sql_with_single_image_blob_and_null_image():
     conn = vane.connect()
 
@@ -793,6 +879,79 @@ def test_ai_prompt_sql_explain_uses_ray_actor_backend(monkeypatch):
     assert "actor_number: 1" in text
 
 
+def test_ai_prompt_sql_vllm_explain_uses_native_operator():
+    conn = vane.connect()
+
+    plan = conn.sql("""
+        EXPLAIN SELECT ai_prompt(
+            chunk,
+            struct_pack(
+                provider := 'vllm',
+                model := 'recording-model',
+                concurrency := 2,
+                batch_size := 1
+            )
+        )
+        FROM (VALUES ('alpha')) AS t(chunk)
+    """).fetchall()
+    text = "\n".join(str(row) for row in plan)
+
+    assert "VLLM_PROJECT" in text
+    assert "subprocess_actor" not in text
+    assert "ray_actor" not in text
+
+
+def test_ai_prompt_sql_vllm_reuses_one_native_executor_across_batches(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+
+    executor = RecordingNativeVLLMExecutor()
+    builds: list[tuple[str, dict[str, object]]] = []
+
+    def build_executor(model, options):
+        builds.append((model, dict(options)))
+        return executor
+
+    monkeypatch.setattr(vllm_executor, "build_executor", build_executor)
+    conn = vane.connect()
+    conn.execute("PRAGMA threads=1")
+    rows = conn.sql("""
+        SELECT id, ai_prompt(
+            chunk,
+            struct_pack(
+                provider := 'vllm',
+                model := 'recording-model',
+                system_message := 'Answer briefly.',
+                concurrency := 2,
+                batch_size := 1,
+                do_prefix_routing := false,
+                on_error := 'ignore'
+            )
+        ) AS response
+        FROM (VALUES (1, 'alpha'), (2, NULL), (3, 'beta')) AS t(id, chunk)
+        ORDER BY id
+    """).fetchall()
+
+    assert rows == [
+        (1, "native:Answer briefly.\n\nalpha"),
+        (2, "native:Answer briefly.\n\n"),
+        (3, "native:Answer briefly.\n\nbeta"),
+    ]
+    assert len(builds) == 1
+    assert builds[0][0] == "recording-model"
+    assert builds[0][1]["concurrency"] == 2
+    assert builds[0][1]["batch_size"] == 1
+    assert builds[0][1]["on_error"] == "null"
+    assert sorted(prompts for _, prompts in executor.submissions) == sorted(
+        [
+            ("Answer briefly.\n\nalpha",),
+            ("Answer briefly.\n\n",),
+            ("Answer briefly.\n\nbeta",),
+        ]
+    )
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
+
+
 def test_ai_sql_helper_builds_prompt_spec_without_execution():
     from vane.ai._sql import build_ai_prompt_sql_spec
 
@@ -818,6 +977,50 @@ def test_ai_sql_helper_builds_multimodal_prompt_spec_without_execution():
     assert spec["schema"] == {"response": "VARCHAR"}
     assert spec["actor_number"] == 1
     assert spec["gpus"] == 0
+
+
+def test_ai_sql_helper_rejects_native_vllm_multimodal_prompt():
+    from vane.ai._sql import build_ai_prompt_sql_spec
+
+    with pytest.raises(ValueError, match="native vLLM ai_prompt does not support image inputs"):
+        build_ai_prompt_sql_spec(
+            {"provider": "vllm", "model": "recording-model"},
+            image_input=True,
+        )
+
+
+def test_ai_sql_helper_builds_native_vllm_spec_without_udf_wrapper():
+    import json
+
+    from vane.ai._sql import build_ai_prompt_sql_spec
+
+    spec = build_ai_prompt_sql_spec(
+        {
+            "provider": "vllm",
+            "model": "recording-model",
+            "system_message": "Answer briefly.",
+            "concurrency": Decimal(3),
+            "batch_size": Decimal(4),
+            "on_error": "ignore",
+        }
+    )
+    native_options = json.loads(spec["options_json"])
+
+    assert spec["execution_kind"] == "native_vllm"
+    assert spec["model"] == "recording-model"
+    assert spec["system_message"] == "Answer briefly."
+    assert "function" not in spec
+    assert native_options["concurrency"] == 3
+    assert native_options["batch_size"] == 4
+    assert native_options["on_error"] == "null"
+    assert "actor_number" not in native_options
+
+
+def test_ai_sql_helper_rejects_vllm_udf_retry_policy():
+    from vane.ai._sql import build_ai_prompt_sql_spec
+
+    with pytest.raises(ValueError, match="native vLLM ai_prompt does not support max_retries"):
+        build_ai_prompt_sql_spec({"provider": "vllm", "max_retries": Decimal(1)})
 
 
 def test_ai_sql_helper_normalizes_decimal_sql_options(monkeypatch):

--- a/tests/ai/test_vllm_expression_composition.py
+++ b/tests/ai/test_vllm_expression_composition.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+import duckdb
+import vane
+
+
+class _ImmediateVLLMExecutor:
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.ready = deque()
+        self.finished = False
+        self.finished_count = 0
+        self.shutdown_count = 0
+
+    def submit(self, _prefix, prompts, rows) -> None:
+        outputs = [f"{self.model}::{prompt}" for prompt in prompts]
+        self.ready.append((outputs, rows))
+
+    def take_ready_result(self):
+        try:
+            return self.ready.popleft()
+        except IndexError:
+            return None
+
+    def finished_submitting(self) -> None:
+        self.finished = True
+        self.finished_count += 1
+
+    def all_tasks_finished(self) -> bool:
+        return self.finished and not self.ready
+
+    def wait_for_result(self) -> None:
+        raise AssertionError("immediate vLLM results must not block")
+
+    def register_wakeup_callback(self, _callback) -> bool:
+        return False
+
+    def shutdown(self) -> None:
+        self.finished = True
+        self.shutdown_count += 1
+
+
+def _record_native_executors(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+
+    executors: list[_ImmediateVLLMExecutor] = []
+
+    def build_executor(model, _options):
+        executor = _ImmediateVLLMExecutor(model)
+        executors.append(executor)
+        return executor
+
+    monkeypatch.setattr(vllm_executor, "build_executor", build_executor)
+    return executors
+
+
+def test_python_vllm_expressions_support_multiple_nested_outputs(monkeypatch):
+    executors = _record_native_executors(monkeypatch)
+    conn = vane.connect()
+    conn.execute("PRAGMA threads=1")
+    rel = conn.sql("SELECT * FROM (VALUES (1, 'Alpha'), (2, 'Beta')) source(id, chunk)")
+
+    lower_prompt = duckdb.FunctionExpression(
+        "lower",
+        vane.ai.prompt(
+            vane.col("chunk"),
+            provider="vllm",
+            model="PY-UPPER",
+            prompt_options={"do_prefix_routing": False},
+        ),
+    ).alias("lowered")
+    wrapped_prompt = duckdb.FunctionExpression(
+        "concat",
+        duckdb.ConstantExpression("["),
+        vane.ai.prompt(
+            vane.col("chunk"),
+            provider="vllm",
+            model="py-wrapped",
+            prompt_options={"do_prefix_routing": False},
+        ),
+        duckdb.ConstantExpression("]"),
+    ).alias("wrapped")
+
+    result = rel.select(vane.col("id"), lower_prompt, wrapped_prompt).order("id")
+
+    assert result.explain().count("VLLM_PROJECT") == 2
+    assert result.fetchall() == [
+        (1, "py-upper::alpha", "[py-wrapped::Alpha]"),
+        (2, "py-upper::beta", "[py-wrapped::Beta]"),
+    ]
+    assert len(executors) == 2
+    assert all(executor.finished_count == 1 for executor in executors)
+    assert all(executor.shutdown_count == 1 for executor in executors)
+
+
+def test_python_vllm_expressions_support_chained_native_prompts(monkeypatch):
+    executors = _record_native_executors(monkeypatch)
+    conn = vane.connect()
+    conn.execute("PRAGMA threads=1")
+    rel = conn.sql("SELECT * FROM (VALUES (1, 'Alpha'), (2, 'Beta')) source(id, chunk)")
+
+    inner_prompt = vane.ai.prompt(
+        vane.col("chunk"),
+        provider="vllm",
+        model="inner",
+        prompt_options={"do_prefix_routing": False},
+    )
+    chained_prompt = vane.ai.prompt(
+        inner_prompt,
+        provider="vllm",
+        model="outer",
+        prompt_options={"do_prefix_routing": False},
+    ).alias("chained")
+
+    result = rel.select(vane.col("id"), chained_prompt).order("id")
+
+    assert result.explain().count("VLLM_PROJECT") == 2
+    assert result.fetchall() == [
+        (1, "outer::inner::Alpha"),
+        (2, "outer::inner::Beta"),
+    ]
+    assert len(executors) == 2
+    assert all(executor.finished_count == 1 for executor in executors)
+    assert all(executor.shutdown_count == 1 for executor in executors)
+
+
+def test_sql_ai_prompt_supports_multiple_calls_nested_in_eager_expressions(monkeypatch):
+    executors = _record_native_executors(monkeypatch)
+    conn = vane.connect()
+    conn.execute("PRAGMA threads=1")
+
+    result = conn.sql("""
+        SELECT id, concat(
+            lower(ai_prompt(
+                chunk,
+                struct_pack(
+                    provider := 'vllm',
+                    model := 'SQL-UPPER',
+                    do_prefix_routing := false
+                )
+            )),
+            ' / ',
+            ai_prompt(
+                chunk,
+                struct_pack(
+                    provider := 'vllm',
+                    model := 'sql-plain',
+                    do_prefix_routing := false
+                )
+            )
+        ) AS combined
+        FROM (VALUES (1, 'Alpha'), (2, 'Beta')) source(id, chunk)
+        ORDER BY id
+    """)
+
+    assert result.explain().count("VLLM_PROJECT") == 2
+    rows = result.fetchall()
+    assert rows == [
+        (1, "sql-upper::alpha / sql-plain::Alpha"),
+        (2, "sql-upper::beta / sql-plain::Beta"),
+    ]
+    assert len(executors) == 2
+    assert all(executor.finished_count == 1 for executor in executors)
+    assert all(executor.shutdown_count == 1 for executor in executors)
+
+
+@pytest.mark.parametrize(
+    ("expression", "source"),
+    [
+        (
+            "CASE WHEN flag THEN vllm(chunk, 'conditional-model') ELSE 'skipped' END",
+            "(VALUES (false, 'secret')) source(flag, chunk)",
+        ),
+        (
+            "coalesce('ready', vllm(chunk, 'conditional-model'))",
+            "(VALUES ('secret')) source(chunk)",
+        ),
+    ],
+)
+def test_vllm_expressions_reject_short_circuit_contexts_without_submitting(monkeypatch, expression, source):
+    executors = _record_native_executors(monkeypatch)
+    conn = vane.connect()
+
+    with pytest.raises(
+        Exception,
+        match="vllm expressions are not supported inside CASE, AND/OR, or COALESCE short-circuit expressions",
+    ):
+        conn.sql(f"SELECT {expression} FROM {source}").fetchall()
+
+    assert executors == []

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -7291,6 +7291,8 @@ def test_recv_expected_restores_socket_timeout_before_marking_broken(monkeypatch
         with pytest.raises(RuntimeError, match="connection reset"):
             executor._recv_expected((subprocess_exec._MSG_READY,), timeout_s=2.0)
     finally:
+        executor._closed = True
+        del executor._mark_broken
         parent_sock.close()
         child_sock.close()
 

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -679,7 +679,12 @@ def test_vllm_remote_submit_failure_rolls_back_inflight(monkeypatch):
         report_start = FakeRemoteMethod("router-start")
         report_completion = FakeRemoteMethod("router-complete")
         route_and_reserve = FakeRemoteMethod(
-            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+            {
+                "actor_idx": 0,
+                "prompt_count": 3,
+                "reservation_id": "reservation-1",
+                "route_reason": "no_prefix",
+            }
         )
         complete = FakeRemoteMethod(0)
         rollback = FakeRemoteMethod(3)
@@ -735,7 +740,12 @@ def test_vllm_remote_submit_async_ref_failure_becomes_executor_error(monkeypatch
         report_start = FakeRemoteMethod("router-start")
         report_completion = FakeRemoteMethod("router-complete")
         route_and_reserve = FakeRemoteMethod(
-            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+            {
+                "actor_idx": 0,
+                "prompt_count": 2,
+                "reservation_id": "reservation-1",
+                "route_reason": "no_prefix",
+            }
         )
         complete = FakeRemoteMethod(0)
         rollback = FakeRemoteMethod(2)
@@ -949,7 +959,12 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
         report_start = FakeRemoteMethod()
         report_completion = FakeRemoteMethod()
         route_and_reserve = FakeRemoteMethod(
-            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+            {
+                "actor_idx": 0,
+                "prompt_count": 2,
+                "reservation_id": "reservation-1",
+                "route_reason": "no_prefix",
+            }
         )
         complete = FakeRemoteMethod(2)
         rollback = FakeRemoteMethod(0)

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -1281,7 +1281,8 @@ def test_vllm_actor_entrypoints_install_explicit_session_environment(monkeypatch
     assert events == ["install", "executor", "install"]
 
 
-def test_vllm_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):
+@pytest.mark.parametrize("failure_type", [RuntimeError, KeyboardInterrupt])
+def test_vllm_actor_shutdown_retains_failed_handles_for_retry(monkeypatch, failure_type):
     import duckdb.execution.vllm as vllm
 
     class FakeRay(types.ModuleType):
@@ -1294,7 +1295,7 @@ def test_vllm_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):
             self.attempts.append((actor, no_restart))
             if actor in self.fail_once:
                 self.fail_once.remove(actor)
-                raise RuntimeError("transient kill failure")
+                raise failure_type("transient kill failure")
 
     fake_ray = FakeRay()
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
@@ -1315,6 +1316,33 @@ def test_vllm_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):
         ("llm-1", True),
         ("llm-0", True),
     ]
+
+
+def test_vllm_worker_borrow_does_not_kill_driver_owned_named_pool(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class FakeRay(types.ModuleType):
+        def __init__(self):
+            super().__init__("ray")
+            self.killed = []
+
+        def kill(self, actor, *, no_restart):
+            self.killed.append((actor, no_restart))
+
+    fake_ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    driver_owner = vllm.LLMActors._from_handles(["llm-0"], "router")
+    worker_borrow = vllm.LLMActors._from_handles(["llm-0"], "router", owned=False)
+
+    worker_borrow.shutdown()
+
+    assert fake_ray.killed == []
+    assert worker_borrow.llm_actors == ["llm-0"]
+    assert worker_borrow.router_actor == "router"
+
+    driver_owner.shutdown()
+
+    assert fake_ray.killed == [("router", True), ("llm-0", True)]
 
 
 def test_udf_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -678,6 +678,12 @@ def test_vllm_remote_submit_failure_rolls_back_inflight(monkeypatch):
     class FakeRouter:
         report_start = FakeRemoteMethod("router-start")
         report_completion = FakeRemoteMethod("router-complete")
+        route_and_reserve = FakeRemoteMethod(
+            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+        )
+        complete = FakeRemoteMethod(0)
+        rollback = FakeRemoteMethod(3)
+        release_executor = FakeRemoteMethod(0)
 
     class FakeActor:
         wait_for_result = FakeRemoteMethod("actor-wait")
@@ -690,10 +696,9 @@ def test_vllm_remote_submit_failure_rolls_back_inflight(monkeypatch):
         router_actor = FakeRouter()
         llm_actors = [FakeActor()]
 
-    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref: ref)
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref)
 
     pool_name = "submit-failure-rollback"
-    vllm._shared_inflight.pop(pool_name, None)
     executor = vllm.RemoteVLLMExecutor(FakeLLMActors(), pool_name=pool_name)
 
     rows = pa.table({"x": [1, 2, 3]})
@@ -729,6 +734,12 @@ def test_vllm_remote_submit_async_ref_failure_becomes_executor_error(monkeypatch
     class FakeRouter:
         report_start = FakeRemoteMethod("router-start")
         report_completion = FakeRemoteMethod("router-complete")
+        route_and_reserve = FakeRemoteMethod(
+            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+        )
+        complete = FakeRemoteMethod(0)
+        rollback = FakeRemoteMethod(2)
+        release_executor = FakeRemoteMethod(0)
 
     class FakeActor:
         wait_for_result = FakeRemoteMethod(False)
@@ -741,7 +752,7 @@ def test_vllm_remote_submit_async_ref_failure_becomes_executor_error(monkeypatch
         router_actor = FakeRouter()
         llm_actors = [FakeActor()]
 
-    def fake_get(ref):
+    def fake_get(ref, **_kwargs):
         if ref.exc is not None:
             raise ref.exc
         return ref.value
@@ -749,7 +760,6 @@ def test_vllm_remote_submit_async_ref_failure_becomes_executor_error(monkeypatch
     monkeypatch.setattr(vllm, "resolve_object_refs_blocking", fake_get)
 
     pool_name = "submit-async-ref-failure"
-    vllm._shared_inflight.pop(pool_name, None)
     executor = vllm.RemoteVLLMExecutor(FakeLLMActors(), pool_name=pool_name)
 
     executor.submit(None, ["a", "b"], pa.table({"x": [1, 2]}))
@@ -791,7 +801,7 @@ def test_vllm_remote_observes_router_lifecycle_refs(monkeypatch):
         router_actor = FakeRouter()
         llm_actors = [FakeActor()]
 
-    def fake_get(ref):
+    def fake_get(ref, **_kwargs):
         observed.append(ref.name)
         return None
 
@@ -823,6 +833,7 @@ def test_vllm_remote_shutdown_reports_completion_once_and_clears_wait_refs(monke
     class FakeRouter:
         report_start = FakeRemoteMethod("router-start")
         report_completion = FakeRemoteMethod("router-complete")
+        release_executor = FakeRemoteMethod("router-release")
 
     class FakeActor:
         wait_for_result = FakeRemoteMethod("actor-wait")
@@ -830,13 +841,21 @@ def test_vllm_remote_shutdown_reports_completion_once_and_clears_wait_refs(monke
         submit_async = FakeRemoteMethod("actor-submit")
         finished_executor = FakeRemoteMethod("actor-finish-executor")
         finished_submitting = FakeRemoteMethod("actor-finish")
+        release_executor = FakeRemoteMethod("actor-release")
 
     class FakeLLMActors:
         router_actor = FakeRouter()
         llm_actors = [FakeActor(), FakeActor()]
 
-    def fake_get(ref):
+        def shutdown(self):
+            observed.append("owner-shutdown")
+
+    def fake_get(ref, **_kwargs):
         observed.append(ref.name)
+        if ref.name == "router-release":
+            return 0
+        if ref.name == "actor-release":
+            return True
         return None
 
     monkeypatch.setattr(vllm, "resolve_object_refs_blocking", fake_get)
@@ -846,7 +865,16 @@ def test_vllm_remote_shutdown_reports_completion_once_and_clears_wait_refs(monke
     executor.shutdown()
     executor.shutdown()
 
-    assert observed == ["router-start", "actor-finish-executor", "actor-finish-executor", "router-complete"]
+    assert observed == [
+        "router-start",
+        "actor-finish-executor",
+        "actor-finish-executor",
+        "router-complete",
+        "router-release",
+        "actor-release",
+        "actor-release",
+        "owner-shutdown",
+    ]
     assert executor._wait_refs_by_actor == [None, None]
 
 
@@ -858,10 +886,17 @@ def test_vllm_actor_wait_for_result_finishes_per_executor_before_global_finish()
     executor.error_message = None
     executor._finished_submitting = False
     executor.running_task_count = 1
+    executor.task_count_lock = threading.Lock()
     executor._result_cv = threading.Condition(threading.Lock())
     executor._per_executor_deques = {"exec-a": deque(), "exec-b": deque()}
     executor._per_executor_running_task_count = {"exec-a": 0, "exec-b": 1}
     executor._per_executor_finished = set()
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_abort_wait_required = set()
+    executor._per_executor_terminal_wait_observed = set()
+    executor._shutdown_called = False
 
     executor.finished_executor("exec-a")
 
@@ -908,11 +943,17 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
 
     class FakeReadyMethod:
         def remote(self, _executor_id):
-            return FakeRef((["out-a", "out-b"], rows))
+            return FakeRef((["out-a", "out-b"], rows, "reservation-1"))
 
     class FakeRouter:
         report_start = FakeRemoteMethod()
         report_completion = FakeRemoteMethod()
+        route_and_reserve = FakeRemoteMethod(
+            {"actor_idx": 0, "reservation_id": "reservation-1", "route_reason": "no_prefix"}
+        )
+        complete = FakeRemoteMethod(2)
+        rollback = FakeRemoteMethod(0)
+        release_executor = FakeRemoteMethod(0)
 
     class FakeActor:
         wait_for_result = FakeWaitMethod()
@@ -925,10 +966,9 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
         router_actor = FakeRouter()
         llm_actors = [FakeActor()]
 
-    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref: ref.value)
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.value)
 
     pool_name = "wait-ref-drain"
-    vllm._shared_inflight.pop(pool_name, None)
     executor = vllm.RemoteVLLMExecutor(FakeLLMActors(), pool_name=pool_name)
 
     executor.submit(None, ["a", "b"], rows)
@@ -945,7 +985,7 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
     assert output_rows is rows
 
 
-def test_vllm_remote_wait_ref_stays_armed_until_callback_records_result():
+def test_vllm_remote_wait_callback_queues_work_without_clearing_the_actor_ref():
     import duckdb.execution.vllm as vllm
 
     class FakeRef:
@@ -957,9 +997,52 @@ def test_vllm_remote_wait_ref_stays_armed_until_callback_records_result():
     executor._shutdown_called = False
     executor._finished = False
     executor._wait_refs_by_actor = [ref]
+    executor._ready_wait_refs = deque()
 
-    assert executor._take_ready_wait_ref(ref) == 0
+    executor._queue_wait_ref_ready(ref)
+
     assert executor._wait_refs_by_actor == [ref]
+    assert list(executor._ready_wait_refs) == [ref]
+
+
+def _new_remote_vllm_error_executor(vllm, monkeypatch, *, release_count=0):
+    class Ref:
+        def __init__(self, value=None):
+            self.value = value
+
+        def future(self):
+            return self
+
+        def add_done_callback(self, callback):
+            callback(self)
+
+    class RemoteMethod:
+        def __init__(self, value=None):
+            self.value = value
+
+        def remote(self, *_args, **_kwargs):
+            return Ref(self.value)
+
+    class Router:
+        report_start = RemoteMethod()
+        report_completion = RemoteMethod()
+        release_executor = RemoteMethod(release_count)
+
+    class Actor:
+        wait_for_result = RemoteMethod(False)
+        take_ready_result = RemoteMethod(None)
+        abort_executor = RemoteMethod(None)
+        release_executor = RemoteMethod(True)
+
+    class Owner:
+        router_actor = Router()
+        llm_actors = [Actor()]
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.value)
+    return vllm.RemoteVLLMExecutor(Owner())
 
 
 def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
@@ -973,6 +1056,10 @@ def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
 
         def cancel(self, ref):
             cancelled.append(ref)
+
+        @staticmethod
+        def is_initialized():
+            return True
 
     class FakeCondition:
         def __init__(self):
@@ -995,21 +1082,14 @@ def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
     submit_ref = object()
     wait_ref = object()
     condition = FakeCondition()
-    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
-    executor.llm_actors = [object()]
+    executor = _new_remote_vllm_error_executor(vllm, monkeypatch, release_count=1)
     executor._result_cv = condition
-    executor._finished = False
-    executor._finished_submitting_flag = False
     executor._submit_per_actor = [1]
     executor._results_per_actor = [0]
     executor._wait_refs_by_actor = [wait_ref]
-    executor._submit_refs = {submit_ref: (0, 1)}
-    executor._error_message = None
-    executor._result_buffer = deque()
-    executor._inflight_lock = threading.Lock()
+    executor._submit_refs = {submit_ref: (0, 1, "reservation-1")}
+    executor._reservations = {"reservation-1": {"actor_idx": 0, "remaining": 1}}
     executor._inflight_per_actor = [1]
-    executor._shutdown_called = False
-    executor._released_outstanding_inflight = False
 
     monkeypatch.setitem(sys.modules, "ray", FakeRay())
     monkeypatch.setattr(vllm, "configured_ray_get_timeout_s", lambda: 0.125)
@@ -1024,24 +1104,16 @@ def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
     assert executor._wait_refs_by_actor == [None]
 
 
-def test_vllm_remote_wait_without_pending_ref_before_completion_is_error():
+def test_vllm_remote_wait_without_pending_ref_before_completion_is_error(monkeypatch):
     import duckdb.execution.vllm as vllm
 
-    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
-    executor.llm_actors = []
-    executor._result_cv = threading.Condition(threading.Lock())
-    executor._finished = False
+    executor = _new_remote_vllm_error_executor(vllm, monkeypatch, release_count=1)
     executor._finished_submitting_flag = True
     executor._submit_per_actor = [1]
     executor._results_per_actor = [0]
     executor._wait_refs_by_actor = [None]
-    executor._submit_refs = {}
-    executor._error_message = None
-    executor._result_buffer = deque()
-    executor._inflight_lock = threading.Lock()
+    executor._reservations = {"reservation-1": {"actor_idx": 0, "remaining": 1}}
     executor._inflight_per_actor = [1]
-    executor._shutdown_called = False
-    executor._released_outstanding_inflight = False
     executor._ensure_remote_wait_refs = lambda: None
 
     with pytest.raises(RuntimeError, match="no pending actor wait refs"):
@@ -1053,48 +1125,11 @@ def test_vllm_remote_wait_without_pending_ref_before_completion_is_error():
 def test_vllm_remote_actor_without_results_after_executor_finish_is_error(monkeypatch):
     import duckdb.execution.vllm as vllm
 
-    class FakeRef:
-        def __init__(self, value):
-            self.value = value
-
-        def future(self):
-            return self
-
-        def add_done_callback(self, callback):
-            callback(self)
-
-    class FakeWaitMethod:
-        def remote(self, _executor_id):
-            return FakeRef(False)
-
-    class FakeReadyMethod:
-        def remote(self, _executor_id):
-            raise AssertionError("take_ready_result should not be called when wait_for_result returns false")
-
-    class FakeActor:
-        wait_for_result = FakeWaitMethod()
-        take_ready_result = FakeReadyMethod()
-
-    def fake_get(ref):
-        return ref.value
-
-    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", fake_get)
-
-    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
-    executor.llm_actors = [FakeActor()]
-    executor._executor_id = "exec-a"
-    executor._result_cv = threading.Condition(threading.Lock())
-    executor._finished = False
+    executor = _new_remote_vllm_error_executor(vllm, monkeypatch)
     executor._finished_submitting_flag = True
     executor._submit_per_actor = [1]
     executor._results_per_actor = [0]
-    executor._wait_refs_by_actor = [None]
-    executor._submit_refs = {}
-    executor._error_message = None
-    executor._result_buffer = deque()
-    executor._inflight_lock = threading.Lock()
     executor._inflight_per_actor = [0]
-    executor._shutdown_called = False
 
     with pytest.raises(RuntimeError, match="finished without returning all submitted results"):
         executor.wait_for_result()
@@ -1103,48 +1138,15 @@ def test_vllm_remote_actor_without_results_after_executor_finish_is_error(monkey
     assert executor._finished is True
 
 
-def test_vllm_remote_actor_missing_results_rolls_back_shared_inflight(monkeypatch):
+def test_vllm_remote_actor_missing_results_releases_outstanding_reservation(monkeypatch):
     import duckdb.execution.vllm as vllm
 
-    class FakeRef:
-        def __init__(self, value):
-            self.value = value
-
-        def future(self):
-            return self
-
-        def add_done_callback(self, callback):
-            callback(self)
-
-    class FakeWaitMethod:
-        def remote(self, _executor_id):
-            return FakeRef(False)
-
-    class FakeReadyMethod:
-        def remote(self, _executor_id):
-            raise AssertionError("take_ready_result should not be called when wait_for_result returns false")
-
-    class FakeActor:
-        wait_for_result = FakeWaitMethod()
-        take_ready_result = FakeReadyMethod()
-
-    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref: ref.value)
-
-    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
-    executor.llm_actors = [FakeActor()]
-    executor._executor_id = "exec-a"
-    executor._result_cv = threading.Condition(threading.Lock())
-    executor._finished = False
+    executor = _new_remote_vllm_error_executor(vllm, monkeypatch, release_count=3)
     executor._finished_submitting_flag = True
     executor._submit_per_actor = [3]
     executor._results_per_actor = [0]
-    executor._wait_refs_by_actor = [None]
-    executor._submit_refs = {}
-    executor._error_message = None
-    executor._result_buffer = deque()
-    executor._inflight_lock = threading.Lock()
+    executor._reservations = {"reservation-1": {"actor_idx": 0, "remaining": 3}}
     executor._inflight_per_actor = [3]
-    executor._shutdown_called = False
 
     with pytest.raises(RuntimeError, match="finished without returning all submitted results"):
         executor.wait_for_result()
@@ -1152,37 +1154,19 @@ def test_vllm_remote_actor_missing_results_rolls_back_shared_inflight(monkeypatc
     assert executor._inflight_per_actor == [0]
 
 
-def test_vllm_router_waits_for_actor_finished_refs(monkeypatch):
+def test_vllm_router_completion_never_finishes_shared_actors_globally():
     import duckdb.execution.vllm as vllm
 
-    observed: list[str] = []
-
-    class FakeRef:
-        def __init__(self, name: str):
-            self.name = name
-
-    class FakeFinishedMethod:
-        def __init__(self, name: str):
-            self.name = name
-
-        def remote(self):
-            return FakeRef(self.name)
-
     class FakeActor:
-        def __init__(self, name: str):
-            self.finished_submitting = FakeFinishedMethod(name)
+        @property
+        def finished_submitting(self):
+            raise AssertionError("shared actor-wide completion must not be used")
 
-    def fake_get(ref):
-        observed.append(ref.name)
-        return None
+    router = vllm.PrefixRouter([FakeActor(), FakeActor()], 0)
 
-    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", fake_get)
-
-    router = vllm.PrefixRouter([FakeActor("finish-0"), FakeActor("finish-1")], 0)
-    router.report_start()
-    router.report_completion()
-
-    assert observed == ["finish-0", "finish-1"]
+    assert router.report_start("exec-a") is True
+    assert router.report_completion("exec-a") is True
+    assert router.report_completion("exec-a") is False
 
 
 def test_vllm_query_owned_actors_receive_explicit_session_environment(monkeypatch):
@@ -1274,7 +1258,7 @@ def test_vllm_actor_entrypoints_install_explicit_session_environment(monkeypatch
         {},
         _install_session_runtime_env=True,
     )
-    vllm.PrefixRouter([], 32, _install_session_runtime_env=True)
+    vllm.PrefixRouter([object()], 32, _install_session_runtime_env=True)
 
     assert events == ["install", "executor", "install"]
 

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -1045,7 +1045,7 @@ def _new_remote_vllm_error_executor(vllm, monkeypatch, *, release_count=0):
     return vllm.RemoteVLLMExecutor(Owner())
 
 
-def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
+def test_vllm_remote_wait_deadline_resolves_submits_before_cancelling_wait_refs(monkeypatch):
     import duckdb.execution.vllm as vllm
 
     cancelled = []
@@ -1079,7 +1079,10 @@ def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
         def notify_all(self):
             self.notified = True
 
-    submit_ref = object()
+    class SubmitRef:
+        value = None
+
+    submit_ref = SubmitRef()
     wait_ref = object()
     condition = FakeCondition()
     executor = _new_remote_vllm_error_executor(vllm, monkeypatch, release_count=1)
@@ -1098,7 +1101,7 @@ def test_vllm_remote_wait_deadline_cancels_outstanding_refs(monkeypatch):
         executor.wait_for_result()
 
     assert condition.timeout == pytest.approx(0.125)
-    assert cancelled == [submit_ref, wait_ref]
+    assert cancelled == [wait_ref]
     assert executor._inflight_per_actor == [0]
     assert executor._submit_refs == {}
     assert executor._wait_refs_by_actor == [None]

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -904,8 +904,8 @@ def test_vllm_actor_wait_for_result_finishes_per_executor_before_global_finish()
     executor._per_executor_errors = {}
     executor._per_executor_aborted = set()
     executor._per_executor_waiters = {}
-    executor._per_executor_abort_wait_required = set()
-    executor._per_executor_terminal_wait_observed = set()
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
     executor._shutdown_called = False
 
     executor.finished_executor("exec-a")
@@ -946,7 +946,7 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
             return FakeRef(self.value)
 
     class FakeWaitMethod:
-        def remote(self, _executor_id):
+        def remote(self, _executor_id, _wait_token):
             nonlocal wait_ref
             wait_ref = FakeRef(True, kind="wait")
             return wait_ref
@@ -1461,6 +1461,107 @@ def test_vllm_ray_execution_requires_runner_owned_runtime(monkeypatch):
 
     with pytest.raises(RuntimeError, match="initialized RayRunner runtime"):
         vllm.build_executor("model", {"use_ray": True})
+
+
+def test_vllm_remote_construction_base_exception_rolls_back_start_and_pool(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    events = []
+
+    class Ref:
+        def __init__(self, name):
+            self.name = name
+
+    class RemoteMethod:
+        def __init__(self, name):
+            self.name = name
+
+        def remote(self, *_args):
+            events.append(self.name)
+            return Ref(self.name)
+
+    class Router:
+        report_start = RemoteMethod("report-start")
+        cancel_executor_start = RemoteMethod("cancel-start")
+
+    class Owner:
+        router_actor = Router()
+        llm_actors = [object()]
+
+        def shutdown(self):
+            events.append("owner-shutdown")
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.is_initialized = lambda: True
+    owner = Owner()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(vllm, "LLMActors", lambda **_kwargs: owner)
+
+    def resolve(ref, **_kwargs):
+        if ref.name == "report-start":
+            raise KeyboardInterrupt("construction interrupted")
+        return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", resolve)
+
+    with pytest.raises(KeyboardInterrupt, match="construction interrupted"):
+        vllm.build_executor("model", {"use_ray": True})
+
+    assert events == ["report-start", "cancel-start", "owner-shutdown"]
+
+
+def test_vllm_remote_construction_cleanup_failures_preserve_base_exception(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    events = []
+    primary_error = KeyboardInterrupt("construction interrupted")
+
+    class Ref:
+        def __init__(self, name):
+            self.name = name
+
+    class RemoteMethod:
+        def __init__(self, name):
+            self.name = name
+
+        def remote(self, *_args):
+            events.append(self.name)
+            return Ref(self.name)
+
+    class Router:
+        report_start = RemoteMethod("report-start")
+        cancel_executor_start = RemoteMethod("cancel-start")
+
+    class Owner:
+        router_actor = Router()
+        llm_actors = [object()]
+
+        def shutdown(self):
+            events.append("owner-shutdown")
+            raise RuntimeError("pool cleanup failed")
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.is_initialized = lambda: True
+    owner = Owner()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(vllm, "LLMActors", lambda **_kwargs: owner)
+
+    def resolve(ref, **_kwargs):
+        if ref.name == "report-start":
+            raise primary_error
+        raise RuntimeError("start rollback failed")
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", resolve)
+
+    with pytest.raises(KeyboardInterrupt) as exc_info:
+        vllm.build_executor("model", {"use_ray": True})
+
+    assert exc_info.value is primary_error
+    assert events == ["report-start", "cancel-start", "owner-shutdown"]
+    assert getattr(primary_error, "_vane_cleanup_failures") == [
+        "vllm router start rollback failed: RuntimeError: start rollback failed",
+        "vllm actor pool construction rollback failed: RuntimeError: pool cleanup failed",
+    ]
 
 
 def test_unified_executor_passes_local_subprocess_actor_pool_option():

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import threading
+import uuid
 from collections import deque
 
 import pytest
@@ -324,6 +325,27 @@ def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeyp
     assert executor.finished_count == 1
     assert not executor.pending
     assert not executor.invalid_wait
+
+
+def test_distributed_collection_preserves_an_explicit_named_pool():
+    import duckdb
+
+    con = duckdb.connect()
+    try:
+        pool_name = "explicit-shared-vllm-pool"
+        options = json.dumps({"use_ray": True, "ray_actor_pool_name": pool_name}, separators=(",", ":"))
+        relation = con.sql(
+            "SELECT vllm(prompt, 'model', '" + options + "') AS generated FROM (VALUES ('hello')) input(prompt)"
+        )
+        plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, str(uuid.uuid4())).to_physical_plan(con)
+
+        nodes = plan.collect_vllm_nodes(conn=con)
+
+        assert len(nodes) == 1
+        assert nodes[0]["pool_name"] == pool_name
+        assert json.loads(nodes[0]["options"])["ray_actor_pool_name"] == pool_name
+    finally:
+        con.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import threading
-import uuid
 from collections import deque
 
 import pytest
@@ -327,23 +326,34 @@ def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeyp
     assert not executor.invalid_wait
 
 
-def test_distributed_collection_preserves_an_explicit_named_pool():
+def test_distributed_collection_keeps_explicit_pool_names_query_scoped():
     import duckdb
 
     con = duckdb.connect()
     try:
-        pool_name = "explicit-shared-vllm-pool"
-        options = json.dumps({"use_ray": True, "ray_actor_pool_name": pool_name}, separators=(",", ":"))
-        relation = con.sql(
-            "SELECT vllm(prompt, 'model', '" + options + "') AS generated FROM (VALUES ('hello')) input(prompt)"
+        explicit_pool_name = "explicit-shared-vllm-pool"
+        options = json.dumps(
+            {"use_ray": True, "ray_actor_pool_name": explicit_pool_name},
+            separators=(",", ":"),
         )
-        plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, str(uuid.uuid4())).to_physical_plan(con)
 
-        nodes = plan.collect_vllm_nodes(conn=con)
+        def collect_node(query_id):
+            relation = con.sql(
+                "SELECT vllm(prompt, 'model', '" + options + "') AS generated FROM (VALUES ('hello')) input(prompt)"
+            )
+            plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, query_id).to_physical_plan(con)
+            nodes = plan.collect_vllm_nodes(conn=con)
+            assert len(nodes) == 1
+            return nodes[0]
 
-        assert len(nodes) == 1
-        assert nodes[0]["pool_name"] == pool_name
-        assert json.loads(nodes[0]["options"])["ray_actor_pool_name"] == pool_name
+        first = collect_node("query-a")
+        second = collect_node("query-b")
+
+        assert first["pool_name"] != explicit_pool_name
+        assert second["pool_name"] != explicit_pool_name
+        assert first["pool_name"] != second["pool_name"]
+        assert json.loads(first["options"])["ray_actor_pool_name"] == first["pool_name"]
+        assert json.loads(second["options"])["ray_actor_pool_name"] == second["pool_name"]
     finally:
         con.close()
 

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
-import sys
 import threading
 from collections import deque
 
@@ -174,6 +172,115 @@ def test_native_bridge_rejects_zero_batch_size_even_if_python_normalization_is_b
         con.close()
 
 
+def test_native_bridge_normalizes_decimal_struct_options(monkeypatch):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    executor = _RecordingExecutor()
+    normalized = {}
+
+    def build_executor(_model, options):
+        normalized.update(options)
+        return executor
+
+    monkeypatch.setattr(vllm, "build_executor", build_executor)
+
+    con = duckdb.connect()
+    try:
+        row = con.execute(
+            """
+            SELECT vllm(
+                'hello',
+                'recording-model',
+                struct_pack(
+                    prefix_match_threshold := 0.33,
+                    gpus_per_actor := 0.25,
+                    engine_init_timeout_s := 1.5
+                )
+            )
+            """
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert row == ("generated:hello",)
+    assert normalized["prefix_match_threshold"] == pytest.approx(0.33)
+    assert normalized["gpus_per_actor"] == pytest.approx(0.25)
+    assert normalized["engine_init_timeout_s"] == pytest.approx(1.5)
+    assert type(normalized["prefix_match_threshold"]) is float
+    assert type(normalized["gpus_per_actor"]) is float
+    assert type(normalized["engine_init_timeout_s"]) is float
+
+
+def test_native_bridge_preserves_sql_boolean_struct_options(monkeypatch):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    executor = _RecordingExecutor()
+    normalized = {}
+
+    def build_executor(_model, options):
+        normalized.update(options)
+        return executor
+
+    monkeypatch.setattr(vllm, "build_executor", build_executor)
+    option_names = (
+        "do_prefix_routing",
+        "use_ray",
+        "use_threading",
+        "require_ray_worker",
+        "ray_worker_only",
+    )
+
+    con = duckdb.connect()
+    try:
+        row = con.execute(
+            """
+            SELECT vllm(
+                'hello',
+                'recording-model',
+                struct_pack(
+                    do_prefix_routing := FALSE,
+                    use_ray := FALSE,
+                    use_threading := FALSE,
+                    require_ray_worker := FALSE,
+                    ray_worker_only := FALSE
+                )
+            )
+            """
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert row == ("generated:hello",)
+    assert {name: normalized[name] for name in option_names} == dict.fromkeys(option_names, False)
+    assert all(type(normalized[name]) is bool for name in option_names)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "use_ray",
+        "use_threading",
+        "require_ray_worker",
+        "ray_worker_only",
+        "_force_background_thread",
+    ],
+)
+def test_native_bridge_rejects_non_boolean_execution_options(monkeypatch, name):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: _RecordingExecutor())
+
+    con = duckdb.connect()
+    try:
+        with pytest.raises(Exception, match=rf"vllm {name} must be a boolean"):
+            con.execute(f"SELECT vllm('hello', 'recording-model', struct_pack({name} := 'false'))").fetchall()
+    finally:
+        con.close()
+
+
 @pytest.mark.timeout(30)
 def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeypatch):
     executor = _DeferredWakeupExecutor()
@@ -219,128 +326,68 @@ def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeyp
     assert not executor.invalid_wait
 
 
-_PARALLEL_FINALIZER_SCRIPT = r"""
-import json
-import threading
-from collections import deque
-
-import duckdb
-import duckdb.execution.vllm as vllm
-
-
-class Fake:
-    def __init__(self):
-        self.condition = threading.Condition()
-        self.pending = deque()
-        self.ready = deque()
-        self.finished = False
-        self.finished_count = 0
-        self.shutdown_count = 0
-        self.wait_count = 0
-        self.finished_event = threading.Event()
-        self.waiters_ready = threading.Event()
-        self.submit_threads = set()
-
-    def submit(self, _prefix, prompts, rows):
-        values = tuple(prompts)
-        self.submit_threads.add(threading.get_ident())
-        with self.condition:
-            self.pending.append((["generated:" + value for value in values], rows))
-
-    def take_ready_result(self):
-        with self.condition:
-            return self.ready.popleft() if self.ready else None
-
-    def finished_submitting(self):
-        self.finished_count += 1
-        self.finished = True
-        self.finished_event.set()
-
-    def all_tasks_finished(self):
-        with self.condition:
-            return self.finished and not self.pending and not self.ready
-
-    def wait_for_result(self):
-        with self.condition:
-            self.wait_count += 1
-            wait_for_shutdown = self.wait_count == 1
-            if self.wait_count >= 2:
-                self.waiters_ready.set()
-            predicate = (lambda: self.shutdown_count) if wait_for_shutdown else (lambda: self.ready or self.shutdown_count)
-            ready = self.condition.wait_for(predicate, timeout=20)
-            if not ready:
-                raise AssertionError("legacy finalizer wait was not released")
-
-    def publish_results(self):
-        with self.condition:
-            self.ready.extend(self.pending)
-            self.pending.clear()
-            self.condition.notify_all()
-
-    def shutdown(self):
-        with self.condition:
-            self.shutdown_count += 1
-            self.condition.notify_all()
-
-
-executor = Fake()
-vllm.build_executor = lambda *_args, **_kwargs: executor
-publisher_errors = []
-
-
-def publish_after_legacy_wait():
-    try:
-        assert executor.finished_event.wait(timeout=20), "native producers did not finish"
-        assert executor.waiters_ready.wait(timeout=20), "native finalizers did not enter concurrent legacy waits"
-        executor.publish_results()
-    except BaseException as exc:
-        publisher_errors.append(exc)
-
-
-publisher = threading.Thread(target=publish_after_legacy_wait, name="vllm-legacy-result-publisher")
-publisher.start()
-options = json.dumps(
-    {
-        "do_prefix_routing": True,
-        "max_buffer_size": 0,
-        "min_bucket_size": 1,
-        "batch_size": None,
-        "inflight_limit": 0,
-    },
-    separators=(",", ":"),
+@pytest.mark.parametrize(
+    "context",
+    ["ctas", "insert_select", "scalar_subquery", "explain_analyze", "prepared"],
 )
-con = duckdb.connect()
-try:
-    con.execute("PRAGMA threads=2")
-    con.execute(
-        "CREATE TABLE parallel_input AS SELECT i::BIGINT id, "
-        "'prefix-' || i::VARCHAR prompt FROM range(300000) t(i)"
-    )
-    count = con.execute(
-        "SELECT count(generated) FROM (SELECT vllm(prompt, 'model', '"
-        + options
-        + "') AS generated FROM parallel_input) q"
-    ).fetchone()[0]
-finally:
-    con.close()
-    publisher.join(timeout=5)
+@pytest.mark.timeout(30)
+def test_native_finalizer_has_scheduler_wakeup_in_materialized_and_nested_contexts(monkeypatch, context):
+    import duckdb
+    import duckdb.execution.vllm as vllm
 
-assert count == 300000
-assert not publisher.is_alive()
-assert publisher_errors == []
-assert len(executor.submit_threads) == 2
-assert executor.finished_count == 1
-assert executor.wait_count >= 1
-assert executor.shutdown_count == 1
-"""
+    executor = _DeferredWakeupExecutor()
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: executor)
+    publisher_errors = []
+
+    def publish_after_arm() -> None:
+        try:
+            assert executor.pending_ready.wait(timeout=20), "native producer did not submit a pending result"
+            assert executor.callback_armed.wait(timeout=20), "native finalizer did not arm a wakeup callback"
+            executor.publish_results()
+        except BaseException as exc:
+            publisher_errors.append(exc)
+
+    publisher = threading.Thread(target=publish_after_arm, name=f"vllm-{context}-result-publisher")
+    publisher.start()
+    con = duckdb.connect()
+    try:
+        con.register("vllm_input", pa.table({"prompt": ["hello"]}))
+        expression = "vllm(prompt, 'recording-model')"
+        if context == "ctas":
+            con.execute(f"CREATE TABLE vllm_output AS SELECT {expression} AS generated FROM vllm_input")
+        elif context == "insert_select":
+            con.execute("CREATE TABLE vllm_output(generated VARCHAR)")
+            con.execute(f"INSERT INTO vllm_output SELECT {expression} FROM vllm_input")
+        elif context == "scalar_subquery":
+            con.execute("SELECT (SELECT vllm('hello', 'recording-model'))").fetchall()
+        elif context == "explain_analyze":
+            con.execute(f"EXPLAIN ANALYZE SELECT {expression} FROM vllm_input").fetchall()
+        else:
+            con.execute("PREPARE vllm_statement AS SELECT vllm(CAST($1 AS VARCHAR), 'recording-model')")
+            con.execute("EXECUTE vllm_statement('hello')").fetchall()
+    finally:
+        con.close()
+        publisher.join(timeout=5)
+
+    assert not publisher.is_alive()
+    assert publisher_errors == []
+    assert [submission[1] for submission in executor.submissions] == [("hello",)]
+    assert executor.wakeup_registrations >= 1
+    assert executor.callback_invocations >= 1
+    assert executor.finished_count == 1
+    assert not executor.pending
+    assert not executor.invalid_wait
 
 
-def test_parallel_legacy_finalizer_wait_survives_shutdown():
-    completed = subprocess.run(
-        [sys.executable, "-c", _PARALLEL_FINALIZER_SCRIPT],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert completed.returncode == 0, completed.stdout + completed.stderr
+def test_native_bridge_rejects_executor_without_wakeup_callback(monkeypatch):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: object())
+
+    con = duckdb.connect()
+    try:
+        with pytest.raises(Exception, match="vllm executor must implement register_wakeup_callback"):
+            con.execute("SELECT vllm('hello', 'model')").fetchall()
+    finally:
+        con.close()

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -126,6 +126,61 @@ def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=
         con.close()
 
 
+@pytest.mark.parametrize("do_prefix_routing", [False, True])
+def test_native_vllm_propagates_null_prompts_without_submitting_them(monkeypatch, do_prefix_routing):
+    executor, rows = _run_recording_sql(
+        monkeypatch,
+        ["alpha", None, "beta"],
+        {
+            "do_prefix_routing": do_prefix_routing,
+            "max_buffer_size": 0,
+            "min_bucket_size": 1,
+            "batch_size": None,
+            "inflight_limit": 0,
+        },
+    )
+
+    assert {row[0]: row[2] for row in rows} == {
+        0: "generated:alpha",
+        1: None,
+        2: "generated:beta",
+    }
+    assert sorted(prompt for _, prompts in executor.submissions for prompt in prompts) == ["alpha", "beta"]
+
+
+def test_native_vllm_all_null_prompts_do_not_build_an_executor(monkeypatch):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    builds = 0
+
+    def build_executor(*_args, **_kwargs):
+        nonlocal builds
+        builds += 1
+        return _RecordingExecutor()
+
+    monkeypatch.setattr(vllm, "build_executor", build_executor)
+    con = duckdb.connect()
+    try:
+        con.register(
+            "vllm_input",
+            pa.table(
+                {
+                    "id": pa.array([0, 1], type=pa.int64()),
+                    "prompt": pa.array([None, None], type=pa.string()),
+                }
+            ),
+        )
+        rows = con.execute(
+            "SELECT id, vllm(prompt, 'recording-model') AS generated FROM vllm_input ORDER BY id"
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert rows == [(0, None), (1, None)]
+    assert builds == 0
+
+
 @pytest.mark.parametrize(
     ("prompts", "expected_prefix"),
     [

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -3,7 +3,44 @@
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
+import sys
+import threading
+import time
+import types
+import warnings
+from collections import deque
+from decimal import Decimal
+
+import pyarrow as pa
 import pytest
+
+
+def test_vllm_control_rpc_timeout_is_configurable(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    monkeypatch.delenv("VANE_VLLM_CONTROL_RPC_TIMEOUT_S", raising=False)
+    assert vllm._vllm_control_rpc_timeout_s() == 30.0
+
+    monkeypatch.setenv("VANE_VLLM_CONTROL_RPC_TIMEOUT_S", "7.5")
+    observed = {}
+
+    def resolve(ref, *, timeout, honor_query_deadline):
+        observed.update(timeout=timeout, honor_query_deadline=honor_query_deadline)
+        return ref
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", resolve)
+    assert vllm._resolve_vllm_control_ref("control-ref") == "control-ref"
+    assert observed == {"timeout": 7.5, "honor_query_deadline": False}
+
+
+@pytest.mark.parametrize("configured", ["not-a-number", "0", "-1", "nan", "inf"])
+def test_vllm_control_rpc_timeout_falls_back_for_invalid_values(monkeypatch, configured):
+    import duckdb.execution.vllm as vllm
+
+    monkeypatch.setenv("VANE_VLLM_CONTROL_RPC_TIMEOUT_S", configured)
+    assert vllm._vllm_control_rpc_timeout_s() == 30.0
 
 
 @pytest.mark.parametrize(
@@ -15,11 +52,16 @@ import pytest
         ({"prefix_match_threshold": float("nan")}, "prefix_match_threshold"),
         ({"prefix_match_threshold": float("inf")}, "prefix_match_threshold"),
         ({"prefix_match_threshold": True}, "prefix_match_threshold"),
+        ({"prefix_match_threshold": Decimal("1.01")}, "prefix_match_threshold"),
         ({"gpus_per_actor": 0}, "gpus_per_actor"),
         ({"gpus_per_actor": 1.5}, "gpus_per_actor"),
         ({"gpus_per_actor": True}, "gpus_per_actor"),
+        ({"gpus_per_actor": Decimal("NaN")}, "gpus_per_actor"),
+        ({"gpus_per_actor": Decimal("1.5")}, "gpus_per_actor"),
         ({"concurrency": True}, "concurrency"),
         ({"do_prefix_routing": "false"}, "do_prefix_routing"),
+        ({"engine_init_timeout_s": Decimal("-0.1")}, "engine_init_timeout_s"),
+        ({"engine_init_timeout_s": True}, "engine_init_timeout_s"),
     ],
 )
 def test_vllm_numeric_options_are_strict(options, message):
@@ -33,3 +75,717 @@ def test_vllm_fractional_gpu_option_is_preserved():
     from duckdb.execution.vllm import normalize_options
 
     assert normalize_options({"gpus_per_actor": 0.25})["gpus_per_actor"] == pytest.approx(0.25)
+
+
+def test_vllm_decimal_options_are_normalized_to_floats():
+    from duckdb.execution.vllm import normalize_options
+
+    normalized = normalize_options(
+        {
+            "gpus_per_actor": Decimal("0.25"),
+            "prefix_match_threshold": Decimal("0.33"),
+            "engine_init_timeout_s": Decimal("1.5"),
+        }
+    )
+
+    assert normalized["gpus_per_actor"] == pytest.approx(0.25)
+    assert normalized["prefix_match_threshold"] == pytest.approx(0.33)
+    assert normalized["engine_init_timeout_s"] == pytest.approx(1.5)
+    assert type(normalized["gpus_per_actor"]) is float
+    assert type(normalized["prefix_match_threshold"]) is float
+    assert type(normalized["engine_init_timeout_s"]) is float
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "use_ray",
+        "use_threading",
+        "require_ray_worker",
+        "ray_worker_only",
+        "_force_background_thread",
+    ],
+)
+def test_vllm_execution_boolean_options_are_strict(name):
+    from duckdb.execution.vllm import normalize_options
+
+    with pytest.raises(ValueError, match=rf"vllm {name} must be a boolean"):
+        normalize_options({name: "false"})
+
+    assert normalize_options({name: False})[name] is False
+
+
+def test_ray_actor_releases_only_terminal_per_executor_state():
+    from duckdb.execution.vllm import RayLocalVLLMExecutor
+
+    executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+    executor.llm = None
+    executor.on_error = "raise"
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._shutdown_called = False
+    executor._finished_submitting = False
+    executor.running_task_count = 0
+    executor.task_count_lock = threading.Lock()
+    executor._result_cv = threading.Condition(threading.RLock())
+    rows = pa.table({"x": [1]})
+    executor._per_executor_deques = {"executor": deque([(None, rows, "reservation")])}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = {"executor"}
+    executor._per_executor_request_ids = {"executor": set()}
+    executor._per_executor_tasks = {"executor": set()}
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_abort_wait_required = set()
+    executor._per_executor_terminal_wait_observed = set()
+
+    assert executor.release_executor("executor") is False
+    assert executor.take_ready_result("executor") == ([None], rows, "reservation")
+    assert executor.release_executor("executor") is True
+
+    executor._per_executor_deques["aborted"] = deque()
+    executor._per_executor_running_task_count["aborted"] = 0
+    executor._per_executor_request_ids["aborted"] = set()
+    executor._per_executor_tasks["aborted"] = set()
+    asyncio.run(executor.abort_executor("aborted"))
+    assert "aborted" in executor._per_executor_aborted
+    assert executor.release_executor("aborted") is True
+
+
+def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity():
+    from duckdb.execution.vllm import RayLocalVLLMExecutor
+
+    executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+    executor.llm = None
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._shutdown_called = False
+    executor._finished_submitting = False
+    executor.running_task_count = 0
+    executor.task_count_lock = threading.Lock()
+    executor._result_cv = threading.Condition(threading.RLock())
+    executor._per_executor_deques = {"executor": deque()}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = set()
+    executor._per_executor_request_ids = {"executor": set()}
+    executor._per_executor_tasks = {"executor": set()}
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_abort_wait_required = set()
+    executor._per_executor_terminal_wait_observed = set()
+
+    async def run_scenario():
+        loop = asyncio.get_running_loop()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(pool)
+        pool_occupied = threading.Event()
+        release_pool = threading.Event()
+        waiter = None
+
+        def occupy_only_worker():
+            pool_occupied.set()
+            release_pool.wait()
+
+        blocker = asyncio.create_task(asyncio.to_thread(occupy_only_worker))
+        try:
+            while not pool_occupied.is_set():
+                await asyncio.sleep(0)
+
+            waiter = asyncio.create_task(executor.wait_for_result("executor"))
+            while executor._per_executor_waiters.get("executor", 0) == 0:
+                await asyncio.sleep(0)
+
+            await asyncio.wait_for(executor.abort_executor("executor", wait_expected=True), timeout=2.0)
+            assert await asyncio.wait_for(waiter, timeout=2.0) is False
+        finally:
+            release_pool.set()
+            if waiter is not None and not waiter.done():
+                waiter.cancel()
+                await asyncio.gather(waiter, return_exceptions=True)
+            await blocker
+
+    asyncio.run(run_scenario())
+
+
+def test_ray_actor_abort_wait_uses_control_rpc_timeout(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    executor = vllm.RayLocalVLLMExecutor.__new__(vllm.RayLocalVLLMExecutor)
+    executor.llm = None
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._shutdown_called = False
+    executor._finished_submitting = False
+    executor.running_task_count = 0
+    executor.task_count_lock = threading.Lock()
+    executor._result_cv = threading.Condition(threading.RLock())
+    executor._per_executor_deques = {"executor": deque()}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = set()
+    executor._per_executor_request_ids = {"executor": set()}
+    executor._per_executor_tasks = {"executor": set()}
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {"executor": 1}
+    executor._per_executor_abort_wait_required = set()
+    executor._per_executor_terminal_wait_observed = set()
+
+    clock = iter((100.0, 106.0, 111.0))
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setenv("VANE_VLLM_CONTROL_RPC_TIMEOUT_S", "10")
+    monkeypatch.setattr(vllm, "time", types.SimpleNamespace(monotonic=lambda: next(clock)))
+    monkeypatch.setattr(vllm.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="abort waiter did not acknowledge termination"):
+        asyncio.run(executor.abort_executor("executor", wait_expected=True))
+
+    assert sleep_calls == [0.01]
+
+
+def test_prefix_router_serializes_global_reservations_and_releases_exactly_once():
+    from duckdb.execution.vllm import PrefixRouter
+
+    router = PrefixRouter([object(), object()], load_balance_threshold=0)
+    executor_ids = [f"executor-{index}" for index in range(32)]
+    for executor_id in executor_ids:
+        router.report_start(executor_id)
+
+    def reserve(executor_id):
+        return router.route_and_reserve(None, 1, executor_id)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        reservations = list(pool.map(reserve, executor_ids))
+
+    assert sum(router.inflight) == len(reservations)
+    assert abs(router.inflight[0] - router.inflight[1]) <= 1
+    for index, reservation in enumerate(reservations):
+        reservation_id = reservation["reservation_id"]
+        operation_id = f"release-{index}"
+        if index % 2:
+            first = router.complete_once(reservation_id, 1, operation_id)
+            replay = router.complete_once(reservation_id, 1, operation_id)
+        else:
+            first = router.rollback_once(reservation_id, 1, operation_id)
+            replay = router.rollback_once(reservation_id, 1, operation_id)
+        assert first["released"] == 1
+        assert replay["released"] == 1
+        assert replay["replayed"] is True
+    assert router.inflight == [0, 0]
+
+
+def test_prefix_router_keeps_affinity_until_load_threshold_is_exceeded():
+    from duckdb.execution.vllm import PrefixRouter
+
+    router = PrefixRouter([object(), object()], load_balance_threshold=1)
+    router.report_start("executor")
+    first = router.route_and_reserve("shared-prefix", 4, "executor")
+    other = router.route_and_reserve("other-prefix", 1, "executor")
+    migrated = router.route_and_reserve("shared-prefix", 1, "executor")
+
+    assert first["actor_idx"] == 0
+    assert other["actor_idx"] == 1
+    assert migrated["actor_idx"] == 1
+    assert migrated["route_reason"] == "load_balance"
+
+
+class _Ref:
+    def __init__(self, value=None, *, ready=True):
+        self._future = concurrent.futures.Future()
+        if ready:
+            self._future.set_result(value)
+
+    def future(self):
+        return self._future
+
+    def resolve(self):
+        return self._future.result(timeout=1)
+
+    def set_result(self, value):
+        self._future.set_result(value)
+
+
+class _RemoteMethod:
+    def __init__(self, function, *, raw_ref=False):
+        self._function = function
+        self._raw_ref = raw_ref
+
+    def remote(self, *args, **kwargs):
+        result = self._function(*args, **kwargs)
+        return result if self._raw_ref else _Ref(result)
+
+
+class _RemoteProxy:
+    def __init__(self, target):
+        self._target = target
+
+    def __getattr__(self, name):
+        return _RemoteMethod(getattr(self._target, name))
+
+
+class _FakeVLLMActor:
+    def __init__(self):
+        self.submissions = []
+        self.results = deque()
+        self.wait_refs = deque()
+        self.released = []
+        self.aborted = []
+        self.finished = []
+        self.submit_async = _RemoteMethod(self._submit)
+        self.wait_for_result = _RemoteMethod(self._wait, raw_ref=True)
+        self.take_ready_result = _RemoteMethod(self._take)
+        self.finished_executor = _RemoteMethod(self._finish)
+        self.release_executor = _RemoteMethod(self._release)
+        self.abort_executor = _RemoteMethod(self._abort)
+
+    def _submit(self, prompts, rows, executor_id, reservation_id):
+        self.submissions.append((list(prompts), rows, executor_id, reservation_id))
+
+    def _wait(self, _executor_id):
+        ref = _Ref(ready=False)
+        self.wait_refs.append(ref)
+        return ref
+
+    def _take(self, _executor_id):
+        return self.results.popleft()
+
+    def _finish(self, executor_id):
+        self.finished.append(executor_id)
+
+    def _release(self, executor_id):
+        self.released.append(executor_id)
+        return True
+
+    def _abort(self, executor_id, _wait_expected):
+        self.aborted.append(executor_id)
+
+    def publish(self, outputs, rows, reservation_id):
+        self.results.append((outputs, rows, reservation_id))
+        self.wait_refs.popleft().set_result(True)
+
+
+def test_remote_reservation_rpc_does_not_block_submit_and_serializes_shutdown(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    complete_entered = threading.Event()
+    allow_complete = threading.Event()
+    shutdown_reported = threading.Event()
+    release_executor_entered = threading.Event()
+
+    class SlowCompleteRouter(vllm.PrefixRouter):
+        def complete_once(self, reservation_id, count, operation_id):
+            complete_entered.set()
+            if not allow_complete.wait(2):
+                raise RuntimeError("test timed out waiting to release complete RPC")
+            return super().complete_once(reservation_id, count, operation_id)
+
+        def report_completion(self, executor_id):
+            result = super().report_completion(executor_id)
+            shutdown_reported.set()
+            return result
+
+        def release_executor_once(self, executor_id, operation_id):
+            release_executor_entered.set()
+            return super().release_executor_once(executor_id, operation_id)
+
+    actor = _FakeVLLMActor()
+    router = SlowCompleteRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    executor.submit(None, ["first"], pa.table({"id": [1]}))
+    first_reservation = actor.submissions[0][3]
+    submit_finished = threading.Event()
+
+    def submit_second():
+        executor.submit(None, ["second"], pa.table({"id": [2]}))
+        submit_finished.set()
+
+    shutdown_future = None
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        complete_future = pool.submit(executor._complete_reservation, first_reservation, 1)
+        assert complete_entered.wait(1)
+        submit_future = pool.submit(submit_second)
+        submit_was_not_blocked = submit_finished.wait(1)
+        if submit_was_not_blocked:
+            shutdown_future = pool.submit(executor.shutdown)
+            shutdown_was_reported = shutdown_reported.wait(1)
+            release_started_during_complete = release_executor_entered.wait(0.1) if shutdown_was_reported else False
+        else:
+            shutdown_was_reported = False
+            release_started_during_complete = False
+        allow_complete.set()
+        complete_future.result(timeout=2)
+        submit_future.result(timeout=2)
+        if shutdown_future is not None:
+            shutdown_future.result(timeout=2)
+
+    if shutdown_future is None:
+        executor.shutdown()
+
+    assert submit_was_not_blocked, "submit waited for a concurrent reservation-release RPC"
+    assert shutdown_was_reported, "shutdown did not reach terminal reservation release"
+    assert not release_started_during_complete, "terminal release raced an in-progress completion"
+    assert release_executor_entered.is_set()
+    assert router.inflight == [0]
+    assert executor._reservations == {}
+    assert executor._inflight_per_actor == [0]
+    assert executor._released_outstanding_inflight is True
+
+
+def test_remote_executor_uses_router_reservation_and_one_shot_wakeup(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    actors = [_FakeVLLMActor(), _FakeVLLMActor()]
+    router = vllm.PrefixRouter(actors, load_balance_threshold=32)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = actors
+        shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    rows = pa.table({"id": [1, 2]})
+    first_wakeup = threading.Event()
+    assert executor.register_wakeup_callback(first_wakeup.set) is True
+
+    executor.submit("prefix", ["a", "b"], rows)
+    assert first_wakeup.wait(1)
+    assert actors[0].submissions
+    reservation_id = actors[0].submissions[0][3]
+    assert router.inflight == [2, 0]
+
+    # Drain the already-ready submit acknowledgement, then arm for actor data.
+    assert executor.take_ready_result() is None
+    result_wakeup = threading.Event()
+    assert executor.register_wakeup_callback(result_wakeup.set) is True
+    actors[0].publish(["out-a", "out-b"], rows, reservation_id)
+    assert result_wakeup.wait(1)
+    assert executor.register_wakeup_callback(lambda: None) is False
+
+    assert executor.take_ready_result() == (["out-a", "out-b"], rows)
+    executor.finished_submitting()
+    assert executor.all_tasks_finished() is True
+    assert router.inflight == [0, 0]
+    assert actors[0].released and actors[1].released
+    executor.shutdown()
+    executor.shutdown()
+    assert executor._actors_owner.shutdown_calls == 1
+
+
+def test_remote_executor_rejects_actor_result_without_reservation_id(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    rows = pa.table({"id": [1]})
+    executor.submit(None, ["prompt"], rows)
+    actor.results.append((["output"], rows))
+
+    try:
+        with pytest.raises(RuntimeError, match="3-item tuple"):
+            executor._drain_ready_actor(0, True, actor.wait_refs[0])
+    finally:
+        executor.shutdown()
+
+
+def test_remote_success_is_not_rejected_when_terminal_actor_cleanup_keeps_failing(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class Actor(_FakeVLLMActor):
+        def __init__(self):
+            super().__init__()
+            self.fail_release = True
+            self.release_attempts = 0
+
+        def _release(self, executor_id):
+            self.release_attempts += 1
+            if self.fail_release:
+                raise RuntimeError("persistent release failure")
+            return super()._release(executor_id)
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+        shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    owner = Owner()
+    executor = vllm.RemoteVLLMExecutor(owner, pool_name="pool")
+    rows = pa.table({"id": [1]})
+    executor.submit(None, ["prompt"], rows)
+    reservation_id = actor.submissions[0][3]
+    actor.publish(["output"], rows, reservation_id)
+
+    assert executor.take_ready_result() == (["output"], rows)
+    executor.finished_submitting()
+    with pytest.warns(RuntimeWarning, match="persistent release failure"):
+        assert executor.all_tasks_finished() is True
+    assert executor._error_message is None
+    assert executor._finished is True
+    assert any("persistent release failure" in error for error in executor._terminal_cleanup_errors)
+
+    with warnings.catch_warnings(record=True) as repeated_cleanup_warnings:
+        warnings.simplefilter("always")
+        executor.shutdown()
+    assert repeated_cleanup_warnings == []
+    assert executor._shutdown_complete is False
+    assert executor._error_message is None
+    assert actor.release_attempts == 2
+    assert owner.shutdown_calls == 1
+
+    actor.fail_release = False
+    executor.shutdown()
+    assert executor._shutdown_complete is True
+    assert actor.released == [executor._executor_id]
+    assert owner.shutdown_calls == 2
+
+
+def test_remote_executor_rearms_wait_for_already_buffered_actor_result(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class ReadyAwareActor(_FakeVLLMActor):
+        def _wait(self, executor_id):
+            if self.results:
+                return _Ref(True)
+            return super()._wait(executor_id)
+
+    actor = ReadyAwareActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    first_rows = pa.table({"id": [1]})
+    second_rows = pa.table({"id": [2]})
+    executor.submit(None, ["first"], first_rows)
+    executor.submit(None, ["second"], second_rows)
+    first_reservation = actor.submissions[0][3]
+    second_reservation = actor.submissions[1][3]
+
+    actor.publish(["out-first"], first_rows, first_reservation)
+    actor.results.append((["out-second"], second_rows, second_reservation))
+
+    assert executor.take_ready_result() == (["out-first"], first_rows)
+    assert executor.take_ready_result() == (["out-second"], second_rows)
+    executor.finished_submitting()
+    assert executor.all_tasks_finished() is True
+    assert router.inflight == [0]
+
+
+def test_remote_executor_acknowledges_submissions_before_finishing_actor(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    events = []
+
+    class DeferredSubmitRef(_Ref):
+        def __init__(self):
+            super().__init__(ready=False)
+
+        def resolve(self):
+            events.append("submit-accepted")
+            self.set_result(None)
+            return None
+
+    class DeferredSubmitMethod:
+        @staticmethod
+        def remote(*_args, **_kwargs):
+            return DeferredSubmitRef()
+
+    class Actor(_FakeVLLMActor):
+        def __init__(self):
+            super().__init__()
+            self.submit_async = DeferredSubmitMethod()
+
+        def _finish(self, executor_id):
+            assert events == ["submit-accepted"]
+            events.append("executor-finished")
+            super()._finish(executor_id)
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+
+    executor.finished_submitting()
+
+    assert events == ["submit-accepted", "executor-finished"]
+
+
+def test_remote_executor_reports_router_completion_when_actor_finish_ack_fails_once(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class Actor(_FakeVLLMActor):
+        def __init__(self):
+            super().__init__()
+            self.fail_finish = True
+
+        def _finish(self, executor_id):
+            if self.fail_finish:
+                self.fail_finish = False
+                raise RuntimeError("finish acknowledgement failed")
+            super()._finish(executor_id)
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+
+    with pytest.raises(RuntimeError, match="finish acknowledgement failed"):
+        executor.finished_submitting()
+
+    assert executor._router_completion_reported is True
+    assert executor._executor_id not in router._active_executors
+    executor.shutdown()
+
+
+def test_remote_shutdown_ignores_expired_query_deadline_for_control_rpcs(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    monkeypatch.delenv("VANE_QUERY_DEADLINE_EPOCH_S", raising=False)
+    monkeypatch.delenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", raising=False)
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+        shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    owner = Owner()
+    executor = vllm.RemoteVLLMExecutor(owner, pool_name="pool")
+    executor_id = executor._executor_id
+    assert executor_id in router._active_executors
+    executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+    assert router.inflight == [1]
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", str(time.time() - 1.0))
+
+    executor.shutdown()
+
+    assert executor._shutdown_complete is True
+    assert executor_id not in router._active_executors
+    assert router.inflight == [0]
+    assert actor.finished == [executor_id]
+    assert actor.aborted == [executor_id]
+    assert actor.released == [executor_id]
+    assert owner.shutdown_calls == 1
+
+
+def test_remote_wait_marks_finished_after_releasing_result_condition():
+    import duckdb.execution.vllm as vllm
+
+    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
+    executor._error_message = None
+    executor._result_buffer = deque()
+    executor._finished = False
+    executor._finished_submitting_flag = True
+    executor._submit_per_actor = []
+    executor._results_per_actor = []
+    executor._wait_refs_by_actor = []
+    executor._result_cv = threading.Condition(threading.Lock())
+    executor._drain_queued_submit_refs = lambda: None
+    executor._drain_queued_wait_refs = lambda: None
+    executor._ensure_remote_wait_refs = lambda: None
+    observed = []
+
+    def mark_finished():
+        assert executor._result_cv.acquire(blocking=False), "_mark_finished called while _result_cv is held"
+        executor._result_cv.release()
+        observed.append("finished")
+        executor._finished = True
+
+    def record_error(exc):
+        executor._error_message = f"{type(exc).__name__}: {exc}"
+
+    executor._mark_finished = mark_finished
+    executor._record_error = record_error
+
+    executor.wait_for_result()
+
+    assert observed == ["finished"]
+
+
+def test_remote_ref_cleanup_does_not_initialize_ray(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    calls = []
+    fake_ray = types.ModuleType("ray")
+
+    def is_initialized():
+        calls.append("checked")
+        return False
+
+    def cancel(_ref):
+        pytest.fail("cleanup must not call ray.cancel before Ray is initialized")
+
+    fake_ray.is_initialized = is_initialized
+    fake_ray.cancel = cancel
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+
+    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
+    executor._cancel_refs([object()])
+
+    assert calls == ["checked"]

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -617,20 +617,72 @@ def test_remote_executor_rejects_actor_result_without_reservation_id(monkeypatch
         executor.shutdown()
 
 
-def test_remote_success_is_not_rejected_when_terminal_actor_cleanup_keeps_failing(monkeypatch):
+def test_remote_success_shutdown_retries_terminal_cleanup_without_warning(monkeypatch):
     import duckdb.execution.vllm as vllm
 
     class Actor(_FakeVLLMActor):
         def __init__(self):
             super().__init__()
-            self.fail_release = True
             self.release_attempts = 0
 
         def _release(self, executor_id):
             self.release_attempts += 1
-            if self.fail_release:
-                raise RuntimeError("persistent release failure")
+            if self.release_attempts == 1:
+                raise RuntimeError("transient release failure")
             return super()._release(executor_id)
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+        shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    owner = Owner()
+    executor = vllm.RemoteVLLMExecutor(owner, pool_name="pool")
+    executor_id = executor._executor_id
+    rows = pa.table({"id": [1]})
+    executor.submit(None, ["prompt"], rows)
+    reservation_id = actor.submissions[0][3]
+    actor.publish(["output"], rows, reservation_id)
+
+    assert executor.take_ready_result() == (["output"], rows)
+    executor.finished_submitting()
+    with warnings.catch_warnings(record=True) as first_cleanup_warnings:
+        warnings.simplefilter("always")
+        assert executor.all_tasks_finished() is True
+    assert first_cleanup_warnings == []
+    assert executor._error_message is None
+    assert executor._finished is True
+    assert actor.release_attempts == 1
+
+    with warnings.catch_warnings(record=True) as final_cleanup_warnings:
+        warnings.simplefilter("always")
+        executor.shutdown()
+    assert final_cleanup_warnings == []
+    assert executor._shutdown_complete is True
+    assert executor._error_message is None
+    assert actor.release_attempts == 2
+    assert actor.released == [executor_id]
+    assert owner.shutdown_calls == 1
+
+
+def test_remote_success_warns_after_final_cleanup_attempt_fails(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class Actor(_FakeVLLMActor):
+        def __init__(self):
+            super().__init__()
+            self.release_attempts = 0
+
+        def _release(self, _executor_id):
+            self.release_attempts += 1
+            raise RuntimeError("persistent release failure")
 
     actor = Actor()
     router = vllm.PrefixRouter([actor], load_balance_threshold=0)
@@ -653,26 +705,53 @@ def test_remote_success_is_not_rejected_when_terminal_actor_cleanup_keeps_failin
 
     assert executor.take_ready_result() == (["output"], rows)
     executor.finished_submitting()
-    with pytest.warns(RuntimeWarning, match="persistent release failure"):
-        assert executor.all_tasks_finished() is True
-    assert executor._error_message is None
-    assert executor._finished is True
-    assert any("persistent release failure" in error for error in executor._terminal_cleanup_errors)
-
-    with warnings.catch_warnings(record=True) as repeated_cleanup_warnings:
+    with warnings.catch_warnings(record=True) as first_cleanup_warnings:
         warnings.simplefilter("always")
+        assert executor.all_tasks_finished() is True
+    assert first_cleanup_warnings == []
+    assert actor.release_attempts == 1
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="final shutdown attempt; no background retry will be attempted",
+    ):
         executor.shutdown()
-    assert repeated_cleanup_warnings == []
+
     assert executor._shutdown_complete is False
     assert executor._error_message is None
     assert actor.release_attempts == 2
     assert owner.shutdown_calls == 1
 
-    actor.fail_release = False
+
+def test_remote_cleanup_does_not_retry_terminal_rpcs_after_owned_pool_is_killed(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class Actor(_FakeVLLMActor):
+        @staticmethod
+        def _release(_executor_id):
+            raise RuntimeError("actor release acknowledgement lost")
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+    router_proxy = _RemoteProxy(router)
+    owner = vllm.LLMActors.__new__(vllm.LLMActors)
+    owner.llm_actors = [actor]
+    owner.router_actor = router_proxy
+    owner.owned = True
+    owner._shutdown_complete = False
+    killed = []
+    fake_ray = types.ModuleType("ray")
+    fake_ray.kill = lambda handle, **_kwargs: killed.append(handle)
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(owner)
+    executor._finished = True
+    executor._finished_submitting_flag = True
+
     executor.shutdown()
+
     assert executor._shutdown_complete is True
-    assert actor.released == [executor._executor_id]
-    assert owner.shutdown_calls == 2
+    assert killed == [actor, router_proxy]
 
 
 def test_remote_executor_rearms_wait_for_already_buffered_actor_result(monkeypatch):
@@ -868,6 +947,86 @@ def test_remote_executor_terminalizes_after_both_route_ack_attempts_fail(monkeyp
     assert executor._released_outstanding_inflight is True
     with pytest.raises(RuntimeError, match="no longer accepts submissions"):
         executor.submit(None, ["another"], pa.table({"id": [2]}))
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"actor_idx": 99},
+        {"operation_id": "wrong-operation"},
+        {"prompt_count": 2},
+        {"reservation_id": 123},
+    ],
+)
+def test_remote_executor_terminalizes_and_reconciles_malformed_route_decision(monkeypatch, override):
+    import duckdb.execution.vllm as vllm
+
+    class MalformedRouteMethod:
+        def __init__(self, router):
+            self.router = router
+
+        def remote(self, *args):
+            decision = self.router.route_and_reserve_once(*args)
+            return _Ref({**decision, **override})
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+    router_proxy = _RemoteProxy(router)
+    router_proxy.route_and_reserve_once = MalformedRouteMethod(router)
+
+    class Owner:
+        router_actor = router_proxy
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+
+    with pytest.raises(RuntimeError, match="invalid reservation"):
+        executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+
+    assert executor._finished is True
+    assert "invalid reservation" in executor._error_message
+    assert actor.aborted == [executor._executor_id]
+    assert executor._executor_id not in router._active_executors
+    assert router.inflight == [0]
+    assert router._reservations == {}
+    assert executor._released_outstanding_inflight is True
+
+
+def test_pending_submit_acknowledgements_each_use_full_control_timeout(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    first_ref = object()
+    second_ref = object()
+    executor = vllm.RemoteVLLMExecutor.__new__(vllm.RemoteVLLMExecutor)
+    executor._result_cv = threading.Condition(threading.RLock())
+    executor._submit_refs = {
+        first_ref: (0, 1, "reservation-1"),
+        second_ref: (0, 1, "reservation-2"),
+    }
+    executor._ready_submit_refs = deque()
+    executor._rollback_submitted_batch = lambda *_args, **_kwargs: None
+
+    observed_timeouts = []
+
+    monkeypatch.setattr(vllm, "_vllm_control_rpc_timeout_s", lambda: 5.0)
+
+    def resolve(_ref, *, timeout, honor_query_deadline):
+        assert honor_query_deadline is False
+        observed_timeouts.append(timeout)
+        raise TimeoutError("submit acknowledgement timed out")
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", resolve)
+
+    errors = executor._await_pending_submit_refs()
+
+    assert len(errors) == 2
+    assert observed_timeouts == [pytest.approx(5.0), pytest.approx(5.0)]
+    assert executor._submit_refs == {}
 
 
 def test_remote_executor_reports_router_completion_when_actor_finish_ack_fails_once(monkeypatch):

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -115,6 +115,33 @@ def test_vllm_execution_boolean_options_are_strict(name):
     assert normalize_options({name: False})[name] is False
 
 
+def test_native_descriptor_forces_background_loop_inside_ray_actor(monkeypatch):
+    import duckdb.execution.vllm as vllm_executor
+    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+
+    fake_vllm = types.ModuleType("vllm")
+
+    class SamplingParams:
+        pass
+
+    fake_vllm.SamplingParams = SamplingParams
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setattr(vllm_executor.LocalVLLMExecutor, "_detect_ray_actor", staticmethod(lambda: True))
+
+    def fake_run_event_loop(executor):
+        executor.loop = object()
+        executor.loop_ready.set()
+
+    monkeypatch.setattr(vllm_executor.LocalVLLMExecutor, "_run_event_loop", fake_run_event_loop)
+
+    options = VLLMPrompterDescriptor(vllm_options={"use_threading": False}).build_physical_vllm_options()
+    executor = vllm_executor.build_executor("test-model", options)
+
+    assert executor._ray_actor_mode is False
+    assert executor.use_threading is True
+    assert executor.loop_ready.is_set()
+
+
 def test_ray_actor_releases_only_terminal_per_executor_state():
     from duckdb.execution.vllm import RayLocalVLLMExecutor
 
@@ -246,6 +273,79 @@ def test_ray_actor_abort_wait_uses_control_rpc_timeout(monkeypatch):
         asyncio.run(executor.abort_executor("executor", wait_expected=True))
 
     assert sleep_calls == [0.01]
+
+
+def test_ray_actor_abort_installs_tombstone_before_awaiting_engine_abort():
+    from duckdb.execution.vllm import RayLocalVLLMExecutor
+
+    abort_started = asyncio.Event()
+    allow_abort = asyncio.Event()
+
+    class Engine:
+        async def abort(self, _request_id):
+            abort_started.set()
+            await allow_abort.wait()
+
+        async def generate(self, *_args, **_kwargs):
+            yield types.SimpleNamespace(outputs=[types.SimpleNamespace(text="late")])
+
+    executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+    executor.llm = Engine()
+    executor.on_error = "raise"
+    executor.sampling_params = object()
+    executor.generate_args = {}
+    executor.counter = 0
+    executor.counter_lock = threading.Lock()
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._shutdown_called = False
+    executor._finished_submitting = False
+    executor.running_task_count = 0
+    executor.task_count_lock = threading.Lock()
+    executor._result_cv = threading.Condition(threading.RLock())
+    executor._ray_actor_mode = True
+    executor.engine_error_message = None
+    executor._per_executor_deques = {"executor": deque()}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = set()
+    executor._per_executor_request_ids = {"executor": {"old-request"}}
+    executor._per_executor_tasks = {"executor": set()}
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_abort_wait_required = set()
+    executor._per_executor_terminal_wait_observed = set()
+
+    async def run_scenario():
+        abort_task = asyncio.create_task(executor.abort_executor("executor"))
+        await abort_started.wait()
+        tombstone_installed = "executor" in executor._per_executor_aborted
+        late_error = None
+        try:
+            await executor.submit_async(
+                ["late"],
+                pa.table({"id": [1]}),
+                "executor",
+                "late-reservation",
+            )
+        except RuntimeError as exc:
+            late_error = exc
+        finally:
+            allow_abort.set()
+            await abort_task
+            await asyncio.sleep(0)
+        return tombstone_installed, late_error
+
+    tombstone_installed, late_error = asyncio.run(run_scenario())
+
+    assert tombstone_installed is True
+    assert late_error is not None
+    assert "already finished" in str(late_error)
+    assert executor.running_task_count == 0
+    assert "executor" not in executor._per_executor_deques
+    assert "executor" not in executor._per_executor_running_task_count
+    assert "executor" not in executor._per_executor_request_ids
+    assert "executor" not in executor._per_executor_tasks
 
 
 def test_prefix_router_serializes_global_reservations_and_releases_exactly_once():
@@ -661,6 +761,113 @@ def test_remote_executor_acknowledges_submissions_before_finishing_actor(monkeyp
     executor.finished_submitting()
 
     assert events == ["submit-accepted", "executor-finished"]
+
+
+def test_remote_executor_consumes_all_submit_acks_before_aborting(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    events = []
+
+    class FailingSubmitRef(_Ref):
+        def __init__(self, name, *, ready):
+            super().__init__(ready=ready)
+            self.name = name
+
+        def resolve(self):
+            events.append(self.name)
+            raise RuntimeError(f"{self.name} failed")
+
+    class SubmitMethod:
+        def __init__(self):
+            self.refs = deque(
+                [
+                    FailingSubmitRef("first-submit-ack", ready=True),
+                    FailingSubmitRef("second-submit-ack", ready=False),
+                ]
+            )
+
+        def remote(self, *_args, **_kwargs):
+            return self.refs.popleft()
+
+    class Actor(_FakeVLLMActor):
+        def __init__(self):
+            super().__init__()
+            self.submit_async = SubmitMethod()
+
+        def _abort(self, executor_id, wait_expected):
+            events.append("abort")
+            return super()._abort(executor_id, wait_expected)
+
+    actor = Actor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    executor.submit(None, ["first"], pa.table({"id": [1]}))
+    executor.submit(None, ["second"], pa.table({"id": [2]}))
+
+    with pytest.raises(RuntimeError, match="first-submit-ack failed"):
+        executor.take_ready_result()
+
+    assert events == ["first-submit-ack", "second-submit-ack", "abort"]
+    assert actor.aborted == [executor._executor_id]
+    assert "second-submit-ack failed" in executor._error_message
+    assert executor._submit_refs == {}
+    assert executor._reservations == {}
+    assert router.inflight == [0]
+
+
+def test_remote_executor_terminalizes_after_both_route_ack_attempts_fail(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class LostRouteAckRef(_Ref):
+        def resolve(self):
+            raise RuntimeError("route acknowledgement lost")
+
+    class LostRouteAckMethod:
+        def __init__(self, router):
+            self.router = router
+
+        def remote(self, *args):
+            decision = self.router.route_and_reserve_once(*args)
+            return LostRouteAckRef(decision)
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+    router_proxy = _RemoteProxy(router)
+    router_proxy.route_and_reserve_once = LostRouteAckMethod(router)
+
+    class Owner:
+        router_actor = router_proxy
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+
+    with pytest.raises(RuntimeError, match="route acknowledgement lost"):
+        executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+
+    assert executor._finished is True
+    assert "route acknowledgement lost" in executor._error_message
+    assert actor.aborted == [executor._executor_id]
+    assert executor._executor_id not in router._active_executors
+    assert router.inflight == [0]
+    assert router._reservations == {}
+    assert executor._released_outstanding_inflight is True
+    with pytest.raises(RuntimeError, match="no longer accepts submissions"):
+        executor.submit(None, ["another"], pa.table({"id": [2]}))
 
 
 def test_remote_executor_reports_router_completion_when_actor_finish_ack_fails_once(monkeypatch):

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 import sys
 import threading
 import time
@@ -15,6 +16,25 @@ from decimal import Decimal
 
 import pyarrow as pa
 import pytest
+
+
+def _packed_native_vllm_secret_options():
+    from vane.ai.providers.vllm import NativeVLLMPromptPlan, _build_native_vllm_options_argument
+
+    descriptor = NativeVLLMPromptPlan(
+        model_name="secret-model",
+        vllm_options={
+            "engine_args": {
+                "hf_token": "hf_OPAQUE-ENGINE-TOKEN",
+                "max_model_len": 2048,
+            },
+            "generate_args": {
+                "api_key": "sk-OPAQUE-GENERATE-KEY",
+                "sampling_params": {"max_tokens": 16},
+            },
+        },
+    )
+    return _build_native_vllm_options_argument(descriptor.build_physical_vllm_options())
 
 
 def test_vllm_control_rpc_timeout_is_configurable(monkeypatch):
@@ -113,6 +133,118 @@ def test_vllm_execution_boolean_options_are_strict(name):
         normalize_options({name: "false"})
 
     assert normalize_options({name: False})[name] is False
+
+
+def test_vllm_unknown_top_level_options_are_rejected():
+    from duckdb.execution.vllm import normalize_options
+
+    with pytest.raises(ValueError, match=r"unknown vllm option.*gpus_per_actorr"):
+        normalize_options({"gpus_per_actorr": 0.25})
+
+
+def test_vllm_opaque_secrets_restore_only_when_local_executor_is_created(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    packed = _packed_native_vllm_secret_options()
+    assert isinstance(packed, dict)
+    public_options = packed["__vane_vllm_public_options_json"]
+    assert "hf_OPAQUE-ENGINE-TOKEN" not in public_options
+    assert "sk-OPAQUE-GENERATE-KEY" not in public_options
+
+    captured = {}
+    executor = object()
+
+    def create_local_executor(model, engine_args, generate_args, **kwargs):
+        captured.update(
+            model=model,
+            engine_args=engine_args,
+            generate_args=generate_args,
+            kwargs=kwargs,
+        )
+        return executor
+
+    monkeypatch.setattr(vllm, "LocalVLLMExecutor", create_local_executor)
+
+    assert vllm.build_executor("secret-model", packed) is executor
+    assert captured["engine_args"]["hf_token"] == "hf_OPAQUE-ENGINE-TOKEN"
+    assert captured["engine_args"]["max_model_len"] == 2048
+    assert captured["generate_args"]["api_key"] == "sk-OPAQUE-GENERATE-KEY"
+    assert captured["generate_args"]["sampling_params"] == {"max_tokens": 16}
+
+
+def test_vllm_opaque_secrets_restore_on_driver_before_named_pool_creation(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    packed = _packed_native_vllm_secret_options()
+    assert isinstance(packed, dict)
+    packed.update(
+        use_ray=True,
+        ray_worker_only=True,
+        ray_actor_pool_name="query-scoped-pool",
+    )
+
+    class Plan:
+        def collect_vllm_nodes(self, conn=None):
+            return [
+                {
+                    "model": "secret-model",
+                    "pool_name": "query-scoped-pool",
+                    "options": packed,
+                }
+            ]
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.is_initialized = lambda: True
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.delenv("VANE_WORKER", raising=False)
+
+    captured = {}
+    actors = object()
+
+    def get_or_create_named(_cls, **kwargs):
+        captured.update(kwargs)
+        return actors
+
+    monkeypatch.setattr(vllm.LLMActors, "get_or_create_named", classmethod(get_or_create_named))
+
+    created, leases = vllm.ensure_named_vllm_pools_for_plan(Plan(), session_config={})
+
+    assert created == [actors]
+    assert leases == {}
+    assert captured["engine_args"]["hf_token"] == "hf_OPAQUE-ENGINE-TOKEN"
+    assert captured["generate_args"]["api_key"] == "sk-OPAQUE-GENERATE-KEY"
+    assert captured["name_prefix"] == "query-scoped-pool"
+
+
+@pytest.mark.parametrize(
+    ("secret_payload", "message"),
+    [
+        (b"not-json", "strict JSON"),
+        (b'{"payload_version":1,"values":[]}', "invalid index"),
+        (b'{"payload_version":1,"values":["secret","unused"]}', "unreferenced"),
+        (
+            b'{"payload_version":1,"payload_version":1,"values":["secret"]}',
+            "strict JSON",
+        ),
+    ],
+)
+def test_vllm_opaque_secret_payload_is_strictly_validated(secret_payload, message):
+    import duckdb.execution.vllm as vllm
+
+    public_options = {
+        "engine_args": {
+            "hf_token": {"__vane_vllm_secret_ref": 0},
+        }
+    }
+    envelope = {
+        "__vane_vllm_payload_version": 1,
+        "__vane_vllm_public_options_json": json.dumps(public_options),
+        "__vane_vllm_secret_payload": secret_payload,
+    }
+
+    normalized = vllm.normalize_options(envelope)
+    with pytest.raises(ValueError, match=message):
+        vllm._restore_native_vllm_secrets(normalized)
 
 
 def test_native_descriptor_forces_background_loop_inside_ray_actor(monkeypatch):
@@ -751,7 +883,7 @@ def test_remote_cleanup_does_not_retry_terminal_rpcs_after_owned_pool_is_killed(
     executor.shutdown()
 
     assert executor._shutdown_complete is True
-    assert killed == [actor, router_proxy]
+    assert killed == [router_proxy, actor]
 
 
 def test_remote_executor_rearms_wait_for_already_buffered_actor_result(monkeypatch):

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -296,8 +296,8 @@ def test_ray_actor_releases_only_terminal_per_executor_state():
     executor._per_executor_errors = {}
     executor._per_executor_aborted = set()
     executor._per_executor_waiters = {}
-    executor._per_executor_abort_wait_required = set()
-    executor._per_executor_terminal_wait_observed = set()
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
 
     assert executor.release_executor("executor") is False
     assert executor.take_ready_result("executor") == ([None], rows, "reservation")
@@ -332,8 +332,8 @@ def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity(
     executor._per_executor_errors = {}
     executor._per_executor_aborted = set()
     executor._per_executor_waiters = {}
-    executor._per_executor_abort_wait_required = set()
-    executor._per_executor_terminal_wait_observed = set()
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
 
     async def run_scenario():
         loop = asyncio.get_running_loop()
@@ -352,11 +352,12 @@ def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity(
             while not pool_occupied.is_set():
                 await asyncio.sleep(0)
 
-            waiter = asyncio.create_task(executor.wait_for_result("executor"))
+            wait_token = "registered-wait"
+            waiter = asyncio.create_task(executor.wait_for_result("executor", wait_token))
             while executor._per_executor_waiters.get("executor", 0) == 0:
                 await asyncio.sleep(0)
 
-            await asyncio.wait_for(executor.abort_executor("executor", wait_expected=True), timeout=2.0)
+            await asyncio.wait_for(executor.abort_executor("executor", wait_token), timeout=2.0)
             assert await asyncio.wait_for(waiter, timeout=2.0) is False
         finally:
             release_pool.set()
@@ -366,6 +367,51 @@ def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity(
             await blocker
 
     asyncio.run(run_scenario())
+
+
+def test_ray_actor_abort_waits_for_late_wait_token_before_releasing_state():
+    from duckdb.execution.vllm import RayLocalVLLMExecutor
+
+    executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+    executor.llm = None
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._shutdown_called = False
+    executor._finished_submitting = False
+    executor.running_task_count = 0
+    executor.task_count_lock = threading.Lock()
+    executor._result_cv = threading.Condition(threading.RLock())
+    executor._per_executor_deques = {"executor": deque()}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = set()
+    executor._per_executor_request_ids = {"executor": set()}
+    executor._per_executor_tasks = {"executor": set()}
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
+
+    async def run_scenario():
+        wait_token = "late-wait"
+        abort_task = asyncio.create_task(executor.abort_executor("executor", wait_token))
+        await asyncio.sleep(0)
+
+        assert abort_task.done() is False
+        assert executor.release_executor("executor") is False
+
+        waiter = asyncio.create_task(executor.wait_for_result("executor", wait_token))
+        assert await asyncio.wait_for(waiter, timeout=2.0) is False
+        await asyncio.wait_for(abort_task, timeout=2.0)
+
+        assert executor.release_executor("executor") is True
+
+    asyncio.run(run_scenario())
+
+    assert "executor" not in executor._per_executor_deques
+    assert "executor" not in executor._per_executor_waiters
+    assert "executor" not in executor._per_executor_wait_tokens_observed
+    assert "executor" not in executor._per_executor_abort_wait_tokens
 
 
 def test_ray_actor_abort_wait_uses_control_rpc_timeout(monkeypatch):
@@ -387,9 +433,9 @@ def test_ray_actor_abort_wait_uses_control_rpc_timeout(monkeypatch):
     executor._per_executor_tasks = {"executor": set()}
     executor._per_executor_errors = {}
     executor._per_executor_aborted = set()
-    executor._per_executor_waiters = {"executor": 1}
-    executor._per_executor_abort_wait_required = set()
-    executor._per_executor_terminal_wait_observed = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
 
     clock = iter((100.0, 106.0, 111.0))
     sleep_calls = []
@@ -401,8 +447,8 @@ def test_ray_actor_abort_wait_uses_control_rpc_timeout(monkeypatch):
     monkeypatch.setattr(vllm, "time", types.SimpleNamespace(monotonic=lambda: next(clock)))
     monkeypatch.setattr(vllm.asyncio, "sleep", fake_sleep)
 
-    with pytest.raises(RuntimeError, match="abort waiter did not acknowledge termination"):
-        asyncio.run(executor.abort_executor("executor", wait_expected=True))
+    with pytest.raises(RuntimeError, match="abort waiter timeout-wait did not acknowledge termination"):
+        asyncio.run(executor.abort_executor("executor", "timeout-wait"))
 
     assert sleep_calls == [0.01]
 
@@ -445,8 +491,8 @@ def test_ray_actor_abort_installs_tombstone_before_awaiting_engine_abort():
     executor._per_executor_errors = {}
     executor._per_executor_aborted = set()
     executor._per_executor_waiters = {}
-    executor._per_executor_abort_wait_required = set()
-    executor._per_executor_terminal_wait_observed = set()
+    executor._per_executor_wait_tokens_observed = {}
+    executor._per_executor_abort_wait_tokens = {}
 
     async def run_scenario():
         abort_task = asyncio.create_task(executor.abort_executor("executor"))
@@ -565,8 +611,10 @@ class _FakeVLLMActor:
         self.submissions = []
         self.results = deque()
         self.wait_refs = deque()
+        self.wait_tokens = []
         self.released = []
         self.aborted = []
+        self.abort_wait_tokens = []
         self.finished = []
         self.submit_async = _RemoteMethod(self._submit)
         self.wait_for_result = _RemoteMethod(self._wait, raw_ref=True)
@@ -578,7 +626,8 @@ class _FakeVLLMActor:
     def _submit(self, prompts, rows, executor_id, reservation_id):
         self.submissions.append((list(prompts), rows, executor_id, reservation_id))
 
-    def _wait(self, _executor_id):
+    def _wait(self, executor_id, wait_token):
+        self.wait_tokens.append((executor_id, wait_token))
         ref = _Ref(ready=False)
         self.wait_refs.append(ref)
         return ref
@@ -593,8 +642,9 @@ class _FakeVLLMActor:
         self.released.append(executor_id)
         return True
 
-    def _abort(self, executor_id, _wait_expected):
+    def _abort(self, executor_id, wait_token):
         self.aborted.append(executor_id)
+        self.abort_wait_tokens.append((executor_id, wait_token))
 
     def publish(self, outputs, rows, reservation_id):
         self.results.append((outputs, rows, reservation_id))
@@ -890,10 +940,10 @@ def test_remote_executor_rearms_wait_for_already_buffered_actor_result(monkeypat
     import duckdb.execution.vllm as vllm
 
     class ReadyAwareActor(_FakeVLLMActor):
-        def _wait(self, executor_id):
+        def _wait(self, executor_id, wait_token):
             if self.results:
                 return _Ref(True)
-            return super()._wait(executor_id)
+            return super()._wait(executor_id, wait_token)
 
     actor = ReadyAwareActor()
     router = vllm.PrefixRouter([actor], load_balance_threshold=0)
@@ -1005,9 +1055,9 @@ def test_remote_executor_consumes_all_submit_acks_before_aborting(monkeypatch):
             super().__init__()
             self.submit_async = SubmitMethod()
 
-        def _abort(self, executor_id, wait_expected):
+        def _abort(self, executor_id, wait_token):
             events.append("abort")
-            return super()._abort(executor_id, wait_expected)
+            return super()._abort(executor_id, wait_token)
 
     actor = Actor()
     router = vllm.PrefixRouter([actor], load_balance_threshold=0)
@@ -1228,6 +1278,8 @@ def test_remote_shutdown_ignores_expired_query_deadline_for_control_rpcs(monkeyp
     assert router.inflight == [0]
     assert actor.finished == [executor_id]
     assert actor.aborted == [executor_id]
+    assert actor.abort_wait_tokens == actor.wait_tokens
+    assert actor.abort_wait_tokens[0][1]
     assert actor.released == [executor_id]
     assert owner.shutdown_calls == 1
 

--- a/tests/slow/test_vllm_ray_protocol_e2e.py
+++ b/tests/slow/test_vllm_ray_protocol_e2e.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-Ray protocol tests for vLLM routing and executor finalization."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import os
+import threading
+import time
+import uuid
+import warnings
+from pathlib import Path
+
+import pytest
+
+ray = pytest.importorskip("ray")
+pa = pytest.importorskip("pyarrow")
+
+from duckdb.execution.vllm import PrefixRouter, RayLocalVLLMExecutor, RemoteVLLMExecutor
+
+
+@pytest.fixture(scope="module")
+def ray_runtime():
+    owned = not ray.is_initialized()
+    if owned:
+        os.environ.setdefault("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "0")
+        pythonpath = os.pathsep.join(
+            entry for entry in (str(Path(__file__).parent), os.environ.get("PYTHONPATH", "")) if entry
+        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Tip: In future versions of Ray, Ray will no longer override accelerator",
+            )
+            ray.init(
+                address="local",
+                namespace=f"vane-vllm-protocol-{uuid.uuid4().hex}",
+                num_cpus=2,
+                num_gpus=0,
+                include_dashboard=False,
+                log_to_driver=False,
+                runtime_env={
+                    "env_vars": {
+                        "PYTHONPATH": pythonpath,
+                        "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
+                    }
+                },
+            )
+    try:
+        yield ray
+    finally:
+        if owned:
+            ray.shutdown()
+
+
+class _DelayedAsyncVLLMActor:
+    """Minimal async actor that makes a terminal-before-submit race deterministic."""
+
+    def __init__(self):
+        self._submitted: dict[str, int] = {}
+        self._finished: set[str] = set()
+        self._events: list[tuple[str, str]] = []
+
+    async def submit_async(self, prompts, _rows, executor_id, _reservation_id):
+        await asyncio.sleep(0.15)
+        self._submitted[executor_id] = self._submitted.get(executor_id, 0) + len(prompts)
+        self._events.append(("submit", executor_id))
+        return True
+
+    async def finished_executor(self, executor_id):
+        if self._submitted.get(executor_id, 0) == 0:
+            raise RuntimeError("finished_executor overtook submit_async")
+        self._finished.add(executor_id)
+        self._events.append(("finish", executor_id))
+        return True
+
+    async def wait_for_result(self, executor_id):
+        while executor_id not in self._finished:
+            await asyncio.sleep(0.01)
+        return False
+
+    def abort_executor(self, _executor_id, _wait_expected):
+        return True
+
+    def release_executor(self, _executor_id):
+        return True
+
+    def events(self):
+        return list(self._events)
+
+
+class _ThreadPoolSaturatedWaitActor:
+    """Exercise RayLocalVLLMExecutor waits on a real Ray actor event loop."""
+
+    def __init__(self):
+        executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+        executor.llm = None
+        executor.completed_tasks = []
+        executor.error_message = None
+        executor._shutdown_called = False
+        executor._finished_submitting = False
+        executor.running_task_count = 0
+        executor.task_count_lock = threading.Lock()
+        executor._result_cv = threading.Condition(threading.RLock())
+        executor._per_executor_deques = {"executor": []}
+        executor._per_executor_running_task_count = {"executor": 0}
+        executor._per_executor_finished = set()
+        executor._per_executor_request_ids = {"executor": set()}
+        executor._per_executor_tasks = {"executor": set()}
+        executor._per_executor_errors = {}
+        executor._per_executor_aborted = set()
+        executor._per_executor_waiters = {}
+        executor._per_executor_abort_wait_required = set()
+        executor._per_executor_terminal_wait_observed = set()
+        self.executor = executor
+        self.pool_started = threading.Event()
+        self.release_pool = threading.Event()
+
+    async def saturate_default_pool(self):
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(concurrent.futures.ThreadPoolExecutor(max_workers=1))
+
+        def occupy_only_worker():
+            self.pool_started.set()
+            self.release_pool.wait()
+
+        await asyncio.to_thread(occupy_only_worker)
+        return True
+
+    async def pool_is_saturated(self):
+        return self.pool_started.is_set()
+
+    async def wait_for_result(self):
+        return await self.executor.wait_for_result("executor")
+
+    async def waiter_count(self):
+        return self.executor._per_executor_waiters.get("executor", 0)
+
+    async def abort_executor(self):
+        await self.executor.abort_executor("executor", wait_expected=True)
+        return True
+
+    async def release_default_pool(self):
+        self.release_pool.set()
+
+
+class _RayActorOwner:
+    def __init__(self, ray_module, llm_actor, router_actor):
+        self._ray = ray_module
+        self.llm_actors = [llm_actor]
+        self.router_actor = router_actor
+        self._closed = False
+
+    def shutdown(self):
+        if self._closed:
+            return
+        self._closed = True
+        for actor in (*self.llm_actors, self.router_actor):
+            try:
+                self._ray.kill(actor, no_restart=True)
+            except TypeError:
+                self._ray.kill(actor)
+
+
+def test_remote_executor_waits_for_real_ray_submit_ack_before_finish(ray_runtime):
+    actor = ray_runtime.remote(_DelayedAsyncVLLMActor).remote()
+    router = ray_runtime.remote(PrefixRouter).remote([actor], 0)
+    owner = _RayActorOwner(ray_runtime, actor, router)
+    executor = RemoteVLLMExecutor(owner)
+
+    try:
+        executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+        executor.finished_submitting()
+
+        events = ray_runtime.get(actor.events.remote())
+        assert [event[0] for event in events] == ["submit", "finish"]
+        assert events[0][1] == events[1][1]
+    finally:
+        executor.shutdown()
+
+
+def test_prefix_router_real_ray_rpc_burst_is_atomic_and_idempotent(ray_runtime):
+    router = ray_runtime.remote(PrefixRouter).remote(["actor-0", "actor-1"], 0)
+    executor_id = f"executor-{uuid.uuid4().hex}"
+    try:
+        assert ray_runtime.get(router.report_start.remote(executor_id)) is True
+
+        first = ray_runtime.get(router.route_and_reserve_once.remote("shared", 3, executor_id, "route-1"))
+        second = ray_runtime.get(router.route_and_reserve_once.remote("shared", 1, executor_id, "route-2"))
+        replay = ray_runtime.get(router.route_and_reserve_once.remote("shared", 1, executor_id, "route-2"))
+
+        assert first["actor_idx"] == 0
+        assert first["route_reason"] == "initial"
+        assert second["actor_idx"] == 1
+        assert second["route_reason"] == "load_balance"
+        assert replay["reservation_id"] == second["reservation_id"]
+        assert replay["replayed"] is True
+
+        burst = ray_runtime.get(
+            [router.route_and_reserve_once.remote(None, 1, executor_id, f"burst-{index}") for index in range(16)]
+        )
+        assert len({decision["reservation_id"] for decision in burst}) == 16
+        assert {decision["actor_idx"] for decision in burst} == {0, 1}
+
+        complete = ray_runtime.get(router.complete_once.remote(first["reservation_id"], 2, "complete-first"))
+        complete_replay = ray_runtime.get(router.complete_once.remote(first["reservation_id"], 2, "complete-first"))
+        assert complete == {"operation_id": "complete-first", "released": 2, "replayed": False}
+        assert complete_replay == {"operation_id": "complete-first", "released": 2, "replayed": True}
+
+        release = ray_runtime.get(router.release_executor_once.remote(executor_id, "release-all"))
+        release_replay = ray_runtime.get(router.release_executor_once.remote(executor_id, "release-all"))
+        assert release["released"] == 18
+        assert release_replay == {"operation_id": "release-all", "released": 18, "replayed": True}
+        assert ray_runtime.get(router.release_executor.remote(executor_id)) == 0
+        assert ray_runtime.get(router.report_completion.remote(executor_id)) is True
+        assert ray_runtime.get(router.report_completion.remote(executor_id)) is False
+    finally:
+        try:
+            ray_runtime.kill(router, no_restart=True)
+        except TypeError:
+            ray_runtime.kill(router)
+
+
+def test_ray_actor_abort_waiter_survives_saturated_default_thread_pool(ray_runtime):
+    actor = ray_runtime.remote(max_concurrency=32)(_ThreadPoolSaturatedWaitActor).remote()
+    saturation_ref = actor.saturate_default_pool.remote()
+    wait_ref = None
+    try:
+        deadline = time.monotonic() + 2.0
+        while not ray_runtime.get(actor.pool_is_saturated.remote()):
+            assert time.monotonic() < deadline, "default thread pool did not saturate"
+            time.sleep(0.01)
+
+        wait_ref = actor.wait_for_result.remote()
+        deadline = time.monotonic() + 2.0
+        while ray_runtime.get(actor.waiter_count.remote()) == 0:
+            assert time.monotonic() < deadline, "executor waiter was not registered"
+            time.sleep(0.01)
+
+        assert ray_runtime.get(actor.abort_executor.remote(), timeout=2.0) is True
+        assert ray_runtime.get(wait_ref, timeout=2.0) is False
+    finally:
+        try:
+            ray_runtime.get(actor.release_default_pool.remote(), timeout=2.0)
+            ray_runtime.get(saturation_ref, timeout=2.0)
+        finally:
+            try:
+                ray_runtime.kill(actor, no_restart=True)
+            except TypeError:
+                ray_runtime.kill(actor)

--- a/tests/slow/test_vllm_ray_protocol_e2e.py
+++ b/tests/slow/test_vllm_ray_protocol_e2e.py
@@ -92,6 +92,43 @@ class _DelayedAsyncVLLMActor:
         return list(self._events)
 
 
+class _FailingSubmitBarrierActor:
+    """Expose whether abort overtakes another in-flight submit acknowledgement."""
+
+    def __init__(self):
+        self._aborted: set[str] = set()
+        self._events: list[tuple[str, str]] = []
+
+    async def submit_async(self, prompts, _rows, executor_id, _reservation_id):
+        if prompts == ["fail"]:
+            await asyncio.sleep(0.05)
+            self._events.append(("submit-failed", executor_id))
+            raise RuntimeError("submit acknowledgement failed")
+        await asyncio.sleep(0.2)
+        self._events.append(("submit-settled", executor_id))
+        return True
+
+    async def finished_executor(self, executor_id):
+        self._events.append(("finish", executor_id))
+        return True
+
+    async def wait_for_result(self, executor_id):
+        while executor_id not in self._aborted:
+            await asyncio.sleep(0.01)
+        return False
+
+    async def abort_executor(self, executor_id, _wait_expected):
+        self._aborted.add(executor_id)
+        self._events.append(("abort", executor_id))
+        return True
+
+    def release_executor(self, _executor_id):
+        return True
+
+    def events(self):
+        return list(self._events)
+
+
 class _ThreadPoolSaturatedWaitActor:
     """Exercise RayLocalVLLMExecutor waits on a real Ray actor event loop."""
 
@@ -178,6 +215,27 @@ def test_remote_executor_waits_for_real_ray_submit_ack_before_finish(ray_runtime
         events = ray_runtime.get(actor.events.remote())
         assert [event[0] for event in events] == ["submit", "finish"]
         assert events[0][1] == events[1][1]
+    finally:
+        executor.shutdown()
+
+
+def test_remote_executor_waits_for_all_real_ray_submit_acks_before_abort(ray_runtime):
+    actor = ray_runtime.remote(max_concurrency=32)(_FailingSubmitBarrierActor).remote()
+    router = ray_runtime.remote(PrefixRouter).remote([actor], 0)
+    owner = _RayActorOwner(ray_runtime, actor, router)
+    executor = RemoteVLLMExecutor(owner)
+
+    try:
+        executor.submit(None, ["fail"], pa.table({"id": [1]}))
+        executor.submit(None, ["settle"], pa.table({"id": [2]}))
+
+        with pytest.raises(RuntimeError, match="submit acknowledgement failed"):
+            executor.finished_submitting()
+
+        events = ray_runtime.get(actor.events.remote())
+        assert [event[0] for event in events] == ["submit-failed", "submit-settled", "abort"]
+        assert len({event[1] for event in events}) == 1
+        assert ray_runtime.get(router.release_executor.remote(executor._executor_id)) == 0
     finally:
         executor.shutdown()
 

--- a/tests/slow/test_vllm_ray_protocol_e2e.py
+++ b/tests/slow/test_vllm_ray_protocol_e2e.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.real_ray, pytest.mark.ray_cluster_owner]
+
 ray = pytest.importorskip("ray")
 pa = pytest.importorskip("pyarrow")
 

--- a/tests/slow/test_vllm_ray_protocol_e2e.py
+++ b/tests/slow/test_vllm_ray_protocol_e2e.py
@@ -77,12 +77,12 @@ class _DelayedAsyncVLLMActor:
         self._events.append(("finish", executor_id))
         return True
 
-    async def wait_for_result(self, executor_id):
+    async def wait_for_result(self, executor_id, _wait_token):
         while executor_id not in self._finished:
             await asyncio.sleep(0.01)
         return False
 
-    def abort_executor(self, _executor_id, _wait_expected):
+    def abort_executor(self, _executor_id, _wait_token):
         return True
 
     def release_executor(self, _executor_id):
@@ -112,12 +112,12 @@ class _FailingSubmitBarrierActor:
         self._events.append(("finish", executor_id))
         return True
 
-    async def wait_for_result(self, executor_id):
+    async def wait_for_result(self, executor_id, _wait_token):
         while executor_id not in self._aborted:
             await asyncio.sleep(0.01)
         return False
 
-    async def abort_executor(self, executor_id, _wait_expected):
+    async def abort_executor(self, executor_id, _wait_token):
         self._aborted.add(executor_id)
         self._events.append(("abort", executor_id))
         return True
@@ -150,9 +150,10 @@ class _ThreadPoolSaturatedWaitActor:
         executor._per_executor_errors = {}
         executor._per_executor_aborted = set()
         executor._per_executor_waiters = {}
-        executor._per_executor_abort_wait_required = set()
-        executor._per_executor_terminal_wait_observed = set()
+        executor._per_executor_wait_tokens_observed = {}
+        executor._per_executor_abort_wait_tokens = {}
         self.executor = executor
+        self.wait_token = "real-ray-wait"
         self.pool_started = threading.Event()
         self.release_pool = threading.Event()
 
@@ -171,13 +172,13 @@ class _ThreadPoolSaturatedWaitActor:
         return self.pool_started.is_set()
 
     async def wait_for_result(self):
-        return await self.executor.wait_for_result("executor")
+        return await self.executor.wait_for_result("executor", self.wait_token)
 
     async def waiter_count(self):
         return self.executor._per_executor_waiters.get("executor", 0)
 
     async def abort_executor(self):
-        await self.executor.abort_executor("executor", wait_expected=True)
+        await self.executor.abort_executor("executor", self.wait_token)
         return True
 
     async def release_default_pool(self):

--- a/vane/ai/_redaction.py
+++ b/vane/ai/_redaction.py
@@ -18,7 +18,8 @@ at construction (:func:`wrap_sensitive_options`), so repr, str, logs,
 exception messages, and assertion diffs show only the fixed placeholder —
 including for pickled copies shipped to workers. The plaintext is restored
 solely at provider execution, immediately before SDK client or engine
-construction, via :func:`unwrap_sensitive_options`.
+construction, either via :func:`unwrap_sensitive_options` or the native
+executor's strict opaque-payload decoder.
 
 This module is private; :class:`Secret` is intentionally not exported from
 the public ``vane.ai`` namespace.

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -20,6 +20,7 @@ from vane.ai.functions import (
     _resolve_ai_batch_size,
     _resolve_provider,
 )
+from vane.ai.protocols import NativePrompterPlan
 
 
 def _drop_none(options: dict[str, Any]) -> dict[str, Any]:
@@ -166,9 +167,9 @@ def build_ai_prompt_sql_spec(
     # vLLM already has a native, relation-scoped physical operator. Keep its
     # executor alive across every input batch and let PhysicalVLLM send the
     # single terminal signal when the relation is exhausted.
-    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+    from vane.ai.providers.vllm import NativeVLLMPromptPlan, _serialize_native_vllm_options
 
-    if isinstance(descriptor, VLLMPrompterDescriptor):
+    if isinstance(descriptor, NativeVLLMPromptPlan):
         if image_input:
             raise ValueError("native vLLM ai_prompt does not support image inputs")
         if max_retries not in (None, 0):
@@ -177,10 +178,7 @@ def build_ai_prompt_sql_spec(
         native_options = descriptor.build_physical_vllm_options()
         if batch_size is not None:
             native_options["batch_size"] = batch_size
-        try:
-            options_json = json.dumps(native_options, ensure_ascii=False, separators=(",", ":"))
-        except (TypeError, ValueError) as exc:
-            raise TypeError("vLLM native options must be JSON-serializable") from exc
+        options_json = _serialize_native_vllm_options(native_options)
 
         return {
             "execution_kind": "native_vllm",
@@ -191,6 +189,8 @@ def build_ai_prompt_sql_spec(
             "system_message": descriptor.system_message,
             "options_json": options_json,
         }
+    if isinstance(descriptor, NativePrompterPlan):
+        raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
     udf_opts = descriptor.get_udf_options()
     resolved_max_retries = udf_opts.max_retries if max_retries is None else max_retries

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -163,6 +163,35 @@ def build_ai_prompt_sql_spec(
     except NotImplementedError as exc:
         raise ValueError(f"Provider {provider!r} is not a prompt provider") from exc
 
+    # vLLM already has a native, relation-scoped physical operator. Keep its
+    # executor alive across every input batch and let PhysicalVLLM send the
+    # single terminal signal when the relation is exhausted.
+    from vane.ai.providers.vllm import VLLMPrompterDescriptor
+
+    if isinstance(descriptor, VLLMPrompterDescriptor):
+        if image_input:
+            raise ValueError("native vLLM ai_prompt does not support image inputs")
+        if max_retries not in (None, 0):
+            raise ValueError("native vLLM ai_prompt does not support max_retries")
+
+        native_options = descriptor.build_physical_vllm_options()
+        if batch_size is not None:
+            native_options["batch_size"] = batch_size
+        try:
+            options_json = json.dumps(native_options, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError) as exc:
+            raise TypeError("vLLM native options must be JSON-serializable") from exc
+
+        return {
+            "execution_kind": "native_vllm",
+            "name": "ai_prompt",
+            "provider": descriptor.get_provider(),
+            "model": descriptor.get_model(),
+            "return_type": "VARCHAR",
+            "system_message": descriptor.system_message,
+            "options_json": options_json,
+        }
+
     udf_opts = descriptor.get_udf_options()
     resolved_max_retries = udf_opts.max_retries if max_retries is None else max_retries
     wrapper = _PromptBatch(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -59,8 +59,9 @@ from vane.ai.options import (
     VLLMPromptOptions,
     VLLMProviderOptions,
 )
+from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import load_provider
-from vane.ai.providers.vllm import VLLMPrompterDescriptor
+from vane.ai.providers.vllm import NativeVLLMPromptPlan, _serialize_native_vllm_options
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -559,7 +560,6 @@ class _PromptBatch:
             return result.model_dump_json()
         if hasattr(result, "json"):
             return result.json()
-        import json
 
         return json.dumps(result, default=str)
 
@@ -848,7 +848,7 @@ def classify_text(
 # ---------------------------------------------------------------------------
 
 
-def _build_native_vllm_expression(messages: Any, descriptor: VLLMPrompterDescriptor) -> duckdb.Expression:
+def _build_native_vllm_expression(messages: Any, descriptor: NativeVLLMPromptPlan) -> duckdb.Expression:
     """Build the native row-preserving ``vllm()`` expression."""
     messages_expr = as_expression(messages)
     # DuckDB's concat() ignores NULL arguments: concat(NULL, '') returns '',
@@ -861,15 +861,7 @@ def _build_native_vllm_expression(messages: Any, descriptor: VLLMPrompterDescrip
         )
     prompt_expr = duckdb.FunctionExpression("concat", *prompt_arguments)
 
-    native_options = descriptor.build_physical_vllm_options()
-    try:
-        options_json = json.dumps(
-            native_options,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-    except (TypeError, ValueError) as exc:
-        raise TypeError("vLLM native options must be JSON-serializable") from exc
+    options_json = _serialize_native_vllm_options(descriptor.build_physical_vllm_options())
 
     return duckdb.FunctionExpression(
         "vllm",
@@ -906,10 +898,11 @@ def _prompt_relation(
 ) -> Any:
     """Generate responses for a relation column via ``rel.map_batches()``.
 
-    ``execution_backend`` is optional; when omitted, the relation API infers
-    the task backend from the active runner. Prefer provider environment
-    variables such as ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, or
-    ``GOOGLE_API_KEY`` over passing API keys in call options.
+    ``execution_backend`` is optional for Python UDF providers; native vLLM
+    prompting rejects it because execution is owned by the query runner.
+    Prefer provider environment variables such as ``OPENAI_API_KEY``,
+    ``ANTHROPIC_API_KEY``, or ``GOOGLE_API_KEY`` over passing API keys in call
+    options.
     """
     prov = _resolve_provider(provider, "openai")
     prompter_kwargs: dict[str, Any] = {
@@ -927,9 +920,14 @@ def _prompt_relation(
     except NotImplementedError as exc:
         raise ValueError(f"Provider {provider!r} is not a prompt provider") from exc
 
-    if isinstance(descriptor, VLLMPrompterDescriptor):
+    if isinstance(descriptor, NativeVLLMPromptPlan):
         if image_columns:
             raise ValueError("native vLLM prompting does not support image_columns")
+        if execution_backend is not None:
+            raise ValueError(
+                "execution_backend applies only to Python UDF providers; "
+                "native vLLM routing is derived from the query runner"
+            )
         relation_alias = getattr(rel, "alias", None)
         column_expr = (
             duckdb.ColumnExpression(relation_alias, column)
@@ -937,15 +935,9 @@ def _prompt_relation(
             else duckdb.ColumnExpression(column)
         )
         expression = _build_native_vllm_expression(column_expr, descriptor).alias(output_column)
-        input_columns = [
-            (
-                duckdb.ColumnExpression(relation_alias, name)
-                if isinstance(relation_alias, str) and relation_alias
-                else duckdb.ColumnExpression(name)
-            )
-            for name in rel.columns
-        ]
-        return rel.select(*input_columns, expression)
+        return rel.select(expression)
+    if isinstance(descriptor, NativePrompterPlan):
+        raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
     udf_opts = descriptor.get_udf_options()
 
@@ -1010,8 +1002,10 @@ def _prompt_expression(
     except NotImplementedError as exc:
         raise ValueError(f"Provider {provider!r} is not a prompt provider") from exc
 
-    if isinstance(descriptor, VLLMPrompterDescriptor):
+    if isinstance(descriptor, NativeVLLMPromptPlan):
         return _build_native_vllm_expression(messages, descriptor)
+    if isinstance(descriptor, NativePrompterPlan):
+        raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
     udf_opts = descriptor.get_udf_options()
 
@@ -1083,8 +1077,9 @@ def prompt(
 
     ``prompt(rel, "column", ...)`` and ``prompt(rel=rel, column="column",
     ...)`` preserve the relation API.
-    The relation API accepts ``execution_backend``; when omitted, it infers the
-    task backend from the active runner.
+    The relation API accepts ``execution_backend`` for Python UDF providers;
+    native vLLM prompting rejects explicit values because the query runner owns
+    its execution mode.
     ``prompt(vane.col("column"), ...)`` returns a row-preserving expression.
     The expression API supports ``provider``, ``model``,
     ``provider_options``, ``prompt_options``, and ``system_message``. When

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -61,7 +61,7 @@ from vane.ai.options import (
 )
 from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import load_provider
-from vane.ai.providers.vllm import NativeVLLMPromptPlan, _serialize_native_vllm_options
+from vane.ai.providers.vllm import NativeVLLMPromptPlan, _build_native_vllm_options_argument
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -861,13 +861,13 @@ def _build_native_vllm_expression(messages: Any, descriptor: NativeVLLMPromptPla
         )
     prompt_expr = duckdb.FunctionExpression("concat", *prompt_arguments)
 
-    options_json = _serialize_native_vllm_options(descriptor.build_physical_vllm_options())
+    options_argument = _build_native_vllm_options_argument(descriptor.build_physical_vllm_options())
 
     return duckdb.FunctionExpression(
         "vllm",
         prompt_expr,
         duckdb.ConstantExpression(descriptor.model_name),
-        duckdb.ConstantExpression(options_json),
+        duckdb.ConstantExpression(options_argument),
     )
 
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -851,21 +851,19 @@ def classify_text(
 def _build_native_vllm_expression(messages: Any, descriptor: NativeVLLMPromptPlan) -> duckdb.Expression:
     """Build the native row-preserving ``vllm()`` expression."""
     messages_expr = as_expression(messages)
-    # DuckDB's concat() ignores NULL arguments: concat(NULL, '') returns '',
-    # and concat('system\n\n', NULL, '') returns 'system\n\n'.
-    prompt_arguments = [messages_expr, duckdb.ConstantExpression("")]
     if descriptor.system_message:
-        prompt_arguments.insert(
-            0,
+        # Unlike concat(), the || operator propagates NULL inputs.
+        messages_expr = duckdb.FunctionExpression(
+            "||",
             duckdb.ConstantExpression(f"{descriptor.system_message}\n\n"),
+            messages_expr,
         )
-    prompt_expr = duckdb.FunctionExpression("concat", *prompt_arguments)
 
     options_argument = _build_native_vllm_options_argument(descriptor.build_physical_vllm_options())
 
     return duckdb.FunctionExpression(
         "vllm",
-        prompt_expr,
+        messages_expr,
         duckdb.ConstantExpression(descriptor.model_name),
         duckdb.ConstantExpression(options_argument),
     )

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -37,12 +37,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import time
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 import pyarrow as pa
 
+import duckdb
 from vane._expression_udf import _build_actor_map_batches_expression
 from vane._expressions import as_expression, is_expression
 from vane.ai.options import (
@@ -58,6 +60,7 @@ from vane.ai.options import (
     VLLMProviderOptions,
 )
 from vane.ai.provider import load_provider
+from vane.ai.providers.vllm import VLLMPrompterDescriptor
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -845,6 +848,37 @@ def classify_text(
 # ---------------------------------------------------------------------------
 
 
+def _build_native_vllm_expression(messages: Any, descriptor: VLLMPrompterDescriptor) -> duckdb.Expression:
+    """Build the native row-preserving ``vllm()`` expression."""
+    messages_expr = as_expression(messages)
+    # DuckDB's concat() ignores NULL arguments: concat(NULL, '') returns '',
+    # and concat('system\n\n', NULL, '') returns 'system\n\n'.
+    prompt_arguments = [messages_expr, duckdb.ConstantExpression("")]
+    if descriptor.system_message:
+        prompt_arguments.insert(
+            0,
+            duckdb.ConstantExpression(f"{descriptor.system_message}\n\n"),
+        )
+    prompt_expr = duckdb.FunctionExpression("concat", *prompt_arguments)
+
+    native_options = descriptor.build_physical_vllm_options()
+    try:
+        options_json = json.dumps(
+            native_options,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError("vLLM native options must be JSON-serializable") from exc
+
+    return duckdb.FunctionExpression(
+        "vllm",
+        prompt_expr,
+        duckdb.ConstantExpression(descriptor.model_name),
+        duckdb.ConstantExpression(options_json),
+    )
+
+
 def _prompt_relation(
     rel: Any,
     column: str,
@@ -892,6 +926,27 @@ def _prompt_relation(
         descriptor = prov.get_prompter(**prompter_kwargs)
     except NotImplementedError as exc:
         raise ValueError(f"Provider {provider!r} is not a prompt provider") from exc
+
+    if isinstance(descriptor, VLLMPrompterDescriptor):
+        if image_columns:
+            raise ValueError("native vLLM prompting does not support image_columns")
+        relation_alias = getattr(rel, "alias", None)
+        column_expr = (
+            duckdb.ColumnExpression(relation_alias, column)
+            if isinstance(relation_alias, str) and relation_alias
+            else duckdb.ColumnExpression(column)
+        )
+        expression = _build_native_vllm_expression(column_expr, descriptor).alias(output_column)
+        input_columns = [
+            (
+                duckdb.ColumnExpression(relation_alias, name)
+                if isinstance(relation_alias, str) and relation_alias
+                else duckdb.ColumnExpression(name)
+            )
+            for name in rel.columns
+        ]
+        return rel.select(*input_columns, expression)
+
     udf_opts = descriptor.get_udf_options()
 
     wrapper = _PromptBatch(
@@ -954,6 +1009,10 @@ def _prompt_expression(
         descriptor = prov.get_prompter(model=model, system_message=system_message, **descriptor_options)
     except NotImplementedError as exc:
         raise ValueError(f"Provider {provider!r} is not a prompt provider") from exc
+
+    if isinstance(descriptor, VLLMPrompterDescriptor):
+        return _build_native_vllm_expression(messages, descriptor)
+
     udf_opts = descriptor.get_udf_options()
 
     wrapper = _PromptBatch(

--- a/vane/ai/options.py
+++ b/vane/ai/options.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, TypeAlias
 
 from vane.ai._redaction import REDACTED_PLACEHOLDER, wrap_sensitive_options
+
+VLLMJSONPrimitive: TypeAlias = str | int | float | bool | None
+VLLMJSONValue: TypeAlias = VLLMJSONPrimitive | list["VLLMJSONValue"] | dict[str, "VLLMJSONValue"]
 
 
 def _set_if_not_none(target: dict[str, Any], key: str, value: object) -> None:
@@ -72,9 +75,13 @@ class OpenAIProviderOptions(_RedactedOptionsRepr):
 
 @dataclass(frozen=True, repr=False)
 class VLLMProviderOptions(_RedactedOptionsRepr):
-    """vLLM provider options for actor count, GPU allocation, and engine args."""
+    """vLLM provider options for actor count, GPU allocation, and engine args.
 
-    engine_args: Mapping[str, Any] | None = None
+    ``engine_args`` crosses the native operator boundary as JSON. Values must
+    therefore contain only JSON primitives, string-keyed mappings, and lists.
+    """
+
+    engine_args: Mapping[str, VLLMJSONValue] | None = None
     concurrency: int | None = None
     gpus_per_actor: float | None = None
 
@@ -227,9 +234,14 @@ class GoogleEmbeddingOptions:
 
 @dataclass(frozen=True, repr=False)
 class VLLMPromptOptions(_RedactedOptionsRepr):
-    """vLLM prompt generation options."""
+    """vLLM prompt generation options.
 
-    generate_args: Mapping[str, Any] | None = None
+    ``generate_args`` crosses the native operator boundary as JSON. Values
+    must therefore contain only JSON primitives, string-keyed mappings, and
+    lists.
+    """
+
+    generate_args: Mapping[str, VLLMJSONValue] | None = None
     max_tokens: int | None = None
     temperature: float | None = None
     on_error: Literal["raise", "log", "ignore"] | None = None

--- a/vane/ai/protocols.py
+++ b/vane/ai/protocols.py
@@ -11,7 +11,7 @@ conforming to the protocol.
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from vane.ai.typing import Descriptor
@@ -77,3 +77,27 @@ class Prompter(Protocol):
 
 class PrompterDescriptor(Descriptor["Prompter"]):
     """Serializable factory for a :class:`Prompter`."""
+
+
+class NativePrompterPlan(ABC):
+    """Serializable prompt metadata consumed directly by a native planner.
+
+    Unlike :class:`PrompterDescriptor`, a native plan does not instantiate a
+    worker-side Python object. Native-aware callers must recognize the plan
+    and lower it before entering the generic Python UDF execution path.
+    """
+
+    @abstractmethod
+    def get_provider(self) -> str:
+        """Return the provider that produced this plan."""
+        ...
+
+    @abstractmethod
+    def get_model(self) -> str:
+        """Return the native model identifier."""
+        ...
+
+    @abstractmethod
+    def get_options(self) -> dict[str, Any]:
+        """Return the provider-specific native planning options."""
+        ...

--- a/vane/ai/provider.py
+++ b/vane/ai/provider.py
@@ -4,8 +4,8 @@
 """Provider base class and registry for AI model backends.
 
 A :class:`Provider` maps high-level intents (embed text, classify text, prompt)
-to concrete :class:`~vane.ai.typing.Descriptor` objects that can be
-serialized and shipped to workers.
+to either concrete :class:`~vane.ai.typing.Descriptor` factories or native
+planning metadata. Both forms are lightweight and serializable.
 
 Supported providers are loaded lazily so optional dependencies (e.g.
 ``transformers``, ``openai``) are only imported when actually used.
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from vane.ai.protocols import (
+        NativePrompterPlan,
         PrompterDescriptor,
         TextClassifierDescriptor,
         TextEmbedderDescriptor,
@@ -124,8 +125,7 @@ class Provider(ABC):
     """Base class for AI model providers.
 
     Subclasses implement ``get_text_embedder``, ``get_text_classifier``, etc.
-    to return lightweight :class:`~vane.ai.typing.Descriptor` objects that
-    know how to instantiate the actual model on a remote worker.
+    to return lightweight descriptors or native planning metadata.
     """
 
     @property
@@ -156,5 +156,5 @@ class Provider(ABC):
         model: str | None = None,
         system_message: str | None = None,
         **options: Any,
-    ) -> PrompterDescriptor:
+    ) -> PrompterDescriptor | NativePrompterPlan:
         raise _not_implemented(self, "prompt")

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -4,9 +4,8 @@
 """vLLM provider — wraps the existing ``duckdb.execution.vllm`` engine.
 
 The vLLM executor already manages its own ``AsyncLLMEngine`` event loop,
-request queuing, prefix routing, and Ray actor pool.  This provider wraps
-that machinery into the Vane AI Provider/Descriptor pattern so users can
-write::
+request queuing, prefix routing, and Ray actor pool. This provider wraps that
+machinery in a planner-only Vane AI provider so users can write::
 
     from vane.ai import prompt
 
@@ -43,14 +42,15 @@ from __future__ import annotations
 
 import copy
 import json
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
-from vane.ai.protocols import PrompterDescriptor
+from vane.ai.options import VLLMJSONValue
+from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import Provider
-from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
     from vane.ai.typing import Options
@@ -74,6 +74,37 @@ def _json_schema_from_return_format(return_format: Any) -> dict[str, Any]:
     )
 
 
+def _canonicalize_native_json(value: Any, path: str = "options") -> Any:
+    """Return a strict JSON-compatible copy or fail with an option path."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"vLLM native option {path} must be finite")
+        return value
+    if isinstance(value, Mapping):
+        canonical: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"vLLM native option {path} must use string keys; got {type(key).__name__}")
+            canonical[key] = _canonicalize_native_json(item, f"{path}.{key}")
+        return canonical
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_native_json(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    raise TypeError(f"vLLM native option {path} must be JSON-compatible; got {type(value).__name__}")
+
+
+def _serialize_native_vllm_options(options: Mapping[str, Any]) -> str:
+    """Serialize native options after enforcing the public JSON boundary."""
+    canonical = _canonicalize_native_json(options)
+    return json.dumps(
+        canonical,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
 class VLLMProvider(Provider):
     """Provider backed by a local or remote vLLM engine."""
 
@@ -93,9 +124,9 @@ class VLLMProvider(Provider):
         system_message: str | None = None,
         return_format: Any | None = None,
         **options: Any,
-    ) -> PrompterDescriptor:
+    ) -> NativeVLLMPromptPlan:
         merged = {**self._options, **options}
-        return VLLMPrompterDescriptor(
+        return NativeVLLMPromptPlan(
             provider_name=self._name,
             model_name=model or merged.pop("model", self.DEFAULT_MODEL),
             system_message=system_message,
@@ -105,10 +136,10 @@ class VLLMProvider(Provider):
 
 
 @dataclass
-class VLLMPrompterDescriptor(PrompterDescriptor):
+class NativeVLLMPromptPlan(NativePrompterPlan):
     """Serializable configuration for native vLLM query planning.
 
-    High-level prompt APIs consume this descriptor while binding the native
+    High-level prompt APIs consume this plan while binding the native
     ``vllm()`` expression. The resulting ``PhysicalVLLM`` operator owns one
     executor for the relation and sends its terminal signal only after every
     input batch has been submitted.
@@ -132,7 +163,7 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
     def get_options(self) -> Options:
         return dict(self.vllm_options)
 
-    def build_physical_vllm_options(self) -> dict[str, Any]:
+    def build_physical_vllm_options(self) -> dict[str, VLLMJSONValue]:
         """Build JSON-ready options for the native ``PhysicalVLLM`` operator.
 
         The Python UDF path used ``actor_number`` to control the number of
@@ -141,7 +172,8 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
         output configuration is copied into vLLM sampling parameters without
         mutating the descriptor or caller-owned nested dictionaries.
         """
-        options = copy.deepcopy(self.vllm_options)
+        options = _canonicalize_native_json(unwrap_sensitive_options(self.vllm_options))
+        assert isinstance(options, dict)
 
         actor_number = options.pop("actor_number", None)
         if actor_number is not None:
@@ -201,52 +233,12 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
         if self.return_format is not None:
             schema = copy.deepcopy(_json_schema_from_return_format(self.return_format))
             sampling_params["structured_outputs"] = {"type": "json", "value": schema}
-        return options
-
-    def get_udf_options(self) -> UDFOptions:
-        opts = self.vllm_options
-        return UDFOptions(
-            batch_size=opts.get("batch_size"),
-            num_gpus=opts.get("gpus_per_actor", 1),
-            actor_number=opts.get("actor_number"),
-            max_retries=0,  # vLLM engine handles retries
-            on_error=opts.get("on_error", "raise"),
-        )
-
-    def instantiate(self) -> VLLMPrompter:
-        return VLLMPrompter(
-            model=self.model_name,
-            system_message=self.system_message,
-            return_format=self.return_format,
-            vllm_options=self.vllm_options,
-        )
+        canonical = _canonicalize_native_json(options)
+        assert isinstance(canonical, dict)
+        return canonical
 
 
-class VLLMPrompter:
-    """Compatibility object that rejects non-native vLLM execution.
-
-    A prompter call cannot see relation boundaries, so it cannot know when the
-    shared executor should receive ``finished_submitting()``. All supported
-    vLLM entry points are therefore lowered to ``PhysicalVLLM`` before this
-    object could be invoked.
-    """
-
-    _NATIVE_ONLY_ERROR = (
-        "VLLMPrompter cannot execute prompts directly; use vane.ai.prompt(..., provider='vllm') "
-        "or SQL ai_prompt(..., provider := 'vllm') so the query planner can use PhysicalVLLM"
-    )
-
-    def __init__(
-        self,
-        model: str,
-        system_message: str | None = None,
-        return_format: Any | None = None,
-        vllm_options: dict[str, Any] | None = None,
-    ):
-        pass
-
-    async def prompt(self, messages: tuple[Any, ...]) -> Any:
-        raise NotImplementedError(self._NATIVE_ONLY_ERROR)
-
-    def prompt_batch(self, texts: list[str]) -> list[Any]:
-        raise NotImplementedError(self._NATIVE_ONLY_ERROR)
+# Compatibility import for callers that used the original name. The object is
+# now explicitly planner-only and no longer inherits PrompterDescriptor or
+# exposes an instantiate() method.
+VLLMPrompterDescriptor = NativeVLLMPromptPlan

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -47,8 +47,18 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
-from vane.ai.options import VLLMJSONValue
+from duckdb.execution._vllm_options_protocol import (
+    _NATIVE_OPTIONS_PAYLOAD_VERSION,
+    _NATIVE_OPTIONS_PUBLIC_KEY,
+    _NATIVE_OPTIONS_RESERVED_KEYS,
+    _NATIVE_OPTIONS_SECRET_KEY,
+    _NATIVE_OPTIONS_VERSION_KEY,
+    _NATIVE_SECRET_PAYLOAD_VALUES_KEY,
+    _NATIVE_SECRET_PAYLOAD_VERSION_KEY,
+    _NATIVE_SECRET_REF_KEY,
+    _dump_vllm_protocol_json,
+)
+from vane.ai._redaction import Secret, wrap_sensitive_options
 from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import Provider
 
@@ -94,15 +104,75 @@ def _canonicalize_native_json(value: Any, path: str = "options") -> Any:
     raise TypeError(f"vLLM native option {path} must be JSON-compatible; got {type(value).__name__}")
 
 
+def _canonicalize_native_plan_json(value: Any, path: str = "options") -> Any:
+    """Validate native options while preserving sealed values for planning."""
+    if isinstance(value, Secret):
+        return Secret(_canonicalize_native_json(value.reveal(), path))
+    if isinstance(value, Mapping):
+        canonical: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"vLLM native option {path} must use string keys; got {type(key).__name__}")
+            canonical[key] = _canonicalize_native_plan_json(item, f"{path}.{key}")
+        return canonical
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_native_plan_json(item, f"{path}[{index}]") for index, item in enumerate(value)]
+    return _canonicalize_native_json(value, path)
+
+
 def _serialize_native_vllm_options(options: Mapping[str, Any]) -> str:
     """Serialize native options after enforcing the public JSON boundary."""
     canonical = _canonicalize_native_json(options)
-    return json.dumps(
-        canonical,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        allow_nan=False,
-    )
+    return _dump_vllm_protocol_json(canonical)
+
+
+def _split_native_vllm_secrets(value: Any, secrets: list[Any], path: str = "options") -> Any:
+    if isinstance(value, Secret):
+        secret_index = len(secrets)
+        secrets.append(value.reveal())
+        return {_NATIVE_SECRET_REF_KEY: secret_index}
+    if isinstance(value, Mapping):
+        if _NATIVE_SECRET_REF_KEY in value:
+            raise ValueError(f"vLLM native option {path} uses reserved field {_NATIVE_SECRET_REF_KEY!r}")
+        return {key: _split_native_vllm_secrets(item, secrets, f"{path}.{key}") for key, item in value.items()}
+    if isinstance(value, list):
+        return [_split_native_vllm_secrets(item, secrets, f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
+def _build_native_vllm_options_argument(options: Mapping[str, Any]) -> str | dict[str, Any]:
+    """Encode sealed native options without exposing them as structured plan fields.
+
+    Plans without credentials retain the legacy JSON representation. Credential-
+    bearing plans use a versioned STRUCT envelope: public options remain JSON,
+    while plaintext values are confined to an opaque BLOB. Opaque here means
+    excluded from structured plan rendering, not encrypted. The runtime decodes
+    the BLOB with strict JSON rather than executable pickle data.
+    """
+    canonical = _canonicalize_native_plan_json(options)
+    assert isinstance(canonical, dict)
+    reserved_protocol_keys = _NATIVE_OPTIONS_RESERVED_KEYS.intersection(canonical)
+    if reserved_protocol_keys:
+        raise ValueError(
+            "vLLM native options use reserved protocol fields: " + ", ".join(sorted(reserved_protocol_keys))
+        )
+    secrets: list[Any] = []
+    public_options = _split_native_vllm_secrets(canonical, secrets)
+    public_options_json = _serialize_native_vllm_options(public_options)
+    if not secrets:
+        return public_options_json
+
+    secret_payload = _dump_vllm_protocol_json(
+        {
+            _NATIVE_SECRET_PAYLOAD_VERSION_KEY: _NATIVE_OPTIONS_PAYLOAD_VERSION,
+            _NATIVE_SECRET_PAYLOAD_VALUES_KEY: secrets,
+        }
+    ).encode("utf-8")
+    return {
+        _NATIVE_OPTIONS_VERSION_KEY: _NATIVE_OPTIONS_PAYLOAD_VERSION,
+        _NATIVE_OPTIONS_PUBLIC_KEY: public_options_json,
+        _NATIVE_OPTIONS_SECRET_KEY: secret_payload,
+    }
 
 
 class VLLMProvider(Provider):
@@ -163,16 +233,17 @@ class NativeVLLMPromptPlan(NativePrompterPlan):
     def get_options(self) -> Options:
         return dict(self.vllm_options)
 
-    def build_physical_vllm_options(self) -> dict[str, VLLMJSONValue]:
-        """Build JSON-ready options for the native ``PhysicalVLLM`` operator.
+    def build_physical_vllm_options(self) -> dict[str, Any]:
+        """Build options for the native ``PhysicalVLLM`` operator.
 
         The Python UDF path used ``actor_number`` to control the number of
         outer UDF actors. The native operator owns one executor instead, so
         that capacity becomes the executor's ``concurrency``. Structured
         output configuration is copied into vLLM sampling parameters without
-        mutating the descriptor or caller-owned nested dictionaries.
+        mutating the descriptor or caller-owned nested dictionaries. Sensitive
+        values stay sealed until the options argument is encoded for the plan.
         """
-        options = _canonicalize_native_json(unwrap_sensitive_options(self.vllm_options))
+        options = _canonicalize_native_plan_json(self.vllm_options)
         assert isinstance(options, dict)
 
         actor_number = options.pop("actor_number", None)
@@ -199,10 +270,12 @@ class NativeVLLMPromptPlan(NativePrompterPlan):
             value = options.pop(name, None)
             if value is not None:
                 sampling_overrides[name] = value
-        if self.return_format is None and not sampling_overrides:
-            return options
 
         generate_args = options.get("generate_args")
+        has_sampling_params = isinstance(generate_args, Mapping) and generate_args.get("sampling_params") is not None
+        if self.return_format is None and not sampling_overrides and not has_sampling_params:
+            return options
+
         if generate_args is None:
             generate_args = {}
         elif isinstance(generate_args, Mapping):
@@ -225,6 +298,7 @@ class NativeVLLMPromptPlan(NativePrompterPlan):
             sampling_params = dict(sampling_params)
         else:
             raise TypeError("vLLM sampling_params must be a mapping or JSON string")
+        sampling_params = wrap_sensitive_options(sampling_params)
         generate_args["sampling_params"] = sampling_params
 
         for name, value in sampling_overrides.items():
@@ -233,7 +307,7 @@ class NativeVLLMPromptPlan(NativePrompterPlan):
         if self.return_format is not None:
             schema = copy.deepcopy(_json_schema_from_return_format(self.return_format))
             sampling_params["structured_outputs"] = {"type": "json", "value": schema}
-        canonical = _canonicalize_native_json(options)
+        canonical = _canonicalize_native_plan_json(options)
         assert isinstance(canonical, dict)
         return canonical
 

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -41,7 +41,9 @@ Under the hood the model's JSON schema is injected into
 
 from __future__ import annotations
 
+import copy
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -70,20 +72,6 @@ def _json_schema_from_return_format(return_format: Any) -> dict[str, Any]:
     raise TypeError(
         f"return_format must be a Pydantic BaseModel class or a JSON schema dict, got {type(return_format).__name__}"
     )
-
-
-def _parse_structured_output(raw_text: str | None, return_format: Any) -> Any:
-    """Parse raw JSON text into a structured object.
-
-    If *return_format* is a Pydantic model class the parsed dict is validated
-    through ``model_validate``.  Otherwise returns a plain ``dict``.
-    """
-    if raw_text is None:
-        return None
-    data = json.loads(raw_text)
-    if hasattr(return_format, "model_validate"):
-        return return_format.model_validate(data)
-    return data
 
 
 class VLLMProvider(Provider):
@@ -118,15 +106,12 @@ class VLLMProvider(Provider):
 
 @dataclass
 class VLLMPrompterDescriptor(PrompterDescriptor):
-    """Serializable factory for a vLLM-backed prompter.
+    """Serializable configuration for native vLLM query planning.
 
-    Stores model name and vLLM configuration.  On ``instantiate()`` it
-    creates a ``LocalVLLMExecutor`` or ``RemoteVLLMExecutor`` via the
-    existing ``duckdb.execution.vllm.build_executor()`` factory.
-
-    When ``return_format`` is set (Pydantic model or JSON schema dict),
-    the JSON schema is injected as ``structured_outputs`` in the executor's
-    ``SamplingParams``.
+    High-level prompt APIs consume this descriptor while binding the native
+    ``vllm()`` expression. The resulting ``PhysicalVLLM`` operator owns one
+    executor for the relation and sends its terminal signal only after every
+    input batch has been submitted.
     """
 
     provider_name: str = "vllm"
@@ -146,6 +131,77 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
 
     def get_options(self) -> Options:
         return dict(self.vllm_options)
+
+    def build_physical_vllm_options(self) -> dict[str, Any]:
+        """Build JSON-ready options for the native ``PhysicalVLLM`` operator.
+
+        The Python UDF path used ``actor_number`` to control the number of
+        outer UDF actors. The native operator owns one executor instead, so
+        that capacity becomes the executor's ``concurrency``. Structured
+        output configuration is copied into vLLM sampling parameters without
+        mutating the descriptor or caller-owned nested dictionaries.
+        """
+        options = copy.deepcopy(self.vllm_options)
+
+        actor_number = options.pop("actor_number", None)
+        if actor_number is not None:
+            options.setdefault("concurrency", actor_number)
+
+        max_retries = options.pop("max_retries", None)
+        if max_retries not in (None, 0):
+            raise ValueError("native vLLM prompting does not support max_retries")
+
+        # PhysicalVLLM invokes the executor through a synchronous C++ bridge.
+        # If that bridge runs inside a generic Ray actor, it still needs a
+        # dedicated event-loop thread rather than Ray's async actor loop.
+        options["use_threading"] = True
+        options["_force_background_thread"] = True
+
+        # The public AI API calls the null-producing policy ``ignore`` while
+        # the native vLLM executor calls the same policy ``null``.
+        if options.get("on_error") == "ignore":
+            options["on_error"] = "null"
+
+        sampling_overrides: dict[str, Any] = {}
+        for name in ("max_tokens", "temperature"):
+            value = options.pop(name, None)
+            if value is not None:
+                sampling_overrides[name] = value
+        if self.return_format is None and not sampling_overrides:
+            return options
+
+        generate_args = options.get("generate_args")
+        if generate_args is None:
+            generate_args = {}
+        elif isinstance(generate_args, Mapping):
+            generate_args = dict(generate_args)
+        else:
+            raise TypeError("vLLM generate_args must be a mapping when sampling parameters are configured")
+        options["generate_args"] = generate_args
+
+        sampling_params = generate_args.get("sampling_params")
+        if sampling_params is None:
+            sampling_params = {}
+        elif isinstance(sampling_params, str):
+            try:
+                sampling_params = json.loads(sampling_params)
+            except json.JSONDecodeError as exc:
+                raise ValueError("vLLM sampling_params JSON could not be parsed") from exc
+            if not isinstance(sampling_params, dict):
+                raise TypeError("vLLM sampling_params JSON must decode to an object")
+        elif isinstance(sampling_params, Mapping):
+            sampling_params = dict(sampling_params)
+        else:
+            raise TypeError("vLLM sampling_params must be a mapping or JSON string")
+        generate_args["sampling_params"] = sampling_params
+
+        for name, value in sampling_overrides.items():
+            sampling_params.setdefault(name, value)
+
+        if self.return_format is not None:
+            schema = copy.deepcopy(_json_schema_from_return_format(self.return_format))
+            sampling_params["structured_outputs"] = {"type": "json", "value": schema}
+        return options
 
     def get_udf_options(self) -> UDFOptions:
         opts = self.vllm_options
@@ -167,12 +223,18 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
 
 
 class VLLMPrompter:
-    """Prompter that uses a vLLM ``LocalVLLMExecutor`` / ``RemoteVLLMExecutor``.
+    """Compatibility object that rejects non-native vLLM execution.
 
-    The executor is created lazily on the first call. Structured output
-    uses ``SamplingParams.structured_outputs`` and the raw JSON output is
-    parsed back into the requested schema/model.
+    A prompter call cannot see relation boundaries, so it cannot know when the
+    shared executor should receive ``finished_submitting()``. All supported
+    vLLM entry points are therefore lowered to ``PhysicalVLLM`` before this
+    object could be invoked.
     """
+
+    _NATIVE_ONLY_ERROR = (
+        "VLLMPrompter cannot execute prompts directly; use vane.ai.prompt(..., provider='vllm') "
+        "or SQL ai_prompt(..., provider := 'vllm') so the query planner can use PhysicalVLLM"
+    )
 
     def __init__(
         self,
@@ -181,119 +243,10 @@ class VLLMPrompter:
         return_format: Any | None = None,
         vllm_options: dict[str, Any] | None = None,
     ):
-        self._model = model
-        self._system_message = system_message
-        self._return_format = return_format
-        # Deep-unwrap restores plaintext sealed by the descriptor (including
-        # nested engine_args/generate_args) before the engine sees the options;
-        # plain dicts from direct callers pass through unchanged.
-        options = unwrap_sensitive_options(vllm_options or {})
-        self._options = {k: v for k, v in options.items() if k not in {"actor_number"}}
-        self._executor = None
-
-        # Pre-compute JSON schema if return_format is set, so the executor
-        # receives the current vLLM structured output config.
-        if self._return_format is not None:
-            schema = _json_schema_from_return_format(self._return_format)
-            gen_args = self._options.setdefault("generate_args", {})
-            sp = gen_args.setdefault("sampling_params", {})
-            if isinstance(sp, dict):
-                sp["structured_outputs"] = {"type": "json", "value": schema}
-
-    def _ensure_executor(self) -> Any:
-        if self._executor is None:
-            from duckdb.execution.vllm import build_executor
-
-            options = dict(self._options)
-            options["use_threading"] = True
-            options["_force_background_thread"] = True
-            self._executor = build_executor(self._model, options)
-        return self._executor
-
-    def _format_prompt(self, text: str) -> str:
-        if self._system_message:
-            return f"{self._system_message}\n\n{text}"
-        return text
-
-    def _maybe_parse(self, raw: str | None) -> Any:
-        """Parse structured output if return_format is set."""
-        if self._return_format is None or raw is None:
-            return raw
-        return _parse_structured_output(raw, self._return_format)
-
-    @staticmethod
-    async def _wait_for_result_async(executor: Any) -> None:
-        import asyncio
-        import inspect
-
-        wait_for_result = executor.wait_for_result
-        if inspect.iscoroutinefunction(wait_for_result):
-            await wait_for_result()
-            return
-        await asyncio.to_thread(wait_for_result)
-
-    @staticmethod
-    def _wait_for_result(executor: Any) -> None:
-        executor.wait_for_result()
+        pass
 
     async def prompt(self, messages: tuple[Any, ...]) -> Any:
-        """Single-row prompt — required by the Prompter protocol.
-
-        For vLLM this is less efficient than batch submission, but
-        allows the wrapper classes in ``functions.py`` to use the
-        standard ``asyncio.gather`` pattern.
-        """
-        if len(messages) != 1 or not isinstance(messages[0], str):
-            raise ValueError("vLLM provider only supports one text prompt; multimodal prompt parts are not supported")
-        text = str(messages[0]) if messages else ""
-        formatted = self._format_prompt(text)
-
-        executor = self._ensure_executor()
-
-        import pyarrow as pa
-
-        dummy_row = pa.table({"_": [""]})
-        executor.submit(None, [formatted], dummy_row)
-        executor.finished_submitting()
-
-        result = executor.take_ready_result()
-        if result is None:
-            await self._wait_for_result_async(executor)
-            result = executor.take_ready_result()
-        if result is None:
-            raise RuntimeError("vllm executor finished without returning a prompt result")
-        output_texts, _row = result
-        return self._maybe_parse(output_texts[0])
+        raise NotImplementedError(self._NATIVE_ONLY_ERROR)
 
     def prompt_batch(self, texts: list[str]) -> list[Any]:
-        """Batch prompt — more efficient for vLLM's continuous batching."""
-        import pyarrow as pa
-
-        executor = self._ensure_executor()
-        prompts = [self._format_prompt(t) for t in texts]
-        rows = pa.table({"_idx": list(range(len(texts)))})
-        executor.submit(None, prompts, rows)
-        executor.finished_submitting()
-
-        results: list[tuple[Any, int]] = []
-        while len(results) < len(texts):
-            result = executor.take_ready_result()
-            if result is None:
-                if executor.all_tasks_finished():
-                    break
-                self._wait_for_result(executor)
-                result = executor.take_ready_result()
-                if result is None:
-                    if executor.all_tasks_finished():
-                        break
-                    raise RuntimeError("vllm executor wait_for_result returned without a ready result")
-            output_texts, row_table = result
-            indices = row_table.column("_idx").to_pylist()
-            for text, idx in zip(output_texts, indices, strict=False):
-                results.append((self._maybe_parse(text), idx))
-
-        if len(results) != len(texts):
-            raise RuntimeError(f"vllm executor returned {len(results)} results for {len(texts)} prompts")
-
-        results.sort(key=lambda x: x[1])
-        return [r[0] for r in results]
+        raise NotImplementedError(self._NATIVE_ONLY_ERROR)


### PR DESCRIPTION
## Summary

This PR makes vLLM prompt execution relation-scoped and safe across SQL/Python planning, the native operator boundary, and shared Ray actor lifecycles.

- Accept SQL `DECIMAL` values for fractional GPU, unit-interval, and engine-initialization timeout options, while strictly validating boolean, finite, and range-constrained values before executor selection.
- Make `PrefixRouter` authoritative for shared affinity routing and executor-owned reservations. Results, waits, errors, aborts, completion, and cleanup are isolated by executor ID and use idempotent operation/reservation identifiers.
- Lower high-level Python and SQL vLLM prompts to native `vllm()` expressions so `LogicalVLLMProject` / `PhysicalVLLM` own submission, completion, and shutdown for the full relation rather than individual Python UDF batches.
- Validate native planner metadata and the JSON option boundary, preserve eager nested-expression composition, and reject lazy short-circuit contexts whose evaluation semantics cannot be preserved.
- Wait for submit acknowledgements before terminal actor RPCs, re-arm one-shot result waits after every drain, and keep control-RPC timeout budgets independent of the query deadline.
- Attempt terminal cleanup once when the executor finishes and once during shutdown. Persistent cleanup failure emits a warning after the final attempt; there is no process-global reconciler, daemon retry thread, or strong-reference registry.
- Stop only anonymous actors owned by the query. Borrowed named pools remain available; named-pool leases and Driver-owned teardown are intentionally outside this PR.
- Require `register_wakeup_callback` at the Python/native boundary and remove the unused `UNSUPPORTED` wakeup fallback.

The public `vane.ai.prompt(..., provider="vllm")` and SQL `ai_prompt(..., provider := "vllm")` entry points remain supported. Native vLLM execution derives Local/Ray routing from the query runner, so `execution_backend` is rejected because it configures Python UDF execution instead. The former executable `VLLMPrompterDescriptor` is now a planner-only compatibility alias and no longer exposes `instantiate()`.

## Related issue

close: #50

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public high-level prompt APIs are unchanged; compatibility and failure behavior are covered above and by API docstrings/tests.

## Validation

- Incremental Release native build and installation passed on the final feature tree before rebasing. The rebase conflict resolution touched only Python redaction integration and its regression test; `git range-diff` confirmed that the native patches are unchanged.
- `python -m pytest -q tests/fast/test_vllm_runtime_fixes.py tests/fast/test_vllm_native_regressions.py tests/fast/test_udf_executor_lifecycle.py` — 250 passed.
- `python -m pytest -q tests/ai/test_ai_functions.py::TestVLLMProvider tests/ai/test_ai_functions.py::TestVLLMStructuredOutput tests/ai/test_expression_ai_functions.py tests/ai/test_expression_ai_sql.py tests/ai/test_vllm_expression_composition.py` — 85 passed, 2 skipped because Pydantic is not installed.
- `python -m pytest -q tests/ai/test_descriptor_secret_redaction.py tests/fast/test_ai_options_repr.py` — 108 passed.
- `python -m pytest -q tests/slow/test_vllm_ray_protocol_e2e.py` — 4 passed using a local Ray runtime without GPU-backed model inference.
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed, including Ruff, Ruff format, ClangFormat, mypy, conflict detection, and private-key checks.
- `git diff --check upstream/main...HEAD` — passed.
- Not tested: GPU-backed real-model inference and optional OpenAI-provider execution tests because the `openai` package is not installed.

No performance claim is included; no model weights, external datasets, or GPU benchmark hardware were used.

## Checklist

- [x] The change is focused and includes regression coverage.
- [x] Public behavior and compatibility impact are documented.
- [x] No new dependencies, copied code, model assets, or datasets are introduced.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications were considered; native options retain main's credential redaction and unwrap only at the execution boundary.
- [x] Native changes were compiled, and the rebased Python/Ray changes passed the relevant regression, end-to-end, formatting, lint, and type checks.