### PR TITLE
[fix](ai) Move AI batch loop ownership to the UDF executor runtime

### DIFF
--- a/duckdb/execution/_async_runtime.py
+++ b/duckdb/execution/_async_runtime.py
@@ -44,11 +44,23 @@ class AsyncRuntime:
         return self._loop.run_until_complete(coro)
 
     def close(self) -> None:
-        """Shut down async generators and close the loop. Idempotent."""
+        """Cancel outstanding tasks and close the loop. Idempotent.
+
+        Mirrors ``asyncio.run``'s teardown: background tasks a coroutine
+        left behind are cancelled and awaited (so their ``finally`` blocks
+        run) before async generators, the default executor, and the loop
+        itself are shut down.
+        """
         loop, self._loop = self._loop, None
         if loop is None or loop.is_closed():
             return
         try:
+            tasks = asyncio.all_tasks(loop)
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
             loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.run_until_complete(loop.shutdown_default_executor())
         finally:
             loop.close()

--- a/duckdb/execution/_async_runtime.py
+++ b/duckdb/execution/_async_runtime.py
@@ -1,0 +1,54 @@
+"""Actor-owned event-loop runtime for async UDF callables.
+
+UDF actors execute batches serially on a single thread, so a UDF callable
+that drives async work (e.g. an AI provider's async SDK client) needs one
+long-lived event loop for the actor's lifetime: driving each batch with a
+fresh ``asyncio.run()`` strands loop-bound state (HTTP connection pools,
+semaphores, tasks) on a closed loop and fails intermittently with
+``RuntimeError: Event loop is closed`` from the second batch on.
+
+The executor owns an :class:`AsyncRuntime` and hands its ``run`` method to
+the callable (see ``UDFExecutor``); callables never create loops or threads
+themselves. The loop is driven with ``run_until_complete`` on the calling
+thread — no background thread — and is closed explicitly when the executor
+shuts down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class AsyncRuntime:
+    """One lazily-created event loop, driven on the caller's thread.
+
+    Not thread-safe: like the UDF executor and user callables, an instance
+    must only be used from the single thread that executes actor batches.
+    ``run()`` raises if that thread is already running an event loop —
+    callers inside async code must ``await`` instead of using this bridge.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop | None:
+        """The owned loop, or ``None`` before first use / after close()."""
+        return self._loop
+
+    def run(self, coro: Any) -> Any:
+        """Drive *coro* to completion on the owned loop and return its result."""
+        if self._loop is None:
+            self._loop = asyncio.new_event_loop()
+        return self._loop.run_until_complete(coro)
+
+    def close(self) -> None:
+        """Shut down async generators and close the loop. Idempotent."""
+        loop, self._loop = self._loop, None
+        if loop is None or loop.is_closed():
+            return
+        try:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        finally:
+            loop.close()

--- a/duckdb/execution/_async_runtime.py
+++ b/duckdb/execution/_async_runtime.py
@@ -38,7 +38,28 @@ class AsyncRuntime:
         return self._loop
 
     def run(self, coro: Any) -> Any:
