### PR TITLE
[fix](ai) Remove library-owned Google default models (#141)

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1276,6 +1276,66 @@ class TestGoogleProvider:
         with pytest.raises(ValueError, match="output dimensionality"):
             GoogleTextEmbedderDescriptor(model_name="gemini-embedding-001", dimensions=dimensions)
 
+    @pytest.mark.parametrize("dimensions", [256.5, True, "256"])
+    def test_embedder_non_integer_dimensions_rejected(self, dimensions):
+        """Non-integer dimensions raise the promised configuration error."""
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        with pytest.raises(ValueError, match="positive integer"):
+            GoogleTextEmbedderDescriptor(model_name="custom-tuned-embedder", dimensions=dimensions)
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "models/gemini-3.6-flash"])
+    def test_unsupported_option_rejected_for_both_model_name_forms(self, model):
+        """The models/ resource form cannot bypass the capability table."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        with pytest.raises(ValueError, match="does not support options"):
+            provider.get_prompter(model=model, temperature=0.2)
+
+    @pytest.mark.parametrize("model", ["gemini-embedding-001", "models/gemini-embedding-001"])
+    def test_embedder_trusted_dimensions_for_both_model_name_forms(self, model):
+        """The models/ resource form still hits the trusted dimensions table."""
+        from vane.ai.providers.google import GoogleProvider
+
+        desc = GoogleProvider(api_key="test").get_text_embedder(model=model)
+        assert desc.model_name == model
+        assert desc.get_dimensions().size == 3072
+
+    @pytest.mark.parametrize("model", ["", "   "])
+    def test_get_prompter_blank_call_model_rejected(self, model):
+        """A blank call-site model is an error, not a provider-config fallback."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", prompt_model="gemini-2.5-pro")
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_prompter(model=model)
+
+    def test_get_prompter_blank_provider_model_rejected(self):
+        """A blank provider-level prompt_model fails at expression-build time."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", prompt_model="")
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_prompter()
+
+    @pytest.mark.parametrize("model", ["", "   "])
+    def test_get_text_embedder_blank_call_model_rejected(self, model):
+        """A blank call-site model is an error, not a provider-config fallback."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", embedding_model="gemini-embedding-001")
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_text_embedder(model=model)
+
+    def test_get_text_embedder_blank_provider_model_rejected(self):
+        """A blank provider-level embedding_model fails at expression-build time."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", embedding_model="")
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_text_embedder()
+
     def test_provider_get_prompter_splits_call_client_options(self):
         """Google prompt call-level client options go to provider_options only."""
         from vane.ai._redaction import Secret
@@ -1328,6 +1388,63 @@ class TestGoogleProvider:
         assert "api_key" not in desc.embed_options
         assert desc.embed_options["task_type"] == "RETRIEVAL_QUERY"
         assert desc.embed_options["on_error"] == "log"
+
+
+class TestGoogleEmbeddingRowPreservation:
+    """embed_text must return exactly one embedding per input row.
+
+    gemini-embedding-2 aggregates multiple direct string inputs into a
+    single embedding, so each input is sent as its own ``types.Content``
+    and the result count is verified against the input count.
+    """
+
+    def _make_embedder(self, embeddings):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, patch
+
+        from vane.ai.providers.google import GoogleTextEmbedder
+
+        with patch("google.genai.Client"):
+            embedder = GoogleTextEmbedder(
+                provider_options={"api_key": "test"},
+                model="gemini-embedding-2",
+            )
+        embed_content = AsyncMock(return_value=SimpleNamespace(embeddings=embeddings))
+        embedder._client.aio.models.embed_content = embed_content
+        return embedder, embed_content
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_two_inputs_yield_two_vectors_via_separate_contents(self):
+        import asyncio
+        from types import SimpleNamespace
+
+        from google.genai import types
+
+        embedder, embed_content = self._make_embedder(
+            [
+                SimpleNamespace(values=[0.1, 0.2]),
+                SimpleNamespace(values=[0.3, 0.4]),
+            ]
+        )
+
+        result = asyncio.run(embedder.embed_text(["first row", "second row"]))
+
+        assert len(result) == 2
+        contents = embed_content.call_args.kwargs["contents"]
+        assert len(contents) == 2
+        assert all(isinstance(c, types.Content) for c in contents)
+        assert contents[0].parts[0].text == "first row"
+        assert contents[1].parts[0].text == "second row"
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_embedding_count_mismatch_raises(self):
+        import asyncio
+        from types import SimpleNamespace
+
+        embedder, _ = self._make_embedder([SimpleNamespace(values=[0.1, 0.2])])
+
+        with pytest.raises(ValueError, match="one embedding per input row"):
+            asyncio.run(embedder.embed_text(["first row", "second row"]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -726,8 +726,18 @@ class TestUDFExecutionOptions:
         assert OpenAITextEmbedderDescriptor(embed_options={"num_gpus": 1}).get_udf_options().num_gpus == 1
         assert OpenAIPrompterDescriptor(prompt_options={"num_gpus": 2}).get_udf_options().num_gpus == 2
         assert AnthropicPrompterDescriptor(prompt_options={"num_gpus": 3}).get_udf_options().num_gpus == 3
-        assert GoogleTextEmbedderDescriptor(embed_options={"num_gpus": 4}).get_udf_options().num_gpus == 4
-        assert GooglePrompterDescriptor(prompt_options={"num_gpus": 5}).get_udf_options().num_gpus == 5
+        assert (
+            GoogleTextEmbedderDescriptor(model_name="gemini-embedding-001", embed_options={"num_gpus": 4})
+            .get_udf_options()
+            .num_gpus
+            == 4
+        )
+        assert (
+            GooglePrompterDescriptor(model_name="gemini-3.6-flash", prompt_options={"num_gpus": 5})
+            .get_udf_options()
+            .num_gpus
+            == 5
+        )
 
     def test_prompt_relation_defaults_keep_task_fanout_and_batch_size_one(self, monkeypatch):
         import vane
@@ -1014,23 +1024,23 @@ class TestGoogleProvider:
         assert "google" in PROVIDERS
 
     def test_embedder_descriptor_creates(self):
-        """GoogleTextEmbedderDescriptor can be created."""
+        """GoogleTextEmbedderDescriptor derives dims for a known model."""
         from vane.ai.providers.google import GoogleTextEmbedderDescriptor
 
         desc = GoogleTextEmbedderDescriptor(
-            model_name="text-embedding-004",
+            model_name="gemini-embedding-001",
         )
         assert desc.get_provider() == "google"
-        assert desc.get_model() == "text-embedding-004"
+        assert desc.get_model() == "gemini-embedding-001"
         dims = desc.get_dimensions()
-        assert dims.size == 768
+        assert dims.size == 3072
 
     def test_embedder_descriptor_custom_dims(self):
         """GoogleTextEmbedderDescriptor supports custom dimensions."""
         from vane.ai.providers.google import GoogleTextEmbedderDescriptor
 
         desc = GoogleTextEmbedderDescriptor(
-            model_name="text-embedding-004",
+            model_name="gemini-embedding-001",
             dimensions=256,
         )
         dims = desc.get_dimensions()
@@ -1042,7 +1052,7 @@ class TestGoogleProvider:
 
         desc = GoogleTextEmbedderDescriptor(
             provider_options={"api_key": "test"},
-            model_name="text-embedding-004",
+            model_name="gemini-embedding-001",
             dimensions=256,
         )
         restored = pickle.loads(pickle.dumps(desc))
@@ -1054,11 +1064,11 @@ class TestGoogleProvider:
         from vane.ai.providers.google import GooglePrompterDescriptor
 
         desc = GooglePrompterDescriptor(
-            model_name="gemini-2.0-flash",
+            model_name="gemini-3.6-flash",
             system_message="Be helpful.",
         )
         assert desc.get_provider() == "google"
-        assert desc.get_model() == "gemini-2.0-flash"
+        assert desc.get_model() == "gemini-3.6-flash"
 
     def test_prompter_descriptor_pickle(self):
         """GooglePrompterDescriptor survives pickle."""
@@ -1066,7 +1076,7 @@ class TestGoogleProvider:
 
         desc = GooglePrompterDescriptor(
             provider_options={"api_key": "test"},
-            model_name="gemini-2.0-flash",
+            model_name="gemini-2.5-pro",
             system_message="Be concise.",
             prompt_options={"temperature": 0.5},
         )
@@ -1078,9 +1088,21 @@ class TestGoogleProvider:
         """Google prompter descriptor produces correct UDFOptions."""
         from vane.ai.providers.google import GooglePrompterDescriptor
 
-        desc = GooglePrompterDescriptor()
+        desc = GooglePrompterDescriptor(model_name="gemini-3.6-flash")
         opts = desc.get_udf_options()
         assert opts.max_api_concurrency == 16
+
+    def test_descriptor_model_name_required(self):
+        """Descriptors cannot be constructed without an explicit model."""
+        from vane.ai.providers.google import (
+            GooglePrompterDescriptor,
+            GoogleTextEmbedderDescriptor,
+        )
+
+        with pytest.raises(TypeError):
+            GooglePrompterDescriptor()
+        with pytest.raises(TypeError):
+            GoogleTextEmbedderDescriptor()
 
     def test_provider_get_prompter(self):
         """GoogleProvider.get_prompter returns descriptor."""
@@ -1088,11 +1110,171 @@ class TestGoogleProvider:
 
         provider = GoogleProvider(api_key="test")
         desc = provider.get_prompter(
-            model="gemini-2.0-flash",
+            model="gemini-3.6-flash",
             system_message="Summarize.",
         )
         assert isinstance(desc, GooglePrompterDescriptor)
-        assert desc.model_name == "gemini-2.0-flash"
+        assert desc.model_name == "gemini-3.6-flash"
+
+    def test_get_prompter_missing_model_raises(self):
+        """No call-site model and no provider config fails fast."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        with pytest.raises(ValueError) as excinfo:
+            provider.get_prompter()
+        message = str(excinfo.value)
+        assert "No prompt model configured" in message
+        assert "model=" in message
+        assert "GoogleProvider(prompt_model=...)" in message
+
+    def test_get_prompter_provider_config_flow_through(self):
+        """Provider-level prompt_model is used when the call omits model."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", prompt_model="gemini-3.6-flash")
+        desc = provider.get_prompter()
+        assert desc.model_name == "gemini-3.6-flash"
+
+    def test_get_prompter_call_model_beats_provider_config(self):
+        """Call-site model overrides the provider-level prompt_model."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", prompt_model="gemini-2.5-pro")
+        desc = provider.get_prompter(model="gemini-3.6-flash")
+        assert desc.model_name == "gemini-3.6-flash"
+
+    def test_get_text_embedder_missing_model_raises(self):
+        """No call-site model and no provider config fails fast."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        with pytest.raises(ValueError) as excinfo:
+            provider.get_text_embedder()
+        message = str(excinfo.value)
+        assert "No embedding model configured" in message
+        assert "model=" in message
+        assert "GoogleProvider(embedding_model=...)" in message
+
+    def test_get_text_embedder_provider_config_flow_through(self):
+        """Provider-level embedding_model is used when the call omits model."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", embedding_model="gemini-embedding-001")
+        desc = provider.get_text_embedder()
+        assert desc.model_name == "gemini-embedding-001"
+        assert desc.get_dimensions().size == 3072
+
+    def test_get_text_embedder_call_model_beats_provider_config(self):
+        """Call-site model overrides the provider-level embedding_model."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", embedding_model="gemini-embedding-2")
+        desc = provider.get_text_embedder(model="gemini-embedding-001")
+        assert desc.model_name == "gemini-embedding-001"
+
+    def test_get_text_embedder_provider_dimensions_flow_through(self):
+        """Provider-level embedding_dimensions covers models without metadata."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(
+            api_key="test",
+            embedding_model="custom-tuned-embedder",
+            embedding_dimensions=1024,
+        )
+        desc = provider.get_text_embedder()
+        assert desc.get_dimensions().size == 1024
+
+    def test_get_text_embedder_call_dimensions_beat_provider_config(self):
+        """Call-site dimensions override the provider-level configuration."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test", embedding_dimensions=1024)
+        desc = provider.get_text_embedder(model="gemini-embedding-001", dimensions=256)
+        assert desc.get_dimensions().size == 256
+
+    def test_provider_ctor_typo_raises_type_error(self):
+        """A mistyped constructor kwarg cannot leak into request options."""
+        from vane.ai.providers.google import GoogleProvider
+
+        with pytest.raises(TypeError):
+            GoogleProvider(promt_model="gemini-3.6-flash")
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.5-flash-lite"])
+    @pytest.mark.parametrize("option", ["temperature", "top_p", "top_k"])
+    def test_unsupported_sampling_option_rejected(self, model, option):
+        """Deprecated sampling params are rejected before dispatch."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        with pytest.raises(ValueError) as excinfo:
+            provider.get_prompter(model=model, **{option: 0.5})
+        message = str(excinfo.value)
+        assert option in message
+        assert model in message
+
+    def test_unsupported_option_rejected_on_direct_descriptor_construction(self):
+        """Validation also covers direct descriptor construction."""
+        from vane.ai.providers.google import GooglePrompterDescriptor
+
+        with pytest.raises(ValueError, match="does not support options"):
+            GooglePrompterDescriptor(
+                model_name="gemini-3.6-flash",
+                prompt_options={"temperature": 0.2},
+            )
+
+    def test_sampling_options_pass_for_untabled_model(self):
+        """Models without a capability-table entry accept sampling params."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        desc = provider.get_prompter(
+            model="gemini-2.5-pro",
+            temperature=0.2,
+            top_p=0.9,
+            top_k=40,
+        )
+        assert desc.prompt_options["temperature"] == 0.2
+        assert desc.prompt_options["top_p"] == 0.9
+        assert desc.prompt_options["top_k"] == 40
+
+    def test_embedder_unknown_model_without_dimensions_raises(self):
+        """Unknown embedding model without explicit dimensions fails fast."""
+        from vane.ai.providers.google import GoogleProvider, GoogleTextEmbedderDescriptor
+
+        provider = GoogleProvider(api_key="test")
+        with pytest.raises(ValueError) as excinfo:
+            provider.get_text_embedder(model="custom-tuned-embedder")
+        message = str(excinfo.value)
+        assert "Cannot derive embedding dimensions" in message
+        assert "dimensions=" in message
+        assert "GoogleProvider(embedding_dimensions=...)" in message
+
+        with pytest.raises(ValueError, match="Cannot derive embedding dimensions"):
+            GoogleTextEmbedderDescriptor(model_name="custom-tuned-embedder")
+
+    def test_embedder_unknown_model_with_explicit_dimensions_flows(self):
+        """Explicit dimensions make an unknown model usable."""
+        from vane.ai.providers.google import GoogleProvider
+
+        provider = GoogleProvider(api_key="test")
+        desc = provider.get_text_embedder(model="custom-tuned-embedder", dimensions=512)
+        assert desc.get_dimensions().size == 512
+
+    def test_embedder_zero_dimensions_rejected(self):
+        """dimensions=0 is rejected instead of silently treated as unset."""
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        with pytest.raises(ValueError, match="positive integer"):
+            GoogleTextEmbedderDescriptor(model_name="custom-tuned-embedder", dimensions=0)
+
+    @pytest.mark.parametrize("dimensions", [64, 4096])
+    def test_embedder_dimensions_outside_documented_range_rejected(self, dimensions):
+        """Dimensions conflicting with trusted model metadata fail fast."""
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        with pytest.raises(ValueError, match="output dimensionality"):
+            GoogleTextEmbedderDescriptor(model_name="gemini-embedding-001", dimensions=dimensions)
 
     def test_provider_get_prompter_splits_call_client_options(self):
         """Google prompt call-level client options go to provider_options only."""
@@ -1101,6 +1283,7 @@ class TestGoogleProvider:
 
         provider = GoogleProvider(api_key="ctor-key")
         desc = provider.get_prompter(
+            model="gemini-2.5-pro",
             api_key="call-key",
             max_api_concurrency=7,
             temperature=0,
@@ -1121,7 +1304,7 @@ class TestGoogleProvider:
 
         provider = GoogleProvider(api_key="test")
         desc = provider.get_text_embedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             dimensions=256,
         )
         assert isinstance(desc, GoogleTextEmbedderDescriptor)
@@ -1134,6 +1317,7 @@ class TestGoogleProvider:
 
         provider = GoogleProvider(api_key="ctor-key")
         desc = provider.get_text_embedder(
+            model="gemini-embedding-001",
             api_key="call-key",
             task_type="RETRIEVAL_QUERY",
             on_error="log",
@@ -1452,19 +1636,19 @@ class TestGoogleStructuredOutput:
     def test_descriptor_has_return_format(self):
         from vane.ai.providers.google import GooglePrompterDescriptor
 
-        desc = GooglePrompterDescriptor(return_format=dict)
+        desc = GooglePrompterDescriptor(model_name="gemini-3.6-flash", return_format=dict)
         assert desc.return_format is dict
 
     def test_descriptor_default_no_return_format(self):
         from vane.ai.providers.google import GooglePrompterDescriptor
 
-        desc = GooglePrompterDescriptor()
+        desc = GooglePrompterDescriptor(model_name="gemini-3.6-flash")
         assert desc.return_format is None
 
     def test_descriptor_pickle_with_return_format(self):
         from vane.ai.providers.google import GooglePrompterDescriptor
 
-        desc = GooglePrompterDescriptor(return_format=dict)
+        desc = GooglePrompterDescriptor(model_name="gemini-3.6-flash", return_format=dict)
         restored = pickle.loads(pickle.dumps(desc))
         assert restored.return_format is dict
 
@@ -1472,7 +1656,7 @@ class TestGoogleStructuredOutput:
         from vane.ai.providers.google import GoogleProvider
 
         prov = GoogleProvider(api_key="test")
-        desc = prov.get_prompter(return_format=dict)
+        desc = prov.get_prompter(model="gemini-3.6-flash", return_format=dict)
         assert desc.return_format is dict
 
 

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -74,7 +74,7 @@ def _google_embedder_descriptor():
 
     return GoogleTextEmbedderDescriptor(
         provider_options={"api_key": API_KEY},
-        model_name="text-embedding-004",
+        model_name="gemini-embedding-001",
         embed_options={"task_type": "RETRIEVAL_QUERY", "auth_token": API_KEY},
     )
 
@@ -84,7 +84,7 @@ def _google_prompter_descriptor():
 
     return GooglePrompterDescriptor(
         provider_options={"api_key": API_KEY},
-        model_name="gemini-2.0-flash",
+        model_name="gemini-2.5-pro",
         prompt_options={"temperature": 0.1, "auth_token": API_KEY},
     )
 
@@ -229,7 +229,9 @@ class TestDescriptorReprRedaction:
     def test_credential_kwarg_landing_in_embed_options_is_redacted(self):
         from vane.ai.providers.google import GoogleProvider
 
-        descriptor = GoogleProvider(api_key=API_KEY).get_text_embedder(auth_token=API_KEY, task_type="RETRIEVAL_QUERY")
+        descriptor = GoogleProvider(api_key=API_KEY).get_text_embedder(
+            model="gemini-embedding-001", auth_token=API_KEY, task_type="RETRIEVAL_QUERY"
+        )
         assert API_KEY not in repr(descriptor)
         assert isinstance(descriptor.embed_options["auth_token"], Secret)
         assert descriptor.embed_options["task_type"] == "RETRIEVAL_QUERY"

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -701,7 +701,9 @@ def embed_text(
         rel: A DuckDB relation containing the source data.
         column: Name of the text column to embed.
         provider: Provider name or instance (default: ``"transformers"``).
-        model: Model identifier (provider-specific default if ``None``).
+        model: Model identifier. Providers without a library default (e.g.
+            ``"google"``) require an explicit model here or on the provider
+            instance and raise :class:`ValueError` otherwise.
         dimensions: Output embedding dimensions (model default if ``None``).
         output_column: Name of the output column (default: ``"embedding"``).
         max_chunk_chars: If set, texts longer than this are split into

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -7,6 +7,12 @@ Supports text embedding via ``embed_content`` and prompting via
 ``generate_content`` with multimodal input (text + images) and
 structured output via ``response_schema``.
 
+Vane does not choose Google models: every prompt or embedding call must
+name a model, either per call (``model=...``) or through explicit
+provider configuration (``GoogleProvider(prompt_model=...,
+embedding_model=...)``). Missing configuration raises :class:`ValueError`
+at expression-build time.
+
 Requires::
 
     pip install 'vane-ai[google]'
@@ -25,6 +31,8 @@ from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from vane.ai.protocols import Prompter, TextEmbedder
     from vane.ai.typing import Embedding, Options
 
@@ -76,10 +84,71 @@ def _raise_retry_after_on_google_error(exc: Exception) -> None:
 # Model metadata
 # ---------------------------------------------------------------------------
 
+# Default output dimensionality per known embedding model, from the Gemini
+# embeddings guide (https://ai.google.dev/gemini-api/docs/embeddings). Only
+# models with trusted metadata belong here; any other model requires the
+# caller to supply ``dimensions`` explicitly.
 _EMBEDDING_DIMS: dict[str, int] = {
-    "text-embedding-004": 768,
-    "embedding-001": 768,
+    "gemini-embedding-001": 3072,
+    "gemini-embedding-2": 3072,
 }
+
+# Documented ``output_dimensionality`` bounds per known embedding model.
+_EMBEDDING_DIM_RANGE: dict[str, tuple[int, int]] = {
+    "gemini-embedding-001": (128, 3072),
+    "gemini-embedding-2": (128, 3072),
+}
+
+# Request options rejected per model before dispatch. Gemini 3.6 Flash and
+# 3.5 Flash-Lite deprecate the classic sampling parameters: the API ignores
+# them today and returns HTTP 400 in future model generations
+# (https://ai.google.dev/gemini-api/docs/latest-model).
+_MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
+    "gemini-3.6-flash": frozenset({"temperature", "top_p", "top_k"}),
+    "gemini-3.5-flash-lite": frozenset({"temperature", "top_p", "top_k"}),
+}
+
+
+def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> None:
+    """Reject request options the selected model is documented not to support.
+
+    Raises:
+        ValueError: If ``options`` contains keys listed for ``model_name``
+            in :data:`_MODEL_UNSUPPORTED_OPTIONS`.
+    """
+    unsupported = _MODEL_UNSUPPORTED_OPTIONS.get(model_name, frozenset())
+    offending = sorted(unsupported.intersection(options))
+    if offending:
+        raise ValueError(
+            f"Google model {model_name!r} does not support options {offending}: "
+            "the Gemini API ignores these sampling parameters and rejects them "
+            "in future model generations. Remove them from the request."
+        )
+
+
+def _validate_embedding_dimensions(model_name: str, dimensions: int | None) -> None:
+    """Validate the embedding-dimensions configuration for ``model_name``.
+
+    Raises:
+        ValueError: If ``dimensions`` is omitted for a model without trusted
+            metadata in :data:`_EMBEDDING_DIMS`, is not a positive integer,
+            or falls outside the documented range for a known model.
+    """
+    if dimensions is None:
+        if model_name not in _EMBEDDING_DIMS:
+            raise ValueError(
+                f"Cannot derive embedding dimensions for Google model {model_name!r}. "
+                "Pass dimensions=... or configure GoogleProvider(embedding_dimensions=...)."
+            )
+        return
+    if dimensions < 1:
+        raise ValueError(f"Embedding dimensions must be a positive integer, got {dimensions!r}.")
+    bounds = _EMBEDDING_DIM_RANGE.get(model_name)
+    if bounds is not None and not bounds[0] <= dimensions <= bounds[1]:
+        raise ValueError(
+            f"Google model {model_name!r} supports output dimensionality "
+            f"between {bounds[0]} and {bounds[1]}, got {dimensions}."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -88,15 +157,46 @@ _EMBEDDING_DIMS: dict[str, int] = {
 
 
 class GoogleProvider(Provider):
-    """Provider backed by Google Generative AI (Gemini)."""
+    """Provider backed by Google Generative AI (Gemini).
 
