### PR TITLE
[fix](ray) Prevent result stream GIL deadlock

### DIFF
--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1928,7 +1928,6 @@ struct PyPhysicalPlanWrapperRunner {
 					return physical_plan.Make<duckdb::PhysicalMaterializedCollector>(data, true);
 				};
 
-				DuckdbGilReleaseMarker gil_marker;
 				py::gil_scoped_release release;
 				auto pending = context.PendingQueryPreparedStatementNoRebind(string("external_plan:") + plan_id,
 				                                                             prepared_data, parameters);
@@ -2234,7 +2233,6 @@ struct PyPhysicalPlanWrapperRunner {
 					native_progress_callback_failed = true;
 				}
 			};
-			DuckdbGilReleaseMarker gil_marker;
 			py::gil_scoped_release release;
 
 			duckdb::PendingExecutionResult exec_result = duckdb::PendingExecutionResult::RESULT_NOT_READY;

--- a/src/duckdb_py/ray/native_fragment_executor.cpp
+++ b/src/duckdb_py/ray/native_fragment_executor.cpp
@@ -980,17 +980,6 @@ static py::dict BuildFragmentStatsSummary(
 }
 
 namespace {
-thread_local bool g_duckdb_py_gil_released = false;
-
-struct DuckdbGilReleaseMarker {
-	DuckdbGilReleaseMarker() {
-		g_duckdb_py_gil_released = true;
-	}
-	~DuckdbGilReleaseMarker() {
-		g_duckdb_py_gil_released = false;
-	}
-};
-
 struct CopyOutputInfo {
 	std::string base;        // staging_root_base (empty for direct-write COPY)
 	std::string run_id;      // staging_run_id (UUID)

--- a/src/duckdb_py/ray/result_stream_bindings.cpp
+++ b/src/duckdb_py/ray/result_stream_bindings.cpp
@@ -21,14 +21,14 @@ struct ResultPartitionStream {
 			throw py::stop_iteration();
 		}
 
-		// Lock stream while polling
-		lock_guard<mutex> guard(stream_mutex_);
-
-		// Release GIL while we block on C++ stream
-		DuckdbGilReleaseMarker gil_marker;
-		py::gil_scoped_release release;
-		auto opt = stream_->next();
-		PythonGILWrapper acquire;
+		std::pair<bool, duckdb::distributed::ResultPartitionRef> opt;
+		{
+			// Release the GIL before contending on the stream mutex. The mutex
+			// must also be released before Python conversion restores the GIL.
+			py::gil_scoped_release release;
+			lock_guard<mutex> guard(stream_mutex_);
+			opt = stream_->next();
+		}
 		if (!opt.first) {
 			throw py::stop_iteration();
 		}


### PR DESCRIPTION
## Summary

- Release the Python GIL before acquiring the result stream mutex, enforcing a consistent GIL-before-mutex lock order.
- Keep the stream mutex limited to `stream_->next()` and release it before converting result partitions back into Python objects.
- Remove the unused `DuckdbGilReleaseMarker` instrumentation.

## Related issue

Closes #58

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This change only corrects internal Ray result-stream synchronization and test infrastructure. Public APIs and configuration remain unchanged.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This change only corrects internal Ray result-stream synchronization and test infrastructure. Public APIs and configuration remain unchanged.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" scripts/format root --changed`
- Incremental Release native build with `VANE_BUILD_TEST_BINDINGS=ON`
- Focused two-consumer GIL regression test: 1 passed
- `tests/fast/test_ray_cpp_bindings.py`: 74 passed, 4 deselected
- `scripts/run_release_tests.sh`: 269 base tests passed and 5 real-Ray tests passed
- Built and validated the sdist; the test-only native source was included
- Commit-time workflow YAML, TOML, Ruff, clang-format, and CMake format checks passed
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.
