### PR TITLE
[fix](tests) Align public runner contracts

### DIFF
--- a/tests/fast/test_expression_udf_map_batches.py
+++ b/tests/fast/test_expression_udf_map_batches.py
@@ -555,22 +555,35 @@ def test_vane_function_batch_row_preserving_batch_size_is_backend_independent():
 
     import vane
 
-    def record_batch_size(table):
-        return pa.table({"seen": [table.num_rows] * table.num_rows})
+    old_runner = os.environ.get("VANE_RUNNER")
+    con = None
+    try:
+        vane.configure(runner="local")
 
-    vane.configure(runner="local")
-    con = vane.connect()
-    relation = con.sql("SELECT i::INTEGER AS x FROM range(5000) t(i)")
-    expression = vane.func.batch(
-        record_batch_size,
-        inputs={"x": vane.col("x")},
-        schema={"seen": "BIGINT"},
-        batch_size=4096,
-        row_preserving=True,
-    )
+        def record_batch_size(table):
+            return pa.table({"seen": [table.num_rows] * table.num_rows})
 
-    result = relation.select(expression.alias("seen")).aggregate("seen, count(*) AS n").order("seen").fetchall()
-    assert result == [(904, 904), (4096, 4096)]
+        con = vane.connect()
+        relation = con.sql("SELECT i::INTEGER AS x FROM range(5000) t(i)")
+        expression = vane.func.batch(
+            record_batch_size,
+            inputs={"x": vane.col("x")},
+            schema={"seen": "BIGINT"},
+            batch_size=4096,
+            row_preserving=True,
+        )
+
+        result = relation.select(expression.alias("seen")).aggregate("seen, count(*) AS n").order("seen").fetchall()
+        assert result == [(904, 904), (4096, 4096)]
+    finally:
+        try:
+            if con is not None:
+                con.close()
+        finally:
+            if old_runner is None:
+                os.environ.pop("VANE_RUNNER", None)
+            else:
+                os.environ["VANE_RUNNER"] = old_runner
 
 
 def test_vane_function_batch_row_preserving_chain_promotes_ref_bundle_without_gpu():

--- a/tests/fast/test_expression_udf_map_batches.py
+++ b/tests/fast/test_expression_udf_map_batches.py
@@ -520,7 +520,7 @@ def test_vane_function_batch_streaming_output_is_sliced_before_grouped_aggregate
         def record_batch_size(table):
             return pa.table({"seen": [table.num_rows] * table.num_rows})
 
-        vane.configure(runner="local-fast")
+        vane.configure(runner="local")
         con = vane.connect()
         relation = con.sql("SELECT i::INTEGER AS x FROM range(5000) t(i)")
         expression = vane.func.batch(
@@ -558,7 +558,7 @@ def test_vane_function_batch_row_preserving_batch_size_is_backend_independent():
     def record_batch_size(table):
         return pa.table({"seen": [table.num_rows] * table.num_rows})
 
-    vane.configure(runner="local-fast")
+    vane.configure(runner="local")
     con = vane.connect()
     relation = con.sql("SELECT i::INTEGER AS x FROM range(5000) t(i)")
     expression = vane.func.batch(

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -47,13 +47,14 @@ assert runners.get_or_infer_runner_type() == "local"
 def test_get_or_create_runner_rejects_native_fte_env_in_subprocess():
     script = """
 import os
+import duckdb
 import duckdb.runners as runners
 
 os.environ["VANE_RUNNER"] = "native-fte"
 try:
     runners.get_or_create_runner()
-except RuntimeError as exc:
-    assert "Please use local-fast, local, or ray" in str(exc)
+except duckdb.InvalidInputException as exc:
+    assert "Please use 'local' or 'ray'" in str(exc)
 else:
     raise AssertionError("native-fte should no longer be a public runner")
 """


### PR DESCRIPTION
## Summary

- use the supported public `local` runner in the two batch-UDF integration tests
- assert the current `native-fte` rejection exception and public runner guidance
- keep internal `VANE_RUNNER=local-fast` coverage unchanged

Fixes #41

## Testing

- 4 focused runner-contract tests passed
- `scripts/run_release_tests.sh`: 272 non-Ray + 5 Ray tests passed
- pre-commit hooks passed