### PR TITLE
[fix](ray) Make result materialization single-flight

### DIFF
--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -137,6 +137,79 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def_readonly("num_rows", &NativePartitionMetadata::num_rows)
 	    .def_readonly("size_bytes", &NativePartitionMetadata::size_bytes);
 
+	m.def(
+	    "ray_backed_result_partition_materialization_for_test",
+	    [](py::object payload, size_t thread_count) {
+		    using duckdb::distributed::python::ray::RayBackedResultPartition;
+
+		    if (thread_count < 2 || thread_count > 64) {
+			    throw InvalidInputException("thread_count must be between 2 and 64");
+		    }
+
+		    auto partition = std::make_shared<RayBackedResultPartition>(std::move(payload), 0, 0, py::none());
+		    std::vector<std::shared_ptr<ColumnDataCollection>> collections(thread_count);
+		    std::vector<std::string> errors(thread_count);
+		    std::atomic<size_t> ready_count {0};
+		    std::atomic<bool> start {false};
+		    std::vector<std::thread> threads;
+		    threads.reserve(thread_count);
+
+		    for (size_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+			    threads.emplace_back([&, thread_idx]() {
+				    ready_count.fetch_add(1, std::memory_order_release);
+				    while (!start.load(std::memory_order_acquire)) {
+					    std::this_thread::yield();
+				    }
+				    try {
+					    PythonGILWrapper gil;
+					    collections[thread_idx] = partition->to_column_data();
+				    } catch (const std::exception &ex) {
+					    errors[thread_idx] = ex.what();
+				    } catch (...) {
+					    errors[thread_idx] = "unknown materialization error";
+				    }
+			    });
+		    }
+
+		    while (ready_count.load(std::memory_order_acquire) != thread_count) {
+			    std::this_thread::yield();
+		    }
+		    {
+			    py::gil_scoped_release release;
+			    start.store(true, std::memory_order_release);
+			    for (auto &thread : threads) {
+				    thread.join();
+			    }
+		    }
+
+		    py::list row_counts;
+		    py::list materialization_errors;
+		    const ColumnDataCollection *first_collection = nullptr;
+		    bool same_collection = true;
+		    for (size_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+			    auto &collection = collections[thread_idx];
+			    row_counts.append(collection ? collection->Count() : 0);
+			    materialization_errors.append(errors[thread_idx]);
+			    if (!collection) {
+				    same_collection = false;
+			    } else if (!first_collection) {
+				    first_collection = collection.get();
+			    } else if (collection.get() != first_collection) {
+				    same_collection = false;
+			    }
+		    }
+
+		    py::dict result;
+		    result["row_counts"] = std::move(row_counts);
+		    result["errors"] = std::move(materialization_errors);
+		    result["same_collection"] = same_collection;
+		    result["num_rows"] = partition->num_rows().value();
+		    result["size_bytes"] = partition->size_bytes().value();
+		    return result;
+	    },
+	    py::arg("payload"), py::arg("thread_count") = 8,
+	    "Exercise concurrent Ray-backed result materialization from GIL-owning native threads.");
+
 	py::class_<NativeDistributedTaskResult>(m, "NativeDistributedTaskResult")
 	    .def(py::init<py::iterable, py::iterable, py::object, py::object, std::string, int, py::object, py::object>(),
 	         py::arg("partition_payloads"), py::arg("partition_metadatas"), py::arg("result_schema"), py::arg("stats"),

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -137,78 +137,16 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def_readonly("num_rows", &NativePartitionMetadata::num_rows)
 	    .def_readonly("size_bytes", &NativePartitionMetadata::size_bytes);
 
-	m.def(
-	    "ray_backed_result_partition_materialization_for_test",
-	    [](py::object payload, size_t thread_count) {
-		    using duckdb::distributed::python::ray::RayBackedResultPartition;
-
-		    if (thread_count < 2 || thread_count > 64) {
-			    throw InvalidInputException("thread_count must be between 2 and 64");
-		    }
-
-		    auto partition = std::make_shared<RayBackedResultPartition>(std::move(payload), 0, 0, py::none());
-		    std::vector<std::shared_ptr<ColumnDataCollection>> collections(thread_count);
-		    std::vector<std::string> errors(thread_count);
-		    std::atomic<size_t> ready_count {0};
-		    std::atomic<bool> start {false};
-		    std::vector<std::thread> threads;
-		    threads.reserve(thread_count);
-
-		    for (size_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
-			    threads.emplace_back([&, thread_idx]() {
-				    ready_count.fetch_add(1, std::memory_order_release);
-				    while (!start.load(std::memory_order_acquire)) {
-					    std::this_thread::yield();
-				    }
-				    try {
-					    PythonGILWrapper gil;
-					    collections[thread_idx] = partition->to_column_data();
-				    } catch (const std::exception &ex) {
-					    errors[thread_idx] = ex.what();
-				    } catch (...) {
-					    errors[thread_idx] = "unknown materialization error";
-				    }
-			    });
-		    }
-
-		    while (ready_count.load(std::memory_order_acquire) != thread_count) {
-			    std::this_thread::yield();
-		    }
-		    {
-			    py::gil_scoped_release release;
-			    start.store(true, std::memory_order_release);
-			    for (auto &thread : threads) {
-				    thread.join();
-			    }
-		    }
-
-		    py::list row_counts;
-		    py::list materialization_errors;
-		    const ColumnDataCollection *first_collection = nullptr;
-		    bool same_collection = true;
-		    for (size_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
-			    auto &collection = collections[thread_idx];
-			    row_counts.append(collection ? collection->Count() : 0);
-			    materialization_errors.append(errors[thread_idx]);
-			    if (!collection) {
-				    same_collection = false;
-			    } else if (!first_collection) {
-				    first_collection = collection.get();
-			    } else if (collection.get() != first_collection) {
-				    same_collection = false;
-			    }
-		    }
-
-		    py::dict result;
-		    result["row_counts"] = std::move(row_counts);
-		    result["errors"] = std::move(materialization_errors);
-		    result["same_collection"] = same_collection;
-		    result["num_rows"] = partition->num_rows().value();
-		    result["size_bytes"] = partition->size_bytes().value();
-		    return result;
-	    },
-	    py::arg("payload"), py::arg("thread_count") = 8,
-	    "Exercise concurrent Ray-backed result materialization from GIL-owning native threads.");
+	using RayBackedResultPartition = duckdb::distributed::python::ray::RayBackedResultPartition;
+	py::class_<RayBackedResultPartition, std::shared_ptr<RayBackedResultPartition>>(m,
+	                                                                                "_RayBackedResultPartitionForTest")
+	    .def(py::init([](py::object payload) {
+		    return std::make_shared<RayBackedResultPartition>(std::move(payload), 0, 0, py::none());
+	    }))
+	    .def("materialize", [](const RayBackedResultPartition &partition) {
+		    auto collection = partition.to_column_data();
+		    return collection ? collection->Count() : 0;
+	    });
 
 	py::class_<NativeDistributedTaskResult>(m, "NativeDistributedTaskResult")
 	    .def(py::init<py::iterable, py::iterable, py::object, py::object, std::string, int, py::object, py::object>(),

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -38,6 +38,21 @@ bool RayTaskPythonRuntimeUsable() {
 	return true;
 }
 
+class ScopedGILReleaseIfHeld {
+public:
+	ScopedGILReleaseIfHeld() {
+		if (RayTaskPythonRuntimeUsable() && PyGILState_Check()) {
+			release_ = std::make_unique<py::gil_scoped_release>();
+		}
+	}
+
+	ScopedGILReleaseIfHeld(const ScopedGILReleaseIfHeld &) = delete;
+	ScopedGILReleaseIfHeld &operator=(const ScopedGILReleaseIfHeld &) = delete;
+
+private:
+	std::unique_ptr<py::gil_scoped_release> release_;
+};
+
 py::object GetLoadedRayModuleOrNone() {
 	auto modules = py::module_::import("sys").attr("modules");
 	if (!py::isinstance<py::dict>(modules)) {
@@ -331,17 +346,33 @@ RayBackedResultPartition::RayBackedResultPartition(py::object object_ref, size_t
 RayBackedResultPartition::~RayBackedResultPartition() = default;
 
 duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::size_bytes() const {
-	if (size_bytes_ == 0 && materialized_collection_) {
-		return duckdb::distributed::DuckDBResult<size_t>::ok(materialized_collection_->SizeInBytes());
+	if (size_bytes_ != 0) {
+		return duckdb::distributed::DuckDBResult<size_t>::ok(size_bytes_);
 	}
-	return duckdb::distributed::DuckDBResult<size_t>::ok(size_bytes_);
+
+	std::shared_ptr<duckdb::ColumnDataCollection> collection;
+	{
+		std::lock_guard<std::mutex> guard(materialize_mutex_);
+		if (materialize_state_ == MaterializationState::READY) {
+			collection = materialized_collection_;
+		}
+	}
+	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->SizeInBytes() : 0);
 }
 
 duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::num_rows() const {
-	if (num_rows_ == 0 && materialized_collection_) {
-		return duckdb::distributed::DuckDBResult<size_t>::ok(materialized_collection_->Count());
+	if (num_rows_ != 0) {
+		return duckdb::distributed::DuckDBResult<size_t>::ok(num_rows_);
 	}
-	return duckdb::distributed::DuckDBResult<size_t>::ok(num_rows_);
+
+	std::shared_ptr<duckdb::ColumnDataCollection> collection;
+	{
+		std::lock_guard<std::mutex> guard(materialize_mutex_);
+		if (materialize_state_ == MaterializationState::READY) {
+			collection = materialized_collection_;
+		}
+	}
+	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->Count() : 0);
 }
 
 py::object RayBackedResultPartition::GetObjectRef() const {
@@ -353,18 +384,64 @@ py::object RayBackedResultPartition::GetLeaseOwner() const {
 }
 
 std::shared_ptr<duckdb::ColumnDataCollection> RayBackedResultPartition::to_column_data() const {
-	if (materialized_collection_) {
-		return materialized_collection_;
+	// Python callers enter with the GIL. Release it before waiting on the
+	// single-flight state so the materializing thread can acquire it.
+	ScopedGILReleaseIfHeld release_gil;
+
+	std::shared_ptr<duckdb::ColumnDataCollection> collection;
+	std::exception_ptr materialize_error;
+	bool materialization_owner = false;
+	{
+		std::unique_lock<std::mutex> guard(materialize_mutex_);
+		materialize_cv_.wait(guard, [this] { return materialize_state_ != MaterializationState::MATERIALIZING; });
+
+		if (materialize_state_ == MaterializationState::READY) {
+			collection = materialized_collection_;
+		} else if (materialize_state_ == MaterializationState::FAILED) {
+			materialize_error = materialize_error_;
+		} else {
+			materialize_state_ = MaterializationState::MATERIALIZING;
+			materialization_owner = true;
+		}
 	}
 
-	std::lock_guard<std::mutex> guard(materialize_mutex_);
-	if (materialized_collection_) {
-		return materialized_collection_;
+	if (!materialization_owner) {
+		if (materialize_error) {
+			std::rethrow_exception(materialize_error);
+		}
+		return collection;
 	}
-	duckdb::PythonGILWrapper gil;
-	auto object_ref = object_ref_.get();
-	materialized_collection_ = MaterializePyPayloadToCollection(object_ref, nullptr);
-	return materialized_collection_;
+
+	try {
+		duckdb::PythonGILWrapper gil;
+		try {
+			auto object_ref = object_ref_.get();
+			collection = MaterializePyPayloadToCollection(object_ref, nullptr);
+		} catch (const py::error_already_set &ex) {
+			// error_already_set owns Python state, so normalize it while the GIL
+			// is held before publishing a failure to native waiters.
+			throw duckdb::InternalException("Failed to materialize Ray result partition: %s", ex.what());
+		}
+	} catch (...) {
+		materialize_error = std::current_exception();
+	}
+
+	{
+		std::lock_guard<std::mutex> guard(materialize_mutex_);
+		if (materialize_error) {
+			materialize_error_ = materialize_error;
+			materialize_state_ = MaterializationState::FAILED;
+		} else {
+			materialized_collection_ = collection;
+			materialize_state_ = MaterializationState::READY;
+		}
+	}
+	materialize_cv_.notify_all();
+
+	if (materialize_error) {
+		std::rethrow_exception(materialize_error);
+	}
+	return collection;
 }
 
 py::object duckdb::distributed::python::ray::ResultPartitionToPyObject(

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -350,13 +350,7 @@ duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::size_bytes()
 		return duckdb::distributed::DuckDBResult<size_t>::ok(size_bytes_);
 	}
 
-	std::shared_ptr<duckdb::ColumnDataCollection> collection;
-	{
-		std::lock_guard<std::mutex> guard(materialize_mutex_);
-		if (materialize_state_ == MaterializationState::READY) {
-			collection = materialized_collection_;
-		}
-	}
+	auto collection = materialized_collection_.load();
 	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->SizeInBytes() : 0);
 }
 
@@ -365,13 +359,7 @@ duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::num_rows() c
 		return duckdb::distributed::DuckDBResult<size_t>::ok(num_rows_);
 	}
 
-	std::shared_ptr<duckdb::ColumnDataCollection> collection;
-	{
-		std::lock_guard<std::mutex> guard(materialize_mutex_);
-		if (materialize_state_ == MaterializationState::READY) {
-			collection = materialized_collection_;
-		}
-	}
+	auto collection = materialized_collection_.load();
 	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->Count() : 0);
 }
 
@@ -384,64 +372,28 @@ py::object RayBackedResultPartition::GetLeaseOwner() const {
 }
 
 std::shared_ptr<duckdb::ColumnDataCollection> RayBackedResultPartition::to_column_data() const {
-	// Python callers enter with the GIL. Release it before waiting on the
-	// single-flight state so the materializing thread can acquire it.
+	// Python callers may enter with the GIL. Release it before call_once waits
+	// so the materializing thread can acquire it.
 	ScopedGILReleaseIfHeld release_gil;
 
-	std::shared_ptr<duckdb::ColumnDataCollection> collection;
-	std::exception_ptr materialize_error;
-	bool materialization_owner = false;
-	{
-		std::unique_lock<std::mutex> guard(materialize_mutex_);
-		materialize_cv_.wait(guard, [this] { return materialize_state_ != MaterializationState::MATERIALIZING; });
-
-		if (materialize_state_ == MaterializationState::READY) {
-			collection = materialized_collection_;
-		} else if (materialize_state_ == MaterializationState::FAILED) {
-			materialize_error = materialize_error_;
-		} else {
-			materialize_state_ = MaterializationState::MATERIALIZING;
-			materialization_owner = true;
-		}
-	}
-
-	if (!materialization_owner) {
-		if (materialize_error) {
-			std::rethrow_exception(materialize_error);
-		}
-		return collection;
-	}
-
-	try {
-		duckdb::PythonGILWrapper gil;
+	std::call_once(materialize_once_, [this] {
 		try {
-			auto object_ref = object_ref_.get();
-			collection = MaterializePyPayloadToCollection(object_ref, nullptr);
-		} catch (const py::error_already_set &ex) {
-			// error_already_set owns Python state, so normalize it while the GIL
-			// is held before publishing a failure to native waiters.
-			throw duckdb::InvalidInputException("Failed to materialize Ray result partition: %s", ex.what());
+			duckdb::PythonGILWrapper gil;
+			try {
+				auto object_ref = object_ref_.get();
+				materialized_collection_.store(MaterializePyPayloadToCollection(object_ref, nullptr));
+			} catch (const py::error_already_set &ex) {
+				throw duckdb::InvalidInputException("Failed to materialize Ray result partition: %s", ex.what());
+			}
+		} catch (...) {
+			materialize_error_ = std::current_exception();
 		}
-	} catch (...) {
-		materialize_error = std::current_exception();
-	}
+	});
 
-	{
-		std::lock_guard<std::mutex> guard(materialize_mutex_);
-		if (materialize_error) {
-			materialize_error_ = materialize_error;
-			materialize_state_ = MaterializationState::FAILED;
-		} else {
-			materialized_collection_ = collection;
-			materialize_state_ = MaterializationState::READY;
-		}
+	if (materialize_error_) {
+		std::rethrow_exception(materialize_error_);
 	}
-	materialize_cv_.notify_all();
-
-	if (materialize_error) {
-		std::rethrow_exception(materialize_error);
-	}
-	return collection;
+	return materialized_collection_.load();
 }
 
 py::object duckdb::distributed::python::ray::ResultPartitionToPyObject(

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -420,7 +420,7 @@ std::shared_ptr<duckdb::ColumnDataCollection> RayBackedResultPartition::to_colum
 		} catch (const py::error_already_set &ex) {
 			// error_already_set owns Python state, so normalize it while the GIL
 			// is held before publishing a failure to native waiters.
-			throw duckdb::InternalException("Failed to materialize Ray result partition: %s", ex.what());
+			throw duckdb::InvalidInputException("Failed to materialize Ray result partition: %s", ex.what());
 		}
 	} catch (...) {
 		materialize_error = std::current_exception();

--- a/src/duckdb_py/ray/task.hpp
+++ b/src/duckdb_py/ray/task.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
-#include <condition_variable>
+#include <atomic>
 #include <exception>
 #include <memory>
 #include <vector>
@@ -146,16 +146,12 @@ public:
 	}
 
 private:
-	enum class MaterializationState : uint8_t { UNMATERIALIZED, MATERIALIZING, READY, FAILED };
-
 	duckdb::distributed::python::ray::SafePyObject object_ref_;
 	duckdb::distributed::python::ray::SafePyObject lease_owner_;
 	size_t num_rows_;
 	size_t size_bytes_;
-	mutable std::mutex materialize_mutex_;
-	mutable std::condition_variable materialize_cv_;
-	mutable MaterializationState materialize_state_ = MaterializationState::UNMATERIALIZED;
-	mutable std::shared_ptr<duckdb::ColumnDataCollection> materialized_collection_;
+	mutable std::once_flag materialize_once_;
+	mutable std::atomic<std::shared_ptr<duckdb::ColumnDataCollection>> materialized_collection_;
 	mutable std::exception_ptr materialize_error_;
 };
 

--- a/src/duckdb_py/ray/task.hpp
+++ b/src/duckdb_py/ray/task.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <condition_variable>
+#include <exception>
 #include <memory>
 #include <vector>
 
@@ -144,12 +146,17 @@ public:
 	}
 
 private:
+	enum class MaterializationState : uint8_t { UNMATERIALIZED, MATERIALIZING, READY, FAILED };
+
 	duckdb::distributed::python::ray::SafePyObject object_ref_;
 	duckdb::distributed::python::ray::SafePyObject lease_owner_;
 	size_t num_rows_;
 	size_t size_bytes_;
 	mutable std::mutex materialize_mutex_;
+	mutable std::condition_variable materialize_cv_;
+	mutable MaterializationState materialize_state_ = MaterializationState::UNMATERIALIZED;
 	mutable std::shared_ptr<duckdb::ColumnDataCollection> materialized_collection_;
+	mutable std::exception_ptr materialize_error_;
 };
 
 std::shared_ptr<duckdb::ColumnDataCollection>

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -30,10 +30,12 @@ def _make_test_physical_plan(con=None):
 
 
 @pytest.mark.parametrize("should_fail", [False, True], ids=["success", "failure"])
