### PR TITLE
[fix](ai) Preserve RetryAfterError pickling; log ignored substitutions; unify Retry-After handling

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1517,7 +1517,10 @@ class TestSharedRetryAfterExtraction:
         assert isinstance(err, RetryAfterError)
         assert err.retry_after == 5.0
 
-    @pytest.mark.parametrize("bad_header", ["-1", "-0.5", "nan", "NaN", "inf", "1e999", "soon", ""])
+    @pytest.mark.parametrize(
+        "bad_header",
+        ["-1", "-0.5", "nan", "NaN", "inf", "1e999", "soon", "", "Thu, 13 Bug 2026 15:37:13 GMT"],
+    )
     def test_malformed_header_uses_default(self, bad_header):
         from vane.ai.functions import _retry_after_error
 
@@ -1569,6 +1572,72 @@ class TestSharedRetryAfterExtraction:
         err = _retry_after_error(self._error(status=429, headers={"retry-after": "8"}))
         assert err is not None
         assert err.retry_after == 8.0
+
+    # --- HTTP-date form (RFC 9110 permits it alongside delay-seconds) ------
+
+    def _pin_clock(self, monkeypatch):
+        import datetime
+
+        from vane.ai import functions
+
+        fixed_now = datetime.datetime(2026, 8, 13, 15, 37, 13, tzinfo=datetime.timezone.utc)
+        monkeypatch.setattr(functions, "_utcnow", lambda: fixed_now)
+        return fixed_now
+
+    def _http_date(self, moment):
+        import email.utils
+
+        return email.utils.format_datetime(moment, usegmt=True)
+
+    def test_http_date_header_honored(self, monkeypatch):
+        import datetime
+
+        from vane.ai.functions import _retry_after_error
+
+        fixed_now = self._pin_clock(monkeypatch)
+        header = self._http_date(fixed_now + datetime.timedelta(seconds=30))
+        err = _retry_after_error(self._error(status=429, headers={"Retry-After": header}))
+        assert err is not None
+        assert err.retry_after == 30.0
+
+    def test_http_date_offset_form_honored(self, monkeypatch):
+        """A non-GMT zone offset still resolves to the same instant."""
+        import datetime
+        import email.utils
+
+        from vane.ai.functions import _retry_after_error
+
+        fixed_now = self._pin_clock(monkeypatch)
+        plus_two = datetime.timezone(datetime.timedelta(hours=2))
+        header = email.utils.format_datetime((fixed_now + datetime.timedelta(seconds=45)).astimezone(plus_two))
+        err = _retry_after_error(self._error(status=429, headers={"Retry-After": header}))
+        assert err is not None
+        assert err.retry_after == 45.0
+
+    def test_http_date_in_the_past_clamps_to_zero(self, monkeypatch):
+        """An already-past date means "retry immediately", not "malformed"."""
+        import datetime
+
+        from vane.ai.functions import _retry_after_error, _retry_wait_seconds
+
+        fixed_now = self._pin_clock(monkeypatch)
+        header = self._http_date(fixed_now - datetime.timedelta(seconds=60))
+        err = _retry_after_error(self._error(status=503, headers={"Retry-After": header}))
+        assert err is not None
+        assert err.retry_after == 0.0
+        assert _retry_wait_seconds(err, attempt=0) == 0.0
+
+    def test_http_date_far_future_still_hits_sleep_cap(self, monkeypatch):
+        import datetime
+
+        from vane.ai.functions import _retry_after_error, _retry_wait_seconds
+
+        fixed_now = self._pin_clock(monkeypatch)
+        header = self._http_date(fixed_now + datetime.timedelta(days=365))
+        err = _retry_after_error(self._error(status=429, headers={"Retry-After": header}))
+        assert err is not None
+        assert err.retry_after == 365 * 24 * 3600.0
+        assert _retry_wait_seconds(err, attempt=0) == 120
 
 
 class TestProviderRetryAfterAdoption:

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1269,6 +1269,50 @@ class TestRetryAfterError:
         assert exc_info.value.__cause__ is None
         assert exc_info.value.__context__ is None
 
+    def test_retry_after_error_survives_pickling(self):
+        """A RetryAfterError transported across a process boundary (Ray worker →
+        driver) keeps its numeric retry_after, sanitized message, and whitelisted
+        status attributes — and never resurrects the original provider error."""
+        import pickle
+
+        from vane.ai.functions import RetryAfterError, _retry_wait_seconds
+
+        class FakeSDKError(RuntimeError):
+            def __init__(self) -> None:
+                super().__init__("rate limited: sk-SECRET-token")
+                self.status_code = 429
+
+        err = RetryAfterError(retry_after=0.5, original=FakeSDKError())
+        restored = pickle.loads(pickle.dumps(err))
+
+        assert isinstance(restored.retry_after, float)
+        assert restored.retry_after == 0.5
+        # The sanitized summary is preserved verbatim (default pickling degraded
+        # it to the generic "RetryAfterError").
+        assert str(restored) == str(err)
+        assert restored.status_code == 429
+        # Sanitization survives transport: the original's secret-bearing message
+        # is never reconstructed.
+        assert "SECRET" not in str(restored)
+        assert restored.__cause__ is None
+        assert restored.__context__ is None
+        # The numeric delay is still honored after transport.
+        assert _retry_wait_seconds(restored, attempt=0) == 0.5
+
+    def test_retry_after_error_without_original_survives_pickling(self):
+        import pickle
+
+        from vane.ai.functions import RetryAfterError
+
+        err = RetryAfterError(retry_after=3.0)
+        restored = pickle.loads(pickle.dumps(err))
+
+        assert isinstance(restored.retry_after, float)
+        assert restored.retry_after == 3.0
+        assert str(restored) == str(err) == "RetryAfterError"
+        assert not hasattr(restored, "status_code")
+        assert restored.__cause__ is None
+
     @pytest.mark.parametrize("bad", [-1.0, -0.001, float("nan"), float("inf"), 10**400, -(10**400)])
     def test_retry_wait_seconds_rejects_malformed_retry_after(self, bad):
         """A non-finite or negative retry_after never becomes the sleep value (issue #469)."""

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1554,6 +1554,202 @@ class TestSharedRetryAfterExtraction:
         assert err.retry_after == 8.0
 
 
