### PR TITLE
[fix](ray) Preserve persistent worker CUDA visibility

### DIFF
--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code="untyped-decorator"
 
 from __future__ import annotations
 
@@ -8,7 +9,8 @@ import os
 import sys
 import threading
 import time
-from typing import Any, NamedTuple
+from collections.abc import Mapping
+from typing import Any, NamedTuple, cast
 
 import ray
 
@@ -137,7 +139,7 @@ def _maybe_chaos_kill_worker(task_id: FteTaskAttemptId) -> None:
     os._exit(88)
 
 
-def _normalize_native_task_result(result: Any):
+def _normalize_native_task_result(result: Any) -> tuple[Any, ...]:
     native_type = require_ray_cxx_attr(
         "NativeDistributedTaskResult",
         hint="Ensure the C++ ray extension is built and importable in this process.",
@@ -348,7 +350,7 @@ def _warm_up_python_native_dependencies() -> None:
         pass
 
 
-def _apply_env_overrides(env_overrides: dict[str, str] | None) -> None:
+def _apply_env_overrides(env_overrides: Mapping[str, str | None] | None) -> None:
     if not env_overrides:
         return
     for key, value in env_overrides.items():
@@ -429,8 +431,6 @@ class RayWorkerActor:
         self._task_heap_capacity_bytes = task_heap_capacity_bytes
         _apply_env_overrides(self._env_overrides)
         os.environ["VANE_WORKER"] = "1"
-        if num_gpus > 0:
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(num_gpus))
         try:
             loop = asyncio.get_running_loop()
             set_event_loop(loop)
@@ -473,7 +473,7 @@ class RayWorkerActor:
         # lightweight cursor (new ClientContext) from this connection.
         # Eagerly create during __init__ so the ~2s startup cost overlaps
         # with actor creation instead of blocking the first task.