-def test_ray_backed_result_partition_materialization_is_single_flight(should_fail):
+def test_ray_backed_result_partition_concurrent_materialization(should_fail):
     script = textwrap.dedent(
         f"""
+        import concurrent.futures
         import json
+        import threading
         import time
 
         import duckdb
@@ -52,9 +54,23 @@ def test_ray_backed_result_partition_materialization_is_single_flight(should_fai
                     raise RuntimeError("materialization boom")
                 return pa.table({{"value": [1, 2, 3]}})
 
+        thread_count = 8
         payload = Payload()
-        result = duckdb.ray_cxx.ray_backed_result_partition_materialization_for_test(payload, 8)
-        print(json.dumps({{"calls": payload.calls, "result": result}}, sort_keys=True))
+        partition = duckdb.ray_cxx._RayBackedResultPartitionForTest(payload)
+        barrier = threading.Barrier(thread_count)
+
+        def materialize():
+            barrier.wait()
+            try:
+                return {{"rows": partition.materialize(), "error": "", "error_type": ""}}
+            except Exception as ex:
+                return {{"rows": 0, "error": str(ex), "error_type": type(ex).__name__}}
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
+            futures = [executor.submit(materialize) for _ in range(thread_count)]
+            results = [future.result() for future in futures]
+
+        print(json.dumps({{"calls": payload.calls, "results": results}}, sort_keys=True))
         """
     )
 
