### PR TITLE
[fix](video) Preserve standard S3 credential behavior

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,8 @@ repos:
         # Check the files in the changed range without recursively surfacing
         # the inherited type debt of every module they import.
         args: ["--follow-imports=skip", "--allow-subclassing-any", "--no-warn-return-any"]
-        additional_dependencies: [numpy, polars]
+        # Keep NumPy stubs compatible with mypy's Python 3.10 target.
+        additional_dependencies: ["numpy<2.3", polars]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,8 +53,9 @@ repos:
         # Check the files in the changed range without recursively surfacing
         # the inherited type debt of every module they import.
         args: ["--follow-imports=skip", "--allow-subclassing-any", "--no-warn-return-any"]
-        # Keep NumPy stubs compatible with mypy's Python 3.10 target.
-        additional_dependencies: ["numpy<2.3", polars]
+        # Keep NumPy stubs compatible with mypy's Python 3.10 target while
+        # allowing the NumPy 2.3 wheels available to Python 3.14 hooks.
+        additional_dependencies: ["numpy<2.4", polars]
 
   - repo: local
     hooks:

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -23,10 +23,12 @@ import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
+from typing import Any, cast
 
 import numpy as np
+import numpy.typing as npt
 import pyarrow as pa
-from PIL import Image
+from PIL import Image  # type: ignore[import-not-found]
 
 from duckdb.datasource import DataSource, DataSourceTask
 
@@ -192,14 +194,14 @@ def _wait_for_memory() -> None:
     IMPORTANT: Only call at task START (before a new video). Never call
     mid-decode or mid-yield — that deadlocks the DuckDB push pipeline.
     """
-    import psutil
+    import psutil  # type: ignore[import-untyped]
 
-    def has_capacity(mem) -> bool:
+    def has_capacity(mem: Any) -> bool:
         if _MEM_MIN_AVAILABLE_BYTES > 0 and mem.available >= _MEM_MIN_AVAILABLE_BYTES:
             return True
         return mem.percent < _MEM_HIGH_WATERMARK
 
-    def has_recovered(mem) -> bool:
+    def has_recovered(mem: Any) -> bool:
         if _MEM_MIN_AVAILABLE_BYTES > 0 and mem.available >= _MEM_MIN_AVAILABLE_BYTES:
             return True
         return mem.percent < _MEM_LOW_WATERMARK
@@ -214,37 +216,48 @@ def _wait_for_memory() -> None:
             return
 
 
+def _s3_filesystem_kwargs() -> dict[str, str | bool]:
+    """Build explicit S3 overrides without bypassing the AWS SDK defaults."""
+    from urllib.parse import urlparse
+
+    kwargs: dict[str, str | bool] = {}
+
+    endpoint_url = _read_optional_text_env(("AWS_ENDPOINT_URL",))
+    if endpoint_url is not None:
+        if "://" in endpoint_url:
+            parsed = urlparse(endpoint_url)
+            endpoint = parsed.netloc or parsed.path
+            if parsed.scheme:
+                kwargs["scheme"] = parsed.scheme
+        else:
+            endpoint = endpoint_url.rstrip("/")
+        kwargs["endpoint_override"] = endpoint
+
+    region = _read_optional_text_env(("AWS_REGION", "AWS_DEFAULT_REGION"))
+    if region is not None:
+        kwargs["region"] = region
+
+    if _read_bool_env("S3FS_ANON", False):
+        kwargs["anonymous"] = True
+
+    return kwargs
+
+
 def _read_s3_bytes(s3_path: str) -> bytes:
     """Read a file from S3 into memory via PyArrow's S3FileSystem."""
     import pyarrow.fs as pa_fs
 
-    ak = os.environ.get("AWS_ACCESS_KEY_ID", "")
-    sk = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-    ep = os.environ.get("AWS_ENDPOINT_URL", "")
-    region = os.environ.get("AWS_REGION", "us-east-1")
-    from urllib.parse import urlparse
-
-    parsed = urlparse(ep)
-    endpoint = parsed.netloc or parsed.path
-    scheme = parsed.scheme or "http"
-    kwargs = {"endpoint_override": endpoint, "region": region, "scheme": scheme}
-    if ak or sk:
-        kwargs["access_key"] = ak
-        kwargs["secret_key"] = sk
-        kwargs["anonymous"] = False
-    else:
-        kwargs["anonymous"] = True
-    fs = pa_fs.S3FileSystem(**kwargs)
+    fs = pa_fs.S3FileSystem(**_s3_filesystem_kwargs())
     obj_path = s3_path[len("s3://") :]
     with fs.open_input_file(obj_path) as f:
         return f.read()
 
 
