### PR TITLE
[fix](video) Reject invalid decode concurrency

### DIFF
--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -145,6 +145,19 @@ def _read_optional_positive_int_env(name: str) -> int | None:
     return result
 
 
+def _read_positive_int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        result = int(value)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer >= 1, got {value!r}") from None
+    if result < 1:
+        raise ValueError(f"{name} must be an integer >= 1, got {value!r}")
+    return result
+
+
 _VIDEO_READER_TIMING_LOG = _read_bool_env(
     "VANE_VIDEO_READER_TIMING_LOG",
     _read_bool_env("VIDEO_READER_TIMING_LOG", _read_bool_env("VIDEO_UDF_TIMING_LOG", False)),
@@ -226,7 +239,7 @@ def _emit_reader_timing(
 
 
 # Limit concurrent video decodes within a single process.
-_MAX_CONCURRENT_DECODES = int(os.environ.get("VANE_MAX_CONCURRENT_DECODES", "1"))
+_MAX_CONCURRENT_DECODES = _read_positive_int_env("VANE_MAX_CONCURRENT_DECODES", 1)
 _decode_semaphore = threading.Semaphore(_MAX_CONCURRENT_DECODES)
 
 # Memory-based backpressure: block NEW decode tasks (not mid-decode!) when

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 import io
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -442,6 +445,43 @@ def test_video_s3_reader_uses_anonymous_mode_only_when_explicit(monkeypatch, rec
     _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {"anonymous": True}
+
+
+@pytest.mark.parametrize(("configured", "expected"), [(None, 1), ("1", 1), ("4", 4)])
+def test_max_concurrent_decodes_accepts_positive_integers(configured, expected):
+    env = os.environ.copy()
+    if configured is None:
+        env.pop("VANE_MAX_CONCURRENT_DECODES", None)
+    else:
+        env["VANE_MAX_CONCURRENT_DECODES"] = configured
+    script = f"""
+import duckdb.datasource.video_reader as video_reader
+
+assert video_reader._MAX_CONCURRENT_DECODES == {expected}
+for _ in range({expected}):
+    assert video_reader._decode_semaphore.acquire(blocking=False)
+assert not video_reader._decode_semaphore.acquire(blocking=False)
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True, env=env, timeout=10)
+
+
+@pytest.mark.parametrize("configured", ["0", "-1", "invalid", "", "   "])
+def test_max_concurrent_decodes_rejects_invalid_values(configured):
+    env = os.environ.copy()
+    env["VANE_MAX_CONCURRENT_DECODES"] = configured
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import duckdb.datasource.video_reader"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert result.returncode != 0
+    assert "VANE_MAX_CONCURRENT_DECODES must be an integer >= 1" in result.stderr
 
 
 def test_video_frame_source_uses_one_ordered_task_for_frame_limit():


### PR DESCRIPTION
## Summary

- validate `VANE_MAX_CONCURRENT_DECODES` before constructing the process-level semaphore
- reject zero, negative, empty, and non-integer values with the variable name and accepted range in the error
- cover default and positive values plus invalid import-time configurations in isolated subprocesses

Fixes #68.

## Validation

- `pre-commit run --files duckdb/datasource/video_reader.py tests/fast/test_video_reader.py` (all hooks passed, including mypy and Ruff format/check)
- `python -m pytest tests/fast/test_video_reader.py` (68 passed)
- `env -u http_proxy -u https_proxy scripts/run_release_tests.sh` (414 passed, 1 skipped in the non-Ray shard; 7 passed in the real-Ray shard)
- `git diff --check origin/main...HEAD`

## Notes

Rebased onto `origin/main` at `e583c7e5`. The updated main branch pins the mypy hook to `numpy<2.4` and uses dynamic imports for optional video dependencies, so the previous PIL/psutil/decord and NumPy-stub lint failures are resolved.