-        """Drive *coro* to completion on the owned loop and return its result."""
+        """Drive *coro* to completion on the owned loop and return its result.
+
+        Nested use — a loop already running on this thread — is rejected
+        *before* anything is scheduled, and the supplied coroutine is closed
+        so the rejection does not strand it un-awaited (``RuntimeWarning:
+        coroutine ... was never awaited``). Callers inside async code must
+        ``await`` instead of using this bridge.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            # Close the coroutine before raising: run_until_complete() would
+            # otherwise wrap it in a task and only then reject, leaking it.
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            raise RuntimeError(
+                "AsyncRuntime.run() cannot be called while an event loop is "
+                "already running on this thread; await the coroutine instead"
+            )
         if self._loop is None:
             self._loop = asyncio.new_event_loop()
         return self._loop.run_until_complete(coro)

--- a/duckdb/execution/_udf_runtime.py
+++ b/duckdb/execution/_udf_runtime.py
@@ -18,6 +18,7 @@ from typing import Any
 import pyarrow as pa
 
 from duckdb import PythonExceptionHandling
+from duckdb.execution._async_runtime import AsyncRuntime
 from duckdb.execution._common import (
     ensure_table as _ensure_table,
 )
@@ -444,6 +445,7 @@ class UDFExecutor:
         self._queue: deque[pa.Table] = deque()
         self._finished_submitting = False
         self._closed = False
+        self._async_runtime: AsyncRuntime | None = None
         self._call_mode = str(payload.get("call_mode") or "")
         if self._call_mode not in ("map_batches", "map_batches_rows", "flat_map", "map"):
             raise ValueError("UDF payload.call_mode must be one of: map_batches, map_batches_rows, flat_map, map")
@@ -472,6 +474,7 @@ class UDFExecutor:
             cache_callable=cache_callable,
             cache_max_entries=cache_max_entries,
         )
+        self._bind_async_runtime()
         self._mode = self._call_mode
         self._is_map_batches = self._call_mode == "map_batches"
         self._is_map_batches_rows = self._call_mode == "map_batches_rows"
@@ -527,6 +530,19 @@ class UDFExecutor:
             cache_callable=cache_callable,
             cache_max_entries=cache_max_entries,
         )
+        self._bind_async_runtime()
+
+    def _bind_async_runtime(self) -> None:
+        """Hand an executor-owned async runtime to callables that ask for one.
+
+        Callables that drive async work (AI batch wrappers) declare a
+        ``bind_async_runtime(run_async)`` hook instead of creating loops
+        themselves; the executor owns the loop and closes it in ``close()``.
+        """
+        bind = getattr(self._map_fn, "bind_async_runtime", None)
+        if callable(bind):
+            self._async_runtime = AsyncRuntime()
+            bind(self._async_runtime.run)
 
     def warm_up(self) -> None:
         """Run an optional UDF-level warmup hook after deserialization."""
@@ -877,14 +893,28 @@ class UDFExecutor:
         self._finished_submitting = True
 
     def close(self) -> None:
-        """Flush buffered work and deterministically release the loaded callable."""
+        """Flush buffered work and deterministically release the loaded callable.
+
+        Callables that were bound an async runtime additionally get their
+        ``close()`` hook invoked (provider clients close on the owned loop)
+        before the loop itself is shut down.
+        """
         if self._closed:
             return
         try:
             self.finished_submitting()
         finally:
             self._closed = True
-            self._map_fn = None
+            map_fn, self._map_fn = self._map_fn, None
+            runtime, self._async_runtime = self._async_runtime, None
+            try:
+                if runtime is not None:
+                    close_fn = getattr(map_fn, "close", None)
+                    if callable(close_fn):
+                        close_fn()
+            finally:
+                if runtime is not None:
+                    runtime.close()
 
     def all_tasks_finished(self) -> bool:
         return self._finished_submitting and not self._queue

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -678,47 +678,50 @@ def _iter_materialized_task_outputs(
             output_index += 1
             yield block, metadata
 
-    if str(stream_payload.get("call_mode") or "") == "map":
-        for raw_table in tables:
-            for block, metadata in emit(
-                _execute_scalar_map_layout(
-                    stream_payload,
-                    _ensure_table(raw_table),
-                    executor,
-                )
-            ):
-                yield block
-                yield metadata
-        executor.finished_submitting()
-        executor.close()
-        return
+    # close() must run on every exit — errors and abandoned generators
+    # included: with callable caching the AI wrapper outlives this executor,
+    # and a skipped close would strand its provider client on a dead loop.
+    try:
+        if str(stream_payload.get("call_mode") or "") == "map":
+            for raw_table in tables:
+                for block, metadata in emit(
+                    _execute_scalar_map_layout(
+                        stream_payload,
+                        _ensure_table(raw_table),
+                        executor,
+                    )
+                ):
+                    yield block
+                    yield metadata
+            executor.finished_submitting()
+            return
 
-    if str(stream_payload.get("call_mode") or "") == "map_batches_rows":
-        for raw_table in tables:
-            for block, metadata in emit(
-                _execute_row_preserving_batch_layout(
-                    stream_payload,
-                    _ensure_table(raw_table),
-                    executor,
-                )
-            ):
-                yield block
-                yield metadata
-        executor.finished_submitting()
-        executor.close()
-        return
+        if str(stream_payload.get("call_mode") or "") == "map_batches_rows":
+            for raw_table in tables:
+                for block, metadata in emit(
+                    _execute_row_preserving_batch_layout(
+                        stream_payload,
+                        _ensure_table(raw_table),
+                        executor,
+                    )
+                ):
+                    yield block
+                    yield metadata
+            executor.finished_submitting()
+            return
 
-    for raw_table in tables:
-        for output in executor.iter_submit(_ensure_table(raw_table)):
+        for raw_table in tables:
+            for output in executor.iter_submit(_ensure_table(raw_table)):
+                for block, metadata in emit(output):
+                    yield block
+                    yield metadata
+        executor.finished_submitting()
+        for output in executor.drain_outputs():
             for block, metadata in emit(output):
                 yield block
                 yield metadata
-    executor.finished_submitting()
-    for output in executor.drain_outputs():
-        for block, metadata in emit(output):
-            yield block
-            yield metadata
-    executor.close()
+    finally:
+        executor.close()
 
 
 def _execute_row_preserving_batch_layout(
@@ -853,16 +856,22 @@ def _iter_ref_bundle_task_outputs(
                 output_count += 1
                 yield output_table, output_metadata
 
-        for output in executor.iter_submit(table):
-            for block, output_metadata in emit_output(output):
-                yield block
-                yield output_metadata
-        executor.finished_submitting()
-        for output in executor.drain_outputs():
-            for block, output_metadata in emit_output(output):
-                yield block
-                yield output_metadata
-        executor.close()
+        # close() must run on every exit — errors and abandoned generators
+        # included: with callable caching the AI wrapper outlives this
+        # executor, and a skipped close would strand its provider client on
+        # a dead loop.
+        try:
+            for output in executor.iter_submit(table):
+                for block, output_metadata in emit_output(output):
+                    yield block
+                    yield output_metadata
+            executor.finished_submitting()
+            for output in executor.drain_outputs():
+                for block, output_metadata in emit_output(output):
+                    yield block
+                    yield output_metadata
+        finally:
+            executor.close()
         if log_task:
             _ray_task_debug_log(
                 "worker_ref_bundle_finished",
@@ -877,9 +886,11 @@ def _iter_ref_bundle_task_outputs(
     if call_mode == "map_batches_rows":
         executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
         configure_loaded_torch_threads()
-        fused = _execute_row_preserving_batch_layout(payload, table, executor)
-        executor.finished_submitting()
-        executor.close()
+        try:
+            fused = _execute_row_preserving_batch_layout(payload, table, executor)
+            executor.finished_submitting()
+        finally:
+            executor.close()
         for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
             yield block
             yield make_stream_block_metadata(block, payload, output_index=output_index)
@@ -890,8 +901,10 @@ def _iter_ref_bundle_task_outputs(
 
     executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
     configure_loaded_torch_threads()
-    fused = _execute_scalar_map_layout(payload, table, executor)
-    executor.close()
+    try:
+        fused = _execute_scalar_map_layout(payload, table, executor)
+    finally:
+        executor.close()
     for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
         yield block
         yield make_stream_block_metadata(block, payload, output_index=output_index)

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -690,6 +690,7 @@ def _iter_materialized_task_outputs(
                 yield block
                 yield metadata
         executor.finished_submitting()
+        executor.close()
         return
 
     if str(stream_payload.get("call_mode") or "") == "map_batches_rows":
@@ -704,6 +705,7 @@ def _iter_materialized_task_outputs(
                 yield block
                 yield metadata
         executor.finished_submitting()
+        executor.close()
         return
 
     for raw_table in tables:
@@ -716,6 +718,7 @@ def _iter_materialized_task_outputs(
         for block, metadata in emit(output):
             yield block
             yield metadata
+    executor.close()
 
 
 def _execute_row_preserving_batch_layout(
@@ -859,6 +862,7 @@ def _iter_ref_bundle_task_outputs(
             for block, output_metadata in emit_output(output):
                 yield block
                 yield output_metadata
+        executor.close()
         if log_task:
             _ray_task_debug_log(
                 "worker_ref_bundle_finished",
@@ -875,6 +879,7 @@ def _iter_ref_bundle_task_outputs(
         configure_loaded_torch_threads()
         fused = _execute_row_preserving_batch_layout(payload, table, executor)
         executor.finished_submitting()
+        executor.close()
         for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
             yield block
             yield make_stream_block_metadata(block, payload, output_index=output_index)
@@ -886,6 +891,7 @@ def _iter_ref_bundle_task_outputs(
     executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
     configure_loaded_torch_threads()
     fused = _execute_scalar_map_layout(payload, table, executor)
+    executor.close()
     for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
         yield block
         yield make_stream_block_metadata(block, payload, output_index=output_index)

--- a/duckdb/execution/udf_subprocess_worker.py
+++ b/duckdb/execution/udf_subprocess_worker.py
@@ -448,7 +448,8 @@ def _execute_task_submit(
             finish_before_drain=True,
         )
     finally:
-        executor.finished_submitting()
+        # close() flushes via finished_submitting() and releases the callable
+        # under its own finally, so cleanup runs even if the flush raises.
         executor.close()
 
 

--- a/duckdb/execution/udf_subprocess_worker.py
+++ b/duckdb/execution/udf_subprocess_worker.py
@@ -449,6 +449,7 @@ def _execute_task_submit(
         )
     finally:
         executor.finished_submitting()
+        executor.close()
 
 
 def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm_name: str) -> None:

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -42,6 +42,23 @@ def _has_module(name: str) -> bool:
         return False
 
 
+def _drive(wrapper, table: pa.Table) -> pa.Table:
+    """Call an AI batch wrapper the way a UDF executor drives it.
+
+    Wrappers no longer own event loops: the executor binds a ``run_async``
+    capability before the first batch. Tests that invoke wrappers directly
+    must do the same.
+    """
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    wrapper.bind_async_runtime(loop.run_until_complete)
+    try:
+        return wrapper(table)
+    finally:
+        loop.close()
+
+
 # ---------------------------------------------------------------------------
 # Mock implementations
 # ---------------------------------------------------------------------------
@@ -259,7 +276,7 @@ class TestWrapperPickle:
         wrapper = _EmbedTextBatch(MockTextEmbedderDescriptor(dim=4), "text", "emb")
         restored = pickle.loads(pickle.dumps(wrapper))
         table = pa.table({"text": ["hello", "world"]})
-        result = restored(table)
+        result = _drive(restored, table)
         assert result.num_rows == 2
         assert result.column_names == ["emb"]
 
@@ -362,7 +379,7 @@ class TestVLLMProvider:
 
             batch = _PromptBatch(desc, "text", "response")
             table = pa.table({"text": ["hi", "hey"]})
-            result = batch(table)
+            result = _drive(batch, table)
 
         mock_prompter.prompt_batch.assert_called_once_with(["hi", "hey"])
         assert result.column("response").to_pylist() == ["Hello!", "World!"]
@@ -868,7 +885,7 @@ class TestPromptSemaphore:
 
         batch = _PromptBatch(mock_desc, "text", "response", max_api_concurrency=2)
         table = pa.table({"text": [f"msg{i}" for i in range(10)]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.num_rows == 10
         assert peak_concurrent <= 2
@@ -899,7 +916,7 @@ class TestPromptSemaphore:
 
         batch = _PromptBatch(mock_desc, "text", "response", max_api_concurrency=None)
         table = pa.table({"text": [f"msg{i}" for i in range(10)]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.num_rows == 10
         # Without semaphore, all 10 should run concurrently
@@ -1966,7 +1983,7 @@ class TestChunking:
 
         # Short text (no chunking) + long text (will be chunked)
         table = pa.table({"text": ["short", "a" * 200]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.num_rows == 2
         emb0 = result.column("embedding")[0].as_py()
@@ -2008,7 +2025,7 @@ class TestChunking:
         batch = _EmbedTextBatch(desc, "text", "embedding")  # no chunking
 
         table = pa.table({"text": ["a" * 5000]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.num_rows == 1
         assert call_count == 1  # single call, no chunking
@@ -2416,7 +2433,7 @@ class TestStructuredOutputExecution:
             return_format=dict,
         )
         table = pa.table({"text": ["Hello", "World"]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.column("response").to_pylist() == [
             '{"answer":"42"}',
@@ -2436,7 +2453,7 @@ class TestStructuredOutputExecution:
 
         batch = _PromptBatch(mock_descriptor, "text", "response")
         table = pa.table({"text": ["Hello"]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert result.column("response").to_pylist() == ["reply to Hello"]
 
@@ -2461,7 +2478,7 @@ class TestStructuredOutputExecution:
             return_format=dict,
         )
         table = pa.table({"text": ["x", "y"]})
-        result = batch(table)
+        result = _drive(batch, table)
         assert result.column("out").to_pylist() == ['{"a":1}', '{"a":2}']
 
 
@@ -2739,7 +2756,7 @@ class TestMultimodalPromptBatch:
                 "image": [b"\x89PNG\r\n\x1a\n\x00\x00"],
             }
         )
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert len(captured_messages) == 1
         assert len(captured_messages[0]) == 2  # text + image bytes
@@ -2773,7 +2790,7 @@ class TestMultimodalPromptBatch:
                 "image": pa.array([None], type=pa.binary()),
             }
         )
-        batch(table)
+        _drive(batch, table)
 
         assert len(captured_messages[0]) == 1  # just text
         assert captured_messages[0][0] == "No image here"
@@ -2805,7 +2822,7 @@ class TestMultimodalPromptBatch:
                 "img2": [b"\xff\xd8\xff"],
             }
         )
-        batch(table)
+        _drive(batch, table)
 
         assert len(captured_messages[0]) == 3  # text + 2 images
 
@@ -2847,7 +2864,7 @@ class TestMultimodalPromptBatch:
                 ),
             }
         )
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert captured_messages == [
             ("Compare these", b"\x89PNG\r\n\x1a\n", b"\xff\xd8\xff"),
@@ -2895,7 +2912,7 @@ class TestMultimodalPromptBatch:
                 ),
             }
         )
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert captured_batches == [["alpha", "beta", "gamma"]]
         assert result.column("response").to_pylist() == [
@@ -2936,7 +2953,7 @@ class TestMultimodalPromptBatch:
                 "image": pa.array([b"ignored", None, b"\x89PNG"], type=pa.binary()),
             }
         )
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert captured_batches == [["Text only"]]
         assert captured_messages == [("With image", b"\x89PNG")]
@@ -3000,7 +3017,7 @@ class TestMultimodalPromptBatch:
                 "images": pa.array([None, [b"", None]], type=pa.list_(pa.binary())),
             }
         )
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert captured_batches == [["empty blob", "empty list item"]]
         assert result.column("response").to_pylist() == [
@@ -3024,7 +3041,7 @@ class TestMultimodalPromptBatch:
 
         batch = _PromptBatch(mock_descriptor, "text", "response")
         table = pa.table({"text": ["Hello"]})
-        result = batch(table)
+        result = _drive(batch, table)
 
         assert captured_messages[0] == ("Hello",)
         assert result.column("response").to_pylist() == ["reply"]
@@ -3973,14 +3990,30 @@ class TestRetryCall:
         assert result is None
 
     def test_awaitable_result_handled(self):
-        """_retry_call correctly handles sync functions returning awaitables."""
+        """_retry_call drives awaitables through the provided run_async."""
+        import asyncio
+
         from vane.ai.functions import _retry_call
 
         async def async_fn():
             return "async_result"
 
-        result = _retry_call(async_fn, max_retries=0, on_error="raise")
+        loop = asyncio.new_event_loop()
+        try:
+            result = _retry_call(async_fn, max_retries=0, on_error="raise", run_async=loop.run_until_complete)
+        finally:
+            loop.close()
         assert result == "async_result"
+
+    def test_awaitable_result_without_run_async_raises(self):
+        """Without a bound runtime an awaitable result is a hard error."""
+        from vane.ai.functions import _retry_call
+
+        async def async_fn():
+            return "unreachable"
+
+        with pytest.raises(RuntimeError, match="bind_async_runtime"):
+            _retry_call(async_fn, max_retries=0, on_error="ignore")
 
     def test_retry_call_async(self):
         import asyncio
@@ -4053,7 +4086,7 @@ class TestWrapperRetry:
         desc = self._make_embed_descriptor(embed)
         wrapper = _EmbedTextBatch(desc, "text", "emb", max_retries=3, on_error="raise")
         table = pa.table({"text": ["hello"]})
-        result = wrapper(table)
+        result = _drive(wrapper, table)
         assert result.column("emb").length() == 1
         assert len(calls) == 2
 
@@ -4066,7 +4099,7 @@ class TestWrapperRetry:
         desc = self._make_embed_descriptor(embed)
         wrapper = _EmbedTextBatch(desc, "text", "emb", max_retries=0, on_error="ignore")
         table = pa.table({"text": ["hello"]})
-        result = wrapper(table)
+        result = _drive(wrapper, table)
         # Should return zero embeddings
         assert result.column("emb").length() == 1
 
@@ -4110,7 +4143,7 @@ class TestWrapperRetry:
             on_error="raise",
         )
         table = pa.table({"text": ["q1"]})
-        result = wrapper(table)
+        result = _drive(wrapper, table)
         assert result.column("response").to_pylist()[0] is not None
         assert call_count == 2
 
@@ -4133,7 +4166,7 @@ class TestWrapperRetry:
             on_error="ignore",
         )
         table = pa.table({"text": ["q1"]})
-        result = wrapper(table)
+        result = _drive(wrapper, table)
         assert result.column("response").to_pylist() == [None]
 
     def test_prompt_batch_api_retry(self):
@@ -4159,6 +4192,6 @@ class TestWrapperRetry:
             on_error="raise",
         )
         table = pa.table({"text": ["q1", "q2"]})
-        result = wrapper(table)
+        result = _drive(wrapper, table)
         assert result.column("response").to_pylist() == ["ok", "ok"]
         assert len(calls) == 2

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass
 
@@ -194,7 +195,12 @@ def test_embed_zero_fill_fallback_survives_dimension_probe_failure():
             return UDFOptions(max_retries=0, on_error="ignore")
 
     wrapper = _EmbedTextBatch(FailingDescriptor(), "text", "embedding", max_retries=0, on_error="ignore")
-    out = wrapper(pa.table({"text": ["a", "b"]}))
+    loop = asyncio.new_event_loop()
+    wrapper.bind_async_runtime(loop.run_until_complete)
+    try:
+        out = wrapper(pa.table({"text": ["a", "b"]}))
+    finally:
+        loop.close()
 
     assert out.num_rows == 2
     assert out.column("embedding").to_pylist() == [None, None]
@@ -386,8 +392,7 @@ def test_ai_prompt_vllm_options_map_to_actor_and_gpu_fields(monkeypatch):
 
 def test_ai_prompt_expression_rejects_gpu_actor_on_local_runner(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    conn = vane.connect()
-    rel = conn.sql("select 1 as id, 'search'::VARCHAR as chunk")
+    vane.connect()
 
     with pytest.raises(duckdb.InvalidInputException, match="GPU resources require a Ray UDF backend"):
         vane.ai.prompt(

--- a/tests/fast/test_ai_async_runtime.py
+++ b/tests/fast/test_ai_async_runtime.py
@@ -333,12 +333,33 @@ def test_close_before_first_batch_is_a_noop(runtime) -> None:
     assert descriptor.instantiations == 0
 
 
-def test_close_skips_providers_without_aclose(runtime) -> None:
-    wrapper = _EmbedTextBatch(PicklableEmbedDescriptor(), "text", "emb")
+def test_close_retains_providers_without_aclose(runtime) -> None:
+    """Sync providers (no loop-bound state) survive close: task backends
+    close the executor per invocation while the callable cache keeps the
+    wrapper, and dropping the provider would reload the model per task."""
+
+    class CountingSyncEmbedDescriptor:
+        def __init__(self) -> None:
+            self.instantiations = 0
+
+        def instantiate(self) -> PicklableEmbedder:
+            self.instantiations += 1
+            return PicklableEmbedder()
+
+    descriptor = CountingSyncEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
     wrapper.bind_async_runtime(runtime.run)
     wrapper(pa.table({"text": ["a"]}))
 
-    wrapper.close()  # PicklableEmbedder has no aclose — must not raise
+    wrapper.close()  # no aclose — provider stays cached, must not raise
+
+    fresh = _Runtime()
+    try:
+        wrapper.bind_async_runtime(fresh.run)
+        wrapper(pa.table({"text": ["ab"]}))
+    finally:
+        fresh.close()
+    assert descriptor.instantiations == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/test_ai_async_runtime.py
+++ b/tests/fast/test_ai_async_runtime.py
@@ -1,0 +1,426 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AI batch wrappers are driven by an executor-bound async runtime.
+
+Covers vane#139: ``_EmbedTextBatch`` and ``_PromptBatch`` cache async SDK
+clients across batches, so the UDF executor binds one long-lived event loop
+per actor (see ``UDFExecutor._bind_async_runtime``) and hands wrappers a
+``run_async`` capability. Wrappers own no loops or threads: the provider
+runtime is instantiated inside the bound loop, every batch (including
+retries and chunked embeds) runs on that same loop, ``close()`` releases
+the provider client on it, and unbound wrappers fail fast instead of
+falling back to ``asyncio.run()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import pickle
+import sys
+import types
+
+import pyarrow as pa
+import pytest
+
+
+def _load_functions() -> types.ModuleType:
+    """Import the real ``vane.ai.functions``, even under the no-duckdb harness.
+
+    The stub harness plugin registers a placeholder for ``vane.ai.functions``
+    because the real module imports duckdb-backed modules at top level. When
+    that placeholder is present, evict it and stub just the duckdb-importing
+    dependencies so the real module under test can load. On CI (where duckdb
+    imports fine) the real module imports normally and nothing is stubbed.
+    """
+    module = sys.modules.get("vane.ai.functions")
+    if getattr(module, "__file__", None):
+        return module  # real module already loaded
+    if module is not None:
+        sys.modules.pop("vane.ai.functions")
+        stub_specs: tuple[tuple[str, tuple[str, ...]], ...] = (
+            ("vane._expressions", ("as_expression", "is_expression")),
+            ("vane._expression_udf", ("_build_actor_map_batches_expression",)),
+        )
+        for name, attrs in stub_specs:
+            if name not in sys.modules:
+                stub = types.ModuleType(name)
+                for attr in attrs:
+                    setattr(stub, attr, lambda *a, **k: None)
+                sys.modules[name] = stub
+    return importlib.import_module("vane.ai.functions")
+
+
+functions = _load_functions()
+
+_EmbedTextBatch = functions._EmbedTextBatch
+_PromptBatch = functions._PromptBatch
+RetryAfterError = functions.RetryAfterError
+
+
+def test_real_functions_module_is_under_test() -> None:
+    """Guard: the harness must import the real module, not the plugin stub."""
+    assert getattr(functions, "__file__", None)
+    assert isinstance(_PromptBatch, type)
+
+
+class _Runtime:
+    """Stand-in for the executor-owned AsyncRuntime: one loop, run_until_complete."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+
+    def run(self, coro):
+        return self.loop.run_until_complete(coro)
+
+    def close(self) -> None:
+        self.loop.close()
+
+
+@pytest.fixture
+def runtime():
+    rt = _Runtime()
+    yield rt
+    rt.close()
+
+
+# ---------------------------------------------------------------------------
+# Picklable fakes (module level so pickle can resolve them by reference)
+# ---------------------------------------------------------------------------
+
+
+class LoopRecordingEmbedder:
+    """Async embedder recording the running loop at construction and per call."""
+
+    def __init__(self) -> None:
+        self.created_on = asyncio.get_running_loop()
+        self.seen_loops: list[asyncio.AbstractEventLoop] = []
+        self.closed_on: asyncio.AbstractEventLoop | None = None
+        self.close_calls = 0
+
+    async def embed_text(self, texts: list[str]) -> list[list[float]]:
+        self.seen_loops.append(asyncio.get_running_loop())
+        return [[float(len(t))] * 2 for t in texts]
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        self.closed_on = asyncio.get_running_loop()
+
+
+class LoopRecordingEmbedDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+        self.embedder: LoopRecordingEmbedder | None = None
+
+    def instantiate(self) -> LoopRecordingEmbedder:
+        self.instantiations += 1
+        self.embedder = LoopRecordingEmbedder()
+        return self.embedder
+
+
+class PicklableEmbedder:
+    async def embed_text(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t))] * 2 for t in texts]
+
+
+class PicklableEmbedDescriptor:
+    def instantiate(self) -> PicklableEmbedder:
+        return PicklableEmbedder()
+
+
+class LoopRecordingPrompter:
+    """Async prompter recording the running loop for each call."""
+
+    def __init__(self) -> None:
+        self.seen_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def prompt(self, messages: tuple) -> str:
+        self.seen_loops.append(asyncio.get_running_loop())
+        return f"echo:{messages[0]}"
+
+
+class LoopRecordingPromptDescriptor:
+    def __init__(self) -> None:
+        self.prompter: LoopRecordingPrompter | None = None
+
+    def instantiate(self) -> LoopRecordingPrompter:
+        self.prompter = LoopRecordingPrompter()
+        return self.prompter
+
+
+class ConcurrencyTrackingPrompter:
+    """Async prompter tracking the peak number of in-flight calls."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+
+    async def prompt(self, messages: tuple) -> str:
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        await asyncio.sleep(0.02)
+        self.active -= 1
+        return f"echo:{messages[0]}"
+
+
+class ConcurrencyTrackingPromptDescriptor:
+    def __init__(self) -> None:
+        self.prompter: ConcurrencyTrackingPrompter | None = None
+
+    def instantiate(self) -> ConcurrencyTrackingPrompter:
+        self.prompter = ConcurrencyTrackingPrompter()
+        return self.prompter
+
+
+class FlakyOncePrompter:
+    """Fails the first call with a zero-wait retryable error, then succeeds."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seen_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def prompt(self, messages: tuple) -> str:
+        self.calls += 1
+        self.seen_loops.append(asyncio.get_running_loop())
+        if self.calls == 1:
+            raise RetryAfterError(0.0, RuntimeError("transient"))
+        return f"echo:{messages[0]}"
+
+
+class FlakyOncePromptDescriptor:
+    def __init__(self) -> None:
+        self.prompter: FlakyOncePrompter | None = None
+
+    def instantiate(self) -> FlakyOncePrompter:
+        self.prompter = FlakyOncePrompter()
+        return self.prompter
+
+
+# ---------------------------------------------------------------------------
+# Loop ownership: client construction, batches, retries, chunking
+# ---------------------------------------------------------------------------
+
+
+def test_embed_client_created_and_used_on_the_bound_loop(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+
+    wrapper(pa.table({"text": ["a"]}))
+    wrapper(pa.table({"text": ["bb", "ccc"]}))
+
+    assert descriptor.instantiations == 1
+    embedder = descriptor.embedder
+    assert embedder.created_on is runtime.loop
+    assert embedder.seen_loops == [runtime.loop, runtime.loop]
+
+
+def test_prompt_batches_share_the_bound_loop(runtime) -> None:
+    descriptor = LoopRecordingPromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response")
+    wrapper.bind_async_runtime(runtime.run)
+
+    first = wrapper(pa.table({"text": ["a", "b"]}))
+    second = wrapper(pa.table({"text": ["c"]}))
+
+    assert first.column("response").to_pylist() == ["echo:a", "echo:b"]
+    assert second.column("response").to_pylist() == ["echo:c"]
+    assert set(descriptor.prompter.seen_loops) == {runtime.loop}
+
+
+def test_prompt_retry_reruns_on_the_same_loop(runtime) -> None:
+    descriptor = FlakyOncePromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response", max_retries=2)
+    wrapper.bind_async_runtime(runtime.run)
+
+    result = wrapper(pa.table({"text": ["q"]}))
+
+    assert result.column("response").to_pylist() == ["echo:q"]
+    assert descriptor.prompter.calls == 2
+    assert set(descriptor.prompter.seen_loops) == {runtime.loop}
+
+
+def test_prompt_semaphore_and_ordering_on_bound_loop(runtime) -> None:
+    descriptor = ConcurrencyTrackingPromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response", max_api_concurrency=2)
+    wrapper.bind_async_runtime(runtime.run)
+
+    texts = [f"m{i}" for i in range(8)]
+    result = wrapper(pa.table({"text": texts}))
+
+    assert result.column("response").to_pylist() == [f"echo:{t}" for t in texts]
+    assert descriptor.prompter.peak <= 2
+
+
+def test_embed_chunking_drives_chunks_on_the_bound_loop(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb", max_chunk_chars=50, chunk_overlap_chars=10)
+    wrapper.bind_async_runtime(runtime.run)
+
+    result = wrapper(pa.table({"text": ["short", "a" * 200]}))
+
+    assert result.num_rows == 2
+    assert set(descriptor.embedder.seen_loops) == {runtime.loop}
+
+
+# ---------------------------------------------------------------------------
+# No fallback: unbound wrappers fail fast
+# ---------------------------------------------------------------------------
+
+
+def test_unbound_embed_wrapper_raises() -> None:
+    wrapper = _EmbedTextBatch(LoopRecordingEmbedDescriptor(), "text", "emb")
+    with pytest.raises(RuntimeError, match="bind_async_runtime"):
+        wrapper(pa.table({"text": ["a"]}))
+
+
+def test_unbound_prompt_wrapper_raises() -> None:
+    wrapper = _PromptBatch(LoopRecordingPromptDescriptor(), "text", "response")
+    with pytest.raises(RuntimeError, match="bind_async_runtime"):
+        wrapper(pa.table({"text": ["a"]}))
+
+
+def test_unbound_wrapper_raises_even_with_on_error_ignore() -> None:
+    """A missing runtime is a programming error, not a provider failure."""
+    wrapper = _EmbedTextBatch(LoopRecordingEmbedDescriptor(), "text", "emb", max_retries=3, on_error="ignore")
+    with pytest.raises(RuntimeError, match="bind_async_runtime"):
+        wrapper(pa.table({"text": ["a"]}))
+
+
+def test_retry_call_requires_runtime_for_awaitables_and_never_retries_it() -> None:
+    attempts = 0
+
+    async def api() -> str:
+        return "unreachable"
+
+    def call() -> object:
+        nonlocal attempts
+        attempts += 1
+        return api()
+
+    with pytest.raises(RuntimeError, match="bind_async_runtime"):
+        functions._retry_call(call, max_retries=5, on_error="ignore", default="fallback")
+    assert attempts == 1
+
+
+# ---------------------------------------------------------------------------
+# close(): provider client released on the owning loop
+# ---------------------------------------------------------------------------
+
+
+def test_close_releases_client_on_the_bound_loop(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["a"]}))
+
+    wrapper.close()
+    wrapper.close()  # idempotent
+
+    embedder = descriptor.embedder
+    assert embedder.close_calls == 1
+    assert embedder.closed_on is runtime.loop
+
+
+def test_close_before_first_batch_is_a_noop(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+
+    wrapper.close()
+
+    assert descriptor.instantiations == 0
+
+
+def test_close_skips_providers_without_aclose(runtime) -> None:
+    wrapper = _EmbedTextBatch(PicklableEmbedDescriptor(), "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["a"]}))
+
+    wrapper.close()  # PicklableEmbedder has no aclose — must not raise
+
+
+# ---------------------------------------------------------------------------
+# Pickling: client and capability never cross process boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_clears_client_and_capability(runtime) -> None:
+    wrapper = _EmbedTextBatch(PicklableEmbedDescriptor(), "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["warm"]}))
+
+    restored = pickle.loads(pickle.dumps(wrapper))
+
+    assert restored._run_async is None
+    assert restored._embedder is None
+    with pytest.raises(RuntimeError, match="bind_async_runtime"):
+        restored(pa.table({"text": ["a"]}))
+
+    fresh = _Runtime()
+    try:
+        restored.bind_async_runtime(fresh.run)
+        result = restored(pa.table({"text": ["ab"]}))
+        assert result.column("emb").to_pylist() == [[2.0, 2.0]]
+    finally:
+        fresh.close()
+
+
+def test_prompt_pickle_clears_client_and_capability(runtime) -> None:
+    descriptor = LoopRecordingPromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response", max_api_concurrency=4)
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["warm"]}))
+
+    state = wrapper.__getstate__()
+
+    assert state["_run_async"] is None
+    assert state["_prompter"] is None
+    assert state["_max_api_concurrency"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Backend adapters forward the capability hooks
+# ---------------------------------------------------------------------------
+
+
+def test_actor_adapter_forwards_bind_and_close(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    actor_cls = functions._adapt_batch_wrapper_for_backend(wrapper, "subprocess_actor")
+
+    actor = actor_cls()
+    actor.bind_async_runtime(runtime.run)
+    actor(pa.table({"text": ["a"]}))
+    actor.close()
+
+    embedder = descriptor.embedder
+    assert embedder.created_on is runtime.loop
+    assert embedder.close_calls == 1
+    assert embedder.closed_on is runtime.loop
+
+
+def test_task_adapter_carries_capability_hooks(runtime) -> None:
+    descriptor = LoopRecordingEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    fn = functions._adapt_batch_wrapper_for_backend(wrapper, "subprocess_task")
+
+    fn.bind_async_runtime(runtime.run)
+    fn(pa.table({"text": ["a"]}))
+    fn.close()
+
+    embedder = descriptor.embedder
+    assert embedder.created_on is runtime.loop
+    assert embedder.close_calls == 1
+
+
+def test_task_adapter_leaves_plain_wrappers_without_hooks() -> None:
+    class PlainWrapper:
+        def __call__(self, table: pa.Table) -> pa.Table:
+            return table
+
+    fn = functions._adapt_batch_wrapper_for_backend(PlainWrapper(), "subprocess_task")
+
+    assert not hasattr(fn, "bind_async_runtime")
+    assert not hasattr(fn, "close")

--- a/tests/fast/test_ai_async_runtime.py
+++ b/tests/fast/test_ai_async_runtime.py
@@ -134,6 +134,95 @@ class PicklableEmbedDescriptor:
         return PicklableEmbedder()
 
 
+class SyncEmbedder:
+    """Synchronous embedder: no loop-bound state, no ``aclose``."""
+
+    def embed_text(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t))] * 2 for t in texts]
+
+
+class CountingSyncEmbedDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+
+    def instantiate(self) -> SyncEmbedder:
+        self.instantiations += 1
+        return SyncEmbedder()
+
+
+class AsyncNoAcloseEmbedder:
+    """Async (loop-bound) embedder that does not expose ``aclose`` — the
+    protocol permits this, and it must still be dropped at close (issue #139)."""
+
+    async def embed_text(self, texts: list[str]) -> list[list[float]]:
+        return [[float(len(t))] * 2 for t in texts]
+
+
+class CountingAsyncEmbedDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+
+    def instantiate(self) -> AsyncNoAcloseEmbedder:
+        self.instantiations += 1
+        return AsyncNoAcloseEmbedder()
+
+
+class AwaitableReturningEmbedder:
+    """A plain ``def embed_text`` that RETURNS an awaitable, no ``aclose`` —
+    static inspection cannot classify it, only observing the awaitable can."""
+
+    def embed_text(self, texts: list[str]):
+        async def _run() -> list[list[float]]:
+            return [[float(len(t))] * 2 for t in texts]
+
+        return _run()
+
+
+class CountingAwaitableEmbedDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+
+    def instantiate(self) -> AwaitableReturningEmbedder:
+        self.instantiations += 1
+        return AwaitableReturningEmbedder()
+
+
+class AsyncNoAclosePrompter:
+    """Async (loop-bound) prompter that does not expose ``aclose``."""
+
+    async def prompt(self, messages: tuple) -> str:
+        return f"echo:{messages[0]}"
+
+
+class CountingAsyncPromptDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+
+    def instantiate(self) -> AsyncNoAclosePrompter:
+        self.instantiations += 1
+        return AsyncNoAclosePrompter()
+
+
+class AwaitableReturningPrompter:
+    """A plain ``def prompt`` that RETURNS an awaitable, no ``aclose`` —
+    static inspection cannot classify it, only observing the awaitable can."""
+
+    def prompt(self, messages: tuple):
+        async def _run() -> str:
+            return f"echo:{messages[0]}"
+
+        return _run()
+
+
+class CountingAwaitablePromptDescriptor:
+    def __init__(self) -> None:
+        self.instantiations = 0
+
+    def instantiate(self) -> AwaitableReturningPrompter:
+        self.instantiations += 1
+        return AwaitableReturningPrompter()
+
+
 class LoopRecordingPrompter:
     """Async prompter recording the running loop for each call."""
 
