### PR TITLE
[fix](runner) Avoid GIL deadlock during initialization

### DIFF
--- a/src/duckdb_py/vane-runners/vane_runners.cpp
+++ b/src/duckdb_py/vane-runners/vane_runners.cpp
@@ -10,8 +10,10 @@
 
 #include <pybind11/pybind11.h>
 #include <Python.h>
+#include <condition_variable>
 #include <mutex>
 #include <memory>
+#include <thread>
 
 #include <cstdlib>
 
@@ -259,66 +261,133 @@ static RunnerConfig get_runner_config_from_env_or_default() {
 }
 
 // ----------------- Singleton management ----------------- //
+enum class VaneRunnerState { UNINITIALIZED, INITIALIZING, INITIALIZED };
+
 static std::shared_ptr<Runner> VANE_RUNNER_PTR = nullptr;
 static std::mutex VANE_RUNNER_MUTEX;
+static std::condition_variable VANE_RUNNER_CONDITION;
+static VaneRunnerState VANE_RUNNER_STATE = VaneRunnerState::UNINITIALIZED;
+static std::thread::id VANE_RUNNER_INITIALIZER_THREAD;
+
+struct RunnerInitializationResult {
+	std::shared_ptr<Runner> runner;
+	bool created;
+};
+
+// All callers enter from Python with the GIL held. Wait without the GIL so the
+// initializer can return from Python, then unlock the runner mutex before the
+// gil_scoped_release destructor reacquires the GIL.
+static void wait_for_runner_initialization() {
+	py::gil_scoped_release release;
+	std::unique_lock<std::mutex> lock(VANE_RUNNER_MUTEX);
+	VANE_RUNNER_CONDITION.wait(lock, [] { return VANE_RUNNER_STATE != VaneRunnerState::INITIALIZING; });
+	lock.unlock();
+}
+
+template <class FACTORY>
+static RunnerInitializationResult initialize_runner(FACTORY &&factory) {
+	for (;;) {
+		bool should_initialize = false;
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			if (VANE_RUNNER_STATE == VaneRunnerState::INITIALIZED) {
+				return {VANE_RUNNER_PTR, false};
+			}
+			if (VANE_RUNNER_STATE == VaneRunnerState::UNINITIALIZED) {
+				VANE_RUNNER_STATE = VaneRunnerState::INITIALIZING;
+				VANE_RUNNER_INITIALIZER_THREAD = std::this_thread::get_id();
+				should_initialize = true;
+			} else if (VANE_RUNNER_INITIALIZER_THREAD == std::this_thread::get_id()) {
+				throw std::runtime_error("Recursive runner initialization is not supported");
+			}
+		}
+
+		if (should_initialize) {
+			break;
+		}
+		wait_for_runner_initialization();
+	}
+
+	try {
+		auto candidate = factory();
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			VANE_RUNNER_PTR = candidate;
+			VANE_RUNNER_STATE = VaneRunnerState::INITIALIZED;
+			VANE_RUNNER_INITIALIZER_THREAD = std::thread::id();
+		}
+		VANE_RUNNER_CONDITION.notify_all();
+		return {std::move(candidate), true};
+	} catch (...) {
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			VANE_RUNNER_STATE = VaneRunnerState::UNINITIALIZED;
+			VANE_RUNNER_INITIALIZER_THREAD = std::thread::id();
+		}
+		VANE_RUNNER_CONDITION.notify_all();
+		throw;
+	}
+}
 
 // get_or_create_runner will initialize once if not set
 static std::shared_ptr<Runner> get_or_create_runner_cpp() {
-	std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-	if (VANE_RUNNER_PTR) {
-		return VANE_RUNNER_PTR;
-	}
-	RunnerConfig cfg = get_runner_config_from_env_or_default();
-	std::unique_ptr<Runner> rptr = cfg.create_runner();
-	VANE_RUNNER_PTR = std::shared_ptr<Runner>(std::move(rptr));
-	return VANE_RUNNER_PTR;
+	auto result = initialize_runner([] {
+		RunnerConfig cfg = get_runner_config_from_env_or_default();
+		return std::shared_ptr<Runner>(cfg.create_runner());
+	});
+	return std::move(result.runner);
 }
 
 // Helper to set runner once, following the Rust OnceLock semantics
 static py::object set_runner_ray_py(py::object address_py = py::none(), bool noop_if_initialized = false,
                                     std::pair<bool, size_t> max_task_backlog = std::make_pair(false, size_t(0)),
                                     std::pair<bool, bool> force_client_mode = std::make_pair(false, false)) {
-	std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-	if (VANE_RUNNER_PTR) {
-		if (noop_if_initialized && VANE_RUNNER_PTR->get_type() == Runner::Type::Ray) {
-			return VANE_RUNNER_PTR->get_pyobj();
+	auto result = initialize_runner([&] {
+		std::pair<bool, std::string> address = std::make_pair(false, std::string());
+		if (!address_py.is_none()) {
+			address = std::make_pair(true, address_py.cast<std::string>());
 		}
+		auto runner = RayRunner::try_new(address, max_task_backlog, force_client_mode);
+		return std::make_shared<Runner>(std::move(runner));
+	});
+	if (!result.created && (!noop_if_initialized || result.runner->get_type() != Runner::Type::Ray)) {
 		throw std::runtime_error("Cannot set runner more than once");
 	}
-	std::pair<bool, std::string> address = std::make_pair(false, std::string());
-	if (!address_py.is_none()) {
-		address = std::make_pair(true, address_py.cast<std::string>());
-	}
-	auto r = RayRunner::try_new(address, max_task_backlog, force_client_mode);
-	VANE_RUNNER_PTR = std::make_shared<Runner>(std::move(r));
-	return VANE_RUNNER_PTR->get_pyobj();
+	return result.runner->get_pyobj();
 }
 
 static py::object set_runner_local_py(py::object num_workers = py::none(), py::object max_running_tasks = py::none(),
                                       py::object execution_mode = py::none()) {
-	std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-	if (VANE_RUNNER_PTR) {
-		if (VANE_RUNNER_PTR->get_type() == Runner::Type::Local) {
-			return VANE_RUNNER_PTR->get_pyobj();
-		}
+	auto result = initialize_runner([&] {
+		auto runner = LocalRunner::try_new(num_workers, max_running_tasks, execution_mode);
+		return std::make_shared<Runner>(std::move(runner));
+	});
+	if (!result.created && result.runner->get_type() != Runner::Type::Local) {
 		throw std::runtime_error("Cannot set runner more than once");
 	}
-	auto r = LocalRunner::try_new(num_workers, max_running_tasks, execution_mode);
-	VANE_RUNNER_PTR = std::make_shared<Runner>(std::move(r));
-	return VANE_RUNNER_PTR->get_pyobj();
+	return result.runner->get_pyobj();
 }
 
 // Helper to teardown runner explicitly during Python exit
 static void teardown_runner_cpp() {
 	std::shared_ptr<Runner> runner;
-	{
-		std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-		if (VANE_RUNNER_PTR) {
-			runner = VANE_RUNNER_PTR;
-			VANE_RUNNER_PTR.reset();
-		} else {
-			return;
+	for (;;) {
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			if (VANE_RUNNER_STATE == VaneRunnerState::UNINITIALIZED) {
+				return;
+			}
+			if (VANE_RUNNER_STATE == VaneRunnerState::INITIALIZED) {
+				runner = VANE_RUNNER_PTR;
+				VANE_RUNNER_PTR.reset();
+				VANE_RUNNER_STATE = VaneRunnerState::UNINITIALIZED;
+				break;
+			}
+			if (VANE_RUNNER_INITIALIZER_THREAD == std::this_thread::get_id()) {
+				throw std::runtime_error("Cannot tear down a runner while initializing it");
+			}
 		}
+		wait_for_runner_initialization();
 	}
 	try {
 		duckdb::PythonGILWrapper gil;
@@ -332,10 +401,30 @@ static void teardown_runner_cpp() {
 
 // Get runner Python object or None
 static py::object get_runner_py() {
-	std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-	if (!VANE_RUNNER_PTR)
-		return py::none();
-	return VANE_RUNNER_PTR->get_pyobj();
+	for (;;) {
+		std::shared_ptr<Runner> runner;
+		bool uninitialized = false;
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			if (VANE_RUNNER_STATE == VaneRunnerState::UNINITIALIZED) {
+				uninitialized = true;
+			}
+			if (VANE_RUNNER_STATE == VaneRunnerState::INITIALIZED) {
+				runner = VANE_RUNNER_PTR;
+			}
+			if (VANE_RUNNER_STATE == VaneRunnerState::INITIALIZING &&
+			    VANE_RUNNER_INITIALIZER_THREAD == std::this_thread::get_id()) {
+				throw std::runtime_error("Cannot get a runner while initializing it");
+			}
+		}
+		if (uninitialized) {
+			return py::none();
+		}
+		if (runner) {
+			return runner->get_pyobj();
+		}
+		wait_for_runner_initialization();
+	}
 }
 
 static py::object get_or_create_runner_py() {
@@ -344,23 +433,27 @@ static py::object get_or_create_runner_py() {
 }
 
 static py::object get_or_infer_runner_type_py() {
-	std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
-	if (VANE_RUNNER_PTR) {
-		if (VANE_RUNNER_PTR->get_type() == Runner::Type::Ray)
-			return py::str(RayRunner::NAME);
-		return py::str(LocalRunner::NAME);
+	for (;;) {
+		std::string runner_type;
+		{
+			std::lock_guard<std::mutex> guard(VANE_RUNNER_MUTEX);
+			if (VANE_RUNNER_STATE == VaneRunnerState::INITIALIZED) {
+				runner_type = VANE_RUNNER_PTR->get_type() == Runner::Type::Ray ? RayRunner::NAME : LocalRunner::NAME;
+			} else if (VANE_RUNNER_STATE == VaneRunnerState::UNINITIALIZED) {
+				runner_type = duckdb::ResolveRunnerTypeFromEnvironment();
+			} else if (VANE_RUNNER_INITIALIZER_THREAD == std::this_thread::get_id()) {
+				throw std::runtime_error("Cannot infer runner type while initializing it");
+			}
+		}
+
+		if (!runner_type.empty()) {
+			if (runner_type == "local-fast" || runner_type == LocalRunner::NAME || runner_type == RayRunner::NAME) {
+				return py::str(runner_type);
+			}
+			throw duckdb::InternalException("normalized runner type '%s' has no public runner name", runner_type);
+		}
+		wait_for_runner_initialization();
 	}
-	auto rt = duckdb::ResolveRunnerTypeFromEnvironment();
-	if (rt == "local-fast") {
-		return py::str("local-fast");
-	}
-	if (rt == LocalRunner::NAME) {
-		return py::str(LocalRunner::NAME);
-	}
-	if (rt == RayRunner::NAME) {
-		return py::str(RayRunner::NAME);
-	}
-	throw duckdb::InternalException("normalized runner type '%s' has no public runner name", rt);
 }
 
 // ------------------ Python binding ------------------ //

--- a/tests/fast/test_vane_config.py
+++ b/tests/fast/test_vane_config.py
@@ -160,6 +160,206 @@ assert runners.get_or_infer_runner_type() == "local"
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
+def test_concurrent_runner_initialization_does_not_deadlock_on_gil():
+    script = r"""
+import faulthandler
+import os
+import sys
+import threading
+
+sys.setswitchinterval(1000.0)
+faulthandler.dump_traceback_later(5.0, repeat=False)
+
+import duckdb
+import duckdb.runners.local.runner as local_runner_module
+
+vane_runners = duckdb.vane_runners_cpp
+vane_runners.teardown_runner()
+os.environ["VANE_RUNNER"] = "local"
+
+barrier = threading.Barrier(2)
+initializer_entered = threading.Event()
+constructor_calls = []
+results = []
+errors = []
+
+
+class BlockingLocalRunner:
+    name = "local"
+
+    def __init__(self, **_kwargs):
+        constructor_calls.append(None)
+        initializer_entered.set()
+        # The first initializer releases the GIL here. The second thread is
+        # already holding the GIL when it returns from the same barrier and
+        # immediately enters the compiled runner binding.
+        barrier.wait(timeout=5.0)
+
+
+local_runner_module.LocalRunner = BlockingLocalRunner
+
+
+def initialize():
+    try:
+        results.append(vane_runners.get_or_create_runner())
+    except BaseException as exc:
+        errors.append(exc)
+
+
+def contend():
+    try:
+        barrier.wait(timeout=5.0)
+        results.append(vane_runners.get_or_create_runner())
+    except BaseException as exc:
+        errors.append(exc)
+
+
+initializer = threading.Thread(target=initialize, daemon=True, name="runner-initializer")
+initializer.start()
+assert initializer_entered.wait(timeout=5.0)
+
+waiter = threading.Thread(target=contend, daemon=True, name="runner-waiter")
+waiter.start()
+
+initializer.join(timeout=5.0)
+waiter.join(timeout=5.0)
+faulthandler.cancel_dump_traceback_later()
+
+assert not initializer.is_alive()
+assert not waiter.is_alive()
+assert errors == []
+assert len(constructor_calls) == 1
+assert len(results) == 2
+assert results[0] is results[1]
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=10)
+
+
+def test_failed_runner_initialization_is_not_published_and_can_retry():
+    script = r"""
+import os
+
+import duckdb
+import duckdb.runners.local.runner as local_runner_module
+
+vane_runners = duckdb.vane_runners_cpp
+vane_runners.teardown_runner()
+os.environ["VANE_RUNNER"] = "local"
+attempts = 0
+
+
+class FlakyLocalRunner:
+    name = "local"
+
+    def __init__(self, **_kwargs):
+        global attempts
+        attempts += 1
+        self.ready = False
+        if attempts == 1:
+            raise RuntimeError("forced runner initialization failure")
+        self.ready = True
+
+
+local_runner_module.LocalRunner = FlakyLocalRunner
+
+try:
+    vane_runners.get_or_create_runner()
+except RuntimeError as exc:
+    assert "forced runner initialization failure" in str(exc)
+else:
+    raise AssertionError("the first runner initialization should fail")
+
+assert vane_runners.get_runner() is None
+
+runner = vane_runners.get_or_create_runner()
+assert attempts == 2
+assert runner.ready is True
+assert vane_runners.get_runner() is runner
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=10)
+
+
+def test_failed_runner_initialization_wakes_waiter_to_retry():
+    script = r"""
+import faulthandler
+import os
+import sys
+import threading
+
+sys.setswitchinterval(1000.0)
+faulthandler.dump_traceback_later(5.0, repeat=False)
+
+import duckdb
+import duckdb.runners.local.runner as local_runner_module
+
+vane_runners = duckdb.vane_runners_cpp
+vane_runners.teardown_runner()
+os.environ["VANE_RUNNER"] = "local"
+
+barrier = threading.Barrier(2)
+initializer_entered = threading.Event()
+attempts = 0
+results = []
+expected_errors = []
+unexpected_errors = []
+
+
+class FailOnceLocalRunner:
+    name = "local"
+
+    def __init__(self, **_kwargs):
+        global attempts
+        attempts += 1
+        if attempts == 1:
+            initializer_entered.set()
+            barrier.wait(timeout=5.0)
+            raise RuntimeError("first attempt failed")
+        self.ready = True
+
+
+local_runner_module.LocalRunner = FailOnceLocalRunner
+
+
+def initialize():
+    try:
+        vane_runners.get_or_create_runner()
+    except RuntimeError as exc:
+        expected_errors.append(str(exc))
+    except BaseException as exc:
+        unexpected_errors.append(exc)
+
+
+def retry():
+    try:
+        barrier.wait(timeout=5.0)
+        results.append(vane_runners.get_or_create_runner())
+    except BaseException as exc:
+        unexpected_errors.append(exc)
+
+
+initializer = threading.Thread(target=initialize, daemon=True, name="failing-initializer")
+initializer.start()
+assert initializer_entered.wait(timeout=5.0)
+
+waiter = threading.Thread(target=retry, daemon=True, name="retrying-waiter")
+waiter.start()
+
+initializer.join(timeout=5.0)
+waiter.join(timeout=5.0)
+faulthandler.cancel_dump_traceback_later()
+
+assert not initializer.is_alive()
+assert not waiter.is_alive()
+assert expected_errors == ["first attempt failed"]
+assert unexpected_errors == []
+assert attempts == 2
+assert len(results) == 1
+assert results[0].ready is True
+assert vane_runners.get_runner() is results[0]
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=10)
+
+
 def test_ray_noop_does_not_reuse_local_runner():
     script = """
 import duckdb.runners as runners
@@ -173,6 +373,34 @@ else:
     raise AssertionError("expected Ray setup to reject existing local runner")
 """
     subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_ray_noop_reuses_existing_runner_without_validating_address():
+    script = """
+import duckdb
+import duckdb.runners.ray.runner as ray_runner_module
+
+
+class FakeRayRunner:
+    name = "ray"
+
+    def __init__(self, *_args):
+        pass
+
+    def close(self):
+        pass
+
+
+ray_runner_module.RayRunner = FakeRayRunner
+vane_runners = duckdb.vane_runners_cpp
+vane_runners.teardown_runner()
+
+first = vane_runners.set_runner_ray(None, False, None, False)
+second = vane_runners.set_runner_ray(object(), True, None, False)
+
+assert second is first
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=10)
 
 
 def test_config_registry_contains_stable_public_fields():


### PR DESCRIPTION
## Summary

- Move Python runner construction outside VANE_RUNNER_MUTEX.
- Coordinate concurrent callers with explicit initialization state and a condition variable while releasing the GIL during waits.
- Reset failed initialization attempts so another caller can retry, and preserve existing Ray no-op behavior.
- Add deterministic regression coverage for the GIL/mutex deadlock, failure publication, waiter takeover, and Ray no-op compatibility.

## Related issue

Closes #60

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in AstroVela/vane-website.

The change only corrects internal runner initialization synchronization.

## Validation

- PATH="$PWD/.venv/bin:$PATH" scripts/format root --changed
- Incremental Release native install with uv pip install . --no-build-isolation
- .venv/bin/python -m pytest -q tests/fast/test_vane_config.py: 24 passed
- scripts/run_release_tests.sh: 270 non-Ray passed and 5 Ray passed
- git diff --check

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.