### PR TITLE
[fix](ray) Make query registration atomic

### DIFF
--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import math
 import threading
 import time
@@ -239,14 +240,29 @@ class ClusterQueryResourceCoordinator:
         with self._lock:
             if demand.query_id in self._queries:
                 raise ValueError(f"query already registered: {demand.query_id}")
+            previous_queries = self._queries
+            previous_next_sequence = self._next_sequence
+            previous_generation = self._generation
             state = _QueryState(
                 demand=demand,
-                sequence=self._next_sequence,
+                sequence=previous_next_sequence,
                 expires_at=timestamp + self._heartbeat_timeout_s,
             )
-            self._next_sequence += 1
-            self._queries[demand.query_id] = state
-            self._rebalance_locked()
+            staged_queries = copy.deepcopy(previous_queries)
+            staged_queries[demand.query_id] = state
+            try:
+                self._queries = staged_queries
+                self._next_sequence = previous_next_sequence + 1
+                self._rebalance_locked()
+            except BaseException:
+                # Rebalancing updates every query allocation in place. Restore
+                # the exact pre-registration objects and counters after any
+                # failure so no partial allocation, heartbeat, or lease state
+                # can escape.
+                self._queries = previous_queries
+                self._next_sequence = previous_next_sequence
+                self._generation = previous_generation
+                raise
             return state.allocation
 
     def refresh_query(

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from duckdb.runners.ray import cluster_resource_coordinator as coordinator_module
 from duckdb.runners.ray.cluster_resource_coordinator import (
     ActorResourceBundle,
     ClusterQueryResourceCoordinator,
@@ -72,6 +73,20 @@ def _demand(
     )
 
 
+def _inject_failure_once(monkeypatch, target, attribute, *, fail_on_call=1):
+    original = getattr(target, attribute)
+    calls = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == fail_on_call:
+            raise RuntimeError(f"injected {attribute} failure")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(target, attribute, fail_once)
+
+
 def test_ray_capacity_uses_alive_node_resources_and_object_store_headroom():
     fake_ray = SimpleNamespace(
         nodes=lambda: [
@@ -136,6 +151,96 @@ def test_ray_capacity_never_uses_host_memory_or_cpu_fallback(monkeypatch):
     capacities = read_ray_node_capacities(fake_ray)
 
     assert capacities[0].resources == _r(cpu=2, heap=180, store=200)
+
+
+@pytest.mark.parametrize(
+    ("target_name", "attribute", "fail_on_call"),
+    [
+        pytest.param("module", "_QueryState", 1, id="state-construction"),
+        pytest.param("copy", "deepcopy", 1, id="state-staging"),
+        pytest.param("coordinator", "_rebalance_locked", 1, id="rebalance-entry"),
+        pytest.param("coordinator", "_place_bundle", 1, id="minimum-placement"),
+        pytest.param("module", "ActorPlacement", 1, id="actor-placement"),
+        pytest.param("coordinator", "_weighted_drf_extras", 1, id="fair-share"),
+        pytest.param("coordinator", "_place_divisible", 1, id="divisible-placement"),
+        pytest.param("module", "NodeResourceAllocation", 1, id="allocation-publication"),
+        pytest.param("module", "_positive_difference", 2, id="debt-publication"),
+    ],
+)
+def test_register_query_failure_is_atomic_across_rebalance_phases(
+    monkeypatch,
+    target_name,
+    attribute,
+    fail_on_call,
+):
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n1", cpu=8, gpu=1, heap=800, store=800),),
+        heartbeat_timeout_s=10,
+    )
+    coordinator.register_query(
+        _demand(
+            "existing",
+            minimum=_r(cpu=1, heap=100, store=100),
+            desired=_r(cpu=4, heap=400, store=400),
+        ),
+        now=0,
+    )
+    before = coordinator.snapshot()
+    previous_state = coordinator._queries["existing"]
+    previous_next_sequence = coordinator._next_sequence
+
+    targets = {
+        "module": coordinator_module,
+        "copy": coordinator_module.copy,
+        "coordinator": coordinator,
+    }
+    _inject_failure_once(
+        monkeypatch,
+        targets[target_name],
+        attribute,
+        fail_on_call=fail_on_call,
+    )
+
+    actor_bundle = _r(cpu=1, gpu=1, heap=100)
+    with pytest.raises(RuntimeError, match=f"injected {attribute} failure"):
+        coordinator.register_query(
+            _demand(
+                "failed",
+                minimum=actor_bundle,
+                desired=_r(cpu=3, gpu=1, heap=300),
+                actor_bundles=(actor_bundle,),
+            ),
+            now=5,
+        )
+
+    assert coordinator.snapshot() == before
+    assert coordinator._queries["existing"] is previous_state
+    assert coordinator._next_sequence == previous_next_sequence
+
+    coordinator.register_query(
+        _demand(
+            "recovery",
+            minimum=_r(cpu=1, heap=100, store=100),
+            desired=_r(cpu=3, heap=300, store=300),
+        ),
+        now=6,
+    )
+    assert coordinator._queries["recovery"].sequence == previous_next_sequence
+    assert coordinator._next_sequence == previous_next_sequence + 1
+
+    registered = coordinator.snapshot()["queries"]
+    refreshed = coordinator.refresh_queries(
+        observed_usage_by_query={
+            "existing": _r(cpu=1, heap=100, store=100),
+            "recovery": _r(cpu=1, heap=100, store=100),
+        },
+        generations={query_id: query["allocation"]["generation"] for query_id, query in registered.items()},
+        now=7,
+    )
+    assert set(refreshed) == {"existing", "recovery"}
+    assert coordinator.expire_queries(now=16.9) == ()
+    assert coordinator.expire_queries(now=17) == ("existing", "recovery")
+    assert coordinator.snapshot()["queries"] == {}
 
 
 def test_equal_weight_queries_receive_equal_dominant_shares():
@@ -422,11 +527,14 @@ def test_refresh_queries_updates_all_usage_and_heartbeats_atomically():
         (_node("n1", cpu=8, heap=800, store=800),),
         heartbeat_timeout_s=10,
     )
-    demand = lambda query_id: _demand(
-        query_id,
-        minimum=_r(cpu=1, heap=100, store=100),
-        desired=_r(cpu=8, heap=800, store=800),
-    )
+
+    def demand(query_id):
+        return _demand(
+            query_id,
+            minimum=_r(cpu=1, heap=100, store=100),
+            desired=_r(cpu=8, heap=800, store=800),
+        )
+
     coordinator.register_query(demand("a"), now=0)
     coordinator.register_query(demand("b"), now=0)
     before = coordinator.snapshot()["queries"]
@@ -454,11 +562,14 @@ def test_refresh_queries_rejects_stale_batch_without_partial_mutation():
         (_node("n1", cpu=8, heap=800, store=800),),
         heartbeat_timeout_s=10,
     )
-    demand = lambda query_id: _demand(
-        query_id,
-        minimum=_r(cpu=1, heap=100),
-        desired=_r(cpu=8, heap=800),
-    )
+
+    def demand(query_id):
+        return _demand(
+            query_id,
+            minimum=_r(cpu=1, heap=100),
+            desired=_r(cpu=8, heap=800),
+        )
+
     coordinator.register_query(demand("a"), now=0)
     coordinator.register_query(demand("b"), now=0)
     before = coordinator.snapshot()["queries"]


### PR DESCRIPTION
## Summary

- stage query registration and rebalancing on an isolated copy of coordinator state
- restore the original query objects, sequence counter, and generation if any rebalance phase fails, preventing ghost queries and partial allocation or heartbeat updates
- add fault-injection coverage across construction, staging, placement, fair-share calculation, allocation publication, and debt publication, including recovery through later register, refresh, and expiry operations

## Related issue

close: #62

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal failure atomicity only; public configuration and APIs are unchanged.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" scripts/format root --changed`
- `PATH="$PWD/.venv/bin:$PATH" pre-commit run --files duckdb/runners/ray/cluster_resource_coordinator.py tests/fast/test_cluster_resource_coordinator.py`
- `.venv/bin/python -m pytest tests/fast/test_cluster_resource_coordinator.py tests/fast/test_driver_query_graph_registration.py -q` (36 passed)
- `PATH="$PWD/.venv/bin:$PATH" scripts/run_release_tests.sh` (272 passed, 9 deselected; 5 real-Ray tests passed, 276 deselected)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
