### PR TITLE
[fix](ray) Preserve plan serialization failures

### DIFF
--- a/duckdb/_ray_cxx.py
+++ b/duckdb/_ray_cxx.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from duckdb._ray_errors import remote_ray_exception
+
 _DEFAULT_HINT = "Ensure the C++ ray extension is built and importable."
 
 
@@ -29,4 +31,5 @@ def validate_plan_serialization_for_submission(plan: Any) -> None:
         validator()
     except Exception as exc:
         query_id = str(plan.idx())
-        raise RuntimeError(f"distributed physical plan serialization preflight failed for query_id={query_id}") from exc
+        message = f"distributed physical plan serialization preflight failed for query_id={query_id}"
+        raise remote_ray_exception(message, exc) from exc

--- a/duckdb/_ray_cxx.py
+++ b/duckdb/_ray_cxx.py
@@ -10,7 +10,7 @@ _DEFAULT_HINT = "Ensure the C++ ray extension is built and importable."
 
 def require_ray_cxx_attr(name: str, *, hint: str | None = None) -> Any:
     """Return a lazily resolved duckdb.ray_cxx binding or raise a clear error."""
-    import _duckdb
+    import _duckdb  # type: ignore[import-not-found]
 
     try:
         return getattr(_duckdb.ray_cxx, name)
@@ -18,3 +18,15 @@ def require_ray_cxx_attr(name: str, *, hint: str | None = None) -> Any:
         raise ImportError(
             f"Required C++ binding `duckdb.ray_cxx.{name}` is not available. {hint or _DEFAULT_HINT}"
         ) from ex
+
+
+def validate_plan_serialization_for_submission(plan: Any) -> None:
+    """Validate a native physical root before Driver resource registration."""
+    validator = getattr(plan, "_validate_serializable_for_submission", None)
+    if not callable(validator):
+        raise TypeError("distributed physical plan serialization validator must be callable")
+    try:
+        validator()
+    except Exception as exc:
+        query_id = str(plan.idx())
+        raise RuntimeError(f"distributed physical plan serialization preflight failed for query_id={query_id}") from exc

