### PR TITLE
[fix](relation) Preserve bindings across relation operators

### DIFF
--- a/external/duckdb/src/execution/distributed/plan/distributed_physical_plan.cpp
+++ b/external/duckdb/src/execution/distributed/plan/distributed_physical_plan.cpp
@@ -49,7 +49,8 @@ DistributedPhysicalPlan::from_duckdb_relation(const shared_ptr<duckdb::Relation>
 		// Use RunFunctionInTransaction to ensure proper transaction context
 		client_context->RunFunctionInTransaction([&]() {
 			// Create a RelationStatement from the relation
-			auto relation_stmt = make_uniq<RelationStatement>(relation);
+			auto statement_binder = Binder::CreateBinder(*client_context);
+			auto relation_stmt = make_uniq<RelationStatement>(relation, *statement_binder);
 
 			// Get a Planner instance from the client context
 			Planner planner(*client_context);

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -246,6 +246,12 @@ public:
 		auto child = ChildRelation();
 		return !child || child->CanSerializeToQueryNode();
 	}
+	//! Whether this relation can be bound directly as another relation's input.
+	//! SQL-serializable relations use the default SQL binding path. Relations
+	//! with a non-SQL binding path override this independently of serialization.
+	virtual bool CanBindAsInput() {
+		return CanSerializeToQueryNode();
+	}
 	void AddExternalDependency(shared_ptr<ExternalDependency> dependency);
 	DUCKDB_API vector<shared_ptr<ExternalDependency>> GetAllDependencies();
 
@@ -254,6 +260,7 @@ protected:
 	//! relations override this to keep their child's BindContext aligned with the plan.
 	virtual BoundStatement BindAsInput(Binder &binder);
 	DUCKDB_API static string RenderWhitespace(idx_t depth);
+	DUCKDB_API static bool ExposesMultiSourceBindings(Relation &child);
 	DUCKDB_API static bool RequiresDirectRelationBinding(Relation &child);
 	DUCKDB_API static bool RequiresSQLMultiSourceBinding(Relation &child);
 	DUCKDB_API static bool CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression);

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -234,20 +234,39 @@ public:
 	virtual Relation *ChildRelation() {
 		return nullptr;
 	}
+	virtual bool ContainsNonSQLRelation() {
+		auto child = ChildRelation();
+		return child && child->ContainsNonSQLRelation();
+	}
+	//! Whether GetQueryNode can represent this relation without losing operators or binding scopes.
+	virtual bool CanSerializeToQueryNode() {
+		if (ContainsNonSQLRelation()) {
+			return false;
+		}
+		auto child = ChildRelation();
+		return !child || child->CanSerializeToQueryNode();
+	}
 	void AddExternalDependency(shared_ptr<ExternalDependency> dependency);
 	DUCKDB_API vector<shared_ptr<ExternalDependency>> GetAllDependencies();
 
 protected:
+	//! Bind this relation for use as another relation's input. Binding-preserving
+	//! relations override this to keep their child's BindContext aligned with the plan.
+	virtual BoundStatement BindAsInput(Binder &binder);
 	DUCKDB_API static string RenderWhitespace(idx_t depth);
-	DUCKDB_API static bool CanMapColumnBindings(Relation &relation);
-	DUCKDB_API static shared_ptr<Binder> CreateBinderForBoundRelation(Binder &binder, Relation &relation,
-	                                                                  const BoundStatement &bound_relation);
-	DUCKDB_API static unique_ptr<Expression> BindExpressionOnBoundRelation(Binder &binder, Relation &relation,
-	                                                                       BoundStatement &bound_relation,
-	                                                                       unique_ptr<ParsedExpression> expression,
-	                                                                       const string &operation);
-	DUCKDB_API static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child, BoundStatement child_bound,
+	DUCKDB_API static bool RequiresDirectRelationBinding(Relation &child);
+	DUCKDB_API static bool RequiresSQLMultiSourceBinding(Relation &child);
+	DUCKDB_API static bool CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression);
+	DUCKDB_API static unique_ptr<TableRef> BindRelationInput(Binder &binder, Relation &child);
+	DUCKDB_API static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child,
 	                                                       unique_ptr<SelectNode> select_node);
+	DUCKDB_API static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
+	                                                                 unique_ptr<LogicalOperator> child);
+	DUCKDB_API static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);
+	DUCKDB_API static void ExpandRelationStar(Binder &binder, unique_ptr<ParsedExpression> expression,
+	                                          vector<unique_ptr<ParsedExpression>> &result);
+	DUCKDB_API static void PlanRelationSubqueries(Binder &binder, unique_ptr<Expression> &expression,
+	                                              unique_ptr<LogicalOperator> &root);
 
 public:
 	template <class TARGET>

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -270,10 +270,6 @@ protected:
 	DUCKDB_API static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
 	                                                                 unique_ptr<LogicalOperator> child);
 	DUCKDB_API static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);
-	DUCKDB_API static void ExpandRelationStar(Binder &binder, unique_ptr<ParsedExpression> expression,
-	                                          vector<unique_ptr<ParsedExpression>> &result);
-	DUCKDB_API static void PlanRelationSubqueries(Binder &binder, unique_ptr<Expression> &expression,
-	                                              unique_ptr<LogicalOperator> &root);
 
 public:
 	template <class TARGET>

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -36,9 +36,12 @@ namespace duckdb {
 struct BoundStatement;
 
 class Binder;
+class DuckDBPyRelation;
 class Expression;
 class LogicalOperator;
+struct PythonReplacementScan;
 class QueryNode;
+class RelationStatement;
 class SelectNode;
 class TableRef;
 
@@ -87,18 +90,7 @@ public:
 public:
 	DUCKDB_API virtual const vector<ColumnDefinition> &Columns() = 0;
 	DUCKDB_API virtual unique_ptr<QueryNode> GetQueryNode() = 0;
-	//! Return whether the relation has a faithful QueryNode representation in the
-	//! current binding context. This check is deliberately not cached because
-	//! catalog and setting changes can alter nested-query name resolution.
-	DUCKDB_API bool CanSerializeToQueryNode();
-	//! Return a freshly validated QueryNode, or nullptr if no faithful
-	//! representation exists. The Binder overload is for callers that already
-	//! hold the ClientContext lock and have an active transaction.
-	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode();
-	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode(Binder &binder);
-	DUCKDB_API bool CanBindAsInput();
 	DUCKDB_API virtual string GetQuery();
-	DUCKDB_API virtual string GetQuery(Binder &binder);
 	DUCKDB_API virtual BoundStatement Bind(Binder &binder);
 	DUCKDB_API virtual string GetAlias();
 
@@ -245,6 +237,13 @@ public:
 	virtual Relation *ChildRelation() {
 		return nullptr;
 	}
+
+	void AddExternalDependency(shared_ptr<ExternalDependency> dependency);
+	DUCKDB_API vector<shared_ptr<ExternalDependency>> GetAllDependencies();
+
+protected:
+	//! Internal capability hooks used while binding relation trees. These are
+	//! deliberately not part of the exported Relation API.
 	virtual bool ContainsNonSQLRelation() {
 		auto child = ChildRelation();
 		return child && child->ContainsNonSQLRelation();
@@ -264,31 +263,52 @@ public:
 	virtual bool CanBindAsInputInternal(Binder &binder) {
 		return CanSerializeToQueryNodeInternal(binder);
 	}
-	void AddExternalDependency(shared_ptr<ExternalDependency> dependency);
-	DUCKDB_API vector<shared_ptr<ExternalDependency>> GetAllDependencies();
-
-protected:
 	//! Build this relation's table reference after the complete relation tree has
 	//! already been validated for SQL serialization.
-	DUCKDB_API virtual unique_ptr<TableRef> GetTableRefInternal();
-	DUCKDB_API static unique_ptr<TableRef> GetTableRefForSerialization(Relation &relation);
+	virtual unique_ptr<TableRef> GetTableRefInternal();
+	static unique_ptr<TableRef> GetTableRefForSerialization(Relation &relation);
 	//! Bind this relation for use as another relation's input. Binding-preserving
 	//! relations override this to keep their child's BindContext aligned with the plan.
 	virtual BoundStatement BindAsInput(Binder &binder);
 	DUCKDB_API static string RenderWhitespace(idx_t depth);
-	DUCKDB_API static bool ExposesMultiSourceBindings(Relation &child);
-	DUCKDB_API static bool RequiresDirectRelationBinding(Binder &binder, Relation &child);
-	DUCKDB_API static bool RequiresSQLMultiSourceBinding(Relation &child);
-	DUCKDB_API static bool CanSerializeExpressionOnBoundChild(Binder &binder, Relation &child, TableRef &bound_child,
-	                                                          const ParsedExpression &expression);
-	DUCKDB_API static unique_ptr<TableRef> BindRelationInput(Binder &binder, Relation &child);
-	DUCKDB_API static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child,
-	                                                       unique_ptr<SelectNode> select_node);
-	DUCKDB_API static unique_ptr<SelectNode> WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
-	                                                       const vector<ColumnDefinition> &columns);
-	DUCKDB_API static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
-	                                                                 unique_ptr<LogicalOperator> child);
-	DUCKDB_API static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);
+	static bool ExposesMultiSourceBindings(Relation &child);
+	static bool RequiresDirectRelationBinding(Binder &binder, Relation &child);
+	static bool RequiresSQLMultiSourceBinding(Relation &child);
+	static bool CanSerializeExpressionOnBoundChild(Binder &binder, Relation &child, TableRef &bound_child,
+	                                               const ParsedExpression &expression);
+	static unique_ptr<TableRef> BindRelationInput(Binder &binder, Relation &child);
+	static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child, unique_ptr<SelectNode> select_node);
+	static unique_ptr<SelectNode> WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
+	                                            const vector<ColumnDefinition> &columns);
+	static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
+	                                                      unique_ptr<LogicalOperator> child);
+	static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);
+
+	static bool ChildContainsNonSQLRelation(Relation &child) {
+		return child.ContainsNonSQLRelation();
+	}
+	static bool ChildCanSerializeToQueryNode(Relation &child, Binder &binder) {
+		return child.CanSerializeToQueryNodeInternal(binder);
+	}
+	static bool ChildCanBindAsInput(Relation &child, Binder &binder) {
+		return child.CanBindAsInputInternal(binder);
+	}
+	static unique_ptr<QueryNode> TryGetSerializableChildQueryNode(Relation &child, Binder &binder) {
+		return child.TryGetSerializableQueryNode(binder);
+	}
+
+private:
+	friend class ClientContext;
+	friend class DuckDBPyRelation;
+	friend class RelationStatement;
+	friend struct PythonReplacementScan;
+
+	//! Return a freshly validated QueryNode, or nullptr if no faithful
+	//! representation exists. These entry points stay private so serialization
+	//! policy does not become part of the public Relation API.
+	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode();
+	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode(Binder &binder);
+	string GetQuery(Binder &binder);
 
 public:
 	template <class TARGET>

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -87,7 +87,18 @@ public:
 public:
 	DUCKDB_API virtual const vector<ColumnDefinition> &Columns() = 0;
 	DUCKDB_API virtual unique_ptr<QueryNode> GetQueryNode() = 0;
+	//! Return whether the relation has a faithful QueryNode representation in the
+	//! current binding context. This check is deliberately not cached because
+	//! catalog and setting changes can alter nested-query name resolution.
+	DUCKDB_API bool CanSerializeToQueryNode();
+	//! Return a freshly validated QueryNode, or nullptr if no faithful
+	//! representation exists. The Binder overload is for callers that already
+	//! hold the ClientContext lock and have an active transaction.
+	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode();
+	DUCKDB_API unique_ptr<QueryNode> TryGetSerializableQueryNode(Binder &binder);
+	DUCKDB_API bool CanBindAsInput();
 	DUCKDB_API virtual string GetQuery();
+	DUCKDB_API virtual string GetQuery(Binder &binder);
 	DUCKDB_API virtual BoundStatement Bind(Binder &binder);
 	DUCKDB_API virtual string GetAlias();
 
@@ -238,35 +249,43 @@ public:
 		auto child = ChildRelation();
 		return child && child->ContainsNonSQLRelation();
 	}
-	//! Whether GetQueryNode can represent this relation without losing operators or binding scopes.
-	virtual bool CanSerializeToQueryNode() {
+	//! Whether GetQueryNode can represent this relation without losing operators
+	//! or binding scopes in the supplied binding context.
+	virtual bool CanSerializeToQueryNodeInternal(Binder &binder) {
 		if (ContainsNonSQLRelation()) {
 			return false;
 		}
 		auto child = ChildRelation();
-		return !child || child->CanSerializeToQueryNode();
+		return !child || child->CanSerializeToQueryNodeInternal(binder);
 	}
 	//! Whether this relation can be bound directly as another relation's input.
 	//! SQL-serializable relations use the default SQL binding path. Relations
 	//! with a non-SQL binding path override this independently of serialization.
-	virtual bool CanBindAsInput() {
-		return CanSerializeToQueryNode();
+	virtual bool CanBindAsInputInternal(Binder &binder) {
+		return CanSerializeToQueryNodeInternal(binder);
 	}
 	void AddExternalDependency(shared_ptr<ExternalDependency> dependency);
 	DUCKDB_API vector<shared_ptr<ExternalDependency>> GetAllDependencies();
 
 protected:
+	//! Build this relation's table reference after the complete relation tree has
+	//! already been validated for SQL serialization.
+	DUCKDB_API virtual unique_ptr<TableRef> GetTableRefInternal();
+	DUCKDB_API static unique_ptr<TableRef> GetTableRefForSerialization(Relation &relation);
 	//! Bind this relation for use as another relation's input. Binding-preserving
 	//! relations override this to keep their child's BindContext aligned with the plan.
 	virtual BoundStatement BindAsInput(Binder &binder);
 	DUCKDB_API static string RenderWhitespace(idx_t depth);
 	DUCKDB_API static bool ExposesMultiSourceBindings(Relation &child);
-	DUCKDB_API static bool RequiresDirectRelationBinding(Relation &child);
+	DUCKDB_API static bool RequiresDirectRelationBinding(Binder &binder, Relation &child);
 	DUCKDB_API static bool RequiresSQLMultiSourceBinding(Relation &child);
-	DUCKDB_API static bool CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression);
+	DUCKDB_API static bool CanSerializeExpressionOnBoundChild(Binder &binder, Relation &child, TableRef &bound_child,
+	                                                          const ParsedExpression &expression);
 	DUCKDB_API static unique_ptr<TableRef> BindRelationInput(Binder &binder, Relation &child);
 	DUCKDB_API static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child,
 	                                                       unique_ptr<SelectNode> select_node);
+	DUCKDB_API static unique_ptr<SelectNode> WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
+	                                                       const vector<ColumnDefinition> &columns);
 	DUCKDB_API static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
 	                                                                 unique_ptr<LogicalOperator> child);
 	DUCKDB_API static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);

--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -36,8 +36,10 @@ namespace duckdb {
 struct BoundStatement;
 
 class Binder;
+class Expression;
 class LogicalOperator;
 class QueryNode;
+class SelectNode;
 class TableRef;
 
 static string CreateRelationAlias(RelationType type, const string &alias) {
@@ -237,6 +239,15 @@ public:
 
 protected:
 	DUCKDB_API static string RenderWhitespace(idx_t depth);
+	DUCKDB_API static bool CanMapColumnBindings(Relation &relation);
+	DUCKDB_API static shared_ptr<Binder> CreateBinderForBoundRelation(Binder &binder, Relation &relation,
+	                                                                  const BoundStatement &bound_relation);
+	DUCKDB_API static unique_ptr<Expression> BindExpressionOnBoundRelation(Binder &binder, Relation &relation,
+	                                                                       BoundStatement &bound_relation,
+	                                                                       unique_ptr<ParsedExpression> expression,
+	                                                                       const string &operation);
+	DUCKDB_API static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child, BoundStatement child_bound,
+	                                                       unique_ptr<SelectNode> select_node);
 
 public:
 	template <class TARGET>

--- a/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -29,10 +35,15 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
+	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+	bool ContainsNonSQLRelation() override {
+		return child->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
@@ -44,6 +44,9 @@ public:
 		return child->ContainsNonSQLRelation();
 	}
 	bool CanSerializeToQueryNode() override;
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
@@ -40,12 +40,14 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+
+protected:
 	bool ContainsNonSQLRelation() override {
-		return child->ContainsNonSQLRelation();
+		return ChildContainsNonSQLRelation(*child);
 	}
 	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/aggregate_relation.hpp
@@ -43,9 +43,9 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return child->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override;
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
@@ -42,6 +42,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -34,6 +40,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_table_relation.hpp
@@ -42,7 +42,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -31,6 +37,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
@@ -39,6 +39,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/create_view_relation.hpp
@@ -39,7 +39,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
@@ -35,14 +35,14 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 
+protected:
 	bool ContainsNonSQLRelation() override {
-		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+		return ChildContainsNonSQLRelation(*left) || ChildContainsNonSQLRelation(*right);
 	}
 	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
-		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
+		return ChildCanSerializeToQueryNode(*left, binder) && ChildCanSerializeToQueryNode(*right, binder);
 	}
 
-protected:
 	unique_ptr<TableRef> GetTableRefInternal() override;
 	BoundStatement BindAsInput(Binder &binder) override;
 };

--- a/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -30,6 +36,15 @@ public:
 	string ToString(idx_t depth) override;
 
 	unique_ptr<TableRef> GetTableRef() override;
+	bool ContainsNonSQLRelation() override {
+		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override {
+		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/cross_product_relation.hpp
@@ -35,15 +35,15 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 
-	unique_ptr<TableRef> GetTableRef() override;
 	bool ContainsNonSQLRelation() override {
 		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override {
-		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
+		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
 	}
 
 protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -31,6 +37,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
@@ -39,6 +39,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/delete_relation.hpp
@@ -39,7 +39,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/delim_get_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/delim_get_relation.hpp
@@ -21,10 +21,12 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
-	unique_ptr<TableRef> GetTableRef() override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
+
+protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
@@ -39,11 +39,12 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
-	}
 
 protected:
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return ChildCanBindAsInput(*child, binder);
+	}
+
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
@@ -39,6 +39,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
@@ -39,6 +39,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
@@ -39,8 +39,8 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/distinct_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -20,6 +26,7 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
+	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;

--- a/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
@@ -37,6 +37,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -29,6 +35,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/explain_relation.hpp
@@ -37,7 +37,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
@@ -41,12 +41,13 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
-	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
-	}
 
 protected:
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return ChildCanBindAsInput(*child, binder);
+	}
+
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -22,6 +28,7 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
+	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;

--- a/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
@@ -42,6 +42,9 @@ public:
 		return child.get();
 	}
 	bool CanSerializeToQueryNode() override;
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
@@ -41,6 +41,10 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanSerializeToQueryNode() override;
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/filter_relation.hpp
@@ -41,9 +41,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanSerializeToQueryNode() override;
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -30,6 +36,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
@@ -38,6 +38,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
@@ -38,7 +38,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -39,6 +45,15 @@ public:
 	string ToString(idx_t depth) override;
 
 	unique_ptr<TableRef> GetTableRef() override;
+	bool ContainsNonSQLRelation() override {
+		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override {
+		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
@@ -44,14 +44,14 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 
+protected:
 	bool ContainsNonSQLRelation() override {
-		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+		return ChildContainsNonSQLRelation(*left) || ChildContainsNonSQLRelation(*right);
 	}
 	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
-		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
+		return ChildCanSerializeToQueryNode(*left, binder) && ChildCanSerializeToQueryNode(*right, binder);
 	}
 
-protected:
 	unique_ptr<TableRef> GetTableRefInternal() override;
 	BoundStatement BindAsInput(Binder &binder) override;
 };

--- a/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/join_relation.hpp
@@ -44,15 +44,15 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 
-	unique_ptr<TableRef> GetTableRef() override;
 	bool ContainsNonSQLRelation() override {
 		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override {
-		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
+		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
 	}
 
 protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
@@ -41,6 +41,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
@@ -41,6 +41,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
@@ -41,11 +41,12 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
-	}
 
 protected:
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return ChildCanBindAsInput(*child, binder);
+	}
+
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/limit_relation.hpp
@@ -41,8 +41,8 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
@@ -33,6 +33,9 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
@@ -30,6 +30,12 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool ContainsNonSQLRelation() override {
+		return true;
+	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
@@ -30,14 +30,15 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 
-protected:
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/local_exchange_relation.hpp
@@ -33,8 +33,8 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/materialized_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/materialized_relation.hpp
@@ -25,8 +25,10 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
-	unique_ptr<TableRef> GetTableRef() override;
 	unique_ptr<QueryNode> GetQueryNode() override;
+
+protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
@@ -44,6 +44,9 @@ public:
 		return child.get();
 	}
 	bool CanSerializeToQueryNode() override;
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -24,6 +30,7 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
+	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;

--- a/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
@@ -43,6 +43,10 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanSerializeToQueryNode() override;
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
@@ -43,12 +43,13 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
-	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
-	}
 
 protected:
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return ChildCanBindAsInput(*child, binder);
+	}
+
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/order_relation.hpp
@@ -43,9 +43,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanSerializeToQueryNode() override;
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
@@ -35,6 +35,10 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+	bool ContainsNonSQLRelation() override {
+		return child->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
@@ -39,6 +39,9 @@ public:
 		return child->ContainsNonSQLRelation();
 	}
 	bool CanSerializeToQueryNode() override;
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
@@ -35,12 +35,14 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+
+protected:
 	bool ContainsNonSQLRelation() override {
-		return child->ContainsNonSQLRelation();
+		return ChildContainsNonSQLRelation(*child);
 	}
 	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/projection_relation.hpp
@@ -38,9 +38,9 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return child->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override;
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override;
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
@@ -29,7 +29,6 @@ public:
 	static unique_ptr<SelectStatement> ParseStatement(ClientContext &context, const string &query, const string &error);
 	unique_ptr<QueryNode> GetQueryNode() override;
 	string GetQuery() override;
-	string GetQuery(Binder &binder) override;
 	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;

--- a/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
@@ -29,7 +29,7 @@ public:
 	static unique_ptr<SelectStatement> ParseStatement(ClientContext &context, const string &query, const string &error);
 	unique_ptr<QueryNode> GetQueryNode() override;
 	string GetQuery() override;
-	unique_ptr<TableRef> GetTableRef() override;
+	string GetQuery(Binder &binder) override;
 	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
@@ -37,6 +37,7 @@ public:
 	string GetAlias() override;
 
 private:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 	unique_ptr<SelectStatement> GetSelectStatement();
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
@@ -39,6 +39,12 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool ContainsNonSQLRelation() override {
+		return true;
+	}
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
@@ -42,6 +42,9 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 protected:
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
@@ -39,14 +39,15 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 
-protected:
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/repartition_relation.hpp
@@ -42,8 +42,8 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return true;
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 protected:

--- a/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
@@ -36,11 +36,13 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+
+protected:
 	bool ContainsNonSQLRelation() override {
-		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+		return ChildContainsNonSQLRelation(*left) || ChildContainsNonSQLRelation(*right);
 	}
 	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
