### PR TITLE
[fix](udf) Account for terminal events in result queue capacity

### DIFF
--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -44,6 +44,7 @@ def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> No
 @dataclass(frozen=True)
 class _DrainCapacity:
     rows: int
+    events: int | None = None
     bytes: int | None = None
     item_bytes: int | None = None
 
@@ -110,7 +111,9 @@ class AsyncResultCollector:
 
     def __init__(self, *, ray_module: Any | None = None) -> None:
         if ray_module is None:
-            import ray as ray_module
+            import ray
+
+            ray_module = ray
 
         self._ray = ray_module
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
@@ -178,8 +181,11 @@ class AsyncResultCollector:
             for slot_id, capacity in parsed.items():
                 ready = self._ready_by_slot.get(slot_id)
                 delivered_rows = 0
+                delivered_events = 0
                 delivered_bytes = 0
                 while ready:
+                    if capacity.events is not None and delivered_events >= capacity.events:
+                        break
                     event = ready[0]
                     if event.kind == "data":
                         if delivered_rows >= capacity.rows:
@@ -196,11 +202,13 @@ class AsyncResultCollector:
                         delivered_rows += 1
                         delivered_bytes += event.size_bytes
                     results.append(ready.popleft().as_tuple())
+                    delivered_events += 1
                 if ready is not None and not ready:
                     self._ready_by_slot.pop(slot_id, None)
                 remaining_bytes = None if capacity.bytes is None else max(0, capacity.bytes - delivered_bytes)
                 self._capacity_by_slot[slot_id] = _DrainCapacity(
                     rows=max(0, capacity.rows - delivered_rows),
+                    events=None if capacity.events is None else max(0, capacity.events - delivered_events),
                     bytes=remaining_bytes,
                     item_bytes=capacity.item_bytes,
                 )
@@ -362,10 +370,12 @@ class AsyncResultCollector:
             if not isinstance(raw, dict) or "rows" not in raw:
                 raise ValueError(f"invalid Ray UDF drain capacity for slot {raw_slot!r}")
             rows = max(0, int(raw["rows"]))
+            events_value = raw.get("events")
             bytes_value = raw.get("bytes")
             item_value = raw.get("item_bytes")
             parsed[int(raw_slot)] = _DrainCapacity(
                 rows=rows,
+                events=None if events_value is None else max(0, int(events_value)),
                 bytes=None if bytes_value is None else max(0, int(bytes_value)),
                 item_bytes=None if item_value is None else max(0, int(item_value)),
             )
@@ -378,15 +388,26 @@ class AsyncResultCollector:
         )
         return ready + in_progress
 
+    def _pending_event_count_locked(self, slot_id: int) -> int:
+        ready = len(self._ready_by_slot.get(slot_id, ()))
+        in_progress = sum(
+            1 for record in self._records.values() if record.slot_id == slot_id and record.phase != "block"
+        )
+        return ready + in_progress
+
     def _may_read_block_locked(self, record: _StreamRecord) -> bool:
         capacity = self._capacity_by_slot.get(record.slot_id)
         if capacity is None or capacity.rows <= 0:
+            return False
+        if capacity.events is not None and capacity.events <= 0:
             return False
         if capacity.bytes is not None and capacity.bytes <= 0:
             return False
         if capacity.item_bytes is not None and capacity.item_bytes <= 0:
             return False
-        return self._pending_data_count_locked(record.slot_id) < capacity.rows
+        if self._pending_data_count_locked(record.slot_id) >= capacity.rows:
+            return False
+        return capacity.events is None or self._pending_event_count_locked(record.slot_id) < capacity.events
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
@@ -517,11 +538,13 @@ class AsyncResultCollector:
         with self._cv:
             if (
                 self._shutdown
+                or future is None
                 or self._records.get(key) is not record
                 or record.terminal
                 or record.completion_future is not future
             ):
                 return
+        assert future is not None
         try:
             future.result()
             record.producer_completed = True
@@ -548,11 +571,13 @@ class AsyncResultCollector:
         with self._cv:
             if (
                 self._shutdown
+                or future is None
                 or self._records.get(key) is not record
                 or record.terminal
                 or record.wait_future is not future
             ):
                 return