@@ -67,20 +83,16 @@ def test_ray_backed_result_partition_materialization_is_single_flight(should_fai
 
     assert completed.returncode == 0, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
     observed = json.loads(completed.stdout.strip().splitlines()[-1])
-    assert observed["calls"] == 1
-
-    result = observed["result"]
+    results = observed["results"]
     if should_fail:
-        assert result["row_counts"] == [0] * 8
-        assert result["same_collection"] is False
-        assert all("materialization boom" in error for error in result["errors"])
-        assert {json.loads(error)["exception_type"] for error in result["errors"]} == {"Invalid Input"}
+        assert observed["calls"] == 1
+        assert [result["rows"] for result in results] == [0] * 8
+        assert all("materialization boom" in result["error"] for result in results)
+        assert {result["error_type"] for result in results} == {"InvalidInputException"}
     else:
-        assert result["row_counts"] == [3] * 8
-        assert result["errors"] == [""] * 8
-        assert result["same_collection"] is True
-        assert result["num_rows"] == 3
-        assert result["size_bytes"] > 0
+        assert observed["calls"] == 1
+        assert [result["rows"] for result in results] == [3] * 8
+        assert [result["error"] for result in results] == [""] * 8
 
 
 def test_distributed_physical_plan_inspectors():

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -29,6 +29,59 @@ def _make_test_physical_plan(con=None):
     ).to_physical_plan(con)
 
 
