### PR TITLE
[fix](ray) Scope progress logging to Ray initialization

### DIFF
--- a/duckdb/_ray_progress_env.py
+++ b/duckdb/_ray_progress_env.py
@@ -40,10 +40,7 @@ def ray_log_to_driver_default() -> bool:
 
 
 def configure_ray_progress_logging_defaults() -> None:
-    """Keep Ray background logs from corrupting Vane's dynamic progress UI."""
-    dynamic_progress = dynamic_ray_progress_enabled()
-    if "RAY_LOG_TO_DRIVER" not in os.environ and dynamic_progress:
-        os.environ["RAY_LOG_TO_DRIVER"] = "0"
+    """Compatibility no-op for imports that previously set global Ray defaults.
 
-    if dynamic_progress and not ray_log_to_driver_default():
-        os.environ.setdefault("RAY_BACKEND_LOG_LEVEL", "fatal")
+    ``RayRunner`` passes Vane's preference directly to ``ray.init`` instead.
+    """

--- a/tests/fast/test_ray_progress_env.py
+++ b/tests/fast/test_ray_progress_env.py
@@ -4,14 +4,52 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 
 import pytest
 
 from duckdb._ray_progress_env import (
-    configure_ray_progress_logging_defaults,
     dynamic_ray_progress_enabled,
     ray_log_to_driver_default,
 )
