### PR TITLE
[fix](ai) Remove the library-owned Anthropic default model (#167)

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1051,14 +1051,22 @@ class TestAnthropicProvider:
         desc = provider.get_prompter(model="claude-call-model")
         assert desc.model_name == "claude-call-model"
 
-    def test_options_model_key_overrides_provider_prompt_model(self):
-        """A model key in call options beats provider-level prompt_model."""
+    @pytest.mark.parametrize("model", ["", "   "])
+    def test_blank_call_model_rejected(self, model):
+        """A blank call-site model is an error, not a provider-config fallback."""
         from vane.ai.providers.anthropic import AnthropicProvider
 
         provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
-        desc = provider.get_prompter(**{"model": "claude-options-model"})
-        assert desc.model_name == "claude-options-model"
-        assert "model" not in desc.prompt_options
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_prompter(model=model)
+
+    def test_blank_provider_prompt_model_rejected(self):
+        """A blank provider-level prompt_model fails at expression-build time."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key", prompt_model="")
+        with pytest.raises(ValueError, match="non-empty string"):
+            provider.get_prompter()
 
     def test_ctor_prompt_model_is_keyword_only(self):
         """prompt_model must be passed by name; positional use is a TypeError."""

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -725,7 +725,12 @@ class TestUDFExecutionOptions:
 
         assert OpenAITextEmbedderDescriptor(embed_options={"num_gpus": 1}).get_udf_options().num_gpus == 1
         assert OpenAIPrompterDescriptor(prompt_options={"num_gpus": 2}).get_udf_options().num_gpus == 2
-        assert AnthropicPrompterDescriptor(prompt_options={"num_gpus": 3}).get_udf_options().num_gpus == 3
+        assert (
+            AnthropicPrompterDescriptor(model_name="claude-test-model", prompt_options={"num_gpus": 3})
+            .get_udf_options()
+            .num_gpus
+            == 3
+        )
         assert (
             GoogleTextEmbedderDescriptor(model_name="gemini-embedding-001", embed_options={"num_gpus": 4})
             .get_udf_options()
@@ -962,7 +967,7 @@ class TestAnthropicProvider:
         """Anthropic descriptor produces correct UDFOptions."""
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor()
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model")
         opts = desc.get_udf_options()
         assert opts.max_api_concurrency == 16
 
@@ -990,6 +995,7 @@ class TestAnthropicProvider:
 
         provider = AnthropicProvider(api_key="ctor-key", base_url="https://ctor.example")
         desc = provider.get_prompter(
+            model="claude-test-model",
             api_key="call-key",
             base_url="https://call.example",
             timeout=30,
@@ -1007,6 +1013,66 @@ class TestAnthropicProvider:
         assert "base_url" not in desc.prompt_options
         assert desc.prompt_options["max_api_concurrency"] == 6
         assert desc.prompt_options["temperature"] == 0
+
+    def test_descriptor_requires_model_name(self):
+        """AnthropicPrompterDescriptor.model_name is required."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(TypeError):
+            AnthropicPrompterDescriptor()
+
+    def test_get_prompter_without_model_raises(self):
+        """Missing model fails fast, naming both fix paths."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key")
+        with pytest.raises(ValueError, match="No prompt model configured") as excinfo:
+            provider.get_prompter()
+        message = str(excinfo.value)
+        assert "model=" in message
+        assert "AnthropicProvider(prompt_model=" in message
+
+    def test_provider_prompt_model_flows_through(self):
+        """Provider-level prompt_model configures the descriptor model."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        desc = provider.get_prompter()
+        assert desc.model_name == "claude-config-model"
+        # prompt_model is provider-level config, never a request option.
+        assert "prompt_model" not in desc.prompt_options
+        assert "prompt_model" not in desc.provider_options
+
+    def test_call_model_overrides_provider_prompt_model(self):
+        """Call-site model beats provider-level prompt_model."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        desc = provider.get_prompter(model="claude-call-model")
+        assert desc.model_name == "claude-call-model"
+
+    def test_options_model_key_overrides_provider_prompt_model(self):
+        """A model key in call options beats provider-level prompt_model."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        desc = provider.get_prompter(**{"model": "claude-options-model"})
+        assert desc.model_name == "claude-options-model"
+        assert "model" not in desc.prompt_options
+
+    def test_ctor_prompt_model_is_keyword_only(self):
+        """prompt_model must be passed by name; positional use is a TypeError."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        with pytest.raises(TypeError):
+            AnthropicProvider("anthropic", "claude-config-model")
+
+    def test_ctor_typo_is_a_type_error(self):
+        """A misspelled ctor kwarg raises immediately instead of leaking into request options."""
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        with pytest.raises(TypeError):
+            AnthropicProvider(api_key="test-key", promt_model="claude-config-model")
 
 
 # ---------------------------------------------------------------------------
@@ -1458,19 +1524,19 @@ class TestAnthropicStructuredOutput:
     def test_descriptor_has_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(return_format=dict)
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", return_format=dict)
         assert desc.return_format is dict
 
     def test_descriptor_default_no_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor()
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model")
         assert desc.return_format is None
 
     def test_descriptor_pickle_with_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(return_format=dict)
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", return_format=dict)
         restored = pickle.loads(pickle.dumps(desc))
         assert restored.return_format is dict
 
@@ -1478,7 +1544,7 @@ class TestAnthropicStructuredOutput:
         from vane.ai.providers.anthropic import AnthropicProvider
 
         prov = AnthropicProvider(api_key="test")
-        desc = prov.get_prompter(return_format=dict)
+        desc = prov.get_prompter(model="claude-test-model", return_format=dict)
         assert desc.return_format is dict
 
     @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -108,18 +108,24 @@ class AnthropicProvider(Provider):
     ) -> PrompterDescriptor:
         """Build a prompter descriptor for an explicitly selected model.
 
-        The model resolves as: call-site ``model`` (including a ``model``
-        key in ``options``) > provider ``prompt_model`` configuration.
+        The model resolves as: call-site ``model`` > provider
+        ``prompt_model`` configuration; the selected value must be a
+        non-empty string.
 
         Raises:
-            ValueError: If no model is configured through either path.
+            ValueError: If no model is configured through either path, or
+                the selected model is not a non-empty string.
         """
         provider_options, prompt_options = self._split_options(options)
-        option_model = prompt_options.pop("model", None)
-        model_name = model or option_model or self._prompt_model
+        model_name = model if model is not None else self._prompt_model
         if model_name is None:
             raise ValueError(
                 "No prompt model configured for the Anthropic provider. "
+                "Pass model=... or configure AnthropicProvider(prompt_model=...)."
+            )
+        if not isinstance(model_name, str) or not model_name.strip():
+            raise ValueError(
+                f"Anthropic prompt model must be a non-empty string, got {model_name!r}. "
                 "Pass model=... or configure AnthropicProvider(prompt_model=...)."
             )
         return AnthropicPrompterDescriptor(

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -7,6 +7,10 @@ Supports prompting via the Anthropic Messages API with multimodal input
 (text + images) and structured output via tool_use. Anthropic does not
 offer an embedding API, so only ``get_prompter`` is implemented.
 
+Vane does not ship a default Anthropic model: the model must be supplied
+per call (``model=...``) or configured on the provider
+(``AnthropicProvider(prompt_model=...)``); the per-call model wins.
+
 Requires::
 
     pip install 'vane-ai[anthropic]'
@@ -42,14 +46,48 @@ def _guess_media_type(data: bytes) -> str:
 
 
 class AnthropicProvider(Provider):
-    """Provider backed by the Anthropic Messages API."""
+    """Provider backed by the Anthropic Messages API.
 
-    DEFAULT_MODEL = "claude-sonnet-4-20250514"
+    Vane does not choose an Anthropic model for you. Configure an
+    application-owned model via ``prompt_model=...`` here, or pass
+    ``model=...`` on each call; the per-call model takes precedence.
+
+    Args:
+        name: Optional display-name override (default ``"anthropic"``).
+        api_key: Anthropic API key. Prefer the ``ANTHROPIC_API_KEY``
+            environment variable over passing keys in code.
+        base_url: Optional API endpoint override.
+        timeout: Optional client timeout forwarded to the Anthropic client.
+        max_retries: Optional client retry count forwarded to the Anthropic
+            client.
+        prompt_model: Model used by ``get_prompter`` when the call does not
+            pass ``model=...``.
+
+    All parameters are named; a mistyped keyword raises :class:`TypeError`
+    instead of silently leaking into API request options.
+    """
+
     _CLIENT_KEYS: ClassVar[frozenset[str]] = frozenset({"api_key", "base_url", "timeout", "max_retries"})
 
-    def __init__(self, name: str | None = None, **options: Any):
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: Any = None,
+        max_retries: int | None = None,
+        prompt_model: str | None = None,
+    ):
         self._name = name or "anthropic"
-        self._options: dict[str, Any] = options
+        self._prompt_model = prompt_model
+        client_options = {
+            "api_key": api_key,
+            "base_url": base_url,
+            "timeout": timeout,
+            "max_retries": max_retries,
+        }
+        self._options: dict[str, Any] = {k: v for k, v in client_options.items() if v is not None}
 
     @property
     def name(self) -> str:
@@ -68,11 +106,26 @@ class AnthropicProvider(Provider):
         return_format: Any | None = None,
         **options: Any,
     ) -> PrompterDescriptor:
+        """Build a prompter descriptor for an explicitly selected model.
+
+        The model resolves as: call-site ``model`` (including a ``model``
+        key in ``options``) > provider ``prompt_model`` configuration.
+
+        Raises:
+            ValueError: If no model is configured through either path.
+        """
         provider_options, prompt_options = self._split_options(options)
+        option_model = prompt_options.pop("model", None)
+        model_name = model or option_model or self._prompt_model
+        if model_name is None:
+            raise ValueError(
+                "No prompt model configured for the Anthropic provider. "
+                "Pass model=... or configure AnthropicProvider(prompt_model=...)."
+            )
         return AnthropicPrompterDescriptor(
             provider_name=self._name,
             provider_options=provider_options,
-            model_name=model or prompt_options.pop("model", self.DEFAULT_MODEL),
+            model_name=model_name,
             system_message=system_message,
             return_format=return_format,
             prompt_options=prompt_options,
@@ -83,13 +136,14 @@ class AnthropicProvider(Provider):
 class AnthropicPrompterDescriptor(PrompterDescriptor):
     """Serializable factory for an Anthropic Messages API prompter.
 
-    Supports structured output via Anthropic's ``tool_use`` mechanism
-    and multimodal input (text + images).
+    ``model_name`` is required — Vane does not ship a default Anthropic
+    model. Supports structured output via Anthropic's ``tool_use``
+    mechanism and multimodal input (text + images).
     """
 
+    model_name: str
     provider_name: str = "anthropic"
     provider_options: dict[str, Any] = field(default_factory=dict)
-    model_name: str = "claude-sonnet-4-20250514"
     system_message: str | None = None
     return_format: Any | None = None
     prompt_options: dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary

Per maintainer direction on #167 and this PR, Vane no longer ships a default Anthropic model. Instead of bumping the retired `claude-sonnet-4-20250514` to another hard-coded id, this PR removes the library-owned default entirely, so model retirements can never again break the provider out of the box, and upgrading Vane can never silently change which model a pipeline calls.

The explicit-model contract:

- `DEFAULT_MODEL` is deleted.
- The model resolves as **call-site `model=...` > `AnthropicProvider(prompt_model=...)` constructor configuration > error**, using explicit `is not None` checks so a call-site value always wins. (An options-mapping `model` key is not a supported channel: `model` binds to the explicit `get_prompter()` parameter before `**options` can ever see it, so the previously advertised branch was unreachable and has been removed per review.)
- A missing model fails fast at expression-build time with a `ValueError` naming both fix paths: `"No prompt model configured for the Anthropic provider. Pass model=... or configure AnthropicProvider(prompt_model=...)."` A blank or whitespace-only model (call-site or provider-level) is likewise rejected at expression-build time instead of surfacing at the remote API.
- The constructor is now fully named (`api_key`, `base_url`, `timeout`, `max_retries`, `prompt_model` — all keyword-only, mirroring the Google provider in #161): provider-level settings are never forwarded into API request options, and a misspelled kwarg raises `TypeError` at construction instead of silently leaking into requests.
- `AnthropicPrompterDescriptor.model_name` is now a required field (no dataclass default), so descriptor defaults and provider constants cannot drift apart again.

This PR is deliberately minimal (no-default only). The strict option-surface contract — full option forwarding/validation, per-model capability checks, and the explicit `max_tokens` chain — follows in a stacked PR closing #146. The same no-default policy lands for Google in #161 (#141).

No backward compatibility, deprecation window, or fallback model is included, per maintainer direction (early-stage project).

## Related issue

close: #167

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The explicit-model contract is documented in the provider module/class docstrings updated in this PR. No published docs pin an Anthropic default model id.

## Validation

- Stub-harness runs (local venv, `anthropic` 0.117.0 installed; duckdb-engine-dependent tests and one Pillow-dependent test are environment-blocked and fail identically on `origin/main`):
  - `pytest -p vane_pkg_stub_plugin --noconftest tests/ai/test_ai_functions.py -k "TestAnthropicProvider or TestAnthropicStructuredOutput or TestAnthropicMultimodal or TestUDFExecutionOptions"` (minus the two environment-blocked tests): **31 passed**.
  - Full `tests/ai/test_ai_functions.py`: 214 passed, 16 environment-blocked failures — the identical 16 fail on `origin/main` (baseline: 205 passed / 16 failed).
  - `tests/ai/test_descriptor_secret_redaction.py`, `tests/fast/test_ai_options_repr.py`, `tests/ai/test_expression_ai_functions.py`: failure set identical to `origin/main` (duckdb-engine stubs), all other tests pass.
- New tests pin: missing-model `ValueError` with both fix paths; `model=` flow-through; `AnthropicProvider(prompt_model=...)` flow-through; call-site beating provider config; blank/whitespace-only model rejection (empty call-site model with provider config, and empty provider-level model); `model_name` required on the descriptor; keyword-only `prompt_model` (positional use is a `TypeError`); a misspelled `promt_model=` kwarg is a `TypeError` (the constructor has no `**options` channel). No new default is pinned.
- `ruff check` / `ruff format --check` clean; pre-commit hooks passed on commit.

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (None added.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (No new surface; the change removes
      an implicit request parameter and adds pre-dispatch validation.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. (Python-only; ruff + pre-commit clean, stub-harness
      tests pass locally, full suite delegated to CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXGCZZzpBqP7D1kivLJABc

