### PR TITLE
[fix](ray) Prevent cross-fragment FTE lock inversion

### DIFF
--- a/duckdb/runners/fte/fte_events.py
+++ b/duckdb/runners/fte/fte_events.py
@@ -78,10 +78,7 @@ class MemoryPressureDetected(FteEvent):
 
 @dataclass(frozen=True)
 class ResourceAdmissionChanged(FteEvent):
-    """Wake pending FTE reservations after resource or worker capacity changes."""
-
-    # Worker capacity is shared across queries; query-resource changes are not.
-    global_scope: bool = False
+    """Wake pending FTE reservations after query resource ownership changes."""
 
 
 @dataclass(frozen=True)

--- a/duckdb/runners/fte/fte_events.py
+++ b/duckdb/runners/fte/fte_events.py
@@ -78,7 +78,14 @@ class MemoryPressureDetected(FteEvent):
 
 @dataclass(frozen=True)
 class ResourceAdmissionChanged(FteEvent):
-    """Wake pending FTE reservations after query resource ownership changes."""
+    """Wake pending FTE reservations after resource ownership changes.
+
+    Internal pump pulses are deliberately excluded from user-facing event
+    progress counters.
+    """
+
+    execution_class: str | None = None
+    internal: bool = False
 
 
 @dataclass(frozen=True)

--- a/duckdb/runners/fte/fte_events.py
+++ b/duckdb/runners/fte/fte_events.py
@@ -78,7 +78,10 @@ class MemoryPressureDetected(FteEvent):
 
 @dataclass(frozen=True)
 class ResourceAdmissionChanged(FteEvent):
-    """Wake pending FTE reservations after query resource ownership changes."""
+    """Wake pending FTE reservations after resource or worker capacity changes."""
+
+    # Worker capacity is shared across queries; query-resource changes are not.
+    global_scope: bool = False
 
 
 @dataclass(frozen=True)

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -923,9 +923,10 @@ class FteFragmentExecution:
         self._worker_command_outbox.append(command)
 
     def pop_worker_commands(self) -> list[Any]:
-        commands = list(self._worker_command_outbox)
-        self._worker_command_outbox.clear()
-        return commands
+        with self._attempt_scheduling_lock:
+            commands = list(self._worker_command_outbox)
+            self._worker_command_outbox.clear()
+            return commands
 
     def _update_partition_locked(self, update: PartitionUpdate) -> bool:
         partition = self.add_partition(update.partition_id)

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -477,9 +477,8 @@ class FteFragmentExecution:
         self.failed = False
         self.no_more_partitions = False
         self._state_lock = threading.RLock()
-        # Serialize the validate/admit/commit sequence while admission callbacks
-        # run without the fragment state lock.  The lock order is scheduling ->
-        # state; global admission callbacks never run while state is held.
+        # Serialize validate/admit/commit while cross-fragment attempt admission
+        # runs without the state lock.  The lock order is scheduling -> state.
         self._attempt_scheduling_lock = threading.RLock()
         self._current_worker_commands: list[Any] | None = None
         self._worker_command_outbox: list[Any] = []
@@ -546,15 +545,11 @@ class FteFragmentExecution:
                     for info in result.partitions_added:
                         self.add_partition(info.partition_id, info.node_requirements)
                 for update in self._coalesce_partition_updates(result.partition_updates):
-                    with self._state_lock:
-                        should_schedule = self._update_partition_locked(update)
-                    attempt = self._schedule_partition_if_ready(update.partition_id) if should_schedule else None
+                    attempt = self.update_partition(update)
                     if attempt is not None:
                         scheduled.append(attempt)
                 for partition_id in result.sealed_partitions:
-                    with self._state_lock:
-                        should_schedule = self._seal_partition_locked(partition_id)
-                    attempt = self._schedule_partition_if_ready(partition_id) if should_schedule else None
+                    attempt = self.seal_partition(partition_id)
                     if attempt is not None:
                         scheduled.append(attempt)
                 with self._state_lock:
@@ -569,33 +564,32 @@ class FteFragmentExecution:
         partition_id: int,
         update: FteTaskUpdateRequest | Mapping[str, Any] | None,
     ) -> FragmentExecutionMutationResult:
-        with self._attempt_scheduling_lock:
-            with self._state_lock:
-                previous_worker_commands = self._current_worker_commands
-                worker_commands: list[Any] = []
-                self._current_worker_commands = worker_commands
-                try:
-                    partition = self.add_partition(partition_id)
-                    update_request = FteTaskUpdateRequest.coerce(update)
-                    if not partition.descriptor.apply_task_update(update_request):
-                        return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
-                    self.descriptor_storage.put(partition.task_id, partition.descriptor)
-                    running = partition.running_attempt
-                    if running is not None:
-                        worker = running.remote_handle
-                        self._record_worker_command(
-                            FteTaskUpdateCommand(
-                                query_id=self.query_id,
-                                fragment_id=self.fragment_id,
-                                worker_id=running.worker_id,
-                                worker=worker,
-                                attempt_id=running.attempt_id,
-                                update=update_request.to_dict(),
-                            )
-                        )
+        with self._attempt_scheduling_lock, self._state_lock:
+            previous_worker_commands = self._current_worker_commands
+            worker_commands: list[Any] = []
+            self._current_worker_commands = worker_commands
+            try:
+                partition = self.add_partition(partition_id)
+                update_request = FteTaskUpdateRequest.coerce(update)
+                if not partition.descriptor.apply_task_update(update_request):
                     return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
-                finally:
-                    self._current_worker_commands = previous_worker_commands
+                self.descriptor_storage.put(partition.task_id, partition.descriptor)
+                running = partition.running_attempt
+                if running is not None:
+                    worker = running.remote_handle
+                    self._record_worker_command(
+                        FteTaskUpdateCommand(
+                            query_id=self.query_id,
+                            fragment_id=self.fragment_id,
+                            worker_id=running.worker_id,
+                            worker=worker,
+                            attempt_id=running.attempt_id,
+                            update=update_request.to_dict(),
+                        )
+                    )
+                return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
+            finally:
+                self._current_worker_commands = previous_worker_commands
 
     @staticmethod
     def _partition_ready_to_schedule(partition: FteTaskPartition) -> bool:
@@ -824,19 +818,18 @@ class FteFragmentExecution:
         self,
         execution_class: FteTaskExecutionClass | str | None = None,
     ) -> ScheduledAttempt | None:
-        with self._attempt_scheduling_lock:
-            with self._state_lock:
-                partition_ids = [
-                    partition.task_id.partition_id
-                    for partition in sorted(self.partitions.values(), key=lambda value: value.task_id.partition_id)
-                    if self._partition_ready_to_schedule(partition)
-                    and self._partition_matches_execution_class(partition, execution_class)
-                ]
-            for partition_id in partition_ids:
-                attempt = self._schedule_partition_if_ready(partition_id, execution_class)
-                if attempt is not None:
-                    return attempt
-            return None
+        with self._state_lock:
+            partition_ids = [
+                partition.task_id.partition_id
+                for partition in sorted(self.partitions.values(), key=lambda value: value.task_id.partition_id)
+                if self._partition_ready_to_schedule(partition)
+                and self._partition_matches_execution_class(partition, execution_class)
+            ]
+        for partition_id in partition_ids:
+            attempt = self._schedule_partition_if_ready(partition_id, execution_class)
+            if attempt is not None:
+                return attempt
+        return None
 
     @staticmethod
     def _coalesce_partition_updates(updates: list[PartitionUpdate]) -> list[PartitionUpdate]:
@@ -1015,30 +1008,29 @@ class FteFragmentExecution:
     ) -> ScheduledAttempt | None:
         attempt = FteTaskAttemptId.coerce(attempt_id)
         should_schedule = False
-        with self._attempt_scheduling_lock:
-            with self._state_lock:
-                partition = self.partitions[attempt.partition_id]
-                running = partition.running_attempts.get(attempt.attempt_id)
-                failure_retryable = retryable and _failure_allows_retry(error)
-                if self.exchange is not None and partition.sink_handle is not None:
-                    self.exchange.sink_aborted(partition.sink_handle, attempt.attempt_id)
-                ready = partition.mark_attempt_failed(attempt, error, retryable=failure_retryable)
-                if ready is not None and _is_memory_failure(error):
-                    partition.failed = True
-                    partition.ready_for_scheduling = False
-                    partition.execution_ready_deferred = False
-                    partition.running_attempts.clear()
+        with self._state_lock:
+            partition = self.partitions[attempt.partition_id]
+            running = partition.running_attempts.get(attempt.attempt_id)
+            failure_retryable = retryable and _failure_allows_retry(error)
+            if self.exchange is not None and partition.sink_handle is not None:
+                self.exchange.sink_aborted(partition.sink_handle, attempt.attempt_id)
+            ready = partition.mark_attempt_failed(attempt, error, retryable=failure_retryable)
+            if ready is not None and _is_memory_failure(error):
+                partition.failed = True
+                partition.ready_for_scheduling = False
+                partition.execution_ready_deferred = False
+                partition.running_attempts.clear()
+                self.failed = True
+            else:
+                if partition.failed:
                     self.failed = True
-                else:
-                    if partition.failed:
-                        self.failed = True
-                    if ready is not None:
-                        if not partition.sealed and partition.execution_class.is_speculative:
-                            partition.ready_for_scheduling = False
-                            partition.execution_ready_deferred = False
-                        else:
-                            partition.mark_ready_for_execution()
-                            should_schedule = True
+                if ready is not None:
+                    if not partition.sealed and partition.execution_class.is_speculative:
+                        partition.ready_for_scheduling = False
+                        partition.execution_ready_deferred = False
+                    else:
+                        partition.mark_ready_for_execution()
+                        should_schedule = True
 
         if running is not None:
             self._record_task_terminal_without_drain(running.remote_handle, attempt)
@@ -1059,43 +1051,42 @@ class FteFragmentExecution:
         if limit == 0:
             return revoked
         try:
-            with self._attempt_scheduling_lock:
-                with self._state_lock:
-                    reached_limit = False
-                    for partition in self.partitions.values():
-                        if partition.finished or partition.failed or not partition.execution_class.is_speculative:
+            with self._state_lock:
+                reached_limit = False
+                for partition in self.partitions.values():
+                    if partition.finished or partition.failed or not partition.execution_class.is_speculative:
+                        continue
+                    running_attempts = sorted(
+                        partition.running_attempts.values(), key=lambda running: running.attempt_id.attempt_id
+                    )
+                    for running in running_attempts:
+                        if worker_id is not None and str(running.worker_id or "") != str(worker_id):
                             continue
-                        running_attempts = sorted(
-                            partition.running_attempts.values(), key=lambda running: running.attempt_id.attempt_id
+                        try:
+                            if running.remote_handle is not None:
+                                running.remote_handle.fte_cancel_task(running.attempt_id.to_dict())
+                        except Exception as exc:
+                            raise self._worker_control_failure(
+                                running,
+                                "fte_cancel_task",
+                                exc,
+                            ) from exc
+                        if self.exchange is not None and partition.sink_handle is not None:
+                            self.exchange.sink_aborted(partition.sink_handle, running.attempt_id.attempt_id)
+                        revoked_attempt = partition.revoke_attempt(
+                            running.attempt_id,
+                            reason or "speculative task revoked",
                         )
-                        for running in running_attempts:
-                            if worker_id is not None and str(running.worker_id or "") != str(worker_id):
-                                continue
-                            try:
-                                if running.remote_handle is not None:
-                                    running.remote_handle.fte_cancel_task(running.attempt_id.to_dict())
-                            except Exception as exc:
-                                raise self._worker_control_failure(
-                                    running,
-                                    "fte_cancel_task",
-                                    exc,
-                                ) from exc
-                            if self.exchange is not None and partition.sink_handle is not None:
-                                self.exchange.sink_aborted(partition.sink_handle, running.attempt_id.attempt_id)
-                            revoked_attempt = partition.revoke_attempt(
-                                running.attempt_id,
-                                reason or "speculative task revoked",
-                            )
-                            if revoked_attempt is None:
-                                continue
-                            pressure_releases.append((running.remote_handle, running.attempt_id))
-                            revoked.append(revoked_attempt)
-                            self.failed = self.failed or partition.failed
-                            if limit is not None and len(revoked) >= limit:
-                                reached_limit = True
-                                break
-                        if reached_limit:
+                        if revoked_attempt is None:
+                            continue
+                        pressure_releases.append((running.remote_handle, running.attempt_id))
+                        revoked.append(revoked_attempt)
+                        self.failed = self.failed or partition.failed
+                        if limit is not None and len(revoked) >= limit:
+                            reached_limit = True
                             break
+                    if reached_limit:
+                        break
         finally:
             for remote_handle, attempt in pressure_releases:
                 self._record_task_terminal_without_drain(remote_handle, attempt)
@@ -1110,14 +1101,13 @@ class FteFragmentExecution:
         retryable_by_partition_id: Mapping[int, bool] | None = None,
     ) -> list[ScheduledAttempt]:
         worker_id = str(worker_id)
-        with self._attempt_scheduling_lock:
-            with self._state_lock:
-                failed_attempts = [
-                    (running.attempt_id, int(partition.task_id.partition_id))
-                    for partition in self.partitions.values()
-                    for running in partition.running_attempts.values()
-                    if running.worker_id == worker_id
-                ]
+        with self._state_lock:
+            failed_attempts = [
+                (running.attempt_id, int(partition.task_id.partition_id))
+                for partition in self.partitions.values()
+                for running in partition.running_attempts.values()
+                if running.worker_id == worker_id
+            ]
         scheduled: list[ScheduledAttempt] = []
         for attempt, partition_id in failed_attempts:
             partition_retryable = retryable
@@ -1136,36 +1126,35 @@ class FteFragmentExecution:
         attempt = FteTaskAttemptId.coerce(attempt_id)
         pressure_releases: list[tuple[str, Any, FteTaskAttemptId]] = []
         try:
-            with self._attempt_scheduling_lock:
-                with self._state_lock:
-                    partition = self.partitions[attempt.partition_id]
-                    running_attempts = list(partition.running_attempts.values())
-                    running = partition.running_attempts.get(attempt.attempt_id)
-                    unselected_running = [
-                        item for item in running_attempts if item.attempt_id.attempt_id != attempt.attempt_id
-                    ]
-                    changed = partition.mark_attempt_finished(attempt, output_stats)
-                    cancel_failure: FteWorkerControlFailure | None = None
-                    if changed:
-                        if running is not None:
-                            pressure_releases.append(("result_ready", running.remote_handle, attempt))
-                        for loser in unselected_running:
-                            try:
-                                if loser.remote_handle is not None:
-                                    loser.remote_handle.fte_cancel_task(loser.attempt_id.to_dict())
-                            except Exception as exc:
-                                if cancel_failure is None:
-                                    cancel_failure = self._worker_control_failure(
-                                        loser,
-                                        "fte_cancel_task",
-                                        exc,
-                                    )
-                            if self.exchange is not None and partition.sink_handle is not None:
-                                self.exchange.sink_aborted(partition.sink_handle, loser.attempt_id.attempt_id)
-                            pressure_releases.append(("terminal", loser.remote_handle, loser.attempt_id))
+            with self._state_lock:
+                partition = self.partitions[attempt.partition_id]
+                running_attempts = list(partition.running_attempts.values())
+                running = partition.running_attempts.get(attempt.attempt_id)
+                unselected_running = [
+                    item for item in running_attempts if item.attempt_id.attempt_id != attempt.attempt_id
+                ]
+                changed = partition.mark_attempt_finished(attempt, output_stats)
+                cancel_failure: FteWorkerControlFailure | None = None
+                if changed:
+                    if running is not None:
+                        pressure_releases.append(("result_ready", running.remote_handle, attempt))
+                    for loser in unselected_running:
+                        try:
+                            if loser.remote_handle is not None:
+                                loser.remote_handle.fte_cancel_task(loser.attempt_id.to_dict())
+                        except Exception as exc:
+                            if cancel_failure is None:
+                                cancel_failure = self._worker_control_failure(
+                                    loser,
+                                    "fte_cancel_task",
+                                    exc,
+                                )
                         if self.exchange is not None and partition.sink_handle is not None:
-                            self.exchange.sink_finished(partition.sink_handle, attempt.attempt_id)
-                        self.descriptor_storage.remove(partition.task_id)
+                            self.exchange.sink_aborted(partition.sink_handle, loser.attempt_id.attempt_id)
+                        pressure_releases.append(("terminal", loser.remote_handle, loser.attempt_id))
+                    if self.exchange is not None and partition.sink_handle is not None:
+                        self.exchange.sink_finished(partition.sink_handle, attempt.attempt_id)
+                    self.descriptor_storage.remove(partition.task_id)
         finally:
             for release_kind, remote_handle, released_attempt in pressure_releases:
                 if release_kind == "result_ready":

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -1005,6 +1005,7 @@ class FteFragmentExecution:
         error: Any = None,
         *,
         retryable: bool = True,
+        schedule_retry: bool = True,
     ) -> ScheduledAttempt | None:
         attempt = FteTaskAttemptId.coerce(attempt_id)
         should_schedule = False
@@ -1034,7 +1035,7 @@ class FteFragmentExecution:
 
         if running is not None:
             self._record_task_terminal_without_drain(running.remote_handle, attempt)
-        if not should_schedule:
+        if not should_schedule or not schedule_retry:
             return None
         return self._schedule_partition_if_ready(attempt.partition_id)
 
@@ -1099,6 +1100,7 @@ class FteFragmentExecution:
         *,
         retryable: bool = True,
         retryable_by_partition_id: Mapping[int, bool] | None = None,
+        schedule_retries: bool = True,
     ) -> list[ScheduledAttempt]:
         worker_id = str(worker_id)
         with self._state_lock:
@@ -1113,7 +1115,12 @@ class FteFragmentExecution:
             partition_retryable = retryable
             if retryable_by_partition_id is not None:
                 partition_retryable = retryable and bool(retryable_by_partition_id.get(partition_id, False))
-            retry = self.task_failed(attempt, error, retryable=partition_retryable)
+            retry = self.task_failed(
+                attempt,
+                error,
+                retryable=partition_retryable,
+                schedule_retry=schedule_retries,
+            )
             if retry is not None:
                 scheduled.append(retry)
         return scheduled
@@ -1170,6 +1177,7 @@ class FteFragmentExecution:
         status: Mapping[str, Any],
         *,
         retryable: bool = True,
+        schedule_retry: bool = True,
     ) -> ScheduledAttempt | None:
         if str(status.get("state", "")).upper() == "UNKNOWN":
             return None
@@ -1192,6 +1200,7 @@ class FteFragmentExecution:
                     attempt_id,
                     _missing_output_stats_failure(attempt_id),
                     retryable=retryable,
+                    schedule_retry=schedule_retry,
                 )
             self.task_finished(attempt_id, output_stats)
             return None
@@ -1201,6 +1210,7 @@ class FteFragmentExecution:
                 attempt_id,
                 status.get("failure") or dict(status),
                 retryable=status_retryable,
+                schedule_retry=schedule_retry,
             )
         return None
 

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -477,6 +477,10 @@ class FteFragmentExecution:
         self.failed = False
         self.no_more_partitions = False
         self._state_lock = threading.RLock()
+        # Serialize the validate/admit/commit sequence while admission callbacks
+        # run without the fragment state lock.  The lock order is scheduling ->
+        # state; global admission callbacks never run while state is held.
+        self._attempt_scheduling_lock = threading.RLock()
         self._current_worker_commands: list[Any] | None = None
         self._worker_command_outbox: list[Any] = []
         self.task_memory_bytes = int(task_memory_bytes)
@@ -527,25 +531,35 @@ class FteFragmentExecution:
             return None
         return _sink_instance_payload(self.task_context_info.get("exchange_sink_instance")) or None
 
+    def _state_lock_owned_by_current_thread(self) -> bool:
+        is_owned = getattr(self._state_lock, "_is_owned", None)
+        return bool(is_owned()) if callable(is_owned) else False
+
     def apply_assignment_result(self, result: AssignmentResult) -> FragmentExecutionMutationResult:
-        with self._state_lock:
+        with self._attempt_scheduling_lock:
             previous_worker_commands = self._current_worker_commands
             worker_commands: list[Any] = []
             self._current_worker_commands = worker_commands
             scheduled: list[ScheduledAttempt] = []
             try:
-                for info in result.partitions_added:
-                    self.add_partition(info.partition_id, info.node_requirements)
+                with self._state_lock:
+                    for info in result.partitions_added:
+                        self.add_partition(info.partition_id, info.node_requirements)
                 for update in self._coalesce_partition_updates(result.partition_updates):