+
+_RAY_LOGGING_ENV_NAMES = ("RAY_LOG_TO_DRIVER", "RAY_BACKEND_LOG_LEVEL")
+
+
+def _assert_import_preserves_ray_logging_env(
+    module_name: str,
+    *,
+    initial_ray_env: dict[str, str] | None = None,
+    import_ray_first: bool = False,
+) -> None:
+    env = os.environ.copy()
+    env["VANE_RUNNER"] = "ray"
+    env["VANE_PROGRESS"] = "auto"
+    for name in _RAY_LOGGING_ENV_NAMES:
+        env.pop(name, None)
+    env.update(initial_ray_env or {})
+
+    ray_import = "import ray" if import_ray_first else ""
+    script = f"""
+import importlib
+import os
+
+ray_logging_env_names = {_RAY_LOGGING_ENV_NAMES!r}
+{ray_import}
+before = {{name: os.environ.get(name) for name in ray_logging_env_names}}
+importlib.import_module({module_name!r})
+after = {{name: os.environ.get(name) for name in ray_logging_env_names}}
+assert after == before, (before, after)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
 
 
 @pytest.mark.parametrize("configured", [None, "", "   "])
@@ -31,12 +69,10 @@ def test_dynamic_ray_progress_disables_ray_driver_log_forwarding(monkeypatch):
     monkeypatch.delenv("RAY_LOG_TO_DRIVER", raising=False)
     monkeypatch.delenv("RAY_BACKEND_LOG_LEVEL", raising=False)
 
-    configure_ray_progress_logging_defaults()
-
     assert dynamic_ray_progress_enabled()
     assert not ray_log_to_driver_default()
-    assert os.environ.get("RAY_LOG_TO_DRIVER") == "0"
-    assert os.environ.get("RAY_BACKEND_LOG_LEVEL") == "fatal"
+    assert os.environ.get("RAY_LOG_TO_DRIVER") is None
+    assert os.environ.get("RAY_BACKEND_LOG_LEVEL") is None
 
 
 def test_log_progress_keeps_ray_driver_log_default(monkeypatch):
@@ -44,8 +80,6 @@ def test_log_progress_keeps_ray_driver_log_default(monkeypatch):
     monkeypatch.setenv("VANE_PROGRESS", "raylog")
     monkeypatch.delenv("RAY_LOG_TO_DRIVER", raising=False)
     monkeypatch.delenv("RAY_BACKEND_LOG_LEVEL", raising=False)
-
-    configure_ray_progress_logging_defaults()
 
     assert not dynamic_ray_progress_enabled()
     assert ray_log_to_driver_default()
@@ -59,21 +93,59 @@ def test_explicit_ray_log_to_driver_is_preserved(monkeypatch):
     monkeypatch.setenv("RAY_LOG_TO_DRIVER", "1")
     monkeypatch.delenv("RAY_BACKEND_LOG_LEVEL", raising=False)
 
-    configure_ray_progress_logging_defaults()
-
     assert dynamic_ray_progress_enabled()
     assert ray_log_to_driver_default()
     assert os.environ.get("RAY_LOG_TO_DRIVER") == "1"
     assert os.environ.get("RAY_BACKEND_LOG_LEVEL") is None
 
 
-def test_explicit_ray_backend_log_level_is_preserved(monkeypatch):
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "vane",
+        "duckdb.runners.ray.runner",
+        "duckdb.runners.ray.driver",
+    ],
+)
+def test_import_does_not_set_process_global_ray_logging_defaults(module_name):
+    _assert_import_preserves_ray_logging_env(module_name)
+
+
+@pytest.mark.parametrize(
+    "initial_ray_env",
+    [
+        {},
+        {"RAY_BACKEND_LOG_LEVEL": "debug"},
+        {"RAY_LOG_TO_DRIVER": "1", "RAY_BACKEND_LOG_LEVEL": "debug"},
+        {"RAY_LOG_TO_DRIVER": "0", "RAY_BACKEND_LOG_LEVEL": "error"},
+    ],
+)
+def test_vane_import_coexists_with_existing_ray_user(initial_ray_env):
+    _assert_import_preserves_ray_logging_env(
+        "vane",
+        initial_ray_env=initial_ray_env,
+        import_ray_first=True,
+    )
+
+
+def test_ray_runner_scopes_progress_logging_to_ray_init(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     monkeypatch.delenv("VANE_PROGRESS", raising=False)
     monkeypatch.delenv("RAY_LOG_TO_DRIVER", raising=False)
-    monkeypatch.setenv("RAY_BACKEND_LOG_LEVEL", "error")
+    monkeypatch.delenv("RAY_BACKEND_LOG_LEVEL", raising=False)
 
-    configure_ray_progress_logging_defaults()
+    from duckdb.runners.ray import runner as ray_runner_module
 
-    assert os.environ.get("RAY_LOG_TO_DRIVER") == "0"
-    assert os.environ.get("RAY_BACKEND_LOG_LEVEL") == "error"
+    init_kwargs = {}
+    monkeypatch.setattr(ray_runner_module, "ensure_vane_session_dir", lambda: None)
+    monkeypatch.setattr(ray_runner_module.ray, "is_initialized", lambda: False)
+    monkeypatch.setattr(ray_runner_module.ray, "init", lambda **kwargs: init_kwargs.update(kwargs))
+
+    ray_runner_module.RayRunner(address="ray://cluster", max_task_backlog=None)
+
+    assert init_kwargs == {
+        "address": "ray://cluster",
+        "log_to_driver": False,
+    }
+    assert os.environ.get("RAY_LOG_TO_DRIVER") is None
+    assert os.environ.get("RAY_BACKEND_LOG_LEVEL") is None

--- a/tests/fast/test_ray_progress_env.py
+++ b/tests/fast/test_ray_progress_env.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from textwrap import dedent
 
 import pytest
 
@@ -31,17 +32,19 @@ def _assert_import_preserves_ray_logging_env(
     env.update(initial_ray_env or {})
 
     ray_import = "import ray" if import_ray_first else ""
-    script = f"""
-import importlib
-import os
+    script = dedent(
+        f"""
+        import importlib
+        import os
 
-ray_logging_env_names = {_RAY_LOGGING_ENV_NAMES!r}
-{ray_import}
-before = {{name: os.environ.get(name) for name in ray_logging_env_names}}
-importlib.import_module({module_name!r})
-after = {{name: os.environ.get(name) for name in ray_logging_env_names}}
-assert after == before, (before, after)
-"""
+        ray_logging_env_names = {_RAY_LOGGING_ENV_NAMES!r}
+        {ray_import}
+        before = {{name: os.environ.get(name) for name in ray_logging_env_names}}
+        importlib.import_module({module_name!r})
+        after = {{name: os.environ.get(name) for name in ray_logging_env_names}}
+        assert after == before, (before, after)
+        """
+    )
     completed = subprocess.run(
         [sys.executable, "-c", script],
         env=env,


### PR DESCRIPTION
## Summary

- stop Vane imports from setting process-global `RAY_LOG_TO_DRIVER` and `RAY_BACKEND_LOG_LEVEL` defaults
- retain the existing import hook as an explicit compatibility no-op while keeping Vane's preference scoped to `ray.init(log_to_driver=...)`
- add fresh-process coverage for top-level, runner, and driver imports plus Ray-first coexistence and user-provided settings

## Related issue

close: #111

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

There is no unavoidable process-wide Ray logging setting after this change; existing environment overrides remain supported and unchanged.

## Validation

- `python -m pytest tests/fast/test_ray_progress_env.py tests/fast/test_vane_config.py -q` (38 passed)
- `scripts/run_release_tests.sh` (272 passed, 1 skipped in the non-Ray shard; 5 passed in the real-Ray shard)
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Python-only change; no native rebuild required

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