-def _build_frame_array(frames: np.ndarray) -> pa.ExtensionArray:
-    frames = np.ascontiguousarray(frames, dtype=np.uint8)
-    if frames.ndim != 4 or frames.shape[-1] != 3:
-        raise ValueError(f"expected RGB frame batch with shape (N, H, W, 3), got {frames.shape!r}")
-    return pa.FixedShapeTensorArray.from_numpy_ndarray(frames)
+def _build_frame_array(frames: npt.ArrayLike) -> pa.ExtensionArray:
+    frame_array: npt.NDArray[np.uint8] = np.ascontiguousarray(frames, dtype=np.uint8)
+    if frame_array.ndim != 4 or frame_array.shape[-1] != 3:
+        raise ValueError(f"expected RGB frame batch with shape (N, H, W, 3), got {frame_array.shape!r}")
+    return pa.FixedShapeTensorArray.from_numpy_ndarray(frame_array)
 
 
 def _int64_array(values: list[int]) -> pa.Array:
@@ -254,13 +267,13 @@ def _int64_array(values: list[int]) -> pa.Array:
 
 def _constant_string_array(value: str, count: int) -> pa.Array:
     encoded = value.encode("utf-8")
-    offsets = np.arange(count + 1, dtype=np.int32) * len(encoded)
+    offsets: npt.NDArray[np.int32] = np.arange(count + 1, dtype=np.int32) * len(encoded)
     data = encoded * count
     return pa.Array.from_buffers(pa.string(), count, [None, pa.py_buffer(offsets), pa.py_buffer(data)])
 
 
-def _open_decord_reader(video_path: str):
-    from decord import VideoReader
+def _open_decord_reader(video_path: str) -> Any:
+    from decord import VideoReader  # type: ignore[import-not-found]
 
     if video_path.startswith("s3://"):
         import io as _io
@@ -269,18 +282,22 @@ def _open_decord_reader(video_path: str):
     return VideoReader(video_path)
 
 
-def _resize_rgb_frame(frame: np.ndarray, width: int, height: int) -> np.ndarray:
+def _resize_rgb_frame(
+    frame: npt.NDArray[np.uint8],
+    width: int,
+    height: int,
+) -> npt.NDArray[np.uint8]:
     pil_image = Image.fromarray(frame)
     return np.array(pil_image.resize((width, height)))
 
 
 def _resize_frame_batch(
-    frames: list[np.ndarray],
+    frames: list[npt.NDArray[np.uint8]],
     *,
     width: int,
     height: int,
     executor: ThreadPoolExecutor | None = None,
-) -> list[np.ndarray]:
+) -> list[npt.NDArray[np.uint8]]:
     if not frames:
         return []
     if _VIDEO_RESIZE_THREADS <= 1 or len(frames) == 1:
@@ -308,8 +325,8 @@ def _decode_video_batches(
     vname = os.path.basename(video_path)
     batch_size = _video_source_udf_output_batch_size(height, width, max_partition_bytes)
 
-    resized = np.empty((batch_size, height, width, 3), dtype=np.uint8)
-    raw_frames: list[np.ndarray] = []
+    resized: npt.NDArray[np.uint8] = np.empty((batch_size, height, width, 3), dtype=np.uint8)
+    raw_frames: list[npt.NDArray[np.uint8]] = []
     indices: list[int] = []
     count = 0
     decode_s = 0.0
@@ -377,7 +394,7 @@ def _decode_video_batches(
 
 def _flush_frame_batch(
     vname: str,
-    resized: np.ndarray,
+    resized: npt.NDArray[np.uint8],
     indices: list[int],
     count: int,
 ) -> pa.RecordBatch:
@@ -562,13 +579,13 @@ def _manifest_int_value(values: list[object], index: int, name: str) -> int:
     value = values[index]
     if value is None:
         raise ValueError(f"VideoFrameSource manifest column {name!r} cannot be NULL")
-    return int(value)
+    return int(cast(Any, value))
 
 
 def _manifest_frame_limit(values: list[object]) -> int | None:
     for value in values:
         if value is not None:
-            return max(0, int(value))
+            return max(0, int(cast(Any, value)))
     return None
 
 
@@ -672,7 +689,7 @@ class VideoFrameTask(DataSourceTask):
     def _flush(
         self,
         vname: str,
-        resized: np.ndarray,
+        resized: npt.NDArray[np.uint8],
         indices: list[int],
         count: int,
     ) -> pa.RecordBatch:
@@ -774,7 +791,7 @@ class VideoFrameSource(DataSource):
                 max_partition_bytes=self.max_partition_bytes,
             )
 
-    def to_udf_relation(self, con):
+    def to_udf_relation(self, con: Any) -> Any:
         import duckdb
 
         manifest = con.sql(_video_frame_source_manifest_sql(self))

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -224,13 +224,12 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool]:
 
     endpoint_url = _read_optional_text_env(("AWS_ENDPOINT_URL",))
     if endpoint_url is not None:
