### PR TITLE
[fix](ai) Harden OpenAI embedder input handling and token estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,6 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 
 - Released per-database runner cache entries after relation write failures
   without resetting the process-wide runner used by other queries.
-- OpenAI embedder: empty or whitespace-only rows are no longer sent to the
-  API (the API rejects empty strings, failing the whole batch); they receive
-  deterministic zero-vector placeholders, or nulls when the embedding
-  dimension is unknowable.
-- OpenAI embedder token estimation counts each non-ASCII character as a full
-  token, so CJK text is chunked conservatively instead of being sent
-  oversized.
-- Chunks of oversized embedding inputs are sent through the same
-  token-limited request batching instead of one unbounded request, and
-  chunk-averaged embeddings are float32 like normal rows.
-- Non-positive `batch_token_limit`/`input_text_token_limit` values are
-  rejected early, and a legitimate token usage of 0 is recorded as 0 instead
-  of null.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,18 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 
 - Released per-database runner cache entries after relation write failures
   without resetting the process-wide runner used by other queries.
-- Hardened OpenAI embedder input handling: empty or whitespace-only rows are
-  no longer sent to the API (OpenAI rejects them, failing the whole batch) and
-  instead receive deterministic zero-vector placeholders, or nulls when the
-  embedding dimension is unknowable; token estimation now counts each
-  non-ASCII character as a full token, so CJK text is chunked conservatively
-  instead of being sent oversized; chunks of oversized inputs are embedded
-  through the same token-limited request batching instead of one unbounded
-  request; chunk-averaged embeddings are float32 like normal rows;
-  non-positive `batch_token_limit`/`input_text_token_limit` values are
-  rejected early; and a legitimate token usage of 0 is recorded as 0 instead
+- OpenAI embedder: empty or whitespace-only rows are no longer sent to the
+  API (the API rejects empty strings, failing the whole batch); they receive
+  deterministic zero-vector placeholders, or nulls when the embedding
+  dimension is unknowable.
+- OpenAI embedder token estimation counts each non-ASCII character as a full
+  token, so CJK text is chunked conservatively instead of being sent
+  oversized.
+- Chunks of oversized embedding inputs are sent through the same
+  token-limited request batching instead of one unbounded request, and
+  chunk-averaged embeddings are float32 like normal rows.
+- Non-positive `batch_token_limit`/`input_text_token_limit` values are
+  rejected early, and a legitimate token usage of 0 is recorded as 0 instead
   of null.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 
 - Released per-database runner cache entries after relation write failures
   without resetting the process-wide runner used by other queries.
+- Hardened OpenAI embedder input handling: empty or whitespace-only rows are
+  no longer sent to the API (OpenAI rejects them, failing the whole batch) and
+  instead receive deterministic zero-vector placeholders, or nulls when the
+  embedding dimension is unknowable; token estimation now counts each
+  non-ASCII character as a full token, so CJK text is chunked conservatively
+  instead of being sent oversized; chunks of oversized inputs are embedded
+  through the same token-limited request batching instead of one unbounded
+  request; chunk-averaged embeddings are float32 like normal rows;
+  non-positive `batch_token_limit`/`input_text_token_limit` values are
+  rejected early; and a legitimate token usage of 0 is recorded as 0 instead
+  of null.
 
 ### Security
 

