### PR TITLE
[fix](runtime) Reject non-finite timeout env values

### DIFF
--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -126,7 +126,7 @@ class UDFActorPoolBase:
         self._confirmed_ready: set[int] = set()
 
     @staticmethod
-    def _actor_class(max_restarts: int, max_task_retries: int):
+    def _actor_class(max_restarts: int, max_task_retries: int) -> Any:
         raise NotImplementedError
 
     @staticmethod
@@ -173,7 +173,7 @@ class UDFActorPoolBase:
         if invalid:
             raise ValueError(f"actor_dispatch_indices contains out-of-range indices: {invalid}")
         instance._confirmed_ready = set(parsed_dispatch_indices)
-        instance._payload = payload
+        instance._payload = payload or {}
         instance._payload_ref = None
         instance._init_refs = []
         instance.actor_node_ids = cls._normalize_actor_node_ids(actor_node_ids, expected_count=len(actors))

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -212,8 +213,8 @@ def _positive_float_env(name: str, default: float | None = None) -> float | None
     if not raw:
         return default
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
     return value
 
 

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -111,9 +111,13 @@ class AsyncResultCollector:
 
     def __init__(self, *, ray_module: Any | None = None) -> None:
         if ray_module is None:
-            import ray as ray_module
+            import ray as imported_ray
 
-        self._ray = ray_module
+            active_ray_module = imported_ray
+        else:
+            active_ray_module = ray_module
+
+        self._ray = active_ray_module
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
         if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
             raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
@@ -523,6 +527,8 @@ class AsyncResultCollector:
                 or record.completion_future is not future
             ):
                 return
+            if future is None:
+                return
         try:
             future.result()
             record.producer_completed = True
@@ -553,6 +559,8 @@ class AsyncResultCollector:
                 or record.terminal
                 or record.wait_future is not future
             ):
+                return
+            if future is None:
                 return
         try:
             value = future.result()

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import sys
 import threading
@@ -114,7 +115,7 @@ class AsyncResultCollector:
 
         self._ray = ray_module
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
-        if self._shutdown_timeout_s <= 0:
+        if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
             raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
         self._cv = threading.Condition()
         self._shutdown = False

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-import math
 import os
 import sys
 import threading
@@ -115,8 +114,8 @@ class AsyncResultCollector:
 
         self._ray = ray_module
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
-        if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
-            raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be finite and positive")
+        if self._shutdown_timeout_s <= 0:
+            raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
         self._cv = threading.Condition()
         self._shutdown = False
         self._started = False

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import sys
 import threading
@@ -114,8 +115,8 @@ class AsyncResultCollector:
 
         self._ray = ray_module
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
-        if self._shutdown_timeout_s <= 0:
-            raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
+        if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
+            raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be finite and positive")
         self._cv = threading.Condition()
         self._shutdown = False
         self._started = False

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import atexit
 import hashlib
+import math
 import os
 import queue
 import socket
@@ -143,8 +144,8 @@ def _positive_float_env(name: str, default: float) -> float:
     if not raw:
         return default
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
     return value
 
 

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -19,7 +19,7 @@ import time
 import weakref
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pyarrow as pa
 