+class TestProviderRetryAfterAdoption:
+    """OpenAI and Anthropic honour Retry-After through the shared helper, so a
+    429/503 behaves the same as it already does for Google (issue #148)."""
+
+    def _rate_limit_error(self, *, status, headers=None):
+        from unittest.mock import MagicMock
+
+        exc = RuntimeError("rate limited: sk-SECRET")
+        exc.status_code = status
+        if headers is not None:
+            response = MagicMock()
+            response.headers = headers
+            exc.response = response
+        else:
+            exc.response = None
+        return exc
+
+    def _openai_prompter(self, side_effect):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vane.ai.providers.openai import OpenAIPrompter
+
+        prompter = OpenAIPrompter.__new__(OpenAIPrompter)
+        prompter._provider_name = "openai"
+        prompter._model = "gpt-test"
+        prompter._system_message = None
+        prompter._use_chat_completions = False
+        prompter._return_format = None
+        prompter._return_raw_response = False
+        prompter._options = {}
+        prompter._client = MagicMock()
+        prompter._client.responses.create = AsyncMock(side_effect=side_effect)
+        return prompter
+
+    def _anthropic_prompter(self, side_effect):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from vane.ai.providers.anthropic import AnthropicPrompter
+
+        prompter = AnthropicPrompter.__new__(AnthropicPrompter)
+        prompter._provider_name = "anthropic"
+        prompter._model = "claude-test"
+        prompter._system_message = None
+        prompter._return_format = None
+        prompter._return_raw_response = False
+        prompter._options = {"max_tokens": 64}
+        prompter._client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock(side_effect=side_effect)))
+        return prompter
+
+    # --- OpenAI: mirror the Google extraction cases ----------------------
+
+    def test_openai_prompt_429_with_header_honored(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._openai_prompter(self._rate_limit_error(status=429, headers={"Retry-After": "10"}))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 10.0
+        assert "SECRET" not in str(ctx.value)
+
+    def test_openai_prompt_503_without_header_uses_default(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._openai_prompter(self._rate_limit_error(status=503))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 5.0
+
+    @pytest.mark.parametrize("bad_header", ["-1", "nan", "inf", "later"])
+    def test_openai_prompt_malformed_header_uses_default(self, bad_header):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._openai_prompter(self._rate_limit_error(status=429, headers={"Retry-After": bad_header}))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 5.0
+
+    def test_openai_prompt_non_rate_limit_status_not_converted(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        error = self._rate_limit_error(status=400)
+        prompter = self._openai_prompter(error)
+        with pytest.raises(Exception) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        # A non-429/503 error propagates unchanged, not as a RetryAfterError.
+        assert not isinstance(ctx.value, RetryAfterError)
+        assert ctx.value is error
+
+    def test_openai_embed_429_honored(self, monkeypatch):
+        """The embed hook point adopts the shared helper too (smoke)."""
+        import asyncio
+        import sys
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vane.ai.functions import RetryAfterError
+        from vane.ai.providers.openai import OpenAITextEmbedder
+
+        class OpenAIError(Exception):
+            pass
+
+        class RateLimitError(OpenAIError):
+            status_code = 429
+
+        error = RateLimitError("rate limited")
+        response = MagicMock()
+        response.headers = {"Retry-After": "10"}
+        error.response = response
+
+        monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAIError=OpenAIError))
+        embedder = OpenAITextEmbedder.__new__(OpenAITextEmbedder)
+        embedder._client = MagicMock()
+        embedder._client.embeddings.create = AsyncMock(side_effect=error)
+        embedder._provider_name = "openai"
+        embedder._model = "text-embedding-test"
+        embedder._dimensions = 4
+        embedder._encoding_format = "float"
+
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(embedder._embed_batch(["hello"]))
+        assert ctx.value.retry_after == 10.0
+
+    # --- Anthropic: mirror the same case set -----------------------------
+
+    def test_anthropic_prompt_429_with_header_honored(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._anthropic_prompter(self._rate_limit_error(status=429, headers={"Retry-After": "7"}))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 7.0
+
+    def test_anthropic_prompt_503_without_header_uses_default(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._anthropic_prompter(self._rate_limit_error(status=503))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 5.0
+
+    def test_anthropic_prompt_non_rate_limit_status_not_converted(self):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        error = self._rate_limit_error(status=400)
+        prompter = self._anthropic_prompter(error)
+        with pytest.raises(Exception) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert not isinstance(ctx.value, RetryAfterError)
+        assert ctx.value is error
+
+    # --- Wrapper seam: the honored delay drives the retry sleep ----------
+
+    def test_openai_retry_after_drives_wrapper_sleep_then_succeeds(self, monkeypatch):
+        import asyncio
+        from types import SimpleNamespace
+
+        from vane.ai.functions import _PromptBatch
+
+        slept: list[float] = []
+
+        async def fake_sleep(seconds):
+            slept.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        error = self._rate_limit_error(status=429, headers={"Retry-After": "10"})
+        success = SimpleNamespace(output_text="answer", usage=None)
+        prompter = self._openai_prompter([error, success])
+
+        class Descriptor:
+            def instantiate(self):
+                return prompter
+
+        wrapper = _PromptBatch(Descriptor(), ["message"], "response", max_retries=2, on_error="raise")
+        result = _drive(wrapper, pa.table({"message": ["hi"]}))
+
+        assert result.column("response").to_pylist() == ["answer"]
+        # The server-requested 10s was honoured, not exponential backoff (1s).
+        assert slept == [10.0]
+
+
 class TestEmbedProviderCapabilityErrors:
     @pytest.mark.parametrize("name", ["batch_size", "actor_number", "batch_token_limit"])
     def test_non_nullable_integer_options_reject_explicit_none_during_planning(self, name):

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2685,6 +2685,56 @@ class TestSubstitutionLogging:
         assert len(messages) == 1
         assert "_ProviderResultError" in messages[0]
 
+    # --- Seam C: native vLLM structured-output validation ----------------
+
+    def _native_validator(self, on_error):
+        from types import SimpleNamespace
+
+        from vane.ai._schema import OutputValidationError
+        from vane.ai.functions import _ValidateStructuredOutputBatch
+
+        def reject(_raw_text):
+            raise OutputValidationError("structured output rejected")
+
+        return _ValidateStructuredOutputBatch(
+            return_format=SimpleNamespace(validate_json=reject),
+            input_column="raw",
+            output_column="out",
+            on_error=on_error,
+        )
+
+    def test_native_validation_ignore_logs_one_warning_per_bad_row(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = self._native_validator("ignore")(pa.table({"raw": ["bad-1", "bad-2"]}))
+
+        assert result.column("out").to_pylist() == [None, None]
+        messages = _warnings(caplog)
+        assert len(messages) == 2
+        assert all("OutputValidationError" in message for message in messages)
+        assert all("bad-1" not in message and "bad-2" not in message for message in messages)
+
+    def test_native_validation_provider_null_passes_without_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = self._native_validator("ignore")(pa.table({"raw": pa.array([None], type=pa.string())}))
+
+        assert result.column("out").to_pylist() == [None]
+        assert _warnings(caplog) == []
+
+    def test_native_validation_raise_mode_logs_nothing(self, caplog):
+        import logging
+
+        from vane.ai._schema import OutputValidationError
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with pytest.raises(OutputValidationError):
+                self._native_validator("raise")(pa.table({"raw": ["bad"]}))
+
+        assert _warnings(caplog) == []
+
 
 # ---------------------------------------------------------------------------
 # Basic Prompt provider contract

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1770,7 +1770,9 @@ class TestProviderRetryAfterAdoption:
         monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
         error = self._rate_limit_error(status=429, headers={"Retry-After": "10"})
-        success = SimpleNamespace(output_text="answer", usage=None)
+        # A terminal, non-refusing Responses result: #572 requires status
+        # "completed" and inspects output blocks for refusals before returning.
+        success = SimpleNamespace(output_text="answer", usage=None, status="completed", output=[])
         prompter = self._openai_prompter([error, success])
 
         class Descriptor:

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1486,6 +1486,74 @@ class TestGoogleRetryHandling:
         assert ctx.value.retry_after == 3.5
 
 
+class TestSharedRetryAfterExtraction:
+    """The provider-agnostic Retry-After extraction helper (issue #148) that
+    every HTTP provider shares, so 429/503 retry timing is uniform."""
+
+    def _error(self, *, status_attr="status_code", status=429, headers=None):
+        from unittest.mock import MagicMock
+
+        exc = RuntimeError("rate limited: sk-SECRET")
+        setattr(exc, status_attr, status)
+        if headers is not None:
+            response = MagicMock()
+            response.headers = headers
+            exc.response = response
+        else:
+            exc.response = None
+        return exc
+
+    def test_429_with_header_honored(self):
+        from vane.ai.functions import RetryAfterError, _retry_after_error
+
+        err = _retry_after_error(self._error(status=429, headers={"Retry-After": "12"}))
+        assert isinstance(err, RetryAfterError)
+        assert err.retry_after == 12.0
+        # Sanitization: the original secret-bearing message is not surfaced.
+        assert "SECRET" not in str(err)
+
+    def test_503_without_header_uses_default(self):
+        from vane.ai.functions import RetryAfterError, _retry_after_error
+
+        err = _retry_after_error(self._error(status=503, headers=None))
+        assert isinstance(err, RetryAfterError)
+        assert err.retry_after == 5.0
+
+    @pytest.mark.parametrize("bad_header", ["-1", "-0.5", "nan", "NaN", "inf", "1e999", "soon", ""])
+    def test_malformed_header_uses_default(self, bad_header):
+        from vane.ai.functions import _retry_after_error
+
+        err = _retry_after_error(self._error(status=429, headers={"Retry-After": bad_header}))
+        assert err is not None
+        assert err.retry_after == 5.0
+
+    @pytest.mark.parametrize("status", [200, 400, 401, 404, 500, None])
+    def test_non_rate_limit_status_not_converted(self, status):
+        from vane.ai.functions import _retry_after_error
+
+        if status is None:
+            exc = RuntimeError("no status here")
+            assert _retry_after_error(exc) is None
+        else:
+            assert _retry_after_error(self._error(status=status, headers=None)) is None
+
+    def test_status_discovered_from_code_attribute(self):
+        """Google-style errors expose the HTTP status as ``.code``, not
+        ``.status_code``; the shared helper must find either."""
+        from vane.ai.functions import _retry_after_error
+
+        err = _retry_after_error(self._error(status_attr="code", status=429, headers=None))
+        assert err is not None
+        assert err.retry_after == 5.0
+
+    def test_header_lookup_is_case_insensitive(self):
+        from vane.ai.functions import _retry_after_error
+
+        err = _retry_after_error(self._error(status=429, headers={"retry-after": "8"}))
+        assert err is not None
+        assert err.retry_after == 8.0
+
+
 class TestEmbedProviderCapabilityErrors:
     @pytest.mark.parametrize("name", ["batch_size", "actor_number", "batch_token_limit"])
     def test_non_nullable_integer_options_reject_explicit_none_during_planning(self, name):

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2052,6 +2052,184 @@ class TestWrapperRetry:
         assert result.column("emb").to_pylist() == [None]
 
 
+_LOGGER_NAME = "vane.ai.functions"
+
+
+def _warnings(caplog) -> list[str]:
+    import logging
+
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+
+
+class TestSubstitutionLogging:
+    """Every NULL substituted for a failed provider call under on_error='ignore'
+    leaves exactly one bounded, sanitized WARNING; 'raise' mode logs nothing."""
+
+    # --- Seam A: retry helpers -------------------------------------------
+
+    def test_retry_call_ignore_logs_one_sanitized_warning(self, caplog):
+        import logging
+
+        from vane.ai.functions import _retry_call
+
+        class TransientError(RuntimeError):
+            status_code = 503
+
+        def fn():
+            raise TransientError("secret-payload")
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _retry_call(fn, max_retries=0, on_error="ignore")
+
+        assert result is None
+        messages = _warnings(caplog)
+        assert len(messages) == 1
+        assert "TransientError" in messages[0]
+        assert "secret-payload" not in messages[0]
+        assert "Traceback" not in messages[0]
+
+    def test_retry_call_raise_mode_logs_nothing(self, caplog):
+        import logging
+
+        from vane.ai.functions import _retry_call
+
+        class TransientError(RuntimeError):
+            status_code = 503
+
+        def fn():
+            raise TransientError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with pytest.raises(TransientError):
+                _retry_call(fn, max_retries=0, on_error="raise")
+
+        assert _warnings(caplog) == []
+
+    def test_retry_call_async_ignore_logs_one_warning(self, caplog):
+        import asyncio
+        import logging
+
+        from vane.ai.functions import _retry_call_async
+
+        class TransientError(RuntimeError):
+            status_code = 503
+
+        async def fn():
+            raise TransientError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = asyncio.run(_retry_call_async(fn, max_retries=0, on_error="ignore"))
+
+        assert result is None
+        assert len(_warnings(caplog)) == 1
+
+    # --- Seam B: embed wrapper -------------------------------------------
+
+    def _make_embed_descriptor(self, embed_fn):
+        desc = MagicMock(spec=[])
+        desc.get_dimensions = MagicMock(return_value=3)
+        embedder = MagicMock(spec=[])
+        embedder.embed_text = embed_fn
+        desc.instantiate = MagicMock(return_value=embedder)
+        return desc
+
+    def test_embed_ignore_logs_one_warning_per_isolated_row(self, caplog):
+        import logging
+
+        from vane.ai.functions import _EmbedTextBatch
+
+        def embed(_texts):
+            raise RuntimeError("permanent failure: sk-SECRET")
+
+        wrapper = _EmbedTextBatch(
+            self._make_embed_descriptor(embed), "text", "emb", 3, max_retries=0, on_error="ignore"
+        )
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _drive(wrapper, pa.table({"text": ["a", "b"]}))
+
+        assert result.column("emb").to_pylist() == [None, None]
+        messages = _warnings(caplog)
+        # Batch call fails, then each of the two rows fails in isolation: one
+        # warning per substituted row.
+        assert len(messages) == 2
+        assert all("RuntimeError" in m for m in messages)
+        assert all("SECRET" not in m for m in messages)
+
+    def test_embed_raise_mode_logs_nothing(self, caplog):
+        import logging
+
+        from vane.ai.functions import _EmbedTextBatch
+
+        def embed(_texts):
+            raise RuntimeError("permanent failure")
+
+        wrapper = _EmbedTextBatch(self._make_embed_descriptor(embed), "text", "emb", 3, max_retries=0, on_error="raise")
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with pytest.raises(Exception):
+                _drive(wrapper, pa.table({"text": ["a"]}))
+
+        assert _warnings(caplog) == []
+
+    # --- Seam B: prompt wrapper ------------------------------------------
+
+    def test_prompt_ignore_logs_only_for_substituted_rows(self, caplog, monkeypatch):
+        import asyncio
+        import logging
+
+        from vane.ai.functions import _PromptBatch
+
+        async def no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+        class Prompter:
+            async def prompt(self, messages):
+                if messages[0] == "fail":
+                    raise RuntimeError("permanent: sk-SECRET")
+                return f"answer:{messages[0]}"
+
+        class Descriptor:
+            def instantiate(self):
+                return Prompter()
+
+        wrapper = _PromptBatch(Descriptor(), ["message"], "response", max_retries=0, on_error="ignore")
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _drive(wrapper, pa.table({"message": ["ok", "fail", None]}))
+
+        assert result.column("response").to_pylist() == ["answer:ok", None, None]
+        # Only the "fail" row is substituted (the None row was never dispatched);
+        # exactly one warning, no double from the downstream None validation.
+        messages = _warnings(caplog)
+        assert len(messages) == 1
+        assert "RuntimeError" in messages[0]
+        assert "SECRET" not in messages[0]
+
+    def test_prompt_ignore_logs_on_bad_result_type(self, caplog):
+        import logging
+
+        from vane.ai.functions import _PromptBatch
+
+        class Prompter:
+            async def prompt(self, messages):
+                return 123  # not text or NULL: a result-contract violation
+
+        class Descriptor:
+            def instantiate(self):
+                return Prompter()
+
+        wrapper = _PromptBatch(Descriptor(), ["message"], "response", max_retries=0, on_error="ignore")
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _drive(wrapper, pa.table({"message": ["hello"]}))
+
+        assert result.column("response").to_pylist() == [None]
+        messages = _warnings(caplog)
+        assert len(messages) == 1
+        assert "_ProviderResultError" in messages[0]
+        # The vane-authored detail message is reduced to the class name.
+        assert "returned int" not in messages[0]
+
+
 # ---------------------------------------------------------------------------
 # Basic Prompt provider contract
 # ---------------------------------------------------------------------------

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1563,6 +1563,18 @@ class TestSharedRetryAfterExtraction:
         err = _retry_after_error(exc)
         assert err is not None
         assert err.retry_after == 6.0
+        # The status exists only on the attached response, which the
+        # constructor's direct-attribute whitelist cannot see; the helper must
+        # attach its normalized discovery so the status survives the two
+        # serialization surfaces used after retry exhaustion: the bounded
+        # warning summary and a pickle round-trip (Ray worker -> driver).
+        from vane.ai.provider import _safe_original_error_summary
+
+        assert err.status_code == 429
+        assert "status_code=429" in _safe_original_error_summary(err)
+        restored = pickle.loads(pickle.dumps(err))
+        assert restored.status_code == 429
+        assert restored.retry_after == 6.0
 
     def test_header_lookup_accepts_lowercase_key(self):
         """Both header casings providers actually emit are accepted (the exact

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2351,6 +2351,28 @@ class TestSubstitutionLogging:
         assert "TransientError" in messages[0]
         assert "secret-payload" not in messages[0]
         assert "Traceback" not in messages[0]
+        # A retry loop reports how many attempts it made before substituting.
+        assert "1 attempt(s)" in messages[0]
+
+    def test_retry_call_warning_counts_all_attempts(self, caplog, monkeypatch):
+        import logging
+
+        from vane.ai import functions
+        from vane.ai.functions import _retry_call
+
+        monkeypatch.setattr(functions.time, "sleep", lambda _seconds: None)
+
+        class TransientError(RuntimeError):
+            status_code = 503
+
+        def fn():
+            raise TransientError("boom")
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            _retry_call(fn, max_retries=2, on_error="ignore")
+
+        # 1 initial try + 2 retries = 3 attempts, all exhausted.
+        assert "3 attempt(s)" in _warnings(caplog)[0]
 
     def test_retry_call_raise_mode_logs_nothing(self, caplog):
         import logging

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1273,8 +1273,6 @@ class TestRetryAfterError:
         """A RetryAfterError transported across a process boundary (Ray worker →
         driver) keeps its numeric retry_after, sanitized message, and whitelisted
         status attributes — and never resurrects the original provider error."""
-        import pickle
-
         from vane.ai.functions import RetryAfterError, _retry_wait_seconds
 
         class FakeSDKError(RuntimeError):
@@ -1300,8 +1298,6 @@ class TestRetryAfterError:
         assert _retry_wait_seconds(restored, attempt=0) == 0.5
 
     def test_retry_after_error_without_original_survives_pickling(self):
-        import pickle
-
         from vane.ai.functions import RetryAfterError
 
         err = RetryAfterError(retry_after=3.0)
@@ -1509,8 +1505,10 @@ class TestSharedRetryAfterExtraction:
         err = _retry_after_error(self._error(status=429, headers={"Retry-After": "12"}))
         assert isinstance(err, RetryAfterError)
         assert err.retry_after == 12.0
-        # Sanitization: the original secret-bearing message is not surfaced.
+        # Sanitization: the original secret-bearing message is not surfaced,
+        # while the whitelisted status attribute is carried over.
         assert "SECRET" not in str(err)
+        assert err.status_code == 429
 
     def test_503_without_header_uses_default(self):
         from vane.ai.functions import RetryAfterError, _retry_after_error
@@ -1546,7 +1544,26 @@ class TestSharedRetryAfterExtraction:
         assert err is not None
         assert err.retry_after == 5.0
 
-    def test_header_lookup_is_case_insensitive(self):
+    @pytest.mark.parametrize("response_attr", ["status_code", "status"])
+    def test_status_discovered_from_response_attribute(self, response_attr):
+        """Some SDK errors carry the status only on the attached response."""
+        from unittest.mock import MagicMock
+
+        from vane.ai.functions import _retry_after_error
+
+        exc = RuntimeError("rate limited")
+        response = MagicMock(spec=[response_attr, "headers"])
+        setattr(response, response_attr, 429)
+        response.headers = {"Retry-After": "6"}
+        exc.response = response
+
+        err = _retry_after_error(exc)
+        assert err is not None
+        assert err.retry_after == 6.0
+
+    def test_header_lookup_accepts_lowercase_key(self):
+        """Both header casings providers actually emit are accepted (the exact
+        two lookups Google's extraction always performed)."""
         from vane.ai.functions import _retry_after_error
 
         err = _retry_after_error(self._error(status=429, headers={"retry-after": "8"}))
@@ -1616,6 +1633,11 @@ class TestProviderRetryAfterAdoption:
             asyncio.run(prompter.prompt(("hello",)))
         assert ctx.value.retry_after == 10.0
         assert "SECRET" not in str(ctx.value)
+        # Sanitization parity with the Google provider: the converted error is
+        # raised outside the SDK-error handler, so the raw error is not
+        # retained as __context__.
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__context__ is None
 
     def test_openai_prompt_503_without_header_uses_default(self):
         import asyncio
@@ -1696,6 +1718,19 @@ class TestProviderRetryAfterAdoption:
         with pytest.raises(RetryAfterError) as ctx:
             asyncio.run(prompter.prompt(("hello",)))
         assert ctx.value.retry_after == 7.0
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__context__ is None
+
+    @pytest.mark.parametrize("bad_header", ["-1", "nan", "inf", "later"])
+    def test_anthropic_prompt_malformed_header_uses_default(self, bad_header):
+        import asyncio
+
+        from vane.ai.functions import RetryAfterError
+
+        prompter = self._anthropic_prompter(self._rate_limit_error(status=429, headers={"Retry-After": bad_header}))
+        with pytest.raises(RetryAfterError) as ctx:
+            asyncio.run(prompter.prompt(("hello",)))
+        assert ctx.value.retry_after == 5.0
 
     def test_anthropic_prompt_503_without_header_uses_default(self):
         import asyncio
@@ -2514,6 +2549,58 @@ class TestSubstitutionLogging:
         assert "_ProviderResultError" in messages[0]
         # The vane-authored detail message is reduced to the class name.
         assert "returned int" not in messages[0]
+
+    def test_prompt_ignore_logs_structured_null_contract_violation(self, caplog):
+        """A provider NULL that violates the structured-output contract is a
+        substitution and must warn — it is not the retry helper's already-logged
+        NULL (regression: the two were conflated and this case was silent)."""
+        import logging
+        from types import SimpleNamespace
+
+        from vane.ai.functions import _PromptBatch
+
+        class Prompter:
+            async def prompt(self, messages):
+                return None  # legitimate provider NULL, illegal for structured output
+
+        class Descriptor:
+            def instantiate(self):
+                return Prompter()
+
+        wrapper = _PromptBatch(
+            Descriptor(),
+            ["message"],
+            "response",
+            return_format=SimpleNamespace(validate_json=lambda text: text),
+            max_retries=0,
+            on_error="ignore",
+        )
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _drive(wrapper, pa.table({"message": ["hello"]}))
+
+        assert result.column("response").to_pylist() == [None]
+        messages = _warnings(caplog)
+        assert len(messages) == 1
+        assert "OutputValidationError" in messages[0]
+
+    def test_embed_ignore_logs_bad_embedding_shape(self, caplog):
+        import logging
+
+        from vane.ai.functions import _EmbedTextBatch
+
+        def embed(texts):
+            return [[1.0, 2.0]] * len(texts)  # wrong width: contract expects 3
+
+        wrapper = _EmbedTextBatch(
+            self._make_embed_descriptor(embed), "text", "emb", 3, max_retries=0, on_error="ignore"
+        )
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _drive(wrapper, pa.table({"text": ["a"]}))
+
+        assert result.column("emb").to_pylist() == [None]
+        messages = _warnings(caplog)
+        assert len(messages) == 1
+        assert "_ProviderResultError" in messages[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -1646,6 +1646,7 @@ def test_native_append_error_rows_logs_one_warning_per_batch(caplog):
 
     executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
     executor.engine_error_message = "engine init exploded"
+    executor.on_error = "null"
     executor.completed_tasks = deque()
     executor._notify_state_change = lambda **_kwargs: None
     rows = pa.table({"x": [1, 2, 3]})
@@ -1657,3 +1658,23 @@ def test_native_append_error_rows_logs_one_warning_per_batch(caplog):
     messages = [r.getMessage() for r in caplog.records if "substituted NULL" in r.getMessage()]
     assert len(messages) == 1  # bounded: one warning per substituted batch, not per row
     assert "vllm engine init failed: engine init exploded" in messages[0]
+
+
+def test_native_append_error_rows_raise_mode_logs_no_substitution_warning(caplog):
+    """No caller reaches _append_error_rows under raise mode today, but the
+    policy mapping must guard it so a future caller cannot log a substitution
+    that is not happening."""
+    import logging
+
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor.engine_error_message = "engine init exploded"
+    executor.on_error = "raise"
+    executor.completed_tasks = deque()
+    executor._notify_state_change = lambda **_kwargs: None
+
+    with caplog.at_level(logging.WARNING, logger="vane.ai.functions"):
+        executor._append_error_rows(pa.table({"x": [1]}))
+
+    assert [r for r in caplog.records if "substituted NULL" in r.getMessage()] == []

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -1584,3 +1584,76 @@ def test_remote_ref_cleanup_does_not_initialize_ray(monkeypatch):
     executor._cancel_refs([object()])
 
     assert calls == ["checked"]
+
+
+def test_native_generate_substitution_logs_bounded_warning(caplog):
+    import logging
+
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor._ray_actor_mode = True
+    executor.engine_error_message = None
+    executor.llm = None  # generation fails before any engine interaction
+    executor.on_error = "null"  # the lowered form of the public on_error="ignore"
+    executor.completed_tasks = deque()
+    executor.task_count_lock = threading.Lock()
+    executor.running_task_count = 1
+    executor._notify_state_change = lambda **_kwargs: None
+    row = pa.table({"x": [1]})
+
+    with caplog.at_level(logging.WARNING, logger="vane.ai.functions"):
+        asyncio.run(executor._generate("prompt text", row))
+
+    assert list(executor.completed_tasks) == [(None, row)]
+    messages = [r.getMessage() for r in caplog.records if "substituted NULL" in r.getMessage()]
+    assert len(messages) == 1
+    assert "vllm engine not initialized" in messages[0]
+    assert "prompt text" not in messages[0]
+
+
+def test_native_generate_raise_mode_logs_no_substitution_warning(caplog):
+    import logging
+
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor._ray_actor_mode = True
+    executor.engine_error_message = None
+    executor.llm = None
+    executor.on_error = "raise"
+    executor.model = "test-model"
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor.error_lock = threading.Lock()
+    executor.task_count_lock = threading.Lock()
+    executor.running_task_count = 1
+    executor._notify_state_change = lambda **_kwargs: None
+    row = pa.table({"x": [1]})
+
+    with caplog.at_level(logging.WARNING, logger="vane.ai.functions"):
+        asyncio.run(executor._generate("prompt text", row))
+
+    assert executor.error_message is not None
+    assert list(executor.completed_tasks) == []
+    assert [r for r in caplog.records if "substituted NULL" in r.getMessage()] == []
+
+
+def test_native_append_error_rows_logs_one_warning_per_batch(caplog):
+    import logging
+
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor.engine_error_message = "engine init exploded"
+    executor.completed_tasks = deque()
+    executor._notify_state_change = lambda **_kwargs: None
+    rows = pa.table({"x": [1, 2, 3]})
+
+    with caplog.at_level(logging.WARNING, logger="vane.ai.functions"):
+        executor._append_error_rows(rows)
+
+    assert [output for output, _row in executor.completed_tasks] == [None, None, None]
+    messages = [r.getMessage() for r in caplog.records if "substituted NULL" in r.getMessage()]
+    assert len(messages) == 1  # bounded: one warning per substituted batch, not per row
+    assert "vllm engine init failed: engine init exploded" in messages[0]

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -142,22 +142,29 @@ def _validate_on_error(on_error: object) -> _OnError:
     return cast(_OnError, on_error)
 
 
-def _log_substituted_failure(exc: Exception, *, on_error: _OnError) -> None:
+def _log_substituted_failure(exc: Exception, *, on_error: _OnError, attempts: int | None = None) -> None:
     """Record one bounded WARNING when a provider failure is replaced with NULL.
 
     Called at each site that swallows a provider error and yields NULL under
     ``on_error='ignore'``; a no-op under ``'raise'`` so callers cannot log a
-    failure they are about to re-raise. Only the exception class and its
-    sanitized numeric-status summary are emitted — never prompt text, row
-    payloads, option mappings, credentials, or a traceback (vane#105) — so a
-    silent data degradation becomes observable without leaking sensitive input.
+    failure they are about to re-raise. ``attempts`` is the number of tries made
+    when the caller is a retry loop (omitted where no attempt count is
+    meaningful). Only the exception class, its sanitized numeric-status summary,
+    and that count are emitted — never prompt text, row payloads, option
+    mappings, credentials, or a traceback (vane#105) — so a silent data
+    degradation becomes observable without leaking sensitive input.
     """
     if on_error == "raise":
         return
-    logger.warning(
-        "vane.ai substituted NULL for a failed provider call: %s",
-        _safe_original_error_summary(exc),
-    )
+    summary = _safe_original_error_summary(exc)
+    if attempts is not None:
+        logger.warning(
+            "vane.ai substituted NULL after %d attempt(s) for a failed provider call: %s",
+            attempts,
+            summary,
+        )
+    else:
+        logger.warning("vane.ai substituted NULL for a failed provider call: %s", summary)
 
 
 def _rebuild_retry_after_error(args: tuple[Any, ...], state: dict[str, Any]) -> RetryAfterError:
@@ -389,7 +396,9 @@ def _retry_call(
     """
     _validate_on_error(on_error)
     last_exc: Exception | None = None
+    attempts = 0
     for attempt in range(1 + max(0, max_retries)):
+        attempts = attempt + 1
         wait: float | None = None
         try:
             result = fn(*args, **kwargs)
@@ -426,7 +435,7 @@ def _retry_call(
     assert last_exc is not None
     if on_error == "raise":
         raise last_exc
-    _log_substituted_failure(last_exc, on_error=on_error)
+    _log_substituted_failure(last_exc, on_error=on_error, attempts=attempts)
     return default
 
 
@@ -448,7 +457,9 @@ async def _retry_call_async(
     """
     _validate_on_error(on_error)
     last_exc: Exception | None = None
+    attempts = 0
     for attempt in range(1 + max(0, max_retries)):
+        attempts = attempt + 1
         wait: float | None = None
         try:
             result = fn(*args, **kwargs)
@@ -474,7 +485,7 @@ async def _retry_call_async(
     assert last_exc is not None
     if on_error == "raise":
         raise last_exc
-    _log_substituted_failure(last_exc, on_error=on_error)
+    _log_substituted_failure(last_exc, on_error=on_error, attempts=attempts)
     return default
 
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -148,8 +148,10 @@ def _log_substituted_failure(exc: Exception, *, on_error: _OnError, attempts: in
     """Record one bounded WARNING when a provider failure is replaced with NULL.
 
     Called at each site that swallows a provider error and yields NULL under
-    ``on_error='ignore'``; a no-op under ``'raise'`` so callers cannot log a
-    failure they are about to re-raise. ``attempts`` is the number of tries made
+    ``on_error='ignore'`` — including the native vLLM executor, whose ``"null"``
+    policy is the lowered form of ``'ignore'`` (see the mapping in
+    ``vane/ai/providers/vllm.py``); a no-op under ``'raise'`` so callers cannot
+    log a failure they are about to re-raise. ``attempts`` is the number of tries made
     when the caller is a retry loop (omitted where no attempt count is
     meaningful). Only the exception class, its sanitized numeric-status summary,
     and that count are emitted — never prompt text, row payloads, option
@@ -1360,9 +1362,10 @@ class _ValidateStructuredOutputBatch:
                 continue
             try:
                 results.append(self._return_format.validate_json(raw_text))
-            except OutputValidationError:
+            except OutputValidationError as exc:
                 if self._on_error == "raise":
                     raise
+                _log_substituted_failure(exc, on_error=self._on_error)
                 results.append(None)
         return pa.table({self._output_column: pa.array(results, type=pa.string())})
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -167,6 +167,13 @@ def _log_substituted_failure(exc: Exception, *, on_error: _OnError, attempts: in
         logger.warning("vane.ai substituted NULL for a failed provider call: %s", summary)
 
 
+# Sentinel a retry-helper caller can pass as ``default`` to tell an
+# already-logged substituted failure apart from a genuine provider NULL —
+# the two must not be conflated, or a NULL that fails downstream result
+# validation would be swallowed without its own warning.
+_SUBSTITUTED_FAILURE = object()
+
+
 def _rebuild_retry_after_error(args: tuple[Any, ...], state: dict[str, Any]) -> RetryAfterError:
     """Reconstruct a pickled :class:`RetryAfterError` from its sanitized state.
 
@@ -355,17 +362,6 @@ def _retry_after_error(exc: Exception) -> RetryAfterError | None:
     if retry_after is None:
         retry_after = _DEFAULT_RETRY_AFTER_SECONDS
     return RetryAfterError(retry_after=retry_after, original=exc)
-
-
-def _raise_if_retry_after(exc: Exception) -> None:
-    """Re-raise a rate-limited provider error as a :class:`RetryAfterError` when
-    it qualifies (429/503); a no-op otherwise, so the caller re-raises the
-    original error. Lets every HTTP provider honour ``Retry-After`` uniformly
-    (issue #148) by delegating to :func:`_retry_after_error`.
-    """
-    retry_error = _retry_after_error(exc)
-    if retry_error is not None:
-        raise retry_error from None
 
 
 def _retry_call(
@@ -1245,6 +1241,7 @@ class _PromptBatch:
                     row_messages[index],
                     max_retries=max_retries,
                     on_error=on_error,
+                    default=_SUBSTITUTED_FAILURE,
                     on_awaitable=self._mark_loop_bound,
                 )
             except ProviderCapabilityError as exc:
@@ -1258,17 +1255,16 @@ class _PromptBatch:
             if provider_error is not None:
                 provider, model = _descriptor_identity(self._descriptor)
                 raise _safe_provider_execution_error(provider, model, "Prompt execution", provider_error) from None
+            if result is _SUBSTITUTED_FAILURE:
+                # The retry helper already logged this substitution before
+                # returning the sentinel; surface it as a NULL row.
+                return None
             try:
                 return self._validate_result(result)
             except (_ProviderResultError, OutputValidationError, RawResponseSerializationError) as exc:
                 if on_error == "raise":
                     raise
-                # A NULL reaching validation is either a legitimate provider NULL
-                # or an already-logged swallowed failure (the retry helper logged
-                # it before substituting None); only a non-NULL payload that fails
-                # the result contract is a fresh substitution to record here.
-                if result is not None:
-                    _log_substituted_failure(exc, on_error=on_error)
+                _log_substituted_failure(exc, on_error=on_error)
                 return None
 
         async def run_all(indices: list[int]) -> list[str | None]:

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -284,6 +284,72 @@ def _is_transient_provider_error(exc: Exception) -> bool:
     return False
 
 
+_RATE_LIMIT_STATUS_CODES = frozenset({429, 503})
+_DEFAULT_RETRY_AFTER_SECONDS = 5.0
+
+
+def _provider_status_code(exc: Exception) -> int | None:
+    """Discover an HTTP status from a provider SDK error.
+
+    Providers surface the status differently — OpenAI/Anthropic expose
+    ``status_code``, Google exposes ``code``, and some attach it to the
+    response — so probe the common locations in a stable order.
+    """
+    for status in (
+        getattr(exc, "status_code", None),
+        getattr(exc, "code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+        getattr(getattr(exc, "response", None), "status", None),
+    ):
+        if isinstance(status, int) and not isinstance(status, bool):
+            return status
+    return None
+
+
+def _parse_retry_after_header(exc: Exception) -> float | None:
+    """Return a usable ``Retry-After`` delay from a provider error's response.
+
+    Returns ``None`` when no response, no header, or a malformed value is
+    present. A negative, NaN, or infinite header (all parseable by ``float()``,
+    e.g. ``"-1"``, ``"nan"``, ``"1e999"``) is treated as malformed and rejected
+    so it never reaches a retry sleep that would raise or hang (issue #469).
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    headers = getattr(response, "headers", None) or {}
+    try:
+        raw = headers.get("Retry-After") or headers.get("retry-after")
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        parsed = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if math.isfinite(parsed) and parsed >= 0:
+        return parsed
+    return None
+
+
+def _retry_after_error(exc: Exception) -> RetryAfterError | None:
+    """Build a :class:`RetryAfterError` for a rate-limited/unavailable provider
+    error, or ``None`` when the error does not qualify.
+
+    Shared by every HTTP provider (issue #148) so 429/503 retry timing is
+    uniform: the server-requested ``Retry-After`` is honoured when present and
+    usable, otherwise a default wait applies. The returned error carries the
+    original for its sanitized summary and status attributes only.
+    """
+    if _provider_status_code(exc) not in _RATE_LIMIT_STATUS_CODES:
+        return None
+    retry_after = _parse_retry_after_header(exc)
+    if retry_after is None:
+        retry_after = _DEFAULT_RETRY_AFTER_SECONDS
+    return RetryAfterError(retry_after=retry_after, original=exc)
+
+
 def _retry_call(
     fn: Any,
     *args: Any,

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import math
 import time
 from collections.abc import Awaitable, Callable, Mapping
@@ -132,11 +133,31 @@ def _provider_is_loop_bound(provider: Any, method_name: str) -> bool:
 
 _OnError = Literal["raise", "ignore"]
 
+logger = logging.getLogger(__name__)
+
 
 def _validate_on_error(on_error: object) -> _OnError:
     if not isinstance(on_error, str) or on_error not in ("raise", "ignore"):
         raise ValueError("on_error must be 'raise' or 'ignore'")
     return cast(_OnError, on_error)
+
+
+def _log_substituted_failure(exc: Exception, *, on_error: _OnError) -> None:
+    """Record one bounded WARNING when a provider failure is replaced with NULL.
+
+    Called at each site that swallows a provider error and yields NULL under
+    ``on_error='ignore'``; a no-op under ``'raise'`` so callers cannot log a
+    failure they are about to re-raise. Only the exception class and its
+    sanitized numeric-status summary are emitted — never prompt text, row
+    payloads, option mappings, credentials, or a traceback (vane#105) — so a
+    silent data degradation becomes observable without leaking sensitive input.
+    """
+    if on_error == "raise":
+        return
+    logger.warning(
+        "vane.ai substituted NULL for a failed provider call: %s",
+        _safe_original_error_summary(exc),
+    )
 
 
 def _rebuild_retry_after_error(args: tuple[Any, ...], state: dict[str, Any]) -> RetryAfterError:
@@ -328,6 +349,7 @@ def _retry_call(
     assert last_exc is not None
     if on_error == "raise":
         raise last_exc
+    _log_substituted_failure(last_exc, on_error=on_error)
     return default
 
 
@@ -375,6 +397,7 @@ async def _retry_call_async(
     assert last_exc is not None
     if on_error == "raise":
         raise last_exc
+    _log_substituted_failure(last_exc, on_error=on_error)
     return default
 
 
@@ -802,9 +825,10 @@ class _EmbedTextBatch:
                 embedding = self._coerce_embedding(value)
                 if normalize:
                     embedding = self._coerce_embedding(_normalize_embedding(embedding))
-            except _ProviderResultError:
+            except _ProviderResultError as exc:
                 if self._on_error == "raise":
                     raise
+                _log_substituted_failure(exc, on_error=self._on_error)
                 embeddings.append(None)
                 continue
             embeddings.append(embedding)
@@ -853,9 +877,10 @@ class _EmbedTextBatch:
             return self._invoke_embedder(texts)
         except _MissingAsyncRuntimeError:
             raise
-        except ProviderCapabilityError:
+        except ProviderCapabilityError as exc:
             if self._on_error == "raise":
                 raise
+            _log_substituted_failure(exc, on_error=self._on_error)
             return [None] * len(texts)
         except Exception:
             if self._on_error == "raise":
@@ -863,13 +888,17 @@ class _EmbedTextBatch:
 
         # A batch-level failure does not identify the failing row. Isolate the
         # inputs so on_error="ignore" nulls only rows that fail independently.
+        # The batch error itself is not logged here: each isolated row that
+        # actually fails logs its own substitution below (a row that recovers
+        # on isolation is not a substitution and must stay silent).
         isolated: list[np.ndarray | None] = []
         for text in texts:
             try:
                 isolated.append(self._invoke_embedder([text])[0])
             except _MissingAsyncRuntimeError:
                 raise
-            except Exception:
+            except Exception as exc:
+                _log_substituted_failure(exc, on_error=self._on_error)
                 isolated.append(None)
         return isolated
 
@@ -1143,9 +1172,15 @@ class _PromptBatch:
                 raise _safe_provider_execution_error(provider, model, "Prompt execution", provider_error) from None
             try:
                 return self._validate_result(result)
-            except (_ProviderResultError, OutputValidationError, RawResponseSerializationError):
+            except (_ProviderResultError, OutputValidationError, RawResponseSerializationError) as exc:
                 if on_error == "raise":
                     raise
+                # A NULL reaching validation is either a legitimate provider NULL
+                # or an already-logged swallowed failure (the retry helper logged
+                # it before substituting None); only a non-NULL payload that fails
+                # the result contract is a fresh substitution to record here.
+                if result is not None:
+                    _log_substituted_failure(exc, on_error=on_error)
                 return None
 
         async def run_all(indices: list[int]) -> list[str | None]:

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -203,21 +203,26 @@ class RetryAfterError(Exception):
     falls back to exponential backoff (see :func:`_retry_wait_seconds`).
     """
 
-    status_code: int  # normalized HTTP status, set by ``_retry_after_error``
+    status_code: int  # normalized HTTP status; absent when never discovered
 
-    def __init__(self, retry_after: float, original: Exception | None = None) -> None:
+    def __init__(self, retry_after: float, original: Exception | None = None, status: int | None = None) -> None:
         self.retry_after = retry_after
         if original is None:
             super().__init__("RetryAfterError")
-            return
-        super().__init__(_safe_original_error_summary(original))
-        for name in ("status_code", "status", "code"):
-            try:
-                value = getattr(original, name, None)
-            except Exception:
-                continue
-            if type(value) is int and -999_999 <= value <= 999_999:
-                setattr(self, name, value)
+        else:
+            super().__init__(_safe_original_error_summary(original))
+            for name in ("status_code", "status", "code"):
+                try:
+                    value = getattr(original, name, None)
+                except Exception:
+                    continue
+                if type(value) is int and -999_999 <= value <= 999_999:
+                    setattr(self, name, value)
+        if status is not None:
+            # A status discovered only on the original's attached response is
+            # not a direct attribute, so the whitelist above cannot see it;
+            # the caller's normalized discovery wins over any direct copy.
+            self.status_code = status
 
     def __reduce__(self) -> tuple[Any, ...]:
         # The default BaseException reduction rebuilds via ``__init__(*self.args)``,
@@ -391,17 +396,12 @@ def _retry_after_error(exc: Exception) -> RetryAfterError | None:
     original for its sanitized summary and status attributes only.
     """
     status = _provider_status_code(exc)
-    if status is None or status not in _RATE_LIMIT_STATUS_CODES:
+    if status not in _RATE_LIMIT_STATUS_CODES:
         return None
     retry_after = _parse_retry_after_header(exc)
     if retry_after is None:
         retry_after = _DEFAULT_RETRY_AFTER_SECONDS
-    error = RetryAfterError(retry_after=retry_after, original=exc)
-    # The constructor whitelists only the original's direct attributes, so a
-    # status discovered on the attached response would be lost from warnings
-    # and pickles without this normalized copy.
-    error.status_code = status
-    return error
+    return RetryAfterError(retry_after=retry_after, original=exc, status=status)
 
 
 def _retry_call(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -139,6 +139,21 @@ def _validate_on_error(on_error: object) -> _OnError:
     return cast(_OnError, on_error)
 
 
+def _rebuild_retry_after_error(args: tuple[Any, ...], state: dict[str, Any]) -> RetryAfterError:
+    """Reconstruct a pickled :class:`RetryAfterError` from its sanitized state.
+
+    The constructor derives the message and status attributes from an
+    ``original`` exception, so feeding a pickled message back through it would
+    misassign the message string to ``retry_after`` and require re-transporting
+    the original provider error — defeating the sanitization. Rebuild the
+    instance directly from its already-sanitized state instead.
+    """
+    exc = RetryAfterError.__new__(RetryAfterError)
+    exc.args = args
+    exc.__dict__.update(state)
+    return exc
+
+
 class RetryAfterError(Exception):
     """Retryable error carrying the requested wait time (in seconds).
 
@@ -162,6 +177,15 @@ class RetryAfterError(Exception):
                 continue
             if type(value) is int and -999_999 <= value <= 999_999:
                 setattr(self, name, value)
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        # The default BaseException reduction rebuilds via ``__init__(*self.args)``,
+        # which feeds the sanitized message in as ``retry_after`` and regenerates
+        # a generic message — losing the summary across a pickle boundary (Ray
+        # worker -> driver). Rebuild from the already-sanitized instance state
+        # (numeric ``retry_after`` plus whitelisted status attributes) without
+        # re-running constructor sanitization or resurrecting the original error.
+        return (_rebuild_retry_after_error, (self.args, dict(self.__dict__)))
 
 
 def _retry_wait_seconds(exc: Exception, attempt: int) -> float:

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -29,6 +29,8 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import datetime
+import email.utils
 import inspect
 import logging
 import math
@@ -320,13 +322,38 @@ def _provider_status_code(exc: Exception) -> int | None:
     return None
 
 
+def _utcnow() -> datetime.datetime:
+    """Current UTC time; a seam so fixed-clock tests can pin HTTP-date parsing."""
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _retry_after_http_date_delay(raw: str) -> float | None:
+    """Seconds until an HTTP-date ``Retry-After`` value, or ``None`` when the
+    value is not a parseable date.
+
+    A date already in the past means "retry immediately", so it clamps to zero
+    rather than being rejected as malformed.
+    """
+    try:
+        when = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        # RFC 5322 parses a "-0000" offset to a naive datetime; HTTP-dates are
+        # always GMT, so interpret it as UTC.
+        when = when.replace(tzinfo=datetime.timezone.utc)
+    return max(0.0, (when - _utcnow()).total_seconds())
+
+
 def _parse_retry_after_header(exc: Exception) -> float | None:
     """Return a usable ``Retry-After`` delay from a provider error's response.
 
-    Returns ``None`` when no response, no header, or a malformed value is
-    present. A negative, NaN, or infinite header (all parseable by ``float()``,
-    e.g. ``"-1"``, ``"nan"``, ``"1e999"``) is treated as malformed and rejected
-    so it never reaches a retry sleep that would raise or hang (issue #469).
+    RFC 9110 permits either delay-seconds or an HTTP-date; both are accepted,
+    a date being converted to the remaining delay. Returns ``None`` when no
+    response, no header, or a malformed value is present. A negative, NaN, or
+    infinite delay-seconds header (all parseable by ``float()``, e.g. ``"-1"``,
+    ``"nan"``, ``"1e999"``) is treated as malformed and rejected so it never
+    reaches a retry sleep that would raise or hang (issue #469).
     """
     response = getattr(exc, "response", None)
     if response is None:
@@ -341,7 +368,10 @@ def _parse_retry_after_header(exc: Exception) -> float | None:
     try:
         parsed = float(raw)
     except (TypeError, ValueError):
-        return None
+        date_delay = _retry_after_http_date_delay(raw) if isinstance(raw, str) else None
+        if date_delay is None:
+            return None
+        parsed = date_delay
     if math.isfinite(parsed) and parsed >= 0:
         return parsed
     return None

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -350,6 +350,17 @@ def _retry_after_error(exc: Exception) -> RetryAfterError | None:
     return RetryAfterError(retry_after=retry_after, original=exc)
 
 
+def _raise_if_retry_after(exc: Exception) -> None:
+    """Re-raise a rate-limited provider error as a :class:`RetryAfterError` when
+    it qualifies (429/503); a no-op otherwise, so the caller re-raises the
+    original error. Lets every HTTP provider honour ``Retry-After`` uniformly
+    (issue #148) by delegating to :func:`_retry_after_error`.
+    """
+    retry_error = _retry_after_error(exc)
+    if retry_error is not None:
+        raise retry_error from None
+
+
 def _retry_call(
     fn: Any,
     *args: Any,

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -201,6 +201,8 @@ class RetryAfterError(Exception):
     falls back to exponential backoff (see :func:`_retry_wait_seconds`).
     """
 
+    status_code: int  # normalized HTTP status, set by ``_retry_after_error``
+
     def __init__(self, retry_after: float, original: Exception | None = None) -> None:
         self.retry_after = retry_after
         if original is None:
@@ -386,12 +388,18 @@ def _retry_after_error(exc: Exception) -> RetryAfterError | None:
     usable, otherwise a default wait applies. The returned error carries the
     original for its sanitized summary and status attributes only.
     """
-    if _provider_status_code(exc) not in _RATE_LIMIT_STATUS_CODES:
+    status = _provider_status_code(exc)
+    if status is None or status not in _RATE_LIMIT_STATUS_CODES:
         return None
     retry_after = _parse_retry_after_header(exc)
     if retry_after is None:
         retry_after = _DEFAULT_RETRY_AFTER_SECONDS
-    return RetryAfterError(retry_after=retry_after, original=exc)
+    error = RetryAfterError(retry_after=retry_after, original=exc)
+    # The constructor whitelists only the original's direct attributes, so a
+    # status discovered on the attached response would be lost from warnings
+    # and pickles without this normalized copy.
+    error.status_code = status
+    return error
 
 
 def _retry_call(

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -272,6 +272,9 @@ class AnthropicPrompter:
                     original_error=exc,
                 )
             else:
+                from vane.ai.functions import _raise_if_retry_after
+
+                _raise_if_retry_after(exc)
                 raise
         if capability_error is not None:
             raise capability_error from None

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -261,6 +261,7 @@ class AnthropicPrompter:
             }
 
         capability_error: ProviderCapabilityError | None = None
+        retry_error: Exception | None = None
         try:
             response = await self._client.messages.create(**kwargs)
         except Exception as exc:
@@ -272,10 +273,15 @@ class AnthropicPrompter:
                     original_error=exc,
                 )
             else:
-                from vane.ai.functions import _raise_if_retry_after
+                from vane.ai.functions import _retry_after_error
 
-                _raise_if_retry_after(exc)
-                raise
+                retry_error = _retry_after_error(exc)
+                if retry_error is None:
+                    raise
+        if retry_error is not None:
+            # Raised outside the handler so the raw SDK error is not retained
+            # as __context__ (mirrors the Google provider's raise shape).
+            raise retry_error from None
         if capability_error is not None:
             raise capability_error from None
 

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -18,7 +18,6 @@ Requires::
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -74,37 +73,13 @@ _IMAGE_MIME_POLICY = ImageMimePolicy(
 def _retry_after_error_from_google_error(exc: Exception) -> Exception | None:
     """Build a safe retry signal for Google 429/503 responses, if applicable.
 
-    Parses the ``Retry-After`` header if present; a missing, unparseable, or
-    malformed (negative or non-finite) header falls back to a 5-second
-    default wait.
+    Thin adapter over the shared, provider-agnostic extraction helper (issue
+    #148) so 429/503 retry timing — header parsing, malformed-value guards
+    (issue #469), and the default wait — is identical across every provider.
     """
-    from vane.ai.functions import RetryAfterError
+    from vane.ai.functions import _retry_after_error
 
-    code = getattr(exc, "code", None)
-    if code not in (429, 503):
-        return None
-
-    # Try to extract Retry-After from the response headers
-    response = getattr(exc, "response", None)
-    retry_after: float | None = None
-    if response is not None:
-        headers = getattr(response, "headers", None) or {}
-        raw = headers.get("Retry-After") or headers.get("retry-after")
-        if raw is not None:
-            try:
-                parsed = float(raw)
-            except (TypeError, ValueError):
-                parsed = None
-            # A negative, NaN, or infinite header (all parseable by float(),
-            # e.g. "-1", "nan", "1e999") is malformed: ignore it and fall back
-            # to the default wait rather than passing it to a retry sleep that
-            # would raise or hang (issue #469).
-            if parsed is not None and math.isfinite(parsed) and parsed >= 0:
-                retry_after = parsed
-    if retry_after is None:
-        retry_after = 5.0  # default wait for 429/503
-
-    return RetryAfterError(retry_after=retry_after, original=exc)
+    return _retry_after_error(exc)
 
 
 def _raise_retry_after_on_google_error(exc: Exception) -> None:

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -696,6 +696,9 @@ class OpenAITextEmbedder:
                     original_error=ex,
                 )
             else:
+                from vane.ai.functions import _raise_if_retry_after
+
+                _raise_if_retry_after(ex)
                 raise
         if capability_error is not None:
             raise capability_error from None
@@ -940,6 +943,9 @@ class OpenAIPrompter:
                     original_error=exc,
                 )
             else:
+                from vane.ai.functions import _raise_if_retry_after
+
+                _raise_if_retry_after(exc)
                 raise
         if capability_error is not None:
             raise capability_error from None
@@ -984,6 +990,9 @@ class OpenAIPrompter:
                     original_error=exc,
                 )
             else:
+                from vane.ai.functions import _raise_if_retry_after
+
+                _raise_if_retry_after(exc)
                 raise
         if capability_error is not None:
             raise capability_error from None

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -652,6 +652,7 @@ class OpenAITextEmbedder:
         from openai import OpenAIError  # type: ignore[import-not-found, import-untyped, unused-ignore]
 
         capability_error: ProviderCapabilityError | None = None
+        retry_error: Exception | None = None
         try:
             encoding_format = getattr(self, "_encoding_format", "float")
             kwargs: dict[str, Any] = {
@@ -696,10 +697,15 @@ class OpenAITextEmbedder:
                     original_error=ex,
                 )
             else:
-                from vane.ai.functions import _raise_if_retry_after
+                from vane.ai.functions import _retry_after_error
 
-                _raise_if_retry_after(ex)
-                raise
+                retry_error = _retry_after_error(ex)
+                if retry_error is None:
+                    raise
+        if retry_error is not None:
+            # Raised outside the handler so the raw SDK error is not retained
+            # as __context__ (mirrors the Google provider's raise shape).
+            raise retry_error from None
         if capability_error is not None:
             raise capability_error from None
         raise AssertionError("OpenAI embedding request completed without a result")
@@ -928,6 +934,7 @@ class OpenAIPrompter:
         """Prompt using the Chat Completions API."""
         options = self._chat_completions_options()
         capability_error: ProviderCapabilityError | None = None
+        retry_error: Exception | None = None
         try:
             response = await self._client.chat.completions.create(
                 model=self._model,
@@ -943,10 +950,15 @@ class OpenAIPrompter:
                     original_error=exc,
                 )
             else:
-                from vane.ai.functions import _raise_if_retry_after
+                from vane.ai.functions import _retry_after_error
 
-                _raise_if_retry_after(exc)
-                raise
+                retry_error = _retry_after_error(exc)
+                if retry_error is None:
+                    raise
+        if retry_error is not None:
+            # Raised outside the handler so the raw SDK error is not retained
+            # as __context__ (mirrors the Google provider's raise shape).
+            raise retry_error from None
         if capability_error is not None:
             raise capability_error from None
         if getattr(self, "_return_raw_response", False):
@@ -975,6 +987,7 @@ class OpenAIPrompter:
         """Prompt using the Responses API."""
         options = self._responses_options()
         capability_error: ProviderCapabilityError | None = None
+        retry_error: Exception | None = None
         try:
             response = await self._client.responses.create(
                 model=self._model,
@@ -990,10 +1003,15 @@ class OpenAIPrompter:
                     original_error=exc,
                 )
             else:
-                from vane.ai.functions import _raise_if_retry_after
+                from vane.ai.functions import _retry_after_error
 
-                _raise_if_retry_after(exc)
-                raise
+                retry_error = _retry_after_error(exc)
+                if retry_error is None:
+                    raise
+        if retry_error is not None:
+            # Raised outside the handler so the raw SDK error is not retained
+            # as __context__ (mirrors the Google provider's raise shape).
+            raise retry_error from None
         if capability_error is not None:
             raise capability_error from None
         if getattr(self, "_return_raw_response", False):

--- a/vane/execution/vllm.py
+++ b/vane/execution/vllm.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, overload
 import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
 
 from vane._native import __standard_vector_size__ as DUCKDB_STANDARD_VECTOR_SIZE
+from vane.ai.functions import _log_substituted_failure
 from vane.ai.provider import _safe_provider_execution_error, _SafeProviderError
 from vane.execution._vllm_options_protocol import (
     _NATIVE_OPTIONS_NORMALIZED_SECRET_KEY,
@@ -444,6 +445,10 @@ class LocalVLLMExecutor(VLLMExecutor):
                             self.error_message = error_message
                 self._notify_state_change(force=True)
             else:
+                # The native "null" policy is the lowered form of the public
+                # on_error="ignore" (vane/ai/providers/vllm.py), so its NULL
+                # substitutions carry the same bounded warning.
+                _log_substituted_failure(exc, on_error="ignore")
                 if executor_id:
                     self._per_executor_deques.setdefault(executor_id, deque()).append((None, row, reservation_id))
                 else:
@@ -466,6 +471,13 @@ class LocalVLLMExecutor(VLLMExecutor):
         reservation_id: str | None = None,
     ) -> None:
         rows = _ensure_table(rows)
+        # One warning per substituted batch, not per row: every caller routes
+        # the same already-sanitized engine-init failure here under the native
+        # "null" policy (the lowered form of the public on_error="ignore").
+        _log_substituted_failure(
+            _SafeProviderError(f"vllm engine init failed: {self.engine_error_message}"),
+            on_error="ignore",
+        )
         for i in range(rows.num_rows):
             row = rows.slice(i, 1)
             if executor_id:

--- a/vane/execution/vllm.py
+++ b/vane/execution/vllm.py
@@ -445,10 +445,7 @@ class LocalVLLMExecutor(VLLMExecutor):
                             self.error_message = error_message
                 self._notify_state_change(force=True)
             else:
-                # The native "null" policy is the lowered form of the public
-                # on_error="ignore" (vane/ai/providers/vllm.py), so its NULL
-                # substitutions carry the same bounded warning.
-                _log_substituted_failure(exc, on_error="ignore")
+                self._log_null_substitution(exc)
                 if executor_id:
                     self._per_executor_deques.setdefault(executor_id, deque()).append((None, row, reservation_id))
                 else:
@@ -464,6 +461,16 @@ class LocalVLLMExecutor(VLLMExecutor):
                     self._per_executor_running_task_count[executor_id] = max(0, remaining)
             self._notify_state_change()
 
+    def _log_null_substitution(self, exc: Exception) -> None:
+        """Emit the bounded substitution warning under the native NULL policy.
+
+        The native "null" policy is the lowered form of the public
+        on_error="ignore" (vane/ai/providers/vllm.py); this is the one place
+        that maps the executor's policy back to the public mode, so raise-mode
+        callers can never log a substitution that is not happening.
+        """
+        _log_substituted_failure(exc, on_error="raise" if self.on_error == "raise" else "ignore")
+
     def _append_error_rows(
         self,
         rows: pa.Table,
@@ -472,12 +479,8 @@ class LocalVLLMExecutor(VLLMExecutor):
     ) -> None:
         rows = _ensure_table(rows)
         # One warning per substituted batch, not per row: every caller routes
-        # the same already-sanitized engine-init failure here under the native
-        # "null" policy (the lowered form of the public on_error="ignore").
-        _log_substituted_failure(
-            _SafeProviderError(f"vllm engine init failed: {self.engine_error_message}"),
-            on_error="ignore",
-        )
+        # the same already-sanitized engine-init failure here.
+        self._log_null_substitution(_SafeProviderError(f"vllm engine init failed: {self.engine_error_message}"))
         for i in range(rows.num_rows):
             row = rows.slice(i, 1)
             if executor_id:


### PR DESCRIPTION
## Summary

Rescoped per the maintainer's request (2026-08-05) to the still-open #148 scope: `RetryAfterError` serialization and the remaining classification/logging gaps. The branch was rebuilt from current `main`; the previously bundled #147 work (execution-option routing, silent-option handling) is dropped — #147 is closed, superseded by #397's API replacement. Of #148's original report, the chunked-embedding retry bypass and the batch-granularity substitution are already fixed on current `main` and are not re-fixed here.

- **Preserve `RetryAfterError` across pickling.** The default `BaseException` reduction rebuilds via `__init__(*args)`, feeding the sanitized message in as `retry_after` and regenerating a generic message, so a Ray worker → driver round trip degraded the sanitized summary. A custom `__reduce__` now rebuilds from the already-sanitized instance state (numeric `retry_after`, message, whitelisted status attributes) without re-running constructor sanitization or resurrecting the original provider error.
- **Make `on_error="ignore"` substitutions observable.** Every provider failure converted to NULL now emits exactly one bounded `WARNING`: exception class, sanitized numeric-status summary, and attempt count where a retry loop knows it — never prompt text, row payloads, option mappings, credentials, or tracebacks (the vane#105 posture). A sentinel default distinguishes an already-logged substituted NULL from a genuine provider NULL, so a structured-output contract violation on a provider NULL also warns instead of disappearing silently. `on_error="raise"` is byte-for-byte unchanged; no new `on_error` mode is introduced.
- **Unify Retry-After handling.** A shared provider-agnostic helper owns the 429/503 qualifying set, header lookup, the #469 malformed-value guards, and the 5-second default. The Google provider's extraction becomes a thin adapter over it (its extraction tests pass unmodified); OpenAI (embeddings, Chat Completions, Responses) and Anthropic (Messages) adopt the same helper, raising the converted error outside the SDK-error handler exactly as Google does so no raw provider error is retained as `__context__`. A server-requested `Retry-After` is now honored identically across providers instead of falling back to exponential backoff. Anthropic 529 overload responses deliberately stay on the existing transient-backoff path.

User-visible changes to call out for release notes: `on_error="ignore"` now logs one warning per substituted provider call, and OpenAI/Anthropic 429/503 retries wait the server-requested `Retry-After` (capped at 120s) instead of exponential backoff.

## Related issue

Addresses the remaining #148 scope as named in the rescope request; whether this fully closes #148 is left to maintainer judgment. The one remaining design-level item — a unified provider error carrier owning `is_retryable`/`status_code`/`retry_after` — is the #152 benchmark discussion and is intentionally not attempted here.

No overlap with #572: terminal-state validation leaves the retry helpers and the non-retryable classification tuple untouched, and this PR does not cross that seam from the other side; the two compose regardless of landing order.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is a provider retry-semantics correctness fix; the compatibility notes above stay in the PR body, per the #480 precedent.

## Validation

- `pre-commit` (ruff check, ruff format, mypy) passes on every commit.
- Targeted tests run locally under a package-stub harness (the native engine cannot be built on this dev machine): `tests/ai/test_ai_functions.py`, `tests/ai/test_prompt_provider_contracts.py`, `tests/fast/test_anthropic_prompter_content.py` — 247 passed, including the new regression coverage for pickling round-trips, substitution logging across both wrappers, shared-helper extraction, and per-provider Retry-After adoption. The 8 remaining local failures are pre-existing environment limits identical on `main` (missing `cloudpickle`; engine-dependent tests).
- Full-suite validation is CI-only for this branch; no local full-suite green is claimed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
      (Scope is exactly the three-item list from the rescope request; each behavior change carries regression tests.)
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (None added.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (The custom `__reduce__` rebuilds only from
      already-sanitized state and cannot resurrect the original provider error; substitution
      warnings emit class names and numeric statuses only.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. (Python-only.)