-        self._shared_conn = None
+        self._shared_conn: Any | None = None
         self._shared_conn_lock = threading.Lock()
         self._get_shared_conn()  # eagerly initialize
         _ray_worker_memory_log(
@@ -676,7 +676,7 @@ class RayWorkerActor:
         status = await self._get_fte_task_manager().create_task(request)
         return _fte_applied_control_status(
             "fte_create_task",
-            request.get("task_id"),
+            cast(str | dict[str, Any], request.get("task_id")),
             status,
         )
 
@@ -832,11 +832,11 @@ class RayWorkerActor:
         self._fragment_lookup_hits += 1
         return fragment_plan
 
-    def _configure_conn(self, conn):
+    def _configure_conn(self, conn: Any) -> None:
         """Apply standard DuckDB settings (S3, threading, etc.) to a connection."""
         _configure_ray_worker_conn(conn, self._duckdb_memory_bytes)
 
-    def _get_shared_conn(self):
+    def _get_shared_conn(self) -> Any:
         """Return the shared DuckDB connection, creating it lazily on first use.
 
         All tasks executed by this actor share the same DatabaseInstance (and
@@ -848,7 +848,7 @@ class RayWorkerActor:
             return self._shared_conn
         with self._shared_conn_lock:
             if self._shared_conn is not None:
-                return self._shared_conn
+                return self._shared_conn  # type: ignore[unreachable]
             import duckdb
 
             conn = duckdb.connect()
@@ -856,7 +856,7 @@ class RayWorkerActor:
             self._shared_conn = conn
             return conn
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Cleanup method called when actor is being destroyed."""
         # Use a try-except to safely handle cleanup during Python shutdown
         try:
@@ -864,7 +864,7 @@ class RayWorkerActor:
 
             # Check if Python is shutting down
             if sys.meta_path is None:
-                return
+                return  # type: ignore[unreachable]
 
             conn = getattr(self, "_shared_conn", None)
             if conn is not None:
@@ -888,7 +888,7 @@ class RayWorkerActor:
 
     def _execute_native_task(
         self,
-        plan,
+        plan: Any,
         scan_task_map: dict[str, str] | None,
         copy_output_info: dict[str, str] | None = None,
         exchange_source_task_map: dict[str, Any] | None = None,
@@ -958,7 +958,7 @@ class RayWorkerActor:
 
     async def run_plan_return(
         self,
-        plan,  # DistributedPhysicalPlan from _duckdb.ray_cxx
+        plan: Any,  # DistributedPhysicalPlan from _duckdb.ray_cxx
         context: dict[str, str] | None,
         query_task_lease: dict[str, Any],
         exchange_sink_instance: dict[str, Any] | bytes | None = None,

--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -4,25 +4,35 @@
 from __future__ import annotations
 
 import os
+from typing import Any
+
+import ray
 
 from duckdb._ray_cxx import require_ray_cxx_attr
-from duckdb.runners.ray.fte_scheduler_config import _is_ray_worker_context
+from duckdb.runners.ray.fragment_worker_client import RayWorkerActorHandle
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _collect_vane_env_overrides,
 )
+from duckdb.runners.ray.fte_scheduler_config import _is_ray_worker_context
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 from duckdb.runners.ray.worker import RayWorkerActor
 from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 
-import ray
-
-
-from duckdb.runners.ray.fragment_worker_client import RayWorkerActorHandle
-
-RayWorkerRuntime = require_ray_cxx_attr(
+RayWorkerRuntime: Any = require_ray_cxx_attr(
     "RayWorkerRuntime",
     hint="Ensure the C++ ray extension is built and importable in the driver process.",
 )
+
+
+def _persistent_worker_runtime_env() -> dict[str, dict[str, str]]:
+    """Keep the node's accelerator visibility in a zero-GPU Ray actor.
+
+    Ray 2.53 through 2.55 clear accelerator visibility for actors that do not
+    reserve accelerators unless this compatibility switch is disabled. Ray
+    2.56 and later preserve it by default, but accepting the switch keeps the
+    behavior stable across the supported Ray range.
+    """
+    return {"env_vars": {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"}}
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
@@ -48,10 +58,16 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
             # max_concurrency limits how many control/execute RPCs can queue
             # inside the actor. FTE backpressure is handled by task
             # status/split-queue feedback and the shared DuckDB TaskScheduler.
+            #
+            # The persistent actor is a node-local execution container, not a
+            # Ray CPU/GPU lease. Vane admission accounts for native fragments
+            # and Ray-backed UDFs, so reserving the node's full CPU/GPU capacity
+            # here would prevent those child Ray workloads from being scheduled.
             _actor_max_conc = int(os.environ.get("VANE_RAY_ACTOR_MAX_CONCURRENCY", "256"))
             actor = RayWorkerActor.options(  # type: ignore[attr-defined]
                 max_concurrency=_actor_max_conc,
                 memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
+                runtime_env=_persistent_worker_runtime_env(),
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node["NodeID"],
                     soft=False,

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -6779,6 +6779,11 @@ def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
 
     assert len(runtimes) == 1
     assert option_calls[0]["memory"] == 358
+    assert option_calls[0]["runtime_env"] == {
+        "env_vars": {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"},
+    }
+    assert "num_cpus" not in option_calls[0]
+    assert "num_gpus" not in option_calls[0]
     assert len(remote_calls) == 1
     assert remote_calls[0]["env_overrides"]["VANE_WORKER_ID"] == "10.0.0.1"
     assert remote_calls[0]["env_overrides"]["VANE_WORKER_INDEX"] == "0"

--- a/tests/fast/test_ray_worker_cuda_visibility.py
+++ b/tests/fast/test_ray_worker_cuda_visibility.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+
+import pytest
+
+ray = pytest.importorskip("ray")
+
+from ray_test_profile import ray_test_object_store_bytes
+
+import duckdb.runners.ray.worker as worker_mod
+from duckdb.runners.ray.worker_pool import _persistent_worker_runtime_env
+
+
+class _RuntimeContext:
+    def get_node_id(self):
+        return "node-a"
+
+
+@pytest.mark.parametrize(
+    "visible_devices",
+    [
+        "2,5",
+        "GPU-deadbeef,GPU-cafebabe",
+        "MIG-GPU-deadbeef/1/0,MIG-GPU-cafebabe/2/0",
+    ],
+)
+def test_ray_worker_init_preserves_node_cuda_visibility(monkeypatch, visible_devices):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible_devices)
+    monkeypatch.setattr(worker_mod.ray, "get_runtime_context", _RuntimeContext)
+    monkeypatch.setattr(worker_mod, "_warm_up_python_native_dependencies", lambda: None)
+    monkeypatch.setattr(worker_mod, "_ensure_python_datasource_runtime", lambda: None)
+    monkeypatch.setattr(actor_cls, "_get_shared_conn", lambda _self: None)
+
+    actor = actor_cls(
+        num_cpus=2,
+        num_gpus=2,
+        duckdb_memory_bytes=128 * 1024**2,
+        task_heap_capacity_bytes=128 * 1024**2,
+        env_overrides={},
+    )
+
+    assert worker_mod.os.environ["CUDA_VISIBLE_DEVICES"] == visible_devices
+    actor_cls.__del__(actor)
+
+
+@pytest.mark.real_ray
+@pytest.mark.ray_cluster_owner
+def test_zero_gpu_ray_worker_preserves_non_contiguous_node_cuda_visibility(monkeypatch):
+    visible_devices = "2,5"
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible_devices)
+    # Exercise the legacy Ray behavior even when this test runs on Ray 2.56+.
+    # The persistent worker's runtime_env must opt back into preservation.
+    monkeypatch.setenv("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "1")
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=r"Tip: In future versions of Ray")
+        ray.init(
+            address="local",
+            include_dashboard=False,
+            log_to_driver=True,
+            num_cpus=1,
+            num_gpus=2,
+            object_store_memory=ray_test_object_store_bytes(),
+        )
+    actor = None
+    try:
+        actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+        class CudaVisibilityProbe(actor_cls):
+            def cuda_visibility(self):
+                return (
+                    worker_mod.os.environ.get("CUDA_VISIBLE_DEVICES"),
+                    ray.get_runtime_context().get_accelerator_ids(),
+                )
+
+        probe_cls = ray.remote(concurrency_groups={"execute": 128, "control": 512})(CudaVisibilityProbe)
+        actor = probe_cls.options(runtime_env=_persistent_worker_runtime_env()).remote(
+            num_cpus=1,
+            num_gpus=2,
+            duckdb_memory_bytes=128 * 1024**2,
+            task_heap_capacity_bytes=128 * 1024**2,
+            env_overrides={},
+        )
+
+        observed_devices, assigned_accelerators = ray.get(actor.cuda_visibility.remote(), timeout=60)
+
+        assert observed_devices == visible_devices
+        assert not assigned_accelerators.get("GPU")
+    finally:
+        if actor is not None:
+            ray.kill(actor, no_restart=True)
+        ray.shutdown()


### PR DESCRIPTION
## Summary

- keep persistent node workers free of Ray CPU/GPU reservations; their node resource counts remain Vane capacity and admission metadata
- preserve each node process CUDA visibility in zero-GPU actors across Ray 2.53+, instead of rebuilding it as contiguous local ordinals
- cover non-contiguous ordinals plus UUID and MIG mappings, and assert worker actor options do not reserve CPU or GPU resources

Shared-cluster isolation and resource leasing or placement groups remain a separate architecture concern.

## Tests

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `python -m pytest -m "not real_ray" tests/fast/test_ray_worker_cuda_visibility.py tests/fast/test_ray_fragment_submission.py` (145 passed)
- real-Ray non-contiguous mapping test on Ray 2.56.1 and Ray 2.55.1
- equivalent actor compatibility check on Ray 2.53.0
- `scripts/run_release_tests.sh` (272 passed, 1 skipped; 5 Ray tests passed)

Closes #74