+@pytest.mark.parametrize("should_fail", [False, True], ids=["success", "failure"])
+def test_ray_backed_result_partition_materialization_is_single_flight(should_fail):
+    script = textwrap.dedent(
+        f"""
+        import json
+        import time
+
+        import duckdb
+        import pyarrow as pa
+
+        should_fail = {should_fail!r}
+
+        class Payload:
+            def __init__(self):
+                self.calls = 0
+
+            def to_arrow(self):
+                self.calls += 1
+                time.sleep(0.2)
+                if should_fail:
+                    raise RuntimeError("materialization boom")
+                return pa.table({{"value": [1, 2, 3]}})
+
+        payload = Payload()
+        result = duckdb.ray_cxx.ray_backed_result_partition_materialization_for_test(payload, 8)
+        print(json.dumps({{"calls": payload.calls, "result": result}}, sort_keys=True))
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert completed.returncode == 0, f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    observed = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert observed["calls"] == 1
+
+    result = observed["result"]
+    if should_fail:
+        assert result["row_counts"] == [0] * 8
+        assert result["same_collection"] is False
+        assert all("materialization boom" in error for error in result["errors"])
+    else:
+        assert result["row_counts"] == [3] * 8
+        assert result["errors"] == [""] * 8
+        assert result["same_collection"] is True
+        assert result["num_rows"] == 3
+        assert result["size_bytes"] > 0
+
+
 def test_distributed_physical_plan_inspectors():
     con = duckdb.connect()
     plan = _make_test_physical_plan(con)

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -74,6 +74,7 @@ def test_ray_backed_result_partition_materialization_is_single_flight(should_fai
         assert result["row_counts"] == [0] * 8
         assert result["same_collection"] is False
         assert all("materialization boom" in error for error in result["errors"])
+        assert {json.loads(error)["exception_type"] for error in result["errors"]} == {"Invalid Input"}
     else:
         assert result["row_counts"] == [3] * 8
         assert result["errors"] == [""] * 8


### PR DESCRIPTION
## Summary

- Replace the racy double-checked `materialized_collection_` cache with `std::call_once` and atomic `shared_ptr` publication.
- Release a caller-held GIL before `call_once` can wait, then perform Python, Ray, and Arrow materialization without holding a Vane mutex.
- Cache the normalized materialization exception inside the once initializer so every waiter receives the same `InvalidInputException` without a hand-written state machine.
- Keep only a thin internal partition binding for tests; Python `ThreadPoolExecutor` and `Barrier` now provide the concurrent test orchestration.

## Related issue

close: #59

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

This changes internal Ray result-partition synchronization only.

## Validation

- `python -m pytest tests/fast/test_ray_cpp_bindings.py -k ray_backed_result_partition_concurrent_materialization -vv` — 2 passed.
- Ten consecutive runs of the concurrent success/failure regression — 20 passed.
- `python -m pytest tests/fast/test_ray_cpp_bindings.py -q` — 73 passed, 4 deselected.
- `python -m pytest tests/fast/test_ray_result_contract.py -q` — 90 passed.
- `scripts/run_release_tests.sh` — 268 passed / 9 deselected in the non-Ray shard; 5 passed / 272 deselected in the real-Ray shard.
- `pre-commit run --files src/duckdb_py/ray/task.hpp src/duckdb_py/ray/task.cpp src/duckdb_py/ray/ray_module.cpp tests/fast/test_ray_cpp_bindings.py` — passed.
- Rebuilt an independent package with `ENABLE_THREAD_SANITIZER=ON`, `ENABLE_SANITIZER=OFF`, and `ENABLE_UBSAN=OFF`. Direct 8-thread success and failure checks both exited 0 under TSAN. The GCC TSAN process used ASLR-disabled execution to avoid its host `unexpected memory mapping` startup failure; the success check limited Arrow CPU and I/O pools to one thread to isolate this synchronization path.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.