-        if "://" in endpoint_url:
-            parsed = urlparse(endpoint_url)
-            endpoint = parsed.netloc or parsed.path
-            if parsed.scheme:
-                kwargs["scheme"] = parsed.scheme
-        else:
-            endpoint = endpoint_url.rstrip("/")
+        # Treat a scheme-less value as an authority so paths are discarded
+        # consistently from endpoint_override.
+        parsed = urlparse(endpoint_url if "://" in endpoint_url else f"//{endpoint_url}")
+        endpoint = parsed.netloc or parsed.path.rstrip("/")
+        if parsed.scheme:
+            kwargs["scheme"] = parsed.scheme
         kwargs["endpoint_override"] = endpoint
 
     region = _read_optional_text_env(("AWS_REGION", "AWS_DEFAULT_REGION"))

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -226,7 +226,10 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool]:
     if endpoint_url is not None:
         # Treat a scheme-less value as an authority so paths are discarded
         # consistently from endpoint_override.
-        parsed = urlparse(endpoint_url if "://" in endpoint_url else f"//{endpoint_url}")
+        parse_target = endpoint_url
+        if "://" not in parse_target and not parse_target.startswith("//"):
+            parse_target = f"//{parse_target}"
+        parsed = urlparse(parse_target)
         endpoint = parsed.netloc or parsed.path.rstrip("/")
         if parsed.scheme:
             kwargs["scheme"] = parsed.scheme

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import io
+
 import numpy as np
 import pyarrow as pa
 import pytest
@@ -15,12 +17,187 @@ from duckdb.datasource.video_reader import (
     _coalesce_video_frame_batches,
     _decode_video_batches,
     _flush_frame_batch,
+    _read_s3_bytes,
     _resize_frame_batch,
     _split_video_path_groups,
     _video_frame_source_manifest_sql,
     _video_frame_source_map_batches,
     _video_source_udf_output_batch_size,
 )
