### PR TITLE
[fix](ai) Concatenate Anthropic text blocks instead of reading content[0]

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1227,8 +1227,13 @@ class TestAnthropicStructuredOutput:
         tool_block.type = "tool_use"
         tool_block.input = {"name": "Alice", "age": 30}
 
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 12
+        mock_usage.output_tokens = 7
+
         mock_response = MagicMock()
         mock_response.content = [tool_block]
+        mock_response.usage = mock_usage
 
         async def mock_create(**kwargs):
             assert "tools" in kwargs
@@ -1252,9 +1257,16 @@ class TestAnthropicStructuredOutput:
         )
 
         text_block = MagicMock()
+        text_block.type = "text"
         text_block.text = "Hello world"
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 8
+        mock_usage.output_tokens = 3
+
         mock_response = MagicMock()
         mock_response.content = [text_block]
+        mock_response.usage = mock_usage
 
         async def mock_create(**kwargs):
             assert "tools" not in kwargs
@@ -1356,9 +1368,16 @@ class TestAnthropicMultimodal:
 
         captured_messages = []
         text_block = MagicMock()
+        text_block.type = "text"
         text_block.text = "I see an image"
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 25
+        mock_usage.output_tokens = 6
+
         mock_response = MagicMock()
         mock_response.content = [text_block]
+        mock_response.usage = mock_usage
 
         async def mock_create(**kwargs):
             captured_messages.append(kwargs["messages"])
@@ -1389,9 +1408,16 @@ class TestAnthropicMultimodal:
 
         captured_messages = []
         text_block = MagicMock()
+        text_block.type = "text"
         text_block.text = "ok"
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 15
+        mock_usage.output_tokens = 2
+
         mock_response = MagicMock()
         mock_response.content = [text_block]
+        mock_response.usage = mock_usage
 
         async def mock_create(**kwargs):
             captured_messages.append(kwargs["messages"])

--- a/tests/fast/test_anthropic_prompter_content.py
+++ b/tests/fast/test_anthropic_prompter_content.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AnthropicPrompter plain-text extraction across response content blocks.
+
+Extended-thinking models return a leading ``thinking`` block (which has
+``.thinking`` and no ``.text``), so ``prompt`` must return the first
+``text`` block rather than assuming ``content[0]`` is text.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+
+def _make_prompter(monkeypatch, content):
+    """Build an AnthropicPrompter whose SDK client returns ``content``."""
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            return SimpleNamespace(content=content, usage=None)
+
+    class FakeAsyncAnthropic:
+        def __init__(self, **options):
+            self.messages = FakeMessages()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "anthropic",
+        SimpleNamespace(AsyncAnthropic=FakeAsyncAnthropic),
+    )
+
+    from vane.ai.providers.anthropic import AnthropicPrompter
+
+    return AnthropicPrompter(provider_options={}, model="claude-test")
+
+
+def _thinking_block(text="Let me think about this."):
+    # Real thinking blocks carry ``.thinking`` and have no ``.text``.
+    return SimpleNamespace(type="thinking", thinking=text)
+
+
+def _text_block(text):
+    return SimpleNamespace(type="text", text=text)
+
+
+def test_prompt_skips_leading_thinking_block(monkeypatch):
+    prompter = _make_prompter(
+        monkeypatch,
+        [_thinking_block(), _text_block("the answer")],
+    )
+
+    assert asyncio.run(prompter.prompt(("hello",))) == "the answer"
+
+
+def test_prompt_returns_text_when_first_block_is_text(monkeypatch):
+    prompter = _make_prompter(monkeypatch, [_text_block("plain reply")])
+
+    assert asyncio.run(prompter.prompt(("hello",))) == "plain reply"
+
+
+def test_prompt_returns_none_for_thinking_only_content(monkeypatch):
+    prompter = _make_prompter(monkeypatch, [_thinking_block()])
+
+    assert asyncio.run(prompter.prompt(("hello",))) is None
+
+
+def test_prompt_returns_none_for_empty_content(monkeypatch):
+    prompter = _make_prompter(monkeypatch, [])
+
+    assert asyncio.run(prompter.prompt(("hello",))) is None

--- a/tests/fast/test_anthropic_prompter_content.py
+++ b/tests/fast/test_anthropic_prompter_content.py
@@ -4,8 +4,8 @@
 """AnthropicPrompter plain-text extraction across response content blocks.
 
 Extended-thinking models return a leading ``thinking`` block (which has
-``.thinking`` and no ``.text``), so ``prompt`` must return the first
-``text`` block rather than assuming ``content[0]`` is text.
+``.thinking`` and no ``.text``), so ``prompt`` must concatenate the
+``text`` blocks rather than assuming ``content[0]`` is text.
 """
 
 import asyncio
@@ -57,6 +57,15 @@ def test_prompt_returns_text_when_first_block_is_text(monkeypatch):
     prompter = _make_prompter(monkeypatch, [_text_block("plain reply")])
 
     assert asyncio.run(prompter.prompt(("hello",))) == "plain reply"
+
+
+def test_prompt_concatenates_multiple_text_blocks(monkeypatch):
+    prompter = _make_prompter(
+        monkeypatch,
+        [_thinking_block(), _text_block("a"), _text_block("b")],
+    )
+
+    assert asyncio.run(prompter.prompt(("hello",))) == "ab"
 
 
 def test_prompt_returns_none_for_thinking_only_content(monkeypatch):

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -317,8 +317,6 @@ class AnthropicPrompter:
             return None
 
         if response.content:
-            return next(
-                (block.text for block in response.content if getattr(block, "type", None) == "text"),
-                None,
-            )
+            text_blocks = [block.text for block in response.content if getattr(block, "type", None) == "text"]
+            return "".join(text_blocks) if text_blocks else None
         return None

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -317,5 +317,8 @@ class AnthropicPrompter:
             return None
 
         if response.content:
-            return response.content[0].text
+            return next(
+                (block.text for block in response.content if getattr(block, "type", None) == "text"),
+                None,
+            )
         return None


### PR DESCRIPTION
## Summary

Extended-thinking Anthropic models return a leading `thinking` block, so indexing `response.content[0].text` raised `AttributeError` (or yielded empty text on compatible servers). `prompt()` now filters content blocks by `type == "text"` and concatenates all text blocks — mirroring the Anthropic SDK's own `get_final_text()` helper, so responses that split text across multiple blocks are never silently truncated — and returns `None` when no text block exists. Existing Anthropic response mocks got realistic `.type`/`.usage` attributes so they keep exercising the production path when the `anthropic` extra is installed.

## Related issue

Closes #140

## Validation

- `tests/fast/test_anthropic_prompter_content.py` (5 cases: [thinking, text] → text; [text] → text; [thinking, text("a"), text("b")] → "ab"; [thinking only] → None; empty → None), red-run verified: on unfixed code the cases reproduce the issue's exact `AttributeError`.
- 210 tests green locally under the no-duckdb import harness (16 pre-existing environment-only failures, unrelated; engine-dependent suites run in CI). `ruff check`/`format` clean; pre-commit hooks passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented in code/docstrings; CHANGELOG intentionally untouched per maintainer guidance.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered (no new surface).
- [x] Native changes were compiled; Python-only changes passed relevant tests (Python-only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014az5eSZxzP2SBDyivvivCk