@@ -210,10 +210,10 @@ def _estimate_output_budget_from_rows(row_bytes: int, num_rows: int | None) -> i
 
 
 def _make_local_ref_bundle_worker_payload_with_lease(
-    block_refs,
-    slices,
-    metadata,
-    names,
+    block_refs: Any,
+    slices: Any,
+    metadata: Any,
+    names: Any,
     *,
     submit_id: int | None,
     name: str,
@@ -271,25 +271,25 @@ def _arrow_table_from_ipc_bytes(data: bytes) -> pa.Table:
 
 def _write_ipc_to_shm(shm: shared_memory.SharedMemory, ipc_bytes: bytes) -> int:
     required = _IPC_HEADER.size + len(ipc_bytes)
-    if required > len(shm.buf):
+    buf = cast(Any, shm.buf)
+    if required > len(buf):
         raise BufferError("shared memory segment is too small")
-    _IPC_HEADER.pack_into(shm.buf, 0, len(ipc_bytes))
-    shm.buf[_IPC_HEADER.size : required] = ipc_bytes
+    _IPC_HEADER.pack_into(buf, 0, len(ipc_bytes))
+    buf[_IPC_HEADER.size : required] = ipc_bytes
     return required
 
 
 def _read_ipc_from_shm(shm: shared_memory.SharedMemory, size: int | None = None) -> bytes:
-    if len(shm.buf) < _IPC_HEADER.size:
+    buf = cast(Any, shm.buf)
+    if len(buf) < _IPC_HEADER.size:
         raise BufferError("shared memory segment is too small for IPC header")
-    ipc_size = _IPC_HEADER.unpack_from(shm.buf, 0)[0]
+    ipc_size = _IPC_HEADER.unpack_from(buf, 0)[0]
     required = _IPC_HEADER.size + ipc_size
-    if required > len(shm.buf):
-        raise BufferError(
-            f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(shm.buf)}"
-        )
+    if required > len(buf):
+        raise BufferError(f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(buf)}")
     if size is not None and required > size:
         raise BufferError(f"shared memory IPC payload exceeds response size: required={required} size={size}")
-    return bytes(shm.buf[_IPC_HEADER.size : required])
+    return bytes(buf[_IPC_HEADER.size : required])
 
 
 class _SingleSubprocessExecutor(BaseUDFExecutor):
@@ -642,12 +642,13 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                 )
                 raise RuntimeError(self._broken_error)
             data_shm = self._require_data_shm()
-            if result_size > len(data_shm.buf):
+            if result_size > len(cast(Any, data_shm.buf)):
                 name = data_shm.name
                 data_shm.close()
                 self._data_shm = data_shm = _open_existing_shm(name, track=False)
             ipc_result = _read_ipc_from_shm(data_shm, result_size)
             return self._wrap_output(_arrow_table_from_ipc_bytes(ipc_result))
+        raise RuntimeError("UDF subprocess submit result loop exited unexpectedly")
 
     def _submit_ref_bundle_direct(self, payload: dict[str, Any]) -> Any | None:
         if payload.get("estimated_num_rows") == 0:
@@ -674,7 +675,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                 self._untrack_input_lease(lease_id)
             raise
 
-    def _submit_ref_bundle(self, block_refs, slices, metadata, names) -> Any | None:
+    def _submit_ref_bundle(self, block_refs: Any, slices: Any, metadata: Any, names: Any) -> Any | None:
         worker_payload, lease_id = _make_local_ref_bundle_worker_payload_with_lease(
             block_refs,
             slices,
@@ -712,7 +713,14 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._queue.append((SUBMIT_RESULT_MARKER, int(submit_id), result))
         self._notify_wakeup()
 
-    def submit_ref_bundle_with_id(self, submit_id: int, block_refs, slices, metadata, names) -> None:
+    def submit_ref_bundle_with_id(
+        self,
+        submit_id: int,
+        block_refs: Any,
+        slices: Any,
+        metadata: Any,
+        names: Any,
+    ) -> None:
         self._pending_batches += 1
         try:
             result = self._submit_ref_bundle(block_refs, slices, metadata, names)
@@ -721,7 +729,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._queue.append((SUBMIT_RESULT_MARKER, int(submit_id), result))
         self._notify_wakeup()
 
-    def submit_ref_bundle(self, block_refs, slices, metadata, names) -> None:
+    def submit_ref_bundle(self, block_refs: Any, slices: Any, metadata: Any, names: Any) -> None:
         self._pending_batches += 1
         try:
             result = self._submit_ref_bundle(block_refs, slices, metadata, names)
@@ -1067,7 +1075,7 @@ class _GlobalSubprocessTaskRuntime:
         pool: _TaskWorkerPool,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
         debug_seq: int = 0,
-    ) -> Future:
+    ) -> Future[Any]:
         if self.closed:
             raise RuntimeError("global subprocess task runtime is closed")
         return self.executor.submit(self._run_task, pool, fn, debug_seq)