-    DEFAULT_EMBED_MODEL = "text-embedding-004"
-    DEFAULT_PROMPT_MODEL = "gemini-2.0-flash"
+    The provider ships no default model IDs: a model must be supplied per
+    call (``model=...``) or through the named constructor parameters below.
+    Call-site arguments always win over constructor configuration.
+
+    Args:
+        name: Optional display-name override (default ``"google"``).
+        api_key: Google API key. Prefer the ``GOOGLE_API_KEY`` environment
+            variable over passing keys in code.
+        prompt_model: Model used by ``get_prompter`` when the call does not
+            pass ``model=...``.
+        embedding_model: Model used by ``get_text_embedder`` when the call
+            does not pass ``model=...``.
+        embedding_dimensions: Embedding output dimensionality used when the
+            call does not pass ``dimensions=...``. Required (here or per
+            call) for embedding models without trusted dimension metadata.
+
+    All parameters are named; a mistyped keyword raises :class:`TypeError`
+    instead of silently leaking into API request options.
+    """
+
     _CLIENT_KEYS: ClassVar[frozenset[str]] = frozenset({"api_key"})
 
-    def __init__(self, name: str | None = None, **options: Any):
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        api_key: str | None = None,
+        prompt_model: str | None = None,
+        embedding_model: str | None = None,
+        embedding_dimensions: int | None = None,
+    ):
         self._name = name or "google"
-        self._options: dict[str, Any] = options
+        self._prompt_model = prompt_model
+        self._embedding_model = embedding_model
+        self._embedding_dimensions = embedding_dimensions
+        self._options: dict[str, Any] = {}
+        if api_key is not None:
+            self._options["api_key"] = api_key
 
     @property
     def name(self) -> str:
@@ -114,12 +214,27 @@ class GoogleProvider(Provider):
         dimensions: int | None = None,
         **options: Any,
     ) -> TextEmbedderDescriptor:
+        """Build an embedder descriptor for an explicitly selected model.
+
+        Raises:
+            ValueError: If neither ``model=...`` nor the provider's
+                ``embedding_model`` is configured, or if dimensions cannot
+                be resolved for the selected model.
+        """
         provider_options, embed_options = self._split_options(options)
-        model_name = model or self.DEFAULT_EMBED_MODEL
+        options_model = embed_options.pop("model", None)
+        model_name = model or options_model or self._embedding_model
+        if model_name is None:
+            raise ValueError(
+                "No embedding model configured for the Google provider. "
+                "Pass model=... or configure GoogleProvider(embedding_model=...)."
+            )
+        if dimensions is None:
+            dimensions = self._embedding_dimensions
         return GoogleTextEmbedderDescriptor(
+            model_name=model_name,
             provider_name=self._name,
             provider_options=provider_options,
-            model_name=model_name,
             dimensions=dimensions,
             embed_options=embed_options,
         )
@@ -131,11 +246,25 @@ class GoogleProvider(Provider):
         return_format: Any | None = None,
         **options: Any,
     ) -> PrompterDescriptor:
+        """Build a prompter descriptor for an explicitly selected model.
+
+        Raises:
+            ValueError: If neither ``model=...`` nor the provider's
+                ``prompt_model`` is configured, or if the selected model
+                does not support one of the requested options.
+        """
         provider_options, prompt_options = self._split_options(options)
+        options_model = prompt_options.pop("model", None)
+        model_name = model or options_model or self._prompt_model
+        if model_name is None:
+            raise ValueError(
+                "No prompt model configured for the Google provider. "
+                "Pass model=... or configure GoogleProvider(prompt_model=...)."
+            )
         return GooglePrompterDescriptor(
+            model_name=model_name,
             provider_name=self._name,
             provider_options=provider_options,
-            model_name=model or prompt_options.pop("model", self.DEFAULT_PROMPT_MODEL),
             system_message=system_message,
             return_format=return_format,
             prompt_options=prompt_options,
@@ -149,15 +278,21 @@ class GoogleProvider(Provider):
 
 @dataclass
 class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
-    """Serializable factory for a Google Generative AI text embedder."""
+    """Serializable factory for a Google Generative AI text embedder.
 
