### PR TITLE
[chore](ci) Gate PRs on CPU fast tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
             process_timeout: 900
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      VANE_FAST_TEST_ARTIFACT_MODE: "1"
       VANE_FAST_TEST_EXCLUDE_GPU: "1"
       VANE_FAST_TEST_JUNIT_DIR: ${{ github.workspace }}/test-results
       VANE_FAST_TEST_NON_RAY_SHARD_COUNT: ${{ matrix.shard_count }}
@@ -258,19 +259,27 @@ jobs:
 
       - name: Verify the artifact-installed CPU environment
         run: |
-          python - <<'PY'
+          site_packages="$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+          PYTHONSAFEPATH=1 PYTHONPATH="$site_packages:$GITHUB_WORKSPACE" python - <<'PY'
           import importlib.metadata
           import pathlib
           import sys
 
           import _duckdb
+          import duckdb
           import torch
+          import vane
 
           distribution = importlib.metadata.distribution("vane-ai")
           extension_path = pathlib.Path(_duckdb.__file__).resolve()
           environment_root = pathlib.Path(sys.prefix).resolve()
           if not extension_path.is_relative_to(environment_root):
               raise RuntimeError(f"_duckdb was not installed from the wheel: {extension_path}")
+          for package in (duckdb, vane):
+              package_path = pathlib.Path(package.__file__).resolve()
+              if not package_path.is_relative_to(environment_root):
+                  raise RuntimeError(f"{package.__name__} was not imported from the wheel: {package_path}")
+              print(f"{package.__name__} package: {package_path}")
           if torch.version.cuda is not None or torch.cuda.is_available():
               raise RuntimeError("fast-test jobs must use the CPU-only PyTorch build")
           print(f"installed {distribution.metadata['Name']} {distribution.version}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,10 +294,13 @@ jobs:
           if [[ "$FAST_TEST_PHASE" != "non-ray" ]]; then
             # A public ubuntu-24.04 runner has 16 GiB RAM and no GPU. Keep the
             # Ray test topology below that physical limit while retaining the
-            # 2 GiB object store required by representative FTE plans.
+            # 2 GiB object store required by representative FTE plans. The
+            # tiny UDF fixtures keep multiple actor pools resident, so they do
+            # not need the production profile's 4 GiB heap per actor.
             export VANE_TEST_RAY_OBJECT_STORE_BYTES=2147483648
             export VANE_FTE_TASK_HEAP_BYTES=1073741824
             export VANE_UDF_TASK_HEAP_BYTES=1073741824
+            export VANE_UDF_ACTOR_HEAP_BYTES=536870912
           fi
           scripts/run_fast_tests.sh "$FAST_TEST_PHASE"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Install the wheel and CPU test dependencies
         run: |
           python -m pip install --upgrade pip uv
-          uv pip install --system --group test dist/*.whl
+          uv pip install --system --group build --group test dist/*.whl
           uv pip check
 
       - name: Verify the artifact-installed CPU environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,11 @@ jobs:
             export VANE_UDF_TASK_HEAP_BYTES=1073741824
             export VANE_UDF_ACTOR_HEAP_BYTES=536870912
           fi
+          if [[ "$FAST_TEST_PHASE" == "owner-ray" ]]; then
+            # This runner is dedicated to one shard, so Ray daemon cleanup can
+            # happen outside pytest without risking an unrelated local cluster.
+            export VANE_FAST_TEST_EXTERNAL_RAY_CLEANUP=1
+          fi
           scripts/run_fast_tests.sh "$FAST_TEST_PHASE"
 
       - name: Stop residual Ray processes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +179,11 @@ jobs:
           env -u VANE_RUNNER python "$GITHUB_WORKSPACE/scripts/verify_base_install.py"
 
       - name: Run the base-installation release tests
-        run: scripts/run_release_tests.sh
+        # This normally takes under a minute. Bound a stuck pytest/Ray teardown
+        # and signal its whole process group so it cannot block the fast-test
+        # jobs that consume the Python 3.12 artifact.
+        timeout-minutes: 12
+        run: timeout --signal=INT --kill-after=30s 600s scripts/run_release_tests.sh
 
       - name: Upload validated artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             ':(exclude,glob).github/ISSUE_TEMPLATE/**' \
             ':(exclude,glob).github/PULL_REQUEST_TEMPLATE/**'; then
             run_full=false
-            echo "Only Markdown or static GitHub templates changed; skipping package and native CI."
+            echo "Only Markdown or static GitHub templates changed; skipping package, native, and fast-test CI."
           else
             run_full=true
             echo "A product, build, dependency, or automation file changed; running full CI."
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     env:
       VCPKG_ROOT: ${{ github.workspace }}/.cache/vcpkg
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/.cache/vcpkg-archives
@@ -187,6 +187,136 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  fast-tests:
+    name: Fast tests (${{ matrix.label }})
+    needs:
+      - changes
+      - native-fast-tests
+    if: needs.changes.outputs.run_full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: non-Ray 1/2
+            phase: non-ray
+            shard_index: 0
+            shard_count: 2
+            process_timeout: 1800
+          - label: non-Ray 2/2
+            phase: non-ray
+            shard_index: 1
+            shard_count: 2
+            process_timeout: 1800
+          - label: shared Ray
+            phase: shared-ray
+            shard_index: 0
+            shard_count: 1
+            process_timeout: 1800
+          - label: isolated Ray owners
+            phase: owner-ray
+            shard_index: 0
+            shard_count: 1
+            process_timeout: 900
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      VANE_FAST_TEST_EXCLUDE_GPU: "1"
+      VANE_FAST_TEST_JUNIT_DIR: ${{ github.workspace }}/test-results
+      VANE_FAST_TEST_NON_RAY_SHARD_COUNT: ${{ matrix.shard_count }}
+      VANE_FAST_TEST_NON_RAY_SHARD_INDEX: ${{ matrix.shard_index }}
+      VANE_FAST_TEST_PROCESS_TIMEOUT_SECONDS: ${{ matrix.process_timeout }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download the built wheel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ci-python-artifacts-3.12
+          path: dist
+
+      - name: Restore the uv package cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/uv
+          key: fast-tests-uv-v1-${{ runner.os }}-${{ runner.arch }}-py312-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install the wheel and CPU test dependencies
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system --group test dist/*.whl
+          uv pip check
+
+      - name: Verify the artifact-installed CPU environment
+        run: |
+          python - <<'PY'
+          import importlib.metadata
+          import pathlib
+          import sys
+
+          import _duckdb
+          import torch
+
+          distribution = importlib.metadata.distribution("vane-ai")
+          extension_path = pathlib.Path(_duckdb.__file__).resolve()
+          environment_root = pathlib.Path(sys.prefix).resolve()
+          if not extension_path.is_relative_to(environment_root):
+              raise RuntimeError(f"_duckdb was not installed from the wheel: {extension_path}")
+          if torch.version.cuda is not None or torch.cuda.is_available():
+              raise RuntimeError("fast-test jobs must use the CPU-only PyTorch build")
+          print(f"installed {distribution.metadata['Name']} {distribution.version}")
+          print(f"native extension: {extension_path}")
+          print(f"PyTorch {torch.__version__}; CUDA unavailable as expected")
+          PY
+
+      - name: Run ${{ matrix.label }} fast-test shard
+        env:
+          FAST_TEST_PHASE: ${{ matrix.phase }}
+        run: |
+          if [[ "$FAST_TEST_PHASE" != "non-ray" ]]; then
+            # A public ubuntu-24.04 runner has 16 GiB RAM and no GPU. Keep the
+            # Ray test topology below that physical limit while retaining the
+            # 2 GiB object store required by representative FTE plans.
+            export VANE_TEST_RAY_OBJECT_STORE_BYTES=2147483648
+            export VANE_FTE_TASK_HEAP_BYTES=1073741824
+            export VANE_UDF_TASK_HEAP_BYTES=1073741824
+          fi
+          scripts/run_fast_tests.sh "$FAST_TEST_PHASE"
+
+      - name: Stop residual Ray processes
+        if: ${{ always() && matrix.phase != 'non-ray' }}
+        continue-on-error: true
+        run: timeout --signal=TERM --kill-after=10s 30s ray stop --force
+
+      - name: Publish the JUnit summary
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          FAST_TEST_LABEL: ${{ matrix.label }}
+        run: |
+          python scripts/summarize_junit.py \
+            --label "$FAST_TEST_LABEL" \
+            "$VANE_FAST_TEST_JUNIT_DIR" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JUnit reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fast-test-results-${{ matrix.phase }}-${{ matrix.shard_index }}
+          path: test-results/*.xml
+          if-no-files-found: warn
+          retention-days: 14
+
   # Keep this as the stable branch-protection check; matrix jobs may be skipped.
   required-ci:
     name: Required CI
@@ -195,11 +325,13 @@ jobs:
       - changes
       - source-package
       - native-fast-tests
+      - fast-tests
     runs-on: ubuntu-24.04
     steps:
       - name: Verify CI results
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
+          FAST_TESTS_RESULT: ${{ needs.fast-tests.result }}
           RUN_FULL: ${{ needs.changes.outputs.run_full }}
           SOURCE_PACKAGE_RESULT: ${{ needs.source-package.result }}
           NATIVE_TESTS_RESULT: ${{ needs.native-fast-tests.result }}
@@ -223,8 +355,9 @@ jobs:
           esac
 
           if [[ "$SOURCE_PACKAGE_RESULT" != "$expected_result" ||
-                "$NATIVE_TESTS_RESULT" != "$expected_result" ]]; then
-            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT" >&2
+                "$NATIVE_TESTS_RESULT" != "$expected_result" ||
+                "$FAST_TESTS_RESULT" != "$expected_result" ]]; then
+            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT" >&2
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,4 +55,5 @@ clusters in separate pytest processes. Do not replace it with one long-lived
 The fast/release Ray shards use a 2 GiB object store by default. Override the
 test-only profile with `VANE_TEST_RAY_OBJECT_STORE_BYTES`; it does not configure
 production clusters. Tests that call `ray.init()` directly must be marked
-`real_ray` and `ray_cluster_owner`.
+`real_ray` and `ray_cluster_owner`. Tests that require CUDA hardware must also
+be marked `gpu`; the standard CPU-only CI fast-test shards exclude that marker.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -90,8 +90,15 @@ clusters use a 2 GiB object store by default;
 not configure production clusters. Tests that call `ray.init()` directly must
 be marked `real_ray` and `ray_cluster_owner`.
 
-Tests that require an externally provisioned service are excluded by default. Run them explicitly when the required
-service and credentials are available:
+CI further splits the non-Ray phase across CPU-only jobs. The jobs install the
+built wheel, use CPU-only PyTorch, cap Ray task heap requests at 1 GiB, and set
+hard pytest-process and job deadlines so the suite fits a standard 4-vCPU,
+16-GiB GitHub-hosted runner. Tests marked `gpu` are excluded there because
+standard runners do not provide CUDA hardware; run the default launcher on a
+GPU host to include them.
+
+Tests that require an externally provisioned service are excluded by default.
+Run them explicitly when the required service and credentials are available:
 
 ```bash
 python -m pytest -m external_service tests/fast

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -35,9 +35,13 @@ class TaskLeaseObjectRefGenerator:
         ray_module: Any | None = None,
     ) -> None:
         if ray_module is None:
-            import ray as ray_module
+            import ray as imported_ray
+
+            active_ray_module = imported_ray
+        else:
+            active_ray_module = ray_module
         try:
-            validate_ray_stream_contract(ray_module)
+            validate_ray_stream_contract(active_ray_module)
         except BaseException:
             admission.release()
             raise
@@ -46,7 +50,7 @@ class TaskLeaseObjectRefGenerator:
         if not request_id or not str(lease.get("lease_id") or ""):
             admission.release()
             raise ValueError("pregranted Ray UDF task admission is missing identity")
-        self._ray = ray_module
+        self._ray = active_ray_module
         self._driver = admission.driver
         self._request_id = request_id
         self._generator: Any | None = None
@@ -119,6 +123,20 @@ class TaskLeaseObjectRefGenerator:
             submitted=bool(submitted),
         )
 
+    def retire_failed(self) -> None:
+        """Retire a terminally failed task without cancelling completed work."""
+        with self._lock:
+            if self._cancelled:
+                return
+            self._cancelled = True
+            submitted = self._submitted
+            self._released = True
+            self._generator = None
+        self._driver.cancel_query_task_lease_request.remote(
+            self._request_id,
+            submitted=bool(submitted),
+        )
+
     def retire_local_state(self) -> None:
         """Drop client-side task payload ownership after terminal cleanup."""
         with self._lock:
@@ -131,10 +149,14 @@ class RayStreamAdapter:
 
     def __init__(self, source: Any, *, ray_module: Any | None = None) -> None:
         if ray_module is None:
-            import ray as ray_module
+            import ray as imported_ray
 
-        validate_ray_stream_contract(ray_module)
-        self._ray = ray_module
+            active_ray_module = imported_ray
+        else:
+            active_ray_module = ray_module
+
+        validate_ray_stream_contract(active_ray_module)
+        self._ray = active_ray_module
         self._source = source
         self._leased = source if isinstance(source, TaskLeaseObjectRefGenerator) else None
         self._generator = self._leased.generator if self._leased is not None else source
@@ -267,6 +289,30 @@ class RayStreamAdapter:
             leased.retire_local_state()
         elif generator is not None:
             self._ray.cancel(generator, force=True, recursive=True)
+        if generator is not None and completion_ref is not None:
+            self._delete_object_ref_stream(generator, completion_ref)
+
+    def retire_failed(self) -> None:
+        """Retire a terminal failure without racing it with ``ray.cancel``.
+
+        Once Ray has published task completion, or a Vane stream has emitted
+        its terminal error pair, force-cancelling the generator can race the
+        normal task reply in Ray's CoreWorker.  The task lease still follows
+        the failure path, but the already-ending remote work is left alone.
+        """
+        if self._retired:
+            return
+        self._retired = True
+        leased = self._leased
+        generator = self._generator
+        completion_ref = self._completion_ref
+        self._source = None
+        self._leased = None
+        self._generator = None
+        self._completion_ref = None
+        if leased is not None:
+            leased.retire_failed()
+            leased.retire_local_state()
         if generator is not None and completion_ref is not None:
             self._delete_object_ref_stream(generator, completion_ref)
 

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -104,6 +104,7 @@ class _StreamRecord:
     wait_kind: str = ""
     wait_future: Any | None = None
     completion_future: Any | None = None
+    terminal_signal_observed: bool = False
 
 
 class AsyncResultCollector:
@@ -536,6 +537,9 @@ class AsyncResultCollector:
                 record.adapter.mark_drained()
             self._maybe_complete_record(record)
         except BaseException as exc:
+            # A failed completion ObjectRef means Ray has already made the task
+            # terminal.  Force-cancelling that task can race its normal reply.
+            record.terminal_signal_observed = True
             with self._cv:
                 shutting_down = self._shutdown
             if not shutting_down:
@@ -584,6 +588,8 @@ class AsyncResultCollector:
             except BaseException as exc:
                 self._fail_record(record, exc)
         except BaseException as exc:
+            if kind == "terminal":
+                record.terminal_signal_observed = True
             with self._cv:
                 shutting_down = self._shutdown
             if not shutting_down:
@@ -613,6 +619,7 @@ class AsyncResultCollector:
         record.metadata_ref = next_ref
 
     def _finish_stream(self, record: _StreamRecord) -> None:
+        record.terminal_signal_observed = True
         if record.phase == "metadata" and record.block_ref is not None:
             raise RuntimeError(
                 "Ray UDF generator terminated after a block without its metadata; "
@@ -628,6 +635,10 @@ class AsyncResultCollector:
         if isinstance(metadata, dict) and metadata.get("event_kind") == "error":
             remote_error = validate_stream_error_metadata(metadata)
             self._validate_task_identity(record, remote_error)
+            # Error pairs are the final two objects emitted by the task.  The
+            # generator is already returning, even if Ray's completion reply
+            # has not reached this worker yet.
+            record.terminal_signal_observed = True
             raise RuntimeError(
                 f"remote Ray UDF failed: {remote_error['exception_type']}: {remote_error['exception_message']}"
             )
@@ -811,7 +822,10 @@ class AsyncResultCollector:
         # slow or the failed generator is being reconstructed.
         self._notify_wakeup()
         self._cancel_record_control(record)
-        record.adapter.cancel()
+        if record.terminal_signal_observed:
+            record.adapter.retire_failed()
+        else:
+            record.adapter.cancel()
         for token in dropped_tokens:
             token.driver.release_query_output_block_lease.remote(
                 token.request_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,6 +389,7 @@ test = [ # dependencies used for running tests
     "gcovr",
     "gcsfs; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "packaging",
+    "pillow",
     "polars",
     "psutil",
     "py4j",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -463,6 +463,7 @@ testpaths = ["tests"]
 pythonpath = ["tests", "tests/fast"]
 markers = [
     "external_service: tests that require an externally provisioned service",
+    "gpu: tests that require CUDA-capable GPU hardware",
     "real_ray: tests that connect to or own a real Ray runtime",
     "ray_cluster_owner: tests that must own a Ray cluster in an isolated pytest process",
     "ray_fault: tests that intentionally kill or restart Ray runtime components",

--- a/scripts/run_fast_tests.sh
+++ b/scripts/run_fast_tests.sh
@@ -11,6 +11,8 @@ Usage: scripts/run_fast_tests.sh [all|non-ray|shared-ray|owner-ray]
 Run the complete fast suite or one process-isolated phase.
 
 Environment variables:
+  VANE_FAST_TEST_ARTIFACT_MODE
+      Set to 1 to test installed packages while retaining checkout support modules.
   VANE_FAST_TEST_EXCLUDE_GPU
       Set to 1 to exclude tests marked gpu on CPU-only hosts.
   VANE_FAST_TEST_JUNIT_DIR
@@ -44,6 +46,22 @@ esac
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$project_root"
+
+artifact_mode="${VANE_FAST_TEST_ARTIFACT_MODE:-0}"
+pytest_mode_args=()
+case "$artifact_mode" in
+  0) ;;
+  1)
+    site_packages="$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+    export PYTHONSAFEPATH=1
+    export PYTHONPATH="${site_packages}:${project_root}${PYTHONPATH:+:${PYTHONPATH}}"
+    pytest_mode_args+=("--import-mode=importlib")
+    ;;
+  *)
+    printf 'VANE_FAST_TEST_ARTIFACT_MODE must be 0 or 1: %s\n' "$artifact_mode" >&2
+    exit 2
+    ;;
+esac
 
 exclude_gpu="${VANE_FAST_TEST_EXCLUDE_GPU:-0}"
 case "$exclude_gpu" in
@@ -92,13 +110,12 @@ ray_object_store_bytes="$(
 run_pytest() {
   if ((process_timeout_seconds > 0)); then
     timeout \
-      --foreground \
       --signal=INT \
       --kill-after=30s \
       "${process_timeout_seconds}s" \
-      python -m pytest "$@"
+      python -m pytest "${pytest_mode_args[@]}" "$@"
   else
-    python -m pytest "$@"
+    python -m pytest "${pytest_mode_args[@]}" "$@"
   fi
 }
 
@@ -151,6 +168,7 @@ run_non_ray_tests() {
     printf '%s\n' "No non-Ray fast tests were collected" >&2
     return 1
   fi
+  local nodeids=()
   mapfile -t nodeids <<<"$collection"
 
   local selected_nodeids=()
@@ -158,6 +176,11 @@ run_non_ray_tests() {
   for ((position = non_ray_shard_index; position < ${#nodeids[@]}; position += non_ray_shard_count)); do
     selected_nodeids+=("${nodeids[position]}")
   done
+  if ((${#selected_nodeids[@]} == 0)); then
+    printf 'Non-Ray shard %d of %d selected no tests; reduce the shard count\n' \
+      "$((non_ray_shard_index + 1))" "$non_ray_shard_count" >&2
+    return 1
+  fi
 
   local report_name
   printf -v report_name \
@@ -185,6 +208,7 @@ run_owner_ray_tests() {
     printf '%s\n' "No real-Ray cluster-owner tests were collected" >&2
     return 1
   fi
+  local owner_nodeids=()
   mapfile -t owner_nodeids <<<"$collection"
 
   local owner_status=0

--- a/scripts/run_fast_tests.sh
+++ b/scripts/run_fast_tests.sh
@@ -15,6 +15,8 @@ Environment variables:
       Set to 1 to test installed packages while retaining checkout support modules.
   VANE_FAST_TEST_EXCLUDE_GPU
       Set to 1 to exclude tests marked gpu on CPU-only hosts.
+  VANE_FAST_TEST_EXTERNAL_RAY_CLEANUP
+      Set to 1 on an isolated host to stop Ray between owner-test processes.
   VANE_FAST_TEST_JUNIT_DIR
       Write one or more JUnit XML reports to this directory.
   VANE_FAST_TEST_NON_RAY_SHARD_COUNT
@@ -69,6 +71,16 @@ case "$exclude_gpu" in
   1) gpu_marker=" and not gpu" ;;
   *)
     printf 'VANE_FAST_TEST_EXCLUDE_GPU must be 0 or 1: %s\n' "$exclude_gpu" >&2
+    exit 2
+    ;;
+esac
+
+external_ray_cleanup="${VANE_FAST_TEST_EXTERNAL_RAY_CLEANUP:-0}"
+case "$external_ray_cleanup" in
+  0 | 1) ;;
+  *)
+    printf 'VANE_FAST_TEST_EXTERNAL_RAY_CLEANUP must be 0 or 1: %s\n' \
+      "$external_ray_cleanup" >&2
     exit 2
     ;;
 esac
@@ -133,6 +145,35 @@ run_reported_pytest() {
 run_ray_pytest() {
   VANE_TEST_RAY_OBJECT_STORE_BYTES="${ray_object_store_bytes}" \
     run_reported_pytest "$@"
+}
+
+run_owner_ray_pytest() {
+  if ((external_ray_cleanup)); then
+    VANE_TEST_EXTERNAL_RAY_CLUSTER_CLEANUP=1 run_ray_pytest "$@"
+  else
+    run_ray_pytest "$@"
+  fi
+}
+
+stop_owner_ray_processes() {
+  local cleanup_command=(ray stop --force)
+  local cleanup_output
+  if command -v timeout >/dev/null 2>&1; then
+    cleanup_command=(
+      timeout
+      --signal=TERM
+      --kill-after=10s
+      30s
+      "${cleanup_command[@]}"
+    )
+  fi
+  if cleanup_output="$("${cleanup_command[@]}" 2>&1)"; then
+    return 0
+  else
+    local cleanup_status=$?
+    printf '%s\n' "$cleanup_output" >&2
+    return "$cleanup_status"
+  fi
 }
 
 collect_nodeids() {
@@ -218,11 +259,17 @@ run_owner_ray_tests() {
     owner_index=$((owner_index + 1))
     local report_name
     printf -v report_name 'owner-ray-%02d' "$owner_index"
-    if ! run_ray_pytest \
+    if ! run_owner_ray_pytest \
       "$report_name" \
       -m "$marker" \
       "$nodeid"; then
       owner_status=1
+    fi
+    if ((external_ray_cleanup)); then
+      if ! stop_owner_ray_processes; then
+        printf 'Ray cleanup failed after owner test %s\n' "$nodeid" >&2
+        owner_status=1
+      fi
     fi
   done
   return "$owner_status"

--- a/scripts/run_fast_tests.sh
+++ b/scripts/run_fast_tests.sh
@@ -4,54 +4,220 @@
 
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/run_fast_tests.sh [all|non-ray|shared-ray|owner-ray]
+
+Run the complete fast suite or one process-isolated phase.
+
+Environment variables:
+  VANE_FAST_TEST_EXCLUDE_GPU
+      Set to 1 to exclude tests marked gpu on CPU-only hosts.
+  VANE_FAST_TEST_JUNIT_DIR
+      Write one or more JUnit XML reports to this directory.
+  VANE_FAST_TEST_NON_RAY_SHARD_COUNT
+      Split the non-Ray phase into this many deterministic shards.
+  VANE_FAST_TEST_NON_RAY_SHARD_INDEX
+      Zero-based non-Ray shard index.
+  VANE_FAST_TEST_PROCESS_TIMEOUT_SECONDS
+      Apply a hard deadline to every pytest process (requires GNU timeout).
+EOF
+}
+
+phase="${1:-all}"
+if (($# > 1)); then
+  usage >&2
+  exit 2
+fi
+case "$phase" in
+  all | non-ray | shared-ray | owner-ray) ;;
+  -h | --help)
+    usage
+    exit
+    ;;
+  *)
+    printf 'Unknown fast-test phase: %s\n' "$phase" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_root"
+
+exclude_gpu="${VANE_FAST_TEST_EXCLUDE_GPU:-0}"
+case "$exclude_gpu" in
+  0) gpu_marker="" ;;
+  1) gpu_marker=" and not gpu" ;;
+  *)
+    printf 'VANE_FAST_TEST_EXCLUDE_GPU must be 0 or 1: %s\n' "$exclude_gpu" >&2
+    exit 2
+    ;;
+esac
+
+non_ray_shard_count="${VANE_FAST_TEST_NON_RAY_SHARD_COUNT:-1}"
+non_ray_shard_index="${VANE_FAST_TEST_NON_RAY_SHARD_INDEX:-0}"
+if [[ ! "$non_ray_shard_count" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'VANE_FAST_TEST_NON_RAY_SHARD_COUNT must be a positive integer: %s\n' "$non_ray_shard_count" >&2
+  exit 2
+fi
+if [[ ! "$non_ray_shard_index" =~ ^[0-9]+$ ]] || ((non_ray_shard_index >= non_ray_shard_count)); then
+  printf 'VANE_FAST_TEST_NON_RAY_SHARD_INDEX must be in [0, %d): %s\n' \
+    "$non_ray_shard_count" "$non_ray_shard_index" >&2
+  exit 2
+fi
+
+process_timeout_seconds="${VANE_FAST_TEST_PROCESS_TIMEOUT_SECONDS:-0}"
+if [[ ! "$process_timeout_seconds" =~ ^[0-9]+$ ]]; then
+  printf 'VANE_FAST_TEST_PROCESS_TIMEOUT_SECONDS must be a non-negative integer: %s\n' \
+    "$process_timeout_seconds" >&2
+  exit 2
+fi
+if ((process_timeout_seconds > 0)) && ! command -v timeout >/dev/null 2>&1; then
+  printf '%s\n' "VANE_FAST_TEST_PROCESS_TIMEOUT_SECONDS requires the GNU timeout command" >&2
+  exit 2
+fi
+
+junit_dir="${VANE_FAST_TEST_JUNIT_DIR:-}"
+if [[ -n "$junit_dir" ]]; then
+  mkdir -p "$junit_dir"
+  junit_dir="$(cd "$junit_dir" && pwd)"
+fi
+
 ray_object_store_bytes="$(
   PYTHONPATH="tests${PYTHONPATH:+:${PYTHONPATH}}" \
     python -c "from ray_test_profile import ray_test_object_store_bytes; print(ray_test_object_store_bytes())"
 )"
 
+run_pytest() {
+  if ((process_timeout_seconds > 0)); then
+    timeout \
+      --foreground \
+      --signal=INT \
+      --kill-after=30s \
+      "${process_timeout_seconds}s" \
+      python -m pytest "$@"
+  else
+    python -m pytest "$@"
+  fi
+}
+
+run_reported_pytest() {
+  local report_name="$1"
+  shift
+
+  local report_args=()
+  if [[ -n "$junit_dir" ]]; then
+    report_args+=("--junitxml=$junit_dir/$report_name.xml")
+  fi
+  run_pytest "${report_args[@]}" "$@"
+}
+
 run_ray_pytest() {
   VANE_TEST_RAY_OBJECT_STORE_BYTES="${ray_object_store_bytes}" \
-    python -m pytest "$@"
+    run_reported_pytest "$@"
 }
 
-# The pure suite gets a full process lifetime, so its Python/native heap is
-# returned to the OS before any Ray control-plane process is created.
-python -m pytest \
-  -m "not external_service and not real_ray" \
-  tests/fast
-
-# All tests in this shard connect to one session-owned Ray cluster.
-run_ray_pytest \
-  -m "not external_service and real_ray and not ray_cluster_owner" \
-  tests/fast
-
-# A cluster owner may start, stop, or kill its own Ray control plane. Collect
-# the checked markers once, then give every owner a fresh pytest OS process.
-owner_collection="$({
-  python -m pytest \
-    -o addopts= \
-    --collect-only \
-    -q \
-    -m "not external_service and real_ray and ray_cluster_owner" \
-    tests/fast
-} 2>&1)" || {
-  printf '%s\n' "${owner_collection}" >&2
-  exit 1
+collect_nodeids() {
+  local marker="$1"
+  local collection
+  collection="$({
+    PYTEST_ADDOPTS= run_pytest \
+      -o addopts= \
+      --collect-only \
+      -q \
+      -m "$marker" \
+      tests/fast
+  } 2>&1)" || {
+    printf '%s\n' "$collection" >&2
+    return 1
+  }
+  printf '%s\n' "$collection" | sed -n '/^tests\/fast\/.*::/p'
 }
 
-mapfile -t owner_nodeids < <(printf '%s\n' "${owner_collection}" | sed -n '/^tests\/fast\/.*::/p')
-if ((${#owner_nodeids[@]} == 0)); then
-  printf '%s\n' "No real-Ray cluster-owner tests were collected" >&2
-  exit 1
-fi
-
-owner_status=0
-for nodeid in "${owner_nodeids[@]}"; do
-  if ! run_ray_pytest \
-    -m "not external_service and real_ray and ray_cluster_owner" \
-    "${nodeid}"; then
-    owner_status=1
+run_non_ray_tests() {
+  local marker="not external_service and not real_ray${gpu_marker}"
+  if ((non_ray_shard_count == 1)); then
+    run_reported_pytest \
+      "non-ray" \
+      -m "$marker" \
+      tests/fast
+    return
   fi
-done
 
-exit "${owner_status}"
+  local collection
+  collection="$(collect_nodeids "$marker")"
+  if [[ -z "$collection" ]]; then
+    printf '%s\n' "No non-Ray fast tests were collected" >&2
+    return 1
+  fi
+  mapfile -t nodeids <<<"$collection"
+
+  local selected_nodeids=()
+  local position
+  for ((position = non_ray_shard_index; position < ${#nodeids[@]}; position += non_ray_shard_count)); do
+    selected_nodeids+=("${nodeids[position]}")
+  done
+
+  local report_name
+  printf -v report_name \
+    'non-ray-%02d-of-%02d' \
+    "$((non_ray_shard_index + 1))" \
+    "$non_ray_shard_count"
+  run_reported_pytest \
+    "$report_name" \
+    -m "$marker" \
+    "${selected_nodeids[@]}"
+}
+
+run_shared_ray_tests() {
+  run_ray_pytest \
+    "shared-ray" \
+    -m "not external_service and real_ray and not ray_cluster_owner${gpu_marker}" \
+    tests/fast
+}
+
+run_owner_ray_tests() {
+  local marker="not external_service and real_ray and ray_cluster_owner${gpu_marker}"
+  local collection
+  collection="$(collect_nodeids "$marker")"
+  if [[ -z "$collection" ]]; then
+    printf '%s\n' "No real-Ray cluster-owner tests were collected" >&2
+    return 1
+  fi
+  mapfile -t owner_nodeids <<<"$collection"
+
+  local owner_status=0
+  local owner_index=0
+  local nodeid
+  for nodeid in "${owner_nodeids[@]}"; do
+    owner_index=$((owner_index + 1))
+    local report_name
+    printf -v report_name 'owner-ray-%02d' "$owner_index"
+    if ! run_ray_pytest \
+      "$report_name" \
+      -m "$marker" \
+      "$nodeid"; then
+      owner_status=1
+    fi
+  done
+  return "$owner_status"
+}
+
+case "$phase" in
+  all)
+    # Keep the real Ray runtime out of the long-lived non-Ray pytest process.
+    run_non_ray_tests
+    run_shared_ray_tests
+    run_owner_ray_tests
+    ;;
+  non-ray)
+    run_non_ray_tests
+    ;;
+  shared-ray)
+    run_shared_ray_tests
+    ;;
+  owner-ray)
+    run_owner_ray_tests
+    ;;
+esac

--- a/scripts/summarize_junit.py
+++ b/scripts/summarize_junit.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TestTotals:
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    seconds: float = 0.0
+
+    def add_suite(self, suite: ET.Element) -> None:
+        self.tests += int(suite.get("tests", "0"))
+        self.failures += int(suite.get("failures", "0"))
+        self.errors += int(suite.get("errors", "0"))
+        self.skipped += int(suite.get("skipped", "0"))
+        self.seconds += float(suite.get("time", "0"))
+
+    @property
+    def passed(self) -> int:
+        return self.tests - self.failures - self.errors - self.skipped
+
+
+def _report_paths(inputs: list[Path]) -> list[Path]:
+    reports: set[Path] = set()
+    for input_path in inputs:
+        if input_path.is_dir():
+            reports.update(input_path.glob("*.xml"))
+        elif input_path.is_file():
+            reports.add(input_path)
+    return sorted(reports)
+
+
+def _top_level_suites(root: ET.Element) -> list[ET.Element]:
+    if root.tag == "testsuite":
+        return [root]
+    return [child for child in root if child.tag == "testsuite"]
+
+
+def summarize(inputs: list[Path]) -> tuple[TestTotals, list[Path]]:
+    totals = TestTotals()
+    reports = _report_paths(inputs)
+    for report in reports:
+        root = ET.parse(report).getroot()
+        for suite in _top_level_suites(root):
+            totals.add_suite(suite)
+    return totals, reports
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render JUnit totals as a GitHub Markdown summary.")
+    parser.add_argument("--label", default="Fast tests", help="Summary row label")
+    parser.add_argument("paths", nargs="+", type=Path, help="JUnit XML files or directories")
+    args = parser.parse_args()
+
+    try:
+        totals, reports = summarize(args.paths)
+    except (ET.ParseError, OSError, ValueError) as exc:
+        print(f"Could not summarize JUnit reports: {exc}", file=sys.stderr)
+        return 1
+
+    print("### Fast-test results")
+    if not reports:
+        print()
+        print(f"No JUnit reports were produced for `{args.label}`.")
+        return 0
+
+    print()
+    print("| Shard | Reports | Tests | Passed | Failed | Errors | Skipped | Time |")
+    print("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    print(
+        f"| {args.label} | {len(reports)} | {totals.tests} | {totals.passed} | "
+        f"{totals.failures} | {totals.errors} | {totals.skipped} | {totals.seconds:.1f}s |"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import subprocess
 import sys
 from importlib.metadata import distribution, metadata, requires, version
@@ -39,6 +40,20 @@ def test_base_distribution_installs_expression_runtime_dependencies():
             base_requirements.add(canonicalize_name(requirement.name))
 
     assert {"numpy", "pyarrow"} <= base_requirements
+
+
+def test_artifact_mode_imports_installed_python_packages():
+    if os.environ.get("VANE_FAST_TEST_ARTIFACT_MODE") != "1":
+        pytest.skip("only applies to artifact-backed fast-test jobs")
+
+    import vane
+
+    environment_root = Path(sys.prefix).resolve()
+    for package in (duckdb, vane):
+        package_path = Path(package.__file__).resolve()
+        assert package_path.is_relative_to(environment_root), (
+            f"{package.__name__} was imported from the checkout: {package_path}"
+        )
 
 
 def _requirements_for_extra(extra):

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -931,6 +931,10 @@ def test_ray_udf_lazy_output_filter_materialize_distributed(ray_runner, duckdb_c
         schema={"id": duckdb.sqltype("INTEGER"), "score": duckdb.sqltype("INTEGER")},
         execution_backend="ray_actor",
         actor_number=2,
+        # This test exercises the two-pool materialization boundary, not
+        # CPU saturation. Fractional actors keep both pools plus the parent
+        # FTE slot schedulable on the standard four-core CI runner.
+        cpus=0.5,
         gpus=0.0,
         batch_size=2,
     )
@@ -939,6 +943,7 @@ def test_ray_udf_lazy_output_filter_materialize_distributed(ray_runner, duckdb_c
         schema={"combined": duckdb.sqltype("INTEGER")},
         execution_backend="ray_actor",
         actor_number=2,
+        cpus=0.5,
         gpus=0.0,
         batch_size=2,
     )

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -440,6 +440,7 @@ def test_ray_scan_filter_projection(ray_runner, duckdb_conn, parquet_path):
     )
 
 
+@pytest.mark.gpu
 def test_ray_vllm_distributed(ray_runner, duckdb_conn):
     pytest.importorskip("pyarrow")
     try:
@@ -688,6 +689,7 @@ def test_ray_udf_lazy_output_defaults_to_enabled(duckdb_conn):
     assert "ray_block_stream_output" in plan
 
 
+@pytest.mark.gpu
 def test_ray_udf_lazy_output_input_passthrough_distributed(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
@@ -749,6 +751,7 @@ def test_ray_udf_lazy_output_input_passthrough_distributed(ray_runner, duckdb_co
     assert set(rows) == {("11",), ("21",), ("31",), ("41",)}
 
 
+@pytest.mark.gpu
 def test_ray_udf_lazy_output_projection_limit_passthrough_distributed(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
@@ -819,6 +822,7 @@ def test_ray_udf_lazy_output_projection_limit_passthrough_distributed(ray_runner
     assert set(rows).issubset({("11",), ("22",), ("33",), ("44",)})
 
 
+@pytest.mark.gpu
 def test_ray_udf_lazy_output_local_exchange_passthrough_distributed(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
@@ -993,6 +997,7 @@ def test_ray_udf_lazy_output_budget_plan(duckdb_conn):
     assert plan.count("ray_block_stream_output") == 2
 
 
+@pytest.mark.gpu
 def test_ray_udf_direct_output_lease_lifetime(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
@@ -1242,6 +1247,7 @@ def test_ray_udf_lazy_streaming_producer_plan(duckdb_conn):
     assert "ray_block_stream_output" in plan
 
 
+@pytest.mark.gpu
 def test_ray_udf_lazy_streaming_producer_yields_ref_bundles(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
@@ -2511,6 +2517,7 @@ def test_ray_task_flat_map_ref_stream_all_empty_output_finishes(tmp_path, ray_su
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+@pytest.mark.gpu
 def test_ray_python_udf_task_consumes_and_emits_ref_bundles_distributed(ray_runner, duckdb_conn, tmp_path, monkeypatch):
     pytest.importorskip("pyarrow")
     import pyarrow as pa

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -350,9 +350,11 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
     monkeypatch.setenv("PYTHONPATH", pythonpath)
     monkeypatch.setenv("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "0")
     monkeypatch.setenv("VANE_FTE_RETRY_INITIAL_DELAY_S", "0")
-    if ray.is_initialized():
-        if _FAULT_RAY_CLUSTER is not None:
+    if _FAULT_RAY_CLUSTER is not None:
+        if ray.is_initialized():
             return
+        _shutdown_ray_for_fault_test()
+    elif ray.is_initialized():
         _shutdown_ray_for_fault_test()
 
     runtime_env_vars = {
@@ -400,7 +402,7 @@ def _shutdown_ray_for_fault_test() -> None:
 def _fault_ray_runtime():
     yield
     _clear_fte_state()
-    if ray.is_initialized():
+    if ray.is_initialized() or _FAULT_RAY_CLUSTER is not None:
         _shutdown_ray_for_fault_test()
 
 

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -377,21 +378,33 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
 def _shutdown_ray_for_fault_test() -> None:
     global _FAULT_RAY_RUNTIME_OWNED
 
+    ray_processes = ()
     try:
         from ray._private import worker as ray_worker
 
         ray_node = getattr(ray_worker.global_worker, "node", None)
+        if ray_node is not None:
+            ray_processes = tuple(
+                (process_type, process_info.process)
+                for process_type, process_infos in ray_node.all_processes.items()
+                for process_info in process_infos
+            )
     except Exception:
-        ray_node = None
+        pass
 
     ray.shutdown()
     _FAULT_RAY_RUNTIME_OWNED = False
-    if ray_node is not None:
-        ray_node.kill_all_processes(
-            check_alive=False,
-            allow_graceful=False,
-            wait=True,
-        )
+    # ray.shutdown() removes the node's process registry even when a process
+    # survives its bounded shutdown wait. Keep our own handles so no Ray reaper
+    # or agent can outlive this owner test and terminate pytest during
+    # session-finalization (before its JUnit report is written).
+    for process_type, process in ray_processes:
+        if process.poll() is None:
+            process.kill()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"Ray {process_type} process did not exit during fault-test cleanup") from exc
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -398,7 +398,7 @@ def _shutdown_ray_for_fault_test() -> None:
         ray.shutdown()
     finally:
         _FAULT_RAY_CLUSTER = None
-        if cluster is not None:
+        if cluster is not None and os.environ.get("VANE_TEST_EXTERNAL_RAY_CLUSTER_CLEANUP") != "1":
             cluster.shutdown()
 
 

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -16,13 +15,14 @@ from ray_test_profile import ray_test_object_store_bytes
 import duckdb
 
 ray = pytest.importorskip("ray")
+Cluster = pytest.importorskip("ray.cluster_utils").Cluster
 pytestmark = [
     pytest.mark.real_ray,
     pytest.mark.ray_cluster_owner,
     pytest.mark.ray_fault,
 ]
 
-_FAULT_RAY_RUNTIME_OWNED = False
+_FAULT_RAY_CLUSTER = None
 
 import duckdb.runners.ray.worker_handle as worker_handle_mod
 from duckdb.runners.ray import worker as worker_mod
@@ -330,7 +330,7 @@ def _register_fault_query(tasks) -> None:
 
 
 def _init_ray_for_fault_test(monkeypatch) -> None:
-    global _FAULT_RAY_RUNTIME_OWNED
+    global _FAULT_RAY_CLUSTER
 
     test_file = Path(__file__).resolve()
     pythonpath_entries = [str(test_file.parent), str(test_file.parents[1])]
@@ -351,7 +351,7 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
     monkeypatch.setenv("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "0")
     monkeypatch.setenv("VANE_FTE_RETRY_INITIAL_DELAY_S", "0")
     if ray.is_initialized():
-        if _FAULT_RAY_RUNTIME_OWNED:
+        if _FAULT_RAY_CLUSTER is not None:
             return
         _shutdown_ray_for_fault_test()
 
@@ -364,47 +364,36 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
         "VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S": os.environ.get("VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S", "0"),
         "VANE_FTE_SPLIT_QUEUE_SPACE_WAIT_TIMEOUT_S": os.environ.get("VANE_FTE_SPLIT_QUEUE_SPACE_WAIT_TIMEOUT_S", "0.1"),
     }
-    ray.init(
-        address="local",
-        ignore_reinit_error=True,
-        log_to_driver=True,
-        num_cpus=int(os.environ.get("VANE_TEST_RAY_NUM_CPUS", "4")),
-        object_store_memory=ray_test_object_store_bytes(),
-        runtime_env={"env_vars": runtime_env_vars},
-    )
-    _FAULT_RAY_RUNTIME_OWNED = True
+    cluster = Cluster()
+    try:
+        cluster.add_node(
+            include_dashboard=False,
+            num_cpus=int(os.environ.get("VANE_TEST_RAY_NUM_CPUS", "4")),
+            num_gpus=0,
+            object_store_memory=ray_test_object_store_bytes(),
+        )
+        ray.init(
+            address=cluster.address,
+            ignore_reinit_error=True,
+            log_to_driver=True,
+            runtime_env={"env_vars": runtime_env_vars},
+        )
+    except BaseException:
+        cluster.shutdown()
+        raise
+    _FAULT_RAY_CLUSTER = cluster
 
 
 def _shutdown_ray_for_fault_test() -> None:
-    global _FAULT_RAY_RUNTIME_OWNED
+    global _FAULT_RAY_CLUSTER
 
-    ray_processes = ()
+    cluster = _FAULT_RAY_CLUSTER
     try:
-        from ray._private import worker as ray_worker
-
-        ray_node = getattr(ray_worker.global_worker, "node", None)
-        if ray_node is not None:
-            ray_processes = tuple(
-                (process_type, process_info.process)
-                for process_type, process_infos in ray_node.all_processes.items()
-                for process_info in process_infos
-            )
-    except Exception:
-        pass
-
-    ray.shutdown()
-    _FAULT_RAY_RUNTIME_OWNED = False
-    # ray.shutdown() removes the node's process registry even when a process
-    # survives its bounded shutdown wait. Keep our own handles so no Ray reaper
-    # or agent can outlive this owner test and terminate pytest during
-    # session-finalization (before its JUnit report is written).
-    for process_type, process in ray_processes:
-        if process.poll() is None:
-            process.kill()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(f"Ray {process_type} process did not exit during fault-test cleanup") from exc
+        ray.shutdown()
+    finally:
+        _FAULT_RAY_CLUSTER = None
+        if cluster is not None:
+            cluster.shutdown()
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -366,7 +366,11 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
         "VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S": os.environ.get("VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S", "0"),
         "VANE_FTE_SPLIT_QUEUE_SPACE_WAIT_TIMEOUT_S": os.environ.get("VANE_FTE_SPLIT_QUEUE_SPACE_WAIT_TIMEOUT_S", "0.1"),
     }
-    cluster = Cluster()
+    # The default Cluster lifecycle starts Ray's fate-sharing reaper and
+    # registers a process-exit hook.  These tests own cleanup explicitly; a
+    # reaper that outlives a faulted actor can otherwise terminate pytest
+    # during session finalization, before its JUnit report is written.
+    cluster = Cluster(shutdown_at_exit=False)
     try:
         cluster.add_node(
             include_dashboard=False,

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -7,6 +7,7 @@ import asyncio
 import threading
 import time
 import uuid
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -646,7 +647,7 @@ def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot
         def result(self, timeout=None):
             if self.timeouts:
                 self.timeouts -= 1
-                raise TimeoutError
+                raise FutureTimeoutError
             return self.value
 
         def done(self):

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -297,6 +297,27 @@ def test_cancelling_started_stream_cancels_remote_work_and_releases_lease():
     assert driver.cancel_query_task_lease_request.calls[0][1] == {"submitted": True}
 
 
+def test_retiring_terminal_failure_does_not_cancel_already_ending_remote_work():
+    fake_ray = _FakeRay()
+    driver = _driver({"granted": True, "lease": _lease()})
+    generator = _Generator([])
+    source = TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, "request-failed"),
+        submitter=lambda _lease: generator,
+        ray_module=fake_ray,
+    )
+    adapter = RayStreamAdapter(source, ray_module=fake_ray)
+
+    adapter.retire_failed()
+    adapter.retire_failed()
+
+    assert fake_ray.cancel_calls == []
+    assert driver.release_query_task_lease.calls == []
+    assert driver.cancel_query_task_lease_request.calls == [(("request-failed",), {"submitted": True})]
+    assert generator.deleted_streams == [generator.completion]
+    assert generator.worker is None
+
+
 @pytest.mark.parametrize("terminal_action", ["retire", "cancel"])
 def test_terminal_stream_cleanup_disarms_ray_generator_destructor(terminal_action):
     fake_ray = _FakeRay()

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -764,6 +764,49 @@ def test_generator_terminating_mid_pair_fails_without_fetching_block():
         collector.shutdown()
 
 
+def test_failed_completion_retires_without_cancelling_terminal_remote_work():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generator = _Generator([], completed=False)
+    adapter = RayStreamAdapter(
+        _source(
+            fake_ray,
+            driver,
+            request_id="failed-completion",
+            submitter=lambda _lease: generator,
+        ),
+        ray_module=fake_ray,
+    )
+    record = _StreamRecord(
+        slot_id=10,
+        submit_id=100,
+        adapter=adapter,
+        sequence=0,
+    )
+    completion_future = Future()
+    completion_future.set_exception(RuntimeError("planned completion failure"))
+    record.completion_future = completion_future
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector._records[(record.slot_id, record.submit_id)] = record
+
+    try:
+        collector._complete_producer_wait(record, completion_future)
+
+        assert collector.drain_results({10: {"rows": 1}}) == [
+            (
+                10,
+                100,
+                "error",
+                "RuntimeError: planned completion failure",
+            )
+        ]
+        assert fake_ray.cancel_calls == []
+        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert generator.deleted_streams == [generator.completion_ref]
+    finally:
+        collector.shutdown()
+
+
 def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
     from duckdb.execution.udf_ray_stream_protocol import make_stream_error_pair
 
@@ -784,7 +827,9 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
         )
         block_ref = _Ref(block, is_block=True)
         holder["block_ref"] = block_ref
-        return _Generator([block_ref, _Ref(metadata)])
+        generator = _Generator([block_ref, _Ref(metadata)])
+        holder["generator"] = generator
+        return generator
 
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
@@ -802,6 +847,9 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
         assert "RuntimeError: planned remote failure" in events[0][3]
         assert driver.acquire_query_output_block_lease.calls == []
         assert holder["block_ref"].future_result_calls == []
+        assert fake_ray.cancel_calls == []
+        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert holder["generator"].deleted_streams == [holder["generator"].completion_ref]
     finally:
         collector.shutdown()
 
@@ -830,6 +878,7 @@ def test_malformed_metadata_fails_only_its_stream_without_output_admission():
         assert "invalid Ray UDF stream metadata" in events[0][3]
         assert driver.acquire_query_output_block_lease.calls == []
         assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert fake_ray.cancel_calls[-1][1] == {"force": True, "recursive": True}
     finally:
         collector.shutdown()
 

--- a/tests/fast/test_vllm_e2e.py
+++ b/tests/fast/test_vllm_e2e.py
@@ -8,7 +8,7 @@ import os
 import pytest
 from ray_test_profile import ray_test_object_store_bytes
 
-pytestmark = [pytest.mark.real_ray, pytest.mark.ray_cluster_owner]
+pytestmark = [pytest.mark.real_ray, pytest.mark.ray_cluster_owner, pytest.mark.gpu]
 
 
 def _explain_text(con, sql):


### PR DESCRIPTION
## Summary

- Gate pull requests on the complete CPU-compatible `tests/fast` suite, split into two deterministic non-Ray shards, one shared-Ray shard, and one process-isolated Ray-owner shard.
- Build, install, and smoke-test release artifacts on every supported Python version (3.10-3.14), then run the fast-test shards against the Python 3.12 wheel with installed `duckdb`, `vane`, and `_duckdb` packages ahead of the checkout.
- Fit the jobs to the standard public GitHub-hosted runner: CPU-only PyTorch, a 2 GiB Ray object store, 1 GiB FTE/UDF task heaps, bounded pytest process groups, a 50-minute fast-job limit, and bounded native/release-test teardown. CUDA tests remain outside the required gate because these runners have no GPU.
- Keep each test-owned Ray cluster in its own pytest process. On the dedicated CI runner, stop Ray only after pytest exits and writes JUnit so daemon teardown cannot terminate the report-producing process or leak into the next owner invocation.
- Fix the terminal UDF-stream completion/cancellation race exposed by the shared-Ray shard, and add regression coverage for retiring completed failure streams without cancelling already-terminal Ray work.
- Publish JUnit XML artifacts and an always-run per-shard summary, including partial results after failures or timeouts. JUnit XML is used here as a language-neutral CI test-report format; pytest remains the test framework.

## Related issue

close: #98

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DEVELOPMENT.md` and `AGENTS.md` document the CPU runner profile and the required `gpu` marker.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `scripts/run_release_tests.sh`: 272 base tests passed; 5 real-Ray tests passed
- Complete local fast launcher: both non-Ray shards, the shared-Ray phase, and all seven isolated owner invocations passed; no Ray processes remained afterward
- [GitHub Actions run 30084882811](https://github.com/AstroVela/vane/actions/runs/30084882811): all source-package and native/release jobs passed on Python 3.10-3.14; all four Python 3.12 fast jobs and `Required CI` passed
- Downloaded CI reports: 10 JUnit XML files, 5,417 passed, 36 skipped, 0 failed, 0 errors (559.9 seconds total test time); `owner-ray-01.xml` through `owner-ray-07.xml` are all present
- Marker inventory: 5,369 non-Ray CPU tests, 77 shared-Ray CPU tests, 7 isolated Ray-owner CPU tests, 8 GPU tests, and 5 external-service tests; all collected fast tests are assigned to exactly one category
- `check-yaml`, GitHub Actions workflow validation, Ruff, shfmt, and `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