-		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
+		return ChildCanSerializeToQueryNode(*left, binder) && ChildCanSerializeToQueryNode(*right, binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -30,6 +36,12 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+	bool ContainsNonSQLRelation() override {
+		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override {
+		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	}
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/setop_relation.hpp
@@ -39,8 +39,8 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return left->ContainsNonSQLRelation() || right->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override {
-		return left->CanSerializeToQueryNode() && right->CanSerializeToQueryNode();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
+		return left->CanSerializeToQueryNodeInternal(binder) && right->CanSerializeToQueryNodeInternal(binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
@@ -37,6 +37,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
@@ -37,8 +37,10 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -19,16 +25,17 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
+	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 
 public:
 	bool InheritsColumnBindings() override {
-		return child->InheritsColumnBindings();
+		return false;
 	}
 	Relation *ChildRelation() override {
-		return child->ChildRelation();
+		return child.get();
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/subquery_relation.hpp
@@ -37,8 +37,8 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -54,6 +54,9 @@ public:
 	bool CanSerializeToQueryNode() override {
 		return !input_relation || input_relation->CanSerializeToQueryNode();
 	}
+	bool CanBindAsInput() override {
+		return !input_relation || input_relation->CanBindAsInput();
+	}
 
 private:
 	void InitializeColumns();

--- a/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -48,6 +48,12 @@ public:
 	void AddNamedParameter(const string &name, Value argument);
 	void RemoveNamedParameterIfExists(const string &name);
 	void SetNamedParameters(named_parameter_map_t &&named_parameters);
+	bool ContainsNonSQLRelation() override {
+		return input_relation && input_relation->ContainsNonSQLRelation();
+	}
+	bool CanSerializeToQueryNode() override {
+		return !input_relation || input_relation->CanSerializeToQueryNode();
+	}
 
 private:
 	void InitializeColumns();

--- a/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -47,23 +47,23 @@ public:
 	void AddNamedParameter(const string &name, Value argument);
 	void RemoveNamedParameterIfExists(const string &name);
 	void SetNamedParameters(named_parameter_map_t &&named_parameters);
-	const vector<string> &GetVirtualColumnNames() const {
-		return virtual_column_names;
-	}
-	bool ContainsNonSQLRelation() override {
-		return input_relation && input_relation->ContainsNonSQLRelation();
-	}
-	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
-		return !input_relation || input_relation->CanSerializeToQueryNodeInternal(binder);
-	}
-	bool CanBindAsInputInternal(Binder &binder) override {
-		return !input_relation || input_relation->CanBindAsInputInternal(binder);
-	}
 
 protected:
+	bool ContainsNonSQLRelation() override {
+		return input_relation && ChildContainsNonSQLRelation(*input_relation);
+	}
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
+		return !input_relation || ChildCanSerializeToQueryNode(*input_relation, binder);
+	}
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return !input_relation || ChildCanBindAsInput(*input_relation, binder);
+	}
+
 	unique_ptr<TableRef> GetTableRefInternal() override;
 
 private:
+	friend class SerializedExpressionScopeChecker;
+
 	void InitializeColumns();
 	void CaptureVirtualColumnNames(const LogicalOperator &plan);
 	BoundStatement BindAsInput(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -48,6 +48,9 @@ public:
 	void AddNamedParameter(const string &name, Value argument);
 	void RemoveNamedParameterIfExists(const string &name);
 	void SetNamedParameters(named_parameter_map_t &&named_parameters);
+	const vector<string> &GetVirtualColumnNames() const {
+		return virtual_column_names;
+	}
 	bool ContainsNonSQLRelation() override {
 		return input_relation && input_relation->ContainsNonSQLRelation();
 	}
@@ -60,8 +63,11 @@ public:
 
 private:
 	void InitializeColumns();
+	void CaptureVirtualColumnNames(const LogicalOperator &plan);
+	BoundStatement BindAsInput(Binder &binder) override;
 
 private:
+	vector<string> virtual_column_names;
 	//! Whether or not to auto initialize the columns on construction
 	bool auto_initialize;
 };

--- a/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_function_relation.hpp
@@ -39,7 +39,6 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
-	unique_ptr<TableRef> GetTableRef() override;
 	BoundStatement Bind(Binder &binder) override;
 
 	const vector<ColumnDefinition> &Columns() override;
@@ -54,12 +53,15 @@ public:
 	bool ContainsNonSQLRelation() override {
 		return input_relation && input_relation->ContainsNonSQLRelation();
 	}
-	bool CanSerializeToQueryNode() override {
-		return !input_relation || input_relation->CanSerializeToQueryNode();
+	bool CanSerializeToQueryNodeInternal(Binder &binder) override {
+		return !input_relation || input_relation->CanSerializeToQueryNodeInternal(binder);
 	}
-	bool CanBindAsInput() override {
-		return !input_relation || input_relation->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return !input_relation || input_relation->CanBindAsInputInternal(binder);
 	}
+
+protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 
 private:
 	void InitializeColumns();

--- a/external/duckdb/src/include/duckdb/main/relation/table_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_relation.hpp
@@ -33,8 +33,6 @@ public:
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
 
-	unique_ptr<TableRef> GetTableRef() override;
-
 	void Insert(const vector<vector<Value>> &values) override;
 	void Insert(vector<vector<unique_ptr<ParsedExpression>>> &&expressions) override;
 	void Update(const string &update, const string &condition = string()) override;
@@ -43,6 +41,7 @@ public:
 	void Delete(const string &condition = string()) override;
 
 protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 	BoundStatement BindAsInput(Binder &binder) override;
 };
 

--- a/external/duckdb/src/include/duckdb/main/relation/table_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/table_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -35,6 +41,9 @@ public:
 	void Update(vector<string> column_names, vector<unique_ptr<ParsedExpression>> &&update,
 	            unique_ptr<ParsedExpression> condition = nullptr) override;
 	void Delete(const string &condition = string()) override;
+
+protected:
+	BoundStatement BindAsInput(Binder &binder) override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
@@ -37,6 +37,9 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+	bool CanBindAsInput() override {
+		return child->CanBindAsInput();
+	}
 
 private:
 	vector<ColumnDefinition> columns;

--- a/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
@@ -37,8 +37,10 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
+
+protected:
 	bool CanBindAsInputInternal(Binder &binder) override {
-		return child->CanBindAsInputInternal(binder);
+		return ChildCanBindAsInput(*child, binder);
 	}
 
 private:

--- a/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/unnest_relation.hpp
@@ -37,8 +37,8 @@ public:
 	Relation *ChildRelation() override {
 		return child.get();
 	}
-	bool CanBindAsInput() override {
-		return child->CanBindAsInput();
+	bool CanBindAsInputInternal(Binder &binder) override {
+		return child->CanBindAsInputInternal(binder);
 	}
 
 private:

--- a/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
@@ -42,6 +42,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -34,6 +40,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/update_relation.hpp
@@ -42,7 +42,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/value_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/value_relation.hpp
@@ -39,7 +39,8 @@ public:
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
 
-	unique_ptr<TableRef> GetTableRef() override;
+protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/view_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/view_relation.hpp
@@ -25,11 +25,13 @@ public:
 
 public:
 	unique_ptr<QueryNode> GetQueryNode() override;
-	unique_ptr<TableRef> GetTableRef() override;
 
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	string GetAlias() override;
+
+protected:
+	unique_ptr<TableRef> GetTableRefInternal() override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
@@ -36,6 +36,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -28,6 +34,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_csv_relation.hpp
@@ -36,7 +36,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
@@ -37,6 +37,8 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
+
+protected:
 	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}

--- a/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -29,6 +35,9 @@ public:
 	const vector<ColumnDefinition> &Columns() override;
 	string ToString(idx_t depth) override;
 	bool IsReadOnly() override {
+		return false;
+	}
+	bool CanSerializeToQueryNode() override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_parquet_relation.hpp
@@ -37,7 +37,7 @@ public:
 	bool IsReadOnly() override {
 		return false;
 	}
-	bool CanSerializeToQueryNode() override {
+	bool CanSerializeToQueryNodeInternal(Binder &) override {
 		return false;
 	}
 };

--- a/external/duckdb/src/include/duckdb/parser/statement/relation_statement.hpp
+++ b/external/duckdb/src/include/duckdb/parser/statement/relation_statement.hpp
@@ -19,6 +19,7 @@ public:
 
 public:
 	explicit RelationStatement(shared_ptr<Relation> relation);
+	RelationStatement(shared_ptr<Relation> relation, Binder &binder);
 
 	shared_ptr<Relation> relation;
 

--- a/external/duckdb/src/include/duckdb/planner/bind_context.hpp
+++ b/external/duckdb/src/include/duckdb/planner/bind_context.hpp
@@ -46,8 +46,6 @@ enum class ColumnBindType { EXPAND_GENERATED_COLUMNS, DO_NOT_EXPAND_GENERATED_CO
 //! The BindContext object keeps track of all the tables and columns that are
 //! encountered during the binding process.
 class BindContext {
-	friend class Relation;
-
 public:
 	explicit BindContext(Binder &binder);
 

--- a/external/duckdb/src/include/duckdb/planner/bind_context.hpp
+++ b/external/duckdb/src/include/duckdb/planner/bind_context.hpp
@@ -96,6 +96,10 @@ public:
 
 	void GetTypesAndNames(vector<string> &result_names, vector<LogicalType> &result_types);
 
+	//! Remove hidden virtual columns from name resolution after an operator that
+	//! only emits the visible columns.
+	void RemoveVirtualColumnBindings();
+
 	//! Adds a base table with the given alias to the BindContext.
 	void AddBaseTable(idx_t index, const string &alias, const vector<string> &names, const vector<LogicalType> &types,
 	                  vector<ColumnIndex> &bound_column_ids, TableCatalogEntry &entry, bool add_row_id = true);

--- a/external/duckdb/src/include/duckdb/planner/bind_context.hpp
+++ b/external/duckdb/src/include/duckdb/planner/bind_context.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -40,6 +46,8 @@ enum class ColumnBindType { EXPAND_GENERATED_COLUMNS, DO_NOT_EXPAND_GENERATED_CO
 //! The BindContext object keeps track of all the tables and columns that are
 //! encountered during the binding process.
 class BindContext {
+	friend class Relation;
+
 public:
 	explicit BindContext(Binder &binder);
 

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -202,8 +202,8 @@ struct QueryBinderState {
 */
 class Binder : public enable_shared_from_this<Binder> {
 	friend class ExpressionBinder;
-	friend class RecursiveDependentJoinPlanner;
 	friend class Relation;
+	friend class RecursiveDependentJoinPlanner;
 
 public:
 	DUCKDB_API static shared_ptr<Binder> CreateBinder(ClientContext &context, optional_ptr<Binder> parent = nullptr,

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -203,6 +203,7 @@ struct QueryBinderState {
 class Binder : public enable_shared_from_this<Binder> {
 	friend class ExpressionBinder;
 	friend class RecursiveDependentJoinPlanner;
+	friend class Relation;
 
 public:
 	DUCKDB_API static shared_ptr<Binder> CreateBinder(ClientContext &context, optional_ptr<Binder> parent = nullptr,

--- a/external/duckdb/src/include/duckdb/planner/table_binding.hpp
+++ b/external/duckdb/src/include/duckdb/planner/table_binding.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -130,6 +136,9 @@ public:
 	ErrorData ColumnNotFoundError(const string &column_name) const override;
 	// These are columns that are present in the name_map, appearing in the order that they're bound
 	const vector<ColumnIndex> &GetBoundColumnIds() const;
+	//! Prevent virtual columns from being resolved in a later binding scope while
+	//! retaining their metadata for the already-bound child plan.
+	void RemoveVirtualColumnBindings();
 
 protected:
 	ColumnBinding GetColumnBinding(column_t column_index);

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -1401,7 +1401,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 		// run the ToString method of any relation we run, mostly to ensure it doesn't crash
 		relation->ToString();
 		relation->GetAlias();
-		if (relation->IsReadOnly()) {
+		if (relation->IsReadOnly() && relation->CanSerializeToQueryNode()) {
 			// verify read only statements by running a select statement
 			auto select = make_uniq<SelectStatement>();
 			select->node = relation->GetQueryNode();

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -1401,18 +1401,29 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 		// run the ToString method of any relation we run, mostly to ensure it doesn't crash
 		relation->ToString();
 		relation->GetAlias();
-		if (relation->IsReadOnly() && relation->CanSerializeToQueryNode()) {
-			// verify read only statements by running a select statement
-			auto select = make_uniq<SelectStatement>();
-			select->node = relation->GetQueryNode();
-			PendingQueryParameters parameters;
-			parameters.query_parameters = query_parameters;
-			parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
-			RunStatementInternal(lock, query, std::move(select), parameters);
+		if (relation->IsReadOnly()) {
+			unique_ptr<QueryNode> query_node;
+			RunFunctionInTransactionInternal(lock, [&]() {
+				auto binder = Binder::CreateBinder(*this);
+				query_node = relation->TryGetSerializableQueryNode(*binder);
+			});
+			if (query_node) {
+				// verify read only statements by running a select statement
+				auto select = make_uniq<SelectStatement>();
+				select->node = std::move(query_node);
+				PendingQueryParameters parameters;
+				parameters.query_parameters = query_parameters;
+				parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+				RunStatementInternal(lock, query, std::move(select), parameters);
+			}
 		}
 	}
 
-	auto relation_stmt = make_uniq<RelationStatement>(relation);
+	unique_ptr<RelationStatement> relation_stmt;
+	RunFunctionInTransactionInternal(lock, [&]() {
+		auto statement_binder = Binder::CreateBinder(*this);
+		relation_stmt = make_uniq<RelationStatement>(relation, *statement_binder);
+	});
 	PendingQueryParameters parameters;
 	parameters.query_parameters = query_parameters;
 	return PendingQueryInternal(lock, std::move(relation_stmt), parameters);

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -594,7 +594,14 @@ unique_ptr<TableRef> Relation::BindRelationInput(Binder &binder, Relation &child
 
 	bool multi_source = child.type == RelationType::JOIN_RELATION || child.type == RelationType::CROSS_PRODUCT_RELATION;
 	bool preserves_bindings = child.InheritsColumnBindings() || multi_source;
-	if (!preserves_bindings) {
+	if (preserves_bindings) {
+		// The bind context is authoritative for the columns that survive an
+		// operator. JoinRef binding retains both inputs in BoundStatement metadata
+		// even when SEMI/ANTI joins remove one side from the output.
+		child_bound.names.clear();
+		child_bound.types.clear();
+		child_binder->bind_context.GetTypesAndNames(child_bound.names, child_bound.types);
+	} else {
 		// Projections, aggregates, and explicit aliases establish a new scope.
 		// Rebase that scope on the bound plan's single output table index.
 		auto input_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
@@ -620,16 +627,6 @@ unique_ptr<LogicalOperator> Relation::PlanRelationFilter(Binder &binder, unique_
 
 void Relation::ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition) {
 	binder.BindWhereStarExpression(condition);
-}
-
-void Relation::ExpandRelationStar(Binder &binder, unique_ptr<ParsedExpression> expression,
-                                  vector<unique_ptr<ParsedExpression>> &result) {
-	binder.ExpandStarExpression(std::move(expression), result);
-}
-
-void Relation::PlanRelationSubqueries(Binder &binder, unique_ptr<Expression> &expression,
-                                      unique_ptr<LogicalOperator> &root) {
-	binder.PlanSubqueries(expression, root);
 }
 
 shared_ptr<Relation> Relation::InsertRel(const string &schema_name, const string &table_name) {

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -280,16 +280,6 @@ unique_ptr<TableRef> Relation::GetTableRefForSerialization(Relation &relation) {
 	return relation.GetTableRefInternal();
 }
 
-bool Relation::CanSerializeToQueryNode() {
-	bool result = false;
-	auto client_context = context->GetContext();
-	client_context->RunFunctionInTransaction([&]() {
-		auto binder = Binder::CreateBinder(*client_context);
-		result = CanSerializeToQueryNodeInternal(*binder);
-	});
-	return result;
-}
-
 unique_ptr<QueryNode> Relation::TryGetSerializableQueryNode() {
 	unique_ptr<QueryNode> result;
 	auto client_context = context->GetContext();
@@ -305,16 +295,6 @@ unique_ptr<QueryNode> Relation::TryGetSerializableQueryNode(Binder &binder) {
 		return nullptr;
 	}
 	return GetQueryNode();
-}
-
-bool Relation::CanBindAsInput() {
-	bool result = false;
-	auto client_context = context->GetContext();
-	client_context->RunFunctionInTransaction([&]() {
-		auto binder = Binder::CreateBinder(*client_context);
-		result = CanBindAsInputInternal(*binder);
-	});
-	return result;
 }
 
 unique_ptr<QueryResult> Relation::Execute() {
@@ -372,8 +352,6 @@ bool Relation::RequiresSQLMultiSourceBinding(Relation &child) {
 	}
 	return child_ptr->type == RelationType::JOIN_RELATION || child_ptr->type == RelationType::CROSS_PRODUCT_RELATION;
 }
-
-namespace {
 
 class SerializedExpressionScopeChecker {
 public:
@@ -707,7 +685,7 @@ private:
 		if (relation.type == RelationType::TABLE_RELATION) {
 			binding.columns.emplace_back("rowid");
 		} else if (relation.type == RelationType::TABLE_FUNCTION_RELATION) {
-			for (auto &column_name : relation.Cast<TableFunctionRelation>().GetVirtualColumnNames()) {
+			for (auto &column_name : relation.Cast<TableFunctionRelation>().virtual_column_names) {
 				binding.columns.push_back(column_name);
 			}
 		}
@@ -834,8 +812,6 @@ private:
 	vector<vector<ColumnBinding>> serialized_output_origins;
 	bool serializable = true;
 };
-
-} // namespace
 
 bool Relation::CanSerializeExpressionOnBoundChild(Binder &binder, Relation &child, TableRef &bound_child,
                                                   const ParsedExpression &expression) {
@@ -1116,6 +1092,9 @@ string Relation::GetQuery() {
 }
 
 string Relation::GetQuery(Binder &binder) {
+	if (type == RelationType::QUERY_RELATION) {
+		return GetQuery();
+	}
 	auto query_node = TryGetSerializableQueryNode(binder);
 	if (!query_node) {
 		return string();

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -28,15 +28,14 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression_binder/relation_binder.hpp"
-#include "duckdb/planner/expression_binder/where_binder.hpp"
-#include "duckdb/planner/table_binding.hpp"
+#include "duckdb/parser/tableref/bound_ref_wrapper.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/main/relation/join_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
@@ -249,6 +248,11 @@ string Relation::GetAlias() {
 }
 
 unique_ptr<TableRef> Relation::GetTableRef() {
+	if (!CanSerializeToQueryNode()) {
+		throw NotImplementedException("Cannot create a table reference for a relation that cannot be faithfully "
+		                              "represented as a SQL query node; conversion would discard the exchange or lose "
+		                              "relation bindings");
+	}
 	auto select = make_uniq<SelectStatement>();
 	select->node = GetQueryNode();
 	return make_uniq<SubqueryRef>(std::move(select), GetAlias());
@@ -268,239 +272,122 @@ unique_ptr<QueryResult> Relation::ExecuteOrThrow() {
 }
 
 BoundStatement Relation::Bind(Binder &binder) {
+	if (!CanSerializeToQueryNode()) {
+		throw NotImplementedException(
+		    "Cannot bind a relation that cannot be faithfully represented as a SQL query node; "
+		    "conversion would discard the exchange or lose relation bindings");
+	}
 	SelectStatement stmt;
 	stmt.node = GetQueryNode();
 	return binder.Bind(stmt.Cast<SQLStatement>());
 }
 
-bool Relation::CanMapColumnBindings(Relation &relation) {
-	if (relation.InheritsColumnBindings()) {
-		auto child = relation.ChildRelation();
-		if (child) {
-			return CanMapColumnBindings(*child);
-		}
-	}
-	switch (relation.type) {
-	case RelationType::JOIN_RELATION: {
-		auto &join = relation.Cast<JoinRelation>();
-		if (!join.using_columns.empty() || !join.condition || join.join_ref_type != JoinRefType::REGULAR ||
-		    join.join_type != JoinType::INNER) {
-			return false;
-		}
-		return CanMapColumnBindings(*join.left) && CanMapColumnBindings(*join.right);
-	}
-	case RelationType::CROSS_PRODUCT_RELATION: {
-		auto &cross = relation.Cast<CrossProductRelation>();
-		return CanMapColumnBindings(*cross.left) && CanMapColumnBindings(*cross.right);
-	}
-	default:
+BoundStatement Relation::BindAsInput(Binder &binder) {
+	return Bind(binder);
+}
+
+bool Relation::RequiresDirectRelationBinding(Relation &child) {
+	if (child.ContainsNonSQLRelation()) {
 		return true;
 	}
+	auto child_ptr = &child;
+	while (child_ptr->InheritsColumnBindings()) {
+		child_ptr = child_ptr->ChildRelation();
+		D_ASSERT(child_ptr);
+	}
+	return child_ptr->type == RelationType::JOIN_RELATION || child_ptr->type == RelationType::CROSS_PRODUCT_RELATION;
 }
 
-struct RelationBindingGroup {
-	string alias;
-	idx_t column_count;
-};
-
-static void CollectBindingGroups(Relation &relation, vector<RelationBindingGroup> &groups) {
-	if (relation.InheritsColumnBindings()) {
-		auto child = relation.ChildRelation();
-		if (child) {
-			CollectBindingGroups(*child, groups);
-			return;
-		}
+bool Relation::RequiresSQLMultiSourceBinding(Relation &child) {
+	auto child_ptr = &child;
+	// Filters can be merged into the same SELECT without changing relational
+	// ordering. Other inheriting relations (LIMIT, DISTINCT, ORDER, etc.) are
+	// semantic boundaries and must remain separate plan nodes.
+	while (child_ptr->type == RelationType::FILTER_RELATION) {
+		child_ptr = child_ptr->ChildRelation();
 	}
-	switch (relation.type) {
-	case RelationType::JOIN_RELATION: {
-		auto &join = relation.Cast<JoinRelation>();
-		if (join.join_type == JoinType::SEMI || join.join_type == JoinType::ANTI) {
-			CollectBindingGroups(*join.left, groups);
-			return;
-		}
-		if (join.join_type == JoinType::RIGHT_SEMI || join.join_type == JoinType::RIGHT_ANTI) {
-			CollectBindingGroups(*join.right, groups);
-			return;
-		}
-		CollectBindingGroups(*join.left, groups);
-		CollectBindingGroups(*join.right, groups);
-		return;
-	}
-	case RelationType::CROSS_PRODUCT_RELATION: {
-		auto &cross = relation.Cast<CrossProductRelation>();
-		CollectBindingGroups(*cross.left, groups);
-		CollectBindingGroups(*cross.right, groups);
-		return;
-	}
-	default:
-		groups.push_back({relation.GetAlias(), relation.Columns().size()});
-		return;
-	}
+	return child_ptr->type == RelationType::JOIN_RELATION || child_ptr->type == RelationType::CROSS_PRODUCT_RELATION;
 }
 
-class MappedRelationBinding : public Binding {
-public:
-	MappedRelationBinding(string alias, vector<string> names, vector<LogicalType> types,
-	                      vector<ColumnBinding> column_bindings_p)
-	    : Binding(BindingType::BASE, BindingAlias(std::move(alias)), std::move(types), std::move(names),
-	              column_bindings_p.empty() ? DConstants::INVALID_INDEX : column_bindings_p[0].table_index),
-	      column_bindings(std::move(column_bindings_p)) {
-		D_ASSERT(column_bindings.size() == this->names.size());
+bool Relation::CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression) {
+	if (!child.CanSerializeToQueryNode()) {
+		return false;
+	}
+	if (!RequiresDirectRelationBinding(child) || RequiresSQLMultiSourceBinding(child)) {
+		return true;
 	}
 
-	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override {
-		column_t column_index;
-		if (!TryGetBindingIndex(colref.GetColumnName(), column_index)) {
-			return BindResult(ColumnNotFoundError(colref.GetColumnName()));
+	// A semantic boundary above a join is emitted as a subquery. Only the
+	// subquery alias survives that boundary; qualified references to the join's
+	// original inputs would produce SQL that cannot bind.
+	auto child_alias = child.GetAlias();
+	bool serializable = true;
+	ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
+	    expression, [&](const ColumnRefExpression &column_ref) {
+		    if (column_ref.IsQualified() && !StringUtil::CIEquals(column_ref.GetTableName(), child_alias)) {
+			    serializable = false;
+		    }
+	    });
+	ParsedExpressionIterator::VisitExpression<StarExpression>(expression, [&](const StarExpression &star) {
+		auto references_other_table = [&](const QualifiedColumnName &column) {
+			return column.IsQualified() && !StringUtil::CIEquals(column.table, child_alias);
+		};
+		if ((!star.relation_name.empty() && !StringUtil::CIEquals(star.relation_name, child_alias)) ||
+		    std::any_of(star.exclude_list.begin(), star.exclude_list.end(), references_other_table) ||
+		    std::any_of(star.rename_list.begin(), star.rename_list.end(),
+		                [&](const auto &entry) { return references_other_table(entry.first); })) {
+			serializable = false;
 		}
-		if (colref.GetAlias().empty()) {
-			colref.SetAlias(names[column_index]);
-		}
-		return BindResult(make_uniq<BoundColumnRefExpression>(colref.GetName(), types[column_index],
-		                                                      column_bindings[column_index], depth));
-	}
+	});
+	return serializable;
+}
 
-private:
-	vector<ColumnBinding> column_bindings;
-};
-
-shared_ptr<Binder> Relation::CreateBinderForBoundRelation(Binder &binder, Relation &relation,
-                                                          const BoundStatement &bound_relation) {
-	auto bindings = bound_relation.plan->GetColumnBindings();
-	D_ASSERT(bindings.size() == bound_relation.names.size());
-	D_ASSERT(bindings.size() == bound_relation.types.size());
-
-	struct BindingColumns {
-		idx_t table_index;
-		vector<string> names;
-		vector<LogicalType> types;
-		vector<ColumnBinding> bindings;
-	};
-	vector<BindingColumns> binding_columns;
-	unordered_map<idx_t, idx_t> binding_positions;
-	for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
-		const auto &binding = bindings[column_idx];
-		auto entry = binding_positions.find(binding.table_index);
-		if (entry == binding_positions.end()) {
-			binding_positions.emplace(binding.table_index, binding_columns.size());
-			binding_columns.push_back({binding.table_index, {}, {}, {}});
-			entry = binding_positions.find(binding.table_index);
-		}
-		auto &columns = binding_columns[entry->second];
-		if (columns.names.size() <= binding.column_index) {
-			columns.names.resize(binding.column_index + 1);
-			columns.types.resize(binding.column_index + 1);
-			columns.bindings.resize(binding.column_index + 1);
-		}
-		columns.names[binding.column_index] = bound_relation.names[column_idx];
-		columns.types[binding.column_index] = bound_relation.types[column_idx];
-		columns.bindings[binding.column_index] = binding;
-	}
-
-	for (auto &columns : binding_columns) {
-		for (idx_t column_idx = 0; column_idx < columns.names.size(); column_idx++) {
-			if (columns.names[column_idx].empty() ||
-			    columns.bindings[column_idx].table_index == DConstants::INVALID_INDEX) {
-				throw InternalException("Failed to build relation bindings: missing column at index %llu", column_idx);
-			}
-		}
-	}
-
-	vector<RelationBindingGroup> relation_groups;
-	CollectBindingGroups(relation, relation_groups);
-	case_insensitive_map_t<bool> used_aliases;
+unique_ptr<TableRef> Relation::BindRelationInput(Binder &binder, Relation &child) {
+	// BoundRefWrapper lets the normal SELECT binder consume a non-SQL child
+	// without converting its logical plan back into a QueryNode. Keep the
+	// child's full BindContext for binding-preserving relations and joins.
 	auto child_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
-	auto add_binding = [&](string alias, vector<string> names, vector<LogicalType> types,
-	                       vector<ColumnBinding> bindings) {
-		QueryResult::DeduplicateColumns(names);
-		if (alias.empty() || used_aliases.find(alias) != used_aliases.end()) {
-			alias = StringUtil::Format("__relation_%llu", bindings[0].table_index);
-		}
-		while (used_aliases.find(alias) != used_aliases.end()) {
-			alias += "_";
-		}
-		used_aliases.emplace(alias, true);
-		child_binder->bind_context.AddBinding(make_uniq<MappedRelationBinding>(std::move(alias), std::move(names),
-		                                                                       std::move(types), std::move(bindings)));
-	};
+	auto child_bound = child.BindAsInput(*child_binder);
+	binder.MoveCorrelatedExpressionsFrom(*child_binder);
 
-	bool mapped_relation_groups = relation_groups.size() == binding_columns.size();
-	if (mapped_relation_groups) {
-		for (idx_t group_idx = 0; group_idx < relation_groups.size(); group_idx++) {
-			if (relation_groups[group_idx].column_count != binding_columns[group_idx].names.size()) {
-				mapped_relation_groups = false;
-				break;
-			}
-		}
+	bool multi_source = child.type == RelationType::JOIN_RELATION || child.type == RelationType::CROSS_PRODUCT_RELATION;
+	bool preserves_bindings = child.InheritsColumnBindings() || multi_source;
+	if (!preserves_bindings) {
+		// Projections, aggregates, and explicit aliases establish a new scope.
+		// Rebase that scope on the bound plan's single output table index.
+		auto input_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
+		auto names = BindContext::AliasColumnNames(child.GetAlias(), child_bound.names, {});
+		input_binder->bind_context.AddGenericBinding(child_bound.plan->GetRootIndex(), child.GetAlias(), names,
+		                                             child_bound.types);
+		child_binder = std::move(input_binder);
 	}
-	if (mapped_relation_groups) {
-		for (idx_t group_idx = 0; group_idx < relation_groups.size(); group_idx++) {
-			auto &columns = binding_columns[group_idx];
-			add_binding(relation_groups[group_idx].alias, std::move(columns.names), std::move(columns.types),
-			            std::move(columns.bindings));
-		}
-		return child_binder;
-	}
-
-	if (binding_columns.size() == 1 && relation_groups.size() > 1) {
-		auto &columns = binding_columns[0];
-		idx_t total_columns = 0;
-		for (auto &group : relation_groups) {
-			total_columns += group.column_count;
-		}
-		if (total_columns == columns.names.size()) {
-			idx_t offset = 0;
-			for (auto &group : relation_groups) {
-				vector<string> names(columns.names.begin() + offset,
-				                     columns.names.begin() + offset + group.column_count);
-				vector<LogicalType> types(columns.types.begin() + offset,
-				                          columns.types.begin() + offset + group.column_count);
-				vector<ColumnBinding> bindings(columns.bindings.begin() + offset,
-				                               columns.bindings.begin() + offset + group.column_count);
-				add_binding(group.alias, std::move(names), std::move(types), std::move(bindings));
-				offset += group.column_count;
-			}
-			return child_binder;
-		}
-	}
-
-	for (auto &columns : binding_columns) {
-		auto alias = binding_columns.size() == 1 ? relation.GetAlias() : string();
-		add_binding(std::move(alias), std::move(columns.names), std::move(columns.types), std::move(columns.bindings));
-	}
-	return child_binder;
+	return make_uniq<BoundRefWrapper>(std::move(child_bound), std::move(child_binder));
 }
 
-unique_ptr<Expression> Relation::BindExpressionOnBoundRelation(Binder &binder, Relation &relation,
-                                                               BoundStatement &bound_relation,
-                                                               unique_ptr<ParsedExpression> expression,
-                                                               const string &operation) {
-	auto child_binder = CreateBinderForBoundRelation(binder, relation, bound_relation);
-	unique_ptr<Expression> bound_expression;
-	if (operation == "filter") {
-		child_binder->BindWhereStarExpression(expression);
-		ExpressionBinder::QualifyColumnNames(*child_binder, expression);
-		WhereBinder where_binder(*child_binder, binder.context);
-		bound_expression = where_binder.Bind(expression);
-	} else {
-		ExpressionBinder::QualifyColumnNames(*child_binder, expression);
-		RelationBinder relation_binder(*child_binder, binder.context, operation);
-		bound_expression = relation_binder.Bind(expression);
-	}
-	if (!bound_expression) {
-		throw InternalException("Failed to bind %s expression", operation);
-	}
-	child_binder->PlanSubqueries(bound_expression, bound_relation.plan);
-	binder.MoveCorrelatedExpressionsFrom(*child_binder);
-	return bound_expression;
+BoundStatement Relation::BindSelectNodeOnChild(Binder &binder, Relation &child, unique_ptr<SelectNode> select_node) {
+	select_node->from_table = BindRelationInput(binder, child);
+	SelectStatement stmt;
+	stmt.node = std::move(select_node);
+	return binder.Bind(stmt.Cast<SQLStatement>());
 }
 
-BoundStatement Relation::BindSelectNodeOnChild(Binder &binder, Relation &child, BoundStatement child_bound,
-                                               unique_ptr<SelectNode> select_node) {
-	auto child_binder = CreateBinderForBoundRelation(binder, child, child_bound);
-	auto result = child_binder->BindSelectNode(*select_node, std::move(child_bound));
-	binder.MoveCorrelatedExpressionsFrom(*child_binder);
-	return result;
+unique_ptr<LogicalOperator> Relation::PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
+                                                         unique_ptr<LogicalOperator> child) {
+	return binder.PlanFilter(std::move(condition), std::move(child));
+}
+
+void Relation::ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition) {
+	binder.BindWhereStarExpression(condition);
+}
+
+void Relation::ExpandRelationStar(Binder &binder, unique_ptr<ParsedExpression> expression,
+                                  vector<unique_ptr<ParsedExpression>> &result) {
+	binder.ExpandStarExpression(std::move(expression), result);
+}
+
+void Relation::PlanRelationSubqueries(Binder &binder, unique_ptr<Expression> &expression,
+                                      unique_ptr<LogicalOperator> &root) {
+	binder.PlanSubqueries(expression, root);
 }
 
 shared_ptr<Relation> Relation::InsertRel(const string &schema_name, const string &table_name) {
@@ -679,6 +566,9 @@ string Relation::ToString() {
 
 // LCOV_EXCL_START
 string Relation::GetQuery() {
+	if (!CanSerializeToQueryNode()) {
+		return string();
+	}
 	return GetQueryNode()->ToString();
 }
 

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -32,10 +32,15 @@
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/parser/query_node/recursive_cte_node.hpp"
+#include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
+#include "duckdb/parser/tableref/list.hpp"
 #include "duckdb/main/relation/join_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
@@ -287,9 +292,13 @@ BoundStatement Relation::BindAsInput(Binder &binder) {
 }
 
 bool Relation::RequiresDirectRelationBinding(Relation &child) {
-	if (child.ContainsNonSQLRelation()) {
-		return true;
+	if (!child.CanSerializeToQueryNode()) {
+		return child.CanBindAsInput();
 	}
+	return ExposesMultiSourceBindings(child);
+}
+
+bool Relation::ExposesMultiSourceBindings(Relation &child) {
 	auto child_ptr = &child;
 	while (child_ptr->InheritsColumnBindings()) {
 		child_ptr = child_ptr->ChildRelation();
@@ -309,37 +318,270 @@ bool Relation::RequiresSQLMultiSourceBinding(Relation &child) {
 	return child_ptr->type == RelationType::JOIN_RELATION || child_ptr->type == RelationType::CROSS_PRODUCT_RELATION;
 }
 
+namespace {
+
+class SerializedExpressionScopeChecker {
+public:
+	explicit SerializedExpressionScopeChecker(string child_alias_p) : child_alias(std::move(child_alias_p)) {
+	}
+
+	bool Check(const ParsedExpression &expression) {
+		VisitExpression(expression);
+		return serializable;
+	}
+
+private:
+	bool QualifierIsVisible(const string &qualifier) const {
+		if (StringUtil::CIEquals(qualifier, child_alias)) {
+			return true;
+		}
+		for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
+			for (auto &alias : *scope) {
+				if (StringUtil::CIEquals(qualifier, alias)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	void VisitExpression(const ParsedExpression &expression) {
+		if (!serializable) {
+			return;
+		}
+		switch (expression.GetExpressionClass()) {
+		case ExpressionClass::COLUMN_REF: {
+			auto &column_ref = expression.Cast<ColumnRefExpression>();
+			if (column_ref.IsQualified() && !QualifierIsVisible(column_ref.GetTableName())) {
+				serializable = false;
+			}
+			return;
+		}
+		case ExpressionClass::STAR: {
+			auto &star = expression.Cast<StarExpression>();
+			auto references_hidden_table = [&](const QualifiedColumnName &column) {
+				return column.IsQualified() && !QualifierIsVisible(column.table);
+			};
+			if ((!star.relation_name.empty() && !QualifierIsVisible(star.relation_name)) ||
+			    std::any_of(star.exclude_list.begin(), star.exclude_list.end(), references_hidden_table) ||
+			    std::any_of(star.rename_list.begin(), star.rename_list.end(),
+			                [&](const auto &entry) { return references_hidden_table(entry.first); })) {
+				serializable = false;
+				return;
+			}
+			break;
+		}
+		case ExpressionClass::SUBQUERY: {
+			auto &subquery = expression.Cast<SubqueryExpression>();
+			if (subquery.child) {
+				VisitExpression(*subquery.child);
+			}
+			if (!subquery.subquery || !subquery.subquery->node) {
+				serializable = false;
+				return;
+			}
+			VisitQueryNode(*subquery.subquery->node);
+			return;
+		}
+		default:
+			break;
+		}
+		ParsedExpressionIterator::EnumerateChildren(expression,
+		                                            [&](const ParsedExpression &child) { VisitExpression(child); });
+	}
+
+	void CollectTableAliases(const TableRef &ref, vector<string> &aliases) {
+		if (!ref.alias.empty()) {
+			aliases.push_back(ref.alias);
+			return;
+		}
+		switch (ref.type) {
+		case TableReferenceType::BASE_TABLE:
+			aliases.push_back(ref.Cast<BaseTableRef>().table_name);
+			break;
+		case TableReferenceType::JOIN: {
+			auto &join = ref.Cast<JoinRef>();
+			CollectTableAliases(*join.left, aliases);
+			CollectTableAliases(*join.right, aliases);
+			break;
+		}
+		case TableReferenceType::TABLE_FUNCTION: {
+			auto &table_function = ref.Cast<TableFunctionRef>();
+			if (table_function.function && table_function.function->GetExpressionClass() == ExpressionClass::FUNCTION) {
+				aliases.push_back(table_function.function->Cast<FunctionExpression>().function_name);
+			}
+			break;
+		}
+		case TableReferenceType::PIVOT:
+			CollectTableAliases(*ref.Cast<PivotRef>().source, aliases);
+			break;
+		default:
+			break;
+		}
+	}
+
+	void VisitTableRef(TableRef &ref) {
+		if (!serializable) {
+			return;
+		}
+		switch (ref.type) {
+		case TableReferenceType::EXPRESSION_LIST: {
+			auto &expression_list = ref.Cast<ExpressionListRef>();
+			for (auto &row : expression_list.values) {
+				for (auto &expression : row) {
+					VisitExpression(*expression);
+				}
+			}
+			break;
+		}
+		case TableReferenceType::JOIN: {
+			auto &join = ref.Cast<JoinRef>();
+			VisitTableRef(*join.left);
+			VisitTableRef(*join.right);
+			if (join.condition) {
+				VisitExpression(*join.condition);
+			}
+			for (auto &expression : join.duplicate_eliminated_columns) {
+				VisitExpression(*expression);
+			}
+			break;
+		}
+		case TableReferenceType::PIVOT: {
+			auto &pivot = ref.Cast<PivotRef>();
+			VisitTableRef(*pivot.source);
+			for (auto &aggregate : pivot.aggregates) {
+				VisitExpression(*aggregate);
+			}
+			for (auto &column : pivot.pivots) {
+				for (auto &expression : column.pivot_expressions) {
+					VisitExpression(*expression);
+				}
+				for (auto &entry : column.entries) {
+					if (entry.expr) {
+						VisitExpression(*entry.expr);
+					}
+				}
+				if (column.subquery) {
+					VisitQueryNode(*column.subquery);
+				}
+			}
+			break;
+		}
+		case TableReferenceType::SUBQUERY: {
+			auto &subquery = ref.Cast<SubqueryRef>();
+			VisitQueryNode(*subquery.subquery->node);
+			break;
+		}
+		case TableReferenceType::TABLE_FUNCTION: {
+			auto &table_function = ref.Cast<TableFunctionRef>();
+			VisitExpression(*table_function.function);
+			if (table_function.subquery) {
+				VisitQueryNode(*table_function.subquery->node);
+			}
+			break;
+		}
+		case TableReferenceType::SHOW_REF: {
+			auto &show = ref.Cast<ShowRef>();
+			if (show.query) {
+				VisitQueryNode(*show.query);
+			}
+			break;
+		}
+		case TableReferenceType::BASE_TABLE:
+		case TableReferenceType::EMPTY_FROM:
+		case TableReferenceType::COLUMN_DATA:
+		case TableReferenceType::DELIM_GET:
+			break;
+		default:
+			serializable = false;
+			break;
+		}
+	}
+
+	void VisitQueryNode(QueryNode &node) {
+		if (!serializable) {
+			return;
+		}
+		for (auto &entry : node.cte_map.map) {
+			VisitQueryNode(*entry.second->query->node);
+		}
+		switch (node.type) {
+		case QueryNodeType::SELECT_NODE: {
+			auto &select = node.Cast<SelectNode>();
+			vector<string> aliases;
+			if (select.from_table) {
+				CollectTableAliases(*select.from_table, aliases);
+			}
+			query_scopes.push_back(std::move(aliases));
+			for (auto &expression : select.select_list) {
+				VisitExpression(*expression);
+			}
+			for (auto &expression : select.groups.group_expressions) {
+				VisitExpression(*expression);
+			}
+			if (select.where_clause) {
+				VisitExpression(*select.where_clause);
+			}
+			if (select.having) {
+				VisitExpression(*select.having);
+			}
+			if (select.qualify) {
+				VisitExpression(*select.qualify);
+			}
+			if (select.from_table) {
+				VisitTableRef(*select.from_table);
+			}
+			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
+			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
+			query_scopes.pop_back();
+			break;
+		}
+		case QueryNodeType::SET_OPERATION_NODE: {
+			auto &set_operation = node.Cast<SetOperationNode>();
+			for (auto &child : set_operation.children) {
+				VisitQueryNode(*child);
+			}
+			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
+			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
+			break;
+		}
+		case QueryNodeType::RECURSIVE_CTE_NODE: {
+			auto &recursive_cte = node.Cast<RecursiveCTENode>();
+			VisitQueryNode(*recursive_cte.left);
+			VisitQueryNode(*recursive_cte.right);
+			for (auto &target : recursive_cte.key_targets) {
+				VisitExpression(*target);
+			}
+			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
+			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
+			break;
+		}
+		default:
+			serializable = false;
+			break;
+		}
+	}
+
+private:
+	string child_alias;
+	vector<vector<string>> query_scopes;
+	bool serializable = true;
+};
+
+} // namespace
+
 bool Relation::CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression) {
 	if (!child.CanSerializeToQueryNode()) {
 		return false;
 	}
-	if (!RequiresDirectRelationBinding(child) || RequiresSQLMultiSourceBinding(child)) {
+	if (!ExposesMultiSourceBindings(child) || RequiresSQLMultiSourceBinding(child)) {
 		return true;
 	}
 
-	// A semantic boundary above a join is emitted as a subquery. Only the
-	// subquery alias survives that boundary; qualified references to the join's
-	// original inputs would produce SQL that cannot bind.
-	auto child_alias = child.GetAlias();
-	bool serializable = true;
-	ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
-	    expression, [&](const ColumnRefExpression &column_ref) {
-		    if (column_ref.IsQualified() && !StringUtil::CIEquals(column_ref.GetTableName(), child_alias)) {
-			    serializable = false;
-		    }
-	    });
-	ParsedExpressionIterator::VisitExpression<StarExpression>(expression, [&](const StarExpression &star) {
-		auto references_other_table = [&](const QualifiedColumnName &column) {
-			return column.IsQualified() && !StringUtil::CIEquals(column.table, child_alias);
-		};
-		if ((!star.relation_name.empty() && !StringUtil::CIEquals(star.relation_name, child_alias)) ||
-		    std::any_of(star.exclude_list.begin(), star.exclude_list.end(), references_other_table) ||
-		    std::any_of(star.rename_list.begin(), star.rename_list.end(),
-		                [&](const auto &entry) { return references_other_table(entry.first); })) {
-			serializable = false;
-		}
-	});
-	return serializable;
+	// A semantic boundary above a join is emitted as a subquery. Check every
+	// qualified reference against the aliases that survive that boundary and
+	// against aliases introduced by nested query scopes.
+	return SerializedExpressionScopeChecker(child.GetAlias()).Check(expression);
 }
 
 unique_ptr<TableRef> Relation::BindRelationInput(Binder &binder, Relation &child) {

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -28,8 +28,13 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_binder/relation_binder.hpp"
+#include "duckdb/planner/expression_binder/where_binder.hpp"
+#include "duckdb/planner/table_binding.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/main/relation/join_relation.hpp"
@@ -266,6 +271,236 @@ BoundStatement Relation::Bind(Binder &binder) {
 	SelectStatement stmt;
 	stmt.node = GetQueryNode();
 	return binder.Bind(stmt.Cast<SQLStatement>());
+}
+
+bool Relation::CanMapColumnBindings(Relation &relation) {
+	if (relation.InheritsColumnBindings()) {
+		auto child = relation.ChildRelation();
+		if (child) {
+			return CanMapColumnBindings(*child);
+		}
+	}
+	switch (relation.type) {
+	case RelationType::JOIN_RELATION: {
+		auto &join = relation.Cast<JoinRelation>();
+		if (!join.using_columns.empty() || !join.condition || join.join_ref_type != JoinRefType::REGULAR ||
+		    join.join_type != JoinType::INNER) {
+			return false;
+		}
+		return CanMapColumnBindings(*join.left) && CanMapColumnBindings(*join.right);
+	}
+	case RelationType::CROSS_PRODUCT_RELATION: {
+		auto &cross = relation.Cast<CrossProductRelation>();
+		return CanMapColumnBindings(*cross.left) && CanMapColumnBindings(*cross.right);
+	}
+	default:
+		return true;
+	}
+}
+
+struct RelationBindingGroup {
+	string alias;
+	idx_t column_count;
+};
+
+static void CollectBindingGroups(Relation &relation, vector<RelationBindingGroup> &groups) {
+	if (relation.InheritsColumnBindings()) {
+		auto child = relation.ChildRelation();
+		if (child) {
+			CollectBindingGroups(*child, groups);
+			return;
+		}
+	}
+	switch (relation.type) {
+	case RelationType::JOIN_RELATION: {
+		auto &join = relation.Cast<JoinRelation>();
+		if (join.join_type == JoinType::SEMI || join.join_type == JoinType::ANTI) {
+			CollectBindingGroups(*join.left, groups);
+			return;
+		}
+		if (join.join_type == JoinType::RIGHT_SEMI || join.join_type == JoinType::RIGHT_ANTI) {
+			CollectBindingGroups(*join.right, groups);
+			return;
+		}
+		CollectBindingGroups(*join.left, groups);
+		CollectBindingGroups(*join.right, groups);
+		return;
+	}
+	case RelationType::CROSS_PRODUCT_RELATION: {
+		auto &cross = relation.Cast<CrossProductRelation>();
+		CollectBindingGroups(*cross.left, groups);
+		CollectBindingGroups(*cross.right, groups);
+		return;
+	}
+	default:
+		groups.push_back({relation.GetAlias(), relation.Columns().size()});
+		return;
+	}
+}
+
+class MappedRelationBinding : public Binding {
+public:
+	MappedRelationBinding(string alias, vector<string> names, vector<LogicalType> types,
+	                      vector<ColumnBinding> column_bindings_p)
+	    : Binding(BindingType::BASE, BindingAlias(std::move(alias)), std::move(types), std::move(names),
+	              column_bindings_p.empty() ? DConstants::INVALID_INDEX : column_bindings_p[0].table_index),
+	      column_bindings(std::move(column_bindings_p)) {
+		D_ASSERT(column_bindings.size() == this->names.size());
+	}
+
+	BindResult Bind(ColumnRefExpression &colref, idx_t depth) override {
+		column_t column_index;
+		if (!TryGetBindingIndex(colref.GetColumnName(), column_index)) {
+			return BindResult(ColumnNotFoundError(colref.GetColumnName()));
+		}
+		if (colref.GetAlias().empty()) {
+			colref.SetAlias(names[column_index]);
+		}
+		return BindResult(make_uniq<BoundColumnRefExpression>(colref.GetName(), types[column_index],
+		                                                      column_bindings[column_index], depth));
+	}
+
+private:
+	vector<ColumnBinding> column_bindings;
+};
+
+shared_ptr<Binder> Relation::CreateBinderForBoundRelation(Binder &binder, Relation &relation,
+                                                          const BoundStatement &bound_relation) {
+	auto bindings = bound_relation.plan->GetColumnBindings();
+	D_ASSERT(bindings.size() == bound_relation.names.size());
+	D_ASSERT(bindings.size() == bound_relation.types.size());
+
+	struct BindingColumns {
+		idx_t table_index;
+		vector<string> names;
+		vector<LogicalType> types;
+		vector<ColumnBinding> bindings;
+	};
+	vector<BindingColumns> binding_columns;
+	unordered_map<idx_t, idx_t> binding_positions;
+	for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
+		const auto &binding = bindings[column_idx];
+		auto entry = binding_positions.find(binding.table_index);
+		if (entry == binding_positions.end()) {
+			binding_positions.emplace(binding.table_index, binding_columns.size());
+			binding_columns.push_back({binding.table_index, {}, {}, {}});
+			entry = binding_positions.find(binding.table_index);
+		}
+		auto &columns = binding_columns[entry->second];
+		if (columns.names.size() <= binding.column_index) {
+			columns.names.resize(binding.column_index + 1);
+			columns.types.resize(binding.column_index + 1);
+			columns.bindings.resize(binding.column_index + 1);
+		}
+		columns.names[binding.column_index] = bound_relation.names[column_idx];
+		columns.types[binding.column_index] = bound_relation.types[column_idx];
+		columns.bindings[binding.column_index] = binding;
+	}
+
+	for (auto &columns : binding_columns) {
+		for (idx_t column_idx = 0; column_idx < columns.names.size(); column_idx++) {
+			if (columns.names[column_idx].empty() ||
+			    columns.bindings[column_idx].table_index == DConstants::INVALID_INDEX) {
+				throw InternalException("Failed to build relation bindings: missing column at index %llu", column_idx);
+			}
+		}
+	}
+
+	vector<RelationBindingGroup> relation_groups;
+	CollectBindingGroups(relation, relation_groups);
+	case_insensitive_map_t<bool> used_aliases;
+	auto child_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
+	auto add_binding = [&](string alias, vector<string> names, vector<LogicalType> types,
+	                       vector<ColumnBinding> bindings) {
+		QueryResult::DeduplicateColumns(names);
+		if (alias.empty() || used_aliases.find(alias) != used_aliases.end()) {
+			alias = StringUtil::Format("__relation_%llu", bindings[0].table_index);
+		}
+		while (used_aliases.find(alias) != used_aliases.end()) {
+			alias += "_";
+		}
+		used_aliases.emplace(alias, true);
+		child_binder->bind_context.AddBinding(make_uniq<MappedRelationBinding>(std::move(alias), std::move(names),
+		                                                                       std::move(types), std::move(bindings)));
+	};
+
+	bool mapped_relation_groups = relation_groups.size() == binding_columns.size();
+	if (mapped_relation_groups) {
+		for (idx_t group_idx = 0; group_idx < relation_groups.size(); group_idx++) {
+			if (relation_groups[group_idx].column_count != binding_columns[group_idx].names.size()) {
+				mapped_relation_groups = false;
+				break;
+			}
+		}
+	}
+	if (mapped_relation_groups) {
+		for (idx_t group_idx = 0; group_idx < relation_groups.size(); group_idx++) {
+			auto &columns = binding_columns[group_idx];
+			add_binding(relation_groups[group_idx].alias, std::move(columns.names), std::move(columns.types),
+			            std::move(columns.bindings));
+		}
+		return child_binder;
+	}
+
+	if (binding_columns.size() == 1 && relation_groups.size() > 1) {
+		auto &columns = binding_columns[0];
+		idx_t total_columns = 0;
+		for (auto &group : relation_groups) {
+			total_columns += group.column_count;
+		}
+		if (total_columns == columns.names.size()) {
+			idx_t offset = 0;
+			for (auto &group : relation_groups) {
+				vector<string> names(columns.names.begin() + offset,
+				                     columns.names.begin() + offset + group.column_count);
+				vector<LogicalType> types(columns.types.begin() + offset,
+				                          columns.types.begin() + offset + group.column_count);
+				vector<ColumnBinding> bindings(columns.bindings.begin() + offset,
+				                               columns.bindings.begin() + offset + group.column_count);
+				add_binding(group.alias, std::move(names), std::move(types), std::move(bindings));
+				offset += group.column_count;
+			}
+			return child_binder;
+		}
+	}
+
+	for (auto &columns : binding_columns) {
+		auto alias = binding_columns.size() == 1 ? relation.GetAlias() : string();
+		add_binding(std::move(alias), std::move(columns.names), std::move(columns.types), std::move(columns.bindings));
+	}
+	return child_binder;
+}
+
+unique_ptr<Expression> Relation::BindExpressionOnBoundRelation(Binder &binder, Relation &relation,
+                                                               BoundStatement &bound_relation,
+                                                               unique_ptr<ParsedExpression> expression,
+                                                               const string &operation) {
+	auto child_binder = CreateBinderForBoundRelation(binder, relation, bound_relation);
+	unique_ptr<Expression> bound_expression;
+	if (operation == "filter") {
+		child_binder->BindWhereStarExpression(expression);
+		ExpressionBinder::QualifyColumnNames(*child_binder, expression);
+		WhereBinder where_binder(*child_binder, binder.context);
+		bound_expression = where_binder.Bind(expression);
+	} else {
+		ExpressionBinder::QualifyColumnNames(*child_binder, expression);
+		RelationBinder relation_binder(*child_binder, binder.context, operation);
+		bound_expression = relation_binder.Bind(expression);
+	}
+	if (!bound_expression) {
+		throw InternalException("Failed to bind %s expression", operation);
+	}
+	child_binder->PlanSubqueries(bound_expression, bound_relation.plan);
+	binder.MoveCorrelatedExpressionsFrom(*child_binder);
+	return bound_expression;
+}
+
+BoundStatement Relation::BindSelectNodeOnChild(Binder &binder, Relation &child, BoundStatement child_bound,
+                                               unique_ptr<SelectNode> select_node) {
+	auto child_binder = CreateBinderForBoundRelation(binder, child, child_bound);
+	auto result = child_binder->BindSelectNode(*select_node, std::move(child_bound));
+	binder.MoveCorrelatedExpressionsFrom(*child_binder);
+	return result;
 }
 
 shared_ptr<Relation> Relation::InsertRel(const string &schema_name, const string &table_name) {

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -295,7 +295,7 @@ bool Relation::RequiresDirectRelationBinding(Relation &child) {
 	if (!child.CanSerializeToQueryNode()) {
 		return child.CanBindAsInput();
 	}
-	return ExposesMultiSourceBindings(child);
+	return child.InheritsColumnBindings() || ExposesMultiSourceBindings(child);
 }
 
 bool Relation::ExposesMultiSourceBindings(Relation &child) {
@@ -322,7 +322,16 @@ namespace {
 
 class SerializedExpressionScopeChecker {
 public:
-	explicit SerializedExpressionScopeChecker(string child_alias_p) : child_alias(std::move(child_alias_p)) {
+	explicit SerializedExpressionScopeChecker(Relation &child) : child_alias(child.GetAlias()) {
+		for (auto &column : child.Columns()) {
+			serialized_columns.push_back(column.Name());
+		}
+		auto source = &child;
+		while (source->InheritsColumnBindings()) {
+			source = source->ChildRelation();
+			D_ASSERT(source);
+		}
+		CollectRelationBindings(*source, hidden_bindings);
 	}
 
 	bool Check(const ParsedExpression &expression) {
@@ -331,18 +340,176 @@ public:
 	}
 
 private:
+	struct ScopedBinding {
+		string catalog;
+		string schema;
+		string alias;
+		vector<string> columns;
+	};
+
+	static bool Matches(const string &left, const string &right) {
+		return StringUtil::CIEquals(left, right);
+	}
+
+	static bool HasColumn(const ScopedBinding &binding, const string &column_name) {
+		return std::any_of(binding.columns.begin(), binding.columns.end(),
+		                   [&](const string &column) { return Matches(column, column_name); });
+	}
+
+	static bool HasAlias(const vector<ScopedBinding> &scope, const string &alias) {
+		return std::any_of(scope.begin(), scope.end(),
+		                   [&](const ScopedBinding &binding) { return Matches(binding.alias, alias); });
+	}
+
+	void CollectRelationBindings(Relation &relation, vector<ScopedBinding> &bindings) {
+		switch (relation.type) {
+		case RelationType::JOIN_RELATION: {
+			auto &join = relation.Cast<JoinRelation>();
+			CollectRelationBindings(*join.left, bindings);
+			CollectRelationBindings(*join.right, bindings);
+			return;
+		}
+		case RelationType::CROSS_PRODUCT_RELATION: {
+			auto &cross_product = relation.Cast<CrossProductRelation>();
+			CollectRelationBindings(*cross_product.left, bindings);
+			CollectRelationBindings(*cross_product.right, bindings);
+			return;
+		}
+		default:
+			break;
+		}
+		ScopedBinding binding;
+		binding.alias = relation.GetAlias();
+		for (auto &column : relation.Columns()) {
+			binding.columns.push_back(column.Name());
+		}
+		if (relation.type == RelationType::TABLE_RELATION) {
+			binding.columns.emplace_back("rowid");
+		} else if (relation.type == RelationType::TABLE_FUNCTION_RELATION) {
+			for (auto &column_name : relation.Cast<TableFunctionRelation>().GetVirtualColumnNames()) {
+				binding.columns.push_back(column_name);
+			}
+		}
+		bindings.push_back(std::move(binding));
+	}
+
 	bool QualifierIsVisible(const string &qualifier) const {
 		if (StringUtil::CIEquals(qualifier, child_alias)) {
 			return true;
 		}
 		for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
-			for (auto &alias : *scope) {
-				if (StringUtil::CIEquals(qualifier, alias)) {
-					return true;
-				}
+			if (HasAlias(*scope, qualifier)) {
+				return true;
 			}
 		}
 		return false;
+	}
+
+	bool BindingMatchesHiddenReference(const ScopedBinding &binding, const ColumnRefExpression &column_ref) const {
+		auto &names = column_ref.column_names;
+		D_ASSERT(names.size() >= 2);
+		// The binder tries table.column, schema.table.column, and
+		// catalog.schema.table.column before interpreting the leading name as a
+		// struct column. Any remaining names are struct fields.
+		idx_t max_table_position = MinValue<idx_t>(2, names.size() - 2);
+		for (idx_t table_position = 0; table_position <= max_table_position; table_position++) {
+			if (Matches(binding.alias, names[table_position]) && HasColumn(binding, names[table_position + 1])) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool ScopeBindsReference(const vector<ScopedBinding> &scope, const ColumnRefExpression &column_ref) const {
+		auto &names = column_ref.column_names;
+		D_ASSERT(names.size() >= 2);
+		for (auto &binding : scope) {
+			// table.column followed by zero or more struct fields
+			if (Matches(binding.alias, names[0]) && HasColumn(binding, names[1])) {
+				return true;
+			}
+			// catalog.schema.table.column or schema.table.column
+			if (names.size() == 3 && Matches(binding.alias, names[1]) && HasColumn(binding, names[2]) &&
+			    ((!binding.catalog.empty() && Matches(binding.catalog, names[0])) ||
+			     (!binding.schema.empty() && Matches(binding.schema, names[0])))) {
+				return true;
+			}
+			if (names.size() >= 4 && Matches(binding.catalog, names[0]) && Matches(binding.schema, names[1]) &&
+			    Matches(binding.alias, names[2]) && HasColumn(binding, names[3])) {
+				return true;
+			}
+		}
+		// If the leading name is a column in this scope, the binder interprets
+		// the remaining names as struct fields before trying an outer scope.
+		return std::any_of(scope.begin(), scope.end(),
+		                   [&](const ScopedBinding &binding) { return HasColumn(binding, names[0]); });
+	}
+
+	bool ReferencesHiddenBinding(const ColumnRefExpression &column_ref) const {
+		if (!column_ref.IsQualified()) {
+			auto &column_name = column_ref.GetColumnName();
+			bool hidden_column =
+			    std::any_of(hidden_bindings.begin(), hidden_bindings.end(),
+			                [&](const ScopedBinding &binding) { return HasColumn(binding, column_name); });
+			bool serialized_column = std::any_of(serialized_columns.begin(), serialized_columns.end(),
+			                                     [&](const string &column) { return Matches(column, column_name); });
+			if (!hidden_column || serialized_column) {
+				return false;
+			}
+			for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
+				if (std::any_of(scope->begin(), scope->end(),
+				                [&](const ScopedBinding &binding) { return HasColumn(binding, column_name); })) {
+					return false;
+				}
+			}
+			return true;
+		}
+		auto &names = column_ref.column_names;
+		if (!child_alias.empty() && Matches(child_alias, names[0]) &&
+		    std::any_of(serialized_columns.begin(), serialized_columns.end(),
+		                [&](const string &column) { return Matches(column, names[1]); })) {
+			// A single-source unary boundary is emitted with the child's alias, so
+			// its materialized output columns remain qualified by that alias. Hidden
+			// virtual columns (e.g., rowid) are intentionally absent here.
+			return false;
+		}
+		bool matches_hidden_binding =
+		    std::any_of(hidden_bindings.begin(), hidden_bindings.end(), [&](const ScopedBinding &binding) {
+			    return BindingMatchesHiddenReference(binding, column_ref);
+		    });
+		if (!matches_hidden_binding) {
+			return false;
+		}
+		for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
+			if (ScopeBindsReference(*scope, column_ref)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool HiddenQualifier(const string &qualifier) const {
+		return std::any_of(hidden_bindings.begin(), hidden_bindings.end(),
+		                   [&](const ScopedBinding &binding) { return Matches(binding.alias, qualifier); });
+	}
+
+	void VisitTableRefQuery(QueryNode &node) {
+		// A FROM item's alias belongs to the containing SELECT and is not visible
+		// inside the query that defines that item. Drop only the current SELECT's
+		// scope while descending, retaining any genuinely correlated outer scopes.
+		D_ASSERT(!query_scopes.empty());
+		auto current_scope = std::move(query_scopes.back());
+		query_scopes.pop_back();
+		VisitQueryNode(node);
+		query_scopes.push_back(std::move(current_scope));
+	}
+
+	void VisitTableRefExpression(const ParsedExpression &expression) {
+		D_ASSERT(!query_scopes.empty());
+		auto current_scope = std::move(query_scopes.back());
+		query_scopes.pop_back();
+		VisitExpression(expression);
+		query_scopes.push_back(std::move(current_scope));
 	}
 
 	void VisitExpression(const ParsedExpression &expression) {
@@ -352,7 +519,7 @@ private:
 		switch (expression.GetExpressionClass()) {
 		case ExpressionClass::COLUMN_REF: {
 			auto &column_ref = expression.Cast<ColumnRefExpression>();
-			if (column_ref.IsQualified() && !QualifierIsVisible(column_ref.GetTableName())) {
+			if (ReferencesHiddenBinding(column_ref)) {
 				serializable = false;
 			}
 			return;
@@ -360,9 +527,14 @@ private:
 		case ExpressionClass::STAR: {
 			auto &star = expression.Cast<StarExpression>();
 			auto references_hidden_table = [&](const QualifiedColumnName &column) {
-				return column.IsQualified() && !QualifierIsVisible(column.table);
+				if (!column.IsQualified()) {
+					return false;
+				}
+				ColumnRefExpression column_ref(column.column, column.table);
+				return ReferencesHiddenBinding(column_ref);
 			};
-			if ((!star.relation_name.empty() && !QualifierIsVisible(star.relation_name)) ||
+			if ((!star.relation_name.empty() && HiddenQualifier(star.relation_name) &&
+			     !QualifierIsVisible(star.relation_name)) ||
 			    std::any_of(star.exclude_list.begin(), star.exclude_list.end(), references_hidden_table) ||
 			    std::any_of(star.rename_list.begin(), star.rename_list.end(),
 			                [&](const auto &entry) { return references_hidden_table(entry.first); })) {
@@ -390,30 +562,79 @@ private:
 		                                            [&](const ParsedExpression &child) { VisitExpression(child); });
 	}
 
-	void CollectTableAliases(const TableRef &ref, vector<string> &aliases) {
+	bool CollectQueryOutputColumns(const QueryNode &node, vector<string> &columns) const {
+		switch (node.type) {
+		case QueryNodeType::SELECT_NODE: {
+			auto &select = node.Cast<SelectNode>();
+			for (auto &expression : select.select_list) {
+				if (expression->GetExpressionClass() == ExpressionClass::STAR) {
+					return false;
+				}
+				columns.push_back(expression->GetName());
+			}
+			return true;
+		}
+		case QueryNodeType::SET_OPERATION_NODE: {
+			auto &set_operation = node.Cast<SetOperationNode>();
+			if (set_operation.children.empty()) {
+				return false;
+			}
+			return CollectQueryOutputColumns(*set_operation.children[0], columns);
+		}
+		case QueryNodeType::RECURSIVE_CTE_NODE:
+			return CollectQueryOutputColumns(*node.Cast<RecursiveCTENode>().left, columns);
+		default:
+			return false;
+		}
+	}
+
+	void CollectTableBindings(const TableRef &ref, vector<ScopedBinding> &bindings) {
 		if (!ref.alias.empty()) {
-			aliases.push_back(ref.alias);
+			ScopedBinding binding;
+			binding.alias = ref.alias;
+			if (ref.type == TableReferenceType::SUBQUERY) {
+				CollectQueryOutputColumns(*ref.Cast<SubqueryRef>().subquery->node, binding.columns);
+			}
+			for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
+				if (i < binding.columns.size()) {
+					binding.columns[i] = ref.column_name_alias[i];
+				} else {
+					binding.columns.push_back(ref.column_name_alias[i]);
+				}
+			}
+			bindings.push_back(std::move(binding));
 			return;
 		}
 		switch (ref.type) {
-		case TableReferenceType::BASE_TABLE:
-			aliases.push_back(ref.Cast<BaseTableRef>().table_name);
+		case TableReferenceType::BASE_TABLE: {
+			auto &base_table = ref.Cast<BaseTableRef>();
+			ScopedBinding binding;
+			binding.catalog = base_table.catalog_name;
+			binding.schema = base_table.schema_name;
+			binding.alias = base_table.table_name;
+			binding.columns = ref.column_name_alias;
+			bindings.push_back(std::move(binding));
 			break;
+		}
 		case TableReferenceType::JOIN: {
 			auto &join = ref.Cast<JoinRef>();
-			CollectTableAliases(*join.left, aliases);
-			CollectTableAliases(*join.right, aliases);
+			CollectTableBindings(*join.left, bindings);
+			CollectTableBindings(*join.right, bindings);
 			break;
 		}
 		case TableReferenceType::TABLE_FUNCTION: {
 			auto &table_function = ref.Cast<TableFunctionRef>();
 			if (table_function.function && table_function.function->GetExpressionClass() == ExpressionClass::FUNCTION) {
-				aliases.push_back(table_function.function->Cast<FunctionExpression>().function_name);
+				ScopedBinding binding;
+				binding.alias = table_function.function->Cast<FunctionExpression>().function_name;
+				binding.columns = ref.column_name_alias;
+				bindings.push_back(std::move(binding));
 			}
 			break;
 		}
 		case TableReferenceType::PIVOT:
-			CollectTableAliases(*ref.Cast<PivotRef>().source, aliases);
+			// PIVOT/UNPIVOT creates a new output binding. Its source aliases are
+			// available to the pivot expressions, but not to the containing SELECT.
 			break;
 		default:
 			break;
@@ -429,7 +650,7 @@ private:
 			auto &expression_list = ref.Cast<ExpressionListRef>();
 			for (auto &row : expression_list.values) {
 				for (auto &expression : row) {
-					VisitExpression(*expression);
+					VisitTableRefExpression(*expression);
 				}
 			}
 			break;
@@ -450,40 +671,40 @@ private:
 			auto &pivot = ref.Cast<PivotRef>();
 			VisitTableRef(*pivot.source);
 			for (auto &aggregate : pivot.aggregates) {
-				VisitExpression(*aggregate);
+				VisitTableRefExpression(*aggregate);
 			}
 			for (auto &column : pivot.pivots) {
 				for (auto &expression : column.pivot_expressions) {
-					VisitExpression(*expression);
+					VisitTableRefExpression(*expression);
 				}
 				for (auto &entry : column.entries) {
 					if (entry.expr) {
-						VisitExpression(*entry.expr);
+						VisitTableRefExpression(*entry.expr);
 					}
 				}
 				if (column.subquery) {
-					VisitQueryNode(*column.subquery);
+					VisitTableRefQuery(*column.subquery);
 				}
 			}
 			break;
 		}
 		case TableReferenceType::SUBQUERY: {
 			auto &subquery = ref.Cast<SubqueryRef>();
-			VisitQueryNode(*subquery.subquery->node);
+			VisitTableRefQuery(*subquery.subquery->node);
 			break;
 		}
 		case TableReferenceType::TABLE_FUNCTION: {
 			auto &table_function = ref.Cast<TableFunctionRef>();
-			VisitExpression(*table_function.function);
+			VisitTableRefExpression(*table_function.function);
 			if (table_function.subquery) {
-				VisitQueryNode(*table_function.subquery->node);
+				VisitTableRefQuery(*table_function.subquery->node);
 			}
 			break;
 		}
 		case TableReferenceType::SHOW_REF: {
 			auto &show = ref.Cast<ShowRef>();
 			if (show.query) {
-				VisitQueryNode(*show.query);
+				VisitTableRefQuery(*show.query);
 			}
 			break;
 		}
@@ -508,11 +729,11 @@ private:
 		switch (node.type) {
 		case QueryNodeType::SELECT_NODE: {
 			auto &select = node.Cast<SelectNode>();
-			vector<string> aliases;
+			vector<ScopedBinding> bindings;
 			if (select.from_table) {
-				CollectTableAliases(*select.from_table, aliases);
+				CollectTableBindings(*select.from_table, bindings);
 			}
-			query_scopes.push_back(std::move(aliases));
+			query_scopes.push_back(std::move(bindings));
 			for (auto &expression : select.select_list) {
 				VisitExpression(*expression);
 			}
@@ -564,7 +785,9 @@ private:
 
 private:
 	string child_alias;
-	vector<vector<string>> query_scopes;
+	vector<string> serialized_columns;
+	vector<ScopedBinding> hidden_bindings;
+	vector<vector<ScopedBinding>> query_scopes;
 	bool serializable = true;
 };
 
@@ -574,26 +797,28 @@ bool Relation::CanSerializeExpressionOnChild(Relation &child, const ParsedExpres
 	if (!child.CanSerializeToQueryNode()) {
 		return false;
 	}
-	if (!ExposesMultiSourceBindings(child) || RequiresSQLMultiSourceBinding(child)) {
+	if (!child.InheritsColumnBindings() || RequiresSQLMultiSourceBinding(child)) {
 		return true;
 	}
 
-	// A semantic boundary above a join is emitted as a subquery. Check every
-	// qualified reference against the aliases that survive that boundary and
-	// against aliases introduced by nested query scopes.
-	return SerializedExpressionScopeChecker(child.GetAlias()).Check(expression);
+	// An inheriting semantic boundary is emitted as a subquery. Check references
+	// against the columns and aliases that survive that boundary, including
+	// aliases introduced by nested query scopes.
+	return SerializedExpressionScopeChecker(child).Check(expression);
 }
 
 unique_ptr<TableRef> Relation::BindRelationInput(Binder &binder, Relation &child) {
 	// BoundRefWrapper lets the normal SELECT binder consume a non-SQL child
 	// without converting its logical plan back into a QueryNode. Keep the
-	// child's full BindContext for binding-preserving relations and joins.
+	// child's full BindContext for binding-preserving relations and native sources.
 	auto child_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
 	auto child_bound = child.BindAsInput(*child_binder);
 	binder.MoveCorrelatedExpressionsFrom(*child_binder);
 
 	bool multi_source = child.type == RelationType::JOIN_RELATION || child.type == RelationType::CROSS_PRODUCT_RELATION;
-	bool preserves_bindings = child.InheritsColumnBindings() || multi_source;
+	bool native_source =
+	    child.type == RelationType::TABLE_RELATION || child.type == RelationType::TABLE_FUNCTION_RELATION;
+	bool preserves_bindings = child.InheritsColumnBindings() || multi_source || native_source;
 	if (preserves_bindings) {
 		// The bind context is authoritative for the columns that survive an
 		// operator. JoinRef binding retains both inputs in BoundStatement metadata

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -28,19 +28,21 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_subquery_expression.hpp"
+#include "duckdb/planner/expression_binder/relation_binder.hpp"
+#include "duckdb/planner/expression_binder/select_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/query_node/bound_select_node.hpp"
 #include "duckdb/parser/tableref/bound_ref_wrapper.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
-#include "duckdb/parser/query_node/recursive_cte_node.hpp"
-#include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
-#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
-#include "duckdb/parser/tableref/list.hpp"
 #include "duckdb/main/relation/join_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
@@ -253,14 +255,66 @@ string Relation::GetAlias() {
 }
 
 unique_ptr<TableRef> Relation::GetTableRef() {
-	if (!CanSerializeToQueryNode()) {
-		throw NotImplementedException("Cannot create a table reference for a relation that cannot be faithfully "
-		                              "represented as a SQL query node; conversion would discard the exchange or lose "
-		                              "relation bindings");
-	}
+	unique_ptr<TableRef> result;
+	auto client_context = context->GetContext();
+	client_context->RunFunctionInTransaction([&]() {
+		auto binder = Binder::CreateBinder(*client_context);
+		if (!CanSerializeToQueryNodeInternal(*binder)) {
+			throw NotImplementedException(
+			    "Cannot create a table reference for a relation that cannot be faithfully "
+			    "represented as a SQL query node; conversion would discard the exchange or lose "
+			    "relation bindings");
+		}
+		result = GetTableRefInternal();
+	});
+	return result;
+}
+
+unique_ptr<TableRef> Relation::GetTableRefInternal() {
 	auto select = make_uniq<SelectStatement>();
 	select->node = GetQueryNode();
 	return make_uniq<SubqueryRef>(std::move(select), GetAlias());
+}
+
+unique_ptr<TableRef> Relation::GetTableRefForSerialization(Relation &relation) {
+	return relation.GetTableRefInternal();
+}
+
+bool Relation::CanSerializeToQueryNode() {
+	bool result = false;
+	auto client_context = context->GetContext();
+	client_context->RunFunctionInTransaction([&]() {
+		auto binder = Binder::CreateBinder(*client_context);
+		result = CanSerializeToQueryNodeInternal(*binder);
+	});
+	return result;
+}
+
+unique_ptr<QueryNode> Relation::TryGetSerializableQueryNode() {
+	unique_ptr<QueryNode> result;
+	auto client_context = context->GetContext();
+	client_context->RunFunctionInTransaction([&]() {
+		auto binder = Binder::CreateBinder(*client_context);
+		result = TryGetSerializableQueryNode(*binder);
+	});
+	return result;
+}
+
+unique_ptr<QueryNode> Relation::TryGetSerializableQueryNode(Binder &binder) {
+	if (!CanSerializeToQueryNodeInternal(binder)) {
+		return nullptr;
+	}
+	return GetQueryNode();
+}
+
+bool Relation::CanBindAsInput() {
+	bool result = false;
+	auto client_context = context->GetContext();
+	client_context->RunFunctionInTransaction([&]() {
+		auto binder = Binder::CreateBinder(*client_context);
+		result = CanBindAsInputInternal(*binder);
+	});
+	return result;
 }
 
 unique_ptr<QueryResult> Relation::Execute() {
@@ -277,13 +331,14 @@ unique_ptr<QueryResult> Relation::ExecuteOrThrow() {
 }
 
 BoundStatement Relation::Bind(Binder &binder) {
-	if (!CanSerializeToQueryNode()) {
+	auto query_node = TryGetSerializableQueryNode(binder);
+	if (!query_node) {
 		throw NotImplementedException(
 		    "Cannot bind a relation that cannot be faithfully represented as a SQL query node; "
 		    "conversion would discard the exchange or lose relation bindings");
 	}
 	SelectStatement stmt;
-	stmt.node = GetQueryNode();
+	stmt.node = std::move(query_node);
 	return binder.Bind(stmt.Cast<SQLStatement>());
 }
 
@@ -291,9 +346,9 @@ BoundStatement Relation::BindAsInput(Binder &binder) {
 	return Bind(binder);
 }
 
-bool Relation::RequiresDirectRelationBinding(Relation &child) {
-	if (!child.CanSerializeToQueryNode()) {
-		return child.CanBindAsInput();
+bool Relation::RequiresDirectRelationBinding(Binder &binder, Relation &child) {
+	if (!child.CanSerializeToQueryNodeInternal(binder)) {
+		return child.CanBindAsInputInternal(binder);
 	}
 	return child.InheritsColumnBindings() || ExposesMultiSourceBindings(child);
 }
@@ -322,10 +377,13 @@ namespace {
 
 class SerializedExpressionScopeChecker {
 public:
-	explicit SerializedExpressionScopeChecker(Relation &child) : child_alias(child.GetAlias()) {
+	SerializedExpressionScopeChecker(Binder &binder, Relation &child, BoundRefWrapper &bound_child)
+	    : child_alias(child.GetAlias()), serialization_parent_binder(binder), bound_child_binder(*bound_child.binder) {
 		for (auto &column : child.Columns()) {
 			serialized_columns.push_back(column.Name());
+			serialized_types.push_back(column.Type());
 		}
+		serialized_columns = BindContext::AliasColumnNames(child_alias, serialized_columns, {});
 		auto source = &child;
 		while (source->InheritsColumnBindings()) {
 			source = source->ChildRelation();
@@ -336,16 +394,283 @@ public:
 
 	bool Check(const ParsedExpression &expression) {
 		VisitExpression(expression);
-		return serializable;
+		return serializable && BoundExpressionBindingsMatch(expression);
 	}
 
 private:
+	struct ResolvedCorrelation {
+		ColumnBinding binding;
+		idx_t depth;
+
+		bool operator==(const ResolvedCorrelation &other) const {
+			return binding == other.binding && depth == other.depth;
+		}
+	};
+
 	struct ScopedBinding {
-		string catalog;
-		string schema;
 		string alias;
 		vector<string> columns;
 	};
+
+	static void AddCorrelation(vector<ResolvedCorrelation> &correlations, ColumnBinding binding, idx_t depth) {
+		ResolvedCorrelation correlation {binding, depth};
+		if (std::find(correlations.begin(), correlations.end(), correlation) == correlations.end()) {
+			correlations.push_back(std::move(correlation));
+		}
+	}
+
+	static void CollectColumnBindings(const Expression &expression, vector<ColumnBinding> &bindings) {
+		ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
+		    expression, [&](const BoundColumnRefExpression &column_ref) {
+			    if (std::find(bindings.begin(), bindings.end(), column_ref.binding) == bindings.end()) {
+				    bindings.push_back(column_ref.binding);
+			    }
+		    });
+	}
+
+	static void InitializeSelectNode(Binder &binder, BoundSelectNode &node) {
+		node.projection_index = binder.GenerateTableIndex();
+		node.group_index = binder.GenerateTableIndex();
+		node.aggregate_index = binder.GenerateTableIndex();
+		node.groupings_index = binder.GenerateTableIndex();
+		node.window_index = binder.GenerateTableIndex();
+		node.prune_index = binder.GenerateTableIndex();
+	}
+
+	static bool CollectSyntheticBinding(const BoundColumnRefExpression &column_ref, const BoundSelectNode &node,
+	                                    vector<ResolvedCorrelation> &bindings) {
+		auto &binding = column_ref.binding;
+		if (binding.table_index == node.aggregate_index) {
+			if (binding.column_index >= node.aggregates.size()) {
+				throw InternalException("Aggregate binding is out of range while checking relation serialization");
+			}
+			CollectBoundExpressionBindings(*node.aggregates[binding.column_index], node, bindings);
+			return true;
+		}
+		if (binding.table_index == node.window_index) {
+			if (binding.column_index >= node.windows.size()) {
+				throw InternalException("Window binding is out of range while checking relation serialization");
+			}
+			CollectBoundExpressionBindings(*node.windows[binding.column_index], node, bindings);
+			return true;
+		}
+		if (binding.table_index == node.group_index) {
+			if (binding.column_index >= node.groups.group_expressions.size()) {
+				throw InternalException("Group binding is out of range while checking relation serialization");
+			}
+			CollectBoundExpressionBindings(*node.groups.group_expressions[binding.column_index], node, bindings);
+			return true;
+		}
+		if (binding.table_index == node.groupings_index) {
+			for (auto &group : node.groups.group_expressions) {
+				CollectBoundExpressionBindings(*group, node, bindings);
+			}
+			return true;
+		}
+		for (auto &entry : node.unnests) {
+			auto &unnest = entry.second;
+			if (binding.table_index != unnest.index) {
+				continue;
+			}
+			if (binding.column_index >= unnest.expressions.size()) {
+				throw InternalException("Unnest binding is out of range while checking relation serialization");
+			}
+			CollectBoundExpressionBindings(*unnest.expressions[binding.column_index], node, bindings);
+			return true;
+		}
+		return false;
+	}
+
+	static void CollectBoundExpressionBindings(const Expression &expression, const BoundSelectNode &node,
+	                                           vector<ResolvedCorrelation> &bindings) {
+		if (expression.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY) {
+			auto &subquery = expression.Cast<BoundSubqueryExpression>();
+			for (auto &correlation : subquery.binder->correlated_columns) {
+				AddCorrelation(bindings, correlation.binding, correlation.depth);
+			}
+		}
+		if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
+			auto &column_ref = expression.Cast<BoundColumnRefExpression>();
+			if (!CollectSyntheticBinding(column_ref, node, bindings)) {
+				AddCorrelation(bindings, column_ref.binding, column_ref.depth);
+			}
+			return;
+		}
+		ExpressionIterator::EnumerateChildren(
+		    expression, [&](const Expression &child) { CollectBoundExpressionBindings(child, node, bindings); });
+	}
+
+	static bool TryBindExpression(Binder &binder, const ParsedExpression &expression,
+	                              vector<ResolvedCorrelation> &bindings, unique_ptr<ParsedExpression> &bound_copy) {
+		bound_copy = expression.Copy();
+		BoundSelectNode node;
+		InitializeSelectNode(binder, node);
+		BoundGroupInformation group_info;
+		try {
+			SelectBinder expression_binder(binder, binder.context, node, group_info);
+			auto bound_expression = expression_binder.Bind(bound_copy);
+			CollectBoundExpressionBindings(*bound_expression, node, bindings);
+			return true;
+		} catch (Exception &ex) {
+			ErrorData error(ex);
+			if (error.Type() != ExceptionType::BINDER) {
+				throw;
+			}
+			return false;
+		}
+	}
+
+	bool NormalizeSerializedBindings(const vector<ResolvedCorrelation> &bindings,
+	                                 vector<ResolvedCorrelation> &normalized) const {
+		for (auto &binding : bindings) {
+			if (binding.binding.table_index != serialized_table_index) {
+				AddCorrelation(normalized, binding.binding, binding.depth);
+				continue;
+			}
+			if (binding.binding.column_index >= serialized_output_origins.size()) {
+				return false;
+			}
+			for (auto &origin : serialized_output_origins[binding.binding.column_index]) {
+				AddCorrelation(normalized, origin, binding.depth);
+			}
+		}
+		return true;
+	}
+
+	static bool BindingsMatch(const vector<ResolvedCorrelation> &left, const vector<ResolvedCorrelation> &right) {
+		if (left.size() != right.size()) {
+			return false;
+		}
+		return std::all_of(left.begin(), left.end(), [&](const auto &binding) {
+			return std::find(right.begin(), right.end(), binding) != right.end();
+		});
+	}
+
+	bool BoundExpressionBindingsMatch(const ParsedExpression &expression) {
+		if (!InitializeSubqueryScopes()) {
+			return false;
+		}
+
+		vector<ResolvedCorrelation> direct_bindings;
+		unique_ptr<ParsedExpression> direct_copy;
+		auto direct_bound = TryBindExpression(bound_child_binder, expression, direct_bindings, direct_copy);
+		vector<ResolvedCorrelation> serialized_bindings;
+		unique_ptr<ParsedExpression> serialized_copy;
+		auto serialized_bound =
+		    TryBindExpression(*serialized_scope_binder, expression, serialized_bindings, serialized_copy);
+
+		if (!direct_bound) {
+			// Binding can expand a macro before rejecting an expression class that is
+			// not valid in a synthetic SELECT. Inspect that expanded tree so hidden
+			// qualifiers introduced by the macro are still detected.
+			VisitExpression(*direct_copy);
+			if (serialized_bound) {
+				return false;
+			}
+			return serializable;
+		}
+		if (!serialized_bound) {
+			return false;
+		}
+
+		vector<ResolvedCorrelation> normalized_bindings;
+		if (!NormalizeSerializedBindings(serialized_bindings, normalized_bindings)) {
+			return false;
+		}
+		return BindingsMatch(direct_bindings, normalized_bindings);
+	}
+
+	bool InitializeSubqueryScopes() {
+		if (serialized_scope_binder) {
+			return serializable;
+		}
+		serialized_scope_binder =
+		    Binder::CreateBinder(serialization_parent_binder.context, &serialization_parent_binder);
+		serialized_table_index = serialized_scope_binder->GenerateTableIndex();
+		serialized_scope_binder->bind_context.AddGenericBinding(serialized_table_index, child_alias, serialized_columns,
+		                                                        serialized_types);
+		ResolveSerializedOutputOrigins();
+		return serializable;
+	}
+
+	void ResolveSerializedOutputOrigins() {
+		vector<unique_ptr<ParsedExpression>> output_columns;
+		StarExpression star;
+		bound_child_binder.bind_context.GenerateAllColumnExpressions(star, output_columns);
+		if (output_columns.size() != serialized_columns.size()) {
+			serializable = false;
+			return;
+		}
+
+		RelationBinder relation_binder(bound_child_binder, bound_child_binder.context, "relation serialization");
+		serialized_output_origins.reserve(output_columns.size());
+		for (auto &column : output_columns) {
+			auto bound_column = relation_binder.Bind(column);
+			vector<ColumnBinding> origins;
+			CollectColumnBindings(*bound_column, origins);
+			if (origins.empty()) {
+				serializable = false;
+				return;
+			}
+			serialized_output_origins.push_back(std::move(origins));
+		}
+	}
+
+	bool TryBindSubquery(const QueryNode &node, Binder &parent, vector<ResolvedCorrelation> &correlations) const {
+		try {
+			auto query = node.Copy();
+			// Correlated lookup walks the active expression binders rather than
+			// Binder parent contexts alone.
+			RelationBinder outer_binder(parent, parent.context, "relation serialization");
+			auto query_binder = Binder::CreateBinder(parent.context, &parent);
+			query_binder->Bind(*query);
+			for (auto &correlation : query_binder->correlated_columns) {
+				AddCorrelation(correlations, correlation.binding, correlation.depth);
+			}
+			return true;
+		} catch (Exception &ex) {
+			ErrorData error(ex);
+			if (error.Type() != ExceptionType::BINDER) {
+				throw;
+			}
+			return false;
+		}
+	}
+
+	bool SubqueryBindingsMatch(const QueryNode &node) {
+		if (!InitializeSubqueryScopes()) {
+			return false;
+		}
+		vector<ResolvedCorrelation> direct_correlations;
+		if (!TryBindSubquery(node, bound_child_binder, direct_correlations)) {
+			return false;
+		}
+		vector<ResolvedCorrelation> serialized_correlations;
+		if (!TryBindSubquery(node, *serialized_scope_binder, serialized_correlations)) {
+			return false;
+		}
+
+		vector<ResolvedCorrelation> normalized_correlations;
+		for (auto &correlation : serialized_correlations) {
+			if (correlation.binding.table_index != serialized_table_index) {
+				AddCorrelation(normalized_correlations, correlation.binding, correlation.depth);
+				continue;
+			}
+			if (correlation.binding.column_index >= serialized_output_origins.size()) {
+				return false;
+			}
+			for (auto &origin : serialized_output_origins[correlation.binding.column_index]) {
+				AddCorrelation(normalized_correlations, origin, correlation.depth);
+			}
+		}
+		if (direct_correlations.size() != normalized_correlations.size()) {
+			return false;
+		}
+		return std::all_of(direct_correlations.begin(), direct_correlations.end(), [&](const auto &correlation) {
+			return std::find(normalized_correlations.begin(), normalized_correlations.end(), correlation) !=
+			       normalized_correlations.end();
+		});
+	}
 
 	static bool Matches(const string &left, const string &right) {
 		return StringUtil::CIEquals(left, right);
@@ -354,11 +679,6 @@ private:
 	static bool HasColumn(const ScopedBinding &binding, const string &column_name) {
 		return std::any_of(binding.columns.begin(), binding.columns.end(),
 		                   [&](const string &column) { return Matches(column, column_name); });
-	}
-
-	static bool HasAlias(const vector<ScopedBinding> &scope, const string &alias) {
-		return std::any_of(scope.begin(), scope.end(),
-		                   [&](const ScopedBinding &binding) { return Matches(binding.alias, alias); });
 	}
 
 	void CollectRelationBindings(Relation &relation, vector<ScopedBinding> &bindings) {
@@ -383,6 +703,7 @@ private:
 		for (auto &column : relation.Columns()) {
 			binding.columns.push_back(column.Name());
 		}
+		binding.columns = BindContext::AliasColumnNames(binding.alias, binding.columns, {});
 		if (relation.type == RelationType::TABLE_RELATION) {
 			binding.columns.emplace_back("rowid");
 		} else if (relation.type == RelationType::TABLE_FUNCTION_RELATION) {
@@ -394,15 +715,7 @@ private:
 	}
 
 	bool QualifierIsVisible(const string &qualifier) const {
-		if (StringUtil::CIEquals(qualifier, child_alias)) {
-			return true;
-		}
-		for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
-			if (HasAlias(*scope, qualifier)) {
-				return true;
-			}
-		}
-		return false;
+		return StringUtil::CIEquals(qualifier, child_alias);
 	}
 
 	bool BindingMatchesHiddenReference(const ScopedBinding &binding, const ColumnRefExpression &column_ref) const {
@@ -420,31 +733,6 @@ private:
 		return false;
 	}
 
-	bool ScopeBindsReference(const vector<ScopedBinding> &scope, const ColumnRefExpression &column_ref) const {
-		auto &names = column_ref.column_names;
-		D_ASSERT(names.size() >= 2);
-		for (auto &binding : scope) {
-			// table.column followed by zero or more struct fields
-			if (Matches(binding.alias, names[0]) && HasColumn(binding, names[1])) {
-				return true;
-			}
-			// catalog.schema.table.column or schema.table.column
-			if (names.size() == 3 && Matches(binding.alias, names[1]) && HasColumn(binding, names[2]) &&
-			    ((!binding.catalog.empty() && Matches(binding.catalog, names[0])) ||
-			     (!binding.schema.empty() && Matches(binding.schema, names[0])))) {
-				return true;
-			}
-			if (names.size() >= 4 && Matches(binding.catalog, names[0]) && Matches(binding.schema, names[1]) &&
-			    Matches(binding.alias, names[2]) && HasColumn(binding, names[3])) {
-				return true;
-			}
-		}
-		// If the leading name is a column in this scope, the binder interprets
-		// the remaining names as struct fields before trying an outer scope.
-		return std::any_of(scope.begin(), scope.end(),
-		                   [&](const ScopedBinding &binding) { return HasColumn(binding, names[0]); });
-	}
-
 	bool ReferencesHiddenBinding(const ColumnRefExpression &column_ref) const {
 		if (!column_ref.IsQualified()) {
 			auto &column_name = column_ref.GetColumnName();
@@ -455,12 +743,6 @@ private:
 			                                     [&](const string &column) { return Matches(column, column_name); });
 			if (!hidden_column || serialized_column) {
 				return false;
-			}
-			for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
-				if (std::any_of(scope->begin(), scope->end(),
-				                [&](const ScopedBinding &binding) { return HasColumn(binding, column_name); })) {
-					return false;
-				}
 			}
 			return true;
 		}
@@ -480,36 +762,12 @@ private:
 		if (!matches_hidden_binding) {
 			return false;
 		}
-		for (auto scope = query_scopes.rbegin(); scope != query_scopes.rend(); scope++) {
-			if (ScopeBindsReference(*scope, column_ref)) {
-				return false;
-			}
-		}
 		return true;
 	}
 
 	bool HiddenQualifier(const string &qualifier) const {
 		return std::any_of(hidden_bindings.begin(), hidden_bindings.end(),
 		                   [&](const ScopedBinding &binding) { return Matches(binding.alias, qualifier); });
-	}
-
-	void VisitTableRefQuery(QueryNode &node) {
-		// A FROM item's alias belongs to the containing SELECT and is not visible
-		// inside the query that defines that item. Drop only the current SELECT's
-		// scope while descending, retaining any genuinely correlated outer scopes.
-		D_ASSERT(!query_scopes.empty());
-		auto current_scope = std::move(query_scopes.back());
-		query_scopes.pop_back();
-		VisitQueryNode(node);
-		query_scopes.push_back(std::move(current_scope));
-	}
-
-	void VisitTableRefExpression(const ParsedExpression &expression) {
-		D_ASSERT(!query_scopes.empty());
-		auto current_scope = std::move(query_scopes.back());
-		query_scopes.pop_back();
-		VisitExpression(expression);
-		query_scopes.push_back(std::move(current_scope));
 	}
 
 	void VisitExpression(const ParsedExpression &expression) {
@@ -552,7 +810,9 @@ private:
 				serializable = false;
 				return;
 			}
-			VisitQueryNode(*subquery.subquery->node);
+			if (!SubqueryBindingsMatch(*subquery.subquery->node)) {
+				serializable = false;
+			}
 			return;
 		}
 		default:
@@ -562,249 +822,39 @@ private:
 		                                            [&](const ParsedExpression &child) { VisitExpression(child); });
 	}
 
-	bool CollectQueryOutputColumns(const QueryNode &node, vector<string> &columns) const {
-		switch (node.type) {
-		case QueryNodeType::SELECT_NODE: {
-			auto &select = node.Cast<SelectNode>();
-			for (auto &expression : select.select_list) {
-				if (expression->GetExpressionClass() == ExpressionClass::STAR) {
-					return false;
-				}
-				columns.push_back(expression->GetName());
-			}
-			return true;
-		}
-		case QueryNodeType::SET_OPERATION_NODE: {
-			auto &set_operation = node.Cast<SetOperationNode>();
-			if (set_operation.children.empty()) {
-				return false;
-			}
-			return CollectQueryOutputColumns(*set_operation.children[0], columns);
-		}
-		case QueryNodeType::RECURSIVE_CTE_NODE:
-			return CollectQueryOutputColumns(*node.Cast<RecursiveCTENode>().left, columns);
-		default:
-			return false;
-		}
-	}
-
-	void CollectTableBindings(const TableRef &ref, vector<ScopedBinding> &bindings) {
-		if (!ref.alias.empty()) {
-			ScopedBinding binding;
-			binding.alias = ref.alias;
-			if (ref.type == TableReferenceType::SUBQUERY) {
-				CollectQueryOutputColumns(*ref.Cast<SubqueryRef>().subquery->node, binding.columns);
-			}
-			for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
-				if (i < binding.columns.size()) {
-					binding.columns[i] = ref.column_name_alias[i];
-				} else {
-					binding.columns.push_back(ref.column_name_alias[i]);
-				}
-			}
-			bindings.push_back(std::move(binding));
-			return;
-		}
-		switch (ref.type) {
-		case TableReferenceType::BASE_TABLE: {
-			auto &base_table = ref.Cast<BaseTableRef>();
-			ScopedBinding binding;
-			binding.catalog = base_table.catalog_name;
-			binding.schema = base_table.schema_name;
-			binding.alias = base_table.table_name;
-			binding.columns = ref.column_name_alias;
-			bindings.push_back(std::move(binding));
-			break;
-		}
-		case TableReferenceType::JOIN: {
-			auto &join = ref.Cast<JoinRef>();
-			CollectTableBindings(*join.left, bindings);
-			CollectTableBindings(*join.right, bindings);
-			break;
-		}
-		case TableReferenceType::TABLE_FUNCTION: {
-			auto &table_function = ref.Cast<TableFunctionRef>();
-			if (table_function.function && table_function.function->GetExpressionClass() == ExpressionClass::FUNCTION) {
-				ScopedBinding binding;
-				binding.alias = table_function.function->Cast<FunctionExpression>().function_name;
-				binding.columns = ref.column_name_alias;
-				bindings.push_back(std::move(binding));
-			}
-			break;
-		}
-		case TableReferenceType::PIVOT:
-			// PIVOT/UNPIVOT creates a new output binding. Its source aliases are
-			// available to the pivot expressions, but not to the containing SELECT.
-			break;
-		default:
-			break;
-		}
-	}
-
-	void VisitTableRef(TableRef &ref) {
-		if (!serializable) {
-			return;
-		}
-		switch (ref.type) {
-		case TableReferenceType::EXPRESSION_LIST: {
-			auto &expression_list = ref.Cast<ExpressionListRef>();
-			for (auto &row : expression_list.values) {
-				for (auto &expression : row) {
-					VisitTableRefExpression(*expression);
-				}
-			}
-			break;
-		}
-		case TableReferenceType::JOIN: {
-			auto &join = ref.Cast<JoinRef>();
-			VisitTableRef(*join.left);
-			VisitTableRef(*join.right);
-			if (join.condition) {
-				VisitExpression(*join.condition);
-			}
-			for (auto &expression : join.duplicate_eliminated_columns) {
-				VisitExpression(*expression);
-			}
-			break;
-		}
-		case TableReferenceType::PIVOT: {
-			auto &pivot = ref.Cast<PivotRef>();
-			VisitTableRef(*pivot.source);
-			for (auto &aggregate : pivot.aggregates) {
-				VisitTableRefExpression(*aggregate);
-			}
-			for (auto &column : pivot.pivots) {
-				for (auto &expression : column.pivot_expressions) {
-					VisitTableRefExpression(*expression);
-				}
-				for (auto &entry : column.entries) {
-					if (entry.expr) {
-						VisitTableRefExpression(*entry.expr);
-					}
-				}
-				if (column.subquery) {
-					VisitTableRefQuery(*column.subquery);
-				}
-			}
-			break;
-		}
-		case TableReferenceType::SUBQUERY: {
-			auto &subquery = ref.Cast<SubqueryRef>();
-			VisitTableRefQuery(*subquery.subquery->node);
-			break;
-		}
-		case TableReferenceType::TABLE_FUNCTION: {
-			auto &table_function = ref.Cast<TableFunctionRef>();
-			VisitTableRefExpression(*table_function.function);
-			if (table_function.subquery) {
-				VisitTableRefQuery(*table_function.subquery->node);
-			}
-			break;
-		}
-		case TableReferenceType::SHOW_REF: {
-			auto &show = ref.Cast<ShowRef>();
-			if (show.query) {
-				VisitTableRefQuery(*show.query);
-			}
-			break;
-		}
-		case TableReferenceType::BASE_TABLE:
-		case TableReferenceType::EMPTY_FROM:
-		case TableReferenceType::COLUMN_DATA:
-		case TableReferenceType::DELIM_GET:
-			break;
-		default:
-			serializable = false;
-			break;
-		}
-	}
-
-	void VisitQueryNode(QueryNode &node) {
-		if (!serializable) {
-			return;
-		}
-		for (auto &entry : node.cte_map.map) {
-			VisitQueryNode(*entry.second->query->node);
-		}
-		switch (node.type) {
-		case QueryNodeType::SELECT_NODE: {
-			auto &select = node.Cast<SelectNode>();
-			vector<ScopedBinding> bindings;
-			if (select.from_table) {
-				CollectTableBindings(*select.from_table, bindings);
-			}
-			query_scopes.push_back(std::move(bindings));
-			for (auto &expression : select.select_list) {
-				VisitExpression(*expression);
-			}
-			for (auto &expression : select.groups.group_expressions) {
-				VisitExpression(*expression);
-			}
-			if (select.where_clause) {
-				VisitExpression(*select.where_clause);
-			}
-			if (select.having) {
-				VisitExpression(*select.having);
-			}
-			if (select.qualify) {
-				VisitExpression(*select.qualify);
-			}
-			if (select.from_table) {
-				VisitTableRef(*select.from_table);
-			}
-			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
-			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
-			query_scopes.pop_back();
-			break;
-		}
-		case QueryNodeType::SET_OPERATION_NODE: {
-			auto &set_operation = node.Cast<SetOperationNode>();
-			for (auto &child : set_operation.children) {
-				VisitQueryNode(*child);
-			}
-			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
-			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
-			break;
-		}
-		case QueryNodeType::RECURSIVE_CTE_NODE: {
-			auto &recursive_cte = node.Cast<RecursiveCTENode>();
-			VisitQueryNode(*recursive_cte.left);
-			VisitQueryNode(*recursive_cte.right);
-			for (auto &target : recursive_cte.key_targets) {
-				VisitExpression(*target);
-			}
-			ParsedExpressionIterator::EnumerateQueryNodeModifiers(
-			    node, [&](unique_ptr<ParsedExpression> &expression) { VisitExpression(*expression); });
-			break;
-		}
-		default:
-			serializable = false;
-			break;
-		}
-	}
-
 private:
 	string child_alias;
 	vector<string> serialized_columns;
+	vector<LogicalType> serialized_types;
 	vector<ScopedBinding> hidden_bindings;
-	vector<vector<ScopedBinding>> query_scopes;
+	Binder &serialization_parent_binder;
+	Binder &bound_child_binder;
+	shared_ptr<Binder> serialized_scope_binder;
+	idx_t serialized_table_index;
+	vector<vector<ColumnBinding>> serialized_output_origins;
 	bool serializable = true;
 };
 
 } // namespace
 
-bool Relation::CanSerializeExpressionOnChild(Relation &child, const ParsedExpression &expression) {
-	if (!child.CanSerializeToQueryNode()) {
-		return false;
-	}
+bool Relation::CanSerializeExpressionOnBoundChild(Binder &binder, Relation &child, TableRef &bound_child,
+                                                  const ParsedExpression &expression) {
 	if (!child.InheritsColumnBindings() || RequiresSQLMultiSourceBinding(child)) {
 		return true;
 	}
+	if (bound_child.type != TableReferenceType::BOUND_TABLE_REF) {
+		throw InternalException("Expected a bound relation input while checking expression serialization");
+	}
+	auto &bound_ref = bound_child.Cast<BoundRefWrapper>();
+	if (!bound_ref.binder) {
+		throw InternalException("Bound relation input is missing its binder");
+	}
 
 	// An inheriting semantic boundary is emitted as a subquery. Check references
-	// against the columns and aliases that survive that boundary, including
-	// aliases introduced by nested query scopes.
-	return SerializedExpressionScopeChecker(child).Check(expression);
+	// against the columns and aliases that survive that boundary. Nested query
+	// scopes are resolved by the Binder in both the direct and serialized inputs,
+	// then compared by their underlying column bindings.
+	return SerializedExpressionScopeChecker(binder, child, bound_ref).Check(expression);
 }
 
 unique_ptr<TableRef> Relation::BindRelationInput(Binder &binder, Relation &child) {
@@ -843,6 +893,34 @@ BoundStatement Relation::BindSelectNodeOnChild(Binder &binder, Relation &child, 
 	SelectStatement stmt;
 	stmt.node = std::move(select_node);
 	return binder.Bind(stmt.Cast<SQLStatement>());
+}
+
+unique_ptr<SelectNode> Relation::WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
+                                               const vector<ColumnDefinition> &columns) {
+	auto statement = make_uniq<SelectStatement>();
+	statement->node = std::move(query_node);
+	auto result = make_uniq<SelectNode>();
+	result->from_table = make_uniq<SubqueryRef>(std::move(statement), alias);
+	vector<string> output_names;
+	output_names.reserve(columns.size());
+	for (auto &column : columns) {
+		output_names.push_back(column.Name());
+	}
+	auto input_names = BindContext::AliasColumnNames(alias, output_names, {});
+	for (idx_t column_idx = 0; column_idx < output_names.size(); column_idx++) {
+		unique_ptr<ColumnRefExpression> column_ref;
+		if (alias.empty()) {
+			column_ref = make_uniq<ColumnRefExpression>(input_names[column_idx]);
+		} else {
+			column_ref = make_uniq<ColumnRefExpression>(input_names[column_idx], alias);
+		}
+		column_ref->SetAlias(output_names[column_idx]);
+		result->select_list.push_back(std::move(column_ref));
+	}
+	if (result->select_list.empty()) {
+		result->select_list.push_back(make_uniq<StarExpression>());
+	}
+	return result;
 }
 
 unique_ptr<LogicalOperator> Relation::PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
@@ -1030,10 +1108,19 @@ string Relation::ToString() {
 
 // LCOV_EXCL_START
 string Relation::GetQuery() {
-	if (!CanSerializeToQueryNode()) {
+	auto query_node = TryGetSerializableQueryNode();
+	if (!query_node) {
 		return string();
 	}
-	return GetQueryNode()->ToString();
+	return query_node->ToString();
+}
+
+string Relation::GetQuery(Binder &binder) {
+	auto query_node = TryGetSerializableQueryNode(binder);
+	if (!query_node) {
+		return string();
+	}
+	return query_node->ToString();
 }
 
 void Relation::Head(idx_t limit) {

--- a/external/duckdb/src/main/relation/aggregate_relation.cpp
+++ b/external/duckdb/src/main/relation/aggregate_relation.cpp
@@ -91,7 +91,7 @@ BoundStatement AggregateRelation::Bind(Binder &binder) {
 }
 
 bool AggregateRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
-	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+	if (!ChildCanSerializeToQueryNode(*child, binder)) {
 		return false;
 	}
 	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {

--- a/external/duckdb/src/main/relation/aggregate_relation.cpp
+++ b/external/duckdb/src/main/relation/aggregate_relation.cpp
@@ -1,7 +1,14 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/aggregate_relation.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -40,16 +47,12 @@ AggregateRelation::AggregateRelation(shared_ptr<Relation> child_p,
 }
 
 unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
-	auto child_ptr = child.get();
-	while (child_ptr->InheritsColumnBindings()) {
-		child_ptr = child_ptr->ChildRelation();
-	}
 	unique_ptr<QueryNode> result;
-	if (child_ptr->type == RelationType::JOIN_RELATION) {
-		// child node is a join: push projection into the child query node
+	if (RequiresSQLMultiSourceBinding(*child)) {
+		// The child has multiple source bindings: push aggregation into its query node.
 		result = child->GetQueryNode();
 	} else {
-		// child node is not a join: create a new select node and push the child as a table reference
+		// The child has one source binding: create a new select node around its table reference.
 		auto select = make_uniq<SelectNode>();
 		select->from_table = child->GetTableRef();
 		result = std::move(select);
@@ -68,6 +71,37 @@ unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
 		select_node.select_list.push_back(expr->Copy());
 	}
 	return result;
+}
+
+BoundStatement AggregateRelation::Bind(Binder &binder) {
+	if (!RequiresDirectRelationBinding(*child)) {
+		return Relation::Bind(binder);
+	}
+	auto select_node = make_uniq<SelectNode>();
+	if (!groups.group_expressions.empty()) {
+		select_node->aggregate_handling = AggregateHandling::STANDARD_HANDLING;
+		select_node->groups = groups.Copy();
+	} else {
+		select_node->aggregate_handling = AggregateHandling::FORCE_AGGREGATES;
+	}
+	for (auto &expr : expressions) {
+		select_node->select_list.push_back(expr->Copy());
+	}
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
+}
+
+bool AggregateRelation::CanSerializeToQueryNode() {
+	for (auto &expression : expressions) {
+		if (!CanSerializeExpressionOnChild(*child, *expression)) {
+			return false;
+		}
+	}
+	for (auto &group : groups.group_expressions) {
+		if (!CanSerializeExpressionOnChild(*child, *group)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 string AggregateRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/aggregate_relation.cpp
+++ b/external/duckdb/src/main/relation/aggregate_relation.cpp
@@ -54,7 +54,7 @@ unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
 	} else {
 		// The child has one source binding: create a new select node around its table reference.
 		auto select = make_uniq<SelectNode>();
-		select->from_table = child->GetTableRef();
+		select->from_table = GetTableRefForSerialization(*child);
 		result = std::move(select);
 	}
 	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
@@ -74,7 +74,7 @@ unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
 }
 
 BoundStatement AggregateRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();
@@ -90,14 +90,22 @@ BoundStatement AggregateRelation::Bind(Binder &binder) {
 	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
 }
 
-bool AggregateRelation::CanSerializeToQueryNode() {
+bool AggregateRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
+	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+		return false;
+	}
+	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {
+		return true;
+	}
+	auto serialization_binder = Binder::CreateBinder(binder.context);
+	auto serialization_input = BindRelationInput(*serialization_binder, *child);
 	for (auto &expression : expressions) {
-		if (!CanSerializeExpressionOnChild(*child, *expression)) {
+		if (!CanSerializeExpressionOnBoundChild(*serialization_binder, *child, *serialization_input, *expression)) {
 			return false;
 		}
 	}
 	for (auto &group : groups.group_expressions) {
-		if (!CanSerializeExpressionOnChild(*child, *group)) {
+		if (!CanSerializeExpressionOnBoundChild(*serialization_binder, *child, *serialization_input, *group)) {
 			return false;
 		}
 	}

--- a/external/duckdb/src/main/relation/create_table_relation.cpp
+++ b/external/duckdb/src/main/relation/create_table_relation.cpp
@@ -29,7 +29,7 @@ CreateTableRelation::CreateTableRelation(shared_ptr<Relation> child_p, string ca
 }
 
 BoundStatement CreateTableRelation::Bind(Binder &binder) {
-	auto query_node = child->TryGetSerializableQueryNode(binder);
+	auto query_node = TryGetSerializableChildQueryNode(*child, binder);
 	if (!query_node) {
 		throw NotImplementedException(
 		    "Cannot create a table from a relation that cannot be faithfully represented as a "

--- a/external/duckdb/src/main/relation/create_table_relation.cpp
+++ b/external/duckdb/src/main/relation/create_table_relation.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/create_table_relation.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
@@ -23,6 +29,11 @@ CreateTableRelation::CreateTableRelation(shared_ptr<Relation> child_p, string ca
 }
 
 BoundStatement CreateTableRelation::Bind(Binder &binder) {
+	if (!child->CanSerializeToQueryNode()) {
+		throw NotImplementedException(
+		    "Cannot create a table from a relation that cannot be faithfully represented as a "
+		    "SQL query node; conversion would discard the exchange or lose relation bindings");
+	}
 	auto select = make_uniq<SelectStatement>();
 	select->node = child->GetQueryNode();
 

--- a/external/duckdb/src/main/relation/create_table_relation.cpp
+++ b/external/duckdb/src/main/relation/create_table_relation.cpp
@@ -29,13 +29,14 @@ CreateTableRelation::CreateTableRelation(shared_ptr<Relation> child_p, string ca
 }
 
 BoundStatement CreateTableRelation::Bind(Binder &binder) {
-	if (!child->CanSerializeToQueryNode()) {
+	auto query_node = child->TryGetSerializableQueryNode(binder);
+	if (!query_node) {
 		throw NotImplementedException(
 		    "Cannot create a table from a relation that cannot be faithfully represented as a "
 		    "SQL query node; conversion would discard the exchange or lose relation bindings");
 	}
 	auto select = make_uniq<SelectStatement>();
-	select->node = child->GetQueryNode();
+	select->node = std::move(query_node);
 
 	CreateStatement stmt;
 	auto info = make_uniq<CreateTableInfo>();

--- a/external/duckdb/src/main/relation/create_view_relation.cpp
+++ b/external/duckdb/src/main/relation/create_view_relation.cpp
@@ -27,7 +27,7 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string sche
 }
 
 BoundStatement CreateViewRelation::Bind(Binder &binder) {
-	auto query_node = child->TryGetSerializableQueryNode(binder);
+	auto query_node = TryGetSerializableChildQueryNode(*child, binder);
 	if (!query_node) {
 		throw NotImplementedException(
 		    "Cannot create a view from a relation that cannot be faithfully represented as a "

--- a/external/duckdb/src/main/relation/create_view_relation.cpp
+++ b/external/duckdb/src/main/relation/create_view_relation.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/create_view_relation.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
@@ -21,6 +27,11 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string sche
 }
 
 BoundStatement CreateViewRelation::Bind(Binder &binder) {
+	if (!child->CanSerializeToQueryNode()) {
+		throw NotImplementedException(
+		    "Cannot create a view from a relation that cannot be faithfully represented as a "
+		    "SQL query node; conversion would discard the exchange or lose relation bindings");
+	}
 	auto select = make_uniq<SelectStatement>();
 	select->node = child->GetQueryNode();
 

--- a/external/duckdb/src/main/relation/create_view_relation.cpp
+++ b/external/duckdb/src/main/relation/create_view_relation.cpp
@@ -27,13 +27,14 @@ CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string sche
 }
 
 BoundStatement CreateViewRelation::Bind(Binder &binder) {
-	if (!child->CanSerializeToQueryNode()) {
+	auto query_node = child->TryGetSerializableQueryNode(binder);
+	if (!query_node) {
 		throw NotImplementedException(
 		    "Cannot create a view from a relation that cannot be faithfully represented as a "
 		    "SQL query node; conversion would discard the exchange or lose relation bindings");
 	}
 	auto select = make_uniq<SelectStatement>();
-	select->node = child->GetQueryNode();
+	select->node = std::move(query_node);
 
 	CreateStatement stmt;
 	auto info = make_uniq<CreateViewInfo>();

--- a/external/duckdb/src/main/relation/cross_product_relation.cpp
+++ b/external/duckdb/src/main/relation/cross_product_relation.cpp
@@ -1,8 +1,15 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/cross_product_relation.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -21,6 +28,14 @@ unique_ptr<QueryNode> CrossProductRelation::GetQueryNode() {
 	result->select_list.push_back(make_uniq<StarExpression>());
 	result->from_table = GetTableRef();
 	return std::move(result);
+}
+
+BoundStatement CrossProductRelation::BindAsInput(Binder &binder) {
+	if (ContainsNonSQLRelation()) {
+		return Relation::Bind(binder);
+	}
+	auto table_ref = GetTableRef();
+	return binder.Bind(*table_ref);
 }
 
 unique_ptr<TableRef> CrossProductRelation::GetTableRef() {

--- a/external/duckdb/src/main/relation/cross_product_relation.cpp
+++ b/external/duckdb/src/main/relation/cross_product_relation.cpp
@@ -26,7 +26,7 @@ CrossProductRelation::CrossProductRelation(shared_ptr<Relation> left_p, shared_p
 unique_ptr<QueryNode> CrossProductRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
@@ -34,14 +34,14 @@ BoundStatement CrossProductRelation::BindAsInput(Binder &binder) {
 	if (ContainsNonSQLRelation()) {
 		return Relation::Bind(binder);
 	}
-	auto table_ref = GetTableRef();
+	auto table_ref = GetTableRefForSerialization(*this);
 	return binder.Bind(*table_ref);
 }
 
-unique_ptr<TableRef> CrossProductRelation::GetTableRef() {
+unique_ptr<TableRef> CrossProductRelation::GetTableRefInternal() {
 	auto cross_product_ref = make_uniq<JoinRef>(ref_type);
-	cross_product_ref->left = left->GetTableRef();
-	cross_product_ref->right = right->GetTableRef();
+	cross_product_ref->left = GetTableRefForSerialization(*left);
+	cross_product_ref->right = GetTableRefForSerialization(*right);
 	return std::move(cross_product_ref);
 }
 

--- a/external/duckdb/src/main/relation/delim_get_relation.cpp
+++ b/external/duckdb/src/main/relation/delim_get_relation.cpp
@@ -14,11 +14,11 @@ DelimGetRelation::DelimGetRelation(const shared_ptr<ClientContext> &context, vec
 unique_ptr<QueryNode> DelimGetRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> DelimGetRelation::GetTableRef() {
+unique_ptr<TableRef> DelimGetRelation::GetTableRefInternal() {
 	auto delim_get_ref = make_uniq<DelimGetRef>(chunk_types);
 	return std::move(delim_get_ref);
 }

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -6,7 +6,9 @@
 
 #include "duckdb/main/relation/distinct_relation.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
@@ -27,16 +29,27 @@ unique_ptr<QueryNode> DistinctRelation::GetQueryNode() {
 }
 
 BoundStatement DistinctRelation::Bind(Binder &binder) {
-	auto child_bound = child->Bind(binder);
+	if (!child->ContainsNonSQLRelation()) {
+		return Relation::Bind(binder);
+	}
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	select_node->AddDistinct();
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
+}
+
+BoundStatement DistinctRelation::BindAsInput(Binder &binder) {
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
 	auto bindings = child_bound.plan->GetColumnBindings();
 	D_ASSERT(bindings.size() == child_bound.names.size());
 	D_ASSERT(bindings.size() == child_bound.types.size());
 
 	vector<unique_ptr<Expression>> targets;
 	targets.reserve(bindings.size());
-	for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
-		unique_ptr<Expression> target = make_uniq<BoundColumnRefExpression>(
-		    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		unique_ptr<Expression> target =
+		    make_uniq<BoundColumnRefExpression>(child_bound.names[i], child_bound.types[i], bindings[i]);
 		ExpressionBinder::PushCollation(binder.context, target, target->return_type);
 		targets.push_back(std::move(target));
 	}

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -29,7 +29,7 @@ unique_ptr<QueryNode> DistinctRelation::GetQueryNode() {
 }
 
 BoundStatement DistinctRelation::Bind(Binder &binder) {
-	if (!child->ContainsNonSQLRelation()) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -62,6 +62,9 @@ BoundStatement DistinctRelation::BindAsInput(Binder &binder) {
 	auto distinct = make_uniq<LogicalDistinct>(std::move(targets), DistinctType::DISTINCT);
 	distinct->AddChild(std::move(child_bound.plan));
 	child_bound.plan = std::move(distinct);
+	// DISTINCT only emits its visible targets. Hidden virtual columns such as
+	// rowid no longer identify a unique output row and must not bind downstream.
+	binder.bind_context.RemoveVirtualColumnBindings();
 	return child_bound;
 }
 

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -42,12 +42,13 @@ BoundStatement DistinctRelation::BindAsInput(Binder &binder) {
 	auto child_ref = BindRelationInput(binder, *child);
 	auto child_bound = binder.Bind(*child_ref);
 	auto bindings = child_bound.plan->GetColumnBindings();
-	D_ASSERT(bindings.size() == child_bound.names.size());
-	D_ASSERT(bindings.size() == child_bound.types.size());
+	if (child_bound.names.size() != child_bound.types.size() || bindings.size() < child_bound.names.size()) {
+		throw InternalException("Distinct relation input metadata does not match its visible column bindings");
+	}
 
 	vector<unique_ptr<Expression>> targets;
-	targets.reserve(bindings.size());
-	for (idx_t i = 0; i < bindings.size(); i++) {
+	targets.reserve(child_bound.names.size());
+	for (idx_t i = 0; i < child_bound.names.size(); i++) {
 		unique_ptr<Expression> target =
 		    make_uniq<BoundColumnRefExpression>(child_bound.names[i], child_bound.types[i], bindings[i]);
 		ExpressionBinder::PushCollation(binder.context, target, target->return_type);

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -24,12 +24,18 @@ DistinctRelation::DistinctRelation(shared_ptr<Relation> child_p)
 
 unique_ptr<QueryNode> DistinctRelation::GetQueryNode() {
 	auto child_node = child->GetQueryNode();
+	bool plain_distinct = child_node->type == QueryNodeType::SELECT_NODE && child_node->modifiers.size() == 1 &&
+	                      child_node->modifiers[0]->type == ResultModifierType::DISTINCT_MODIFIER &&
+	                      child_node->modifiers[0]->Cast<DistinctModifier>().distinct_on_targets.empty();
+	if (child_node->type != QueryNodeType::SELECT_NODE || (!child_node->modifiers.empty() && !plain_distinct)) {
+		child_node = WrapQueryNode(std::move(child_node), child->GetAlias(), child->Columns());
+	}
 	child_node->AddDistinct();
 	return child_node;
 }
 
 BoundStatement DistinctRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -1,6 +1,15 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/distinct_relation.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_distinct.hpp"
 
 namespace duckdb {
 
@@ -15,6 +24,26 @@ unique_ptr<QueryNode> DistinctRelation::GetQueryNode() {
 	auto child_node = child->GetQueryNode();
 	child_node->AddDistinct();
 	return child_node;
+}
+
+BoundStatement DistinctRelation::Bind(Binder &binder) {
+	auto child_bound = child->Bind(binder);
+	auto bindings = child_bound.plan->GetColumnBindings();
+	D_ASSERT(bindings.size() == child_bound.names.size());
+	D_ASSERT(bindings.size() == child_bound.types.size());
+
+	vector<unique_ptr<Expression>> targets;
+	targets.reserve(bindings.size());
+	for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
+		unique_ptr<Expression> target = make_uniq<BoundColumnRefExpression>(
+		    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
+		ExpressionBinder::PushCollation(binder.context, target, target->return_type);
+		targets.push_back(std::move(target));
+	}
+	auto distinct = make_uniq<LogicalDistinct>(std::move(targets), DistinctType::DISTINCT);
+	distinct->AddChild(std::move(child_bound.plan));
+	child_bound.plan = std::move(distinct);
+	return child_bound;
 }
 
 string DistinctRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_binder/relation_binder.hpp"
 #include "duckdb/planner/operator/logical_distinct.hpp"
 
 namespace duckdb {
@@ -41,16 +41,15 @@ BoundStatement DistinctRelation::Bind(Binder &binder) {
 BoundStatement DistinctRelation::BindAsInput(Binder &binder) {
 	auto child_ref = BindRelationInput(binder, *child);
 	auto child_bound = binder.Bind(*child_ref);
-	auto bindings = child_bound.plan->GetColumnBindings();
-	if (child_bound.names.size() != child_bound.types.size() || bindings.size() < child_bound.names.size()) {
-		throw InternalException("Distinct relation input metadata does not match its visible column bindings");
-	}
+	vector<unique_ptr<ParsedExpression>> visible_columns;
+	StarExpression star;
+	binder.bind_context.GenerateAllColumnExpressions(star, visible_columns);
+	RelationBinder relation_binder(binder, binder.context, "distinct");
 
 	vector<unique_ptr<Expression>> targets;
-	targets.reserve(child_bound.names.size());
-	for (idx_t i = 0; i < child_bound.names.size(); i++) {
-		unique_ptr<Expression> target =
-		    make_uniq<BoundColumnRefExpression>(child_bound.names[i], child_bound.types[i], bindings[i]);
+	targets.reserve(visible_columns.size());
+	for (auto &column : visible_columns) {
+		auto target = relation_binder.Bind(column);
 		ExpressionBinder::PushCollation(binder.context, target, target->return_type);
 		targets.push_back(std::move(target));
 	}

--- a/external/duckdb/src/main/relation/explain_relation.cpp
+++ b/external/duckdb/src/main/relation/explain_relation.cpp
@@ -21,7 +21,7 @@ ExplainRelation::ExplainRelation(shared_ptr<Relation> child_p, ExplainType type,
 }
 
 BoundStatement ExplainRelation::Bind(Binder &binder) {
-	auto relation_stmt = make_uniq<RelationStatement>(child);
+	auto relation_stmt = make_uniq<RelationStatement>(child, binder);
 	ExplainStatement explain(std::move(relation_stmt), type, format);
 	return binder.Bind(explain.Cast<SQLStatement>());
 }

--- a/external/duckdb/src/main/relation/filter_relation.cpp
+++ b/external/duckdb/src/main/relation/filter_relation.cpp
@@ -67,7 +67,7 @@ BoundStatement FilterRelation::BindAsInput(Binder &binder) {
 }
 
 bool FilterRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
-	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+	if (!ChildCanSerializeToQueryNode(*child, binder)) {
 		return false;
 	}
 	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {

--- a/external/duckdb/src/main/relation/filter_relation.cpp
+++ b/external/duckdb/src/main/relation/filter_relation.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/expression_binder/where_binder.hpp"
 
 namespace duckdb {
 
@@ -24,12 +24,8 @@ FilterRelation::FilterRelation(shared_ptr<Relation> child_p, unique_ptr<ParsedEx
 }
 
 unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
-	auto child_ptr = child.get();
-	while (child_ptr->InheritsColumnBindings()) {
-		child_ptr = child_ptr->ChildRelation();
-	}
-	if (child_ptr->type == RelationType::JOIN_RELATION) {
-		// child node is a join: push filter into WHERE clause of select node
+	if (RequiresSQLMultiSourceBinding(*child)) {
+		// The child has multiple source bindings: push the filter into its WHERE clause.
 		auto child_node = child->GetQueryNode();
 		D_ASSERT(child_node->type == QueryNodeType::SELECT_NODE);
 		auto &select_node = child_node->Cast<SelectNode>();
@@ -50,15 +46,28 @@ unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
 }
 
 BoundStatement FilterRelation::Bind(Binder &binder) {
-	if (!CanMapColumnBindings(*child)) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
-	auto child_bound = child->Bind(binder);
-	auto bound_condition = BindExpressionOnBoundRelation(binder, *child, child_bound, condition->Copy(), "filter");
-	auto filter = make_uniq<LogicalFilter>(std::move(bound_condition));
-	filter->AddChild(std::move(child_bound.plan));
-	child_bound.plan = std::move(filter);
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	select_node->where_clause = condition->Copy();
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
+}
+
+BoundStatement FilterRelation::BindAsInput(Binder &binder) {
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
+	auto condition_copy = condition->Copy();
+	ExpandRelationFilter(binder, condition_copy);
+	WhereBinder where_binder(binder, binder.context);
+	auto bound_condition = where_binder.Bind(condition_copy);
+	child_bound.plan = PlanRelationFilter(binder, std::move(bound_condition), std::move(child_bound.plan));
 	return child_bound;
+}
+
+bool FilterRelation::CanSerializeToQueryNode() {
+	return CanSerializeExpressionOnChild(*child, *condition);
 }
 
 string FilterRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/filter_relation.cpp
+++ b/external/duckdb/src/main/relation/filter_relation.cpp
@@ -39,14 +39,14 @@ unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
 	} else {
 		auto result = make_uniq<SelectNode>();
 		result->select_list.push_back(make_uniq<StarExpression>());
-		result->from_table = child->GetTableRef();
+		result->from_table = GetTableRefForSerialization(*child);
 		result->where_clause = condition->Copy();
 		return std::move(result);
 	}
 }
 
 BoundStatement FilterRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();
@@ -66,8 +66,16 @@ BoundStatement FilterRelation::BindAsInput(Binder &binder) {
 	return child_bound;
 }
 
-bool FilterRelation::CanSerializeToQueryNode() {
-	return CanSerializeExpressionOnChild(*child, *condition);
+bool FilterRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
+	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+		return false;
+	}
+	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {
+		return true;
+	}
+	auto serialization_binder = Binder::CreateBinder(binder.context);
+	auto serialization_input = BindRelationInput(*serialization_binder, *child);
+	return CanSerializeExpressionOnBoundChild(*serialization_binder, *child, *serialization_input, *condition);
 }
 
 string FilterRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/filter_relation.cpp
+++ b/external/duckdb/src/main/relation/filter_relation.cpp
@@ -1,9 +1,17 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/filter_relation.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/query_node/set_operation_node.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 
 namespace duckdb {
 
@@ -39,6 +47,18 @@ unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
 		result->where_clause = condition->Copy();
 		return std::move(result);
 	}
+}
+
+BoundStatement FilterRelation::Bind(Binder &binder) {
+	if (!CanMapColumnBindings(*child)) {
+		return Relation::Bind(binder);
+	}
+	auto child_bound = child->Bind(binder);
+	auto bound_condition = BindExpressionOnBoundRelation(binder, *child, child_bound, condition->Copy(), "filter");
+	auto filter = make_uniq<LogicalFilter>(std::move(bound_condition));
+	filter->AddChild(std::move(child_bound.plan));
+	child_bound.plan = std::move(filter);
+	return child_bound;
 }
 
 string FilterRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/insert_relation.cpp
+++ b/external/duckdb/src/main/relation/insert_relation.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/insert_relation.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
@@ -20,6 +26,10 @@ InsertRelation::InsertRelation(shared_ptr<Relation> child_p, string catalog_name
 }
 
 BoundStatement InsertRelation::Bind(Binder &binder) {
+	if (!child->CanSerializeToQueryNode()) {
+		throw NotImplementedException("Cannot insert from a relation that cannot be faithfully represented as a SQL "
+		                              "query node; conversion would discard the exchange or lose relation bindings");
+	}
 	InsertStatement stmt;
 	auto select = make_uniq<SelectStatement>();
 	select->node = child->GetQueryNode();

--- a/external/duckdb/src/main/relation/insert_relation.cpp
+++ b/external/duckdb/src/main/relation/insert_relation.cpp
@@ -26,7 +26,7 @@ InsertRelation::InsertRelation(shared_ptr<Relation> child_p, string catalog_name
 }
 
 BoundStatement InsertRelation::Bind(Binder &binder) {
-	auto query_node = child->TryGetSerializableQueryNode(binder);
+	auto query_node = TryGetSerializableChildQueryNode(*child, binder);
 	if (!query_node) {
 		throw NotImplementedException("Cannot insert from a relation that cannot be faithfully represented as a SQL "
 		                              "query node; conversion would discard the exchange or lose relation bindings");

--- a/external/duckdb/src/main/relation/insert_relation.cpp
+++ b/external/duckdb/src/main/relation/insert_relation.cpp
@@ -26,13 +26,14 @@ InsertRelation::InsertRelation(shared_ptr<Relation> child_p, string catalog_name
 }
 
 BoundStatement InsertRelation::Bind(Binder &binder) {
-	if (!child->CanSerializeToQueryNode()) {
+	auto query_node = child->TryGetSerializableQueryNode(binder);
+	if (!query_node) {
 		throw NotImplementedException("Cannot insert from a relation that cannot be faithfully represented as a SQL "
 		                              "query node; conversion would discard the exchange or lose relation bindings");
 	}
 	InsertStatement stmt;
 	auto select = make_uniq<SelectStatement>();
-	select->node = child->GetQueryNode();
+	select->node = std::move(query_node);
 
 	stmt.catalog = catalog_name;
 	stmt.schema = schema_name;

--- a/external/duckdb/src/main/relation/join_relation.cpp
+++ b/external/duckdb/src/main/relation/join_relation.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/join_relation.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
@@ -5,6 +11,7 @@
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/main/client_context_wrapper.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -33,6 +40,14 @@ unique_ptr<QueryNode> JoinRelation::GetQueryNode() {
 	result->select_list.push_back(make_uniq<StarExpression>());
 	result->from_table = GetTableRef();
 	return std::move(result);
+}
+
+BoundStatement JoinRelation::BindAsInput(Binder &binder) {
+	if (ContainsNonSQLRelation()) {
+		return Relation::Bind(binder);
+	}
+	auto table_ref = GetTableRef();
+	return binder.Bind(*table_ref);
 }
 
 unique_ptr<TableRef> JoinRelation::GetTableRef() {

--- a/external/duckdb/src/main/relation/join_relation.cpp
+++ b/external/duckdb/src/main/relation/join_relation.cpp
@@ -38,7 +38,7 @@ JoinRelation::JoinRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> rig
 unique_ptr<QueryNode> JoinRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
@@ -46,14 +46,14 @@ BoundStatement JoinRelation::BindAsInput(Binder &binder) {
 	if (ContainsNonSQLRelation()) {
 		return Relation::Bind(binder);
 	}
-	auto table_ref = GetTableRef();
+	auto table_ref = GetTableRefForSerialization(*this);
 	return binder.Bind(*table_ref);
 }
 
-unique_ptr<TableRef> JoinRelation::GetTableRef() {
+unique_ptr<TableRef> JoinRelation::GetTableRefInternal() {
 	auto join_ref = make_uniq<JoinRef>(join_ref_type);
-	join_ref->left = left->GetTableRef();
-	join_ref->right = right->GetTableRef();
+	join_ref->left = GetTableRefForSerialization(*left);
+	join_ref->right = GetTableRefForSerialization(*right);
 	if (condition) {
 		join_ref->condition = condition->Copy();
 	}

--- a/external/duckdb/src/main/relation/limit_relation.cpp
+++ b/external/duckdb/src/main/relation/limit_relation.cpp
@@ -53,7 +53,7 @@ string LimitRelation::ToString(idx_t depth) {
 }
 
 BoundStatement LimitRelation::Bind(Binder &binder) {
-	if (!child->ContainsNonSQLRelation()) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();

--- a/external/duckdb/src/main/relation/limit_relation.cpp
+++ b/external/duckdb/src/main/relation/limit_relation.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
@@ -52,9 +53,19 @@ string LimitRelation::ToString(idx_t depth) {
 }
 
 BoundStatement LimitRelation::Bind(Binder &binder) {
+	if (!child->ContainsNonSQLRelation()) {
+		return Relation::Bind(binder);
+	}
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	return BindSelectNodeOnChild(binder, *this, std::move(select_node));
+}
+
+BoundStatement LimitRelation::BindAsInput(Binder &binder) {
 	// Bind child directly (NOT through the SQL GetQueryNode() round-trip)
 	// to preserve non-SQL-representable child nodes like LocalExchangeRelation.
-	auto child_bound = child->Bind(binder);
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
 
 	BoundLimitNode limit_val_bound;
 	BoundLimitNode offset_val_bound;

--- a/external/duckdb/src/main/relation/limit_relation.cpp
+++ b/external/duckdb/src/main/relation/limit_relation.cpp
@@ -23,6 +23,12 @@ LimitRelation::LimitRelation(shared_ptr<Relation> child_p, int64_t limit, int64_
 
 unique_ptr<QueryNode> LimitRelation::GetQueryNode() {
 	auto child_node = child->GetQueryNode();
+	if (std::any_of(child_node->modifiers.begin(), child_node->modifiers.end(), [](const auto &modifier) {
+		    return modifier->type == ResultModifierType::LIMIT_MODIFIER ||
+		           modifier->type == ResultModifierType::LIMIT_PERCENT_MODIFIER;
+	    })) {
+		child_node = WrapQueryNode(std::move(child_node), child->GetAlias(), child->Columns());
+	}
 	auto limit_node = make_uniq<LimitModifier>();
 	if (limit >= 0) {
 		limit_node->limit = make_uniq<ConstantExpression>(Value::BIGINT(limit));
@@ -53,7 +59,7 @@ string LimitRelation::ToString(idx_t depth) {
 }
 
 BoundStatement LimitRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();

--- a/external/duckdb/src/main/relation/local_exchange_relation.cpp
+++ b/external/duckdb/src/main/relation/local_exchange_relation.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "duckdb/main/relation/local_exchange_relation.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/common_types.hpp"
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -20,20 +21,8 @@ LocalExchangeRelation::LocalExchangeRelation(shared_ptr<Relation> child_p, idx_t
 }
 
 unique_ptr<QueryNode> LocalExchangeRelation::GetQueryNode() {
-	// LocalExchange has no SQL representation, but we must NOT return
-	// child->GetQueryNode() directly.  Doing so makes this node invisible
-	// to downstream Relation operations (e.g. LimitRelation::GetQueryNode())
-	// which modify the child query node in-place and silently drop the
-	// LOCAL_EXCHANGE from the final plan.
-	//
-	// Instead, wrap the child as a subquery table-reference so that the
-	// child's plan is opaque to the parent.  When this node is actually
-	// bound, LocalExchangeRelation::Bind() (not the base-class SQL path)
-	// is called and properly inserts LogicalLocalExchange.
-	auto select = make_uniq<SelectNode>();
-	select->from_table = child->GetTableRef();
-	select->select_list.push_back(make_uniq<StarExpression>());
-	return std::move(select);
+	throw NotImplementedException(
+	    "A local-exchange relation has no SQL query-node representation; converting it would discard the exchange");
 }
 
 string LocalExchangeRelation::GetQuery() {
@@ -49,7 +38,14 @@ const vector<ColumnDefinition> &LocalExchangeRelation::Columns() {
 }
 
 BoundStatement LocalExchangeRelation::Bind(Binder &binder) {
-	auto child_bound = child->Bind(binder);
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	return BindSelectNodeOnChild(binder, *this, std::move(select_node));
+}
+
+BoundStatement LocalExchangeRelation::BindAsInput(Binder &binder) {
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
 
 	size_t num_partitions_sz = static_cast<size_t>(num_partitions);
 	auto spec = RepartitionSpec::create_random(num_partitions_sz);

--- a/external/duckdb/src/main/relation/materialized_relation.cpp
+++ b/external/duckdb/src/main/relation/materialized_relation.cpp
@@ -30,11 +30,11 @@ MaterializedRelation::MaterializedRelation(const shared_ptr<ClientContext> &cont
 unique_ptr<QueryNode> MaterializedRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> MaterializedRelation::GetTableRef() {
+unique_ptr<TableRef> MaterializedRelation::GetTableRefInternal() {
 	auto table_ref = make_uniq<ColumnDataRef>(collection);
 	for (auto &col : columns) {
 		table_ref->expected_names.push_back(col.Name());

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -6,13 +6,12 @@
 
 #include "duckdb/main/relation/order_relation.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/config.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
 
 namespace duckdb {
@@ -25,83 +24,86 @@ OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> o
 }
 
 unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
-	auto select = make_uniq<SelectNode>();
-	select->from_table = child->GetTableRef();
-	select->select_list.push_back(make_uniq<StarExpression>());
+	unique_ptr<QueryNode> result;
+	if (RequiresSQLMultiSourceBinding(*child)) {
+		result = child->GetQueryNode();
+	} else {
+		auto select = make_uniq<SelectNode>();
+		select->from_table = child->GetTableRef();
+		select->select_list.push_back(make_uniq<StarExpression>());
+		result = std::move(select);
+	}
+	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
+	auto &select = result->Cast<SelectNode>();
 	auto order_node = make_uniq<OrderModifier>();
 	for (idx_t i = 0; i < orders.size(); i++) {
 		order_node->orders.emplace_back(orders[i].type, orders[i].null_order, orders[i].expression->Copy());
 	}
-	select->modifiers.push_back(std::move(order_node));
-	return std::move(select);
+	select.modifiers.push_back(std::move(order_node));
+	return result;
 }
 
 BoundStatement OrderRelation::Bind(Binder &binder) {
-	if (!CanMapColumnBindings(*child)) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
-	bool order_by_all = false;
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	auto order_node = make_uniq<OrderModifier>();
 	for (auto &order : orders) {
-		if (order.expression->HasSubquery() || order.expression->IsAggregate() || order.expression->IsWindow()) {
-			return Relation::Bind(binder);
-		}
-		if (order.expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
-			auto &constant = order.expression->Cast<ConstantExpression>();
-			if (!constant.value.type().IsIntegral()) {
-				return Relation::Bind(binder);
-			}
-		}
-		if (order.expression->GetExpressionType() == ExpressionType::STAR) {
-			auto &star = order.expression->Cast<StarExpression>();
-			if (orders.size() != 1 || !star.exclude_list.empty() || !star.replace_list.empty() || star.expr) {
-				return Relation::Bind(binder);
-			}
-			order_by_all = true;
-		}
+		order_node->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
 	}
+	select_node->modifiers.push_back(std::move(order_node));
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
+}
 
-	auto child_bound = child->Bind(binder);
-	auto bindings = child_bound.plan->GetColumnBindings();
-	D_ASSERT(bindings.size() == child_bound.names.size());
-	D_ASSERT(bindings.size() == child_bound.types.size());
+BoundStatement OrderRelation::BindAsInput(Binder &binder) {
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
+	vector<unique_ptr<ParsedExpression>> visible_columns;
+	ExpandRelationStar(binder, make_uniq<StarExpression>(), visible_columns);
 
 	auto &config = DBConfig::GetConfig(binder.context);
+	ExpressionBinder expression_binder(binder, binder.context);
 	vector<BoundOrderByNode> bound_orders;
 	for (auto &order : orders) {
 		auto order_type = config.ResolveOrder(binder.context, order.type);
 		auto null_order = config.ResolveNullOrder(binder.context, order_type, order.null_order);
-		if (order_by_all) {
-			for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
-				unique_ptr<Expression> expression = make_uniq<BoundColumnRefExpression>(
-				    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
-				ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
-				bound_orders.emplace_back(order_type, null_order, std::move(expression));
+		vector<unique_ptr<ParsedExpression>> order_expressions;
+		ExpandRelationStar(binder, order.expression->Copy(), order_expressions);
+		for (auto &expression : order_expressions) {
+			if (expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
+				auto &constant = expression->Cast<ConstantExpression>();
+				if (constant.value.type().IsIntegral()) {
+					auto position = constant.value.GetValue<int64_t>();
+					if (position <= 0 || static_cast<idx_t>(position) > visible_columns.size()) {
+						throw BinderException("ORDER BY position %lld is not in select list", position);
+					}
+					expression = visible_columns[static_cast<idx_t>(position - 1)]->Copy();
+				}
 			}
-			continue;
-		}
-		if (order.expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
-			auto &constant = order.expression->Cast<ConstantExpression>();
-			auto order_value = constant.value.GetValue<int64_t>();
-			if (order_value <= 0 || NumericCast<idx_t>(order_value) > bindings.size()) {
-				throw BinderException(*order.expression, "ORDER term out of range - should be between 1 and %llu",
-				                      bindings.size());
-			}
-			auto column_idx = NumericCast<idx_t>(order_value - 1);
-			unique_ptr<Expression> expression = make_uniq<BoundColumnRefExpression>(
-			    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
-			ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
-			bound_orders.emplace_back(order_type, null_order, std::move(expression));
-			continue;
-		}
-		auto expression = BindExpressionOnBoundRelation(binder, *child, child_bound, order.expression->Copy(), "order");
-		ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
-		bound_orders.emplace_back(order_type, null_order, std::move(expression));
-	}
 
-	auto logical_order = make_uniq<LogicalOrder>(std::move(bound_orders));
-	logical_order->AddChild(std::move(child_bound.plan));
-	child_bound.plan = std::move(logical_order);
+			auto bound_expression = expression_binder.Bind(expression);
+			ExpressionBinder::PushCollation(binder.context, bound_expression, bound_expression->return_type);
+			bound_orders.emplace_back(order_type, null_order, std::move(bound_expression));
+		}
+	}
+	for (auto &order : bound_orders) {
+		PlanRelationSubqueries(binder, order.expression, child_bound.plan);
+	}
+	auto order = make_uniq<LogicalOrder>(std::move(bound_orders));
+	order->AddChild(std::move(child_bound.plan));
+	child_bound.plan = std::move(order);
 	return child_bound;
+}
+
+bool OrderRelation::CanSerializeToQueryNode() {
+	for (auto &order : orders) {
+		if (!CanSerializeExpressionOnChild(*child, *order.expression)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 string OrderRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -8,13 +8,29 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
-#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
-#include "duckdb/main/config.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_order.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
+
+static void InlineOrderProjection(unique_ptr<Expression> &expression, const LogicalProjection &projection) {
+	if (expression->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &column_ref = expression->Cast<BoundColumnRefExpression>();
+		if (column_ref.binding.table_index == projection.table_index) {
+			if (column_ref.binding.column_index >= projection.expressions.size()) {
+				throw InternalException("Order relation projection reference is out of range");
+			}
+			expression = projection.expressions[column_ref.binding.column_index]->Copy();
+			return;
+		}
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expression, [&](unique_ptr<Expression> &child) { InlineOrderProjection(child, projection); });
+}
 
 OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> orders)
     : Relation(child_p->context, RelationType::ORDER_RELATION), orders(std::move(orders)), child(std::move(child_p)) {
@@ -58,43 +74,44 @@ BoundStatement OrderRelation::Bind(Binder &binder) {
 }
 
 BoundStatement OrderRelation::BindAsInput(Binder &binder) {
-	auto child_ref = BindRelationInput(binder, *child);
-	auto child_bound = binder.Bind(*child_ref);
-	vector<unique_ptr<ParsedExpression>> visible_columns;
-	ExpandRelationStar(binder, make_uniq<StarExpression>(), visible_columns);
-
-	auto &config = DBConfig::GetConfig(binder.context);
-	ExpressionBinder expression_binder(binder, binder.context);
-	vector<BoundOrderByNode> bound_orders;
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	auto order_node = make_uniq<OrderModifier>();
 	for (auto &order : orders) {
-		auto order_type = config.ResolveOrder(binder.context, order.type);
-		auto null_order = config.ResolveNullOrder(binder.context, order_type, order.null_order);
-		vector<unique_ptr<ParsedExpression>> order_expressions;
-		ExpandRelationStar(binder, order.expression->Copy(), order_expressions);
-		for (auto &expression : order_expressions) {
-			if (expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
-				auto &constant = expression->Cast<ConstantExpression>();
-				if (constant.value.type().IsIntegral()) {
-					auto position = constant.value.GetValue<int64_t>();
-					if (position <= 0 || static_cast<idx_t>(position) > visible_columns.size()) {
-						throw BinderException("ORDER BY position %lld is not in select list", position);
-					}
-					expression = visible_columns[static_cast<idx_t>(position - 1)]->Copy();
-				}
-			}
+		order_node->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
+	}
+	select_node->modifiers.push_back(std::move(order_node));
+	auto result = BindSelectNodeOnChild(binder, *child, std::move(select_node));
 
-			auto bound_expression = expression_binder.Bind(expression);
-			ExpressionBinder::PushCollation(binder.context, bound_expression, bound_expression->return_type);
-			bound_orders.emplace_back(order_type, null_order, std::move(bound_expression));
-		}
+	// The SELECT binder evaluates ORDER BY-only expressions in a temporary
+	// projection. Inline those expressions into the LogicalOrder and remove the
+	// projection so the child's table bindings remain visible to later relation
+	// operators. Window, UNNEST, and subquery plan nodes below it are retained.
+	auto root = std::move(result.plan);
+	if (root->type == LogicalProjection::TYPE && root->children.size() == 1 &&
+	    root->children[0]->type == LogicalOrder::TYPE) {
+		root = std::move(root->children[0]);
 	}
-	for (auto &order : bound_orders) {
-		PlanRelationSubqueries(binder, order.expression, child_bound.plan);
+	if (root->type == LogicalProjection::TYPE) {
+		D_ASSERT(root->children.size() == 1);
+		result.plan = std::move(root->children[0]);
+		return result;
 	}
-	auto order = make_uniq<LogicalOrder>(std::move(bound_orders));
-	order->AddChild(std::move(child_bound.plan));
-	child_bound.plan = std::move(order);
-	return child_bound;
+	if (root->type != LogicalOrder::TYPE || root->children.size() != 1 ||
+	    root->children[0]->type != LogicalProjection::TYPE) {
+		throw InternalException("Unexpected logical plan for an order relation");
+	}
+
+	auto &logical_order = root->Cast<LogicalOrder>();
+	auto projection_op = std::move(root->children[0]);
+	auto &projection = projection_op->Cast<LogicalProjection>();
+	D_ASSERT(projection.children.size() == 1);
+	for (auto &order : logical_order.orders) {
+		InlineOrderProjection(order.expression, projection);
+	}
+	root->children[0] = std::move(projection.children[0]);
+	result.plan = std::move(root);
+	return result;
 }
 
 bool OrderRelation::CanSerializeToQueryNode() {

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -158,7 +158,7 @@ BoundStatement OrderRelation::BindAsInput(Binder &binder) {
 }
 
 bool OrderRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
-	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+	if (!ChildCanSerializeToQueryNode(*child, binder)) {
 		return false;
 	}
 	if (orders.empty() || !child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -61,9 +61,16 @@ unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
 		result = child->GetQueryNode();
 	} else {
 		auto select = make_uniq<SelectNode>();
-		select->from_table = child->GetTableRef();
+		select->from_table = GetTableRefForSerialization(*child);
 		select->select_list.push_back(make_uniq<StarExpression>());
 		result = std::move(select);
+	}
+	if (std::any_of(result->modifiers.begin(), result->modifiers.end(), [](const auto &modifier) {
+		    return modifier->type == ResultModifierType::ORDER_MODIFIER ||
+		           modifier->type == ResultModifierType::LIMIT_MODIFIER ||
+		           modifier->type == ResultModifierType::LIMIT_PERCENT_MODIFIER;
+	    })) {
+		result = WrapQueryNode(std::move(result), child->GetAlias(), child->Columns());
 	}
 	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
 	auto &select = result->Cast<SelectNode>();
@@ -79,7 +86,7 @@ BoundStatement OrderRelation::Bind(Binder &binder) {
 	if (orders.empty()) {
 		return child->Bind(binder);
 	}
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();
@@ -150,16 +157,19 @@ BoundStatement OrderRelation::BindAsInput(Binder &binder) {
 	return result;
 }
 
-bool OrderRelation::CanSerializeToQueryNode() {
-	if (!child->CanSerializeToQueryNode()) {
+bool OrderRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
+	if (!child->CanSerializeToQueryNodeInternal(binder)) {
 		return false;
 	}
-	for (auto &order : orders) {
-		if (!CanSerializeExpressionOnChild(*child, *order.expression)) {
-			return false;
-		}
+	if (orders.empty() || !child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {
+		return true;
 	}
-	return true;
+	auto serialization_binder = Binder::CreateBinder(binder.context);
+	auto serialization_input = BindRelationInput(*serialization_binder, *child);
+	return std::all_of(orders.begin(), orders.end(), [&](const auto &order) {
+		return CanSerializeExpressionOnBoundChild(*serialization_binder, *child, *serialization_input,
+		                                          *order.expression);
+	});
 }
 
 string OrderRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -1,8 +1,19 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/order_relation.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/operator/logical_order.hpp"
 
 namespace duckdb {
 
@@ -23,6 +34,74 @@ unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
 	}
 	select->modifiers.push_back(std::move(order_node));
 	return std::move(select);
+}
+
+BoundStatement OrderRelation::Bind(Binder &binder) {
+	if (!CanMapColumnBindings(*child)) {
+		return Relation::Bind(binder);
+	}
+	bool order_by_all = false;
+	for (auto &order : orders) {
+		if (order.expression->HasSubquery() || order.expression->IsAggregate() || order.expression->IsWindow()) {
+			return Relation::Bind(binder);
+		}
+		if (order.expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
+			auto &constant = order.expression->Cast<ConstantExpression>();
+			if (!constant.value.type().IsIntegral()) {
+				return Relation::Bind(binder);
+			}
+		}
+		if (order.expression->GetExpressionType() == ExpressionType::STAR) {
+			auto &star = order.expression->Cast<StarExpression>();
+			if (orders.size() != 1 || !star.exclude_list.empty() || !star.replace_list.empty() || star.expr) {
+				return Relation::Bind(binder);
+			}
+			order_by_all = true;
+		}
+	}
+
+	auto child_bound = child->Bind(binder);
+	auto bindings = child_bound.plan->GetColumnBindings();
+	D_ASSERT(bindings.size() == child_bound.names.size());
+	D_ASSERT(bindings.size() == child_bound.types.size());
+
+	auto &config = DBConfig::GetConfig(binder.context);
+	vector<BoundOrderByNode> bound_orders;
+	for (auto &order : orders) {
+		auto order_type = config.ResolveOrder(binder.context, order.type);
+		auto null_order = config.ResolveNullOrder(binder.context, order_type, order.null_order);
+		if (order_by_all) {
+			for (idx_t column_idx = 0; column_idx < bindings.size(); column_idx++) {
+				unique_ptr<Expression> expression = make_uniq<BoundColumnRefExpression>(
+				    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
+				ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
+				bound_orders.emplace_back(order_type, null_order, std::move(expression));
+			}
+			continue;
+		}
+		if (order.expression->GetExpressionClass() == ExpressionClass::CONSTANT) {
+			auto &constant = order.expression->Cast<ConstantExpression>();
+			auto order_value = constant.value.GetValue<int64_t>();
+			if (order_value <= 0 || NumericCast<idx_t>(order_value) > bindings.size()) {
+				throw BinderException(*order.expression, "ORDER term out of range - should be between 1 and %llu",
+				                      bindings.size());
+			}
+			auto column_idx = NumericCast<idx_t>(order_value - 1);
+			unique_ptr<Expression> expression = make_uniq<BoundColumnRefExpression>(
+			    child_bound.names[column_idx], child_bound.types[column_idx], bindings[column_idx]);
+			ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
+			bound_orders.emplace_back(order_type, null_order, std::move(expression));
+			continue;
+		}
+		auto expression = BindExpressionOnBoundRelation(binder, *child, child_bound, order.expression->Copy(), "order");
+		ExpressionBinder::PushCollation(binder.context, expression, expression->return_type);
+		bound_orders.emplace_back(order_type, null_order, std::move(expression));
+	}
+
+	auto logical_order = make_uniq<LogicalOrder>(std::move(bound_orders));
+	logical_order->AddChild(std::move(child_bound.plan));
+	child_bound.plan = std::move(logical_order);
+	return child_bound;
 }
 
 string OrderRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -6,6 +6,7 @@
 
 #include "duckdb/main/relation/order_relation.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
@@ -32,6 +33,18 @@ static void InlineOrderProjection(unique_ptr<Expression> &expression, const Logi
 	    *expression, [&](unique_ptr<Expression> &child) { InlineOrderProjection(child, projection); });
 }
 
+static bool TryGetOrderProjectionIndex(const Expression &expression, idx_t projection_index, idx_t &column_index) {
+	if (expression.type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &column_ref = expression.Cast<BoundColumnRefExpression>();
+	if (column_ref.binding.table_index != projection_index) {
+		return false;
+	}
+	column_index = column_ref.binding.column_index;
+	return true;
+}
+
 OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> orders)
     : Relation(child_p->context, RelationType::ORDER_RELATION), orders(std::move(orders)), child(std::move(child_p)) {
 	D_ASSERT(child.get() != this);
@@ -40,6 +53,9 @@ OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> o
 }
 
 unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
+	if (orders.empty()) {
+		return child->GetQueryNode();
+	}
 	unique_ptr<QueryNode> result;
 	if (RequiresSQLMultiSourceBinding(*child)) {
 		result = child->GetQueryNode();
@@ -60,6 +76,9 @@ unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
 }
 
 BoundStatement OrderRelation::Bind(Binder &binder) {
+	if (orders.empty()) {
+		return child->Bind(binder);
+	}
 	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
@@ -74,6 +93,10 @@ BoundStatement OrderRelation::Bind(Binder &binder) {
 }
 
 BoundStatement OrderRelation::BindAsInput(Binder &binder) {
+	if (orders.empty()) {
+		auto child_ref = BindRelationInput(binder, *child);
+		return binder.Bind(*child_ref);
+	}
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
 	auto order_node = make_uniq<OrderModifier>();
@@ -106,15 +129,31 @@ BoundStatement OrderRelation::BindAsInput(Binder &binder) {
 	auto projection_op = std::move(root->children[0]);
 	auto &projection = projection_op->Cast<LogicalProjection>();
 	D_ASSERT(projection.children.size() == 1);
+	unordered_set<idx_t> seen_projection_columns;
+	vector<BoundOrderByNode> rewritten_orders;
+	rewritten_orders.reserve(logical_order.orders.size());
 	for (auto &order : logical_order.orders) {
+		idx_t projection_column;
+		if (TryGetOrderProjectionIndex(*order.expression, projection.table_index, projection_column) &&
+		    !seen_projection_columns.insert(projection_column).second) {
+			// The SELECT binder shares identical ORDER BY expressions through one
+			// projection slot. A repeated sort key is redundant; dropping it keeps
+			// volatile expressions at one evaluation per input row.
+			continue;
+		}
 		InlineOrderProjection(order.expression, projection);
+		rewritten_orders.push_back(std::move(order));
 	}
+	logical_order.orders = std::move(rewritten_orders);
 	root->children[0] = std::move(projection.children[0]);
 	result.plan = std::move(root);
 	return result;
 }
 
 bool OrderRelation::CanSerializeToQueryNode() {
+	if (!child->CanSerializeToQueryNode()) {
+		return false;
+	}
 	for (auto &order : orders) {
 		if (!CanSerializeExpressionOnChild(*child, *order.expression)) {
 			return false;

--- a/external/duckdb/src/main/relation/projection_relation.cpp
+++ b/external/duckdb/src/main/relation/projection_relation.cpp
@@ -6,6 +6,7 @@
 
 #include "duckdb/main/relation/projection_relation.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
@@ -30,16 +31,12 @@ ProjectionRelation::ProjectionRelation(shared_ptr<Relation> child_p,
 }
 
 unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
-	auto child_ptr = child.get();
-	while (child_ptr->InheritsColumnBindings()) {
-		child_ptr = child_ptr->ChildRelation();
-	}
 	unique_ptr<QueryNode> result;
-	if (child_ptr->type == RelationType::JOIN_RELATION) {
-		// child node is a join: push projection into the child query node
+	if (RequiresSQLMultiSourceBinding(*child)) {
+		// The child has multiple source bindings: push projection into its query node.
 		result = child->GetQueryNode();
 	} else {
-		// child node is not a join: create a new select node and push the child as a table reference
+		// The child has one source binding: create a new select node around its table reference.
 		auto select = make_uniq<SelectNode>();
 		select->from_table = child->GetTableRef();
 		result = std::move(select);
@@ -55,17 +52,25 @@ unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
 }
 
 BoundStatement ProjectionRelation::Bind(Binder &binder) {
-	if (!CanMapColumnBindings(*child)) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
-	auto child_bound = child->Bind(binder);
 	auto select_node = make_uniq<SelectNode>();
 	select_node->aggregate_handling = AggregateHandling::NO_AGGREGATES_ALLOWED;
 	select_node->select_list.reserve(expressions.size());
 	for (auto &expr : expressions) {
 		select_node->select_list.push_back(expr->Copy());
 	}
-	return BindSelectNodeOnChild(binder, *child, std::move(child_bound), std::move(select_node));
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
+}
+
+bool ProjectionRelation::CanSerializeToQueryNode() {
+	for (auto &expression : expressions) {
+		if (!CanSerializeExpressionOnChild(*child, *expression)) {
+			return false;
+		}
+	}
+	return true;
 }
 
 string ProjectionRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/projection_relation.cpp
+++ b/external/duckdb/src/main/relation/projection_relation.cpp
@@ -65,7 +65,7 @@ BoundStatement ProjectionRelation::Bind(Binder &binder) {
 }
 
 bool ProjectionRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
-	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+	if (!ChildCanSerializeToQueryNode(*child, binder)) {
 		return false;
 	}
 	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {

--- a/external/duckdb/src/main/relation/projection_relation.cpp
+++ b/external/duckdb/src/main/relation/projection_relation.cpp
@@ -5,17 +5,11 @@
 // Modified by Vane contributors.
 
 #include "duckdb/main/relation/projection_relation.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression_binder/relation_binder.hpp"
-#include "duckdb/planner/operator/logical_projection.hpp"
-
-#include <unordered_map>
 
 namespace duckdb {
 
@@ -61,87 +55,17 @@ unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
 }
 
 BoundStatement ProjectionRelation::Bind(Binder &binder) {
-	// Preserve the input aliases when projecting directly from a join. Binding
-	// the child plan first collapses the join output into a single binding.
-	if (child->type == RelationType::JOIN_RELATION) {
+	if (!CanMapColumnBindings(*child)) {
 		return Relation::Bind(binder);
 	}
-
 	auto child_bound = child->Bind(binder);
-
-	auto bindings = child_bound.plan->GetColumnBindings();
-	D_ASSERT(bindings.size() == child_bound.names.size());
-	D_ASSERT(bindings.size() == child_bound.types.size());
-
-	std::unordered_map<idx_t, vector<string>> names_by_table;
-	std::unordered_map<idx_t, vector<LogicalType>> types_by_table;
-
-	for (idx_t i = 0; i < bindings.size(); i++) {
-		const auto &binding = bindings[i];
-		auto &names = names_by_table[binding.table_index];
-		auto &types = types_by_table[binding.table_index];
-		if (names.size() <= binding.column_index) {
-			names.resize(binding.column_index + 1);
-			types.resize(binding.column_index + 1);
-		}
-		names[binding.column_index] = child_bound.names[i];
-		types[binding.column_index] = child_bound.types[i];
-	}
-
-	for (auto &entry : names_by_table) {
-		auto &names = entry.second;
-		for (idx_t i = 0; i < names.size(); i++) {
-			if (names[i].empty()) {
-				throw InternalException("Failed to build projection bindings: missing column at index %llu", i);
-			}
-		}
-	}
-
-	auto expr_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
-	bool single_binding = names_by_table.size() == 1;
-	for (auto &entry : names_by_table) {
-		auto table_index = entry.first;
-		auto &names = entry.second;
-		auto &types = types_by_table[table_index];
-		string alias = single_binding ? child->GetAlias() : StringUtil::Format("__projection_%llu", table_index);
-		expr_binder->bind_context.AddGenericBinding(table_index, alias, names, types);
-	}
-
-	vector<unique_ptr<ParsedExpression>> projection_exprs;
-	projection_exprs.reserve(expressions.size());
+	auto select_node = make_uniq<SelectNode>();
+	select_node->aggregate_handling = AggregateHandling::NO_AGGREGATES_ALLOWED;
+	select_node->select_list.reserve(expressions.size());
 	for (auto &expr : expressions) {
-		if (StarExpression::IsStar(*expr) || StarExpression::IsColumns(*expr) ||
-		    StarExpression::IsColumnsUnpacked(*expr)) {
-			return Relation::Bind(binder);
-		}
-		projection_exprs.push_back(expr->Copy());
+		select_node->select_list.push_back(expr->Copy());
 	}
-
-	RelationBinder relation_binder(*expr_binder, binder.context, "projection");
-	vector<unique_ptr<Expression>> bound_expressions;
-	bound_expressions.reserve(projection_exprs.size());
-
-	BoundStatement result;
-	for (auto &expr : projection_exprs) {
-		ExpressionBinder::QualifyColumnNames(*expr_binder, expr);
-		auto bound_expr = relation_binder.Bind(expr);
-		if (!bound_expr) {
-			throw InternalException("Failed to bind projection expression");
-		}
-		result.names.push_back(bound_expr->GetName());
-		result.types.push_back(bound_expr->return_type);
-		bound_expressions.push_back(std::move(bound_expr));
-	}
-	if (bound_expressions.empty()) {
-		throw BinderException("Projection list is empty");
-	}
-
-	auto projection = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(bound_expressions));
-	projection->AddChild(std::move(child_bound.plan));
-	result.plan = std::move(projection);
-
-	binder.MoveCorrelatedExpressionsFrom(*expr_binder);
-	return result;
+	return BindSelectNodeOnChild(binder, *child, std::move(child_bound), std::move(select_node));
 }
 
 string ProjectionRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/projection_relation.cpp
+++ b/external/duckdb/src/main/relation/projection_relation.cpp
@@ -38,7 +38,7 @@ unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
 	} else {
 		// The child has one source binding: create a new select node around its table reference.
 		auto select = make_uniq<SelectNode>();
-		select->from_table = child->GetTableRef();
+		select->from_table = GetTableRefForSerialization(*child);
 		result = std::move(select);
 	}
 	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
@@ -52,7 +52,7 @@ unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
 }
 
 BoundStatement ProjectionRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	auto select_node = make_uniq<SelectNode>();
@@ -64,13 +64,18 @@ BoundStatement ProjectionRelation::Bind(Binder &binder) {
 	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
 }
 
-bool ProjectionRelation::CanSerializeToQueryNode() {
-	for (auto &expression : expressions) {
-		if (!CanSerializeExpressionOnChild(*child, *expression)) {
-			return false;
-		}
+bool ProjectionRelation::CanSerializeToQueryNodeInternal(Binder &binder) {
+	if (!child->CanSerializeToQueryNodeInternal(binder)) {
+		return false;
 	}
-	return true;
+	if (!child->InheritsColumnBindings() || RequiresSQLMultiSourceBinding(*child)) {
+		return true;
+	}
+	auto serialization_binder = Binder::CreateBinder(binder.context);
+	auto serialization_input = BindRelationInput(*serialization_binder, *child);
+	return std::all_of(expressions.begin(), expressions.end(), [&](const auto &expression) {
+		return CanSerializeExpressionOnBoundChild(*serialization_binder, *child, *serialization_input, *expression);
+	});
 }
 
 string ProjectionRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -53,10 +53,6 @@ string QueryRelation::GetQuery() {
 	return query;
 }
 
-string QueryRelation::GetQuery(Binder &) {
-	return query;
-}
-
 unique_ptr<TableRef> QueryRelation::GetTableRefInternal() {
 	auto subquery_ref = make_uniq<SubqueryRef>(GetSelectStatement(), GetAlias());
 	return std::move(subquery_ref);

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -53,7 +53,11 @@ string QueryRelation::GetQuery() {
 	return query;
 }
 
-unique_ptr<TableRef> QueryRelation::GetTableRef() {
+string QueryRelation::GetQuery(Binder &) {
+	return query;
+}
+
+unique_ptr<TableRef> QueryRelation::GetTableRefInternal() {
 	auto subquery_ref = make_uniq<SubqueryRef>(GetSelectStatement(), GetAlias());
 	return std::move(subquery_ref);
 }

--- a/external/duckdb/src/main/relation/repartition_relation.cpp
+++ b/external/duckdb/src/main/relation/repartition_relation.cpp
@@ -3,14 +3,13 @@
 
 #include "duckdb/main/relation/repartition_relation.hpp"
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_binder/relation_binder.hpp"
 #include "duckdb/planner/operator/logical_repartition.hpp"
-
-#include <unordered_map>
 
 namespace duckdb {
 
@@ -23,10 +22,8 @@ RepartitionRelation::RepartitionRelation(shared_ptr<Relation> child_p, idx_t num
 }
 
 unique_ptr<QueryNode> RepartitionRelation::GetQueryNode() {
-	// Repartition is not representable in SQL; fall back to the child query node.
-	// This keeps relation->TableFunction (map_batches) working, at the cost of
-	// dropping repartition in SQL-based paths.
-	return child->GetQueryNode();
+	throw NotImplementedException(
+	    "A repartitioned relation has no SQL query-node representation; converting it would discard the exchange");
 }
 
 string RepartitionRelation::GetQuery() {
@@ -42,46 +39,15 @@ const vector<ColumnDefinition> &RepartitionRelation::Columns() {
 }
 
 BoundStatement RepartitionRelation::Bind(Binder &binder) {
-	auto child_bound = child->Bind(binder);
-	auto bindings = child_bound.plan->GetColumnBindings();
-	D_ASSERT(bindings.size() == child_bound.names.size());
-	D_ASSERT(bindings.size() == child_bound.types.size());
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	return BindSelectNodeOnChild(binder, *this, std::move(select_node));
+}
 
-	std::unordered_map<idx_t, vector<string>> names_by_table;
-	std::unordered_map<idx_t, vector<LogicalType>> types_by_table;
-
-	for (idx_t i = 0; i < bindings.size(); i++) {
-		const auto &binding = bindings[i];
-		auto &names = names_by_table[binding.table_index];
-		auto &types = types_by_table[binding.table_index];
-		if (names.size() <= binding.column_index) {
-			names.resize(binding.column_index + 1);
-			types.resize(binding.column_index + 1);
-		}
-		names[binding.column_index] = child_bound.names[i];
-		types[binding.column_index] = child_bound.types[i];
-	}
-
-	for (auto &entry : names_by_table) {
-		auto &names = entry.second;
-		for (idx_t i = 0; i < names.size(); i++) {
-			if (names[i].empty()) {
-				throw InternalException("Failed to build repartition bindings: missing column at index %llu", i);
-			}
-		}
-	}
-
-	auto expr_binder = Binder::CreateBinder(binder.context, binder.shared_from_this());
-	bool single_binding = names_by_table.size() == 1;
-	for (auto &entry : names_by_table) {
-		auto table_index = entry.first;
-		auto &names = entry.second;
-		auto &types = types_by_table[table_index];
-		string alias = single_binding ? child->GetAlias() : StringUtil::Format("__repartition_%llu", table_index);
-		expr_binder->bind_context.AddGenericBinding(table_index, alias, names, types);
-	}
-
-	RelationBinder relation_binder(*expr_binder, binder.context, "repartition");
+BoundStatement RepartitionRelation::BindAsInput(Binder &binder) {
+	auto child_ref = BindRelationInput(binder, *child);
+	auto child_bound = binder.Bind(*child_ref);
+	RelationBinder relation_binder(binder, binder.context, "repartition");
 	vector<ExprRef> partition_exprs;
 	partition_exprs.reserve(partition_by.size());
 	vector<unique_ptr<Expression>> bound_partition_exprs;

--- a/external/duckdb/src/main/relation/subquery_relation.cpp
+++ b/external/duckdb/src/main/relation/subquery_relation.cpp
@@ -25,7 +25,7 @@ unique_ptr<QueryNode> SubqueryRelation::GetQueryNode() {
 }
 
 BoundStatement SubqueryRelation::Bind(Binder &binder) {
-	if (!child->ContainsNonSQLRelation()) {
+	if (!RequiresDirectRelationBinding(*child)) {
 		return Relation::Bind(binder);
 	}
 	// An alias is an explicit binding boundary. Bind the child through the

--- a/external/duckdb/src/main/relation/subquery_relation.cpp
+++ b/external/duckdb/src/main/relation/subquery_relation.cpp
@@ -1,6 +1,15 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/subquery_relation.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -13,6 +22,19 @@ SubqueryRelation::SubqueryRelation(shared_ptr<Relation> child_p, const string &a
 
 unique_ptr<QueryNode> SubqueryRelation::GetQueryNode() {
 	return child->GetQueryNode();
+}
+
+BoundStatement SubqueryRelation::Bind(Binder &binder) {
+	if (!child->ContainsNonSQLRelation()) {
+		return Relation::Bind(binder);
+	}
+	// An alias is an explicit binding boundary. Bind the child through the
+	// transient relation-input path so non-SQL operators remain in the plan.
+	// When this relation is used as an input, its projection is exposed under
+	// this relation's alias rather than the child's aliases.
+	auto select_node = make_uniq<SelectNode>();
+	select_node->select_list.push_back(make_uniq<StarExpression>());
+	return BindSelectNodeOnChild(binder, *child, std::move(select_node));
 }
 
 const vector<ColumnDefinition> &SubqueryRelation::Columns() {

--- a/external/duckdb/src/main/relation/subquery_relation.cpp
+++ b/external/duckdb/src/main/relation/subquery_relation.cpp
@@ -25,7 +25,7 @@ unique_ptr<QueryNode> SubqueryRelation::GetQueryNode() {
 }
 
 BoundStatement SubqueryRelation::Bind(Binder &binder) {
-	if (!RequiresDirectRelationBinding(*child)) {
+	if (!RequiresDirectRelationBinding(binder, *child)) {
 		return Relation::Bind(binder);
 	}
 	// An alias is an explicit binding boundary. Bind the child through the

--- a/external/duckdb/src/main/relation/table_function_relation.cpp
+++ b/external/duckdb/src/main/relation/table_function_relation.cpp
@@ -101,11 +101,11 @@ void TableFunctionRelation::CaptureVirtualColumnNames(const LogicalOperator &pla
 unique_ptr<QueryNode> TableFunctionRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> TableFunctionRelation::GetTableRef() {
+unique_ptr<TableRef> TableFunctionRelation::GetTableRefInternal() {
 	vector<unique_ptr<ParsedExpression>> children;
 	if (input_relation) { // input relation becomes first parameter if present, always
 		auto subquery = make_uniq<SubqueryExpression>();
@@ -212,7 +212,7 @@ BoundStatement TableFunctionRelation::BindAsInput(Binder &binder) {
 	if (input_relation) {
 		return Bind(binder);
 	}
-	auto table_ref = GetTableRef();
+	auto table_ref = GetTableRefForSerialization(*this);
 	auto result = binder.Bind(*table_ref);
 	CaptureVirtualColumnNames(*result.plan);
 	return result;

--- a/external/duckdb/src/main/relation/table_function_relation.cpp
+++ b/external/duckdb/src/main/relation/table_function_relation.cpp
@@ -25,6 +25,7 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
@@ -77,6 +78,26 @@ void TableFunctionRelation::InitializeColumns() {
 	TryBindRelation(columns);
 }
 
+void TableFunctionRelation::CaptureVirtualColumnNames(const LogicalOperator &plan) {
+	if (plan.type == LogicalGet::TYPE) {
+		auto &get = plan.Cast<LogicalGet>();
+		auto function_name = QualifiedName::Parse(name).name;
+		if (StringUtil::CIEquals(get.function.name, function_name)) {
+			for (auto &entry : get.virtual_columns) {
+				auto &column_name = entry.second.name;
+				if (!column_name.empty() &&
+				    std::none_of(virtual_column_names.begin(), virtual_column_names.end(),
+				                 [&](const string &existing) { return StringUtil::CIEquals(existing, column_name); })) {
+					virtual_column_names.push_back(column_name);
+				}
+			}
+		}
+	}
+	for (auto &child : plan.children) {
+		CaptureVirtualColumnNames(*child);
+	}
+}
+
 unique_ptr<QueryNode> TableFunctionRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
@@ -116,7 +137,9 @@ unique_ptr<TableRef> TableFunctionRelation::GetTableRef() {
 
 BoundStatement TableFunctionRelation::Bind(Binder &binder) {
 	if (!input_relation) {
-		return Relation::Bind(binder);
+		auto result = Relation::Bind(binder);
+		CaptureVirtualColumnNames(*result.plan);
+		return result;
 	}
 
 	auto qualified_name = QualifiedName::Parse(name);
@@ -131,7 +154,9 @@ BoundStatement TableFunctionRelation::Bind(Binder &binder) {
 	    *binder.GetCatalogEntry(catalog, schema, table_function_lookup, OnEntryNotFound::THROW_EXCEPTION);
 	if (func_catalog.type == CatalogType::TABLE_MACRO_ENTRY) {
 		// Fall back to SQL binding for macros.
-		return Relation::Bind(binder);
+		auto result = Relation::Bind(binder);
+		CaptureVirtualColumnNames(*result.plan);
+		return result;
 	}
 	D_ASSERT(func_catalog.type == CatalogType::TABLE_FUNCTION_ENTRY);
 	auto &function_entry = func_catalog.Cast<TableFunctionCatalogEntry>();
@@ -177,8 +202,20 @@ BoundStatement TableFunctionRelation::Bind(Binder &binder) {
 
 	TableFunctionRef ref;
 	ref.alias = name;
-	return binder.BindTableFunctionWithInput(table_function, ref, std::move(bound_parameters),
-	                                         std::move(bound_named_parameters), child_bound);
+	auto result = binder.BindTableFunctionWithInput(table_function, ref, std::move(bound_parameters),
+	                                                std::move(bound_named_parameters), child_bound);
+	CaptureVirtualColumnNames(*result.plan);
+	return result;
+}
+
+BoundStatement TableFunctionRelation::BindAsInput(Binder &binder) {
+	if (input_relation) {
+		return Bind(binder);
+	}
+	auto table_ref = GetTableRef();
+	auto result = binder.Bind(*table_ref);
+	CaptureVirtualColumnNames(*result.plan);
+	return result;
 }
 
 string TableFunctionRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/table_relation.cpp
+++ b/external/duckdb/src/main/relation/table_relation.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/main/relation/table_relation.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
@@ -7,6 +13,7 @@
 #include "duckdb/main/relation/update_relation.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -32,6 +39,11 @@ unique_ptr<TableRef> TableRelation::GetTableRef() {
 	table_ref->table_name = description->table;
 	table_ref->catalog_name = description->database;
 	return std::move(table_ref);
+}
+
+BoundStatement TableRelation::BindAsInput(Binder &binder) {
+	auto table_ref = GetTableRef();
+	return binder.Bind(*table_ref);
 }
 
 string TableRelation::GetAlias() {

--- a/external/duckdb/src/main/relation/table_relation.cpp
+++ b/external/duckdb/src/main/relation/table_relation.cpp
@@ -29,11 +29,11 @@ TableRelation::TableRelation(const shared_ptr<RelationContextWrapper> &context,
 unique_ptr<QueryNode> TableRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> TableRelation::GetTableRef() {
+unique_ptr<TableRef> TableRelation::GetTableRefInternal() {
 	auto table_ref = make_uniq<BaseTableRef>();
 	table_ref->schema_name = description->schema;
 	table_ref->table_name = description->table;
@@ -42,7 +42,7 @@ unique_ptr<TableRef> TableRelation::GetTableRef() {
 }
 
 BoundStatement TableRelation::BindAsInput(Binder &binder) {
-	auto table_ref = GetTableRef();
+	auto table_ref = GetTableRefForSerialization(*this);
 	return binder.Bind(*table_ref);
 }
 

--- a/external/duckdb/src/main/relation/unnest_relation.cpp
+++ b/external/duckdb/src/main/relation/unnest_relation.cpp
@@ -27,7 +27,7 @@ unique_ptr<QueryNode> UnnestRelation::GetQueryNode() {
 	// Fallback AST path (used by default Relation::Bind if custom Bind not called).
 	// Builds: SELECT * EXCLUDE(col), unnest(col) AS col FROM (child)
 	auto result = make_uniq<SelectNode>();
-	result->from_table = child->GetTableRef();
+	result->from_table = GetTableRefForSerialization(*child);
 
 	auto star = make_uniq<StarExpression>();
 	star->exclude_list.insert(QualifiedColumnName(column_name));

--- a/external/duckdb/src/main/relation/value_relation.cpp
+++ b/external/duckdb/src/main/relation/value_relation.cpp
@@ -75,11 +75,11 @@ ValueRelation::ValueRelation(const shared_ptr<RelationContextWrapper> &context,
 unique_ptr<QueryNode> ValueRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> ValueRelation::GetTableRef() {
+unique_ptr<TableRef> ValueRelation::GetTableRefInternal() {
 	auto table_ref = make_uniq<ExpressionListRef>();
 	// set the expected types/names
 	if (columns.empty()) {

--- a/external/duckdb/src/main/relation/view_relation.cpp
+++ b/external/duckdb/src/main/relation/view_relation.cpp
@@ -28,11 +28,11 @@ ViewRelation::ViewRelation(const shared_ptr<ClientContext> &context, unique_ptr<
 unique_ptr<QueryNode> ViewRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
 	result->select_list.push_back(make_uniq<StarExpression>());
-	result->from_table = GetTableRef();
+	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);
 }
 
-unique_ptr<TableRef> ViewRelation::GetTableRef() {
+unique_ptr<TableRef> ViewRelation::GetTableRefInternal() {
 	if (premade_tableref) {
 		return premade_tableref->Copy();
 	}

--- a/external/duckdb/src/optimizer/join_elimination.cpp
+++ b/external/duckdb/src/optimizer/join_elimination.cpp
@@ -39,7 +39,7 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_DISTINCT: {
 		auto &distinct = op.Cast<LogicalDistinct>();
-		if (distinct.distinct_type != DistinctType::DISTINCT) {
+		if (distinct.distinct_type != DistinctType::DISTINCT || distinct.distinct_targets.empty()) {
 			break;
 		}
 		column_binding_set_t distinct_group;
@@ -54,8 +54,14 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 				break;
 			}
 			auto &col_ref = target->Cast<BoundColumnRefExpression>();
+			if (table_idx != col_ref.binding.table_index) {
+				// Join elimination tracks a distinct group through a single table
+				// binding. A DISTINCT directly over a join can retain bindings from
+				// multiple inputs, so it cannot be represented by this map.
+				can_add = false;
+				break;
+			}
 			distinct_group.insert(col_ref.binding);
-			D_ASSERT(table_idx == col_ref.binding.table_index);
 		}
 		if (can_add) {
 			pipe_info.distinct_groups[table_idx] = std::move(distinct_group);

--- a/external/duckdb/src/optimizer/join_order/relation_manager.cpp
+++ b/external/duckdb/src/optimizer/join_order/relation_manager.cpp
@@ -122,6 +122,20 @@ static bool OperatorIsNonReorderable(LogicalOperatorType op_type) {
 	}
 }
 
+static bool OperatorIsRelationBoundary(LogicalOperatorType op_type) {
+	switch (op_type) {
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_LIMIT:
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+	case LogicalOperatorType::LOGICAL_TOP_N:
+	case LogicalOperatorType::LOGICAL_REPARTITION:
+	case LogicalOperatorType::LOGICAL_LOCAL_EXCHANGE:
+		return true;
+	default:
+		return false;
+	}
+}
+
 bool ExpressionContainsColumnRef(const Expression &root_expr) {
 	bool contains_column_ref = false;
 	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(
@@ -164,7 +178,8 @@ static bool JoinIsReorderable(LogicalOperator &op) {
 static bool HasNonReorderableChild(LogicalOperator &op) {
 	LogicalOperator *tmp = &op;
 	while (tmp->children.size() == 1) {
-		if (OperatorNeedsRelation(tmp->type) || OperatorIsNonReorderable(tmp->type)) {
+		if (OperatorNeedsRelation(tmp->type) || OperatorIsNonReorderable(tmp->type) ||
+		    OperatorIsRelationBoundary(tmp->type)) {
 			return true;
 		}
 		tmp = tmp->children[0].get();
@@ -209,7 +224,7 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 	vector<reference<LogicalOperator>> datasource_filters;
 	optional_ptr<LogicalOperator> limit_op = nullptr;
 	// pass through single child operators
-	while (op->children.size() == 1 && !OperatorNeedsRelation(op->type)) {
+	while (op->children.size() == 1 && !OperatorNeedsRelation(op->type) && !OperatorIsRelationBoundary(op->type)) {
 		if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
 			if (HasNonReorderableChild(*op)) {
 				datasource_filters.push_back(*op);
@@ -221,7 +236,8 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 		}
 		op = op->children[0].get();
 	}
-	bool non_reorderable_operation = false;
+	bool relation_boundary = OperatorIsRelationBoundary(op->type);
+	bool non_reorderable_operation = relation_boundary;
 	if (OperatorIsNonReorderable(op->type)) {
 		// set operation, optimize separately in children
 		non_reorderable_operation = true;
@@ -236,7 +252,9 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 		}
 	}
 	if (non_reorderable_operation) {
-		// we encountered a non-reordable operation (setop or non-inner join)
+		// We encountered an operation that the surrounding join graph cannot cross. For
+		// row-set and exchange boundaries, optimize the child join graph independently
+		// and retain the entire operator as a single relation in the outer graph.
 		// we do not reorder non-inner joins yet, however we do want to expand the potential join graph around them
 		// non-inner joins are also tricky because we can't freely make conditions through them
 		// e.g. suppose we have (left LEFT OUTER JOIN right WHERE right IS NOT NULL), the join can generate
@@ -252,6 +270,9 @@ bool RelationManager::ExtractJoinRelations(JoinOrderOptimizer &optimizer, Logica
 		}
 
 		auto combined_stats = RelationStatisticsHelper::CombineStatsOfNonReorderableOperator(*op, children_stats);
+		if (relation_boundary) {
+			combined_stats.cardinality = op->EstimateCardinality(context);
+		}
 		op->SetEstimatedCardinality(combined_stats.cardinality);
 		if (!datasource_filters.empty()) {
 			combined_stats.cardinality = (idx_t)MaxValue(

--- a/external/duckdb/src/parser/statement/relation_statement.cpp
+++ b/external/duckdb/src/parser/statement/relation_statement.cpp
@@ -8,6 +8,11 @@ RelationStatement::RelationStatement(shared_ptr<Relation> relation_p)
 	query = relation->GetQuery();
 }
 
+RelationStatement::RelationStatement(shared_ptr<Relation> relation_p, Binder &binder)
+    : SQLStatement(StatementType::RELATION_STATEMENT), relation(std::move(relation_p)) {
+	query = relation->GetQuery(binder);
+}
+
 unique_ptr<SQLStatement> RelationStatement::Copy() const {
 	return unique_ptr<RelationStatement>(new RelationStatement(*this));
 }

--- a/external/duckdb/src/planner/bind_context.cpp
+++ b/external/duckdb/src/planner/bind_context.cpp
@@ -635,6 +635,14 @@ void BindContext::GetTypesAndNames(vector<string> &result_names, vector<LogicalT
 	}
 }
 
+void BindContext::RemoveVirtualColumnBindings() {
+	for (auto &binding : bindings_list) {
+		if (binding->GetBindingType() == BindingType::TABLE) {
+			binding->Cast<TableBinding>().RemoveVirtualColumnBindings();
+		}
+	}
+}
+
 void BindContext::AddBinding(unique_ptr<Binding> binding) {
 	bindings_list.push_back(std::move(binding));
 }

--- a/external/duckdb/src/planner/table_binding.cpp
+++ b/external/duckdb/src/planner/table_binding.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/planner/table_binding.hpp"
 
 #include "duckdb/common/string_util.hpp"
@@ -224,12 +230,22 @@ const vector<ColumnIndex> &TableBinding::GetBoundColumnIds() const {
 		D_ASSERT(result.second);
 		auto it = std::find_if(name_map.begin(), name_map.end(),
 		                       [&](const std::pair<const string, idx_t> &it) { return it.second == id; });
-		// assert that every id appears in the name_map
-		D_ASSERT(it != name_map.end());
+		// Virtual columns can be hidden from a later binding scope after they
+		// have already been bound in the child plan.
+		D_ASSERT(it != name_map.end() || virtual_columns.find(id) != virtual_columns.end());
 		// the order that they appear in is not guaranteed to be sequential
 	}
 #endif
 	return bound_column_ids;
+}
+
+void TableBinding::RemoveVirtualColumnBindings() {
+	for (auto &virtual_column : virtual_columns) {
+		auto entry = name_map.find(virtual_column.second.name);
+		if (entry != name_map.end() && entry->second == virtual_column.first) {
+			name_map.erase(entry);
+		}
+	}
 }
 
 ColumnBinding TableBinding::GetColumnBinding(column_t column_index) {

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -1222,6 +1222,41 @@ TEST_CASE("Relation input binding is independent from SQL serialization", "[rela
 	auto explain = make_shared_ptr<ExplainRelation>(left);
 	REQUIRE_FALSE(explain->CanSerializeToQueryNode());
 	REQUIRE_FALSE(explain->CanBindAsInput());
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE semi_left(left_id INTEGER, left_value VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO semi_left VALUES (1, 'one'), (2, 'two'), (2, 'two')"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE semi_right(right_id INTEGER, right_value BIGINT)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO semi_right VALUES (1, 100), (3, 300), (3, 300)"));
+	auto semi_left = con.Table("semi_left")->Alias("sl");
+	auto semi_right = con.Table("semi_right")->Alias("sr");
+
+	auto left_semi = semi_left->Join(semi_right, "sl.left_id = sr.right_id", JoinType::SEMI)
+	                     ->Distinct()
+	                     ->Project("sl.left_id, sl.left_value");
+	REQUIRE_NOTHROW(result = left_semi->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"one"}));
+
+	auto left_anti = semi_left->Join(semi_right, "sl.left_id = sr.right_id", JoinType::ANTI)
+	                     ->Distinct()
+	                     ->Project("sl.left_id, sl.left_value");
+	REQUIRE_NOTHROW(result = left_anti->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {2}));
+	REQUIRE(CHECK_COLUMN(result, 1, {"two"}));
+
+	auto right_semi = semi_left->Join(semi_right, "sl.left_id = sr.right_id", JoinType::RIGHT_SEMI)
+	                      ->Distinct()
+	                      ->Project("sr.right_id, sr.right_value");
+	REQUIRE_NOTHROW(result = right_semi->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	REQUIRE(CHECK_COLUMN(result, 1, {100}));
+
+	auto right_anti = semi_left->Join(semi_right, "sl.left_id = sr.right_id", JoinType::RIGHT_ANTI)
+	                      ->Distinct()
+	                      ->Project("sr.right_id, sr.right_value");
+	REQUIRE_NOTHROW(result = right_anti->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {3}));
+	REQUIRE(CHECK_COLUMN(result, 1, {300}));
 }
 
 TEST_CASE("Test LocalExchange preserved after Limit", "[relation_api][local_exchange]") {

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -1213,19 +1213,18 @@ TEST_CASE("Relation input binding is independent from SQL serialization", "[rela
 	REQUIRE(CHECK_COLUMN(result, 0, {2}));
 
 	auto direct_bound = distinct_join->Project("r.value AS x");
-	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
-	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE(direct_bound->GetQuery().empty());
 	REQUIRE_THROWS_AS(direct_bound->GetTableRef(), NotImplementedException);
 	REQUIRE_NOTHROW(result = direct_bound->Filter("x > 100")->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {200}));
 
 	auto exchange = left->LocalExchange(2);
-	REQUIRE_FALSE(exchange->CanSerializeToQueryNode());
-	REQUIRE(exchange->CanBindAsInput());
+	REQUIRE(exchange->GetQuery().empty());
+	REQUIRE_NOTHROW(result = exchange->Execute());
 
 	auto explain = make_shared_ptr<ExplainRelation>(left);
-	REQUIRE_FALSE(explain->CanSerializeToQueryNode());
-	REQUIRE_FALSE(explain->CanBindAsInput());
+	REQUIRE(explain->GetQuery().empty());
+	REQUIRE_THROWS_AS(explain->GetTableRef(), NotImplementedException);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE semi_left(left_id INTEGER, left_value VARCHAR)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO semi_left VALUES (1, 'one'), (2, 'two'), (2, 'two')"));
@@ -1336,8 +1335,7 @@ TEST_CASE("Empty order is an identity and inherits child serializability", "[rel
 	auto values = con.Values("(42)");
 	duckdb::vector<OrderByNode> serializable_orders;
 	auto serializable_order = values->Order(std::move(serializable_orders));
-	REQUIRE(serializable_order->CanSerializeToQueryNode());
-	REQUIRE(serializable_order->CanBindAsInput());
+	REQUIRE_FALSE(serializable_order->GetQuery().empty());
 	REQUIRE_NOTHROW(result = serializable_order->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 
@@ -1345,8 +1343,7 @@ TEST_CASE("Empty order is an identity and inherits child serializability", "[rel
 	duckdb::vector<OrderByNode> exchange_orders;
 	auto ordered = exchange->Order(std::move(exchange_orders));
 
-	REQUIRE_FALSE(ordered->CanSerializeToQueryNode());
-	REQUIRE(ordered->CanBindAsInput());
+	REQUIRE(ordered->GetQuery().empty());
 	REQUIRE_NOTHROW(result = ordered->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 	REQUIRE_NOTHROW(result = ordered->Limit(1)->Execute());
@@ -1370,34 +1367,29 @@ TEST_CASE("Bound local query scopes determine relation serialization", "[relatio
 	auto boundary = left->Join(right, "l.join_key = r.join_key")->Distinct();
 
 	auto correlated = boundary->Project("(SELECT l.id) AS value");
-	REQUIRE_FALSE(correlated->CanSerializeToQueryNode());
 	REQUIRE(correlated->GetQuery().empty());
 	REQUIRE_NOTHROW(result = correlated->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {7}));
 
 	auto local = boundary->Project("(SELECT l.id FROM local_scope_source AS l) AS value");
-	REQUIRE(local->CanSerializeToQueryNode());
 	REQUIRE_FALSE(local->GetQuery().empty());
 	REQUIRE_NOTHROW(result = local->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE MACRO relation_field(value) AS value.id"));
 	auto macro_correlated = boundary->Project("relation_field(l) AS value");
-	REQUIRE_FALSE(macro_correlated->CanSerializeToQueryNode());
 	REQUIRE(macro_correlated->GetQuery().empty());
 	REQUIRE_NOTHROW(result = macro_correlated->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {7}));
 
 	auto using_boundary = left->Join(right, "join_key")->Distinct();
 	auto surviving_output = using_boundary->Project("(SELECT join_key) AS value");
-	REQUIRE(surviving_output->CanSerializeToQueryNode());
 	REQUIRE_FALSE(surviving_output->GetQuery().empty());
 	REQUIRE_NOTHROW(result = surviving_output->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 
 	auto outer_boundary = left->Join(right, "join_key", JoinType::OUTER)->Distinct();
 	auto coalesced_output = outer_boundary->Project("(SELECT join_key) AS value");
-	REQUIRE(coalesced_output->CanSerializeToQueryNode());
 	REQUIRE_FALSE(coalesced_output->GetQuery().empty());
 	REQUIRE_NOTHROW(result = coalesced_output->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {1}));
@@ -1415,19 +1407,16 @@ TEST_CASE("Relation serialization follows current catalog bindings", "[relation_
 	                    ->Distinct()
 	                    ->Project("(SELECT r.right_value FROM local_scope_source AS r) AS value");
 
-	REQUIRE(relation->CanSerializeToQueryNode());
 	REQUIRE_FALSE(relation->GetQuery().empty());
 	REQUIRE_NOTHROW(result = relation->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE VIEW local_scope_source AS SELECT 99 AS other"));
-	REQUIRE_FALSE(relation->CanSerializeToQueryNode());
 	REQUIRE(relation->GetQuery().empty());
 	REQUIRE_NOTHROW(result = relation->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {100}));
 
 	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE VIEW local_scope_source AS SELECT 84 AS right_value"));
-	REQUIRE(relation->CanSerializeToQueryNode());
 	REQUIRE_FALSE(relation->GetQuery().empty());
 	REQUIRE_NOTHROW(result = relation->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {84}));
@@ -1479,13 +1468,12 @@ TEST_CASE("Struct fields preserve relation serialization boundaries", "[relation
 	auto boundary = left->Join(right, "l.id = r.id")->Distinct();
 
 	auto serialized = boundary->Project("payload.a.b.c.d AS value");
-	REQUIRE(serialized->CanSerializeToQueryNode());
+	REQUIRE_FALSE(serialized->GetQuery().empty());
 	REQUIRE_NOTHROW(result = serialized->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {7}));
 
 	auto direct_bound = boundary->Project("l.payload.a.b.c.d AS value");
-	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
-	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE(direct_bound->GetQuery().empty());
 	REQUIRE_NOTHROW(result = direct_bound->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {7}));
 }
@@ -1500,12 +1488,11 @@ TEST_CASE("Virtual columns survive single-source relation boundaries", "[relatio
 	auto boundary = con.Table("virtual_source")->Distinct();
 
 	auto serialized = boundary->Project("virtual_source.value");
-	REQUIRE(serialized->CanSerializeToQueryNode());
+	REQUIRE_FALSE(serialized->GetQuery().empty());
 	REQUIRE_NOTHROW(result = serialized->Execute());
 
 	auto direct_bound = boundary->Project("virtual_source.rowid AS row_id")->Order("row_id");
-	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
-	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE(direct_bound->GetQuery().empty());
 	REQUIRE_NOTHROW(result = direct_bound->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {0, 1}));
 }

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/enums/joinref_type.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/main/relation/explain_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "iostream"
 #include "test_helpers.hpp"
@@ -1190,6 +1191,37 @@ TEST_CASE("Test create table with empty name", "[relation_api]") {
 
 	auto values = con.Values("(42)");
 	REQUIRE_THROWS_AS(values->Create(""), ParserException);
+}
+
+TEST_CASE("Relation input binding is independent from SQL serialization", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE binding_left(id INTEGER, value INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO binding_left VALUES (1, 10), (2, 20)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE binding_right(id INTEGER, value INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO binding_right VALUES (1, 100), (2, 200)"));
+
+	auto left = con.Table("binding_left")->Alias("l");
+	auto right = con.Table("binding_right")->Alias("r");
+	auto distinct_join = left->Join(right, "l.id = r.id")->Distinct();
+	REQUIRE_NOTHROW(result = distinct_join->Aggregate("count(*)")->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {2}));
+
+	auto direct_bound = distinct_join->Project("r.value AS x");
+	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
+	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE_NOTHROW(result = direct_bound->Filter("x > 100")->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {200}));
+
+	auto exchange = left->LocalExchange(2);
+	REQUIRE_FALSE(exchange->CanSerializeToQueryNode());
+	REQUIRE(exchange->CanBindAsInput());
+
+	auto explain = make_shared_ptr<ExplainRelation>(left);
+	REQUIRE_FALSE(explain->CanSerializeToQueryNode());
+	REQUIRE_FALSE(explain->CanBindAsInput());
 }
 
 TEST_CASE("Test LocalExchange preserved after Limit", "[relation_api][local_exchange]") {

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -1478,21 +1478,34 @@ TEST_CASE("Struct fields preserve relation serialization boundaries", "[relation
 	REQUIRE(CHECK_COLUMN(result, 0, {7}));
 }
 
-TEST_CASE("Virtual columns survive single-source relation boundaries", "[relation_api]") {
+TEST_CASE("Distinct removes virtual columns from inherited relation bindings", "[relation_api]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 	duckdb::unique_ptr<QueryResult> result;
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE virtual_source(value INTEGER)"));
 	REQUIRE_NO_FAIL(con.Query("INSERT INTO virtual_source VALUES (10), (20)"));
+	auto filtered = con.Table("virtual_source")->Filter("value > 0");
+	auto filtered_rowid = filtered->Project("virtual_source.rowid AS row_id")->Order("row_id");
+	REQUIRE_NOTHROW(result = filtered_rowid->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {0, 1}));
+
 	auto boundary = con.Table("virtual_source")->Distinct();
 
 	auto serialized = boundary->Project("virtual_source.value");
 	REQUIRE_FALSE(serialized->GetQuery().empty());
 	REQUIRE_NOTHROW(result = serialized->Execute());
 
-	auto direct_bound = boundary->Project("virtual_source.rowid AS row_id")->Order("row_id");
-	REQUIRE(direct_bound->GetQuery().empty());
-	REQUIRE_NOTHROW(result = direct_bound->Execute());
-	REQUIRE(CHECK_COLUMN(result, 0, {0, 1}));
+	REQUIRE_THROWS(boundary->Project("virtual_source.rowid AS row_id"));
+
+	auto rowid_filtered_boundary = con.Table("virtual_source")->Filter("rowid >= 0")->Distinct();
+	REQUIRE_NOTHROW(result = rowid_filtered_boundary->Project("value")->Order("value")->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {10, 20}));
+	REQUIRE_THROWS(rowid_filtered_boundary->Project("rowid"));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE named_rowid(rowid INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO named_rowid VALUES (10), (20)"));
+	auto named_rowid = con.Table("named_rowid")->Distinct()->Project("rowid")->Order("rowid");
+	REQUIRE_NOTHROW(result = named_rowid->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {10, 20}));
 }

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -941,6 +941,25 @@ TEST_CASE("Test table function relations", "[relation_api]") {
 	REQUIRE_THROWS(con.TableFunction("blabla"));
 }
 
+TEST_CASE("Test non-SQL exchanges with table in-out functions", "[relation_api][exchange]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	auto values = con.Values("(42)", {"i"});
+	REQUIRE_NOTHROW(result =
+	                    values->Repartition(2, duckdb::vector<string> {})->TableFunction("summary", {})->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {"[42]"}));
+	REQUIRE_NOTHROW(result = values->LocalExchange(2)->TableFunction("summary", {})->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {"[42]"}));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE MACRO relation_macro(x) AS TABLE SELECT x AS i"));
+	REQUIRE_THROWS_WITH(values->Repartition(2, duckdb::vector<string> {})->TableFunction("relation_macro", {}),
+	                    Catch::Matchers::Contains("would discard"));
+	REQUIRE_THROWS_WITH(values->LocalExchange(2)->TableFunction("relation_macro", {}),
+	                    Catch::Matchers::Contains("would discard"));
+}
+
 TEST_CASE("Test CSV Relation with union by name", "[relation_api]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -1322,3 +1322,73 @@ TEST_CASE("Test LocalExchange preserved after Limit", "[relation_api][local_exch
 	// The EXPLAIN output should contain LOCAL_EXCHANGE
 	REQUIRE(explain_str.find("LOCAL_EXCHANGE") != string::npos);
 }
+
+TEST_CASE("Empty order is an identity and inherits child serializability", "[relation_api][local_exchange]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA enable_verification"));
+	auto values = con.Values("(42)");
+	duckdb::vector<OrderByNode> serializable_orders;
+	auto serializable_order = values->Order(std::move(serializable_orders));
+	REQUIRE(serializable_order->CanSerializeToQueryNode());
+	REQUIRE(serializable_order->CanBindAsInput());
+	REQUIRE_NOTHROW(result = serializable_order->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	auto exchange = con.Values("(42)")->LocalExchange(2);
+	duckdb::vector<OrderByNode> exchange_orders;
+	auto ordered = exchange->Order(std::move(exchange_orders));
+
+	REQUIRE_FALSE(ordered->CanSerializeToQueryNode());
+	REQUIRE(ordered->CanBindAsInput());
+	REQUIRE_NOTHROW(result = ordered->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+	REQUIRE_NOTHROW(result = ordered->Limit(1)->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("Struct fields preserve relation serialization boundaries", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE nested_left AS SELECT "
+	                          "{'a': {'b': {'c': {'d': 7}}}} AS payload, 1 AS id"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE nested_right AS SELECT 1 AS id"));
+	auto left = con.Table("nested_left")->Alias("l");
+	auto right = con.Table("nested_right")->Alias("r");
+	auto boundary = left->Join(right, "l.id = r.id")->Distinct();
+
+	auto serialized = boundary->Project("payload.a.b.c.d AS value");
+	REQUIRE(serialized->CanSerializeToQueryNode());
+	REQUIRE_NOTHROW(result = serialized->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {7}));
+
+	auto direct_bound = boundary->Project("l.payload.a.b.c.d AS value");
+	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
+	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE_NOTHROW(result = direct_bound->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {7}));
+}
+
+TEST_CASE("Virtual columns survive single-source relation boundaries", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE virtual_source(value INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO virtual_source VALUES (10), (20)"));
+	auto boundary = con.Table("virtual_source")->Distinct();
+
+	auto serialized = boundary->Project("virtual_source.value");
+	REQUIRE(serialized->CanSerializeToQueryNode());
+	REQUIRE_NOTHROW(result = serialized->Execute());
+
+	auto direct_bound = boundary->Project("virtual_source.rowid AS row_id")->Order("row_id");
+	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
+	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE_NOTHROW(result = direct_bound->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {0, 1}));
+}

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/main/relation/explain_relation.hpp"
+#include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "iostream"
 #include "test_helpers.hpp"
@@ -1104,9 +1105,11 @@ TEST_CASE("Test Relation Query setting query", "[relation_api]") {
 	DuckDB db;
 	Connection con(db);
 
-	auto query = con.RelationFromQuery("SELECT current_query()");
-	auto result = query->Limit(1)->Execute();
-	REQUIRE(!result->Fetch()->GetValue(0, 0).ToString().empty());
+	const string query_text = "SELECT current_query() /* preserve relation query text */";
+	auto statement = QueryRelation::ParseStatement(*con.context, query_text, "Expected a SELECT statement");
+	auto query = con.RelationFromQuery(std::move(statement), "queryrelation", query_text);
+	auto result = query->Execute();
+	REQUIRE(result->Fetch()->GetValue(0, 0).ToString() == query_text);
 }
 
 TEST_CASE("Construct ValueRelation with RelationContextWrapper and operate on it", "[relation_api][txn][wrapper]") {
@@ -1212,6 +1215,7 @@ TEST_CASE("Relation input binding is independent from SQL serialization", "[rela
 	auto direct_bound = distinct_join->Project("r.value AS x");
 	REQUIRE_FALSE(direct_bound->CanSerializeToQueryNode());
 	REQUIRE(direct_bound->CanBindAsInput());
+	REQUIRE_THROWS_AS(direct_bound->GetTableRef(), NotImplementedException);
 	REQUIRE_NOTHROW(result = direct_bound->Filter("x > 100")->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {200}));
 
@@ -1347,6 +1351,119 @@ TEST_CASE("Empty order is an identity and inherits child serializability", "[rel
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 	REQUIRE_NOTHROW(result = ordered->Limit(1)->Execute());
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+}
+
+TEST_CASE("Bound local query scopes determine relation serialization", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE scope_left(id INTEGER, join_key INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO scope_left VALUES (7, 1)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE scope_right(join_key INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO scope_right VALUES (1)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE local_scope_source(id INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO local_scope_source VALUES (42)"));
+
+	auto left = con.Table("scope_left")->Alias("l");
+	auto right = con.Table("scope_right")->Alias("r");
+	auto boundary = left->Join(right, "l.join_key = r.join_key")->Distinct();
+
+	auto correlated = boundary->Project("(SELECT l.id) AS value");
+	REQUIRE_FALSE(correlated->CanSerializeToQueryNode());
+	REQUIRE(correlated->GetQuery().empty());
+	REQUIRE_NOTHROW(result = correlated->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {7}));
+
+	auto local = boundary->Project("(SELECT l.id FROM local_scope_source AS l) AS value");
+	REQUIRE(local->CanSerializeToQueryNode());
+	REQUIRE_FALSE(local->GetQuery().empty());
+	REQUIRE_NOTHROW(result = local->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE MACRO relation_field(value) AS value.id"));
+	auto macro_correlated = boundary->Project("relation_field(l) AS value");
+	REQUIRE_FALSE(macro_correlated->CanSerializeToQueryNode());
+	REQUIRE(macro_correlated->GetQuery().empty());
+	REQUIRE_NOTHROW(result = macro_correlated->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {7}));
+
+	auto using_boundary = left->Join(right, "join_key")->Distinct();
+	auto surviving_output = using_boundary->Project("(SELECT join_key) AS value");
+	REQUIRE(surviving_output->CanSerializeToQueryNode());
+	REQUIRE_FALSE(surviving_output->GetQuery().empty());
+	REQUIRE_NOTHROW(result = surviving_output->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	auto outer_boundary = left->Join(right, "join_key", JoinType::OUTER)->Distinct();
+	auto coalesced_output = outer_boundary->Project("(SELECT join_key) AS value");
+	REQUIRE(coalesced_output->CanSerializeToQueryNode());
+	REQUIRE_FALSE(coalesced_output->GetQuery().empty());
+	REQUIRE_NOTHROW(result = coalesced_output->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+}
+
+TEST_CASE("Relation serialization follows current catalog bindings", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE VIEW local_scope_source AS SELECT 42 AS right_value"));
+	auto left = con.RelationFromQuery("SELECT 1 AS join_key", "l");
+	auto right = con.RelationFromQuery("SELECT 1 AS join_key, 100 AS right_value", "r");
+	auto relation = left->Join(right, "l.join_key = r.join_key")
+	                    ->Distinct()
+	                    ->Project("(SELECT r.right_value FROM local_scope_source AS r) AS value");
+
+	REQUIRE(relation->CanSerializeToQueryNode());
+	REQUIRE_FALSE(relation->GetQuery().empty());
+	REQUIRE_NOTHROW(result = relation->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE VIEW local_scope_source AS SELECT 99 AS other"));
+	REQUIRE_FALSE(relation->CanSerializeToQueryNode());
+	REQUIRE(relation->GetQuery().empty());
+	REQUIRE_NOTHROW(result = relation->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {100}));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE OR REPLACE VIEW local_scope_source AS SELECT 84 AS right_value"));
+	REQUIRE(relation->CanSerializeToQueryNode());
+	REQUIRE_FALSE(relation->GetQuery().empty());
+	REQUIRE_NOTHROW(result = relation->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {84}));
+}
+
+TEST_CASE("Relation SQL preserves result modifier boundaries", "[relation_api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE modifier_values(id INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO modifier_values VALUES (1), (1), (2)"));
+	auto values = con.Table("modifier_values")->Order("id");
+
+	auto limited_distinct = values->Limit(2)->Distinct();
+	REQUIRE_NOTHROW(result = limited_distinct->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	REQUIRE_FALSE(limited_distinct->GetQuery().empty());
+	REQUIRE_NOTHROW(result = con.Query(limited_distinct->GetQuery()));
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	auto double_limit = values->Limit(2)->Limit(1);
+	REQUIRE_NOTHROW(result = double_limit->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	REQUIRE_FALSE(double_limit->GetQuery().empty());
+	REQUIRE_NOTHROW(result = con.Query(double_limit->GetQuery()));
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	auto union_left = con.RelationFromQuery("SELECT 1 AS id", "union_left");
+	auto union_right = con.RelationFromQuery("SELECT 1 AS id", "union_right");
+	auto union_distinct = union_left->Union(union_right)->Distinct();
+	REQUIRE_NOTHROW(result = union_distinct->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+	REQUIRE_FALSE(union_distinct->GetQuery().empty());
+	REQUIRE_NOTHROW(result = con.Query(union_distinct->GetQuery()));
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
 }
 
 TEST_CASE("Struct fields preserve relation serialization boundaries", "[relation_api]") {

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -456,6 +456,10 @@ string DuckDBPyRelation::ToSQL() {
 		// This relation is just a wrapper around a result set, can't figure out what the SQL was
 		return "";
 	}
+	if (!rel->CanSerializeToQueryNode()) {
+		// Some logical operators and binding scopes have no faithful SQL representation.
+		return "";
+	}
 	try {
 		return rel->GetQueryNode()->ToString();
 	} catch (const std::exception &) {

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -456,7 +456,12 @@ string DuckDBPyRelation::ToSQL() {
 		// This relation is just a wrapper around a result set, can't figure out what the SQL was
 		return "";
 	}
-	auto query_node = rel->TryGetSerializableQueryNode();
+	unique_ptr<QueryNode> query_node;
+	{
+		D_ASSERT(py::gil_check());
+		py::gil_scoped_release release;
+		query_node = rel->TryGetSerializableQueryNode();
+	}
 	if (!query_node) {
 		// Some logical operators and binding scopes have no faithful SQL representation.
 		return "";

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -456,17 +456,17 @@ string DuckDBPyRelation::ToSQL() {
 		// This relation is just a wrapper around a result set, can't figure out what the SQL was
 		return "";
 	}
-	unique_ptr<QueryNode> query_node;
-	{
-		D_ASSERT(py::gil_check());
-		py::gil_scoped_release release;
-		query_node = rel->TryGetSerializableQueryNode();
-	}
-	if (!query_node) {
-		// Some logical operators and binding scopes have no faithful SQL representation.
-		return "";
-	}
 	try {
+		unique_ptr<QueryNode> query_node;
+		{
+			D_ASSERT(py::gil_check());
+			py::gil_scoped_release release;
+			query_node = rel->TryGetSerializableQueryNode();
+		}
+		if (!query_node) {
+			// Some logical operators and binding scopes have no faithful SQL representation.
+			return "";
+		}
 		return query_node->ToString();
 	} catch (const std::exception &) {
 		return "";

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -456,12 +456,13 @@ string DuckDBPyRelation::ToSQL() {
 		// This relation is just a wrapper around a result set, can't figure out what the SQL was
 		return "";
 	}
-	if (!rel->CanSerializeToQueryNode()) {
+	auto query_node = rel->TryGetSerializableQueryNode();
+	if (!query_node) {
 		// Some logical operators and binding scopes have no faithful SQL representation.
 		return "";
 	}
 	try {
-		return rel->GetQueryNode()->ToString();
+		return query_node->ToString();
 	} catch (const std::exception &) {
 		return "";
 	}

--- a/src/duckdb_py/python_replacement_scan.cpp
+++ b/src/duckdb_py/python_replacement_scan.cpp
@@ -143,6 +143,11 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 			    "created by another Connection and can therefore not be used by this Connection.",
 			    name);
 		}
+		if (!pyrel->GetRel().CanSerializeToQueryNode()) {
+			throw NotImplementedException("Cannot use a relation that cannot be faithfully represented as a SQL query "
+			                              "node in a replacement scan; conversion would discard the exchange or lose "
+			                              "relation bindings");
+		}
 		// create a subquery from the underlying relation object
 		auto select = make_uniq<SelectStatement>();
 		select->node = pyrel->GetRel().GetQueryNode();

--- a/src/duckdb_py/python_replacement_scan.cpp
+++ b/src/duckdb_py/python_replacement_scan.cpp
@@ -18,6 +18,7 @@
 #include "duckdb_python/pandas/pandas_scan.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb_python/pyrelation.hpp"
+#include "duckdb/planner/binder.hpp"
 #include <duckdb/main/settings.hpp>
 #include "duckdb_python/pybind11/gil_wrapper.hpp"
 
@@ -143,14 +144,16 @@ unique_ptr<TableRef> PythonReplacementScan::TryReplacementObject(const py::objec
 			    "created by another Connection and can therefore not be used by this Connection.",
 			    name);
 		}
-		if (!pyrel->GetRel().CanSerializeToQueryNode()) {
+		auto binder = Binder::CreateBinder(context);
+		auto query_node = pyrel->GetRel().TryGetSerializableQueryNode(*binder);
+		if (!query_node) {
 			throw NotImplementedException("Cannot use a relation that cannot be faithfully represented as a SQL query "
 			                              "node in a replacement scan; conversion would discard the exchange or lose "
 			                              "relation bindings");
 		}
 		// create a subquery from the underlying relation object
 		auto select = make_uniq<SelectStatement>();
-		select->node = pyrel->GetRel().GetQueryNode();
+		select->node = std::move(query_node);
 		auto subquery = make_uniq<SubqueryRef>(std::move(select));
 		auto dependency = make_uniq<ExternalDependency>();
 		dependency->AddDependency("replacement_cache", PythonDependencyItem::Create(entry));

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -28,7 +28,8 @@ static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::
 	auto client_context = rel->context->GetContext();
 	string serialized_plan;
 	client_context->RunFunctionInTransaction([&]() {
-		auto relation_stmt = make_uniq<duckdb::RelationStatement>(rel);
+		auto statement_binder = duckdb::Binder::CreateBinder(*client_context);
+		auto relation_stmt = make_uniq<duckdb::RelationStatement>(rel, *statement_binder);
 		duckdb::Planner planner(*client_context);
 		planner.CreatePlan(std::move(relation_stmt));
 		auto logical_plan = std::move(planner.plan);

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -1,6 +1,12 @@
 from collections import Counter
 from itertools import product
 
+# SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: MIT AND Apache-2.0
+#
+# Modified by Vane contributors.
+
 import pytest
 
 import duckdb
@@ -120,6 +126,13 @@ class TestRAPIJoins:
 
         assert relation.order("1").limit(1).fetchone() == (1, "a")
 
+    def test_order_by_ordinal_uses_visible_columns_after_using_join(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1, 'L1'), (2, 'L2')) data(id, value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 'z'), (2, 'a')) data(id, sort_key)").set_alias("r")
+        relation = left.join(right, "id")
+
+        assert relation.order("3").limit(1).project("*").fetchall() == [(2, "L2", "a")]
+
     def test_filter_columns_expression(self, con):
         relation = con.sql("SELECT * FROM (VALUES (1, 2), (1, -1)) data(a, b)")
 
@@ -160,6 +173,121 @@ class TestRAPIJoins:
         result = relation.project("emp1.emp_id, emp2.emp_id AS manager_id")
 
         assert sorted(result.fetchall()) == sorted(expected)
+
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("project", [(1, 10), (1, 20), (2, 10), (2, 20)]),
+            ("filter", [(2, 10), (2, 20)]),
+            ("order", [(2, 20), (2, 10), (1, 20), (1, 10)]),
+            ("aggregate", [(1, 30), (2, 30)]),
+        ],
+    )
+    def test_cross_join_qualified_bindings_survive_unary_operations(self, con, operation, expected):
+        left = con.sql("SELECT * FROM (VALUES (1), (2)) AS data(i)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (10), (20)) AS data(i)").set_alias("r")
+        relation = left.cross(right)
+
+        if operation == "project":
+            result = relation.project("l.i AS left_i, r.i AS right_i")
+        elif operation == "filter":
+            result = relation.filter("l.i = 2")
+        elif operation == "order":
+            result = relation.order("l.i DESC, r.i DESC")
+        else:
+            result = relation.aggregate("l.i AS left_i, sum(r.i) AS total", "l.i")
+
+        rows = result.fetchall()
+        if operation == "order":
+            assert rows == expected
+        else:
+            assert sorted(rows) == expected
+
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("project", [(2, 10), (2, 20)]),
+            ("filter", [(2, 20)]),
+            ("order", [(2, 20), (2, 10)]),
+            ("aggregate", [(2, 30)]),
+        ],
+    )
+    def test_cross_join_qualified_bindings_survive_inheriting_filter(self, con, operation, expected):
+        left = con.sql("SELECT * FROM (VALUES (1), (2)) AS data(i)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (10), (20)) AS data(i)").set_alias("r")
+        filtered = left.cross(right).filter("l.i = 2")
+
+        if operation == "project":
+            result = filtered.project("l.i AS left_i, r.i AS right_i")
+        elif operation == "filter":
+            result = filtered.filter("r.i = 20")
+        elif operation == "order":
+            result = filtered.order("r.i DESC")
+        else:
+            result = filtered.aggregate("l.i AS left_i, sum(r.i) AS total", "l.i")
+
+        rows = result.fetchall()
+        if operation == "order":
+            assert rows == expected
+        else:
+            assert sorted(rows) == expected
+
+    def test_cross_join_limit_remains_before_aggregate(self, con):
+        left = con.sql("SELECT 1 AS a FROM range(3)").set_alias("l")
+        right = con.sql("SELECT 10 AS b").set_alias("r")
+
+        result = left.cross(right).limit(1).aggregate("sum(a)")
+
+        assert result.fetchall() == [(1,)]
+
+    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    def test_direct_bound_relation_does_not_emit_unbindable_sql(self, con, boundary):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id")
+        if boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(1)
+        else:
+            relation = relation.order("r.right_value")
+        relation = relation.project("r.right_value")
+
+        assert relation.fetchall() == [(20,)]
+        assert relation.sql_query() == ""
+
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM relation")
+
+    def test_explicit_alias_restores_serializable_scope_after_join_boundary(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").distinct().set_alias("joined").project("joined.right_value")
+
+        sql = relation.sql_query()
+        assert sql
+        assert con.sql(sql).fetchall() == relation.fetchall() == [(20,)]
+
+    def test_unqualified_projection_after_join_boundary_remains_serializable(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").distinct().project("right_value")
+
+        sql = relation.sql_query()
+        assert sql
+        assert con.sql(sql).fetchall() == relation.fetchall() == [(20,)]
+
+    @pytest.mark.parametrize("operation", ["create", "create_view", "insert_into"])
+    def test_direct_bound_relation_rejects_sql_terminal_operations(self, con, operation):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").distinct().project("r.right_value")
+        target = f"direct_bound_{operation}"
+        if operation == "insert_into":
+            con.execute(f"CREATE TABLE {target} (right_value INTEGER)")
+
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            getattr(relation, operation)(target)
 
     @pytest.mark.parametrize("threads", [1, 4])
     @pytest.mark.parametrize("left_count,right_count", CROSS_JOIN_BOUNDARY_CASES)

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -377,6 +377,29 @@ class TestRAPIJoins:
 
         assert result.fetchall() == [(2,)]
 
+    @pytest.mark.parametrize("join_type", ["semi", "anti"])
+    def test_distinct_semi_anti_join_uses_surviving_output(self, con, join_type):
+        left = con.sql("SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (2, 'two')) data(id, value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1), (3)) data(id)").set_alias("r")
+
+        result = left.join(right, "l.id = r.id", join_type).distinct().project("l.id, l.value")
+
+        expected = [(1, "one")] if join_type == "semi" else [(2, "two")]
+        assert result.fetchall() == expected
+
+    @pytest.mark.parametrize("consumer", ["limit", "distinct"])
+    def test_window_order_over_join_remains_chainable(self, con, consumer):
+        left = con.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
+        ordered = left.join(right, "l.id = r.id").order("row_number() OVER (ORDER BY l.id DESC)")
+
+        if consumer == "limit":
+            result = ordered.limit(1).project("l.id, r.value")
+            assert result.fetchall() == [(2, 20)]
+        else:
+            result = ordered.distinct().project("l.id, r.value").order("1")
+            assert result.fetchall() == [(1, 10), (2, 20)]
+
     def test_explicit_alias_restores_serializable_scope_after_join_boundary(self, con):
         left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
         right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -259,6 +259,125 @@ class TestRAPIJoins:
         with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
             con.sql("SELECT * FROM relation")
 
+    @pytest.mark.parametrize("operation", ["filter", "order", "project", "aggregate", "distinct", "limit", "alias"])
+    def test_direct_bound_projection_remains_chainable(self, con, operation):
+        left = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 100), (2, 200)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").distinct().project("r.right_value AS x")
+
+        if operation == "filter":
+            result = relation.filter("x > 100")
+        elif operation == "order":
+            result = relation.order("x DESC")
+        elif operation == "project":
+            result = relation.project("x + 1 AS y")
+        elif operation == "aggregate":
+            result = relation.aggregate("sum(x)")
+        elif operation == "distinct":
+            result = relation.distinct()
+        elif operation == "limit":
+            result = relation.limit(1)
+        else:
+            result = relation.set_alias("projected").filter("projected.x >= 100")
+
+        rows = result.fetchall()
+        assert result.sql_query() == ""
+        if operation == "filter":
+            assert rows == [(200,)]
+        elif operation == "order":
+            assert rows == [(200,), (100,)]
+        elif operation == "project":
+            assert sorted(rows) == [(101,), (201,)]
+        elif operation == "aggregate":
+            assert rows == [(300,)]
+        elif operation == "limit":
+            assert len(rows) == 1
+            assert rows[0] in {(100,), (200,)}
+        else:
+            assert sorted(rows) == [(100,), (200,)]
+
+    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    def test_correlated_subquery_after_join_boundary_is_not_serialized(self, con, boundary):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id")
+        if boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(1)
+        else:
+            relation = relation.order("r.right_value")
+        relation = relation.project("(SELECT r.right_value) AS value")
+
+        assert relation.fetchall() == [(20,)]
+        assert relation.sql_query() == ""
+
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM relation")
+
+    def test_explicit_alias_restores_serializable_scope_for_correlated_subquery(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")
+        relation = (
+            left.join(right, "l.id = r.id")
+            .distinct()
+            .set_alias("joined")
+            .project("(SELECT joined.right_value) AS value")
+        )
+
+        sql = relation.sql_query()
+        assert sql
+        assert con.sql(sql).fetchall() == relation.fetchall() == [(20,)]
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("(SELECT 42) AS value", [(42,), (42,)]),
+            ("(SELECT r.value FROM (VALUES (42)) r(value)) AS value", [(42,), (42,)]),
+            ("(SELECT (SELECT r.value) FROM (VALUES (42)) r(value)) AS value", [(42,), (42,)]),
+        ],
+    )
+    def test_uncorrelated_subquery_after_join_boundary_remains_serializable(self, con, expression, expected):
+        left = con.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").distinct().project(expression)
+
+        sql = relation.sql_query()
+        assert sql
+        assert relation.fetchall() == expected
+        assert con.sql(sql).fetchall() == expected
+
+    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    def test_join_boundary_survives_uncorrelated_subquery(self, con, boundary):
+        left = con.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id")
+        if boundary == "distinct":
+            relation = relation.distinct()
+            expected = [(10,), (20,)]
+        elif boundary == "limit":
+            relation = relation.limit(1)
+            expected = [(10,)]
+        else:
+            relation = relation.order("r.value DESC")
+            expected = [(20,), (10,), (10,)]
+
+        result = relation.project("r.value + (SELECT 0) AS value")
+
+        rows = result.fetchall()
+        if boundary == "distinct":
+            assert sorted(rows) == expected
+        else:
+            assert rows == expected
+
+    def test_distinct_join_can_feed_aggregate(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
+
+        result = left.join(right, "l.id = r.id").distinct().aggregate("count(*)")
+
+        assert result.fetchall() == [(2,)]
+
     def test_explicit_alias_restores_serializable_scope_after_join_boundary(self, con):
         left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")
         right = con.sql("SELECT * FROM (VALUES (1, 20)) data(id, right_value)").set_alias("r")

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -648,15 +648,42 @@ class TestRAPIJoins:
             con.sql("SELECT * FROM result")
 
     @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
-    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    @pytest.mark.parametrize("boundary", ["limit", "order"])
     def test_virtual_rowid_after_join_boundary_is_not_serialized(self, con, boundary, expression):
         con.execute("CREATE TABLE rowid_source(value INTEGER)")
         con.execute("INSERT INTO rowid_source VALUES (10), (20)")
         left = con.table("rowid_source")
         right = con.sql("SELECT 1 AS join_key").set_alias("r")
         relation = left.cross(right)
-        if boundary == "distinct":
-            relation = relation.distinct()
+        if boundary == "limit":
+            relation = relation.limit(2)
+        else:
+            relation = relation.order("rowid_source.value")
+        result = relation.project(expression)
+
+        assert sorted(result.fetchall()) == [(0,), (1,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
+    def test_virtual_rowid_after_distinct_join_boundary_is_rejected(self, con, expression):
+        con.execute("CREATE TABLE rowid_source(value INTEGER)")
+        con.execute("INSERT INTO rowid_source VALUES (10), (20)")
+        left = con.table("rowid_source")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+
+        with pytest.raises(duckdb.BinderException, match="rowid"):
+            left.cross(right).distinct().project(expression)
+
+    @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
+    @pytest.mark.parametrize("boundary", ["filter", "limit", "order"])
+    def test_virtual_rowid_after_single_source_boundary_is_not_serialized(self, con, boundary, expression):
+        con.execute("CREATE TABLE rowid_source(value INTEGER)")
+        con.execute("INSERT INTO rowid_source VALUES (10), (20)")
+        relation = con.table("rowid_source")
+        if boundary == "filter":
+            relation = relation.filter("value > 0")
         elif boundary == "limit":
             relation = relation.limit(2)
         else:
@@ -669,52 +696,32 @@ class TestRAPIJoins:
             con.sql("SELECT * FROM result")
 
     @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
-    @pytest.mark.parametrize("boundary", ["filter", "distinct", "limit", "order"])
-    def test_virtual_rowid_after_single_source_boundary_is_not_serialized(self, con, boundary, expression):
+    def test_virtual_rowid_after_single_source_distinct_is_rejected(self, con, expression):
         con.execute("CREATE TABLE rowid_source(value INTEGER)")
         con.execute("INSERT INTO rowid_source VALUES (10), (20)")
-        relation = con.table("rowid_source")
-        if boundary == "filter":
-            relation = relation.filter("value > 0")
-        elif boundary == "distinct":
-            relation = relation.distinct()
-        elif boundary == "limit":
-            relation = relation.limit(2)
-        else:
-            relation = relation.order("rowid_source.value")
-        result = relation.project(expression)
 
-        assert sorted(result.fetchall()) == [(0,), (1,)]
-        assert result.sql_query() == ""
-        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
-            con.sql("SELECT * FROM result")
+        with pytest.raises(duckdb.BinderException, match="rowid"):
+            con.table("rowid_source").distinct().project(expression)
 
     @pytest.mark.parametrize(
-        ("expression", "expected"),
+        "expression",
         [
-            ("read_parquet.filename AS value", None),
-            ("filename AS value", None),
-            ("read_parquet.file_index AS value", [(0,)]),
-            ("file_index AS value", [(0,)]),
-            ("read_parquet.file_row_number AS value", [(0,)]),
-            ("file_row_number AS value", [(0,)]),
+            "read_parquet.filename AS value",
+            "filename AS value",
+            "read_parquet.file_index AS value",
+            "file_index AS value",
+            "read_parquet.file_row_number AS value",
+            "file_row_number AS value",
         ],
     )
-    def test_table_function_virtual_column_after_join_boundary_is_not_serialized(
-        self, con, tmp_path, expression, expected
-    ):
+    def test_table_function_virtual_column_after_distinct_join_boundary_is_rejected(self, con, tmp_path, expression):
         parquet_path = tmp_path / "virtual_columns.parquet"
         con.execute(f"COPY (SELECT 1 AS id) TO '{parquet_path}' (FORMAT PARQUET)")
         left = con.table_function("read_parquet", [str(parquet_path)])
         right = con.sql("SELECT 1 AS join_key").set_alias("r")
-        result = left.cross(right).distinct().project(expression)
-        if expected is None:
-            expected = [(str(parquet_path),)]
 
-        assert result.fetchall() == expected
-        assert result.sql_query() == ""
-        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
-            con.sql("SELECT * FROM result")
+        with pytest.raises(duckdb.BinderException):
+            left.cross(right).distinct().project(expression)
 
     @pytest.mark.parametrize(
         ("expression", "expected"),
@@ -727,7 +734,7 @@ class TestRAPIJoins:
             ("file_row_number AS value", [(0,)]),
         ],
     )
-    @pytest.mark.parametrize("boundary", ["filter", "distinct", "limit", "order"])
+    @pytest.mark.parametrize("boundary", ["filter", "limit", "order"])
     def test_table_function_virtual_column_after_single_source_boundary_is_not_serialized(
         self, con, tmp_path, expression, expected, boundary
     ):
@@ -736,8 +743,6 @@ class TestRAPIJoins:
         relation = con.table_function("read_parquet", [str(parquet_path)])
         if boundary == "filter":
             relation = relation.filter("id > 0")
-        elif boundary == "distinct":
-            relation = relation.distinct()
         elif boundary == "limit":
             relation = relation.limit(1)
         else:
@@ -750,6 +755,25 @@ class TestRAPIJoins:
         assert result.sql_query() == ""
         with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
             con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "read_parquet.filename AS value",
+            "filename AS value",
+            "read_parquet.file_index AS value",
+            "file_index AS value",
+            "read_parquet.file_row_number AS value",
+            "file_row_number AS value",
+        ],
+    )
+    def test_table_function_virtual_column_after_single_source_distinct_is_rejected(self, con, tmp_path, expression):
+        parquet_path = tmp_path / "single_source_distinct_virtual_columns.parquet"
+        con.execute(f"COPY (SELECT 1 AS id) TO '{parquet_path}' (FORMAT PARQUET)")
+        relation = con.table_function("read_parquet", [str(parquet_path)])
+
+        with pytest.raises(duckdb.BinderException):
+            relation.distinct().project(expression)
 
     @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
     def test_join_boundary_survives_uncorrelated_subquery(self, con, boundary):

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -347,6 +347,238 @@ class TestRAPIJoins:
         assert con.sql(sql).fetchall() == expected
 
     @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    def test_struct_field_after_join_boundary_remains_serializable(self, con, boundary):
+        left = con.sql("SELECT {'a': 7} AS payload, 1 AS id").set_alias("l")
+        right = con.sql("SELECT 1 AS id").set_alias("r")
+        relation = left.join(right, "l.id = r.id")
+        if boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(1)
+        else:
+            relation = relation.order("l.id")
+        result = relation.project("payload.a AS value")
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(7,)]
+        assert con.sql(sql).fetchall() == [(7,)]
+        assert con.sql("SELECT * FROM result").fetchall() == [(7,)]
+
+    def test_lambda_field_after_join_boundary_remains_serializable(self, con):
+        left = con.sql("SELECT [{'a': 7}] AS payloads, 1 AS id").set_alias("l")
+        right = con.sql("SELECT 1 AS id").set_alias("r")
+        result = (
+            left.join(right, "l.id = r.id").distinct().project("list_transform(payloads, item -> item.a) AS values")
+        )
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [([7],)]
+        assert con.sql(sql).fetchall() == [([7],)]
+
+    def test_deep_struct_field_after_join_boundary_remains_serializable(self, con):
+        left = con.sql("SELECT {'a': {'b': {'c': {'d': 7}}}} AS payload, 1 AS id").set_alias("l")
+        right = con.sql("SELECT 1 AS id").set_alias("r")
+        result = left.join(right, "l.id = r.id").distinct().project("payload.a.b.c.d AS value")
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(7,)]
+        assert con.sql(sql).fetchall() == [(7,)]
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("(SELECT l.id FROM (VALUES (99)) l(other)) AS value", [(7,)]),
+            ("(SELECT l.payload.a FROM (VALUES (99)) payload(a)) AS value", [(8,)]),
+        ],
+    )
+    def test_nested_alias_without_matching_column_does_not_hide_join_binding(self, con, expression, expected):
+        left = con.sql("SELECT 7 AS id, {'a': 8} AS payload, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = left.join(right, "l.join_key = r.join_key").distinct().project(expression)
+
+        assert result.fetchall() == expected
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    def test_nested_alias_with_matching_column_hides_join_binding(self, con):
+        left = con.sql("SELECT 1 AS id").set_alias("l")
+        right = con.sql("SELECT 1 AS id, 100 AS value").set_alias("r")
+        result = (
+            left.join(right, "l.id = r.id").distinct().project("(SELECT r.value FROM (VALUES (42)) r(value)) AS value")
+        )
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(42,)]
+        assert con.sql(sql).fetchall() == [(42,)]
+
+    def test_nested_subquery_output_column_hides_join_binding(self, con):
+        left = con.sql("SELECT 1 AS id").set_alias("l")
+        right = con.sql("SELECT 1 AS id, 100 AS right_value").set_alias("r")
+        result = (
+            left.join(right, "l.id = r.id")
+            .distinct()
+            .project("(SELECT r.right_value FROM (SELECT 42 AS right_value) r) AS value")
+        )
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(42,)]
+        assert con.sql(sql).fetchall() == [(42,)]
+
+    def test_from_subquery_alias_is_not_visible_inside_its_own_query(self, con):
+        left = con.sql("SELECT 7 AS id, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = (
+            left.join(right, "l.join_key = r.join_key")
+            .distinct()
+            .project("(SELECT id FROM (SELECT l.id) l(id)) AS value")
+        )
+
+        assert result.fetchall() == [(7,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    def test_table_function_alias_is_not_visible_inside_its_arguments(self, con):
+        left = con.sql("SELECT 2 AS id, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = (
+            left.join(right, "l.join_key = r.join_key")
+            .distinct()
+            .project("(SELECT count(*) FROM range(l.id) l(id)) AS value")
+        )
+
+        assert result.fetchall() == [(2,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    def test_pivot_source_alias_is_not_visible_after_pivot(self, con):
+        left = con.sql("SELECT 7 AS id, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = (
+            left.join(right, "l.join_key = r.join_key")
+            .distinct()
+            .project(
+                "(SELECT l.id FROM (VALUES (1, 'a')) l(id, pivot_key) PIVOT (count(*) FOR pivot_key IN ('a'))) AS value"
+            )
+        )
+
+        assert result.fetchall() == [(7,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
+    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
+    def test_virtual_rowid_after_join_boundary_is_not_serialized(self, con, boundary, expression):
+        con.execute("CREATE TABLE rowid_source(value INTEGER)")
+        con.execute("INSERT INTO rowid_source VALUES (10), (20)")
+        left = con.table("rowid_source")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        relation = left.cross(right)
+        if boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(2)
+        else:
+            relation = relation.order("rowid_source.value")
+        result = relation.project(expression)
+
+        assert sorted(result.fetchall()) == [(0,), (1,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize("expression", ["rowid_source.rowid AS row_id", "rowid AS row_id"])
+    @pytest.mark.parametrize("boundary", ["filter", "distinct", "limit", "order"])
+    def test_virtual_rowid_after_single_source_boundary_is_not_serialized(self, con, boundary, expression):
+        con.execute("CREATE TABLE rowid_source(value INTEGER)")
+        con.execute("INSERT INTO rowid_source VALUES (10), (20)")
+        relation = con.table("rowid_source")
+        if boundary == "filter":
+            relation = relation.filter("value > 0")
+        elif boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(2)
+        else:
+            relation = relation.order("rowid_source.value")
+        result = relation.project(expression)
+
+        assert sorted(result.fetchall()) == [(0,), (1,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("read_parquet.filename AS value", None),
+            ("filename AS value", None),
+            ("read_parquet.file_index AS value", [(0,)]),
+            ("file_index AS value", [(0,)]),
+            ("read_parquet.file_row_number AS value", [(0,)]),
+            ("file_row_number AS value", [(0,)]),
+        ],
+    )
+    def test_table_function_virtual_column_after_join_boundary_is_not_serialized(
+        self, con, tmp_path, expression, expected
+    ):
+        parquet_path = tmp_path / "virtual_columns.parquet"
+        con.execute(f"COPY (SELECT 1 AS id) TO '{parquet_path}' (FORMAT PARQUET)")
+        left = con.table_function("read_parquet", [str(parquet_path)])
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = left.cross(right).distinct().project(expression)
+        if expected is None:
+            expected = [(str(parquet_path),)]
+
+        assert result.fetchall() == expected
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("read_parquet.filename AS value", None),
+            ("filename AS value", None),
+            ("read_parquet.file_index AS value", [(0,)]),
+            ("file_index AS value", [(0,)]),
+            ("read_parquet.file_row_number AS value", [(0,)]),
+            ("file_row_number AS value", [(0,)]),
+        ],
+    )
+    @pytest.mark.parametrize("boundary", ["filter", "distinct", "limit", "order"])
+    def test_table_function_virtual_column_after_single_source_boundary_is_not_serialized(
+        self, con, tmp_path, expression, expected, boundary
+    ):
+        parquet_path = tmp_path / "single_source_virtual_columns.parquet"
+        con.execute(f"COPY (SELECT 1 AS id) TO '{parquet_path}' (FORMAT PARQUET)")
+        relation = con.table_function("read_parquet", [str(parquet_path)])
+        if boundary == "filter":
+            relation = relation.filter("id > 0")
+        elif boundary == "distinct":
+            relation = relation.distinct()
+        elif boundary == "limit":
+            relation = relation.limit(1)
+        else:
+            relation = relation.order("id")
+        result = relation.project(expression)
+        if expected is None:
+            expected = [(str(parquet_path),)]
+
+        assert result.fetchall() == expected
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    @pytest.mark.parametrize("boundary", ["distinct", "limit", "order"])
     def test_join_boundary_survives_uncorrelated_subquery(self, con, boundary):
         left = con.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)").set_alias("l")
         right = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
@@ -377,6 +609,25 @@ class TestRAPIJoins:
 
         assert result.fetchall() == [(2,)]
 
+    def test_distinct_using_join_uses_visible_output_columns(self, con):
+        left = con.sql("SELECT 1::INTEGER AS id, 'same' AS left_value").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES ('1', 'same'), ('01', 'same')) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "id").distinct()
+
+        expected = [(1, "same", "same")]
+        assert relation.fetchall() == expected
+        assert relation.limit(10).fetchall() == expected
+        assert relation.aggregate("count(*)").fetchall() == [(1,)]
+
+    def test_distinct_full_outer_using_join_uses_coalesced_key(self, con):
+        left = con.sql("SELECT * FROM (VALUES (1, 'left'), (1, 'left')) data(id, left_value)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (2, 'right'), (2, 'right')) data(id, right_value)").set_alias("r")
+        relation = left.join(right, "id", "outer").distinct()
+
+        expected = [(1, "left", None), (2, None, "right")]
+        assert relation.order("id").limit(10).fetchall() == expected
+        assert relation.aggregate("count(*)").fetchall() == [(2,)]
+
     @pytest.mark.parametrize("join_type", ["semi", "anti"])
     def test_distinct_semi_anti_join_uses_surviving_output(self, con, join_type):
         left = con.sql("SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (2, 'two')) data(id, value)").set_alias("l")
@@ -399,6 +650,24 @@ class TestRAPIJoins:
         else:
             result = ordered.distinct().project("l.id, r.value").order("1")
             assert result.fetchall() == [(1, 10), (2, 20)]
+
+    def test_chained_order_reuses_duplicate_volatile_projection(self, con):
+        left = con.sql("SELECT * FROM range(4) data(id)").set_alias("l")
+        right = con.sql("SELECT 1 AS value").set_alias("r")
+        relation = left.cross(right)
+
+        con.execute("CREATE SEQUENCE direct_order_sequence START 1")
+        relation.order("nextval('direct_order_sequence'), nextval('direct_order_sequence')").fetchall()
+
+        con.execute("CREATE SEQUENCE chained_order_sequence START 1")
+        relation.order("nextval('chained_order_sequence'), nextval('chained_order_sequence')").limit(4).fetchall()
+
+        con.execute("CREATE SEQUENCE distinct_order_sequence START 1")
+        relation.order("nextval('distinct_order_sequence'), nextval('distinct_order_sequence') + 0").limit(4).fetchall()
+
+        assert con.sql("SELECT currval('direct_order_sequence')").fetchone() == (4,)
+        assert con.sql("SELECT currval('chained_order_sequence')").fetchone() == (4,)
+        assert con.sql("SELECT currval('distinct_order_sequence')").fetchone() == (8,)
 
     def test_explicit_alias_restores_serializable_scope_after_join_boundary(self, con):
         left = con.sql("SELECT * FROM (VALUES (1, 10)) data(id, left_value)").set_alias("l")

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -430,6 +430,179 @@ class TestRAPIJoins:
         assert result.fetchall() == [(42,)]
         assert con.sql(sql).fetchall() == [(42,)]
 
+    def test_deduplicated_hidden_column_name_is_not_serialized(self, con):
+        left = con.sql("SELECT 1 AS x, 2 AS x").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        boundary = left.cross(right).distinct()
+
+        hidden = boundary.project("l.x_1 AS value")
+        assert hidden.fetchall() == [(2,)]
+        assert hidden.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM hidden")
+
+        surviving = boundary.project("x_1 AS value")
+        sql = surviving.sql_query()
+        assert sql
+        assert surviving.fetchall() == [(2,)]
+        assert con.sql(sql).fetchall() == [(2,)]
+
+    @pytest.mark.parametrize(
+        ("setup_sql", "expression"),
+        [
+            (
+                "CREATE TABLE local_scope_source AS SELECT 42 AS id",
+                "(SELECT l.id FROM local_scope_source AS l) AS value",
+            ),
+            (
+                "CREATE VIEW local_scope_source AS SELECT 42 AS id",
+                "(SELECT l.id FROM local_scope_source AS l) AS value",
+            ),
+            (
+                "CREATE TABLE local_scope_source AS SELECT 42 AS id",
+                "(SELECT l.id FROM (SELECT * FROM local_scope_source) AS l) AS value",
+            ),
+            (
+                None,
+                "(SELECT l.range FROM range(42, 43) AS l) AS value",
+            ),
+            (
+                "CREATE TABLE local_scope_source AS SELECT 42 AS id",
+                "(WITH local AS (SELECT * FROM local_scope_source) SELECT l.id FROM local AS l) AS value",
+            ),
+        ],
+    )
+    def test_bound_local_scope_hides_join_binding(self, con, setup_sql, expression):
+        if setup_sql:
+            con.execute(setup_sql)
+        left = con.sql("SELECT 7 AS id, 7 AS range, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = left.join(right, "l.join_key = r.join_key").distinct().project(expression)
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(42,)]
+        assert con.sql(sql).fetchall() == [(42,)]
+        assert con.sql("SELECT * FROM result").fetchall() == [(42,)]
+
+    def test_relation_serialization_rebinds_after_catalog_change(self, con):
+        con.execute("PRAGMA enable_verification")
+        con.execute("CREATE VIEW local_scope_source AS SELECT 42 AS right_value")
+        left = con.sql("SELECT 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key, 100 AS right_value").set_alias("r")
+        result = (
+            left.join(right, "l.join_key = r.join_key")
+            .distinct()
+            .project("(SELECT r.right_value FROM local_scope_source AS r) AS value")
+        )
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(42,)]
+        assert con.sql(sql).fetchall() == [(42,)]
+        assert con.sql("SELECT * FROM result").fetchall() == [(42,)]
+
+        con.execute("CREATE OR REPLACE VIEW local_scope_source AS SELECT 99 AS other")
+        assert result.fetchall() == [(100,)]
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+        con.execute("CREATE OR REPLACE VIEW local_scope_source AS SELECT 84 AS right_value")
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(84,)]
+        assert con.sql(sql).fetchall() == [(84,)]
+        assert con.sql("SELECT * FROM result").fetchall() == [(84,)]
+
+    @pytest.mark.parametrize("operation", ["project", "filter", "order", "aggregate"])
+    def test_bound_subquery_scope_controls_unary_expression_serialization(self, con, operation):
+        con.execute("CREATE TABLE local_scope_source AS SELECT 42 AS id")
+        left = con.sql("SELECT 7 AS id, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        boundary = left.join(right, "l.join_key = r.join_key").distinct()
+
+        if operation == "project":
+            local = boundary.project("(SELECT l.id FROM local_scope_source AS l) AS value")
+            correlated = boundary.project("(SELECT l.id) AS value")
+            expected_local = [(42,)]
+            expected_correlated = [(7,)]
+        elif operation == "filter":
+            local = boundary.filter("(SELECT l.id FROM local_scope_source AS l) = 42")
+            correlated = boundary.filter("(SELECT l.id) = 7")
+            expected_local = expected_correlated = [(7, 1, 1)]
+        elif operation == "order":
+            local = boundary.order("(SELECT l.id FROM local_scope_source AS l)")
+            correlated = boundary.order("(SELECT l.id)")
+            expected_local = expected_correlated = [(7, 1, 1)]
+        else:
+            local = boundary.aggregate("(SELECT l.id FROM local_scope_source AS l) AS value")
+            correlated = boundary.aggregate("(SELECT l.id) AS value")
+            expected_local = [(42,)]
+            expected_correlated = [(7,)]
+
+        sql = local.sql_query()
+        assert sql
+        assert local.fetchall() == expected_local
+        assert con.sql(sql).fetchall() == expected_local
+        assert con.sql("SELECT * FROM local").fetchall() == expected_local
+
+        assert correlated.sql_query() == ""
+        assert correlated.fetchall() == expected_correlated
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM correlated")
+
+    @pytest.mark.parametrize("operation", ["project", "filter", "order", "aggregate", "window_order"])
+    def test_macro_expansion_cannot_restore_hidden_join_binding(self, con, operation):
+        con.execute("CREATE MACRO relation_field(value) AS value.id")
+        left = con.sql("SELECT * FROM (VALUES (7, 1), (8, 1)) data(id, join_key)").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        boundary = left.join(right, "l.join_key = r.join_key").distinct()
+
+        if operation == "project":
+            result = boundary.project("relation_field(l) AS value")
+            assert sorted(result.fetchall()) == [(7,), (8,)]
+        elif operation == "filter":
+            result = boundary.filter("relation_field(l) = 7")
+            assert result.fetchall() == [(7, 1, 1)]
+        elif operation == "order":
+            result = boundary.order("relation_field(l) DESC")
+            assert result.fetchall() == [(8, 1, 1), (7, 1, 1)]
+        elif operation == "aggregate":
+            result = boundary.aggregate("min(relation_field(l)) AS value")
+            assert result.fetchall() == [(7,)]
+        else:
+            result = boundary.order("first_value(relation_field(l)) OVER (ORDER BY id DESC)")
+            assert sorted(result.fetchall()) == [(7, 1, 1), (8, 1, 1)]
+
+        assert result.sql_query() == ""
+        with pytest.raises(duckdb.NotImplementedException, match="faithfully represented"):
+            con.sql("SELECT * FROM result")
+
+    def test_macro_expansion_keeps_surviving_struct_column_serializable(self, con):
+        con.execute("CREATE MACRO relation_field(value) AS value.id")
+        left = con.sql("SELECT {'id': 42} AS payload, 1 AS join_key").set_alias("l")
+        right = con.sql("SELECT 1 AS join_key").set_alias("r")
+        result = left.join(right, "l.join_key = r.join_key").distinct().project("relation_field(payload) AS value")
+
+        sql = result.sql_query()
+        assert sql
+        assert result.fetchall() == [(42,)]
+        assert con.sql(sql).fetchall() == [(42,)]
+        assert con.sql("SELECT * FROM result").fetchall() == [(42,)]
+
+    @pytest.mark.parametrize(("join_type", "expected"), [("inner", [(1,)]), ("outer", [(1,), (2,), (3,)])])
+    def test_correlated_surviving_using_column_remains_serializable(self, con, join_type, expected):
+        left = con.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1), (3)) data(id)").set_alias("r")
+        result = left.join(right, "id", join_type).distinct().project("(SELECT id) AS value")
+
+        sql = result.sql_query()
+        assert sql
+        assert sorted(result.fetchall()) == expected
+        assert sorted(con.sql(sql).fetchall()) == expected
+        assert con.sql("SELECT * FROM result ORDER BY value").fetchall() == expected
+
     def test_from_subquery_alias_is_not_visible_inside_its_own_query(self, con):
         left = con.sql("SELECT 7 AS id, 1 AS join_key").set_alias("l")
         right = con.sql("SELECT 1 AS join_key").set_alias("r")

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -6,7 +6,6 @@ from itertools import product
 # SPDX-License-Identifier: MIT AND Apache-2.0
 #
 # Modified by Vane contributors.
-
 import pytest
 
 import duckdb

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -105,6 +105,62 @@ class TestRAPIJoins:
         res = rel.fetchall()
         assert res == [(1, 1, 1, 4), (2, 1, 1, 4), (3, 2, 1, 4), (1, 1, 3, 5), (2, 1, 3, 5), (3, 2, 3, 5)]
 
+    def test_cross_join_qualified_non_key_projection(self, con):
+        result = con.table("tbl_a").cross(con.table("tbl_b")).project("tbl_a.b, tbl_b.b")
+
+        assert result.order("1, 2").limit(1).fetchall() == [(1, 4)]
+
+    def test_real_table_join_qualified_non_key_projection(self, con):
+        relation = con.table("tbl_a").join(con.table("tbl_b"), "tbl_a.b = tbl_b.a")
+
+        assert relation.project("tbl_a.a, tbl_b.b").order("1").fetchall() == [(1, 4), (2, 4)]
+
+    def test_order_by_ordinal_preserves_relation_ordering(self, con):
+        relation = con.sql("SELECT * FROM (VALUES (2, 'b'), (1, 'a')) data(id, label)")
+
+        assert relation.order("1").limit(1).fetchone() == (1, "a")
+
+    def test_filter_columns_expression(self, con):
+        relation = con.sql("SELECT * FROM (VALUES (1, 2), (1, -1)) data(a, b)")
+
+        assert relation.filter("COLUMNS(*) > 0").fetchall() == [(1, 2)]
+
+    def test_order_by_subquery_uses_sql_binding(self, con):
+        relation = con.sql("SELECT * FROM (VALUES (2), (1)) data(id)")
+
+        assert relation.order("(SELECT -id)").fetchall() == [(2,), (1,)]
+
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("direct", [(2, 1), (2, 1), (3, 1)]),
+            ("filter", [(2, 1)]),
+            ("ordered_limit", [(3, 1)]),
+            ("distinct", [(2, 1), (2, 1), (3, 1)]),
+        ],
+    )
+    def test_qualified_join_bindings_survive_unary_relations(self, con, operation, expected):
+        con.execute("PRAGMA enable_verification")
+        con.execute(
+            "CREATE TEMP TABLE employees AS SELECT * FROM "
+            "(VALUES (1, -1, 'manager'), (2, 1, 'alpha'), (2, 1, 'beta'), (3, 1, 'gamma')) "
+            "data(emp_id, superior_emp_id, variant)"
+        )
+        employees = con.table("employees")
+        left = employees.set_alias("emp1")
+        right = employees.set_alias("emp2")
+        relation = left.join(right, "emp1.superior_emp_id = emp2.emp_id")
+        if operation == "filter":
+            relation = relation.filter("emp1.variant = 'beta'")
+        elif operation == "ordered_limit":
+            relation = relation.order("emp1.emp_id DESC").limit(1)
+        elif operation == "distinct":
+            relation = relation.distinct()
+
+        result = relation.project("emp1.emp_id, emp2.emp_id AS manager_id")
+
+        assert sorted(result.fetchall()) == sorted(expected)
+
     @pytest.mark.parametrize("threads", [1, 4])
     @pytest.mark.parametrize("left_count,right_count", CROSS_JOIN_BOUNDARY_CASES)
     def test_cross_join_vector_boundaries(self, con, threads, left_count, right_count):

--- a/tests/fast/relational_api/test_rapi_functions.py
+++ b/tests/fast/relational_api/test_rapi_functions.py
@@ -1,3 +1,5 @@
+import pytest
+
 import duckdb
 
 
@@ -10,3 +12,12 @@ class TestRAPIFunctions:
     def test_rapi_relation_sql_query(self):
         res = duckdb.table_function("range", [10])
         assert res.sql_query() == 'SELECT * FROM "range"(10)'
+
+    def test_rapi_relation_sql_query_after_catalog_change(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE TABLE sql_query_catalog_change(x INTEGER)")
+        relation = duckdb_cursor.table("sql_query_catalog_change").limit(1).project("x")
+        duckdb_cursor.execute("DROP TABLE sql_query_catalog_change")
+
+        assert relation.sql_query() == ""
+        with pytest.raises(duckdb.CatalogException):
+            relation.fetchall()

--- a/tests/fast/relational_api/test_rapi_query.py
+++ b/tests/fast/relational_api/test_rapi_query.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: MIT AND Apache-2.0
+#
+# Modified by Vane contributors.
+
 import platform
 import sys
 
@@ -26,6 +32,26 @@ def scoped_default(duckdb_cursor):
 
 
 class TestRAPIQuery:
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("project", [(1,), (2,)]),
+            ("filter", [(2,)]),
+            ("order", [(2,), (1,)]),
+        ],
+    )
+    def test_explicit_alias_is_binding_boundary_after_filter(self, duckdb_cursor, operation, expected):
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1), (-1)) data(id)").filter("id > 0").set_alias("foo")
+
+        if operation == "project":
+            result = relation.project("foo.id").order("foo.id")
+        elif operation == "filter":
+            result = relation.filter("foo.id > 1")
+        else:
+            result = relation.order("foo.id DESC")
+
+        assert result.fetchall() == expected
+
     @pytest.mark.parametrize("steps", [1, 2, 3, 4])
     def test_query_chain(self, steps):
         con = duckdb.default_connection()

--- a/tests/fast/relational_api/test_rapi_query.py
+++ b/tests/fast/relational_api/test_rapi_query.py
@@ -61,6 +61,14 @@ class TestRAPIQuery:
         assert duplicate_names.columns == ["x", "x"]
         assert duckdb_cursor.sql(duplicate_names_sql).columns == ["x", "x"]
 
+    def test_distinct_above_order_requires_a_final_order_for_deterministic_results(self, duckdb_cursor):
+        values = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)")
+        ordered_distinct = values.order("id DESC").distinct()
+
+        plan = ordered_distinct.explain()
+        assert plan.index("HASH_GROUP_BY") < plan.index("ORDER_BY")
+        assert ordered_distinct.order("id").fetchall() == [(1,), (2,)]
+
     @pytest.mark.parametrize(
         ("operation", "expected"),
         [

--- a/tests/fast/relational_api/test_rapi_query.py
+++ b/tests/fast/relational_api/test_rapi_query.py
@@ -32,6 +32,35 @@ def scoped_default(duckdb_cursor):
 
 
 class TestRAPIQuery:
+    def test_sql_query_preserves_result_modifier_boundaries(self, duckdb_cursor):
+        values = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (1), (2)) data(id)").order("id")
+
+        limited_distinct = values.limit(2).distinct()
+        limited_distinct_sql = limited_distinct.sql_query()
+        assert limited_distinct_sql
+        assert limited_distinct.fetchall() == [(1,)]
+        assert duckdb_cursor.sql(limited_distinct_sql).fetchall() == [(1,)]
+        assert duckdb_cursor.sql("SELECT * FROM limited_distinct").fetchall() == [(1,)]
+
+        double_limit = values.limit(2).limit(1)
+        double_limit_sql = double_limit.sql_query()
+        assert double_limit_sql
+        assert double_limit.fetchall() == [(1,)]
+        assert duckdb_cursor.sql(double_limit_sql).fetchall() == [(1,)]
+        assert duckdb_cursor.sql("SELECT * FROM double_limit").fetchall() == [(1,)]
+
+        union_distinct = duckdb_cursor.sql("SELECT 1 AS id").union(duckdb_cursor.sql("SELECT 1 AS id")).distinct()
+        union_distinct_sql = union_distinct.sql_query()
+        assert union_distinct_sql
+        assert union_distinct.fetchall() == [(1,)]
+        assert duckdb_cursor.sql(union_distinct_sql).fetchall() == [(1,)]
+        assert duckdb_cursor.sql("SELECT * FROM union_distinct").fetchall() == [(1,)]
+
+        duplicate_names = duckdb_cursor.sql("SELECT 1 AS x, 2 AS x").limit(1).distinct()
+        duplicate_names_sql = duplicate_names.sql_query()
+        assert duplicate_names.columns == ["x", "x"]
+        assert duckdb_cursor.sql(duplicate_names_sql).columns == ["x", "x"]
+
     @pytest.mark.parametrize(
         ("operation", "expected"),
         [

--- a/tests/fast/relational_api/test_rapi_windows.py
+++ b/tests/fast/relational_api/test_rapi_windows.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: MIT AND Apache-2.0
+#
+# Modified by Vane contributors.
+
 import pytest
 
 import duckdb
@@ -49,6 +55,25 @@ class TestRAPIWindows:
         assert len(result) == len(expected)
         assert all(r == e for r, e in zip(result, expected, strict=False))
 
+    def test_row_number_preserves_expression_name(self, table):
+        result = table.row_number("over (order by id, t)")
+
+        assert result.columns == ["row_number() OVER (ORDER BY id, t)"]
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_window_with_star_preserves_non_sql_exchange(self, table, exchange_method, plan_node):
+        relation = getattr(table, exchange_method)(2).project("*, row_number() OVER (ORDER BY id, t) AS row_number")
+
+        plan = relation.explain()
+        assert plan_node in plan
+        assert "WINDOW" in plan
+
+        rows = sorted(relation.fetchall(), key=lambda row: (row[0], row[2]))
+        assert [row[-1] for row in rows] == list(range(1, 9))
+
     @pytest.mark.parametrize(
         ("exchange_method", "plan_node"),
         [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
@@ -65,6 +90,229 @@ class TestRAPIWindows:
         assert plan_node in plan
         assert "WINDOW" in plan
         assert sorted(result.fetchall()) == [(1, 10, 1), (2, 10, 2)]
+
+    def test_window_star_deduplicates_child_column_names(self, duckdb_cursor):
+        relation = duckdb_cursor.sql("SELECT 1 AS x, 2 AS x").row_number("over ()", "*")
+
+        assert relation.columns == ["x", "x_1", "row_number() OVER ()"]
+        assert relation.fetchall() == [(1, 2, 1)]
+
+    def test_window_expands_nested_columns_star(self, duckdb_cursor):
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (10, 20), (30, 40)) data(a, b)")
+
+        result = relation.project("COLUMNS(*) + row_number() OVER ()").fetchall()
+
+        assert result == [(11, 21), (32, 42)]
+
+    def test_window_projection_preserves_qualified_aliases_through_filter(self, duckdb_cursor):
+        left = duckdb_cursor.sql("SELECT 1 AS left_value, 10 AS join_key").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 2 AS right_value, 10 AS join_key").set_alias("right_data")
+        joined = left.join(right, "left_data.join_key = right_data.join_key").filter("left_data.left_value = 1")
+
+        relation = joined.project("left_data.*, right_data.right_value, row_number() OVER () AS row_number")
+
+        assert relation.columns == ["left_value", "join_key", "right_value", "row_number"]
+        assert relation.fetchall() == [(1, 10, 2, 1)]
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_unqualified_window_projection_preserves_exchange_join(self, duckdb_cursor, exchange_method, plan_node):
+        left = duckdb_cursor.sql("SELECT 1 AS left_value, 10 AS left_key").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 2 AS right_value, 10 AS right_key").set_alias("right_data")
+        joined = left.join(right, "left_data.left_key = right_data.right_key")
+        relation = getattr(joined, exchange_method)(2).project("*, row_number() OVER () AS row_number")
+
+        assert plan_node in relation.explain()
+        assert relation.fetchall() == [(1, 10, 2, 10, 1)]
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    @pytest.mark.parametrize(
+        ("filter_before_exchange", "expected"),
+        [(False, [(1, 10), (2, 20)]), (True, [(2, 20)])],
+    )
+    def test_exchange_preserves_qualified_join_bindings(
+        self, duckdb_cursor, exchange_method, plan_node, filter_before_exchange, expected
+    ):
+        left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(left_value)").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(right_key, right_value)").set_alias(
+            "right_data"
+        )
+        joined = left.join(right, "left_data.left_value = right_data.right_key")
+        if filter_before_exchange:
+            joined = joined.filter("left_data.left_value = 2")
+
+        exchanged = getattr(joined, exchange_method)(2)
+        result = exchanged.project("left_data.left_value, right_data.right_value")
+
+        assert plan_node in result.explain()
+        assert sorted(result.fetchall()) == expected
+
+    @pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+    def test_qualified_join_bindings_survive_operations_after_exchange(self, duckdb_cursor, exchange_method):
+        left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(left_value)").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(right_key, right_value)").set_alias(
+            "right_data"
+        )
+        joined = left.join(right, "left_data.left_value = right_data.right_key")
+
+        result = (
+            getattr(joined, exchange_method)(2)
+            .filter("left_data.left_value > 0")
+            .order("right_data.right_value DESC")
+            .project("left_data.left_value, right_data.right_value")
+        )
+
+        assert result.fetchall() == [(2, 20), (1, 10)]
+
+    @pytest.mark.parametrize("exchange_method", [None, "repartition", "local_exchange"])
+    def test_window_order_resolves_prior_projection_alias(self, duckdb_cursor, exchange_method):
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1)) data(a)")
+        if exchange_method is not None:
+            relation = getattr(relation, exchange_method)(2)
+
+        result = relation.project("*, a + 1 AS x, row_number() OVER (ORDER BY x) AS row_number").order("a")
+
+        assert result.fetchall() == [(1, 2, 1), (2, 3, 2)]
+
+    def test_window_order_rejects_later_projection_alias(self, duckdb_cursor):
+        relation = duckdb_cursor.sql("SELECT 1 AS a")
+
+        with pytest.raises(duckdb.BinderException, match="cannot be referenced before it is defined"):
+            relation.project("row_number() OVER (ORDER BY x), a + 1 AS x")
+
+    def test_projection_resolves_prior_alias_without_window(self, duckdb_cursor):
+        relation = duckdb_cursor.sql("SELECT 1 AS a")
+
+        result = relation.project("*, a + 1 AS x, x + 1 AS y")
+
+        assert result.fetchall() == [(1, 2, 3)]
+
+    def test_projection_binds_macro_expanded_window(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE MACRO relation_row_number(x) AS row_number() OVER (ORDER BY x)")
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1)) data(a)")
+
+        result = relation.project("*, relation_row_number(a) AS row_number").order("a")
+
+        assert result.fetchall() == [(1, 1), (2, 2)]
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("(SELECT 42) AS value", [(1, 42), (2, 42)]),
+            ("(SELECT a + 10) AS value", [(1, 11), (2, 12)]),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [(None, None), ("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_projection_binds_scalar_subquery(self, duckdb_cursor, expression, expected, exchange_method, plan_node):
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1)) data(a)")
+        if exchange_method is not None:
+            relation = getattr(relation, exchange_method)(2)
+
+        result = relation.project(f"a, {expression}")
+
+        if plan_node is not None:
+            assert plan_node in result.explain()
+        assert sorted(result.fetchall()) == expected
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_projection_unnest_preserves_exchange(self, duckdb_cursor, exchange_method, plan_node):
+        relation = duckdb_cursor.sql("SELECT 1 AS id, [10, 20] AS values")
+        exchanged = getattr(relation, exchange_method)(2)
+        result = exchanged.project("* EXCLUDE (values), unnest(values) AS value")
+
+        assert plan_node in result.explain()
+        assert sorted(result.fetchall()) == [(1, 10), (1, 20)]
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_alias_after_exchange_preserves_plan_node(self, duckdb_cursor, exchange_method, plan_node):
+        relation = duckdb_cursor.sql("SELECT 1 AS a")
+        exchanged = getattr(relation, exchange_method)(2).set_alias("wrapped")
+        projected = exchanged.project("wrapped.a, row_number() OVER () AS row_number")
+
+        assert plan_node in projected.explain()
+        assert projected.fetchall() == [(1, 1)]
+
+    def test_alias_is_binding_boundary_over_join(self, duckdb_cursor):
+        left = duckdb_cursor.sql("SELECT 1 AS left_value, 10 AS left_key").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 2 AS right_value, 10 AS right_key").set_alias("right_data")
+        wrapped = left.join(right, "left_data.left_key = right_data.right_key").set_alias("wrapped")
+
+        result = wrapped.filter("wrapped.left_value = 1").project("wrapped.*, row_number() OVER () AS row_number")
+
+        assert result.fetchall() == [(1, 10, 2, 10, 1)]
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_alias_over_exchange_join_preserves_plan_node(self, duckdb_cursor, exchange_method, plan_node):
+        left = duckdb_cursor.sql("SELECT 1 AS left_value, 10 AS left_key").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 2 AS right_value, 10 AS right_key").set_alias("right_data")
+        joined = left.join(right, "left_data.left_key = right_data.right_key")
+        wrapped = getattr(joined, exchange_method)(2).set_alias("wrapped")
+
+        result = wrapped.project("wrapped.*, row_number() OVER () AS row_number")
+
+        assert plan_node in result.explain()
+        assert result.fetchall() == [(1, 10, 2, 10, 1)]
+        with pytest.raises(duckdb.BinderException, match='Referenced table "left_data" not found'):
+            wrapped.project("left_data.left_value")
+
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    @pytest.mark.parametrize(
+        ("operation", "child_plan_node"),
+        [("project", "PROJECTION"), ("distinct", "HASH_GROUP_BY"), ("order", "ORDER_BY")],
+    )
+    def test_window_preserves_exchange_after_unary_operation(
+        self, duckdb_cursor, exchange_method, plan_node, operation, child_plan_node
+    ):
+        relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1), (1)) data(id)")
+        if operation == "project":
+            relation = relation.project("id, id + 10 AS projected")
+            expected = [(1, 11, 1), (1, 11, 2), (2, 12, 3)]
+        elif operation == "distinct":
+            relation = relation.distinct()
+            expected = [(1, 1), (2, 2)]
+        else:
+            relation = relation.order("id DESC")
+            expected = [(1, 1), (1, 2), (2, 3)]
+
+        result = getattr(relation, exchange_method)(2).row_number("OVER (ORDER BY id)", "*")
+        plan = result.explain()
+
+        assert plan_node in plan
+        exchange_position = plan.index(plan_node)
+        assert plan.index("WINDOW") < exchange_position
+        assert plan.find(child_plan_node, exchange_position + len(plan_node)) >= 0
+        assert result.fetchall() == expected
+
+    @pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+    def test_struct_field_projection_over_exchange_join(self, duckdb_cursor, exchange_method):
+        left = duckdb_cursor.sql("SELECT {'a': 7} AS payload, 10 AS left_key").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 10 AS right_key").set_alias("right_data")
+        joined = left.join(right, "left_data.left_key = right_data.right_key")
+        exchanged = getattr(joined, exchange_method)(2)
+
+        result = exchanged.project("payload.a, row_number() OVER () AS row_number")
+
+        assert result.fetchall() == [(7, 1)]
 
     def test_rank(self, table):
         result = table.rank("over ()").execute().fetchall()

--- a/tests/fast/relational_api/test_rapi_windows.py
+++ b/tests/fast/relational_api/test_rapi_windows.py
@@ -49,6 +49,23 @@ class TestRAPIWindows:
         assert len(result) == len(expected)
         assert all(r == e for r, e in zip(result, expected, strict=False))
 
+    @pytest.mark.parametrize(
+        ("exchange_method", "plan_node"),
+        [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+    )
+    def test_row_number_preserves_qualified_join_bindings_and_exchange(self, duckdb_cursor, exchange_method, plan_node):
+        left = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1)) data(value)").set_alias("left_data")
+        right = duckdb_cursor.sql("SELECT 10 AS join_key").set_alias("right_data")
+        joined = left.join(right, "right_data.join_key = 10")
+        exchanged = getattr(joined, exchange_method)(2)
+
+        result = exchanged.row_number("over (order by left_data.value)", "*")
+
+        plan = result.explain()
+        assert plan_node in plan
+        assert "WINDOW" in plan
+        assert sorted(result.fetchall()) == [(1, 10, 1), (2, 10, 2)]
+
     def test_rank(self, table):
         result = table.rank("over ()").execute().fetchall()
         expected = [1] * 8

--- a/tests/fast/relational_api/test_repartition.py
+++ b/tests/fast/relational_api/test_repartition.py
@@ -136,6 +136,30 @@ def test_aggregate_preserves_exchange(duckdb_cursor, exchange_method, plan_node,
     assert sorted(result.fetchall()) == expected
 
 
+@pytest.mark.parametrize(
+    ("exchange_method", "plan_node"),
+    [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+)
+@pytest.mark.parametrize("operation", ["project", "filter", "order"])
+def test_exchange_over_join_survives_uncorrelated_subquery(duckdb_cursor, exchange_method, plan_node, operation):
+    left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("left_data")
+    right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("right_data")
+    relation = getattr(left.join(right, "left_data.id = right_data.id"), exchange_method)(2)
+
+    if operation == "project":
+        result = relation.project("right_data.value + (SELECT 1) AS value")
+        expected = [(11,), (21,)]
+    elif operation == "filter":
+        result = relation.filter("(SELECT true)")
+        expected = [(1, 1, 10), (2, 2, 20)]
+    else:
+        result = relation.order("(SELECT 1)")
+        expected = [(1, 1, 10), (2, 2, 20)]
+
+    assert plan_node in result.explain()
+    assert sorted(result.fetchall()) == expected
+
+
 @pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
 @pytest.mark.parametrize("operation", ["join", "cross", "union", "except", "intersect"])
 def test_binary_relational_operations_fail_before_discarding_exchange(duckdb_cursor, exchange_method, operation):

--- a/tests/fast/relational_api/test_repartition.py
+++ b/tests/fast/relational_api/test_repartition.py
@@ -28,3 +28,156 @@ def test_repartition_invalid_partitions(duckdb_cursor):
     rel = duckdb_cursor.query("select i from range(5) t(i)")
     with pytest.raises(duckdb.InvalidInputException):
         rel.repartition(0)
+
+
+def test_repartition_deduplicates_binding_names(duckdb_cursor):
+    relation = duckdb_cursor.sql("SELECT 1 AS x, 2 AS x")
+
+    assert relation.repartition(2).fetchall() == [(1, 2)]
+
+
+def test_repartition_binds_qualified_partition_expression(duckdb_cursor):
+    left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(left_value)").set_alias("left_data")
+    right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(right_key, right_value)").set_alias(
+        "right_data"
+    )
+    joined = left.join(right, "left_data.left_value = right_data.right_key")
+
+    result = joined.repartition(2, "left_data.left_value").project("left_data.left_value, right_data.right_value")
+
+    assert sorted(result.fetchall()) == [(1, 10), (2, 20)]
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+def test_exchange_join_direct_result_preserves_column_order(duckdb_cursor, exchange_method):
+    left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(left_value)").set_alias("left_data")
+    right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(right_key, right_value)").set_alias(
+        "right_data"
+    )
+    joined = left.join(right, "left_data.left_value = right_data.right_key")
+
+    result = getattr(joined, exchange_method)(2)
+
+    assert result.columns == ["left_value", "right_key", "right_value"]
+    assert sorted(result.fetchall()) == [(1, 1, 10), (2, 2, 20)]
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+def test_exchange_chain_executes_with_query_verification(duckdb_cursor, exchange_method):
+    duckdb_cursor.execute("PRAGMA enable_verification")
+    relation = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2).project("i + 1 AS value")
+
+    assert relation.fetchall() == [(2,)]
+    assert "PROJECTION" in relation.explain()
+
+
+@pytest.mark.parametrize(
+    ("exchange_method", "plan_node"),
+    [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+)
+@pytest.mark.parametrize("operation", ["filter", "order", "distinct"])
+def test_relational_operations_preserve_exchange(duckdb_cursor, exchange_method, plan_node, operation):
+    relation = duckdb_cursor.sql("SELECT * FROM (VALUES (2), (1), (1)) data(i)")
+    exchanged = getattr(relation, exchange_method)(2)
+
+    if operation == "filter":
+        result = exchanged.filter("i > 1")
+        expected = [(2,)]
+    elif operation == "order":
+        result = exchanged.order("i")
+        expected = [(1,), (1,), (2,)]
+    else:
+        result = exchanged.distinct()
+        expected = [(1,), (2,)]
+
+    assert plan_node in result.explain()
+    rows = result.fetchall()
+    if operation == "order":
+        assert rows == expected
+    else:
+        assert sorted(rows) == expected
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+@pytest.mark.parametrize("outer_operation", ["project", "filter"])
+def test_distinct_preserves_collation_through_exchange(duckdb_cursor, exchange_method, outer_operation):
+    duckdb_cursor.execute("CREATE TABLE collated_values(value VARCHAR COLLATE nocase)")
+    duckdb_cursor.execute("INSERT INTO collated_values VALUES ('A'), ('a')")
+    relation = getattr(duckdb_cursor.table("collated_values"), exchange_method)(2).distinct()
+
+    if outer_operation == "project":
+        relation = relation.project("value")
+    else:
+        relation = relation.filter("value = 'a'")
+
+    rows = relation.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0].lower() == "a"
+
+
+@pytest.mark.parametrize(
+    ("exchange_method", "plan_node"),
+    [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+)
+@pytest.mark.parametrize(
+    ("aggregate", "groups", "expected"),
+    [
+        ("sum(i) AS total", None, [(4,)]),
+        ("k, sum(i) AS total", "k", [(0, 2), (1, 2)]),
+    ],
+)
+def test_aggregate_preserves_exchange(duckdb_cursor, exchange_method, plan_node, aggregate, groups, expected):
+    relation = duckdb_cursor.sql("SELECT i, i % 2 AS k FROM (VALUES (1), (1), (2)) data(i)")
+    exchanged = getattr(relation, exchange_method)(2)
+
+    result = exchanged.aggregate(aggregate) if groups is None else exchanged.aggregate(aggregate, groups)
+
+    assert plan_node in result.explain()
+    assert sorted(result.fetchall()) == expected
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+@pytest.mark.parametrize("operation", ["join", "cross", "union", "except", "intersect"])
+def test_binary_relational_operations_fail_before_discarding_exchange(duckdb_cursor, exchange_method, operation):
+    left = duckdb_cursor.sql("SELECT 1 AS i").set_alias("left_data")
+    right = duckdb_cursor.sql("SELECT 1 AS i").set_alias("right_data")
+    exchanged = getattr(left, exchange_method)(2)
+
+    with pytest.raises(duckdb.NotImplementedException, match="would discard"):
+        if operation == "join":
+            exchanged.join(right, "left_data.i = right_data.i")
+        elif operation == "cross":
+            exchanged.cross(right)
+        elif operation == "union":
+            exchanged.union(right)
+        elif operation == "except":
+            exchanged.except_(right)
+        else:
+            exchanged.intersect(right)
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+def test_python_replacement_scan_fails_before_discarding_exchange(duckdb_cursor, exchange_method):
+    relation_with_exchange = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2)
+
+    with pytest.raises(duckdb.NotImplementedException, match="would discard"):
+        duckdb_cursor.sql("SELECT * FROM relation_with_exchange")
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+def test_non_sql_exchange_has_no_sql_string(duckdb_cursor, exchange_method):
+    relation = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2).project("i + 1 AS value")
+
+    assert relation.sql_query() == ""
+
+
+@pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
+@pytest.mark.parametrize("operation", ["create", "create_view", "insert_into"])
+def test_sql_terminal_operations_fail_before_discarding_exchange(duckdb_cursor, exchange_method, operation):
+    relation = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2)
+    target = f"exchange_{exchange_method}_{operation}"
+    if operation == "insert_into":
+        duckdb_cursor.execute(f"CREATE TABLE {target} (i INTEGER)")
+
+    with pytest.raises(duckdb.NotImplementedException, match="discard the exchange"):
+        getattr(relation, operation)(target)

--- a/tests/fast/relational_api/test_repartition.py
+++ b/tests/fast/relational_api/test_repartition.py
@@ -182,7 +182,7 @@ def test_binary_relational_operations_fail_before_discarding_exchange(duckdb_cur
 
 @pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
 def test_python_replacement_scan_fails_before_discarding_exchange(duckdb_cursor, exchange_method):
-    relation_with_exchange = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2)
+    relation_with_exchange = getattr(duckdb_cursor.sql("SELECT 1 AS i"), exchange_method)(2)  # noqa: F841
 
     with pytest.raises(duckdb.NotImplementedException, match="would discard"):
         duckdb_cursor.sql("SELECT * FROM relation_with_exchange")

--- a/tests/fast/spark/test_spark_join.py
+++ b/tests/fast/spark/test_spark_join.py
@@ -350,6 +350,44 @@ class TestDataFrameJoin:
             key=lambda x: x.emp_id,
         )
 
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("direct", [Row(emp_id=2, manager_id=1), Row(emp_id=2, manager_id=1), Row(emp_id=3, manager_id=1)]),
+            ("filter", [Row(emp_id=2, manager_id=1)]),
+            ("ordered_limit", [Row(emp_id=3, manager_id=1)]),
+            ("distinct", [Row(emp_id=2, manager_id=1), Row(emp_id=2, manager_id=1), Row(emp_id=3, manager_id=1)]),
+        ],
+    )
+    def test_self_join_qualified_bindings_survive_unary_relations(self, spark, operation, expected):
+        employees = spark.createDataFrame(
+            [
+                (1, -1, "manager"),
+                (2, 1, "alpha"),
+                (2, 1, "beta"),
+                (3, 1, "gamma"),
+            ],
+            ["emp_id", "superior_emp_id", "variant"],
+        )
+        relation = employees.alias("emp1").join(
+            employees.alias("emp2"),
+            col("emp1.superior_emp_id") == col("emp2.emp_id"),
+            "inner",
+        )
+        if operation == "filter":
+            relation = relation.filter(col("emp1.variant") == "beta")
+        elif operation == "ordered_limit":
+            relation = relation.orderBy(col("emp1.emp_id").desc()).limit(1)
+        elif operation == "distinct":
+            relation = relation.distinct()
+
+        result = relation.select(
+            col("emp1.emp_id"),
+            col("emp2.emp_id").alias("manager_id"),
+        ).collect()
+
+        assert sorted(result) == sorted(expected)
+
     def test_cross_join(self, spark):
         data1 = [(1, "Carol"), (2, "Alice"), (3, "Dave")]
         data2 = [(4, "A"), (5, "B")]

--- a/tests/fast/test_ray_udf_plan_replay.py
+++ b/tests/fast/test_ray_udf_plan_replay.py
@@ -45,6 +45,49 @@ def _execute_fresh_physical_plan(target, physical):
             pool.shutdown(kill=True)
 
 
+def test_qualified_join_projection_survives_logical_plan_pickle_to_fresh_connection():
+    source = duckdb.connect()
+    target = None
+    try:
+        left = source.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("l")
+        right = source.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
+        relation = left.join(right, "l.id = r.id").project("l.id AS id, r.value AS value").order("id")
+
+        target, physical, _ = _round_trip_to_fresh_physical_plan(relation)
+        table = _execute_fresh_physical_plan(target, physical)
+
+        assert table.column(0).to_pylist() == [1, 2]
+        assert table.column(1).to_pylist() == [10, 20]
+    finally:
+        if target is not None:
+            target.close()
+        source.close()
+
+
+def test_repartition_projection_survives_logical_plan_pickle_to_fresh_connection():
+    source = duckdb.connect()
+    target = None
+    try:
+        relation = (
+            source.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)")
+            .set_alias("source_data")
+            .repartition(2)
+            .project("source_data.id AS id, source_data.value + 1 AS value")
+            .order("id")
+        )
+
+        target, physical, _ = _round_trip_to_fresh_physical_plan(relation)
+        assert "Repartition" in physical.repr_ascii(False)
+        table = _execute_fresh_physical_plan(target, physical)
+
+        assert table.column(0).to_pylist() == [1, 2]
+        assert table.column(1).to_pylist() == [11, 21]
+    finally:
+        if target is not None:
+            target.close()
+        source.close()
+
+
 def test_attached_scalar_alias_survives_logical_plan_pickle_to_fresh_connection():
     source = vane.connect()
 


### PR DESCRIPTION
## Summary

- separate faithful SQL serialization from relation-input binding with internal, binder-aware capability checks
- feed already-bound logical plans into DuckDB's normal `SelectNode` binder through a transient `BoundRefWrapper`, without representing exchanges as SQL AST table references
- preserve qualified bindings across projection, filter, order, aggregate, distinct, limit, repartition, local exchange, and subsequent chained relation operations
- treat an explicitly aliased `SubqueryRelation` as a binding boundary, so `rel.filter(...).set_alias("foo")` consistently exposes `foo.*`
- validate nested expression scopes against real binder contexts before SQL serialization, including aliased base tables, views, derived tables, table functions, CTEs, and catalog changes
- keep `DISTINCT`, `LIMIT`, `ORDER BY`, `TOP N`, `REPARTITION`, and `LOCAL_EXCHANGE` as optimizer-visible relation boundaries, and decline unsafe join elimination for multi-binding `DISTINCT` targets
- make `DISTINCT` a binding boundary for hidden virtual columns: downstream `rowid`/table-function virtual-column references are rejected, while a real column named `rowid` remains available
- release the Python GIL while `sql_query()` performs its transactional serialization/binding probe
- add fresh-connection logical-plan pickle/replay coverage for qualified join projections and repartitioned projections
- preserve Spark column names and qualified self-join bindings across `drop`, `dropDuplicates`, `unionByName`, filtering, ordering/limit, and distinct operations
- keep relation serialization/input-binding probes private or protected instead of extending the public `Relation` API

The branch is rebased onto `upstream/main@79436b8b`.

There is no new Python API. The implementation adds internal C++ `Relation` subclass hooks in the vendored DuckDB tree, so native consumers must rebuild with Vane rather than mix binaries from before and after this change. Ray stream teardown and runner-integration changes are intentionally not included.

## Behavioral notes

- compositions that cannot faithfully serialize an exchange now raise `NotImplementedException` instead of silently dropping `REPARTITION`/`LOCAL_EXCHANGE`
- `relation.order(...).distinct()` preserves the requested operator order (`DISTINCT` above `ORDER BY`), but SQL does not guarantee the final output order after `DISTINCT`; append a final `.order(...)` when deterministic ordering is required
- hidden virtual columns no longer bind after `DISTINCT`, because they are not emitted by the distinct operator and cannot identify a surviving row deterministically

## Related issues

Closes #32.
Closes #33.
Closes #34.
Closes #36.
Closes #44.
Closes #54.

Current `main` has two independent fast-suite fixture/contract regressions that are intentionally kept out of this relation PR:

- #41 / PR #175: public runner contract tests
- #43 / PR #176: FTE fault-injection fixture identities

## Documentation impact

- [x] No user-facing API documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The behavioral compatibility notes above are recorded here for release-note use.

## Validation

- incremental Release install through `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- focused relation/replay regressions — 47 passed
- complete modified Python test files — 195 passed
- `scripts/run_native_tests.sh '[relation_api]'` — 35 test cases and 651 assertions passed
- `python -m pytest tests/fast/test_udf_process.py` — 4 passed
- `scripts/run_release_tests.sh` — non-Ray: 272 passed; shared-Ray release: 5 passed
- `scripts/run_fast_tests.sh` non-Ray shard — 5,122 passed, 41 skipped, 95 deselected, 8 xfailed, 1 xpassed; 3 unchanged `main` failures covered by PR #175
- full fast shared-Ray shard — 78 passed, 17 skipped, 5,175 deselected
- full fast owner-Ray shard — 3 environment skips; 5 unchanged `main` FTE-fixture failures covered by PR #176
- confirmed all eight failing fast tests and their implementation/fixture files are byte-identical to `upstream/main@79436b8b`
- `scripts/format workspace --changed`
- `pre-commit run --files <all changed files>`
- `git diff --check`

## Checklist

- [x] The change is focused and includes regression coverage.
- [x] Public behavior and native compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. (No new dependencies or assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. (Those surfaces are unchanged.)
- [x] Native changes were compiled; affected native, Python, release, formatting, and lint checks passed.