+    ``model_name`` is required. ``dimensions`` is required unless the model
+    has trusted metadata in :data:`_EMBEDDING_DIMS`; both are validated at
+    construction time, before anything ships to workers.
+    """
+
+    model_name: str
     provider_name: str = "google"
     provider_options: dict[str, Any] = field(default_factory=dict)
-    model_name: str = "text-embedding-004"
     dimensions: int | None = None
     embed_options: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        _validate_embedding_dimensions(self.model_name, self.dimensions)
         self.provider_options = wrap_sensitive_options(self.provider_options)
         self.embed_options = wrap_sensitive_options(self.embed_options)
 
@@ -171,10 +306,9 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
         return dict(self.embed_options)
 
     def get_dimensions(self) -> EmbeddingDimensions:
-        if self.dimensions:
+        if self.dimensions is not None:
             return EmbeddingDimensions(size=self.dimensions)
-        size = _EMBEDDING_DIMS.get(self.model_name, 768)
-        return EmbeddingDimensions(size=size)
+        return EmbeddingDimensions(size=_EMBEDDING_DIMS[self.model_name])
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(
@@ -263,16 +397,20 @@ class GooglePrompterDescriptor(PrompterDescriptor):
 
     Supports structured output via ``response_schema`` and multimodal
     input (text + images via ``Part.from_bytes``).
+
+    ``model_name`` is required, and the model/option combination is
+    validated at construction time, before anything ships to workers.
     """
 