--- a/duckdb/_ray_errors.py
+++ b/duckdb/_ray_errors.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import traceback
+from typing import Any
+
+_MAX_REMOTE_EXCEPTION_CHAIN_DEPTH = 16
+_MAX_REMOTE_TRACEBACK_CHARS = 64 * 1024
+
+
+class RemoteRayException(RuntimeError):
+    """Pickle-safe carrier for an exception chain crossing a Ray boundary."""
+
+    def __init__(self, message: str, payload: dict[str, Any]) -> None:
+        self.message = str(message)
+        self.payload = dict(payload)
+        super().__init__(self.message, self.payload)
+        cause = _restore_remote_exception(self.payload.get("cause"))
+        if cause is not None:
+            self.__cause__ = cause
+            self.__suppress_context__ = True
+
+    @classmethod
+    def from_exception(cls, exc: BaseException) -> RemoteRayException:
+        payload = _serialize_remote_exception(exc)
+        return cls(str(payload["message"]), payload)
+
+    def restore(self) -> BaseException:
+        return _restore_remote_exception(self.payload) or RuntimeError(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class RemoteRayCause(RuntimeError):
+    """Fallback when the original remote exception type cannot be rebuilt."""
+
+    def __init__(self, remote_type: str, message: str) -> None:
+        self.remote_type = str(remote_type)
+        self.remote_message = str(message)
+        super().__init__(f"{self.remote_type}: {self.remote_message}")
+
+
+def remote_ray_exception(message: str, cause: BaseException) -> RemoteRayException:
+    """Build a transport exception while retaining the in-process cause."""
+    outer = RuntimeError(str(message))
+    outer.__cause__ = cause
+    outer.__suppress_context__ = True
+    transported = RemoteRayException.from_exception(outer)
+    transported.__cause__ = cause
+    transported.__suppress_context__ = True
+    return transported
+
+
+def restore_remote_ray_exception(exc: BaseException) -> BaseException | None:
+    """Restore a transported exception from a RayTaskError or direct carrier."""
+    cause = getattr(exc, "cause", None)
+    if isinstance(cause, RemoteRayException):
+        return cause.restore()
+    if isinstance(exc, RemoteRayException):
+        return exc.restore()
+    return None
+
+
+def _safe_exception_message(exc: BaseException) -> str:
+    try:
+        return str(exc)
+    except BaseException:
+        return f"<{type(exc).__name__} failed to render>"
+
+
+def _safe_exception_traceback(exc: BaseException) -> str:
+    try:
+        rendered = "".join(
+            traceback.format_exception(
+                type(exc),
+                exc,
+                exc.__traceback__,
+                chain=False,
+            )
+        )
+    except BaseException:
+        return ""
+    if len(rendered) <= _MAX_REMOTE_TRACEBACK_CHARS:
+        return rendered
+    return rendered[-_MAX_REMOTE_TRACEBACK_CHARS:]
+
+
+def _serialize_remote_exception(
+    exc: BaseException,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> dict[str, Any]:
+    if seen is None:
+        seen = set()
+    exc_type = type(exc)
+    payload: dict[str, Any] = {
+        "module": str(getattr(exc_type, "__module__", "builtins")),
+        "qualname": str(getattr(exc_type, "__qualname__", exc_type.__name__)),
+        "message": _safe_exception_message(exc),
+        "traceback": _safe_exception_traceback(exc),
+        "cause": None,
+    }
+    if depth >= _MAX_REMOTE_EXCEPTION_CHAIN_DEPTH or id(exc) in seen:
+        return payload
+    seen.add(id(exc))
+    cause = exc.__cause__
+    if cause is not None:
+        payload["cause"] = _serialize_remote_exception(
+            cause,
+            depth=depth + 1,
+            seen=seen,
+        )
+    return payload
+
+
+def _resolve_remote_exception_type(module_name: str, qualname: str) -> type[Exception] | None:
+    if not module_name or not qualname or "<locals>" in qualname:
+        return None
+    try:
+        value: Any = importlib.import_module(module_name)
+        for part in qualname.split("."):
+            value = getattr(value, part)
+    except (AttributeError, ImportError, ValueError):
+        return None
+    if not isinstance(value, type) or not issubclass(value, Exception):
+        return None
+    return value
+
+
+def _restore_remote_exception(payload: Any) -> BaseException | None:
+    if not isinstance(payload, dict):
+        return None
+    module_name = str(payload.get("module") or "builtins")
+    qualname = str(payload.get("qualname") or "RuntimeError")
+    message = str(payload.get("message") or "")
+    remote_type = f"{module_name}.{qualname}"
+    exception_type = _resolve_remote_exception_type(module_name, qualname)
+    if exception_type is None:
+        restored: BaseException = RemoteRayCause(remote_type, message)
+    else:
+        try:
+            restored = exception_type(message)
+        except BaseException:
+            restored = RemoteRayCause(remote_type, message)
+
+    try:
+        restored.remote_exception_type = remote_type  # type: ignore[attr-defined]
+        restored.remote_traceback = str(payload.get("traceback") or "")  # type: ignore[attr-defined]
+    except BaseException:
+        pass
+
+    cause = _restore_remote_exception(payload.get("cause"))
+    if cause is not None:
+        restored.__cause__ = cause
+        restored.__suppress_context__ = True
+    return restored

--- a/duckdb/_ray_errors.py
+++ b/duckdb/_ray_errors.py
@@ -8,7 +8,11 @@ import traceback
 from typing import Any
 
 _MAX_REMOTE_EXCEPTION_CHAIN_DEPTH = 16
+_MAX_REMOTE_EXCEPTION_MESSAGE_CHARS = 64 * 1024
 _MAX_REMOTE_TRACEBACK_CHARS = 64 * 1024
+_MAX_REMOTE_EXCEPTION_VALUE_DEPTH = 16
+_MAX_REMOTE_EXCEPTION_VALUE_ITEMS = 1024
+_MAX_REMOTE_EXCEPTION_VALUE_BYTES = 64 * 1024
 
 
 class RemoteRayException(RuntimeError):
@@ -18,10 +22,22 @@ class RemoteRayException(RuntimeError):
         self.message = str(message)
         self.payload = dict(payload)
         super().__init__(self.message, self.payload)
-        cause = _restore_remote_exception(self.payload.get("cause"))
+        chain_seen = {id(payload), id(self.payload)}
+        cause = _restore_optional_remote_exception(
+            self.payload["cause"],
+            depth=1,
+            seen=chain_seen,
+        )
+        context = _restore_optional_remote_exception(
+            self.payload["context"],
+            depth=1,
+            seen=chain_seen,
+        )
         if cause is not None:
             self.__cause__ = cause
-            self.__suppress_context__ = True
+        if context is not None:
+            self.__context__ = context
+        self.__suppress_context__ = self.payload["suppress_context"]
 
     @classmethod
     def from_exception(cls, exc: BaseException) -> RemoteRayException:
@@ -29,19 +45,10 @@ class RemoteRayException(RuntimeError):
         return cls(str(payload["message"]), payload)
 
     def restore(self) -> BaseException:
-        return _restore_remote_exception(self.payload) or RuntimeError(self.message)
+        return _restore_remote_exception(self.payload)
 
     def __str__(self) -> str:
         return self.message
-
-
-class RemoteRayCause(RuntimeError):
-    """Fallback when the original remote exception type cannot be rebuilt."""
-
-    def __init__(self, remote_type: str, message: str) -> None:
-        self.remote_type = str(remote_type)
-        self.remote_message = str(message)
-        super().__init__(f"{self.remote_type}: {self.remote_message}")
 
 
 def remote_ray_exception(message: str, cause: BaseException) -> RemoteRayException:
@@ -67,9 +74,13 @@ def restore_remote_ray_exception(exc: BaseException) -> BaseException | None:
 
 def _safe_exception_message(exc: BaseException) -> str:
     try:
-        return str(exc)
+        rendered = str(exc)
     except BaseException:
         return f"<{type(exc).__name__} failed to render>"
+    if len(rendered) <= _MAX_REMOTE_EXCEPTION_MESSAGE_CHARS:
+        return rendered
+    suffix = "... <remote exception message truncated>"
+    return rendered[: _MAX_REMOTE_EXCEPTION_MESSAGE_CHARS - len(suffix)] + suffix
 
 
 def _safe_exception_traceback(exc: BaseException) -> str:
@@ -89,6 +100,104 @@ def _safe_exception_traceback(exc: BaseException) -> str:
     return rendered[-_MAX_REMOTE_TRACEBACK_CHARS:]
 
 
+def _copy_transport_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+    budget: list[int] | None = None,
+) -> Any:
+    if budget is None:
+        budget = [
+            _MAX_REMOTE_EXCEPTION_VALUE_ITEMS,
+            _MAX_REMOTE_EXCEPTION_VALUE_BYTES,
+        ]
+    if budget[0] <= 0:
+        raise ValueError("remote exception constructor exceeds the item limit")
+    budget[0] -= 1
+
+    if value is None or type(value) in (bool, int, float, str, bytes):
+        if type(value) is int:
+            value_size = max(1, (value.bit_length() + 7) // 8)
+        elif type(value) is float:
+            value_size = 8
+        elif type(value) is str:
+            if len(value) > budget[1]:
+                raise ValueError("remote exception constructor exceeds the byte limit")
+            value_size = len(value.encode("utf-8", errors="surrogatepass"))
+        elif type(value) is bytes:
+            value_size = len(value)
+        else:
+            value_size = 1
+        if value_size > budget[1]:
+            raise ValueError("remote exception constructor exceeds the byte limit")
+        budget[1] -= value_size
+        return value
+
+    if depth >= _MAX_REMOTE_EXCEPTION_VALUE_DEPTH:
+        raise ValueError("remote exception constructor exceeds the depth limit")
+    if type(value) not in (dict, list, tuple):
+        raise TypeError("remote exception constructor contains an unsupported value")
+
+    if seen is None:
+        seen = set()
+    if id(value) in seen:
+        raise ValueError("remote exception constructor contains a cycle")
+    seen.add(id(value))
+    try:
+        if type(value) is dict:
+            copied_dict: dict[Any, Any] = {}
+            for key, item in value.items():
+                copied_key = _copy_transport_value(
+                    key,
+                    depth=depth + 1,
+                    seen=seen,
+                    budget=budget,
+                )
+                copied_item = _copy_transport_value(
+                    item,
+                    depth=depth + 1,
+                    seen=seen,
+                    budget=budget,
+                )
+                copied_dict[copied_key] = copied_item
+            return copied_dict
+
+        copied_items = []
+        for item in value:
+            copied_item = _copy_transport_value(
+                item,
+                depth=depth + 1,
+                seen=seen,
+                budget=budget,
+            )
+            copied_items.append(copied_item)
+        return tuple(copied_items) if type(value) is tuple else copied_items
+    finally:
+        seen.remove(id(value))
+
+
+def _exception_constructor(exc: BaseException) -> dict[str, Any]:
+    reduced = exc.__reduce__()
+    if type(reduced) is not tuple or len(reduced) not in (2, 3):
+        raise TypeError("remote exception has an unsupported reducer")
+    if reduced[0] is not type(exc) or type(reduced[1]) is not tuple:
+        raise TypeError("remote exception has an unsupported constructor")
+
+    budget = [
+        _MAX_REMOTE_EXCEPTION_VALUE_ITEMS,
+        _MAX_REMOTE_EXCEPTION_VALUE_BYTES,
+    ]
+    args = _copy_transport_value(reduced[1], budget=budget)
+    state = _copy_transport_value(
+        reduced[2] if len(reduced) == 3 else None,
+        budget=budget,
+    )
+    if state is not None and (type(state) is not dict or any(type(name) is not str for name in state)):
+        raise TypeError("remote exception has an unsupported constructor state")
+    return {"args": args, "state": state}
+
+
 def _serialize_remote_exception(
     exc: BaseException,
     *,
@@ -103,7 +212,10 @@ def _serialize_remote_exception(
         "qualname": str(getattr(exc_type, "__qualname__", exc_type.__name__)),
         "message": _safe_exception_message(exc),
         "traceback": _safe_exception_traceback(exc),
+        "constructor": _exception_constructor(exc),
         "cause": None,
+        "context": None,
+        "suppress_context": bool(exc.__suppress_context__),
     }
     if depth >= _MAX_REMOTE_EXCEPTION_CHAIN_DEPTH or id(exc) in seen:
         return payload
@@ -115,47 +227,117 @@ def _serialize_remote_exception(
             depth=depth + 1,
             seen=seen,
         )
+    elif exc.__context__ is not None and not exc.__suppress_context__:
+        payload["context"] = _serialize_remote_exception(
+            exc.__context__,
+            depth=depth + 1,
+            seen=seen,
+        )
     return payload
 
 
-def _resolve_remote_exception_type(module_name: str, qualname: str) -> type[Exception] | None:
+def _resolve_remote_exception_type(module_name: str, qualname: str) -> type[BaseException]:
     if not module_name or not qualname or "<locals>" in qualname:
-        return None
-    try:
-        value: Any = importlib.import_module(module_name)
-        for part in qualname.split("."):
-            value = getattr(value, part)
-    except (AttributeError, ImportError, ValueError):
-        return None
-    if not isinstance(value, type) or not issubclass(value, Exception):
-        return None
+        raise TypeError("remote exception type is not importable")
+    value: Any = importlib.import_module(module_name)
+    for part in qualname.split("."):
+        value = getattr(value, part)
+    if not isinstance(value, type) or not issubclass(value, BaseException):
+        raise TypeError("remote exception type is not an exception")
     return value
 
 
-def _restore_remote_exception(payload: Any) -> BaseException | None:
-    if not isinstance(payload, dict):
+def _restore_optional_remote_exception(
+    payload: Any,
+    *,
+    depth: int,
+    seen: set[int],
+) -> BaseException | None:
+    if payload is None:
         return None
-    module_name = str(payload.get("module") or "builtins")
-    qualname = str(payload.get("qualname") or "RuntimeError")
-    message = str(payload.get("message") or "")
+    return _restore_remote_exception(payload, depth=depth, seen=seen)
+
+
+def _restore_remote_exception(
+    payload: Any,
+    *,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> BaseException:
+    if depth > _MAX_REMOTE_EXCEPTION_CHAIN_DEPTH:
+        raise ValueError("remote exception chain exceeds the depth limit")
+    if type(payload) is not dict:
+        raise TypeError("remote exception payload must be a dict")
+    if seen is None:
+        seen = set()
+    if id(payload) in seen:
+        raise ValueError("remote exception chain contains a cycle")
+    seen.add(id(payload))
+    try:
+        return _restore_remote_exception_payload(payload, depth=depth, seen=seen)
+    finally:
+        seen.remove(id(payload))
+
+
+def _restore_remote_exception_payload(
+    payload: dict[str, Any],
+    *,
+    depth: int,
+    seen: set[int],
+) -> BaseException:
+    module_name = payload["module"]
+    qualname = payload["qualname"]
+    message = payload["message"]
+    remote_traceback = payload["traceback"]
+    suppress_context = payload["suppress_context"]
+    if not all(type(value) is str for value in (module_name, qualname, message, remote_traceback)):
+        raise TypeError("remote exception payload strings must be strings")
+    if type(suppress_context) is not bool:
+        raise TypeError("remote exception suppress_context must be a bool")
+
     remote_type = f"{module_name}.{qualname}"
     exception_type = _resolve_remote_exception_type(module_name, qualname)
-    if exception_type is None:
-        restored: BaseException = RemoteRayCause(remote_type, message)
-    else:
-        try:
-            restored = exception_type(message)
-        except BaseException:
-            restored = RemoteRayCause(remote_type, message)
+    constructor = payload["constructor"]
+    if type(constructor) is not dict:
+        raise TypeError("remote exception constructor must be a dict")
+    budget = [
+        _MAX_REMOTE_EXCEPTION_VALUE_ITEMS,
+        _MAX_REMOTE_EXCEPTION_VALUE_BYTES,
+    ]
+    args = _copy_transport_value(constructor["args"], budget=budget)
+    state = _copy_transport_value(
+        constructor["state"],
+        budget=budget,
+    )
+    if type(args) is not tuple:
+        raise TypeError("remote exception constructor arguments must be a tuple")
+    if state is not None and (type(state) is not dict or any(type(name) is not str for name in state)):
+        raise TypeError("remote exception constructor state must be a string-keyed dict")
+    restored = exception_type(*args)
+    if not isinstance(restored, BaseException):
+        raise TypeError("remote exception constructor returned a non-exception")
+    if state is not None:
+        restored.__setstate__(state)
 
     try:
         restored.remote_exception_type = remote_type  # type: ignore[attr-defined]
-        restored.remote_traceback = str(payload.get("traceback") or "")  # type: ignore[attr-defined]
+        restored.remote_traceback = remote_traceback  # type: ignore[attr-defined]
     except BaseException:
         pass
 
-    cause = _restore_remote_exception(payload.get("cause"))
+    cause = _restore_optional_remote_exception(
+        payload["cause"],
+        depth=depth + 1,
+        seen=seen,
+    )
+    context = _restore_optional_remote_exception(
+        payload["context"],
+        depth=depth + 1,
+        seen=seen,
+    )
     if cause is not None:
         restored.__cause__ = cause
-        restored.__suppress_context__ = True
+    if context is not None:
+        restored.__context__ = context
+    restored.__suppress_context__ = suppress_context
     return restored

--- a/duckdb/_ray_errors.py
+++ b/duckdb/_ray_errors.py
@@ -22,22 +22,6 @@ class RemoteRayException(RuntimeError):
         self.message = str(message)
         self.payload = dict(payload)
         super().__init__(self.message, self.payload)
-        chain_seen = {id(payload), id(self.payload)}
-        cause = _restore_optional_remote_exception(
-            self.payload["cause"],
-            depth=1,
-            seen=chain_seen,
-        )
-        context = _restore_optional_remote_exception(
-            self.payload["context"],
-            depth=1,
-            seen=chain_seen,
-        )
-        if cause is not None:
-            self.__cause__ = cause
-        if context is not None:
-            self.__context__ = context
-        self.__suppress_context__ = self.payload["suppress_context"]
 
     @classmethod
     def from_exception(cls, exc: BaseException) -> RemoteRayException:

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -10,7 +10,8 @@ import time
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import TYPE_CHECKING, Any
 
-from duckdb.runners.common import QueryDeadlineExceeded
+from duckdb._ray_errors import restore_remote_ray_exception
+from duckdb.runners.common import QueryDeadlineExceeded as QueryDeadlineExceeded
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -146,9 +147,15 @@ def resolve_object_refs_blocking(
         raise ValueError("wait_interval_s must be positive")
 
     _reject_running_event_loop()
-    return _resolve_object_refs(
-        object_refs,
-        timeout,
-        on_wait=on_wait,
-        wait_interval_s=wait_interval_s,
-    )
+    try:
+        return _resolve_object_refs(
+            object_refs,
+            timeout,
+            on_wait=on_wait,
+            wait_interval_s=wait_interval_s,
+        )
+    except BaseException as exc:
+        restored = restore_remote_ray_exception(exc)
+        if restored is not None:
+            raise restored
+        raise

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -147,6 +147,7 @@ def resolve_object_refs_blocking(
         raise ValueError("wait_interval_s must be positive")
 
     _reject_running_event_loop()
+    restored: BaseException | None = None
     try:
         return _resolve_object_refs(
             object_refs,
@@ -156,6 +157,8 @@ def resolve_object_refs_blocking(
         )
     except BaseException as exc:
         restored = restore_remote_ray_exception(exc)
-        if restored is not None:
-            raise restored
-        raise
+        if restored is None:
+            raise
+    # Raising outside the handler keeps Python from replacing a restored
+    # implicit remote context with the local RayTaskError.
+    raise restored

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -15,6 +15,7 @@ release_tests=(
   tests/fast/test_expression_udf_contracts.py
   tests/fast/test_local_e2e.py
   tests/fast/test_ray_cpp_bindings.py
+  tests/fast/test_ray_remote_exceptions.py
   tests/fast/test_ray_result_contract.py
   tests/fast/test_fte_production_readiness.py
 )

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -159,8 +159,11 @@ struct PyPhysicalPlanWrapper {
 		serializer.Begin();
 		physical_plan->Serialize(serializer);
 		serializer.End();
-		auto data_ptr = stream.GetData();
 		auto data_size = stream.GetPosition();
+		if (data_size == 0) {
+			throw duckdb::InternalException("DistributedPhysicalPlan serialized a non-empty root to an empty payload");
+		}
+		auto data_ptr = stream.GetData();
 		return string(reinterpret_cast<const char *>(data_ptr), data_size);
 	}
 
@@ -759,6 +762,9 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj) const
 	plan_wrapper.client_context_ = conn_wrapper.con.GetConnection().context;
 	plan_wrapper.udf_registrations_ = udf_registrations_;
 	plan_wrapper.connection_snapshot_ = connection_snapshot_;
+	auto validate_serialization =
+	    py::module_::import("duckdb._ray_cxx").attr("validate_plan_serialization_for_submission");
+	validate_serialization(py::cast(plan_wrapper));
 	RememberQueryUDFRegistrations(plan_wrapper.query_id_, plan_wrapper.udf_registrations_);
 	return plan_wrapper;
 }

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -825,8 +825,10 @@ public:
 
 	DuckDBResult<void> submit_fte_task_events(std::vector<duckdb::distributed::WorkerTask> tasks) override {
 		string query_id;
+		string submission_error_owner;
 		try {
 			query_id = QueryIdFromTaskEvents(tasks);
+			submission_error_owner = duckdb::distributed::python::ray::SubmissionErrorOwnerQueryId(tasks, query_id);
 			if (!tasks.empty() && query_id.empty()) {
 				return DuckDBResult<void>::err(DuckDBError::value_error("FTE task events require non-empty query_id"));
 			}
@@ -841,7 +843,7 @@ public:
 			StorePythonResultHandles(query_id, std::move(raw_handles));
 			return DuckDBResult<void>::ok();
 		} catch (const py::error_already_set &e) {
-			submission_errors_.Store(query_id, e);
+			submission_errors_.Store(submission_error_owner, e);
 			return DuckDBResult<void>::err(
 			    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
 		} catch (const std::exception &e) {

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -847,8 +847,7 @@ public:
 			return DuckDBResult<void>::err(
 			    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
 		} catch (const std::exception &e) {
-			return DuckDBResult<void>::err(
-			    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
+			return DuckDBResult<void>::err(DuckDBError(string("submit_fte_task_events failed: ") + e.what()));
 		}
 	}
 

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -824,8 +824,9 @@ public:
 	}
 
 	DuckDBResult<void> submit_fte_task_events(std::vector<duckdb::distributed::WorkerTask> tasks) override {
+		string query_id;
 		try {
-			auto query_id = QueryIdFromTaskEvents(tasks);
+			query_id = QueryIdFromTaskEvents(tasks);
 			if (!tasks.empty() && query_id.empty()) {
 				return DuckDBResult<void>::err(DuckDBError::value_error("FTE task events require non-empty query_id"));
 			}
@@ -839,6 +840,10 @@ public:
 			py::object raw_handles = backend.attr("submit_tasks")(py_tasks);
 			StorePythonResultHandles(query_id, std::move(raw_handles));
 			return DuckDBResult<void>::ok();
+		} catch (const py::error_already_set &e) {
+			submission_errors_.Store(query_id, e);
+			return DuckDBResult<void>::err(
+			    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
 		} catch (const std::exception &e) {
 			return DuckDBResult<void>::err(
 			    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
@@ -961,6 +966,7 @@ public:
 		if (query_id.empty()) {
 			return;
 		}
+		submission_errors_.Discard(query_id);
 		std::exception_ptr result_cleanup_error;
 		try {
 			ClearResultHandles(query_id);
@@ -999,6 +1005,11 @@ public:
 		if (backend_drop_error) {
 			std::rethrow_exception(backend_drop_error);
 		}
+	}
+
+	void rethrow_submission_error(const string &query_id) {
+		submission_errors_.RethrowAsCause(query_id,
+		                                  string("distributed worker task submission failed for query_id=") + query_id);
 	}
 
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const {
@@ -1042,6 +1053,7 @@ public:
 private:
 	mutable mutex mutex_;
 	duckdb::distributed::python::ray::SafePyObject backend_;
+	duckdb::distributed::python::ray::PythonExceptionStore submission_errors_;
 	std::unordered_map<string, std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>>>
 	    result_handles_by_query_;
 	std::unordered_map<string, std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>>>
@@ -1453,6 +1465,14 @@ struct PyPhysicalPlanWrapperRunner {
 		return {};
 	}
 
+	void rethrow_submission_error(const string &query_id) {
+		if (ray_worker_manager_) {
+			ray_worker_manager_->rethrow_submission_error(query_id);
+		} else if (py_backend_worker_manager_) {
+			py_backend_worker_manager_->rethrow_submission_error(query_id);
+		}
+	}
+
 	std::shared_ptr<ResultPartitionStream> run_plan(const PyPhysicalPlanWrapper &plan,
 	                                                duckdb::shared_ptr<duckdb::ClientContext> client_context = nullptr,
 	                                                duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
@@ -1515,6 +1535,7 @@ struct PyPhysicalPlanWrapperRunner {
 				res = runner->run_plan(plan.plan_);
 			}
 
+			rethrow_submission_error(plan.idx());
 			if (!res.is_ok()) {
 				throw py::value_error(res.error().what());
 			}
@@ -1525,6 +1546,18 @@ struct PyPhysicalPlanWrapperRunner {
 			}
 			auto stream = std::make_shared<duckdb::distributed::PlanResultStream>(std::move(plan_result.stream));
 			auto py_stream = std::make_shared<ResultPartitionStream>(stream);
+			auto query_id = plan.idx();
+			if (ray_worker_manager_) {
+				auto worker_manager = ray_worker_manager_;
+				py_stream->rethrow_pending_error_ = [worker_manager, query_id]() {
+					worker_manager->rethrow_submission_error(query_id);
+				};
+			} else if (py_backend_worker_manager_) {
+				auto worker_manager = py_backend_worker_manager_;
+				py_stream->rethrow_pending_error_ = [worker_manager, query_id]() {
+					worker_manager->rethrow_submission_error(query_id);
+				};
+			}
 			py_stream->keepalive_ = run_state;
 			return py_stream;
 		} catch (const py::error_already_set &ex) {
@@ -1624,6 +1657,7 @@ struct PyPhysicalPlanWrapperRunner {
 				run_plan_ms = elapsed_ms(run_plan_started);
 			}
 
+			rethrow_submission_error(plan.idx());
 			if (!res.is_ok()) {
 				throw py::value_error(res.error().what());
 			}

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -626,6 +626,23 @@ void register_ray_bindings(py::module_ &mod) {
 	    py::arg("has_plan") = false, py::arg("query_id") = py::none(),
 	    "Create a worker task with explicit plan/query-id presence for native tests.");
 
+	m.def(
+	    "_submission_error_owner_query_id_for_test",
+	    [](const string &execution_query_id, py::object resource_query_id_obj) {
+		    std::unordered_map<string, string> context {{"query_id", execution_query_id}};
+		    if (!resource_query_id_obj.is_none()) {
+			    context["resource_query_id"] = resource_query_id_obj.cast<string>();
+		    }
+		    auto config = std::make_shared<duckdb::distributed::DuckDBExecutionConfig>(
+		        duckdb::distributed::DuckDBExecutionConfig::from_env());
+		    std::vector<duckdb::distributed::WorkerTask> tasks;
+		    tasks.emplace_back(duckdb::distributed::TaskContext(), duckdb::distributed::DuckPhysicalPlanRef(),
+		                       std::move(config), std::move(context), "SubmissionErrorOwnerForTest");
+		    return duckdb::distributed::python::ray::SubmissionErrorOwnerQueryId(tasks, execution_query_id);
+	    },
+	    py::arg("execution_query_id"), py::arg("resource_query_id") = py::none(),
+	    "Resolve the query that owns a retained submission exception.");
+
 	py::class_<PyLogicalPlan>(m, "PyLogicalPlan")
 	    .def_static("from_duckdb_relation",
 	                [](py::object relation_obj, py::object query_id_obj) {

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -121,6 +121,22 @@ namespace duckdb {
 #include "logical_plan_bindings.cpp"
 #include "distributed_plan_bindings.cpp"
 
+class PhysicalNonSerializableOperatorForTest : public PhysicalOperator {
+public:
+	explicit PhysicalNonSerializableOperatorForTest(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::DUMMY_SCAN, {LogicalType::INTEGER}, 1) {
+	}
+
+	string GetName() const override {
+		return "INTENTIONALLY_NON_SERIALIZABLE";
+	}
+
+protected:
+	void SerializeOperatorData(Serializer &) const override {
+		throw NotImplementedException("INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized");
+	}
+};
+
 void register_ray_bindings(py::module_ &mod) {
 	auto m = mod.def_submodule("ray_cxx");
 	m.doc() = "C++ Ray execution bindings (experimental)";
@@ -511,7 +527,8 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def(py::pickle(
 	        // __getstate__: serialize the plan
 	        [](const PyPhysicalPlanWrapper &p) {
-		        // If we have deferred serialized bytes, pass them through
+		        // An absent plan is an explicit optional state. A materialized
+		        // or deferred root must always carry a non-empty payload.
 		        if (!p.has_root()) {
 			        if (!p.serialized_root_.empty()) {
 				        return py::make_tuple(true, py::bytes(p.serialized_root_), p.query_id_, p.udf_registrations_,
@@ -521,32 +538,40 @@ void register_ray_bindings(py::module_ &mod) {
 			                              p.connection_snapshot_);
 		        }
 
-		        try {
-			        auto physical_plan = p.plan_->physical_plan();
-			        duckdb::MemoryStream stream;
-			        duckdb::SerializationOptions options;
-			        options.serialization_compatibility = duckdb::SerializationCompatibility::Latest();
-			        options.serialize_default_values = true;
-			        duckdb::BinarySerializer serializer(stream, options);
-			        serializer.Begin();
-			        physical_plan->Serialize(serializer);
-			        serializer.End();
-			        auto data_ptr = stream.GetData();
-			        auto data_size = stream.GetPosition();
-			        return py::make_tuple(true, py::bytes(reinterpret_cast<const char *>(data_ptr), data_size),
-			                              p.query_id_, p.udf_registrations_, p.udf_actor_handles_,
-			                              p.connection_snapshot_);
-		        } catch (const std::exception &ex) {
-			        return py::make_tuple(false, py::bytes(""), p.query_id_, p.udf_registrations_, p.udf_actor_handles_,
-			                              p.connection_snapshot_);
+		        auto physical_plan = p.plan_->physical_plan();
+		        duckdb::MemoryStream stream;
+		        duckdb::SerializationOptions options;
+		        options.serialization_compatibility = duckdb::SerializationCompatibility::Latest();
+		        options.serialize_default_values = true;
+		        duckdb::BinarySerializer serializer(stream, options);
+		        serializer.Begin();
+		        physical_plan->Serialize(serializer);
+		        serializer.End();
+		        auto data_size = stream.GetPosition();
+		        if (data_size == 0) {
+			        throw duckdb::InternalException(
+			            "DistributedPhysicalPlan serialized a non-empty root to an empty payload");
 		        }
+		        auto data_ptr = stream.GetData();
+		        return py::make_tuple(true, py::bytes(reinterpret_cast<const char *>(data_ptr), data_size), p.query_id_,
+		                              p.udf_registrations_, p.udf_actor_handles_, p.connection_snapshot_);
 	        },
 	        // __setstate__: store deferred bytes for later deserialization
 	        [](py::tuple t) {
-		        if (t.size() < 2) {
+		        if (t.size() < 2 || t.size() > 6) {
 			        throw duckdb::InternalException("Invalid state for PyPhysicalPlanWrapper pickle");
 		        }
 		        bool has_data = t[0].cast<bool>();
+		        py::bytes serialized = t[1].cast<py::bytes>();
+		        string data_str = serialized;
+		        if (has_data && data_str.empty()) {
+			        throw duckdb::InternalException(
+			            "Invalid PyPhysicalPlanWrapper pickle: serialized root is marked present but empty");
+		        }
+		        if (!has_data && !data_str.empty()) {
+			        throw duckdb::InternalException(
+			            "Invalid PyPhysicalPlanWrapper pickle: absent root carries serialized data");
+		        }
 		        string query_id;
 		        if (t.size() >= 3) {
 			        query_id = t[2].cast<string>();
@@ -568,14 +593,48 @@ void register_ray_bindings(py::module_ &mod) {
 		        RememberQueryUDFActorHandles(result.query_id_, result.udf_actor_handles_);
 
 		        if (has_data) {
-			        py::bytes serialized = t[1].cast<py::bytes>();
-			        string data_str = serialized;
-			        if (!data_str.empty()) {
-				        result.serialized_root_ = std::move(data_str);
-			        }
+			        result.serialized_root_ = std::move(data_str);
 		        }
 		        return result;
 	        }));
+
+	m.def(
+	    "_make_non_serializable_physical_plan_for_test",
+	    [](const string &query_id) {
+		    if (query_id.empty()) {
+			    throw duckdb::InternalException("test physical plan requires a non-empty query_id");
+		    }
+		    auto physical_plan = std::make_shared<duckdb::PhysicalPlan>(duckdb::Allocator::DefaultAllocator());
+		    auto &root = physical_plan->Make<PhysicalNonSerializableOperatorForTest>();
+		    physical_plan->SetRoot(root);
+		    uint16_t idx = duckdb::distributed::get_query_idx_counter().fetch_add(1);
+		    auto config = std::make_shared<duckdb::distributed::DuckDBExecutionConfig>(
+		        duckdb::distributed::DuckDBExecutionConfig::from_env());
+		    auto distributed_plan = std::make_shared<duckdb::distributed::DistributedPhysicalPlan>(
+		        idx, query_id, std::move(physical_plan), std::move(config));
+		    return PyPhysicalPlanWrapper(std::move(distributed_plan));
+	    },
+	    py::arg("query_id"), "Create an intentionally non-serializable physical plan for native tests.");
+
+	m.def(
+	    "_make_worker_task_for_test",
+	    [](bool has_plan, py::object query_id_obj) {
+		    duckdb::distributed::DuckPhysicalPlanRef physical_plan;
+		    if (has_plan) {
+			    physical_plan = std::make_shared<duckdb::PhysicalPlan>(duckdb::Allocator::DefaultAllocator());
+		    }
+		    auto config = std::make_shared<duckdb::distributed::DuckDBExecutionConfig>(
+		        duckdb::distributed::DuckDBExecutionConfig::from_env());
+		    std::unordered_map<string, string> context;
+		    if (!query_id_obj.is_none()) {
+			    context["query_id"] = query_id_obj.cast<string>();
+		    }
+		    duckdb::distributed::WorkerTask task(duckdb::distributed::TaskContext(), std::move(physical_plan),
+		                                         std::move(config), std::move(context), "WorkerTaskForTest");
+		    return RayWorkerTask(std::move(task));
+	    },
+	    py::arg("has_plan") = false, py::arg("query_id") = py::none(),
+	    "Create a worker task with explicit plan/query-id presence for native tests.");
 
 	py::class_<PyLogicalPlan>(m, "PyLogicalPlan")
 	    .def_static("from_duckdb_relation",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -524,6 +524,10 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def("collect_vllm_nodes", &PyPhysicalPlanWrapper::collect_vllm_nodes, py::arg("conn") = py::none())
 	    .def("set_udf_actor_handles", &PyPhysicalPlanWrapper::set_udf_actor_handles, py::arg("handles_map"),
 	         py::arg("conn") = py::none())
+	    .def(
+	        "_validate_serializable_for_submission",
+	        [](const PyPhysicalPlanWrapper &p) { (void)p.serialize_root_for_clone(); },
+	        "Validate the physical root before distributed query registration.")
 	    .def(py::pickle(
 	        // __getstate__: serialize the plan
 	        [](const PyPhysicalPlanWrapper &p) {
@@ -538,23 +542,9 @@ void register_ray_bindings(py::module_ &mod) {
 			                              p.connection_snapshot_);
 		        }
 
-		        auto physical_plan = p.plan_->physical_plan();
-		        duckdb::MemoryStream stream;
-		        duckdb::SerializationOptions options;
-		        options.serialization_compatibility = duckdb::SerializationCompatibility::Latest();
-		        options.serialize_default_values = true;
-		        duckdb::BinarySerializer serializer(stream, options);
-		        serializer.Begin();
-		        physical_plan->Serialize(serializer);
-		        serializer.End();
-		        auto data_size = stream.GetPosition();
-		        if (data_size == 0) {
-			        throw duckdb::InternalException(
-			            "DistributedPhysicalPlan serialized a non-empty root to an empty payload");
-		        }
-		        auto data_ptr = stream.GetData();
-		        return py::make_tuple(true, py::bytes(reinterpret_cast<const char *>(data_ptr), data_size), p.query_id_,
-		                              p.udf_registrations_, p.udf_actor_handles_, p.connection_snapshot_);
+		        auto serialized_root = p.serialize_root_for_clone();
+		        return py::make_tuple(true, py::bytes(serialized_root), p.query_id_, p.udf_registrations_,
+		                              p.udf_actor_handles_, p.connection_snapshot_);
 	        },
 	        // __setstate__: store deferred bytes for later deserialization
 	        [](py::tuple t) {

--- a/src/duckdb_py/ray/result_stream_bindings.cpp
+++ b/src/duckdb_py/ray/result_stream_bindings.cpp
@@ -3,9 +3,12 @@
 
 // Included by ray_module.cpp inside namespace duckdb.
 
+#include <functional>
+
 struct ResultPartitionStream {
 	std::shared_ptr<duckdb::distributed::PlanResultStream> stream_;
 	std::shared_ptr<void> keepalive_;
+	std::function<void()> rethrow_pending_error_;
 	mutex stream_mutex_;
 
 	explicit ResultPartitionStream(std::shared_ptr<duckdb::distributed::PlanResultStream> stream)
@@ -22,12 +25,23 @@ struct ResultPartitionStream {
 		}
 
 		std::pair<bool, duckdb::distributed::ResultPartitionRef> opt;
+		std::exception_ptr stream_error;
 		{
 			// Release the GIL before contending on the stream mutex. The mutex
-			// must also be released before Python conversion restores the GIL.
+			// must also be released before restoring a Python submission error.
 			py::gil_scoped_release release;
 			lock_guard<mutex> guard(stream_mutex_);
-			opt = stream_->next();
+			try {
+				opt = stream_->next();
+			} catch (...) {
+				stream_error = std::current_exception();
+			}
+		}
+		if (stream_error) {
+			if (rethrow_pending_error_) {
+				rethrow_pending_error_();
+			}
+			std::rethrow_exception(stream_error);
 		}
 		if (!opt.first) {
 			throw py::stop_iteration();

--- a/src/duckdb_py/ray/result_stream_bindings.cpp
+++ b/src/duckdb_py/ray/result_stream_bindings.cpp
@@ -3,6 +3,7 @@
 
 // Included by ray_module.cpp inside namespace duckdb.
 
+#include <exception>
 #include <functional>
 
 struct ResultPartitionStream {

--- a/src/duckdb_py/ray/safe_pyobject.hpp
+++ b/src/duckdb_py/ray/safe_pyobject.hpp
@@ -161,8 +161,12 @@ public:
 			return;
 		}
 		PythonGILWrapper gil;
-		stored.Restore();
-		py::raise_from(PyExc_RuntimeError, message.c_str());
+		auto original = stored.value.get();
+		if (stored.traceback.has_value()) {
+			original.attr("__traceback__") = stored.traceback.get();
+		}
+		auto transported = py::module_::import("duckdb._ray_errors").attr("remote_ray_exception")(message, original);
+		PyErr_SetObject(py::type::of(transported).ptr(), transported.ptr());
 		throw py::error_already_set();
 	}
 

--- a/src/duckdb_py/ray/safe_pyobject.hpp
+++ b/src/duckdb_py/ray/safe_pyobject.hpp
@@ -6,6 +6,10 @@
 
 #include <pybind11/pybind11.h>
 
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
 namespace py = pybind11;
 
 namespace duckdb {
@@ -106,6 +110,86 @@ struct SafePyObject {
 	bool has_value() const {
 		return has_value_ && obj_.ptr();
 	}
+};
+
+struct SafePythonException {
+	SafePyObject type;
+	SafePyObject value;
+	SafePyObject traceback;
+
+	SafePythonException() = default;
+	explicit SafePythonException(const py::error_already_set &error)
+	    : type(py::object(error.type())), value(py::object(error.value())), traceback(py::object(error.trace())) {
+	}
+
+	bool has_value() const {
+		return type.has_value() && value.has_value();
+	}
+
+	void Restore() const {
+		if (!has_value()) {
+			return;
+		}
+		auto type_obj = type.get();
+		auto value_obj = value.get();
+		PyObject *traceback_ptr = nullptr;
+		if (traceback.has_value()) {
+			auto traceback_obj = traceback.get();
+			traceback_ptr = traceback_obj.release().ptr();
+		}
+		PyErr_Restore(type_obj.release().ptr(), value_obj.release().ptr(), traceback_ptr);
+	}
+};
+
+// Retains normalized Python exception triples while a background DuckDB task
+// reports its string-only DuckDBError through PlanExecutionStatus.
+class PythonExceptionStore {
+public:
+	void Store(const std::string &query_id, const py::error_already_set &error) {
+		if (query_id.empty()) {
+			return;
+		}
+		PythonGILWrapper gil;
+		SafePythonException stored(error);
+		std::lock_guard<std::mutex> guard(mutex_);
+		errors_.try_emplace(query_id, std::move(stored));
+	}
+
+	void RethrowAsCause(const std::string &query_id, const std::string &message) {
+		auto stored = Take(query_id);
+		if (!stored.has_value()) {
+			return;
+		}
+		PythonGILWrapper gil;
+		stored.Restore();
+		py::raise_from(PyExc_RuntimeError, message.c_str());
+		throw py::error_already_set();
+	}
+
+	void Discard(const std::string &query_id) {
+		(void)Take(query_id);
+	}
+
+private:
+	SafePythonException Take(const std::string &query_id) {
+		SafePythonException stored;
+		if (query_id.empty()) {
+			return stored;
+		}
+		{
+			std::lock_guard<std::mutex> guard(mutex_);
+			auto entry = errors_.find(query_id);
+			if (entry == errors_.end()) {
+				return stored;
+			}
+			stored = std::move(entry->second);
+			errors_.erase(entry);
+		}
+		return stored;
+	}
+
+	std::mutex mutex_;
+	std::unordered_map<std::string, SafePythonException> errors_;
 };
 
 } // namespace ray

--- a/src/duckdb_py/ray/safe_pyobject.hpp
+++ b/src/duckdb_py/ray/safe_pyobject.hpp
@@ -118,8 +118,11 @@ struct SafePythonException {
 	SafePyObject traceback;
 
 	SafePythonException() = default;
-	explicit SafePythonException(const py::error_already_set &error)
-	    : type(py::object(error.type())), value(py::object(error.value())), traceback(py::object(error.trace())) {
+	explicit SafePythonException(const py::error_already_set &error) {
+		PythonGILWrapper gil;
+		type = SafePyObject(py::object(error.type()));
+		value = SafePyObject(py::object(error.value()));
+		traceback = SafePyObject(py::object(error.trace()));
 	}
 
 	bool has_value() const {
@@ -130,6 +133,7 @@ struct SafePythonException {
 		if (!has_value()) {
 			return;
 		}
+		PythonGILWrapper gil;
 		auto type_obj = type.get();
 		auto value_obj = value.get();
 		PyObject *traceback_ptr = nullptr;

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -1018,6 +1018,9 @@ py::object RayWorkerTask::Plan() const {
 	if (query_id_entry == task_context.end() || query_id_entry->second.empty()) {
 		throw duckdb::InternalException("RayWorkerTask::Plan requires non-empty task context query_id");
 	}
+	if (!plan_ref->HasRoot()) {
+		throw duckdb::InternalException("RayWorkerTask::Plan received a present physical plan without a root");
+	}
 	py::object query_id_obj = py::str(query_id_entry->second);
 	auto udf_registrations_obj = ray_cxx.attr("_lookup_query_udf_registrations")(query_id_obj);
 	auto udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(query_id_obj);

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -1012,42 +1012,24 @@ py::object RayWorkerTask::Plan() const {
 
 	// Create PyPhysicalPlanWrapper by passing the plan via capsule
 	duckdb::PythonGILWrapper gil;
-	try {
-
-		// Import the module
-		auto ray_cxx = py::module_::import("_duckdb.ray_cxx");
-		auto task_context = task_.context();
-		py::object query_id_obj = py::none();
-		py::object udf_registrations_obj = py::none();
-		py::object udf_actor_handles_obj = py::none();
-		py::object connection_snapshot_obj = py::none();
-		auto query_id_entry = task_context.find("query_id");
-		if (query_id_entry != task_context.end() && !query_id_entry->second.empty()) {
-			query_id_obj = py::str(query_id_entry->second);
-			udf_registrations_obj = ray_cxx.attr("_lookup_query_udf_registrations")(query_id_obj);
-			udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(query_id_obj);
-			connection_snapshot_obj = ray_cxx.attr("_lookup_query_connection_snapshot")(query_id_obj);
-		} else {
-			throw duckdb::InternalException("RayWorkerTask::Plan requires non-empty task context query_id");
-		}
-
-		// Create a capsule containing the shared_ptr
-		auto *plan_copy = new std::shared_ptr<duckdb::PhysicalPlan>(plan_ref);
-		py::capsule plan_capsule(plan_copy,
-		                         [](void *ptr) { delete static_cast<std::shared_ptr<duckdb::PhysicalPlan> *>(ptr); });
-
-		// Call the Python helper to create PyPhysicalPlanWrapper from capsule
-		auto create_fn = ray_cxx.attr("_create_physical_plan_from_capsule");
-
-		auto result = create_fn(plan_capsule, query_id_obj, udf_registrations_obj, udf_actor_handles_obj,
-		                        connection_snapshot_obj);
-
-		return result;
-	} catch (const py::error_already_set &) {
-		throw;
-	} catch (const std::exception &e) {
-		return py::none();
+	auto ray_cxx = py::module_::import("_duckdb.ray_cxx");
+	auto task_context = task_.context();
+	auto query_id_entry = task_context.find("query_id");
+	if (query_id_entry == task_context.end() || query_id_entry->second.empty()) {
+		throw duckdb::InternalException("RayWorkerTask::Plan requires non-empty task context query_id");
 	}
+	py::object query_id_obj = py::str(query_id_entry->second);
+	auto udf_registrations_obj = ray_cxx.attr("_lookup_query_udf_registrations")(query_id_obj);
+	auto udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(query_id_obj);
+	auto connection_snapshot_obj = ray_cxx.attr("_lookup_query_connection_snapshot")(query_id_obj);
+
+	// The capsule owns this shared_ptr copy if any later Python or C++ step
+	// raises, so materialization errors can propagate without leaking it.
+	auto *plan_copy = new std::shared_ptr<duckdb::PhysicalPlan>(plan_ref);
+	py::capsule plan_capsule(plan_copy,
+	                         [](void *ptr) { delete static_cast<std::shared_ptr<duckdb::PhysicalPlan> *>(ptr); });
+	auto create_fn = ray_cxx.attr("_create_physical_plan_from_capsule");
+	return create_fn(plan_capsule, query_id_obj, udf_registrations_obj, udf_actor_handles_obj, connection_snapshot_obj);
 }
 
 py::dict RayWorkerTask::Inputs() const {

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -1023,11 +1023,13 @@ py::object RayWorkerTask::Plan() const {
 	auto udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(query_id_obj);
 	auto connection_snapshot_obj = ray_cxx.attr("_lookup_query_connection_snapshot")(query_id_obj);
 
-	// The capsule owns this shared_ptr copy if any later Python or C++ step
-	// raises, so materialization errors can propagate without leaking it.
-	auto *plan_copy = new std::shared_ptr<duckdb::PhysicalPlan>(plan_ref);
-	py::capsule plan_capsule(plan_copy,
+	// Keep ownership locally until the capsule is fully constructed. Capsule
+	// construction can allocate and raise before its destructor callback owns
+	// the pointer.
+	auto plan_copy = std::make_unique<std::shared_ptr<duckdb::PhysicalPlan>>(plan_ref);
+	py::capsule plan_capsule(plan_copy.get(),
 	                         [](void *ptr) { delete static_cast<std::shared_ptr<duckdb::PhysicalPlan> *>(ptr); });
+	plan_copy.release();
 	auto create_fn = ray_cxx.attr("_create_physical_plan_from_capsule");
 	return create_fn(plan_capsule, query_id_obj, udf_registrations_obj, udf_actor_handles_obj, connection_snapshot_obj);
 }

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -392,8 +392,9 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 	if (!operation) {
 		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
+	string query_id;
 	try {
-		auto query_id = QueryIdFromTaskEvents(tasks);
+		query_id = QueryIdFromTaskEvents(tasks);
 		if (!tasks.empty() && query_id.empty()) {
 			return DuckDBResult<void>::err(DuckDBError::value_error("FTE task events require non-empty query_id"));
 		}
@@ -435,9 +436,17 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 			workers[worker_idx]->SubmitFteTaskEvents(worker_tasks);
 		}
 		return DuckDBResult<void>::ok();
+	} catch (const py::error_already_set &e) {
+		submission_errors_.Store(query_id, e);
+		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
 	} catch (const std::exception &e) {
 		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
 	}
+}
+
+void RayWorkerManager::rethrow_submission_error(const string &query_id) {
+	submission_errors_.RethrowAsCause(query_id,
+	                                  string("distributed worker task submission failed for query_id=") + query_id);
 }
 
 DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager::worker_snapshots() const {
@@ -640,6 +649,7 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 	if (!operation) {
 		throw std::runtime_error("Ray worker manager is shut down");
 	}
+	submission_errors_.Discard(query_id);
 	std::vector<std::string> errors;
 	std::vector<std::string> prepare_errors;
 	try {

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -463,7 +463,7 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		submission_errors_.Store(submission_error_owner, e);
 		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
 	} catch (const std::exception &e) {
-		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
+		return DuckDBResult<void>::err(DuckDBError(string("submit_fte_task_events failed: ") + e.what()));
 	}
 }
 

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -51,6 +51,27 @@ void RayWorkerManager::EndOperation() const {
 	shutdown_cv_.notify_all();
 }
 
+std::string
+duckdb::distributed::python::ray::SubmissionErrorOwnerQueryId(const std::vector<duckdb::distributed::WorkerTask> &tasks,
+                                                              const std::string &execution_query_id) {
+	std::string resource_query_id;
+	for (const auto &task : tasks) {
+		const auto &context = task.context();
+		auto it = context.find("resource_query_id");
+		if (it == context.end() || it->second.empty()) {
+			continue;
+		}
+		if (resource_query_id.empty()) {
+			resource_query_id = it->second;
+			continue;
+		}
+		if (resource_query_id != it->second) {
+			throw std::runtime_error("FTE submit batch contains multiple resource_query_id values");
+		}
+	}
+	return resource_query_id.empty() ? execution_query_id : resource_query_id;
+}
+
 std::string RayWorkerManager::QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks) {
 	std::string query_id;
 	for (const auto &task : tasks) {
@@ -393,8 +414,10 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
 	string query_id;
+	string submission_error_owner;
 	try {
 		query_id = QueryIdFromTaskEvents(tasks);
+		submission_error_owner = SubmissionErrorOwnerQueryId(tasks, query_id);
 		if (!tasks.empty() && query_id.empty()) {
 			return DuckDBResult<void>::err(DuckDBError::value_error("FTE task events require non-empty query_id"));
 		}
@@ -437,7 +460,7 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		}
 		return DuckDBResult<void>::ok();
 	} catch (const py::error_already_set &e) {
-		submission_errors_.Store(query_id, e);
+		submission_errors_.Store(submission_error_owner, e);
 		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
 	} catch (const std::exception &e) {
 		return DuckDBResult<void>::err(DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <string>
 
+#include "safe_pyobject.hpp"
 #include "worker.hpp"
 #include "task.hpp"
 #include "duckdb/execution/distributed/utils/channel.hpp"
@@ -43,6 +44,7 @@ public:
 	    const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) override;
 
 	void drop_query_fragments(const string &query_id);
+	void rethrow_submission_error(const string &query_id);
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const;
 
 private:
@@ -83,6 +85,7 @@ private:
 	mutable mutex mutex_;
 	mutable std::condition_variable shutdown_cv_;
 	mutable State state_;
+	PythonExceptionStore submission_errors_;
 
 	bool BeginOperation() const;
 	void EndOperation() const;

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -23,6 +23,9 @@ namespace distributed {
 namespace python {
 namespace ray {
 
+string SubmissionErrorOwnerQueryId(const std::vector<duckdb::distributed::WorkerTask> &tasks,
+                                   const string &execution_query_id);
+
 class RayWorkerManager : public duckdb::distributed::WorkerManager {
 public:
 	DuckDBResult<void> submit_fte_task_events(std::vector<duckdb::distributed::WorkerTask> tasks) override;

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -11,6 +11,7 @@ import pytest
 
 import duckdb
 from duckdb._ray_cxx import validate_plan_serialization_for_submission
+from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.ray.query_execution_graph import (
     ActorPlacement,
     NodeResourceAllocation,
@@ -264,6 +265,7 @@ def test_driver_rejects_non_serializable_plan_before_query_registration(entrypoi
         coroutine = getattr(runner_cls, entrypoint)(runner, _ValidatingLogicalPlan(physical_plan, events))
         asyncio.run(coroutine)
 
+    assert isinstance(exc_info.value, RemoteRayException)
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
     assert "INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized" in str(exc_info.value.__cause__)
     with pytest.raises(KeyError, match="query graph is not registered"):

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 
 import pytest
 
+import duckdb
+from duckdb._ray_cxx import validate_plan_serialization_for_submission
 from duckdb.runners.ray.query_execution_graph import (
     ActorPlacement,
     NodeResourceAllocation,
@@ -32,6 +34,13 @@ class _FakeLogicalPlan:
         assert conn is not None
         self._events.append("physical_plan")
         return self._physical_plan
+
+
+class _ValidatingLogicalPlan(_FakeLogicalPlan):
+    def to_physical_plan(self, conn):
+        physical_plan = super().to_physical_plan(conn)
+        validate_plan_serialization_for_submission(physical_plan)
+        return physical_plan
 
 
 class _FakePhysicalPlan:
@@ -240,47 +249,33 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
     assert "plan_runner" not in events
 
 
-def test_driver_rolls_back_query_registration_when_plan_submission_serialization_fails():
+@pytest.mark.parametrize("entrypoint", ["run_plan", "run_copy_plan"])
+def test_driver_rejects_non_serializable_plan_before_query_registration(entrypoint):
     events = []
     coordinator = _FakeCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
-    query_id = "query-plan-serialization-failure"
-    physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
-    serialization_error = RuntimeError("INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized")
+    query_id = f"query-plan-serialization-failure-{entrypoint}"
+    physical_plan = duckdb.ray_cxx._make_non_serializable_physical_plan_for_test(query_id)
 
-    runner._precreate_udf_actors = lambda *_args: []
+    with pytest.raises(
+        RuntimeError,
+        match=f"distributed physical plan serialization preflight failed for query_id={query_id}",
+    ) as exc_info:
+        coroutine = getattr(runner_cls, entrypoint)(runner, _ValidatingLogicalPlan(physical_plan, events))
+        asyncio.run(coroutine)
 
-    class _FailingPlanRunner:
-        def run_plan(self, _plan, _conn):
-            raise serialization_error
-
-    runner._get_plan_runner = _FailingPlanRunner
-
-    def _drop_fragments_and_release(actual_query_id):
-        events.append("fragment_drop")
-        runner_cls._release_query_resources(
-            runner,
-            actual_query_id,
-            reason="query_fragments_dropped",
-            admission_fenced=True,
-        )
-
-    runner._drop_query_fragments_sync = _drop_fragments_and_release
-
-    with pytest.raises(RuntimeError) as exc_info:
-        asyncio.run(runner_cls.run_plan(runner, _FakeLogicalPlan(physical_plan, events)))
-
-    assert exc_info.value is serialization_error
+    assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
+    assert "INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized" in str(exc_info.value.__cause__)
     with pytest.raises(KeyError, match="query graph is not registered"):
         get_query_resource_manager(query_id)
-    assert coordinator.released == [(query_id, 7)]
+    assert coordinator.released == []
     assert coordinator.allocations == {}
     assert runner._query_graphs == {}
     assert runner._query_allocations == {}
     assert query_id not in runner.curr_plans
     assert query_id not in runner.curr_streams
     assert query_id not in runner._plan_query_ids
-    assert "fragment_drop" in events
+    assert events == ["physical_plan"]
 
 
 def test_driver_exposes_query_task_and_output_lease_api():

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -240,6 +240,49 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
     assert "plan_runner" not in events
 
 
+def test_driver_rolls_back_query_registration_when_plan_submission_serialization_fails():
+    events = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    query_id = "query-plan-serialization-failure"
+    physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
+    serialization_error = RuntimeError("INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized")
+
+    runner._precreate_udf_actors = lambda *_args: []
+
+    class _FailingPlanRunner:
+        def run_plan(self, _plan, _conn):
+            raise serialization_error
+
+    runner._get_plan_runner = _FailingPlanRunner
+
+    def _drop_fragments_and_release(actual_query_id):
+        events.append("fragment_drop")
+        runner_cls._release_query_resources(
+            runner,
+            actual_query_id,
+            reason="query_fragments_dropped",
+            admission_fenced=True,
+        )
+
+    runner._drop_query_fragments_sync = _drop_fragments_and_release
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner_cls.run_plan(runner, _FakeLogicalPlan(physical_plan, events)))
+
+    assert exc_info.value is serialization_error
+    with pytest.raises(KeyError, match="query graph is not registered"):
+        get_query_resource_manager(query_id)
+    assert coordinator.released == [(query_id, 7)]
+    assert coordinator.allocations == {}
+    assert runner._query_graphs == {}
+    assert runner._query_allocations == {}
+    assert query_id not in runner.curr_plans
+    assert query_id not in runner.curr_streams
+    assert query_id not in runner._plan_query_ids
+    assert "fragment_drop" in events
+
+
 def test_driver_exposes_query_task_and_output_lease_api():
     from duckdb.runners.ray.driver import RayQueryDriverActor
 

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -1701,6 +1701,7 @@ def test_native_cxx_run_copy_plan_preserves_worker_plan_exception_cause(tmp_path
         con.close()
 
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
+    assert exc_info.value.__cause__.__traceback__ is not None
     assert f"copy plan lookup sentinel for {query_id}" in str(exc_info.value.__cause__)
     assert submission_calls == [1]
     assert dropped_queries == [query_id]

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -1660,6 +1660,53 @@ def test_native_cxx_run_copy_plan_failure_cleans_local_staging(tmp_path, monkeyp
         con.close()
 
 
+def test_native_cxx_run_copy_plan_preserves_worker_plan_exception_cause(tmp_path, monkeypatch):
+    import _duckdb
+
+    con, dst, query_id, plan = _captured_native_copy_plan(tmp_path, monkeypatch, local_staging=True)
+    submission_calls = []
+    dropped_queries = []
+
+    class Backend:
+        def worker_snapshots(self):
+            return [
+                {
+                    "worker_id": "native-worker-0",
+                    "num_cpus": 1.0,
+                    "num_gpus": 0.0,
+                    "total_memory_bytes": 1024,
+                }
+            ]
+
+        def submit_tasks(self, tasks):
+            submission_calls.append(len(tasks))
+            tasks[0].plan()
+            return []
+
+        def drop_query(self, actual_query_id):
+            dropped_queries.append(actual_query_id)
+
+    def fail_lookup(actual_query_id):
+        raise duckdb.NotImplementedException(f"copy plan lookup sentinel for {actual_query_id}")
+
+    monkeypatch.setattr(_duckdb.ray_cxx, "_lookup_query_udf_registrations", fail_lookup)
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner(Backend())
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match=f"distributed worker task submission failed for query_id={query_id}",
+        ) as exc_info:
+            runner.run_copy_plan(plan, con)
+    finally:
+        con.close()
+
+    assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
+    assert f"copy plan lookup sentinel for {query_id}" in str(exc_info.value.__cause__)
+    assert submission_calls == [1]
+    assert dropped_queries == [query_id]
+    assert not dst.exists()
+
+
 def test_native_cxx_run_copy_plan_surfaces_backend_cleanup_failure(tmp_path, monkeypatch):
     con, _dst, relation = _capture_native_copy_relation(tmp_path, monkeypatch, local_staging=True)
 

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -1663,6 +1663,8 @@ def test_native_cxx_run_copy_plan_failure_cleans_local_staging(tmp_path, monkeyp
 def test_native_cxx_run_copy_plan_preserves_worker_plan_exception_cause(tmp_path, monkeypatch):
     import _duckdb
 
+    from duckdb._ray_errors import RemoteRayException
+
     con, dst, query_id, plan = _captured_native_copy_plan(tmp_path, monkeypatch, local_staging=True)
     submission_calls = []
     dropped_queries = []
@@ -1700,6 +1702,7 @@ def test_native_cxx_run_copy_plan_preserves_worker_plan_exception_cause(tmp_path
     finally:
         con.close()
 
+    assert isinstance(exc_info.value, RemoteRayException)
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
     assert exc_info.value.__cause__.__traceback__ is not None
     assert f"copy plan lookup sentinel for {query_id}" in str(exc_info.value.__cause__)

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 import duckdb
+import duckdb._ray_cxx as ray_cxx_helpers
 from duckdb.runners.fte.fte_exchange import ExchangeSinkHandle, ExchangeSinkInstanceHandle
 
 
@@ -40,6 +41,40 @@ def test_physical_plan_pickle_propagates_non_serializable_operator_error():
         match="INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized",
     ):
         pickle.dumps(plan)
+
+
+def test_physical_plan_submission_preflight_accepts_serializable_root():
+    plan = _make_test_physical_plan()
+
+    assert plan._validate_serializable_for_submission() is None
+
+
+def test_logical_to_physical_plan_propagates_submission_preflight_cause(monkeypatch):
+    con = duckdb.connect()
+    logical_plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        con.sql("SELECT 1 AS i"),
+        "query-preflight-wiring",
+    )
+    non_serializable_plan = duckdb.ray_cxx._make_non_serializable_physical_plan_for_test("query-preflight-wiring")
+    validate_submission = ray_cxx_helpers.validate_plan_serialization_for_submission
+
+    def validate_non_serializable_plan(_plan):
+        validate_submission(non_serializable_plan)
+
+    monkeypatch.setattr(
+        ray_cxx_helpers,
+        "validate_plan_serialization_for_submission",
+        validate_non_serializable_plan,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="distributed physical plan serialization preflight failed for query_id=query-preflight-wiring",
+    ) as exc_info:
+        logical_plan.to_physical_plan(con)
+
+    assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
+    assert "INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized" in str(exc_info.value.__cause__)
 
 
 @pytest.mark.parametrize("query_id", [None, ""], ids=["absent", "empty"])

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import pickle
 import queue
 import socket
 import socketserver
@@ -28,6 +29,34 @@ def _make_test_physical_plan(con=None):
         relation,
         str(uuid.uuid4()),
     ).to_physical_plan(con)
+
+
+def test_physical_plan_pickle_propagates_non_serializable_operator_error():
+    plan = duckdb.ray_cxx._make_non_serializable_physical_plan_for_test("query-non-serializable")
+
+    assert plan.has_root() is True
+    with pytest.raises(
+        duckdb.NotImplementedException,
+        match="INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized",
+    ):
+        pickle.dumps(plan)
+
+
+@pytest.mark.parametrize("query_id", [None, ""], ids=["absent", "empty"])
+def test_worker_task_plan_rejects_missing_query_id(query_id):
+    task = duckdb.ray_cxx._make_worker_task_for_test(True, query_id)
+
+    with pytest.raises(
+        duckdb.InternalException,
+        match="RayWorkerTask::Plan requires non-empty task context query_id",
+    ):
+        task.plan()
+
+
+def test_worker_task_plan_keeps_absent_plan_explicit():
+    task = duckdb.ray_cxx._make_worker_task_for_test()
+
+    assert task.plan() is None
 
 
 @pytest.mark.parametrize("should_fail", [False, True], ids=["success", "failure"])

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -20,6 +20,7 @@ import pytest
 
 import duckdb
 import duckdb._ray_cxx as ray_cxx_helpers
+from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.fte.fte_exchange import ExchangeSinkHandle, ExchangeSinkInstanceHandle
 
 
@@ -73,6 +74,7 @@ def test_logical_to_physical_plan_propagates_submission_preflight_cause(monkeypa
     ) as exc_info:
         logical_plan.to_physical_plan(con)
 
+    assert isinstance(exc_info.value, RemoteRayException)
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
     assert "INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized" in str(exc_info.value.__cause__)
 
@@ -173,6 +175,7 @@ def test_worker_submission_preserves_worker_plan_exception_cause(monkeypatch, ma
         runner.drop_query_fragments(query_id)
         con.close()
 
+    assert isinstance(exc_info.value, RemoteRayException)
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
     assert exc_info.value.__cause__.__traceback__ is not None
     assert f"plan lookup sentinel for {query_id}" in str(exc_info.value.__cause__)

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -153,6 +153,16 @@ def test_worker_submission_preserves_worker_plan_exception_cause(monkeypatch, ma
         def drop_query(self, _query_id):
             return None
 
+        def fte_prepare_drop_query(self, _query_id):
+            return {
+                "tasks_removed": 0,
+                "tasks_canceled": 0,
+                "fragments_removed": 0,
+            }
+
+        def fte_cleanup_query(self, _query_id):
+            return {}
+
         def fte_drop_query(self, _query_id):
             return {
                 "tasks_removed": 0,

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -94,6 +94,91 @@ def test_worker_task_plan_keeps_absent_plan_explicit():
     assert task.plan() is None
 
 
+@pytest.mark.parametrize("manager_kind", ["python-backend", "ray-worker-manager"])
+def test_worker_submission_preserves_worker_plan_exception_cause(monkeypatch, manager_kind):
+    import _duckdb
+
+    query_id = f"query-worker-plan-error-{manager_kind}"
+    submission_calls = []
+
+    class SubmissionTarget:
+        def worker_snapshots(self):
+            return [
+                {
+                    "worker_id": "worker-1",
+                    "num_cpus": 4.0,
+                    "num_gpus": 0.0,
+                    "total_memory_bytes": 4 << 30,
+                }
+            ]
+
+        def submit_tasks(self, tasks):
+            submission_calls.append(len(tasks))
+            tasks[0].plan()
+            return []
+
+        def drop_query(self, _query_id):
+            return None
+
+        def fte_drop_query(self, _query_id):
+            return {
+                "tasks_removed": 0,
+                "tasks_canceled": 0,
+                "fragments_removed": 0,
+            }
+
+        def shutdown(self):
+            return None
+
+    target = SubmissionTarget()
+    con = duckdb.connect()
+    plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        con.sql("SELECT 1 AS i"),
+        query_id,
+    ).to_physical_plan(con)
+
+    def fail_lookup(actual_query_id):
+        raise duckdb.NotImplementedException(f"plan lookup sentinel for {actual_query_id}")
+
+    monkeypatch.setattr(_duckdb.ray_cxx, "_lookup_query_udf_registrations", fail_lookup)
+    if manager_kind == "python-backend":
+        runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner(target)
+    else:
+        import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+        monkeypatch.setattr(
+            ray_worker_handle,
+            "start_ray_workers",
+            lambda _existing_ids: [
+                duckdb.ray_cxx.RayWorkerRuntime(
+                    "worker-1",
+                    target,
+                    4.0,
+                    0.0,
+                    4 << 30,
+                )
+            ],
+        )
+        monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+        runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+
+    stream = runner.run_plan(plan, con)
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match=f"distributed worker task submission failed for query_id={query_id}",
+        ) as exc_info:
+            list(stream)
+    finally:
+        runner.drop_query_fragments(query_id)
+        con.close()
+
+    assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
+    assert exc_info.value.__cause__.__traceback__ is not None
+    assert f"plan lookup sentinel for {query_id}" in str(exc_info.value.__cause__)
+    assert submission_calls == [1]
+
+
 @pytest.mark.parametrize("should_fail", [False, True], ids=["success", "failure"])
 def test_ray_backed_result_partition_concurrent_materialization(should_fail):
     script = textwrap.dedent(

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -96,6 +96,37 @@ def test_worker_task_plan_keeps_absent_plan_explicit():
     assert task.plan() is None
 
 
+def test_worker_task_plan_rejects_present_plan_without_root():
+    task = duckdb.ray_cxx._make_worker_task_for_test(True, "query-rootless-worker-plan")
+
+    with pytest.raises(
+        duckdb.InternalException,
+        match="RayWorkerTask::Plan received a present physical plan without a root",
+    ):
+        task.plan()
+
+
+@pytest.mark.parametrize(
+    ("execution_query_id", "resource_query_id", "expected"),
+    [
+        ("query-root", None, "query-root"),
+        ("query-root:orderby:sample", "query-root", "query-root"),
+    ],
+)
+def test_submission_error_is_owned_by_outer_resource_query(
+    execution_query_id,
+    resource_query_id,
+    expected,
+):
+    assert (
+        duckdb.ray_cxx._submission_error_owner_query_id_for_test(
+            execution_query_id,
+            resource_query_id,
+        )
+        == expected
+    )
+
+
 @pytest.mark.parametrize("manager_kind", ["python-backend", "ray-worker-manager"])
 def test_worker_submission_preserves_worker_plan_exception_cause(monkeypatch, manager_kind):
     import _duckdb

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pickle
+from typing import Any
+
+import pytest
+
+import duckdb
+from duckdb._ray_errors import RemoteRayException
+from duckdb.runners.ray import driver
+from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
+
+
+def _chained_error(label: str) -> RuntimeError:
+    try:
+        raise duckdb.NotImplementedException(f"{label} original")
+    except duckdb.NotImplementedException as cause:
+        try:
+            raise RuntimeError(f"{label} outer") from cause
+        except RuntimeError as outer:
+            return outer
+
+
+def _assert_restored_chain(exc: RuntimeError, label: str) -> None:
+    assert str(exc) == f"{label} outer"
+    assert isinstance(exc.__cause__, duckdb.NotImplementedException)
+    assert str(exc.__cause__) == f"{label} original"
+    assert exc.__cause__.remote_exception_type == "_duckdb.NotImplementedException"
+    assert f"NotImplementedException: {label} original" in exc.__cause__.remote_traceback
+
+
+def test_remote_ray_exception_pickle_round_trip_restores_cause_chain():
+    transported = RemoteRayException.from_exception(_chained_error("pickle"))
+
+    restored = pickle.loads(pickle.dumps(transported)).restore()
+
+    assert isinstance(restored, RuntimeError)
+    _assert_restored_chain(restored, "pickle")
+
+
+def test_safe_get_restores_serialized_ray_exception_chain():
+    class FakeRayTaskError(RuntimeError):
+        def __init__(self, cause: BaseException) -> None:
+            self.cause = cause
+            super().__init__(cause)
+
+    class FailedFuture:
+        def result(self, timeout=None):
+            raise FakeRayTaskError(RemoteRayException.from_exception(_chained_error("safe-get")))
+
+    class FailedRef:
+        def future(self):
+            return FailedFuture()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        resolve_object_refs_blocking(FailedRef())
+
+    _assert_restored_chain(exc_info.value, "safe-get")
+
+
+def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, monkeypatch):
+    import ray
+
+    @ray.remote
+    def fail_with_chain(label: str) -> None:
+        import duckdb as remote_duckdb
+        from duckdb._ray_errors import remote_ray_exception as build_remote_ray_exception
+
+        try:
+            raise remote_duckdb.NotImplementedException(f"{label} original")
+        except remote_duckdb.NotImplementedException as cause:
+            raise build_remote_ray_exception(f"{label} outer", cause) from cause
+
+    @ray.remote
+    def succeed(value: Any = None) -> Any:
+        return value
+
+    class SuccessMethod:
+        def __init__(self, value: Any = None) -> None:
+            self.value = value
+
+        def remote(self, *_args, **_kwargs):
+            return succeed.remote(self.value)
+
+    class FailureMethod:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def remote(self, *_args, **_kwargs):
+            return fail_with_chain.remote(self.label)
+
+    class Plan:
+        def idx(self) -> str:
+            return "remote-error-plan"
+
+    class Runner:
+        install_env_overrides = SuccessMethod()
+        close_plan = SuccessMethod()
+        progress_snapshot = SuccessMethod()
+
+        def __init__(self, failure_path: str) -> None:
+            self.run_plan = FailureMethod("preflight") if failure_path == "preflight" else SuccessMethod()
+            self.get_next_partition = FailureMethod("stream") if failure_path == "stream" else SuccessMethod(None)
+            self.run_copy_plan = FailureMethod("copy") if failure_path == "copy" else SuccessMethod()
+
+    monkeypatch.setattr(driver, "_collect_vane_env_overrides", dict)
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+
+    for failure_path in ("preflight", "stream", "copy"):
+        client = object.__new__(driver.RayQueryDriverClient)
+        client.runner = Runner(failure_path)
+        with pytest.raises(RuntimeError) as exc_info:
+            if failure_path == "copy":
+                client.run_copy_plan(Plan())
+            else:
+                list(client.stream_plan(Plan()))
+        _assert_restored_chain(exc_info.value, failure_path)

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 import duckdb
+import duckdb._ray_errors as ray_errors
 from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.ray import driver
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
@@ -41,6 +42,120 @@ def test_remote_ray_exception_pickle_round_trip_restores_cause_chain():
     _assert_restored_chain(restored, "pickle")
 
 
+@pytest.mark.parametrize(
+    ("original", "attributes"),
+    [
+        (KeyError("missing-key"), {}),
+        (
+            FileNotFoundError(2, "No such file", "/tmp/input.parquet"),
+            {"errno": 2, "filename": "/tmp/input.parquet"},
+        ),
+        (
+            ImportError("provider failed", name="provider", path="/tmp/provider.py"),
+            {"name": "provider", "path": "/tmp/provider.py"},
+        ),
+    ],
+)
+def test_remote_ray_exception_preserves_builtin_constructor_state(original, attributes):
+    transported = RemoteRayException.from_exception(original)
+
+    restored = pickle.loads(pickle.dumps(transported)).restore()
+
+    assert type(restored) is type(original)
+    assert restored.args == original.args
+    assert str(restored) == str(original)
+    for name, value in attributes.items():
+        assert getattr(restored, name) == value
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        object(),
+        list(range(2048)),
+        "x" * (65 * 1024),
+    ],
+    ids=["unsupported-type", "too-many-items", "too-many-bytes"],
+)
+def test_remote_ray_exception_rejects_unsafe_constructor_arguments(argument):
+    original = RuntimeError(argument)
+
+    with pytest.raises((TypeError, ValueError), match="remote exception constructor"):
+        RemoteRayException.from_exception(original)
+
+
+def test_remote_ray_exception_pickle_round_trip_restores_implicit_context():
+    try:
+        try:
+            raise KeyError("context")
+        except KeyError:
+            raise RuntimeError("outer")
+    except RuntimeError as original:
+        transported = RemoteRayException.from_exception(original)
+
+    restored = pickle.loads(pickle.dumps(transported)).restore()
+
+    assert isinstance(restored, RuntimeError)
+    assert restored.__cause__ is None
+    assert isinstance(restored.__context__, KeyError)
+    assert str(restored.__context__) == "'context'"
+    assert restored.__suppress_context__ is False
+
+
+def test_remote_ray_exception_type_resolution_failure_is_propagated(monkeypatch):
+    def fail_import(_module_name):
+        raise RuntimeError("provider import exploded")
+
+    monkeypatch.setattr(ray_errors.importlib, "import_module", fail_import)
+    transported = RemoteRayException(
+        "remote failure",
+        {
+            "module": "provider.module",
+            "qualname": "ProviderError",
+            "message": "remote failure",
+            "traceback": "",
+            "constructor": {"args": ("remote failure",), "state": None},
+            "cause": None,
+            "context": None,
+            "suppress_context": False,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="provider import exploded"):
+        transported.restore()
+
+
+def test_remote_ray_exception_rejects_old_payload_schema():
+    with pytest.raises(KeyError):
+        RemoteRayException(
+            "remote failure",
+            {
+                "module": "builtins",
+                "qualname": "RuntimeError",
+                "message": "remote failure",
+                "traceback": "",
+                "cause": None,
+            },
+        )
+
+
+def test_remote_ray_exception_rejects_cyclic_exception_chain():
+    payload = {
+        "module": "builtins",
+        "qualname": "RuntimeError",
+        "message": "cycle",
+        "traceback": "",
+        "constructor": {"args": ("cycle",), "state": None},
+        "cause": None,
+        "context": None,
+        "suppress_context": True,
+    }
+    payload["cause"] = payload
+
+    with pytest.raises(ValueError, match="remote exception chain contains a cycle"):
+        RemoteRayException("cycle", payload)
+
+
 def test_safe_get_restores_serialized_ray_exception_chain():
     class FakeRayTaskError(RuntimeError):
         def __init__(self, cause: BaseException) -> None:
@@ -59,6 +174,71 @@ def test_safe_get_restores_serialized_ray_exception_chain():
         resolve_object_refs_blocking(FailedRef())
 
     _assert_restored_chain(exc_info.value, "safe-get")
+
+
+def test_safe_get_preserves_restored_implicit_context():
+    try:
+        try:
+            raise KeyError("context")
+        except KeyError:
+            raise RuntimeError("outer")
+    except RuntimeError as original:
+        transported = RemoteRayException.from_exception(original)
+
+    class FakeRayTaskError(RuntimeError):
+        def __init__(self, cause: BaseException) -> None:
+            self.cause = cause
+            super().__init__(cause)
+
+    class FailedFuture:
+        def result(self, timeout=None):
+            raise FakeRayTaskError(transported)
+
+    class FailedRef:
+        def future(self):
+            return FailedFuture()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        resolve_object_refs_blocking(FailedRef())
+
+    assert exc_info.value.__cause__ is None
+    assert isinstance(exc_info.value.__context__, KeyError)
+    assert str(exc_info.value.__context__) == "'context'"
+
+
+def test_real_ray_preserves_implicit_context_and_constructor_state(ray_local):
+    import ray
+
+    @ray.remote
+    def fail_with_implicit_context():
+        from duckdb._ray_errors import RemoteRayException as RemoteCarrier
+
+        try:
+            try:
+                raise KeyError("context")
+            except KeyError:
+                raise RuntimeError("outer")
+        except RuntimeError as original:
+            transported = RemoteCarrier.from_exception(original)
+        raise transported
+
+    @ray.remote
+    def fail_with_structured_exception():
+        from duckdb._ray_errors import RemoteRayException as RemoteCarrier
+
+        original = FileNotFoundError(2, "No such file", "/tmp/input.parquet")
+        raise RemoteCarrier.from_exception(original)
+
+    with pytest.raises(RuntimeError) as context_info:
+        resolve_object_refs_blocking(fail_with_implicit_context.remote())
+    assert context_info.value.__cause__ is None
+    assert isinstance(context_info.value.__context__, KeyError)
+    assert str(context_info.value.__context__) == "'context'"
+
+    with pytest.raises(FileNotFoundError) as structured_info:
+        resolve_object_refs_blocking(fail_with_structured_exception.remote())
+    assert structured_info.value.errno == 2
+    assert structured_info.value.filename == "/tmp/input.parquet"
 
 
 def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, monkeypatch):

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -125,18 +125,37 @@ def test_remote_ray_exception_type_resolution_failure_is_propagated(monkeypatch)
         transported.restore()
 
 
+def test_remote_ray_exception_defers_local_cause_resolution_until_restore():
+    class LocalSubmissionError(RuntimeError):
+        pass
+
+    transported = ray_errors.remote_ray_exception(
+        "distributed submission failed",
+        LocalSubmissionError("worker-only failure"),
+    )
+
+    round_tripped = pickle.loads(pickle.dumps(transported))
+
+    assert str(round_tripped) == "distributed submission failed"
+    assert round_tripped.__cause__ is None
+    with pytest.raises(TypeError, match="remote exception type is not importable"):
+        round_tripped.restore()
+
+
 def test_remote_ray_exception_rejects_old_payload_schema():
+    transported = RemoteRayException(
+        "remote failure",
+        {
+            "module": "builtins",
+            "qualname": "RuntimeError",
+            "message": "remote failure",
+            "traceback": "",
+            "cause": None,
+        },
+    )
+
     with pytest.raises(KeyError):
-        RemoteRayException(
-            "remote failure",
-            {
-                "module": "builtins",
-                "qualname": "RuntimeError",
-                "message": "remote failure",
-                "traceback": "",
-                "cause": None,
-            },
-        )
+        transported.restore()
 
 
 def test_remote_ray_exception_rejects_cyclic_exception_chain():
@@ -151,9 +170,10 @@ def test_remote_ray_exception_rejects_cyclic_exception_chain():
         "suppress_context": True,
     }
     payload["cause"] = payload
+    transported = RemoteRayException("cycle", payload)
 
     with pytest.raises(ValueError, match="remote exception chain contains a cycle"):
-        RemoteRayException("cycle", payload)
+        transported.restore()
 
 
 def test_safe_get_restores_serialized_ray_exception_chain():


### PR DESCRIPTION
## Summary

- validate every native physical root during logical-to-physical conversion, before Driver query-resource registration, and chain the original serialization exception into a query-scoped preflight error
- retain Python submission exceptions across the background DuckDB status channel, encode their type, message, traceback, and cause chain in a pickle-safe carrier, and restore the chain after the Driver actor Ray RPC for streaming and COPY callers
- propagate worker-plan lookup and physical-plan pickle failures instead of converting them to `None` or an empty payload
- keep genuinely absent plans explicit and reject inconsistent or empty serialized-root states
- transfer the worker-plan capsule payload with RAII so capsule-construction failures cannot leak the copied `shared_ptr`
- cover real native preflight wiring, both worker-manager submission paths, an intentionally non-serializable operator, streaming and COPY cleanup, missing query IDs, absent plans, and the real Ray client boundary

## Related issue

close: #77

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" scripts/format root --changed`
- pre-commit on all changed implementation/test files: passed, including Ruff, clang-format, shfmt, and mypy
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- focused native streaming/COPY carrier regressions: 4 passed
- focused pickle, `safe_get`, and real-Ray client-boundary regressions: 3 passed
- affected Ray bindings, Driver registration, native FTE backend, safe-get lifecycle, and result-contract tests: 427 passed, 4 optional MinIO tests skipped, 6 deselected
- `PATH="$PWD/.venv/bin:$PATH" scripts/run_release_tests.sh`: 282 passed, 10 deselected; real-Ray shard 6 passed, 286 deselected

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data,
      model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