+        assert future is not None
         try:
             value = future.result()
             _collector_debug_log(f"ready_{kind}", record)

--- a/src/duckdb_py/duckdb_python.cpp
+++ b/src/duckdb_py/duckdb_python.cpp
@@ -45,6 +45,7 @@ namespace duckdb {
 
 py::dict GetUDFExecutorDebugCounters();
 void ResetUDFExecutorDebugCounters();
+py::dict TestUDFFallbackResultQueue(py::object collector, idx_t slot_id, idx_t queue_capacity, idx_t submit_count);
 
 enum PySQLTokenType : uint8_t {
 	PY_SQL_TOKEN_IDENTIFIER = 0,
@@ -1163,6 +1164,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) { // NOLINT
 	RegisterVLLMExecutorFactory();
 	m.def("_udf_executor_debug_counters", &GetUDFExecutorDebugCounters);
 	m.def("_reset_udf_executor_debug_counters", &ResetUDFExecutorDebugCounters);
+	m.def("_test_udf_fallback_result_queue", &TestUDFFallbackResultQueue);
 	m.def("_shutdown_udf_executor_dispatcher", &ShutdownUDFExecutorDispatcher);
 	try {
 		py::module_::import("atexit").attr("register")(m.attr("_shutdown_udf_executor_dispatcher"));

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -147,6 +147,22 @@ static atomic<uint64_t> g_udf_direct_arrow_table_conversion_count {0};
 static atomic<uint64_t> g_udf_direct_output_arrow_table_conversion_count {0};
 static atomic<uint64_t> g_udf_python_export_under_client_context_lock_count {0};
 
+static py::dict MakeUDFDrainCapacity(idx_t rows, bool has_event_capacity, idx_t events, bool has_byte_capacity,
+                                     idx_t bytes, bool has_item_byte_capacity, idx_t item_bytes) {
+	py::dict result;
+	result[py::str("rows")] = py::int_(rows);
+	if (has_event_capacity) {
+		result[py::str("events")] = py::int_(events);
+	}
+	if (has_byte_capacity) {
+		result[py::str("bytes")] = py::int_(bytes);
+	}
+	if (has_item_byte_capacity) {
+		result[py::str("item_bytes")] = py::int_(item_bytes);
+	}
+	return result;
+}
+
 // Global mutex protecting ClientContext access from multiple threads.
 // DuckDB's ClientContext is NOT thread-safe.  With VANE_REPARTITION_COUNT>1,
 // multiple pipeline threads call Submit() (which reads from ClientContext),
@@ -1031,6 +1047,8 @@ struct DispatcherCommand {
 	DispatcherRefSubmitTask ref_submit_task; // only used for SUBMIT_REF_BUNDLE
 };
 
+static constexpr size_t DEFAULT_MAX_RESULT_QUEUE_PER_SLOT = 4;
+
 struct ExecutorSlot {
 	uint64_t id = 0;
 	Value payload;
@@ -1058,6 +1076,7 @@ struct ExecutorSlot {
 	// Result queue: dispatcher pushes, pipeline threads pop
 	mutex result_lock;
 	std::deque<UDFResult> result_queue;
+	size_t result_queue_capacity = DEFAULT_MAX_RESULT_QUEUE_PER_SLOT;
 
 	// Optional push consumer used by queue-driven streaming breaker sources.
 	mutex consumer_lock;
@@ -1126,12 +1145,12 @@ static ClientContext &RequireActiveSlotContext(ExecutorSlot &slot) {
 
 class GlobalPythonDispatcher {
 public:
-	static constexpr size_t MAX_RESULT_QUEUE_PER_SLOT = 4;
-
 	static GlobalPythonDispatcher &Instance() {
 		static GlobalPythonDispatcher instance;
 		return instance;
 	}
+
+	py::dict TestFallbackResultQueue(py::object collector, idx_t slot_id, idx_t queue_capacity, idx_t submit_count);
 
 	// Register a new executor slot.  Returns slot ID and stores the raw
 	// pointer in *out_slot (valid until Unregister).
@@ -1837,8 +1856,10 @@ private:
 
 	struct SlotResultCapacity {
 		idx_t rows = 0;
+		idx_t events = 0;
 		idx_t bytes = 0;
 		idx_t item_bytes = 0;
+		bool has_event_capacity = false;
 		bool has_byte_capacity = false;
 		bool has_item_byte_capacity = false;
 	};
@@ -1862,10 +1883,14 @@ private:
 		}
 		lock_guard<mutex> rg(slot.result_lock);
 		SlotResultCapacity result;
-		if (slot.result_queue.size() >= MAX_RESULT_QUEUE_PER_SLOT) {
+		// The fallback queue stores both data and terminal results. Registered
+		// streaming consumers own their control-event buffering separately.
+		result.has_event_capacity = true;
+		if (slot.result_queue.size() >= slot.result_queue_capacity) {
 			return result;
 		}
-		result.rows = static_cast<idx_t>(MAX_RESULT_QUEUE_PER_SLOT - slot.result_queue.size());
+		result.rows = static_cast<idx_t>(slot.result_queue_capacity - slot.result_queue.size());
+		result.events = result.rows;
 		return result;
 	}
 
@@ -2165,9 +2190,17 @@ private:
 		result.rows = MakeEmptyDataChunk();
 		result.submit_complete = true;
 		result.submit_id = submit_id;
+		bool queued = false;
 		{
 			lock_guard<mutex> rg(slot.result_lock);
-			slot.result_queue.push_back(std::move(result));
+			if (slot.result_queue.size() < slot.result_queue_capacity) {
+				slot.result_queue.push_back(std::move(result));
+				queued = true;
+			}
+		}
+		if (!queued) {
+			SetSlotError(slot, "terminal UDF event exceeded reserved result queue capacity");
+			return;
 		}
 		ReleaseTerminalSubmit(slot, submit_id);
 		MaybeMarkSlotFinished(slot);
@@ -2183,10 +2216,10 @@ private:
 		UDFOutputConsumer queue_consumer;
 		queue_consumer.data_capacity = [&slot]() {
 			lock_guard<mutex> rg(slot.result_lock);
-			if (slot.result_queue.size() >= MAX_RESULT_QUEUE_PER_SLOT) {
+			if (slot.result_queue.size() >= slot.result_queue_capacity) {
 				return idx_t(0);
 			}
-			return static_cast<idx_t>(MAX_RESULT_QUEUE_PER_SLOT - slot.result_queue.size());
+			return static_cast<idx_t>(slot.result_queue_capacity - slot.result_queue.size());
 		};
 		queue_consumer.accept_event = [this, &slot](UDFOutputEvent &&event) {
 			if (event.kind == UDFOutputEventKind::ERROR) {
@@ -2725,14 +2758,9 @@ private:
 					if (capacity.rows > 0) {
 						debug_capacity_positive_slots++;
 					}
-					py::dict capacity_obj;
-					capacity_obj[py::str("rows")] = py::int_(capacity.rows);
-					if (capacity.has_byte_capacity) {
-						capacity_obj[py::str("bytes")] = py::int_(capacity.bytes);
-					}
-					if (capacity.has_item_byte_capacity) {
-						capacity_obj[py::str("item_bytes")] = py::int_(capacity.item_bytes);
-					}
+					auto capacity_obj = MakeUDFDrainCapacity(
+					    capacity.rows, capacity.has_event_capacity, capacity.events, capacity.has_byte_capacity,
+					    capacity.bytes, capacity.has_item_byte_capacity, capacity.item_bytes);
 					capacities[py::int_(slot->id)] = std::move(capacity_obj);
 				}
 
@@ -3199,6 +3227,135 @@ private:
 	std::deque<std::function<void()>> deferred_wakeups;
 	unique_ptr<RegisteredObject> async_collector; // Python AsyncResultCollector
 };
+
+py::dict GlobalPythonDispatcher::TestFallbackResultQueue(py::object collector, idx_t slot_id, idx_t queue_capacity,
+                                                         idx_t submit_count) {
+	if (queue_capacity == 0) {
+		throw InvalidInputException("fallback result queue test capacity must be positive");
+	}
+	if (submit_count > static_cast<idx_t>(std::numeric_limits<int>::max())) {
+		throw InvalidInputException("fallback result queue test submit count is too large");
+	}
+
+	ExecutorSlot slot;
+	slot.id = slot_id;
+	slot.result_queue_capacity = static_cast<size_t>(queue_capacity);
+	slot.inflight_count.store(static_cast<int>(submit_count));
+
+	py::list event_capacities;
+	py::list remaining_event_capacities;
+	py::list queue_sizes;
+	py::list dequeued_events;
+	bool stalled = false;
+	constexpr idx_t MAX_DRAIN_ROUNDS = 16;
+	idx_t drain_round = 0;
+	for (; drain_round < MAX_DRAIN_ROUNDS && slot.inflight_count.load() > 0 && !slot.has_error.load(); drain_round++) {
+		auto capacity = GetSlotResultCapacity(slot);
+		if (capacity.has_event_capacity) {
+			event_capacities.append(py::int_(capacity.events));
+		} else {
+			event_capacities.append(py::none());
+		}
+		py::dict capacities;
+		capacities[py::int_(slot_id)] = MakeUDFDrainCapacity(
+		    capacity.rows, capacity.has_event_capacity, capacity.events, capacity.has_byte_capacity, capacity.bytes,
+		    capacity.has_item_byte_capacity, capacity.item_bytes);
+		auto results = collector.attr("drain_results")(std::move(capacities)).cast<py::list>();
+		if (results.empty()) {
+			stalled = true;
+			break;
+		}
+
+		for (auto &item : results) {
+			auto event = item.cast<py::tuple>();
+			const auto event_size = py::len(event);
+			if (event_size != 4 && event_size != 6) {
+				throw InvalidInputException("fallback result queue test received an invalid event tuple");
+			}
+			if (event[0].cast<idx_t>() != slot_id) {
+				throw InvalidInputException("fallback result queue test received an event for another slot");
+			}
+			auto submit_id = event[1].cast<idx_t>();
+			auto event_kind = event[2].cast<string>();
+			if (event_kind == "data") {
+				UDFResult result;
+				result.outputs = MakeEmptyDataChunk();
+				result.rows = MakeEmptyDataChunk();
+				result.submit_complete = false;
+				result.submit_id = submit_id;
+				if (!TryDeliverResult(slot, std::move(result))) {
+					SetSlotError(slot, "fallback result queue test delivery was rejected");
+				}
+			} else if (event_kind == "complete") {
+				QueueTerminalControlResult(slot, submit_id);
+			} else {
+				throw InvalidInputException("fallback result queue test received unsupported event '%s'", event_kind);
+			}
+
+			size_t queue_size = 0;
+			{
+				lock_guard<mutex> rg(slot.result_lock);
+				queue_size = slot.result_queue.size();
+			}
+			queue_sizes.append(py::int_(queue_size));
+			auto remaining_capacity = GetSlotResultCapacity(slot);
+			if (remaining_capacity.has_event_capacity) {
+				remaining_event_capacities.append(py::int_(remaining_capacity.events));
+			} else {
+				remaining_event_capacities.append(py::none());
+			}
+			if (slot.has_error.load()) {
+				break;
+			}
+		}
+		if (slot.has_error.load()) {
+			break;
+		}
+
+		UDFResult result;
+		bool has_result = false;
+		{
+			lock_guard<mutex> rg(slot.result_lock);
+			if (!slot.result_queue.empty()) {
+				result = std::move(slot.result_queue.front());
+				slot.result_queue.pop_front();
+				has_result = true;
+			}
+		}
+		if (has_result) {
+			dequeued_events.append(
+			    py::make_tuple(py::int_(result.submit_id), py::str(result.submit_complete ? "complete" : "data")));
+		}
+	}
+	if (drain_round == MAX_DRAIN_ROUNDS && slot.inflight_count.load() > 0) {
+		stalled = true;
+	}
+
+	size_t remaining_queue_size = 0;
+	{
+		lock_guard<mutex> rg(slot.result_lock);
+		remaining_queue_size = slot.result_queue.size();
+	}
+	py::object error = py::none();
+	{
+		lock_guard<mutex> eg(slot.error_lock);
+		if (slot.has_error.load()) {
+			error = py::str(slot.error);
+		}
+	}
+
+	py::dict outcome;
+	outcome[py::str("event_capacities")] = std::move(event_capacities);
+	outcome[py::str("remaining_event_capacities")] = std::move(remaining_event_capacities);
+	outcome[py::str("queue_sizes")] = std::move(queue_sizes);
+	outcome[py::str("dequeued_events")] = std::move(dequeued_events);
+	outcome[py::str("terminal_submit_count")] = py::int_(slot.terminal_submit_ids.size());
+	outcome[py::str("inflight_count")] = py::int_(slot.inflight_count.load());
+	outcome[py::str("remaining_queue_size")] = py::int_(remaining_queue_size);
+	outcome[py::str("stalled")] = py::bool_(stalled);
+	outcome[py::str("error")] = std::move(error);
+	return outcome;
+}
 
 struct CollectorOutputLeaseCallbackState {
 	mutex lock;
@@ -3761,6 +3918,15 @@ void ResetUDFExecutorDebugCounters() {
 	g_udf_direct_arrow_table_conversion_count.store(0, std::memory_order_relaxed);
 	g_udf_direct_output_arrow_table_conversion_count.store(0, std::memory_order_relaxed);
 	g_udf_python_export_under_client_context_lock_count.store(0, std::memory_order_relaxed);
+}
+
+py::dict TestUDFFallbackResultQueue(py::object collector, idx_t slot_id, idx_t queue_capacity, idx_t submit_count) {
+	const char *test_hooks = std::getenv("VANE_ENABLE_UDF_TEST_HOOKS");
+	if (!test_hooks || string(test_hooks) != "1") {
+		throw InvalidInputException("UDF test hooks are disabled");
+	}
+	return GlobalPythonDispatcher::Instance().TestFallbackResultQueue(std::move(collector), slot_id, queue_capacity,
+	                                                                  submit_count);
 }
 
 void ShutdownUDFExecutorDispatcher() {

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -11,12 +11,15 @@ import weakref
 from concurrent.futures import Future
 from types import SimpleNamespace
 
+import _duckdb
 import pytest
 
 import duckdb.execution.udf_stream_result_collector as collector_module
 from duckdb.execution.ray_stream_adapter import RayStreamAdapter, TaskLeaseObjectRefGenerator
 from duckdb.execution.udf_stream_result_collector import (
     AsyncResultCollector,
+    _OutputLeaseToken,
+    _ReadyEvent,
     _StreamRecord,
 )
 from duckdb.execution.udf_task_admission import TaskAdmission
@@ -734,6 +737,49 @@ def test_empty_stream_completion_progresses_with_zero_data_capacity():
         collector.shutdown()
 
 
+def test_native_fallback_queue_preserves_interleaved_terminal_and_data_events(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    token = _OutputLeaseToken(
+        request_id="interleaved-request",
+        lease_id="interleaved-lease",
+        driver=driver,
+        slot_id=4,
+        submit_id=42,
+        size_bytes=1,
+    )
+    monkeypatch.setenv("VANE_ENABLE_UDF_TEST_HOOKS", "1")
+    with collector._cv:
+        collector._ready_by_slot[4].extend(
+            [
+                _ReadyEvent(4, 41, "complete", None),
+                _ReadyEvent(4, 42, "data", "payload", size_bytes=1, output_token=token),
+                _ReadyEvent(4, 42, "complete", None),
+            ]
+        )
+
+    try:
+        outcome = _duckdb._test_udf_fallback_result_queue(collector, 4, 1, 2)
+
+        assert outcome["event_capacities"] == [1, 1, 1]
+        assert outcome["remaining_event_capacities"] == [0, 0, 0]
+        assert outcome["queue_sizes"] == [1, 1, 1]
+        assert outcome["dequeued_events"] == [
+            (41, "complete"),
+            (42, "data"),
+            (42, "complete"),
+        ]
+        assert outcome["terminal_submit_count"] == 2
+        assert outcome["inflight_count"] == 0
+        assert outcome["remaining_queue_size"] == 0
+        assert outcome["stalled"] is False
+        assert outcome["error"] is None
+        assert collector.slot_has_pending(4) is False
+    finally:
+        collector.shutdown()
+
+
 def test_generator_terminating_mid_pair_fails_without_fetching_block():
     fake_ray = _FakeRay()
     driver = _Driver()
@@ -849,6 +895,7 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         80,
         _source(fake_ray, driver, request_id="blocking-cancel", submitter=submitter),
     )
+    record = collector._records[(8, 80)]
     try:
         deadline = time.monotonic() + 2.0
         while not driver.mark_query_task_lease_submitted.calls and time.monotonic() < deadline:
@@ -856,17 +903,19 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         assert driver.mark_query_task_lease_submitted.calls
         wakeup.clear()
 
-        collector.drain_results({8: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+        collector.drain_results({8: {"rows": 1, "events": 1, "bytes": 128, "item_bytes": 128}})
 
         assert fake_ray.cancel_started.wait(timeout=2.0)
         assert wakeup.is_set(), "terminal error was not published before ray.cancel"
         fake_ray.allow_cancel.set()
         events = _drain_until(
             collector,
-            {8: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            {8: {"rows": 1, "events": 1, "bytes": 128, "item_bytes": 128}},
             predicate=lambda values: any(item[2] == "error" for item in values),
         )
         assert [item[2] for item in events] == ["error"]
+        assert record.terminal is True
+        assert collector.slot_has_pending(8) is False
     finally:
         fake_ray.allow_cancel.set()
         collector.shutdown()
@@ -905,7 +954,7 @@ def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queu
         collector.shutdown()
 
 
-def test_slot_cancellation_recursively_cancels_stream_and_releases_output_lease():
+def test_slot_cancellation_terminalizes_once_and_releases_output_lease():
     fake_ray = _FakeRay()
     driver = _Driver()
 
@@ -921,18 +970,26 @@ def test_slot_cancellation_recursively_cancels_stream_and_releases_output_lease(
         60,
         _source(fake_ray, driver, request_id="cancel-active", submitter=submitter),
     )
+    record = collector._records[(6, 60)]
     try:
         events = _drain_until(
             collector,
-            {6: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            {6: {"rows": 1, "events": 1, "bytes": 128, "item_bytes": 128}},
             predicate=lambda values: any(item[2] == "data" for item in values),
         )
         assert events[0][2] == "data"
         collector.cancel_slot(6)
+        cancel_call_count = len(fake_ray.cancel_calls)
+        release_call_count = len(driver.release_query_output_block_lease.calls)
+        collector.cancel_slot(6)
+
+        assert record.terminal is True
         assert fake_ray.cancel_calls
         assert fake_ray.cancel_calls[-1][1] == {"force": True, "recursive": True}
-        assert len(driver.release_query_output_block_lease.calls) == 1
+        assert cancel_call_count == len(fake_ray.cancel_calls) == 1
+        assert release_call_count == len(driver.release_query_output_block_lease.calls) == 1
         assert collector.slot_has_pending(6) is False
+        assert collector.drain_results({6: {"rows": 1, "events": 1}}) == []
     finally:
         collector.shutdown()
 


### PR DESCRIPTION
<!-- Title format: [type](scope) Subject -->

## Summary

<!-- Describe the user-visible or architectural change and why it is needed. -->

The fallback UDF result queue reserved capacity only for data events even though completion events used the same bounded queue. An interleaved completion could consume the last slot and make an already-admitted data event fail the capacity contract.

This change adds a total event budget for fallback drains, bounds terminal enqueueing, and adds deterministic capacity-one coverage for normal, error, and cancellation paths. There is no public API or compatibility change.

## Related issue

Close: #80 

<!-- Link the issue or write `N/A` for a small, self-contained change. -->

## Documentation impact

<!-- Select exactly one option. -->

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

<!-- Link the documentation PR or add follow-up notes here. -->

## Validation

<!-- List the exact checks you ran. Include relevant hardware, dataset, runner, and batch settings for performance changes. -->

  - Incremental native build and installation
  - `scripts/format root --changed`
  - Changed-file pre-commit checks
  - `tests/fast/test_udf_stream_result_collector.py`: 18 passed
  - Release suite: 266 non-Ray and 5 real-Ray tests passed
  - `git diff --check`

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