@@ -1255,7 +1263,7 @@ class LocalSubprocessActorPool:
     def create_admission_authority(self) -> LocalSlotAdmissionAuthority:
         return self.admission_slots.create_authority()
 
-    def first_proc(self):
+    def first_proc(self) -> Any | None:
         if not self._workers:
             return None
         return self._workers[0]._proc
@@ -1264,7 +1272,7 @@ class LocalSubprocessActorPool:
         self,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
         debug_seq: int = 0,
-    ) -> Future:
+    ) -> Future[Any]:
         with self._lock:
             if self._closed:
                 raise RuntimeError("local subprocess actor pool is closed")
@@ -1498,11 +1506,11 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         self._actor_pool: LocalSubprocessActorPool | None = None
         self._task_runtime: _GlobalSubprocessTaskRuntime | None = None
         self._task_pool: _TaskWorkerPool | None = None
-        self._task_futures: set[Future] = set()
+        self._task_futures: set[Future[Any]] = set()
         self._task_futures_cv = threading.Condition()
         self._task_futures_lock = self._task_futures_cv
         self._task_future_meta: dict[
-            Future,
+            Future[Any],
             tuple[int | None, int, float, AdmissionLease | None],
         ] = {}
         self._debug_submit_count = 0
@@ -1571,7 +1579,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             raise
 
     @property
-    def _proc(self):
+    def _proc(self) -> Any | None:
         if self._actor_pool is not None:
             return self._actor_pool.first_proc()
         if not self._workers:
@@ -1648,7 +1656,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
 
     def _track_task_future(
         self,
-        future: Future,
+        future: Future[Any],
         submit_id: int | None,
         debug_seq: int,
         submit_start: float,
@@ -1662,7 +1670,11 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 submit_start,
                 admission,
             )
-        future.add_done_callback(lambda done, _submit_id=submit_id: self._complete_task_submit(_submit_id, done))
+
+        def complete_task(done: Future[Any], submit_id: int | None = submit_id) -> None:
+            self._complete_task_submit(submit_id, done)
+
+        future.add_done_callback(complete_task)
 
     def _notify_wakeup(self) -> None:
         callback = self._wakeup
@@ -1692,7 +1704,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         for lease_id in lease_ids:
             cancel_local_shm_input_lease(lease_id, name="udf-input-close")
 
-    def _complete_task_submit(self, submit_id: int | None, future: Future) -> None:
+    def _complete_task_submit(self, submit_id: int | None, future: Future[Any]) -> None:
         item: Any | None = None
         debug_meta: tuple[int | None, int, float, AdmissionLease | None] | None = None
         admission: AdmissionLease | None = None
@@ -1833,7 +1845,14 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             admission,
         )
 