--- a/tests/fast/test_openai_embedder_input_handling.py
+++ b/tests/fast/test_openai_embedder_input_handling.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Input-handling tests for the OpenAI embedder (issue #144).
+
+Covers empty-row splicing, conservative CJK token estimation, token-limited
+batching of oversized-input chunks, float32 dtype consistency, token-limit
+validation, and zero-usage metrics recording.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import vane.ai.metrics as ai_metrics
+from vane.ai.providers.openai import OpenAIPrompter, OpenAITextEmbedder
+
+
+class FakeOpenAIError(Exception):
+    pass
+
+
+class FakeEmbeddingServer:
+    """Records embeddings.create requests; embeds text ``t`` as ``[len(t)] * dim``.
+
+    Mirrors the real API's rejection of empty-string inputs: one empty input
+    fails the entire request.
+    """
+
+    def __init__(self, dim: int = 8):
+        self.dim = dim
+        self.requests: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.requests.append(kwargs)
+        texts = kwargs["input"]
+        if any(t == "" for t in texts):
+            raise FakeOpenAIError("'$.input' is invalid: empty string")
+        dim = kwargs.get("dimensions", self.dim)
+        data = [SimpleNamespace(embedding=[float(len(t))] * dim) for t in texts]
+        return SimpleNamespace(data=data, usage=None)
+
+
+def _install_fake_openai(monkeypatch, server):
+    def fake_async_openai(**_kwargs):
+        return SimpleNamespace(embeddings=SimpleNamespace(create=server.create))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(AsyncOpenAI=fake_async_openai, OpenAIError=FakeOpenAIError),
+    )
+
+
+def _make_embedder(monkeypatch, server, **kwargs):
+    _install_fake_openai(monkeypatch, server)
+    return OpenAITextEmbedder(provider_options={"api_key": "test-key"}, **kwargs)
+
+
+def test_empty_and_null_rows_are_spliced_not_sent(monkeypatch):
+    server = FakeEmbeddingServer()
+    embedder = _make_embedder(monkeypatch, server, model="text-embedding-3-small", dimensions=4)
+
+    result = asyncio.run(embedder.embed_text(["alpha", "", "beta", None, "   \n"]))
+
+    assert [req["input"] for req in server.requests] == [["alpha", "beta"]]
+    assert len(result) == 5
+    np.testing.assert_array_equal(result[0], np.full(4, 5.0, dtype=np.float32))
+    np.testing.assert_array_equal(result[2], np.full(4, 4.0, dtype=np.float32))
+    for position in (1, 3, 4):
+        assert result[position].dtype == np.float32
+        np.testing.assert_array_equal(result[position], np.zeros(4, dtype=np.float32))
+
+
+def test_all_empty_rows_use_model_dimension_table(monkeypatch):
+    server = FakeEmbeddingServer()
+    embedder = _make_embedder(monkeypatch, server, model="text-embedding-3-small")
+
+    result = asyncio.run(embedder.embed_text(["", None]))
+
+    assert server.requests == []
+    assert len(result) == 2
+    for row in result:
+        assert row.dtype == np.float32
+        assert row.shape == (1536,)
+        assert not row.any()
+
+
+def test_all_empty_rows_unknown_model_fall_back_to_none(monkeypatch):
+    server = FakeEmbeddingServer()
+    embedder = _make_embedder(monkeypatch, server, model="custom-model")
+
+    result = asyncio.run(embedder.embed_text(["", "  "]))
+
+    assert server.requests == []
+    assert result == [None, None]
+
+
+def test_empty_row_dimension_inferred_from_first_embedding(monkeypatch):
+    server = FakeEmbeddingServer(dim=8)
+    embedder = _make_embedder(monkeypatch, server, model="custom-model")
+
+    result = asyncio.run(embedder.embed_text(["", "hello"]))
+
+    assert [req["input"] for req in server.requests] == [["hello"]]
+    np.testing.assert_array_equal(result[0], np.zeros(8, dtype=np.float32))
+    np.testing.assert_array_equal(result[1], np.full(8, 5.0, dtype=np.float32))
+
+
+def test_cjk_text_estimate_triggers_conservative_chunking(monkeypatch):
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="custom-model",
+        input_text_token_limit=100,
+    )
+    # CJK runs ~1 token per char: 250 real tokens. The old ``len // 3``
+    # estimate said 83 tokens and sent it whole, over the limit.
+    text = "汉" * 250
+
+    result = asyncio.run(embedder.embed_text([text]))
+
+    sent = [t for req in server.requests for t in req["input"]]
+    assert len(sent) > 1  # chunked
+    assert all(len(chunk) <= 100 for chunk in sent)  # each chunk within the limit
+    assert "".join(sent) == text
+    assert len(result) == 1
+    assert result[0].dtype == np.float32
+    np.testing.assert_allclose(np.linalg.norm(result[0]), 1.0, atol=1e-6)
+
+
+def test_oversized_chunks_respect_batch_token_limit(monkeypatch):
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="custom-model",
+        input_text_token_limit=10,
+        batch_token_limit=15,
+    )
+    text = "a" * 90  # 30 estimated tokens: chunked, chunks must not share one request
+
+    result = asyncio.run(embedder.embed_text([text]))
+
+    assert len(server.requests) >= 2
+    for req in server.requests:
+        assert sum(len(t) for t in req["input"]) // 3 < 15
+    assert "".join(t for req in server.requests for t in req["input"]) == text
+    assert len(result) == 1
+
+
+def test_oversized_average_is_float32(monkeypatch):
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="custom-model",
+        input_text_token_limit=10,
+    )
+
+    result = asyncio.run(embedder.embed_text(["a" * 90]))
+
+    assert len(result) == 1
+    assert result[0].dtype == np.float32
+
+
+def test_row_order_preserved_with_empty_oversized_and_normal_rows(monkeypatch):
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="text-embedding-3-small",
+        dimensions=4,
+        input_text_token_limit=100,
+    )
+    oversized = "汉" * 250
+
+    result = asyncio.run(embedder.embed_text(["alpha", "", oversized, "beta"]))
+
+    assert len(result) == 4
+    np.testing.assert_array_equal(result[0], np.full(4, 5.0, dtype=np.float32))
+    np.testing.assert_array_equal(result[1], np.zeros(4, dtype=np.float32))
+    np.testing.assert_allclose(np.linalg.norm(result[2]), 1.0, atol=1e-6)
+    np.testing.assert_array_equal(result[3], np.full(4, 4.0, dtype=np.float32))
+    # Non-empty rows are sent exactly once, in order.
+    sent = [t for req in server.requests for t in req["input"]]
+    assert sent[0] == "alpha"
+    assert sent[-1] == "beta"
+    assert "".join(sent[1:-1]) == oversized
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"batch_token_limit": 0},
+        {"batch_token_limit": -1},
+        {"input_text_token_limit": 0},
+        {"input_text_token_limit": -5},
+    ],
+)
+def test_non_positive_token_limits_are_rejected(monkeypatch, limits):
+    server = FakeEmbeddingServer()
+    _install_fake_openai(monkeypatch, server)
+
+    with pytest.raises(ValueError, match="token_limit"):
+        OpenAITextEmbedder(provider_options={"api_key": "test-key"}, model="custom-model", **limits)
+
+
+def test_prompter_records_legitimate_zero_usage(monkeypatch):
+    _install_fake_openai(monkeypatch, FakeEmbeddingServer())
+    recorded: list[dict] = []
+    monkeypatch.setattr(ai_metrics, "record_token_metrics", lambda **kwargs: recorded.append(kwargs))
+    prompter = OpenAIPrompter(provider_options={"api_key": "test-key"}, model="gpt-4o-mini")
+
+    usage = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    prompter._record_usage(SimpleNamespace(usage=usage))
+
+    assert recorded == [
+        {
+            "protocol": "prompt",
+            "model": "gpt-4o-mini",
+            "provider": "openai",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
+    ]
+
+
+def test_prompter_usage_falls_back_to_responses_api_fields(monkeypatch):
+    _install_fake_openai(monkeypatch, FakeEmbeddingServer())
+    recorded: list[dict] = []
+    monkeypatch.setattr(ai_metrics, "record_token_metrics", lambda **kwargs: recorded.append(kwargs))
+    prompter = OpenAIPrompter(provider_options={"api_key": "test-key"}, model="gpt-4o-mini")
+
+    usage = SimpleNamespace(input_tokens=30, output_tokens=15, total_tokens=45)
+    prompter._record_usage(SimpleNamespace(usage=usage))
+
+    assert recorded[0]["input_tokens"] == 30
+    assert recorded[0]["output_tokens"] == 15
+    assert recorded[0]["total_tokens"] == 45

--- a/tests/fast/test_openai_embedder_input_handling.py
+++ b/tests/fast/test_openai_embedder_input_handling.py
@@ -153,6 +153,27 @@ def test_oversized_chunks_respect_batch_token_limit(monkeypatch):
     assert len(result) == 1
 
 
+def test_inverted_limits_still_bound_each_request(monkeypatch):
+    """input_text_token_limit above batch_token_limit must not produce over-limit requests."""
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="custom-model",
+        input_text_token_limit=40,
+        batch_token_limit=10,
+    )
+    text = "a" * 150  # 50 estimated tokens: oversized, but chunks must fit the batch limit
+
+    result = asyncio.run(embedder.embed_text([text]))
+
+    assert len(server.requests) >= 2
+    for req in server.requests:
+        assert sum(len(t) for t in req["input"]) // 3 <= 10
+    assert "".join(t for req in server.requests for t in req["input"]) == text
+    assert len(result) == 1
+
+
 def test_oversized_average_is_float32(monkeypatch):
     server = FakeEmbeddingServer(dim=4)
     embedder = _make_embedder(

--- a/tests/fast/test_openai_embedder_input_handling.py
+++ b/tests/fast/test_openai_embedder_input_handling.py
@@ -174,6 +174,29 @@ def test_inverted_limits_still_bound_each_request(monkeypatch):
     assert len(result) == 1
 
 
+def test_medium_row_between_inverted_limits_is_chunked(monkeypatch):
+    """A row estimated between batch_token_limit and input_text_token_limit must still be chunked."""
+    server = FakeEmbeddingServer(dim=4)
+    embedder = _make_embedder(
+        monkeypatch,
+        server,
+        model="custom-model",
+        input_text_token_limit=40,
+        batch_token_limit=10,
+    )
+    # 20 estimated tokens: below the input limit but above the batch limit,
+    # so sending it whole would exceed the per-request cap.
+    text = "a" * 60
+
+    result = asyncio.run(embedder.embed_text([text]))
+
+    assert len(server.requests) >= 2
+    for req in server.requests:
+        assert sum(len(t) for t in req["input"]) // 3 <= 10
+    assert "".join(t for req in server.requests for t in req["input"]) == text
+    assert len(result) == 1
+
+
 def test_oversized_average_is_float32(monkeypatch):
     server = FakeEmbeddingServer(dim=4)
     embedder = _make_embedder(

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -69,6 +69,47 @@ def _chunk_text(text: str, char_size: int) -> list[str]:
     return [text[i : i + char_size] for i in range(0, len(text), char_size)]
 
 
+def _estimate_tokens(text: str) -> int:
+    """Conservatively estimate the token count of *text*.
+
+    ASCII characters count at ~3 chars per token; every non-ASCII character
+    counts as a full token (CJK scripts run close to 1 token per character,
+    so a plain ``len(text) // 3`` badly underestimates them). O(len(text))
+    and dependency-free.
+    """
+    ascii_count = len(text.encode("ascii", errors="ignore"))
+    non_ascii_count = len(text) - ascii_count
+    return ascii_count // 3 + non_ascii_count
+
+
+def _chunk_text_by_tokens(text: str, token_limit: int) -> list[str]:
+    """Split *text* into chunks whose estimated token count is <= *token_limit*.
+
+    Uses the same per-character accounting as :func:`_estimate_tokens`, so a
+    chunk is guaranteed to stay within the limit regardless of how ASCII and
+    non-ASCII characters are distributed.
+    """
+    chunks: list[str] = []
+    start = 0
+    ascii_count = 0
+    non_ascii_count = 0
+    for index, char in enumerate(text):
+        if ord(char) < 128:
+            ascii_count += 1
+        else:
+            non_ascii_count += 1
+        if ascii_count // 3 + non_ascii_count > token_limit and index > start:
+            chunks.append(text[start:index])
+            start = index
+            if ord(char) < 128:
+                ascii_count, non_ascii_count = 1, 0
+            else:
+                ascii_count, non_ascii_count = 0, 1
+    if start < len(text):
+        chunks.append(text[start:])
+    return chunks
+
+
 # OpenAI-specific keys sealed in addition to the shared sensitive-key table.
 # ``organization`` identifies the paying account and must not leak via repr,
 # but it is not a generic credential, so it stays out of the shared table
@@ -225,11 +266,20 @@ class OpenAITextEmbedder:
 
     * **batch_token_limit** — max estimated tokens per API request (default 300k).
     * **input_text_token_limit** — max tokens for a single input text.
-      Texts exceeding this are split into character chunks, embedded
-      separately, and recombined via length-weighted averaging + L2
-      normalisation.  The estimation is conservative: ``len(text) // 3``
-      (≈ 1 token per 3 chars), which is O(1) and avoids a tiktoken
-      dependency.
+      Texts exceeding this are split into chunks, embedded separately
+      (through the same token-limited request batching), and recombined via
+      length-weighted averaging + L2 normalisation.
+
+    Token counts are estimated heuristically: ASCII characters at ~3 chars
+    per token, and every non-ASCII character as a full token (CJK scripts
+    run close to 1 token per character). The estimate is O(len(text)) and
+    avoids a tiktoken dependency; it can still undercount rare multi-token
+    characters, but is conservative for common ASCII and CJK text.
+
+    Empty inputs (``None``, ``""``, or whitespace-only) are never sent to
+    the API — OpenAI rejects them with an error for the whole request.
+    Their rows receive deterministic placeholder vectors instead; see
+    :meth:`embed_text`.
     """
 
     def __init__(
@@ -245,6 +295,10 @@ class OpenAITextEmbedder:
 
         if encoding_format not in {"float", "base64"}:
             raise ValueError("encoding_format must be 'float' or 'base64'")
+        if batch_token_limit <= 0:
+            raise ValueError(f"batch_token_limit must be positive, got {batch_token_limit!r}")
+        if input_text_token_limit is not None and input_text_token_limit <= 0:
+            raise ValueError(f"input_text_token_limit must be positive, got {input_text_token_limit!r}")
         # Restore plaintext credentials sealed by the descriptor; plain dicts
         # from direct callers pass through unchanged.
         provider_options = unwrap_sensitive_options(provider_options)
@@ -268,32 +322,46 @@ class OpenAITextEmbedder:
         await self._client.close()
 
     async def embed_text(self, text: list[str]) -> list[Embedding]:
-        embeddings: list[Embedding] = []
+        """Embed *text*, returning one float32 embedding per input row.
+
+        Empty rows (``None``, ``""``, or whitespace-only) are never sent to
+        the API — OpenAI rejects empty inputs with an error that fails the
+        whole request. Each such row receives a deterministic zero vector
+        whose dimension comes from, in order: the configured ``dimensions``,
+        the first embedding produced in this call, or the known model
+        dimension table. When the dimension is unknowable (every row empty
+        and an unrecognised model), those rows are ``None``. Non-empty rows
+        are unaffected.
+        """
+        results: list[Embedding] = [None] * len(text)
+        empty_positions: list[int] = []
         batch: list[str] = []
+        batch_positions: list[int] = []
         batch_tokens = 0
-        approx_chars_per_token = 3
 
         async def flush() -> None:
-            nonlocal batch, batch_tokens
+            nonlocal batch, batch_positions, batch_tokens
             if not batch:
                 return
-            result = await self._embed_batch(batch)
-            embeddings.extend(result)
+            for position, embedding in zip(batch_positions, await self._embed_batch(batch)):
+                results[position] = embedding
             batch = []
+            batch_positions = []
             batch_tokens = 0
 
-        for item in text:
-            if item is None:
-                item = ""
-            est_tokens = len(item) // approx_chars_per_token
+        for position, item in enumerate(text):
+            if item is None or not item.strip():
+                empty_positions.append(position)
+                continue
+            est_tokens = _estimate_tokens(item)
 
             if est_tokens > self._input_text_token_limit:
-                # Oversized single input — flush pending batch, chunk, embed,
-                # then recombine via weighted average + L2 normalisation.
+                # Oversized single input — flush pending batch, chunk, embed
+                # the chunks through token-limited requests, then recombine
+                # via weighted average + L2 normalisation.
                 await flush()
-                chunk_char_size = self._input_text_token_limit * approx_chars_per_token
-                chunks = _chunk_text(item, chunk_char_size)
-                chunk_embeddings = await self._embed_batch(chunks)
+                chunks = _chunk_text_by_tokens(item, self._input_text_token_limit)
+                chunk_embeddings = await self._embed_chunks(chunks)
                 chunk_lens = np.array(
                     [len(c) for c in chunks],
                     dtype=np.float64,
@@ -302,15 +370,48 @@ class OpenAITextEmbedder:
                 norm = np.linalg.norm(avg)
                 if norm > 0:
                     avg = avg / norm
-                embeddings.append(avg)
+                results[position] = avg.astype(np.float32)
                 continue
 
             if est_tokens + batch_tokens >= self._batch_token_limit:
                 await flush()
             batch.append(item)
+            batch_positions.append(position)
             batch_tokens += est_tokens
 
         await flush()
+
+        if empty_positions:
+            dimension = self._placeholder_dimension(results)
+            if dimension is not None:
+                for position in empty_positions:
+                    results[position] = np.zeros(dimension, dtype=np.float32)
+        return results
+
+    def _placeholder_dimension(self, results: list[Embedding]) -> int | None:
+        """Dimension for empty-row placeholder vectors, ``None`` if unknowable."""
+        if self._dimensions is not None:
+            return self._dimensions
+        for embedding in results:
+            if embedding is not None:
+                return int(np.asarray(embedding).shape[-1])
+        return _MODEL_DIMS.get(self._model)
+
+    async def _embed_chunks(self, chunks: list[str]) -> list[Embedding]:
+        """Embed *chunks* through requests that respect ``batch_token_limit``."""
+        embeddings: list[Embedding] = []
+        batch: list[str] = []
+        batch_tokens = 0
+        for chunk in chunks:
+            est_tokens = _estimate_tokens(chunk)
+            if batch and est_tokens + batch_tokens >= self._batch_token_limit:
+                embeddings.extend(await self._embed_batch(batch))
+                batch = []
+                batch_tokens = 0
+            batch.append(chunk)
+            batch_tokens += est_tokens
+        if batch:
+            embeddings.extend(await self._embed_batch(batch))
         return embeddings
 
     async def _embed_batch(self, texts: list[str]) -> list[Embedding]:
@@ -537,12 +638,19 @@ class OpenAIPrompter:
 
         # Chat Completions API: prompt_tokens / completion_tokens / total_tokens
         # Responses API: input_tokens / output_tokens / total_tokens
+        # Explicit None checks: a legitimate count of 0 must be recorded as 0.
+        input_tokens = getattr(usage, "prompt_tokens", None)
+        if input_tokens is None:
+            input_tokens = getattr(usage, "input_tokens", None)
+        output_tokens = getattr(usage, "completion_tokens", None)
+        if output_tokens is None:
+            output_tokens = getattr(usage, "output_tokens", None)
         record_token_metrics(
             protocol="prompt",
             model=self._model,
             provider="openai",
-            input_tokens=(getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", None)),
-            output_tokens=(getattr(usage, "completion_tokens", None) or getattr(usage, "output_tokens", None)),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
             total_tokens=getattr(usage, "total_tokens", None),
         )
 

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -268,9 +268,14 @@ class OpenAITextEmbedder:
 
     * **batch_token_limit** — max estimated tokens per API request (default 300k).
     * **input_text_token_limit** — max tokens for a single input text.
-      Texts exceeding this are split into chunks, embedded separately
-      (through the same token-limited request batching), and recombined via
-      length-weighted averaging + L2 normalisation.
+
+    The effective per-input bound is ``min(input_text_token_limit,
+    batch_token_limit)``, so a single input can never exceed one request's
+    budget even when ``input_text_token_limit`` is configured above
+    ``batch_token_limit``. Texts exceeding the effective bound are split
+    into chunks, embedded separately (through the same token-limited
+    request batching), and recombined via length-weighted averaging + L2
+    normalisation.
 
     Token counts are estimated heuristically: ASCII characters at ~3 chars
     per token, and every non-ASCII character as a full token (CJK scripts
@@ -311,6 +316,11 @@ class OpenAITextEmbedder:
         self._input_text_token_limit = (
             input_text_token_limit if input_text_token_limit is not None else _get_input_token_limit(model)
         )
+        # A single input can never exceed one request's budget, so the
+        # per-input bound is capped by the per-request bound. This also
+        # catches medium rows whose estimate lies between the two limits
+        # when input_text_token_limit is configured above batch_token_limit.
+        self._effective_input_limit = min(self._input_text_token_limit, self._batch_token_limit)
         # Filter out non-OpenAI keys before passing to client
         client_opts = {
             k: v
@@ -358,15 +368,16 @@ class OpenAITextEmbedder:
                 continue
             est_tokens = _estimate_tokens(item)
 
-            if est_tokens > self._input_text_token_limit:
+            if est_tokens > self._effective_input_limit:
                 # Oversized single input — flush pending batch, chunk, embed
                 # the chunks through token-limited requests, then recombine
-                # via weighted average + L2 normalisation.
+                # via weighted average + L2 normalisation. The effective
+                # limit bounds both this threshold and the chunk size, so a
+                # chunk always fits one request even when
+                # input_text_token_limit is configured above
+                # batch_token_limit.
                 await flush()
-                # Bound each chunk by BOTH limits so a single chunk always
-                # fits one request, even when input_text_token_limit is
-                # configured above batch_token_limit.
-                chunks = _chunk_text_by_tokens(item, min(self._input_text_token_limit, self._batch_token_limit))
+                chunks = _chunk_text_by_tokens(item, self._effective_input_limit)
                 chunk_embeddings = await self._embed_chunks(chunks)
                 chunk_lens = np.array(
                     [len(c) for c in chunks],

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -64,6 +64,8 @@ def _get_input_token_limit(model: str) -> int:
     return _MODEL_INPUT_TOKEN_LIMITS.get(model, _DEFAULT_INPUT_TOKEN_LIMIT)
 
 
+# Retained for callers and tests that chunk by raw character count; the
+# embedder itself now uses the token-aware _chunk_text_by_tokens instead.
 def _chunk_text(text: str, char_size: int) -> list[str]:
     """Split *text* into character-level chunks of at most *char_size*."""
     return [text[i : i + char_size] for i in range(0, len(text), char_size)]
@@ -321,19 +323,20 @@ class OpenAITextEmbedder:
         """Release the SDK client's connection pool on the owning loop."""
         await self._client.close()
 
-    async def embed_text(self, text: list[str]) -> list[Embedding]:
+    async def embed_text(self, text: list[str]) -> list[Embedding | None]:
         """Embed *text*, returning one float32 embedding per input row.
 
-        Empty rows (``None``, ``""``, or whitespace-only) are never sent to
-        the API — OpenAI rejects empty inputs with an error that fails the
-        whole request. Each such row receives a deterministic zero vector
+        Empty rows are never sent to the API: OpenAI rejects ``""`` inputs
+        with an error that fails the whole request, and ``None`` /
+        whitespace-only rows are normalised to the same deterministic
+        placeholder for consistency. Each such row receives a zero vector
         whose dimension comes from, in order: the configured ``dimensions``,
         the first embedding produced in this call, or the known model
         dimension table. When the dimension is unknowable (every row empty
         and an unrecognised model), those rows are ``None``. Non-empty rows
         are unaffected.
         """
-        results: list[Embedding] = [None] * len(text)
+        results: list[Embedding | None] = [None] * len(text)
         empty_positions: list[int] = []
         batch: list[str] = []
         batch_positions: list[int] = []
@@ -343,7 +346,7 @@ class OpenAITextEmbedder:
             nonlocal batch, batch_positions, batch_tokens
             if not batch:
                 return
-            for position, embedding in zip(batch_positions, await self._embed_batch(batch)):
+            for position, embedding in zip(batch_positions, await self._embed_batch(batch), strict=True):
                 results[position] = embedding
             batch = []
             batch_positions = []
@@ -360,7 +363,10 @@ class OpenAITextEmbedder:
                 # the chunks through token-limited requests, then recombine
                 # via weighted average + L2 normalisation.
                 await flush()
-                chunks = _chunk_text_by_tokens(item, self._input_text_token_limit)
+                # Bound each chunk by BOTH limits so a single chunk always
+                # fits one request, even when input_text_token_limit is
+                # configured above batch_token_limit.
+                chunks = _chunk_text_by_tokens(item, min(self._input_text_token_limit, self._batch_token_limit))
                 chunk_embeddings = await self._embed_chunks(chunks)
                 chunk_lens = np.array(
                     [len(c) for c in chunks],
@@ -388,7 +394,7 @@ class OpenAITextEmbedder:
                     results[position] = np.zeros(dimension, dtype=np.float32)
         return results
 
-    def _placeholder_dimension(self, results: list[Embedding]) -> int | None:
+    def _placeholder_dimension(self, results: list[Embedding | None]) -> int | None:
         """Dimension for empty-row placeholder vectors, ``None`` if unknowable."""
         if self._dimensions is not None:
             return self._dimensions


### PR DESCRIPTION
## Summary

Fixes #144. Three input-handling defects in the OpenAI embedder, plus minor items:

- **Empty rows no longer poison the batch**: `None`/`""`/whitespace-only rows are never sent (the API rejects empty strings, failing the whole request); each receives a deterministic zero-vector placeholder whose dimension resolves via configured `dimensions` → first embedding of the same call → model dims table, with `None` as the documented last resort. Placement is positional; non-empty rows are unaffected.
- **CJK-safe token estimation**: `len//3` under-counted CJK (~1 token/char), sending oversized text unchunked into 400s. The estimate is now `ascii_count // 3 + non_ascii_count` — deliberately dependency-free (no tiktoken) so chunk counts are deterministic across environments.
- **Oversized inputs respect `batch_token_limit`**: one effective per-input limit, `min(input_text_token_limit, batch_token_limit)`, drives both the oversized-row threshold and chunk sizing, so any row whose estimate exceeds one request's budget — including medium rows between inverted limits — is chunked and embedded through token-limit-bounded requests instead of one unbounded call.
- Minor: chunk-averaged embeddings cast to float32; non-positive limits rejected early; a legitimate usage of 0 recorded as 0; strict zip so a short API response fails loudly instead of leaving silent `None` rows.

Follow-up commits address code-review findings (strict zip, the effective per-input limit above, `list[Embedding | None]` annotation, docstring accuracy).

## Validation

- New `tests/fast/test_openai_embedder_input_handling.py` (16 tests, fake OpenAI server): red-run verified — 13 failed on unfixed code, each reproducing its target defect; the inverted-limits and medium-row-between-inverted-limits cases were each red-run against the code they fix.
- 187 tests green locally under the no-duckdb import harness; the 4 CI-only token-limit pins were replicated locally against branch code and hold. `ruff check`/`format` clean; pre-commit hooks passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented in code/docstrings (whitespace-only rows now get placeholders instead of real embeddings — deliberate normalization, documented); CHANGELOG intentionally untouched per maintainer guidance.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered (no new surface; fewer failure-path leaks).
- [x] Native changes were compiled; Python-only changes passed relevant tests (Python-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014az5eSZxzP2SBDyivvivCk