### PR TITLE
[fix](ai) Give vLLM prompter a working executor lifecycle across batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,6 @@ All notable user-visible changes are documented here. Vane is currently in alpha
   Vane engine customizations as monorepo commits, so normal clones no longer
   require submodule initialization or carry DuckDB's complete commit history.
 
-### Fixed
-
-- Fixed vLLM prompting failing from the second batch on in Ray-remote mode
-  ("vllm executor is already finished"): the executor id is no longer retired
-  after every call; it is retired exactly once at prompter teardown, via an
-  explicit `close()` on the batch wrapper with `__del__` as fallback.
-
 ### Security
 
 - Documented the trust boundaries around Python UDFs, Ray workers, credentials, native parsers, and remote model code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable user-visible changes are documented here. Vane is currently in alpha
   Vane engine customizations as monorepo commits, so normal clones no longer
   require submodule initialization or carry DuckDB's complete commit history.
 
+### Fixed
+
+- Fixed vLLM prompting failing from the second batch on in Ray-remote mode
+  ("vllm executor is already finished"): the executor id is no longer retired
+  after every call; it is retired exactly once at prompter teardown, via an
+  explicit `close()` on the batch wrapper with `__del__` as fallback.
+
 ### Security
 
 - Documented the trust boundaries around Python UDFs, Ray workers, credentials, native parsers, and remote model code.

