### PR TITLE
[fix](fte) Make worker finalization exception-safe

### DIFF
--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -14,6 +14,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte.debug_memory import (
+    debug_flag_enabled,
+    describe_result_payload,
+    log_debug,
+    process_memory_snapshot,
+)
 from duckdb.runners.fte.fte_config import (
     FTE_WORKER_RUNTIME,
     FteWorkerAdmissionConfig,
@@ -30,12 +36,6 @@ from duckdb.runners.fte.fte_descriptor import (
 from duckdb.runners.fte.fte_exchange import collect_spooling_output_stats
 from duckdb.runners.fte.fte_state import _TERMINAL_STATES, FteTaskState
 from duckdb.runners.fte.fte_types import FteSplit, FteTaskAttemptId
-from duckdb.runners.fte.debug_memory import (
-    debug_flag_enabled,
-    describe_result_payload,
-    log_debug,
-    process_memory_snapshot,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -259,7 +259,7 @@ class FteTaskExecution:
         request: Mapping[str, Any],
         execute_fn: Callable[[Mapping[str, Any]], Awaitable[Any]],
         *,
-        status_callback: Callable[["FteTaskExecution"], None] | None = None,
+        status_callback: Callable[["FteTaskExecution"], object] | None = None,
         require_query_task_lease: bool = False,
         default_task_memory_bytes: int | None = None,
     ) -> None:
@@ -847,23 +847,25 @@ class FteTaskExecution:
 
         if update_request.source_node_ids:
             current = {str(source) for source in (self.request.get("source_node_ids") or [])}
-            merged = current | set(update_request.source_node_ids)
-            if merged != current:
-                self.request["source_node_ids"] = sorted(merged)
+            merged_source_node_ids = current | set(update_request.source_node_ids)
+            if merged_source_node_ids != current:
+                self.request["source_node_ids"] = sorted(merged_source_node_ids)
                 changed = True
         if update_request.dynamic_scan_source_node_ids:
-            merged = self.dynamic_scan_source_ids | set(update_request.dynamic_scan_source_node_ids)
-            if merged != self.dynamic_scan_source_ids:
-                self.dynamic_scan_source_ids = merged
-                self._add_dynamic_source_queues("scan_task", merged)
-                self.request["dynamic_scan_source_node_ids"] = sorted(merged)
+            merged_scan_source_ids = self.dynamic_scan_source_ids | set(update_request.dynamic_scan_source_node_ids)
+            if merged_scan_source_ids != self.dynamic_scan_source_ids:
+                self.dynamic_scan_source_ids = merged_scan_source_ids
+                self._add_dynamic_source_queues("scan_task", merged_scan_source_ids)
+                self.request["dynamic_scan_source_node_ids"] = sorted(merged_scan_source_ids)
                 changed = True
         if update_request.dynamic_exchange_source_node_ids:
-            merged = self.dynamic_exchange_source_ids | set(update_request.dynamic_exchange_source_node_ids)
-            if merged != self.dynamic_exchange_source_ids:
-                self.dynamic_exchange_source_ids = merged
-                self._add_dynamic_source_queues("exchange_source_task", merged)
-                self.request["dynamic_exchange_source_node_ids"] = sorted(merged)
+            merged_exchange_source_ids = self.dynamic_exchange_source_ids | set(
+                update_request.dynamic_exchange_source_node_ids
+            )
+            if merged_exchange_source_ids != self.dynamic_exchange_source_ids:
+                self.dynamic_exchange_source_ids = merged_exchange_source_ids
+                self._add_dynamic_source_queues("exchange_source_task", merged_exchange_source_ids)
+                self.request["dynamic_exchange_source_node_ids"] = sorted(merged_exchange_source_ids)
                 changed = True
 
         for source_id, splits in update_request.initial_splits.items():
@@ -889,11 +891,11 @@ class FteTaskExecution:
                 self.request["output_buffers"] = dict(output_buffers or {})
                 changed = True
         if update_request.dynamic_filter_domains:
-            merged = dict(self.dynamic_filter_domains)
-            merged.update(update_request.dynamic_filter_domains)
-            if merged != self.dynamic_filter_domains:
-                self.dynamic_filter_domains = merged
-                self.request["dynamic_filter_domains"] = dict(merged)
+            merged_dynamic_filter_domains = dict(self.dynamic_filter_domains)
+            merged_dynamic_filter_domains.update(update_request.dynamic_filter_domains)
+            if merged_dynamic_filter_domains != self.dynamic_filter_domains:
+                self.dynamic_filter_domains = merged_dynamic_filter_domains
+                self.request["dynamic_filter_domains"] = dict(merged_dynamic_filter_domains)
                 changed = True
 
         if changed:
@@ -1142,7 +1144,11 @@ class FteWorkerTaskManager:
         execution.start()
         self._publish_status(execution)
         self._admission_debug_log("start_task", execution, reason=reason)
-        execution.add_done_callback(lambda future, task_key=key: self._task_done(task_key, future))
+
+        def task_done(future: asyncio.Task[Any]) -> None:
+            self._task_done(key, future)
+
+        execution.add_done_callback(task_done)
 
     def _task_done(self, task_key: str, _future: asyncio.Task[Any]) -> None:
         self.running_tasks.discard(task_key)
@@ -1222,12 +1228,12 @@ class FteWorkerTaskManager:
         key = self._key(task_id)
         execution = self.tasks.get(key)
         if execution is not None:
-            status = self._publish_status(execution)
-            status.pop("result", None)
-            return status
-        status = self._dropped_status(task_id)
-        if status is not None:
-            updated = dict(status)
+            published_status = self._publish_status(execution)
+            published_status.pop("result", None)
+            return published_status
+        dropped_status = self._dropped_status(task_id)
+        if dropped_status is not None:
+            updated = dict(dropped_status)
             updated.pop("result", None)
             return updated
         return self._unknown_status(task_id)
@@ -1237,12 +1243,12 @@ class FteWorkerTaskManager:
         execution = self.tasks.get(key)
         if execution is not None:
             execution.release_result(reason="release_task_result")
-            status = self._publish_status(execution)
-            status.pop("result", None)
-            return status
-        status = self._dropped_status(task_id)
-        if status is not None:
-            updated = dict(status)
+            published_status = self._publish_status(execution)
+            published_status.pop("result", None)
+            return published_status
+        dropped_status = self._dropped_status(task_id)
+        if dropped_status is not None:
+            updated = dict(dropped_status)
             updated.pop("result", None)
             self._store_dropped_status(key, updated)
             return updated

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -580,6 +580,8 @@ class FteTaskExecution:
             self._future.add_done_callback(callback)
 
     async def _run(self) -> None:
+        result_stored = False
+        dynamic_source_splits_completed = False
         try:
             if self.fte_runtime:
                 await self._wait_for_fte_splits_sealed()
@@ -595,23 +597,33 @@ class FteTaskExecution:
             result = await self.execute_fn(self.request)
             with self._status_lock:
                 self.result = result
+                result_stored = True
                 self._result_stored_at = time.time()
+            self._complete_dynamic_source_splits()
+            dynamic_source_splits_completed = True
             self._log_result_lifecycle("result_stored", result=result)
-        except asyncio.CancelledError:
-            self._transition(FteTaskState.CANCELED)
-            raise
-        except Exception as exc:
-            self._transition(FteTaskState.FAILED, failure=_failure_payload(exc))
-        else:
-            result = self.result
             with self._status_lock:
                 self.status.output_stats = self._extract_output_stats(result)
-            self._complete_dynamic_source_splits()
             final_task_stats = self._extract_task_stats(result)
             final_split_stats = self.split_queue_status()
             if final_task_stats or final_split_stats:
                 self._record_task_stats({**final_task_stats, **final_split_stats})
             self._transition(FteTaskState.FINISHED)
+        except asyncio.CancelledError:
+            self._transition(FteTaskState.CANCELED)
+            raise
+        except Exception as exc:
+            if result_stored and not dynamic_source_splits_completed:
+                try:
+                    self._complete_dynamic_source_splits()
+                except Exception:
+                    pass
+            if result_stored:
+                try:
+                    self.release_result(reason="task_failed")
+                except Exception:
+                    pass
+            self._transition(FteTaskState.FAILED, failure=_failure_payload(exc))
 
     def _complete_dynamic_source_splits(self) -> None:
         queues = [

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -392,8 +392,11 @@ class FteTaskExecution:
         with self._status_lock:
             status = self.status.to_dict()
             if self.status.state in _TERMINAL_STATES:
-                # Finalization may have failed in a native queue accessor.
-                split_queue_status = dict(self._last_split_queue_status)
+                try:
+                    split_queue_status = self._refresh_split_queue_status()
+                except Exception:
+                    # Finalization may have failed in a native queue accessor.
+                    split_queue_status = dict(self._last_split_queue_status)
             else:
                 split_queue_status = self._refresh_split_queue_status()
             status.update(split_queue_status)
@@ -1154,21 +1157,24 @@ class FteWorkerTaskManager:
         self.running_tasks.add(key)
         self._sync_udf_active_fte_fragment_tasks()
         execution.start()
-        self._publish_status(execution)
-        self._admission_debug_log("start_task", execution, reason=reason)
 
         def task_done(future: asyncio.Task[Any]) -> None:
             self._task_done(key, future)
 
         execution.add_done_callback(task_done)
+        self._publish_status(execution)
+        self._admission_debug_log("start_task", execution, reason=reason)
 
     def _task_done(self, task_key: str, _future: asyncio.Task[Any]) -> None:
         self.running_tasks.discard(task_key)
-        self._sync_udf_active_fte_fragment_tasks()
         execution = self.tasks.get(task_key)
         try:
-            if execution is not None:
-                self._publish_status(execution)
+            self._sync_udf_active_fte_fragment_tasks()
+            try:
+                if execution is not None:
+                    self._publish_status(execution)
+            except Exception:
+                pass
             self._admission_debug_log("task_done", execution)
         finally:
             self._drain_queue()

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -300,6 +300,7 @@ class FteTaskExecution:
             source_id: {split.sequence_id for split in splits} for source_id, splits in self.initial_splits.items()
         }
         self.status = TaskStatus(self.task_id, FteTaskState.PLANNED)
+        self._last_split_queue_status: dict[str, Any] = {}
         self.result: Any = None
         self._result_stored_at: float | None = None
         self._result_release_count = 0
@@ -390,13 +391,24 @@ class FteTaskExecution:
     def status_payload(self) -> dict[str, Any]:
         with self._status_lock:
             status = self.status.to_dict()
-            status.update(self.split_queue_status())
+            if self.status.state in _TERMINAL_STATES:
+                # Finalization may have failed in a native queue accessor.
+                split_queue_status = dict(self._last_split_queue_status)
+            else:
+                split_queue_status = self._refresh_split_queue_status()
+            status.update(split_queue_status)
             status["memory_requirement_bytes"] = self.memory_requirement_bytes
             output_buffer_status = _output_buffer_status(self.output_buffers)
             if output_buffer_status is not None:
                 status["output_buffer_status"] = output_buffer_status
             if self.status.state == FteTaskState.FINISHED:
                 status["result"] = self.result
+        return status
+
+    def _refresh_split_queue_status(self) -> dict[str, Any]:
+        status = self.split_queue_status()
+        with self._status_lock:
+            self._last_split_queue_status = dict(status)
         return status
 
     def split_queue_status(self) -> dict[str, Any]:
@@ -605,7 +617,7 @@ class FteTaskExecution:
             with self._status_lock:
                 self.status.output_stats = self._extract_output_stats(result)
             final_task_stats = self._extract_task_stats(result)
-            final_split_stats = self.split_queue_status()
+            final_split_stats = self._refresh_split_queue_status()
             if final_task_stats or final_split_stats:
                 self._record_task_stats({**final_task_stats, **final_split_stats})
             self._transition(FteTaskState.FINISHED)
@@ -1154,10 +1166,12 @@ class FteWorkerTaskManager:
         self.running_tasks.discard(task_key)
         self._sync_udf_active_fte_fragment_tasks()
         execution = self.tasks.get(task_key)
-        if execution is not None:
-            self._publish_status(execution)
-        self._admission_debug_log("task_done", execution)
-        self._drain_queue()
+        try:
+            if execution is not None:
+                self._publish_status(execution)
+            self._admission_debug_log("task_done", execution)
+        finally:
+            self._drain_queue()
 
     def _sync_udf_active_fte_fragment_tasks(self) -> None:
         if not self.sync_udf_active_fragment_tasks:

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -213,6 +213,22 @@ def _fte_worker_task_manager(
     )
 
 
+async def _wait_for_terminal_task_status(manager, task_id, initial_status):
+    status = initial_status
+    while status["state"] not in {
+        FteTaskState.FINISHED.value,
+        FteTaskState.FAILED.value,
+        FteTaskState.CANCELED.value,
+        FteTaskState.ABORTED.value,
+    }:
+        status = await manager.wait_task_status(
+            task_id,
+            min_version=status["version"],
+            timeout_s=1.0,
+        )
+    return status
+
+
 def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_slots: int):
     stage_id = f"stage:{query_id}:node:{node_id}:fte"
     graph = QueryExecutionGraph(
@@ -3791,6 +3807,122 @@ def test_fte_worker_task_manager_unknown_status_is_non_throwing():
         assert status["task_id_string"] == "q.9.3.0"
         with pytest.raises(KeyError, match="unknown FTE task attempt"):
             await manager.add_splits(task_id, "7", [])
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    ("failure_point", "failure_message"),
+    [
+        ("file_stat", "planned output file stat failure"),
+        ("integer_conversion", "invalid literal for int"),
+        ("split_queue_status", "planned split queue status failure"),
+        ("finished_transition", "planned FINISHED transition failure"),
+    ],
+)
+def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_slot(
+    monkeypatch,
+    tmp_path,
+    failure_point,
+    failure_message,
+):
+    first_task_id = "q-finalize.0.0.0"
+    second_task_id = "q-finalize.0.1.0"
+    output_dir = tmp_path / "attempt"
+    output_dir.mkdir()
+    output_file = output_dir / "partition_0_data.arrow"
+    output_file.write_bytes(b"payload")
+
+    async def execute_fn(request):
+        task_id = str(FteTaskAttemptId.coerce(request["task_id"]))
+        if task_id == first_task_id and failure_point == "integer_conversion":
+            return ([], [{"num_rows": "not-an-integer", "size_bytes": 1}], None, [])
+        return {"ok": task_id}
+
+    async def run():
+        manager = _fte_worker_task_manager(execute_fn, max_running_tasks=1)
+        first_request = {
+            "task_id": first_task_id,
+            "fragment_id": "q-finalize:node:scan",
+        }
+        if failure_point == "file_stat":
+            first_request["exchange_sink_instance"] = {"attempt_path": str(output_dir)}
+
+        first_initial = await manager.create_task(first_request)
+        first_execution = manager.tasks[first_task_id]
+        original_complete_dynamic_source_splits = first_execution._complete_dynamic_source_splits
+        complete_dynamic_source_splits_calls = 0
+
+        def track_complete_dynamic_source_splits():
+            nonlocal complete_dynamic_source_splits_calls
+            complete_dynamic_source_splits_calls += 1
+            original_complete_dynamic_source_splits()
+
+        monkeypatch.setattr(
+            first_execution,
+            "_complete_dynamic_source_splits",
+            track_complete_dynamic_source_splits,
+        )
+
+        if failure_point == "file_stat":
+            original_stat = Path.stat
+
+            def fail_output_file_stat(path, *args, **kwargs):
+                if path == output_file:
+                    raise RuntimeError(failure_message)
+                return original_stat(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "stat", fail_output_file_stat)
+        elif failure_point == "split_queue_status":
+            original_split_queue_status = first_execution.split_queue_status
+            injected = False
+
+            def fail_split_queue_status_once():
+                nonlocal injected
+                if not injected:
+                    injected = True
+                    raise RuntimeError(failure_message)
+                return original_split_queue_status()
+
+            monkeypatch.setattr(first_execution, "split_queue_status", fail_split_queue_status_once)
+        elif failure_point == "finished_transition":
+            original_transition = first_execution._transition
+
+            def fail_finished_transition(state, *, failure=None):
+                if state == FteTaskState.FINISHED:
+                    raise RuntimeError(failure_message)
+                return original_transition(state, failure=failure)
+
+            monkeypatch.setattr(first_execution, "_transition", fail_finished_transition)
+
+        second_initial = await manager.create_task(
+            {
+                "task_id": second_task_id,
+                "fragment_id": "q-finalize:node:scan",
+            }
+        )
+        assert second_initial["state"] == FteTaskState.QUEUED.value
+
+        first_terminal = await asyncio.wait_for(
+            _wait_for_terminal_task_status(manager, first_task_id, first_initial),
+            timeout=2.0,
+        )
+        assert first_terminal["state"] == FteTaskState.FAILED.value
+        assert first_terminal["failure"]["message"].startswith(failure_message)
+        assert complete_dynamic_source_splits_calls == 1
+        assert first_execution.result is None
+
+        second_terminal = await asyncio.wait_for(
+            _wait_for_terminal_task_status(manager, second_task_id, second_initial),
+            timeout=2.0,
+        )
+        assert second_terminal["state"] == FteTaskState.FINISHED.value
+        assert first_task_id not in manager.running_tasks
+
+        assert manager.release_task_result(first_task_id)["state"] == FteTaskState.FAILED.value
+        assert manager.release_task_result(first_task_id)["state"] == FteTaskState.FAILED.value
+        assert await manager.drop_query("q-finalize") == {"removed": 2, "canceled": 0}
+        assert await manager.drop_query("q-finalize") == {"removed": 0, "canceled": 0}
 
     asyncio.run(run())
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -832,6 +832,43 @@ def test_fte_task_execution_split_seal_wait_rechecks_after_clear():
     asyncio.run(asyncio.wait_for(execution._wait_for_fte_splits_sealed(), timeout=0.1))
 
 
+def test_fte_task_execution_terminal_status_refreshes_split_stats_with_fallback(monkeypatch):
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {
+            "task_id": "q-terminal-stats.0.0.0",
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+    execution._last_split_queue_status = {
+        "completed_split_count": 0,
+        "completed_input_bytes": 0,
+    }
+    execution.status.state = FteTaskState.FAILED
+    refreshed_status = {
+        "completed_split_count": 1,
+        "completed_input_bytes": 128,
+    }
+    monkeypatch.setattr(execution, "split_queue_status", lambda: dict(refreshed_status))
+
+    terminal_status = execution.status_payload()
+
+    assert terminal_status["completed_split_count"] == 1
+    assert terminal_status["completed_input_bytes"] == 128
+    assert execution._last_split_queue_status == refreshed_status
+
+    def fail_split_queue_status():
+        raise RuntimeError("persistent native split status failure")
+
+    monkeypatch.setattr(execution, "split_queue_status", fail_split_queue_status)
+    fallback_status = execution.status_payload()
+    assert fallback_status["completed_split_count"] == 1
+    assert fallback_status["completed_input_bytes"] == 128
+
+
 def test_fte_query_status_uses_fragment_execution_snapshot():
     class _SnapshotOnlyFragmentExecution:
         @property
@@ -3835,8 +3872,11 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
 
     async def execute_fn(request):
         task_id = str(FteTaskAttemptId.coerce(request["task_id"]))
-        if task_id == first_task_id and failure_point == "integer_conversion":
-            return ([], [{"num_rows": "not-an-integer", "size_bytes": 1}], None, [])
+        if task_id == first_task_id:
+            queue = request["fte_scan_source_queues"]["7"]
+            assert queue.try_get_next()["state"] == "SPLIT"
+            if failure_point == "integer_conversion":
+                return ([], [{"num_rows": "not-an-integer", "size_bytes": 1}], None, [])
         return {"ok": task_id}
 
     async def run():
@@ -3844,6 +3884,10 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
         first_request = {
             "task_id": first_task_id,
             "fragment_id": "q-finalize:node:scan",
+            "dynamic_scan_source_node_ids": ["7"],
+            "initial_splits": {
+                "7": [{"sequence_id": 0, "kind": "scan_task", "data": b"finalization-input"}],
+            },
         }
         if failure_point == "file_stat":
             first_request["exchange_sink_instance"] = {"attempt_path": str(output_dir)}
@@ -3910,7 +3954,10 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
         assert first_execution.result is None
         terminal_split_queue_status_calls = split_queue_status_calls
         if failure_point == "split_queue_status":
-            assert first_terminal["submitted_split_count"] == 0
+            assert first_terminal["submitted_split_count"] == 1
+            assert first_terminal["completed_split_count"] == 0
+        else:
+            assert first_terminal["completed_split_count"] == 1
 
         second_terminal = await asyncio.wait_for(
             _wait_for_terminal_task_status(manager, second_task_id, second_initial),
@@ -3923,9 +3970,86 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
         assert manager.release_task_result(first_task_id)["state"] == FteTaskState.FAILED.value
         if failure_point == "split_queue_status":
             assert terminal_split_queue_status_calls > 0
-            assert split_queue_status_calls == terminal_split_queue_status_calls
+            assert split_queue_status_calls > terminal_split_queue_status_calls
         assert await manager.drop_query("q-finalize") == {"removed": 2, "canceled": 0}
         assert await manager.drop_query("q-finalize") == {"removed": 0, "canceled": 0}
+
+    asyncio.run(run())
+
+
+def test_fte_worker_task_manager_task_done_drains_after_status_publication_failure(monkeypatch):
+    first_task_id = "q-publish.0.0.0"
+    second_task_id = "q-publish.0.1.0"
+    release_first = asyncio.Event()
+
+    async def execute_fn(request):
+        task_id = str(FteTaskAttemptId.coerce(request["task_id"]))
+        if task_id == first_task_id:
+            await release_first.wait()
+        return {"ok": task_id}
+
+    async def run():
+        manager = _fte_worker_task_manager(execute_fn, max_running_tasks=1)
+        first_initial = await manager.create_task(
+            {
+                "task_id": first_task_id,
+                "fragment_id": "q-publish:node:scan",
+            }
+        )
+        first_execution = manager.tasks[first_task_id]
+        second_initial = await manager.create_task(
+            {
+                "task_id": second_task_id,
+                "fragment_id": "q-publish:node:scan",
+            }
+        )
+        assert second_initial["state"] == FteTaskState.QUEUED.value
+
+        original_task_done = manager._task_done
+        original_publish_status = manager._publish_status
+        inside_task_done = False
+        publication_failures = 0
+
+        def track_task_done(task_key, future):
+            nonlocal inside_task_done
+            inside_task_done = True
+            try:
+                return original_task_done(task_key, future)
+            finally:
+                inside_task_done = False
+
+        def fail_first_done_publication(execution):
+            nonlocal publication_failures
+            if inside_task_done and execution is first_execution:
+                publication_failures += 1
+                raise RuntimeError("planned terminal status publication failure")
+            return original_publish_status(execution)
+
+        monkeypatch.setattr(manager, "_task_done", track_task_done)
+        monkeypatch.setattr(manager, "_publish_status", fail_first_done_publication)
+        loop = asyncio.get_running_loop()
+        loop_errors = []
+        previous_exception_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+        try:
+            release_first.set()
+            first_terminal = await asyncio.wait_for(
+                _wait_for_terminal_task_status(manager, first_task_id, first_initial),
+                timeout=2.0,
+            )
+            second_terminal = await asyncio.wait_for(
+                _wait_for_terminal_task_status(manager, second_task_id, second_initial),
+                timeout=2.0,
+            )
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(previous_exception_handler)
+
+        assert first_terminal["state"] == FteTaskState.FINISHED.value
+        assert second_terminal["state"] == FteTaskState.FINISHED.value
+        assert publication_failures == 1
+        assert loop_errors == []
+        assert first_task_id not in manager.running_tasks
 
     asyncio.run(run())
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -3852,6 +3852,7 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
         first_execution = manager.tasks[first_task_id]
         original_complete_dynamic_source_splits = first_execution._complete_dynamic_source_splits
         complete_dynamic_source_splits_calls = 0
+        split_queue_status_calls = 0
 
         def track_complete_dynamic_source_splits():
             nonlocal complete_dynamic_source_splits_calls
@@ -3874,17 +3875,13 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
 
             monkeypatch.setattr(Path, "stat", fail_output_file_stat)
         elif failure_point == "split_queue_status":
-            original_split_queue_status = first_execution.split_queue_status
-            injected = False
 
-            def fail_split_queue_status_once():
-                nonlocal injected
-                if not injected:
-                    injected = True
-                    raise RuntimeError(failure_message)
-                return original_split_queue_status()
+            def fail_split_queue_status():
+                nonlocal split_queue_status_calls
+                split_queue_status_calls += 1
+                raise RuntimeError(failure_message)
 
-            monkeypatch.setattr(first_execution, "split_queue_status", fail_split_queue_status_once)
+            monkeypatch.setattr(first_execution, "split_queue_status", fail_split_queue_status)
         elif failure_point == "finished_transition":
             original_transition = first_execution._transition
 
@@ -3911,6 +3908,9 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
         assert first_terminal["failure"]["message"].startswith(failure_message)
         assert complete_dynamic_source_splits_calls == 1
         assert first_execution.result is None
+        terminal_split_queue_status_calls = split_queue_status_calls
+        if failure_point == "split_queue_status":
+            assert first_terminal["submitted_split_count"] == 0
 
         second_terminal = await asyncio.wait_for(
             _wait_for_terminal_task_status(manager, second_task_id, second_initial),
@@ -3921,6 +3921,9 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
 
         assert manager.release_task_result(first_task_id)["state"] == FteTaskState.FAILED.value
         assert manager.release_task_result(first_task_id)["state"] == FteTaskState.FAILED.value
+        if failure_point == "split_queue_status":
+            assert terminal_split_queue_status_calls > 0
+            assert split_queue_status_calls == terminal_split_queue_status_calls
         assert await manager.drop_query("q-finalize") == {"removed": 2, "canceled": 0}
         assert await manager.drop_query("q-finalize") == {"removed": 0, "canceled": 0}
 


### PR DESCRIPTION
## Summary

- Keep output stats extraction, task stats conversion, split queue finalization, and terminal publication inside one exception-safe boundary.
- Convert every finalization exception into a terminal `FAILED` payload, complete consumed dynamic splits, and release unusable result payloads without blocking later cleanup.
- Add fault injection for file stats, integer conversion, split queue status, and the `FINISHED` transition; verify the failed task releases its slot and repeated cleanup remains safe.

## Related issue

close: #61

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Internal worker lifecycle behavior only; public APIs and configuration are unchanged.

## Validation

- `scripts/format root --changed`
- `python -m pytest -q tests/fast/test_ray_fte.py` (138 passed)
- `scripts/run_release_tests.sh` (272 base tests passed; 5 real-Ray tests passed)
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.