-                    attempt = self.update_partition(update)
+                    with self._state_lock:
+                        should_schedule = self._update_partition_locked(update)
+                    attempt = self._schedule_partition_if_ready(update.partition_id) if should_schedule else None
                     if attempt is not None:
                         scheduled.append(attempt)
                 for partition_id in result.sealed_partitions:
-                    attempt = self.seal_partition(partition_id)
+                    with self._state_lock:
+                        should_schedule = self._seal_partition_locked(partition_id)
+                    attempt = self._schedule_partition_if_ready(partition_id) if should_schedule else None
                     if attempt is not None:
                         scheduled.append(attempt)
-                if result.no_more_partitions:
-                    self.no_more_partitions = True
+                with self._state_lock:
+                    if result.no_more_partitions:
+                        self.no_more_partitions = True
                 return FragmentExecutionMutationResult.from_attempts(scheduled, worker_commands)
             finally:
                 self._current_worker_commands = previous_worker_commands
@@ -555,32 +569,33 @@ class FteFragmentExecution:
         partition_id: int,
         update: FteTaskUpdateRequest | Mapping[str, Any] | None,
     ) -> FragmentExecutionMutationResult:
-        with self._state_lock:
-            previous_worker_commands = self._current_worker_commands
-            worker_commands: list[Any] = []
-            self._current_worker_commands = worker_commands
-            try:
-                partition = self.add_partition(partition_id)
-                update_request = FteTaskUpdateRequest.coerce(update)
-                if not partition.descriptor.apply_task_update(update_request):
-                    return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
-                self.descriptor_storage.put(partition.task_id, partition.descriptor)
-                running = partition.running_attempt
-                if running is not None:
-                    worker = running.remote_handle
-                    self._record_worker_command(
-                        FteTaskUpdateCommand(
-                            query_id=self.query_id,
-                            fragment_id=self.fragment_id,
-                            worker_id=running.worker_id,
-                            worker=worker,
-                            attempt_id=running.attempt_id,
-                            update=update_request.to_dict(),
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                previous_worker_commands = self._current_worker_commands
+                worker_commands: list[Any] = []
+                self._current_worker_commands = worker_commands
+                try:
+                    partition = self.add_partition(partition_id)
+                    update_request = FteTaskUpdateRequest.coerce(update)
+                    if not partition.descriptor.apply_task_update(update_request):
+                        return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
+                    self.descriptor_storage.put(partition.task_id, partition.descriptor)
+                    running = partition.running_attempt
+                    if running is not None:
+                        worker = running.remote_handle
+                        self._record_worker_command(
+                            FteTaskUpdateCommand(
+                                query_id=self.query_id,
+                                fragment_id=self.fragment_id,
+                                worker_id=running.worker_id,
+                                worker=worker,
+                                attempt_id=running.attempt_id,
+                                update=update_request.to_dict(),
+                            )
                         )
-                    )
-                return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
-            finally:
-                self._current_worker_commands = previous_worker_commands
+                    return FragmentExecutionMutationResult(worker_commands=tuple(worker_commands))
+                finally:
+                    self._current_worker_commands = previous_worker_commands
 
     @staticmethod
     def _partition_ready_to_schedule(partition: FteTaskPartition) -> bool:
@@ -640,9 +655,7 @@ class FteFragmentExecution:
                     return True
             return False
 
-    def _maybe_create_attempt(self, partition: FteTaskPartition) -> ScheduledAttempt | None:
-        if self.attempt_admission_callback is not None and not self.attempt_admission_callback(partition):
-            return None
+    def _create_attempt_after_admission(self, partition: FteTaskPartition) -> ScheduledAttempt | None:
         partition.mark_waiting_for_node()
         if self.worker_reservation_callback is not None:
             self.worker_reservation_callback(partition)
@@ -651,6 +664,30 @@ class FteFragmentExecution:
             return self.start_attempt_with_worker(partition)
         except FteWorkerReservationUnavailable:
             return None
+
+    def _schedule_partition_if_ready(
+        self,
+        partition_id: int,
+        execution_class: FteTaskExecutionClass | str | None = None,
+    ) -> ScheduledAttempt | None:
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                partition = self.partitions.get(int(partition_id))
+                if partition is None or not self._partition_ready_to_schedule(partition):
+                    return None
+                if not self._partition_matches_execution_class(partition, execution_class):
+                    return None
+
+            if self.attempt_admission_callback is not None and not self.attempt_admission_callback(partition):
+                return None
+
+            with self._state_lock:
+                current = self.partitions.get(int(partition_id))
+                if current is not partition or not self._partition_ready_to_schedule(partition):
+                    return None
+                if not self._partition_matches_execution_class(partition, execution_class):
+                    return None
+                return self._create_attempt_after_admission(partition)
 
     @staticmethod
     def _transition_from_partition(partition: FteTaskPartition) -> ExecutionClassTransition:
@@ -787,13 +824,16 @@ class FteFragmentExecution:
         self,
         execution_class: FteTaskExecutionClass | str | None = None,
     ) -> ScheduledAttempt | None:
-        with self._state_lock:
-            for partition in sorted(self.partitions.values(), key=lambda value: value.task_id.partition_id):
-                if not self._partition_ready_to_schedule(partition):
-                    continue
-                if not self._partition_matches_execution_class(partition, execution_class):
-                    continue
-                attempt = self._maybe_create_attempt(partition)
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                partition_ids = [
+                    partition.task_id.partition_id
+                    for partition in sorted(self.partitions.values(), key=lambda value: value.task_id.partition_id)
+                    if self._partition_ready_to_schedule(partition)
+                    and self._partition_matches_execution_class(partition, execution_class)
+                ]
+            for partition_id in partition_ids:
+                attempt = self._schedule_partition_if_ready(partition_id, execution_class)
                 if attempt is not None:
                     return attempt
             return None
@@ -853,6 +893,36 @@ class FteFragmentExecution:
             cause=exc,
         )
 
+    @staticmethod
+    def _record_task_result_ready_without_drain(
+        remote_handle: Any,
+        attempt_id: FteTaskAttemptId,
+    ) -> None:
+        record_without_drain = getattr(
+            remote_handle,
+            "record_fte_task_result_ready_without_drain",
+            None,
+        )
+        if callable(record_without_drain):
+            record_without_drain(attempt_id)
+            return
+        remote_handle.record_fte_task_result_ready(attempt_id)
+
+    @staticmethod
+    def _record_task_terminal_without_drain(
+        remote_handle: Any,
+        attempt_id: FteTaskAttemptId,
+    ) -> None:
+        record_without_drain = getattr(
+            remote_handle,
+            "record_fte_task_terminal_without_drain",
+            None,
+        )
+        if callable(record_without_drain):
+            record_without_drain(attempt_id)
+            return
+        remote_handle.record_fte_task_terminal(attempt_id)
+
     def _record_worker_command(self, command: Any) -> None:
         if self._current_worker_commands is not None:
             self._current_worker_commands.append(command)
@@ -864,7 +934,7 @@ class FteFragmentExecution:
         self._worker_command_outbox.clear()
         return commands
 
-    def update_partition(self, update: PartitionUpdate) -> ScheduledAttempt | None:
+    def _update_partition_locked(self, update: PartitionUpdate) -> bool:
         partition = self.add_partition(update.partition_id)
         running_before_update = partition.running_attempt
         added = partition.descriptor.append_splits(update.source_node_id, update.splits)
@@ -880,8 +950,8 @@ class FteFragmentExecution:
         )
         if should_start:
             if not self._mark_partition_ready_for_execution(partition):
-                return None
-            return self._maybe_create_attempt(partition)
+                return False
+            return True
 
         if running_before_update is not None:
             worker = running_before_update.remote_handle
@@ -898,7 +968,7 @@ class FteFragmentExecution:
                 )
                 self._record_worker_command(command)
             if marked_no_more:
-                command = FteNoMoreSplitsCommand(
+                no_more_command = FteNoMoreSplitsCommand(
                     query_id=self.query_id,
                     fragment_id=self.fragment_id,
                     worker_id=running_before_update.worker_id,
@@ -906,19 +976,35 @@ class FteFragmentExecution:
                     attempt_id=running_before_update.attempt_id,
                     source_node_id=update.source_node_id,
                 )
-                self._record_worker_command(command)
-        return None
+                self._record_worker_command(no_more_command)
+        return False
 
-    def seal_partition(self, partition_id: int) -> ScheduledAttempt | None:
+    def update_partition(self, update: PartitionUpdate) -> ScheduledAttempt | None:
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                should_schedule = self._update_partition_locked(update)
+            if not should_schedule:
+                return None
+            return self._schedule_partition_if_ready(update.partition_id)
+
+    def _seal_partition_locked(self, partition_id: int) -> bool:
         partition = self.add_partition(partition_id)
         old_class = partition.seal()
         if old_class is not None:
             self._emit_execution_class_transitions([self._transition_from_partition(partition)])
         if partition.running_attempt is None and not partition.finished and not partition.failed:
             if not self._mark_partition_ready_for_execution(partition):
+                return False
+            return True
+        return False
+
+    def seal_partition(self, partition_id: int) -> ScheduledAttempt | None:
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                should_schedule = self._seal_partition_locked(partition_id)
+            if not should_schedule:
                 return None
-            return self._maybe_create_attempt(partition)
-        return None
+            return self._schedule_partition_if_ready(partition_id)
 
     def task_failed(
         self,
@@ -927,47 +1013,38 @@ class FteFragmentExecution:
         *,
         retryable: bool = True,
     ) -> ScheduledAttempt | None:
-        with self._state_lock:
-            attempt = FteTaskAttemptId.coerce(attempt_id)
-            partition = self.partitions[attempt.partition_id]
-            running = partition.running_attempts.get(attempt.attempt_id)
-            failure_retryable = retryable and _failure_allows_retry(error)
-            if self.exchange is not None and partition.sink_handle is not None:
-                self.exchange.sink_aborted(partition.sink_handle, attempt.attempt_id)
-            ready = partition.mark_attempt_failed(attempt, error, retryable=failure_retryable)
-            if ready is not None and _is_memory_failure(error):
-                partition.failed = True
-                partition.ready_for_scheduling = False
-                partition.execution_ready_deferred = False
-                partition.running_attempts.clear()
-                self.failed = True
-                if running is not None:
-                    running.remote_handle.record_fte_task_terminal(attempt)
-                return None
-            if partition.failed:
-                self.failed = True
-            if ready is None:
-                if running is not None:
-                    running.remote_handle.record_fte_task_terminal(attempt)
-                return None
-            if not partition.sealed and partition.execution_class.is_speculative:
-                partition.ready_for_scheduling = False
-                partition.execution_ready_deferred = False
-                if running is not None:
-                    running.remote_handle.record_fte_task_terminal(attempt)
-                return None
-            partition.mark_ready_for_execution()
-            if running is not None:
-                record_without_drain = getattr(
-                    running.remote_handle,
-                    "record_fte_task_terminal_without_drain",
-                    None,
-                )
-                if callable(record_without_drain):
-                    record_without_drain(attempt)
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        should_schedule = False
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                partition = self.partitions[attempt.partition_id]
+                running = partition.running_attempts.get(attempt.attempt_id)
+                failure_retryable = retryable and _failure_allows_retry(error)
+                if self.exchange is not None and partition.sink_handle is not None:
+                    self.exchange.sink_aborted(partition.sink_handle, attempt.attempt_id)
+                ready = partition.mark_attempt_failed(attempt, error, retryable=failure_retryable)
+                if ready is not None and _is_memory_failure(error):
+                    partition.failed = True
+                    partition.ready_for_scheduling = False
+                    partition.execution_ready_deferred = False
+                    partition.running_attempts.clear()
+                    self.failed = True
                 else:
-                    running.remote_handle.record_fte_task_terminal(attempt)
-            return self._maybe_create_attempt(partition)
+                    if partition.failed:
+                        self.failed = True
+                    if ready is not None:
+                        if not partition.sealed and partition.execution_class.is_speculative:
+                            partition.ready_for_scheduling = False
+                            partition.execution_ready_deferred = False
+                        else:
+                            partition.mark_ready_for_execution()
+                            should_schedule = True
+
+        if running is not None:
+            self._record_task_terminal_without_drain(running.remote_handle, attempt)
+        if not should_schedule:
+            return None
+        return self._schedule_partition_if_ready(attempt.partition_id)
 
     def revoke_speculative_attempts(
         self,
@@ -977,42 +1054,51 @@ class FteFragmentExecution:
         reason: Any = None,
     ) -> list[RevokedAttempt]:
         revoked: list[RevokedAttempt] = []
+        pressure_releases: list[tuple[Any, FteTaskAttemptId]] = []
         limit = None if max_count is None else max(0, int(max_count))
         if limit == 0:
             return revoked
-        with self._state_lock:
-            for partition in self.partitions.values():
-                if partition.finished or partition.failed or not partition.execution_class.is_speculative:
-                    continue
-                running_attempts = sorted(
-                    partition.running_attempts.values(), key=lambda running: running.attempt_id.attempt_id
-                )
-                for running in running_attempts:
-                    if worker_id is not None and str(running.worker_id or "") != str(worker_id):
-                        continue
-                    try:
-                        if running.remote_handle is not None:
-                            running.remote_handle.fte_cancel_task(running.attempt_id.to_dict())
-                    except Exception as exc:
-                        raise self._worker_control_failure(
-                            running,
-                            "fte_cancel_task",
-                            exc,
-                        ) from exc
-                    if self.exchange is not None and partition.sink_handle is not None:
-                        self.exchange.sink_aborted(partition.sink_handle, running.attempt_id.attempt_id)
-                    revoked_attempt = partition.revoke_attempt(
-                        running.attempt_id,
-                        reason or "speculative task revoked",
-                    )
-                    if revoked_attempt is None:
-                        continue
-                    running.remote_handle.record_fte_task_terminal(running.attempt_id)
-                    revoked.append(revoked_attempt)
-                    if partition.failed:
-                        self.failed = True
-                    if limit is not None and len(revoked) >= limit:
-                        return revoked
+        try:
+            with self._attempt_scheduling_lock:
+                with self._state_lock:
+                    reached_limit = False
+                    for partition in self.partitions.values():
+                        if partition.finished or partition.failed or not partition.execution_class.is_speculative:
+                            continue
+                        running_attempts = sorted(
+                            partition.running_attempts.values(), key=lambda running: running.attempt_id.attempt_id
+                        )
+                        for running in running_attempts:
+                            if worker_id is not None and str(running.worker_id or "") != str(worker_id):
+                                continue
+                            try:
+                                if running.remote_handle is not None:
+                                    running.remote_handle.fte_cancel_task(running.attempt_id.to_dict())
+                            except Exception as exc:
+                                raise self._worker_control_failure(
+                                    running,
+                                    "fte_cancel_task",
+                                    exc,
+                                ) from exc
+                            if self.exchange is not None and partition.sink_handle is not None:
+                                self.exchange.sink_aborted(partition.sink_handle, running.attempt_id.attempt_id)
+                            revoked_attempt = partition.revoke_attempt(
+                                running.attempt_id,
+                                reason or "speculative task revoked",
+                            )
+                            if revoked_attempt is None:
+                                continue
+                            pressure_releases.append((running.remote_handle, running.attempt_id))
+                            revoked.append(revoked_attempt)
+                            self.failed = self.failed or partition.failed
+                            if limit is not None and len(revoked) >= limit:
+                                reached_limit = True
+                                break
+                        if reached_limit:
+                            break
+        finally:
+            for remote_handle, attempt in pressure_releases:
+                self._record_task_terminal_without_drain(remote_handle, attempt)
         return revoked
 
     def mark_worker_failed(
@@ -1023,62 +1109,72 @@ class FteFragmentExecution:
         retryable: bool = True,
         retryable_by_partition_id: Mapping[int, bool] | None = None,
     ) -> list[ScheduledAttempt]:
-        with self._state_lock:
-            worker_id = str(worker_id)
-            scheduled: list[ScheduledAttempt] = []
-            for partition in self.partitions.values():
+        worker_id = str(worker_id)
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
                 failed_attempts = [
-                    running.attempt_id
+                    (running.attempt_id, int(partition.task_id.partition_id))
+                    for partition in self.partitions.values()
                     for running in partition.running_attempts.values()
                     if running.worker_id == worker_id
                 ]
-                for attempt in failed_attempts:
-                    partition_retryable = retryable
-                    if retryable_by_partition_id is not None:
-                        partition_retryable = retryable and bool(
-                            retryable_by_partition_id.get(int(partition.task_id.partition_id), False)
-                        )
-                    retry = self.task_failed(attempt, error, retryable=partition_retryable)
-                    if retry is not None:
-                        scheduled.append(retry)
-            return scheduled
+        scheduled: list[ScheduledAttempt] = []
+        for attempt, partition_id in failed_attempts:
+            partition_retryable = retryable
+            if retryable_by_partition_id is not None:
+                partition_retryable = retryable and bool(retryable_by_partition_id.get(partition_id, False))
+            retry = self.task_failed(attempt, error, retryable=partition_retryable)
+            if retry is not None:
+                scheduled.append(retry)
+        return scheduled
 
     def task_finished(
         self,
         attempt_id: FteTaskAttemptId | str | Mapping[str, Any],
         output_stats: Any = None,
     ) -> bool:
-        with self._state_lock:
-            attempt = FteTaskAttemptId.coerce(attempt_id)
-            partition = self.partitions[attempt.partition_id]
-            running_attempts = list(partition.running_attempts.values())
-            running = partition.running_attempts.get(attempt.attempt_id)
-            unselected_running = [item for item in running_attempts if item.attempt_id.attempt_id != attempt.attempt_id]
-            changed = partition.mark_attempt_finished(attempt, output_stats)
-            if changed:
-                if running is not None:
-                    running.remote_handle.record_fte_task_result_ready(attempt)
-                cancel_failure: FteWorkerControlFailure | None = None
-                for loser in unselected_running:
-                    try:
-                        if loser.remote_handle is not None:
-                            loser.remote_handle.fte_cancel_task(loser.attempt_id.to_dict())
-                    except Exception as exc:
-                        if cancel_failure is None:
-                            cancel_failure = self._worker_control_failure(
-                                loser,
-                                "fte_cancel_task",
-                                exc,
-                            )
-                    if self.exchange is not None and partition.sink_handle is not None:
-                        self.exchange.sink_aborted(partition.sink_handle, loser.attempt_id.attempt_id)
-                    loser.remote_handle.record_fte_task_terminal(loser.attempt_id)
-                if self.exchange is not None and partition.sink_handle is not None:
-                    self.exchange.sink_finished(partition.sink_handle, attempt.attempt_id)
-                self.descriptor_storage.remove(partition.task_id)
-                if cancel_failure is not None:
-                    raise cancel_failure
-            return changed
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        pressure_releases: list[tuple[str, Any, FteTaskAttemptId]] = []
+        try:
+            with self._attempt_scheduling_lock:
+                with self._state_lock:
+                    partition = self.partitions[attempt.partition_id]
+                    running_attempts = list(partition.running_attempts.values())
+                    running = partition.running_attempts.get(attempt.attempt_id)
+                    unselected_running = [
+                        item for item in running_attempts if item.attempt_id.attempt_id != attempt.attempt_id
+                    ]
+                    changed = partition.mark_attempt_finished(attempt, output_stats)
+                    cancel_failure: FteWorkerControlFailure | None = None
+                    if changed:
+                        if running is not None:
+                            pressure_releases.append(("result_ready", running.remote_handle, attempt))
+                        for loser in unselected_running:
+                            try:
+                                if loser.remote_handle is not None:
+                                    loser.remote_handle.fte_cancel_task(loser.attempt_id.to_dict())
+                            except Exception as exc:
+                                if cancel_failure is None:
+                                    cancel_failure = self._worker_control_failure(
+                                        loser,
+                                        "fte_cancel_task",
+                                        exc,
+                                    )
+                            if self.exchange is not None and partition.sink_handle is not None:
+                                self.exchange.sink_aborted(partition.sink_handle, loser.attempt_id.attempt_id)
+                            pressure_releases.append(("terminal", loser.remote_handle, loser.attempt_id))
+                        if self.exchange is not None and partition.sink_handle is not None:
+                            self.exchange.sink_finished(partition.sink_handle, attempt.attempt_id)
+                        self.descriptor_storage.remove(partition.task_id)
+        finally:
+            for release_kind, remote_handle, released_attempt in pressure_releases:
+                if release_kind == "result_ready":
+                    self._record_task_result_ready_without_drain(remote_handle, released_attempt)
+                else:
+                    self._record_task_terminal_without_drain(remote_handle, released_attempt)
+        if cancel_failure is not None:
+            raise cancel_failure
+        return changed
 
     def handle_task_status(
         self,

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -498,7 +498,7 @@ class FteQueryScheduler:
                 callbacks.append(registration.resume)
         self._run_task_source_callbacks(callbacks)
 
-    def enqueue(self, event: FteEvent) -> None:
+    def enqueue(self, event: FteEvent, *, priority: bool = False) -> None:
         if event.query_id != self.query_id:
             raise ValueError(f"event query_id {event.query_id!r} does not match scheduler {self.query_id!r}")
         callbacks: list[Callable[[], None]] = []
@@ -509,7 +509,10 @@ class FteQueryScheduler:
                 if event.execution_class in self._queued_internal_admission_classes:
                     return
                 self._queued_internal_admission_classes.add(event.execution_class)
-            self._events.append(event)
+            if priority:
+                self._events.appendleft(event)
+            else:
+                self._events.append(event)
             callbacks.extend(self._task_source_pause_callbacks_locked())
         self._run_task_source_callbacks(callbacks)
 

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -415,16 +415,12 @@ class FteEventDrivenTaskSource:
             self.close()
 
     def close(self) -> None:
-        should_resume = False
         with self._lock:
             if self._closed:
                 return
-            should_resume = self._paused
-        if should_resume:
-            self.resume()
-        with self._lock:
-            if self._closed:
-                return
+            if self._paused:
+                self._paused = False
+                self.resume_count += 1
             self._closed = True
         self.scheduler.unregister_task_source(self.source_id, resume=False)
 
@@ -432,10 +428,8 @@ class FteEventDrivenTaskSource:
 class FteQueryScheduler:
     """Small per-query event loop facade for FTE scheduling.
 
-    The first implementation slice centralizes event ingestion and ordered
-    dispatch while existing submit/status handlers still perform the
-    concrete mutations. Later phases move those mutations behind event handlers
-    owned by this class.
+    Event handlers perform the concrete mutations, but only while this
+    scheduler owns the query's single writer slot.
     """
 
     def __init__(self, query_id: str) -> None:
@@ -457,6 +451,7 @@ class FteQueryScheduler:
         self._retry_delay_generation = 0
         self._retry_delay_timer: threading.Timer | None = None
         self._draining = False
+        self._queued_internal_admission_classes: set[str | None] = set()
         self._failed_worker_ids: set[str] = set()
         self._task_sources: dict[str, FteTaskSourceRegistration] = {}
 
@@ -510,6 +505,10 @@ class FteQueryScheduler:
         with self._lock:
             if self._state != "RUNNING" and not isinstance(event, QueryAbort):
                 return
+            if isinstance(event, ResourceAdmissionChanged) and event.internal:
+                if event.execution_class in self._queued_internal_admission_classes:
+                    return
+                self._queued_internal_admission_classes.add(event.execution_class)
             self._events.append(event)
             callbacks.extend(self._task_source_pause_callbacks_locked())
         self._run_task_source_callbacks(callbacks)
@@ -517,30 +516,42 @@ class FteQueryScheduler:
     def drain(self, handlers: FteEventHandlers | None = None) -> list[Any]:
         outputs: list[Any] = []
         with self._lock:
-            already_draining = self._draining
-            if not already_draining:
-                self._draining = True
-        if already_draining:
-            return outputs
+            if self._draining:
+                return outputs
+            self._draining = True
         try:
             while True:
+                callbacks: list[Callable[[], None]] = []
                 with self._lock:
                     if not self._events:
-                        break
-                    event = self._events.popleft()
-                    event_handlers = handlers or self._handlers
+                        # Publish idle in the same critical section as the
+                        # empty observation.  An enqueue after this point
+                        # either becomes the next drainer or is seen here.
+                        self._draining = False
+                        callbacks.extend(self._task_source_resume_callbacks_locked())
+                        event = None
+                        event_handlers = None
+                    else:
+                        event = self._events.popleft()
+                        if isinstance(event, ResourceAdmissionChanged) and event.internal:
+                            self._queued_internal_admission_classes.discard(event.execution_class)
+                        event_handlers = handlers or self._handlers
+                self._run_task_source_callbacks(callbacks)
+                if event is None:
+                    return outputs
+                assert event_handlers is not None
                 outputs.extend(self._handle_event(event, event_handlers))
-                callbacks: list[Callable[[], None]] = []
+                callbacks = []
                 with self._lock:
                     callbacks.extend(self._task_source_resume_callbacks_locked())
                 self._run_task_source_callbacks(callbacks)
-        finally:
-            callbacks: list[Callable[[], None]] = []
+        except BaseException:
+            callbacks = []
             with self._lock:
                 self._draining = False
                 callbacks.extend(self._task_source_resume_callbacks_locked())
             self._run_task_source_callbacks(callbacks)
-        return outputs
+            raise
 
     def fail(self, reason: Any = None) -> None:
         callbacks: list[Callable[[], None]] = []
@@ -550,6 +561,7 @@ class FteQueryScheduler:
             self._state = "FAILED"
             self._failure_reason = "" if reason is None else str(reason)
             self._events.clear()
+            self._queued_internal_admission_classes.clear()
             if self._retry_delay_timer is not None:
                 self._retry_delay_timer.cancel()
                 self._retry_delay_timer = None
@@ -565,6 +577,7 @@ class FteQueryScheduler:
             self._state = "CLOSED"
             self._failure_reason = None
             self._events.clear()
+            self._queued_internal_admission_classes.clear()
             self._fragment_states.clear()
             self._failed_worker_ids.clear()
             self._task_sources.clear()
@@ -684,11 +697,12 @@ class FteQueryScheduler:
         handlers: FteEventHandlers,
     ) -> list[Any]:
         event_type = event.event_type
-        with self._lock:
-            self._processed_events += 1
-            self._last_event_type = event_type
-            self._last_progress_at = time.monotonic()
-            self._event_counts[event_type] = self._event_counts.get(event_type, 0) + 1
+        if not (isinstance(event, ResourceAdmissionChanged) and event.internal):
+            with self._lock:
+                self._processed_events += 1
+                self._last_event_type = event_type
+                self._last_progress_at = time.monotonic()
+                self._event_counts[event_type] = self._event_counts.get(event_type, 0) + 1
 
         if isinstance(event, SplitEventsSubmitted):
             if handlers.on_split_events is None:
@@ -734,6 +748,7 @@ class FteQueryScheduler:
             with self._lock:
                 self._state = "ABORTED"
                 self._events.clear()
+                self._queued_internal_admission_classes.clear()
             if handlers.on_query_abort is None:
                 return []
             return list(handlers.on_query_abort(event) or [])
@@ -745,6 +760,8 @@ class FteSchedulerRegistry:
         self._lock = threading.RLock()
         self._schedulers: dict[str, FteQueryScheduler] = {}
         self._pending_drain_cursor_query_id: str | None = None
+        self._pending_drain_running = False
+        self._pending_drain_dirty = False
 
     def get_or_create(self, query_id: str) -> FteQueryScheduler:
         query_id = str(query_id or "").strip()
@@ -779,8 +796,39 @@ class FteSchedulerRegistry:
             schedulers = list(self._schedulers.values())
             self._schedulers.clear()
             self._pending_drain_cursor_query_id = None
+            self._pending_drain_dirty = False
         for scheduler in schedulers:
             scheduler.close()
+
+    def run_pending_drain(
+        self,
+        drain_round: Callable[[list[str]], list[Any]],
+    ) -> list[Any]:
+        """Run the global admission pump without entering queries directly.
+
+        Each turn delegates one quantum to every query's own scheduler.
+        Re-entrant capacity notifications only dirty the active pump; the
+        leader observes that bit before atomically publishing itself idle.
+        """
+        outputs: list[Any] = []
+        with self._lock:
+            self._pending_drain_dirty = True
+            if self._pending_drain_running:
+                return outputs
+            self._pending_drain_running = True
+        try:
+            while True:
+                with self._lock:
+                    if not self._pending_drain_dirty:
+                        self._pending_drain_running = False
+                        return outputs
+                    self._pending_drain_dirty = False
+                    query_ids = self.ordered_pending_drain_query_ids(list(self._schedulers))
+                outputs.extend(drain_round(query_ids))
+        except BaseException:
+            with self._lock:
+                self._pending_drain_running = False
+            raise
 
     def record_pending_drain_progress(self, query_id: str) -> None:
         query_id = str(query_id or "").strip()

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -52,7 +52,6 @@ class FteWorkerCommandMixin:
         _bind_fte_scheduler_handlers: Any
         _fte_partition_owner: Any
         _fte_task_handle_cls: Any
-        _fte_worker_placement_manager: Any
 
     def _execute_fte_fragment_execution_worker_commands(
         self,
@@ -104,12 +103,15 @@ class FteWorkerCommandMixin:
                     )
                     raise fragment_execution.worker_control_failure_for_command(command, exc) from exc
                 if isinstance(command, FteCreateTaskCommand):
-                    self._fte_worker_placement_manager.release_reservation(
-                        query_id=command.query_id,
-                        fragment_id=command.fragment_id,
-                        partition_id=command.partition_id,
+                    command.worker.record_fte_task_started_from_reservation(
+                        command.query_id,
+                        command.fragment_id,
+                        command.partition_id,
+                        command.attempt_id,
+                        command.request,
                     )
-                fragment_execution.handle_worker_command_success(command)
+                else:
+                    fragment_execution.handle_worker_command_success(command)
                 _fte_command_debug_log(
                     "execute_command_done",
                     command_index=command_index,

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -8,21 +8,21 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte import fte_status_wait_timeout_s
+from duckdb.runners.fte.fte_events import FteCreateTaskCommand
+from duckdb.runners.fte.fte_scheduler import FteAttemptStatusWatcher
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_REGISTRY_LOCK,
     _FTE_SCHEDULERS,
     _FTE_STATUS_WATCHERS,
 )
-from duckdb.runners.fte import fte_status_wait_timeout_s
-from duckdb.runners.fte.fte_events import FteCreateTaskCommand
 from duckdb.runners.ray.fte_fragment_scheduler import (
+    _store_fte_result_handles,
     begin_fte_registry_operation,
     end_fte_registry_operation,
-    _store_fte_result_handles,
     fte_partition_task_lease_payload,
 )
-from duckdb.runners.fte.fte_scheduler import FteAttemptStatusWatcher
 
 if TYPE_CHECKING:
     from duckdb.runners.fte import FteFragmentExecution, FteTaskAttemptId
@@ -47,6 +47,13 @@ def _fte_command_debug_log(event: str, **fields: Any) -> None:
 
 
 class FteWorkerCommandMixin:
+    if TYPE_CHECKING:
+        # Supplied by the other mixins on the composed Ray worker handle.
+        _bind_fte_scheduler_handlers: Any
+        _fte_partition_owner: Any
+        _fte_task_handle_cls: Any
+        _fte_worker_placement_manager: Any
+
     def _execute_fte_fragment_execution_worker_commands(
         self,
         fragment_execution: FteFragmentExecution,
@@ -136,40 +143,59 @@ class FteWorkerCommandMixin:
         fragment_id: str,
         scheduled_attempts: list[Any],
     ) -> list[Any]:
-        with _FTE_REGISTRY_LOCK:
-            if str(query_id) in _FTE_CLOSING_QUERIES:
-                return []
-        fte_handle_cls = self._fte_task_handle_cls()
-        handles: list[Any] = []
-        watcher_requests: list[tuple[FteTaskAttemptId, Any]] = []
-        for scheduled_attempt in scheduled_attempts:
-            owner = (
-                self._fte_partition_owner(
-                    query_id,
-                    fragment_id,
-                    scheduled_attempt.attempt_id.partition_id,
+        if not scheduled_attempts:
+            return []
+        query_id = str(query_id)
+        if not begin_fte_registry_operation(query_id):
+            return []
+        try:
+            fte_handle_cls = self._fte_task_handle_cls()
+            handles: list[Any] = []
+            watcher_requests: list[tuple[FteTaskAttemptId, Any]] = []
+            for scheduled_attempt in scheduled_attempts:
+                owner = (
+                    self._fte_partition_owner(
+                        query_id,
+                        fragment_id,
+                        scheduled_attempt.attempt_id.partition_id,
+                    )
+                    or self
                 )
-                or self
+                handle = fte_handle_cls(scheduled_attempt.attempt_id, owner)
+                task_context_info = dict(scheduled_attempt.descriptor.task_context_info)
+                if (
+                    "exchange_sink_instance" not in task_context_info
+                    and scheduled_attempt.request.get("exchange_sink_instance") is not None
+                ):
+                    task_context_info["exchange_sink_instance"] = scheduled_attempt.request.get(
+                        "exchange_sink_instance"
+                    )
+                if task_context_info:
+                    handle.task_context_info = task_context_info
+                query_task_lease = scheduled_attempt.request.get("query_task_lease")
+                if not isinstance(query_task_lease, dict):
+                    raise RuntimeError(f"scheduled FTE attempt {scheduled_attempt.attempt_id} has no query task lease")
+                handle.query_task_lease = dict(query_task_lease)
+                handles.append(handle)
+                watcher_requests.append((scheduled_attempt.attempt_id, owner))
+            # Make results visible before a watcher can publish terminal
+            # status; the outer lifecycle token keeps teardown from observing
+            # this publication half-complete.
+            _store_fte_result_handles(
+                query_id,
+                handles,
+                registry_operation_owned=True,
             )
-            handle = fte_handle_cls(scheduled_attempt.attempt_id, owner)
-            task_context_info = dict(scheduled_attempt.descriptor.task_context_info)
-            if (
-                "exchange_sink_instance" not in task_context_info
-                and scheduled_attempt.request.get("exchange_sink_instance") is not None
-            ):
-                task_context_info["exchange_sink_instance"] = scheduled_attempt.request.get("exchange_sink_instance")
-            if task_context_info:
-                handle.task_context_info = task_context_info
-            query_task_lease = scheduled_attempt.request.get("query_task_lease")
-            if not isinstance(query_task_lease, dict):
-                raise RuntimeError(f"scheduled FTE attempt {scheduled_attempt.attempt_id} has no query task lease")
-            handle.query_task_lease = dict(query_task_lease)
-            handles.append(handle)
-            watcher_requests.append((scheduled_attempt.attempt_id, owner))
-        _store_fte_result_handles(query_id, handles)
-        for attempt_id, owner in watcher_requests:
-            self._start_fte_attempt_status_watcher(query_id, attempt_id, owner)
-        return handles
+            for attempt_id, owner in watcher_requests:
+                self._start_fte_attempt_status_watcher(query_id, attempt_id, owner)
+            with _FTE_REGISTRY_LOCK:
+                if query_id in _FTE_CLOSING_QUERIES:
+                    # Successful teardown owns registry removal.  Retain the
+                    # handles if remote teardown fails and must be retried.
+                    return []
+            return handles
+        finally:
+            end_fte_registry_operation(query_id)
 
     def _start_fte_attempt_status_watcher(
         self,

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -185,6 +185,10 @@ class FteWorkerEventHandlingMixin:
                 self._execute_fte_fragment_execution_outbox(fragment_execution)
         except FteWorkerControlFailure as exc:
             return self._handles_for_fte_worker_control_failure(exc)
+        except Exception:
+            if terminal:
+                self._drain_fte_pending_tasks()
+            raise
         handles = (
             []
             if scheduled is None

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -22,7 +22,10 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_STATUS_WATCHERS,
 )
 from duckdb.runners.ray.fragment_worker_exchange import apply_exchange_selector_update
-from duckdb.runners.ray.fragment_worker_failures import mark_fte_worker_failed_for_event
+from duckdb.runners.ray.fragment_worker_failures import (
+    mark_fte_worker_failed_for_event,
+    quarantine_fte_worker,
+)
 from duckdb.runners.ray.fragment_worker_ordering import fragment_execution_key_for_fte_attempt
 from duckdb.runners.ray.fragment_worker_reservations import (
     fte_worker_reservation_event_state,
@@ -51,23 +54,40 @@ class FteWorkerEventHandlingMixin:
         self,
         failure: FteWorkerControlFailure,
     ) -> list[Any]:
-        query_id = failure.attempt_id.task_id.query_id
-        with _FTE_REGISTRY_LOCK:
-            if query_id in _FTE_CLOSING_QUERIES:
-                return []
-        scheduler = _FTE_SCHEDULERS.get(query_id)
-        if scheduler is None:
-            return []
-        self._bind_fte_scheduler_handlers(scheduler)
-        scheduler.enqueue(
-            WorkerFailed(
-                query_id,
-                failure.worker_id,
-                failure,
+        """Fence a failed worker before queued work can observe it as live."""
+
+        failed_worker_ids = quarantine_fte_worker(failure.worker_id)
+        query_ids = set(_FTE_SCHEDULERS.query_ids())
+        query_ids.add(failure.attempt_id.task_id.query_id)
+        schedulers = []
+        for query_id in sorted(query_ids):
+            with _FTE_REGISTRY_LOCK:
+                if query_id in _FTE_CLOSING_QUERIES:
+                    continue
+            scheduler = _FTE_SCHEDULERS.get(query_id)
+            if scheduler is None:
+                continue
+            self._bind_fte_scheduler_handlers(scheduler)
+            scheduler.enqueue(
+                WorkerFailed(
+                    query_id,
+                    failure.worker_id,
+                    failure,
+                    failed_worker_ids=failed_worker_ids,
+                ),
+                # Control failures happen inside an active drain.  Reconcile
+                # them before reservation completions already in that queue.
+                priority=True,
             )
-        )
-        scheduler.drain()
-        return []
+            schedulers.append(scheduler)
+
+        handles: list[Any] = []
+        for scheduler in schedulers:
+            try:
+                handles.extend(scheduler.drain())
+            except Exception as exc:
+                scheduler.fail(f"FTE worker failure handling failed: {exc}")
+        return handles
 
     def _handles_for_marked_fte_worker_failed(
         self,

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -172,7 +172,12 @@ class FteWorkerEventHandlingMixin:
         if fragment_execution is None:
             return []
         try:
-            scheduled = fragment_execution.handle_task_status(event.status)
+            scheduled = fragment_execution.handle_task_status(
+                event.status,
+                schedule_retry=False,
+            )
+            if terminal:
+                self._enqueue_fte_global_pending_drain(query_id)
             with _FTE_REGISTRY_LOCK:
                 if query_id in _FTE_CLOSING_QUERIES:
                     return []
@@ -189,8 +194,6 @@ class FteWorkerEventHandlingMixin:
                 [scheduled],
             )
         )
-        if terminal:
-            self._enqueue_fte_global_pending_drain(query_id)
         return handles
 
     def _handles_for_exchange_selector_updated_event(self, event: ExchangeSelectorUpdated) -> list[Any]:

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -122,18 +122,20 @@ class FteWorkerEventHandlingMixin:
         except Exception as exc:
             remove_pending_fte_worker_reservation_if_current(key, future)
             raise RuntimeError(f"FTE worker reservation failed: {exc}") from exc
-        partition = fragment_execution.partitions.get(int(event.partition_id))
-        if partition is None or partition.running_attempt is not None or partition.finished or partition.failed:
-            remove_pending_fte_worker_reservation_if_current(key, future)
-            FteWorkerPlacementManager.release_owner(
-                query_id=key[0],
-                fragment_id=key[1],
-                partition_id=key[2],
-            )
-            return []
-        remove_pending_fte_worker_reservation_if_current(key, future)
         try:
-            scheduled = fragment_execution.start_attempt_with_worker(partition)
+            with fragment_execution._attempt_scheduling_lock:
+                partition = fragment_execution.partitions.get(int(event.partition_id))
+                if partition is None or partition.running_attempt is not None or partition.finished or partition.failed:
+                    if remove_pending_fte_worker_reservation_if_current(key, future):
+                        FteWorkerPlacementManager.release_owner(
+                            query_id=key[0],
+                            fragment_id=key[1],
+                            partition_id=key[2],
+                        )
+                    return []
+                if not remove_pending_fte_worker_reservation_if_current(key, future):
+                    return []
+                scheduled = fragment_execution.start_attempt_with_worker(partition)
             self._execute_fte_fragment_execution_outbox(fragment_execution)
         except FteWorkerControlFailure as exc:
             return self._handles_for_fte_worker_control_failure(exc)

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -10,12 +10,13 @@ from duckdb.runners.fte import (
     FteWorkerControlFailure,
     FteWorkerReservationUnavailable,
 )
-from duckdb.runners.fte.fte_events import ResourceAdmissionChanged, WorkerFailed
+from duckdb.runners.fte.fte_events import WorkerFailed
 from duckdb.runners.fte.fte_scheduler import FteEventHandlers
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_FRAGMENT_EXECUTIONS,
     _FTE_FRAGMENT_STATES,
+    _FTE_PENDING_WORKER_RESERVATIONS,
     _FTE_REGISTRY_LOCK,
     _FTE_SCHEDULERS,
     _FTE_STATUS_WATCHERS,
@@ -39,17 +40,12 @@ class FteWorkerEventHandlingMixin:
         _drain_fte_pending_tasks: Any
         _execute_fte_fragment_execution_mutation_result: Any
         _execute_fte_fragment_execution_outbox: Any
+        _execute_fte_fragment_execution_worker_commands: Any
         _handles_for_fte_scheduled_attempts: Any
         _revoke_fte_speculative_tasks_for_memory_pressure_direct: Any
         _submit_fte_pending_tasks: Any
         _task_input_stream_exhausted_direct: Any
         _try_reserve_fte_partition_for_node_wait: Any
-
-    @staticmethod
-    def _enqueue_fte_global_pending_drain(query_id: str) -> None:
-        scheduler = _FTE_SCHEDULERS.get(str(query_id))
-        if scheduler is not None:
-            scheduler.enqueue(ResourceAdmissionChanged(str(query_id), global_scope=True))
 
     def _handles_for_fte_worker_control_failure(
         self,
@@ -102,9 +98,13 @@ class FteWorkerEventHandlingMixin:
         with _FTE_REGISTRY_LOCK:
             if str(event.query_id) in _FTE_CLOSING_QUERIES:
                 return []
-        scheduled_by_stage = mark_fte_worker_failed_for_event(event)
-        handles = self._handles_for_marked_fte_worker_failed(scheduled_by_stage) if scheduled_by_stage else []
-        self._enqueue_fte_global_pending_drain(event.query_id)
+        handles: list[Any] = []
+        try:
+            scheduled_by_stage = mark_fte_worker_failed_for_event(event)
+            if scheduled_by_stage:
+                handles.extend(self._handles_for_marked_fte_worker_failed(scheduled_by_stage))
+        finally:
+            handles.extend(self._drain_fte_pending_tasks())
         return handles
 
     def _handles_for_worker_reservation_completed_event(self, event: WorkerReservationCompleted) -> list[Any]:
@@ -114,16 +114,31 @@ class FteWorkerEventHandlingMixin:
         key, future, fragment_execution = fte_worker_reservation_event_state(event)
         if future is None or fragment_execution is None:
             return []
-        if event.error is not None:
-            remove_pending_fte_worker_reservation_if_current(key, future)
-            raise RuntimeError(f"FTE worker reservation failed: {event.error}")
         try:
-            future.result()
-        except Exception as exc:
-            remove_pending_fte_worker_reservation_if_current(key, future)
-            raise RuntimeError(f"FTE worker reservation failed: {exc}") from exc
-        try:
+            reservation_error = event.error
+            if reservation_error is None:
+                try:
+                    future.result()
+                except Exception as exc:
+                    reservation_error = exc
+            if reservation_error is not None:
+                failure = RuntimeError(f"FTE worker reservation failed: {reservation_error}")
+                with _FTE_REGISTRY_LOCK:
+                    if (
+                        str(event.query_id) in _FTE_CLOSING_QUERIES
+                        or _FTE_PENDING_WORKER_RESERVATIONS.get(key) is not future
+                    ):
+                        return []
+                    if isinstance(reservation_error, BaseException):
+                        raise failure from reservation_error
+                    raise failure
             with fragment_execution._attempt_scheduling_lock:
+                with _FTE_REGISTRY_LOCK:
+                    if (
+                        str(event.query_id) in _FTE_CLOSING_QUERIES
+                        or _FTE_PENDING_WORKER_RESERVATIONS.get(key) is not future
+                    ):
+                        return []
                 partition = fragment_execution.partitions.get(int(event.partition_id))
                 if partition is None or partition.running_attempt is not None or partition.finished or partition.failed:
                     if remove_pending_fte_worker_reservation_if_current(key, future):
@@ -136,7 +151,16 @@ class FteWorkerEventHandlingMixin:
                 if not remove_pending_fte_worker_reservation_if_current(key, future):
                     return []
                 scheduled = fragment_execution.start_attempt_with_worker(partition)
-            self._execute_fte_fragment_execution_outbox(fragment_execution)
+                worker_commands = fragment_execution.pop_worker_commands()
+            self._execute_fte_fragment_execution_worker_commands(
+                fragment_execution,
+                worker_commands,
+            )
+            handles = self._handles_for_fte_scheduled_attempts(
+                event.query_id,
+                str(event.fragment_id),
+                [scheduled],
+            )
         except FteWorkerControlFailure as exc:
             return self._handles_for_fte_worker_control_failure(exc)
         except FteWorkerReservationUnavailable:
@@ -146,11 +170,6 @@ class FteWorkerEventHandlingMixin:
                 if str(event.query_id) in _FTE_CLOSING_QUERIES:
                     return []
             raise
-        handles = self._handles_for_fte_scheduled_attempts(
-            event.query_id,
-            str(event.fragment_id),
-            [scheduled],
-        )
         handles.extend(self._drain_fte_pending_tasks())
         return handles
 
@@ -178,33 +197,32 @@ class FteWorkerEventHandlingMixin:
             fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get(fragment_execution_key)
         if fragment_execution is None:
             return []
+        handles: list[Any] = []
         try:
             scheduled = fragment_execution.handle_task_status(
                 event.status,
                 schedule_retry=False,
             )
-            if terminal:
-                self._enqueue_fte_global_pending_drain(query_id)
             with _FTE_REGISTRY_LOCK:
-                if query_id in _FTE_CLOSING_QUERIES:
-                    return []
-            if scheduled is not None:
+                closing = query_id in _FTE_CLOSING_QUERIES
+            if not closing and scheduled is not None:
                 self._execute_fte_fragment_execution_outbox(fragment_execution)
+                handles.extend(
+                    self._handles_for_fte_scheduled_attempts(
+                        query_id,
+                        fragment_id,
+                        [scheduled],
+                    )
+                )
         except FteWorkerControlFailure as exc:
-            return self._handles_for_fte_worker_control_failure(exc)
+            handles.extend(self._handles_for_fte_worker_control_failure(exc))
         except Exception:
+            with _FTE_REGISTRY_LOCK:
+                if query_id not in _FTE_CLOSING_QUERIES:
+                    raise
+        finally:
             if terminal:
-                self._drain_fte_pending_tasks()
-            raise
-        handles = (
-            []
-            if scheduled is None
-            else self._handles_for_fte_scheduled_attempts(
-                query_id,
-                fragment_id,
-                [scheduled],
-            )
-        )
+                handles.extend(self._drain_fte_pending_tasks())
         return handles
 
     def _handles_for_exchange_selector_updated_event(self, event: ExchangeSelectorUpdated) -> list[Any]:
@@ -275,7 +293,7 @@ class FteWorkerEventHandlingMixin:
                     query_id_filter=event.query_id,
                 ),
                 on_resource_admission_changed=lambda event: self._drain_fte_pending_tasks(
-                    query_id_filter=None if event.global_scope else event.query_id
+                    query_id_filter=event.query_id
                 ),
                 on_worker_reservation_completed=self._handles_for_worker_reservation_completed_event,
                 on_retry_delay_expired=lambda event: self._drain_fte_pending_tasks(query_id_filter=event.query_id),

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -141,6 +141,11 @@ class FteWorkerEventHandlingMixin:
             return self._handles_for_fte_worker_control_failure(exc)
         except FteWorkerReservationUnavailable:
             return self._drain_fte_pending_tasks(query_id_filter=event.query_id)
+        except Exception:
+            with _FTE_REGISTRY_LOCK:
+                if str(event.query_id) in _FTE_CLOSING_QUERIES:
+                    return []
+            raise
         handles = self._handles_for_fte_scheduled_attempts(
             event.query_id,
             str(event.fragment_id),

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -28,7 +28,7 @@ from duckdb.runners.ray.fragment_worker_reservations import (
     fte_worker_reservation_event_state,
     remove_pending_fte_worker_reservation_if_current,
 )
-from duckdb.runners.ray.fte_fragment_scheduler import FteWorkerPlacementManager
+from duckdb.runners.ray.fte_fragment_scheduler import FteWorkerPlacementManager, request_fte_pending_task_drain
 
 if TYPE_CHECKING:
     from duckdb.runners.fte.fte_events import ExchangeSelectorUpdated, TaskStatusChanged, WorkerReservationCompleted
@@ -104,7 +104,7 @@ class FteWorkerEventHandlingMixin:
             if scheduled_by_stage:
                 handles.extend(self._handles_for_marked_fte_worker_failed(scheduled_by_stage))
         finally:
-            handles.extend(self._drain_fte_pending_tasks())
+            handles.extend(request_fte_pending_task_drain())
         return handles
 
     def _handles_for_worker_reservation_completed_event(self, event: WorkerReservationCompleted) -> list[Any]:
@@ -129,9 +129,23 @@ class FteWorkerEventHandlingMixin:
                         or _FTE_PENDING_WORKER_RESERVATIONS.get(key) is not future
                     ):
                         return []
-                    if isinstance(reservation_error, BaseException):
-                        raise failure from reservation_error
-                    raise failure
+                if not remove_pending_fte_worker_reservation_if_current(key, future):
+                    return []
+                try:
+                    FteWorkerPlacementManager.release_owner(
+                        query_id=key[0],
+                        fragment_id=key[1],
+                        partition_id=key[2],
+                    )
+                finally:
+                    scheduler = _FTE_SCHEDULERS.get(event.query_id)
+                    if scheduler is not None:
+                        scheduler.fail(failure)
+                    request_fte_pending_task_drain()
+                if isinstance(reservation_error, BaseException):
+                    raise failure from reservation_error
+                raise failure
+            released_invalid_reservation = False
             with fragment_execution._attempt_scheduling_lock:
                 with _FTE_REGISTRY_LOCK:
                     if (
@@ -139,19 +153,33 @@ class FteWorkerEventHandlingMixin:
                         or _FTE_PENDING_WORKER_RESERVATIONS.get(key) is not future
                     ):
                         return []
-                partition = fragment_execution.partitions.get(int(event.partition_id))
-                if partition is None or partition.running_attempt is not None or partition.finished or partition.failed:
-                    if remove_pending_fte_worker_reservation_if_current(key, future):
+                with fragment_execution._state_lock:
+                    partition = fragment_execution.partitions.get(int(event.partition_id))
+                    if (
+                        partition is None
+                        or partition.running_attempt is not None
+                        or partition.finished
+                        or partition.failed
+                    ):
+                        released_invalid_reservation = remove_pending_fte_worker_reservation_if_current(key, future)
+                        scheduled = None
+                        worker_commands = []
+                    else:
+                        if not remove_pending_fte_worker_reservation_if_current(key, future):
+                            return []
+                        scheduled = fragment_execution.start_attempt_with_worker(partition)
+                        worker_commands = fragment_execution.pop_worker_commands()
+            if scheduled is None:
+                if released_invalid_reservation:
+                    try:
                         FteWorkerPlacementManager.release_owner(
                             query_id=key[0],
                             fragment_id=key[1],
                             partition_id=key[2],
                         )
-                    return []
-                if not remove_pending_fte_worker_reservation_if_current(key, future):
-                    return []
-                scheduled = fragment_execution.start_attempt_with_worker(partition)
-                worker_commands = fragment_execution.pop_worker_commands()
+                    finally:
+                        request_fte_pending_task_drain()
+                return []
             self._execute_fte_fragment_execution_worker_commands(
                 fragment_execution,
                 worker_commands,
@@ -164,13 +192,13 @@ class FteWorkerEventHandlingMixin:
         except FteWorkerControlFailure as exc:
             return self._handles_for_fte_worker_control_failure(exc)
         except FteWorkerReservationUnavailable:
-            return self._drain_fte_pending_tasks(query_id_filter=event.query_id)
+            return request_fte_pending_task_drain()
         except Exception:
             with _FTE_REGISTRY_LOCK:
                 if str(event.query_id) in _FTE_CLOSING_QUERIES:
                     return []
             raise
-        handles.extend(self._drain_fte_pending_tasks())
+        handles.extend(request_fte_pending_task_drain())
         return handles
 
     def _handles_for_task_status_changed_event(self, event: TaskStatusChanged) -> list[Any]:
@@ -222,7 +250,7 @@ class FteWorkerEventHandlingMixin:
                     raise
         finally:
             if terminal:
-                handles.extend(self._drain_fte_pending_tasks())
+                handles.extend(request_fte_pending_task_drain())
         return handles
 
     def _handles_for_exchange_selector_updated_event(self, event: ExchangeSelectorUpdated) -> list[Any]:
@@ -277,15 +305,16 @@ class FteWorkerEventHandlingMixin:
         return handles
 
     def _bind_fte_scheduler_handlers(self, scheduler: Any) -> None:
+        def on_source_input_exhausted(source_ids: set[str]) -> list[Any]:
+            return self._task_input_stream_exhausted_direct(
+                source_ids,
+                query_id_filter=scheduler.query_id,
+            )
+
         scheduler.set_handlers(
             FteEventHandlers(
                 on_split_events=self._submit_fte_pending_tasks,
-                on_source_input_exhausted=lambda source_ids, query_id=scheduler.query_id: (
-                    self._task_input_stream_exhausted_direct(
-                        source_ids,
-                        query_id_filter=query_id,
-                    )
-                ),
+                on_source_input_exhausted=on_source_input_exhausted,
                 on_task_status_changed=self._handles_for_task_status_changed_event,
                 on_worker_failed=self._handles_for_worker_failed_event,
                 on_memory_pressure_detected=lambda event: self._revoke_fte_speculative_tasks_for_memory_pressure_direct(
@@ -293,10 +322,12 @@ class FteWorkerEventHandlingMixin:
                     query_id_filter=event.query_id,
                 ),
                 on_resource_admission_changed=lambda event: self._drain_fte_pending_tasks(
-                    query_id_filter=event.query_id
+                    query_id_filter=event.query_id,
+                    max_scheduled_attempts=1,
+                    execution_class_filter=event.execution_class,
                 ),
                 on_worker_reservation_completed=self._handles_for_worker_reservation_completed_event,
-                on_retry_delay_expired=lambda event: self._drain_fte_pending_tasks(query_id_filter=event.query_id),
+                on_retry_delay_expired=lambda _event: request_fte_pending_task_drain(),
                 on_exchange_selector_updated=self._handles_for_exchange_selector_updated_event,
             )
         )

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -10,7 +10,7 @@ from duckdb.runners.fte import (
     FteWorkerControlFailure,
     FteWorkerReservationUnavailable,
 )
-from duckdb.runners.fte.fte_events import WorkerFailed
+from duckdb.runners.fte.fte_events import ResourceAdmissionChanged, WorkerFailed
 from duckdb.runners.fte.fte_scheduler import FteEventHandlers
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
@@ -34,6 +34,23 @@ if TYPE_CHECKING:
 
 
 class FteWorkerEventHandlingMixin:
+    if TYPE_CHECKING:
+        # Supplied by the other mixins on the composed Ray worker handle.
+        _drain_fte_pending_tasks: Any
+        _execute_fte_fragment_execution_mutation_result: Any
+        _execute_fte_fragment_execution_outbox: Any
+        _handles_for_fte_scheduled_attempts: Any
+        _revoke_fte_speculative_tasks_for_memory_pressure_direct: Any
+        _submit_fte_pending_tasks: Any
+        _task_input_stream_exhausted_direct: Any
+        _try_reserve_fte_partition_for_node_wait: Any
+
+    @staticmethod
+    def _enqueue_fte_global_pending_drain(query_id: str) -> None:
+        scheduler = _FTE_SCHEDULERS.get(str(query_id))
+        if scheduler is not None:
+            scheduler.enqueue(ResourceAdmissionChanged(str(query_id), global_scope=True))
+
     def _handles_for_fte_worker_control_failure(
         self,
         failure: FteWorkerControlFailure,
@@ -86,9 +103,9 @@ class FteWorkerEventHandlingMixin:
             if str(event.query_id) in _FTE_CLOSING_QUERIES:
                 return []
         scheduled_by_stage = mark_fte_worker_failed_for_event(event)
-        if not scheduled_by_stage:
-            return []
-        return self._handles_for_marked_fte_worker_failed(scheduled_by_stage)
+        handles = self._handles_for_marked_fte_worker_failed(scheduled_by_stage) if scheduled_by_stage else []
+        self._enqueue_fte_global_pending_drain(event.query_id)
+        return handles
 
     def _handles_for_worker_reservation_completed_event(self, event: WorkerReservationCompleted) -> list[Any]:
         with _FTE_REGISTRY_LOCK:
@@ -133,12 +150,13 @@ class FteWorkerEventHandlingMixin:
     def _handles_for_task_status_changed_event(self, event: TaskStatusChanged) -> list[Any]:
         raw_state = event.status.get("state")
         state = raw_state if isinstance(raw_state, FteTaskState) else FteTaskState(str(raw_state))
-        if state in {
+        terminal = state in {
             FteTaskState.FINISHED,
             FteTaskState.FAILED,
             FteTaskState.CANCELED,
             FteTaskState.ABORTED,
-        }:
+        }
+        if terminal:
             with _FTE_REGISTRY_LOCK:
                 watcher = _FTE_STATUS_WATCHERS.get(str(event.attempt_id))
             if watcher is not None:
@@ -162,13 +180,18 @@ class FteWorkerEventHandlingMixin:
                 self._execute_fte_fragment_execution_outbox(fragment_execution)
         except FteWorkerControlFailure as exc:
             return self._handles_for_fte_worker_control_failure(exc)
-        if scheduled is None:
-            return []
-        return self._handles_for_fte_scheduled_attempts(
-            query_id,
-            fragment_id,
-            [scheduled],
+        handles = (
+            []
+            if scheduled is None
+            else self._handles_for_fte_scheduled_attempts(
+                query_id,
+                fragment_id,
+                [scheduled],
+            )
         )
+        if terminal:
+            self._enqueue_fte_global_pending_drain(query_id)
+        return handles
 
     def _handles_for_exchange_selector_updated_event(self, event: ExchangeSelectorUpdated) -> list[Any]:
         query_id = str(event.query_id)
@@ -221,7 +244,7 @@ class FteWorkerEventHandlingMixin:
                 fragment_state.exhausted_source_node_ids.add(source_node_id)
         return handles
 
-    def _bind_fte_scheduler_handlers(self, scheduler) -> None:
+    def _bind_fte_scheduler_handlers(self, scheduler: Any) -> None:
         scheduler.set_handlers(
             FteEventHandlers(
                 on_split_events=self._submit_fte_pending_tasks,
@@ -238,7 +261,7 @@ class FteWorkerEventHandlingMixin:
                     query_id_filter=event.query_id,
                 ),
                 on_resource_admission_changed=lambda event: self._drain_fte_pending_tasks(
-                    query_id_filter=event.query_id
+                    query_id_filter=None if event.global_scope else event.query_id
                 ),
                 on_worker_reservation_completed=self._handles_for_worker_reservation_completed_event,
                 on_retry_delay_expired=lambda event: self._drain_fte_pending_tasks(query_id_filter=event.query_id),

--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -9,12 +9,25 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_REGISTRY_LOCK,
     _FTE_SCHEDULERS,
+    _FTE_WORKER_HANDLES,
 )
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _expanded_fte_failed_worker_ids,
     _fte_retry_remaining_delay_s,
     _mark_fte_worker_failed,
 )
+
+
+def quarantine_fte_worker(worker_id: str) -> frozenset[str]:
+    """Make a failed worker ineligible before per-query reconciliation."""
+
+    failed_worker_ids = frozenset(_expanded_fte_failed_worker_ids(worker_id))
+    with _FTE_REGISTRY_LOCK:
+        for failed_worker_id in failed_worker_ids:
+            handle = _FTE_WORKER_HANDLES.get(failed_worker_id)
+            if handle is not None:
+                handle._fte_healthy = False
+    return failed_worker_ids
 
 
 def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[Any], list[Any]]]:
@@ -27,7 +40,7 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
     failed_worker_ids = (
         {str(item) for item in event.failed_worker_ids}
         if event.failed_worker_ids is not None
-        else _expanded_fte_failed_worker_ids(event.worker_id)
+        else set(quarantine_fte_worker(event.worker_id))
     )
     new_failed_worker_ids = scheduler.record_worker_failure(failed_worker_ids)
     if not new_failed_worker_ids:

--- a/duckdb/runners/ray/fragment_worker_pressure_accounting.py
+++ b/duckdb/runners/ray/fragment_worker_pressure_accounting.py
@@ -149,6 +149,23 @@ class FteWorkerPressureAccountingMixin:
                 self._fte_pressure.memory_bytes_by_attempt.pop(key, None)
             self._fte_pressure.last_seen_at = time.time()
 
+    def record_fte_task_started_from_reservation(
+        self,
+        query_id: str,
+        fragment_id: str,
+        partition_id: int,
+        attempt_id: Any,
+        request: Mapping[str, Any],
+    ) -> None:
+        """Move reservation pressure to running without exposing free capacity."""
+
+        reservation_key = partition_reservation_key(query_id, fragment_id, partition_id)
+        with _FTE_REGISTRY_LOCK:
+            self._fte_pressure.reserved_partitions.discard(reservation_key)
+            self._fte_pressure.memory_bytes_by_reservation.pop(reservation_key, None)
+            self._fte_pressure.execution_class_by_reservation.pop(reservation_key, None)
+            self.record_fte_task_started(attempt_id, request)
+
     def record_fte_splits_added(self, attempt_id: Any, split_count: int) -> None:
         key = attempt_key(attempt_id)
         with _FTE_REGISTRY_LOCK:

--- a/duckdb/runners/ray/fragment_worker_pressure_accounting.py
+++ b/duckdb/runners/ray/fragment_worker_pressure_accounting.py
@@ -14,7 +14,10 @@ from duckdb.runners.ray.fragment_worker_pressure import (
     initial_split_count,
     partition_reservation_key,
 )
-from duckdb.runners.ray.fte_fragment_scheduler import _memory_requirement_bytes
+from duckdb.runners.ray.fte_fragment_scheduler import (
+    _memory_requirement_bytes,
+    request_fte_pending_task_drain,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -178,7 +181,7 @@ class FteWorkerPressureAccountingMixin:
         except Exception:
             return
         if drain:
-            self._drain_fte_pending_tasks()
+            request_fte_pending_task_drain()
 
     def record_fte_task_result_ready(self, attempt_id: Any) -> None:
         """Stop charging worker execution pressure while task output is adopted."""

--- a/duckdb/runners/ray/fragment_worker_pressure_accounting.py
+++ b/duckdb/runners/ray/fragment_worker_pressure_accounting.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte import FteTaskAttemptId, FteTaskExecutionClass
 from duckdb.runners.ray.fragment_registry import _FTE_REGISTRY_LOCK
 from duckdb.runners.ray.fragment_worker_pressure import (
     attempt_key,
@@ -13,7 +14,6 @@ from duckdb.runners.ray.fragment_worker_pressure import (
     initial_split_count,
     partition_reservation_key,
 )
-from duckdb.runners.fte import FteTaskAttemptId, FteTaskExecutionClass
 from duckdb.runners.ray.fte_fragment_scheduler import _memory_requirement_bytes
 
 if TYPE_CHECKING:
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
 
 
 class FteWorkerPressureAccountingMixin:
+    if TYPE_CHECKING:
+        # Supplied by the composed Ray worker handle.
+        _fte_pressure: Any
+        _drain_fte_pending_tasks: Any
+
     def finish_fte_task_with_outputs(
         self,
         attempt_id: Any,
@@ -179,6 +184,9 @@ class FteWorkerPressureAccountingMixin:
         """Stop charging worker execution pressure while task output is adopted."""
 
         self._record_fte_task_pressure_complete(attempt_id, drain=True)
+
+    def record_fte_task_result_ready_without_drain(self, attempt_id: Any) -> None:
+        self._record_fte_task_pressure_complete(attempt_id, drain=False)
 
     def record_fte_task_terminal(self, attempt_id: Any, *, drain: bool = True) -> None:
         self._record_fte_task_pressure_complete(attempt_id, drain=drain)

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -59,6 +59,7 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     end_fte_registry_operation,
     ensure_fte_fragment_progress_topology,
     fte_registry_query_is_closing,
+    request_fte_pending_task_drain,
     transfer_fte_registry_operations_to_ref,
 )
 from duckdb.runners.ray.fte_scheduler_config import (
@@ -91,6 +92,8 @@ def _registered_fte_task_memory_bytes(
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from duckdb.runners.fte import FteSplit
 
 
@@ -122,6 +125,29 @@ def _truthy_context_flag(context: dict[str, Any], key: str) -> bool:
 
 
 class FteWorkerSubmissionMixin:
+    if TYPE_CHECKING:
+        # Supplied by the other mixins on the composed Ray worker handle.
+        _apply_fte_execution_class_transitions: Any
+        _bind_fte_scheduler_handlers: Any
+        _execute_fte_fragment_execution_mutation_result: Any
+        _execute_fte_fragment_execution_outbox: Any
+        _fragment_query_ids: Any
+        _fragment_registration_lock: Any
+        _fragment_registration_refs: Any
+        _fte_fragment_executions: Any
+        _fte_worker_placement_manager: Any
+        _handles_for_fte_scheduled_attempts: Any
+        _handles_for_fte_worker_control_failure: Any
+        _next_fte_fragment_execution_id: Any
+        _next_fte_split_sequence: Any
+        _registered_fragment_ids: Any
+        _release_deferred_fte_execution_partitions: Any
+        _request_fte_worker_reservation_for_partition: Any
+        _try_complete_fte_worker_reservation_future: Any
+        _try_reserve_fte_partition_for_node_wait: Any
+        actor_handle: Any
+        worker_id: Any
+
     def _ensure_fragment_progress_topology(
         self,
         query_id: str,
@@ -217,7 +243,7 @@ class FteWorkerSubmissionMixin:
 
         fragment_registration_result = item.get("fragment_registration_result")
 
-        def select_partition_owner(partition):
+        def select_partition_owner(partition: Any) -> Any:
             try:
                 reservation = self._fte_worker_placement_manager.acquire(
                     query_id=query_id,
@@ -245,14 +271,14 @@ class FteWorkerSubmissionMixin:
                 raise
             return reservation.worker_id, reservation.worker
 
-        def apply_execution_class_transitions(transitions):
+        def apply_execution_class_transitions(transitions: Any) -> None:
             self._apply_fte_execution_class_transitions(query_id, fragment_id, transitions)
 
-        def admit_execution(partition):
+        def admit_execution(partition: Any) -> bool:
             fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
             return _admit_fte_partition_execution_ready(query_id, fragment_execution, partition)
 
-        def admit_attempt(partition):
+        def admit_attempt(partition: Any) -> bool:
             fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
             pending_worker_reservation = pending_fte_worker_reservation_future(
                 query_id,
@@ -270,7 +296,7 @@ class FteWorkerSubmissionMixin:
                 return False
             return _admit_fte_partition_node_wait(query_id, partition, fragment_execution)
 
-        def request_worker_reservation(partition):
+        def request_worker_reservation(partition: Any) -> bool:
             fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
             if fragment_execution is None:
                 return False
@@ -320,18 +346,33 @@ class FteWorkerSubmissionMixin:
         self._fte_fragment_executions[key] = fragment_execution
         return fragment_execution
 
-    def _drain_fte_pending_tasks(self, *, query_id_filter: str | None = None) -> list[Any]:
+    def _drain_fte_pending_tasks(
+        self,
+        *,
+        query_id_filter: str | None = None,
+        max_scheduled_attempts: int | None = None,
+        execution_class_filter: FteTaskExecutionClass | str | None = None,
+    ) -> list[Any]:
+        if query_id_filter is None:
+            return request_fte_pending_task_drain()
         handles: list[Any] = []
-        if query_id_filter is not None:
-            query_id_filter = str(query_id_filter)
-            if fte_registry_query_is_closing(query_id_filter):
-                return []
+        query_id_filter = str(query_id_filter or "").strip()
+        if not query_id_filter:
+            raise ValueError("query_id_filter must be non-empty")
+        if fte_registry_query_is_closing(query_id_filter):
+            return []
+        if max_scheduled_attempts is not None:
+            max_scheduled_attempts = max(1, int(max_scheduled_attempts))
+        if execution_class_filter is not None:
+            execution_class_filter = FteTaskExecutionClass.coerce(execution_class_filter)
+        scheduled_attempt_count = 0
         fragment_execution_items = fte_fragment_execution_items(query_id_filter)
         fragment_execution_items = [
             item for item in fragment_execution_items if not fte_registry_query_is_closing(item[0][0])
         ]
 
         def schedule_execution_class(execution_class: FteTaskExecutionClass) -> tuple[bool, bool]:
+            nonlocal scheduled_attempt_count
             made_progress = False
             should_drain_events = False
             released = self._release_deferred_fte_execution_partitions(
@@ -347,6 +388,8 @@ class FteWorkerSubmissionMixin:
                 fragment_execution_items,
                 execution_class=execution_class,
             ):
+                if max_scheduled_attempts is not None and scheduled_attempt_count >= max_scheduled_attempts:
+                    break
                 try:
                     pending_reservation_done_count_before = fte_pending_worker_reservation_done_count(query_id_filter)
                     scheduled = fragment_execution.schedule_next_pending_partition(execution_class)
@@ -363,6 +406,7 @@ class FteWorkerSubmissionMixin:
                         break
                     continue
                 made_progress = True
+                scheduled_attempt_count += 1
                 handles.extend(
                     self._handles_for_fte_scheduled_attempts(
                         query_id,
@@ -375,27 +419,39 @@ class FteWorkerSubmissionMixin:
         while True:
             made_progress = False
             should_drain_events = False
-            for execution_class in (
-                FteTaskExecutionClass.EAGER_SPECULATIVE,
-                FteTaskExecutionClass.STANDARD,
-            ):
+            execution_classes = (
+                (execution_class_filter,)
+                if execution_class_filter is not None
+                else (
+                    FteTaskExecutionClass.EAGER_SPECULATIVE,
+                    FteTaskExecutionClass.STANDARD,
+                )
+            )
+            for execution_class in execution_classes:
+                if max_scheduled_attempts is not None and scheduled_attempt_count >= max_scheduled_attempts:
+                    break
                 class_progress, class_should_drain = schedule_execution_class(execution_class)
                 made_progress = class_progress or made_progress
                 should_drain_events = class_should_drain or should_drain_events
                 if should_drain_events:
                     break
-            if not should_drain_events and not _has_fte_pending_standard_partitions(fragment_execution_items):
+            if (
+                not should_drain_events
+                and execution_class_filter is None
+                and (max_scheduled_attempts is None or scheduled_attempt_count < max_scheduled_attempts)
+                and not _has_fte_pending_standard_partitions(fragment_execution_items)
+            ):
                 class_progress, class_should_drain = schedule_execution_class(FteTaskExecutionClass.SPECULATIVE)
                 made_progress = class_progress or made_progress
                 should_drain_events = class_should_drain or should_drain_events
             if should_drain_events:
                 break
+            if max_scheduled_attempts is not None and scheduled_attempt_count >= max_scheduled_attempts:
+                break
             if not made_progress:
                 break
-        for query_id in sorted({query_id for (query_id, _), _ in fragment_execution_items}):
-            scheduler = _FTE_SCHEDULERS.get(query_id)
-            if scheduler is not None and not scheduler.is_draining():
-                handles.extend(scheduler.drain())
+        if scheduled_attempt_count:
+            handles.extend(request_fte_pending_task_drain())
         return order_fte_scheduled_handles(handles)
 
     def _submit_fte_pending_tasks_via_scheduler(
@@ -437,7 +493,7 @@ class FteWorkerSubmissionMixin:
                     query_id: str = query_id,
                     query_pending: list[dict[str, Any]] = query_pending,
                     chunk_size: int = chunk_size,
-                ):
+                ) -> Iterator[SplitEventsSubmitted]:
                     for offset in range(0, len(query_pending), chunk_size):
                         yield SplitEventsSubmitted.from_events(
                             query_id,
@@ -790,7 +846,7 @@ class FteWorkerSubmissionMixin:
         )
         return handles
 
-    def submit_tasks(self, tasks: list[RayWorkerTask]) -> list[Any]:
+    def submit_tasks(self, tasks: list[Any]) -> list[Any]:
         started_at = time.monotonic()
         _fte_submission_debug_log("submit_tasks_start", task_count=len(tasks))
         if not tasks:

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -398,7 +398,8 @@ class FteWorkerSubmissionMixin:
                         self._execute_fte_fragment_execution_outbox(fragment_execution)
                 except FteWorkerControlFailure as exc:
                     handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    continue
+                    should_drain_events = True
+                    break
                 if scheduled is None:
                     if pending_reservation_done_count_after > pending_reservation_done_count_before:
                         made_progress = True

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -1578,8 +1578,7 @@ def _has_replacement_fte_worker(
 # 1. Scheduler and registry locks protect queues/snapshots only and are released
 #    before fragment state is inspected.
 # 2. A thread may hold one fragment state lock at a time.
-# 3. Global fragment traversal and external admission callbacks run with no
-#    fragment state lock held.
+# 3. Global fragment traversal runs with no fragment state lock held.
 def _assert_no_fte_fragment_state_lock_held(
     fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
 ) -> None:

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -2813,7 +2813,7 @@ def refresh_fte_running_task_stats(query_id: str | None = None) -> None:
                 validate_fte_status_identity(status, running.attempt_id)
                 if fte_registry_query_is_closing(fragment_execution.query_id):
                     continue
-                fragment_execution.handle_task_status(status)
+                running.remote_handle.handle_fte_task_status(status)
             except Exception:
                 pass
 

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -2246,6 +2246,7 @@ def _mark_fte_worker_failed(
                 error or f"FTE worker lost: {failed_worker_id}",
                 retryable=True,
                 retryable_by_partition_id=retryable_by_partition_id,
+                schedule_retries=False,
             )
             if scheduled:
                 scheduled_by_stage.append((query_id, fragment_id, scheduled, []))

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -627,6 +627,10 @@ def quiesce_fte_registry_for_query(query_id: str) -> None:
                     f"{_FTE_ACTIVE_OPERATIONS_BY_QUERY.get(query_key, 0)}"
                 )
             _FTE_REGISTRY_CONDITION.wait(remaining)
+    # An operation admitted before close may publish its watcher while the
+    # first join is running.  No new operation can start after close, so this
+    # second pass is the final watcher ownership cut.
+    _stop_fte_status_watchers(query_key)
 
 
 def open_fte_registry_for_query(query_id: str) -> None:
@@ -786,6 +790,10 @@ def _drop_fte_registry_for_query(query_id: str) -> None:
         return
     quiesce_fte_registry_for_query(query_id)
     FteWorkerPlacementManager.release_query(query_id)
+    # Query-resource and reservation capacity may already be visible.  Signal
+    # before the remaining local cleanup so a later teardown error cannot
+    # strand unrelated queries.
+    request_fte_pending_task_drain()
     pending_worker_reservation_futures: list[FteWorkerReservationFuture] = []
     worker_handles: list[Any] = []
     with _FTE_REGISTRY_LOCK:
@@ -822,19 +830,84 @@ def _drop_fte_registry_for_query(query_id: str) -> None:
         worker_handles = [handle for handle in _FTE_WORKER_HANDLES.values() if handle is not None]
         _FTE_REGISTRY_CONDITION.notify_all()
     _FTE_SCHEDULERS.drop_query(query_id)
-    for handle in worker_handles:
-        handle._drop_fte_state_for_query(query_id)
+    try:
+        for handle in worker_handles:
+            handle._drop_fte_state_for_query(query_id)
+    finally:
+        # Worker-local running pressure is released by the cleanup above, not
+        # by release_query().  Keep this wake in a finally block so partial
+        # cleanup cannot strand capacity either.
+        request_fte_pending_task_drain()
     for future in pending_worker_reservation_futures:
         future.cancel()
 
 
-def _store_fte_result_handles(query_id: str, handles: list[Any]) -> None:
+def _store_fte_result_handles(
+    query_id: str,
+    handles: list[Any],
+    *,
+    registry_operation_owned: bool = False,
+) -> None:
     if not handles:
         return
     with _FTE_REGISTRY_LOCK:
-        if str(query_id) in _FTE_CLOSING_QUERIES:
+        if not registry_operation_owned and str(query_id) in _FTE_CLOSING_QUERIES:
             raise RuntimeError(f"FTE query registry is closing: {query_id}")
         _FTE_RESULT_HANDLES_BY_QUERY.setdefault(str(query_id), []).extend(handles)
+
+
+def request_fte_pending_task_drain() -> list[Any]:
+    """Signal and, when elected leader, run the single-flight admission pump."""
+    from duckdb.runners.fte.fte_events import ResourceAdmissionChanged
+
+    def drain_query(
+        query_id: str,
+        execution_class: FteTaskExecutionClass,
+    ) -> list[Any]:
+        if not begin_fte_registry_operation(query_id):
+            return []
+        try:
+            scheduler = _FTE_SCHEDULERS.get(query_id)
+            if scheduler is None:
+                return []
+            scheduler.enqueue(
+                ResourceAdmissionChanged(
+                    query_id,
+                    execution_class=execution_class.value,
+                    internal=True,
+                )
+            )
+            return scheduler.drain()
+        finally:
+            end_fte_registry_operation(query_id)
+
+    def drain_round(query_ids: list[str]) -> list[Any]:
+        handles: list[Any] = []
+
+        def drain_execution_class(execution_class: FteTaskExecutionClass) -> None:
+            for query_id in query_ids:
+                scheduler = _FTE_SCHEDULERS.get(query_id)
+                if scheduler is None or scheduler.stats().state != "RUNNING":
+                    continue
+                try:
+                    handles.extend(drain_query(query_id, execution_class))
+                except Exception as exc:
+                    scheduler.fail(f"FTE admission failed: {exc}")
+
+        drain_execution_class(FteTaskExecutionClass.EAGER_SPECULATIVE)
+        drain_execution_class(FteTaskExecutionClass.STANDARD)
+        with _FTE_REGISTRY_LOCK:
+            candidate_fragment_execution_items = [
+                (key, fragment_execution)
+                for key, fragment_execution in _FTE_FRAGMENT_EXECUTIONS.items()
+                if key[0] not in _FTE_CLOSING_QUERIES
+                and callable(getattr(fragment_execution, "has_pending_partitions", None))
+            ]
+        if not _has_fte_pending_standard_partitions_for_active_queries(candidate_fragment_execution_items):
+            drain_execution_class(FteTaskExecutionClass.SPECULATIVE)
+        return handles
+
+    return _FTE_SCHEDULERS.run_pending_drain(drain_round)
 
 
 def _fte_execution_queries_waiting_for_resource(
@@ -858,12 +931,24 @@ def _fte_execution_queries_waiting_for_resource(
     for (execution_query_id, _fragment_id), fragment_execution in fragment_execution_items:
         if execution_query_id in closing_queries:
             continue
-        owner_query_id, _stage_id = resource_identity_from_context(fragment_execution.context)
-        if owner_query_id != resource_query_key:
+        scheduler = _FTE_SCHEDULERS.get(execution_query_id)
+        if scheduler is None or scheduler.stats().state != "RUNNING":
             continue
-        if fragment_execution.has_pending_partitions():
+        try:
+            owner_query_id, _stage_id = resource_identity_from_context(fragment_execution.context)
+            if owner_query_id != resource_query_key:
+                continue
+            has_pending_partitions = fragment_execution.has_pending_partitions()
+        except Exception as exc:
+            scheduler.fail(f"FTE resource admission scan failed: {exc}")
+            continue
+        if has_pending_partitions:
             execution_query_ids.add(execution_query_id)
-    return tuple(sorted(execution_query_ids))
+    return tuple(
+        query_id
+        for query_id in sorted(execution_query_ids)
+        if (scheduler := _FTE_SCHEDULERS.get(query_id)) is not None and scheduler.stats().state == "RUNNING"
+    )
 
 
 def drain_fte_resource_admission_change(query_id: str) -> list[Any]:
@@ -874,16 +959,9 @@ def drain_fte_resource_admission_change(query_id: str) -> list[Any]:
     concurrent status/event drain either handles this event or leaves it queued
     for the active drainer.
     """
-    from duckdb.runners.fte.fte_events import ResourceAdmissionChanged
-
-    handles: list[Any] = []
-    for execution_query_id in _fte_execution_queries_waiting_for_resource(query_id):
-        scheduler = _FTE_SCHEDULERS.get(execution_query_id)
-        if scheduler is None:
-            continue
-        scheduler.enqueue(ResourceAdmissionChanged(execution_query_id))
-        handles.extend(scheduler.drain())
-    return handles
+    if not _fte_execution_queries_waiting_for_resource(query_id):
+        return []
+    return request_fte_pending_task_drain()
 
 
 def has_fte_resource_admission_waiter(query_id: str) -> bool:
@@ -1634,6 +1712,23 @@ def _has_fte_pending_standard_partitions(
     )
 
 
+def _has_fte_pending_standard_partitions_for_active_queries(
+    fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
+) -> bool:
+    """Keep another query's admission scan failure local to that query."""
+    _assert_no_fte_fragment_state_lock_held(fragment_execution_items)
+    for key, fragment_execution in fragment_execution_items:
+        scheduler = _FTE_SCHEDULERS.get(key[0])
+        if scheduler is None or scheduler.stats().state != "RUNNING":
+            continue
+        try:
+            if fragment_execution.has_pending_partitions(FteTaskExecutionClass.STANDARD):
+                return True
+        except Exception as exc:
+            scheduler.fail(f"FTE admission scan failed: {exc}")
+    return False
+
+
 def _admit_fte_partition_execution_ready(
     query_id: str,
     fragment_execution: FteFragmentExecution | None,
@@ -1658,11 +1753,14 @@ def _admit_fte_partition_node_wait(
     if fragment_execution is not None:
         _sync_write_sink_stage_for_fragment(fragment_execution)
     with _FTE_REGISTRY_LOCK:
-        fragment_execution_items = list(_FTE_FRAGMENT_EXECUTIONS.items())
+        fragment_execution_items = [
+            item for item in _FTE_FRAGMENT_EXECUTIONS.items() if item[0][0] not in _FTE_CLOSING_QUERIES
+        ]
     if partition.node_wait_started_at is None:
         execution_class = FteTaskExecutionClass.coerce(partition.execution_class)
-        if execution_class == FteTaskExecutionClass.SPECULATIVE and _has_fte_pending_standard_partitions(
-            fragment_execution_items
+        if (
+            execution_class == FteTaskExecutionClass.SPECULATIVE
+            and _has_fte_pending_standard_partitions_for_active_queries(fragment_execution_items)
         ):
             return False
     if fragment_execution is None:

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -8,7 +8,7 @@ import hashlib
 import math
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from duckdb.runners.fte import (
@@ -222,10 +222,11 @@ def _normalize_exchange_selector_selected(
     selected: dict[int, dict[str, Any]] = {}
     if not selected_payload:
         return selected
+    items: Iterable[tuple[Any, Any]]
     if isinstance(selected_payload, Mapping):
         items = selected_payload.items()
     elif isinstance(selected_payload, (list, tuple)):
-        normalized_items = []
+        normalized_items: list[tuple[Any, Any]] = []
         for entry in selected_payload:
             if not isinstance(entry, Mapping):
                 raise ValueError("exchange selector selected list entries must be mappings")
@@ -1573,11 +1574,33 @@ def _has_replacement_fte_worker(
     )
 
 
+# FTE lock hierarchy:
+# 1. Scheduler and registry locks protect queues/snapshots only and are released
+#    before fragment state is inspected.
+# 2. A thread may hold one fragment state lock at a time.
+# 3. Global fragment traversal and external admission callbacks run with no
+#    fragment state lock held.
+def _assert_no_fte_fragment_state_lock_held(
+    fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
+) -> None:
+    if not __debug__:
+        return
+    held_keys = [
+        key
+        for key, fragment_execution in fragment_execution_items
+        if fragment_execution._state_lock_owned_by_current_thread()
+    ]
+    assert not held_keys, (
+        f"FTE lock hierarchy violation: global fragment traversal while holding a fragment state lock: {held_keys}"
+    )
+
+
 def _ordered_fte_fragment_execution_items_for_pending_drain(
     fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
     *,
     execution_class: FteTaskExecutionClass | str | None = None,
 ) -> list[tuple[tuple[str, str], FteFragmentExecution]]:
+    _assert_no_fte_fragment_state_lock_held(fragment_execution_items)
     if not fragment_execution_items:
         return []
     if execution_class is not None:
@@ -1605,6 +1628,7 @@ def _ordered_fte_fragment_execution_items_for_pending_drain(
 def _has_fte_pending_standard_partitions(
     fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
 ) -> bool:
+    _assert_no_fte_fragment_state_lock_held(fragment_execution_items)
     return any(
         fragment_execution.has_pending_partitions(FteTaskExecutionClass.STANDARD)
         for _, fragment_execution in fragment_execution_items

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -3212,7 +3212,19 @@ def test_fte_worker_capacity_registers_every_ready_partition_with_credit_authori
     assert len([call for call in actor.fte_calls if call[0] == "create"]) == 2
 
 
-def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
+@pytest.mark.parametrize(
+    ("terminal_state", "terminal_extra", "next_query_a_attempt"),
+    [
+        ("FINISHED", {}, "query-a.0.1.0"),
+        ("FAILED", {"failure": {"message": "retry me"}}, "query-a.0.0.1"),
+    ],
+)
+def test_fte_pending_drain_is_fair_across_queries(
+    monkeypatch,
+    terminal_state,
+    terminal_extra,
+    next_query_a_attempt,
+):
     monkeypatch.setattr(
         RayWorkerActorHandle,
         "_fte_task_handle_cls",
@@ -3230,13 +3242,21 @@ def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
         [
             _FakeTask(
                 name="query-a-task-0",
-                context={"query_id": "query-a", "node_id": "8"},
+                context={
+                    "query_id": "query-a",
+                    "node_id": "8",
+                    "task_execution_class": "STANDARD",
+                },
                 inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
                 plan={"plan": "exchange-template"},
             ),
             _FakeTask(
                 name="query-a-task-1",
-                context={"query_id": "query-a", "node_id": "8"},
+                context={
+                    "query_id": "query-a",
+                    "node_id": "8",
+                    "task_execution_class": "STANDARD",
+                },
                 inputs={"3": {"kind": "exchange_source_task", "data": b"p1"}},
                 plan={"plan": "exchange-template"},
             ),
@@ -3246,7 +3266,11 @@ def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
         [
             _FakeTask(
                 name="query-b-task-0",
-                context={"query_id": "query-b", "node_id": "8"},
+                context={
+                    "query_id": "query-b",
+                    "node_id": "8",
+                    "task_execution_class": "STANDARD",
+                },
                 inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
                 plan={"plan": "exchange-template"},
             )
@@ -3261,9 +3285,10 @@ def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
 
     completion_handles = handle.handle_fte_task_status(
         {
-            "state": "FINISHED",
+            "state": terminal_state,
             "task_id": query_a_handles[0].task_id.to_dict(),
             "version": 1,
+            **terminal_extra,
         }
     )
     first_scheduled = handle.pop_fte_result_handles("query-b")
@@ -3272,7 +3297,7 @@ def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
     assert [str(task_handle.task_id) for task_handle in first_scheduled] == ["query-b.0.0.0"]
     handle.record_fte_task_terminal(first_scheduled[0].task_id)
     second_scheduled = handle.pop_fte_result_handles("query-a")
-    assert [str(task_handle.task_id) for task_handle in second_scheduled] == ["query-a.0.1.0"]
+    assert [str(task_handle.task_id) for task_handle in second_scheduled] == [next_query_a_attempt]
 
 
 def test_fte_pending_drain_prefers_standard_over_speculative(monkeypatch):
@@ -4196,15 +4221,15 @@ def test_fte_worker_failure_replays_all_owned_stage_partitions(monkeypatch):
     assert actor1.register_payloads == [
         [
             {
-                "fragment_id": "query-host-loss:node:scan",
-                "plan": {"plan": "scan-template"},
+                "fragment_id": "query-host-loss:node:exchange",
+                "plan": {"plan": "exchange-template"},
                 "query_id": "query-host-loss",
             }
         ],
         [
             {
-                "fragment_id": "query-host-loss:node:exchange",
-                "plan": {"plan": "exchange-template"},
+                "fragment_id": "query-host-loss:node:scan",
+                "plan": {"plan": "scan-template"},
                 "query_id": "query-host-loss",
             }
         ],
@@ -5581,7 +5606,8 @@ def test_fte_status_handler_keeps_watcher_until_terminal_status(monkeypatch):
         def __init__(self):
             self.statuses = []
 
-        def handle_task_status(self, status):
+        def handle_task_status(self, status, *, schedule_retry=True):
+            del schedule_retry
             self.statuses.append(dict(status))
             return None
 
@@ -5812,7 +5838,8 @@ def test_fte_registry_close_waits_for_terminal_handler_and_suppresses_retry(monk
             }
 
     class _BlockedFragmentExecution:
-        def handle_task_status(self, _status):
+        def handle_task_status(self, _status, *, schedule_retry=True):
+            del schedule_retry
             handler_entered.set()
             assert release_handler.wait(2.0)
             return object()
@@ -5872,6 +5899,74 @@ def test_fte_registry_close_waits_for_terminal_handler_and_suppresses_retry(monk
     assert watcher.is_alive() is False
     assert retry_attempts == []
     assert outbox_executions == []
+
+
+def test_fte_terminal_close_race_still_drains_other_queries(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    query_a_handles = handle.submit_tasks([task("query-a")])
+    query_b_handles = handle.submit_tasks([task("query-b")])
+
+    assert [str(task_handle.task_id) for task_handle in query_a_handles] == ["query-a.0.0.0"]
+    assert query_b_handles == []
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-a")] == ["query-a.0.0.0"]
+
+    fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[("query-a", "query-a:node:8")]
+    original_handle_task_status = fragment_execution.handle_task_status
+    mutation_done = threading.Event()
+    release_handler = threading.Event()
+
+    def blocked_handle_task_status(status, *, schedule_retry=True):
+        result = original_handle_task_status(status, schedule_retry=schedule_retry)
+        mutation_done.set()
+        assert release_handler.wait(2.0)
+        return result
+
+    monkeypatch.setattr(fragment_execution, "handle_task_status", blocked_handle_task_status)
+    completion_handles = []
+    completion_errors = []
+
+    def finish_query_a():
+        try:
+            completion_handles.extend(
+                handle.handle_fte_task_status(
+                    {
+                        "state": "FINISHED",
+                        "task_id": query_a_handles[0].task_id.to_dict(),
+                        "version": 1,
+                    }
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            completion_errors.append(exc)
+
+    completion_thread = threading.Thread(target=finish_query_a)
+    completion_thread.start()
+    assert mutation_done.wait(1.0)
+
+    worker_handle_mod.close_fte_registry_for_query("query-a")
+    release_handler.set()
+    completion_thread.join(2.0)
+
+    assert completion_thread.is_alive() is False
+    assert completion_errors == []
+    assert [str(task_handle.task_id) for task_handle in completion_handles] == ["query-b.0.0.0"]
+    scheduled_query_b = handle.pop_fte_result_handles("query-b")
+    assert [str(task_handle.task_id) for task_handle in scheduled_query_b] == ["query-b.0.0.0"]
 
 
 def test_fte_registry_close_fences_inflight_remote_mutation_ownership():

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2723,6 +2723,18 @@ def _completed_test_reservation(future, worker):
     )
 
 
+class _BlockingStringError(RuntimeError):
+    def __init__(self, message, entered, release):
+        super().__init__(message)
+        self._entered = entered
+        self._release = release
+
+    def __str__(self):
+        self._entered.set()
+        assert self._release.wait(5.0)
+        return super().__str__()
+
+
 def test_fte_completed_worker_reservation_reselects_when_event_worker_failed(monkeypatch):
     query_id = "query-reservation-worker-failed"
     actor0, failed, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
@@ -2863,7 +2875,8 @@ def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypa
 
     first_reservation_removed = threading.Event()
     allow_first_attempt_start = threading.Event()
-    pending_drain_entered = threading.Event()
+    pending_drain_started = threading.Event()
+    command_handoff_lock_owned = []
     remove_generations = []
     original_remove = worker_events_mod.remove_pending_fte_worker_reservation_if_current
 
@@ -2886,15 +2899,20 @@ def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypa
         assert first_reservation_removed.wait(5.0)
 
         fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, pending_key[1])]
-        original_schedule_next = fragment_execution.schedule_next_pending_partition
+        original_pop_worker_commands = fragment_execution.pop_worker_commands
 
-        def observed_schedule_next(*args, **kwargs):
-            pending_drain_entered.set()
-            return original_schedule_next(*args, **kwargs)
+        def observed_pop_worker_commands():
+            command_handoff_lock_owned.append(fragment_execution._attempt_scheduling_lock._is_owned())
+            return original_pop_worker_commands()
 
-        monkeypatch.setattr(fragment_execution, "schedule_next_pending_partition", observed_schedule_next)
-        drain = executor.submit(handle._drain_fte_pending_tasks)
-        assert pending_drain_entered.wait(5.0)
+        monkeypatch.setattr(fragment_execution, "pop_worker_commands", observed_pop_worker_commands)
+
+        def drain_pending():
+            pending_drain_started.set()
+            return handle._drain_fte_pending_tasks()
+
+        drain = executor.submit(drain_pending)
+        assert pending_drain_started.wait(5.0)
         allow_first_attempt_start.set()
         completion.result(timeout=5.0)
         drain.result(timeout=5.0)
@@ -2904,7 +2922,205 @@ def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypa
     assert worker_handle_mod._FTE_PARTITION_OWNERS[pending_key] is handle
     assert pending_key in worker_handle_mod._FTE_PARTITION_TASK_LEASES
     assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert command_handoff_lock_owned == [True]
     assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0, 1]
+
+
+def test_fte_failed_worker_reservation_blocks_concurrent_retry(monkeypatch):
+    query_id = "query-reservation-failure-race"
+    actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    error_format_entered = threading.Event()
+    release_error_format = threading.Event()
+    pending_future.set_exception(
+        _BlockingStringError(
+            "planned worker reservation failure",
+            error_format_entered,
+            release_error_format,
+        )
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+    completion_errors = []
+
+    def drain_completion():
+        try:
+            scheduler.drain()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            completion_errors.append(exc)
+
+    completion_thread = threading.Thread(target=drain_completion)
+    completion_thread.start()
+    assert error_format_entered.wait(1.0)
+    try:
+        concurrent_handles = handle._drain_fte_pending_tasks()
+        with worker_handle_mod._FTE_REGISTRY_LOCK:
+            current_future = worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS.get(pending_key)
+            current_generation = worker_handle_mod._FTE_WORKER_RESERVATION_GENERATIONS[pending_key]
+    finally:
+        release_error_format.set()
+        completion_thread.join(2.0)
+
+    assert completion_thread.is_alive() is False
+    assert len(completion_errors) == 1
+    assert isinstance(completion_errors[0], RuntimeError)
+    assert str(completion_errors[0]) == "FTE worker reservation failed: planned worker reservation failure"
+    assert concurrent_handles == []
+    assert current_future is pending_future
+    assert current_generation == pending_future.reservation_generation
+    assert pending_future.done() is True
+    assert pending_key not in worker_handle_mod._FTE_PARTITION_OWNERS
+    assert pending_key not in worker_handle_mod._FTE_PARTITION_TASK_LEASES
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
+def test_fte_failed_worker_reservation_ignores_replacement_generation(monkeypatch):
+    query_id = "query-reservation-failure-stale"
+    actor, handle, pending_key, old_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    error_format_entered = threading.Event()
+    release_error_format = threading.Event()
+    old_future.set_exception(
+        _BlockingStringError(
+            "planned stale worker reservation failure",
+            error_format_entered,
+            release_error_format,
+        )
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+    completion_results = []
+    completion_errors = []
+
+    def drain_completion():
+        try:
+            completion_results.append(scheduler.drain())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            completion_errors.append(exc)
+
+    completion_thread = threading.Thread(target=drain_completion)
+    completion_thread.start()
+    assert error_format_entered.wait(1.0)
+    try:
+        with worker_handle_mod._FTE_REGISTRY_LOCK:
+            removed_future = worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS.pop(pending_key, None)
+            fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, pending_key[1])]
+        partition = fragment_execution.partitions[pending_key[2]]
+        new_future, created = handle._fte_worker_placement_manager.request_async(
+            query_id=query_id,
+            fragment_execution_id=fragment_execution.fragment_execution_id,
+            fragment_id=pending_key[1],
+            partition_id=pending_key[2],
+            memory_requirement_bytes=partition.memory_requirement_bytes,
+            execution_class=partition.execution_class,
+            node_requirements=partition.node_requirements,
+            node_requirements_wait_started_at=partition.node_wait_started_at,
+            on_done=handle._enqueue_fte_worker_reservation_completion,
+        )
+    finally:
+        release_error_format.set()
+        completion_thread.join(2.0)
+
+    assert completion_thread.is_alive() is False
+    assert completion_errors == []
+    assert completion_results == [[]]
+    assert removed_future is old_future
+    assert created is True
+    assert new_future.reservation_generation == old_future.reservation_generation + 1
+    assert worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS[pending_key] is new_future
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
+def test_fte_failed_worker_reservation_racing_query_drop_is_ignored(monkeypatch):
+    query_id = "query-reservation-failure-drop"
+    actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    error_format_entered = threading.Event()
+    release_error_format = threading.Event()
+    pending_future.set_exception(
+        _BlockingStringError(
+            "planned worker reservation failure",
+            error_format_entered,
+            release_error_format,
+        )
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+    completion_results = []
+    completion_errors = []
+
+    def drain_completion():
+        try:
+            completion_results.append(scheduler.drain())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            completion_errors.append(exc)
+
+    completion_thread = threading.Thread(target=drain_completion)
+    completion_thread.start()
+    assert error_format_entered.wait(1.0)
+    try:
+        drop_result = handle.fte_drop_query(query_id)
+    finally:
+        release_error_format.set()
+        completion_thread.join(2.0)
+
+    assert completion_thread.is_alive() is False
+    assert completion_errors == []
+    assert completion_results == [[]]
+    assert drop_result == {"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert (query_id, pending_key[1]) not in worker_handle_mod._FTE_FRAGMENT_EXECUTIONS
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
+def test_fte_worker_reservation_handle_publication_racing_query_drop_is_ignored(monkeypatch):
+    query_id = "query-reservation-handle-drop"
+    actor, handle, pending_key, _ = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    running = handle.pop_fte_result_handles(query_id)
+    assert len(running) == 1
+    handle_construction_entered = threading.Event()
+    release_handle_construction = threading.Event()
+
+    class _BlockingFteTaskHandle(_FakeFteTaskHandle):
+        def __init__(self, task_id, worker_handle):
+            handle_construction_entered.set()
+            assert release_handle_construction.wait(5.0)
+            super().__init__(task_id, worker_handle)
+
+    monkeypatch.setattr(handle, "_fte_task_handle_cls", lambda: _BlockingFteTaskHandle)
+    completion_errors = []
+
+    def release_running_capacity():
+        try:
+            handle.record_fte_task_terminal(running[0].task_id)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            completion_errors.append(exc)
+
+    completion_thread = threading.Thread(target=release_running_capacity)
+    completion_thread.start()
+    assert handle_construction_entered.wait(1.0)
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0, 1]
+    try:
+        drop_result = handle.fte_drop_query(query_id)
+    finally:
+        release_handle_construction.set()
+        completion_thread.join(2.0)
+
+    assert completion_thread.is_alive() is False
+    assert completion_errors == []
+    assert drop_result == {"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert (query_id, pending_key[1]) not in worker_handle_mod._FTE_FRAGMENT_EXECUTIONS
+    assert handle.pop_fte_result_handles(query_id) == []
 
 
 def test_fte_pending_worker_reservation_cancelled_on_query_drop(monkeypatch):
@@ -4044,7 +4260,6 @@ def test_fte_worker_failure_replays_descriptor_on_new_owner(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4146,7 +4361,6 @@ def test_fte_worker_failure_retry_waits_for_scheduling_delayer(monkeypatch):
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
         "RetryDelayExpired": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4203,7 +4417,6 @@ def test_fte_split_append_control_failure_replays_on_replacement(monkeypatch):
         "SplitEventsSubmitted": 2,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4275,7 +4488,6 @@ def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):
         "SplitEventsSubmitted": 2,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4992,7 +5204,6 @@ def test_fte_exchange_selector_event_updates_running_and_pending_consumers(monke
         "WorkerReservationCompleted": 2,
         "ExchangeSelectorUpdated": 1,
         "TaskStatusChanged": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -5757,6 +5968,7 @@ def test_fte_status_handler_keeps_watcher_until_terminal_status(monkeypatch):
         "fragment_execution_key_for_fte_attempt",
         lambda _attempt_id: (query_id, fragment_id),
     )
+    monkeypatch.setattr(handle, "_drain_fte_pending_tasks", lambda **_kwargs: [])
     worker_handle_mod._FTE_STATUS_WATCHERS[str(attempt_id)] = watcher
     worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, fragment_id)] = fragment_execution
     try:
@@ -6038,7 +6250,7 @@ def test_fte_registry_close_waits_for_terminal_handler_and_suppresses_retry(monk
     assert outbox_executions == []
 
 
-def test_fte_terminal_close_race_still_drains_other_queries(monkeypatch):
+def test_fte_terminal_query_drop_race_still_drains_other_queries(monkeypatch):
     monkeypatch.setattr(
         fragment_submission_mod,
         "_split_exchange_source_task_by_partition",
@@ -6095,12 +6307,13 @@ def test_fte_terminal_close_race_still_drains_other_queries(monkeypatch):
     completion_thread.start()
     assert mutation_done.wait(1.0)
 
-    worker_handle_mod.close_fte_registry_for_query("query-a")
+    drop_result = handle.fte_drop_query("query-a")
     release_handler.set()
     completion_thread.join(2.0)
 
     assert completion_thread.is_alive() is False
     assert completion_errors == []
+    assert drop_result == {"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}
     assert [str(task_handle.task_id) for task_handle in completion_handles] == ["query-b.0.0.0"]
     scheduled_query_b = handle.pop_fte_result_handles("query-b")
     assert [str(task_handle.task_id) for task_handle in scheduled_query_b] == ["query-b.0.0.0"]
@@ -6445,7 +6658,6 @@ def test_fte_task_status_event_marks_partition_finished(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 1,
         "TaskStatusChanged": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6484,7 +6696,6 @@ def test_fte_task_status_event_retries_failed_attempt(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 2,
         "TaskStatusChanged": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6523,7 +6734,6 @@ def test_fte_task_status_event_oom_is_terminal_for_registered_heap(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 1,
         "TaskStatusChanged": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6721,7 +6931,6 @@ def test_fte_input_stream_exhausted_control_failure_replays_sealed_descriptor(mo
         "WorkerReservationCompleted": 2,
         "SourceInputExhausted": 1,
         "WorkerFailed": 1,
-        "ResourceAdmissionChanged": 1,
     }
 
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -4,6 +4,7 @@
 import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -2805,6 +2806,63 @@ def test_fte_stale_worker_reservation_generation_does_not_consume_new_future(mon
     assert scheduled[0].worker_handle is replacement
     assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
     assert [call[1]["task_id"]["partition_id"] for call in actor1.fte_calls if call[0] == "create"] == [1]
+
+
+def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypatch):
+    from duckdb.runners.ray import fragment_worker_events as worker_events_mod
+
+    query_id = "query-reservation-completion-race"
+    actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    running = handle.pop_fte_result_handles(query_id)
+    assert len(running) == 1
+
+    first_reservation_removed = threading.Event()
+    allow_first_attempt_start = threading.Event()
+    pending_drain_entered = threading.Event()
+    remove_generations = []
+    original_remove = worker_events_mod.remove_pending_fte_worker_reservation_if_current
+
+    def blocked_remove(key, future):
+        removed = original_remove(key, future)
+        if removed:
+            remove_generations.append(future.reservation_generation)
+        if removed and len(remove_generations) == 1:
+            first_reservation_removed.set()
+            assert allow_first_attempt_start.wait(5.0)
+        return removed
+
+    monkeypatch.setattr(
+        worker_events_mod,
+        "remove_pending_fte_worker_reservation_if_current",
+        blocked_remove,
+    )
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        completion = executor.submit(handle.record_fte_task_terminal, running[0].task_id)
+        assert first_reservation_removed.wait(5.0)
+
+        fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, pending_key[1])]
+        original_schedule_next = fragment_execution.schedule_next_pending_partition
+
+        def observed_schedule_next(*args, **kwargs):
+            pending_drain_entered.set()
+            return original_schedule_next(*args, **kwargs)
+
+        monkeypatch.setattr(fragment_execution, "schedule_next_pending_partition", observed_schedule_next)
+        drain = executor.submit(handle._drain_fte_pending_tasks)
+        assert pending_drain_entered.wait(5.0)
+        allow_first_attempt_start.set()
+        completion.result(timeout=5.0)
+        drain.result(timeout=5.0)
+
+    assert remove_generations == [pending_future.reservation_generation]
+    assert fragment_execution.partitions[1].running_attempt is not None
+    assert worker_handle_mod._FTE_PARTITION_OWNERS[pending_key] is handle
+    assert pending_key in worker_handle_mod._FTE_PARTITION_TASK_LEASES
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0, 1]
 
 
 def test_fte_pending_worker_reservation_cancelled_on_query_drop(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -3300,6 +3300,43 @@ def test_fte_pending_drain_is_fair_across_queries(
     assert [str(task_handle.task_id) for task_handle in second_scheduled] == [next_query_a_attempt]
 
 
+def test_fte_status_refresh_drains_released_capacity_across_queries(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    handle.submit_tasks([task("query-a")])
+    assert handle.submit_tasks([task("query-b")]) == []
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-a")] == ["query-a.0.0.0"]
+
+    monkeypatch.setattr(
+        handle,
+        "fte_get_task_status",
+        lambda task_id, timeout_s=None: {
+            "state": "FINISHED",
+            "task_id": task_id,
+            "version": 1,
+        },
+    )
+    worker_handle_mod.refresh_fte_running_task_stats("query-a")
+
+    query_a_stage = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[("query-a", "query-a:node:8")]
+    assert query_a_stage.partitions[0].finished is True
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-b")] == ["query-b.0.0.0"]
+
+
 def test_fte_pending_drain_prefers_standard_over_speculative(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,
@@ -5967,6 +6004,45 @@ def test_fte_terminal_close_race_still_drains_other_queries(monkeypatch):
     assert [str(task_handle.task_id) for task_handle in completion_handles] == ["query-b.0.0.0"]
     scheduled_query_b = handle.pop_fte_result_handles("query-b")
     assert [str(task_handle.task_id) for task_handle in scheduled_query_b] == ["query-b.0.0.0"]
+
+
+def test_fte_terminal_mutation_error_still_drains_other_queries(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    query_a_handles = handle.submit_tasks([task("query-a")])
+    assert handle.submit_tasks([task("query-b")]) == []
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-a")] == ["query-a.0.0.0"]
+
+    fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[("query-a", "query-a:node:8")]
+
+    def fail_descriptor_remove(_task_id):
+        raise OSError("descriptor spill unlink failed")
+
+    monkeypatch.setattr(fragment_execution.descriptor_storage, "remove", fail_descriptor_remove)
+    with pytest.raises(OSError, match="descriptor spill unlink failed"):
+        handle.handle_fte_task_status(
+            {
+                "state": "FINISHED",
+                "task_id": query_a_handles[0].task_id.to_dict(),
+                "version": 1,
+            }
+        )
+
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-b")] == ["query-b.0.0.0"]
 
 
 def test_fte_registry_close_fences_inflight_remote_mutation_ownership():

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2358,6 +2358,71 @@ def test_fte_owner_selection_uses_reserved_memory_pressure(monkeypatch):
     assert high_memory.fte_pressure_stats()["total_memory_bytes"] == 0
 
 
+def test_fte_create_promotes_reservation_to_running_atomically(monkeypatch):
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+    publish_started = threading.Event()
+    allow_publish = threading.Event()
+    query_b_started = threading.Event()
+    query_b_done = threading.Event()
+    errors = []
+    handles_by_query = {}
+    original_record_started = handle.record_fte_task_started
+
+    def record_started_with_barrier(attempt_id, request):
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        if attempt.task_id.query_id == "query-atomic-a":
+            publish_started.set()
+            if not allow_publish.wait(2.0):
+                raise RuntimeError("timed out waiting to publish running pressure")
+        return original_record_started(attempt_id, request)
+
+    monkeypatch.setattr(handle, "record_fte_task_started", record_started_with_barrier)
+
+    def submit(query_id, node_id):
+        try:
+            if query_id == "query-atomic-b":
+                query_b_started.set()
+            handles_by_query[query_id] = handle.submit_tasks(
+                [
+                    _FakeTask(
+                        name=f"scan-{query_id}",
+                        context={"query_id": query_id, "node_id": node_id},
+                        inputs={node_id: {"kind": "scan_task", "data": query_id.encode()}},
+                    )
+                ]
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            if query_id == "query-atomic-b":
+                query_b_done.set()
+
+    thread_a = threading.Thread(target=submit, args=("query-atomic-a", "7"))
+    thread_b = threading.Thread(target=submit, args=("query-atomic-b", "8"))
+    thread_a.start()
+    try:
+        assert publish_started.wait(2.0)
+        thread_b.start()
+        assert query_b_started.wait(2.0)
+        query_b_completed_during_handoff = query_b_done.wait(0.1)
+    finally:
+        allow_publish.set()
+        thread_a.join(2.0)
+        if thread_b.ident is not None:
+            thread_b.join(2.0)
+
+    assert thread_a.is_alive() is False
+    assert thread_b.is_alive() is False
+    assert errors == []
+    assert query_b_completed_during_handoff is False
+    assert [str(item.task_id) for item in handles_by_query["query-atomic-a"]] == ["query-atomic-a.0.0.0"]
+    assert handles_by_query["query-atomic-b"] == []
+    create_requests = _create_requests(actor)
+    assert [request["task_id"]["query_id"] for request in create_requests] == ["query-atomic-a"]
+    assert handle.fte_pressure_stats()["total_memory_bytes"] == 10
+
+
 def test_ray_worker_handle_requires_positive_ray_memory_capacity():
     actor = _FakeActor()
 
@@ -4704,6 +4769,85 @@ def test_fte_split_append_control_failure_replays_on_replacement(monkeypatch):
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
     }
+
+
+def test_fte_control_failure_preempts_queued_work_across_queries(monkeypatch):
+    monkeypatch.setattr(
+        RayWorkerActorHandle,
+        "_fte_task_handle_cls",
+        staticmethod(lambda: _FakeFteTaskHandle),
+    )
+
+    class _FailFirstCreateActor(_FakeActor):
+        failed = False
+
+        def _fte_create_task(self, request):
+            self.fte_calls.append(("create", request))
+            if request["task_id"]["query_id"] == "query-control-barrier" and not self.failed:
+                self.failed = True
+                replacement._fte_healthy = True
+                raise RuntimeError("planned first create failure")
+            return self._control_status("fte_create_task", request["task_id"])
+
+    actor = _FailFirstCreateActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60, worker_id="worker-0")
+    replacement_actor = _FakeActor()
+    replacement = RayWorkerActorHandle(
+        replacement_actor,
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-1",
+    )
+    replacement._fte_healthy = False
+    other_handles = handle.submit_tasks(
+        [
+            _FakeTask(
+                name="scan-other",
+                context={"query_id": "query-control-other", "node_id": "6"},
+                inputs={"6": {"kind": "scan_task", "data": b"other"}},
+            )
+        ]
+    )
+    tasks = [
+        _FakeTask(
+            name="scan-a",
+            context={"query_id": "query-control-barrier", "node_id": "7"},
+            inputs={"7": {"kind": "scan_task", "data": b"a"}},
+        ),
+        _FakeTask(
+            name="scan-b",
+            context={"query_id": "query-control-barrier", "node_id": "8"},
+            inputs={"8": {"kind": "scan_task", "data": b"b"}},
+        ),
+    ]
+
+    handles = handle.submit_tasks(tasks)
+
+    assert len(other_handles) == 1
+    assert other_handles[0].worker_handle is handle
+    assert len(handles) == 3
+    assert all(task_handle.worker_handle is replacement for task_handle in handles)
+    assert [str(FteTaskAttemptId.coerce(request["task_id"])) for request in _create_requests(actor)] == [
+        "query-control-other.0.0.0",
+        "query-control-barrier.0.0.0",
+    ]
+    assert [str(FteTaskAttemptId.coerce(request["task_id"])) for request in _create_requests(replacement_actor)] == [
+        "query-control-other.0.0.1",
+        "query-control-barrier.0.0.1",
+        "query-control-barrier.1.0.0",
+    ]
+    assert handle._fte_healthy is False
+    assert "worker-0" not in worker_handle_mod._FTE_WORKER_HANDLES
+    query_owners = {
+        key: owner
+        for key, owner in worker_handle_mod._FTE_PARTITION_OWNERS.items()
+        if key[0] in {"query-control-barrier", "query-control-other"}
+    }
+    assert set(query_owners) == {
+        ("query-control-barrier", "query-control-barrier:node:7", 0),
+        ("query-control-barrier", "query-control-barrier:node:8", 0),
+        ("query-control-other", "query-control-other:node:6", 0),
+    }
+    assert all(owner is replacement for owner in query_owners.values())
 
 
 def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2909,7 +2909,7 @@ def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypa
 
         def drain_pending():
             pending_drain_started.set()
-            return handle._drain_fte_pending_tasks()
+            return worker_handle_mod.request_fte_pending_task_drain()
 
         drain = executor.submit(drain_pending)
         assert pending_drain_started.wait(5.0)
@@ -2955,7 +2955,7 @@ def test_fte_failed_worker_reservation_blocks_concurrent_retry(monkeypatch):
     completion_thread.start()
     assert error_format_entered.wait(1.0)
     try:
-        concurrent_handles = handle._drain_fte_pending_tasks()
+        concurrent_handles = worker_handle_mod.request_fte_pending_task_drain()
         with worker_handle_mod._FTE_REGISTRY_LOCK:
             current_future = worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS.get(pending_key)
             current_generation = worker_handle_mod._FTE_WORKER_RESERVATION_GENERATIONS[pending_key]
@@ -2971,8 +2971,10 @@ def test_fte_failed_worker_reservation_blocks_concurrent_retry(monkeypatch):
     assert current_future is pending_future
     assert current_generation == pending_future.reservation_generation
     assert pending_future.done() is True
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
     assert pending_key not in worker_handle_mod._FTE_PARTITION_OWNERS
     assert pending_key not in worker_handle_mod._FTE_PARTITION_TASK_LEASES
+    assert scheduler.stats().state == "FAILED"
     assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
 
 
@@ -3651,6 +3653,290 @@ def test_fte_status_refresh_drains_released_capacity_across_queries(monkeypatch)
     query_a_stage = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[("query-a", "query-a:node:8")]
     assert query_a_stage.partitions[0].finished is True
     assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-b")] == ["query-b.0.0.0"]
+
+
+def test_fte_capacity_pump_isolates_failed_query_reservation(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id, execution_class="STANDARD"):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={
+                "query_id": query_id,
+                "node_id": "8",
+                "task_execution_class": execution_class,
+            },
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    query_a_handle = handle.submit_tasks([task("query-pump-a")])[0]
+    assert handle.submit_tasks([task("query-pump-b")]) == []
+    assert handle.submit_tasks([task("query-pump-c", "SPECULATIVE")]) == []
+    pending_key = ("query-pump-b", "query-pump-b:node:8", 0)
+    pending_future = worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS[pending_key]
+    pending_future.set_exception(RuntimeError("planned query-b reservation failure"))
+
+    handle.record_fte_task_terminal(query_a_handle.task_id)
+
+    query_a_scheduler = worker_handle_mod._FTE_SCHEDULERS.get("query-pump-a")
+    query_b_scheduler = worker_handle_mod._FTE_SCHEDULERS.get("query-pump-b")
+    assert query_a_scheduler is not None
+    assert query_b_scheduler is not None
+    assert query_a_scheduler.stats().state == "RUNNING"
+    assert query_b_scheduler.stats().state == "FAILED"
+    assert "planned query-b reservation failure" in str(query_b_scheduler.stats().failure_reason)
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-pump-c")] == [
+        "query-pump-c.0.0.0"
+    ]
+
+
+def test_fte_speculative_admission_isolates_other_query_scan_failure():
+    failed_scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-scan-failure")
+    healthy_scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-scan-healthy")
+
+    class _BrokenFragmentExecution:
+        @staticmethod
+        def _state_lock_owned_by_current_thread():
+            return False
+
+        @staticmethod
+        def has_pending_partitions(*_args):
+            raise RuntimeError("planned admission scan failure")
+
+    class _SpeculativePartition:
+        node_wait_started_at = None
+        execution_class = "SPECULATIVE"
+
+    worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[("query-scan-failure", "fragment-0")] = _BrokenFragmentExecution()
+
+    assert (
+        worker_handle_mod._admit_fte_partition_node_wait(
+            "query-scan-healthy",
+            _SpeculativePartition(),
+        )
+        is False
+    )
+    assert failed_scheduler.stats().state == "FAILED"
+    assert "planned admission scan failure" in str(failed_scheduler.stats().failure_reason)
+    assert healthy_scheduler.stats().state == "RUNNING"
+
+
+def test_fte_resource_waiter_scan_isolates_failed_query():
+    resource_query_id = "query-resource-scan"
+    failed_query_id = "query-resource-scan-failure"
+    healthy_query_id = "query-resource-scan-healthy"
+    failed_scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create(failed_query_id)
+    worker_handle_mod._FTE_SCHEDULERS.get_or_create(healthy_query_id)
+
+    class _FragmentExecution:
+        context = {
+            "resource_query_id": resource_query_id,
+            "resource_stage_id": f"stage:{resource_query_id}:node:8:fte",
+        }
+
+        def __init__(self, error=None):
+            self.error = error
+
+        def has_pending_partitions(self):
+            if self.error is not None:
+                raise self.error
+            return True
+
+    worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(failed_query_id, "fragment-0")] = _FragmentExecution(
+        RuntimeError("planned resource waiter scan failure")
+    )
+    worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(healthy_query_id, "fragment-0")] = _FragmentExecution()
+
+    assert worker_handle_mod._fte_execution_queries_waiting_for_resource(resource_query_id) == (healthy_query_id,)
+    assert failed_scheduler.stats().state == "FAILED"
+    assert "planned resource waiter scan failure" in str(failed_scheduler.stats().failure_reason)
+
+
+def test_fte_query_drop_durably_wakes_other_pending_queries(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    assert len(handle.submit_tasks([task("query-drop-a")])) == 1
+    assert handle.submit_tasks([task("query-drop-b")]) == []
+
+    handle.fte_drop_query("query-drop-a")
+
+    scheduled = handle.pop_fte_result_handles("query-drop-b")
+    assert [str(task_handle.task_id) for task_handle in scheduled] == ["query-drop-b.0.0.0"]
+
+
+def test_fte_capacity_pump_preserves_create_before_followup_worker_commands(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    create_handoff_entered = threading.Event()
+    release_create_handoff = threading.Event()
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+    original_execute_commands = handle._execute_fte_fragment_execution_worker_commands
+
+    def block_before_create(fragment_execution, worker_commands):
+        if fragment_execution.query_id == "query-command-order" and any(
+            command.command_type == "FteCreateTaskCommand" for command in worker_commands
+        ):
+            create_handoff_entered.set()
+            assert release_create_handoff.wait(5.0)
+        return original_execute_commands(fragment_execution, worker_commands)
+
+    monkeypatch.setattr(
+        handle,
+        "_execute_fte_fragment_execution_worker_commands",
+        block_before_create,
+    )
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    blocker = handle.submit_tasks([task("query-command-blocker")])[0]
+    assert handle.submit_tasks([task("query-command-order")]) == []
+    release_errors = []
+
+    def release_capacity():
+        try:
+            handle.record_fte_task_terminal(blocker.task_id)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            release_errors.append(exc)
+
+    release_thread = threading.Thread(target=release_capacity)
+    release_thread.start()
+    assert create_handoff_entered.wait(1.0)
+
+    handle.task_input_stream_exhausted_for_query("query-command-order", ["3"])
+    release_create_handoff.set()
+    release_thread.join(2.0)
+
+    assert release_thread.is_alive() is False
+    assert release_errors == []
+    ordered_calls = [
+        call[0]
+        for call in actor.fte_calls
+        if (call[0] == "create" and call[1]["task_id"]["query_id"] == "query-command-order")
+        or (call[0] == "no_more_splits" and call[1]["query_id"] == "query-command-order")
+    ]
+    assert ordered_calls == ["create", "no_more_splits"]
+
+
+def test_fte_handle_publication_holds_query_lifecycle_through_watcher_registration(monkeypatch):
+    monkeypatch.setattr(
+        fragment_submission_mod,
+        "_split_exchange_source_task_by_partition",
+        lambda value: ([(int(value[-1:]), value)], 2, 2, False),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")
+
+    def task(query_id):
+        return _FakeTask(
+            name=f"{query_id}-task-0",
+            context={"query_id": query_id, "node_id": "8"},
+            inputs={"3": {"kind": "exchange_source_task", "data": b"p0"}},
+            plan={"plan": "exchange-template"},
+        )
+
+    blocker = handle.submit_tasks([task("query-publication-blocker")])[0]
+    assert handle.submit_tasks([task("query-publication")]) == []
+    watcher_registration_entered = threading.Event()
+    release_watcher_registration = threading.Event()
+
+    def block_watcher_registration(*_args, **_kwargs):
+        watcher_registration_entered.set()
+        assert release_watcher_registration.wait(5.0)
+
+    monkeypatch.setattr(
+        handle,
+        "_start_fte_attempt_status_watcher",
+        block_watcher_registration,
+    )
+    local_drop_entered = threading.Event()
+    release_local_drop = threading.Event()
+    original_drop_registry = task_control_mod._drop_fte_registry_for_query
+
+    def block_local_registry_drop(query_id):
+        local_drop_entered.set()
+        assert release_local_drop.wait(5.0)
+        return original_drop_registry(query_id)
+
+    monkeypatch.setattr(
+        task_control_mod,
+        "_drop_fte_registry_for_query",
+        block_local_registry_drop,
+    )
+    release_errors = []
+
+    def release_capacity():
+        try:
+            handle.record_fte_task_terminal(blocker.task_id)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            release_errors.append(exc)
+
+    release_thread = threading.Thread(target=release_capacity)
+    release_thread.start()
+    assert watcher_registration_entered.wait(1.0)
+
+    drop_done = threading.Event()
+    drop_results = []
+
+    def drop_query():
+        try:
+            drop_results.append(handle.fte_drop_query("query-publication"))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            drop_results.append(exc)
+        finally:
+            drop_done.set()
+
+    drop_thread = threading.Thread(target=drop_query)
+    drop_thread.start()
+    drop_completed_before_publication = drop_done.wait(0.1)
+    release_watcher_registration.set()
+    release_thread.join(2.0)
+    try:
+        assert local_drop_entered.wait(1.0)
+        with worker_handle_mod._FTE_REGISTRY_LOCK:
+            retained_handles = list(worker_handle_mod._FTE_RESULT_HANDLES_BY_QUERY.get("query-publication", []))
+    finally:
+        release_local_drop.set()
+    drop_thread.join(2.0)
+
+    assert drop_completed_before_publication is False
+    assert release_thread.is_alive() is False
+    assert drop_thread.is_alive() is False
+    assert release_errors == []
+    assert [str(result_handle.task_id) for result_handle in retained_handles] == ["query-publication.0.0.0"]
+    assert drop_results == [{"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}]
+    assert handle.pop_fte_result_handles("query-publication") == []
 
 
 def test_fte_pending_drain_prefers_standard_over_speculative(monkeypatch):
@@ -6314,7 +6600,9 @@ def test_fte_terminal_query_drop_race_still_drains_other_queries(monkeypatch):
     assert completion_thread.is_alive() is False
     assert completion_errors == []
     assert drop_result == {"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}
-    assert [str(task_handle.task_id) for task_handle in completion_handles] == ["query-b.0.0.0"]
+    # Query B was admitted by the teardown-owned pump, not returned through
+    # the already-closing query A event.
+    assert completion_handles == []
     scheduled_query_b = handle.pop_fte_result_handles("query-b")
     assert [str(task_handle.task_id) for task_handle in scheduled_query_b] == ["query-b.0.0.0"]
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2766,6 +2766,48 @@ def test_fte_worker_reservation_completion_after_query_drop_is_ignored(monkeypat
     assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
 
 
+def test_fte_worker_reservation_completion_racing_query_drop_is_ignored(monkeypatch):
+    from duckdb.runners.ray import fragment_worker_events as worker_events_mod
+
+    query_id = "query-reservation-during-drop"
+    actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    pending_future.set_result(_completed_test_reservation(pending_future, handle))
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+
+    reservation_removed = threading.Event()
+    allow_completion = threading.Event()
+    original_remove = worker_events_mod.remove_pending_fte_worker_reservation_if_current
+
+    def blocked_remove(key, future):
+        removed = original_remove(key, future)
+        if removed:
+            reservation_removed.set()
+            assert allow_completion.wait(5.0)
+        return removed
+
+    monkeypatch.setattr(
+        worker_events_mod,
+        "remove_pending_fte_worker_reservation_if_current",
+        blocked_remove,
+    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        completion = executor.submit(scheduler.drain)
+        assert reservation_removed.wait(5.0)
+        try:
+            handle.fte_drop_query(query_id)
+        finally:
+            allow_completion.set()
+        assert completion.result(timeout=5.0) == []
+
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert (query_id, pending_key[1]) not in worker_handle_mod._FTE_FRAGMENT_EXECUTIONS
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
 def test_fte_stale_worker_reservation_generation_does_not_consume_new_future(monkeypatch):
     query_id = "query-reservation-stale-generation"
     actor0, handle, pending_key, old_future = _submit_strict_worker_reservation_pending_pair(

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -73,6 +73,13 @@ class RayWorkerActorHandle(_ProductionRayWorkerActorHandle):
         self.record_fte_task_terminal(attempt_id)
         return result
 
+    def record_fte_task_result_ready_without_drain(self, attempt_id):
+        result = super().record_fte_task_result_ready_without_drain(attempt_id)
+        # Match the immediate-adoption model without re-entering pending drain
+        # while a fragment completion is being applied.
+        self.record_fte_task_terminal(attempt_id, drain=False)
+        return result
+
     def _ensure_fragment_progress_topology(self, query_id, fragment_id, fragment_plan):
         topology = {
             "schema": "pipeline_topology",
@@ -3252,9 +3259,16 @@ def test_fte_pending_drain_is_fair_across_queries(monkeypatch):
     assert query_b_handles == []
     assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-a")] == ["query-a.0.0.0"]
 
-    handle.record_fte_task_terminal(query_a_handles[0].task_id)
+    completion_handles = handle.handle_fte_task_status(
+        {
+            "state": "FINISHED",
+            "task_id": query_a_handles[0].task_id.to_dict(),
+            "version": 1,
+        }
+    )
     first_scheduled = handle.pop_fte_result_handles("query-b")
 
+    assert [str(task_handle.task_id) for task_handle in completion_handles] == ["query-b.0.0.0"]
     assert [str(task_handle.task_id) for task_handle in first_scheduled] == ["query-b.0.0.0"]
     handle.record_fte_task_terminal(first_scheduled[0].task_id)
     second_scheduled = handle.pop_fte_result_handles("query-a")
@@ -3868,6 +3882,7 @@ def test_fte_worker_failure_replays_descriptor_on_new_owner(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -3969,6 +3984,7 @@ def test_fte_worker_failure_retry_waits_for_scheduling_delayer(monkeypatch):
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
         "RetryDelayExpired": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4025,6 +4041,7 @@ def test_fte_split_append_control_failure_replays_on_replacement(monkeypatch):
         "SplitEventsSubmitted": 2,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4096,6 +4113,7 @@ def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):
         "SplitEventsSubmitted": 2,
         "WorkerReservationCompleted": 2,
         "WorkerFailed": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -4812,6 +4830,7 @@ def test_fte_exchange_selector_event_updates_running_and_pending_consumers(monke
         "WorkerReservationCompleted": 2,
         "ExchangeSelectorUpdated": 1,
         "TaskStatusChanged": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6155,6 +6174,7 @@ def test_fte_task_status_event_marks_partition_finished(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 1,
         "TaskStatusChanged": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6193,6 +6213,7 @@ def test_fte_task_status_event_retries_failed_attempt(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 2,
         "TaskStatusChanged": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6231,6 +6252,7 @@ def test_fte_task_status_event_oom_is_terminal_for_registered_heap(monkeypatch):
         "SplitEventsSubmitted": 1,
         "WorkerReservationCompleted": 1,
         "TaskStatusChanged": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 
@@ -6428,6 +6450,7 @@ def test_fte_input_stream_exhausted_control_failure_replays_sealed_descriptor(mo
         "WorkerReservationCompleted": 2,
         "SourceInputExhausted": 1,
         "WorkerFailed": 1,
+        "ResourceAdmissionChanged": 1,
     }
 
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -1709,6 +1709,49 @@ def _handle_live_worker_statuses(stage, *, retryable=True):
     return scheduled
 
 
+def test_fte_worker_command_outbox_pop_owns_attempt_scheduling_lock():
+    stage = FteFragmentExecution(
+        "query-outbox-handoff",
+        0,
+        fragment_id="query-outbox-handoff:node:1",
+        task_memory_bytes=1,
+    )
+    copy_started = threading.Event()
+    release_copy = threading.Event()
+
+    class _PausedOutbox(list):
+        def __iter__(self):
+            snapshot = tuple(super().__iter__())
+            copy_started.set()
+            assert release_copy.wait(5.0)
+            return iter(snapshot)
+
+    stage._worker_command_outbox = _PausedOutbox(["first"])
+    popped = []
+    pop_errors = []
+
+    def pop_commands():
+        try:
+            popped.extend(stage.pop_worker_commands())
+        except BaseException as exc:  # pragma: no cover - asserted below
+            pop_errors.append(exc)
+
+    pop_thread = threading.Thread(target=pop_commands)
+    pop_thread.start()
+    assert copy_started.wait(1.0)
+    acquired_during_copy = stage._attempt_scheduling_lock.acquire(blocking=False)
+    if acquired_during_copy:
+        stage._attempt_scheduling_lock.release()
+    release_copy.set()
+    pop_thread.join(2.0)
+
+    assert pop_thread.is_alive() is False
+    assert pop_errors == []
+    assert acquired_during_copy is False
+    assert popped == ["first"]
+    assert stage._worker_command_outbox == []
+
+
 def test_fte_two_query_fragment_callbacks_do_not_cross_state_locks():
     callback_barrier = threading.Barrier(2)
     callback_lock_ownership = {}

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -1709,6 +1709,104 @@ def _handle_live_worker_statuses(stage, *, retryable=True):
     return scheduled
 
 
+def test_fte_two_query_fragment_callbacks_do_not_cross_state_locks():
+    callback_barrier = threading.Barrier(2)
+    callback_lock_ownership = {}
+    callback_errors = []
+
+    completion_stage = None
+    admission_stage = None
+
+    class _CompletionWorker(_FakeLiveWorker):
+        def record_fte_task_result_ready(self, _attempt_id):
+            callback_lock_ownership["completion"] = completion_stage._state_lock_owned_by_current_thread()
+            callback_barrier.wait(timeout=5.0)
+            admission_stage.has_pending_partitions()
+
+    completion_worker = _CompletionWorker("worker-completion")
+    completion_stage = _fte_fragment_execution(
+        "query-completion-lock-order",
+        1,
+        fragment_id="query-completion-lock-order:node:scan",
+        worker=completion_worker,
+    )
+    completion_attempt = completion_stage.apply_assignment_result(
+        AssignmentResult(partitions_added=[PartitionInfo(0)], sealed_partitions=[0])
+    )[0]
+
+    admission_worker = _FakeLiveWorker("worker-admission")
+    admission_stage = _fte_fragment_execution(
+        "query-admission-lock-order",
+        2,
+        fragment_id="query-admission-lock-order:node:exchange",
+        worker=admission_worker,
+        attempt_admission_callback=lambda _partition: False,
+        source_node_ids={"3"},
+        dynamic_exchange_source_node_ids={"3"},
+    )
+    assert (
+        admission_stage.apply_assignment_result(
+            AssignmentResult(
+                partitions_added=[PartitionInfo(0)],
+                partition_updates=[
+                    PartitionUpdate(
+                        0,
+                        "3",
+                        [{"sequence_id": 0, "kind": "exchange_source_task", "data": b"p0"}],
+                        ready_for_scheduling=True,
+                    )
+                ],
+            )
+        )
+        == []
+    )
+
+    def admit_after_global_priority_check(_partition):
+        callback_lock_ownership["admission"] = admission_stage._state_lock_owned_by_current_thread()
+        callback_barrier.wait(timeout=5.0)
+        completion_stage.has_pending_partitions()
+        return False
+
+    admission_stage.attempt_admission_callback = admit_after_global_priority_check
+
+    def run(callback):
+        try:
+            callback()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            callback_errors.append(exc)
+
+    completion_thread = threading.Thread(
+        target=run,
+        args=(lambda: completion_stage.task_finished(completion_attempt.attempt_id),),
+        daemon=True,
+    )
+    admission_thread = threading.Thread(
+        target=run,
+        args=(admission_stage.schedule_next_pending_partition,),
+        daemon=True,
+    )
+    completion_thread.start()
+    admission_thread.start()
+    completion_thread.join(timeout=5.0)
+    admission_thread.join(timeout=5.0)
+
+    assert completion_thread.is_alive() is False
+    assert admission_thread.is_alive() is False
+    assert callback_errors == []
+    assert callback_lock_ownership == {"completion": False, "admission": False}
+
+
+def test_fte_global_pending_scan_rejects_held_fragment_state_lock():
+    stage = _fte_fragment_execution(
+        "query-lock-hierarchy",
+        1,
+        fragment_id="query-lock-hierarchy:node:scan",
+    )
+
+    with stage._state_lock, pytest.raises(AssertionError, match="fragment state lock"):
+        fte_fragment_scheduler._has_fte_pending_standard_partitions([((stage.query_id, stage.fragment_id), stage)])
+
+
 def test_fte_worker_command_executor_requires_split_queue_wait_protocol():
     attempt_id = FteTaskAttemptId(FteTaskId("q", 0, 1), 0)
     command = FteAddSplitsCommand(

--- a/tests/fast/test_ray_fte_event_scheduler.py
+++ b/tests/fast/test_ray_fte_event_scheduler.py
@@ -5,20 +5,21 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 
 import pytest
 
 from duckdb.runners.ray.fte import FteTaskAttemptId, FteTaskId
 from duckdb.runners.ray.fte_events import (
     MemoryPressureDetected,
-    ResourceAdmissionChanged,
-    WorkerReservationCompleted,
     QueryAbort,
+    ResourceAdmissionChanged,
     RetryDelayExpired,
     SourceInputExhausted,
     SplitEventsSubmitted,
     TaskStatusChanged,
     WorkerFailed,
+    WorkerReservationCompleted,
 )
 from duckdb.runners.ray.fte_scheduler import (
     FteAttemptStatusWatcher,
@@ -151,6 +152,136 @@ def test_event_scheduler_uses_bound_handlers_by_default():
 
     assert scheduler.drain() == ["ok"]
     assert calls == [[7]]
+
+
+def test_event_scheduler_does_not_lose_enqueue_during_idle_handoff():
+    scheduler = FteQueryScheduler("query-idle-handoff")
+    processed = []
+    empty_check_released = threading.Event()
+    concurrent_drain_done = threading.Event()
+    drainer_thread_id = [None]
+
+    class _CoordinatedLock:
+        def __init__(self):
+            self._lock = threading.RLock()
+            self._arm_handoff = False
+            self._block_next_drainer_acquire = False
+
+        def __enter__(self):
+            if threading.get_ident() == drainer_thread_id[0] and self._block_next_drainer_acquire:
+                assert concurrent_drain_done.wait(5.0)
+                self._block_next_drainer_acquire = False
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_args):
+            self._lock.release()
+            if threading.get_ident() == drainer_thread_id[0] and self._arm_handoff:
+                self._arm_handoff = False
+                self._block_next_drainer_acquire = True
+                empty_check_released.set()
+
+    coordinated_lock = _CoordinatedLock()
+
+    class _CoordinatedQueue(deque):
+        def __bool__(self):
+            nonempty = bool(len(self))
+            if not nonempty and threading.get_ident() == drainer_thread_id[0]:
+                coordinated_lock._arm_handoff = True
+            return nonempty
+
+    scheduler._lock = coordinated_lock
+    scheduler._events = _CoordinatedQueue()
+    scheduler.set_handlers(
+        FteEventHandlers(
+            on_split_events=lambda events: processed.extend(event["value"] for event in events) or [],
+        )
+    )
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 1}],
+        )
+    )
+
+    drain_errors = []
+
+    def drain_initial_event():
+        drainer_thread_id[0] = threading.get_ident()
+        try:
+            scheduler.drain()
+        except BaseException as exc:  # pragma: no cover - asserted below
+            drain_errors.append(exc)
+
+    drain_thread = threading.Thread(target=drain_initial_event)
+    drain_thread.start()
+    assert empty_check_released.wait(1.0)
+
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 2}],
+        )
+    )
+    scheduler.drain()
+    concurrent_drain_done.set()
+    drain_thread.join(2.0)
+
+    assert drain_thread.is_alive() is False
+    assert drain_errors == []
+    assert processed == [1, 2]
+    assert scheduler.stats().queued_events == 0
+
+
+def test_scheduler_registry_pending_drain_is_single_flight_and_durable():
+    registry = FteSchedulerRegistry()
+    registry.get_or_create("query-a")
+    registry.get_or_create("query-b")
+    calls = []
+    active_depth = 0
+    max_active_depth = 0
+
+    def drain_round(query_ids):
+        nonlocal active_depth, max_active_depth
+        active_depth += 1
+        max_active_depth = max(max_active_depth, active_depth)
+        try:
+            for query_id in query_ids:
+                calls.append(query_id)
+                if calls == ["query-a"]:
+                    assert registry.run_pending_drain(drain_round) == []
+            return []
+        finally:
+            active_depth -= 1
+
+    assert registry.run_pending_drain(drain_round) == []
+    assert calls == ["query-a", "query-b", "query-a", "query-b"]
+    assert max_active_depth == 1
+
+
+def test_event_scheduler_coalesces_pending_internal_admission_pulses():
+    scheduler = FteQueryScheduler("query-admission-pulse")
+    calls = []
+    pulse = ResourceAdmissionChanged(
+        scheduler.query_id,
+        execution_class="STANDARD",
+        internal=True,
+    )
+
+    scheduler.enqueue(pulse)
+    scheduler.enqueue(pulse)
+
+    assert scheduler.stats().queued_events == 1
+    assert (
+        scheduler.drain(
+            FteEventHandlers(
+                on_resource_admission_changed=lambda event: calls.append(event.execution_class) or [],
+            )
+        )
+        == []
+    )
+    assert calls == ["STANDARD"]
+    assert scheduler.stats().processed_events == 0
 
 
 def test_event_scheduler_pauses_and_resumes_registered_task_source():


### PR DESCRIPTION
## Summary

- make each per-query FTE scheduler the single writer for admission and status mutations
- route every capacity release through one global single-flight dirty-bit admission pump
- preserve admission priority in explicit phases: eager speculative, standard, then speculative only when no active query has standard work pending
- admit at most one attempt per query/class event quantum and coalesce duplicate internal admission pulses
- release terminal pressure outside fragment state locks and keep global fragment scans outside every fragment lock
- fence result-handle publication through status-watcher registration against query teardown
- isolate reservation and admission-scan failures to the affected query while continuing healthy queries
- preserve retryable registry ownership until teardown succeeds

## Root cause

Completion could hold fragment F1 state and synchronously drain all pending fragments, while admission held fragment F2 state and inspected F1 for global priority. The opposite F1 -> F2 and F2 -> F1 order formed an ABBA deadlock. Incremental wakeup fixes still left multiple callers able to enter cross-query admission, which created separate fairness, lost-wakeup, and teardown races.

The long-term fix gives cross-query admission one owner. Capacity changes only dirty the global pump; the pump delegates bounded work to each query scheduler, and each scheduler serializes that query state. Fragment callbacks never perform a global traversal while holding a fragment state lock.

## Regression coverage

Deterministic tests cover:

- the original two-query/two-fragment lock inversion
- scheduler idle-handoff and pump dirty-bit wakeups
- duplicate internal pulse coalescing
- failed reservation and failed global-scan isolation
- standard/speculative priority and cross-query fairness
- reservation completion versus concurrent drains and query drop
- create-before-follow-up command ordering
- result-handle publication versus watcher registration and retryable teardown ownership
- capacity release during terminal status and query teardown

## Testing

- `pre-commit run --files <changed files>`
- `python -m pytest tests/fast/test_ray_fte_event_scheduler.py tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_fte.py` (319 passed)
- `scripts/run_release_tests.sh` (266 non-real-Ray passed; 5 real-Ray passed)

Closes #63