+    model_name: str
     provider_name: str = "google"
     provider_options: dict[str, Any] = field(default_factory=dict)
-    model_name: str = "gemini-2.0-flash"
     system_message: str | None = None
     return_format: Any | None = None
     prompt_options: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        _validate_prompt_options(self.model_name, self.prompt_options)
         self.provider_options = wrap_sensitive_options(self.provider_options)
         self.prompt_options = wrap_sensitive_options(self.prompt_options)
 

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -109,6 +109,16 @@ _MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
 }
 
 
+def _canonical_model_id(model_name: str) -> str:
+    """Strip the Gemini API ``models/`` resource prefix for local lookups.
+
+    The Google Gen AI SDK accepts both ``gemini-3.6-flash`` and
+    ``models/gemini-3.6-flash``; local metadata and capability tables key on
+    the bare ID, while the caller-provided value is sent to the SDK verbatim.
+    """
+    return model_name.removeprefix("models/")
+
+
 def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> None:
     """Reject request options the selected model is documented not to support.
 
@@ -116,7 +126,7 @@ def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> Non
         ValueError: If ``options`` contains keys listed for ``model_name``
             in :data:`_MODEL_UNSUPPORTED_OPTIONS`.
     """
-    unsupported = _MODEL_UNSUPPORTED_OPTIONS.get(model_name, frozenset())
+    unsupported = _MODEL_UNSUPPORTED_OPTIONS.get(_canonical_model_id(model_name), frozenset())
     offending = sorted(unsupported.intersection(options))
     if offending:
         raise ValueError(
@@ -134,16 +144,19 @@ def _validate_embedding_dimensions(model_name: str, dimensions: int | None) -> N
             metadata in :data:`_EMBEDDING_DIMS`, is not a positive integer,
             or falls outside the documented range for a known model.
     """
+    canonical = _canonical_model_id(model_name)
     if dimensions is None:
-        if model_name not in _EMBEDDING_DIMS:
+        if canonical not in _EMBEDDING_DIMS:
             raise ValueError(
                 f"Cannot derive embedding dimensions for Google model {model_name!r}. "
                 "Pass dimensions=... or configure GoogleProvider(embedding_dimensions=...)."
             )
         return
+    if isinstance(dimensions, bool) or not isinstance(dimensions, int):
+        raise ValueError(f"Embedding dimensions must be a positive integer, got {dimensions!r}.")
     if dimensions < 1:
         raise ValueError(f"Embedding dimensions must be a positive integer, got {dimensions!r}.")
-    bounds = _EMBEDDING_DIM_RANGE.get(model_name)
+    bounds = _EMBEDDING_DIM_RANGE.get(canonical)
     if bounds is not None and not bounds[0] <= dimensions <= bounds[1]:
         raise ValueError(
             f"Google model {model_name!r} supports output dimensionality "
@@ -222,11 +235,15 @@ class GoogleProvider(Provider):
                 be resolved for the selected model.
         """
         provider_options, embed_options = self._split_options(options)
-        options_model = embed_options.pop("model", None)
-        model_name = model or options_model or self._embedding_model
+        model_name = model if model is not None else self._embedding_model
         if model_name is None:
             raise ValueError(
                 "No embedding model configured for the Google provider. "
+                "Pass model=... or configure GoogleProvider(embedding_model=...)."
+            )
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise ValueError(
+                f"Google embedding model must be a non-empty string, got {model_name!r}. "
                 "Pass model=... or configure GoogleProvider(embedding_model=...)."
             )
         if dimensions is None:
@@ -254,11 +271,15 @@ class GoogleProvider(Provider):
                 does not support one of the requested options.
         """
         provider_options, prompt_options = self._split_options(options)
-        options_model = prompt_options.pop("model", None)
-        model_name = model or options_model or self._prompt_model
+        model_name = model if model is not None else self._prompt_model
         if model_name is None:
             raise ValueError(
                 "No prompt model configured for the Google provider. "
+                "Pass model=... or configure GoogleProvider(prompt_model=...)."
+            )
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise ValueError(
+                f"Google prompt model must be a non-empty string, got {model_name!r}. "
                 "Pass model=... or configure GoogleProvider(prompt_model=...)."
             )
         return GooglePrompterDescriptor(
@@ -308,7 +329,7 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_dimensions(self) -> EmbeddingDimensions:
         if self.dimensions is not None:
             return EmbeddingDimensions(size=self.dimensions)
-        return EmbeddingDimensions(size=_EMBEDDING_DIMS[self.model_name])
+        return EmbeddingDimensions(size=_EMBEDDING_DIMS[_canonical_model_id(self.model_name)])
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(
@@ -368,9 +389,14 @@ class GoogleTextEmbedder:
         }
 
     async def embed_text(self, text: list[str]) -> list[Embedding]:
+        from google.genai import types
+
+        # Embedding models such as gemini-embedding-2 aggregate multiple
+        # direct string inputs into a single embedding; one Content per input
+        # keeps the call row-preserving.
         kwargs: dict[str, Any] = {
             "model": self._model,
-            "contents": text,
+            "contents": [types.Content(parts=[types.Part.from_text(text=t)]) for t in text],
         }
         config = dict(self._options)
         if self._dimensions is not None:
@@ -383,7 +409,14 @@ class GoogleTextEmbedder:
         except Exception as exc:
             _raise_retry_after_on_google_error(exc)
             raise
-        return [np.array(e.values, dtype=np.float32) for e in result.embeddings]
+        embeddings = result.embeddings or []
+        if len(embeddings) != len(text):
+            raise ValueError(
+                f"Google embed_content returned {len(embeddings)} embeddings for "
+                f"{len(text)} inputs with model {self._model!r}; embedding calls "
+                "must return exactly one embedding per input row."
+            )
+        return [np.array(e.values, dtype=np.float32) for e in embeddings]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reworked per maintainer direction on this PR: instead of bumping the retired Google default model IDs to newer ones, Vane stops choosing Google models altogether. No compatibility shim, deprecation window, legacy fallback, or automatic fallback model.

**Explicit-model contract.** `DEFAULT_EMBED_MODEL` / `DEFAULT_PROMPT_MODEL` are deleted. A model must be supplied per call (`model=...`) or through explicit user-owned provider configuration via new named constructor parameters: `GoogleProvider(prompt_model=..., embedding_model=..., embedding_dimensions=...)`. The constructor is now fully named (`name`, `api_key`, and the three config parameters), so a mistyped kwarg raises `TypeError` immediately instead of silently leaking into API request bodies. Generic `**options` passthrough for request options is unchanged on `get_prompter` / `get_text_embedder` and the expression-level option objects.

**Precedence chain.** One rule for models and dimensions: call-site argument > provider constructor configuration > `ValueError`. The error is raised at expression-build time (descriptor construction), not on a worker, and names both fix paths, e.g.:

> No prompt model configured for the Google provider. Pass model=... or configure GoogleProvider(prompt_model=...).

**Required descriptor model.** `model_name` is now a required field (no dataclass default) on `GoogleTextEmbedderDescriptor` and `GooglePrompterDescriptor`, so the provider constants and dataclass defaults cannot drift apart again.

**Model/option validation before dispatch.** A per-provider capability table

```python
_MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
    "gemini-3.6-flash": frozenset({"temperature", "top_p", "top_k"}),
    "gemini-3.5-flash-lite": frozenset({"temperature", "top_p", "top_k"}),
}
```

plus `_validate_prompt_options(model_name, options)` runs in `GooglePrompterDescriptor.__post_init__`, so both the `get_prompter` path and direct descriptor construction reject unsupported combinations with a clear `ValueError` instead of forwarding parameters the Gemini API ignores today and will reject with HTTP 400 in future model generations ([latest-model migration guide](https://ai.google.dev/gemini-api/docs/latest-model) — both listed models are documented there). The table/helper shape is deliberately convention-aligned across hosted providers so a later lift into a core capability framework (#152) is mechanical.

**Embedding dimensions (absorbs #145 item 1 per maintainer comment).** The silent `_EMBEDDING_DIMS.get(model, 768)` fallback is deleted. Dimensions resolve as: explicit `dimensions` (call-site, else provider `embedding_dimensions`) > trusted per-model metadata > `ValueError`. The metadata table now carries only current models (`gemini-embedding-001` and `gemini-embedding-2`, both 3072-dim by default per the [embeddings guide](https://ai.google.dev/gemini-api/docs/embeddings)); the retired `text-embedding-004` / `embedding-001` entries are gone. Explicit dimensions outside the documented 128–3072 range for a known model, or non-positive values, are rejected at build time. The `if self.dimensions:` 0-is-falsy bug is fixed (`is not None`), so `dimensions=0` can never again silently degrade to a 768-wide guess.

**Review round (2026-07-28).** Addresses the three review findings:

1. **Row preservation (blocker).** `embed_text` now sends each input as its own `types.Content` — a multi-input `contents` list would be aggregated into a single embedding by `gemini-embedding-2` — and raises `ValueError` if the API returns a different number of embeddings than inputs.
2. **Resource-name canonicalization.** All local capability/metadata lookups strip the `models/` prefix, so `models/gemini-3.6-flash` can no longer bypass the sampling-parameter rejection and `models/gemini-embedding-001` hits the trusted dimensions table; the caller-provided name is still sent to the SDK verbatim.
3. **Dimensions type validation.** `dimensions` must be a non-boolean integer: `256.5`, `True`, or `"256"` raise the promised configuration `ValueError` before the bounds check.

Model resolution additionally uses explicit `is not None` precedence and rejects blank/whitespace model IDs at expression-build time (matching the same hardening requested on #168); the unreachable options-`model` branch is removed.

## Related issue

close: #141

Also implements the 768-fallback item of #145 (maintainer asked for it to ride in this PR); the remaining #145 items (batch cap, role-structured conversations) follow in a stacked PR.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Provider and function docstrings in this repo are updated to describe the explicit-model contract.

## Validation

- `pytest tests/ai/test_ai_functions.py tests/ai/test_descriptor_secret_redaction.py` (local stub harness): 308 passed, including 38 new tests; the only failures are the same environment-dependent ones as unmodified `main` (missing Pillow/duckdb/transformers/vllm locally).
- New coverage: missing-model failure (prompt + embed) with both fix paths asserted; explicit `model=` flow-through; provider-config flow-through; call-beats-config precedence (models and dimensions); `gemini-3.6-flash` / `gemini-3.5-flash-lite` × `temperature`/`top_p`/`top_k` rejected pre-dispatch (provider path and direct descriptor construction); the same options pass for a model absent from the table; known-model dimension derivation (3072); explicit-dimensions flow-through; `dimensions=0` and out-of-documented-range dimensions rejected; unknown model without dimensions rejected; constructor typo raises `TypeError`; `model_name` required on both descriptors; two-input row preservation via separate `Content`s and count-mismatch rejection; both bare and `models/`-prefixed forms for capability and dimensions lookups; non-integer dimensions (`256.5`/`True`/`"256"`) rejected; blank/whitespace model rejection (call-site and provider-level, prompt + embed).
- `ruff check` / `ruff format` via pre-commit: passed.
- Model facts verified against live Google docs: [latest-model migration guide](https://ai.google.dev/gemini-api/docs/latest-model) (deprecated sampling parameters, affected models, future HTTP 400), [embeddings guide](https://ai.google.dev/gemini-api/docs/embeddings) (current models, 3072 default, 128–3072 supported output dimensionality).

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

Breaking changes (intentional, per maintainer direction — no backward compatibility):

- Google calls without an explicit model now raise `ValueError` at expression-build time.
- The `GoogleProvider` constructor no longer accepts arbitrary kwargs (`TypeError` on unknown names); request options belong on the call (`get_prompter(...)` / `get_text_embedder(...)` / option objects), where generic passthrough is unchanged.
- Unknown embedding models require explicit `dimensions`; known models validate the requested dimensionality against documented bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXGCZZzpBqP7D1kivLJABc

