### PR TITLE
[fix](distributed) Isolate process-local Flight service lifecycle

### DIFF
--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -1035,40 +1035,45 @@ class FteWorkerTaskManager:
         self.max_dropped_task_statuses = 4096
         self._status_cache_lock = threading.RLock()
         self._status_cache: dict[str, dict[str, Any]] = {}
+        self._lifecycle_lock = threading.RLock()
+        self._shutdown = False
         self._admission_debug_log("manager_init")
 
     async def create_task(self, request: Mapping[str, Any]) -> dict[str, Any]:
-        execution = FteTaskExecution(
-            request,
-            self.execute_fn,
-            status_callback=self._publish_status,
-            require_query_task_lease=self.require_query_task_lease,
-            default_task_memory_bytes=self.admission_config.task_memory_bytes,
-        )
-        key = str(execution.task_id)
-        existing = self.tasks.get(key)
-        if existing is not None:
-            return self._publish_status(existing)
-        if execution.memory_requirement_bytes > self.admission_config.memory_budget_bytes:
-            raise RuntimeError(
-                f"FTE task {execution.task_id} heap {execution.memory_requirement_bytes} "
-                "exceeds worker task-heap capacity "
-                f"{self.admission_config.memory_budget_bytes}"
+        with self._lifecycle_lock:
+            if self._shutdown:
+                raise RuntimeError("FTE worker task manager is shut down")
+            execution = FteTaskExecution(
+                request,
+                self.execute_fn,
+                status_callback=self._publish_status,
+                require_query_task_lease=self.require_query_task_lease,
+                default_task_memory_bytes=self.admission_config.task_memory_bytes,
             )
-        if key in self.dropped_task_statuses:
-            self.dropped_task_statuses.pop(key, None)
-            try:
-                self.dropped_task_order.remove(key)
-            except ValueError:
-                pass
-        with self._status_cache_lock:
-            self._status_cache.pop(key, None)
-        self.tasks[key] = execution
-        self.query_tasks.setdefault(execution.task_id.query_id, set()).add(key)
-        self._publish_status(execution)
-        self._admission_debug_log("create_task", execution)
-        self._admit_or_queue(execution)
-        return self._publish_status(execution)
+            key = str(execution.task_id)
+            existing = self.tasks.get(key)
+            if existing is not None:
+                return self._publish_status(existing)
+            if execution.memory_requirement_bytes > self.admission_config.memory_budget_bytes:
+                raise RuntimeError(
+                    f"FTE task {execution.task_id} heap {execution.memory_requirement_bytes} "
+                    "exceeds worker task-heap capacity "
+                    f"{self.admission_config.memory_budget_bytes}"
+                )
+            if key in self.dropped_task_statuses:
+                self.dropped_task_statuses.pop(key, None)
+                try:
+                    self.dropped_task_order.remove(key)
+                except ValueError:
+                    pass
+            with self._status_cache_lock:
+                self._status_cache.pop(key, None)
+            self.tasks[key] = execution
+            self.query_tasks.setdefault(execution.task_id.query_id, set()).add(key)
+            self._publish_status(execution)
+            self._admission_debug_log("create_task", execution)
+            self._admit_or_queue(execution)
+            return self._publish_status(execution)
 
     @staticmethod
     def _key(task_id: Any) -> str:
@@ -1471,3 +1476,35 @@ class FteWorkerTaskManager:
                 f"failed to fully drop FTE query {query_id}; retained failed task ownership: " + details
             ) from errors[0][1]
         return {"removed": removed, "canceled": canceled}
+
+    def shutdown(self) -> dict[str, int]:
+        """Synchronously cancel every task before the actor runtime joins threads."""
+        with self._lifecycle_lock:
+            self._shutdown = True
+            removed = 0
+            canceled = 0
+            errors: list[tuple[str, BaseException]] = []
+            for key, execution in list(self.tasks.items()):
+                try:
+                    if execution.status.state not in _TERMINAL_STATES:
+                        execution.cancel()
+                        canceled += 1
+                    execution.release_result(reason="worker_shutdown")
+                except BaseException as exc:
+                    errors.append((key, exc))
+                    continue
+                self.tasks.pop(key, None)
+                self.running_tasks.discard(key)
+                removed += 1
+            self.query_tasks.clear()
+            self.queued_tasks.clear()
+            try:
+                self._sync_udf_active_fte_fragment_tasks()
+            except BaseException as exc:
+                errors.append(("<sync-admission>", exc))
+            if errors:
+                details = "; ".join(f"task={key}: {type(exc).__name__}: {exc}" for key, exc in errors)
+                raise RuntimeError("failed to cancel all FTE tasks during worker shutdown: " + details) from errors[0][
+                    1
+                ]
+            return {"removed": removed, "canceled": canceled}

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -1189,17 +1189,21 @@ class FteWorkerTaskManager:
             return
 
     def _drain_queue(self) -> None:
-        while self.queued_tasks:
-            key = self.queued_tasks.popleft()
-            execution = self.tasks.get(key)
-            if execution is None or execution.status.state in _TERMINAL_STATES:
-                continue
-            block_reason = self._capacity_block_reason(execution)
-            if block_reason:
-                self.queued_tasks.appendleft(key)
-                self._admission_debug_log("drain_blocked", execution, reason=block_reason)
+        with self._lifecycle_lock:
+            if self._shutdown:
+                self.queued_tasks.clear()
                 return
-            self._start_execution(execution, reason="drain")
+            while self.queued_tasks:
+                key = self.queued_tasks.popleft()
+                execution = self.tasks.get(key)
+                if execution is None or execution.status.state in _TERMINAL_STATES:
+                    continue
+                block_reason = self._capacity_block_reason(execution)
+                if block_reason:
+                    self.queued_tasks.appendleft(key)
+                    self._admission_debug_log("drain_blocked", execution, reason=block_reason)
+                    return
+                self._start_execution(execution, reason="drain")
 
     def _executor_stats(self, task_key: str | None = None) -> dict[str, Any]:
         stats: dict[str, Any] = {
@@ -1481,6 +1485,7 @@ class FteWorkerTaskManager:
         """Synchronously cancel every task before the actor runtime joins threads."""
         with self._lifecycle_lock:
             self._shutdown = True
+            self.queued_tasks.clear()
             removed = 0
             canceled = 0
             errors: list[tuple[str, BaseException]] = []
@@ -1497,7 +1502,6 @@ class FteWorkerTaskManager:
                 self.running_tasks.discard(key)
                 removed += 1
             self.query_tasks.clear()
-            self.queued_tasks.clear()
             try:
                 self._sync_udf_active_fte_fragment_tasks()
             except BaseException as exc:

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -9,7 +9,7 @@ import os
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -292,7 +292,7 @@ def _collect_vane_env_overrides() -> dict[str, str]:
     return collect_vane_env_overrides()
 
 
-def _apply_env_overrides(env_overrides: dict[str, str] | None) -> None:
+def _apply_env_overrides(env_overrides: Mapping[str, str | None] | None) -> None:
     if not env_overrides:
         return
     for key, value in env_overrides.items():
@@ -324,7 +324,7 @@ class FteWorkerTaskHandle:
     status_wait_timeout_s: float = 0.0
     task_context_info: dict[str, Any] | None = None
     query_task_lease: dict[str, Any] | None = None
-    _result: RayTaskResult | None = None
+    _result: Any = None
     _error: Exception | None = None
     _future: Any = None
     task: Any = None
@@ -361,6 +361,13 @@ class FteWorkerTaskHandle:
         if self.status_wait_timeout_s <= 0:
             self.status_wait_timeout_s = fte_status_wait_timeout_s()
 
+    def _attempt_id(self) -> FteTaskAttemptId:
+        return FteTaskAttemptId.coerce(self.task_id)
+
+    def _terminal_state_is_set(self) -> bool:
+        """Reload terminal state after another thread or awaited RPC may mutate it."""
+        return self._is_done
+
     def _ensure_started(self) -> None:
         with self._lifecycle_lock:
             if self._is_done or self._result is not None or self._error is not None:
@@ -380,7 +387,7 @@ class FteWorkerTaskHandle:
             min_version = self._last_status_version
         return await asyncio.to_thread(
             self.worker_handle.fte_wait_task_status,
-            self.task_id.to_dict(),
+            self._attempt_id().to_dict(),
             min_version,
             self.status_wait_timeout_s,
         )
@@ -397,7 +404,7 @@ class FteWorkerTaskHandle:
         message = str(exc)
         return "did not complete within" in message or "timed out" in message.lower()
 
-    async def _watch_status(self) -> RayTaskResult:
+    async def _watch_status(self) -> Any:
         while True:
             with self._lifecycle_lock:
                 if self._is_done:
@@ -414,7 +421,7 @@ class FteWorkerTaskHandle:
                 if self._is_soft_status_wait_timeout(exc):
                     continue
                 with self._lifecycle_lock:
-                    if self._is_done:
+                    if self._terminal_state_is_set():
                         continue
                 terminal_error = await self._finalize_status_watch_failure(
                     exc,
@@ -475,7 +482,7 @@ class FteWorkerTaskHandle:
             message += "; cleanup also failed: " + "; ".join(cleanup_errors)
         terminal_error = exc if not cleanup_errors and isinstance(exc, Exception) else RuntimeError(message)
         with self._lifecycle_lock:
-            if self._is_done:
+            if self._terminal_state_is_set():
                 return None
             self._error = terminal_error
             self._result = None
@@ -503,7 +510,7 @@ class FteWorkerTaskHandle:
                 self._is_done = True
             return self._is_done
 
-    def get_result_sync(self) -> RayTaskResult:
+    def get_result_sync(self) -> Any:
         with self._lifecycle_lock:
             if not self.done():
                 raise RuntimeError("FTE task result not ready")
@@ -514,7 +521,7 @@ class FteWorkerTaskHandle:
             self.ack()
             return self._result
 
-    async def get_result(self) -> RayTaskResult:
+    async def get_result(self) -> Any:
         with self._lifecycle_lock:
             self._ensure_started()
             future = self._future
@@ -531,7 +538,7 @@ class FteWorkerTaskHandle:
                 return
             errors: list[str] = []
             try:
-                self.worker_handle.fte_cancel_task(self.task_id.to_dict())
+                self.worker_handle.fte_cancel_task(self._attempt_id().to_dict())
             except Exception as exc:
                 errors.append(f"cancel failed: {exc}")
             try:
@@ -566,14 +573,14 @@ class FteWorkerTaskHandle:
         with self._lifecycle_lock:
             if self._acked:
                 return
-            self.worker_handle.enqueue_fte_ack_task_result(self.task_id.to_dict())
+            self.worker_handle.enqueue_fte_ack_task_result(self._attempt_id().to_dict())
             self._acked = True
 
     def release_result_payload(self) -> None:
         with self._lifecycle_lock:
             if self._released:
                 return
-            self.worker_handle.enqueue_fte_release_task_result(self.task_id.to_dict())
+            self.worker_handle.enqueue_fte_release_task_result(self._attempt_id().to_dict())
             self._released = True
 
     def _apply_status(self, status: dict[str, Any]) -> Exception | None:
@@ -637,7 +644,7 @@ class FteWorkerTaskHandle:
                     self._stats_from_status(status),
                     None,
                     0,
-                    self.task_context_info.get("exchange_sink_instance"),
+                    (self.task_context_info or {}).get("exchange_sink_instance"),
                 )
             self._record_fte_task_terminal()
             try:
@@ -678,7 +685,7 @@ class FteWorkerTaskHandle:
         outputs: list[dict[str, Any]],
     ) -> list[Any]:
         owners = self.worker_handle.finish_fte_task_with_outputs(
-            self.task_id.to_dict(),
+            self._attempt_id().to_dict(),
             dict(self.query_task_lease or {}),
             outputs,
         )
@@ -734,7 +741,7 @@ class FteWorkerTaskHandle:
         self._result = None
         return cleanup_errors
 
-    def _normalize_raw_result(self, raw_result: Any) -> RayTaskResult:
+    def _normalize_raw_result(self, raw_result: Any) -> Any:
         if isinstance(raw_result, RayTaskResult):
             self._finish_task_output_ownership([])
             return raw_result
@@ -802,9 +809,10 @@ class FteWorkerTaskHandle:
         return RayTaskResult.success([], [], None)
 
     def _requires_final_output_stats(self) -> bool:
-        if self.task_context_info.get("exchange_sink_instance") is not None:
+        task_context_info = self.task_context_info or {}
+        if task_context_info.get("exchange_sink_instance") is not None:
             return True
-        return bool(self.task_context_info.get("requires_spooling_output_stats"))
+        return bool(task_context_info.get("requires_spooling_output_stats"))
 
     @staticmethod
     def _output_stats_from_status(status: dict[str, Any]) -> Any:
@@ -843,7 +851,7 @@ class FteWorkerTaskHandle:
         return []
 
 
-def batch_wait_ready(handles: list) -> list[int]:
+def batch_wait_ready(handles: list[Any]) -> list[int]:
     """Batch-check which worker task handle instances are ready.
 
     Called from C++ RayTaskResultPoller under a single GIL acquisition.  Each
@@ -949,7 +957,7 @@ class RayQueryDriverActor:
         # Eagerly create DuckDB connection during __init__ so the ~2s
         # cold-start cost overlaps with actor creation instead of
         # blocking the first query.
-        self._duckdb_conn = None
+        self._duckdb_conn: Any = None
         self._ensure_duckdb_conn()
 
         # Eagerly create PlanRunner + warm up Worker workers so the
@@ -1049,11 +1057,11 @@ class RayQueryDriverActor:
             _drop_fte_registry_for_query(query_id)
         except BaseException as exc:
             self._query_resource_admission_bridge_poisoned = True
-            details = [*errors, exc]
+            quiesce_errors: list[BaseException] = [*errors, exc]
             raise QueryFteRegistryQuiesceError(
                 f"local FTE registry did not quiesce for {query_id}; "
                 "driver admission bridge poisoned: "
-                + "; ".join(f"{type(error).__name__}: {error}" for error in details)
+                + "; ".join(f"{type(error).__name__}: {error}" for error in quiesce_errors)
             ) from exc
         if release_resources:
             try:
@@ -1179,7 +1187,7 @@ class RayQueryDriverActor:
                 return dict(cached)
         return await asyncio.shield(build)
 
-    def _ensure_duckdb_conn(self):
+    def _ensure_duckdb_conn(self) -> Any:
         """Eagerly create the DuckDB connection."""
         if self._duckdb_conn is not None:
             return self._duckdb_conn
@@ -1795,17 +1803,19 @@ class RayQueryDriverActor:
         }
         identity = state["identity"]
         if "block_id" in identity:
-            owner_key = (str(identity["query_id"]), str(identity["block_id"]))
-            owners = self._query_output_request_owner_by_identity
+            output_owner_key = (str(identity["query_id"]), str(identity["block_id"]))
+            output_owners = self._query_output_request_owner_by_identity
+            if output_owners.get(output_owner_key) == str(request_id):
+                output_owners.pop(output_owner_key, None)
         else:
-            owner_key = (
+            task_owner_key = (
                 str(identity["query_id"]),
                 str(identity["task_id"]),
                 str(identity["attempt_id"]),
             )
-            owners = self._query_task_request_owner_by_identity
-        if owners.get(owner_key) == str(request_id):
-            owners.pop(owner_key, None)
+            task_owners = self._query_task_request_owner_by_identity
+            if task_owners.get(task_owner_key) == str(request_id):
+                task_owners.pop(task_owner_key, None)
 
     def _fail_query_admission_requests(self, query_id: str) -> None:
         """Resolve every pending request before its query manager disappears."""
@@ -2793,7 +2803,7 @@ class RayQueryDriverActor:
                 self.plan_runner.warm_up()
             return self.plan_runner
 
-    def _precreate_udf_actors(self, plan: Any, graph: Any, allocation: Any) -> list:
+    def _precreate_udf_actors(self, plan: Any, graph: Any, allocation: Any) -> list[Any]:
         """Create Ray actors and inject handles without waiting for model init."""
         from duckdb.execution.udf_ray import prepare_actor_pools_for_plan
 
@@ -2816,7 +2826,7 @@ class RayQueryDriverActor:
 
         wait_for_actor_pools_ready(actor_pools)
 
-    def _precreate_vllm_actors(self, plan: Any) -> list:
+    def _precreate_vllm_actors(self, plan: Any) -> list[Any]:
         """Pre-create Ray actor pools for vLLM nodes on the driver."""
         from duckdb.execution.vllm import ensure_named_vllm_pools_for_plan
 
@@ -3202,7 +3212,7 @@ class RayQueryDriverActor:
                 # the event loop.
                 stream = self.curr_streams[plan_id]
 
-                def _safe_blocking_next():
+                def _safe_blocking_next() -> Any | None:
                     try:
                         return stream.blocking_next()
                     except StopIteration:
@@ -3294,7 +3304,7 @@ def _maybe_set_distributed_cluster_capacity() -> None:
     if not nodes:
         return
 
-    def _usable(node: dict) -> bool:
+    def _usable(node: dict[str, Any]) -> bool:
         if not node.get("Alive", True):
             return False
         resources = node.get("Resources", {}) or {}

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -903,6 +903,7 @@ class RayQueryDriverActor:
         self._query_task_request_owner_by_identity: dict[tuple[str, str, str], str] = {}
         self._query_output_request_owner_by_identity: dict[tuple[str, str], str] = {}
         self._query_resource_closing_queries: set[str] = set()
+        self._query_pending_execution_teardowns: dict[str, set[str]] = {}
         self._query_task_admission_pumps: set[str] = set()
         self._query_output_admission_pumps: set[str] = set()
         self._query_fte_admission_pumps: dict[str, asyncio.Task[Any]] = {}
@@ -922,6 +923,10 @@ class RayQueryDriverActor:
         self._progress_snapshot_lock = threading.Lock()
         self._progress_snapshot_builds: dict[tuple[str, float | None], asyncio.Task[Any]] = {}
         self._progress_snapshot_cache: dict[tuple[str, float | None], dict[str, Any]] = {}
+        self._plan_runner_lifecycle_lock = threading.RLock()
+        self._driver_shutdown_lock = asyncio.Lock()
+        self._driver_shutdown_started = False
+        self._driver_shutdown_complete = False
         self._driver_duckdb_memory_bytes = duckdb_memory_bytes
         self._env_overrides = env_overrides or {}
         _apply_env_overrides(self._env_overrides)
@@ -975,6 +980,11 @@ class RayQueryDriverActor:
                 f"failed to fence query teardown before fragment drop for {query_id}: {type(exc).__name__}: {exc}"
             ) from exc
         errors: list[BaseException] = []
+        pending_execution_teardowns = getattr(self, "_query_pending_execution_teardowns", None)
+        if pending_execution_teardowns is None:
+            pending_execution_teardowns = {}
+            self._query_pending_execution_teardowns = pending_execution_teardowns
+        remembered_execution_query_ids = set(pending_execution_teardowns.get(str(query_id), ()))
         try:
             plan_runner = self._get_plan_runner()
             from duckdb.runners.ray.fte_fragment_scheduler import (
@@ -987,25 +997,46 @@ class RayQueryDriverActor:
             errors.append(exc)
             execution_query_ids = {str(query_id)}
             plan_runner = None
+        execution_query_ids.update(remembered_execution_query_ids)
+        pending_execution_teardowns.setdefault(str(query_id), set()).update(execution_query_ids)
+        successful_execution_query_ids: set[str] = set()
         if plan_runner is not None:
             for execution_query_id in sorted(execution_query_ids):
                 try:
                     plan_runner.drop_query_fragments(execution_query_id)
                 except BaseException as exc:
                     errors.append(exc)
+                else:
+                    successful_execution_query_ids.add(execution_query_id)
         from duckdb.runners.ray.fte_fragment_scheduler import (
             fte_query_remote_teardown_blockers,
         )
 
-        teardown_blockers = fte_query_remote_teardown_blockers(query_id)
-        if teardown_blockers:
+        teardown_blockers_by_query: dict[str, tuple[str, ...]] = {}
+        for execution_query_id in sorted(execution_query_ids):
+            blockers = fte_query_remote_teardown_blockers(execution_query_id)
+            if blockers:
+                teardown_blockers_by_query[execution_query_id] = blockers
+        pending_for_query = pending_execution_teardowns[str(query_id)]
+        pending_for_query.difference_update(
+            execution_query_id
+            for execution_query_id in successful_execution_query_ids
+            if execution_query_id not in teardown_blockers_by_query
+        )
+        if errors or teardown_blockers_by_query or pending_for_query:
             details = [
                 *(f"{type(error).__name__}: {error}" for error in errors),
-                "owners=" + ", ".join(teardown_blockers),
+                *(
+                    f"owners[{execution_query_id}]=" + ", ".join(blockers)
+                    for execution_query_id, blockers in sorted(teardown_blockers_by_query.items())
+                ),
             ]
+            if pending_for_query:
+                details.append("pending_execution_queries=" + ", ".join(sorted(pending_for_query)))
             raise QueryTeardownOwnershipError(
                 f"distributed query teardown retains remote ownership for {query_id}: " + "; ".join(details)
             ) from (errors[0] if errors else None)
+        pending_execution_teardowns.pop(str(query_id), None)
         try:
             # The remote fan-out is best effort, but local FTE ownership must
             # be fully quiesced before QRM/coordinator release. This second,
@@ -1165,7 +1196,22 @@ class RayQueryDriverActor:
 
     def ping(self) -> bool:
         """Health-check: returns True if the actor is alive."""
+        if self._driver_shutdown_started:
+            raise RuntimeError("Ray query driver is shutting down")
         return True
+
+    async def shutdown(self) -> None:
+        """Stop background maintenance and gracefully drain every worker actor."""
+        async with self._driver_shutdown_lock:
+            if self._driver_shutdown_complete:
+                return
+            with self._plan_runner_lifecycle_lock:
+                self._driver_shutdown_started = True
+                plan_runner = self.plan_runner
+            await self.stop_query_resource_maintenance()
+            if plan_runner is not None:
+                await asyncio.to_thread(plan_runner.shutdown)
+            self._driver_shutdown_complete = True
 
     @staticmethod
     def _sum_node_capacity(node_capacities: tuple[Any, ...]) -> Any:
@@ -2735,14 +2781,17 @@ class RayQueryDriverActor:
             _apply_duckdb_thread_setting(self._duckdb_conn)
 
     def _get_plan_runner(self) -> Any:
-        if self.plan_runner is None:
-            DistributedPhysicalPlanRunner = require_ray_cxx_attr(
-                "DistributedPhysicalPlanRunner",
-                hint="Ensure the C++ ray extension is built and importable in this process.",
-            )
-            self.plan_runner = DistributedPhysicalPlanRunner()
-            self.plan_runner.warm_up()
-        return self.plan_runner
+        with self._plan_runner_lifecycle_lock:
+            if self._driver_shutdown_started:
+                raise RuntimeError("Ray query driver is shutting down")
+            if self.plan_runner is None:
+                DistributedPhysicalPlanRunner = require_ray_cxx_attr(
+                    "DistributedPhysicalPlanRunner",
+                    hint="Ensure the C++ ray extension is built and importable in this process.",
+                )
+                self.plan_runner = DistributedPhysicalPlanRunner()
+                self.plan_runner.warm_up()
+            return self.plan_runner
 
     def _precreate_udf_actors(self, plan: Any, graph: Any, allocation: Any) -> list:
         """Create Ray actors and inject handles without waiting for model init."""
@@ -3352,6 +3401,14 @@ class RayQueryDriverClient:
             and current_gcs_address != self._ray_gcs_address
         ):
             return
+        try:
+            resolve_object_refs_blocking(
+                runner.shutdown.remote(),
+                timeout=300,
+                honor_query_deadline=False,
+            )
+        except Exception:
+            pass
         try:
             ray.kill(runner, no_restart=True)
         except TypeError:

--- a/duckdb/runners/ray/fragment_worker_client.py
+++ b/duckdb/runners/ray/fragment_worker_client.py
@@ -88,7 +88,7 @@ class RayWorkerActorHandle(
             _FTE_WORKER_HANDLES[worker_id] = self
 
     @staticmethod
-    def _fte_task_handle_cls():
+    def _fte_task_handle_cls() -> type[Any]:
         # Lazy import to avoid a module import cycle with driver.py.
         from duckdb.runners.ray.driver import FteWorkerTaskHandle
 

--- a/duckdb/runners/ray/fragment_worker_client.py
+++ b/duckdb/runners/ray/fragment_worker_client.py
@@ -81,7 +81,9 @@ class RayWorkerActorHandle(
         self._fte_control_query_by_task: dict[str, str] = {}
         self._fte_control_operation_by_task: dict[str, str] = {}
         self._fte_drop_incomplete_queries: set[str] = set()
+        self._fte_prepare_terminal_errors: dict[str, BaseException] = {}
         self._fragment_drop_incomplete_queries: set[str] = set()
+        self._worker_shutdown_started = False
         with _FTE_REGISTRY_LOCK:
             _FTE_WORKER_HANDLES[worker_id] = self
 

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code="attr-defined"
 
 from __future__ import annotations
 
@@ -420,7 +421,7 @@ class FteWorkerLifecycleMixin:
                 raise RuntimeError(f"FTE query {query_id} failed: {status}")
             if bool(status.get("finished")):
                 return status
-            if has_deadline and time.monotonic() >= deadline:
+            if deadline is not None and time.monotonic() >= deadline:
                 raise TimeoutError(f"timed out waiting for FTE query {query_id}: {status}")
             time.sleep(0.01)
 
@@ -458,4 +459,19 @@ class FteWorkerLifecycleMixin:
                 current = _FTE_WORKER_HANDLES.get(str(self.worker_id))
                 if current is self:
                     _FTE_WORKER_HANDLES.pop(str(self.worker_id), None)
-        ray.kill(self.actor_handle)
+        shutdown_error: BaseException | None = None
+        try:
+            shutdown_method = getattr(self.actor_handle, "shutdown", None)
+            if shutdown_method is None:
+                raise RuntimeError("Ray worker actor does not expose shutdown")
+            resolve_object_refs_blocking(
+                shutdown_method.remote(),
+                timeout=30,
+                honor_query_deadline=False,
+            )
+        except BaseException as exc:
+            shutdown_error = exc
+        finally:
+            ray.kill(self.actor_handle)
+        if shutdown_error is not None:
+            raise RuntimeError(f"Ray worker graceful shutdown failed: {shutdown_error}") from shutdown_error

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -446,7 +446,10 @@ class FteWorkerLifecycleMixin:
                 self._fte_sequences.pop(key, None)
         self._fte_pressure.drop_query(query_id)
 
-    def shutdown(self) -> None:
+    def _begin_worker_shutdown(self) -> None:
+        if getattr(self, "_worker_shutdown_started", False):
+            return
+        self._worker_shutdown_started = True
         if self.worker_id:
             try:
                 self.mark_fte_worker_failed(
@@ -459,13 +462,29 @@ class FteWorkerLifecycleMixin:
                 current = _FTE_WORKER_HANDLES.get(str(self.worker_id))
                 if current is self:
                     _FTE_WORKER_HANDLES.pop(str(self.worker_id), None)
+
+    def prepare_shutdown(self) -> None:
+        """Fence and drain this worker without stopping its Flight service."""
+        self._begin_worker_shutdown()
+        prepare_method = getattr(self.actor_handle, "prepare_shutdown", None)
+        if prepare_method is None:
+            raise RuntimeError("Ray worker actor does not expose prepare_shutdown")
+        resolve_object_refs_blocking(
+            prepare_method.remote(),
+            timeout=30,
+            honor_query_deadline=False,
+        )
+
+    def finish_shutdown(self) -> None:
+        """Stop the prepared worker service and terminate the Ray actor."""
+        self._begin_worker_shutdown()
         shutdown_error: BaseException | None = None
         try:
-            shutdown_method = getattr(self.actor_handle, "shutdown", None)
-            if shutdown_method is None:
-                raise RuntimeError("Ray worker actor does not expose shutdown")
+            finish_method = getattr(self.actor_handle, "finish_shutdown", None)
+            if finish_method is None:
+                raise RuntimeError("Ray worker actor does not expose finish_shutdown")
             resolve_object_refs_blocking(
-                shutdown_method.remote(),
+                finish_method.remote(),
                 timeout=30,
                 honor_query_deadline=False,
             )
@@ -475,3 +494,8 @@ class FteWorkerLifecycleMixin:
             ray.kill(self.actor_handle)
         if shutdown_error is not None:
             raise RuntimeError(f"Ray worker graceful shutdown failed: {shutdown_error}") from shutdown_error
+
+    def abort_shutdown(self) -> None:
+        """Force-terminate an actor after the distributed prepare barrier fails."""
+        self._begin_worker_shutdown()
+        ray.kill(self.actor_handle)

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -6,21 +6,22 @@ from __future__ import annotations
 import concurrent.futures
 import time
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from duckdb.runners.ray.fragment_worker_control import (
-    enqueue_ordered_fte_control,
-)
+from duckdb.runners.fte import FteTaskAttemptId, validate_fte_status_identity
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_REGISTRY_LOCK,
 )
+from duckdb.runners.ray.fragment_worker_control import (
+    enqueue_ordered_fte_control,
+)
 from duckdb.runners.ray.fte_fragment_scheduler import (
+    _drop_fragment_plan_refs_for_query,
+    _drop_fte_registry_for_query,
     begin_fte_registry_operation,
     begin_fte_registry_teardown_operation,
     close_fte_registry_for_query,
-    _drop_fragment_plan_refs_for_query,
-    _drop_fte_registry_for_query,
     end_fte_registry_operation,
     end_fte_registry_teardown_operation,
     quiesce_fte_registry_for_query,
@@ -37,7 +38,6 @@ from duckdb.runners.ray.safe_get import (
     configured_ray_get_timeout_s,
     resolve_object_refs_blocking,
 )
-from duckdb.runners.fte import FteTaskAttemptId, validate_fte_status_identity
 
 
 class FteControlBarrierPendingError(RuntimeError):
@@ -49,10 +49,23 @@ class FteControlBarrierTerminalError(RuntimeError):
 
 
 class FteWorkerTaskControlMixin:
+    actor_handle: Any
+    _fte_control_lock: Any
+    _fte_control_tails_by_task: dict[str, Any]
+    _fte_control_query_by_task: dict[str, str]
+    _fte_control_operation_by_task: dict[str, str]
+    _fte_drop_incomplete_queries: set[str]
+    _fte_prepare_terminal_errors: dict[str, BaseException]
+    _fragment_drop_incomplete_queries: set[str]
+
+    if TYPE_CHECKING:
+
+        def _drop_fragment_registration_state(self, query_id: str) -> None: ...
+
     def _fte_control_rpc(
         self,
         method_name: str,
-        *args,
+        *args: Any,
         timeout_s: float | None = None,
         cancel_event: Any = None,
     ) -> Any:

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -236,7 +236,7 @@ class FteWorkerTaskControlMixin:
                 end_fte_registry_operation(query_id)
             raise
 
-    def _submit_tracked_fte_drop_ref(self, query_id: str) -> Any:
+    def _submit_tracked_fte_drop_ref(self, query_id: str, method_name: str) -> Any:
         begin_fte_registry_teardown_operation(query_id)
         owns_registry_operation = True
         try:
@@ -246,7 +246,8 @@ class FteWorkerTaskControlMixin:
             drop_ref = None
             for attempt in range(attempts):
                 try:
-                    drop_ref = self.actor_handle.fte_drop_query.remote(query_id)
+                    method = getattr(self.actor_handle, method_name)
+                    drop_ref = method.remote(query_id)
                     break
                 except Exception as exc:
                     last_error = exc
@@ -534,6 +535,16 @@ class FteWorkerTaskControlMixin:
                     self._fte_control_query_by_task.pop(task_key, None)
                     self._fte_control_operation_by_task.pop(task_key, None)
 
+        terminal_error: FteControlBarrierTerminalError | None = None
+        if terminal_errors:
+            terminal_error = FteControlBarrierTerminalError(
+                f"FTE control barrier reached terminal failures for {query_key}: " + "; ".join(terminal_errors)
+            )
+            # Terminal entries are removed from the control tail above. Keep
+            # their failure visible across a simultaneous pending operation,
+            # fence retry, or remote-drop retry until final storage cleanup.
+            with self._fte_control_lock:
+                self._fte_prepare_terminal_errors.setdefault(query_key, terminal_error)
         if pending_entries:
             details = ["pending=" + ",".join(task_key for task_key, _, _ in pending_entries)]
             if barrier_resolution_error is not None:
@@ -542,11 +553,8 @@ class FteWorkerTaskControlMixin:
             raise FteControlBarrierPendingError(
                 f"FTE control barrier still has non-terminal operations for {query_key}: " + "; ".join(details)
             )
-        if terminal_errors:
-            details = list(terminal_errors)
-            raise FteControlBarrierTerminalError(
-                f"FTE control barrier reached terminal failures for {query_key}: " + "; ".join(details)
-            )
+        if terminal_error is not None:
+            raise terminal_error
         return statuses
 
     def _has_fte_control_state_for_query(self, query_id: str) -> bool:
@@ -557,7 +565,11 @@ class FteWorkerTaskControlMixin:
     def _has_fte_teardown_state_for_query(self, query_id: str) -> bool:
         query_key = str(query_id or "").strip()
         with self._fte_control_lock:
-            return query_key in self._fte_drop_incomplete_queries or query_key in self._fragment_drop_incomplete_queries
+            return (
+                query_key in self._fte_drop_incomplete_queries
+                or query_key in self._fragment_drop_incomplete_queries
+                or query_key in self._fte_prepare_terminal_errors
+            )
 
     def fte_cancel_task(self, task_id: str | dict[str, Any]) -> dict[str, Any]:
         raw_status = self._enqueue_ordered_fte_control_rpc("fte_cancel_task", task_id)
@@ -565,7 +577,7 @@ class FteWorkerTaskControlMixin:
             raise TypeError("worker actor fte_cancel_task must return a dict")
         return dict(raw_status)
 
-    def fte_drop_query(self, query_id: str) -> dict[str, int]:
+    def fte_prepare_drop_query(self, query_id: str) -> dict[str, int]:
         query_id = (query_id or "").strip()
         if not query_id:
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
@@ -600,18 +612,21 @@ class FteWorkerTaskControlMixin:
             raise FteControlBarrierPendingError(
                 f"FTE query teardown retained pending control ownership for {query_id}: {barrier_pending_error}"
             ) from barrier_pending_error
+        if barrier_error is not None:
+            with self._fte_control_lock:
+                self._fte_prepare_terminal_errors.setdefault(query_id, barrier_error)
         drop_error: BaseException | None = None
         local_error: BaseException | None = None
         result: dict[str, int] = {}
         try:
-            drop_ref = self._submit_tracked_fte_drop_ref(query_id)
+            drop_ref = self._submit_tracked_fte_drop_ref(query_id, "fte_prepare_drop_query")
             raw_result = self._get_fte_control_ref(
-                "fte_drop_query",
+                "fte_prepare_drop_query",
                 drop_ref,
                 honor_query_deadline=False,
             )
             if not isinstance(raw_result, dict):
-                raise TypeError("worker actor fte_drop_query must return a dict")
+                raise TypeError("worker actor fte_prepare_drop_query must return a dict")
             result = {str(key): int(value) for key, value in raw_result.items()}
         except BaseException as exc:
             drop_error = exc
@@ -620,11 +635,9 @@ class FteWorkerTaskControlMixin:
                 self._drop_fragment_registration_state(query_id)
                 _drop_fragment_plan_refs_for_query(query_id)
                 _drop_fte_registry_for_query(query_id)
-                with self._fte_control_lock:
-                    self._fte_drop_incomplete_queries.discard(query_id)
             except BaseException as exc:
                 local_error = exc
-        if barrier_error is not None or drop_error is not None or local_error is not None:
+        if drop_error is not None or local_error is not None:
             details = []
             if barrier_error is not None:
                 details.append(f"barrier={type(barrier_error).__name__}: {barrier_error}")
@@ -636,4 +649,38 @@ class FteWorkerTaskControlMixin:
                 local_error if local_error is not None else (barrier_error if barrier_error is not None else drop_error)
             )
             raise RuntimeError(f"FTE query teardown failed for {query_id}: " + "; ".join(details)) from cause
+        return result
+
+    def fte_cleanup_query(self, query_id: str) -> dict[str, int]:
+        query_id = (query_id or "").strip()
+        if not query_id:
+            return {
+                "flight_shuffle_registry_entries_removed": 0,
+                "flight_shuffle_storage_entries_removed": 0,
+                "flight_shuffle_cleanup_errors": 0,
+            }
+        try:
+            cleanup_ref = self._submit_tracked_fte_drop_ref(query_id, "fte_cleanup_query")
+            raw_result = self._get_fte_control_ref(
+                "fte_cleanup_query",
+                cleanup_ref,
+                honor_query_deadline=False,
+            )
+            if not isinstance(raw_result, dict):
+                raise TypeError("worker actor fte_cleanup_query must return a dict")
+            result = {str(key): int(value) for key, value in raw_result.items()}
+        except BaseException as exc:
+            raise RuntimeError(f"FTE query storage cleanup failed for {query_id}: {exc}") from exc
+        with self._fte_control_lock:
+            self._fte_drop_incomplete_queries.discard(query_id)
+            terminal_error = self._fte_prepare_terminal_errors.pop(query_id, None)
+        if terminal_error is not None:
+            raise RuntimeError(
+                f"FTE query teardown reached a terminal control failure for {query_id}: {terminal_error}"
+            ) from terminal_error
+        return result
+
+    def fte_drop_query(self, query_id: str) -> dict[str, int]:
+        result = self.fte_prepare_drop_query(query_id)
+        result.update(self.fte_cleanup_query(query_id))
         return result

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -475,6 +475,9 @@ class RayWorkerActor:
         # with actor creation instead of blocking the first task.
         self._shared_conn: Any | None = None
         self._shared_conn_lock = threading.Lock()
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_started = False
+        self._shutdown_complete = False
         self._get_shared_conn()  # eagerly initialize
         _ray_worker_memory_log(
             "actor_initialized",
@@ -844,11 +847,11 @@ class RayWorkerActor:
         call ``self._get_shared_conn().cursor()`` to obtain a lightweight cursor
         with its own ClientContext.
         """
-        if self._shared_conn is not None:
-            return self._shared_conn
         with self._shared_conn_lock:
+            if self._shutdown_started:
+                raise RuntimeError("Ray worker runtime is shut down")
             if self._shared_conn is not None:
-                return self._shared_conn  # type: ignore[unreachable]
+                return self._shared_conn
             import duckdb
 
             conn = duckdb.connect()
@@ -856,33 +859,46 @@ class RayWorkerActor:
             self._shared_conn = conn
             return conn
 
-    def __del__(self) -> None:
-        """Cleanup method called when actor is being destroyed."""
-        # Use a try-except to safely handle cleanup during Python shutdown
-        try:
-            import sys
-
-            # Check if Python is shutting down
-            if sys.meta_path is None:
-                return  # type: ignore[unreachable]
-
-            conn = getattr(self, "_shared_conn", None)
-            if conn is not None:
+    def _shutdown_worker_runtime(self) -> None:
+        with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+            errors: list[str] = []
+            with self._shared_conn_lock:
+                self._shutdown_started = True
+                conn = self._shared_conn
                 self._shared_conn = None
+            if conn is not None:
                 try:
                     conn.interrupt()
-                except Exception:
-                    pass
-                try:
-                    import time
-
-                    time.sleep(0.5)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    errors.append(f"interrupt DuckDB connection: {exc}")
                 try:
                     conn.close()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    errors.append(f"close DuckDB connection: {exc}")
+            try:
+                shutdown_flight = require_ray_cxx_attr(
+                    "shutdown_local_flight_service",
+                    hint="Ensure the C++ ray extension is built with Flight service lifecycle support.",
+                )
+                shutdown_flight()
+            except Exception as exc:
+                errors.append(f"stop process-local Flight service: {exc}")
+            if errors:
+                raise RuntimeError("; ".join(errors))
+            self._shutdown_complete = True
+
+    @ray.method(concurrency_group="control")
+    def shutdown(self) -> None:
+        self._shutdown_worker_runtime()
+
+    def __del__(self) -> None:
+        """Cleanup method called when actor is being destroyed."""
+        try:
+            if sys.meta_path is None:
+                return  # type: ignore[unreachable]
+            self._shutdown_worker_runtime()
         except Exception:
             pass
 

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -30,6 +30,7 @@ from duckdb.runners.fte import (
 from duckdb.runners.fte.debug_memory import describe_result_payload, log_debug, process_memory_snapshot
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
+from duckdb.runners.ray.fte_scheduler_config import _fte_control_rpc_timeout_s
 
 
 def _fte_applied_control_status(
@@ -94,7 +95,7 @@ def _chaos_worker_loss_matches(task_id: FteTaskAttemptId) -> bool:
     return not (target_task and target_task != str(task_id))
 
 
-def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, int]:
+def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, Any]:
     query_id = str(query_id or "").strip()
     if not query_id:
         return {
@@ -103,6 +104,7 @@ def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, int]:
             "cleanup_errors": 0,
             "cleanup_pending": 0,
             "active_executions": 0,
+            "last_error": "",
         }
     cleanup_fn = require_ray_cxx_attr(
         "cleanup_flight_shuffle_for_query",
@@ -117,6 +119,7 @@ def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, int]:
         "cleanup_errors": int(raw.get("cleanup_errors", 0)),
         "cleanup_pending": int(raw.get("cleanup_pending", 0)),
         "active_executions": int(raw.get("active_executions", 0)),
+        "last_error": str(raw.get("last_error", "")),
     }
 
 
@@ -128,10 +131,57 @@ def _close_flight_shuffle_query(query_id: str) -> None:
     close_fn(str(query_id))
 
 
-async def _drain_flight_shuffle_for_query(query_id: str, *, timeout_s: float = 30.0) -> dict[str, int]:
+def _flight_shuffle_query_status(query_id: str) -> dict[str, int]:
+    status_fn = require_ray_cxx_attr(
+        "flight_shuffle_query_status",
+        hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+    )
+    raw = status_fn(str(query_id))
+    if not isinstance(raw, dict):
+        raise TypeError("Flight shuffle query status binding must return a dict")
+    return {
+        "cleanup_pending": int(raw.get("cleanup_pending", 0)),
+        "active_executions": int(raw.get("active_executions", 0)),
+    }
+
+
+async def _wait_flight_shuffle_executions_for_query(query_id: str, *, timeout_s: float | None = None) -> None:
+    if timeout_s is None:
+        timeout_s = _fte_control_rpc_timeout_s() * 0.8
+    deadline = time.monotonic() + max(0.0, float(timeout_s))
+    backoff_s = 0.01
+    while True:
+        status = await asyncio.to_thread(_flight_shuffle_query_status, query_id)
+        if status["active_executions"] == 0:
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                "timed out waiting for Flight shuffle native executions "
+                f"for {query_id}: active_executions={status['active_executions']}"
+            )
+        await asyncio.sleep(backoff_s)
+        backoff_s = min(backoff_s * 2, 0.5)
+
+
+def _retire_flight_shuffle_query(query_id: str) -> None:
+    retire_fn = require_ray_cxx_attr(
+        "retire_flight_shuffle_query",
+        hint="Ensure the C++ ray extension is built with Flight shuffle query retirement support.",
+    )
+    retire_fn(str(query_id))
+
+
+async def _drain_flight_shuffle_for_query(
+    query_id: str,
+    *,
+    timeout_s: float | None = None,
+) -> dict[str, Any]:
+    if timeout_s is None:
+        timeout_s = _fte_control_rpc_timeout_s() * 0.8
     deadline = time.monotonic() + max(0.0, float(timeout_s))
     total_registry_removed = 0
     total_storage_removed = 0
+    backoff_s = 0.01
     while True:
         cleanup = await asyncio.to_thread(_cleanup_flight_shuffle_for_query, query_id)
         total_registry_removed += cleanup["registry_entries_removed"]
@@ -145,9 +195,11 @@ async def _drain_flight_shuffle_for_query(query_id: str, *, timeout_s: float = 3
                 "timed out draining Flight shuffle query "
                 f"{query_id}: active_executions={cleanup['active_executions']} "
                 f"cleanup_pending={cleanup['cleanup_pending']} "
-                f"cleanup_errors={cleanup['cleanup_errors']}"
+                f"cleanup_errors={cleanup['cleanup_errors']} "
+                f"last_error={cleanup['last_error']!r}"
             )
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(backoff_s)
+        backoff_s = min(backoff_s * 2, 0.5)
 
 
 def _maybe_chaos_kill_worker(task_id: FteTaskAttemptId) -> None:
@@ -498,8 +550,15 @@ class RayWorkerActor:
         # with actor creation instead of blocking the first task.
         self._shared_conn: Any | None = None
         self._shared_conn_lock = threading.Lock()
-        self._shutdown_lock = threading.Lock()
+        self._shutdown_lock = threading.RLock()
+        self._native_execution_condition = threading.Condition()
+        self._native_execution_count = 0
+        self._native_execution_counts_by_query: dict[str, int] = {}
+        self._active_native_cursors: set[Any] = set()
+        self._native_cursor_query_ids: dict[Any, str] = {}
+        self._closing_native_queries: set[str] = set()
         self._shutdown_started = False
+        self._shutdown_prepared = False
         self._shutdown_complete = False
         self._get_shared_conn()  # eagerly initialize
         _ray_worker_memory_log(
@@ -509,8 +568,19 @@ class RayWorkerActor:
             worker_label=_fte_worker_label(),
         )
 
+    def _ensure_worker_runtime_running(self) -> None:
+        shutdown_lock = getattr(self, "_shutdown_lock", None)
+        if shutdown_lock is None:
+            if getattr(self, "_shutdown_started", False):
+                raise RuntimeError("Ray worker runtime is shutting down")
+            return
+        with shutdown_lock:
+            if getattr(self, "_shutdown_started", False):
+                raise RuntimeError("Ray worker runtime is shutting down")
+
     @ray.method(concurrency_group="control")
     def install_env_overrides(self, env_overrides: dict[str, str] | None) -> None:
+        self._ensure_worker_runtime_running()
         self._env_overrides = env_overrides or {}
         _apply_env_overrides(self._env_overrides)
 
@@ -523,6 +593,7 @@ class RayWorkerActor:
         - plan: plan object (PhysicalPlan / DistributedPhysicalPlan wrapper)
         - query_id: query identity for lifecycle cleanup
         """
+        self._ensure_worker_runtime_running()
         registered = 0
         existing = 0
         self._fragment_register_calls += 1
@@ -571,6 +642,7 @@ class RayWorkerActor:
             for entry_index, resolved_plan in zip(pending_ref_indexes, resolved_plans, strict=False):
                 pending_entries[entry_index]["plan"] = resolved_plan
 
+        self._ensure_worker_runtime_running()
         for entry in pending_entries:
             fragment_id = str(entry["fragment_id"])
             plan = entry.get("plan")
@@ -601,6 +673,7 @@ class RayWorkerActor:
 
     @ray.method(concurrency_group="control")
     def drop_query_fragments(self, query_id: str) -> int:
+        self._ensure_worker_runtime_running()
         fragment_ids = self._query_fragments.pop(query_id, set())
         removed = 0
         for fragment_id in fragment_ids:
@@ -623,14 +696,21 @@ class RayWorkerActor:
         }
 
     def _get_fte_task_manager(self) -> FteWorkerTaskManager:
-        if self._fte_task_manager is None:
-            self._fte_task_manager = FteWorkerTaskManager(
-                self._execute_fte_request,
-                admission_config=self._fte_admission_config,
-                require_query_task_lease=True,
-                worker_label=_fte_worker_label(),
-            )
-        return self._fte_task_manager
+        shutdown_lock = getattr(self, "_shutdown_lock", None)
+        if shutdown_lock is None:
+            shutdown_lock = threading.RLock()
+            self._shutdown_lock = shutdown_lock
+        with shutdown_lock:
+            if getattr(self, "_shutdown_started", False):
+                raise RuntimeError("Ray worker runtime is shutting down")
+            if self._fte_task_manager is None:
+                self._fte_task_manager = FteWorkerTaskManager(
+                    self._execute_fte_request,
+                    admission_config=self._fte_admission_config,
+                    require_query_task_lease=True,
+                    worker_label=_fte_worker_label(),
+                )
+            return self._fte_task_manager
 
     async def _execute_fte_request(self, request: dict[str, Any]) -> Any:
         import duckdb
@@ -801,21 +881,49 @@ class RayWorkerActor:
         return _fte_applied_control_status("fte_cancel_task", task_id, status)
 
     @ray.method(concurrency_group="control")
-    async def fte_drop_query(self, query_id: str) -> dict[str, int]:
+    async def fte_prepare_drop_query(self, query_id: str) -> dict[str, int]:
         _close_flight_shuffle_query(query_id)
+        interrupt_errors = self._close_worker_native_query(query_id)
         try:
             fte_result = await self._get_fte_task_manager().drop_query(query_id)
             fragments_removed = self.drop_query_fragments(query_id)
         finally:
-            flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
+            drain_results = await asyncio.gather(
+                self._wait_worker_native_executions_for_query(query_id),
+                _wait_flight_shuffle_executions_for_query(query_id),
+                return_exceptions=True,
+            )
+            drain_errors = [result for result in drain_results if isinstance(result, BaseException)]
+            if drain_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in drain_errors)
+                raise RuntimeError(f"failed to drain native executions for {query_id}: {details}") from drain_errors[0]
+        if interrupt_errors:
+            raise RuntimeError(
+                f"failed to interrupt {len(interrupt_errors)} native execution(s) for {query_id}: "
+                + "; ".join(interrupt_errors)
+            )
         return {
             "tasks_removed": int(fte_result["removed"]),
             "tasks_canceled": int(fte_result["canceled"]),
             "fragments_removed": int(fragments_removed),
+        }
+
+    @ray.method(concurrency_group="control")
+    async def fte_cleanup_query(self, query_id: str) -> dict[str, int]:
+        flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
+        _retire_flight_shuffle_query(query_id)
+        self._retire_worker_native_query(query_id)
+        return {
             "flight_shuffle_registry_entries_removed": int(flight_shuffle_cleanup["registry_entries_removed"]),
             "flight_shuffle_storage_entries_removed": int(flight_shuffle_cleanup["storage_entries_removed"]),
             "flight_shuffle_cleanup_errors": int(flight_shuffle_cleanup["cleanup_errors"]),
         }
+
+    @ray.method(concurrency_group="control")
+    async def fte_drop_query(self, query_id: str) -> dict[str, int]:
+        result = await self.fte_prepare_drop_query(query_id)
+        result.update(await self.fte_cleanup_query(query_id))
+        return result
 
     def _get_plan_runner(self) -> Any:
         if self._plan_runner is None:
@@ -885,47 +993,210 @@ class RayWorkerActor:
             self._shared_conn = conn
             return conn
 
-    def _shutdown_worker_runtime(self) -> None:
+    def _begin_worker_native_execution(self, query_id: str) -> None:
+        query_id = str(query_id or "").strip()
+        if not query_id:
+            raise ValueError("native execution admission requires a query_id")
+        with self._native_execution_condition:
+            if self._shutdown_started:
+                raise RuntimeError("Ray worker runtime is shutting down")
+            if query_id in self._closing_native_queries:
+                raise RuntimeError(f"native query is closing: {query_id}")
+            self._native_execution_count += 1
+            self._native_execution_counts_by_query[query_id] = (
+                self._native_execution_counts_by_query.get(query_id, 0) + 1
+            )
+
+    def _end_worker_native_execution(self, query_id: str) -> None:
+        query_id = str(query_id or "").strip()
+        with self._native_execution_condition:
+            if self._native_execution_count <= 0:
+                raise RuntimeError("Ray worker native execution ownership underflow")
+            query_count = self._native_execution_counts_by_query.get(query_id, 0)
+            if query_count <= 0:
+                raise RuntimeError(f"Ray worker native query execution ownership underflow: {query_id}")
+            self._native_execution_count -= 1
+            if query_count == 1:
+                self._native_execution_counts_by_query.pop(query_id, None)
+            else:
+                self._native_execution_counts_by_query[query_id] = query_count - 1
+            self._native_execution_condition.notify_all()
+
+    def _register_native_cursor(self, cursor: Any, query_id: str = "") -> bool:
+        with self._native_execution_condition:
+            self._active_native_cursors.add(cursor)
+            self._native_cursor_query_ids[cursor] = str(query_id)
+            return str(query_id) not in self._closing_native_queries
+
+    def _unregister_native_cursor(self, cursor: Any) -> None:
+        with self._native_execution_condition:
+            self._active_native_cursors.discard(cursor)
+            self._native_cursor_query_ids.pop(cursor, None)
+            self._native_execution_condition.notify_all()
+
+    def _worker_native_query_is_closing(self, query_id: str) -> bool:
+        with self._native_execution_condition:
+            return str(query_id) in self._closing_native_queries
+
+    async def _wait_worker_native_executions_for_query(
+        self,
+        query_id: str,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        query_id = str(query_id or "").strip()
+        if timeout_s is None:
+            timeout_s = _fte_control_rpc_timeout_s() * 0.8
+        deadline = time.monotonic() + max(0.0, float(timeout_s))
+        backoff_s = 0.01
+        while True:
+            with self._native_execution_condition:
+                active_executions = self._native_execution_counts_by_query.get(query_id, 0)
+            if active_executions == 0:
+                return
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "timed out waiting for Ray worker native executions "
+                    f"for {query_id}: active_executions={active_executions}"
+                )
+            await asyncio.sleep(backoff_s)
+            backoff_s = min(backoff_s * 2, 0.5)
+
+    def _close_worker_native_query(self, query_id: str) -> list[str]:
+        query_id = str(query_id)
+        with self._native_execution_condition:
+            self._closing_native_queries.add(query_id)
+            cursors = [
+                cursor
+                for cursor, cursor_query_id in self._native_cursor_query_ids.items()
+                if cursor_query_id == query_id
+            ]
+        errors: list[str] = []
+        for cursor in cursors:
+            try:
+                cursor.interrupt()
+            except Exception as exc:
+                errors.append(str(exc))
+        return errors
+
+    def _retire_worker_native_query(self, query_id: str) -> None:
+        with self._native_execution_condition:
+            query_id = str(query_id)
+            active_executions = self._native_execution_counts_by_query.get(query_id, 0)
+            if active_executions:
+                raise RuntimeError(
+                    "cannot retire Ray worker native query with active executions: "
+                    f"{query_id} active_executions={active_executions}"
+                )
+            self._closing_native_queries.discard(query_id)
+
+    def _prepare_worker_runtime_shutdown(self) -> None:
         shutdown_lock = getattr(self, "_shutdown_lock", None)
         if shutdown_lock is None:
-            shutdown_lock = threading.Lock()
+            shutdown_lock = threading.RLock()
             self._shutdown_lock = shutdown_lock
         with shutdown_lock:
-            if getattr(self, "_shutdown_complete", False):
+            if getattr(self, "_shutdown_prepared", False) or getattr(self, "_shutdown_complete", False):
                 return
             errors: list[str] = []
+            native_condition = getattr(self, "_native_execution_condition", None)
+            if native_condition is None:
+                native_condition = threading.Condition()
+                self._native_execution_condition = native_condition
+                self._native_execution_count = 0
+                self._native_execution_counts_by_query = {}
+                self._active_native_cursors = set()
+                self._native_cursor_query_ids = {}
+                self._closing_native_queries = set()
+            with native_condition:
+                self._shutdown_started = True
+            task_manager = getattr(self, "_fte_task_manager", None)
+            if task_manager is not None:
+                try:
+                    task_manager.shutdown()
+                except Exception as exc:
+                    errors.append(f"cancel FTE tasks: {exc}")
             shared_conn_lock = getattr(self, "_shared_conn_lock", None)
             if shared_conn_lock is None:
                 shared_conn_lock = threading.Lock()
                 self._shared_conn_lock = shared_conn_lock
             with shared_conn_lock:
-                self._shutdown_started = True
                 conn = getattr(self, "_shared_conn", None)
-                self._shared_conn = None
             if conn is not None:
                 try:
                     conn.interrupt()
                 except Exception as exc:
                     errors.append(f"interrupt DuckDB connection: {exc}")
+            deadline = time.monotonic() + 25.0
+            cursor_interrupt_errors: set[str] = set()
+            while True:
+                with native_condition:
+                    active_executions = int(getattr(self, "_native_execution_count", 0))
+                    active_cursors = list(getattr(self, "_active_native_cursors", ()))
+                if active_executions == 0:
+                    break
+                for cursor in active_cursors:
+                    try:
+                        cursor.interrupt()
+                    except Exception as exc:
+                        message = f"interrupt active DuckDB cursor: {exc}"
+                        if message not in cursor_interrupt_errors:
+                            cursor_interrupt_errors.add(message)
+                            errors.append(message)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    errors.append(f"timed out waiting for {active_executions} native execution(s) to stop")
+                    break
+                with native_condition:
+                    if self._native_execution_count > 0:
+                        native_condition.wait(timeout=min(0.1, remaining))
+            with native_condition:
+                native_drained = self._native_execution_count == 0
+            if not native_drained:
+                raise RuntimeError("; ".join(errors))
+            with shared_conn_lock:
+                conn = getattr(self, "_shared_conn", None)
+            if conn is not None:
                 try:
                     conn.close()
                 except Exception as exc:
                     errors.append(f"close DuckDB connection: {exc}")
-            try:
-                shutdown_flight = require_ray_cxx_attr(
-                    "shutdown_local_flight_service",
-                    hint="Ensure the C++ ray extension is built with Flight service lifecycle support.",
-                )
-                shutdown_flight()
-            except Exception as exc:
-                errors.append(f"stop process-local Flight service: {exc}")
+                else:
+                    with shared_conn_lock:
+                        if getattr(self, "_shared_conn", None) is conn:
+                            self._shared_conn = None
             if errors:
                 raise RuntimeError("; ".join(errors))
+            self._shutdown_prepared = True
+
+    def _finish_worker_runtime_shutdown(self) -> None:
+        shutdown_lock = getattr(self, "_shutdown_lock", None)
+        if shutdown_lock is None:
+            shutdown_lock = threading.RLock()
+            self._shutdown_lock = shutdown_lock
+        with shutdown_lock:
+            if getattr(self, "_shutdown_complete", False):
+                return
+            if not getattr(self, "_shutdown_prepared", False):
+                raise RuntimeError("Ray worker runtime shutdown was not prepared")
+            shutdown_flight = require_ray_cxx_attr(
+                "shutdown_local_flight_service",
+                hint="Ensure the C++ ray extension is built with Flight service lifecycle support.",
+            )
+            shutdown_flight()
             self._shutdown_complete = True
 
     @ray.method(concurrency_group="control")
-    def shutdown(self) -> None:
-        self._shutdown_worker_runtime()
+    def prepare_shutdown(self) -> None:
+        self._prepare_worker_runtime_shutdown()
+
+    @ray.method(concurrency_group="control")
+    def finish_shutdown(self) -> None:
+        self._finish_worker_runtime_shutdown()
+
+    def _shutdown_worker_runtime(self) -> None:
+        self._prepare_worker_runtime_shutdown()
+        self._finish_worker_runtime_shutdown()
 
     def __del__(self) -> None:
         """Cleanup method called when actor is being destroyed."""
@@ -948,9 +1219,11 @@ class RayWorkerActor:
         dynamic_filter_domains: dict[str, Any] | None = None,
         native_progress_callback: Any | None = None,
         debug_context: dict[str, Any] | None = None,
+        native_query_id: str = "",
     ) -> Any:
         conn = self._get_shared_conn()
         cursor = conn.cursor()
+        query_admitted = self._register_native_cursor(cursor, native_query_id)
         debug_context = dict(debug_context or {})
         start = time.monotonic()
         _ray_worker_memory_log(
@@ -963,6 +1236,8 @@ class RayWorkerActor:
         )
 
         try:
+            if not query_admitted:
+                raise RuntimeError(f"native query is closing: {native_query_id}")
             plan_runner = self._get_plan_runner()
             scan_task_arg = scan_task_map or None
             result = plan_runner.execute_native(
@@ -998,6 +1273,8 @@ class RayWorkerActor:
                 cursor.close()
             except Exception:
                 pass
+            finally:
+                self._unregister_native_cursor(cursor)
 
     @staticmethod
     async def _await_fragment_registration(registration_result: Any | None) -> None:
@@ -1026,21 +1303,33 @@ class RayWorkerActor:
         scan_task_map, exchange_source_task_map = _extract_native_task_maps_from_context(context)
         run_start = time.monotonic()
         _ray_worker_memory_log("run_plan_return_start", **debug_context)
-        query_id = str(query_task_lease.get("query_id") or "").strip()
+        # Native execution, shuffle publication, and actor teardown are owned by
+        # the execution query. The resource query can differ for nested
+        # executions and is only the owner of the admission lease.
+        query_id = str(query_task_lease.get("execution_query_id") or "").strip()
         if not query_id:
-            raise RuntimeError("native task execution requires a query_id")
+            raise RuntimeError("native task execution requires an execution_query_id")
+
+        begin_execution = require_ray_cxx_attr(
+            "begin_flight_shuffle_query_execution",
+            hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+        )
+        end_execution = require_ray_cxx_attr(
+            "end_flight_shuffle_query_execution",
+            hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+        )
+
+        self._begin_worker_native_execution(query_id)
+        try:
+            begin_execution(query_id)
+        except BaseException:
+            self._end_worker_native_execution(query_id)
+            raise
 
         def execute_native_task() -> Any:
-            begin_execution = require_ray_cxx_attr(
-                "begin_flight_shuffle_query_execution",
-                hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
-            )
-            end_execution = require_ray_cxx_attr(
-                "end_flight_shuffle_query_execution",
-                hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
-            )
-            begin_execution(query_id)
             try:
+                if self._worker_native_query_is_closing(query_id):
+                    raise RuntimeError(f"native query is closing: {query_id}")
                 return self._execute_native_task(
                     plan,
                     scan_task_map or None,
@@ -1052,11 +1341,23 @@ class RayWorkerActor:
                     dynamic_filter_domains=dynamic_filter_domains,
                     native_progress_callback=native_progress_callback,
                     debug_context=debug_context,
+                    native_query_id=query_id,
                 )
             finally:
-                end_execution(query_id)
+                try:
+                    end_execution(query_id)
+                finally:
+                    self._end_worker_native_execution(query_id)
 
-        result_list = await asyncio.to_thread(execute_native_task)
+        try:
+            native_future = asyncio.get_running_loop().run_in_executor(None, execute_native_task)
+        except BaseException:
+            try:
+                end_execution(query_id)
+            finally:
+                self._end_worker_native_execution(query_id)
+            raise
+        result_list = await asyncio.shield(native_future)
         (
             payloads,
             partition_metadatas,

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -101,30 +101,53 @@ def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, int]:
             "registry_entries_removed": 0,
             "storage_entries_removed": 0,
             "cleanup_errors": 0,
+            "cleanup_pending": 0,
+            "active_executions": 0,
         }
-    try:
-        cleanup_fn = require_ray_cxx_attr(
-            "cleanup_flight_shuffle_for_query",
-            hint="Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
-        )
-        raw = cleanup_fn(query_id)
-    except Exception:
-        return {
-            "registry_entries_removed": 0,
-            "storage_entries_removed": 0,
-            "cleanup_errors": 1,
-        }
+    cleanup_fn = require_ray_cxx_attr(
+        "cleanup_flight_shuffle_for_query",
+        hint="Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
+    )
+    raw = cleanup_fn(query_id)
     if not isinstance(raw, dict):
-        return {
-            "registry_entries_removed": 0,
-            "storage_entries_removed": 0,
-            "cleanup_errors": 1,
-        }
+        raise TypeError("Flight shuffle cleanup binding must return a dict")
     return {
         "registry_entries_removed": int(raw.get("registry_entries_removed", 0)),
         "storage_entries_removed": int(raw.get("storage_entries_removed", 0)),
         "cleanup_errors": int(raw.get("cleanup_errors", 0)),
+        "cleanup_pending": int(raw.get("cleanup_pending", 0)),
+        "active_executions": int(raw.get("active_executions", 0)),
     }
+
+
+def _close_flight_shuffle_query(query_id: str) -> None:
+    close_fn = require_ray_cxx_attr(
+        "close_flight_shuffle_query",
+        hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+    )
+    close_fn(str(query_id))
+
+
+async def _drain_flight_shuffle_for_query(query_id: str, *, timeout_s: float = 30.0) -> dict[str, int]:
+    deadline = time.monotonic() + max(0.0, float(timeout_s))
+    total_registry_removed = 0
+    total_storage_removed = 0
+    while True:
+        cleanup = await asyncio.to_thread(_cleanup_flight_shuffle_for_query, query_id)
+        total_registry_removed += cleanup["registry_entries_removed"]
+        total_storage_removed += cleanup["storage_entries_removed"]
+        if cleanup["active_executions"] == 0 and cleanup["cleanup_pending"] == 0 and cleanup["cleanup_errors"] == 0:
+            cleanup["registry_entries_removed"] = total_registry_removed
+            cleanup["storage_entries_removed"] = total_storage_removed
+            return cleanup
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                "timed out draining Flight shuffle query "
+                f"{query_id}: active_executions={cleanup['active_executions']} "
+                f"cleanup_pending={cleanup['cleanup_pending']} "
+                f"cleanup_errors={cleanup['cleanup_errors']}"
+            )
+        await asyncio.sleep(0.01)
 
 
 def _maybe_chaos_kill_worker(task_id: FteTaskAttemptId) -> None:
@@ -779,9 +802,12 @@ class RayWorkerActor:
 
     @ray.method(concurrency_group="control")
     async def fte_drop_query(self, query_id: str) -> dict[str, int]:
-        fte_result = await self._get_fte_task_manager().drop_query(query_id)
-        fragments_removed = self.drop_query_fragments(query_id)
-        flight_shuffle_cleanup = _cleanup_flight_shuffle_for_query(query_id)
+        _close_flight_shuffle_query(query_id)
+        try:
+            fte_result = await self._get_fte_task_manager().drop_query(query_id)
+            fragments_removed = self.drop_query_fragments(query_id)
+        finally:
+            flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
         return {
             "tasks_removed": int(fte_result["removed"]),
             "tasks_canceled": int(fte_result["canceled"]),
@@ -860,13 +886,21 @@ class RayWorkerActor:
             return conn
 
     def _shutdown_worker_runtime(self) -> None:
-        with self._shutdown_lock:
-            if self._shutdown_complete:
+        shutdown_lock = getattr(self, "_shutdown_lock", None)
+        if shutdown_lock is None:
+            shutdown_lock = threading.Lock()
+            self._shutdown_lock = shutdown_lock
+        with shutdown_lock:
+            if getattr(self, "_shutdown_complete", False):
                 return
             errors: list[str] = []
-            with self._shared_conn_lock:
+            shared_conn_lock = getattr(self, "_shared_conn_lock", None)
+            if shared_conn_lock is None:
+                shared_conn_lock = threading.Lock()
+                self._shared_conn_lock = shared_conn_lock
+            with shared_conn_lock:
                 self._shutdown_started = True
-                conn = self._shared_conn
+                conn = getattr(self, "_shared_conn", None)
                 self._shared_conn = None
             if conn is not None:
                 try:
@@ -992,19 +1026,37 @@ class RayWorkerActor:
         scan_task_map, exchange_source_task_map = _extract_native_task_maps_from_context(context)
         run_start = time.monotonic()
         _ray_worker_memory_log("run_plan_return_start", **debug_context)
-        result_list = await asyncio.to_thread(
-            self._execute_native_task,
-            plan,
-            scan_task_map or None,
-            copy_output_info=copy_output_info,
-            exchange_source_task_map=exchange_source_task_map or None,
-            exchange_sink_instance=exchange_sink_instance,
-            fte_scan_source_queues=fte_scan_source_queues,
-            fte_exchange_source_queues=fte_exchange_source_queues,
-            dynamic_filter_domains=dynamic_filter_domains,
-            native_progress_callback=native_progress_callback,
-            debug_context=debug_context,
-        )
+        query_id = str(query_task_lease.get("query_id") or "").strip()
+        if not query_id:
+            raise RuntimeError("native task execution requires a query_id")
+
+        def execute_native_task() -> Any:
+            begin_execution = require_ray_cxx_attr(
+                "begin_flight_shuffle_query_execution",
+                hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+            )
+            end_execution = require_ray_cxx_attr(
+                "end_flight_shuffle_query_execution",
+                hint="Ensure the C++ ray extension is built with Flight shuffle query fencing support.",
+            )
+            begin_execution(query_id)
+            try:
+                return self._execute_native_task(
+                    plan,
+                    scan_task_map or None,
+                    copy_output_info=copy_output_info,
+                    exchange_source_task_map=exchange_source_task_map or None,
+                    exchange_sink_instance=exchange_sink_instance,
+                    fte_scan_source_queues=fte_scan_source_queues,
+                    fte_exchange_source_queues=fte_exchange_source_queues,
+                    dynamic_filter_domains=dynamic_filter_domains,
+                    native_progress_callback=native_progress_callback,
+                    debug_context=debug_context,
+                )
+            finally:
+                end_execution(query_id)
+
+        result_list = await asyncio.to_thread(execute_native_task)
         (
             payloads,
             partition_metadatas,
@@ -1029,7 +1081,7 @@ class RayWorkerActor:
                 )
             ),
         )
-        if exchange_sink_instance is None:
+        if native_exchange_sink_instance is not None:
             exchange_sink_instance = native_exchange_sink_instance
         if len(payloads) != len(partition_metadatas):
             raise RuntimeError(

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -333,6 +333,7 @@ ExchangeSinkInstanceHandle FlightExchange::InstantiateSink(const ExchangeSinkHan
 	ExchangeSinkInstanceHandle instance;
 	instance.sink_handle = handle;
 	instance.attempt_id = attempt_id;
+	instance.query_id = ctx_.query_id;
 	instance.output_location = BuildSinkOutputLocation(exchange_instance_id_, handle, attempt_id);
 	instance.output_partition_count = output_partition_count_;
 	auto &attempt_metadata = sink_attempts_[handle.task_partition_id][attempt_id];
@@ -643,7 +644,7 @@ DuckDBResult<void> FlightExchangeSink::Finish() {
 	}
 	// Register the ShuffleCache in the global registry
 	// so FlightServer / FlightExchangeSource can find it
-	return ShuffleCacheRegistry::Instance().Register(handle_.output_location, shuffle_cache_,
+	return ShuffleCacheRegistry::Instance().Register(handle_.output_location, shuffle_cache_, handle_.query_id,
 	                                                 handle_.flight_server_epoch, handle_.attempt_id);
 }
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -32,7 +32,6 @@
 #include <algorithm>
 #include <mutex>
 #include <sstream>
-#include <unordered_set>
 
 namespace duckdb {
 namespace distributed {
@@ -315,7 +314,7 @@ std::string BuildSinkOutputLocation(const std::string &exchange_instance_id, con
 FlightExchange::FlightExchange(const ExchangeContext &ctx, idx_t output_partition_count,
                                const FlightExchangeConfig &config, ClientContext *context)
     : ctx_(ctx), output_partition_count_(output_partition_count), config_(config), context_(context),
-      exchange_instance_id_(ctx.exchange_id + "__instance_" + UUID::ToString(UUID::GenerateRandomUUID())) {
+      exchange_instance_id_(UUID::ToString(UUID::GenerateRandomUUID())) {
 }
 
 FlightExchange::~FlightExchange() {
@@ -324,12 +323,23 @@ FlightExchange::~FlightExchange() {
 
 ExchangeSinkHandle FlightExchange::AddSink(idx_t task_partition_id) {
 	std::lock_guard<std::mutex> lock(mutex_);
-	all_sinks_.push_back(task_partition_id);
+	if (closed_) {
+		throw InvalidInputException("Flight exchange is closed");
+	}
+	if (std::find(all_sinks_.begin(), all_sinks_.end(), task_partition_id) == all_sinks_.end()) {
+		all_sinks_.push_back(task_partition_id);
+	}
 	return ExchangeSinkHandle {task_partition_id};
 }
 
 ExchangeSinkInstanceHandle FlightExchange::InstantiateSink(const ExchangeSinkHandle &handle, idx_t attempt_id) {
 	std::lock_guard<std::mutex> lock(mutex_);
+	if (closed_) {
+		throw InvalidInputException("Flight exchange is closed");
+	}
+	if (std::find(all_sinks_.begin(), all_sinks_.end(), handle.task_partition_id) == all_sinks_.end()) {
+		throw InvalidInputException("Flight sink partition was not registered");
+	}
 	ExchangeSinkInstanceHandle instance;
 	instance.sink_handle = handle;
 	instance.attempt_id = attempt_id;
@@ -344,39 +354,93 @@ ExchangeSinkInstanceHandle FlightExchange::InstantiateSink(const ExchangeSinkHan
 }
 
 void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id) {
-	ExchangeSinkInstanceHandle instance;
-	instance.sink_handle = handle;
-	instance.attempt_id = attempt_id;
-	SinkFinished(instance, std::string(), 0);
+	SinkFinished(handle, attempt_id, std::string(), 0);
 }
 
 void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id, const std::string &node_id,
                                   int flight_port) {
 	ExchangeSinkInstanceHandle instance;
-	instance.sink_handle = handle;
-	instance.attempt_id = attempt_id;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (closed_) {
+			throw InvalidInputException("Flight exchange is closed");
+		}
+		auto sink_entry = sink_attempts_.find(handle.task_partition_id);
+		if (sink_entry == sink_attempts_.end()) {
+			throw InvalidInputException("finished Flight sink partition was not instantiated");
+		}
+		auto attempt_entry = sink_entry->second.find(attempt_id);
+		if (attempt_entry == sink_entry->second.end()) {
+			throw InvalidInputException("finished Flight sink attempt was not instantiated");
+		}
+		instance.sink_handle = handle;
+		instance.attempt_id = attempt_id;
+		instance.query_id = ctx_.query_id;
+		instance.output_location = attempt_entry->second.output_location;
+		instance.output_partition_count = output_partition_count_;
+	}
 	SinkFinished(instance, node_id, flight_port);
 }
 
 void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id,
                                   int flight_port) {
+	if (instance.query_id != ctx_.query_id) {
+		throw InvalidInputException("finished Flight sink query does not match its exchange");
+	}
+	if (instance.output_partition_count != output_partition_count_) {
+		throw InvalidInputException("finished Flight sink partition count does not match its exchange");
+	}
+	if (flight_port < 0) {
+		throw InvalidInputException("finished Flight sink port must be non-negative");
+	}
+	if (flight_port > 0 && node_id.empty()) {
+		throw InvalidInputException("finished Flight sink is missing its worker node id");
+	}
 	if (flight_port > 0 && instance.flight_server_epoch.empty()) {
 		throw InvalidInputException("finished Flight sink is missing its server epoch");
 	}
 	bool cleanup_unselected = false;
 	{
 		std::lock_guard<std::mutex> lock(mutex_);
+		if (closed_) {
+			throw InvalidInputException("Flight exchange is closed");
+		}
 		const auto &handle = instance.sink_handle;
 		const auto attempt_id = instance.attempt_id;
-		auto &attempt_metadata = sink_attempts_[handle.task_partition_id][attempt_id];
-		attempt_metadata.task_partition_id = handle.task_partition_id;
-		attempt_metadata.attempt_id = attempt_id;
-		if (attempt_metadata.output_location.empty()) {
-			attempt_metadata.output_location = instance.output_location.empty()
-			                                       ? BuildSinkOutputLocation(exchange_instance_id_, handle, attempt_id)
-			                                       : instance.output_location;
-		} else if (!instance.output_location.empty() && attempt_metadata.output_location != instance.output_location) {
+		if (std::find(all_sinks_.begin(), all_sinks_.end(), handle.task_partition_id) == all_sinks_.end()) {
+			throw InvalidInputException("finished Flight sink partition was not registered");
+		}
+		auto sink_entry = sink_attempts_.find(handle.task_partition_id);
+		if (sink_entry == sink_attempts_.end()) {
+			sink_entry =
+			    sink_attempts_.emplace(handle.task_partition_id, std::unordered_map<idx_t, SinkAttemptMetadata> {})
+			        .first;
+		}
+		auto attempt_entry = sink_entry->second.find(attempt_id);
+		if (attempt_entry == sink_entry->second.end()) {
+			auto expected_output_location = BuildSinkOutputLocation(exchange_instance_id_, handle, attempt_id);
+			if (instance.output_location.empty() || instance.output_location != expected_output_location) {
+				throw InvalidInputException("finished Flight retry output location does not match its exchange");
+			}
+			SinkAttemptMetadata metadata;
+			metadata.task_partition_id = handle.task_partition_id;
+			metadata.attempt_id = attempt_id;
+			metadata.output_location = instance.output_location;
+			attempt_entry = sink_entry->second.emplace(attempt_id, std::move(metadata)).first;
+		}
+		auto &attempt_metadata = attempt_entry->second;
+		if (instance.output_location.empty() || attempt_metadata.output_location != instance.output_location) {
 			throw InvalidInputException("finished Flight sink output location does not match instantiated attempt");
+		}
+		if (!node_id.empty() && !attempt_metadata.node_id.empty() && attempt_metadata.node_id != node_id) {
+			throw InvalidInputException("finished Flight sink node does not match its published attempt");
+		}
+		if (flight_port > 0 && attempt_metadata.flight_port > 0 && attempt_metadata.flight_port != flight_port) {
+			throw InvalidInputException("finished Flight sink port does not match its published attempt");
+		}
+		if (!instance.flight_server_epoch.empty() && !attempt_metadata.flight_server_epoch.empty() &&
+		    attempt_metadata.flight_server_epoch != instance.flight_server_epoch) {
+			throw InvalidInputException("finished Flight sink epoch does not match its published attempt");
 		}
 		if (!node_id.empty()) {
 			attempt_metadata.node_id = node_id;
@@ -404,6 +468,12 @@ void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, co
 }
 
 void FlightExchange::AllRequiredSinksFinished() {
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (closed_) {
+			throw InvalidInputException("Flight exchange is closed");
+		}
+	}
 	CleanupUnselectedAttempts();
 }
 
@@ -425,6 +495,10 @@ std::vector<FlightExchange::SinkAttemptMetadata> FlightExchange::CollectUnselect
 			if (cleaned_output_locations_.find(attempt_metadata.output_location) != cleaned_output_locations_.end()) {
 				continue;
 			}
+			// Claim cleanup while holding the coordinator lock. Sink completion
+			// and the final barrier may run concurrently, but storage ownership
+			// must be exercised by only one caller at a time.
+			cleaned_output_locations_.insert(attempt_metadata.output_location);
 			attempts.push_back(attempt_metadata);
 		}
 	}
@@ -435,7 +509,11 @@ bool FlightExchange::CleanupAttemptStorage(const SinkAttemptMetadata &attempt_me
 	if (attempt_metadata.output_location.empty()) {
 		return true;
 	}
-	ShuffleCacheRegistry::Instance().Remove(attempt_metadata.output_location);
+	// If the completed attempt belongs to this process, keep its storage under
+	// query-scoped cleanup ownership until teardown observes a successful
+	// deletion. Remote attempts are not present in this process-local catalog,
+	// so the path-based cleanup below remains necessary in either case.
+	ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(attempt_metadata.output_location);
 	if (config_.local_dirs.empty() || attempt_metadata.node_id.empty()) {
 		return false;
 	}
@@ -460,21 +538,29 @@ void FlightExchange::CleanupUnselectedAttempts() {
 		attempts = CollectUnselectedAttemptsForCleanupLocked();
 	}
 	for (const auto &attempt : attempts) {
-		if (!CleanupAttemptStorage(attempt, "unselected")) {
-			continue;
+		bool cleaned = false;
+		try {
+			cleaned = CleanupAttemptStorage(attempt, "unselected");
+		} catch (...) {
+			std::lock_guard<std::mutex> lock(mutex_);
+			cleaned_output_locations_.erase(attempt.output_location);
+			throw;
 		}
-		std::lock_guard<std::mutex> lock(mutex_);
-		cleaned_output_locations_.insert(attempt.output_location);
+		if (!cleaned) {
+			std::lock_guard<std::mutex> lock(mutex_);
+			cleaned_output_locations_.erase(attempt.output_location);
+		}
 	}
 }
 
 std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 	std::vector<ExchangeSourceHandle> handles;
 	std::vector<std::pair<idx_t, SinkAttemptMetadata>> selected_attempts;
-	bool has_sinks = false;
 	{
 		std::lock_guard<std::mutex> lock(mutex_);
-		has_sinks = !all_sinks_.empty();
+		if (closed_) {
+			throw InvalidInputException("Flight exchange is closed");
+		}
 		std::vector<std::pair<idx_t, idx_t>> selected_attempt_ids(selected_attempts_.begin(), selected_attempts_.end());
 		std::sort(selected_attempt_ids.begin(), selected_attempt_ids.end(),
 		          [](const std::pair<idx_t, idx_t> &lhs, const std::pair<idx_t, idx_t> &rhs) {
@@ -492,31 +578,14 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 				}
 			}
 			if (attempt_metadata.output_location.empty()) {
-				ExchangeSinkHandle sink_handle;
-				sink_handle.task_partition_id = sink_partition_id;
-				attempt_metadata.output_location =
-				    BuildSinkOutputLocation(exchange_instance_id_, sink_handle, attempt_id);
+				throw InvalidInputException("selected Flight sink attempt is missing its catalog identity");
 			}
 			attempt_metadata.task_partition_id = sink_partition_id;
 			attempt_metadata.attempt_id = attempt_id;
 			selected_attempts.emplace_back(sink_partition_id, std::move(attempt_metadata));
 		}
 	}
-	if (selected_attempts.empty() && has_sinks) {
-		return handles;
-	}
 	if (selected_attempts.empty()) {
-		for (idx_t i = 0; i < output_partition_count_; i++) {
-			ExchangeSourceHandle handle;
-			handle.partition_id = i;
-			handle.attempt_id = 0;
-			handle.flight_port = config_.flight_port;
-			ExchangeSourceFile file;
-			file.path = exchange_instance_id_;
-			file.file_size = 0;
-			handle.files.push_back(std::move(file));
-			handles.push_back(std::move(handle));
-		}
 		return handles;
 	}
 
@@ -571,19 +640,6 @@ void FlightExchange::Close() {
 		return;
 	}
 	closed_ = true;
-	// Clean up the ShuffleCacheRegistry entry
-	ShuffleCacheRegistry::Instance().Remove(exchange_instance_id_);
-	std::unordered_set<std::string> output_locations;
-	for (const auto &sink_entry : sink_attempts_) {
-		for (const auto &attempt_entry : sink_entry.second) {
-			if (!attempt_entry.second.output_location.empty()) {
-				output_locations.insert(attempt_entry.second.output_location);
-			}
-		}
-	}
-	for (const auto &output_location : output_locations) {
-		ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(output_location);
-	}
 }
 
 // ─── FlightExchangeSink ─────────────────────────────────
@@ -591,6 +647,12 @@ void FlightExchange::Close() {
 FlightExchangeSink::FlightExchangeSink(std::shared_ptr<ShuffleCache> shuffle_cache,
                                        const ExchangeSinkInstanceHandle &handle, ClientContext *context)
     : shuffle_cache_(std::move(shuffle_cache)), handle_(handle), context_(context) {
+	auto track_result = ShuffleCacheRegistry::Instance().TrackPending(
+	    handle_.output_location, shuffle_cache_, handle_.query_id, handle_.flight_server_epoch, handle_.attempt_id);
+	if (track_result.is_err()) {
+		throw InvalidInputException("Failed to track Flight exchange sink attempt: %s", track_result.error().what());
+	}
+	write_lease_ = std::move(track_result.value());
 }
 
 FlightExchangeSink::~FlightExchangeSink() {
@@ -629,26 +691,43 @@ void FlightExchangeSink::WaitUnblocked() {
 }
 
 DuckDBResult<void> FlightExchangeSink::Finish() {
-	finished_ = true;
+	if (finished_) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("sink already finished"));
+	}
 	if (!context_) {
-		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("sink has no client context"));
+		auto result = DuckDBResult<void>::err(DuckDBError::invalid_state_error("sink has no client context"));
+		Abort();
+		return result;
 	}
 	// Flush all remaining buffered data to disk IPC files
 	auto flush_res = shuffle_cache_->FlushAll(*context_, shuffle_cache_->BufferedNames());
 	if (flush_res.is_err()) {
+		Abort();
 		return flush_res;
 	}
 	auto manifest_res = shuffle_cache_->WriteAttemptManifest(handle_.sink_handle.task_partition_id, handle_.attempt_id);
 	if (manifest_res.is_err()) {
+		Abort();
 		return manifest_res;
 	}
-	// Register the ShuffleCache in the global registry
-	// so FlightServer / FlightExchangeSource can find it
-	return ShuffleCacheRegistry::Instance().Register(handle_.output_location, shuffle_cache_, handle_.query_id,
-	                                                 handle_.flight_server_epoch, handle_.attempt_id);
+	// Publish only after both data and the committed manifest are durable.
+	auto publish_result = ShuffleCacheRegistry::Instance().Publish(
+	    handle_.output_location, shuffle_cache_, handle_.query_id, handle_.flight_server_epoch, handle_.attempt_id);
+	if (publish_result.is_err()) {
+		Abort();
+		return publish_result;
+	}
+	write_lease_.reset();
+	finished_ = true;
+	return DuckDBResult<void>::ok();
 }
 
 DuckDBResult<void> FlightExchangeSink::Abort() {
+	if (finished_) {
+		return DuckDBResult<void>::ok();
+	}
+	ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(handle_.output_location);
+	write_lease_.reset();
 	finished_ = true;
 	return DuckDBResult<void>::ok();
 }
@@ -659,6 +738,9 @@ size_t FlightExchangeSink::GetMemoryUsage() const {
 
 DuckDBResult<void> FlightExchangeSink::EnsureSchema(ClientContext &context, const vector<LogicalType> &types,
                                                     const vector<string> &names) {
+	if (finished_) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("sink already finished"));
+	}
 	return shuffle_cache_->EnsureSchemaFile(context, types, names);
 }
 
@@ -685,10 +767,6 @@ struct FlightExchangeSource::PartitionStreamState {
 	bool needs_cast = false;
 };
 
-FlightExchangeSource::FlightExchangeSource(const std::string &exchange_id, ClientContext *context)
-    : exchange_id_(exchange_id), context_(context) {
-}
-
 FlightExchangeSource::FlightExchangeSource(const FlightExchangeConfig &config, ClientContext *context)
     : config_(config), context_(context) {
 }
@@ -698,10 +776,6 @@ FlightExchangeSource::~FlightExchangeSource() {
 }
 
 void FlightExchangeSource::AddSourceHandles(std::vector<ExchangeSourceHandle> handles) {
-	// Extract exchange_id from the first handle's file path if not yet set
-	if (exchange_id_.empty() && !handles.empty() && !handles[0].files.empty()) {
-		exchange_id_ = handles[0].files[0].path;
-	}
 	handles_.insert(handles_.end(), std::make_move_iterator(handles.begin()), std::make_move_iterator(handles.end()));
 }
 
@@ -714,8 +788,11 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 
 	auto partition_id = handle.partition_id;
 	auto source_node_id = handle.node_id.empty() ? config_.node_id : handle.node_id;
-	auto output_location =
-	    (!handle.files.empty() && !handle.files[0].path.empty()) ? handle.files[0].path : exchange_id_;
+	if (handle.files.empty() || handle.files[0].path.empty()) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    DuckDBError::invalid_state_error("Flight exchange source handle is missing its catalog identity"));
+	}
+	auto output_location = handle.files[0].path;
 	auto source_flight_port = handle.flight_port > 0 ? handle.flight_port : config_.flight_port;
 
 	auto stream = make_uniq<PartitionStreamState>();
@@ -725,11 +802,10 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	DuckDBResult<ShufflePartitionFiles> files_res = DuckDBResult<ShufflePartitionFiles>::err(
 	    DuckDBError::invalid_state_error("uninitialized exchange source file result"));
 	std::shared_ptr<ShuffleCache> file_cache;
-	bool committed_manifest_recovery_failed = false;
 	const bool uses_object_storage = FlightExchangeUsesObjectStorage(config_);
-	auto try_manifest_recovery = [&]() -> bool {
+	auto replay_object_manifest = [&]() {
 		if (config_.local_dirs.empty()) {
-			return false;
+			return;
 		}
 		ShuffleCacheConfig cache_config;
 		cache_config.shuffle_stage_id = output_location;
@@ -738,47 +814,47 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		cache_config.local_dirs = config_.local_dirs;
 		auto manifest_cache = MakeFlightExchangeShuffleCache(cache_config, config_, context_);
 		if (!manifest_cache->HasCommittedManifest()) {
-			if (uses_object_storage) {
-				committed_manifest_recovery_failed = true;
-				files_res = DuckDBResult<ShufflePartitionFiles>::err(DuckDBError::invalid_state_error(
-				    "object-storage shuffle attempt manifest is not committed: " + manifest_cache->ManifestFilePath()));
-				return true;
-			}
-			return false;
+			files_res = DuckDBResult<ShufflePartitionFiles>::err(DuckDBError::invalid_state_error(
+			    "object-storage shuffle attempt manifest is not committed: " + manifest_cache->ManifestFilePath()));
+			return;
 		}
 		auto manifest_res = manifest_cache->GetPartitionFilesFromManifest(partition_id);
 		if (manifest_res.is_ok()) {
 			files_res = std::move(manifest_res);
 			file_cache = std::move(manifest_cache);
 		} else {
-			committed_manifest_recovery_failed = true;
 			files_res = DuckDBResult<ShufflePartitionFiles>::err(manifest_res.error());
 		}
-		return true;
 	};
 
 	// Object storage must be replayed from the durable manifest using this
 	// task's ClientContext/FileOpener, not the sink task's registry cache.
 	if (!uses_object_storage && source_node_id == config_.node_id) {
-		if (!cache_ || cache_key_ != output_location) {
-			cache_ = ShuffleCacheRegistry::Instance().Get(output_location);
-			cache_key_ = output_location;
-		}
-		if (cache_) {
-			files_res = cache_->GetPartitionFiles(partition_id);
-			if (files_res.is_ok() && files_res.value().files.empty() && cache_->HasCommittedManifest()) {
-				auto manifest_res = cache_->GetPartitionFilesFromManifest(partition_id);
+		auto cache_res = ShuffleCacheRegistry::Instance().Resolve(output_location, handle.flight_server_epoch,
+		                                                          source_node_id, handle.attempt_id);
+		if (cache_res.is_ok()) {
+			auto resolved_cache = std::move(cache_res.value());
+			if (!resolved_cache->HasCommittedManifest()) {
+				files_res = DuckDBResult<ShufflePartitionFiles>::err(DuckDBError::invalid_state_error(
+				    "local Flight exchange attempt is not committed: " + output_location));
+			} else {
+				files_res = resolved_cache->GetPartitionFiles(partition_id);
+			}
+			if (files_res.is_ok() && files_res.value().files.empty()) {
+				auto manifest_res = resolved_cache->GetPartitionFilesFromManifest(partition_id);
 				if (manifest_res.is_ok()) {
 					files_res = std::move(manifest_res);
 				}
 			}
 			if (files_res.is_ok()) {
-				file_cache = cache_;
+				file_cache = std::move(resolved_cache);
 			}
+		} else {
+			files_res = DuckDBResult<ShufflePartitionFiles>::err(cache_res.error());
 		}
 	}
-	if (files_res.is_err()) {
-		try_manifest_recovery();
+	if (files_res.is_err() && uses_object_storage) {
+		replay_object_manifest();
 	}
 	if (files_res.is_ok()) {
 		stream->kind = PartitionStreamState::Kind::LOCAL_FILES;
@@ -786,13 +862,11 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		stream->files = std::move(files_res.value().files);
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::ok(std::move(stream));
 	}
-	if (committed_manifest_recovery_failed || uses_object_storage) {
-		const auto prefix = uses_object_storage
-		                        ? "object-storage FlightExchange source failed to replay committed manifest"
-		                        : "FlightExchange source failed to read selected attempt";
+	if (uses_object_storage) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(DuckDBError::external_error(
-		    std::string(prefix) + " for exchange_id=" + output_location + " source_node_id=" + source_node_id +
-		    " partition=" + std::to_string(partition_id) + ": " + files_res.error().what()));
+		    "object-storage FlightExchange source failed to replay committed manifest for exchange_id=" +
+		    output_location + " source_node_id=" + source_node_id + " partition=" + std::to_string(partition_id) +
+		    ": " + files_res.error().what()));
 	}
 	if (handle.flight_server_epoch.empty()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/function/table/arrow.hpp"
@@ -38,24 +39,21 @@ namespace distributed {
 
 namespace {
 
-std::mutex &LocalFlightServerMutex() {
-	static std::mutex mutex;
-	return mutex;
-}
+struct LocalFlightServiceState {
+	std::mutex mutex;
+	std::unique_ptr<FlightServer> server;
+	std::string bind_host;
+	int requested_port = 0;
+	int actual_port = 0;
+	std::string server_epoch;
+};
 
-std::unique_ptr<FlightServer> &LocalFlightServerInstance() {
-	static std::unique_ptr<FlightServer> server;
-	return server;
-}
-
-std::string &LocalFlightServerNodeId() {
-	static std::string node_id;
-	return node_id;
-}
-
-int &LocalFlightServerPort() {
-	static int port = 0;
-	return port;
+LocalFlightServiceState &LocalFlightService() {
+	// The service can call into the catalog until its server thread joins.
+	// Construct the catalog first so static teardown destroys the service first.
+	(void)ShuffleCacheRegistry::Instance();
+	static LocalFlightServiceState service;
+	return service;
 }
 
 std::string BuildFlightLocation(const FlightExchangeConfig &config, const std::string &node_id) {
@@ -235,7 +233,7 @@ DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>> ConnectFlightExchange
 	return DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>>::ok(std::move(client_res).ValueOrDie());
 }
 
-DuckDBResult<void> EnsureLocalFlightServerStarted(const FlightExchangeConfig &config) {
+DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightExchangeConfig &config) {
 	if (config.local_dirs.empty()) {
 		return DuckDBResult<void>::ok();
 	}
@@ -243,47 +241,70 @@ DuckDBResult<void> EnsureLocalFlightServerStarted(const FlightExchangeConfig &co
 		return DuckDBResult<void>::ok();
 	}
 
-	auto &server_mutex = LocalFlightServerMutex();
-	auto &server = LocalFlightServerInstance();
-	auto &started_node_id = LocalFlightServerNodeId();
-	auto &started_port = LocalFlightServerPort();
-	std::lock_guard<std::mutex> guard(server_mutex);
-	if (server && started_node_id == config.node_id) {
-		return DuckDBResult<void>::ok();
-	}
-	if (server && started_node_id != config.node_id) {
-		auto stop_res = server->Stop();
-		server.reset();
-		started_port = 0;
-		if (stop_res.is_err()) {
-			return stop_res;
+	auto &service = LocalFlightService();
+	std::lock_guard<std::mutex> guard(service.mutex);
+	if (service.server) {
+		if (service.bind_host != config.flight_bind_host || service.requested_port != config.flight_port) {
+			std::ostringstream message;
+			message << "process-local Flight service already listens on requested address " << service.bind_host << ":"
+			        << service.requested_port << " (actual port " << service.actual_port
+			        << "); refusing conflicting address " << config.flight_bind_host << ":" << config.flight_port;
+			return DuckDBResult<void>::err(DuckDBError::invalid_state_error(message.str()));
 		}
+		return DuckDBResult<void>::ok();
 	}
 
 	FlightServerConfig server_config;
 	server_config.bind_host = config.flight_bind_host;
 	server_config.port = config.flight_port;
-	server_config.local_dirs = config.local_dirs;
-	server = std::unique_ptr<FlightServer>(new FlightServer(std::move(server_config)));
+	server_config.server_epoch = UUID::ToString(UUID::GenerateRandomUUID());
+	auto server = std::unique_ptr<FlightServer>(new FlightServer(server_config));
 	auto start_res = server->Start();
 	if (start_res.is_err()) {
-		server.reset();
 		return start_res;
 	}
-	started_node_id = config.node_id;
-	started_port = server->port();
+	service.bind_host = config.flight_bind_host;
+	service.requested_port = config.flight_port;
+	service.actual_port = server->port();
+	service.server_epoch = std::move(server_config.server_epoch);
+	service.server = std::move(server);
 	return DuckDBResult<void>::ok();
 }
 
 int CurrentLocalFlightServerPort() {
-	auto &server_mutex = LocalFlightServerMutex();
-	std::lock_guard<std::mutex> guard(server_mutex);
-	return LocalFlightServerPort();
+	auto &service = LocalFlightService();
+	std::lock_guard<std::mutex> guard(service.mutex);
+	return service.actual_port;
 }
 
-std::string BuildSinkOutputLocation(const ExchangeContext &ctx, const ExchangeSinkHandle &handle, idx_t attempt_id) {
+std::string CurrentLocalFlightServerEpoch() {
+	auto &service = LocalFlightService();
+	std::lock_guard<std::mutex> guard(service.mutex);
+	return service.server_epoch;
+}
+
+DuckDBResult<void> ShutdownLocalFlightServerInternal() {
+	auto &service = LocalFlightService();
+	std::lock_guard<std::mutex> guard(service.mutex);
+	if (!service.server) {
+		return DuckDBResult<void>::ok();
+	}
+	auto stop_res = service.server->Stop();
+	if (stop_res.is_err()) {
+		return stop_res;
+	}
+	service.server.reset();
+	service.bind_host.clear();
+	service.requested_port = 0;
+	service.actual_port = 0;
+	service.server_epoch.clear();
+	return DuckDBResult<void>::ok();
+}
+
+std::string BuildSinkOutputLocation(const std::string &exchange_instance_id, const ExchangeSinkHandle &handle,
+                                    idx_t attempt_id) {
 	std::ostringstream ss;
-	ss << ctx.exchange_id << "__sink_" << handle.task_partition_id << "__attempt_" << attempt_id;
+	ss << exchange_instance_id << "__sink_" << handle.task_partition_id << "__attempt_" << attempt_id;
 	return ss.str();
 }
 
@@ -293,7 +314,8 @@ std::string BuildSinkOutputLocation(const ExchangeContext &ctx, const ExchangeSi
 
 FlightExchange::FlightExchange(const ExchangeContext &ctx, idx_t output_partition_count,
                                const FlightExchangeConfig &config, ClientContext *context)
-    : ctx_(ctx), output_partition_count_(output_partition_count), config_(config), context_(context) {
+    : ctx_(ctx), output_partition_count_(output_partition_count), config_(config), context_(context),
+      exchange_instance_id_(ctx.exchange_id + "__instance_" + UUID::ToString(UUID::GenerateRandomUUID())) {
 }
 
 FlightExchange::~FlightExchange() {
@@ -311,7 +333,7 @@ ExchangeSinkInstanceHandle FlightExchange::InstantiateSink(const ExchangeSinkHan
 	ExchangeSinkInstanceHandle instance;
 	instance.sink_handle = handle;
 	instance.attempt_id = attempt_id;
-	instance.output_location = BuildSinkOutputLocation(ctx_, handle, attempt_id);
+	instance.output_location = BuildSinkOutputLocation(exchange_instance_id_, handle, attempt_id);
 	instance.output_partition_count = output_partition_count_;
 	auto &attempt_metadata = sink_attempts_[handle.task_partition_id][attempt_id];
 	attempt_metadata.task_partition_id = handle.task_partition_id;
@@ -321,25 +343,48 @@ ExchangeSinkInstanceHandle FlightExchange::InstantiateSink(const ExchangeSinkHan
 }
 
 void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id) {
-	SinkFinished(handle, attempt_id, std::string(), 0);
+	ExchangeSinkInstanceHandle instance;
+	instance.sink_handle = handle;
+	instance.attempt_id = attempt_id;
+	SinkFinished(instance, std::string(), 0);
 }
 
 void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id, const std::string &node_id,
                                   int flight_port) {
+	ExchangeSinkInstanceHandle instance;
+	instance.sink_handle = handle;
+	instance.attempt_id = attempt_id;
+	SinkFinished(instance, node_id, flight_port);
+}
+
+void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id,
+                                  int flight_port) {
+	if (flight_port > 0 && instance.flight_server_epoch.empty()) {
+		throw InvalidInputException("finished Flight sink is missing its server epoch");
+	}
 	bool cleanup_unselected = false;
 	{
 		std::lock_guard<std::mutex> lock(mutex_);
+		const auto &handle = instance.sink_handle;
+		const auto attempt_id = instance.attempt_id;
 		auto &attempt_metadata = sink_attempts_[handle.task_partition_id][attempt_id];
 		attempt_metadata.task_partition_id = handle.task_partition_id;
 		attempt_metadata.attempt_id = attempt_id;
 		if (attempt_metadata.output_location.empty()) {
-			attempt_metadata.output_location = BuildSinkOutputLocation(ctx_, handle, attempt_id);
+			attempt_metadata.output_location = instance.output_location.empty()
+			                                       ? BuildSinkOutputLocation(exchange_instance_id_, handle, attempt_id)
+			                                       : instance.output_location;
+		} else if (!instance.output_location.empty() && attempt_metadata.output_location != instance.output_location) {
+			throw InvalidInputException("finished Flight sink output location does not match instantiated attempt");
 		}
 		if (!node_id.empty()) {
 			attempt_metadata.node_id = node_id;
 		}
 		if (flight_port > 0) {
 			attempt_metadata.flight_port = flight_port;
+		}
+		if (!instance.flight_server_epoch.empty()) {
+			attempt_metadata.flight_server_epoch = instance.flight_server_epoch;
 		}
 
 		auto selected_entry = selected_attempts_.find(handle.task_partition_id);
@@ -448,7 +493,8 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 			if (attempt_metadata.output_location.empty()) {
 				ExchangeSinkHandle sink_handle;
 				sink_handle.task_partition_id = sink_partition_id;
-				attempt_metadata.output_location = BuildSinkOutputLocation(ctx_, sink_handle, attempt_id);
+				attempt_metadata.output_location =
+				    BuildSinkOutputLocation(exchange_instance_id_, sink_handle, attempt_id);
 			}
 			attempt_metadata.task_partition_id = sink_partition_id;
 			attempt_metadata.attempt_id = attempt_id;
@@ -465,7 +511,7 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 			handle.attempt_id = 0;
 			handle.flight_port = config_.flight_port;
 			ExchangeSourceFile file;
-			file.path = ctx_.exchange_id;
+			file.path = exchange_instance_id_;
 			file.file_size = 0;
 			handle.files.push_back(std::move(file));
 			handles.push_back(std::move(handle));
@@ -506,6 +552,7 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 			handle.attempt_id = attempt_id;
 			handle.node_id = attempt_metadata.node_id;
 			handle.flight_port = attempt_metadata.flight_port > 0 ? attempt_metadata.flight_port : config_.flight_port;
+			handle.flight_server_epoch = attempt_metadata.flight_server_epoch;
 			handle.files.push_back(build_source_file(attempt_metadata, partition_id));
 			handles.push_back(std::move(handle));
 		}
@@ -524,7 +571,7 @@ void FlightExchange::Close() {
 	}
 	closed_ = true;
 	// Clean up the ShuffleCacheRegistry entry
-	ShuffleCacheRegistry::Instance().Remove(ctx_.exchange_id);
+	ShuffleCacheRegistry::Instance().Remove(exchange_instance_id_);
 	std::unordered_set<std::string> output_locations;
 	for (const auto &sink_entry : sink_attempts_) {
 		for (const auto &attempt_entry : sink_entry.second) {
@@ -596,8 +643,8 @@ DuckDBResult<void> FlightExchangeSink::Finish() {
 	}
 	// Register the ShuffleCache in the global registry
 	// so FlightServer / FlightExchangeSource can find it
-	ShuffleCacheRegistry::Instance().Register(handle_.output_location, shuffle_cache_);
-	return DuckDBResult<void>::ok();
+	return ShuffleCacheRegistry::Instance().Register(handle_.output_location, shuffle_cache_,
+	                                                 handle_.flight_server_epoch, handle_.attempt_id);
 }
 
 DuckDBResult<void> FlightExchangeSink::Abort() {
@@ -746,6 +793,10 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		    std::string(prefix) + " for exchange_id=" + output_location + " source_node_id=" + source_node_id +
 		    " partition=" + std::to_string(partition_id) + ": " + files_res.error().what()));
 	}
+	if (handle.flight_server_epoch.empty()) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    DuckDBError::invalid_state_error("remote Flight exchange source handle is missing its server epoch"));
+	}
 
 	auto location = BuildFlightLocationForPort(config_, source_node_id, source_flight_port);
 	auto client_res = ConnectFlightExchangeClient(location);
@@ -756,8 +807,10 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 
 	arrow::flight::Ticket flight_ticket;
 	FlightExchangeTicket ticket;
-	ticket.shuffle_stage_id = output_location;
+	ticket.server_epoch = handle.flight_server_epoch;
+	ticket.exchange_instance_id = output_location;
 	ticket.node_id = source_node_id;
+	ticket.attempt_id = handle.attempt_id;
 	ticket.partition_idx = partition_id;
 	flight_ticket.ticket = ticket.Serialize();
 
@@ -969,8 +1022,10 @@ std::unique_ptr<ExchangeSink> FlightExchangeManager::CreateSink(const ExchangeSi
 	if (server_res.is_err()) {
 		throw std::runtime_error(server_res.error().what());
 	}
+	auto sink_handle = handle;
+	sink_handle.flight_server_epoch = GetLocalFlightServerEpoch();
 	auto shuffle_cache = MakeFlightExchangeShuffleCache(cache_config, config_, context_);
-	return std::unique_ptr<ExchangeSink>(new FlightExchangeSink(shuffle_cache, handle, context_));
+	return std::unique_ptr<ExchangeSink>(new FlightExchangeSink(shuffle_cache, sink_handle, context_));
 }
 
 std::unique_ptr<ExchangeSource> FlightExchangeManager::CreateSource() {
@@ -982,7 +1037,21 @@ int FlightExchangeManager::GetLocalFlightServerPort() {
 	return CurrentLocalFlightServerPort();
 }
 
+std::string FlightExchangeManager::GetLocalFlightServerEpoch() {
+	return CurrentLocalFlightServerEpoch();
+}
+
+DuckDBResult<void> FlightExchangeManager::EnsureLocalFlightServerStarted(const FlightExchangeConfig &config) {
+	return EnsureLocalFlightServerStartedInternal(config);
+}
+
+DuckDBResult<void> FlightExchangeManager::ShutdownLocalFlightServer() {
+	return ShutdownLocalFlightServerInternal();
+}
+
 void FlightExchangeManager::Shutdown() {
+	// Exchange managers are session-scoped users of the process-local service.
+	// The worker runtime owns service shutdown explicitly.
 }
 
 } // namespace distributed

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager_stub.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager_stub.cpp
@@ -48,6 +48,19 @@ int FlightExchangeManager::GetLocalFlightServerPort() {
 	return 0;
 }
 
+std::string FlightExchangeManager::GetLocalFlightServerEpoch() {
+	return std::string();
+}
+
+DuckDBResult<void> FlightExchangeManager::EnsureLocalFlightServerStarted(const FlightExchangeConfig &) {
+	return DuckDBResult<void>::err(
+	    DuckDBError::invalid_state_error("Flight exchange is disabled. Rebuild with BUILD_DISTRIBUTED_EXCHANGE=ON."));
+}
+
+DuckDBResult<void> FlightExchangeManager::ShutdownLocalFlightServer() {
+	return DuckDBResult<void>::ok();
+}
+
 void FlightExchangeManager::Shutdown() {
 }
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
@@ -176,6 +176,7 @@ public:
 
 	arrow::Status Close() override {
 		current_input_.reset();
+		cache_.reset();
 		return arrow::Status::OK();
 	}
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
@@ -13,23 +13,12 @@
 #include <arrow/io/api.h>
 #include <arrow/buffer.h>
 #include <algorithm>
-#include <sstream>
 #include <vector>
 
 namespace duckdb {
 namespace distributed {
 
 namespace {
-
-std::string FlightServerSanitizePathComponent(const std::string &value) {
-	std::string out = value;
-	for (auto &ch : out) {
-		if (ch == '/' || ch == '\\') {
-			ch = '_';
-		}
-	}
-	return out;
-}
 
 DuckDBError FlightServerArrowToError(const arrow::Status &status, const std::string &context) {
 	return DuckDBError::external_error(context + ": " + status.ToString());
@@ -46,32 +35,6 @@ DuckDBResult<arrow::flight::Location> MakeLocation(const FlightServerConfig &con
 		    FlightServerArrowToError(location_res.status(), "create flight location"));
 	}
 	return DuckDBResult<arrow::flight::Location>::ok(std::move(location_res).ValueOrDie());
-}
-
-std::string NodeDirectory(const FlightServerConfig &config, const std::string &shuffle_stage_id,
-                          const std::string &node_id) {
-	auto stage = FlightServerSanitizePathComponent(shuffle_stage_id);
-	auto node = FlightServerSanitizePathComponent(node_id);
-	auto base_dir = config.local_dirs.empty() ? std::string() : config.local_dirs[0];
-	std::ostringstream ss;
-	ss << base_dir << "/shuffle_" << stage << "/node_" << node;
-	return ss.str();
-}
-
-std::string PartitionDirectory(const FlightServerConfig &config, const std::string &shuffle_stage_id,
-                               const std::string &node_id, idx_t partition_idx) {
-	auto stage = FlightServerSanitizePathComponent(shuffle_stage_id);
-	auto node = FlightServerSanitizePathComponent(node_id);
-	auto base_dir =
-	    config.local_dirs.empty() ? std::string() : config.local_dirs[partition_idx % config.local_dirs.size()];
-	std::ostringstream ss;
-	ss << base_dir << "/shuffle_" << stage << "/node_" << node << "/partition_" << partition_idx;
-	return ss.str();
-}
-
-std::string SchemaFilePath(const FlightServerConfig &config, const std::string &shuffle_stage_id,
-                           const std::string &node_id) {
-	return NodeDirectory(config, shuffle_stage_id, node_id) + "/schema.arrow";
 }
 
 /// Lazy-streaming RecordBatchReader that reads batches on-demand from multiple
@@ -151,12 +114,13 @@ private:
 /// FlightData.ipc_message = { metadata: flatbuf bytes, body_buffers: [body bytes] }
 class ZeroCopyIPCStreamFlightDataStream : public arrow::flight::FlightDataStream {
 public:
-	static arrow::Result<std::unique_ptr<ZeroCopyIPCStreamFlightDataStream>> Open(std::vector<std::string> files) {
+	static arrow::Result<std::unique_ptr<ZeroCopyIPCStreamFlightDataStream>> Open(std::vector<std::string> files,
+	                                                                              std::shared_ptr<ShuffleCache> cache) {
 		if (files.empty()) {
 			return arrow::Status::Invalid("no files to stream");
 		}
-		auto stream =
-		    std::unique_ptr<ZeroCopyIPCStreamFlightDataStream>(new ZeroCopyIPCStreamFlightDataStream(std::move(files)));
+		auto stream = std::unique_ptr<ZeroCopyIPCStreamFlightDataStream>(
+		    new ZeroCopyIPCStreamFlightDataStream(std::move(files), std::move(cache)));
 		ARROW_RETURN_NOT_OK(stream->Initialize());
 		return stream;
 	}
@@ -216,7 +180,8 @@ public:
 	}
 
 private:
-	explicit ZeroCopyIPCStreamFlightDataStream(std::vector<std::string> files) : files_(std::move(files)) {
+	ZeroCopyIPCStreamFlightDataStream(std::vector<std::string> files, std::shared_ptr<ShuffleCache> cache)
+	    : files_(std::move(files)), cache_(std::move(cache)) {
 	}
 
 	arrow::Status Initialize() {
@@ -231,6 +196,7 @@ private:
 	}
 
 	std::vector<std::string> files_;
+	std::shared_ptr<ShuffleCache> cache_;
 	std::shared_ptr<arrow::Schema> schema_;
 	std::shared_ptr<arrow::io::ReadableFile> current_input_;
 	size_t current_file_idx_ = 0;
@@ -256,58 +222,47 @@ public:
 			return arrow::Status::Invalid(ticket_res.error().what());
 		}
 		auto ticket = std::move(ticket_res.value());
-
-		std::vector<std::string> files;
-
-		// Priority 1: Look up ShuffleCacheRegistry (aligned with Vane's do_get)
-		auto cache = ShuffleCacheRegistry::Instance().Get(ticket.shuffle_stage_id);
-		bool visible_committed_attempt = cache != nullptr;
-		if (cache) {
-			auto files_res = cache->GetPartitionFiles(ticket.partition_idx);
-			if (!files_res.is_err()) {
-				for (auto &f : files_res.value().files) {
-					files.push_back(f.path);
-				}
-			}
+		if (ticket.server_epoch != config_.server_epoch) {
+			return arrow::Status::Invalid("flight ticket server epoch is stale");
 		}
 
-		// Priority 2: durable manifest recovery (cross-process / registry-loss scenario)
-		if (files.empty() && !config_.local_dirs.empty()) {
-			ShuffleCacheConfig cache_config;
-			cache_config.shuffle_stage_id = ticket.shuffle_stage_id;
-			cache_config.node_id = ticket.node_id;
-			cache_config.num_partitions = std::max<idx_t>(ticket.partition_idx + 1, 1);
-			cache_config.local_dirs = config_.local_dirs;
-			ShuffleCache manifest_cache(std::move(cache_config));
-			if (manifest_cache.HasCommittedManifest()) {
-				visible_committed_attempt = true;
-				auto files_res = manifest_cache.GetPartitionFilesFromManifest(ticket.partition_idx);
-				if (files_res.is_err()) {
-					return arrow::Status::IOError(files_res.error().what());
-				}
-				for (const auto &f : files_res.value().files) {
-					files.push_back(f.path);
-				}
+		auto cache_res = ShuffleCacheRegistry::Instance().Resolve(ticket.exchange_instance_id, ticket.server_epoch,
+		                                                          ticket.node_id, ticket.attempt_id);
+		if (cache_res.is_err()) {
+			return arrow::Status::Invalid(cache_res.error().what());
+		}
+		auto cache = std::move(cache_res.value());
+
+		if (!cache->HasCommittedManifest()) {
+			return arrow::Status::Invalid("flight exchange attempt is not committed: " + ticket.exchange_instance_id);
+		}
+
+		auto files_res = cache->GetPartitionFiles(ticket.partition_idx);
+		if (files_res.is_err()) {
+			return arrow::Status::IOError(files_res.error().what());
+		}
+		if (files_res.value().files.empty()) {
+			files_res = cache->GetPartitionFilesFromManifest(ticket.partition_idx);
+			if (files_res.is_err()) {
+				return arrow::Status::IOError(files_res.error().what());
 			}
+		}
+		std::vector<std::string> files;
+		for (const auto &file : files_res.value().files) {
+			files.push_back(file.path);
 		}
 		std::sort(files.begin(), files.end());
 
-		if (files.empty() && !visible_committed_attempt) {
-			return arrow::Status::Invalid("flight exchange attempt is not committed: " + ticket.shuffle_stage_id);
-		}
 		if (files.empty()) {
 			// Return empty stream with schema only
-			if (config_.local_dirs.empty()) {
-				return arrow::Status::Invalid("flight server local_dirs is empty and no cache found");
-			}
-			auto schema_path = SchemaFilePath(config_, ticket.shuffle_stage_id, ticket.node_id);
-			ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchemaFromFile(schema_path));
+			ARROW_ASSIGN_OR_RAISE(auto schema, ReadSchemaFromFile(cache->SchemaFilePath()));
 			arrow::RecordBatchVector empty;
 			ARROW_ASSIGN_OR_RAISE(auto reader, arrow::RecordBatchReader::Make(empty, schema));
 			*stream = std::unique_ptr<arrow::flight::RecordBatchStream>(new arrow::flight::RecordBatchStream(reader));
 		} else {
 			// True zero-copy: read raw IPC stream bytes directly into FlightPayload
-			ARROW_ASSIGN_OR_RAISE(auto zc_stream, ZeroCopyIPCStreamFlightDataStream::Open(std::move(files)));
+			ARROW_ASSIGN_OR_RAISE(auto zc_stream,
+			                      ZeroCopyIPCStreamFlightDataStream::Open(std::move(files), std::move(cache)));
 			*stream = std::move(zc_stream);
 		}
 		return arrow::Status::OK();
@@ -358,11 +313,7 @@ FlightServer::~FlightServer() {
 		return;
 	}
 	if (impl_ && impl_->server()) {
-		auto status = impl_->server()->Shutdown();
-		if (!status.ok()) {
-			server_thread_.detach();
-			return;
-		}
+		(void)impl_->server()->Shutdown();
 	}
 	server_thread_.join();
 }
@@ -379,8 +330,8 @@ DuckDBResult<void> FlightServer::StartInternal() {
 	if (!impl_) {
 		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("flight server not initialized"));
 	}
-	if (config_.local_dirs.empty()) {
-		return DuckDBResult<void>::err(DuckDBError::value_error("flight server local_dirs is empty"));
+	if (config_.server_epoch.empty()) {
+		return DuckDBResult<void>::err(DuckDBError::value_error("flight server epoch is empty"));
 	}
 	auto start_res = impl_->Start();
 	if (start_res.is_err()) {

--- a/external/duckdb/src/execution/distributed/exchange/flight_ticket.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_ticket.cpp
@@ -3,6 +3,8 @@
 
 #include "duckdb/execution/distributed/exchange/flight_ticket.hpp"
 
+#include <algorithm>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -29,44 +31,64 @@ std::vector<std::string> SplitLines(const std::string &input) {
 	return parts;
 }
 
+DuckDBResult<idx_t> ParseIndex(const std::string &value, const std::string &field) {
+	if (value.empty() || std::any_of(value.begin(), value.end(), [](char ch) { return ch < '0' || ch > '9'; })) {
+		return DuckDBResult<idx_t>::err(DuckDBError::value_error("invalid flight ticket " + field));
+	}
+	try {
+		size_t parsed_chars = 0;
+		auto parsed = std::stoull(value, &parsed_chars);
+		if (parsed_chars != value.size() ||
+		    parsed > static_cast<unsigned long long>(std::numeric_limits<idx_t>::max())) {
+			return DuckDBResult<idx_t>::err(DuckDBError::value_error("invalid flight ticket " + field));
+		}
+		return DuckDBResult<idx_t>::ok(static_cast<idx_t>(parsed));
+	} catch (const std::exception &) {
+		return DuckDBResult<idx_t>::err(DuckDBError::value_error("invalid flight ticket " + field));
+	}
+}
+
 } // namespace
 
 std::string FlightExchangeTicket::Serialize() const {
 	std::ostringstream ss;
-	ss << kTicketVersion << '\n' << shuffle_stage_id << '\n' << node_id << '\n' << partition_idx;
+	ss << kTicketVersion << '\n'
+	   << server_epoch << '\n'
+	   << exchange_instance_id << '\n'
+	   << node_id << '\n'
+	   << attempt_id << '\n'
+	   << partition_idx;
 	return ss.str();
 }
 
 DuckDBResult<FlightExchangeTicket> FlightExchangeTicket::Parse(const std::string &ticket) {
 	auto parts = SplitLines(ticket);
-	if (parts.size() != 4) {
+	if (parts.size() != 6) {
 		return DuckDBResult<FlightExchangeTicket>::err(DuckDBError::value_error("invalid flight ticket format"));
 	}
 	if (parts[0] != kTicketVersion) {
 		return DuckDBResult<FlightExchangeTicket>::err(DuckDBError::value_error("unsupported flight ticket version"));
 	}
-	if (parts[1].empty() || parts[2].empty()) {
+	if (parts[1].empty() || parts[2].empty() || parts[3].empty()) {
 		return DuckDBResult<FlightExchangeTicket>::err(
-		    DuckDBError::value_error("flight ticket missing stage or node id"));
+		    DuckDBError::value_error("flight ticket missing server epoch, exchange instance, or node id"));
 	}
 
-	idx_t partition_idx = 0;
-	try {
-		auto parsed = std::stoll(parts[3]);
-		if (parsed < 0) {
-			return DuckDBResult<FlightExchangeTicket>::err(
-			    DuckDBError::value_error("flight ticket partition index is negative"));
-		}
-		partition_idx = static_cast<idx_t>(parsed);
-	} catch (const std::exception &) {
-		return DuckDBResult<FlightExchangeTicket>::err(
-		    DuckDBError::value_error("flight ticket partition index parse failed"));
+	auto attempt_id = ParseIndex(parts[4], "attempt id");
+	if (attempt_id.is_err()) {
+		return DuckDBResult<FlightExchangeTicket>::err(attempt_id.error());
+	}
+	auto partition_idx = ParseIndex(parts[5], "partition index");
+	if (partition_idx.is_err()) {
+		return DuckDBResult<FlightExchangeTicket>::err(partition_idx.error());
 	}
 
 	FlightExchangeTicket result;
-	result.shuffle_stage_id = parts[1];
-	result.node_id = parts[2];
-	result.partition_idx = partition_idx;
+	result.server_epoch = parts[1];
+	result.exchange_instance_id = parts[2];
+	result.node_id = parts[3];
+	result.attempt_id = attempt_id.value();
+	result.partition_idx = partition_idx.value();
 	return DuckDBResult<FlightExchangeTicket>::ok(std::move(result));
 }
 

--- a/external/duckdb/src/execution/distributed/pipeline_node/pipeline_node.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/pipeline_node.cpp
@@ -23,7 +23,7 @@ void RecordRemoteExchangeFinishedSinks(Exchange &exchange, const std::vector<Mat
 			node_id = *worker_id;
 		}
 		const auto &sink_instance = outputs[i].exchange_sink_instance();
-		exchange.SinkFinished(sink_instance.sink_handle, sink_instance.attempt_id, node_id, outputs[i].flight_port());
+		exchange.SinkFinished(sink_instance, node_id, outputs[i].flight_port());
 	}
 }
 

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -467,7 +467,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				node_id = *worker_id;
 			}
 			const auto &sink_instance = output.exchange_sink_instance();
-			exchange->SinkFinished(sink_instance.sink_handle, sink_instance.attempt_id, node_id, output.flight_port());
+			exchange->SinkFinished(sink_instance, node_id, output.flight_port());
 			return send_new_source_handles("sink_output");
 		};
 		auto materialize_profile_start = std::chrono::steady_clock::now();

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -40,7 +40,8 @@ vector<std::string> CollectShuffleSourceNodes(const std::vector<ExchangeSourceHa
 
 std::string ExchangeSourceHandleKey(const ExchangeSourceHandle &handle) {
 	std::ostringstream ss;
-	ss << handle.partition_id << '|' << handle.attempt_id << '|' << handle.node_id << '|' << handle.flight_port;
+	ss << handle.partition_id << '|' << handle.attempt_id << '|' << handle.node_id << '|' << handle.flight_port << '|'
+	   << handle.flight_server_epoch;
 	for (const auto &file : handle.files) {
 		ss << '|' << file.path << ':' << file.rows << ':' << file.file_size;
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -318,7 +318,7 @@ static DuckDBResult<void> RecordOrderByExchangeSinkOutput(Exchange &exchange, co
 		node_id = *worker_id;
 	}
 	const auto &sink_instance = output.exchange_sink_instance();
-	exchange.SinkFinished(sink_instance.sink_handle, sink_instance.attempt_id, node_id, output.flight_port());
+	exchange.SinkFinished(sink_instance, node_id, output.flight_port());
 	return DuckDBResult<void>::ok();
 }
 

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -54,6 +54,7 @@ void ExchangeSinkInstanceTaskDescriptor::Serialize(Serializer &serializer) const
 	serializer.WriteProperty(2, "attempt_id", sink_instance.attempt_id);
 	serializer.WriteProperty(3, "output_location", sink_instance.output_location);
 	serializer.WriteProperty(4, "output_partition_count", sink_instance.output_partition_count);
+	serializer.WriteProperty(5, "flight_server_epoch", sink_instance.flight_server_epoch);
 }
 
 ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deserialize(Deserializer &deserializer) {
@@ -64,6 +65,7 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	    deserializer.ReadPropertyWithExplicitDefault<string>(3, "output_location", "");
 	result.sink_instance.output_partition_count =
 	    deserializer.ReadPropertyWithDefault<idx_t>(4, "output_partition_count");
+	result.sink_instance.flight_server_epoch = deserializer.ReadProperty<string>(5, "flight_server_epoch");
 	return result;
 }
 

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -55,6 +55,7 @@ void ExchangeSinkInstanceTaskDescriptor::Serialize(Serializer &serializer) const
 	serializer.WriteProperty(3, "output_location", sink_instance.output_location);
 	serializer.WriteProperty(4, "output_partition_count", sink_instance.output_partition_count);
 	serializer.WriteProperty(5, "flight_server_epoch", sink_instance.flight_server_epoch);
+	serializer.WriteProperty(6, "query_id", sink_instance.query_id);
 }
 
 ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deserialize(Deserializer &deserializer) {
@@ -66,6 +67,7 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	result.sink_instance.output_partition_count =
 	    deserializer.ReadPropertyWithDefault<idx_t>(4, "output_partition_count");
 	result.sink_instance.flight_server_epoch = deserializer.ReadProperty<string>(5, "flight_server_epoch");
+	result.sink_instance.query_id = deserializer.ReadProperty<string>(6, "query_id");
 	return result;
 }
 

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -22,6 +22,60 @@ namespace distributed {
 
 namespace {
 
+bool SetValidationError(std::string *error, const std::string &message) {
+	if (error) {
+		*error = message;
+	}
+	return false;
+}
+
+bool ExtractSinkOutputLocationPrefix(const ExchangeSinkInstanceHandle &handle, std::string &prefix,
+                                     std::string *error) {
+	const auto sink_suffix = std::string("__sink_") + std::to_string(handle.sink_handle.task_partition_id) +
+	                         "__attempt_" + std::to_string(handle.attempt_id);
+	if (handle.output_location.size() < sink_suffix.size() ||
+	    handle.output_location.compare(handle.output_location.size() - sink_suffix.size(), sink_suffix.size(),
+	                                   sink_suffix) != 0) {
+		return SetValidationError(error, "remote exchange sink plan has an invalid sink output location");
+	}
+	prefix = handle.output_location.substr(0, handle.output_location.size() - sink_suffix.size());
+	if (prefix.empty()) {
+		return SetValidationError(error, "remote exchange sink plan is missing its exchange instance id");
+	}
+	return true;
+}
+
+bool ValidateRuntimeSinkHandle(const PhysicalRemoteExchangeSink &sink, const ExchangeSinkInstanceHandle &runtime_handle,
+                               std::string *error) {
+	const auto &plan_handle = sink.SinkHandle();
+	if (plan_handle.query_id.empty()) {
+		return SetValidationError(error, "remote exchange sink plan is missing query ownership");
+	}
+	if (runtime_handle.query_id.empty() || runtime_handle.query_id != plan_handle.query_id) {
+		return SetValidationError(error, "runtime exchange sink query does not match the plan");
+	}
+	if (plan_handle.output_partition_count != sink.NumPartitions()) {
+		return SetValidationError(error, "remote exchange sink plan has an inconsistent output partition count");
+	}
+	if (runtime_handle.output_partition_count == 0 || runtime_handle.output_partition_count != sink.NumPartitions()) {
+		return SetValidationError(error, "runtime exchange sink output partition count does not match the plan");
+	}
+	if (plan_handle.output_location.empty()) {
+		return SetValidationError(error, "remote exchange sink plan is missing its output location");
+	}
+	std::string exchange_instance_prefix;
+	if (!ExtractSinkOutputLocationPrefix(plan_handle, exchange_instance_prefix, error)) {
+		return false;
+	}
+	const auto expected_output_location = exchange_instance_prefix + "__sink_" +
+	                                      std::to_string(runtime_handle.sink_handle.task_partition_id) + "__attempt_" +
+	                                      std::to_string(runtime_handle.attempt_id);
+	if (runtime_handle.output_location != expected_output_location) {
+		return SetValidationError(error, "runtime exchange sink output location does not match the plan");
+	}
+	return true;
+}
+
 bool ApplyExchangeSinkInstanceToOperator(PhysicalOperator &op, const ExchangeSinkInstanceTaskDescriptor &task,
                                          std::string *error, idx_t &applied) {
 	if (op.type == PhysicalOperatorType::EXCHANGE_SINK) {
@@ -33,8 +87,8 @@ bool ApplyExchangeSinkInstanceToOperator(PhysicalOperator &op, const ExchangeSin
 			return false;
 		}
 		auto sink_handle = task.sink_instance;
-		if (sink_handle.output_partition_count == 0) {
-			sink_handle.output_partition_count = sink->NumPartitions();
+		if (!ValidateRuntimeSinkHandle(*sink, sink_handle, error)) {
+			return false;
 		}
 		sink->ApplyRuntimeSinkHandle(std::move(sink_handle));
 		applied++;

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -69,6 +69,7 @@ void ExchangeSourceTaskDescriptor::Serialize(Serializer &serializer) const {
 				});
 			});
 			obj.WriteProperty(5, "attempt_id", handle.attempt_id);
+			obj.WriteProperty(6, "flight_server_epoch", handle.flight_server_epoch);
 		});
 	});
 	serializer.WriteProperty(3, "source_partition_count", source_partition_count);
@@ -95,6 +96,7 @@ ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deseriali
 				handle.files.push_back(std::move(file));
 			});
 			handle.attempt_id = obj.ReadPropertyWithExplicitDefault<idx_t>(5, "attempt_id", 0);
+			handle.flight_server_epoch = obj.ReadProperty<string>(6, "flight_server_epoch");
 		});
 		result.source_handles.push_back(std::move(handle));
 	});

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -252,10 +252,6 @@ SinkResultType PhysicalRemoteExchangeSink::Sink(ExecutionContext &context, DataC
 SinkFinalizeType PhysicalRemoteExchangeSink::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                                       OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<RemoteSinkGlobalState>();
-	auto result = gstate.sink->Finish();
-	if (result.is_err()) {
-		throw IOException(std::string("[RemoteExchangeSink] Finish failed: ") + result.error().what());
-	}
 	// Ensure schema.arrow is written even for 0-row exchanges so downstream
 	// Flight readers can open the exchange without ENOENT errors.
 	vector<string> col_names;
@@ -264,6 +260,25 @@ SinkFinalizeType PhysicalRemoteExchangeSink::Finalize(Pipeline &pipeline, Event 
 		col_names.push_back("col" + std::to_string(i));
 	}
 	auto schema_result = gstate.sink->EnsureSchema(context, types, col_names);
+	if (schema_result.is_err()) {
+		auto message = std::string("[RemoteExchangeSink] EnsureSchema failed: ") + schema_result.error().what();
+		auto abort_result = gstate.sink->Abort();
+		if (abort_result.is_err()) {
+			message += "; Abort failed: ";
+			message += abort_result.error().what();
+		}
+		throw IOException(message);
+	}
+	auto result = gstate.sink->Finish();
+	if (result.is_err()) {
+		auto message = std::string("[RemoteExchangeSink] Finish failed: ") + result.error().what();
+		auto abort_result = gstate.sink->Abort();
+		if (abort_result.is_err()) {
+			message += "; Abort failed: ";
+			message += abort_result.error().what();
+		}
+		throw IOException(message);
+	}
 	return SinkFinalizeType::READY;
 }
 

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -282,21 +282,27 @@ namespace duckdb {
 void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) const {
 	// Write the same field layout as PhysicalExchangeSink so the worker-side
 	// deserializer (EXCHANGE_SINK case) can reconstruct a working sink.
+	auto flight_manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(exchange_mgr_);
+	if (!flight_manager) {
+		throw SerializationException("PhysicalRemoteExchangeSink requires a FlightExchangeManager");
+	}
+	const auto &flight_config = flight_manager->config();
+	vector<string> local_dirs(flight_config.local_dirs.begin(), flight_config.local_dirs.end());
 	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
-	serializer.WriteProperty(104, "node_id", distributed::ResolveFlightExchangeNodeIdFromEnv());
+	serializer.WriteProperty(104, "node_id", flight_config.node_id);
 	serializer.WriteProperty(105, "num_partitions", num_partitions_);
 	serializer.WriteProperty(106, "repartition_type", static_cast<uint8_t>(repartition_type_));
 	serializer.WriteProperty(107, "partition_by", partition_by_);
-	auto local_dirs = distributed::ResolveFlightExchangeLocalDirsFromEnv();
 	serializer.WriteProperty(108, "local_dirs", local_dirs);
-	serializer.WriteProperty(109, "flight_bind_host", std::string("0.0.0.0"));
-	serializer.WriteProperty(110, "flight_port", distributed::ResolveFlightExchangeEnvInt("DUCKDB_FLIGHT_PORT", 0));
+	serializer.WriteProperty(109, "flight_bind_host", flight_config.flight_bind_host);
+	serializer.WriteProperty(110, "flight_port", flight_config.flight_port);
 	serializer.WriteProperty(111, "sink_task_partition_id", sink_handle_.sink_handle.task_partition_id);
 	serializer.WriteProperty(112, "sink_attempt_id", sink_handle_.attempt_id);
 	serializer.WriteProperty(113, "sink_output_location", sink_handle_.output_location);
 	serializer.WriteProperty(114, "range_boundaries", range_boundaries_);
 	serializer.WriteProperty(115, "range_order_modifiers", range_order_modifiers_);
 	serializer.WriteProperty(116, "flight_server_epoch", sink_handle_.flight_server_epoch);
+	serializer.WriteProperty(117, "query_id", sink_handle_.query_id);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -296,6 +296,7 @@ void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) c
 	serializer.WriteProperty(113, "sink_output_location", sink_handle_.output_location);
 	serializer.WriteProperty(114, "range_boundaries", range_boundaries_);
 	serializer.WriteProperty(115, "range_order_modifiers", range_order_modifiers_);
+	serializer.WriteProperty(116, "flight_server_epoch", sink_handle_.flight_server_epoch);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -310,6 +310,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	vector<string> handle_paths;
 	vector<int> handle_flight_ports;
 	vector<idx_t> handle_attempt_ids;
+	vector<string> handle_flight_server_epochs;
 	vector<string> local_dirs;
 	if (exchange_mgr_) {
 		auto flight_mgr = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(exchange_mgr_);
@@ -323,12 +324,14 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	handle_paths.reserve(source_handles_.size());
 	handle_flight_ports.reserve(source_handles_.size());
 	handle_attempt_ids.reserve(source_handles_.size());
+	handle_flight_server_epochs.reserve(source_handles_.size());
 	for (const auto &handle : source_handles_) {
 		handle_partition_ids.push_back(handle.partition_id);
 		handle_node_ids.push_back(handle.node_id);
 		handle_paths.push_back(handle.files.empty() ? string() : handle.files[0].path);
 		handle_flight_ports.push_back(handle.flight_port);
 		handle_attempt_ids.push_back(handle.attempt_id);
+		handle_flight_server_epochs.push_back(handle.flight_server_epoch);
 	}
 	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
 	serializer.WriteProperty(104, "partition_indices", partition_indices_);
@@ -344,6 +347,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WritePropertyWithDefault(112, "runtime_source_node_id", runtime_source_node_id_, optional_idx());
 	serializer.WriteProperty(113, "source_handle_attempt_ids", handle_attempt_ids);
 	serializer.WriteProperty(114, "local_dirs", local_dirs);
+	serializer.WriteProperty(115, "source_handle_flight_server_epochs", handle_flight_server_epochs);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -312,12 +312,15 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	vector<idx_t> handle_attempt_ids;
 	vector<string> handle_flight_server_epochs;
 	vector<string> local_dirs;
-	if (exchange_mgr_) {
-		auto flight_mgr = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(exchange_mgr_);
-		if (flight_mgr) {
-			local_dirs.insert(local_dirs.end(), flight_mgr->config().local_dirs.begin(),
-			                  flight_mgr->config().local_dirs.end());
-		}
+	auto flight_mgr = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(exchange_mgr_);
+	if (!flight_mgr) {
+		throw SerializationException("PhysicalRemoteExchangeSource requires a FlightExchangeManager");
+	}
+	const auto &flight_config = flight_mgr->config();
+	local_dirs.insert(local_dirs.end(), flight_config.local_dirs.begin(), flight_config.local_dirs.end());
+	auto flight_location_template = flight_config.flight_location_template;
+	if (flight_location_template.empty()) {
+		flight_location_template = "grpc://{node}:" + std::to_string(flight_config.flight_port);
 	}
 	handle_partition_ids.reserve(source_handles_.size());
 	handle_node_ids.reserve(source_handles_.size());
@@ -336,10 +339,8 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
 	serializer.WriteProperty(104, "partition_indices", partition_indices_);
 	serializer.WriteProperty(105, "source_nodes", source_nodes_);
-	serializer.WriteProperty(106, "flight_location_template",
-	                         std::string("grpc://{node}:") +
-	                             std::to_string(distributed::ResolveFlightExchangeEnvInt("DUCKDB_FLIGHT_PORT", 0)));
-	serializer.WriteProperty(107, "flight_timeout_seconds", 0.0);
+	serializer.WriteProperty(106, "flight_location_template", flight_location_template);
+	serializer.WriteProperty(107, "flight_timeout_seconds", flight_config.flight_timeout_seconds);
 	serializer.WriteProperty(108, "source_handle_partition_ids", handle_partition_ids);
 	serializer.WriteProperty(109, "source_handle_node_ids", handle_node_ids);
 	serializer.WriteProperty(110, "source_handle_paths", handle_paths);
@@ -348,6 +349,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(113, "source_handle_attempt_ids", handle_attempt_ids);
 	serializer.WriteProperty(114, "local_dirs", local_dirs);
 	serializer.WriteProperty(115, "source_handle_flight_server_epochs", handle_flight_server_epochs);
+	serializer.WriteProperty(116, "source_catalog_handles_explicit", true);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1191,6 +1191,10 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto local_dirs = deserializer.ReadPropertyWithDefault<vector<string>>(114, "local_dirs");
 		auto source_handle_flight_server_epochs =
 		    deserializer.ReadProperty<vector<string>>(115, "source_handle_flight_server_epochs");
+		auto source_catalog_handles_explicit = deserializer.ReadProperty<bool>(116, "source_catalog_handles_explicit");
+		if (!source_catalog_handles_explicit) {
+			throw SerializationException("remote exchange source requires explicit catalog handles");
+		}
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
@@ -1200,52 +1204,26 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 		std::vector<distributed::ExchangeSourceHandle> source_handles;
-		if (!source_handle_partition_ids.empty() || !source_handle_node_ids.empty() || !source_handle_paths.empty()) {
-			if (source_handle_partition_ids.size() != source_handle_node_ids.size() ||
-			    source_handle_partition_ids.size() != source_handle_paths.size()) {
-				throw SerializationException("remote exchange source handle metadata is inconsistent");
-			}
-			if (!source_handle_flight_ports.empty() &&
-			    source_handle_flight_ports.size() != source_handle_partition_ids.size()) {
-				throw SerializationException("remote exchange source flight port metadata is inconsistent");
-			}
-			if (!source_handle_attempt_ids.empty() &&
-			    source_handle_attempt_ids.size() != source_handle_partition_ids.size()) {
-				throw SerializationException("remote exchange source attempt metadata is inconsistent");
-			}
-			if (source_handle_flight_server_epochs.size() != source_handle_partition_ids.size()) {
-				throw SerializationException("remote exchange source Flight epoch metadata is inconsistent");
-			}
-			source_handles.reserve(source_handle_partition_ids.size());
-			for (idx_t i = 0; i < source_handle_partition_ids.size(); i++) {
-				distributed::ExchangeSourceHandle sh;
-				sh.partition_id = source_handle_partition_ids[i];
-				sh.attempt_id = source_handle_attempt_ids.empty() ? 0 : source_handle_attempt_ids[i];
-				sh.node_id = source_handle_node_ids[i];
-				sh.flight_port = source_handle_flight_ports.empty() ? 0 : source_handle_flight_ports[i];
-				sh.flight_server_epoch = source_handle_flight_server_epochs[i];
-				distributed::ExchangeSourceFile file;
-				file.path = source_handle_paths[i];
-				file.file_size = 0;
-				sh.files.push_back(std::move(file));
-				source_handles.push_back(std::move(sh));
-			}
-		} else if (!runtime_source_node_id.IsValid()) {
-			// Legacy fallback for plans serialized before explicit source handles
-			for (auto partition_idx : partition_indices) {
-				for (idx_t i = 0; i < source_nodes.size(); i++) {
-					distributed::ExchangeSourceHandle sh;
-					sh.partition_id = partition_idx;
-					sh.attempt_id = 0;
-					sh.node_id = source_nodes[i];
-					sh.flight_port = 0;
-					distributed::ExchangeSourceFile file;
-					file.path = exchange_id;
-					file.file_size = 0;
-					sh.files.push_back(std::move(file));
-					source_handles.push_back(std::move(sh));
-				}
-			}
+		if (source_handle_partition_ids.size() != source_handle_node_ids.size() ||
+		    source_handle_partition_ids.size() != source_handle_paths.size() ||
+		    source_handle_partition_ids.size() != source_handle_flight_ports.size() ||
+		    source_handle_partition_ids.size() != source_handle_attempt_ids.size() ||
+		    source_handle_partition_ids.size() != source_handle_flight_server_epochs.size()) {
+			throw SerializationException("remote exchange source handle metadata is inconsistent");
+		}
+		source_handles.reserve(source_handle_partition_ids.size());
+		for (idx_t i = 0; i < source_handle_partition_ids.size(); i++) {
+			distributed::ExchangeSourceHandle sh;
+			sh.partition_id = source_handle_partition_ids[i];
+			sh.attempt_id = source_handle_attempt_ids[i];
+			sh.node_id = source_handle_node_ids[i];
+			sh.flight_port = source_handle_flight_ports[i];
+			sh.flight_server_epoch = source_handle_flight_server_epochs[i];
+			distributed::ExchangeSourceFile file;
+			file.path = source_handle_paths[i];
+			file.file_size = 0;
+			sh.files.push_back(std::move(file));
+			source_handles.push_back(std::move(sh));
 		}
 		return make_uniq<PhysicalRemoteExchangeSource>(physical_plan, std::move(types), estimated_cardinality,
 		                                               std::move(exchange_id), std::move(partition_indices),

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1166,6 +1166,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto range_order_modifiers =
 		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(115, "range_order_modifiers", {});
 		sink_handle.flight_server_epoch = deserializer.ReadProperty<string>(116, "flight_server_epoch");
+		sink_handle.query_id = deserializer.ReadProperty<string>(117, "query_id");
 		return make_uniq<PhysicalRemoteExchangeSink>(
 		    physical_plan, std::move(types), estimated_cardinality, std::move(exchange_id), num_partitions,
 		    repartition_type, std::move(partition_by), std::move(sink_handle), std::move(exchange_mgr),

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1165,6 +1165,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(114, "range_boundaries", {});
 		auto range_order_modifiers =
 		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(115, "range_order_modifiers", {});
+		sink_handle.flight_server_epoch = deserializer.ReadProperty<string>(116, "flight_server_epoch");
 		return make_uniq<PhysicalRemoteExchangeSink>(
 		    physical_plan, std::move(types), estimated_cardinality, std::move(exchange_id), num_partitions,
 		    repartition_type, std::move(partition_by), std::move(sink_handle), std::move(exchange_mgr),
@@ -1187,6 +1188,8 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto source_handle_attempt_ids =
 		    deserializer.ReadPropertyWithDefault<vector<idx_t>>(113, "source_handle_attempt_ids");
 		auto local_dirs = deserializer.ReadPropertyWithDefault<vector<string>>(114, "local_dirs");
+		auto source_handle_flight_server_epochs =
+		    deserializer.ReadProperty<vector<string>>(115, "source_handle_flight_server_epochs");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
@@ -1209,6 +1212,9 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 			    source_handle_attempt_ids.size() != source_handle_partition_ids.size()) {
 				throw SerializationException("remote exchange source attempt metadata is inconsistent");
 			}
+			if (source_handle_flight_server_epochs.size() != source_handle_partition_ids.size()) {
+				throw SerializationException("remote exchange source Flight epoch metadata is inconsistent");
+			}
 			source_handles.reserve(source_handle_partition_ids.size());
 			for (idx_t i = 0; i < source_handle_partition_ids.size(); i++) {
 				distributed::ExchangeSourceHandle sh;
@@ -1216,6 +1222,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 				sh.attempt_id = source_handle_attempt_ids.empty() ? 0 : source_handle_attempt_ids[i];
 				sh.node_id = source_handle_node_ids[i];
 				sh.flight_port = source_handle_flight_ports.empty() ? 0 : source_handle_flight_ports[i];
+				sh.flight_server_epoch = source_handle_flight_server_epochs[i];
 				distributed::ExchangeSourceFile file;
 				file.path = source_handle_paths[i];
 				file.file_size = 0;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange.hpp
@@ -57,6 +57,12 @@ public:
 		SinkFinished(handle, attempt_id);
 	}
 
+	/// Notify that a concrete sink instance finished, including transport
+	/// incarnation metadata returned by the worker.
+	virtual void SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id, int flight_port) {
+		SinkFinished(instance.sink_handle, instance.attempt_id, node_id, flight_port);
+	}
+
 	/// Notify that all required sinks have finished.
 	/// Triggers source handle creation (e.g., listing committed files).
 	virtual void AllRequiredSinksFinished() = 0;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
@@ -41,6 +41,8 @@ struct ExchangeSinkHandle {
 struct ExchangeSinkInstanceHandle {
 	ExchangeSinkHandle sink_handle;
 	idx_t attempt_id = 0;
+	/// Query that owns this concrete attempt.
+	std::string query_id;
 	/// Implementation-specific: output directory (Spooling),
 	/// Flight server address (Flight), etc.
 	std::string output_location;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
@@ -45,6 +45,8 @@ struct ExchangeSinkInstanceHandle {
 	/// Flight server address (Flight), etc.
 	std::string output_location;
 	idx_t output_partition_count = 0;
+	/// Process-local Flight service incarnation that published this attempt.
+	std::string flight_server_epoch;
 };
 
 // ─── Source Handles ──────────────────────────────────────
@@ -69,6 +71,7 @@ struct ExchangeSourceHandle {
 	idx_t attempt_id = 0;
 	std::string node_id;
 	int flight_port = 0;
+	std::string flight_server_epoch;
 	std::vector<ExchangeSourceFile> files;
 };
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_sink.hpp
@@ -61,7 +61,7 @@ public:
 
 	/// Ensure the output schema metadata is written even when no data was
 	/// produced (0-row exchange).  Called by PhysicalRemoteExchangeSink::Finalize
-	/// after Finish() so that downstream readers can still open the exchange.
+	/// before Finish() so the schema is part of the committed attempt.
 	virtual DuckDBResult<void> EnsureSchema(ClientContext &context, const vector<LogicalType> &types,
 	                                        const vector<string> &names) {
 		return DuckDBResult<void>::ok(); // default no-op

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -195,6 +195,7 @@ public:
 	void SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id) override;
 	void SinkFinished(const ExchangeSinkHandle &handle, idx_t attempt_id, const std::string &node_id,
 	                  int flight_port) override;
+	void SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id, int flight_port) override;
 	void AllRequiredSinksFinished() override;
 	std::vector<ExchangeSourceHandle> GetSourceHandles() override;
 	idx_t GetNumPartitions() const override;
@@ -208,12 +209,14 @@ private:
 		std::string output_location;
 		std::string node_id;
 		int flight_port = 0;
+		std::string flight_server_epoch;
 	};
 
 	ExchangeContext ctx_;
 	idx_t output_partition_count_;
 	FlightExchangeConfig config_;
 	ClientContext *context_;
+	std::string exchange_instance_id_;
 
 	std::mutex mutex_;
 	std::vector<idx_t> all_sinks_;
@@ -301,6 +304,9 @@ public:
 	}
 
 	static int GetLocalFlightServerPort();
+	static std::string GetLocalFlightServerEpoch();
+	static DuckDBResult<void> EnsureLocalFlightServerStarted(const FlightExchangeConfig &config);
+	static DuckDBResult<void> ShutdownLocalFlightServer();
 
 	const FlightExchangeConfig &config() const {
 		return config_;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -248,6 +248,7 @@ public:
 
 private:
 	std::shared_ptr<ShuffleCache> shuffle_cache_;
+	ShuffleCacheRegistry::WriteLease write_lease_;
 	ExchangeSinkInstanceHandle handle_;
 	ClientContext *context_;
 	bool finished_ = false;
@@ -257,7 +258,6 @@ private:
 
 class FlightExchangeSource : public ExchangeSource {
 public:
-	explicit FlightExchangeSource(const std::string &exchange_id, ClientContext *context);
 	explicit FlightExchangeSource(const FlightExchangeConfig &config, ClientContext *context);
 	~FlightExchangeSource() override;
 
@@ -273,10 +273,7 @@ private:
 	struct PartitionStreamState;
 
 	FlightExchangeConfig config_;
-	std::string exchange_id_;
 	ClientContext *context_;
-	std::shared_ptr<ShuffleCache> cache_;
-	std::string cache_key_;
 	std::vector<ExchangeSourceHandle> handles_;
 	idx_t current_handle_idx_ = 0;
 	bool closed_ = false;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_server.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_server.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <memory>
 #include <thread>
-#include <vector>
 
 namespace duckdb {
 namespace distributed {
@@ -16,7 +15,7 @@ namespace distributed {
 struct FlightServerConfig {
 	std::string bind_host;
 	int port = 0;
-	std::vector<std::string> local_dirs;
+	std::string server_epoch;
 };
 
 class FlightServer {

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_ticket.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_ticket.hpp
@@ -11,8 +11,10 @@ namespace duckdb {
 namespace distributed {
 
 struct FlightExchangeTicket {
-	std::string shuffle_stage_id;
+	std::string server_epoch;
+	std::string exchange_instance_id;
 	std::string node_id;
+	idx_t attempt_id = 0;
 	idx_t partition_idx = 0;
 
 	std::string Serialize() const;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
@@ -136,6 +136,7 @@ public:
 	DuckDBResult<idx_t> RemoveAttemptStorage() const;
 	std::string ManifestFilePath() const;
 	std::string CommittedMarkerPath() const;
+	std::string SchemaFilePath() const;
 
 private:
 	//! Flush a single partition buffer to an IPC file.
@@ -148,7 +149,6 @@ private:
 	std::string PartitionDirectory(idx_t partition_idx) const;
 	std::string MakePartitionFilePath(idx_t partition_idx);
 	std::string NodeDirectory() const;
-	std::string SchemaFilePath() const;
 
 	ShuffleCacheConfig config_;
 	std::shared_ptr<ShuffleStorage> storage_;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -33,6 +33,17 @@ private:
 		explicit CacheLeaseState(std::shared_ptr<ShuffleCache> cache_p) : cache(std::move(cache_p)) {
 		}
 
+		void AcquireWriter() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			active_writers++;
+		}
+
+		void ReleaseWriter() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			D_ASSERT(active_writers > 0);
+			active_writers--;
+		}
+
 		bool TryAcquireReader() {
 			std::lock_guard<std::mutex> lock(cleanup_mutex);
 			if (cleanup_requested || cleanup_complete) {
@@ -55,7 +66,7 @@ private:
 
 		DuckDBResult<idx_t> CleanupIfReady() {
 			std::lock_guard<std::mutex> lock(cleanup_mutex);
-			if (!cleanup_requested || cleanup_complete || active_readers > 0) {
+			if (!cleanup_requested || cleanup_complete || active_writers > 0 || active_readers > 0) {
 				return DuckDBResult<idx_t>::ok(0);
 			}
 			auto result = cache->RemoveAttemptStorage();
@@ -74,9 +85,22 @@ private:
 
 	private:
 		mutable std::mutex cleanup_mutex;
+		idx_t active_writers = 0;
 		idx_t active_readers = 0;
 		bool cleanup_requested = false;
 		bool cleanup_complete = false;
+	};
+
+	struct CacheWriteLease {
+		explicit CacheWriteLease(std::shared_ptr<CacheLeaseState> state_p) : state(std::move(state_p)) {
+			state->AcquireWriter();
+		}
+
+		~CacheWriteLease() {
+			state->ReleaseWriter();
+		}
+
+		std::shared_ptr<CacheLeaseState> state;
 	};
 
 	struct CacheBorrowLease {
@@ -91,11 +115,18 @@ private:
 	};
 
 	struct Entry {
+		Entry(std::string exchange_id_p, std::string query_id_p, std::shared_ptr<CacheLeaseState> state_p,
+		      std::string server_epoch_p, idx_t attempt_id_p, bool published_p)
+		    : exchange_id(std::move(exchange_id_p)), query_id(std::move(query_id_p)), state(std::move(state_p)),
+		      server_epoch(std::move(server_epoch_p)), attempt_id(attempt_id_p), published(published_p) {
+		}
+
 		std::string exchange_id;
 		std::string query_id;
 		std::shared_ptr<CacheLeaseState> state;
 		std::string server_epoch;
 		idx_t attempt_id = 0;
+		bool published = false;
 	};
 
 	struct QueryState {
@@ -112,7 +143,10 @@ public:
 		idx_t cleanup_errors = 0;
 		idx_t cleanup_pending = 0;
 		idx_t active_executions = 0;
+		std::string last_error;
 	};
+
+	using WriteLease = std::shared_ptr<void>;
 
 	static ShuffleCacheRegistry &Instance() {
 		static ShuffleCacheRegistry instance;
@@ -150,10 +184,10 @@ public:
 		return DuckDBResult<void>::ok();
 	}
 
-	/// Fence late publishers and move all currently published attempts to cleanup ownership.
-	DuckDBResult<void> CloseQuery(const std::string &query_id) {
+	/// Fence late publishers and move every tracked attempt to cleanup ownership.
+	DuckDBResult<idx_t> CloseQuery(const std::string &query_id) {
 		if (query_id.empty()) {
-			return DuckDBResult<void>::err(DuckDBError::value_error("query close requires a query id"));
+			return DuckDBResult<idx_t>::err(DuckDBError::value_error("query close requires a query id"));
 		}
 		std::vector<std::shared_ptr<CacheLeaseState>> removed;
 		{
@@ -174,6 +208,62 @@ public:
 				state->RequestCleanup();
 			}
 		}
+		return DuckDBResult<idx_t>::ok(static_cast<idx_t>(removed.size()));
+	}
+
+	/// Track a sink attempt before it can write any storage. The returned lease
+	/// prevents query cleanup from deleting files while the sink is still writing.
+	DuckDBResult<WriteLease> TrackPending(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache,
+	                                      const std::string &query_id, std::string server_epoch = std::string(),
+	                                      idx_t attempt_id = 0) {
+		if (exchange_id.empty() || query_id.empty() || !cache) {
+			return DuckDBResult<WriteLease>::err(
+			    DuckDBError::value_error("pending shuffle cache requires an exchange id, query id, and cache"));
+		}
+		if (cache->config().shuffle_stage_id != exchange_id) {
+			return DuckDBResult<WriteLease>::err(DuckDBError::value_error(
+			    "pending shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
+		}
+
+		auto state = std::make_shared<CacheLeaseState>(std::move(cache));
+		WriteLease writer_lease = std::make_shared<CacheWriteLease>(state);
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			auto query_it = query_states_.find(query_id);
+			if (query_it != query_states_.end() && query_it->second.closing) {
+				// TrackPending runs before the sink can write. Rejecting here
+				// must not delete this path: an older published incarnation can
+				// still have readers whose leases belong to a different state.
+				return DuckDBResult<WriteLease>::err(
+				    DuckDBError::invalid_state_error("query closed before shuffle sink creation: " + query_id));
+			}
+			if (registry_.find(exchange_id) != registry_.end() ||
+			    std::any_of(deferred_cleanup_.begin(), deferred_cleanup_.end(),
+			                [&](const Entry &entry) { return entry.exchange_id == exchange_id; })) {
+				return DuckDBResult<WriteLease>::err(
+				    DuckDBError::invalid_state_error("conflicting pending shuffle cache for exchange " + exchange_id));
+			}
+			registry_.emplace(exchange_id,
+			                  Entry {exchange_id, query_id, state, std::move(server_epoch), attempt_id, false});
+			return DuckDBResult<WriteLease>::ok(std::move(writer_lease));
+		}
+	}
+
+	/// Make an already-tracked, committed attempt visible to readers.
+	DuckDBResult<void> Publish(const std::string &exchange_id, const std::shared_ptr<ShuffleCache> &cache,
+	                           const std::string &query_id, const std::string &server_epoch, idx_t attempt_id) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto query_it = query_states_.find(query_id);
+		if (query_it != query_states_.end() && query_it->second.closing) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("query closed before shuffle cache publication: " + query_id));
+		}
+		auto it = registry_.find(exchange_id);
+		if (it == registry_.end() || !DescriptorsMatch(it->second, cache, query_id, server_epoch, attempt_id)) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("pending shuffle cache is not owned by this sink: " + exchange_id));
+		}
+		it->second.published = true;
 		return DuckDBResult<void>::ok();
 	}
 
@@ -185,9 +275,14 @@ public:
 			return DuckDBResult<void>::err(
 			    DuckDBError::value_error("shuffle cache registration requires an exchange id, query id, and cache"));
 		}
+		if (cache->config().shuffle_stage_id != exchange_id) {
+			return DuckDBResult<void>::err(DuckDBError::value_error(
+			    "shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
+		}
 
 		auto state = std::make_shared<CacheLeaseState>(std::move(cache));
 		bool query_closing = false;
+		bool owns_cleanup = false;
 		{
 			std::lock_guard<std::mutex> lock(mutex_);
 			auto query_it = query_states_.find(query_id);
@@ -195,19 +290,37 @@ public:
 			if (!query_closing) {
 				auto existing = registry_.find(exchange_id);
 				if (existing != registry_.end()) {
-					if (!DescriptorsMatch(existing->second, state->cache, query_id, server_epoch, attempt_id)) {
+					if (!existing->second.published ||
+					    !DescriptorsMatch(existing->second, state->cache, query_id, server_epoch, attempt_id)) {
 						return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
 						    "conflicting shuffle cache registration for exchange " + exchange_id));
 					}
 					return DuckDBResult<void>::ok();
 				}
-				Entry entry {exchange_id, query_id, std::move(state), std::move(server_epoch), attempt_id};
+				if (std::any_of(deferred_cleanup_.begin(), deferred_cleanup_.end(),
+				                [&](const Entry &entry) { return entry.exchange_id == exchange_id; })) {
+					return DuckDBResult<void>::err(
+					    DuckDBError::invalid_state_error("shuffle cache cleanup still owns exchange " + exchange_id));
+				}
+				Entry entry {exchange_id, query_id, std::move(state), std::move(server_epoch), attempt_id, true};
 				registry_.emplace(exchange_id, std::move(entry));
 				return DuckDBResult<void>::ok();
 			}
-			deferred_cleanup_.push_back(Entry {exchange_id, query_id, state, std::move(server_epoch), attempt_id});
+			const auto storage_already_owned =
+			    registry_.find(exchange_id) != registry_.end() ||
+			    std::any_of(deferred_cleanup_.begin(), deferred_cleanup_.end(),
+			                [&](const Entry &entry) { return entry.exchange_id == exchange_id; });
+			if (!storage_already_owned) {
+				deferred_cleanup_.push_back(
+				    Entry {exchange_id, query_id, state, std::move(server_epoch), attempt_id, true});
+				owns_cleanup = true;
+			}
 		}
 
+		if (!owns_cleanup) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("query closed before shuffle cache publication: " + query_id));
+		}
 		state->RequestCleanup();
 		auto cleanup_result = state->CleanupIfReady();
 		RemoveCompletedDeferred();
@@ -222,7 +335,7 @@ public:
 	std::shared_ptr<ShuffleCache> Get(const std::string &exchange_id) const {
 		std::lock_guard<std::mutex> lock(mutex_);
 		auto it = registry_.find(exchange_id);
-		if (it == registry_.end()) {
+		if (it == registry_.end() || !it->second.published) {
 			return nullptr;
 		}
 		return Borrow(it->second.state);
@@ -233,7 +346,7 @@ public:
 	                                                    const std::string &node_id, idx_t attempt_id) const {
 		std::lock_guard<std::mutex> lock(mutex_);
 		auto it = registry_.find(exchange_id);
-		if (it == registry_.end() || !it->second.state || !it->second.state->cache) {
+		if (it == registry_.end() || !it->second.published || !it->second.state || !it->second.state->cache) {
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight exchange attempt is not published: " + exchange_id));
 		}
@@ -292,9 +405,76 @@ public:
 		if (close_result.is_err()) {
 			CleanupResult result;
 			result.cleanup_errors = 1;
+			result.last_error = close_result.error().what();
 			return result;
 		}
-		return CleanupMatching([&](const Entry &entry) { return entry.query_id == query_id; }, &query_id);
+		auto result = CleanupMatching([&](const Entry &entry) { return entry.query_id == query_id; }, &query_id);
+		result.registry_entries_removed += close_result.value();
+		return result;
+	}
+
+	/// Inspect the query fence without starting storage deletion.
+	CleanupResult QueryStatus(const std::string &query_id) const {
+		CleanupResult result;
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto query_it = query_states_.find(query_id);
+		if (query_it != query_states_.end()) {
+			result.active_executions = query_it->second.active_executions;
+		}
+		for (const auto &entry : registry_) {
+			if (entry.second.query_id == query_id) {
+				result.cleanup_pending++;
+			}
+		}
+		for (const auto &entry : deferred_cleanup_) {
+			if (entry.query_id == query_id) {
+				result.cleanup_pending++;
+			}
+		}
+		return result;
+	}
+
+	/// Remove a closed-query tombstone once every scheduled native execution
+	/// and every owned cache attempt has been joined and cleaned.
+	DuckDBResult<void> RetireQuery(const std::string &query_id) {
+		if (query_id.empty()) {
+			return DuckDBResult<void>::err(DuckDBError::value_error("query retirement requires a query id"));
+		}
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto query_it = query_states_.find(query_id);
+		if (query_it == query_states_.end()) {
+			for (const auto &entry : registry_) {
+				if (entry.second.query_id == query_id) {
+					return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+					    "query cannot retire with registered shuffle attempts: " + query_id));
+				}
+			}
+			for (const auto &entry : deferred_cleanup_) {
+				if (entry.query_id == query_id) {
+					return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+					    "query cannot retire with pending shuffle cleanup: " + query_id));
+				}
+			}
+			return DuckDBResult<void>::ok();
+		}
+		if (!query_it->second.closing || query_it->second.active_executions != 0) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("query cannot retire before native executions drain: " + query_id));
+		}
+		for (const auto &entry : registry_) {
+			if (entry.second.query_id == query_id) {
+				return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+				    "query cannot retire with registered shuffle attempts: " + query_id));
+			}
+		}
+		for (const auto &entry : deferred_cleanup_) {
+			if (entry.query_id == query_id) {
+				return DuckDBResult<void>::err(
+				    DuckDBError::invalid_state_error("query cannot retire with pending shuffle cleanup: " + query_id));
+			}
+		}
+		query_states_.erase(query_it);
+		return DuckDBResult<void>::ok();
 	}
 
 	/// Test/maintenance helper for exchange-prefix cleanup.
@@ -337,6 +517,7 @@ private:
 	CleanupResult CleanupMatching(MATCH &&matches, const std::string *query_id) {
 		CleanupResult result;
 		std::vector<std::shared_ptr<CacheLeaseState>> candidates;
+		bool query_has_active_executions = false;
 		{
 			std::lock_guard<std::mutex> lock(mutex_);
 			for (auto it = registry_.begin(); it != registry_.end();) {
@@ -358,18 +539,22 @@ private:
 				auto query_it = query_states_.find(*query_id);
 				if (query_it != query_states_.end()) {
 					result.active_executions = query_it->second.active_executions;
+					query_has_active_executions = query_it->second.active_executions > 0;
 				}
 			}
 		}
 
-		for (const auto &state : candidates) {
-			state->RequestCleanup();
-			auto cleanup_result = state->CleanupIfReady();
-			if (cleanup_result.is_err()) {
-				result.cleanup_errors++;
-				continue;
+		if (!query_has_active_executions) {
+			for (const auto &state : candidates) {
+				state->RequestCleanup();
+				auto cleanup_result = state->CleanupIfReady();
+				if (cleanup_result.is_err()) {
+					result.cleanup_errors++;
+					result.last_error = cleanup_result.error().what();
+					continue;
+				}
+				result.storage_entries_removed += cleanup_result.value();
 			}
-			result.storage_entries_removed += cleanup_result.value();
 		}
 
 		{

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -3,10 +3,11 @@
 
 /**
  * @file shuffle_cache_registry.hpp
- * @brief Global registry of ShuffleCache instances keyed by exchange_id.
+ * @brief Process-local catalog of published ShuffleCache instances.
  *
- * Sinks register their ShuffleCache after FlushAll; Sources and the
- * FlightServer look up caches by exchange_id to read partition data.
+ * Sinks publish committed attempts after FlushAll. Sources and the Flight
+ * service borrow catalog entries by opaque exchange-attempt ID. A borrowed
+ * entry keeps its storage alive until the reader releases it.
  */
 
 #pragma once
@@ -25,7 +26,56 @@ namespace distributed {
 
 class ShuffleCacheRegistry {
 private:
-	using RegistryMap = std::unordered_map<std::string, std::shared_ptr<ShuffleCache>>;
+	struct CacheLeaseState {
+		explicit CacheLeaseState(std::shared_ptr<ShuffleCache> cache_p) : cache(std::move(cache_p)) {
+		}
+
+		~CacheLeaseState() {
+			try {
+				std::lock_guard<std::mutex> lock(cleanup_mutex);
+				if (cleanup_requested && !cleanup_complete) {
+					(void)CleanupLocked();
+				}
+			} catch (...) {
+			}
+		}
+
+		void RequestCleanup() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			cleanup_requested = true;
+		}
+
+		DuckDBResult<idx_t> CleanupIfRequested() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			if (!cleanup_requested || cleanup_complete) {
+				return DuckDBResult<idx_t>::ok(0);
+			}
+			return CleanupLocked();
+		}
+
+		std::shared_ptr<ShuffleCache> cache;
+
+	private:
+		DuckDBResult<idx_t> CleanupLocked() {
+			auto result = cache->RemoveAttemptStorage();
+			if (result.is_ok()) {
+				cleanup_complete = true;
+			}
+			return result;
+		}
+
+		std::mutex cleanup_mutex;
+		bool cleanup_requested = false;
+		bool cleanup_complete = false;
+	};
+
+	struct Entry {
+		std::shared_ptr<CacheLeaseState> state;
+		std::string server_epoch;
+		idx_t attempt_id = 0;
+	};
+
+	using RegistryMap = std::unordered_map<std::string, Entry>;
 
 public:
 	struct CleanupResult {
@@ -39,11 +89,26 @@ public:
 		return instance;
 	}
 
-	/// Register a ShuffleCache for an exchange (called after sink FlushAll).
-	void Register(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache) {
+	/// Publish a committed ShuffleCache descriptor for an exchange attempt.
+	DuckDBResult<void> Register(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache,
+	                            std::string server_epoch = std::string(), idx_t attempt_id = 0) {
+		if (exchange_id.empty() || !cache) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::value_error("shuffle cache registration requires an exchange id and cache"));
+		}
 		std::lock_guard<std::mutex> lock(mutex_);
+		auto existing = registry_.find(exchange_id);
+		if (existing != registry_.end()) {
+			if (!DescriptorsMatch(existing->second, cache, server_epoch, attempt_id)) {
+				return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+				    "conflicting shuffle cache registration for exchange " + exchange_id));
+			}
+			return DuckDBResult<void>::ok();
+		}
+		Entry entry {std::make_shared<CacheLeaseState>(std::move(cache)), std::move(server_epoch), attempt_id};
 		deferred_cleanup_.erase(exchange_id);
-		registry_[exchange_id] = std::move(cache);
+		registry_.emplace(exchange_id, std::move(entry));
+		return DuckDBResult<void>::ok();
 	}
 
 	/// Look up a ShuffleCache by exchange_id.
@@ -53,7 +118,33 @@ public:
 		if (it == registry_.end()) {
 			return nullptr;
 		}
-		return it->second;
+		return Borrow(it->second.state);
+	}
+
+	/// Resolve a ticket only while its exact exchange attempt is published.
+	DuckDBResult<std::shared_ptr<ShuffleCache>> Resolve(const std::string &exchange_id, const std::string &server_epoch,
+	                                                    const std::string &node_id, idx_t attempt_id) const {
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto it = registry_.find(exchange_id);
+		if (it == registry_.end() || !it->second.state || !it->second.state->cache) {
+			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
+			    DuckDBError::invalid_state_error("flight exchange attempt is not published: " + exchange_id));
+		}
+		const auto &entry = it->second;
+		const auto &config = entry.state->cache->config();
+		if (entry.server_epoch != server_epoch) {
+			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
+			    DuckDBError::invalid_state_error("flight ticket server epoch is stale"));
+		}
+		if (entry.attempt_id != attempt_id) {
+			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
+			    DuckDBError::invalid_state_error("flight ticket attempt id does not match the published attempt"));
+		}
+		if (config.shuffle_stage_id != exchange_id || config.node_id != node_id) {
+			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
+			    DuckDBError::invalid_state_error("flight ticket exchange or node identity does not match"));
+		}
+		return DuckDBResult<std::shared_ptr<ShuffleCache>>::ok(Borrow(entry.state));
 	}
 
 	/// Remove a ShuffleCache (when exchange closes).
@@ -68,7 +159,7 @@ public:
 		if (it == registry_.end()) {
 			return;
 		}
-		if (it->second) {
+		if (it->second.state && it->second.state->cache) {
 			deferred_cleanup_[exchange_id] = it->second;
 		}
 		registry_.erase(it);
@@ -79,7 +170,7 @@ public:
 		if (exchange_id_prefix.empty()) {
 			return result;
 		}
-		std::vector<std::pair<std::string, std::shared_ptr<ShuffleCache>>> removed;
+		std::vector<std::pair<std::string, std::shared_ptr<CacheLeaseState>>> removed;
 		{
 			std::lock_guard<std::mutex> lock(mutex_);
 			CollectByPrefix(registry_, exchange_id_prefix, removed);
@@ -90,7 +181,11 @@ public:
 			if (!entry.second) {
 				continue;
 			}
-			auto cleanup_res = entry.second->RemoveAttemptStorage();
+			entry.second->RequestCleanup();
+			if (entry.second.use_count() > 1) {
+				continue;
+			}
+			auto cleanup_res = entry.second->CleanupIfRequested();
 			if (cleanup_res.is_err()) {
 				result.cleanup_errors++;
 				continue;
@@ -103,14 +198,35 @@ public:
 private:
 	ShuffleCacheRegistry() = default;
 
+	static std::shared_ptr<ShuffleCache> Borrow(const std::shared_ptr<CacheLeaseState> &state) {
+		if (!state || !state->cache) {
+			return nullptr;
+		}
+		return std::shared_ptr<ShuffleCache>(state, state->cache.get());
+	}
+
+	static bool DescriptorsMatch(const Entry &left, const std::shared_ptr<ShuffleCache> &right_cache,
+	                             const std::string &right_server_epoch, idx_t right_attempt_id) {
+		if (!left.state || !left.state->cache || !right_cache || left.state->cache.get() != right_cache.get() ||
+		    left.server_epoch != right_server_epoch || left.attempt_id != right_attempt_id) {
+			return false;
+		}
+		const auto &left_config = left.state->cache->config();
+		const auto &right_config = right_cache->config();
+		return left_config.shuffle_stage_id == right_config.shuffle_stage_id &&
+		       left_config.node_id == right_config.node_id &&
+		       left_config.num_partitions == right_config.num_partitions &&
+		       left_config.local_dirs == right_config.local_dirs;
+	}
+
 	static void CollectByPrefix(RegistryMap &registry, const std::string &exchange_id_prefix,
-	                            std::vector<std::pair<std::string, std::shared_ptr<ShuffleCache>>> &removed) {
+	                            std::vector<std::pair<std::string, std::shared_ptr<CacheLeaseState>>> &removed) {
 		for (auto it = registry.begin(); it != registry.end();) {
 			if (it->first.rfind(exchange_id_prefix, 0) != 0) {
 				++it;
 				continue;
 			}
-			removed.emplace_back(it->first, it->second);
+			removed.emplace_back(it->first, it->second.state);
 			it = registry.erase(it);
 		}
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -6,18 +6,21 @@
  * @brief Process-local catalog of published ShuffleCache instances.
  *
  * Sinks publish committed attempts after FlushAll. Sources and the Flight
- * service borrow catalog entries by opaque exchange-attempt ID. A borrowed
- * entry keeps its storage alive until the reader releases it.
+ * service borrow catalog entries by opaque exchange-attempt ID. Query close
+ * fences late publishers and keeps cleanup work visible until all readers and
+ * native executions have drained.
  */
 
 #pragma once
 
 #include "duckdb/execution/distributed/exchange/shuffle_cache.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -30,14 +33,19 @@ private:
 		explicit CacheLeaseState(std::shared_ptr<ShuffleCache> cache_p) : cache(std::move(cache_p)) {
 		}
 
-		~CacheLeaseState() {
-			try {
-				std::lock_guard<std::mutex> lock(cleanup_mutex);
-				if (cleanup_requested && !cleanup_complete) {
-					(void)CleanupLocked();
-				}
-			} catch (...) {
+		bool TryAcquireReader() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			if (cleanup_requested || cleanup_complete) {
+				return false;
 			}
+			active_readers++;
+			return true;
+		}
+
+		void ReleaseReader() {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			D_ASSERT(active_readers > 0);
+			active_readers--;
 		}
 
 		void RequestCleanup() {
@@ -45,18 +53,11 @@ private:
 			cleanup_requested = true;
 		}
 
-		DuckDBResult<idx_t> CleanupIfRequested() {
+		DuckDBResult<idx_t> CleanupIfReady() {
 			std::lock_guard<std::mutex> lock(cleanup_mutex);
-			if (!cleanup_requested || cleanup_complete) {
+			if (!cleanup_requested || cleanup_complete || active_readers > 0) {
 				return DuckDBResult<idx_t>::ok(0);
 			}
-			return CleanupLocked();
-		}
-
-		std::shared_ptr<ShuffleCache> cache;
-
-	private:
-		DuckDBResult<idx_t> CleanupLocked() {
 			auto result = cache->RemoveAttemptStorage();
 			if (result.is_ok()) {
 				cleanup_complete = true;
@@ -64,15 +65,42 @@ private:
 			return result;
 		}
 
-		std::mutex cleanup_mutex;
+		bool CleanupComplete() const {
+			std::lock_guard<std::mutex> lock(cleanup_mutex);
+			return cleanup_complete;
+		}
+
+		std::shared_ptr<ShuffleCache> cache;
+
+	private:
+		mutable std::mutex cleanup_mutex;
+		idx_t active_readers = 0;
 		bool cleanup_requested = false;
 		bool cleanup_complete = false;
 	};
 
+	struct CacheBorrowLease {
+		explicit CacheBorrowLease(std::shared_ptr<CacheLeaseState> state_p) : state(std::move(state_p)) {
+		}
+
+		~CacheBorrowLease() {
+			state->ReleaseReader();
+		}
+
+		std::shared_ptr<CacheLeaseState> state;
+	};
+
 	struct Entry {
+		std::string exchange_id;
+		std::string query_id;
 		std::shared_ptr<CacheLeaseState> state;
 		std::string server_epoch;
 		idx_t attempt_id = 0;
+	};
+
+	struct QueryState {
+		idx_t active_executions = 0;
+		bool closing = false;
 	};
 
 	using RegistryMap = std::unordered_map<std::string, Entry>;
@@ -82,6 +110,8 @@ public:
 		idx_t registry_entries_removed = 0;
 		idx_t storage_entries_removed = 0;
 		idx_t cleanup_errors = 0;
+		idx_t cleanup_pending = 0;
+		idx_t active_executions = 0;
 	};
 
 	static ShuffleCacheRegistry &Instance() {
@@ -89,26 +119,103 @@ public:
 		return instance;
 	}
 
-	/// Publish a committed ShuffleCache descriptor for an exchange attempt.
-	DuckDBResult<void> Register(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache,
-	                            std::string server_epoch = std::string(), idx_t attempt_id = 0) {
-		if (exchange_id.empty() || !cache) {
+	/// Mark one native query execution active, unless teardown already started.
+	DuckDBResult<void> BeginQueryExecution(const std::string &query_id) {
+		if (query_id.empty()) {
 			return DuckDBResult<void>::err(
-			    DuckDBError::value_error("shuffle cache registration requires an exchange id and cache"));
+			    DuckDBError::value_error("query execution registration requires a query id"));
 		}
 		std::lock_guard<std::mutex> lock(mutex_);
-		auto existing = registry_.find(exchange_id);
-		if (existing != registry_.end()) {
-			if (!DescriptorsMatch(existing->second, cache, server_epoch, attempt_id)) {
-				return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
-				    "conflicting shuffle cache registration for exchange " + exchange_id));
-			}
-			return DuckDBResult<void>::ok();
+		auto &state = query_states_[query_id];
+		if (state.closing) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("query is closing and cannot start new native work: " + query_id));
 		}
-		Entry entry {std::make_shared<CacheLeaseState>(std::move(cache)), std::move(server_epoch), attempt_id};
-		deferred_cleanup_.erase(exchange_id);
-		registry_.emplace(exchange_id, std::move(entry));
+		state.active_executions++;
 		return DuckDBResult<void>::ok();
+	}
+
+	/// Release one native query execution after the underlying thread exits.
+	DuckDBResult<void> EndQueryExecution(const std::string &query_id) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto it = query_states_.find(query_id);
+		if (it == query_states_.end() || it->second.active_executions == 0) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("query has no active native execution: " + query_id));
+		}
+		it->second.active_executions--;
+		if (it->second.active_executions == 0 && !it->second.closing) {
+			query_states_.erase(it);
+		}
+		return DuckDBResult<void>::ok();
+	}
+
+	/// Fence late publishers and move all currently published attempts to cleanup ownership.
+	DuckDBResult<void> CloseQuery(const std::string &query_id) {
+		if (query_id.empty()) {
+			return DuckDBResult<void>::err(DuckDBError::value_error("query close requires a query id"));
+		}
+		std::vector<std::shared_ptr<CacheLeaseState>> removed;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			query_states_[query_id].closing = true;
+			for (auto it = registry_.begin(); it != registry_.end();) {
+				if (it->second.query_id != query_id) {
+					++it;
+					continue;
+				}
+				removed.push_back(it->second.state);
+				deferred_cleanup_.push_back(std::move(it->second));
+				it = registry_.erase(it);
+			}
+		}
+		for (const auto &state : removed) {
+			if (state) {
+				state->RequestCleanup();
+			}
+		}
+		return DuckDBResult<void>::ok();
+	}
+
+	/// Publish a committed ShuffleCache descriptor for an exchange attempt.
+	DuckDBResult<void> Register(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache,
+	                            const std::string &query_id, std::string server_epoch = std::string(),
+	                            idx_t attempt_id = 0) {
+		if (exchange_id.empty() || query_id.empty() || !cache) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::value_error("shuffle cache registration requires an exchange id, query id, and cache"));
+		}
+
+		auto state = std::make_shared<CacheLeaseState>(std::move(cache));
+		bool query_closing = false;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			auto query_it = query_states_.find(query_id);
+			query_closing = query_it != query_states_.end() && query_it->second.closing;
+			if (!query_closing) {
+				auto existing = registry_.find(exchange_id);
+				if (existing != registry_.end()) {
+					if (!DescriptorsMatch(existing->second, state->cache, query_id, server_epoch, attempt_id)) {
+						return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+						    "conflicting shuffle cache registration for exchange " + exchange_id));
+					}
+					return DuckDBResult<void>::ok();
+				}
+				Entry entry {exchange_id, query_id, std::move(state), std::move(server_epoch), attempt_id};
+				registry_.emplace(exchange_id, std::move(entry));
+				return DuckDBResult<void>::ok();
+			}
+			deferred_cleanup_.push_back(Entry {exchange_id, query_id, state, std::move(server_epoch), attempt_id});
+		}
+
+		state->RequestCleanup();
+		auto cleanup_result = state->CleanupIfReady();
+		RemoveCompletedDeferred();
+		if (cleanup_result.is_err()) {
+			return DuckDBResult<void>::err(cleanup_result.error());
+		}
+		return DuckDBResult<void>::err(
+		    DuckDBError::invalid_state_error("query closed before shuffle cache publication: " + query_id));
 	}
 
 	/// Look up a ShuffleCache by exchange_id.
@@ -144,71 +251,78 @@ public:
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight ticket exchange or node identity does not match"));
 		}
-		return DuckDBResult<std::shared_ptr<ShuffleCache>>::ok(Borrow(entry.state));
+		auto borrowed = Borrow(entry.state);
+		if (!borrowed) {
+			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
+			    DuckDBError::invalid_state_error("flight exchange attempt is closing: " + exchange_id));
+		}
+		return DuckDBResult<std::shared_ptr<ShuffleCache>>::ok(std::move(borrowed));
 	}
 
-	/// Remove a ShuffleCache (when exchange closes).
+	/// Remove a catalog entry without taking ownership of its storage.
 	void Remove(const std::string &exchange_id) {
 		std::lock_guard<std::mutex> lock(mutex_);
 		registry_.erase(exchange_id);
 	}
 
+	/// Move a catalog entry to explicit deferred-cleanup ownership.
 	void RemoveForDeferredCleanup(const std::string &exchange_id) {
-		std::lock_guard<std::mutex> lock(mutex_);
-		auto it = registry_.find(exchange_id);
-		if (it == registry_.end()) {
-			return;
-		}
-		if (it->second.state && it->second.state->cache) {
-			deferred_cleanup_[exchange_id] = it->second;
-		}
-		registry_.erase(it);
-	}
-
-	CleanupResult RemoveAndCleanupByPrefix(const std::string &exchange_id_prefix) {
-		CleanupResult result;
-		if (exchange_id_prefix.empty()) {
-			return result;
-		}
-		std::vector<std::pair<std::string, std::shared_ptr<CacheLeaseState>>> removed;
+		std::shared_ptr<CacheLeaseState> removed;
 		{
 			std::lock_guard<std::mutex> lock(mutex_);
-			CollectByPrefix(registry_, exchange_id_prefix, removed);
-			CollectByPrefix(deferred_cleanup_, exchange_id_prefix, removed);
+			auto it = registry_.find(exchange_id);
+			if (it == registry_.end()) {
+				return;
+			}
+			removed = it->second.state;
+			deferred_cleanup_.push_back(std::move(it->second));
+			registry_.erase(it);
 		}
-		result.registry_entries_removed = static_cast<idx_t>(removed.size());
-		for (auto &entry : removed) {
-			if (!entry.second) {
-				continue;
-			}
-			entry.second->RequestCleanup();
-			if (entry.second.use_count() > 1) {
-				continue;
-			}
-			auto cleanup_res = entry.second->CleanupIfRequested();
-			if (cleanup_res.is_err()) {
-				result.cleanup_errors++;
-				continue;
-			}
-			result.storage_entries_removed += cleanup_res.value();
+		if (removed) {
+			removed->RequestCleanup();
 		}
-		return result;
+	}
+
+	/// Retry all cleanup owned by one exact query.
+	CleanupResult RemoveAndCleanupByQuery(const std::string &query_id) {
+		if (query_id.empty()) {
+			return {};
+		}
+		auto close_result = CloseQuery(query_id);
+		if (close_result.is_err()) {
+			CleanupResult result;
+			result.cleanup_errors = 1;
+			return result;
+		}
+		return CleanupMatching([&](const Entry &entry) { return entry.query_id == query_id; }, &query_id);
+	}
+
+	/// Test/maintenance helper for exchange-prefix cleanup.
+	CleanupResult RemoveAndCleanupByPrefix(const std::string &exchange_id_prefix) {
+		if (exchange_id_prefix.empty()) {
+			return {};
+		}
+		return CleanupMatching([&](const Entry &entry) { return entry.exchange_id.rfind(exchange_id_prefix, 0) == 0; },
+		                       nullptr);
 	}
 
 private:
 	ShuffleCacheRegistry() = default;
 
 	static std::shared_ptr<ShuffleCache> Borrow(const std::shared_ptr<CacheLeaseState> &state) {
-		if (!state || !state->cache) {
+		if (!state || !state->cache || !state->TryAcquireReader()) {
 			return nullptr;
 		}
-		return std::shared_ptr<ShuffleCache>(state, state->cache.get());
+		auto lease = std::make_shared<CacheBorrowLease>(state);
+		return std::shared_ptr<ShuffleCache>(lease, state->cache.get());
 	}
 
 	static bool DescriptorsMatch(const Entry &left, const std::shared_ptr<ShuffleCache> &right_cache,
-	                             const std::string &right_server_epoch, idx_t right_attempt_id) {
+	                             const std::string &right_query_id, const std::string &right_server_epoch,
+	                             idx_t right_attempt_id) {
 		if (!left.state || !left.state->cache || !right_cache || left.state->cache.get() != right_cache.get() ||
-		    left.server_epoch != right_server_epoch || left.attempt_id != right_attempt_id) {
+		    left.query_id != right_query_id || left.server_epoch != right_server_epoch ||
+		    left.attempt_id != right_attempt_id) {
 			return false;
 		}
 		const auto &left_config = left.state->cache->config();
@@ -219,21 +333,76 @@ private:
 		       left_config.local_dirs == right_config.local_dirs;
 	}
 
-	static void CollectByPrefix(RegistryMap &registry, const std::string &exchange_id_prefix,
-	                            std::vector<std::pair<std::string, std::shared_ptr<CacheLeaseState>>> &removed) {
-		for (auto it = registry.begin(); it != registry.end();) {
-			if (it->first.rfind(exchange_id_prefix, 0) != 0) {
-				++it;
+	template <class MATCH>
+	CleanupResult CleanupMatching(MATCH &&matches, const std::string *query_id) {
+		CleanupResult result;
+		std::vector<std::shared_ptr<CacheLeaseState>> candidates;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			for (auto it = registry_.begin(); it != registry_.end();) {
+				if (!matches(it->second)) {
+					++it;
+					continue;
+				}
+				deferred_cleanup_.push_back(std::move(it->second));
+				it = registry_.erase(it);
+				result.registry_entries_removed++;
+			}
+			std::unordered_set<CacheLeaseState *> seen;
+			for (const auto &entry : deferred_cleanup_) {
+				if (matches(entry) && entry.state && seen.insert(entry.state.get()).second) {
+					candidates.push_back(entry.state);
+				}
+			}
+			if (query_id) {
+				auto query_it = query_states_.find(*query_id);
+				if (query_it != query_states_.end()) {
+					result.active_executions = query_it->second.active_executions;
+				}
+			}
+		}
+
+		for (const auto &state : candidates) {
+			state->RequestCleanup();
+			auto cleanup_result = state->CleanupIfReady();
+			if (cleanup_result.is_err()) {
+				result.cleanup_errors++;
 				continue;
 			}
-			removed.emplace_back(it->first, it->second.state);
-			it = registry.erase(it);
+			result.storage_entries_removed += cleanup_result.value();
 		}
+
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			deferred_cleanup_.erase(
+			    std::remove_if(deferred_cleanup_.begin(), deferred_cleanup_.end(),
+			                   [&](const Entry &entry) { return matches(entry) && entry.state->CleanupComplete(); }),
+			    deferred_cleanup_.end());
+			for (const auto &entry : deferred_cleanup_) {
+				if (matches(entry)) {
+					result.cleanup_pending++;
+				}
+			}
+			if (query_id) {
+				auto query_it = query_states_.find(*query_id);
+				result.active_executions = query_it == query_states_.end() ? 0 : query_it->second.active_executions;
+			}
+		}
+		return result;
+	}
+
+	void RemoveCompletedDeferred() {
+		std::lock_guard<std::mutex> lock(mutex_);
+		deferred_cleanup_.erase(
+		    std::remove_if(deferred_cleanup_.begin(), deferred_cleanup_.end(),
+		                   [](const Entry &entry) { return entry.state && entry.state->CleanupComplete(); }),
+		    deferred_cleanup_.end());
 	}
 
 	mutable std::mutex mutex_;
 	RegistryMap registry_;
-	RegistryMap deferred_cleanup_;
+	std::vector<Entry> deferred_cleanup_;
+	std::unordered_map<std::string, QueryState> query_states_;
 };
 
 } // namespace distributed

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
@@ -66,6 +66,9 @@ public:
 	const distributed::ExchangeSinkInstanceHandle &SinkHandle() const {
 		return sink_handle_;
 	}
+	const std::shared_ptr<distributed::ExchangeManager> &GetExchangeManager() const {
+		return exchange_mgr_;
+	}
 	void ApplyRuntimeSinkHandle(distributed::ExchangeSinkInstanceHandle sink_handle) {
 		sink_handle_ = std::move(sink_handle);
 	}

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp
@@ -68,6 +68,9 @@ public:
 	const std::vector<distributed::ExchangeSourceHandle> &SourceHandles() const {
 		return source_handles_;
 	}
+	const std::shared_ptr<distributed::ExchangeManager> &GetExchangeManager() const {
+		return exchange_mgr_;
+	}
 	const vector<std::string> &SourceNodes() const {
 		return source_nodes_;
 	}

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -307,7 +307,7 @@ private:
 TEST_CASE("Exchange: FlightExchangeTicket roundtrip", "[distributed][exchange]") {
 	FlightExchangeTicket ticket;
 	ticket.server_epoch = "epoch_1";
-	ticket.exchange_instance_id = "stage_1__instance_a__sink_0__attempt_3";
+	ticket.exchange_instance_id = "55f8c578-9c57-4b9d-bdc2-ef62d1dfc323__sink_0__attempt_3";
 	ticket.node_id = "node_2";
 	ticket.attempt_id = 3;
 	ticket.partition_idx = 7;
@@ -432,6 +432,12 @@ TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descript
 	REQUIRE(registry.Register(exchange_id, conflicting_cache, query_id, "epoch-a", 4).is_err());
 	REQUIRE(registry.Get(exchange_id).get() == cache.get());
 
+	auto mismatched_config = config;
+	mismatched_config.shuffle_stage_id = "different-exchange";
+	auto mismatched_cache = std::make_shared<ShuffleCache>(std::move(mismatched_config));
+	REQUIRE(registry.TrackPending(exchange_id, mismatched_cache, query_id, "epoch-a", 4).is_err());
+	REQUIRE(registry.Register(exchange_id, mismatched_cache, query_id, "epoch-a", 4).is_err());
+
 	registry.RemoveForDeferredCleanup(exchange_id);
 	REQUIRE(registry.Get(exchange_id) == nullptr);
 	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 4).is_err());
@@ -503,10 +509,88 @@ TEST_CASE("Exchange: ShuffleCacheRegistry retains and retries failed cleanup", "
 	auto first_cleanup = registry.RemoveAndCleanupByQuery(query_id);
 	REQUIRE(first_cleanup.cleanup_errors == 1);
 	REQUIRE(first_cleanup.cleanup_pending == 1);
+	REQUIRE(first_cleanup.last_error.find("injected mock object cleanup failure") != std::string::npos);
 
 	auto retry_cleanup = registry.RemoveAndCleanupByQuery(query_id);
 	REQUIRE(retry_cleanup.cleanup_errors == 0);
 	REQUIRE(retry_cleanup.cleanup_pending == 0);
+	REQUIRE(retry_cleanup.last_error.empty());
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
+TEST_CASE("Exchange: deferred cleanup retains exclusive attempt identity", "[distributed][exchange]") {
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string exchange_id = "registry_deferred_identity__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_deferred_identity")};
+	auto original_cache = std::make_shared<ShuffleCache>(config);
+	REQUIRE(registry.Register(exchange_id, original_cache, "registry-deferred-owner", "epoch-a", 0).is_ok());
+	registry.RemoveForDeferredCleanup(exchange_id);
+
+	auto replacement_cache = std::make_shared<ShuffleCache>(config);
+	REQUIRE(registry.TrackPending(exchange_id, replacement_cache, "registry-replacement-owner", "epoch-b", 0).is_err());
+	REQUIRE(registry.Register(exchange_id, replacement_cache, "registry-replacement-owner", "epoch-b", 0).is_err());
+
+	auto cleanup = registry.RemoveAndCleanupByPrefix(exchange_id);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 0);
+}
+
+TEST_CASE("Exchange: unpublished sink attempts stay hidden and retain cleanup ownership", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-pending-writer-query";
+	const std::string exchange_id = "registry_pending_writer__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_pending_writer")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(config));
+
+	auto lease_result = registry.TrackPending(exchange_id, cache, query_id, "epoch-a", 0);
+	REQUIRE(lease_result.is_ok());
+	auto writer_lease = std::move(lease_result.value());
+	REQUIRE(registry.Get(exchange_id) == nullptr);
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 0).is_err());
+
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(cache->WriteChunk(context, chunk, 0, {"value"}).is_ok());
+	REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+	auto files = cache->GetPartitionFiles(0);
+	REQUIRE(files.is_ok());
+	REQUIRE(files.value().files.size() == 1);
+	auto fs = FileSystem::CreateLocal();
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+
+	REQUIRE(registry.CloseQuery(query_id).is_ok());
+	auto while_writing = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(while_writing.cleanup_pending == 1);
+	REQUIRE(while_writing.storage_entries_removed == 0);
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+
+	writer_lease.reset();
+	auto after_writer = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(after_writer.cleanup_pending == 0);
+	REQUIRE(after_writer.cleanup_errors == 0);
+	REQUIRE(after_writer.storage_entries_removed > 0);
+	REQUIRE_FALSE(fs->FileExists(files.value().files[0].path));
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+
+	// Retirement bounds tombstone growth and permits an explicitly new
+	// generation to reuse the same identity after every old job was joined.
+	REQUIRE(registry.BeginQueryExecution(query_id).is_ok());
+	REQUIRE(registry.EndQueryExecution(query_id).is_ok());
 }
 
 TEST_CASE("Exchange: query close fences late cache publication until native execution drains",
@@ -554,6 +638,103 @@ TEST_CASE("Exchange: query close fences late cache publication until native exec
 	REQUIRE(after_drain.cleanup_pending == 0);
 	REQUIRE(after_drain.cleanup_errors == 0);
 	REQUIRE(registry.Get(exchange_id) == nullptr);
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
+TEST_CASE("Exchange: late pending sink cannot delete a borrowed closed-query attempt", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-late-pending-query";
+	const std::string exchange_id = "registry_late_pending__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_late_pending")};
+	auto published_cache = std::make_shared<ShuffleCache>(config);
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(published_cache->WriteChunk(context, chunk, 0, {"value"}).is_ok());
+	REQUIRE(published_cache->FlushAll(context, {"value"}).is_ok());
+	REQUIRE(published_cache->WriteAttemptManifest(0, 0).is_ok());
+	auto files = published_cache->GetPartitionFiles(0);
+	REQUIRE(files.is_ok());
+	REQUIRE(files.value().files.size() == 1);
+	auto fs = FileSystem::CreateLocal();
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+
+	REQUIRE(registry.Register(exchange_id, published_cache, query_id, "epoch-a", 0).is_ok());
+	auto borrowed_result = registry.Resolve(exchange_id, "epoch-a", "node-a", 0);
+	REQUIRE(borrowed_result.is_ok());
+	auto borrowed = std::move(borrowed_result.value());
+	REQUIRE(registry.CloseQuery(query_id).is_ok());
+
+	auto late_cache = std::make_shared<ShuffleCache>(config);
+	REQUIRE(registry.TrackPending(exchange_id, late_cache, query_id, "epoch-a", 0).is_err());
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+	auto late_registered_cache = std::make_shared<ShuffleCache>(config);
+	REQUIRE(registry.Register(exchange_id, late_registered_cache, query_id, "epoch-a", 0).is_err());
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+	auto while_borrowed = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(while_borrowed.cleanup_pending == 1);
+	REQUIRE(while_borrowed.storage_entries_removed == 0);
+	REQUIRE(fs->FileExists(files.value().files[0].path));
+
+	borrowed.reset();
+	auto after_release = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(after_release.cleanup_pending == 0);
+	REQUIRE(after_release.cleanup_errors == 0);
+	REQUIRE(after_release.storage_entries_removed > 0);
+	REQUIRE_FALSE(fs->FileExists(files.value().files[0].path));
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
+TEST_CASE("Exchange: query cleanup waits for native execution before deleting committed storage",
+          "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-native-cleanup-fence-query";
+	const std::string exchange_id = "registry_native_cleanup_fence__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_native_cleanup_fence")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(config));
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(cache->WriteChunk(context, chunk, 0, {"value"}).is_ok());
+	REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+	REQUIRE(cache->HasCommittedManifest());
+
+	REQUIRE(registry.BeginQueryExecution(query_id).is_ok());
+	REQUIRE(registry.Register(exchange_id, cache, query_id, "epoch-a", 0).is_ok());
+	auto while_active = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(while_active.registry_entries_removed == 1);
+	REQUIRE(while_active.active_executions == 1);
+	REQUIRE(while_active.cleanup_pending == 1);
+	REQUIRE(while_active.storage_entries_removed == 0);
+	REQUIRE(cache->HasCommittedManifest());
+
+	REQUIRE(registry.EndQueryExecution(query_id).is_ok());
+	auto after_drain = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(after_drain.active_executions == 0);
+	REQUIRE(after_drain.cleanup_pending == 0);
+	REQUIRE(after_drain.cleanup_errors == 0);
+	REQUIRE(after_drain.storage_entries_removed > 0);
+	REQUIRE_FALSE(cache->HasCommittedManifest());
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
 }
 
 TEST_CASE("Exchange: Flight service isolates published attempts and rejects released or stale tickets",
@@ -916,6 +1097,9 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	auto sink_handle1 = exchange->AddSink(1);
 	REQUIRE(sink_handle0.task_partition_id == 0);
 	REQUIRE(sink_handle1.task_partition_id == 1);
+	REQUIRE(exchange->AddSink(0).task_partition_id == 0);
+	REQUIRE_THROWS_WITH(exchange->InstantiateSink(ExchangeSinkHandle {99}, 0),
+	                    Catch::Matchers::Contains("partition was not registered"));
 
 	// Instantiate sinks
 	auto inst0 = exchange->InstantiateSink(sink_handle0, 0);
@@ -923,11 +1107,41 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	REQUIRE(inst0.output_partition_count == 4);
 	REQUIRE(inst1.output_partition_count == 4);
 	REQUIRE(inst0.output_location != inst1.output_location);
-	REQUIRE(inst0.output_location.find(ctx.exchange_id) != string::npos);
-	REQUIRE(inst1.output_location.find(ctx.exchange_id) != string::npos);
+	REQUIRE(inst0.output_location.find(ctx.exchange_id) == string::npos);
+	REQUIRE(inst1.output_location.find(ctx.exchange_id) == string::npos);
+	REQUIRE(inst0.output_location.find("__sink_0__attempt_0") != string::npos);
+	REQUIRE(inst1.output_location.find("__sink_1__attempt_0") != string::npos);
+
+	auto wrong_query = inst0;
+	wrong_query.query_id = "other-query";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_query, "", 0), Catch::Matchers::Contains("query does not match"));
+	auto wrong_location = inst0;
+	wrong_location.output_location += "__wrong";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_location, "", 0),
+	                    Catch::Matchers::Contains("output location does not match"));
+	auto wrong_partition_count = inst0;
+	wrong_partition_count.output_partition_count++;
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_partition_count, "", 0),
+	                    Catch::Matchers::Contains("partition count does not match"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(inst0, "worker-0", -1),
+	                    Catch::Matchers::Contains("port must be non-negative"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(sink_handle0, 99),
+	                    Catch::Matchers::Contains("attempt was not instantiated"));
 
 	// Finish sinks
-	exchange->SinkFinished(sink_handle0, 0);
+	inst0.flight_server_epoch = "worker-0-epoch";
+	exchange->SinkFinished(inst0, "worker-0", 5000);
+	exchange->SinkFinished(inst0, "worker-0", 5000);
+	auto wrong_node = inst0;
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_node, "worker-other", 5000),
+	                    Catch::Matchers::Contains("node does not match"));
+	auto wrong_port = inst0;
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_port, "worker-0", 5001),
+	                    Catch::Matchers::Contains("port does not match"));
+	auto wrong_epoch = inst0;
+	wrong_epoch.flight_server_epoch = "worker-other-epoch";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_epoch, "worker-0", 5000),
+	                    Catch::Matchers::Contains("epoch does not match"));
 	exchange->SinkFinished(sink_handle1, 0);
 	exchange->AllRequiredSinksFinished();
 
@@ -936,6 +1150,26 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	// Source handles generated for non-empty partitions
 	// (may be empty since no data was actually written)
 
+	exchange->Close();
+	REQUIRE_THROWS_WITH(exchange->AddSink(2), Catch::Matchers::Contains("exchange is closed"));
+	REQUIRE_THROWS_WITH(exchange->GetSourceHandles(), Catch::Matchers::Contains("exchange is closed"));
+}
+
+TEST_CASE("Exchange: FlightExchange with no sinks has no unpublished source handles", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config;
+	config.node_id = "node-empty";
+	config.local_dirs = {TestCreatePath("exchange_no_sinks")};
+	FlightExchangeManager manager(config, conn.context.get());
+
+	ExchangeContext ctx;
+	ctx.query_id = "empty-query";
+	ctx.exchange_id = "empty-stage";
+	auto exchange = manager.CreateExchange(ctx, 4);
+	exchange->AllRequiredSinksFinished();
+	REQUIRE(exchange->GetSourceHandles().empty());
 	exchange->Close();
 }
 
@@ -960,6 +1194,8 @@ TEST_CASE("Exchange: same logical stage has isolated exchange instances and dire
 	auto instance_a = exchange_a->InstantiateSink(exchange_a->AddSink(0), 0);
 	auto instance_b = exchange_b->InstantiateSink(exchange_b->AddSink(0), 0);
 	REQUIRE(instance_a.output_location != instance_b.output_location);
+	REQUIRE(instance_a.output_location.find(ctx.exchange_id) == string::npos);
+	REQUIRE(instance_b.output_location.find(ctx.exchange_id) == string::npos);
 
 	ShuffleCacheConfig cache_config_a;
 	cache_config_a.shuffle_stage_id = instance_a.output_location;
@@ -978,11 +1214,59 @@ TEST_CASE("Exchange: same logical stage has isolated exchange instances and dire
 	REQUIRE(registry.Register(instance_b.output_location, cache_b, ctx.query_id, "epoch-a", 0).is_ok());
 
 	exchange_a->Close();
-	REQUIRE(registry.Get(instance_a.output_location) == nullptr);
+	REQUIRE(registry.Get(instance_a.output_location).get() == cache_a.get());
 	REQUIRE(registry.Get(instance_b.output_location).get() == cache_b.get());
 
 	exchange_b->Close();
-	registry.RemoveAndCleanupByPrefix(ctx.exchange_id);
+	REQUIRE(registry.Get(instance_a.output_location).get() == cache_a.get());
+	REQUIRE(registry.Get(instance_b.output_location).get() == cache_b.get());
+	auto cleanup = registry.RemoveAndCleanupByQuery(ctx.query_id);
+	REQUIRE(cleanup.registry_entries_removed == 2);
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(registry.RetireQuery(ctx.query_id).is_ok());
+}
+
+TEST_CASE("Exchange: FlightExchange accepts validated dynamically derived retry attempts", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config;
+	config.node_id = "coordinator";
+	config.local_dirs = {TestCreatePath("exchange_dynamic_retry")};
+	FlightExchangeManager manager(config, conn.context.get());
+	ExchangeContext ctx;
+	ctx.query_id = "dynamic-retry-query";
+	ctx.exchange_id = "diagnostic-stage";
+	auto exchange = manager.CreateExchange(ctx, 1);
+	auto sink = exchange->AddSink(0);
+	auto initial = exchange->InstantiateSink(sink, 0);
+
+	auto retry = initial;
+	retry.attempt_id = 2;
+	auto suffix = retry.output_location.rfind("__attempt_0");
+	REQUIRE(suffix != std::string::npos);
+	retry.output_location.replace(suffix, std::string("__attempt_0").size(), "__attempt_2");
+	retry.flight_server_epoch = "retry-epoch";
+	exchange->SinkFinished(retry, "worker-retry", 5010);
+
+	auto handles = exchange->GetSourceHandles();
+	REQUIRE(handles.size() == 1);
+	REQUIRE(handles[0].attempt_id == 2);
+	REQUIRE(handles[0].node_id == "worker-retry");
+	REQUIRE(handles[0].flight_port == 5010);
+	REQUIRE(handles[0].flight_server_epoch == "retry-epoch");
+	REQUIRE(handles[0].files.size() == 1);
+	REQUIRE(handles[0].files[0].path == retry.output_location);
+
+	auto forged_retry = initial;
+	forged_retry.attempt_id = 3;
+	forged_retry.output_location = "forged-output";
+	forged_retry.flight_server_epoch = "retry-epoch";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(forged_retry, "worker-retry", 5010),
+	                    Catch::Matchers::Contains("retry output location does not match"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(sink, 3), Catch::Matchers::Contains("attempt was not instantiated"));
+	exchange->Close();
 }
 
 TEST_CASE("Exchange: process-local Flight service has immutable network config and explicit shutdown",
@@ -997,8 +1281,12 @@ TEST_CASE("Exchange: process-local Flight service has immutable network config a
 	ExchangeSinkInstanceHandle handle;
 	handle.sink_handle.task_partition_id = 0;
 	handle.attempt_id = 0;
+	handle.query_id = "service-lifecycle-query";
 	handle.output_location = "service_lifecycle__instance_a__sink_0__attempt_0";
 	handle.output_partition_count = 1;
+	auto handle_b = handle;
+	handle_b.sink_handle.task_partition_id = 1;
+	handle_b.output_location = "service_lifecycle__instance_a__sink_1__attempt_0";
 
 	FlightExchangeConfig config_a;
 	config_a.node_id = "node-a";
@@ -1017,7 +1305,7 @@ TEST_CASE("Exchange: process-local Flight service has immutable network config a
 	config_b.local_dirs = {TestCreatePath("flight_service_lifecycle_b")};
 	config_b.node_id = "node-b";
 	FlightExchangeManager manager_b(config_b);
-	auto sink_b = manager_b.CreateSink(handle);
+	auto sink_b = manager_b.CreateSink(handle_b);
 	REQUIRE(sink_b != nullptr);
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == first_port);
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch() == first_epoch);
@@ -1035,6 +1323,10 @@ TEST_CASE("Exchange: process-local Flight service has immutable network config a
 
 	sink_a.reset();
 	sink_b.reset();
+	auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(handle.query_id);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(ShuffleCacheRegistry::Instance().RetireQuery(handle.query_id).is_ok());
 	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == 0);
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch().empty());
@@ -1047,6 +1339,10 @@ TEST_CASE("Exchange: process-local Flight service has immutable network config a
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == first_port);
 	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch() != first_epoch);
 	fixed_sink.reset();
+	cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(handle.query_id);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(ShuffleCacheRegistry::Instance().RetireQuery(handle.query_id).is_ok());
 	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
 }
 
@@ -1112,6 +1408,31 @@ TEST_CASE("Exchange: FlightExchange selects first successful sink attempt", "[di
 	REQUIRE(sink0_handles == 2);
 	REQUIRE(sink1_handles == 2);
 
+	exchange->Close();
+}
+
+TEST_CASE("Exchange: failed unselected-attempt cleanup releases its retry claim", "[distributed][exchange]") {
+	FlightExchangeConfig config;
+	config.node_id = "coordinator";
+	config.local_dirs = {"s3://bucket/shuffle"};
+	FlightExchangeManager manager(config);
+
+	ExchangeContext ctx;
+	ctx.query_id = "unselected-cleanup-retry-query";
+	ctx.exchange_id = "unselected-cleanup-retry-stage";
+	auto exchange = manager.CreateExchange(ctx, 1);
+	auto sink = exchange->AddSink(0);
+	auto selected = exchange->InstantiateSink(sink, 0);
+	auto unselected = exchange->InstantiateSink(sink, 1);
+
+	exchange->SinkFinished(selected, "worker-selected", 0);
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(unselected, "worker-unselected", 0),
+	                    Catch::Matchers::Contains("requires ClientContext"));
+
+	// A thrown cleanup must release the in-flight claim. The final barrier
+	// therefore retries the same attempt instead of silently treating it as
+	// already cleaned.
+	REQUIRE_THROWS_WITH(exchange->AllRequiredSinksFinished(), Catch::Matchers::Contains("requires ClientContext"));
 	exchange->Close();
 }
 
@@ -1202,12 +1523,64 @@ TEST_CASE("Exchange: FlightExchangeSink memory usage", "[distributed][exchange]"
 	ExchangeSinkInstanceHandle handle;
 	handle.sink_handle.task_partition_id = 0;
 	handle.attempt_id = 0;
+	handle.query_id = "sink-memory-query";
+	handle.output_location = "sink_mem_test";
 	handle.output_partition_count = 1;
 
 	FlightExchangeSink sink(cache, handle, conn.context.get());
 
 	// Memory usage should be 0 (disk-first)
 	REQUIRE(sink.GetMemoryUsage() == 0);
+	REQUIRE(sink.Abort().is_ok());
+	auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(handle.query_id);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(ShuffleCacheRegistry::Instance().RetireQuery(handle.query_id).is_ok());
+}
+
+TEST_CASE("Exchange: FlightExchangeSink abort retains partially flushed attempt cleanup", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+
+	const std::string query_id = "sink-abort-query";
+	const std::string exchange_id = "sink_abort__sink_0__attempt_0";
+	ShuffleCacheConfig cache_config;
+	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.node_id = "node_1";
+	cache_config.num_partitions = 1;
+	cache_config.local_dirs = {TestCreatePath("exchange_sink_abort")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(cache_config));
+
+	ExchangeSinkInstanceHandle handle;
+	handle.sink_handle.task_partition_id = 0;
+	handle.attempt_id = 0;
+	handle.query_id = query_id;
+	handle.output_location = exchange_id;
+	handle.output_partition_count = 1;
+
+	FlightExchangeSink sink(cache, handle, &context);
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(sink.AddChunk(0, chunk).is_ok());
+	REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+	auto files = cache->GetPartitionFiles(0);
+	REQUIRE(files.is_ok());
+	REQUIRE(files.value().files.size() == 1);
+	auto file_path = files.value().files[0].path;
+	auto fs = FileSystem::CreateLocal();
+	REQUIRE(fs->FileExists(file_path));
+	REQUIRE(ShuffleCacheRegistry::Instance().Get(exchange_id) == nullptr);
+
+	REQUIRE(sink.Abort().is_ok());
+	auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(query_id);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(cleanup.storage_entries_removed > 0);
+	REQUIRE_FALSE(fs->FileExists(file_path));
+	REQUIRE(ShuffleCacheRegistry::Instance().RetireQuery(query_id).is_ok());
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -1244,18 +1617,23 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 	REQUIRE(cache->WriteChunk(context, chunk1, 1, {"id", "name"}).is_ok());
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
 
 	// Register the cache
 	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_test_stage", cache, "source-test-query").is_ok());
 
 	// Create source and read partition 0
-	FlightExchangeSource source("source_test_stage", &context);
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node_1";
+	FlightExchangeSource source(source_config, &context);
 
 	REQUIRE(source.IsBlocked() == false);
 
 	// Add source handle for partition 0
 	ExchangeSourceHandle handle0;
 	handle0.partition_id = 0;
+	handle0.node_id = "node_1";
+	handle0.files.push_back(ExchangeSourceFile("source_test_stage", 0));
 	source.AddSourceHandles({handle0});
 
 	REQUIRE(source.IsFinished() == false);
@@ -1305,14 +1683,21 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 	REQUIRE(cache->WriteChunk(context, chunk2, 2, {"id", "name"}).is_ok());
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
 	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_multi_stage", cache, "source-multi-test-query").is_ok());
 
 	// Source reads both partitions
-	FlightExchangeSource source("source_multi_stage", &context);
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node_1";
+	FlightExchangeSource source(source_config, &context);
 
 	ExchangeSourceHandle h0, h2;
 	h0.partition_id = 0;
+	h0.node_id = "node_1";
+	h0.files.push_back(ExchangeSourceFile("source_multi_stage", 0));
 	h2.partition_id = 2;
+	h2.node_id = "node_1";
+	h2.files.push_back(ExchangeSourceFile("source_multi_stage", 0));
 	source.AddSourceHandles({h0, h2});
 
 	vector<int32_t> read_ids;
@@ -1358,6 +1743,7 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	PopulateTwoColumnChunk(chunk0, types, {1, 2}, {"a", "b"});
 	REQUIRE(cache0->WriteChunk(context, chunk0, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache0->FlushAll(context, cache0->BufferedNames()).is_ok());
+	REQUIRE(cache0->WriteAttemptManifest(0, 0).is_ok());
 	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage0, cache0, "source-switch-test-query").is_ok());
 
 	ShuffleCacheConfig cache1_config;
@@ -1371,6 +1757,7 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	PopulateTwoColumnChunk(chunk1, types, {3, 4}, {"c", "d"});
 	REQUIRE(cache1->WriteChunk(context, chunk1, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache1->FlushAll(context, cache1->BufferedNames()).is_ok());
+	REQUIRE(cache1->WriteAttemptManifest(1, 0).is_ok());
 	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage1, cache1, "source-switch-test-query").is_ok());
 
 	FlightExchangeConfig source_config;
@@ -1409,11 +1796,59 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	ShuffleCacheRegistry::Instance().Remove(stage1);
 }
 
+TEST_CASE("Exchange: FlightExchangeSource revalidates local handle attempt identity", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	const std::string exchange_id = "source_local_identity__sink_0__attempt_0";
+	const std::string query_id = "source-local-identity-query";
+
+	ShuffleCacheConfig cache_config;
+	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.node_id = "node-local";
+	cache_config.num_partitions = 1;
+	cache_config.local_dirs = {TestCreatePath("exchange_source_local_identity")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(cache_config));
+	DataChunk input;
+	input.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	input.SetCardinality(1);
+	input.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(cache->WriteChunk(context, input, 0, {"value"}).is_ok());
+	REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+	REQUIRE(ShuffleCacheRegistry::Instance().Register(exchange_id, cache, query_id, "", 0).is_ok());
+
+	ExchangeSourceHandle valid;
+	valid.partition_id = 0;
+	valid.attempt_id = 0;
+	valid.node_id = "node-local";
+	valid.files.push_back(ExchangeSourceFile(exchange_id, 0));
+	auto invalid = valid;
+	invalid.attempt_id = 1;
+
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node-local";
+	source_config.expected_types = {LogicalType::INTEGER};
+	FlightExchangeSource source(source_config, &context);
+	source.AddSourceHandles({valid, invalid});
+
+	DataChunk output;
+	output.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	REQUIRE(source.ReadChunk(output));
+	REQUIRE(output.size() == 1);
+	REQUIRE(output.GetValue(0, 0).GetValue<int32_t>() == 42);
+	REQUIRE_THROWS_WITH(source.ReadChunk(output), Catch::Matchers::Contains("missing its server epoch"));
+
+	source.Close();
+	ShuffleCacheRegistry::Instance().Remove(exchange_id);
+}
+
 TEST_CASE("Exchange: FlightExchangeSource no handles", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 
-	FlightExchangeSource source("nonexistent_stage", conn.context.get());
+	FlightExchangeConfig source_config;
+	FlightExchangeSource source(source_config, conn.context.get());
 
 	// Without handles, should be finished immediately
 	REQUIRE(source.IsFinished() == true);
@@ -1422,6 +1857,68 @@ TEST_CASE("Exchange: FlightExchangeSource no handles", "[distributed][exchange]"
 	vector<LogicalType> types = {LogicalType::INTEGER};
 	chunk.Initialize(Allocator::DefaultAllocator(), types);
 	REQUIRE(source.ReadChunk(chunk) == false);
+}
+
+TEST_CASE("Exchange: FlightExchangeSource rejects handles without catalog identity", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node-1";
+	FlightExchangeSource source(source_config, conn.context.get());
+	ExchangeSourceHandle handle;
+	handle.partition_id = 0;
+	handle.node_id = "node-1";
+	source.AddSourceHandles({handle});
+
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	REQUIRE_THROWS_WITH(source.ReadChunk(chunk), Catch::Matchers::Contains("missing its catalog identity"));
+}
+
+TEST_CASE("Exchange: FlightExchangeSource close releases catalog borrow for query cleanup", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	const std::string query_id = "source-close-cleanup-query";
+	const std::string exchange_id = "source_close_cleanup_attempt";
+	ShuffleCacheConfig cache_config;
+	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.node_id = "node-1";
+	cache_config.num_partitions = 1;
+	cache_config.local_dirs = {TestCreatePath("exchange_source_close_cleanup")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(cache_config));
+	DataChunk input;
+	input.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	input.SetCardinality(1);
+	input.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(cache->WriteChunk(*conn.context, input, 0, {"value"}).is_ok());
+	REQUIRE(cache->FlushAll(*conn.context, {"value"}).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+	auto &registry = ShuffleCacheRegistry::Instance();
+	REQUIRE(registry.Register(exchange_id, cache, query_id).is_ok());
+
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node-1";
+	FlightExchangeSource source(source_config, conn.context.get());
+	ExchangeSourceHandle handle;
+	handle.partition_id = 0;
+	handle.node_id = "node-1";
+	handle.files.push_back(ExchangeSourceFile(exchange_id, 0));
+	source.AddSourceHandles({handle});
+
+	DataChunk output;
+	output.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	REQUIRE(source.ReadChunk(output));
+	REQUIRE(output.GetValue(0, 0).GetValue<int32_t>() == 42);
+	auto while_borrowed = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(while_borrowed.cleanup_pending == 1);
+
+	source.Close();
+	auto after_close = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(after_close.cleanup_errors == 0);
+	REQUIRE(after_close.cleanup_pending == 0);
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -1470,9 +1967,13 @@ TEST_CASE("Exchange: End-to-end sink to source pipeline", "[distributed][exchang
 
 	// ─── Phase 2: Read data via source (partition 0) ───
 
-	FlightExchangeSource source0(exchange_id, &context);
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node_1";
+	FlightExchangeSource source0(source_config, &context);
 	ExchangeSourceHandle sh0;
 	sh0.partition_id = 0;
+	sh0.node_id = "node_1";
+	sh0.files.push_back(ExchangeSourceFile(exchange_id, 0));
 	source0.AddSourceHandles({sh0});
 
 	vector<int32_t> read_ids0;
@@ -1491,9 +1992,11 @@ TEST_CASE("Exchange: End-to-end sink to source pipeline", "[distributed][exchang
 
 	// ─── Phase 3: Read data via source (partition 1) ───
 
-	FlightExchangeSource source1(exchange_id, &context);
+	FlightExchangeSource source1(source_config, &context);
 	ExchangeSourceHandle sh1;
 	sh1.partition_id = 1;
+	sh1.node_id = "node_1";
+	sh1.files.push_back(ExchangeSourceFile(exchange_id, 0));
 	source1.AddSourceHandles({sh1});
 
 	vector<int32_t> read_ids1;
@@ -1520,13 +2023,18 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 	auto &context = *conn.context;
 
 	const std::string exchange_id = "multi_sink_test";
-
-	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
-	cache_config.node_id = "node_1";
-	cache_config.num_partitions = 2;
-	cache_config.local_dirs = {TestCreatePath("exchange_multi_sink")};
-	auto cache = std::make_shared<ShuffleCache>(std::move(cache_config));
+	const std::string output0 = exchange_id + "__sink_0__attempt_0";
+	const std::string output1 = exchange_id + "__sink_1__attempt_0";
+	auto make_cache = [&](const std::string &output_location, const std::string &dir) {
+		ShuffleCacheConfig cache_config;
+		cache_config.shuffle_stage_id = output_location;
+		cache_config.node_id = "node_1";
+		cache_config.num_partitions = 2;
+		cache_config.local_dirs = {TestCreatePath(dir)};
+		return std::make_shared<ShuffleCache>(std::move(cache_config));
+	};
+	auto cache0 = make_cache(output0, "exchange_multi_sink_0");
+	auto cache1 = make_cache(output1, "exchange_multi_sink_1");
 
 	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::VARCHAR};
 
@@ -1536,10 +2044,10 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 		handle.sink_handle.task_partition_id = 0;
 		handle.attempt_id = 0;
 		handle.query_id = "exchange-multi-sink-query";
-		handle.output_location = exchange_id;
+		handle.output_location = output0;
 		handle.output_partition_count = 2;
 
-		FlightExchangeSink sink1(cache, handle, &context);
+		FlightExchangeSink sink1(cache0, handle, &context);
 		DataChunk chunk;
 		PopulateTwoColumnChunk(chunk, types, {1, 2}, {"a", "b"});
 		REQUIRE(sink1.AddChunk(0, chunk).is_ok());
@@ -1552,26 +2060,28 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 		handle.sink_handle.task_partition_id = 1;
 		handle.attempt_id = 0;
 		handle.query_id = "exchange-multi-sink-query";
-		handle.output_location = exchange_id;
+		handle.output_location = output1;
 		handle.output_partition_count = 2;
 
-		FlightExchangeSink sink2(cache, handle, &context);
+		FlightExchangeSink sink2(cache1, handle, &context);
 		DataChunk chunk;
 		PopulateTwoColumnChunk(chunk, types, {3, 4}, {"c", "d"});
 		REQUIRE(sink2.AddChunk(0, chunk).is_ok());
 		REQUIRE(sink2.Finish().is_ok());
 	}
 
-	// Source reads partition 0 — should have data from both sinks
-	// First verify via cache directly
-	auto read_res = cache->ReadPartition(context, 0, types);
-	REQUIRE(read_res.is_ok());
-	auto total_rows = read_res.value()->Count();
-
-	FlightExchangeSource source(exchange_id, &context);
-	ExchangeSourceHandle sh;
-	sh.partition_id = 0;
-	source.AddSourceHandles({sh});
+	FlightExchangeConfig source_config;
+	source_config.node_id = "node_1";
+	FlightExchangeSource source(source_config, &context);
+	ExchangeSourceHandle sh0;
+	sh0.partition_id = 0;
+	sh0.node_id = "node_1";
+	sh0.files.push_back(ExchangeSourceFile(output0, 0));
+	ExchangeSourceHandle sh1;
+	sh1.partition_id = 0;
+	sh1.node_id = "node_1";
+	sh1.files.push_back(ExchangeSourceFile(output1, 0));
+	source.AddSourceHandles({sh0, sh1});
 
 	vector<int32_t> read_ids;
 	vector<string> read_names;
@@ -1586,8 +2096,7 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 	}
 
 	// Should have all rows from both sinks
-	REQUIRE(read_ids.size() == total_rows);
-	REQUIRE(read_ids.size() >= 2); // At least one sink's data
+	REQUIRE(read_ids.size() == 4);
 
 	// All read IDs should be from the expected set
 	std::set<int32_t> id_set(read_ids.begin(), read_ids.end());
@@ -1597,5 +2106,6 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 	}
 
 	source.Close();
-	ShuffleCacheRegistry::Instance().Remove(exchange_id);
+	ShuffleCacheRegistry::Instance().Remove(output0);
+	ShuffleCacheRegistry::Instance().Remove(output1);
 }

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/execution/distributed/exchange/flight_ticket.hpp"
+#include "duckdb/execution/distributed/exchange/flight_client.hpp"
 #include "duckdb/execution/distributed/exchange/shuffle_cache.hpp"
 #include "duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp"
 #include "duckdb/execution/distributed/exchange/flight_exchange_manager.hpp"
@@ -297,8 +298,10 @@ private:
 
 TEST_CASE("Exchange: FlightExchangeTicket roundtrip", "[distributed][exchange]") {
 	FlightExchangeTicket ticket;
-	ticket.shuffle_stage_id = "stage_1";
+	ticket.server_epoch = "epoch_1";
+	ticket.exchange_instance_id = "stage_1__instance_a__sink_0__attempt_3";
 	ticket.node_id = "node_2";
+	ticket.attempt_id = 3;
 	ticket.partition_idx = 7;
 
 	auto encoded = ticket.Serialize();
@@ -306,18 +309,26 @@ TEST_CASE("Exchange: FlightExchangeTicket roundtrip", "[distributed][exchange]")
 	REQUIRE(parsed.is_ok());
 
 	auto result = parsed.value();
-	REQUIRE(result.shuffle_stage_id == ticket.shuffle_stage_id);
+	REQUIRE(result.server_epoch == ticket.server_epoch);
+	REQUIRE(result.exchange_instance_id == ticket.exchange_instance_id);
 	REQUIRE(result.node_id == ticket.node_id);
+	REQUIRE(result.attempt_id == ticket.attempt_id);
 	REQUIRE(result.partition_idx == ticket.partition_idx);
 }
 
 TEST_CASE("Exchange: FlightExchangeTicket parse errors", "[distributed][exchange]") {
 	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v2\nstage\nnode\n1").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\n\nnode\n1").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\n\n1").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode\n-1").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode\nnope").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode\n1").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v2\nepoch\nstage\nnode\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\n\nstage\nnode\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\n\nnode\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\n\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n-1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\n-2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\nnope\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\nnope").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1x\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\n2x").is_err());
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -385,6 +396,159 @@ TEST_CASE("Exchange: ShuffleCacheRegistry multiple entries", "[distributed][exch
 	REQUIRE(registry.Get("multi_test_2").get() == cache2.get());
 
 	registry.Remove("multi_test_2");
+}
+
+TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descriptor identity",
+          "[distributed][exchange]") {
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string exchange_id = "registry_identity_stage";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 2;
+	config.local_dirs = {TestCreatePath("registry_identity_a")};
+	auto cache = std::make_shared<ShuffleCache>(config);
+
+	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 4).is_ok());
+	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 4).is_ok());
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 4).is_ok());
+	REQUIRE(registry.Resolve(exchange_id, "epoch-old", "node-a", 4).is_err());
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 3).is_err());
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-b", 4).is_err());
+
+	auto conflicting_config = config;
+	conflicting_config.local_dirs = {TestCreatePath("registry_identity_b")};
+	auto conflicting_cache = std::make_shared<ShuffleCache>(std::move(conflicting_config));
+	REQUIRE(registry.Register(exchange_id, conflicting_cache, "epoch-a", 4).is_err());
+	REQUIRE(registry.Get(exchange_id).get() == cache.get());
+
+	registry.RemoveForDeferredCleanup(exchange_id);
+	REQUIRE(registry.Get(exchange_id) == nullptr);
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 4).is_err());
+	registry.RemoveAndCleanupByPrefix(exchange_id);
+}
+
+TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string exchange_id = "registry_lease_stage__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_lease")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(config));
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(cache->WriteChunk(context, chunk, 0, {"value"}).is_ok());
+	REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+	REQUIRE(cache->HasCommittedManifest());
+
+	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 0).is_ok());
+	auto lease_result = registry.Resolve(exchange_id, "epoch-a", "node-a", 0);
+	REQUIRE(lease_result.is_ok());
+	auto lease = std::move(lease_result.value());
+	registry.RemoveForDeferredCleanup(exchange_id);
+
+	auto cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_stage");
+	REQUIRE(cleanup.registry_entries_removed == 1);
+	REQUIRE(cleanup.storage_entries_removed == 0);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cache->HasCommittedManifest());
+
+	lease.reset();
+	REQUIRE_FALSE(cache->HasCommittedManifest());
+}
+
+TEST_CASE("Exchange: Flight service isolates published attempts and rejects released or stale tickets",
+          "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string prefix = "overlapping-stage";
+	const std::string exchange_a = prefix + "__instance_a__sink_0__attempt_1";
+	const std::string exchange_b = prefix + "__instance_b__sink_0__attempt_1";
+	const std::string epoch = "catalog-isolation-epoch";
+	const std::string node_id = "node-a";
+
+	auto make_committed_cache = [&](const std::string &exchange_id, const std::string &dir, int32_t value) {
+		ShuffleCacheConfig config;
+		config.shuffle_stage_id = exchange_id;
+		config.node_id = node_id;
+		config.num_partitions = 1;
+		config.local_dirs = {dir};
+		auto cache = std::make_shared<ShuffleCache>(std::move(config));
+		DataChunk chunk;
+		chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::INTEGER(value));
+		REQUIRE(cache->WriteChunk(context, chunk, 0, {"value"}).is_ok());
+		REQUIRE(cache->FlushAll(context, {"value"}).is_ok());
+		REQUIRE(cache->WriteAttemptManifest(0, 1).is_ok());
+		return cache;
+	};
+
+	auto cache_a = make_committed_cache(exchange_a, TestCreatePath("flight_catalog_isolation_a"), 11);
+	auto cache_b = make_committed_cache(exchange_b, TestCreatePath("flight_catalog_isolation_b"), 22);
+	REQUIRE(registry.Register(exchange_a, cache_a, epoch, 1).is_ok());
+	REQUIRE(registry.Register(exchange_b, cache_b, epoch, 1).is_ok());
+
+	FlightServerConfig server_config;
+	server_config.bind_host = "127.0.0.1";
+	server_config.port = 0;
+	server_config.server_epoch = epoch;
+	FlightServer server(std::move(server_config));
+	REQUIRE(server.Start().is_ok());
+	FlightClientConfig client_config;
+	client_config.location = "grpc://127.0.0.1:" + std::to_string(server.port());
+	FlightClient client(std::move(client_config));
+
+	auto fetch = [&](const std::string &exchange_id, const std::string &ticket_epoch) {
+		FlightExchangeTicket ticket;
+		ticket.server_epoch = ticket_epoch;
+		ticket.exchange_instance_id = exchange_id;
+		ticket.node_id = node_id;
+		ticket.attempt_id = 1;
+		ticket.partition_idx = 0;
+		return client.FetchPartition(context, ticket, {LogicalType::INTEGER});
+	};
+	auto fetched_a = fetch(exchange_a, epoch);
+	auto fetched_b = fetch(exchange_b, epoch);
+	REQUIRE(fetched_a.is_ok());
+	REQUIRE(fetched_b.is_ok());
+	REQUIRE(fetched_a.value()->Count() == 1);
+	REQUIRE(fetched_b.value()->Count() == 1);
+	vector<int32_t> values_a;
+	vector<int32_t> values_b;
+	for (auto &chunk : fetched_a.value()->Chunks()) {
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			values_a.push_back(chunk.GetValue(0, row).GetValue<int32_t>());
+		}
+	}
+	for (auto &chunk : fetched_b.value()->Chunks()) {
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			values_b.push_back(chunk.GetValue(0, row).GetValue<int32_t>());
+		}
+	}
+	REQUIRE(values_a == vector<int32_t> {11});
+	REQUIRE(values_b == vector<int32_t> {22});
+
+	registry.RemoveForDeferredCleanup(exchange_a);
+	REQUIRE(fetch(exchange_a, epoch).is_err());
+	REQUIRE(fetch(exchange_b, epoch).is_ok());
+	REQUIRE(fetch(exchange_b, "stale-epoch").is_err());
+
+	REQUIRE(server.Stop().is_ok());
+	registry.RemoveForDeferredCleanup(exchange_b);
+	registry.RemoveAndCleanupByPrefix(prefix);
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -685,6 +849,117 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	exchange->Close();
 }
 
+TEST_CASE("Exchange: same logical stage has isolated exchange instances and directories", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config_a;
+	config_a.node_id = "node-a";
+	config_a.local_dirs = {TestCreatePath("exchange_instance_a")};
+	FlightExchangeConfig config_b;
+	config_b.node_id = "node-a";
+	config_b.local_dirs = {TestCreatePath("exchange_instance_b")};
+	FlightExchangeManager manager_a(config_a, conn.context.get());
+	FlightExchangeManager manager_b(config_b, conn.context.get());
+
+	ExchangeContext ctx;
+	ctx.query_id = "same-query";
+	ctx.exchange_id = "same-stage";
+	auto exchange_a = manager_a.CreateExchange(ctx, 1);
+	auto exchange_b = manager_b.CreateExchange(ctx, 1);
+	auto instance_a = exchange_a->InstantiateSink(exchange_a->AddSink(0), 0);
+	auto instance_b = exchange_b->InstantiateSink(exchange_b->AddSink(0), 0);
+	REQUIRE(instance_a.output_location != instance_b.output_location);
+
+	ShuffleCacheConfig cache_config_a;
+	cache_config_a.shuffle_stage_id = instance_a.output_location;
+	cache_config_a.node_id = "node-a";
+	cache_config_a.num_partitions = 1;
+	cache_config_a.local_dirs = config_a.local_dirs;
+	ShuffleCacheConfig cache_config_b;
+	cache_config_b.shuffle_stage_id = instance_b.output_location;
+	cache_config_b.node_id = "node-a";
+	cache_config_b.num_partitions = 1;
+	cache_config_b.local_dirs = config_b.local_dirs;
+	auto cache_a = std::make_shared<ShuffleCache>(std::move(cache_config_a));
+	auto cache_b = std::make_shared<ShuffleCache>(std::move(cache_config_b));
+	auto &registry = ShuffleCacheRegistry::Instance();
+	REQUIRE(registry.Register(instance_a.output_location, cache_a, "epoch-a", 0).is_ok());
+	REQUIRE(registry.Register(instance_b.output_location, cache_b, "epoch-a", 0).is_ok());
+
+	exchange_a->Close();
+	REQUIRE(registry.Get(instance_a.output_location) == nullptr);
+	REQUIRE(registry.Get(instance_b.output_location).get() == cache_b.get());
+
+	exchange_b->Close();
+	registry.RemoveAndCleanupByPrefix(ctx.exchange_id);
+}
+
+TEST_CASE("Exchange: process-local Flight service has immutable network config and explicit shutdown",
+          "[distributed][exchange]") {
+	struct ServiceGuard {
+		~ServiceGuard() {
+			FlightExchangeManager::ShutdownLocalFlightServer();
+		}
+	} guard;
+	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
+
+	ExchangeSinkInstanceHandle handle;
+	handle.sink_handle.task_partition_id = 0;
+	handle.attempt_id = 0;
+	handle.output_location = "service_lifecycle__instance_a__sink_0__attempt_0";
+	handle.output_partition_count = 1;
+
+	FlightExchangeConfig config_a;
+	config_a.node_id = "node-a";
+	config_a.flight_bind_host = "127.0.0.1";
+	config_a.flight_port = 0;
+	config_a.local_dirs = {TestCreatePath("flight_service_lifecycle_a")};
+	FlightExchangeManager manager_a(config_a);
+	auto sink_a = manager_a.CreateSink(handle);
+	REQUIRE(sink_a != nullptr);
+	const auto first_port = FlightExchangeManager::GetLocalFlightServerPort();
+	const auto first_epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
+	REQUIRE(first_port > 0);
+	REQUIRE(!first_epoch.empty());
+
+	auto config_b = config_a;
+	config_b.local_dirs = {TestCreatePath("flight_service_lifecycle_b")};
+	config_b.node_id = "node-b";
+	FlightExchangeManager manager_b(config_b);
+	auto sink_b = manager_b.CreateSink(handle);
+	REQUIRE(sink_b != nullptr);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == first_port);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch() == first_epoch);
+
+	auto conflicting_config = config_b;
+	conflicting_config.flight_port = first_port;
+	FlightExchangeManager conflicting_manager(conflicting_config);
+	REQUIRE_THROWS_WITH(conflicting_manager.CreateSink(handle),
+	                    Catch::Matchers::Contains("refusing conflicting address"));
+
+	manager_a.Shutdown();
+	manager_b.Shutdown();
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == first_port);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch() == first_epoch);
+
+	sink_a.reset();
+	sink_b.reset();
+	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == 0);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch().empty());
+
+	auto fixed_config = config_a;
+	fixed_config.flight_port = first_port;
+	FlightExchangeManager fixed_manager(fixed_config);
+	auto fixed_sink = fixed_manager.CreateSink(handle);
+	REQUIRE(fixed_sink != nullptr);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerPort() == first_port);
+	REQUIRE(FlightExchangeManager::GetLocalFlightServerEpoch() != first_epoch);
+	fixed_sink.reset();
+	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
+}
+
 TEST_CASE("Exchange: FlightExchange selects first successful sink attempt", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
@@ -710,9 +985,12 @@ TEST_CASE("Exchange: FlightExchange selects first successful sink attempt", "[di
 	REQUIRE(sink0_attempt1.output_location.find("__sink_0__attempt_1") != std::string::npos);
 	REQUIRE(sink1_attempt0.output_location.find("__sink_1__attempt_0") != std::string::npos);
 
-	exchange->SinkFinished(sink0, 1, "worker-retry", 5010);
-	exchange->SinkFinished(sink0, 0, "worker-late", 5011);
-	exchange->SinkFinished(sink1, 0, "worker-first", 5012);
+	sink0_attempt1.flight_server_epoch = "worker-retry-epoch";
+	exchange->SinkFinished(sink0_attempt1, "worker-retry", 5010);
+	sink0_attempt0.flight_server_epoch = "worker-late-epoch";
+	exchange->SinkFinished(sink0_attempt0, "worker-late", 5011);
+	sink1_attempt0.flight_server_epoch = "worker-first-epoch";
+	exchange->SinkFinished(sink1_attempt0, "worker-first", 5012);
 	exchange->AllRequiredSinksFinished();
 
 	auto source_handles = exchange->GetSourceHandles();
@@ -727,6 +1005,7 @@ TEST_CASE("Exchange: FlightExchange selects first successful sink attempt", "[di
 			REQUIRE(handle.attempt_id == 1);
 			REQUIRE(handle.node_id == "worker-retry");
 			REQUIRE(handle.flight_port == 5010);
+			REQUIRE(handle.flight_server_epoch == "worker-retry-epoch");
 			REQUIRE(handle.files[0].path.find("__attempt_1") != std::string::npos);
 			REQUIRE(handle.files[0].path.find("__attempt_0") == std::string::npos);
 		} else if (handle.files[0].path.find("__sink_1__") != std::string::npos) {
@@ -734,6 +1013,7 @@ TEST_CASE("Exchange: FlightExchange selects first successful sink attempt", "[di
 			REQUIRE(handle.attempt_id == 0);
 			REQUIRE(handle.node_id == "worker-first");
 			REQUIRE(handle.flight_port == 5012);
+			REQUIRE(handle.flight_server_epoch == "worker-first-epoch");
 			REQUIRE(handle.files[0].path.find("__attempt_0") != std::string::npos);
 		} else {
 			FAIL("unexpected source handle path");

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -28,6 +28,8 @@
 #include <iterator>
 #include <utility>
 #include <cstdlib>
+#include <condition_variable>
+#include <thread>
 
 using namespace duckdb;
 using namespace duckdb::distributed;
@@ -126,7 +128,8 @@ void CollectCollectionRows(ColumnDataCollection &collection, vector<int32_t> &ou
 
 class MockObjectShuffleStorage final : public ShuffleStorage {
 public:
-	explicit MockObjectShuffleStorage(std::string root) : root_(std::move(root)), fs_(FileSystem::CreateLocal()) {
+	explicit MockObjectShuffleStorage(std::string root, idx_t remove_failures = 0)
+	    : root_(std::move(root)), fs_(FileSystem::CreateLocal()), remove_failures_remaining_(remove_failures) {
 	}
 
 	bool SupportsObjectPaths() const override {
@@ -193,6 +196,10 @@ public:
 	}
 
 	DuckDBResult<idx_t> RemoveAll(const std::string &path) const override {
+		if (remove_failures_remaining_ > 0) {
+			remove_failures_remaining_--;
+			return DuckDBResult<idx_t>::err(DuckDBError::io_error("injected mock object cleanup failure"));
+		}
 		return RemoveAllRecursive(MapPath(path));
 	}
 
@@ -288,6 +295,7 @@ private:
 
 	std::string root_;
 	unique_ptr<FileSystem> fs_;
+	mutable idx_t remove_failures_remaining_ = 0;
 };
 
 } // namespace
@@ -346,7 +354,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry register/get/remove", "[distributed][e
 	config.local_dirs = {TestCreatePath("registry_test")};
 
 	auto cache = std::make_shared<ShuffleCache>(std::move(config));
-	registry.Register("registry_test_stage", cache);
+	REQUIRE(registry.Register("registry_test_stage", cache, "registry-test-query").is_ok());
 
 	// Get should return the same cache
 	auto retrieved = registry.Get("registry_test_stage");
@@ -384,8 +392,8 @@ TEST_CASE("Exchange: ShuffleCacheRegistry multiple entries", "[distributed][exch
 	auto cache1 = std::make_shared<ShuffleCache>(std::move(config1));
 	auto cache2 = std::make_shared<ShuffleCache>(std::move(config2));
 
-	registry.Register("multi_test_1", cache1);
-	registry.Register("multi_test_2", cache2);
+	REQUIRE(registry.Register("multi_test_1", cache1, "registry-multi-query").is_ok());
+	REQUIRE(registry.Register("multi_test_2", cache2, "registry-multi-query").is_ok());
 
 	REQUIRE(registry.Get("multi_test_1").get() == cache1.get());
 	REQUIRE(registry.Get("multi_test_2").get() == cache2.get());
@@ -402,6 +410,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descript
           "[distributed][exchange]") {
 	auto &registry = ShuffleCacheRegistry::Instance();
 	const std::string exchange_id = "registry_identity_stage";
+	const std::string query_id = "registry-identity-query";
 
 	ShuffleCacheConfig config;
 	config.shuffle_stage_id = exchange_id;
@@ -410,8 +419,8 @@ TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descript
 	config.local_dirs = {TestCreatePath("registry_identity_a")};
 	auto cache = std::make_shared<ShuffleCache>(config);
 
-	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 4).is_ok());
-	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 4).is_ok());
+	REQUIRE(registry.Register(exchange_id, cache, query_id, "epoch-a", 4).is_ok());
+	REQUIRE(registry.Register(exchange_id, cache, query_id, "epoch-a", 4).is_ok());
 	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 4).is_ok());
 	REQUIRE(registry.Resolve(exchange_id, "epoch-old", "node-a", 4).is_err());
 	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 3).is_err());
@@ -420,7 +429,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descript
 	auto conflicting_config = config;
 	conflicting_config.local_dirs = {TestCreatePath("registry_identity_b")};
 	auto conflicting_cache = std::make_shared<ShuffleCache>(std::move(conflicting_config));
-	REQUIRE(registry.Register(exchange_id, conflicting_cache, "epoch-a", 4).is_err());
+	REQUIRE(registry.Register(exchange_id, conflicting_cache, query_id, "epoch-a", 4).is_err());
 	REQUIRE(registry.Get(exchange_id).get() == cache.get());
 
 	registry.RemoveForDeferredCleanup(exchange_id);
@@ -435,6 +444,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases",
 	auto &context = *conn.context;
 	auto &registry = ShuffleCacheRegistry::Instance();
 	const std::string exchange_id = "registry_lease_stage__sink_0__attempt_0";
+	const std::string query_id = "registry-lease-query";
 
 	ShuffleCacheConfig config;
 	config.shuffle_stage_id = exchange_id;
@@ -451,20 +461,99 @@ TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases",
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
 	REQUIRE(cache->HasCommittedManifest());
 
-	REQUIRE(registry.Register(exchange_id, cache, "epoch-a", 0).is_ok());
+	REQUIRE(registry.Register(exchange_id, cache, query_id, "epoch-a", 0).is_ok());
 	auto lease_result = registry.Resolve(exchange_id, "epoch-a", "node-a", 0);
 	REQUIRE(lease_result.is_ok());
 	auto lease = std::move(lease_result.value());
 	registry.RemoveForDeferredCleanup(exchange_id);
 
 	auto cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_stage");
-	REQUIRE(cleanup.registry_entries_removed == 1);
+	REQUIRE(cleanup.registry_entries_removed == 0);
 	REQUIRE(cleanup.storage_entries_removed == 0);
 	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.cleanup_pending == 1);
 	REQUIRE(cache->HasCommittedManifest());
 
 	lease.reset();
+	REQUIRE(cache->HasCommittedManifest());
+	cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_stage");
+	REQUIRE(cleanup.cleanup_pending == 0);
+	REQUIRE(cleanup.cleanup_errors == 0);
+	REQUIRE(cleanup.storage_entries_removed > 0);
 	REQUIRE_FALSE(cache->HasCommittedManifest());
+}
+
+TEST_CASE("Exchange: ShuffleCacheRegistry retains and retries failed cleanup", "[distributed][exchange]") {
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-cleanup-retry-query";
+	const std::string exchange_id = "registry_cleanup_retry__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {"mock://shuffle"};
+	auto storage =
+	    std::make_shared<MockObjectShuffleStorage>(TestCreatePath("registry_cleanup_retry"), /*remove_failures=*/1);
+	auto cache = std::make_shared<ShuffleCache>(std::move(config), std::move(storage));
+
+	REQUIRE(registry.Register(exchange_id, cache, query_id, "epoch-a", 0).is_ok());
+	registry.RemoveForDeferredCleanup(exchange_id);
+
+	auto first_cleanup = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(first_cleanup.cleanup_errors == 1);
+	REQUIRE(first_cleanup.cleanup_pending == 1);
+
+	auto retry_cleanup = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(retry_cleanup.cleanup_errors == 0);
+	REQUIRE(retry_cleanup.cleanup_pending == 0);
+}
+
+TEST_CASE("Exchange: query close fences late cache publication until native execution drains",
+          "[distributed][exchange]") {
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-close-race-query";
+	const std::string exchange_id = "registry_close_race__sink_0__attempt_0";
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("registry_close_race")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(config));
+
+	REQUIRE(registry.BeginQueryExecution(query_id).is_ok());
+	REQUIRE(registry.CloseQuery(query_id).is_ok());
+	std::mutex publish_mutex;
+	std::condition_variable publish_ready;
+	bool may_publish = false;
+	bool publication_rejected = false;
+	bool execution_released = false;
+	std::thread publisher([&]() {
+		{
+			std::unique_lock<std::mutex> lock(publish_mutex);
+			publish_ready.wait(lock, [&]() { return may_publish; });
+		}
+		publication_rejected = registry.Register(exchange_id, cache, query_id, "epoch-a", 0).is_err();
+		execution_released = registry.EndQueryExecution(query_id).is_ok();
+	});
+
+	auto while_active = registry.RemoveAndCleanupByQuery(query_id);
+	{
+		std::lock_guard<std::mutex> lock(publish_mutex);
+		may_publish = true;
+	}
+	publish_ready.notify_one();
+	publisher.join();
+
+	REQUIRE(while_active.active_executions == 1);
+	REQUIRE(publication_rejected);
+	REQUIRE(execution_released);
+	auto after_drain = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(after_drain.active_executions == 0);
+	REQUIRE(after_drain.cleanup_pending == 0);
+	REQUIRE(after_drain.cleanup_errors == 0);
+	REQUIRE(registry.Get(exchange_id) == nullptr);
 }
 
 TEST_CASE("Exchange: Flight service isolates published attempts and rejects released or stale tickets",
@@ -478,6 +567,7 @@ TEST_CASE("Exchange: Flight service isolates published attempts and rejects rele
 	const std::string exchange_b = prefix + "__instance_b__sink_0__attempt_1";
 	const std::string epoch = "catalog-isolation-epoch";
 	const std::string node_id = "node-a";
+	const std::string query_id = "catalog-isolation-query";
 
 	auto make_committed_cache = [&](const std::string &exchange_id, const std::string &dir, int32_t value) {
 		ShuffleCacheConfig config;
@@ -498,8 +588,8 @@ TEST_CASE("Exchange: Flight service isolates published attempts and rejects rele
 
 	auto cache_a = make_committed_cache(exchange_a, TestCreatePath("flight_catalog_isolation_a"), 11);
 	auto cache_b = make_committed_cache(exchange_b, TestCreatePath("flight_catalog_isolation_b"), 22);
-	REQUIRE(registry.Register(exchange_a, cache_a, epoch, 1).is_ok());
-	REQUIRE(registry.Register(exchange_b, cache_b, epoch, 1).is_ok());
+	REQUIRE(registry.Register(exchange_a, cache_a, query_id, epoch, 1).is_ok());
+	REQUIRE(registry.Register(exchange_b, cache_b, query_id, epoch, 1).is_ok());
 
 	FlightServerConfig server_config;
 	server_config.bind_host = "127.0.0.1";
@@ -884,8 +974,8 @@ TEST_CASE("Exchange: same logical stage has isolated exchange instances and dire
 	auto cache_a = std::make_shared<ShuffleCache>(std::move(cache_config_a));
 	auto cache_b = std::make_shared<ShuffleCache>(std::move(cache_config_b));
 	auto &registry = ShuffleCacheRegistry::Instance();
-	REQUIRE(registry.Register(instance_a.output_location, cache_a, "epoch-a", 0).is_ok());
-	REQUIRE(registry.Register(instance_b.output_location, cache_b, "epoch-a", 0).is_ok());
+	REQUIRE(registry.Register(instance_a.output_location, cache_a, ctx.query_id, "epoch-a", 0).is_ok());
+	REQUIRE(registry.Register(instance_b.output_location, cache_b, ctx.query_id, "epoch-a", 0).is_ok());
 
 	exchange_a->Close();
 	REQUIRE(registry.Get(instance_a.output_location) == nullptr);
@@ -1046,6 +1136,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	ExchangeSinkInstanceHandle handle;
 	handle.sink_handle.task_partition_id = 0;
 	handle.attempt_id = 0;
+	handle.query_id = "sink-test-query";
 	handle.output_location = "sink_test_stage";
 	handle.output_partition_count = 2;
 
@@ -1155,7 +1246,7 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
 
 	// Register the cache
-	ShuffleCacheRegistry::Instance().Register("source_test_stage", cache);
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_test_stage", cache, "source-test-query").is_ok());
 
 	// Create source and read partition 0
 	FlightExchangeSource source("source_test_stage", &context);
@@ -1214,7 +1305,7 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 	REQUIRE(cache->WriteChunk(context, chunk2, 2, {"id", "name"}).is_ok());
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
-	ShuffleCacheRegistry::Instance().Register("source_multi_stage", cache);
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_multi_stage", cache, "source-multi-test-query").is_ok());
 
 	// Source reads both partitions
 	FlightExchangeSource source("source_multi_stage", &context);
@@ -1267,7 +1358,7 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	PopulateTwoColumnChunk(chunk0, types, {1, 2}, {"a", "b"});
 	REQUIRE(cache0->WriteChunk(context, chunk0, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache0->FlushAll(context, cache0->BufferedNames()).is_ok());
-	ShuffleCacheRegistry::Instance().Register(stage0, cache0);
+	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage0, cache0, "source-switch-test-query").is_ok());
 
 	ShuffleCacheConfig cache1_config;
 	cache1_config.shuffle_stage_id = stage1;
@@ -1280,7 +1371,7 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	PopulateTwoColumnChunk(chunk1, types, {3, 4}, {"c", "d"});
 	REQUIRE(cache1->WriteChunk(context, chunk1, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache1->FlushAll(context, cache1->BufferedNames()).is_ok());
-	ShuffleCacheRegistry::Instance().Register(stage1, cache1);
+	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage1, cache1, "source-switch-test-query").is_ok());
 
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
@@ -1356,6 +1447,7 @@ TEST_CASE("Exchange: End-to-end sink to source pipeline", "[distributed][exchang
 	ExchangeSinkInstanceHandle handle;
 	handle.sink_handle.task_partition_id = 0;
 	handle.attempt_id = 0;
+	handle.query_id = "exchange-e2e-query";
 	handle.output_location = exchange_id;
 	handle.output_partition_count = 2;
 
@@ -1443,6 +1535,7 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 		ExchangeSinkInstanceHandle handle;
 		handle.sink_handle.task_partition_id = 0;
 		handle.attempt_id = 0;
+		handle.query_id = "exchange-multi-sink-query";
 		handle.output_location = exchange_id;
 		handle.output_partition_count = 2;
 
@@ -1458,6 +1551,7 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 		ExchangeSinkInstanceHandle handle;
 		handle.sink_handle.task_partition_id = 1;
 		handle.attempt_id = 0;
+		handle.query_id = "exchange-multi-sink-query";
 		handle.output_location = exchange_id;
 		handle.output_partition_count = 2;
 

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
 #include "duckdb/execution/distributed/exchange/flight_exchange_manager.hpp"
+#include "duckdb/execution/distributed/plan/exchange_sink_instance_task.hpp"
 #include "duckdb/execution/distributed/plan/exchange_source_task.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
@@ -1168,6 +1169,86 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	REQUIRE(roundtrip_manager->config().flight_port == 4242);
 }
 
+TEST_CASE("ApplyExchangeSinkInstanceToPlan validates runtime sink ownership",
+          "[serialization][physical_plan][exchange]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+
+	distributed::ExchangeSinkInstanceHandle plan_handle;
+	plan_handle.sink_handle.task_partition_id = 7;
+	plan_handle.attempt_id = 0;
+	plan_handle.query_id = "query-runtime-sink";
+	plan_handle.output_location = "opaque-exchange__sink_7__attempt_0";
+	plan_handle.output_partition_count = 4;
+
+	distributed::FlightExchangeConfig flight_config;
+	flight_config.node_id = "node-1";
+	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
+	auto &sink_op = plan.Make<PhysicalRemoteExchangeSink>(vector<LogicalType> {LogicalType::INTEGER}, 123,
+	                                                      "diagnostic-stage", 4, RepartitionSpec::Type::Random,
+	                                                      vector<unique_ptr<Expression>> {}, plan_handle, exchange_mgr);
+	auto &sink = sink_op.Cast<PhysicalRemoteExchangeSink>();
+	plan.SetRoot(sink);
+
+	distributed::ExchangeSinkInstanceTaskDescriptor descriptor;
+	descriptor.sink_instance = plan_handle;
+	descriptor.sink_instance.attempt_id = 2;
+	descriptor.sink_instance.output_location = "opaque-exchange__sink_7__attempt_2";
+
+	string error;
+	auto invalid = descriptor;
+	invalid.sink_instance.query_id = "other-query";
+	REQUIRE_FALSE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.find("query") != string::npos);
+	REQUIRE(sink.SinkHandle().attempt_id == 0);
+
+	error.clear();
+	invalid = descriptor;
+	invalid.sink_instance.sink_handle.task_partition_id = 8;
+	REQUIRE_FALSE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.find("output location") != string::npos);
+	REQUIRE(sink.SinkHandle().attempt_id == 0);
+
+	error.clear();
+	invalid = descriptor;
+	invalid.sink_instance.sink_handle.task_partition_id = 8;
+	invalid.sink_instance.output_location = "opaque-exchange__sink_8__attempt_2";
+	REQUIRE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.empty());
+	REQUIRE(sink.SinkHandle().sink_handle.task_partition_id == 8);
+	REQUIRE(sink.SinkHandle().output_location == "opaque-exchange__sink_8__attempt_2");
+
+	error.clear();
+	invalid = descriptor;
+	invalid.sink_instance.sink_handle.task_partition_id = 7;
+	invalid.sink_instance.output_location = "opaque-exchange__sink_7__attempt_2";
+	REQUIRE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.empty());
+
+	error.clear();
+	invalid = descriptor;
+	invalid.sink_instance.output_partition_count = 0;
+	REQUIRE_FALSE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.find("partition count") != string::npos);
+	REQUIRE(sink.SinkHandle().attempt_id == 2);
+
+	error.clear();
+	invalid = descriptor;
+	invalid.sink_instance.output_location = "other-exchange__sink_7__attempt_2";
+	REQUIRE_FALSE(distributed::ApplyExchangeSinkInstanceToPlan(plan, invalid, &error));
+	REQUIRE(error.find("output location") != string::npos);
+	REQUIRE(sink.SinkHandle().attempt_id == 2);
+
+	error.clear();
+	REQUIRE(distributed::ApplyExchangeSinkInstanceToPlan(plan, descriptor, &error));
+	REQUIRE(error.empty());
+	REQUIRE(sink.SinkHandle().query_id == "query-runtime-sink");
+	REQUIRE(sink.SinkHandle().sink_handle.task_partition_id == 7);
+	REQUIRE(sink.SinkHandle().attempt_id == 2);
+	REQUIRE(sink.SinkHandle().output_location == "opaque-exchange__sink_7__attempt_2");
+	REQUIRE(sink.SinkHandle().output_partition_count == 4);
+}
+
 TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source handles",
           "[serialization][physical_plan][exchange]") {
 	Allocator allocator;
@@ -1204,6 +1285,8 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
+	flight_config.flight_location_template = "grpc://{node}:6123";
+	flight_config.flight_timeout_seconds = 7.5;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", partition_indices,
@@ -1247,6 +1330,11 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[2].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[2].files.size() == 1);
 	REQUIRE(source_ptr->SourceHandles()[2].files[0].path == "shuffle_stage__sink_0__attempt_0");
+	auto roundtrip_manager =
+	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
+	REQUIRE(roundtrip_manager != nullptr);
+	REQUIRE(roundtrip_manager->config().flight_location_template == "grpc://{node}:6123");
+	REQUIRE(roundtrip_manager->config().flight_timeout_seconds == 7.5);
 }
 
 TEST_CASE("PhysicalRemoteExchangeSource serialization preserves runtime source binding node id",
@@ -1287,6 +1375,40 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves runtime source b
 	REQUIRE(source_ptr->SourceHandles().empty());
 	REQUIRE(source_ptr->RuntimeSourceNodeId().IsValid());
 	REQUIRE(source_ptr->RuntimeSourceNodeId().GetIndex() == 42);
+}
+
+TEST_CASE("PhysicalRemoteExchangeSource serialization preserves an explicit empty catalog",
+          "[serialization][physical_plan][exchange]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+
+	distributed::FlightExchangeConfig flight_config;
+	flight_config.node_id = "node-1";
+	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
+	auto &source_op = plan.Make<PhysicalRemoteExchangeSource>(
+	    vector<LogicalType> {LogicalType::INTEGER}, 0, "empty-exchange", vector<idx_t> {0},
+	    std::vector<distributed::ExchangeSourceHandle> {}, exchange_mgr, vector<string> {}, optional_idx());
+	auto &source = dynamic_cast<PhysicalRemoteExchangeSource &>(source_op);
+
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	source.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	auto *source_ptr = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
+	REQUIRE(source_ptr != nullptr);
+	REQUIRE(source_ptr->ExchangeId() == "empty-exchange");
+	REQUIRE(source_ptr->PartitionIndices() == vector<idx_t> {0});
+	REQUIRE(source_ptr->SourceHandles().empty());
+	REQUIRE_FALSE(source_ptr->RuntimeSourceNodeId().IsValid());
 }
 
 TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle attempt ids",

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -1118,12 +1118,16 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	distributed::ExchangeSinkInstanceHandle sink_handle;
 	sink_handle.sink_handle.task_partition_id = 7;
 	sink_handle.attempt_id = 2;
+	sink_handle.query_id = "query-session-a";
 	sink_handle.output_location = "shuffle_stage__sink_7__attempt_2";
 	sink_handle.output_partition_count = 4;
 	sink_handle.flight_server_epoch = "sink-epoch";
 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
+	flight_config.local_dirs = {"/session-a/shuffle-0", "/session-a/shuffle-1"};
+	flight_config.flight_bind_host = "127.0.0.2";
+	flight_config.flight_port = 4242;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	vector<unique_ptr<Expression>> partition_by;
@@ -1150,9 +1154,18 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	REQUIRE(sink_ptr->NumPartitions() == 4);
 	REQUIRE(sink_ptr->SinkHandle().sink_handle.task_partition_id == 7);
 	REQUIRE(sink_ptr->SinkHandle().attempt_id == 2);
+	REQUIRE(sink_ptr->SinkHandle().query_id == "query-session-a");
 	REQUIRE(sink_ptr->SinkHandle().output_location == "shuffle_stage__sink_7__attempt_2");
 	REQUIRE(sink_ptr->SinkHandle().output_partition_count == 4);
 	REQUIRE(sink_ptr->SinkHandle().flight_server_epoch == "sink-epoch");
+	auto roundtrip_manager =
+	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(sink_ptr->GetExchangeManager());
+	const std::vector<std::string> expected_local_dirs = {"/session-a/shuffle-0", "/session-a/shuffle-1"};
+	REQUIRE(roundtrip_manager != nullptr);
+	REQUIRE(roundtrip_manager->config().node_id == "node-1");
+	REQUIRE(roundtrip_manager->config().local_dirs == expected_local_dirs);
+	REQUIRE(roundtrip_manager->config().flight_bind_host == "127.0.0.2");
+	REQUIRE(roundtrip_manager->config().flight_port == 4242);
 }
 
 TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source handles",

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -1120,6 +1120,7 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	sink_handle.attempt_id = 2;
 	sink_handle.output_location = "shuffle_stage__sink_7__attempt_2";
 	sink_handle.output_partition_count = 4;
+	sink_handle.flight_server_epoch = "sink-epoch";
 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
@@ -1151,6 +1152,7 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	REQUIRE(sink_ptr->SinkHandle().attempt_id == 2);
 	REQUIRE(sink_ptr->SinkHandle().output_location == "shuffle_stage__sink_7__attempt_2");
 	REQUIRE(sink_ptr->SinkHandle().output_partition_count == 4);
+	REQUIRE(sink_ptr->SinkHandle().flight_server_epoch == "sink-epoch");
 }
 
 TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source handles",
@@ -1167,6 +1169,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle0.partition_id = 0;
 	handle0.attempt_id = 3;
 	handle0.node_id = "node-1";
+	handle0.flight_server_epoch = "epoch-1";
 	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0));
 	source_handles.push_back(handle0);
 
@@ -1174,6 +1177,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle1.partition_id = 0;
 	handle1.attempt_id = 4;
 	handle1.node_id = "node-2";
+	handle1.flight_server_epoch = "epoch-2";
 	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_0", 0));
 	source_handles.push_back(handle1);
 
@@ -1181,6 +1185,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle2.partition_id = 1;
 	handle2.attempt_id = 3;
 	handle2.node_id = "node-1";
+	handle2.flight_server_epoch = "epoch-1";
 	handle2.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0));
 	source_handles.push_back(handle2);
 
@@ -1214,16 +1219,19 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[0].partition_id == 0);
 	REQUIRE(source_ptr->SourceHandles()[0].attempt_id == 3);
 	REQUIRE(source_ptr->SourceHandles()[0].node_id == "node-1");
+	REQUIRE(source_ptr->SourceHandles()[0].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[0].files.size() == 1);
 	REQUIRE(source_ptr->SourceHandles()[0].files[0].path == "shuffle_stage__sink_0__attempt_0");
 	REQUIRE(source_ptr->SourceHandles()[1].partition_id == 0);
 	REQUIRE(source_ptr->SourceHandles()[1].attempt_id == 4);
 	REQUIRE(source_ptr->SourceHandles()[1].node_id == "node-2");
+	REQUIRE(source_ptr->SourceHandles()[1].flight_server_epoch == "epoch-2");
 	REQUIRE(source_ptr->SourceHandles()[1].files.size() == 1);
 	REQUIRE(source_ptr->SourceHandles()[1].files[0].path == "shuffle_stage__sink_1__attempt_0");
 	REQUIRE(source_ptr->SourceHandles()[2].partition_id == 1);
 	REQUIRE(source_ptr->SourceHandles()[2].attempt_id == 3);
 	REQUIRE(source_ptr->SourceHandles()[2].node_id == "node-1");
+	REQUIRE(source_ptr->SourceHandles()[2].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[2].files.size() == 1);
 	REQUIRE(source_ptr->SourceHandles()[2].files[0].path == "shuffle_stage__sink_0__attempt_0");
 }
@@ -1280,7 +1288,8 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	handle0.attempt_id = 7;
 	handle0.node_id = "node-1";
 	handle0.flight_port = 5010;
-	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_7", 11));
+	handle0.flight_server_epoch = "epoch-1";
+	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_7", 0, 11));
 	descriptor.source_handles.push_back(handle0);
 
 	distributed::ExchangeSourceHandle handle1;
@@ -1288,7 +1297,8 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	handle1.attempt_id = 2;
 	handle1.node_id = "node-2";
 	handle1.flight_port = 5011;
-	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_2", 17));
+	handle1.flight_server_epoch = "epoch-2";
+	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_2", 0, 17));
 	descriptor.source_handles.push_back(handle1);
 
 	auto roundtrip = distributed::ExchangeSourceTaskDescriptor::DeserializeFromBytes(descriptor.SerializeToBytes());
@@ -1301,6 +1311,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.source_handles[0].attempt_id == 7);
 	REQUIRE(roundtrip.source_handles[0].node_id == "node-1");
 	REQUIRE(roundtrip.source_handles[0].flight_port == 5010);
+	REQUIRE(roundtrip.source_handles[0].flight_server_epoch == "epoch-1");
 	REQUIRE(roundtrip.source_handles[0].files.size() == 1);
 	REQUIRE(roundtrip.source_handles[0].files[0].path == "shuffle_stage__sink_0__attempt_7");
 	REQUIRE(roundtrip.source_handles[0].files[0].file_size == 11);
@@ -1308,6 +1319,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.source_handles[1].attempt_id == 2);
 	REQUIRE(roundtrip.source_handles[1].node_id == "node-2");
 	REQUIRE(roundtrip.source_handles[1].flight_port == 5011);
+	REQUIRE(roundtrip.source_handles[1].flight_server_epoch == "epoch-2");
 	REQUIRE(roundtrip.source_handles[1].files.size() == 1);
 	REQUIRE(roundtrip.source_handles[1].files[0].path == "shuffle_stage__sink_1__attempt_2");
 	REQUIRE(roundtrip.source_handles[1].files[0].file_size == 17);
@@ -1337,13 +1349,13 @@ TEST_CASE("ApplyExchangeSourceTasksToPlan patches runtime-bound exchange source"
 	handle0.partition_id = 0;
 	handle0.attempt_id = 5;
 	handle0.node_id = "node-1";
-	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 11));
+	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0, 11));
 	descriptor.source_handles.push_back(handle0);
 	distributed::ExchangeSourceHandle handle1;
 	handle1.partition_id = 1;
 	handle1.attempt_id = 6;
 	handle1.node_id = "node-2";
-	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_0", 17));
+	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_0", 0, 17));
 	descriptor.source_handles.push_back(handle1);
 
 	std::unordered_map<idx_t, distributed::ExchangeSourceTaskDescriptor> tasks;

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1824,10 +1824,15 @@ struct PyPhysicalPlanWrapperRunner {
 		ApplyTaskLocalCopyOutput(*physical_plan, copy_output_info, &context);
 
 		auto &root_op = physical_plan->Root();
-		py::object task_exchange_sink_instance_obj = py::none();
-		if (exchange_sink_instance_task) {
-			task_exchange_sink_instance_obj = py::bytes(exchange_sink_instance_task->SerializeToBytes());
-		}
+		auto task_exchange_sink_instance_obj = [&]() -> py::object {
+			if (!exchange_sink_instance_task) {
+				return py::none();
+			}
+			auto completed_task = *exchange_sink_instance_task;
+			completed_task.sink_instance.flight_server_epoch =
+			    duckdb::distributed::FlightExchangeManager::GetLocalFlightServerEpoch();
+			return py::bytes(completed_task.SerializeToBytes());
+		};
 
 		py::list results;
 		auto build_result_schema = [&](const duckdb::vector<string> &names,
@@ -1842,7 +1847,7 @@ struct PyPhysicalPlanWrapperRunner {
 			return BuildNativeTaskResult(payloads, metadatas, build_result_schema(names, result_types), py::list(),
 			                             std::move(task_stats), status,
 			                             duckdb::distributed::FlightExchangeManager::GetLocalFlightServerPort(),
-			                             task_exchange_sink_instance_obj);
+			                             task_exchange_sink_instance_obj());
 		};
 		auto build_table_result = [&](const py::object &table, idx_t row_count, const duckdb::vector<string> &names,
 		                              const duckdb::vector<duckdb::LogicalType> &result_types,
@@ -1858,7 +1863,7 @@ struct PyPhysicalPlanWrapperRunner {
 			return BuildNativeTaskResult(payloads, metadatas, build_result_schema(names, result_types), py::list(),
 			                             std::move(task_stats), "ok",
 			                             duckdb::distributed::FlightExchangeManager::GetLocalFlightServerPort(),
-			                             task_exchange_sink_instance_obj);
+			                             task_exchange_sink_instance_obj());
 		};
 		auto build_executed_result = [&](py::object task_stats) -> py::object {
 			duckdb::vector<string> names;

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1430,6 +1430,13 @@ struct PyPhysicalPlanWrapperRunner {
 		worker_manager_->worker_snapshots();
 	}
 
+	void shutdown() {
+		auto result = worker_manager_->shutdown();
+		if (result.is_err()) {
+			throw std::runtime_error(result.error().what());
+		}
+	}
+
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const {
 		if (ray_worker_manager_) {
 			return ray_worker_manager_->fragment_stats_by_worker();

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -393,6 +393,45 @@ void register_ray_bindings(py::module_ &mod) {
 	    [](const string &query_id) { return LookupQueryConnectionSnapshot(query_id); }, py::arg("query_id"));
 
 	m.def(
+	    "begin_flight_shuffle_query_execution",
+	    [](const string &query_id) {
+		    auto result = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().BeginQueryExecution(query_id);
+		    }();
+		    if (result.is_err()) {
+			    throw std::runtime_error(result.error().what());
+		    }
+	    },
+	    py::arg("query_id"));
+
+	m.def(
+	    "end_flight_shuffle_query_execution",
+	    [](const string &query_id) {
+		    auto result = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().EndQueryExecution(query_id);
+		    }();
+		    if (result.is_err()) {
+			    throw std::runtime_error(result.error().what());
+		    }
+	    },
+	    py::arg("query_id"));
+
+	m.def(
+	    "close_flight_shuffle_query",
+	    [](const string &query_id) {
+		    auto result = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().CloseQuery(query_id);
+		    }();
+		    if (result.is_err()) {
+			    throw std::runtime_error(result.error().what());
+		    }
+	    },
+	    py::arg("query_id"));
+
+	m.def(
 	    "cleanup_flight_shuffle_for_query",
 	    [](const string &query_id) {
 		    py::dict out;
@@ -400,13 +439,19 @@ void register_ray_bindings(py::module_ &mod) {
 			    out["registry_entries_removed"] = 0;
 			    out["storage_entries_removed"] = 0;
 			    out["cleanup_errors"] = 0;
+			    out["cleanup_pending"] = 0;
+			    out["active_executions"] = 0;
 			    return out;
 		    }
-		    auto cleanup_result =
-		        duckdb::distributed::ShuffleCacheRegistry::Instance().RemoveAndCleanupByPrefix(query_id + "_");
+		    auto cleanup_result = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(query_id);
+		    }();
 		    out["registry_entries_removed"] = cleanup_result.registry_entries_removed;
 		    out["storage_entries_removed"] = cleanup_result.storage_entries_removed;
 		    out["cleanup_errors"] = cleanup_result.cleanup_errors;
+		    out["cleanup_pending"] = cleanup_result.cleanup_pending;
+		    out["active_executions"] = cleanup_result.active_executions;
 		    return out;
 	    },
 	    py::arg("query_id"));
@@ -925,6 +970,9 @@ void register_ray_bindings(py::module_ &mod) {
 				        if (d.contains("flight_server_epoch")) {
 					        exchange_sink_instance_task.sink_instance.flight_server_epoch =
 					            py::str(d["flight_server_epoch"]).cast<string>();
+				        }
+				        if (d.contains("query_id")) {
+					        exchange_sink_instance_task.sink_instance.query_id = py::str(d["query_id"]).cast<string>();
 				        }
 				        has_exchange_sink_instance_task = true;
 			        } else {
@@ -1744,8 +1792,11 @@ void register_ray_bindings(py::module_ &mod) {
 
 		    auto cleanup_cache = make_cache(cleanup_stage);
 		    auto keep_cache = make_cache(keep_stage);
-		    ShuffleCacheRegistry::Instance().Register(cleanup_stage, cleanup_cache);
-		    ShuffleCacheRegistry::Instance().Register(keep_stage, keep_cache);
+		    auto cleanup_register = ShuffleCacheRegistry::Instance().Register(cleanup_stage, cleanup_cache, query_id);
+		    auto keep_register = ShuffleCacheRegistry::Instance().Register(keep_stage, keep_cache, keep_query_id);
+		    if (cleanup_register.is_err() || keep_register.is_err()) {
+			    throw std::runtime_error("failed to register query cleanup test caches");
+		    }
 		    ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(cleanup_stage);
 		    auto cleanup_registry_after_defer = ShuffleCacheRegistry::Instance().Get(cleanup_stage) != nullptr;
 
@@ -3267,7 +3318,8 @@ void register_ray_bindings(py::module_ &mod) {
 			    throw std::runtime_error(partial_files_res.error().what());
 		    }
 		    const std::string server_epoch = "uncommitted-attempt-epoch";
-		    auto register_res = ShuffleCacheRegistry::Instance().Register(output_location, writer, server_epoch, 1);
+		    auto register_res = ShuffleCacheRegistry::Instance().Register(
+		        output_location, writer, "flight-server-uncommitted-rejected-query", server_epoch, 1);
 		    if (register_res.is_err()) {
 			    throw std::runtime_error(register_res.error().what());
 		    }

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -124,6 +124,15 @@ namespace duckdb {
 void register_ray_bindings(py::module_ &mod) {
 	auto m = mod.def_submodule("ray_cxx");
 	m.doc() = "C++ Ray execution bindings (experimental)";
+	m.def("shutdown_local_flight_service", []() {
+		auto result = []() {
+			py::gil_scoped_release release;
+			return duckdb::distributed::FlightExchangeManager::ShutdownLocalFlightServer();
+		}();
+		if (result.is_err()) {
+			throw std::runtime_error(result.error().what());
+		}
+	});
 
 	py::class_<RayResultPartitionRef>(m, "RayResultPartitionRef")
 	    .def(py::init<py::object, size_t, size_t, py::object>())
@@ -913,6 +922,10 @@ void register_ray_bindings(py::module_ &mod) {
 					        exchange_sink_instance_task.sink_instance.output_location =
 					            py::str(d["attempt_path"]).cast<string>();
 				        }
+				        if (d.contains("flight_server_epoch")) {
+					        exchange_sink_instance_task.sink_instance.flight_server_epoch =
+					            py::str(d["flight_server_epoch"]).cast<string>();
+				        }
 				        has_exchange_sink_instance_task = true;
 			        } else {
 				        throw py::value_error("exchange_sink_instance must be bytes or dict");
@@ -1208,6 +1221,9 @@ void register_ray_bindings(py::module_ &mod) {
 			    if (d.contains("flight_port")) {
 				    handle.flight_port = py::int_(d["flight_port"]).cast<int>();
 			    }
+			    if (d.contains("flight_server_epoch")) {
+				    handle.flight_server_epoch = py::str(d["flight_server_epoch"]).cast<string>();
+			    }
 			    if (d.contains("files")) {
 				    auto files = py::reinterpret_borrow<py::iterable>(d["files"]);
 				    for (auto file_item : files) {
@@ -1246,6 +1262,9 @@ void register_ray_bindings(py::module_ &mod) {
 			    d["attempt_id"] = handle.attempt_id;
 			    d["node_id"] = handle.node_id;
 			    d["flight_port"] = handle.flight_port;
+			    if (!handle.flight_server_epoch.empty()) {
+				    d["flight_server_epoch"] = handle.flight_server_epoch;
+			    }
 			    py::list files;
 			    for (const auto &file : handle.files) {
 				    py::dict fd;
@@ -1278,12 +1297,15 @@ void register_ray_bindings(py::module_ &mod) {
 		    auto exchange = mgr.CreateExchange(ctx, 2);
 		    auto sink0 = exchange->AddSink(0);
 		    auto sink1 = exchange->AddSink(1);
-		    exchange->InstantiateSink(sink0, 0);
-		    exchange->InstantiateSink(sink0, 1);
-		    exchange->InstantiateSink(sink1, 0);
-		    exchange->SinkFinished(sink0, 1, "worker-retry", 5010);
-		    exchange->SinkFinished(sink0, 0, "worker-late", 5011);
-		    exchange->SinkFinished(sink1, 0, "worker-first", 5012);
+		    auto sink0_attempt0 = exchange->InstantiateSink(sink0, 0);
+		    auto sink0_attempt1 = exchange->InstantiateSink(sink0, 1);
+		    auto sink1_attempt0 = exchange->InstantiateSink(sink1, 0);
+		    sink0_attempt1.flight_server_epoch = "worker-retry-epoch";
+		    sink0_attempt0.flight_server_epoch = "worker-late-epoch";
+		    sink1_attempt0.flight_server_epoch = "worker-first-epoch";
+		    exchange->SinkFinished(sink0_attempt1, "worker-retry", 5010);
+		    exchange->SinkFinished(sink0_attempt0, "worker-late", 5011);
+		    exchange->SinkFinished(sink1_attempt0, "worker-first", 5012);
 		    exchange->AllRequiredSinksFinished();
 		    auto handles = exchange->GetSourceHandles();
 		    exchange->Close();
@@ -1295,6 +1317,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    d["attempt_id"] = handle.attempt_id;
 			    d["node_id"] = handle.node_id;
 			    d["flight_port"] = handle.flight_port;
+			    d["flight_server_epoch"] = handle.flight_server_epoch;
 			    d["path"] = handle.files.empty() ? string() : handle.files[0].path;
 			    out.append(d);
 		    }
@@ -1320,6 +1343,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    exchange->InstantiateSink(sink0, 0);
 		    auto sink0_attempt1 = exchange->InstantiateSink(sink0, 1);
 		    auto sink1_attempt0 = exchange->InstantiateSink(sink1, 0);
+		    sink0_attempt1.flight_server_epoch = "worker-retry-epoch";
+		    sink1_attempt0.flight_server_epoch = "worker-first-epoch";
 
 		    std::vector<MaterializedOutput> outputs;
 		    auto retry_output = MaterializedOutput({}, make_worker_id("worker-retry"));
@@ -1344,6 +1369,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    d["attempt_id"] = handle.attempt_id;
 			    d["node_id"] = handle.node_id;
 			    d["flight_port"] = handle.flight_port;
+			    d["flight_server_epoch"] = handle.flight_server_epoch;
 			    d["path"] = handle.files.empty() ? string() : handle.files[0].path;
 			    out.append(d);
 		    }
@@ -2967,7 +2993,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    FlightServerConfig server_config;
 		    server_config.bind_host = "127.0.0.1";
 		    server_config.port = 0;
-		    server_config.local_dirs = {local_dir};
+		    server_config.server_epoch = "shared-manifest-reader-epoch";
 		    FlightServer server(std::move(server_config));
 		    auto start_res = server.Start();
 		    if (start_res.is_err()) {
@@ -2978,34 +3004,25 @@ void register_ray_bindings(py::module_ &mod) {
 		    client_config.location = "grpc://127.0.0.1:" + std::to_string(server.port());
 		    FlightClient client(std::move(client_config));
 		    FlightExchangeTicket ticket;
-		    ticket.shuffle_stage_id = output_location;
+		    ticket.server_epoch = "shared-manifest-reader-epoch";
+		    ticket.exchange_instance_id = output_location;
 		    ticket.node_id = writer_node_id;
+		    ticket.attempt_id = 1;
 		    ticket.partition_idx = static_cast<idx_t>(partition_id);
 		    auto collection_res = client.FetchPartition(context, ticket, types);
 		    auto stop_res = server.Stop();
-		    if (collection_res.is_err()) {
-			    throw std::runtime_error(collection_res.error().what());
-		    }
 		    if (stop_res.is_err()) {
 			    throw std::runtime_error(stop_res.error().what());
 		    }
-		    auto collection = std::move(collection_res.value());
-
-		    py::list values;
-		    for (auto &chunk : collection->Chunks()) {
-			    for (idx_t row = 0; row < chunk.size(); row++) {
-				    values.append(chunk.GetValue(0, row).GetValue<int32_t>());
-			    }
-		    }
 
 		    py::dict out;
-		    out["values"] = values;
-		    out["row_count"] = collection->Count();
+		    out["fetch_error"] = collection_res.is_err();
+		    out["error"] = collection_res.is_err() ? collection_res.error().what() : "";
 		    out["registry_present"] = ShuffleCacheRegistry::Instance().Get(output_location) != nullptr;
 		    return out;
 	    },
 	    py::arg("local_dir"), py::arg("output_location"), py::arg("writer_node_id"), py::arg("partition_id"),
-	    "Serve a committed shared-manifest exchange attempt from a fresh FlightServer process.");
+	    "Verify that an unpublished manifest is not served by a fresh FlightServer process.");
 
 	m.def(
 	    "remote_exchange_source_local_dirs_roundtrip_recovery_for_test",
@@ -3138,7 +3155,7 @@ void register_ray_bindings(py::module_ &mod) {
 	    py::arg("local_dir"), "Exercise EXCHANGE_SOURCE local_dirs serialization through manifest recovery.");
 
 	m.def(
-	    "flight_server_manifest_recovery_for_test",
+	    "flight_server_rejects_unpublished_manifest_for_test",
 	    [](const std::string &local_dir) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
@@ -3181,7 +3198,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    FlightServerConfig server_config;
 		    server_config.bind_host = "127.0.0.1";
 		    server_config.port = 0;
-		    server_config.local_dirs = {local_dir};
+		    server_config.server_epoch = "unpublished-manifest-epoch";
 		    FlightServer server(std::move(server_config));
 		    auto start_res = server.Start();
 		    if (start_res.is_err()) {
@@ -3192,33 +3209,24 @@ void register_ray_bindings(py::module_ &mod) {
 		    client_config.location = "grpc://127.0.0.1:" + std::to_string(server.port());
 		    FlightClient client(std::move(client_config));
 		    FlightExchangeTicket ticket;
-		    ticket.shuffle_stage_id = output_location;
+		    ticket.server_epoch = "unpublished-manifest-epoch";
+		    ticket.exchange_instance_id = output_location;
 		    ticket.node_id = node_id;
+		    ticket.attempt_id = 1;
 		    ticket.partition_idx = 1;
 		    auto collection_res = client.FetchPartition(context, ticket, types);
 		    auto stop_res = server.Stop();
-		    if (collection_res.is_err()) {
-			    throw std::runtime_error(collection_res.error().what());
-		    }
 		    if (stop_res.is_err()) {
 			    throw std::runtime_error(stop_res.error().what());
 		    }
-		    auto collection = std::move(collection_res.value());
-
-		    py::list values;
-		    for (auto &chunk : collection->Chunks()) {
-			    for (idx_t row = 0; row < chunk.size(); row++) {
-				    values.append(chunk.GetValue(0, row).GetValue<int32_t>());
-			    }
-		    }
 
 		    py::dict out;
-		    out["values"] = values;
-		    out["row_count"] = collection->Count();
+		    out["fetch_error"] = collection_res.is_err();
+		    out["error"] = collection_res.is_err() ? collection_res.error().what() : "";
 		    out["registry_present"] = ShuffleCacheRegistry::Instance().Get(output_location) != nullptr;
 		    return out;
 	    },
-	    py::arg("local_dir"), "Exercise FlightServer manifest recovery when ShuffleCacheRegistry has no entry.");
+	    py::arg("local_dir"), "Verify FlightServer rejects a manifest with no published catalog entry.");
 
 	m.def(
 	    "flight_server_uncommitted_attempt_rejected_for_test",
@@ -3240,30 +3248,34 @@ void register_ray_bindings(py::module_ &mod) {
 		    write_config.node_id = node_id;
 		    write_config.num_partitions = 1;
 		    write_config.local_dirs = {local_dir};
-		    ShuffleCache writer(write_config);
+		    auto writer = std::make_shared<ShuffleCache>(write_config);
 
 		    DataChunk input;
 		    input.Initialize(Allocator::DefaultAllocator(), types);
 		    input.SetCardinality(1);
 		    input.SetValue(0, 0, Value::INTEGER(61));
-		    auto write_res = writer.WriteChunk(context, input, 0, names);
+		    auto write_res = writer->WriteChunk(context, input, 0, names);
 		    if (write_res.is_err()) {
 			    throw std::runtime_error(write_res.error().what());
 		    }
-		    auto flush_res = writer.FlushAll(context, names);
+		    auto flush_res = writer->FlushAll(context, names);
 		    if (flush_res.is_err()) {
 			    throw std::runtime_error(flush_res.error().what());
 		    }
-		    auto partial_files_res = writer.GetPartitionFiles(0);
+		    auto partial_files_res = writer->GetPartitionFiles(0);
 		    if (partial_files_res.is_err()) {
 			    throw std::runtime_error(partial_files_res.error().what());
 		    }
-		    ShuffleCacheRegistry::Instance().Remove(output_location);
+		    const std::string server_epoch = "uncommitted-attempt-epoch";
+		    auto register_res = ShuffleCacheRegistry::Instance().Register(output_location, writer, server_epoch, 1);
+		    if (register_res.is_err()) {
+			    throw std::runtime_error(register_res.error().what());
+		    }
 
 		    FlightServerConfig server_config;
 		    server_config.bind_host = "127.0.0.1";
 		    server_config.port = 0;
-		    server_config.local_dirs = {local_dir};
+		    server_config.server_epoch = server_epoch;
 		    FlightServer server(std::move(server_config));
 		    auto start_res = server.Start();
 		    if (start_res.is_err()) {
@@ -3274,18 +3286,21 @@ void register_ray_bindings(py::module_ &mod) {
 		    client_config.location = "grpc://127.0.0.1:" + std::to_string(server.port());
 		    FlightClient client(std::move(client_config));
 		    FlightExchangeTicket ticket;
-		    ticket.shuffle_stage_id = output_location;
+		    ticket.server_epoch = server_epoch;
+		    ticket.exchange_instance_id = output_location;
 		    ticket.node_id = node_id;
+		    ticket.attempt_id = 1;
 		    ticket.partition_idx = 0;
 		    auto collection_res = client.FetchPartition(context, ticket, types);
 		    auto stop_res = server.Stop();
+		    ShuffleCacheRegistry::Instance().Remove(output_location);
 		    if (stop_res.is_err()) {
 			    throw std::runtime_error(stop_res.error().what());
 		    }
 
 		    py::dict out;
 		    out["partial_file_count"] = partial_files_res.value().files.size();
-		    out["committed_manifest"] = writer.HasCommittedManifest();
+		    out["committed_manifest"] = writer->HasCommittedManifest();
 		    out["fetch_error"] = collection_res.is_err();
 		    out["error"] = collection_res.is_err() ? collection_res.error().what() : "";
 		    return out;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -209,8 +209,7 @@ void register_ray_bindings(py::module_ &mod) {
 	                           })
 	    .def_property_readonly("num_cpus", &RayWorkerRuntime::TotalNumCpus)
 	    .def_property_readonly("num_gpus", &RayWorkerRuntime::TotalNumGpus)
-	    .def_property_readonly("total_memory_bytes", &RayWorkerRuntime::TotalMemoryBytes)
-	    .def("shutdown", &RayWorkerRuntime::Shutdown);
+	    .def_property_readonly("total_memory_bytes", &RayWorkerRuntime::TotalMemoryBytes);
 	// Note: submit_task is not exposed - only used internally from C++
 
 	py::class_<duckdb::distributed::FteSplitQueue, std::shared_ptr<duckdb::distributed::FteSplitQueue>>(m,
@@ -292,7 +291,10 @@ void register_ray_bindings(py::module_ &mod) {
 	         })
 	    .def("shutdown",
 	         [](RayWorkerManager &self) {
-		         auto res = self.shutdown();
+		         auto res = [&]() {
+			         py::gil_scoped_release release;
+			         return self.shutdown();
+		         }();
 		         if (res.is_err()) {
 			         throw duckdb::InternalException(res.error().what());
 		         }
@@ -432,6 +434,20 @@ void register_ray_bindings(py::module_ &mod) {
 	    py::arg("query_id"));
 
 	m.def(
+	    "flight_shuffle_query_status",
+	    [](const string &query_id) {
+		    auto status = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().QueryStatus(query_id);
+		    }();
+		    py::dict out;
+		    out["cleanup_pending"] = status.cleanup_pending;
+		    out["active_executions"] = status.active_executions;
+		    return out;
+	    },
+	    py::arg("query_id"));
+
+	m.def(
 	    "cleanup_flight_shuffle_for_query",
 	    [](const string &query_id) {
 		    py::dict out;
@@ -441,6 +457,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    out["cleanup_errors"] = 0;
 			    out["cleanup_pending"] = 0;
 			    out["active_executions"] = 0;
+			    out["last_error"] = "";
 			    return out;
 		    }
 		    auto cleanup_result = [&]() {
@@ -452,7 +469,21 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["cleanup_errors"] = cleanup_result.cleanup_errors;
 		    out["cleanup_pending"] = cleanup_result.cleanup_pending;
 		    out["active_executions"] = cleanup_result.active_executions;
+		    out["last_error"] = cleanup_result.last_error;
 		    return out;
+	    },
+	    py::arg("query_id"));
+
+	m.def(
+	    "retire_flight_shuffle_query",
+	    [](const string &query_id) {
+		    auto result = [&]() {
+			    py::gil_scoped_release release;
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().RetireQuery(query_id);
+		    }();
+		    if (result.is_err()) {
+			    throw std::runtime_error(result.error().what());
+		    }
 	    },
 	    py::arg("query_id"));
 
@@ -771,6 +802,11 @@ void register_ray_bindings(py::module_ &mod) {
 	        py::arg("file_infos"), py::arg("copy_spec"), py::arg("staging_root"), py::arg("conn") = py::none())
 	    .def("drop_query_fragments", &PyPhysicalPlanWrapperRunner::drop_query_fragments, py::arg("query_id"))
 	    .def("warm_up", &PyPhysicalPlanWrapperRunner::warm_up)
+	    .def("shutdown",
+	         [](PyPhysicalPlanWrapperRunner &self) {
+		         py::gil_scoped_release release;
+		         self.shutdown();
+	         })
 	    .def("fragment_stats",
 	         [](PyPhysicalPlanWrapperRunner &self) {
 		         return BuildFragmentStatsSummary(self.fragment_stats_by_worker());
@@ -1565,8 +1601,11 @@ void register_ray_bindings(py::module_ &mod) {
 		    };
 
 		    auto lost_node_id = write_attempt(lost_instance, {101});
+		    lost_instance.flight_server_epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
 		    auto selected_node_id = write_attempt(selected_instance, {201, 202});
-		    exchange->SinkFinished(sink_handle, 1, selected_node_id, 0);
+		    selected_instance.flight_server_epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
+		    const auto flight_port = FlightExchangeManager::GetLocalFlightServerPort();
+		    exchange->SinkFinished(selected_instance, selected_node_id, flight_port);
 		    exchange->AllRequiredSinksFinished();
 		    auto handles = exchange->GetSourceHandles();
 
@@ -1586,7 +1625,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    };
 
 		    auto selected_values_before_late_loser = read_values(handles);
-		    exchange->SinkFinished(sink_handle, 0, lost_node_id, 0);
+		    exchange->SinkFinished(lost_instance, lost_node_id, flight_port);
 		    auto selected_values_after_late_loser = read_values(handles);
 
 		    auto manifest_exists = [&](const ExchangeSinkInstanceHandle &instance, const std::string &node_id) {
@@ -1621,6 +1660,14 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["lost_manifest_exists_after_late_loser"] = manifest_exists(lost_instance, lost_node_id);
 		    out["selected_manifest_exists_after_late_loser"] = manifest_exists(selected_instance, selected_node_id);
 		    exchange->Close();
+		    auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(exchange_context.query_id);
+		    if (cleanup.cleanup_errors != 0 || cleanup.cleanup_pending != 0) {
+			    throw std::runtime_error("failed to clean selected-attempt dataplane test query");
+		    }
+		    auto retire = ShuffleCacheRegistry::Instance().RetireQuery(exchange_context.query_id);
+		    if (retire.is_err()) {
+			    throw std::runtime_error(retire.error().what());
+		    }
 		    return out;
 	    },
 	    py::arg("local_dir"), "Verify FlightExchangeSource reads only the selected retry attempt data.");
@@ -1686,8 +1733,11 @@ void register_ray_bindings(py::module_ &mod) {
 		    };
 
 		    auto selected_node_id = write_attempt(selected_instance, 101);
-		    exchange->SinkFinished(sink_handle, 0, selected_node_id, 0);
+		    selected_instance.flight_server_epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
+		    const auto flight_port = FlightExchangeManager::GetLocalFlightServerPort();
+		    exchange->SinkFinished(selected_instance, selected_node_id, flight_port);
 		    auto loser_node_id = write_attempt(loser_instance, 202);
+		    loser_instance.flight_server_epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
 
 		    auto make_cache = [&](const std::string &output_location, const std::string &cache_node_id) {
 			    ShuffleCacheConfig cache_config;
@@ -1707,7 +1757,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    auto loser_registry_before =
 		        ShuffleCacheRegistry::Instance().Get(loser_instance.output_location) != nullptr;
 
-		    exchange->SinkFinished(sink_handle, 1, loser_node_id, 0);
+		    exchange->SinkFinished(loser_instance, loser_node_id, flight_port);
 		    exchange->AllRequiredSinksFinished();
 		    auto handles = exchange->GetSourceHandles();
 
@@ -1748,6 +1798,14 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["loser_output_location"] = loser_instance.output_location;
 		    out["handle_paths"] = handle_paths;
 		    out["handle_attempts"] = handle_attempts;
+		    auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(ctx.query_id);
+		    if (cleanup.cleanup_errors != 0 || cleanup.cleanup_pending != 0) {
+			    throw std::runtime_error("failed to clean unselected-attempt test query");
+		    }
+		    auto retire = ShuffleCacheRegistry::Instance().RetireQuery(ctx.query_id);
+		    if (retire.is_err()) {
+			    throw std::runtime_error(retire.error().what());
+		    }
 		    return out;
 	    },
 	    py::arg("local_dir"), "Exercise cleanup of successful unselected FlightExchange attempts.");
@@ -2514,6 +2572,14 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["selected_values_after_loser_cleanup"] = selected_values_after_cleanup;
 		    out["lost_manifest_after_cleanup_error"] = lost_manifest_after_cleanup_error;
 		    out["selected_cleanup_removed"] = selected_cleanup_res.value();
+		    auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(exchange_context.query_id);
+		    if (cleanup.cleanup_errors != 0 || cleanup.cleanup_pending != 0) {
+			    throw std::runtime_error("failed to clean MinIO selected-attempt test query");
+		    }
+		    auto retire = ShuffleCacheRegistry::Instance().RetireQuery(exchange_context.query_id);
+		    if (retire.is_err()) {
+			    throw std::runtime_error(retire.error().what());
+		    }
 		    tx_guard.Commit();
 		    return out;
 	    },
@@ -2754,7 +2820,7 @@ void register_ray_bindings(py::module_ &mod) {
 	    py::arg("local_dir"), "Exercise ShuffleCache manifest commit on a fake no-rename object storage backend.");
 
 	m.def(
-	    "flight_exchange_source_manifest_recovery_for_test",
+	    "flight_exchange_source_rejects_local_manifest_for_test",
 	    [](const std::string &local_dir) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
@@ -2766,7 +2832,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<LogicalType> types = {LogicalType::INTEGER};
 		    vector<string> names = {"value"};
 		    const std::string output_location = "flight_exchange_source_manifest_recovery_test__sink_0__attempt_1";
-		    const std::string node_id = "node-a";
+		    const std::string node_id = "127.0.0.1";
+		    const std::string server_epoch = "unpublished-local-manifest-epoch";
 
 		    ShuffleCacheConfig write_config;
 		    write_config.shuffle_stage_id = output_location;
@@ -2796,6 +2863,16 @@ void register_ray_bindings(py::module_ &mod) {
 		    }
 		    ShuffleCacheRegistry::Instance().Remove(output_location);
 
+		    FlightServerConfig server_config;
+		    server_config.bind_host = "127.0.0.1";
+		    server_config.port = 0;
+		    server_config.server_epoch = server_epoch;
+		    FlightServer server(std::move(server_config));
+		    auto start_res = server.Start();
+		    if (start_res.is_err()) {
+			    throw std::runtime_error(start_res.error().what());
+		    }
+
 		    FlightExchangeConfig source_config;
 		    source_config.node_id = node_id;
 		    source_config.local_dirs = {local_dir};
@@ -2806,6 +2883,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    handle.partition_id = 1;
 		    handle.attempt_id = 1;
 		    handle.node_id = node_id;
+		    handle.flight_port = server.port();
+		    handle.flight_server_epoch = server_epoch;
 		    ExchangeSourceFile file;
 		    file.path = output_location;
 		    file.file_size = 0;
@@ -2830,10 +2909,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    return out;
 	    },
 	    py::arg("local_dir"),
-	    "Exercise FlightExchangeSource manifest recovery when ShuffleCacheRegistry has no entry.");
+	    "Verify that FlightExchangeSource rejects a local manifest missing published server identity.");
 
 	m.def(
-	    "flight_exchange_source_shared_manifest_recovery_for_test",
+	    "flight_exchange_source_rejects_shared_manifest_for_test",
 	    [](const std::string &local_dir) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
@@ -2846,8 +2925,9 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<string> names = {"value"};
 		    const std::string output_location =
 		        "flight_exchange_source_shared_manifest_recovery_test__sink_0__attempt_1";
-		    const std::string writer_node_id = "writer-node";
+		    const std::string writer_node_id = "127.0.0.1";
 		    const std::string reader_node_id = "reader-node";
+		    const std::string server_epoch = "unpublished-shared-manifest-epoch";
 
 		    ShuffleCacheConfig write_config;
 		    write_config.shuffle_stage_id = output_location;
@@ -2876,6 +2956,16 @@ void register_ray_bindings(py::module_ &mod) {
 		    }
 		    ShuffleCacheRegistry::Instance().Remove(output_location);
 
+		    FlightServerConfig server_config;
+		    server_config.bind_host = "127.0.0.1";
+		    server_config.port = 0;
+		    server_config.server_epoch = server_epoch;
+		    FlightServer server(std::move(server_config));
+		    auto start_res = server.Start();
+		    if (start_res.is_err()) {
+			    throw std::runtime_error(start_res.error().what());
+		    }
+
 		    FlightExchangeConfig source_config;
 		    source_config.node_id = reader_node_id;
 		    source_config.local_dirs = {local_dir};
@@ -2886,6 +2976,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    handle.partition_id = 1;
 		    handle.attempt_id = 1;
 		    handle.node_id = writer_node_id;
+		    handle.flight_port = server.port();
+		    handle.flight_server_epoch = server_epoch;
 		    ExchangeSourceFile file;
 		    file.path = output_location;
 		    file.file_size = 0;
@@ -2912,10 +3004,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    return out;
 	    },
 	    py::arg("local_dir"),
-	    "Exercise shared filesystem manifest recovery for a remote writer without using Flight server.");
+	    "Verify that FlightExchangeSource rejects a shared manifest missing published server identity.");
 
 	m.def(
-	    "flight_exchange_source_write_shared_manifest_for_test",
+	    "flight_exchange_source_write_unpublished_shared_manifest_for_test",
 	    [](const std::string &local_dir) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
@@ -2927,7 +3019,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<LogicalType> types = {LogicalType::INTEGER};
 		    vector<string> names = {"value"};
 		    const std::string output_location = "flight_exchange_source_cross_process_manifest_test__sink_0__attempt_1";
-		    const std::string writer_node_id = "writer-node";
+		    const std::string writer_node_id = "127.0.0.1";
 		    const idx_t sink_partition_id = 0;
 		    const idx_t attempt_id = 1;
 		    const idx_t output_partition_id = 1;
@@ -2968,10 +3060,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["registry_present"] = ShuffleCacheRegistry::Instance().Get(output_location) != nullptr;
 		    return out;
 	    },
-	    py::arg("local_dir"), "Write a committed shared-manifest exchange attempt for cross-process recovery tests.");
+	    py::arg("local_dir"), "Write a committed but unpublished shared-manifest exchange attempt.");
 
 	m.def(
-	    "flight_exchange_source_read_shared_manifest_for_test",
+	    "flight_exchange_source_rejects_unpublished_shared_manifest_for_test",
 	    [](const std::string &local_dir, const std::string &output_location, const std::string &writer_node_id,
 	       const std::string &reader_node_id, int64_t partition_id, int64_t attempt_id) {
 		    using namespace duckdb;
@@ -2986,6 +3078,16 @@ void register_ray_bindings(py::module_ &mod) {
 		    auto &context = *conn.context;
 
 		    vector<LogicalType> types = {LogicalType::INTEGER};
+		    const std::string server_epoch = "unpublished-cross-process-manifest-epoch";
+		    FlightServerConfig server_config;
+		    server_config.bind_host = "127.0.0.1";
+		    server_config.port = 0;
+		    server_config.server_epoch = server_epoch;
+		    FlightServer server(std::move(server_config));
+		    auto start_res = server.Start();
+		    if (start_res.is_err()) {
+			    throw std::runtime_error(start_res.error().what());
+		    }
 		    FlightExchangeConfig source_config;
 		    source_config.node_id = reader_node_id;
 		    source_config.local_dirs = {local_dir};
@@ -2996,6 +3098,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    handle.partition_id = static_cast<idx_t>(partition_id);
 		    handle.attempt_id = static_cast<idx_t>(attempt_id);
 		    handle.node_id = writer_node_id;
+		    handle.flight_port = server.port();
+		    handle.flight_server_epoch = server_epoch;
 		    ExchangeSourceFile file;
 		    file.path = output_location;
 		    file.file_size = 0;
@@ -3023,10 +3127,10 @@ void register_ray_bindings(py::module_ &mod) {
 	    },
 	    py::arg("local_dir"), py::arg("output_location"), py::arg("writer_node_id"), py::arg("reader_node_id"),
 	    py::arg("partition_id"), py::arg("attempt_id"),
-	    "Read a committed shared-manifest exchange attempt in a fresh process.");
+	    "Verify that a fresh process rejects a committed but unpublished shared-manifest exchange attempt.");
 
 	m.def(
-	    "flight_server_read_shared_manifest_for_test",
+	    "flight_server_rejects_unpublished_shared_manifest_for_test",
 	    [](const std::string &local_dir, const std::string &output_location, const std::string &writer_node_id,
 	       int64_t partition_id) {
 		    using namespace duckdb;
@@ -3076,26 +3180,13 @@ void register_ray_bindings(py::module_ &mod) {
 	    "Verify that an unpublished manifest is not served by a fresh FlightServer process.");
 
 	m.def(
-	    "remote_exchange_source_local_dirs_roundtrip_recovery_for_test",
+	    "remote_exchange_source_rejects_local_dirs_manifest_for_test",
 	    [](const std::string &local_dir) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    auto current_node_id = []() -> std::string {
-			    const char *v = std::getenv("RAY_NODE_IP_ADDRESS");
-			    if (v && v[0]) {
-				    return v;
-			    }
-			    v = std::getenv("RAY_NODE_ID");
-			    if (v && v[0]) {
-				    return v;
-			    }
-			    v = std::getenv("HOSTNAME");
-			    if (v && v[0]) {
-				    return v;
-			    }
-			    return "local";
-		    }();
+		    const std::string current_node_id = "127.0.0.1";
+		    const std::string server_epoch = "unpublished-serialized-manifest-epoch";
 
 		    DuckDB db(nullptr);
 		    Connection conn(db);
@@ -3131,6 +3222,16 @@ void register_ray_bindings(py::module_ &mod) {
 		    }
 		    ShuffleCacheRegistry::Instance().Remove(output_location);
 
+		    FlightServerConfig server_config;
+		    server_config.bind_host = "127.0.0.1";
+		    server_config.port = 0;
+		    server_config.server_epoch = server_epoch;
+		    FlightServer server(std::move(server_config));
+		    auto start_res = server.Start();
+		    if (start_res.is_err()) {
+			    throw std::runtime_error(start_res.error().what());
+		    }
+
 		    Allocator allocator;
 		    PhysicalPlan plan(allocator);
 		    vector<idx_t> partition_indices = {1};
@@ -3140,6 +3241,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    handle.partition_id = 1;
 		    handle.attempt_id = 1;
 		    handle.node_id = current_node_id;
+		    handle.flight_port = server.port();
+		    handle.flight_server_epoch = server_epoch;
 		    ExchangeSourceFile file;
 		    file.path = output_location;
 		    file.file_size = 0;
@@ -3203,7 +3306,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["registry_present"] = ShuffleCacheRegistry::Instance().Get(output_location) != nullptr;
 		    return out;
 	    },
-	    py::arg("local_dir"), "Exercise EXCHANGE_SOURCE local_dirs serialization through manifest recovery.");
+	    py::arg("local_dir"), "Verify that serialized EXCHANGE_SOURCE cannot bypass catalog identity via local_dirs.");
 
 	m.def(
 	    "flight_server_rejects_unpublished_manifest_for_test",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -973,6 +973,10 @@ void register_ray_bindings(py::module_ &mod) {
 				        }
 				        if (py::isinstance<py::dict>(sink_handle_obj)) {
 					        auto sink_handle = sink_handle_obj.cast<py::dict>();
+					        if (sink_handle.contains("query_id")) {
+						        exchange_sink_instance_task.sink_instance.query_id =
+						            py::str(sink_handle["query_id"]).cast<string>();
+					        }
 					        if (sink_handle.contains("partition_id")) {
 						        exchange_sink_instance_task.sink_instance.sink_handle.task_partition_id =
 						            py::int_(sink_handle["partition_id"]).cast<idx_t>();
@@ -1471,7 +1475,9 @@ void register_ray_bindings(py::module_ &mod) {
 		                                    make_worker_id("worker-original"));
 
 		    std::string worker_id;
+		    std::string exchange_sink_query_id;
 		    bool has_output = false;
+		    bool has_exchange_sink_instance = false;
 		    int flight_port = 0;
 		    {
 			    pybind11::gil_scoped_release release;
@@ -1492,6 +1498,10 @@ void register_ray_bindings(py::module_ &mod) {
 					    worker_id = *output.worker_id();
 				    }
 				    flight_port = output.flight_port();
+				    has_exchange_sink_instance = output.has_exchange_sink_instance();
+				    if (has_exchange_sink_instance) {
+					    exchange_sink_query_id = output.exchange_sink_instance().query_id;
+				    }
 				    task_handle.AckPollResult();
 				    task_handle.ReleasePollResult();
 				    break;
@@ -1504,6 +1514,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    result["worker_id"] = worker_id;
 		    result["has_output"] = has_output;
 		    result["flight_port"] = flight_port;
+		    result["has_exchange_sink_instance"] = has_exchange_sink_instance;
+		    result["exchange_sink_query_id"] = exchange_sink_query_id;
 		    return result;
 	    },
 	    py::arg("handle"),

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -124,6 +124,9 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	if (d.contains("flight_server_epoch")) {
 		out.flight_server_epoch = py::str(d["flight_server_epoch"]).cast<string>();
 	}
+	if (d.contains("query_id")) {
+		out.query_id = py::str(d["query_id"]).cast<string>();
+	}
 	return true;
 }
 
@@ -1084,6 +1087,10 @@ py::object RayWorkerTask::ExchangeSinkInstance() const {
 	result["partition_id"] = instance.sink_handle.task_partition_id;
 	result["attempt_id"] = instance.attempt_id;
 	result["output_partition_count"] = instance.output_partition_count;
+	result["query_id"] = instance.query_id;
+	if (!instance.flight_server_epoch.empty()) {
+		result["flight_server_epoch"] = instance.flight_server_epoch;
+	}
 	if (!instance.output_location.empty()) {
 		result["output_location"] = instance.output_location;
 		result["attempt_path"] = instance.output_location;

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -121,6 +121,9 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	} else if (d.contains("attempt_path")) {
 		out.output_location = py::str(d["attempt_path"]).cast<string>();
 	}
+	if (d.contains("flight_server_epoch")) {
+		out.flight_server_epoch = py::str(d["flight_server_epoch"]).cast<string>();
+	}
 	return true;
 }
 

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -100,6 +100,9 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	}
 	if (py::isinstance<py::dict>(sink_handle_obj)) {
 		auto sink_handle = sink_handle_obj.cast<py::dict>();
+		if (sink_handle.contains("query_id")) {
+			out.query_id = py::str(sink_handle["query_id"]).cast<string>();
+		}
 		if (sink_handle.contains("task_partition_id")) {
 			out.sink_handle.task_partition_id = py::int_(sink_handle["task_partition_id"]).cast<duckdb::idx_t>();
 		} else if (sink_handle.contains("partition_id")) {

--- a/src/duckdb_py/ray/worker.cpp
+++ b/src/duckdb_py/ray/worker.cpp
@@ -170,12 +170,20 @@ std::vector<RayTaskResultHandle> RayWorkerRuntime::WrapFtePythonHandles(const py
 	return handles;
 }
 
-void RayWorkerRuntime::DropQueryFragments(const string &query_id) {
+void RayWorkerRuntime::PrepareDropQuery(const string &query_id) {
 	if (query_id.empty()) {
 		return;
 	}
 	duckdb::PythonGILWrapper gil;
-	ray_worker_handle_.attr("fte_drop_query")(query_id);
+	ray_worker_handle_.attr("fte_prepare_drop_query")(query_id);
+}
+
+void RayWorkerRuntime::CleanupQuery(const string &query_id) {
+	if (query_id.empty()) {
+		return;
+	}
+	duckdb::PythonGILWrapper gil;
+	ray_worker_handle_.attr("fte_cleanup_query")(query_id);
 }
 
 void RayWorkerRuntime::TaskInputStreamExhaustedForQuery(
@@ -229,10 +237,17 @@ std::unordered_map<std::string, duckdb::idx_t> RayWorkerRuntime::FragmentStats()
 	return stats;
 }
 
-void RayWorkerRuntime::Shutdown() {
+void RayWorkerRuntime::PrepareShutdown() {
 	duckdb::PythonGILWrapper gil;
-	try {
-		ray_worker_handle_.attr("shutdown")();
-	} catch (...) {
-	}
+	ray_worker_handle_.attr("prepare_shutdown")();
+}
+
+void RayWorkerRuntime::FinishShutdown() {
+	duckdb::PythonGILWrapper gil;
+	ray_worker_handle_.attr("finish_shutdown")();
+}
+
+void RayWorkerRuntime::AbortShutdown() {
+	duckdb::PythonGILWrapper gil;
+	ray_worker_handle_.attr("abort_shutdown")();
 }

--- a/src/duckdb_py/ray/worker.hpp
+++ b/src/duckdb_py/ray/worker.hpp
@@ -59,10 +59,13 @@ public:
 	                                      const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids);
 	QueryStatus FteQueryStatus(const string &query_id);
 	std::vector<RayTaskResultHandle> PopFteResultHandles(const string &query_id);
-	void DropQueryFragments(const string &query_id);
+	void PrepareDropQuery(const string &query_id);
+	void CleanupQuery(const string &query_id);
 	std::unordered_map<string, idx_t> FragmentStats() const;
 
-	void Shutdown();
+	void PrepareShutdown();
+	void FinishShutdown();
+	void AbortShutdown();
 
 	// worker interface
 	const WorkerId &Id() const {

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -33,6 +33,24 @@ static bool IsUnselectedFteHandle(const RayWorkerRuntime::TaskResultHandleType &
 	       finished_status->selected_attempt_task_ids.end();
 }
 
+bool RayWorkerManager::BeginOperation() const {
+	lock_guard<mutex> guard(mutex_);
+	if (state_.shutdown_started) {
+		return false;
+	}
+	state_.active_operations++;
+	return true;
+}
+
+void RayWorkerManager::EndOperation() const {
+	{
+		lock_guard<mutex> guard(mutex_);
+		D_ASSERT(state_.active_operations > 0);
+		state_.active_operations--;
+	}
+	shutdown_cv_.notify_all();
+}
+
 std::string RayWorkerManager::QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks) {
 	std::string query_id;
 	for (const auto &task : tasks) {
@@ -370,6 +388,10 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 }
 
 DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::distributed::WorkerTask> tasks) {
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
 	try {
 		auto query_id = QueryIdFromTaskEvents(tasks);
 		if (!tasks.empty() && query_id.empty()) {
@@ -378,6 +400,9 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		auto collect_workers = [&]() {
 			std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
 			lock_guard<mutex> guard(mutex_);
+			if (state_.shutdown_started) {
+				throw std::runtime_error("Ray worker manager is shut down");
+			}
 			workers.reserve(state_.ray_workers.size());
 			for (auto &kv : state_.ray_workers) {
 				workers.push_back(kv.second);
@@ -416,10 +441,19 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 }
 
 DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager::worker_snapshots() const {
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
+		    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
 	bool should_refresh = false;
 	std::vector<string> existing_ids;
 	{
 		lock_guard<mutex> guard(mutex_);
+		if (state_.shutdown_started) {
+			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
+			    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+		}
 		should_refresh = !state_.last_refresh.first ||
 		                 (std::chrono::steady_clock::now() - state_.last_refresh.second) > REFRESH_INTERVAL;
 		if (should_refresh) {
@@ -461,12 +495,27 @@ DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager:
 				new_workers.push_back(std::move(worker));
 			}
 
+			bool reject_new_workers = false;
 			{
 				lock_guard<mutex> guard(mutex_);
-				for (auto &worker : new_workers) {
-					state_.ray_workers.emplace(duckdb::distributed::make_worker_id(*worker->Id()), worker);
+				if (state_.shutdown_started) {
+					reject_new_workers = true;
+				} else {
+					for (auto &worker : new_workers) {
+						state_.ray_workers.emplace(duckdb::distributed::make_worker_id(*worker->Id()), worker);
+					}
+					state_.last_refresh = std::make_pair(true, std::chrono::steady_clock::now());
 				}
-				state_.last_refresh = std::make_pair(true, std::chrono::steady_clock::now());
+			}
+			if (reject_new_workers) {
+				for (auto &worker : new_workers) {
+					try {
+						worker->AbortShutdown();
+					} catch (...) {
+					}
+				}
+				return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
+				    DuckDBError::invalid_state_error("Ray worker manager shut down during worker refresh"));
 			}
 		} catch (const py::error_already_set &e) {
 			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
@@ -483,6 +532,10 @@ DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager:
 	std::vector<duckdb::distributed::WorkerSnapshot> snapshots;
 	{
 		lock_guard<mutex> guard(mutex_);
+		if (state_.shutdown_started) {
+			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
+			    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+		}
 		snapshots.reserve(state_.ray_workers.size());
 		for (auto &kv : state_.ray_workers) {
 			snapshots.emplace_back(kv.first, kv.second->TotalNumCpus(), kv.second->TotalNumGpus(),
@@ -495,14 +548,86 @@ DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager:
 DuckDBResult<void> RayWorkerManager::shutdown() {
 	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
 	{
-		lock_guard<mutex> guard(mutex_);
+		std::unique_lock<mutex> guard(mutex_);
+		if (state_.shutdown_started) {
+			shutdown_cv_.wait(guard, [&]() { return state_.shutdown_finished; });
+			if (!state_.shutdown_error.empty()) {
+				return DuckDBResult<void>::err(DuckDBError::external_error(state_.shutdown_error));
+			}
+			return DuckDBResult<void>::ok();
+		}
+		state_.shutdown_started = true;
 		workers.reserve(state_.ray_workers.size());
 		for (auto &kv : state_.ray_workers) {
 			workers.push_back(kv.second);
 		}
 	}
+	std::vector<std::string> errors;
+	std::vector<std::string> prepare_errors;
 	for (auto &worker : workers) {
-		worker->Shutdown();
+		const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
+		try {
+			worker->PrepareShutdown();
+		} catch (const std::exception &ex) {
+			prepare_errors.push_back(worker_id + ": " + ex.what());
+		} catch (...) {
+			prepare_errors.push_back(worker_id + ": unknown prepare-shutdown error");
+		}
+	}
+	errors.insert(errors.end(), prepare_errors.begin(), prepare_errors.end());
+	// Flight shutdown waits for in-flight RPCs. Stop services only after every
+	// worker has canceled and joined native work, so cross-worker readers cannot
+	// deadlock a server that is being stopped earlier in this loop.
+	if (prepare_errors.empty()) {
+		for (auto &worker : workers) {
+			const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
+			try {
+				worker->FinishShutdown();
+			} catch (const std::exception &ex) {
+				errors.push_back(worker_id + ": " + ex.what());
+			} catch (...) {
+				errors.push_back(worker_id + ": unknown finish-shutdown error");
+			}
+		}
+	} else {
+		for (auto &worker : workers) {
+			const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
+			try {
+				worker->AbortShutdown();
+			} catch (const std::exception &ex) {
+				errors.push_back(worker_id + " force termination: " + ex.what());
+			} catch (...) {
+				errors.push_back(worker_id + ": unknown force-termination error");
+			}
+		}
+	}
+	decltype(state_.fte_result_handles_by_query) result_handles;
+	decltype(state_.retained_fte_result_handles_by_query) retained_result_handles;
+	{
+		std::unique_lock<mutex> guard(mutex_);
+		shutdown_cv_.wait(guard, [&]() { return state_.active_operations == 0; });
+		state_.ray_workers.clear();
+		result_handles = std::move(state_.fte_result_handles_by_query);
+		retained_result_handles = std::move(state_.retained_fte_result_handles_by_query);
+		state_.last_refresh = {};
+	}
+	result_handles.clear();
+	retained_result_handles.clear();
+	std::string error_message;
+	if (!errors.empty()) {
+		error_message = "Ray worker shutdown failed with " + std::to_string(errors.size()) + " error(s)";
+		for (const auto &error : errors) {
+			error_message += "; " + error;
+		}
+	}
+	{
+		lock_guard<mutex> guard(mutex_);
+		state_.shutdown_error = error_message;
+		state_.shutdown_finished = true;
+	}
+	shutdown_cv_.notify_all();
+	if (!error_message.empty()) {
+		return DuckDBResult<void>::err(DuckDBError::external_error(std::move(error_message)));
 	}
 	return DuckDBResult<void>::ok();
 }
@@ -511,7 +636,12 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 	if (query_id.empty()) {
 		return;
 	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		throw std::runtime_error("Ray worker manager is shut down");
+	}
 	std::vector<std::string> errors;
+	std::vector<std::string> prepare_errors;
 	try {
 		ClearFteResultHandles(query_id);
 	} catch (const std::exception &ex) {
@@ -530,15 +660,30 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 	for (auto &worker : workers) {
 		const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
 		try {
-			worker->DropQueryFragments(query_id);
+			worker->PrepareDropQuery(query_id);
 		} catch (const std::exception &ex) {
-			errors.push_back(worker_id + ": " + ex.what());
+			prepare_errors.push_back(worker_id + ": " + ex.what());
 		} catch (...) {
-			errors.push_back(worker_id + ": unknown teardown error");
+			prepare_errors.push_back(worker_id + ": unknown prepare-teardown error");
+		}
+	}
+	errors.insert(errors.end(), prepare_errors.begin(), prepare_errors.end());
+	// Storage deletion is a distributed barrier: no worker may clean its
+	// published attempts until every worker has fenced and drained native work.
+	if (prepare_errors.empty()) {
+		for (auto &worker : workers) {
+			const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
+			try {
+				worker->CleanupQuery(query_id);
+			} catch (const std::exception &ex) {
+				errors.push_back(worker_id + ": " + ex.what());
+			} catch (...) {
+				errors.push_back(worker_id + ": unknown storage-cleanup error");
+			}
 		}
 	}
 	if (!errors.empty()) {
-		std::string message = "failed to drop query fragments on " + std::to_string(errors.size()) + " worker(s)";
+		std::string message = "query teardown failed with " + std::to_string(errors.size()) + " error(s)";
 		for (const auto &error : errors) {
 			message += "; " + error;
 		}
@@ -551,6 +696,10 @@ DuckDBResult<void> RayWorkerManager::task_input_stream_exhausted_for_query(
 	if (query_id.empty()) {
 		return DuckDBResult<void>::err(
 		    DuckDBError::value_error("FTE task input exhaustion requires non-empty query_id"));
+	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
 
 	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
@@ -616,6 +765,11 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 	if (query_id.empty()) {
 		return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 		    DuckDBError::value_error("query_id must be non-empty"));
+	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
+		    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
 
 	std::vector<duckdb::distributed::MaterializedOutput> outputs;
@@ -694,6 +848,10 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 
 std::unordered_map<std::string, std::unordered_map<std::string, duckdb::idx_t>>
 RayWorkerManager::fragment_stats_by_worker() const {
+	OperationGuard operation(*this);
+	if (!operation) {
+		throw std::runtime_error("Ray worker manager is shut down");
+	}
 	std::vector<std::pair<std::string, std::shared_ptr<RayWorkerRuntime>>> workers;
 	{
 		lock_guard<mutex> guard(mutex_);
@@ -714,6 +872,10 @@ RayWorkerManager::fragment_stats_by_worker() const {
 }
 
 DuckDBResult<void> RayWorkerManager::try_autoscale(const std::vector<TaskResourceRequest> &bundles) {
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
 	try {
 		double req_cpus = 0, req_gpus = 0;
 		size_t req_mem = 0;
@@ -727,6 +889,9 @@ DuckDBResult<void> RayWorkerManager::try_autoscale(const std::vector<TaskResourc
 		size_t cluster_mem = 0;
 		{
 			lock_guard<mutex> guard(mutex_);
+			if (state_.shutdown_started) {
+				return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+			}
 			for (auto &kv : state_.ray_workers) {
 				cluster_cpus += kv.second->TotalNumCpus();
 				cluster_gpus += kv.second->TotalNumGpus();

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <mutex>
+#include <condition_variable>
 #include <chrono>
 #include <memory>
 
@@ -52,11 +53,39 @@ private:
 		    fte_result_handles_by_query;
 		std::unordered_map<string, std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>>>
 		    retained_fte_result_handles_by_query;
+		idx_t active_operations = 0;
+		bool shutdown_started = false;
+		bool shutdown_finished = false;
+		std::string shutdown_error;
+	};
+
+	class OperationGuard {
+	public:
+		explicit OperationGuard(const RayWorkerManager &manager)
+		    : manager_(manager), active_(manager_.BeginOperation()) {
+		}
+		OperationGuard(const OperationGuard &) = delete;
+		OperationGuard &operator=(const OperationGuard &) = delete;
+		~OperationGuard() {
+			if (active_) {
+				manager_.EndOperation();
+			}
+		}
+		explicit operator bool() const {
+			return active_;
+		}
+
+	private:
+		const RayWorkerManager &manager_;
+		bool active_;
 	};
 
 	mutable mutex mutex_;
+	mutable std::condition_variable shutdown_cv_;
 	mutable State state_;
 
+	bool BeginOperation() const;
+	void EndOperation() const;
 	static string QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks);
 	void StoreFteResultHandles(const string &query_id,
 	                           std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>> handles);

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -11,6 +11,7 @@ import textwrap
 import threading
 import types
 import uuid
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -76,6 +77,128 @@ def test_drop_resource_query_closes_owned_internal_fte_queries(monkeypatch):
         "q-drop-owned_orderby_range",
         "q-drop-owned_orderby_sample",
     ]
+
+
+def test_drop_resource_query_remembers_failed_internal_teardown_after_registry_loss(monkeypatch):
+    import duckdb.runners.ray.fte_fragment_scheduler as fte_scheduler
+    from duckdb.runners.ray.driver import QueryTeardownOwnershipError, RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    runner._query_pending_execution_teardowns = {}
+    runner._release_query_resources = lambda *_args, **_kwargs: released_queries.append("released")
+
+    resource_query_id = "q-drop-retry"
+    execution_query_id = f"{resource_query_id}_orderby"
+    discovered = [(execution_query_id,), ()]
+    monkeypatch.setattr(
+        fte_scheduler,
+        "fte_execution_query_ids_for_resource",
+        lambda _query_id: discovered.pop(0),
+    )
+    monkeypatch.setattr(fte_scheduler, "fte_query_remote_teardown_blockers", lambda _query_id: ())
+    monkeypatch.setattr(fte_scheduler, "_drop_fte_registry_for_query", lambda _query_id: None)
+
+    calls: list[str] = []
+    failed_once = False
+
+    def drop_query_fragments(query_id):
+        nonlocal failed_once
+        calls.append(query_id)
+        if query_id == execution_query_id and not failed_once:
+            failed_once = True
+            raise RuntimeError("planned nested cleanup failure")
+
+    released_queries: list[str] = []
+    runner._get_plan_runner = lambda: SimpleNamespace(drop_query_fragments=drop_query_fragments)
+
+    with pytest.raises(QueryTeardownOwnershipError, match="pending_execution_queries"):
+        runner._drop_query_fragments_sync(resource_query_id)
+
+    assert runner._query_pending_execution_teardowns == {resource_query_id: {execution_query_id}}
+    assert released_queries == []
+
+    runner._drop_query_fragments_sync(resource_query_id)
+
+    assert calls == [
+        resource_query_id,
+        execution_query_id,
+        resource_query_id,
+        execution_query_id,
+    ]
+    assert runner._query_pending_execution_teardowns == {}
+    assert released_queries == ["released"]
+
+
+def test_driver_actor_shutdown_reaches_plan_runner_once():
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    events: list[str] = []
+    runner._driver_shutdown_lock = asyncio.Lock()
+    runner._plan_runner_lifecycle_lock = threading.RLock()
+    runner._driver_shutdown_started = False
+    runner._driver_shutdown_complete = False
+    runner.plan_runner = SimpleNamespace(shutdown=lambda: events.append("workers-shutdown"))
+
+    async def stop_maintenance():
+        events.append("maintenance-stopped")
+
+    runner.stop_query_resource_maintenance = stop_maintenance
+
+    async def shutdown_twice():
+        await runner_cls.shutdown(runner)
+        await runner_cls.shutdown(runner)
+
+    asyncio.run(shutdown_twice())
+
+    assert events == ["maintenance-stopped", "workers-shutdown"]
+    assert runner._driver_shutdown_started is True
+    assert runner._driver_shutdown_complete is True
+
+
+def test_driver_client_close_gracefully_shuts_down_before_kill(monkeypatch):
+    from duckdb.runners.ray import driver as driver_module
+
+    events: list[str] = []
+    shutdown_ref = object()
+
+    class ShutdownMethod:
+        @staticmethod
+        def remote():
+            events.append("shutdown-rpc")
+            return shutdown_ref
+
+    actor = SimpleNamespace(shutdown=ShutdownMethod())
+    client = object.__new__(driver_module.RayQueryDriverClient)
+    client.runner = actor
+    client._ray_gcs_address = "gcs-a"
+
+    monkeypatch.setattr(driver_module.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver_module.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+
+    def resolve(ref, **kwargs):
+        assert ref is shutdown_ref
+        assert kwargs == {"timeout": 300, "honor_query_deadline": False}
+        events.append("shutdown-complete")
+
+    def kill(target, *, no_restart):
+        assert target is actor
+        assert no_restart is True
+        events.append("kill")
+
+    monkeypatch.setattr(driver_module, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(driver_module.ray, "kill", kill)
+
+    client.close()
+
+    assert client.runner is None
+    assert events == ["shutdown-rpc", "shutdown-complete", "kill"]
 
 
 def test_precreate_udf_actors_skips_non_actor_backend(monkeypatch):

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import queue
 import subprocess
@@ -11,7 +12,6 @@ import textwrap
 import threading
 import types
 import uuid
-import asyncio
 from types import SimpleNamespace
 
 import pytest

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -969,8 +969,10 @@ def test_cxx_distributed_runner_accepts_python_backend_without_ray_worker_startu
 
     runner.warm_up()
     stats = runner.fragment_stats()
+    runner.shutdown()
 
     assert backend.worker_snapshots_calls == 1
+    assert backend.shutdown_calls == 1
     assert stats["workers"] == {}
     assert stats["totals"] == {}
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -388,7 +388,7 @@ def test_flight_exchange_cleans_successful_unselected_attempt(tmp_path):
 def test_shuffle_cache_registry_query_cleanup_removes_attempt_storage(tmp_path):
     result = duckdb.ray_cxx.shuffle_cache_registry_query_cleanup_for_test(str(tmp_path))
 
-    assert result["registry_entries_removed"] == 1
+    assert result["registry_entries_removed"] == 0
     assert result["storage_entries_removed"] > 0
     assert result["cleanup_errors"] == 0
     assert result["cleanup_registry_after_defer"] is False

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -206,6 +206,7 @@ def test_exchange_source_task_descriptor_preserves_attempt_ids():
             "attempt_id": 7,
             "node_id": "node-a",
             "flight_port": 5010,
+            "flight_server_epoch": "epoch-a",
             "files": [{"path": "shuffle__sink_0__attempt_7", "file_size": 11}],
         },
         {
@@ -213,6 +214,7 @@ def test_exchange_source_task_descriptor_preserves_attempt_ids():
             "attempt_id": 2,
             "node_id": "node-b",
             "flight_port": 5011,
+            "flight_server_epoch": "epoch-b",
             "files": [{"path": "shuffle__sink_1__attempt_2", "file_size": 17}],
         },
     ]
@@ -283,10 +285,12 @@ def test_flight_exchange_selected_attempt_runtime_path():
     assert all(h["attempt_id"] == 1 for h in sink0_handles)
     assert all(h["node_id"] == "worker-retry" for h in sink0_handles)
     assert all(h["flight_port"] == 5010 for h in sink0_handles)
+    assert all(h["flight_server_epoch"] == "worker-retry-epoch" for h in sink0_handles)
     assert all("__attempt_1" in h["path"] for h in sink0_handles)
     assert all(h["attempt_id"] == 0 for h in sink1_handles)
     assert all(h["node_id"] == "worker-first" for h in sink1_handles)
     assert all(h["flight_port"] == 5012 for h in sink1_handles)
+    assert all(h["flight_server_epoch"] == "worker-first-epoch" for h in sink1_handles)
 
 
 def test_flight_exchange_materialized_output_attempt_metadata_drives_completion():
@@ -300,11 +304,13 @@ def test_flight_exchange_materialized_output_attempt_metadata_drives_completion(
     assert all(h["attempt_id"] == 1 for h in sink0_handles)
     assert all(h["node_id"] == "worker-retry" for h in sink0_handles)
     assert all(h["flight_port"] == 5010 for h in sink0_handles)
+    assert all(h["flight_server_epoch"] == "worker-retry-epoch" for h in sink0_handles)
     assert all("__attempt_1" in h["path"] for h in sink0_handles)
     assert all("__attempt_0" not in h["path"] for h in sink0_handles)
     assert all(h["attempt_id"] == 0 for h in sink1_handles)
     assert all(h["node_id"] == "worker-first" for h in sink1_handles)
     assert all(h["flight_port"] == 5012 for h in sink1_handles)
+    assert all(h["flight_server_epoch"] == "worker-first-epoch" for h in sink1_handles)
 
 
 def test_ray_task_result_handle_uses_refreshed_worker_id_at_completion():
@@ -1202,7 +1208,7 @@ def test_flight_exchange_source_recovers_shared_manifest_after_writer_process_ex
     assert reader_result["writer_node_id"] != reader_result["reader_node_id"]
 
 
-def test_flight_server_recovers_shared_manifest_after_writer_process_exit(tmp_path):
+def test_flight_server_rejects_unpublished_manifest_after_writer_process_exit(tmp_path):
     writer_result = _write_shared_manifest_in_subprocess(tmp_path)
     reader_code = textwrap.dedent(
         f"""
@@ -1215,7 +1221,6 @@ def test_flight_server_recovers_shared_manifest_after_writer_process_exit(tmp_pa
             {writer_result["writer_node_id"]!r},
             {int(writer_result["partition_id"])},
         ))
-        result["values"] = list(result["values"])
         print(json.dumps(result), flush=True)
         """
     )
@@ -1223,8 +1228,8 @@ def test_flight_server_recovers_shared_manifest_after_writer_process_exit(tmp_pa
 
     assert Path(writer_result["manifest_path"]).exists()
     assert Path(writer_result["committed_path"]).exists()
-    assert reader_result["values"] == [81, 82, 83]
-    assert reader_result["row_count"] == 3
+    assert reader_result["fetch_error"] is True
+    assert "not published" in reader_result["error"]
     assert reader_result["registry_present"] is False
 
 
@@ -1236,11 +1241,11 @@ def test_remote_exchange_source_local_dirs_survive_serialization_for_manifest_re
     assert result["registry_present"] is False
 
 
-def test_flight_server_recovers_from_manifest_after_registry_loss(tmp_path):
-    result = duckdb.ray_cxx.flight_server_manifest_recovery_for_test(str(tmp_path))
+def test_flight_server_rejects_manifest_after_registry_loss(tmp_path):
+    result = duckdb.ray_cxx.flight_server_rejects_unpublished_manifest_for_test(str(tmp_path))
 
-    assert result["values"] == [31, 32]
-    assert result["row_count"] == 2
+    assert result["fetch_error"] is True
+    assert "not published" in result["error"]
     assert result["registry_present"] is False
 
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -379,7 +379,7 @@ def test_flight_exchange_cleans_successful_unselected_attempt(tmp_path):
     assert result["selected_registry_after_cleanup"] is True
     assert result["loser_registry_after_cleanup"] is False
     assert result["selected_manifest_after_close"] is True
-    assert result["selected_registry_after_close"] is False
+    assert result["selected_registry_after_close"] is True
     assert set(result["handle_attempts"]) == {0}
     assert all(path == result["selected_output_location"] for path in result["handle_paths"])
     assert result["selected_output_location"] != result["loser_output_location"]
@@ -1137,21 +1137,14 @@ def test_shuffle_cache_fake_object_no_rename_manifest_commit(tmp_path):
     assert "attempt_id=7\n" in result["manifest"]
 
 
-def test_flight_exchange_source_recovers_from_manifest_after_registry_loss(tmp_path):
-    result = duckdb.ray_cxx.flight_exchange_source_manifest_recovery_for_test(str(tmp_path))
-
-    assert result["values"] == [21, 22, 23, 24]
-    assert result["finished"] is True
-    assert result["registry_present"] is False
+def test_flight_exchange_source_rejects_local_manifest_after_registry_loss(tmp_path):
+    with pytest.raises(Exception, match="not published"):
+        duckdb.ray_cxx.flight_exchange_source_rejects_local_manifest_for_test(str(tmp_path))
 
 
-def test_flight_exchange_source_recovers_remote_writer_from_shared_manifest(tmp_path):
-    result = duckdb.ray_cxx.flight_exchange_source_shared_manifest_recovery_for_test(str(tmp_path))
-
-    assert result["values"] == [71, 72, 73]
-    assert result["finished"] is True
-    assert result["registry_present"] is False
-    assert result["writer_node_id"] != result["reader_node_id"]
+def test_flight_exchange_source_rejects_remote_shared_manifest_without_catalog_publication(tmp_path):
+    with pytest.raises(Exception, match="not published"):
+        duckdb.ray_cxx.flight_exchange_source_rejects_shared_manifest_for_test(str(tmp_path))
 
 
 def _run_python_json(code: str) -> dict:
@@ -1172,29 +1165,33 @@ def _write_shared_manifest_in_subprocess(tmp_path) -> dict:
         import json
         import duckdb
 
-        result = dict(duckdb.ray_cxx.flight_exchange_source_write_shared_manifest_for_test({str(tmp_path)!r}))
+        result = dict(duckdb.ray_cxx.flight_exchange_source_write_unpublished_shared_manifest_for_test({str(tmp_path)!r}))
         print(json.dumps(result), flush=True)
         """
     )
     return _run_python_json(writer_code)
 
 
-def test_flight_exchange_source_recovers_shared_manifest_after_writer_process_exit(tmp_path):
+def test_flight_exchange_source_rejects_shared_manifest_after_writer_process_exit(tmp_path):
     writer_result = _write_shared_manifest_in_subprocess(tmp_path)
     reader_code = textwrap.dedent(
         f"""
         import json
         import duckdb
 
-        result = dict(duckdb.ray_cxx.flight_exchange_source_read_shared_manifest_for_test(
-            {str(tmp_path)!r},
-            {writer_result["output_location"]!r},
-            {writer_result["writer_node_id"]!r},
-            "reader-node",
-            {int(writer_result["partition_id"])},
-            {int(writer_result["attempt_id"])},
-        ))
-        result["values"] = list(result["values"])
+        try:
+            duckdb.ray_cxx.flight_exchange_source_rejects_unpublished_shared_manifest_for_test(
+                {str(tmp_path)!r},
+                {writer_result["output_location"]!r},
+                {writer_result["writer_node_id"]!r},
+                "reader-node",
+                {int(writer_result["partition_id"])},
+                {int(writer_result["attempt_id"])},
+            )
+        except Exception as exc:
+            result = {{"read_error": str(exc)}}
+        else:
+            result = {{"read_error": ""}}
         print(json.dumps(result), flush=True)
         """
     )
@@ -1202,10 +1199,7 @@ def test_flight_exchange_source_recovers_shared_manifest_after_writer_process_ex
 
     assert Path(writer_result["manifest_path"]).exists()
     assert Path(writer_result["committed_path"]).exists()
-    assert reader_result["values"] == [81, 82, 83]
-    assert reader_result["finished"] is True
-    assert reader_result["registry_present"] is False
-    assert reader_result["writer_node_id"] != reader_result["reader_node_id"]
+    assert "not published" in reader_result["read_error"]
 
 
 def test_flight_server_rejects_unpublished_manifest_after_writer_process_exit(tmp_path):
@@ -1215,7 +1209,7 @@ def test_flight_server_rejects_unpublished_manifest_after_writer_process_exit(tm
         import json
         import duckdb
 
-        result = dict(duckdb.ray_cxx.flight_server_read_shared_manifest_for_test(
+        result = dict(duckdb.ray_cxx.flight_server_rejects_unpublished_shared_manifest_for_test(
             {str(tmp_path)!r},
             {writer_result["output_location"]!r},
             {writer_result["writer_node_id"]!r},
@@ -1233,12 +1227,9 @@ def test_flight_server_rejects_unpublished_manifest_after_writer_process_exit(tm
     assert reader_result["registry_present"] is False
 
 
-def test_remote_exchange_source_local_dirs_survive_serialization_for_manifest_recovery(tmp_path):
-    result = duckdb.ray_cxx.remote_exchange_source_local_dirs_roundtrip_recovery_for_test(str(tmp_path))
-
-    assert result["values"] == [41, 42]
-    assert result["node_id"]
-    assert result["registry_present"] is False
+def test_serialized_remote_exchange_source_does_not_bypass_catalog_with_local_dirs(tmp_path):
+    with pytest.raises(Exception, match="not published"):
+        duckdb.ray_cxx.remote_exchange_source_rejects_local_dirs_manifest_for_test(str(tmp_path))
 
 
 def test_flight_server_rejects_manifest_after_registry_loss(tmp_path):
@@ -2030,15 +2021,20 @@ def test_distributed_physical_plan_clone_scan_queue_cancel_does_not_cancel_sibli
 def test_ray_worker_manager_integration(monkeypatch):
     class DummyRayWorkerHandle:
         def __init__(self):
-            self.fte_drop_query_calls = []
+            self.fte_prepare_drop_query_calls = []
+            self.fte_cleanup_query_calls = []
 
-        def fte_drop_query(self, query_id):
-            self.fte_drop_query_calls.append(query_id)
+        def fte_prepare_drop_query(self, query_id):
+            self.fte_prepare_drop_query_calls.append(query_id)
             return {
                 "tasks_removed": 1,
                 "tasks_canceled": 0,
                 "fragments_removed": 1,
             }
+
+        def fte_cleanup_query(self, query_id):
+            self.fte_cleanup_query_calls.append(query_id)
+            return {}
 
         def stats_fragments(self):
             return {
@@ -2084,7 +2080,8 @@ def test_ray_worker_manager_integration(monkeypatch):
     assert stats["totals"]["lookup_hits"] == 3
 
     mgr.drop_query_fragments("query-lifecycle")
-    assert dummy_worker_handle.fte_drop_query_calls == ["query-lifecycle"]
+    assert dummy_worker_handle.fte_prepare_drop_query_calls == ["query-lifecycle"]
+    assert dummy_worker_handle.fte_cleanup_query_calls == ["query-lifecycle"]
 
 
 def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypatch):
@@ -2095,8 +2092,8 @@ def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypat
             self.worker_id = worker_id
             self.fail = fail
 
-        def fte_drop_query(self, query_id):
-            calls.append((self.worker_id, query_id))
+        def fte_prepare_drop_query(self, query_id):
+            calls.append(("prepare", self.worker_id, query_id))
             if self.fail:
                 raise RuntimeError(f"{self.worker_id} is dead")
             return {
@@ -2104,6 +2101,10 @@ def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypat
                 "tasks_canceled": 0,
                 "fragments_removed": 1,
             }
+
+        def fte_cleanup_query(self, query_id):
+            calls.append(("cleanup", self.worker_id, query_id))
+            return {}
 
         def shutdown(self):
             pass
@@ -2137,8 +2138,8 @@ def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypat
         manager.drop_query_fragments("query-best-effort-drop")
 
     assert sorted(calls) == [
-        ("worker-dead", "query-best-effort-drop"),
-        ("worker-live", "query-best-effort-drop"),
+        ("prepare", "worker-dead", "query-best-effort-drop"),
+        ("prepare", "worker-live", "query-best-effort-drop"),
     ]
 
 
@@ -2179,13 +2180,17 @@ def test_ray_worker_manager_drop_fans_out_after_result_payload_release_failure(m
             self.result_handles = []
             return handles
 
-        def fte_drop_query(self, actual_query_id):
-            drop_calls.append((self.worker_id, actual_query_id))
+        def fte_prepare_drop_query(self, actual_query_id):
+            drop_calls.append(("prepare", self.worker_id, actual_query_id))
             return {
                 "tasks_removed": 0,
                 "tasks_canceled": 0,
                 "fragments_removed": 0,
             }
+
+        def fte_cleanup_query(self, actual_query_id):
+            drop_calls.append(("cleanup", self.worker_id, actual_query_id))
+            return {}
 
         def shutdown(self):
             pass
@@ -2220,9 +2225,321 @@ def test_ray_worker_manager_drop_fans_out_after_result_payload_release_failure(m
     with pytest.raises(Exception, match="result payload release failed"):
         manager.drop_query_fragments(query_id)
 
+    assert [phase for phase, _worker_id, _query_id in drop_calls] == [
+        "prepare",
+        "prepare",
+        "cleanup",
+        "cleanup",
+    ]
     assert sorted(drop_calls) == [
-        ("worker-other", query_id),
-        ("worker-with-result", query_id),
+        ("cleanup", "worker-other", query_id),
+        ("cleanup", "worker-with-result", query_id),
+        ("prepare", "worker-other", query_id),
+        ("prepare", "worker-with-result", query_id),
+    ]
+
+
+def test_ray_worker_manager_shutdown_uses_global_prepare_barrier(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    class DummyRayWorkerHandle:
+        def __init__(self, worker_id):
+            self.worker_id = worker_id
+
+        def prepare_shutdown(self):
+            calls.append(("prepare", self.worker_id))
+
+        def finish_shutdown(self):
+            assert len([phase for phase, _ in calls if phase == "prepare"]) == 2
+            calls.append(("finish", self.worker_id))
+
+        def abort_shutdown(self):
+            raise AssertionError("successful shutdown must not force-terminate actors")
+
+    def start_ray_workers(_existing_ids):
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-a",
+                DummyRayWorkerHandle("worker-a"),
+                1.0,
+                0.0,
+                1024,
+            ),
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-b",
+                DummyRayWorkerHandle("worker-b"),
+                1.0,
+                0.0,
+                1024,
+            ),
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 2
+
+    manager.shutdown()
+
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "finish", "finish"]
+    assert sorted(worker_id for phase, worker_id in calls if phase == "prepare") == ["worker-a", "worker-b"]
+    assert sorted(worker_id for phase, worker_id in calls if phase == "finish") == ["worker-a", "worker-b"]
+    manager.shutdown()
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "finish", "finish"]
+    with pytest.raises(Exception, match="shut down"):
+        manager.worker_snapshots()
+    with pytest.raises(Exception, match="shut down"):
+        manager.try_autoscale([{"CPU": 100, "GPU": 0, "memory": 0}])
+
+
+def test_ray_worker_manager_concurrent_shutdown_waits_for_first_result(monkeypatch):
+    prepare_entered = threading.Event()
+    release_prepare = threading.Event()
+    calls: list[str] = []
+
+    class DummyRayWorkerHandle:
+        def prepare_shutdown(self):
+            calls.append("prepare")
+            prepare_entered.set()
+            assert release_prepare.wait(timeout=5)
+
+        def finish_shutdown(self):
+            calls.append("finish")
+
+        def abort_shutdown(self):
+            raise AssertionError("successful shutdown must not abort")
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(
+        ray_worker_handle,
+        "start_ray_workers",
+        lambda _existing_ids: [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-a",
+                DummyRayWorkerHandle(),
+                1.0,
+                0.0,
+                1024,
+            )
+        ],
+    )
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 1
+
+    outcomes: list[str] = []
+
+    def shutdown():
+        try:
+            manager.shutdown()
+        except BaseException as exc:
+            outcomes.append(f"error:{exc}")
+        else:
+            outcomes.append("ok")
+
+    first = threading.Thread(target=shutdown)
+    second = threading.Thread(target=shutdown)
+    first.start()
+    assert prepare_entered.wait(timeout=5)
+    second.start()
+    time.sleep(0.05)
+    assert outcomes == []
+    assert second.is_alive()
+
+    release_prepare.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+    assert first.is_alive() is False
+    assert second.is_alive() is False
+    assert outcomes == ["ok", "ok"]
+    assert calls == ["prepare", "finish"]
+
+
+def test_ray_worker_manager_shutdown_waits_for_entered_result_collection(monkeypatch):
+    status_entered = threading.Event()
+    release_status = threading.Event()
+    shutdown_finished = threading.Event()
+
+    class DummyRayWorkerHandle:
+        def fte_query_status(self, query_id):
+            status_entered.set()
+            assert release_status.wait(timeout=5)
+            return {
+                "failed": False,
+                "finished": True,
+                "selected_attempt_task_ids": [],
+            }
+
+        def pop_fte_result_handles(self, _query_id):
+            return []
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            raise AssertionError("successful shutdown must not abort")
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(
+        ray_worker_handle,
+        "start_ray_workers",
+        lambda _existing_ids: [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-a",
+                DummyRayWorkerHandle(),
+                1.0,
+                0.0,
+                1024,
+            )
+        ],
+    )
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 1
+
+    wait_outcomes: list[str] = []
+
+    def wait_query():
+        try:
+            manager.wait_fte_query("query-entered-before-shutdown", 5.0)
+        except BaseException as exc:
+            wait_outcomes.append(f"error:{exc}")
+        else:
+            wait_outcomes.append("ok")
+
+    def shutdown():
+        manager.shutdown()
+        shutdown_finished.set()
+
+    waiter = threading.Thread(target=wait_query)
+    closer = threading.Thread(target=shutdown)
+    waiter.start()
+    assert status_entered.wait(timeout=5)
+    closer.start()
+    time.sleep(0.05)
+    assert shutdown_finished.is_set() is False
+
+    release_status.set()
+    waiter.join(timeout=5)
+    closer.join(timeout=5)
+    assert waiter.is_alive() is False
+    assert closer.is_alive() is False
+    assert wait_outcomes == ["ok"]
+    assert shutdown_finished.is_set()
+
+
+def test_ray_worker_manager_shutdown_aborts_all_actors_after_prepare_error(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    class DummyRayWorkerHandle:
+        def __init__(self, worker_id, *, fail):
+            self.worker_id = worker_id
+            self.fail = fail
+
+        def prepare_shutdown(self):
+            calls.append(("prepare", self.worker_id))
+            if self.fail:
+                raise RuntimeError(f"{self.worker_id} prepare failed")
+
+        def finish_shutdown(self):
+            raise AssertionError("Flight services must not stop after a failed prepare barrier")
+
+        def abort_shutdown(self):
+            calls.append(("abort", self.worker_id))
+
+    def start_ray_workers(_existing_ids):
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-failing",
+                DummyRayWorkerHandle("worker-failing", fail=True),
+                1.0,
+                0.0,
+                1024,
+            ),
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-clean",
+                DummyRayWorkerHandle("worker-clean", fail=False),
+                1.0,
+                0.0,
+                1024,
+            ),
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 2
+
+    with pytest.raises(Exception, match="worker-failing prepare failed"):
+        manager.shutdown()
+
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "abort", "abort"]
+    assert sorted(worker_id for phase, worker_id in calls if phase == "abort") == [
+        "worker-clean",
+        "worker-failing",
+    ]
+
+
+def test_ray_worker_manager_shutdown_finishes_all_actors_after_finish_error(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    class DummyRayWorkerHandle:
+        def __init__(self, worker_id, *, fail):
+            self.worker_id = worker_id
+            self.fail = fail
+
+        def prepare_shutdown(self):
+            calls.append(("prepare", self.worker_id))
+
+        def finish_shutdown(self):
+            calls.append(("finish", self.worker_id))
+            if self.fail:
+                raise RuntimeError(f"{self.worker_id} finish failed")
+
+        def abort_shutdown(self):
+            raise AssertionError("a finish error happens after the prepare barrier")
+
+    def start_ray_workers(_existing_ids):
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-failing",
+                DummyRayWorkerHandle("worker-failing", fail=True),
+                1.0,
+                0.0,
+                1024,
+            ),
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-clean",
+                DummyRayWorkerHandle("worker-clean", fail=False),
+                1.0,
+                0.0,
+                1024,
+            ),
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 2
+
+    with pytest.raises(Exception, match="worker-failing finish failed"):
+        manager.shutdown()
+
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "finish", "finish"]
+    assert sorted(worker_id for phase, worker_id in calls if phase == "finish") == [
+        "worker-clean",
+        "worker-failing",
     ]
 
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 import duckdb
+from duckdb.runners.fte.fte_exchange import ExchangeSinkHandle, ExchangeSinkInstanceHandle
 
 
 def _make_test_physical_plan(con=None):
@@ -313,7 +314,7 @@ def test_flight_exchange_materialized_output_attempt_metadata_drives_completion(
     assert all(h["flight_server_epoch"] == "worker-first-epoch" for h in sink1_handles)
 
 
-def test_ray_task_result_handle_uses_refreshed_worker_id_at_completion():
+def test_ray_task_result_handle_uses_refreshed_worker_id_and_nested_sink_query_id():
     class _AdoptingHandle:
         worker_id = "worker-original"
 
@@ -334,12 +335,16 @@ def test_ray_task_result_handle_uses_refreshed_worker_id_at_completion():
             return True
 
         def get_result_sync(self):
+            sink_instance = ExchangeSinkInstanceHandle(
+                ExchangeSinkHandle("query-nested", "exchange-nested", 0),
+                1,
+            )
             return duckdb.ray_cxx.RayTaskResult.success(
                 [],
                 [],
                 None,
                 5010,
-                {"sink_handle": {"partition_id": 0}, "attempt_id": 1},
+                sink_instance.to_dict(),
             )
 
         def release_result_payload(self):
@@ -351,6 +356,8 @@ def test_ray_task_result_handle_uses_refreshed_worker_id_at_completion():
     assert result["worker_id"] == "worker-retry"
     assert result["has_output"] is True
     assert result["flight_port"] == 5010
+    assert result["has_exchange_sink_instance"] is True
+    assert result["exchange_sink_query_id"] == "query-nested"
     assert handle.release_calls == 1
 
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2003,6 +2003,8 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
                 "registry_entries_removed": 2,
                 "storage_entries_removed": 7,
                 "cleanup_errors": 0,
+                "cleanup_pending": 0,
+                "active_executions": 0,
             }
 
         return _cleanup
@@ -2015,8 +2017,94 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
         "registry_entries_removed": 2,
         "storage_entries_removed": 7,
         "cleanup_errors": 0,
+        "cleanup_pending": 0,
+        "active_executions": 0,
     }
     assert calls == [("query-drop", "Ensure the C++ ray extension is built with Flight shuffle cleanup support.")]
+
+
+def test_worker_flight_shuffle_cleanup_drain_retries_pending_work(monkeypatch):
+    cleanups = iter(
+        [
+            {
+                "registry_entries_removed": 2,
+                "storage_entries_removed": 0,
+                "cleanup_errors": 1,
+                "cleanup_pending": 1,
+                "active_executions": 1,
+            },
+            {
+                "registry_entries_removed": 0,
+                "storage_entries_removed": 7,
+                "cleanup_errors": 0,
+                "cleanup_pending": 0,
+                "active_executions": 0,
+            },
+        ]
+    )
+    monkeypatch.setattr(worker_mod, "_cleanup_flight_shuffle_for_query", lambda _query_id: next(cleanups))
+
+    result = asyncio.run(worker_mod._drain_flight_shuffle_for_query("query-drop", timeout_s=1))
+
+    assert result == {
+        "registry_entries_removed": 2,
+        "storage_entries_removed": 7,
+        "cleanup_errors": 0,
+        "cleanup_pending": 0,
+        "active_executions": 0,
+    }
+
+
+def test_worker_drop_query_fences_before_cancel_and_drains_afterward(monkeypatch):
+    events: list[str] = []
+
+    class TaskManager:
+        async def drop_query(self, query_id):
+            assert query_id == "query-drop"
+            events.append("cancel")
+            return {"removed": 2, "canceled": 1}
+
+    class DummyWorker:
+        @staticmethod
+        def _get_fte_task_manager():
+            return TaskManager()
+
+        @staticmethod
+        def drop_query_fragments(query_id):
+            assert query_id == "query-drop"
+            events.append("fragments")
+            return 3
+
+    def close(query_id):
+        assert query_id == "query-drop"
+        events.append("close")
+
+    async def drain(query_id):
+        assert query_id == "query-drop"
+        events.append("drain")
+        return {
+            "registry_entries_removed": 4,
+            "storage_entries_removed": 5,
+            "cleanup_errors": 0,
+            "cleanup_pending": 0,
+            "active_executions": 0,
+        }
+
+    monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", close)
+    monkeypatch.setattr(worker_mod, "_drain_flight_shuffle_for_query", drain)
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+    result = asyncio.run(actor_class.fte_drop_query(DummyWorker(), "query-drop"))
+
+    assert events == ["close", "cancel", "fragments", "drain"]
+    assert result == {
+        "tasks_removed": 2,
+        "tasks_canceled": 1,
+        "fragments_removed": 3,
+        "flight_shuffle_registry_entries_removed": 4,
+        "flight_shuffle_storage_entries_removed": 5,
+        "flight_shuffle_cleanup_errors": 0,
+    }
 
 
 def test_fte_control_rpc_retries_transient_failure(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import subprocess
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -160,6 +162,8 @@ class _FakeActor:
         self.fte_release_task_result = _FakeRemoteMethod(self._fte_release_task_result)
         self.fte_cancel_task = _FakeRemoteMethod(self._fte_cancel_task)
         self.fte_drop_query = _FakeRemoteMethod(self._fte_drop_query)
+        self.fte_prepare_drop_query = _FakeRemoteMethod(self._fte_drop_query)
+        self.fte_cleanup_query = _FakeRemoteMethod(self._fte_cleanup_query)
 
     def _register_fragments(self, payload):
         self.register_payloads.append(payload)
@@ -239,6 +243,10 @@ class _FakeActor:
     def _fte_drop_query(self, query_id):
         self.fte_calls.append(("drop_query", query_id))
         return {"tasks_removed": 1, "tasks_canceled": 0, "fragments_removed": 2}
+
+    def _fte_cleanup_query(self, query_id):
+        self.fte_calls.append(("cleanup_query", query_id))
+        return {}
 
 
 class _FakeFteTaskHandle:
@@ -838,6 +846,7 @@ def test_fte_worker_actor_handle_wraps_control_rpcs():
         "release",
         "cancel",
         "drop_query",
+        "cleanup_query",
     ]
     assert handle._registered_fragment_ids == {"other:node:b"}
 
@@ -1013,6 +1022,16 @@ def test_fte_control_barrier_rejects_contradictory_status_identities(monkeypatch
 
     with pytest.raises(RuntimeError, match="status identity mismatch"):
         handle.close_and_flush_fte_controls("q-control-identity")
+    assert handle._has_fte_teardown_state_for_query("q-control-identity") is True
+    with pytest.raises(RuntimeError, match="old generation state"):
+        worker_handle_mod.open_fte_registry_for_query("q-control-identity")
+
+    # A real teardown clears the terminal error after remote storage cleanup.
+    # This focused barrier test has no cleanup endpoint, so release its
+    # deliberately retained ownership before reopening the global test state.
+    with handle._fte_control_lock:
+        handle._fte_prepare_terminal_errors.pop("q-control-identity")
+    worker_handle_mod.open_fte_registry_for_query("q-control-identity")
 
 
 def test_worker_control_status_rejects_contradictory_status_identities():
@@ -1168,7 +1187,7 @@ def test_remote_drop_timeout_retains_fence_and_local_generation(monkeypatch):
     query_id = "query-remote-drop-timeout-fence"
     future = _DeferredFuture()
     actor = _FakeActor()
-    actor.fte_drop_query = _DeferredDrop(_DeferredRef(future))
+    actor.fte_prepare_drop_query = _DeferredDrop(_DeferredRef(future))
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
     fragment_id = f"{query_id}:node:1"
     with handle._fragment_registration_lock:
@@ -1253,7 +1272,7 @@ def test_pending_teardown_on_one_worker_does_not_block_drop_fanout(monkeypatch):
     pending_future = _DeferredFuture()
     pending_ref = _Ref(pending_future)
     actor1 = _FakeActor()
-    actor1.fte_drop_query = _DropMethod(pending_ref)
+    actor1.fte_prepare_drop_query = _DropMethod(pending_ref)
     actor2 = _FakeActor()
     handle1 = RayWorkerActorHandle(
         actor1,
@@ -1281,7 +1300,7 @@ def test_pending_teardown_on_one_worker_does_not_block_drop_fanout(monkeypatch):
         "tasks_canceled": 0,
         "fragments_removed": 2,
     }
-    assert actor1.fte_drop_query.calls == [query_id]
+    assert actor1.fte_prepare_drop_query.calls == [query_id]
     assert [call for call in actor2.fte_calls if call[0] == "drop_query"] == [("drop_query", query_id)]
 
     pending_future.complete({"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0})
@@ -1383,6 +1402,97 @@ def test_pending_control_barrier_does_not_submit_remote_drop(monkeypatch):
     worker_handle_mod.open_fte_registry_for_query(query_id)
 
 
+def test_terminal_control_failure_survives_simultaneous_pending_control(monkeypatch):
+    class _FailedFuture:
+        def result(self, timeout=None):
+            raise RuntimeError("planned terminal control failure")
+
+    class _PendingFuture:
+        def __init__(self):
+            self.value = None
+
+        def result(self, timeout=None):
+            if self.value is None:
+                raise TimeoutError("planned pending control")
+            return self.value
+
+        def complete(self, value):
+            self.value = value
+
+    class _Ref:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    class _AckMethod:
+        def __init__(self, failed_ref, pending_ref):
+            self.failed_ref = failed_ref
+            self.pending_ref = pending_ref
+
+        def remote(self, task_id, *_args):
+            if int(task_id["partition_id"]) == 0:
+                return self.failed_ref
+            return self.pending_ref
+
+    query_id = "query-terminal-and-pending-control"
+    failed_task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    pending_task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 1,
+        "attempt_id": 0,
+    }
+    pending_future = _PendingFuture()
+    actor = _FakeActor()
+    actor.fte_ack_task_result = _AckMethod(_Ref(_FailedFuture()), _Ref(pending_future))
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    handle.enqueue_fte_ack_task_result(failed_task_id)
+    handle.enqueue_fte_ack_task_result(pending_task_id)
+
+    def resolve(refs, **_kwargs):
+        if isinstance(refs, list):
+            return [ref.future().result() for ref in refs]
+        return refs.future().result()
+
+    monkeypatch.setattr(
+        task_control_mod,
+        "resolve_object_refs_blocking",
+        resolve,
+    )
+
+    with pytest.raises(
+        task_control_mod.FteControlBarrierPendingError,
+        match="retained pending control ownership",
+    ):
+        handle.fte_drop_query(query_id)
+
+    assert [call for call in actor.fte_calls if call[0] == "drop_query"] == []
+    pending_future.complete(
+        {
+            "state": "FINISHED",
+            "task_id": pending_task_id,
+            "_fte_control_operation": "fte_ack_task_result",
+            "_fte_control_applied": True,
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="planned terminal control failure"):
+        handle.fte_drop_query(query_id)
+
+    assert [call for call in actor.fte_calls if call[0] == "drop_query"] == [("drop_query", query_id)]
+    assert [call for call in actor.fte_calls if call[0] == "cleanup_query"] == [("cleanup_query", query_id)]
+    assert handle._has_fte_control_state_for_query(query_id) is False
+    assert handle._has_fte_teardown_state_for_query(query_id) is False
+    worker_handle_mod.open_fte_registry_for_query(query_id)
+
+
 def test_terminal_failed_control_allows_drop_and_clears_ownership(monkeypatch):
     class _FailedFuture:
         def result(self, timeout=None):
@@ -1431,6 +1541,78 @@ def test_terminal_failed_control_allows_drop_and_clears_ownership(monkeypatch):
 
     assert original_drop_ref is actor.fte_drop_query
     assert [call for call in actor.fte_calls if call[0] == "drop_query"] == [("drop_query", query_id)]
+    assert handle._has_fte_control_state_for_query(query_id) is False
+    assert handle._has_fte_teardown_state_for_query(query_id) is False
+    worker_handle_mod.open_fte_registry_for_query(query_id)
+
+
+def test_terminal_control_failure_survives_retryable_remote_drop_failure(monkeypatch):
+    monkeypatch.setenv("VANE_FTE_CONTROL_RPC_MAX_ATTEMPTS", "1")
+
+    class _FailedFuture:
+        def result(self, timeout=None):
+            raise RuntimeError("planned terminal control failure")
+
+    class _Ref:
+        def future(self):
+            return _FailedFuture()
+
+    class _AckMethod:
+        def remote(self, *_args):
+            return _Ref()
+
+    class _FailOnceActor(_FakeActor):
+        def __init__(self):
+            super().__init__()
+            self.fail_once = True
+
+        def _fte_drop_query(self, query_id):
+            self.fte_calls.append(("drop_query", query_id))
+            if self.fail_once:
+                self.fail_once = False
+                raise RuntimeError("planned remote drop failure")
+            return {
+                "tasks_removed": 1,
+                "tasks_canceled": 0,
+                "fragments_removed": 2,
+            }
+
+    query_id = "query-terminal-control-with-retryable-drop"
+    task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    actor = _FailOnceActor()
+    actor.fte_ack_task_result = _AckMethod()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    handle.enqueue_fte_ack_task_result(task_id)
+
+    def resolve(refs, **_kwargs):
+        if isinstance(refs, list):
+            raise RuntimeError("planned terminal control failure")
+        return refs.future().result()
+
+    monkeypatch.setattr(
+        task_control_mod,
+        "resolve_object_refs_blocking",
+        resolve,
+    )
+
+    with pytest.raises(RuntimeError, match="planned remote drop failure"):
+        handle.fte_drop_query(query_id)
+
+    assert handle._has_fte_teardown_state_for_query(query_id) is True
+
+    with pytest.raises(RuntimeError, match="planned terminal control failure"):
+        handle.fte_drop_query(query_id)
+
+    assert [call for call in actor.fte_calls if call[0] == "drop_query"] == [
+        ("drop_query", query_id),
+        ("drop_query", query_id),
+    ]
+    assert [call for call in actor.fte_calls if call[0] == "cleanup_query"] == [("cleanup_query", query_id)]
     assert handle._has_fte_control_state_for_query(query_id) is False
     assert handle._has_fte_teardown_state_for_query(query_id) is False
     worker_handle_mod.open_fte_registry_for_query(query_id)
@@ -2005,6 +2187,7 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
                 "cleanup_errors": 0,
                 "cleanup_pending": 0,
                 "active_executions": 0,
+                "last_error": "",
             }
 
         return _cleanup
@@ -2019,6 +2202,7 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
         "cleanup_errors": 0,
         "cleanup_pending": 0,
         "active_executions": 0,
+        "last_error": "",
     }
     assert calls == [("query-drop", "Ensure the C++ ray extension is built with Flight shuffle cleanup support.")]
 
@@ -2055,7 +2239,25 @@ def test_worker_flight_shuffle_cleanup_drain_retries_pending_work(monkeypatch):
     }
 
 
-def test_worker_drop_query_fences_before_cancel_and_drains_afterward(monkeypatch):
+def test_worker_flight_shuffle_cleanup_timeout_reports_storage_error(monkeypatch):
+    monkeypatch.setattr(
+        worker_mod,
+        "_cleanup_flight_shuffle_for_query",
+        lambda _query_id: {
+            "registry_entries_removed": 0,
+            "storage_entries_removed": 0,
+            "cleanup_errors": 1,
+            "cleanup_pending": 1,
+            "active_executions": 0,
+            "last_error": "permission denied",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="last_error='permission denied'"):
+        asyncio.run(worker_mod._drain_flight_shuffle_for_query("query-drop", timeout_s=0))
+
+
+def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypatch):
     events: list[str] = []
 
     class TaskManager:
@@ -2075,9 +2277,29 @@ def test_worker_drop_query_fences_before_cancel_and_drains_afterward(monkeypatch
             events.append("fragments")
             return 3
 
+        @staticmethod
+        def _close_worker_native_query(query_id):
+            assert query_id == "query-drop"
+            events.append("native-close")
+            return []
+
+        @staticmethod
+        async def _wait_worker_native_executions_for_query(query_id):
+            assert query_id == "query-drop"
+            events.append("worker-wait")
+
+        @staticmethod
+        def _retire_worker_native_query(query_id):
+            assert query_id == "query-drop"
+            events.append("native-retire")
+
     def close(query_id):
         assert query_id == "query-drop"
         events.append("close")
+
+    async def wait_for_executions(query_id):
+        assert query_id == "query-drop"
+        events.append("flight-wait")
 
     async def drain(query_id):
         assert query_id == "query-drop"
@@ -2088,15 +2310,35 @@ def test_worker_drop_query_fences_before_cancel_and_drains_afterward(monkeypatch
             "cleanup_errors": 0,
             "cleanup_pending": 0,
             "active_executions": 0,
+            "last_error": "",
         }
 
+    def retire(query_id):
+        assert query_id == "query-drop"
+        events.append("retire")
+
     monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", close)
+    monkeypatch.setattr(worker_mod, "_wait_flight_shuffle_executions_for_query", wait_for_executions)
     monkeypatch.setattr(worker_mod, "_drain_flight_shuffle_for_query", drain)
+    monkeypatch.setattr(worker_mod, "_retire_flight_shuffle_query", retire)
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
 
-    result = asyncio.run(actor_class.fte_drop_query(DummyWorker(), "query-drop"))
+    prepare_result = asyncio.run(actor_class.fte_prepare_drop_query(DummyWorker(), "query-drop"))
+    cleanup_result = asyncio.run(actor_class.fte_cleanup_query(DummyWorker(), "query-drop"))
+    result = dict(prepare_result)
+    result.update(cleanup_result)
 
-    assert events == ["close", "cancel", "fragments", "drain"]
+    assert events == [
+        "close",
+        "native-close",
+        "cancel",
+        "fragments",
+        "worker-wait",
+        "flight-wait",
+        "drain",
+        "retire",
+        "native-retire",
+    ]
     assert result == {
         "tasks_removed": 2,
         "tasks_canceled": 1,
@@ -7546,12 +7788,25 @@ def test_submit_tasks_extracts_exchange_source_task_inputs(monkeypatch):
 
 
 def test_ray_worker_actor_class_cloudpickle_roundtrip():
-    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    script = """
+import ray
 
-    payload = ray.cloudpickle.dumps(actor_cls)
-    restored = ray.cloudpickle.loads(payload)
+from duckdb.runners.ray import worker as worker_mod
 
-    assert restored.__name__ == actor_cls.__name__
+actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+payload = ray.cloudpickle.dumps(actor_cls)
+restored = ray.cloudpickle.loads(payload)
+assert restored.__name__ == actor_cls.__name__
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_ray_worker_fte_admission_log_uses_worker_id(monkeypatch, capsys):
@@ -7818,6 +8073,10 @@ def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
 def test_execute_native_task_passes_exchange_and_sink_inputs():
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._native_execution_condition = threading.Condition()
+    actor._active_native_cursors = set()
+    actor._native_cursor_query_ids = {}
+    actor._closing_native_queries = set()
     calls = []
 
     class _FakeCursor:
@@ -7916,6 +8175,10 @@ def test_execute_native_task_passes_exchange_and_sink_inputs():
 def test_execute_native_task_uses_shared_database_for_fte():
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._native_execution_condition = threading.Condition()
+    actor._active_native_cursors = set()
+    actor._native_cursor_query_ids = {}
+    actor._closing_native_queries = set()
     calls = []
     closed = []
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -3345,9 +3345,10 @@ def test_fte_fragment_execution_retries_base_remote_exchange_sink_instance():
         "task_partition_id": 0,
         "partition_id": 0,
         "attempt_id": 0,
+        "query_id": "q",
         "output_partition_count": 4,
-        "output_location": "q_shuffle_3__sink_0__attempt_0",
-        "attempt_path": "q_shuffle_3__sink_0__attempt_0",
+        "output_location": "55f8c578-9c57-4b9d-bdc2-ef62d1dfc323__sink_0__attempt_0",
+        "attempt_path": "55f8c578-9c57-4b9d-bdc2-ef62d1dfc323__sink_0__attempt_0",
     }
 
     def select_worker(partition):
@@ -3387,6 +3388,7 @@ def test_fte_fragment_execution_retries_base_remote_exchange_sink_instance():
     assert retry.request["exchange_sink_instance"]["output_location"].endswith("__attempt_1")
     assert retry.request["exchange_sink_instance"]["attempt_path"].endswith("__attempt_1")
     assert retry.request["exchange_sink_instance"]["output_partition_count"] == 4
+    assert retry.request["exchange_sink_instance"]["query_id"] == "q"
     assert retry_request["exchange_sink_instance"] == retry.request["exchange_sink_instance"]
 
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -991,6 +991,75 @@ def test_normalize_native_task_result_preserves_schema_and_stats():
     assert task_stats == {"processed_input_rows": 3, "processed_input_bytes": 42}
 
 
+def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
+    from duckdb.runners.ray import worker as worker_module
+
+    events: list[tuple[str, str]] = []
+    original_require = worker_module.require_ray_cxx_attr
+
+    def fake_require(name, hint=None):
+        assert hint
+        if name == "begin_flight_shuffle_query_execution":
+            return lambda query_id: events.append(("begin", query_id))
+        if name == "end_flight_shuffle_query_execution":
+            return lambda query_id: events.append(("end", query_id))
+        return original_require(name, hint=hint)
+
+    completed_descriptor = {
+        "query_id": "query-native-descriptor",
+        "attempt_id": 2,
+        "flight_server_epoch": "worker-epoch",
+    }
+    native_result = duckdb.ray_cxx.NativeDistributedTaskResult(
+        [],
+        [],
+        None,
+        [],
+        "ok",
+        31337,
+        completed_descriptor,
+        {},
+    )
+
+    class DummyWorker:
+        _env_overrides: dict[str, str] = {}
+
+        @staticmethod
+        def _execute_native_task(*args, **kwargs):
+            return native_result
+
+    monkeypatch.setattr(worker_module, "require_ray_cxx_attr", fake_require)
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+    query_lease = {
+        "lease_id": "lease-native-descriptor",
+        "query_id": "query-native-descriptor",
+        "stage_id": "stage-native-descriptor",
+        "attempt_id": "query-native-descriptor.0.0.0",
+        "target_output_block_bytes": 1,
+        "output_window_bytes": 1,
+    }
+
+    result = asyncio.run(
+        actor_class.run_plan_return(
+            DummyWorker(),
+            object(),
+            None,
+            query_lease,
+            exchange_sink_instance={
+                "query_id": "query-native-descriptor",
+                "attempt_id": 2,
+            },
+        )
+    )
+
+    assert result[4] == 31337
+    assert result[5] == completed_descriptor
+    assert events == [
+        ("begin", "query-native-descriptor"),
+        ("end", "query-native-descriptor"),
+    ]
+
+
 def test_normalize_native_task_result_rejects_legacy_shapes():
     with pytest.raises(TypeError, match="execute_native must return NativeDistributedTaskResult"):
         _normalize_native_task_result(([], [], None))

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -1025,14 +1025,28 @@ def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
         _env_overrides: dict[str, str] = {}
 
         @staticmethod
+        def _begin_worker_native_execution(query_id):
+            events.append(("worker_begin", query_id))
+
+        @staticmethod
+        def _end_worker_native_execution(query_id):
+            events.append(("worker_end", query_id))
+
+        @staticmethod
+        def _worker_native_query_is_closing(_query_id):
+            return False
+
+        @staticmethod
         def _execute_native_task(*args, **kwargs):
+            events.append(("execute", "query-native-descriptor"))
             return native_result
 
     monkeypatch.setattr(worker_module, "require_ray_cxx_attr", fake_require)
     actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
     query_lease = {
         "lease_id": "lease-native-descriptor",
-        "query_id": "query-native-descriptor",
+        "query_id": "resource-query-native-descriptor",
+        "execution_query_id": "query-native-descriptor",
         "stage_id": "stage-native-descriptor",
         "attempt_id": "query-native-descriptor.0.0.0",
         "target_output_block_bytes": 1,
@@ -1055,8 +1069,11 @@ def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
     assert result[4] == 31337
     assert result[5] == completed_descriptor
     assert events == [
+        ("worker_begin", "query-native-descriptor"),
         ("begin", "query-native-descriptor"),
+        ("execute", "query-native-descriptor"),
         ("end", "query-native-descriptor"),
+        ("worker_end", "query-native-descriptor"),
     ]
 
 
@@ -2535,13 +2552,22 @@ def test_remote_exchange_sink_progress_does_not_add_result_collector(tmp_path, m
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
+
+        def fte_cleanup_query(self, _query_id):
+            return {}
 
         def task_input_stream_exhausted_for_query(self, _query_id, _source_node_ids):
             return []
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     worker = _CapturingWorker()
@@ -3055,13 +3081,22 @@ def test_run_copy_plan_propagates_worker_task_failure_before_finalize(tmp_path, 
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
+
+        def fte_cleanup_query(self, _query_id):
+            return {}
 
         def task_input_stream_exhausted_for_query(self, _query_id, _source_node_ids):
             return []
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners as runners_mod
@@ -3183,13 +3218,22 @@ def test_run_copy_plan_direct_write_failure_cleans_uncommitted_run(tmp_path, mon
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
+
+        def fte_cleanup_query(self, _query_id):
+            return {}
 
         def task_input_stream_exhausted_for_query(self, _query_id, _source_node_ids):
             return []
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners as runners_mod
@@ -3251,10 +3295,19 @@ def test_wait_fte_query_propagates_status_errors(monkeypatch):
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def fte_cleanup_query(self, _query_id):
+            return {}
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3300,10 +3353,19 @@ def test_wait_fte_query_releases_gil_while_waiting(monkeypatch):
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def fte_cleanup_query(self, _query_id):
+            return {}
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3354,7 +3416,13 @@ def test_wait_fte_query_rejects_malformed_query_status(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3416,7 +3484,13 @@ def test_wait_fte_query_rejects_result_handles_without_task_id(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3479,7 +3553,13 @@ def test_wait_fte_query_rejects_result_handles_without_worker_id(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3558,10 +3638,19 @@ def test_wait_fte_query_propagates_selected_attempt_handle_errors(monkeypatch):
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def fte_cleanup_query(self, _query_id):
+            return {}
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3678,7 +3767,13 @@ def test_wait_fte_query_ignores_retry_loser_attempt_errors(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3771,10 +3866,19 @@ def test_wait_fte_query_release_failure_preserves_failed_handle_and_releases_res
         def stats_fragments(self):
             return {"registered_total": 0, "existing_total": 0, "lookup_hits": 0}
 
-        def fte_drop_query(self, _query_id):
+        def fte_prepare_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def fte_cleanup_query(self, _query_id):
+            return {}
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3902,7 +4006,13 @@ def test_wait_fte_query_does_not_drain_pending_retry_loser_attempt(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -3997,7 +4107,13 @@ def test_wait_fte_query_clears_cached_handles_after_failed_status(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -4085,7 +4201,13 @@ def test_wait_fte_query_timeout_preserves_collected_handles(monkeypatch):
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle
@@ -4175,7 +4297,13 @@ def test_wait_fte_query_respects_timeout_after_finished_status_during_drain(monk
         def fte_drop_query(self, _query_id):
             return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
-        def shutdown(self):
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
             return None
 
     import duckdb.runners.ray.worker_handle as ray_worker_handle

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -16,6 +16,7 @@ import pytest
 
 import duckdb
 from duckdb.runners.common import PartitionMetadata
+from duckdb.runners.fte.fte_exchange import ExchangeSinkHandle, ExchangeSinkInstanceHandle
 from duckdb.runners.ray import driver
 from duckdb.runners.ray.partition_metadata import PartitionMetadataAccessor
 from duckdb.runners.ray.safe_get import QueryDeadlineExceeded
@@ -2538,7 +2539,7 @@ def test_describe_native_progress_materializes_deferred_clone_without_execution(
     assert scan_pipeline["input_rows"] == 10
 
 
-def test_remote_exchange_sink_progress_does_not_add_result_collector(tmp_path, monkeypatch):
+def test_remote_exchange_sink_accepts_nested_query_id_without_result_collector(tmp_path, monkeypatch):
     import duckdb.runners.ray.worker_handle as ray_worker_handle
 
     class _CapturingWorker:
@@ -2600,12 +2601,25 @@ def test_remote_exchange_sink_progress_does_not_add_result_collector(tmp_path, m
             topology = duckdb.ray_cxx.describe_native_progress(con.cursor(), task_plan)
             operators = [operator for pipeline in topology["pipelines"] for operator in pipeline["operators"]]
             if "EXCHANGE_SINK" in operators:
+                native_sink_instance = task.exchange_sink_instance()
+                sink_instance = ExchangeSinkInstanceHandle(
+                    ExchangeSinkHandle(
+                        native_sink_instance["query_id"],
+                        "nested-query-id-regression",
+                        native_sink_instance["partition_id"],
+                    ),
+                    native_sink_instance["attempt_id"],
+                    native_sink_instance.get("output_location"),
+                ).to_dict()
+                sink_instance["output_partition_count"] = native_sink_instance["output_partition_count"]
+                assert "query_id" not in sink_instance
+                assert sink_instance["sink_handle"]["query_id"] == native_sink_instance["query_id"]
                 sink_topologies.append(topology)
                 sink_results.append(
                     runner.execute_native(
                         con.cursor(),
                         task_plan,
-                        exchange_sink_instance=task.exchange_sink_instance(),
+                        exchange_sink_instance=sink_instance,
                     )
                 )
 

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from duckdb.runners.ray.fragment_worker_lifecycle import FteWorkerLifecycleMixin
+
+
+class _RemoteMethod:
+    def __init__(self, events: list[str], result: object) -> None:
+        self._events = events
+        self._result = result
+
+    def remote(self) -> object:
+        self._events.append("shutdown-rpc")
+        return self._result
+
+
+class _Actor:
+    def __init__(self, events: list[str], result: object) -> None:
+        self.shutdown = _RemoteMethod(events, result)
+
+
+def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
+    lifecycle = FteWorkerLifecycleMixin()
+    lifecycle.worker_id = ""
+    lifecycle.actor_handle = actor
+    return lifecycle
+
+
+def test_worker_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
+    from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
+
+    events: list[str] = []
+    result = object()
+    lifecycle = _lifecycle(_Actor(events, result))
+
+    def resolve(ref, **kwargs):
+        assert ref is result
+        assert kwargs == {"timeout": 30, "honor_query_deadline": False}
+        events.append("shutdown-resolved")
+
+    monkeypatch.setattr(lifecycle_module, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(lifecycle_module.ray, "kill", lambda actor: events.append("kill"))
+
+    lifecycle.shutdown()
+
+    assert events == ["shutdown-rpc", "shutdown-resolved", "kill"]
+
+
+def test_worker_shutdown_kills_actor_when_graceful_rpc_fails(monkeypatch):
+    from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
+
+    events: list[str] = []
+    result = object()
+    lifecycle = _lifecycle(_Actor(events, result))
+
+    def fail_resolve(ref, **kwargs):
+        assert ref is result
+        events.append("shutdown-failed")
+        raise RuntimeError("stop failed")
+
+    monkeypatch.setattr(lifecycle_module, "resolve_object_refs_blocking", fail_resolve)
+    monkeypatch.setattr(lifecycle_module.ray, "kill", lambda actor: events.append("kill"))
+
+    with pytest.raises(RuntimeError, match="graceful shutdown failed"):
+        lifecycle.shutdown()
+
+    assert events == ["shutdown-rpc", "shutdown-failed", "kill"]

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -3,24 +3,29 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+from types import SimpleNamespace
+
 import pytest
 
 from duckdb.runners.ray.fragment_worker_lifecycle import FteWorkerLifecycleMixin
 
 
 class _RemoteMethod:
-    def __init__(self, events: list[str], result: object) -> None:
+    def __init__(self, events: list[str], result: object, event: str = "shutdown-rpc") -> None:
         self._events = events
         self._result = result
+        self._event = event
 
     def remote(self) -> object:
-        self._events.append("shutdown-rpc")
+        self._events.append(self._event)
         return self._result
 
 
 class _Actor:
     def __init__(self, events: list[str], result: object) -> None:
-        self.shutdown = _RemoteMethod(events, result)
+        self.finish_shutdown = _RemoteMethod(events, result, "finish-rpc")
 
 
 def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
@@ -30,7 +35,7 @@ def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
     return lifecycle
 
 
-def test_worker_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
+def test_worker_finish_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
     from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
 
     events: list[str] = []
@@ -45,12 +50,12 @@ def test_worker_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
     monkeypatch.setattr(lifecycle_module, "resolve_object_refs_blocking", resolve)
     monkeypatch.setattr(lifecycle_module.ray, "kill", lambda actor: events.append("kill"))
 
-    lifecycle.shutdown()
+    lifecycle.finish_shutdown()
 
-    assert events == ["shutdown-rpc", "shutdown-resolved", "kill"]
+    assert events == ["finish-rpc", "shutdown-resolved", "kill"]
 
 
-def test_worker_shutdown_kills_actor_when_graceful_rpc_fails(monkeypatch):
+def test_worker_finish_shutdown_kills_actor_when_graceful_rpc_fails(monkeypatch):
     from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
 
     events: list[str] = []
@@ -66,6 +71,286 @@ def test_worker_shutdown_kills_actor_when_graceful_rpc_fails(monkeypatch):
     monkeypatch.setattr(lifecycle_module.ray, "kill", lambda actor: events.append("kill"))
 
     with pytest.raises(RuntimeError, match="graceful shutdown failed"):
-        lifecycle.shutdown()
+        lifecycle.finish_shutdown()
 
-    assert events == ["shutdown-rpc", "shutdown-failed", "kill"]
+    assert events == ["finish-rpc", "shutdown-failed", "kill"]
+
+
+def test_worker_two_phase_shutdown_keeps_actor_alive_until_finish(monkeypatch):
+    from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
+
+    events: list[str] = []
+    prepare_result = object()
+    finish_result = object()
+
+    class Actor:
+        prepare_shutdown = _RemoteMethod(events, prepare_result, "prepare-rpc")
+        finish_shutdown = _RemoteMethod(events, finish_result, "finish-rpc")
+
+    lifecycle = _lifecycle(Actor())
+
+    def resolve(ref, **kwargs):
+        assert kwargs == {"timeout": 30, "honor_query_deadline": False}
+        if ref is prepare_result:
+            events.append("prepare-resolved")
+        elif ref is finish_result:
+            events.append("finish-resolved")
+        else:
+            raise AssertionError(ref)
+
+    monkeypatch.setattr(lifecycle_module, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(lifecycle_module.ray, "kill", lambda actor: events.append("kill"))
+
+    lifecycle.prepare_shutdown()
+    assert events == ["prepare-rpc", "prepare-resolved"]
+
+    lifecycle.finish_shutdown()
+    assert events == ["prepare-rpc", "prepare-resolved", "finish-rpc", "finish-resolved", "kill"]
+
+
+def test_query_close_interrupts_only_owned_native_cursors():
+    from duckdb.runners.ray import worker as worker_module
+
+    class Cursor:
+        def __init__(self):
+            self.interrupts = 0
+
+        def interrupt(self):
+            self.interrupts += 1
+
+    class DummyActor:
+        _native_execution_condition = threading.Condition()
+        _native_execution_counts_by_query: dict[str, int] = {}
+        _active_native_cursors: set[Cursor] = set()
+        _native_cursor_query_ids: dict[Cursor, str] = {}
+        _closing_native_queries: set[str] = set()
+
+    actor = DummyActor()
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+    query_cursor = Cursor()
+    other_cursor = Cursor()
+
+    assert actor_class._register_native_cursor(actor, query_cursor, "query-a") is True
+    assert actor_class._register_native_cursor(actor, other_cursor, "query-b") is True
+    assert actor_class._close_worker_native_query(actor, "query-a") == []
+    assert query_cursor.interrupts == 1
+    assert other_cursor.interrupts == 0
+    assert actor_class._worker_native_query_is_closing(actor, "query-a") is True
+
+    late_cursor = Cursor()
+    assert actor_class._register_native_cursor(actor, late_cursor, "query-a") is False
+    actor_class._unregister_native_cursor(actor, query_cursor)
+    actor_class._unregister_native_cursor(actor, other_cursor)
+    actor_class._unregister_native_cursor(actor, late_cursor)
+    actor_class._retire_worker_native_query(actor, "query-a")
+    assert actor_class._worker_native_query_is_closing(actor, "query-a") is False
+
+
+def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch):
+    from duckdb.runners.ray import worker as worker_module
+
+    events: list[str] = []
+    interrupted = threading.Event()
+    native_finished = threading.Event()
+
+    class Cursor:
+        def interrupt(self):
+            events.append("cursor-interrupt")
+            interrupted.set()
+
+    class Connection:
+        def interrupt(self):
+            events.append("connection-interrupt")
+
+        def close(self):
+            assert native_finished.is_set()
+            events.append("connection-close")
+
+    class TaskManager:
+        def shutdown(self):
+            events.append("tasks-canceled")
+
+    class DummyActor:
+        _shutdown_lock = threading.Lock()
+        _shared_conn_lock = threading.Lock()
+        _native_execution_condition = threading.Condition()
+        _native_execution_count = 1
+        _native_execution_counts_by_query = {"query-a": 1}
+        _active_native_cursors = {Cursor()}
+        _shutdown_started = False
+        _shutdown_prepared = False
+        _shutdown_complete = False
+        _shared_conn = Connection()
+        _fte_task_manager = TaskManager()
+
+    actor = DummyActor()
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+
+    def finish_native():
+        assert interrupted.wait(timeout=5)
+        events.append("native-finished")
+        native_finished.set()
+        with actor._native_execution_condition:
+            actor._active_native_cursors.clear()
+            actor._native_execution_count -= 1
+            actor._native_execution_counts_by_query.clear()
+            actor._native_execution_condition.notify_all()
+
+    native_thread = threading.Thread(target=finish_native)
+    native_thread.start()
+    monkeypatch.setattr(
+        worker_module,
+        "require_ray_cxx_attr",
+        lambda name, hint=None: (
+            lambda: (
+                events.append("flight-stopped")
+                if name == "shutdown_local_flight_service"
+                else (_ for _ in ()).throw(AssertionError(name))
+            )
+        ),
+    )
+
+    actor_class._prepare_worker_runtime_shutdown(actor)
+    native_thread.join(timeout=5)
+
+    assert native_thread.is_alive() is False
+    assert actor._shutdown_started is True
+    assert actor._shutdown_prepared is True
+    assert actor._shutdown_complete is False
+    assert actor._shared_conn is None
+    assert events == [
+        "tasks-canceled",
+        "connection-interrupt",
+        "cursor-interrupt",
+        "native-finished",
+        "connection-close",
+    ]
+
+    actor_class._finish_worker_runtime_shutdown(actor)
+    assert actor._shutdown_complete is True
+    assert events[-1] == "flight-stopped"
+    with pytest.raises(RuntimeError, match="shutting down"):
+        actor_class._begin_worker_native_execution(actor, "query-a")
+    with pytest.raises(RuntimeError, match="shutting down"):
+        actor_class._ensure_worker_runtime_running(actor)
+
+
+def test_query_teardown_waits_for_pre_registration_native_admission():
+    from duckdb.runners.ray import worker as worker_module
+
+    class DummyActor:
+        _shutdown_started = False
+        _native_execution_condition = threading.Condition()
+        _native_execution_count = 0
+        _native_execution_counts_by_query: dict[str, int] = {}
+        _active_native_cursors: set[object] = set()
+        _native_cursor_query_ids: dict[object, str] = {}
+        _closing_native_queries: set[str] = set()
+
+    actor = DummyActor()
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+    query_id = "query-admitted-before-native-registration"
+
+    # Model the exact gap after Python admission but before the C++ registry's
+    # begin_query_execution call.
+    actor_class._begin_worker_native_execution(actor, query_id)
+    assert actor_class._close_worker_native_query(actor, query_id) == []
+
+    async def exercise_barrier():
+        barrier = asyncio.create_task(
+            actor_class._wait_worker_native_executions_for_query(actor, query_id, timeout_s=1.0)
+        )
+        await asyncio.sleep(0)
+        assert barrier.done() is False
+        with pytest.raises(RuntimeError, match="active executions"):
+            actor_class._retire_worker_native_query(actor, query_id)
+
+        actor_class._end_worker_native_execution(actor, query_id)
+        await barrier
+        actor_class._retire_worker_native_query(actor, query_id)
+
+    asyncio.run(exercise_barrier())
+    assert actor._native_execution_count == 0
+    assert actor._native_execution_counts_by_query == {}
+    assert actor_class._worker_native_query_is_closing(actor, query_id) is False
+
+
+def test_fte_task_manager_rejects_new_tasks_after_shutdown():
+    from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
+    from duckdb.runners.fte.fte_worker_runtime import FteWorkerTaskManager
+
+    async def execute(_request):
+        raise AssertionError("shut-down manager must not execute a task")
+
+    manager = FteWorkerTaskManager(
+        execute,
+        admission_config=FteWorkerAdmissionConfig(
+            max_running_tasks=1,
+            mode="test",
+            memory_budget_bytes=1,
+        ),
+    )
+    assert manager.shutdown() == {"removed": 0, "canceled": 0}
+    assert manager.shutdown() == {"removed": 0, "canceled": 0}
+    with pytest.raises(RuntimeError, match="shut down"):
+        asyncio.run(manager.create_task({}))
+
+
+def test_fte_task_manager_shutdown_retries_retained_task_cleanup():
+    from duckdb.runners.fte import FteTaskState
+    from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
+    from duckdb.runners.fte.fte_worker_runtime import FteWorkerTaskManager
+
+    async def execute(_request):
+        raise AssertionError("injected task must not execute")
+
+    class Execution:
+        def __init__(self):
+            self.status = SimpleNamespace(state=FteTaskState.RUNNING)
+            self.cancel_calls = 0
+            self.release_calls = 0
+
+        def cancel(self):
+            self.cancel_calls += 1
+            self.status.state = FteTaskState.CANCELED
+
+        def release_result(self, *, reason):
+            assert reason == "worker_shutdown"
+            self.release_calls += 1
+            if self.release_calls == 1:
+                raise RuntimeError("planned release failure")
+
+    manager = FteWorkerTaskManager(
+        execute,
+        admission_config=FteWorkerAdmissionConfig(
+            max_running_tasks=1,
+            mode="test",
+            memory_budget_bytes=1,
+        ),
+    )
+    execution = Execution()
+    manager.tasks["task"] = execution
+    manager.running_tasks.add("task")
+
+    with pytest.raises(RuntimeError, match="planned release failure"):
+        manager.shutdown()
+
+    assert manager.tasks == {"task": execution}
+    assert execution.cancel_calls == 1
+    assert manager.shutdown() == {"removed": 1, "canceled": 0}
+    assert manager.tasks == {}
+    assert execution.release_calls == 2
+
+
+def test_actor_task_manager_creation_is_rejected_after_shutdown_starts():
+    from duckdb.runners.ray import worker as worker_module
+
+    class DummyActor:
+        _shutdown_lock = threading.RLock()
+        _shutdown_started = True
+        _fte_task_manager = None
+
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        actor_class._get_fte_task_manager(DummyActor())

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -342,6 +342,55 @@ def test_fte_task_manager_shutdown_retries_retained_task_cleanup():
     assert execution.release_calls == 2
 
 
+def test_fte_task_manager_shutdown_does_not_admit_queued_task_from_completion_callback():
+    from duckdb.runners.fte import FteTaskState
+    from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
+    from duckdb.runners.fte.fte_worker_runtime import FteWorkerTaskManager
+
+    async def execute(_request):
+        raise AssertionError("queued task must not execute during shutdown")
+
+    manager = FteWorkerTaskManager(
+        execute,
+        admission_config=FteWorkerAdmissionConfig(
+            max_running_tasks=1,
+            mode="test",
+            memory_budget_bytes=1,
+        ),
+    )
+    started = []
+
+    class Execution:
+        def __init__(self, state, *, on_release=None):
+            self.status = SimpleNamespace(state=state)
+            self.memory_requirement_bytes = 1
+            self.on_release = on_release
+
+        def cancel(self):
+            self.status.state = FteTaskState.CANCELED
+
+        def release_result(self, *, reason):
+            assert reason == "worker_shutdown"
+            if self.on_release is not None:
+                self.on_release()
+
+    def finish_running_task_during_shutdown():
+        manager.running_tasks.discard("running")
+        manager._drain_queue()
+
+    running = Execution(FteTaskState.RUNNING, on_release=finish_running_task_during_shutdown)
+    queued = Execution(FteTaskState.QUEUED)
+    manager.tasks["running"] = running
+    manager.tasks["queued"] = queued
+    manager.running_tasks.add("running")
+    manager.queued_tasks.append("queued")
+    manager._start_execution = lambda execution, *, reason: started.append((execution, reason))
+
+    assert manager.shutdown() == {"removed": 2, "canceled": 2}
+    assert started == []
+    assert list(manager.queued_tasks) == []
+
+
 def test_actor_task_manager_creation_is_rejected_after_shutdown_starts():
     from duckdb.runners.ray import worker as worker_module
 


### PR DESCRIPTION
## Summary

- make the worker process own one Flight service with immutable bind configuration, explicit shutdown, thread join, and port release
- publish committed shuffle attempts in a process-local catalog under unique exchange-instance identities and exact query ownership
- return the native completed sink descriptor so the worker Flight epoch reaches the coordinator
- serialize sink network and local-directory settings from the owning Flight session instead of rereading process environment
- fence query teardown before task cancellation, track the real native thread lifetime, and reject late cache publication after close
- keep deferred cleanup in an explicit pending queue; report, retry, and drain reader-held or failed cleanup before teardown completes
- carry the server epoch through sink/source metadata and use a strict six-field `v1` ticket (`epoch`, exchange instance, node, attempt, partition)
- resolve remote reads only through live catalog entries, rejecting stale epochs, released attempts, and unpublished manifests

## Intentional wire behavior

The ticket version remains `v1`, but its schema is replaced in place. The previous four-field `v1` shape is rejected. This PR intentionally adds no compatibility parser and no server-side directory or manifest fallback.

## Validation

- `scripts/format workspace --changed` — passed
- incremental PEP 517 native build/install — passed
- `scripts/run_native_tests.sh '[distributed][exchange]'` — 38 cases, 459 assertions passed
- native serialization/exchange filter — 7 cases, 115 assertions passed
- Flight-disabled C++20 `duckdb_static` build — 270/270 targets passed
- affected Python suite — 559 passed, 4 deselected
- `scripts/run_release_tests.sh` — 278 passed, 1 skipped, then 5 Ray integration tests passed
- `scripts/run_fast_tests.sh` non-Ray phase — 5,391 passed, 27 skipped, 8 xfailed, 1 xpassed
- `scripts/run_fast_tests.sh` shared-Ray phase — 78 passed, 6 skipped
- `scripts/run_fast_tests.sh` owner-Ray phase — 6 passed, 3 environment-dependent skips, including a passing non-contiguous CUDA visibility integration test

Fixes #73