--- a/tests/fast/test_vllm_prompter_lifecycle.py
+++ b/tests/fast/test_vllm_prompter_lifecycle.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executor lifecycle contract for ``VLLMPrompter`` (#143).
+
+The prompter caches one executor for its lifetime.  ``finished_submitting()``
+must NOT run per ``prompt()``/``prompt_batch()`` call: in Ray-remote mode it
+permanently retires the executor id on every actor, so the second call would
+fail with "vllm executor <id> is already finished".  It runs exactly once, at
+``close()``/teardown, via ``executor.shutdown()``.
+
+The fake executor below enforces the Ray-remote contract (submit after finish
+raises), so these tests fail against the old per-call lifecycle.
+"""
+
+import asyncio
+
+import pytest
+
+from vane.ai.providers.vllm import VLLMPrompter
+
+
+class FakeExecutor:
+    """Records lifecycle calls; serves one result per submitted prompt.
+
+    Mirrors the Ray-remote ``RemoteVLLMExecutor`` contract: once submission
+    is finished (via ``finished_submitting`` or ``shutdown``), any further
+    ``submit`` raises — exactly the failure mode of issue #143.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.pending = []
+        self.finished = False
+        self.shutdown_calls = 0
+
+    def submit(self, prefix, prompts, rows):
+        if self.finished:
+            raise RuntimeError("vllm executor fake-id is already finished")
+        self.calls.append(("submit", list(prompts)))
+        for i in range(rows.num_rows):
+            self.pending.append((prompts[i], rows.slice(i, 1)))
+
+    def finished_submitting(self):
+        self.calls.append(("finished_submitting",))
+        self.finished = True
+
+    def take_ready_result(self):
+        if not self.pending:
+            return None
+        prompt, row = self.pending.pop(0)
+        return [f"echo:{prompt}"], row
+
+    def all_tasks_finished(self):
+        return not self.pending
+
+    def wait_for_result(self):
+        self.calls.append(("wait_for_result",))
+
+    def shutdown(self):
+        self.calls.append(("shutdown",))
+        self.shutdown_calls += 1
+        self.finished = True
+
+
+def _prompter_with_fake():
+    prompter = VLLMPrompter(model="test-model")
+    executor = FakeExecutor()
+    prompter._executor = executor
+    return prompter, executor
+
+
+def test_two_consecutive_prompt_batch_calls_both_submit():
+    """Second (and later) batches must submit on the same cached executor."""
+    prompter, executor = _prompter_with_fake()
+
+    first = prompter.prompt_batch(["a", "b"])
+    second = prompter.prompt_batch(["c", "d"])
+
+    assert first == ["echo:a", "echo:b"]
+    assert second == ["echo:c", "echo:d"]
+    submits = [call for call in executor.calls if call[0] == "submit"]
+    assert submits == [("submit", ["a", "b"]), ("submit", ["c", "d"])]
+
+
+def test_prompt_batch_does_not_finish_submitting_per_call():
+    """finished_submitting must not run per call — only at teardown."""
+    prompter, executor = _prompter_with_fake()
+
+    prompter.prompt_batch(["a", "b"])
+    prompter.prompt_batch(["c"])
+
+    assert ("finished_submitting",) not in executor.calls
+    assert ("shutdown",) not in executor.calls
+
+
+def test_consecutive_single_prompt_calls_both_submit():
+    """prompt() has the same deferred lifecycle as prompt_batch()."""
+    prompter, executor = _prompter_with_fake()
+
+    first = asyncio.run(prompter.prompt(("hello",)))
+    second = asyncio.run(prompter.prompt(("again",)))
+
+    assert first == "echo:hello"
+    assert second == "echo:again"
+    assert ("finished_submitting",) not in executor.calls
+
+
+def test_close_shuts_down_executor_exactly_once():
+    """close() finishes the executor via shutdown() and is idempotent."""
+    prompter, executor = _prompter_with_fake()
+
+    prompter.prompt_batch(["a"])
+    prompter.close()
+
+    assert executor.shutdown_calls == 1
+    assert prompter._executor is None
+
+    prompter.close()
+    assert executor.shutdown_calls == 1
+
+
+def test_del_shuts_down_executor():
+    """GC teardown releases the executor without raising."""
+    prompter, executor = _prompter_with_fake()
+
+    prompter.__del__()
+
+    assert executor.shutdown_calls == 1
+    assert prompter._executor is None
+
+
+def test_del_swallows_shutdown_errors():
+    """Destructors must not raise even if shutdown fails."""
+    prompter, executor = _prompter_with_fake()
+
+    def boom():
+        raise RuntimeError("shutdown failed")
+
+    executor.shutdown = boom
+    prompter.__del__()  # must not raise
+
+
+def test_submit_after_close_surfaces_finished_error():
+    """Using a prompter after close() recreates no fake — executor is gone.
+
+    Guards the invariant that close() drops the cached executor reference
+    rather than leaving a finished executor that would poison later calls.
+    """
+    prompter, executor = _prompter_with_fake()
+    prompter.close()
+
+    # The cached (now finished) executor must not be reused.
+    assert prompter._executor is None
+    with pytest.raises(RuntimeError, match="already finished"):
+        executor.submit(None, ["x"], _one_row_table())
+
+
+def _one_row_table():
+    import pyarrow as pa
+
+    return pa.table({"_idx": [0]})

--- a/tests/fast/test_vllm_prompter_lifecycle.py
+++ b/tests/fast/test_vllm_prompter_lifecycle.py
@@ -243,3 +243,57 @@ def test_prompt_batch_del_swallows_close_errors():
 
     wrapper._prompter = ExplodingPrompter()
     wrapper.__del__()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Actor adapter forwards close() to the wrapped batch object
+#
+# Actor backends own a _ConfiguredAIBatchActor instance, not the _PromptBatch
+# itself, so _PromptBatch.close() is only reachable if the adapter forwards it.
+# ---------------------------------------------------------------------------
+
+
+def _actor_adapter_wrapping_prompt_batch():
+    functions = _load_real_functions()
+    batch = functions._PromptBatch(object(), "messages", "response", None)
+    prompter = CloseRecordingPrompter()
+    batch._prompter = prompter
+    actor_cls = functions._adapt_batch_wrapper_for_backend(batch, "subprocess_actor")
+    return actor_cls(), batch, prompter
+
+
+def test_actor_adapter_close_delegates_to_wrapped_batch():
+    adapter, batch, prompter = _actor_adapter_wrapping_prompt_batch()
+
+    adapter.close()
+    assert prompter.close_calls == 1
+    assert batch._prompter is None
+
+    adapter.close()  # idempotent through _PromptBatch.close()
+    assert prompter.close_calls == 1
+
+
+def test_actor_adapter_del_delegates_to_wrapped_batch():
+    adapter, batch, prompter = _actor_adapter_wrapping_prompt_batch()
+
+    adapter.__del__()
+    assert prompter.close_calls == 1
+    assert batch._prompter is None
+
+
+def test_actor_adapter_close_tolerates_wrappers_without_close():
+    functions = _load_real_functions()
+    actor_cls = functions._adapt_batch_wrapper_for_backend(lambda table: table, "subprocess_actor")
+    adapter = actor_cls()
+    adapter.close()  # plain-function wrapper: no close attr, must not raise
+
+
+def test_actor_adapter_del_swallows_close_errors():
+    functions = _load_real_functions()
+
+    class ExplodingWrapper:
+        def close(self):
+            raise RuntimeError("teardown boom")
+
+    actor_cls = functions._adapt_batch_wrapper_for_backend(ExplodingWrapper(), "subprocess_actor")
+    actor_cls().__del__()  # must not raise

--- a/tests/fast/test_vllm_prompter_lifecycle.py
+++ b/tests/fast/test_vllm_prompter_lifecycle.py
@@ -142,10 +142,10 @@ def test_del_swallows_shutdown_errors():
 
 
 def test_submit_after_close_surfaces_finished_error():
-    """Using a prompter after close() recreates no fake — executor is gone.
+    """close() must drop the executor reference so a fresh one is built next call.
 
-    Guards the invariant that close() drops the cached executor reference
-    rather than leaving a finished executor that would poison later calls.
+    Guards the invariant that close() clears the cache rather than leaving
+    a finished executor behind that would poison later calls.
     """
     prompter, executor = _prompter_with_fake()
     prompter.close()
@@ -160,3 +160,86 @@ def _one_row_table():
     import pyarrow as pa
 
     return pa.table({"_idx": [0]})
+
+
+# ---------------------------------------------------------------------------
+# _PromptBatch delegates teardown to the prompter (explicit close hook)
+# ---------------------------------------------------------------------------
+
+
+def _load_real_functions():
+    """Import the real ``vane.ai.functions``, even under the no-duckdb harness.
+
+    The stub harness registers a placeholder for ``vane.ai.functions``; evict
+    it and stub just the duckdb-importing dependencies so the real module
+    under test can load. On CI (where duckdb imports fine) nothing is stubbed.
+    """
+    import importlib
+    import sys
+    import types
+
+    module = sys.modules.get("vane.ai.functions")
+    if getattr(module, "__file__", None):
+        return module
+    if module is not None:
+        sys.modules.pop("vane.ai.functions")
+        stub_specs = (
+            ("vane._expressions", ("as_expression", "is_expression")),
+            ("vane._expression_udf", ("_build_actor_map_batches_expression",)),
+        )
+        for name, attrs in stub_specs:
+            if name not in sys.modules:
+                stub = types.ModuleType(name)
+                for attr in attrs:
+                    setattr(stub, attr, lambda *a, **k: None)
+                sys.modules[name] = stub
+    return importlib.import_module("vane.ai.functions")
+
+
+class CloseRecordingPrompter:
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+
+def test_prompt_batch_close_closes_prompter_once():
+    functions = _load_real_functions()
+    wrapper = functions._PromptBatch(object(), "messages", "response", None)
+    prompter = CloseRecordingPrompter()
+    wrapper._prompter = prompter
+
+    wrapper.close()
+    assert prompter.close_calls == 1
+    assert wrapper._prompter is None
+
+    wrapper.close()  # idempotent
+    assert prompter.close_calls == 1
+
+
+def test_prompt_batch_close_tolerates_prompters_without_close():
+    functions = _load_real_functions()
+    wrapper = functions._PromptBatch(object(), "messages", "response", None)
+    wrapper._prompter = object()
+    wrapper.close()
+    assert wrapper._prompter is None
+
+
+def test_prompt_batch_close_before_first_use_is_noop():
+    functions = _load_real_functions()
+    wrapper = functions._PromptBatch(object(), "messages", "response", None)
+    wrapper.close()
+    assert wrapper._prompter is None
+
+
+def test_prompt_batch_del_swallows_close_errors():
+    functions = _load_real_functions()
+    wrapper = functions._PromptBatch(object(), "messages", "response", None)
+
+    class ExplodingPrompter:
+        def close(self):
+            raise RuntimeError("teardown boom")
+
+    wrapper._prompter = ExplodingPrompter()
+    wrapper.__del__()  # must not raise

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -542,6 +542,26 @@ class _PromptBatch:
         self._on_error: _OnError = on_error
         self._prompter = None  # lazy: instantiate on first __call__
 
+    def close(self) -> None:
+        """Tear down the cached prompter if it holds releasable resources.
+
+        Prompters with a ``close()`` (e.g. the vLLM prompter, which must
+        retire its executor id on the engine actors) are closed explicitly
+        here rather than relying only on their ``__del__``. Idempotent.
+        """
+        prompter, self._prompter = self._prompter, None
+        if prompter is not None:
+            close = getattr(prompter, "close", None)
+            if close is not None:
+                close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            # Interpreter or actor teardown — destructors must not raise.
+            pass
+
     def _serialize_result(self, result: Any) -> str | None:
         """Convert a prompt result to a string for the output column."""
         if result is None:

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -240,6 +240,25 @@ def _adapt_batch_wrapper_for_backend(wrapper: Any, execution_backend: str | None
             def __call__(self, table: pa.Table) -> pa.Table:
                 return self._wrapper(table)
 
+            def close(self) -> None:
+                """Forward teardown to the wrapped batch object.
+
+                Actor backends hold this adapter, not the batch wrapper, so
+                the wrapper's ``close()`` (e.g. ``_PromptBatch`` retiring a
+                vLLM executor) is only reachable through here. Idempotent
+                because the wrapped ``close()`` is.
+                """
+                close = getattr(self._wrapper, "close", None)
+                if close is not None:
+                    close()
+
+            def __del__(self) -> None:
+                try:
+                    self.close()
+                except Exception:
+                    # Interpreter or actor teardown — destructors must not raise.
+                    pass
+
         return _ConfiguredAIBatchActor
 
     if backend in ("", "subprocess_task", "ray_task"):

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -317,8 +317,10 @@ class VLLMPrompter:
         prompt call instead would permanently finish the executor id in
         Ray-remote mode and break every call after the first (#143).
 
-        Idempotent; also invoked from ``__del__`` when the owning UDF wrapper
-        or actor is torn down.
+        Idempotent. Called explicitly by the owning batch wrapper's
+        teardown (``_PromptBatch.close()``), with ``__del__`` as a
+        GC-timed fallback. A prompt call after ``close()`` rebuilds a
+        fresh executor (and, in local mode, a fresh engine) on demand.
         """
         executor, self._executor = self._executor, None
         if executor is not None:

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -169,9 +169,14 @@ class VLLMPrompterDescriptor(PrompterDescriptor):
 class VLLMPrompter:
     """Prompter that uses a vLLM ``LocalVLLMExecutor`` / ``RemoteVLLMExecutor``.
 
-    The executor is created lazily on the first call. Structured output
-    uses ``SamplingParams.structured_outputs`` and the raw JSON output is
-    parsed back into the requested schema/model.
+    The executor is created lazily on the first call and reused for the
+    prompter's lifetime — engines and Ray actor pools are expensive, so they
+    must survive across ``prompt()``/``prompt_batch()`` calls.  Because of
+    that reuse, ``finished_submitting()`` is never called per prompt call;
+    it runs once at teardown via :meth:`close` (see there for details).
+
+    Structured output uses ``SamplingParams.structured_outputs`` and the raw
+    JSON output is parsed back into the requested schema/model.
     """
 
     def __init__(
@@ -252,7 +257,11 @@ class VLLMPrompter:
 
         dummy_row = pa.table({"_": [""]})
         executor.submit(None, [formatted], dummy_row)
-        executor.finished_submitting()
+        # finished_submitting() is deliberately NOT called here: in Ray-remote
+        # mode it permanently retires this executor id on every actor, which
+        # would make any subsequent call fail (#143).  It is deferred to
+        # close().  The result wait below is woken by result arrival, not by
+        # the finished flag.
 
         result = executor.take_ready_result()
         if result is None:
@@ -271,7 +280,9 @@ class VLLMPrompter:
         prompts = [self._format_prompt(t) for t in texts]
         rows = pa.table({"_idx": list(range(len(texts)))})
         executor.submit(None, prompts, rows)
-        executor.finished_submitting()
+        # No finished_submitting() here — deferred to close(); see prompt().
+        # The drain loop below collects exactly len(texts) results, so it
+        # never needs the finished flag to terminate.
 
         results: list[tuple[Any, int]] = []
         while len(results) < len(texts):
@@ -295,3 +306,28 @@ class VLLMPrompter:
 
         results.sort(key=lambda x: x[1])
         return [r[0] for r in results]
+
+    def close(self) -> None:
+        """Tear down the cached executor.
+
+        This is the one place submission is marked finished: ``shutdown()``
+        calls ``finished_submitting()`` for the remote executor (retiring the
+        executor id on every actor and balancing the router's start/completion
+        count) and stops the local executor's engine loop.  Doing this per
+        prompt call instead would permanently finish the executor id in
+        Ray-remote mode and break every call after the first (#143).
+
+        Idempotent; also invoked from ``__del__`` when the owning UDF wrapper
+        or actor is torn down.
+        """
+        executor, self._executor = self._executor, None
+        if executor is not None:
+            executor.shutdown()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            # Interpreter or actor teardown — engine state is going away
+            # anyway, and destructors must not raise.
+            pass


### PR DESCRIPTION
## Summary

## Validation

- New `tests/fast/test_vllm_prompter_lifecycle.py` (11 tests: consecutive submits succeed, no per-call finished_submitting, close-once idempotency, `__del__` teardown and error-swallowing, and `_PromptBatch` → prompter close delegation). Red-run verified: the lifecycle tests fail on unfixed main with the exact "already finished" error.
- 136 tests green locally under the no-duckdb import harness; real engine/Ray-pool behavior is CI-only (vLLM not installed on this machine). `ruff check`/`format` clean; pre-commit hooks passed.
- A follow-up commit addresses code-review findings (explicit close hook on the batch wrapper instead of relying solely on finalizers, docstring precision).

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented in code/docstrings; CHANGELOG intentionally untouched per maintainer guidance.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered (teardown only; no new surface).
- [x] Native changes were compiled; Python-only changes passed relevant tests (Python-only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014az5eSZxzP2SBDyivvivCk