@@ -338,25 +427,17 @@ def test_close_before_first_batch_is_a_noop(runtime) -> None:
     assert descriptor.instantiations == 0
 
 
-def test_close_retains_providers_without_aclose(runtime) -> None:
-    """Sync providers (no loop-bound state) survive close: task backends
-    close the executor per invocation while the callable cache keeps the
-    wrapper, and dropping the provider would reload the model per task."""
-
-    class CountingSyncEmbedDescriptor:
-        def __init__(self) -> None:
-            self.instantiations = 0
-
-        def instantiate(self) -> PicklableEmbedder:
-            self.instantiations += 1
-            return PicklableEmbedder()
-
+def test_close_retains_sync_provider(runtime) -> None:
+    """A proven-synchronous embedder (sync ``embed_text``, no ``aclose``) holds
+    no loop-bound state and survives close: task backends close the executor
+    per invocation while the callable cache keeps the wrapper, so dropping it
+    would reload the model per task."""
     descriptor = CountingSyncEmbedDescriptor()
     wrapper = _EmbedTextBatch(descriptor, "text", "emb")
     wrapper.bind_async_runtime(runtime.run)
     wrapper(pa.table({"text": ["a"]}))
 
-    wrapper.close()  # no aclose — provider stays cached, must not raise
+    wrapper.close()  # sync provider stays cached, must not raise
 
     fresh = _Runtime()
     try:
@@ -365,6 +446,86 @@ def test_close_retains_providers_without_aclose(runtime) -> None:
     finally:
         fresh.close()
     assert descriptor.instantiations == 1
+
+
+def test_close_drops_async_embedder_without_aclose(runtime) -> None:
+    """The maintainer's #139 reproduction: an async embedder without ``aclose``
+    is loop-bound, so it is dropped at close and re-instantiated on the next
+    (fresh-loop) batch rather than reused across loops."""
+    descriptor = CountingAsyncEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["a"]}))
+
+    wrapper.close()
+
+    fresh = _Runtime()
+    try:
+        wrapper.bind_async_runtime(fresh.run)
+        wrapper(pa.table({"text": ["ab"]}))
+    finally:
+        fresh.close()
+    assert descriptor.instantiations == 2
+
+
+def test_close_drops_async_prompter_without_aclose(runtime) -> None:
+    """``Prompter.prompt`` is async by protocol: a prompter without ``aclose``
+    is still loop-bound and dropped at close, then re-instantiated."""
+    descriptor = CountingAsyncPromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["a"]}))
+
+    wrapper.close()
+
+    fresh = _Runtime()
+    try:
+        wrapper.bind_async_runtime(fresh.run)
+        wrapper(pa.table({"text": ["ab"]}))
+    finally:
+        fresh.close()
+    assert descriptor.instantiations == 2
+
+
+def test_close_drops_embedder_after_observed_awaitable(runtime) -> None:
+    """A plain ``def embed_text`` that returns an awaitable is not a coroutine
+    function, so static inspection cannot classify it; observing the awaitable
+    at runtime still marks it loop-bound, so it is dropped at close."""
+    descriptor = CountingAwaitableEmbedDescriptor()
+    wrapper = _EmbedTextBatch(descriptor, "text", "emb")
+    wrapper.bind_async_runtime(runtime.run)
+    wrapper(pa.table({"text": ["a"]}))  # observes the awaitable → marks loop-bound
+
+    wrapper.close()
+
+    fresh = _Runtime()
+    try:
+        wrapper.bind_async_runtime(fresh.run)
+        wrapper(pa.table({"text": ["ab"]}))
+    finally:
+        fresh.close()
+    assert descriptor.instantiations == 2
+
+
+def test_close_drops_prompter_after_observed_awaitable(runtime) -> None:
+    """The per-row prompt path (no ``prompt_batch``) also reports observed
+    awaitables: a plain ``def prompt`` returning an awaitable is marked
+    loop-bound and dropped at close."""
+    descriptor = CountingAwaitablePromptDescriptor()
+    wrapper = _PromptBatch(descriptor, "text", "response")
+    wrapper.bind_async_runtime(runtime.run)
+    result = wrapper(pa.table({"text": ["a"]}))  # observes the awaitable
+    assert result.column("response").to_pylist() == ["echo:a"]
+
+    wrapper.close()
+
+    fresh = _Runtime()
+    try:
+        wrapper.bind_async_runtime(fresh.run)
+        wrapper(pa.table({"text": ["ab"]}))
+    finally:
+        fresh.close()
+    assert descriptor.instantiations == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/test_udf_async_runtime_executor.py
+++ b/tests/fast/test_udf_async_runtime_executor.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The UDF executor owns the async runtime it hands to async callables.
+
+Covers vane#139 at the executor layer: ``UDFExecutor`` creates one
+``AsyncRuntime`` per executor for callables that declare a
+``bind_async_runtime`` hook, drives it with ``run_until_complete`` on the
+actor's own execution thread (no background thread), and releases the
+callable's resources plus the loop in ``close()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("pyarrow")
+
+import pyarrow as pa
+
+
+def _pickle(obj):
+    cloudpickle = pytest.importorskip("cloudpickle")
+    return cloudpickle.dumps(obj)
+
+
+class AsyncBatchCallable:
+    """Actor-style callable that drives its batch through the bound runtime."""
+
+    def __init__(self) -> None:
+        self.run_async = None
+        self.seen_loops: list[asyncio.AbstractEventLoop] = []
+        self.seen_threads: list[int] = []
+        self.closed = False
+
+    def bind_async_runtime(self, run_async) -> None:
+        self.run_async = run_async
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __call__(self, table: pa.Table) -> pa.Table:
+        async def _work() -> pa.Table:
+            import threading
+
+            self.seen_loops.append(asyncio.get_running_loop())
+            self.seen_threads.append(threading.get_ident())
+            return table
+
+        return self.run_async(_work())
+
+
+def _actor_map_batches_payload(cls) -> dict:
+    return {
+        "function_pickle": _pickle(cls),
+        "call_mode": "map_batches",
+        "execution_backend": "subprocess_actor",
+        "actor_number": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AsyncRuntime unit behavior
+# ---------------------------------------------------------------------------
+
+
+def test_async_runtime_lazy_loop_reused_across_runs():
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+    assert runtime.loop is None
+
+    async def loop_of() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    first = runtime.run(loop_of())
+    second = runtime.run(loop_of())
+
+    assert first is second is runtime.loop
+    runtime.close()
+
+
+def test_async_runtime_runs_on_the_calling_thread():
+    import threading
+
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+
+    async def thread_of() -> int:
+        return threading.get_ident()
+
+    assert runtime.run(thread_of()) == threading.get_ident()
+    runtime.close()
+
+
+def test_async_runtime_close_is_idempotent_and_closes_loop():
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+
+    async def nothing() -> None:
+        return None
+
+    runtime.run(nothing())
+    loop = runtime.loop
+    runtime.close()
+    runtime.close()
+
+    assert loop.is_closed()
+    assert runtime.loop is None
+
+
+def test_async_runtime_close_before_first_run_is_noop():
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+    runtime.close()
+    assert runtime.loop is None
+
+
+def test_async_runtime_close_finalizes_async_generators():
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+    finalized = []
+
+    async def agen():
+        try:
+            yield 1
+            yield 2
+        finally:
+            finalized.append(True)
+
+    async def start() -> int:
+        gen = agen()
+        return await gen.__anext__()
+
+    assert runtime.run(start()) == 1
+    assert not finalized
+    runtime.close()
+    assert finalized == [True]
+
+
+def test_async_runtime_rejects_nested_use_no_fallback():
+    """Inside async code callers must await; there is no bridge thread."""
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    outer = AsyncRuntime()
+    inner = AsyncRuntime()
+
+    async def nested() -> None:
+        async def noop() -> None:
+            return None
+
+        inner.run(noop())
+
+    with pytest.raises(RuntimeError):
+        outer.run(nested())
+    outer.close()
+    inner.close()
+
+
+# ---------------------------------------------------------------------------
+# Executor wiring
+# ---------------------------------------------------------------------------
+
+
+def test_executor_binds_runtime_and_batches_share_one_loop():
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    executor = UDFExecutor(_actor_map_batches_payload(AsyncBatchCallable))
+    executor.submit(pa.table({"x": [1]}))
+    executor.submit(pa.table({"x": [2, 3]}))
+    executor.finished_submitting()
+    outputs = executor.drain_outputs()
+
+    callable_instance = executor._map_fn
+    assert sum(t.num_rows for t in outputs) == 3
+    assert len(callable_instance.seen_loops) == 2
+    assert len(set(callable_instance.seen_loops)) == 1
+
+    import threading
+
+    assert set(callable_instance.seen_threads) == {threading.get_ident()}
+
+    loop = callable_instance.seen_loops[0]
+    executor.close()
+    assert callable_instance.closed
+    assert loop.is_closed()
+
+
+def test_executor_close_is_idempotent():
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    executor = UDFExecutor(_actor_map_batches_payload(AsyncBatchCallable))
+    executor.close()
+    executor.close()
+
+
+def test_executor_without_hook_binds_nothing():
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    def identity(table: pa.Table) -> pa.Table:
+        return table
+
+    executor = UDFExecutor(
+        {
+            "function_pickle": _pickle(identity),
+            "call_mode": "map_batches",
+            "execution_backend": "subprocess_task",
+        }
+    )
+
+    assert executor._async_runtime is None
+    executor.close()  # no-op without a bound runtime

--- a/tests/fast/test_udf_async_runtime_executor.py
+++ b/tests/fast/test_udf_async_runtime_executor.py
@@ -171,20 +171,37 @@ def test_async_runtime_close_finalizes_async_generators():
 
 
 def test_async_runtime_rejects_nested_use_no_fallback():
-    """Inside async code callers must await; there is no bridge thread."""
+    """Inside async code callers must await; there is no bridge thread.
+
+    The rejected coroutine is closed rather than left un-awaited, so no
+    ``RuntimeWarning: coroutine ... was never awaited`` escapes and no
+    fallback loop is created for the rejected runtime.
+    """
+    import gc
+    import warnings
+
     from duckdb.execution._async_runtime import AsyncRuntime
 
     outer = AsyncRuntime()
     inner = AsyncRuntime()
+    ran: list[str] = []
 
     async def nested() -> None:
         async def noop() -> None:
-            return None
+            ran.append("noop")  # must never run: run() rejects before scheduling
 
         inner.run(noop())
 
-    with pytest.raises(RuntimeError):
-        outer.run(nested())
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(RuntimeError, match="await"):
+            outer.run(nested())
+        gc.collect()  # force any leaked coroutine to surface its warning here
+
+    assert ran == []  # the rejected coroutine body never executed
+    assert not any("never awaited" in str(w.message) for w in caught)
+    assert not any(issubclass(w.category, RuntimeWarning) for w in caught)
+    assert inner.loop is None  # rejection created no fallback loop
     outer.close()
     inner.close()
 

--- a/tests/fast/test_udf_async_runtime_executor.py
+++ b/tests/fast/test_udf_async_runtime_executor.py
@@ -121,6 +121,32 @@ def test_async_runtime_close_before_first_run_is_noop():
     assert runtime.loop is None
 
 
+def test_async_runtime_close_cancels_pending_tasks():
+    """Background tasks left behind by a coroutine are cancelled — their
+    finally blocks run — instead of being destroyed with the loop."""
+    from duckdb.execution._async_runtime import AsyncRuntime
+
+    runtime = AsyncRuntime()
+    states: list[str] = []
+
+    async def background() -> None:
+        try:
+            states.append("started")
+            await asyncio.sleep(30)
+            states.append("finished")
+        finally:
+            states.append("cleaned-up")
+
+    async def spawn() -> None:
+        asyncio.get_running_loop().create_task(background())
+        await asyncio.sleep(0)  # let the task start
+
+    runtime.run(spawn())
+    assert states == ["started"]
+    runtime.close()
+    assert states == ["started", "cleaned-up"]
+
+
 def test_async_runtime_close_finalizes_async_generators():
     from duckdb.execution._async_runtime import AsyncRuntime
 

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -7686,6 +7686,7 @@ def test_subprocess_task_submit_flushes_compute_tail_before_drain(monkeypatch):
     class FakeRuntimeExecutor:
         def __init__(self, _payload, *, cache_callable=False):
             self.finished = False
+            self.closed = False
             self.input_rows = 0
             created.append(self)
 
@@ -7694,6 +7695,9 @@ def test_subprocess_task_submit_flushes_compute_tail_before_drain(monkeypatch):
 
         def finished_submitting(self):
             self.finished = True
+
+        def close(self):
+            self.closed = True
 
         def drain_outputs(self):
             if not self.finished:
@@ -7731,6 +7735,7 @@ def test_subprocess_task_submit_flushes_compute_tail_before_drain(monkeypatch):
     assert descriptor["metadata"] == [{"rows": [3], "num_rows": 1, "ipc_size_bytes": 1}]
     assert descriptor["names"] == ["rows"]
     assert created and created[0].finished
+    assert created[0].closed
 
 
 @pytest.mark.parametrize(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -74,19 +74,15 @@ def _resolve_provider(provider: str | Provider | None, default: str = "transform
     return provider
 
 
-def _run_async(coro: Any) -> Any:
-    """Run an awaitable, handling the case where a loop is already running."""
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
+class _MissingAsyncRuntimeError(RuntimeError):
+    """A wrapper needed its executor-bound async runtime but none was bound."""
 
-    if loop and loop.is_running():
-        import concurrent.futures
 
-        with concurrent.futures.ThreadPoolExecutor(1) as pool:
-            return pool.submit(asyncio.run, coro).result()
-    return asyncio.run(coro)
+def _missing_async_runtime() -> _MissingAsyncRuntimeError:
+    return _MissingAsyncRuntimeError(
+        "AI batch wrappers must be driven by a UDF executor that binds an "
+        "async runtime via bind_async_runtime(); they do not own event loops"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +112,7 @@ def _retry_call(
     max_retries: int = 3,
     on_error: _OnError = "raise",
     default: Any = None,
+    run_async: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Call *fn* with exponential-backoff retry and on_error handling.
@@ -126,14 +123,24 @@ def _retry_call(
         on_error: ``"raise"`` re-raises on final failure; ``"log"`` and
             ``"ignore"`` return *default*.
         default: Value to return when on_error is not ``"raise"``.
+        run_async: Callable used to drive awaitable results. Batch wrappers
+            pass their executor-bound runtime so cached SDK clients see one
+            loop across batches; required when *fn* returns an awaitable.
     """
     last_exc: Exception | None = None
     for attempt in range(1 + max(0, max_retries)):
         try:
             result = fn(*args, **kwargs)
             if inspect.isawaitable(result):
-                result = _run_async(result)
+                if run_async is None:
+                    result.close()
+                    raise _missing_async_runtime()
+                result = run_async(result)
             return result
+        except _MissingAsyncRuntimeError:
+            # Programming error, not a transient API failure: never retried,
+            # never converted to a default by on_error.
+            raise
         except Exception as exc:
             last_exc = exc
             if attempt < max_retries:
@@ -237,6 +244,16 @@ def _adapt_batch_wrapper_for_backend(wrapper: Any, execution_backend: str | None
             def __init__(self) -> None:
                 self._wrapper = wrapper
 
+            def bind_async_runtime(self, run_async: Any) -> None:
+                bind = getattr(self._wrapper, "bind_async_runtime", None)
+                if bind is not None:
+                    bind(run_async)
+
+            def close(self) -> None:
+                close = getattr(self._wrapper, "close", None)
+                if close is not None:
+                    close()
+
             def __call__(self, table: pa.Table) -> pa.Table:
                 return self._wrapper(table)
 
@@ -246,6 +263,13 @@ def _adapt_batch_wrapper_for_backend(wrapper: Any, execution_backend: str | None
 
         def _run_ai_batch(table: pa.Table) -> pa.Table:
             return wrapper(table)
+
+        # Task executors are per-invocation: the executor binds a runtime,
+        # runs the batch, and closes it — client lifecycle matches the task.
+        bind = getattr(wrapper, "bind_async_runtime", None)
+        if bind is not None:
+            _run_ai_batch.bind_async_runtime = bind  # type: ignore[attr-defined]
+            _run_ai_batch.close = wrapper.close  # type: ignore[attr-defined]
 
         return _run_ai_batch
 
@@ -372,7 +396,15 @@ def _embedding_zero_size(descriptor: Any, arrow_type: Any | None) -> int:
 
 
 class _EmbedTextBatch:
-    """Stateful wrapper — model loaded once per actor via instantiate()."""
+    """Stateful wrapper — model loaded once per actor via instantiate().
+
+    Async execution is driven exclusively through an executor-bound
+    ``run_async`` capability (see ``UDFExecutor._bind_async_runtime``); the
+    wrapper never creates event loops or threads. The provider runtime is
+    instantiated inside the bound loop so its async SDK client binds to the
+    loop that serves every batch, and ``close()`` releases the client on
+    that same loop at actor shutdown.
+    """
 
     def __init__(
         self,
@@ -399,11 +431,44 @@ class _EmbedTextBatch:
         # Arrow type when they already know the dimensions.
         self._arrow_type = arrow_type
         self._embedder = None  # lazy: instantiate on first __call__
+        self._run_async: Any = None  # executor-bound capability
+
+    def bind_async_runtime(self, run_async: Any) -> None:
+        """Receive the executor-owned async driver (see UDFExecutor)."""
+        self._run_async = run_async
+
+    def _require_run_async(self) -> Any:
+        if self._run_async is None:
+            raise _missing_async_runtime()
+        return self._run_async
 
     def _ensure_embedder(self) -> Any:
         if self._embedder is None:
-            self._embedder = self._descriptor.instantiate()
+            run_async = self._require_run_async()
+
+            async def _instantiate() -> Any:
+                # Construct inside the bound loop so the async SDK client's
+                # connection pool binds to the loop serving every batch.
+                return self._descriptor.instantiate()
+
+            self._embedder = run_async(_instantiate())
         return self._embedder
+
+    def close(self) -> None:
+        """Release the provider client on the bound loop. Idempotent."""
+        embedder, self._embedder = self._embedder, None
+        if embedder is None or self._run_async is None:
+            return
+        aclose = getattr(embedder, "aclose", None)
+        if aclose is not None:
+            self._run_async(aclose())
+
+    def __getstate__(self) -> dict[str, Any]:
+        # The cached client and the bound runtime capability are process-local.
+        state = self.__dict__.copy()
+        state["_embedder"] = None
+        state["_run_async"] = None
+        return state
 
     def _zero_fill(self, count: int) -> list[Any]:
         """Zero embeddings when possible; nulls when the dimension is unknowable."""
@@ -425,6 +490,7 @@ class _EmbedTextBatch:
                 texts,
                 max_retries=self._max_retries,
                 on_error=self._on_error,
+                run_async=self._require_run_async(),
             )
             if result is None:
                 result = self._zero_fill(len(texts))
@@ -460,7 +526,7 @@ class _EmbedTextBatch:
         # Embed all chunks in one batch
         chunk_embeddings = self._ensure_embedder().embed_text(all_chunks)
         if inspect.isawaitable(chunk_embeddings):
-            chunk_embeddings = _run_async(chunk_embeddings)
+            chunk_embeddings = self._require_run_async()(chunk_embeddings)
 
         # Reassemble: weighted average for multi-chunk texts
         results: list[Any] = []
@@ -520,6 +586,13 @@ class _PromptBatch:
     When ``image_columns`` is set, image data from those columns is packed
     alongside text into multimodal message tuples. List-valued image cells are
     expanded in order and NULL or zero-length image values are skipped.
+
+    Async execution is driven exclusively through an executor-bound
+    ``run_async`` capability (see ``UDFExecutor._bind_async_runtime``); the
+    wrapper never creates event loops or threads. The provider runtime is
+    instantiated inside the bound loop so its async SDK client binds to the
+    loop that serves every batch, and ``close()`` releases the client on
+    that same loop at actor shutdown.
     """
 
     def __init__(
@@ -544,6 +617,44 @@ class _PromptBatch:
         self._max_retries = max_retries
         self._on_error: _OnError = on_error
         self._prompter = None  # lazy: instantiate on first __call__
+        self._run_async: Any = None  # executor-bound capability
+
+    def bind_async_runtime(self, run_async: Any) -> None:
+        """Receive the executor-owned async driver (see UDFExecutor)."""
+        self._run_async = run_async
+
+    def _require_run_async(self) -> Any:
+        if self._run_async is None:
+            raise _missing_async_runtime()
+        return self._run_async
+
+    def _ensure_prompter(self) -> Any:
+        if self._prompter is None:
+            run_async = self._require_run_async()
+
+            async def _instantiate() -> Any:
+                # Construct inside the bound loop so the async SDK client's
+                # connection pool binds to the loop serving every batch.
+                return self._descriptor.instantiate()
+
+            self._prompter = run_async(_instantiate())
+        return self._prompter
+
+    def close(self) -> None:
+        """Release the provider client on the bound loop. Idempotent."""
+        prompter, self._prompter = self._prompter, None
+        if prompter is None or self._run_async is None:
+            return
+        aclose = getattr(prompter, "aclose", None)
+        if aclose is not None:
+            self._run_async(aclose())
+
+    def __getstate__(self) -> dict[str, Any]:
+        # The cached client and the bound runtime capability are process-local.
+        state = self.__dict__.copy()
+        state["_prompter"] = None
+        state["_run_async"] = None
+        return state
 
     def _serialize_result(self, result: Any) -> str | None:
         """Convert a prompt result to a string for the output column."""
@@ -567,8 +678,7 @@ class _PromptBatch:
         if self._propagate_null_prompts and not active_indices:
             return pa.table({self._output_column: pa.array(results, type=pa.string())})
 
-        if self._prompter is None:
-            self._prompter = self._descriptor.instantiate()
+        self._ensure_prompter()
         texts = [t if t is not None else "" for t in texts]
 
         # Build per-row message tuples (text + optional image columns)
@@ -609,6 +719,7 @@ class _PromptBatch:
                 [texts[idx] for idx in text_indices],
                 max_retries=self._max_retries,
                 on_error=self._on_error,
+                run_async=self._require_run_async(),
             )
             if text_results is None:
                 text_results = [None] * len(text_indices)
@@ -648,7 +759,7 @@ class _PromptBatch:
             return await asyncio.gather(*(single(idx) for idx in prompt_indices))
 
         if prompt_indices:
-            prompt_results = _run_async(run_all())
+            prompt_results = self._require_run_async()(run_all())
             for idx, result in zip(prompt_indices, prompt_results, strict=True):
                 results[idx] = result
         return pa.table({self._output_column: results})

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -89,6 +89,37 @@ def _missing_async_runtime() -> _MissingAsyncRuntimeError:
     )
 
 
+def _provider_is_loop_bound(provider: Any, method_name: str) -> bool:
+    """Whether a cached provider statically shows event-loop-bound state that
+    must be released before its loop is torn down.
+
+    Positive signals:
+
+    * the provider exposes ``aclose`` (a client that must be awaited shut) —
+      a *sufficient* signal, never a necessary one;
+    * the driven method (``embed_text`` / ``prompt``) is a coroutine function
+      — the protocol-sanctioned way to own a loop-bound async client
+      (``AsyncOpenAI`` / ``AsyncAnthropic`` / ``genai.Client``).
+
+    The strongest signal — an awaitable actually observed from the driven
+    method at runtime — is delivered separately: the wrappers pass their
+    ``_mark_loop_bound`` callback as ``on_awaitable`` to the retry helpers, so
+    even a plain ``def`` that returns an awaitable (which static inspection
+    cannot classify) upgrades to loop-bound the moment it runs.
+
+    A missing ``aclose()`` is never taken as proof of synchronicity: the public
+    ``TextEmbedder`` / ``Prompter`` protocols permit an async provider that does
+    not expose it, and treating such a provider as synchronous strands its
+    loop-bound client across event loops (issue #139). Genuinely synchronous
+    providers (e.g. the Transformers embedder) match no signal and stay cached
+    across per-task executors so their model is not reloaded.
+    """
+    if getattr(provider, "aclose", None) is not None:
+        return True
+    method = getattr(provider, method_name, None)
+    return method is not None and inspect.iscoroutinefunction(inspect.unwrap(method))
+
+
 # ---------------------------------------------------------------------------
 # Retry / on_error helpers
 # ---------------------------------------------------------------------------
@@ -117,6 +148,7 @@ def _retry_call(
     on_error: _OnError = "raise",
     default: Any = None,
     run_async: Any = None,
+    on_awaitable: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Call *fn* with exponential-backoff retry and on_error handling.
@@ -130,12 +162,18 @@ def _retry_call(
         run_async: Callable used to drive awaitable results. Batch wrappers
             pass their executor-bound runtime so cached SDK clients see one
             loop across batches; required when *fn* returns an awaitable.
+        on_awaitable: Optional zero-arg callback invoked the first time *fn*
+            returns an awaitable — lets a wrapper learn its provider is
+            loop-bound even when static inspection cannot tell (a plain
+            ``def`` that returns an awaitable), so ``close()`` releases it.
     """
     last_exc: Exception | None = None
     for attempt in range(1 + max(0, max_retries)):
         try:
             result = fn(*args, **kwargs)
             if inspect.isawaitable(result):
+                if on_awaitable is not None:
+                    on_awaitable()
                 if run_async is None:
                     result.close()
                     raise _missing_async_runtime()
@@ -170,13 +208,23 @@ async def _retry_call_async(
     max_retries: int = 3,
     on_error: _OnError = "raise",
     default: Any = None,
+    on_awaitable: Any = None,
     **kwargs: Any,
 ) -> Any:
-    """Async variant of :func:`_retry_call`."""
+    """Async variant of :func:`_retry_call`.
+
+    ``on_awaitable`` mirrors :func:`_retry_call`: invoked when *fn* returns an
+    awaitable, so a wrapper learns its provider is loop-bound even when the
+    method is a plain ``def`` returning an awaitable (which
+    ``iscoroutinefunction`` cannot classify).
+    """
     last_exc: Exception | None = None
     for attempt in range(1 + max(0, max_retries)):
         try:
-            return await fn(*args, **kwargs)
+            result = fn(*args, **kwargs)
+            if on_awaitable is not None and inspect.isawaitable(result):
+                on_awaitable()
+            return await result
         except Exception as exc:
             last_exc = exc
             if attempt < max_retries:
@@ -436,6 +484,7 @@ class _EmbedTextBatch:
         self._arrow_type = arrow_type
         self._embedder = None  # lazy: instantiate on first __call__
         self._run_async: Any = None  # executor-bound capability
+        self._embedder_loop_bound = False  # set once the embedder is known loop-bound
 
     def bind_async_runtime(self, run_async: Any) -> None:
         """Receive the executor-owned async driver (see UDFExecutor)."""
@@ -445,6 +494,9 @@ class _EmbedTextBatch:
         if self._run_async is None:
             raise _missing_async_runtime()
         return self._run_async
+
+    def _mark_loop_bound(self) -> None:
+        self._embedder_loop_bound = True
 
     def _ensure_embedder(self) -> Any:
         if self._embedder is None:
@@ -456,30 +508,39 @@ class _EmbedTextBatch:
                 return self._descriptor.instantiate()
 
             self._embedder = run_async(_instantiate())
+            if _provider_is_loop_bound(self._embedder, "embed_text"):
+                self._embedder_loop_bound = True
         return self._embedder
 
     def close(self) -> None:
-        """Release a loop-owned provider client on the bound loop. Idempotent.
+        """Release a loop-bound embedder on the bound loop. Idempotent.
 
-        Providers without ``aclose`` (transformers, vLLM) hold no loop-bound
-        state and stay cached: task backends close the executor after every
-        invocation while the process-local callable cache keeps the wrapper,
-        so dropping them would reload the model on each task.
+        ``TextEmbedder.embed_text`` may be sync or async. A loop-bound embedder
+        — a coroutine ``embed_text``, an observed awaitable result, or an
+        ``aclose()`` hook — is dropped so the next batch re-instantiates on the
+        fresh loop (issue #139); a missing ``aclose()`` is never treated as
+        proof of synchronicity. A proven-synchronous embedder (e.g. the
+        Transformers embedder) holds no loop-bound state and stays cached:
+        task backends close the executor after every invocation while the
+        process-local callable cache keeps the wrapper, so dropping it would
+        reload the model on each task.
         """
         embedder = self._embedder
         if embedder is None or self._run_async is None:
             return
-        aclose = getattr(embedder, "aclose", None)
-        if aclose is None:
+        if not self._embedder_loop_bound:
             return
         self._embedder = None
-        self._run_async(aclose())
+        aclose = getattr(embedder, "aclose", None)
+        if aclose is not None:
+            self._run_async(aclose())
 
     def __getstate__(self) -> dict[str, Any]:
         # The cached client and the bound runtime capability are process-local.
         state = self.__dict__.copy()
         state["_embedder"] = None
         state["_run_async"] = None
+        state["_embedder_loop_bound"] = False  # recomputed on next _ensure_embedder()
         return state
 
     def _zero_fill(self, count: int) -> list[Any]:
@@ -503,6 +564,7 @@ class _EmbedTextBatch:
                 max_retries=self._max_retries,
                 on_error=self._on_error,
                 run_async=self._require_run_async(),
+                on_awaitable=self._mark_loop_bound,
             )
             if result is None:
                 result = self._zero_fill(len(texts))
@@ -538,6 +600,7 @@ class _EmbedTextBatch:
         # Embed all chunks in one batch
         chunk_embeddings = self._ensure_embedder().embed_text(all_chunks)
         if inspect.isawaitable(chunk_embeddings):
+            self._mark_loop_bound()
             chunk_embeddings = self._require_run_async()(chunk_embeddings)
 
         # Reassemble: weighted average for multi-chunk texts
@@ -630,6 +693,7 @@ class _PromptBatch:
         self._on_error: _OnError = on_error
         self._prompter = None  # lazy: instantiate on first __call__
         self._run_async: Any = None  # executor-bound capability
+        self._prompter_loop_bound = False  # set once the prompter is known loop-bound
 
     def bind_async_runtime(self, run_async: Any) -> None:
         """Receive the executor-owned async driver (see UDFExecutor)."""
@@ -639,6 +703,9 @@ class _PromptBatch:
         if self._run_async is None:
             raise _missing_async_runtime()
         return self._run_async
+
+    def _mark_loop_bound(self) -> None:
+        self._prompter_loop_bound = True
 
     def _ensure_prompter(self) -> Any:
         if self._prompter is None:
@@ -650,30 +717,38 @@ class _PromptBatch:
                 return self._descriptor.instantiate()
 
             self._prompter = run_async(_instantiate())
+            if _provider_is_loop_bound(self._prompter, "prompt"):
+                self._prompter_loop_bound = True
         return self._prompter
 
     def close(self) -> None:
-        """Release a loop-owned provider client on the bound loop. Idempotent.
+        """Release a loop-bound prompter on the bound loop. Idempotent.
 
-        Providers without ``aclose`` (transformers, vLLM) hold no loop-bound
-        state and stay cached: task backends close the executor after every
-        invocation while the process-local callable cache keeps the wrapper,
-        so dropping them would reload the model on each task.
+        ``Prompter.prompt`` is ``async`` by protocol, so a conforming prompter
+        owns loop-bound state (its async SDK client) and is dropped on close so
+        the next batch re-instantiates on the fresh loop (issue #139),
+        ``aclose()`` being awaited when the client exposes it; a missing
+        ``aclose()`` is never treated as proof of synchronicity. A provider
+        that proves synchronous (no coroutine ``prompt``, no observed
+        awaitable, no ``aclose``) stays cached so per-task executors do not
+        reload it. (vLLM prompting is planner-only and is never cached here.)
         """
         prompter = self._prompter
         if prompter is None or self._run_async is None:
             return
-        aclose = getattr(prompter, "aclose", None)
-        if aclose is None:
+        if not self._prompter_loop_bound:
             return
         self._prompter = None
-        self._run_async(aclose())
+        aclose = getattr(prompter, "aclose", None)
+        if aclose is not None:
+            self._run_async(aclose())
 
     def __getstate__(self) -> dict[str, Any]:
         # The cached client and the bound runtime capability are process-local.
         state = self.__dict__.copy()
         state["_prompter"] = None
         state["_run_async"] = None
+        state["_prompter_loop_bound"] = False  # recomputed on next _ensure_prompter()
         return state
 
     def _serialize_result(self, result: Any) -> str | None:
@@ -739,6 +814,7 @@ class _PromptBatch:
                 max_retries=self._max_retries,
                 on_error=self._on_error,
                 run_async=self._require_run_async(),
+                on_awaitable=self._mark_loop_bound,
             )
             if text_results is None:
                 text_results = [None] * len(text_indices)
@@ -761,6 +837,7 @@ class _PromptBatch:
                             row_messages[idx],
                             max_retries=max_retries,
                             on_error=on_error,
+                            on_awaitable=self._mark_loop_bound,
                         )
                         return self._serialize_result(result) if self._return_format else result
 
@@ -772,6 +849,7 @@ class _PromptBatch:
                     row_messages[idx],
                     max_retries=max_retries,
                     on_error=on_error,
+                    on_awaitable=self._mark_loop_bound,
                 )
                 return self._serialize_result(result) if self._return_format else result
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -455,13 +455,21 @@ class _EmbedTextBatch:
         return self._embedder
 
     def close(self) -> None:
-        """Release the provider client on the bound loop. Idempotent."""
-        embedder, self._embedder = self._embedder, None
+        """Release a loop-owned provider client on the bound loop. Idempotent.
+
+        Providers without ``aclose`` (transformers, vLLM) hold no loop-bound
+        state and stay cached: task backends close the executor after every
+        invocation while the process-local callable cache keeps the wrapper,
+        so dropping them would reload the model on each task.
+        """
+        embedder = self._embedder
         if embedder is None or self._run_async is None:
             return
         aclose = getattr(embedder, "aclose", None)
-        if aclose is not None:
-            self._run_async(aclose())
+        if aclose is None:
+            return
+        self._embedder = None
+        self._run_async(aclose())
 
     def __getstate__(self) -> dict[str, Any]:
         # The cached client and the bound runtime capability are process-local.
@@ -641,13 +649,21 @@ class _PromptBatch:
         return self._prompter
 
     def close(self) -> None:
-        """Release the provider client on the bound loop. Idempotent."""
-        prompter, self._prompter = self._prompter, None
+        """Release a loop-owned provider client on the bound loop. Idempotent.
+
+        Providers without ``aclose`` (transformers, vLLM) hold no loop-bound
+        state and stay cached: task backends close the executor after every
+        invocation while the process-local callable cache keeps the wrapper,
+        so dropping them would reload the model on each task.
+        """
+        prompter = self._prompter
         if prompter is None or self._run_async is None:
             return
         aclose = getattr(prompter, "aclose", None)
-        if aclose is not None:
-            self._run_async(aclose())
+        if aclose is None:
+            return
+        self._prompter = None
+        self._run_async(aclose())
 
     def __getstate__(self) -> dict[str, Any]:
         # The cached client and the bound runtime capability are process-local.

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -176,6 +176,10 @@ class AnthropicPrompter:
         }
         self._client = AsyncAnthropic(**client_opts)
 
+    async def aclose(self) -> None:
+        """Release the SDK client's connection pool on the owning loop."""
+        await self._client.close()
+
     # --- Multimodal message processing -----------------------------------
 
     def _process_message(self, msg: Any) -> dict[str, Any]:

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -388,6 +388,10 @@ class GoogleTextEmbedder:
             }
         }
 
+    async def aclose(self) -> None:
+        """Release the SDK client's async connection pool on the owning loop."""
+        await self._client.aio.aclose()
+
     async def embed_text(self, text: list[str]) -> list[Embedding]:
         from google.genai import types
 
@@ -519,6 +523,10 @@ class GooglePrompter:
                 "max_retries",
             }
         }
+
+    async def aclose(self) -> None:
+        """Release the SDK client's async connection pool on the owning loop."""
+        await self._client.aio.aclose()
 
     # --- Multimodal message processing -----------------------------------
 

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -263,6 +263,10 @@ class OpenAITextEmbedder:
         }
         self._client = AsyncOpenAI(**client_opts)
 
+    async def aclose(self) -> None:
+        """Release the SDK client's connection pool on the owning loop."""
+        await self._client.close()
+
     async def embed_text(self, text: list[str]) -> list[Embedding]:
         embeddings: list[Embedding] = []
         batch: list[str] = []
@@ -444,6 +448,10 @@ class OpenAIPrompter:
             if k in {"api_key", "base_url", "organization", "timeout", "max_retries"}
         }
         self._client = AsyncOpenAI(**client_opts)
+
+    async def aclose(self) -> None:
+        """Release the SDK client's connection pool on the owning loop."""
+        await self._client.close()
 
     # --- Multimodal message processing -----------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #139. AI batch wrappers cache their provider runtime (and its async SDK client — `AsyncOpenAI`/`AsyncAnthropic`/`genai.Client`) across batches, but drove every batch with a fresh `asyncio.run()`, stranding the client's httpx connection pool on a closed event loop → intermittent `RuntimeError: Event loop is closed` from the second batch on.

**Ownership model (reworked per maintainer review):** the loop belongs to the actor runtime, not the wrappers.

- `duckdb/execution/_async_runtime.py` adds `AsyncRuntime`: one lazily-created event loop driven with `run_until_complete` on the actor's own execution thread — **no background threads**. Actors execute batches serially, so no locking or cross-thread machinery is needed.
- `UDFExecutor` owns one `AsyncRuntime` per executor and binds its `run` to any callable declaring a `bind_async_runtime(run_async)` hook (same duck-typed pattern as the existing `warm_up`). Its `close()` (from #225) now additionally invokes the callable's `close()` hook and shuts the loop down (`client aclose → shutdown_asyncgens → loop.close`).
- `_EmbedTextBatch`/`_PromptBatch` only **receive** the `run_async` capability: they never create loops or threads, instantiate the provider runtime *inside* the bound loop (so the SDK client's pool binds to the loop serving every batch), run all paths (retries, chunking, semaphore fan-out, `prompt_batch`) on it, and `close()` releases the provider client on that same loop.
- Provider runtimes gained `async aclose()`: OpenAI embedder/prompter and Anthropic prompter via `await client.close()`, Google embedder/prompter via `await client.aio.aclose()`.
- Explicit shutdown wiring: subprocess actor workers already call `executor.close()` on parent-requested close (#225); task executors close per submit; Ray task generators close at end-of-stream. Ray *actors* have no termination hook in the codebase today — there the loop dies with the actor process, and unlike the previous revision nothing leaks a thread.
- **No compatibility fallbacks** (per maintainer direction): the old `_run_async` (`asyncio.run` + nested-loop bridge thread) is deleted; a wrapper invoked without a bound runtime raises immediately (`_MissingAsyncRuntimeError`, never retried, never swallowed by `on_error`), and `AsyncRuntime.run()` from inside a running loop raises — async callers must `await`.

Wrappers still pickle as capability-less shells (client and `run_async` are process-local), so actor-side unpickling rebinds through the executor.

## Validation

- New `tests/fast/test_ai_async_runtime.py` (18 tests: client created/used on the bound loop, batch/retry/chunking/semaphore loop identity, ordering, unbound-wrapper fail-fast incl. `on_error="ignore"`, close-on-owning-loop + idempotency, pickle clears client+capability, adapter hook forwarding for actor/task backends).
- New `tests/fast/test_udf_async_runtime_executor.py` (9 tests: `AsyncRuntime` lazy loop/reuse/calling-thread execution/close idempotency/asyncgen finalization/nested-use rejection; `UDFExecutor` binds the runtime, batches share one loop on the executor thread, `close()` runs the callable hook and closes the loop, no-op without the hook).
- Direct-invocation call sites in `tests/ai/test_ai_functions.py` / `test_expression_ai_functions.py` now bind a runtime the way the executor does (`_drive` helper).
- Locally (no-duckdb import harness): the new wrapper suite is green and `tests/ai/test_ai_functions.py`'s failure set is byte-identical to `origin/main`'s pre-existing environment-dependent set — zero regressions. Engine-dependent suites are CI-gated as usual; `pre-commit` (ruff check/format, mypy) passes on all changed files.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented in code/docstrings; CHANGELOG intentionally untouched per maintainer guidance.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered (loop state and the run_async capability never pickle; provider clients are closed explicitly at actor shutdown).
- [x] Native changes were compiled; Python-only changes passed relevant tests (Python-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017r1gHYKDHjEyFgmnsJD9JV