+
+_S3_ENV_NAMES = (
+    "S3FS_ANON",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_ENDPOINT_URL",
+)
+
+
+@pytest.fixture
+def recording_s3_filesystem(monkeypatch):
+    import pyarrow.fs as pa_fs
+
+    recorded = {}
+
+    class RecordingS3FileSystem:
+        def __init__(self, **kwargs):
+            recorded["kwargs"] = kwargs
+
+        def open_input_file(self, path):
+            recorded["path"] = path
+            return io.BytesIO(b"video-bytes")
+
+    monkeypatch.setattr(pa_fs, "S3FileSystem", RecordingS3FileSystem)
+    return recorded
+
+
+def _clear_s3_environment(monkeypatch):
+    for name in _S3_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_video_s3_reader_uses_default_aws_sdk_chain(monkeypatch, recording_s3_filesystem):
+    _clear_s3_environment(monkeypatch)
+
+    result = _read_s3_bytes("s3://media-bucket/clips/example.mp4")
+
+    assert result == b"video-bytes"
+    assert recording_s3_filesystem == {
+        "kwargs": {},
+        "path": "media-bucket/clips/example.mp4",
+    }
+
+
+@pytest.mark.parametrize(
+    "credential_env",
+    [
+        {"AWS_PROFILE": "media-reader"},
+        {
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/media-reader",
+            "AWS_ROLE_SESSION_NAME": "vane-video-test",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/aws/token",
+        },
+    ],
+    ids=["profile", "web-identity-role"],
+)
+def test_video_s3_reader_leaves_profile_and_role_credentials_to_sdk(
+    monkeypatch,
+    recording_s3_filesystem,
+    credential_env,
+):
+    _clear_s3_environment(monkeypatch)
+    for name, value in credential_env.items():
+        monkeypatch.setenv(name, value)
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {}
+
+
+def test_video_s3_reader_leaves_static_session_credentials_to_sdk(monkeypatch, recording_s3_filesystem):
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "temporary-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "temporary-secret-key")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "temporary-session-token")
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {}
+
+
+@pytest.mark.parametrize(
+    "partial_credentials",
+    [
+        {"AWS_ACCESS_KEY_ID": "access-key-without-secret"},
+        {"AWS_SECRET_ACCESS_KEY": "secret-key-without-access"},
+    ],
+    ids=["access-key-only", "secret-key-only"],
+)
+def test_video_s3_reader_leaves_partial_static_credentials_to_sdk(
+    monkeypatch,
+    recording_s3_filesystem,
+    partial_credentials,
+):
+    _clear_s3_environment(monkeypatch)
+    for name, value in partial_credentials.items():
+        monkeypatch.setenv(name, value)
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {}
+
+
+@pytest.mark.parametrize("region_env", ["AWS_REGION", "AWS_DEFAULT_REGION"])
+def test_video_s3_reader_passes_custom_https_endpoint_and_region(
+    monkeypatch,
+    recording_s3_filesystem,
+    region_env,
+):
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test:9443")
+    monkeypatch.setenv(region_env, "eu-west-1")
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {
+        "endpoint_override": "objects.example.test:9443",
+        "region": "eu-west-1",
+        "scheme": "https",
+    }
+
+
+@pytest.mark.parametrize(
+    ("endpoint_url", "expected_kwargs"),
+    [
+        ("objects.example.test:9443", {"endpoint_override": "objects.example.test:9443"}),
+        (
+            "http://127.0.0.1:9000",
+            {"endpoint_override": "127.0.0.1:9000", "scheme": "http"},
+        ),
+    ],
+)
+def test_video_s3_reader_uses_pyarrow_secure_default_when_endpoint_has_no_scheme(
+    monkeypatch,
+    recording_s3_filesystem,
+    endpoint_url,
+    expected_kwargs,
+):
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", endpoint_url)
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == expected_kwargs
+
+
+def test_video_s3_reader_does_not_enable_anonymous_mode_when_explicitly_disabled(
+    monkeypatch,
+    recording_s3_filesystem,
+):
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("S3FS_ANON", "false")
+
+    _read_s3_bytes("s3://media-bucket/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {}
+
+
+def test_video_s3_reader_uses_anonymous_mode_only_when_explicit(monkeypatch, recording_s3_filesystem):
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("S3FS_ANON", "true")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ignored-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ignored-secret-key")
+
+    _read_s3_bytes("s3://public-media/example.mp4")
+
+    assert recording_s3_filesystem["kwargs"] == {"anonymous": True}
 
 
 def test_video_frame_source_uses_one_ordered_task_for_frame_limit():

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -161,6 +161,10 @@ def test_video_s3_reader_passes_custom_https_endpoint_and_region(
             {"endpoint_override": "objects.example.test:9443"},
         ),
         (
+            "//objects.example.test:9443/prefix",
+            {"endpoint_override": "objects.example.test:9443"},
+        ),
+        (
             "http://127.0.0.1:9000/prefix",
             {"endpoint_override": "127.0.0.1:9000", "scheme": "http"},
         ),

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -141,7 +141,7 @@ def test_video_s3_reader_passes_custom_https_endpoint_and_region(
     region_env,
 ):
     _clear_s3_environment(monkeypatch)
-    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test:9443")
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test:9443/prefix")
     monkeypatch.setenv(region_env, "eu-west-1")
 
     _read_s3_bytes("s3://media-bucket/example.mp4")
@@ -156,14 +156,17 @@ def test_video_s3_reader_passes_custom_https_endpoint_and_region(
 @pytest.mark.parametrize(
     ("endpoint_url", "expected_kwargs"),
     [
-        ("objects.example.test:9443", {"endpoint_override": "objects.example.test:9443"}),
         (
-            "http://127.0.0.1:9000",
+            "objects.example.test:9443/prefix",
+            {"endpoint_override": "objects.example.test:9443"},
+        ),
+        (
+            "http://127.0.0.1:9000/prefix",
             {"endpoint_override": "127.0.0.1:9000", "scheme": "http"},
         ),
     ],
 )
-def test_video_s3_reader_uses_pyarrow_secure_default_when_endpoint_has_no_scheme(
+def test_video_s3_reader_normalizes_endpoint_override(
     monkeypatch,
     recording_s3_filesystem,
     endpoint_url,


### PR DESCRIPTION
## Summary

- Construct the video reader PyArrow S3 filesystem with only explicitly configured endpoint, region, and anonymous overrides.
- Leave profiles, roles, web identity, static/session credentials, and other credential sources to the AWS SDK chain; preserve PyArrow HTTPS defaults when no scheme is configured.
- Add recording-filesystem regression coverage for the default chain, profile/role credentials, temporary credentials, custom endpoints/regions, and explicit anonymous mode.
- Keep changed-file mypy checks compatible with the configured Python 3.10 target while allowing NumPy 2.3 wheels for Python 3.14 hook environments.

## Related issue

close: #96

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change restores the documented/default AWS and PyArrow configuration behavior without adding a new public option.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Fresh Python 3.10.20 mypy environment: resolved NumPy 2.2.6; passed with the Python 3.10 mypy target.
- Fresh Python 3.14.6 pre-commit environment: installed the NumPy 2.3.5 wheel; mypy passed with the Python 3.10 target.
- `python -m pytest tests/fast/test_video_reader.py tests/fast/test_datasource_distributed_scan.py -q` (34 passed)
- `scripts/run_release_tests.sh` (non-Ray: 272 passed, 1 skipped, 9 deselected; real-Ray: 5 passed, 277 deselected)
- Python-only/configuration change; no native source change.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.