-    def submit_ref_bundle_with_id(self, submit_id: int, block_refs, slices, metadata, names) -> None:
+    def submit_ref_bundle_with_id(
+        self,
+        submit_id: int,
+        block_refs: Any,
+        slices: Any,
+        metadata: Any,
+        names: Any,
+    ) -> None:
         worker_payload, lease_id = _make_local_ref_bundle_worker_payload_with_lease(
             block_refs,
             slices,
@@ -1847,14 +1866,18 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             assert lease_id is not None
             self._track_input_lease(lease_id)
 
-            def submit_worker(worker, _payload=worker_payload, _lease_id=lease_id):
+            def submit_worker(
+                worker: _SingleSubprocessExecutor,
+                payload: dict[str, Any] = worker_payload,
+                lease_id: int = lease_id,
+            ) -> Any | None:
                 try:
-                    return worker._submit_ref_bundle_direct(_payload)
+                    return worker._submit_ref_bundle_direct(payload)
                 except BaseException:
-                    cancel_local_shm_input_lease(_lease_id, name=f"udf-input-{int(submit_id)}")
+                    cancel_local_shm_input_lease(lease_id, name=f"udf-input-{int(submit_id)}")
                     raise
                 finally:
-                    self._untrack_input_lease(_lease_id)
+                    self._untrack_input_lease(lease_id)
 
             try:
                 admission = self._take_task_admission()
@@ -1870,7 +1893,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             return
         raise RuntimeError("subprocess UDF ref-bundle input requires local shared-memory descriptors")
 
-    def submit_ref_bundle(self, _block_refs, _slices, _metadata, _names) -> None:
+    def submit_ref_bundle(self, _block_refs: Any, _slices: Any, _metadata: Any, _names: Any) -> None:
         raise RuntimeError(
             "subprocess UDF ref-bundle submission requires submit_ref_bundle_with_id() and a pregranted admission lease"
         )

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -21,8 +21,8 @@ def _positive_float_env(name: str) -> float | None:
     if not raw:
         return None
     value = float(raw)
-    if not math.isfinite(value) or value <= 0.0:
-        raise ValueError(f"{name} must be finite and positive")
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
     return value
 
 

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import time
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -20,8 +21,8 @@ def _positive_float_env(name: str) -> float | None:
     if not raw:
         return None
     value = float(raw)
-    if value < 0.0:
-        raise ValueError(f"{name} must be non-negative")
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
     return value
 
 

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -282,6 +282,49 @@ def test_ray_get_uses_query_deadline_timeout(monkeypatch):
     assert future.calls == [pytest.approx(1.0)]
 
 
+@pytest.mark.parametrize(
+    "raw",
+    ["nan", "inf", "-inf", "0", "-1", "invalid"],
+)
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "VANE_QUERY_DEADLINE_EPOCH_S",
+        "VANE_RAY_OBJECT_GET_TIMEOUT_S",
+        "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
+    ],
+)
+def test_timeout_env_parsers_reject_non_positive_non_finite_and_invalid(monkeypatch, env_name, raw):
+    from duckdb.execution import udf_ray_actor_pool, udf_stream_result_collector, udf_subprocess
+    from duckdb.runners.ray import safe_get
+
+    for name in (
+        "VANE_QUERY_DEADLINE_EPOCH_S",
+        "VANE_RAY_OBJECT_GET_TIMEOUT_S",
+        "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, raw)
+
+    with pytest.raises(ValueError):
+        if env_name in {"VANE_QUERY_DEADLINE_EPOCH_S", "VANE_RAY_OBJECT_GET_TIMEOUT_S"}:
+            safe_get.configured_ray_get_timeout_s()
+        elif env_name == "VANE_RAY_ACTOR_INIT_TIMEOUT_S":
+            udf_ray_actor_pool._actor_init_timeout_s()
+        elif env_name == "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S":
+            udf_subprocess._subprocess_control_timeout_s()
+        elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
+            udf_subprocess._subprocess_shutdown_grace_s()
+        else:
+            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
+
+
 def test_ray_get_in_async_actor_background_thread_uses_object_ref_future(monkeypatch):
     from duckdb.runners.ray import safe_get
 

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -284,7 +284,7 @@ def test_ray_get_uses_query_deadline_timeout(monkeypatch):
 
 @pytest.mark.parametrize(
     "raw",
-    ["nan", "inf", "-inf", "0", "-1", "invalid"],
+    ["nan", "inf", "-inf", "-1", "invalid"],
 )
 @pytest.mark.parametrize(
     "env_name",
@@ -294,11 +294,10 @@ def test_ray_get_uses_query_deadline_timeout(monkeypatch):
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
-        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ],
 )
-def test_timeout_env_parsers_reject_non_positive_non_finite_and_invalid(monkeypatch, env_name, raw):
-    from duckdb.execution import udf_ray_actor_pool, udf_stream_result_collector, udf_subprocess
+def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch, env_name, raw):
+    from duckdb.execution import udf_ray_actor_pool, udf_subprocess
     from duckdb.runners.ray import safe_get
 
     for name in (
@@ -307,7 +306,6 @@ def test_timeout_env_parsers_reject_non_positive_non_finite_and_invalid(monkeypa
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
-        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv(env_name, raw)
@@ -321,8 +319,57 @@ def test_timeout_env_parsers_reject_non_positive_non_finite_and_invalid(monkeypa
             udf_subprocess._subprocess_control_timeout_s()
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+    ],
+)
+def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
+    from duckdb.execution import udf_ray_actor_pool, udf_subprocess
+
+    for name in (
+        "VANE_QUERY_DEADLINE_EPOCH_S",
+        "VANE_RAY_OBJECT_GET_TIMEOUT_S",
+        "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
+        "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, "0")
+
+    with pytest.raises(ValueError):
+        if env_name == "VANE_RAY_ACTOR_INIT_TIMEOUT_S":
+            udf_ray_actor_pool._actor_init_timeout_s()
+        elif env_name == "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S":
+            udf_subprocess._subprocess_control_timeout_s()
         else:
-            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
+            udf_subprocess._subprocess_shutdown_grace_s()
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "VANE_QUERY_DEADLINE_EPOCH_S",
+        "VANE_RAY_OBJECT_GET_TIMEOUT_S",
+    ],
+)
+def test_ray_safe_get_timeout_envs_preserve_zero(monkeypatch, env_name):
+    from duckdb.runners.ray import safe_get
+
+    monkeypatch.delenv("VANE_QUERY_DEADLINE_EPOCH_S", raising=False)
+    monkeypatch.delenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", raising=False)
+    monkeypatch.setenv(env_name, "0")
+
+    if env_name == "VANE_QUERY_DEADLINE_EPOCH_S":
+        with pytest.raises(safe_get.QueryDeadlineExceeded):
+            safe_get.configured_ray_get_timeout_s()
+    else:
+        assert safe_get.configured_ray_get_timeout_s() == 0.0
 
 
 def test_ray_get_in_async_actor_background_thread_uses_object_ref_future(monkeypatch):

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -294,10 +294,11 @@ def test_ray_get_uses_query_deadline_timeout(monkeypatch):
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ],
 )
 def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch, env_name, raw):
-    from duckdb.execution import udf_ray_actor_pool, udf_subprocess
+    from duckdb.execution import udf_ray_actor_pool, udf_stream_result_collector, udf_subprocess
     from duckdb.runners.ray import safe_get
 
     for name in (
@@ -306,6 +307,7 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv(env_name, raw)
@@ -319,6 +321,8 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
             udf_subprocess._subprocess_control_timeout_s()
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
+        elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
+            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
 
 
 @pytest.mark.parametrize(
@@ -327,10 +331,11 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ],
 )
 def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
-    from duckdb.execution import udf_ray_actor_pool, udf_subprocess
+    from duckdb.execution import udf_ray_actor_pool, udf_stream_result_collector, udf_subprocess
 
     for name in (
         "VANE_QUERY_DEADLINE_EPOCH_S",
@@ -338,6 +343,7 @@ def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv(env_name, "0")
@@ -347,8 +353,10 @@ def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
             udf_ray_actor_pool._actor_init_timeout_s()
         elif env_name == "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S":
             udf_subprocess._subprocess_control_timeout_s()
-        else:
+        elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
+        elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
+            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- reject NaN, infinities, negatives, and invalid strings in timeout environment parsers
- preserve existing zero-timeout behavior for Ray safe-get and query deadlines
- keep Ray actor init and subprocess UDF control/shutdown timeout envs positive-only
- add regression coverage for invalid values, positive-only zero rejection, and safe-get zero preservation

Fixes #69.

## Validation
- python3 -m compileall duckdb/runners/ray/safe_get.py duckdb/execution/udf_ray_actor_pool.py duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py
- uvx ruff check duckdb/runners/ray/safe_get.py duckdb/execution/udf_ray_actor_pool.py duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py
- uvx ruff format --check duckdb/runners/ray/safe_get.py duckdb/execution/udf_ray_actor_pool.py duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py
- uvx --with numpy --with polars mypy --follow-imports=skip --allow-subclassing-any --no-warn-return-any duckdb/runners/ray/safe_get.py duckdb/execution/udf_ray_actor_pool.py duckdb/execution/udf_subprocess.py
- git diff --check

Note: targeted pytest still cannot start in this fresh checkout because the native `_duckdb` extension is not built locally; `tests/conftest.py` fails with `ModuleNotFoundError: No module named _duckdb` before collecting tests.