### PR TITLE
[feat](distributed) Unify distributed result consumers

### DIFF
--- a/src/duckdb_py/CMakeLists.txt
+++ b/src/duckdb_py/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(
   pyfilesystem.cpp
   pyrelation.cpp
   pyresult.cpp
+  pyresult_source.cpp
   pystatement.cpp
   python_dependency.cpp
   python_import_cache.cpp

--- a/src/duckdb_py/include/duckdb_python/pyresult.hpp
+++ b/src/duckdb_py/include/duckdb_python/pyresult.hpp
@@ -8,18 +8,18 @@
 
 #pragma once
 
+#include "duckdb_python/arrow/arrow_array_stream.hpp"
 #include "duckdb_python/numpy/numpy_result_conversion.hpp"
-#include "duckdb.hpp"
-#include "duckdb/main/chunk_scan_state.hpp"
-#include "duckdb_python/pybind11/pybind_wrapper.hpp"
-#include "duckdb_python/python_objects.hpp"
 #include "duckdb_python/pybind11/dataframe.hpp"
+#include "duckdb_python/pyresult_source.hpp"
+#include "duckdb_python/python_objects.hpp"
 
 namespace duckdb {
 
 struct DuckDBPyResult {
 public:
 	explicit DuckDBPyResult(unique_ptr<QueryResult> result);
+	explicit DuckDBPyResult(unique_ptr<DuckDBPyResultSource> source);
 	~DuckDBPyResult();
 
 public:
@@ -67,19 +67,20 @@ private:
 	PandasDataFrame FrameFromNumpy(bool date_as_object, const py::handle &o);
 
 	void ConvertDateTimeTypes(PandasDataFrame &df, bool date_as_object) const;
-	unique_ptr<DataChunk> FetchNext(QueryResult &result);
-	unique_ptr<DataChunk> FetchNextRaw(QueryResult &result);
+	unique_ptr<DataChunk> FetchNext(bool raw = false);
 	unique_ptr<NumpyResultConversion> InitializeNumpyConversion(bool pandas = false);
+	const DuckDBPyResultMetadata &Metadata() const;
 
 private:
 	idx_t chunk_offset = 0;
 
-	unique_ptr<QueryResult> result;
+	unique_ptr<DuckDBPyResultSource> source;
 	unique_ptr<DataChunk> current_chunk;
 	// Holds the categories of Categorical/ENUM types
 	unordered_map<idx_t, py::list> categories;
 	// Holds the categorical type of Categorical/ENUM types
 	unordered_map<idx_t, py::object> categories_type;
+	bool row_consumption_started = false;
 	bool result_closed = false;
 };
 

--- a/src/duckdb_py/include/duckdb_python/pyresult_source.hpp
+++ b/src/duckdb_py/include/duckdb_python/pyresult_source.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/common/arrow/arrow.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb_python/pybind11/pybind_wrapper.hpp"
+
+namespace duckdb {
+
+struct DuckDBPyResultMetadata {
+	vector<string> names;
+	vector<LogicalType> types;
+	ClientProperties client_properties;
+};
+
+//! A backend-neutral source consumed by DuckDBPyResult.
+//!
+//! Local execution wraps DuckDB's QueryResult. Distributed execution exposes
+//! the runner's Arrow partition stream through the same chunk/Arrow surfaces,
+//! so Python result conversion and cursor state remain shared.
+class DuckDBPyResultSource {
+public:
+	virtual ~DuckDBPyResultSource() = default;
+
+	virtual const DuckDBPyResultMetadata &Metadata() const = 0;
+	virtual unique_ptr<DataChunk> FetchChunk(bool raw = false) = 0;
+	virtual ArrowArrayStream TakeArrowStream(idx_t rows_per_batch) = 0;
+	virtual optional_idx KnownRowCount() const = 0;
+	virtual bool IsClosed() const = 0;
+	virtual void Close() = 0;
+};
+
+unique_ptr<DuckDBPyResultSource> MakeLocalPyResultSource(unique_ptr<QueryResult> result);
+
+unique_ptr<DuckDBPyResultSource> MakeDistributedArrowPyResultSource(py::object table_iterator, vector<string> names,
+                                                                    vector<LogicalType> types,
+                                                                    const shared_ptr<ClientContext> &context);
+
+} // namespace duckdb

--- a/src/duckdb_py/include/duckdb_python/pyresult_source.hpp
+++ b/src/duckdb_py/include/duckdb_python/pyresult_source.hpp
@@ -35,8 +35,9 @@ public:
 
 unique_ptr<DuckDBPyResultSource> MakeLocalPyResultSource(unique_ptr<QueryResult> result);
 
-unique_ptr<DuckDBPyResultSource> MakeDistributedArrowPyResultSource(py::object table_iterator, vector<string> names,
-                                                                    vector<LogicalType> types,
-                                                                    const shared_ptr<ClientContext> &context);
+unique_ptr<DuckDBPyResultSource>
+MakeDistributedArrowPyResultSource(py::object table_iterator, py::object prefetched_partition,
+                                   bool has_prefetched_partition, bool iterator_exhausted, vector<string> names,
+                                   vector<LogicalType> types, const shared_ptr<ClientContext> &context);
 
 } // namespace duckdb

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -1102,18 +1102,46 @@ unique_ptr<QueryResult> DuckDBPyRelation::ExecuteInternal(bool stream_result) {
 
 void DuckDBPyRelation::ExecuteOrThrow(bool stream_result) {
 	if (ResolveRunnerType() == "ray") {
+		auto context = rel->context->GetContext();
+		auto &client_config = ClientConfig::GetConfig(*context);
+		auto result_collector = client_config.get_result_collector;
+		ScopedConfigSetting result_collector_scope(
+		    client_config, [](ClientConfig &config) { config.get_result_collector = nullptr; },
+		    [&result_collector](ClientConfig &config) { config.get_result_collector = std::move(result_collector); });
+
 		this->executed = true;
+		py::object table_iterator;
 		try {
 			auto runner = GetOrCreateRunnerForDB(rel, "ray");
 			auto py_relation = DuckDBPyRelation(rel);
 			py_relation.SetConnectionOwner(connection_owner);
 			auto py_relation_obj = py::cast(std::move(py_relation));
-			auto table_iterator = runner.attr("run_iter_tables")(py_relation_obj, py::int_(1));
+			table_iterator = py::iter(runner.attr("run_iter_tables")(py_relation_obj, py::int_(1)));
+			py::object prefetched_partition;
+			bool has_prefetched_partition = false;
+			bool iterator_exhausted = false;
+			PyObject *next_ptr = PyIter_Next(table_iterator.ptr());
+			if (next_ptr) {
+				prefetched_partition = py::reinterpret_steal<py::object>(next_ptr);
+				has_prefetched_partition = true;
+			} else if (PyErr_Occurred()) {
+				throw py::error_already_set();
+			} else {
+				iterator_exhausted = true;
+			}
 			ForgetRunnerForDB(rel);
-			result = make_uniq<DuckDBPyResult>(MakeDistributedArrowPyResultSource(std::move(table_iterator), names,
-			                                                                      types, rel->context->GetContext()));
+			result = make_uniq<DuckDBPyResult>(MakeDistributedArrowPyResultSource(
+			    std::move(table_iterator), std::move(prefetched_partition), has_prefetched_partition,
+			    iterator_exhausted, names, types, context));
 			return;
 		} catch (...) {
+			if (table_iterator && py::hasattr(table_iterator, "close")) {
+				try {
+					table_iterator.attr("close")();
+				} catch (py::error_already_set &ex) {
+					ex.discard_as_unraisable("closing distributed result iterator after startup failure");
+				}
+			}
 			ForgetRunnerForDB(rel);
 			throw;
 		}
@@ -1252,11 +1280,18 @@ PandasDataFrame DuckDBPyRelation::FetchDFChunk(idx_t vectors_per_chunk, bool dat
 		}
 		ExecuteOrThrow(true);
 	}
-	AssertResultOpen();
+	AssertResult();
 	return result->FetchDFChunk(vectors_per_chunk, date_as_object);
 }
 
+static void ValidateArrowBatchSize(idx_t batch_size) {
+	if (batch_size == 0) {
+		throw std::runtime_error("Approximate Batch Size of Record Batch MUST be higher than 0");
+	}
+}
+
 duckdb::pyarrow::Table DuckDBPyRelation::ToArrowTableInternal(idx_t batch_size, bool to_polars) {
+	ValidateArrowBatchSize(batch_size);
 	if (!result) {
 		if (!rel) {
 			return py::none();
@@ -1343,6 +1378,7 @@ PolarsDataFrame DuckDBPyRelation::ToPolars(idx_t batch_size, bool lazy) {
 }
 
 duckdb::pyarrow::RecordBatchReader DuckDBPyRelation::ToRecordBatch(idx_t batch_size) {
+	ValidateArrowBatchSize(batch_size);
 	if (!result) {
 		if (!rel) {
 			return py::none();

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -914,6 +914,53 @@ static string ResolveRunnerType() {
 	return ResolveRunnerTypeFromEnvironment();
 }
 
+static void ValidateDistributedResultType(const LogicalType &type, bool arrow_lossless_conversion) {
+	if (type.id() == LogicalTypeId::ENUM || type.id() == LogicalTypeId::AGGREGATE_STATE ||
+	    type.id() == LogicalTypeId::VARIANT) {
+		throw NotImplementedException(
+		    "Distributed execution cannot preserve result type %s through the Arrow transport", type.ToString());
+	}
+	if (!arrow_lossless_conversion && (type.id() == LogicalTypeId::HUGEINT || type.id() == LogicalTypeId::UHUGEINT ||
+	                                   type.id() == LogicalTypeId::UUID || type.id() == LogicalTypeId::BIT ||
+	                                   type.id() == LogicalTypeId::TIME_TZ || type.IsJSONType())) {
+		throw NotImplementedException(
+		    "Distributed execution cannot preserve result type %s while arrow_lossless_conversion is false",
+		    type.ToString());
+	}
+
+	switch (type.id()) {
+	case LogicalTypeId::LIST:
+		ValidateDistributedResultType(ListType::GetChildType(type), arrow_lossless_conversion);
+		break;
+	case LogicalTypeId::ARRAY:
+		ValidateDistributedResultType(ArrayType::GetChildType(type), arrow_lossless_conversion);
+		break;
+	case LogicalTypeId::MAP:
+		ValidateDistributedResultType(MapType::KeyType(type), arrow_lossless_conversion);
+		ValidateDistributedResultType(MapType::ValueType(type), arrow_lossless_conversion);
+		break;
+	case LogicalTypeId::STRUCT:
+		for (const auto &child : StructType::GetChildTypes(type)) {
+			ValidateDistributedResultType(child.second, arrow_lossless_conversion);
+		}
+		break;
+	case LogicalTypeId::UNION:
+		for (idx_t child_idx = 0; child_idx < UnionType::GetMemberCount(type); child_idx++) {
+			ValidateDistributedResultType(UnionType::GetMemberType(type, child_idx), arrow_lossless_conversion);
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+static void ValidateDistributedResultTypes(const vector<LogicalType> &types, ClientContext &context) {
+	const auto client_properties = context.GetClientProperties();
+	for (const auto &type : types) {
+		ValidateDistributedResultType(type, client_properties.arrow_lossless_conversion);
+	}
+}
+
 // ── Per-database runner instances ──────────────────────────────────────
 // Each DatabaseInstance gets its own runner (created lazily).
 // Replaces the global VANE_RUNNER_PTR singleton for write dispatch.
@@ -1103,6 +1150,7 @@ unique_ptr<QueryResult> DuckDBPyRelation::ExecuteInternal(bool stream_result) {
 void DuckDBPyRelation::ExecuteOrThrow(bool stream_result) {
 	if (ResolveRunnerType() == "ray") {
 		auto context = rel->context->GetContext();
+		ValidateDistributedResultTypes(types, *context);
 		auto &client_config = ClientConfig::GetConfig(*context);
 		auto result_collector = client_config.get_result_collector;
 		ScopedConfigSetting result_collector_scope(

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/function/pragma/pragma_functions.hpp"
 #include "duckdb/parser/statement/pragma_statement.hpp"
 #include "duckdb/common/box_renderer.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
@@ -1100,6 +1101,24 @@ unique_ptr<QueryResult> DuckDBPyRelation::ExecuteInternal(bool stream_result) {
 }
 
 void DuckDBPyRelation::ExecuteOrThrow(bool stream_result) {
+	if (ResolveRunnerType() == "ray") {
+		this->executed = true;
+		try {
+			auto runner = GetOrCreateRunnerForDB(rel, "ray");
+			auto py_relation = DuckDBPyRelation(rel);
+			py_relation.SetConnectionOwner(connection_owner);
+			auto py_relation_obj = py::cast(std::move(py_relation));
+			auto table_iterator = runner.attr("run_iter_tables")(py_relation_obj, py::int_(1));
+			ForgetRunnerForDB(rel);
+			result = make_uniq<DuckDBPyResult>(MakeDistributedArrowPyResultSource(std::move(table_iterator), names,
+			                                                                      types, rel->context->GetContext()));
+			return;
+		} catch (...) {
+			ForgetRunnerForDB(rel);
+			throw;
+		}
+	}
+
 	auto query_result = ExecuteInternal(stream_result);
 	if (!query_result) {
 		throw InternalException("ExecuteOrThrow - no query available to execute");
@@ -2316,12 +2335,28 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FlatMap(
 string DuckDBPyRelation::ToStringInternal(const BoxRendererConfig &config, bool invalidate_cache) {
 	AssertRelation();
 	if (rendered_result.empty() || invalidate_cache) {
-		BoxRenderer renderer;
+		BoxRenderer renderer(config);
 		auto limit = Limit(config.limit, 0);
-		auto res = limit->ExecuteInternal();
-
 		auto context = rel->context->GetContext();
-		rendered_result = res->ToBox(*context, config);
+		if (ResolveRunnerType() == "ray") {
+			limit->ExecuteOrThrow(true);
+			ColumnDataCollection collection(*context, types);
+			while (true) {
+				unique_ptr<DataChunk> chunk;
+				{
+					py::gil_scoped_release release;
+					chunk = limit->result->FetchChunk();
+				}
+				if (!chunk || chunk->size() == 0) {
+					break;
+				}
+				collection.Append(*chunk);
+			}
+			rendered_result = renderer.ToString(*context, names, collection);
+		} else {
+			auto res = limit->ExecuteInternal();
+			rendered_result = res->ToBox(*context, config);
+		}
 	}
 	return rendered_result;
 }
@@ -2345,55 +2380,7 @@ bool DuckDBPyRelation::TryPrintDistributed(const BoxRendererConfig &config) {
 	if (ResolveRunnerType() != "ray") {
 		return false;
 	}
-
-	auto runner = GetOrCreateRunnerForDB(rel, "ray");
-	auto limited_relation = Limit(static_cast<int64_t>(config.limit), 0);
-	auto limited_relation_obj = py::cast(std::move(limited_relation));
-	py::list tables;
-	try {
-		auto table_iter = runner.attr("run_iter_tables")(limited_relation_obj, py::int_(1));
-		for (auto table : py::reinterpret_borrow<py::iterable>(table_iter)) {
-			tables.append(table);
-		}
-	} catch (...) {
-		ForgetRunnerForDB(rel);
-		throw;
-	}
-	ForgetRunnerForDB(rel);
-
-	unique_ptr<QueryResult> result;
-	if (py::len(tables) == 0) {
-		auto empty_relation = EmptyResult(rel->context->GetContext(), types, names);
-		result = empty_relation->ExecuteInternal();
-	} else {
-		py::object arrow_table = tables[0];
-		if (py::len(tables) > 1) {
-			auto pyarrow = py::module_::import("pyarrow");
-			arrow_table = pyarrow.attr("concat_tables")(tables);
-		}
-
-		// Arrow permits duplicate field names, but DuckDB's Arrow scanner resolves
-		// fields by name. Use unique scan names and restore the relation's names in
-		// the renderer below.
-		py::list scan_names;
-		for (idx_t column_idx = 0; column_idx < names.size(); column_idx++) {
-			scan_names.append(py::str("__vane_show_column_" + std::to_string(column_idx)));
-		}
-		arrow_table = arrow_table.attr("rename_columns")(scan_names);
-
-		auto duckdb_module = py::module_::import("duckdb");
-		auto local_relation_obj = duckdb_module.attr("from_arrow")(arrow_table);
-		auto &local_relation = local_relation_obj.cast<DuckDBPyRelation &>();
-		result = local_relation.ExecuteInternal();
-	}
-
-	if (!result || result->type != QueryResultType::MATERIALIZED_RESULT) {
-		throw InternalException("Distributed show did not produce a materialized result");
-	}
-	auto &materialized = result->Cast<MaterializedQueryResult>();
-	BoxRenderer renderer(config);
-	auto context = rel->context->GetContext();
-	py::print(py::str(renderer.ToString(*context, names, materialized.Collection())));
+	py::print(py::str(ToStringInternal(config, true)));
 	return true;
 }
 

--- a/src/duckdb_py/pyresult.cpp
+++ b/src/duckdb_py/pyresult.cpp
@@ -34,8 +34,12 @@ using namespace pybind11::literals;
 
 namespace duckdb {
 
-DuckDBPyResult::DuckDBPyResult(unique_ptr<QueryResult> result_p) : result(std::move(result_p)) {
-	if (!result) {
+DuckDBPyResult::DuckDBPyResult(unique_ptr<QueryResult> result_p)
+    : DuckDBPyResult(MakeLocalPyResultSource(std::move(result_p))) {
+}
+
+DuckDBPyResult::DuckDBPyResult(unique_ptr<DuckDBPyResultSource> source_p) : source(std::move(source_p)) {
+	if (!source) {
 		throw InternalException("PyResult created without a result object");
 	}
 }
@@ -44,108 +48,70 @@ DuckDBPyResult::~DuckDBPyResult() {
 	try {
 		D_ASSERT(py::gil_check());
 		py::gil_scoped_release gil;
-		result.reset();
+		source.reset();
 		current_chunk.reset();
 	} catch (...) { // NOLINT
 	}
 }
 
+const DuckDBPyResultMetadata &DuckDBPyResult::Metadata() const {
+	if (!source) {
+		throw InvalidInputException("result closed");
+	}
+	return source->Metadata();
+}
+
 ClientProperties DuckDBPyResult::GetClientProperties() {
-	return result->client_properties;
+	return Metadata().client_properties;
 }
 
 const vector<string> &DuckDBPyResult::GetNames() {
-	if (!result) {
-		throw InternalException("Calling GetNames without a result object");
-	}
-	return result->names;
+	return Metadata().names;
 }
 
 const vector<LogicalType> &DuckDBPyResult::GetTypes() {
-	if (!result) {
-		throw InternalException("Calling GetTypes without a result object");
-	}
-	return result->types;
+	return Metadata().types;
 }
 
 unique_ptr<DataChunk> DuckDBPyResult::FetchChunk() {
-	if (!result) {
-		throw InternalException("FetchChunk called without a result object");
-	}
-	return FetchNext(*result);
+	return FetchNext();
 }
 
-unique_ptr<DataChunk> DuckDBPyResult::FetchNext(QueryResult &query_result) {
-	if (!result_closed && query_result.type == QueryResultType::STREAM_RESULT &&
-	    !query_result.Cast<StreamQueryResult>().IsOpen()) {
+unique_ptr<DataChunk> DuckDBPyResult::FetchNext(bool raw) {
+	if (!source) {
+		throw InvalidInputException("result closed");
+	}
+	row_consumption_started = true;
+	auto chunk = source->FetchChunk(raw);
+	if (!chunk || chunk->size() == 0) {
 		result_closed = true;
-		return nullptr;
-	}
-	if (query_result.type == QueryResultType::STREAM_RESULT) {
-		auto &stream_result = query_result.Cast<StreamQueryResult>();
-		StreamExecutionResult execution_result;
-		while (!StreamQueryResult::IsChunkReady(execution_result = stream_result.ExecuteTask())) {
-			{
-				PythonGILWrapper gil;
-				if (PyErr_CheckSignals() != 0) {
-					throw std::runtime_error("Query interrupted");
-				}
-			}
-			if (execution_result == StreamExecutionResult::BLOCKED) {
-				stream_result.WaitForTask();
-			}
-		}
-		if (execution_result == StreamExecutionResult::EXECUTION_CANCELLED) {
-			throw InvalidInputException("The execution of the query was cancelled before it could finish, likely "
-			                            "caused by executing a different query");
-		}
-		if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
-			stream_result.ThrowError();
-		}
-	}
-	auto chunk = query_result.Fetch();
-	if (query_result.HasError()) {
-		query_result.ThrowError();
-	}
-	return chunk;
-}
-
-unique_ptr<DataChunk> DuckDBPyResult::FetchNextRaw(QueryResult &query_result) {
-	if (!result_closed && query_result.type == QueryResultType::STREAM_RESULT &&
-	    !query_result.Cast<StreamQueryResult>().IsOpen()) {
-		result_closed = true;
-		return nullptr;
-	}
-	auto chunk = query_result.FetchRaw();
-	if (query_result.HasError()) {
-		query_result.ThrowError();
 	}
 	return chunk;
 }
 
 Optional<py::tuple> DuckDBPyResult::Fetchone() {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("result closed");
 	}
 	if (!current_chunk || chunk_offset >= current_chunk->size()) {
 		py::gil_scoped_release release;
-		current_chunk = FetchNext(*result);
+		current_chunk = FetchNext();
 		chunk_offset = 0;
 	}
 
 	if (!current_chunk || current_chunk->size() == 0) {
 		return py::none();
 	}
-	py::tuple res(result->types.size());
+	auto &metadata = Metadata();
+	py::tuple res(metadata.types.size());
 
-	for (idx_t col_idx = 0; col_idx < result->types.size(); col_idx++) {
-		auto &mask = FlatVector::Validity(current_chunk->data[col_idx]);
-		if (!mask.RowIsValid(chunk_offset)) {
+	for (idx_t col_idx = 0; col_idx < metadata.types.size(); col_idx++) {
+		auto val = current_chunk->data[col_idx].GetValue(chunk_offset);
+		if (val.IsNull()) {
 			res[col_idx] = py::none();
 			continue;
 		}
-		auto val = current_chunk->data[col_idx].GetValue(chunk_offset);
-		res[col_idx] = PythonObject::FromValue(val, result->types[col_idx], result->client_properties);
+		res[col_idx] = PythonObject::FromValue(val, metadata.types[col_idx], metadata.client_properties);
 	}
 	chunk_offset++;
 	return res;
@@ -180,7 +146,7 @@ py::dict DuckDBPyResult::FetchNumpy() {
 }
 
 void DuckDBPyResult::FillNumpy(py::dict &res, idx_t col_idx, NumpyResultConversion &conversion, const char *name) {
-	if (result->types[col_idx].id() == LogicalTypeId::ENUM) {
+	if (Metadata().types[col_idx].id() == LogicalTypeId::ENUM) {
 		auto &import_cache = *DuckDBPyConnection::ImportCache();
 		auto pandas_categorical = import_cache.pandas.Categorical();
 		auto categorical_dtype = import_cache.pandas.CategoricalDtype();
@@ -204,9 +170,9 @@ void DuckDBPyResult::FillNumpy(py::dict &res, idx_t col_idx, NumpyResultConversi
 	}
 }
 
-void InsertCategory(QueryResult &result, unordered_map<idx_t, py::list> &categories) {
-	for (idx_t col_idx = 0; col_idx < result.types.size(); col_idx++) {
-		auto &type = result.types[col_idx];
+static void InsertCategory(const vector<LogicalType> &types, unordered_map<idx_t, py::list> &categories) {
+	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
+		auto &type = types[col_idx];
 		if (type.id() == LogicalTypeId::ENUM) {
 			// It's an ENUM type, in addition to converting the codes we must convert the categories
 			if (categories.find(col_idx) == categories.end()) {
@@ -221,25 +187,25 @@ void InsertCategory(QueryResult &result, unordered_map<idx_t, py::list> &categor
 }
 
 unique_ptr<NumpyResultConversion> DuckDBPyResult::InitializeNumpyConversion(bool pandas) {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("result closed");
 	}
 
 	idx_t initial_capacity = STANDARD_VECTOR_SIZE * 2ULL;
-	if (result->type == QueryResultType::MATERIALIZED_RESULT) {
-		// materialized query result: we know exactly how much space we need
-		auto &materialized = result->Cast<MaterializedQueryResult>();
-		initial_capacity = materialized.RowCount();
+	auto known_row_count = source->KnownRowCount();
+	if (known_row_count.IsValid()) {
+		initial_capacity = known_row_count.GetIndex();
 	}
 
+	auto &metadata = Metadata();
 	auto conversion =
-	    make_uniq<NumpyResultConversion>(result->types, initial_capacity, result->client_properties, pandas);
+	    make_uniq<NumpyResultConversion>(metadata.types, initial_capacity, metadata.client_properties, pandas);
 	return conversion;
 }
 
 py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk,
                                             unique_ptr<NumpyResultConversion> conversion_p) {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("result closed");
 	}
 	if (!conversion_p) {
@@ -247,44 +213,39 @@ py::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 	}
 	auto &conversion = *conversion_p;
 
-	if (result->type == QueryResultType::MATERIALIZED_RESULT) {
-		auto &materialized = result->Cast<MaterializedQueryResult>();
-		for (auto &chunk : materialized.Collection().Chunks()) {
-			conversion.Append(chunk);
-		}
-		InsertCategory(materialized, categories);
-		materialized.Collection().Reset();
-	} else {
-		D_ASSERT(result->type == QueryResultType::STREAM_RESULT);
-		if (!stream) {
-			vectors_per_chunk = NumericLimits<idx_t>::Maximum();
-		}
-		auto &stream_result = result->Cast<StreamQueryResult>();
-		for (idx_t count_vec = 0; count_vec < vectors_per_chunk; count_vec++) {
-			if (!stream_result.IsOpen()) {
-				break;
-			}
-			unique_ptr<DataChunk> chunk;
-			{
-				D_ASSERT(py::gil_check());
-				py::gil_scoped_release release;
-				chunk = FetchNextRaw(stream_result);
-			}
-			if (!chunk || chunk->size() == 0) {
-				//! finished
-				break;
-			}
-			conversion.Append(*chunk);
-			InsertCategory(stream_result, categories);
-		}
+	if (!stream) {
+		vectors_per_chunk = NumericLimits<idx_t>::Maximum();
 	}
+
+	idx_t count_vec = 0;
+	if (current_chunk && chunk_offset < current_chunk->size() && count_vec < vectors_per_chunk) {
+		current_chunk->Slice(chunk_offset, current_chunk->size() - chunk_offset);
+		conversion.Append(*current_chunk);
+		current_chunk.reset();
+		chunk_offset = 0;
+		count_vec++;
+	}
+	for (; count_vec < vectors_per_chunk; count_vec++) {
+		unique_ptr<DataChunk> chunk;
+		{
+			D_ASSERT(py::gil_check());
+			py::gil_scoped_release release;
+			chunk = FetchNext(true);
+		}
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		conversion.Append(*chunk);
+	}
+	InsertCategory(Metadata().types, categories);
 
 	// now that we have materialized the result in contiguous arrays, construct the actual NumPy arrays or categorical
 	// types
 	py::dict res;
-	auto names = result->names;
+	auto &metadata = Metadata();
+	auto names = metadata.names;
 	QueryResult::DeduplicateColumns(names);
-	for (idx_t col_idx = 0; col_idx < result->names.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < metadata.names.size(); col_idx++) {
 		auto &name = names[col_idx];
 		FillNumpy(res, col_idx, conversion, name.c_str());
 	}
@@ -299,16 +260,17 @@ static void ReplaceDFColumn(PandasDataFrame &df, const char *col_name, idx_t idx
 // TODO: unify these with an enum/flag to indicate which conversions to do
 void DuckDBPyResult::ConvertDateTimeTypes(PandasDataFrame &df, bool date_as_object) const {
 	auto names = df.attr("columns").cast<vector<string>>();
+	auto &metadata = Metadata();
 
-	for (idx_t i = 0; i < result->ColumnCount(); i++) {
+	for (idx_t i = 0; i < metadata.types.size(); i++) {
 		auto column = df.attr("__getitem__")(names[i].c_str());
-		if (result->types[i] == LogicalType::TIMESTAMP_TZ) {
+		if (metadata.types[i] == LogicalType::TIMESTAMP_TZ) {
 			// first localize to UTC then convert to timezone_config
 			auto utc_local = column.attr("dt").attr("tz_localize")("UTC");
-			auto new_value = utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone);
+			auto new_value = utc_local.attr("dt").attr("tz_convert")(metadata.client_properties.time_zone);
 			// We need to create the column anew because the exact dt changed to a new timezone
 			ReplaceDFColumn(df, names[i].c_str(), i, new_value);
-		} else if (date_as_object && result->types[i] == LogicalType::DATE) {
+		} else if (date_as_object && metadata.types[i] == LogicalType::DATE) {
 			// Convert through numpy datetime64[D] to avoid pandas accessor lifetime issues on pandas>=3
 			auto numpy_dates = column.attr("to_numpy")("dtype"_a = "datetime64[D]");
 			auto new_value = numpy_dates.attr("astype")("object");
@@ -392,7 +354,7 @@ PandasDataFrame DuckDBPyResult::FrameFromNumpy(bool date_as_object, const py::ha
 	ConvertDateTimeTypes(df, date_as_object);
 
 	auto names = df.attr("columns").cast<vector<string>>();
-	D_ASSERT(result->ColumnCount() == names.size());
+	D_ASSERT(Metadata().types.size() == names.size());
 	return df;
 }
 
@@ -425,160 +387,52 @@ py::dict DuckDBPyResult::FetchTF() {
 }
 
 duckdb::pyarrow::Table DuckDBPyResult::FetchArrowTable(idx_t rows_per_batch, bool to_polars) {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("There is no query result");
 	}
-	auto names = result->names;
+	auto names = Metadata().names;
 	if (to_polars) {
 		QueryResult::DeduplicateColumns(names);
 	}
 
-	if (!result) {
-		throw InvalidInputException("result closed");
+	auto reader = FetchRecordBatchReader(rows_per_batch);
+	py::object arrow_table = reader.attr("read_all")();
+	if (to_polars) {
+		arrow_table = arrow_table.attr("rename_columns")(names);
 	}
-	auto pyarrow_lib_module = py::module::import("pyarrow").attr("lib");
-
-	py::list batches;
-	if (result->type == QueryResultType::ARROW_RESULT) {
-		auto &arrow_result = result->Cast<ArrowQueryResult>();
-		auto arrays = arrow_result.ConsumeArrays();
-		for (auto &array : arrays) {
-			ArrowSchema arrow_schema;
-			auto result_names = arrow_result.names;
-			if (to_polars) {
-				QueryResult::DeduplicateColumns(result_names);
-			}
-			ArrowArray data = array->arrow_array;
-			array->arrow_array.release = nullptr;
-			ArrowConverter::ToArrowSchema(&arrow_schema, arrow_result.types, result_names,
-			                              arrow_result.client_properties);
-			TransformDuckToArrowChunk(arrow_schema, data, batches);
-		}
-	} else {
-		QueryResultChunkScanState scan_state(*result.get());
-		while (true) {
-			ArrowArray data;
-			idx_t count;
-			auto &query_result = *result.get();
-			{
-				D_ASSERT(py::gil_check());
-				py::gil_scoped_release release;
-				count = ArrowUtil::FetchChunk(scan_state, query_result.client_properties, rows_per_batch, &data,
-				                              ArrowTypeExtensionData::GetExtensionTypes(
-				                                  *query_result.client_properties.client_context, query_result.types));
-			}
-			if (count == 0) {
-				break;
-			}
-			ArrowSchema arrow_schema;
-			auto result_names = query_result.names;
-			if (to_polars) {
-				QueryResult::DeduplicateColumns(result_names);
-			}
-			ArrowConverter::ToArrowSchema(&arrow_schema, query_result.types, result_names,
-			                              query_result.client_properties);
-			TransformDuckToArrowChunk(arrow_schema, data, batches);
-		}
-	}
-
-	return pyarrow::ToArrowTable(result->types, names, std::move(batches), result->client_properties);
+	return py::cast<duckdb::pyarrow::Table>(arrow_table);
 }
 
 ArrowArrayStream DuckDBPyResult::FetchArrowArrayStream(idx_t rows_per_batch) {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("There is no query result");
 	}
-	ResultArrowArrayStreamWrapper *result_stream = new ResultArrowArrayStreamWrapper(std::move(result), rows_per_batch);
-	// The 'result_stream' is part of the 'private_data' of the ArrowArrayStream and its lifetime is bound to that of
-	// the ArrowArrayStream.
-	return result_stream->stream;
+	if (row_consumption_started || current_chunk) {
+		throw InvalidInputException("Cannot switch a partially consumed row result to an Arrow stream");
+	}
+	auto stream = source->TakeArrowStream(rows_per_batch);
+	source.reset();
+	return stream;
 }
 
 duckdb::pyarrow::RecordBatchReader DuckDBPyResult::FetchRecordBatchReader(idx_t rows_per_batch) {
-	if (!result) {
+	if (!source) {
 		throw InvalidInputException("There is no query result");
 	}
 	PythonGILWrapper acquire;
 	auto pyarrow_lib_module = py::module::import("pyarrow").attr("lib");
 	auto record_batch_reader_func = pyarrow_lib_module.attr("RecordBatchReader").attr("_import_from_c");
 	auto stream = FetchArrowArrayStream(rows_per_batch);
-	py::object record_batch_reader = record_batch_reader_func((uint64_t)&stream); // NOLINT
-	return py::cast<duckdb::pyarrow::RecordBatchReader>(record_batch_reader);
+	try {
+		py::object record_batch_reader = record_batch_reader_func((uint64_t)&stream); // NOLINT
+		return py::cast<duckdb::pyarrow::RecordBatchReader>(record_batch_reader);
+	} catch (...) {
+		if (stream.release) {
+			stream.release(&stream);
+		}
+		throw;
+	}
 }
-
-// Wraps pre-built Arrow arrays from an ArrowQueryResult into an ArrowArrayStream.
-// This avoids the double-materialization that happens when using ResultArrowArrayStreamWrapper
-// with an ArrowQueryResult (which throws NotImplementedException from FetchInternal).
-struct ArrowQueryResultStreamWrapper {
-	ArrowQueryResultStreamWrapper(unique_ptr<QueryResult> result_p) : result(std::move(result_p)), index(0) {
-		auto &arrow_result = result->Cast<ArrowQueryResult>();
-		arrays = arrow_result.ConsumeArrays();
-		types = result->types;
-		names = result->names;
-		client_properties = result->client_properties;
-
-		stream.private_data = this;
-		stream.get_schema = GetSchema;
-		stream.get_next = GetNext;
-		stream.release = Release;
-		stream.get_last_error = GetLastError;
-	}
-
-	static int GetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
-		if (!stream->release) {
-			return -1;
-		}
-		auto self = reinterpret_cast<ArrowQueryResultStreamWrapper *>(stream->private_data);
-		out->release = nullptr;
-		try {
-			ArrowConverter::ToArrowSchema(out, self->types, self->names, self->client_properties);
-		} catch (std::runtime_error &e) {
-			self->last_error = e.what();
-			return -1;
-		}
-		return 0;
-	}
-
-	static int GetNext(ArrowArrayStream *stream, ArrowArray *out) {
-		if (!stream->release) {
-			return -1;
-		}
-		auto self = reinterpret_cast<ArrowQueryResultStreamWrapper *>(stream->private_data);
-		if (self->index >= self->arrays.size()) {
-			out->release = nullptr;
-			return 0;
-		}
-		*out = self->arrays[self->index]->arrow_array;
-		self->arrays[self->index]->arrow_array.release = nullptr;
-		self->index++;
-		return 0;
-	}
-
-	static void Release(ArrowArrayStream *stream) {
-		if (!stream || !stream->release) {
-			return;
-		}
-		stream->release = nullptr;
-		delete reinterpret_cast<ArrowQueryResultStreamWrapper *>(stream->private_data);
-	}
-
-	static const char *GetLastError(ArrowArrayStream *stream) {
-		if (!stream->release) {
-			return "stream was released";
-		}
-		auto self = reinterpret_cast<ArrowQueryResultStreamWrapper *>(stream->private_data);
-		return self->last_error.c_str();
-	}
-
-	ArrowArrayStream stream;
-	unique_ptr<QueryResult> result;
-	vector<unique_ptr<ArrowArrayWrapper>> arrays;
-	vector<LogicalType> types;
-	vector<string> names;
-	ClientProperties client_properties;
-	idx_t index;
-	string last_error;
-};
 
 // Destructor for capsules that own a heap-allocated ArrowArrayStream (slow path).
 static void ArrowArrayStreamPyCapsuleDestructor(PyObject *object) {
@@ -594,18 +448,6 @@ static void ArrowArrayStreamPyCapsuleDestructor(PyObject *object) {
 }
 
 py::object DuckDBPyResult::FetchArrowCapsule(idx_t rows_per_batch) {
-	if (result && result->type == QueryResultType::ARROW_RESULT) {
-		// Fast path: yield pre-built Arrow arrays directly.
-		// The wrapper is heap-allocated; Release() deletes it via private_data.
-		// We heap-allocate a separate ArrowArrayStream for the capsule so that the capsule
-		// holds a stable pointer even after the wrapper is consumed and deleted by a scan.
-		auto wrapper = new ArrowQueryResultStreamWrapper(std::move(result));
-		auto stream = new ArrowArrayStream();
-		*stream = wrapper->stream;
-		wrapper->stream.release = nullptr;
-		return py::capsule(stream, "arrow_array_stream", ArrowArrayStreamPyCapsuleDestructor);
-	}
-	// Existing slow path for MaterializedQueryResult / StreamQueryResult
 	auto stream_p = FetchArrowArrayStream(rows_per_batch);
 	auto stream = new ArrowArrayStream();
 	*stream = stream_p;
@@ -624,7 +466,12 @@ py::list DuckDBPyResult::GetDescription(const vector<string> &names, const vecto
 }
 
 void DuckDBPyResult::Close() {
-	result = nullptr;
+	current_chunk.reset();
+	chunk_offset = 0;
+	if (source) {
+		source->Close();
+		source.reset();
+	}
 }
 
 bool DuckDBPyResult::IsClosed() const {

--- a/src/duckdb_py/pyresult.cpp
+++ b/src/duckdb_py/pyresult.cpp
@@ -410,6 +410,9 @@ ArrowArrayStream DuckDBPyResult::FetchArrowArrayStream(idx_t rows_per_batch) {
 	if (row_consumption_started || current_chunk) {
 		throw InvalidInputException("Cannot switch a partially consumed row result to an Arrow stream");
 	}
+	if (rows_per_batch == 0) {
+		throw std::runtime_error("Approximate Batch Size of Record Batch MUST be higher than 0");
+	}
 	auto stream = source->TakeArrowStream(rows_per_batch);
 	source.reset();
 	return stream;
@@ -448,10 +451,19 @@ static void ArrowArrayStreamPyCapsuleDestructor(PyObject *object) {
 }
 
 py::object DuckDBPyResult::FetchArrowCapsule(idx_t rows_per_batch) {
-	auto stream_p = FetchArrowArrayStream(rows_per_batch);
-	auto stream = new ArrowArrayStream();
-	*stream = stream_p;
-	return py::capsule(stream, "arrow_array_stream", ArrowArrayStreamPyCapsuleDestructor);
+	auto stream = make_uniq<ArrowArrayStream>();
+	stream->release = nullptr;
+	*stream = FetchArrowArrayStream(rows_per_batch);
+	try {
+		auto capsule = py::capsule(stream.get(), "arrow_array_stream", ArrowArrayStreamPyCapsuleDestructor);
+		stream.release();
+		return capsule;
+	} catch (...) {
+		if (stream->release) {
+			stream->release(stream.get());
+		}
+		throw;
+	}
 }
 
 py::list DuckDBPyResult::GetDescription(const vector<string> &names, const vector<LogicalType> &types) {

--- a/src/duckdb_py/pyresult.cpp
+++ b/src/duckdb_py/pyresult.cpp
@@ -81,12 +81,12 @@ unique_ptr<DataChunk> DuckDBPyResult::FetchNext(bool raw) {
 	if (!source) {
 		throw InvalidInputException("result closed");
 	}
-	row_consumption_started = true;
-	auto chunk = source->FetchChunk(raw);
-	if (!chunk || chunk->size() == 0) {
+	if (source->IsClosed()) {
 		result_closed = true;
+		return nullptr;
 	}
-	return chunk;
+	row_consumption_started = true;
+	return source->FetchChunk(raw);
 }
 
 Optional<py::tuple> DuckDBPyResult::Fetchone() {

--- a/src/duckdb_py/pyresult_source.cpp
+++ b/src/duckdb_py/pyresult_source.cpp
@@ -1,0 +1,581 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT AND Apache-2.0
+
+#include "duckdb_python/pyresult_source.hpp"
+
+#include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/arrow_query_result.hpp"
+#include "duckdb/common/arrow/arrow_wrapper.hpp"
+#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
+#include "duckdb/common/enums/stream_execution_result.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/stream_query_result.hpp"
+#include "duckdb_python/pybind11/gil_wrapper.hpp"
+#include "ray/safe_pyobject.hpp"
+
+namespace duckdb {
+
+using distributed::python::ray::SafePyObject;
+
+namespace {
+
+class LocalQueryResultSource : public DuckDBPyResultSource {
+public:
+	explicit LocalQueryResultSource(unique_ptr<QueryResult> result_p) : result(std::move(result_p)) {
+		if (!result) {
+			throw InternalException("LocalQueryResultSource created without a result");
+		}
+		metadata.names = result->names;
+		metadata.types = result->types;
+		metadata.client_properties = result->client_properties;
+	}
+
+	const DuckDBPyResultMetadata &Metadata() const override {
+		return metadata;
+	}
+
+	unique_ptr<DataChunk> FetchChunk(bool raw) override {
+		if (!result) {
+			throw InvalidInputException("result closed");
+		}
+		if (closed) {
+			return nullptr;
+		}
+		if (!closed && result->type == QueryResultType::STREAM_RESULT && !result->Cast<StreamQueryResult>().IsOpen()) {
+			closed = true;
+			return nullptr;
+		}
+
+		if (!raw && result->type == QueryResultType::STREAM_RESULT) {
+			auto &stream_result = result->Cast<StreamQueryResult>();
+			StreamExecutionResult execution_result;
+			while (!StreamQueryResult::IsChunkReady(execution_result = stream_result.ExecuteTask())) {
+				{
+					PythonGILWrapper gil;
+					if (PyErr_CheckSignals() != 0) {
+						throw std::runtime_error("Query interrupted");
+					}
+				}
+				if (execution_result == StreamExecutionResult::BLOCKED) {
+					stream_result.WaitForTask();
+				}
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_CANCELLED) {
+				throw InvalidInputException("The execution of the query was cancelled before it could finish, likely "
+				                            "caused by executing a different query");
+			}
+			if (execution_result == StreamExecutionResult::EXECUTION_ERROR) {
+				stream_result.ThrowError();
+			}
+		}
+
+		auto chunk = raw ? result->FetchRaw() : result->Fetch();
+		if (result->HasError()) {
+			result->ThrowError();
+		}
+		if (!chunk || chunk->size() == 0) {
+			closed = true;
+		}
+		return chunk;
+	}
+
+	ArrowArrayStream TakeArrowStream(idx_t rows_per_batch) override;
+
+	optional_idx KnownRowCount() const override {
+		if (result && result->type == QueryResultType::MATERIALIZED_RESULT) {
+			return result->Cast<MaterializedQueryResult>().RowCount();
+		}
+		return optional_idx();
+	}
+
+	bool IsClosed() const override {
+		return closed || !result;
+	}
+
+	void Close() override {
+		if (result && result->type == QueryResultType::STREAM_RESULT) {
+			result->Cast<StreamQueryResult>().Close();
+		}
+		result.reset();
+		closed = true;
+	}
+
+private:
+	DuckDBPyResultMetadata metadata;
+	unique_ptr<QueryResult> result;
+	bool closed = false;
+};
+
+//! ArrowQueryResult stores already-exported arrays and cannot be consumed via
+//! QueryResult::Fetch(). This owner exposes those arrays as an Arrow C stream.
+struct ArrowQueryResultStreamOwner {
+	explicit ArrowQueryResultStreamOwner(unique_ptr<QueryResult> result_p) : result(std::move(result_p)) {
+		auto &arrow_result = result->Cast<ArrowQueryResult>();
+		arrays = arrow_result.ConsumeArrays();
+		types = result->types;
+		names = result->names;
+		client_properties = result->client_properties;
+
+		stream.private_data = this;
+		stream.get_schema = GetSchema;
+		stream.get_next = GetNext;
+		stream.release = Release;
+		stream.get_last_error = GetLastError;
+	}
+
+	static int GetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
+		if (!stream || !stream->release) {
+			return -1;
+		}
+		auto self = reinterpret_cast<ArrowQueryResultStreamOwner *>(stream->private_data);
+		out->release = nullptr;
+		try {
+			ArrowConverter::ToArrowSchema(out, self->types, self->names, self->client_properties);
+			return 0;
+		} catch (std::exception &ex) {
+			self->last_error = ex.what();
+			return -1;
+		}
+	}
+
+	static int GetNext(ArrowArrayStream *stream, ArrowArray *out) {
+		if (!stream || !stream->release) {
+			return -1;
+		}
+		auto self = reinterpret_cast<ArrowQueryResultStreamOwner *>(stream->private_data);
+		if (self->index >= self->arrays.size()) {
+			out->release = nullptr;
+			return 0;
+		}
+		*out = self->arrays[self->index]->arrow_array;
+		self->arrays[self->index]->arrow_array.release = nullptr;
+		self->index++;
+		return 0;
+	}
+
+	static void Release(ArrowArrayStream *stream) {
+		if (!stream || !stream->release) {
+			return;
+		}
+		stream->release = nullptr;
+		delete reinterpret_cast<ArrowQueryResultStreamOwner *>(stream->private_data);
+	}
+
+	static const char *GetLastError(ArrowArrayStream *stream) {
+		if (!stream || !stream->release) {
+			return "stream was released";
+		}
+		auto self = reinterpret_cast<ArrowQueryResultStreamOwner *>(stream->private_data);
+		return self->last_error.c_str();
+	}
+
+	ArrowArrayStream stream;
+	unique_ptr<QueryResult> result;
+	vector<unique_ptr<ArrowArrayWrapper>> arrays;
+	vector<LogicalType> types;
+	vector<string> names;
+	ClientProperties client_properties;
+	idx_t index = 0;
+	string last_error;
+};
+
+ArrowArrayStream LocalQueryResultSource::TakeArrowStream(idx_t rows_per_batch) {
+	if (!result) {
+		throw InvalidInputException("result closed");
+	}
+	closed = true;
+	if (result->type == QueryResultType::ARROW_RESULT) {
+		auto owner = new ArrowQueryResultStreamOwner(std::move(result));
+		return owner->stream;
+	}
+	auto owner = new ResultArrowArrayStreamWrapper(std::move(result), rows_per_batch);
+	return owner->stream;
+}
+
+static bool ResultPythonRuntimeUsable() {
+	return distributed::python::ray::SafePyObjectCanDecRef();
+}
+
+//! Flattens the iterator of pyarrow.Table partitions into one Arrow C stream.
+//! The external schema is derived from the relation rather than partition
+//! field names (distributed partitions currently use positional c0/c1 names).
+struct DistributedArrowStreamOwner {
+	DistributedArrowStreamOwner(py::object iterator_p, vector<string> names_p, vector<LogicalType> types_p,
+	                            const shared_ptr<ClientContext> &context_p, idx_t rows_per_batch_p)
+	    : iterator(SafePyObject(py::iter(iterator_p))), names(std::move(names_p)), types(std::move(types_p)),
+	      context(context_p), client_properties(context_p->GetClientProperties()), rows_per_batch(rows_per_batch_p) {
+		stream.private_data = this;
+		stream.get_schema = GetSchema;
+		stream.get_next = GetNext;
+		stream.release = Release;
+		stream.get_last_error = GetLastError;
+	}
+
+	~DistributedArrowStreamOwner() {
+		Close();
+	}
+
+	static int GetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
+		if (!stream || !stream->release) {
+			return -1;
+		}
+		auto self = reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
+		out->release = nullptr;
+		try {
+			ArrowConverter::ToArrowSchema(out, self->types, self->names, self->client_properties);
+			return 0;
+		} catch (std::exception &ex) {
+			self->last_error = ex.what();
+			return -1;
+		}
+	}
+
+	static int GetNext(ArrowArrayStream *stream, ArrowArray *out) {
+		if (!stream || !stream->release) {
+			return -1;
+		}
+		auto self = reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
+		out->release = nullptr;
+		try {
+			return self->Next(out);
+		} catch (py::error_already_set &ex) {
+			self->last_error = ex.what();
+			return -1;
+		} catch (std::exception &ex) {
+			self->last_error = ex.what();
+			return -1;
+		} catch (...) {
+			self->last_error = "unknown distributed result stream error";
+			return -1;
+		}
+	}
+
+	static void Release(ArrowArrayStream *stream) {
+		if (!stream || !stream->release) {
+			return;
+		}
+		stream->release = nullptr;
+		delete reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
+	}
+
+	static const char *GetLastError(ArrowArrayStream *stream) {
+		if (!stream || !stream->release) {
+			return "stream was released";
+		}
+		auto self = reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
+		return self->last_error.c_str();
+	}
+
+	int Next(ArrowArray *out) {
+		while (true) {
+			if (current_stream.release) {
+				PythonGILWrapper gil;
+				if (current_stream.get_next(&current_stream, out)) {
+					auto error = current_stream.get_last_error ? current_stream.get_last_error(&current_stream)
+					                                           : "unknown Arrow stream error";
+					throw InvalidInputException("Distributed result Arrow stream failed: %s", error);
+				}
+				if (out->release) {
+					return 0;
+				}
+				current_stream.release(&current_stream);
+			}
+
+			if (exhausted) {
+				out->release = nullptr;
+				return 0;
+			}
+			OpenNextPartition();
+		}
+	}
+
+	void OpenNextPartition() {
+		PythonGILWrapper gil;
+		auto iterator_obj = iterator.get();
+		PyObject *next_ptr = PyIter_Next(iterator_obj.ptr());
+		if (!next_ptr) {
+			if (PyErr_Occurred()) {
+				throw py::error_already_set();
+			}
+			exhausted = true;
+			return;
+		}
+
+		auto table = NormalizeTable(py::reinterpret_steal<py::object>(next_ptr));
+		py::object arrow_source = table;
+		if (rows_per_batch > 0 && py::hasattr(table, "to_reader")) {
+			arrow_source = table.attr("to_reader")(py::arg("max_chunksize") = rows_per_batch);
+		}
+		auto capsule_obj = arrow_source.attr("__arrow_c_stream__")();
+		auto capsule = py::reinterpret_borrow<py::capsule>(capsule_obj);
+		auto exported_stream = capsule.get_pointer<ArrowArrayStream>();
+		if (!exported_stream || !exported_stream->release) {
+			throw InvalidInputException("Distributed result returned a released Arrow stream");
+		}
+		current_stream = *exported_stream;
+		exported_stream->release = nullptr;
+
+		ArrowSchema actual_schema;
+		actual_schema.release = nullptr;
+		if (current_stream.get_schema(&current_stream, &actual_schema)) {
+			auto error = current_stream.get_last_error ? current_stream.get_last_error(&current_stream)
+			                                           : "unknown Arrow schema error";
+			throw InvalidInputException("Failed to read distributed result schema: %s", error);
+		}
+		if (!actual_schema.release) {
+			throw InvalidInputException("Distributed result returned a released Arrow schema");
+		}
+		try {
+			ArrowTableSchema actual;
+			ArrowTableFunction::PopulateArrowTableSchema(*context, actual, actual_schema);
+			auto actual_types = actual.GetTypes();
+			if (actual_types.size() != types.size()) {
+				throw InvalidInputException("Distributed result partition %d has %d columns, expected %d",
+				                            partition_index, actual_types.size(), types.size());
+			}
+			for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
+				if (actual_types[col_idx] != types[col_idx]) {
+					throw InvalidInputException("Distributed result partition %d column %d has type %s, expected %s",
+					                            partition_index, col_idx, actual_types[col_idx].ToString(),
+					                            types[col_idx].ToString());
+				}
+			}
+		} catch (...) {
+			actual_schema.release(&actual_schema);
+			throw;
+		}
+		actual_schema.release(&actual_schema);
+		partition_index++;
+	}
+
+	py::object NormalizeTable(py::object table) {
+		auto column_count = py::cast<idx_t>(table.attr("num_columns"));
+		if (column_count != types.size()) {
+			throw InvalidInputException("Distributed result partition %d has %d columns, expected %d", partition_index,
+			                            column_count, types.size());
+		}
+
+		ArrowSchema expected_arrow_schema;
+		expected_arrow_schema.release = nullptr;
+		ArrowConverter::ToArrowSchema(&expected_arrow_schema, types, names, client_properties);
+		py::object schema;
+		try {
+			auto pyarrow_lib = py::module_::import("pyarrow").attr("lib");
+			schema = pyarrow_lib.attr("Schema").attr("_import_from_c")((uint64_t)&expected_arrow_schema); // NOLINT
+		} catch (...) {
+			if (expected_arrow_schema.release) {
+				expected_arrow_schema.release(&expected_arrow_schema);
+			}
+			throw;
+		}
+		py::list columns;
+		for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
+			auto column = table.attr("column")(col_idx);
+			py::object expected_type = schema.attr("field")(col_idx).attr("type");
+			if (!py::cast<bool>(column.attr("type").attr("equals")(expected_type))) {
+				try {
+					column = column.attr("cast")(expected_type, py::arg("safe") = true);
+				} catch (py::error_already_set &ex) {
+					throw InvalidInputException(
+					    "Distributed result partition %d column %d cannot be safely cast to %s: %s", partition_index,
+					    col_idx, types[col_idx].ToString(), ex.what());
+				}
+			}
+			columns.append(column);
+		}
+		return py::module_::import("pyarrow").attr("Table").attr("from_arrays")(columns, py::arg("schema") = schema);
+	}
+
+	void Close() {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		if (current_stream.release) {
+			if (ResultPythonRuntimeUsable()) {
+				PythonGILWrapper gil;
+				current_stream.release(&current_stream);
+			} else {
+				current_stream.release = nullptr;
+			}
+		}
+		if (!iterator.empty() && ResultPythonRuntimeUsable()) {
+			PythonGILWrapper gil;
+			auto iterator_obj = iterator.get();
+			try {
+				if (py::hasattr(iterator_obj, "close")) {
+					iterator_obj.attr("close")();
+				}
+			} catch (py::error_already_set &ex) {
+				ex.discard_as_unraisable("closing distributed result stream");
+			}
+		}
+		iterator.reset_with_gil();
+	}
+
+	ArrowArrayStream stream;
+	SafePyObject iterator;
+	vector<string> names;
+	vector<LogicalType> types;
+	shared_ptr<ClientContext> context;
+	ClientProperties client_properties;
+	idx_t rows_per_batch;
+	ArrowArrayStream current_stream {};
+	idx_t partition_index = 0;
+	bool exhausted = false;
+	bool closed = false;
+	string last_error;
+};
+
+class DistributedArrowResultSource : public DuckDBPyResultSource {
+public:
+	DistributedArrowResultSource(py::object table_iterator, vector<string> names, vector<LogicalType> types,
+	                             const shared_ptr<ClientContext> &context_p)
+	    : iterator(SafePyObject(std::move(table_iterator))), context(context_p) {
+		if (!context) {
+			throw InternalException("DistributedArrowResultSource created without a context");
+		}
+		metadata.names = std::move(names);
+		metadata.types = std::move(types);
+		metadata.client_properties = context->GetClientProperties();
+	}
+
+	~DistributedArrowResultSource() override {
+		Close();
+	}
+
+	const DuckDBPyResultMetadata &Metadata() const override {
+		return metadata;
+	}
+
+	unique_ptr<DataChunk> FetchChunk(bool raw) override {
+		(void)raw;
+		EnsureStream(STANDARD_VECTOR_SIZE);
+		if (closed) {
+			return nullptr;
+		}
+
+		while (!current_scan ||
+		       current_scan->chunk_offset >= NumericCast<idx_t>(current_scan->chunk->arrow_array.length)) {
+			current_scan.reset();
+			auto array = stream->GetNextChunk();
+			if (!array || !array->arrow_array.release) {
+				stream.reset();
+				closed = true;
+				return nullptr;
+			}
+			if (array->arrow_array.length == 0) {
+				continue;
+			}
+			auto owned_array = make_uniq<ArrowArrayWrapper>();
+			owned_array->arrow_array = array->arrow_array;
+			array->arrow_array.release = nullptr;
+			current_scan = make_uniq<ArrowScanLocalState>(std::move(owned_array), *context);
+			for (idx_t col_idx = 0; col_idx < metadata.types.size(); col_idx++) {
+				current_scan->column_ids.push_back(col_idx);
+			}
+		}
+
+		auto remaining = NumericCast<idx_t>(current_scan->chunk->arrow_array.length) - current_scan->chunk_offset;
+		auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, remaining);
+		auto output = make_uniq<DataChunk>();
+		output->Initialize(*context, metadata.types, count);
+		output->SetCardinality(count);
+		ArrowTableFunction::ArrowToDuckDB(*current_scan, arrow_table.GetColumns(), *output, false);
+		current_scan->chunk_offset += output->size();
+		output->Verify();
+		chunk_consumption_started = true;
+		return output;
+	}
+
+	ArrowArrayStream TakeArrowStream(idx_t rows_per_batch) override {
+		if (chunk_consumption_started || current_scan) {
+			throw InvalidInputException("Cannot switch a partially consumed distributed row result to an Arrow stream");
+		}
+		EnsureStream(rows_per_batch);
+		if (!stream) {
+			throw InvalidInputException("result closed");
+		}
+		auto result = stream->arrow_array_stream;
+		stream->arrow_array_stream.release = nullptr;
+		stream.reset();
+		closed = true;
+		return result;
+	}
+
+	optional_idx KnownRowCount() const override {
+		return optional_idx();
+	}
+
+	bool IsClosed() const override {
+		return closed;
+	}
+
+	void Close() override {
+		if (closed && iterator.empty() && !stream) {
+			return;
+		}
+		current_scan.reset();
+		stream.reset();
+		if (!iterator.empty() && ResultPythonRuntimeUsable()) {
+			PythonGILWrapper gil;
+			auto iterator_obj = iterator.get();
+			try {
+				if (py::hasattr(iterator_obj, "close")) {
+					iterator_obj.attr("close")();
+				}
+			} catch (py::error_already_set &ex) {
+				ex.discard_as_unraisable("closing distributed result iterator");
+			}
+		}
+		iterator.reset_with_gil();
+		closed = true;
+	}
+
+private:
+	void EnsureStream(idx_t rows_per_batch) {
+		if (stream || closed) {
+			return;
+		}
+		if (iterator.empty()) {
+			throw InvalidInputException("result closed");
+		}
+
+		PythonGILWrapper gil;
+		auto owner =
+		    new DistributedArrowStreamOwner(iterator.get(), metadata.names, metadata.types, context, rows_per_batch);
+		iterator.reset_with_gil();
+		stream = make_uniq<ArrowArrayStreamWrapper>();
+		stream->arrow_array_stream = owner->stream;
+
+		ArrowSchemaWrapper schema;
+		stream->GetSchema(schema);
+		ArrowTableFunction::PopulateArrowTableSchema(*context, arrow_table, schema.arrow_schema);
+	}
+
+	DuckDBPyResultMetadata metadata;
+	SafePyObject iterator;
+	shared_ptr<ClientContext> context;
+	unique_ptr<ArrowArrayStreamWrapper> stream;
+	ArrowTableSchema arrow_table;
+	unique_ptr<ArrowScanLocalState> current_scan;
+	bool chunk_consumption_started = false;
+	bool closed = false;
+};
+
+} // namespace
+
+unique_ptr<DuckDBPyResultSource> MakeLocalPyResultSource(unique_ptr<QueryResult> result) {
+	return make_uniq<LocalQueryResultSource>(std::move(result));
+}
+
+unique_ptr<DuckDBPyResultSource> MakeDistributedArrowPyResultSource(py::object table_iterator, vector<string> names,
+                                                                    vector<LogicalType> types,
+                                                                    const shared_ptr<ClientContext> &context) {
+	return make_uniq<DistributedArrowResultSource>(std::move(table_iterator), std::move(names), std::move(types),
+	                                               context);
+}
+
+} // namespace duckdb

--- a/src/duckdb_py/pyresult_source.cpp
+++ b/src/duckdb_py/pyresult_source.cpp
@@ -421,13 +421,16 @@ struct DistributedArrowStreamOwner {
 		} else if (extension_name != "arrow.json") {
 			return false;
 		}
-		return CanNormalizeArrowOffsetWidths(actual_type.attr("storage_type"), expected_type.attr("storage_type"),
-		                                     type_predicates);
+		return CanNormalizeArrowType(actual_type.attr("storage_type"), expected_type.attr("storage_type"),
+		                             type_predicates);
 	}
 
-	static bool CanNormalizeArrowOffsetWidths(const py::object &actual_type, const py::object &expected_type,
-	                                          const py::object &type_predicates) {
+	static bool CanNormalizeArrowType(const py::object &actual_type, const py::object &expected_type,
+	                                  const py::object &type_predicates) {
 		if (py::cast<bool>(actual_type.attr("equals")(expected_type))) {
+			return true;
+		}
+		if (CanNormalizeArrowExtensionStorage(actual_type, expected_type, type_predicates)) {
 			return true;
 		}
 		auto same_family = [&](std::initializer_list<const char *> predicate_names) {
@@ -439,13 +442,13 @@ struct DistributedArrowStreamOwner {
 			return true;
 		}
 		if (same_family({"is_list", "is_large_list", "is_list_view", "is_large_list_view"})) {
-			return CanNormalizeArrowOffsetWidths(actual_type.attr("value_type"), expected_type.attr("value_type"),
-			                                     type_predicates);
+			return CanNormalizeArrowType(actual_type.attr("value_type"), expected_type.attr("value_type"),
+			                             type_predicates);
 		}
 		if (same_family({"is_fixed_size_list"})) {
 			return py::cast<idx_t>(actual_type.attr("list_size")) == py::cast<idx_t>(expected_type.attr("list_size")) &&
-			       CanNormalizeArrowOffsetWidths(actual_type.attr("value_type"), expected_type.attr("value_type"),
-			                                     type_predicates);
+			       CanNormalizeArrowType(actual_type.attr("value_type"), expected_type.attr("value_type"),
+			                             type_predicates);
 		}
 		if (same_family({"is_struct"})) {
 			auto field_count = py::cast<idx_t>(actual_type.attr("num_fields"));
@@ -457,8 +460,7 @@ struct DistributedArrowStreamOwner {
 				auto expected_field = expected_type.attr("field")(field_idx);
 				if (py::cast<string>(actual_field.attr("name")) != py::cast<string>(expected_field.attr("name")) ||
 				    py::cast<bool>(actual_field.attr("nullable")) != py::cast<bool>(expected_field.attr("nullable")) ||
-				    !CanNormalizeArrowOffsetWidths(actual_field.attr("type"), expected_field.attr("type"),
-				                                   type_predicates)) {
+				    !CanNormalizeArrowType(actual_field.attr("type"), expected_field.attr("type"), type_predicates)) {
 					return false;
 				}
 			}
@@ -467,23 +469,118 @@ struct DistributedArrowStreamOwner {
 		if (same_family({"is_map"})) {
 			return py::cast<bool>(actual_type.attr("keys_sorted")) ==
 			           py::cast<bool>(expected_type.attr("keys_sorted")) &&
-			       CanNormalizeArrowOffsetWidths(actual_type.attr("key_type"), expected_type.attr("key_type"),
-			                                     type_predicates) &&
-			       CanNormalizeArrowOffsetWidths(actual_type.attr("item_type"), expected_type.attr("item_type"),
-			                                     type_predicates);
+			       CanNormalizeArrowType(actual_type.attr("key_type"), expected_type.attr("key_type"),
+			                             type_predicates) &&
+			       CanNormalizeArrowType(actual_type.attr("item_type"), expected_type.attr("item_type"),
+			                             type_predicates);
 		}
 		return false;
 	}
 
-	static py::object NormalizeArrowExtensionStorage(const py::object &column, const py::object &expected_type) {
-		auto pyarrow = py::module_::import("pyarrow");
-		auto extension_array = pyarrow.attr("ExtensionArray");
-		auto expected_storage_type = expected_type.attr("storage_type");
+	static py::object NormalizeArrowArray(const py::object &array, const py::object &expected_type,
+	                                      const py::object &pyarrow, const py::object &type_predicates) {
+		auto actual_type = array.attr("type");
+		if (py::cast<bool>(actual_type.attr("equals")(expected_type))) {
+			return array;
+		}
+		if (CanNormalizeArrowExtensionStorage(actual_type, expected_type, type_predicates)) {
+			auto storage = NormalizeArrowArray(array.attr("storage"), expected_type.attr("storage_type"), pyarrow,
+			                                   type_predicates);
+			return pyarrow.attr("ExtensionArray").attr("from_storage")(expected_type, storage);
+		}
+		auto same_family = [&](std::initializer_list<const char *> predicate_names) {
+			return ArrowTypeMatchesAny(type_predicates, actual_type, predicate_names) &&
+			       ArrowTypeMatchesAny(type_predicates, expected_type, predicate_names);
+		};
+		if (same_family({"is_string", "is_large_string", "is_string_view"}) ||
+		    same_family({"is_binary", "is_large_binary", "is_binary_view"})) {
+			return array.attr("cast")(expected_type, py::arg("safe") = true);
+		}
+		if (same_family({"is_list", "is_large_list", "is_list_view", "is_large_list_view"})) {
+			auto values = NormalizeArrowArray(array.attr("flatten")(), expected_type.attr("value_type"), pyarrow,
+			                                  type_predicates);
+			auto large_offsets =
+			    ArrowTypeMatchesAny(type_predicates, expected_type, {"is_large_list", "is_large_list_view"});
+			auto int64_type = pyarrow.attr("int64")();
+			auto offset_type = large_offsets ? int64_type : pyarrow.attr("int32")();
+			auto sizes =
+			    array.attr("value_lengths")().attr("fill_null")(0).attr("cast")(int64_type, py::arg("safe") = true);
+			auto compute = py::module_::import("pyarrow.compute");
+			py::list offset_arrays;
+			offset_arrays.append(pyarrow.attr("array")(py::make_tuple(0), py::arg("type") = int64_type));
+			offset_arrays.append(compute.attr("cumulative_sum")(sizes));
+			auto offsets = pyarrow.attr("concat_arrays")(offset_arrays);
+			if (!large_offsets) {
+				sizes = sizes.attr("cast")(offset_type, py::arg("safe") = true);
+				offsets = offsets.attr("cast")(offset_type, py::arg("safe") = true);
+			}
+			auto mask = array.attr("is_null")();
+			if (ArrowTypeMatchesAny(type_predicates, expected_type, {"is_list"})) {
+				return pyarrow.attr("ListArray")
+				    .attr("from_arrays")(offsets, values, py::arg("type") = expected_type, py::arg("mask") = mask);
+			}
+			if (ArrowTypeMatchesAny(type_predicates, expected_type, {"is_large_list"})) {
+				return pyarrow.attr("LargeListArray")
+				    .attr("from_arrays")(offsets, values, py::arg("type") = expected_type, py::arg("mask") = mask);
+			}
+			auto view_offsets = offsets.attr("slice")(0, py::len(array));
+			if (ArrowTypeMatchesAny(type_predicates, expected_type, {"is_list_view"})) {
+				return pyarrow.attr("ListViewArray")
+				    .attr("from_arrays")(view_offsets, sizes, values, py::arg("type") = expected_type,
+				                         py::arg("mask") = mask);
+			}
+			return pyarrow.attr("LargeListViewArray")
+			    .attr("from_arrays")(view_offsets, sizes, values, py::arg("type") = expected_type,
+			                         py::arg("mask") = mask);
+		}
+		if (same_family({"is_fixed_size_list"})) {
+			auto list_size = py::cast<idx_t>(actual_type.attr("list_size"));
+			auto array_offset = py::cast<idx_t>(array.attr("offset"));
+			auto array_length = NumericCast<idx_t>(py::len(array));
+			auto values = array.attr("values").attr("slice")(array_offset * list_size, array_length * list_size);
+			values = NormalizeArrowArray(values, expected_type.attr("value_type"), pyarrow, type_predicates);
+			return pyarrow.attr("FixedSizeListArray")
+			    .attr("from_arrays")(values, py::arg("type") = expected_type,
+			                         py::arg("mask") = array.attr("is_null")());
+		}
+		if (same_family({"is_struct"})) {
+			py::list fields;
+			auto field_count = py::cast<idx_t>(expected_type.attr("num_fields"));
+			for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+				fields.append(NormalizeArrowArray(array.attr("field")(field_idx),
+				                                  expected_type.attr("field")(field_idx).attr("type"), pyarrow,
+				                                  type_predicates));
+			}
+			return pyarrow.attr("StructArray")
+			    .attr("from_arrays")(fields, py::arg("type") = expected_type,
+			                         py::arg("mask") = array.attr("is_null")());
+		}
+		if (same_family({"is_map"})) {
+			auto offsets = array.attr("offsets");
+			auto start = py::cast<idx_t>(offsets.attr("__getitem__")(0).attr("as_py")());
+			auto end = py::cast<idx_t>(offsets.attr("__getitem__")(-1).attr("as_py")());
+			auto entry_count = end - start;
+			auto compute = py::module_::import("pyarrow.compute");
+			auto normalized_offsets =
+			    compute.attr("subtract")(offsets, start).attr("cast")(pyarrow.attr("int32")(), py::arg("safe") = true);
+			auto keys = array.attr("keys").attr("slice")(start, entry_count);
+			keys = NormalizeArrowArray(keys, expected_type.attr("key_type"), pyarrow, type_predicates);
+			auto items = array.attr("items").attr("slice")(start, entry_count);
+			items = NormalizeArrowArray(items, expected_type.attr("item_type"), pyarrow, type_predicates);
+			return pyarrow.attr("MapArray")
+			    .attr("from_arrays")(normalized_offsets, keys, items, py::arg("type") = expected_type,
+			                         py::arg("mask") = array.attr("is_null")());
+		}
+		throw InternalException("Unsupported Arrow normalization from %s to %s", py::cast<string>(py::str(actual_type)),
+		                        py::cast<string>(py::str(expected_type)));
+	}
+
+	static py::object NormalizeArrowColumn(const py::object &column, const py::object &expected_type,
+	                                       const py::object &pyarrow, const py::object &type_predicates) {
 		py::list normalized_chunks;
 		for (auto chunk_handle : column.attr("chunks")) {
 			auto chunk = py::reinterpret_borrow<py::object>(chunk_handle);
-			auto storage = chunk.attr("storage").attr("cast")(expected_storage_type, py::arg("safe") = true);
-			normalized_chunks.append(extension_array.attr("from_storage")(expected_type, storage));
+			normalized_chunks.append(NormalizeArrowArray(chunk, expected_type, pyarrow, type_predicates));
 		}
 		return pyarrow.attr("chunked_array")(normalized_chunks, py::arg("type") = expected_type);
 	}
@@ -509,27 +606,21 @@ struct DistributedArrowStreamOwner {
 			throw;
 		}
 		py::list columns;
-		auto type_predicates = py::module_::import("pyarrow.types");
+		auto pyarrow = py::module_::import("pyarrow");
+		auto type_predicates = pyarrow.attr("types");
 		for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
 			auto column = table.attr("column")(col_idx);
 			py::object expected_type = schema.attr("field")(col_idx).attr("type");
 			auto actual_type = column.attr("type");
 			if (!py::cast<bool>(actual_type.attr("equals")(expected_type))) {
-				auto normalize_extension_storage =
-				    CanNormalizeArrowExtensionStorage(actual_type, expected_type, type_predicates);
-				if (!normalize_extension_storage &&
-				    !CanNormalizeArrowOffsetWidths(actual_type, expected_type, type_predicates)) {
+				if (!CanNormalizeArrowType(actual_type, expected_type, type_predicates)) {
 					throw InvalidInputException(
 					    "Distributed result partition %d column %d has Arrow type %s, expected %s for DuckDB type %s",
 					    partition_index, col_idx, py::cast<string>(py::str(actual_type)),
 					    py::cast<string>(py::str(expected_type)), types[col_idx].ToString());
 				}
 				try {
-					if (normalize_extension_storage) {
-						column = NormalizeArrowExtensionStorage(column, expected_type);
-					} else {
-						column = column.attr("cast")(expected_type, py::arg("safe") = true);
-					}
+					column = NormalizeArrowColumn(column, expected_type, pyarrow, type_predicates);
 				} catch (py::error_already_set &ex) {
 					throw InvalidInputException("Distributed result partition %d column %d failed Arrow offset-width "
 					                            "normalization from %s to %s: %s",
@@ -539,7 +630,7 @@ struct DistributedArrowStreamOwner {
 			}
 			columns.append(column);
 		}
-		return py::module_::import("pyarrow").attr("Table").attr("from_arrays")(columns, py::arg("schema") = schema);
+		return pyarrow.attr("Table").attr("from_arrays")(columns, py::arg("schema") = schema);
 	}
 
 	void Fail(string error) {

--- a/src/duckdb_py/pyresult_source.cpp
+++ b/src/duckdb_py/pyresult_source.cpp
@@ -15,6 +15,8 @@
 #include "duckdb_python/pybind11/gil_wrapper.hpp"
 #include "ray/safe_pyobject.hpp"
 
+#include <initializer_list>
+
 namespace duckdb {
 
 using distributed::python::ray::SafePyObject;
@@ -202,10 +204,15 @@ static bool ResultPythonRuntimeUsable() {
 //! The external schema is derived from the relation rather than partition
 //! field names (distributed partitions currently use positional c0/c1 names).
 struct DistributedArrowStreamOwner {
-	DistributedArrowStreamOwner(py::object iterator_p, vector<string> names_p, vector<LogicalType> types_p,
+	DistributedArrowStreamOwner(py::object iterator_p, py::object prefetched_partition_p, bool has_prefetched_partition,
+	                            bool iterator_exhausted, vector<string> names_p, vector<LogicalType> types_p,
 	                            const shared_ptr<ClientContext> &context_p, idx_t rows_per_batch_p)
 	    : iterator(SafePyObject(py::iter(iterator_p))), names(std::move(names_p)), types(std::move(types_p)),
-	      context(context_p), client_properties(context_p->GetClientProperties()), rows_per_batch(rows_per_batch_p) {
+	      context(context_p), client_properties(context_p->GetClientProperties()), rows_per_batch(rows_per_batch_p),
+	      exhausted(iterator_exhausted) {
+		if (has_prefetched_partition) {
+			prefetched_partition = SafePyObject(std::move(prefetched_partition_p));
+		}
 		stream.private_data = this;
 		stream.get_schema = GetSchema;
 		stream.get_next = GetNext;
@@ -223,11 +230,14 @@ struct DistributedArrowStreamOwner {
 		}
 		auto self = reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
 		out->release = nullptr;
+		if (self->failed) {
+			return -1;
+		}
 		try {
 			ArrowConverter::ToArrowSchema(out, self->types, self->names, self->client_properties);
 			return 0;
 		} catch (std::exception &ex) {
-			self->last_error = ex.what();
+			self->Fail(ex.what());
 			return -1;
 		}
 	}
@@ -238,16 +248,23 @@ struct DistributedArrowStreamOwner {
 		}
 		auto self = reinterpret_cast<DistributedArrowStreamOwner *>(stream->private_data);
 		out->release = nullptr;
+		if (self->failed) {
+			return -1;
+		}
+		// DuckDB can invoke this callback after releasing the GIL. Keep it held
+		// through the catch blocks so Python exceptions are also formatted and
+		// destroyed while the Python runtime is protected.
+		PythonGILWrapper gil;
 		try {
 			return self->Next(out);
 		} catch (py::error_already_set &ex) {
-			self->last_error = ex.what();
+			self->Fail(ex.what());
 			return -1;
 		} catch (std::exception &ex) {
-			self->last_error = ex.what();
+			self->Fail(ex.what());
 			return -1;
 		} catch (...) {
-			self->last_error = "unknown distributed result stream error";
+			self->Fail("unknown distributed result stream error");
 			return -1;
 		}
 	}
@@ -268,13 +285,23 @@ struct DistributedArrowStreamOwner {
 		return self->last_error.c_str();
 	}
 
+	static string StreamErrorOr(ArrowArrayStream &stream, const char *fallback) {
+		if (!stream.get_last_error) {
+			return fallback;
+		}
+		const char *error = stream.get_last_error(&stream);
+		return error && error[0] != '\0' ? error : fallback;
+	}
+
 	int Next(ArrowArray *out) {
 		while (true) {
 			if (current_stream.release) {
 				PythonGILWrapper gil;
 				if (current_stream.get_next(&current_stream, out)) {
-					auto error = current_stream.get_last_error ? current_stream.get_last_error(&current_stream)
-					                                           : "unknown Arrow stream error";
+					auto error = StreamErrorOr(current_stream, "unknown Arrow stream error");
+					if (out->release) {
+						out->release(out);
+					}
 					throw InvalidInputException("Distributed result Arrow stream failed: %s", error);
 				}
 				if (out->release) {
@@ -293,17 +320,24 @@ struct DistributedArrowStreamOwner {
 
 	void OpenNextPartition() {
 		PythonGILWrapper gil;
-		auto iterator_obj = iterator.get();
-		PyObject *next_ptr = PyIter_Next(iterator_obj.ptr());
-		if (!next_ptr) {
-			if (PyErr_Occurred()) {
-				throw py::error_already_set();
+		py::object table;
+		if (!prefetched_partition.empty()) {
+			table = prefetched_partition.get();
+			prefetched_partition.reset_with_gil();
+		} else {
+			auto iterator_obj = iterator.get();
+			PyObject *next_ptr = PyIter_Next(iterator_obj.ptr());
+			if (!next_ptr) {
+				if (PyErr_Occurred()) {
+					throw py::error_already_set();
+				}
+				exhausted = true;
+				return;
 			}
-			exhausted = true;
-			return;
+			table = py::reinterpret_steal<py::object>(next_ptr);
 		}
 
-		auto table = NormalizeTable(py::reinterpret_steal<py::object>(next_ptr));
+		table = NormalizeTable(std::move(table));
 		py::object arrow_source = table;
 		if (rows_per_batch > 0 && py::hasattr(table, "to_reader")) {
 			arrow_source = table.attr("to_reader")(py::arg("max_chunksize") = rows_per_batch);
@@ -314,14 +348,19 @@ struct DistributedArrowStreamOwner {
 		if (!exported_stream || !exported_stream->release) {
 			throw InvalidInputException("Distributed result returned a released Arrow stream");
 		}
+		if (!exported_stream->get_schema || !exported_stream->get_next) {
+			throw InvalidInputException("Distributed result returned an Arrow stream without required callbacks");
+		}
 		current_stream = *exported_stream;
 		exported_stream->release = nullptr;
 
 		ArrowSchema actual_schema;
 		actual_schema.release = nullptr;
 		if (current_stream.get_schema(&current_stream, &actual_schema)) {
-			auto error = current_stream.get_last_error ? current_stream.get_last_error(&current_stream)
-			                                           : "unknown Arrow schema error";
+			auto error = StreamErrorOr(current_stream, "unknown Arrow schema error");
+			if (actual_schema.release) {
+				actual_schema.release(&actual_schema);
+			}
 			throw InvalidInputException("Failed to read distributed result schema: %s", error);
 		}
 		if (!actual_schema.release) {
@@ -350,6 +389,105 @@ struct DistributedArrowStreamOwner {
 		partition_index++;
 	}
 
+	static bool ArrowTypeMatchesAny(const py::object &type_predicates, const py::object &type,
+	                                std::initializer_list<const char *> predicate_names) {
+		for (const auto *predicate_name : predicate_names) {
+			if (py::hasattr(type_predicates, predicate_name) &&
+			    py::cast<bool>(type_predicates.attr(predicate_name)(type))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static bool CanNormalizeArrowExtensionStorage(const py::object &actual_type, const py::object &expected_type,
+	                                              const py::object &type_predicates) {
+		if (!py::hasattr(actual_type, "extension_name") || !py::hasattr(expected_type, "extension_name") ||
+		    !py::hasattr(actual_type, "storage_type") || !py::hasattr(expected_type, "storage_type")) {
+			return false;
+		}
+		auto extension_name = py::cast<string>(actual_type.attr("extension_name"));
+		if (extension_name != py::cast<string>(expected_type.attr("extension_name"))) {
+			return false;
+		}
+		if (extension_name == "arrow.opaque") {
+			if (!py::hasattr(actual_type, "type_name") || !py::hasattr(expected_type, "type_name") ||
+			    !py::hasattr(actual_type, "vendor_name") || !py::hasattr(expected_type, "vendor_name") ||
+			    py::cast<string>(actual_type.attr("type_name")) != py::cast<string>(expected_type.attr("type_name")) ||
+			    py::cast<string>(actual_type.attr("vendor_name")) !=
+			        py::cast<string>(expected_type.attr("vendor_name"))) {
+				return false;
+			}
+		} else if (extension_name != "arrow.json") {
+			return false;
+		}
+		return CanNormalizeArrowOffsetWidths(actual_type.attr("storage_type"), expected_type.attr("storage_type"),
+		                                     type_predicates);
+	}
+
+	static bool CanNormalizeArrowOffsetWidths(const py::object &actual_type, const py::object &expected_type,
+	                                          const py::object &type_predicates) {
+		if (py::cast<bool>(actual_type.attr("equals")(expected_type))) {
+			return true;
+		}
+		auto same_family = [&](std::initializer_list<const char *> predicate_names) {
+			return ArrowTypeMatchesAny(type_predicates, actual_type, predicate_names) &&
+			       ArrowTypeMatchesAny(type_predicates, expected_type, predicate_names);
+		};
+		if (same_family({"is_string", "is_large_string", "is_string_view"}) ||
+		    same_family({"is_binary", "is_large_binary", "is_binary_view"})) {
+			return true;
+		}
+		if (same_family({"is_list", "is_large_list", "is_list_view", "is_large_list_view"})) {
+			return CanNormalizeArrowOffsetWidths(actual_type.attr("value_type"), expected_type.attr("value_type"),
+			                                     type_predicates);
+		}
+		if (same_family({"is_fixed_size_list"})) {
+			return py::cast<idx_t>(actual_type.attr("list_size")) == py::cast<idx_t>(expected_type.attr("list_size")) &&
+			       CanNormalizeArrowOffsetWidths(actual_type.attr("value_type"), expected_type.attr("value_type"),
+			                                     type_predicates);
+		}
+		if (same_family({"is_struct"})) {
+			auto field_count = py::cast<idx_t>(actual_type.attr("num_fields"));
+			if (field_count != py::cast<idx_t>(expected_type.attr("num_fields"))) {
+				return false;
+			}
+			for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+				auto actual_field = actual_type.attr("field")(field_idx);
+				auto expected_field = expected_type.attr("field")(field_idx);
+				if (py::cast<string>(actual_field.attr("name")) != py::cast<string>(expected_field.attr("name")) ||
+				    py::cast<bool>(actual_field.attr("nullable")) != py::cast<bool>(expected_field.attr("nullable")) ||
+				    !CanNormalizeArrowOffsetWidths(actual_field.attr("type"), expected_field.attr("type"),
+				                                   type_predicates)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if (same_family({"is_map"})) {
+			return py::cast<bool>(actual_type.attr("keys_sorted")) ==
+			           py::cast<bool>(expected_type.attr("keys_sorted")) &&
+			       CanNormalizeArrowOffsetWidths(actual_type.attr("key_type"), expected_type.attr("key_type"),
+			                                     type_predicates) &&
+			       CanNormalizeArrowOffsetWidths(actual_type.attr("item_type"), expected_type.attr("item_type"),
+			                                     type_predicates);
+		}
+		return false;
+	}
+
+	static py::object NormalizeArrowExtensionStorage(const py::object &column, const py::object &expected_type) {
+		auto pyarrow = py::module_::import("pyarrow");
+		auto extension_array = pyarrow.attr("ExtensionArray");
+		auto expected_storage_type = expected_type.attr("storage_type");
+		py::list normalized_chunks;
+		for (auto chunk_handle : column.attr("chunks")) {
+			auto chunk = py::reinterpret_borrow<py::object>(chunk_handle);
+			auto storage = chunk.attr("storage").attr("cast")(expected_storage_type, py::arg("safe") = true);
+			normalized_chunks.append(extension_array.attr("from_storage")(expected_type, storage));
+		}
+		return pyarrow.attr("chunked_array")(normalized_chunks, py::arg("type") = expected_type);
+	}
+
 	py::object NormalizeTable(py::object table) {
 		auto column_count = py::cast<idx_t>(table.attr("num_columns"));
 		if (column_count != types.size()) {
@@ -371,21 +509,45 @@ struct DistributedArrowStreamOwner {
 			throw;
 		}
 		py::list columns;
+		auto type_predicates = py::module_::import("pyarrow.types");
 		for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
 			auto column = table.attr("column")(col_idx);
 			py::object expected_type = schema.attr("field")(col_idx).attr("type");
-			if (!py::cast<bool>(column.attr("type").attr("equals")(expected_type))) {
-				try {
-					column = column.attr("cast")(expected_type, py::arg("safe") = true);
-				} catch (py::error_already_set &ex) {
+			auto actual_type = column.attr("type");
+			if (!py::cast<bool>(actual_type.attr("equals")(expected_type))) {
+				auto normalize_extension_storage =
+				    CanNormalizeArrowExtensionStorage(actual_type, expected_type, type_predicates);
+				if (!normalize_extension_storage &&
+				    !CanNormalizeArrowOffsetWidths(actual_type, expected_type, type_predicates)) {
 					throw InvalidInputException(
-					    "Distributed result partition %d column %d cannot be safely cast to %s: %s", partition_index,
-					    col_idx, types[col_idx].ToString(), ex.what());
+					    "Distributed result partition %d column %d has Arrow type %s, expected %s for DuckDB type %s",
+					    partition_index, col_idx, py::cast<string>(py::str(actual_type)),
+					    py::cast<string>(py::str(expected_type)), types[col_idx].ToString());
+				}
+				try {
+					if (normalize_extension_storage) {
+						column = NormalizeArrowExtensionStorage(column, expected_type);
+					} else {
+						column = column.attr("cast")(expected_type, py::arg("safe") = true);
+					}
+				} catch (py::error_already_set &ex) {
+					throw InvalidInputException("Distributed result partition %d column %d failed Arrow offset-width "
+					                            "normalization from %s to %s: %s",
+					                            partition_index, col_idx, py::cast<string>(py::str(actual_type)),
+					                            py::cast<string>(py::str(expected_type)), ex.what());
 				}
 			}
 			columns.append(column);
 		}
 		return py::module_::import("pyarrow").attr("Table").attr("from_arrays")(columns, py::arg("schema") = schema);
+	}
+
+	void Fail(string error) {
+		if (!failed) {
+			last_error = std::move(error);
+			failed = true;
+		}
+		Close();
 	}
 
 	void Close() {
@@ -412,11 +574,13 @@ struct DistributedArrowStreamOwner {
 				ex.discard_as_unraisable("closing distributed result stream");
 			}
 		}
+		prefetched_partition.reset_with_gil();
 		iterator.reset_with_gil();
 	}
 
 	ArrowArrayStream stream;
 	SafePyObject iterator;
+	SafePyObject prefetched_partition;
 	vector<string> names;
 	vector<LogicalType> types;
 	shared_ptr<ClientContext> context;
@@ -426,16 +590,22 @@ struct DistributedArrowStreamOwner {
 	idx_t partition_index = 0;
 	bool exhausted = false;
 	bool closed = false;
+	bool failed = false;
 	string last_error;
 };
 
 class DistributedArrowResultSource : public DuckDBPyResultSource {
 public:
-	DistributedArrowResultSource(py::object table_iterator, vector<string> names, vector<LogicalType> types,
-	                             const shared_ptr<ClientContext> &context_p)
-	    : iterator(SafePyObject(std::move(table_iterator))), context(context_p) {
+	DistributedArrowResultSource(py::object table_iterator, py::object prefetched_partition,
+	                             bool has_prefetched_partition_p, bool iterator_exhausted_p, vector<string> names,
+	                             vector<LogicalType> types, const shared_ptr<ClientContext> &context_p)
+	    : iterator(SafePyObject(std::move(table_iterator))), has_prefetched_partition(has_prefetched_partition_p),
+	      iterator_exhausted(iterator_exhausted_p), context(context_p) {
 		if (!context) {
 			throw InternalException("DistributedArrowResultSource created without a context");
+		}
+		if (has_prefetched_partition) {
+			this->prefetched_partition = SafePyObject(std::move(prefetched_partition));
 		}
 		metadata.names = std::move(names);
 		metadata.types = std::move(types);
@@ -514,7 +684,7 @@ public:
 	}
 
 	void Close() override {
-		if (closed && iterator.empty() && !stream) {
+		if (closed && iterator.empty() && prefetched_partition.empty() && !stream) {
 			return;
 		}
 		current_scan.reset();
@@ -530,6 +700,7 @@ public:
 				ex.discard_as_unraisable("closing distributed result iterator");
 			}
 		}
+		prefetched_partition.reset_with_gil();
 		iterator.reset_with_gil();
 		closed = true;
 	}
@@ -544,19 +715,29 @@ private:
 		}
 
 		PythonGILWrapper gil;
-		auto owner =
-		    new DistributedArrowStreamOwner(iterator.get(), metadata.names, metadata.types, context, rows_per_batch);
+		auto new_stream = make_uniq<ArrowArrayStreamWrapper>();
+		auto owner = make_uniq<DistributedArrowStreamOwner>(iterator.get(), prefetched_partition.get(),
+		                                                    has_prefetched_partition, iterator_exhausted,
+		                                                    metadata.names, metadata.types, context, rows_per_batch);
+		new_stream->arrow_array_stream = owner->stream;
+		owner.release(); // The ArrowArrayStream release callback now owns the stream owner.
+		prefetched_partition.reset_with_gil();
 		iterator.reset_with_gil();
-		stream = make_uniq<ArrowArrayStreamWrapper>();
-		stream->arrow_array_stream = owner->stream;
 
 		ArrowSchemaWrapper schema;
-		stream->GetSchema(schema);
-		ArrowTableFunction::PopulateArrowTableSchema(*context, arrow_table, schema.arrow_schema);
+		new_stream->GetSchema(schema);
+		ArrowTableSchema new_arrow_table;
+		ArrowTableFunction::PopulateArrowTableSchema(*context, new_arrow_table, schema.arrow_schema);
+
+		stream = std::move(new_stream);
+		arrow_table = std::move(new_arrow_table);
 	}
 
 	DuckDBPyResultMetadata metadata;
 	SafePyObject iterator;
+	SafePyObject prefetched_partition;
+	bool has_prefetched_partition;
+	bool iterator_exhausted;
 	shared_ptr<ClientContext> context;
 	unique_ptr<ArrowArrayStreamWrapper> stream;
 	ArrowTableSchema arrow_table;
@@ -571,11 +752,13 @@ unique_ptr<DuckDBPyResultSource> MakeLocalPyResultSource(unique_ptr<QueryResult>
 	return make_uniq<LocalQueryResultSource>(std::move(result));
 }
 
-unique_ptr<DuckDBPyResultSource> MakeDistributedArrowPyResultSource(py::object table_iterator, vector<string> names,
-                                                                    vector<LogicalType> types,
-                                                                    const shared_ptr<ClientContext> &context) {
-	return make_uniq<DistributedArrowResultSource>(std::move(table_iterator), std::move(names), std::move(types),
-	                                               context);
+unique_ptr<DuckDBPyResultSource>
+MakeDistributedArrowPyResultSource(py::object table_iterator, py::object prefetched_partition,
+                                   bool has_prefetched_partition, bool iterator_exhausted, vector<string> names,
+                                   vector<LogicalType> types, const shared_ptr<ClientContext> &context) {
+	return make_uniq<DistributedArrowResultSource>(std::move(table_iterator), std::move(prefetched_partition),
+	                                               has_prefetched_partition, iterator_exhausted, std::move(names),
+	                                               std::move(types), context);
 }
 
 } // namespace duckdb

--- a/src/duckdb_py/pyresult_source.cpp
+++ b/src/duckdb_py/pyresult_source.cpp
@@ -441,6 +441,13 @@ struct DistributedArrowStreamOwner {
 		    same_family({"is_binary", "is_large_binary", "is_binary_view"})) {
 			return true;
 		}
+		if (same_family({"is_timestamp"})) {
+			auto actual_timezone = actual_type.attr("tz");
+			auto expected_timezone = expected_type.attr("tz");
+			return !py::none().is(actual_timezone) && !py::none().is(expected_timezone) &&
+			       !py::cast<string>(actual_timezone).empty() && !py::cast<string>(expected_timezone).empty() &&
+			       py::cast<string>(actual_type.attr("unit")) == py::cast<string>(expected_type.attr("unit"));
+		}
 		if (same_family({"is_list", "is_large_list", "is_list_view", "is_large_list_view"})) {
 			return CanNormalizeArrowType(actual_type.attr("value_type"), expected_type.attr("value_type"),
 			                             type_predicates);
@@ -451,6 +458,28 @@ struct DistributedArrowStreamOwner {
 			                             type_predicates);
 		}
 		if (same_family({"is_struct"})) {
+			auto field_count = py::cast<idx_t>(actual_type.attr("num_fields"));
+			if (field_count != py::cast<idx_t>(expected_type.attr("num_fields"))) {
+				return false;
+			}
+			for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+				auto actual_field = actual_type.attr("field")(field_idx);
+				auto expected_field = expected_type.attr("field")(field_idx);
+				if (py::cast<string>(actual_field.attr("name")) != py::cast<string>(expected_field.attr("name")) ||
+				    py::cast<bool>(actual_field.attr("nullable")) != py::cast<bool>(expected_field.attr("nullable")) ||
+				    !CanNormalizeArrowType(actual_field.attr("type"), expected_field.attr("type"), type_predicates)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if (same_family({"is_union"})) {
+			if (py::cast<string>(actual_type.attr("mode")) != "sparse" ||
+			    py::cast<string>(expected_type.attr("mode")) != "sparse" ||
+			    py::cast<vector<int64_t>>(actual_type.attr("type_codes")) !=
+			        py::cast<vector<int64_t>>(expected_type.attr("type_codes"))) {
+				return false;
+			}
 			auto field_count = py::cast<idx_t>(actual_type.attr("num_fields"));
 			if (field_count != py::cast<idx_t>(expected_type.attr("num_fields"))) {
 				return false;
@@ -494,6 +523,9 @@ struct DistributedArrowStreamOwner {
 		};
 		if (same_family({"is_string", "is_large_string", "is_string_view"}) ||
 		    same_family({"is_binary", "is_large_binary", "is_binary_view"})) {
+			return array.attr("cast")(expected_type, py::arg("safe") = true);
+		}
+		if (same_family({"is_timestamp"})) {
 			return array.attr("cast")(expected_type, py::arg("safe") = true);
 		}
 		if (same_family({"is_list", "is_large_list", "is_list_view", "is_large_list_view"})) {
@@ -554,6 +586,30 @@ struct DistributedArrowStreamOwner {
 			return pyarrow.attr("StructArray")
 			    .attr("from_arrays")(fields, py::arg("type") = expected_type,
 			                         py::arg("mask") = array.attr("is_null")());
+		}
+		if (same_family({"is_union"})) {
+			py::list children;
+			auto field_count = py::cast<idx_t>(expected_type.attr("num_fields"));
+			for (idx_t field_idx = 0; field_idx < field_count; field_idx++) {
+				children.append(NormalizeArrowArray(array.attr("field")(field_idx),
+				                                    expected_type.attr("field")(field_idx).attr("type"), pyarrow,
+				                                    type_predicates));
+			}
+
+			py::list type_id_buffers;
+			type_id_buffers.append(py::none());
+			type_id_buffers.append(array.attr("buffers")().attr("__getitem__")(1));
+			auto type_ids = pyarrow.attr("Array").attr("from_buffers")(
+			    pyarrow.attr("int8")(), py::len(array), type_id_buffers, py::arg("offset") = array.attr("offset"));
+			py::list type_id_chunks;
+			type_id_chunks.append(type_ids);
+			type_ids = pyarrow.attr("concat_arrays")(type_id_chunks);
+
+			py::list union_buffers;
+			union_buffers.append(py::none());
+			union_buffers.append(type_ids.attr("buffers")().attr("__getitem__")(1));
+			return pyarrow.attr("Array").attr("from_buffers")(expected_type, py::len(array), union_buffers,
+			                                                  py::arg("children") = children);
 		}
 		if (same_family({"is_map"})) {
 			auto offsets = array.attr("offsets");
@@ -622,7 +678,7 @@ struct DistributedArrowStreamOwner {
 				try {
 					column = NormalizeArrowColumn(column, expected_type, pyarrow, type_predicates);
 				} catch (py::error_already_set &ex) {
-					throw InvalidInputException("Distributed result partition %d column %d failed Arrow offset-width "
+					throw InvalidInputException("Distributed result partition %d column %d failed Arrow type "
 					                            "normalization from %s to %s: %s",
 					                            partition_index, col_idx, py::cast<string>(py::str(actual_type)),
 					                            py::cast<string>(py::str(expected_type)), ex.what());

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -393,10 +393,10 @@ def test_distributed_empty_result_keeps_schema(monkeypatch):
     runner = _FakeRayRunner([])
     _install_fake_ray_runner(monkeypatch, runner)
 
-    row_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name")
+    row_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
     assert row_relation.fetchall() == []
 
-    arrow_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name")
+    arrow_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
     result = arrow_relation.to_arrow_table()
     assert result.schema.names == ["name"]
     assert result.schema.types == [pa.string()]
@@ -534,6 +534,63 @@ def test_distributed_result_normalizes_nested_lossless_arrow_extension_storage(
     assert len(runner.calls) == 1
 
 
+def test_distributed_result_normalizes_sliced_sparse_union_children(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    producer = duckdb.connect()
+    producer.execute("SET arrow_large_buffer_size = true")
+    table = producer.sql("""
+        SELECT
+            CASE
+                WHEN i % 2 = 0
+                    THEN ('ray-' || i::VARCHAR)::UNION(s VARCHAR, i BIGINT)
+                ELSE i::BIGINT::UNION(s VARCHAR, i BIGINT)
+            END AS c0
+        FROM range(6) AS t(i)
+    """).to_arrow_table()
+    table = table.slice(1, 4)
+
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    relation = duckdb.connect().sql("SELECT NULL::UNION(s VARCHAR, i BIGINT) AS value")
+    assert relation.fetchall() == [(1,), ("ray-2",), (3,), ("ray-4",)]
+    assert len(runner.calls) == 1
+
+
+def test_distributed_result_normalizes_timestamp_timezone_metadata(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    producer = duckdb.connect()
+    producer.execute("SET TimeZone = 'UTC'")
+    table = producer.sql("SELECT TIMESTAMPTZ '2024-01-01 12:00:00+00' AS c0").to_arrow_table()
+    assert table.schema.field(0).type.tz == "UTC"
+
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+    consumer = duckdb.connect()
+    consumer.execute("SET TimeZone = 'America/New_York'")
+
+    value = consumer.sql("SELECT TIMESTAMPTZ '2024-01-01 12:00:00+00' AS value").fetchone()[0]
+    assert value.isoformat() == "2024-01-01T07:00:00-05:00"
+    assert len(runner.calls) == 1
+
+
+def test_distributed_result_does_not_reinterpret_naive_timestamp_as_timestamp_timezone(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    table = duckdb.connect().sql("SELECT TIMESTAMP '2024-01-01 12:00:00' AS c0").to_arrow_table()
+
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+    consumer = duckdb.connect()
+    consumer.execute("SET TimeZone = 'America/New_York'")
+
+    relation = consumer.sql("SELECT TIMESTAMPTZ '2024-01-01 12:00:00+00' AS value")
+    with pytest.raises(
+        duckdb.InvalidInputException,
+        match=r"has Arrow type timestamp\[us\], expected timestamp\[us, tz=America/New_York\]",
+    ):
+        relation.fetchall()
+
+
 @pytest.mark.parametrize(
     "query",
     [
@@ -591,7 +648,7 @@ def test_distributed_result_rejects_untransportable_types_before_starting_runner
         ),
     ],
 )
-def test_distributed_result_normalizes_only_arrow_offset_widths(monkeypatch, query, table, expected):
+def test_distributed_result_normalizes_arrow_offset_widths(monkeypatch, query, table, expected):
     runner = _FakeRayRunner([table])
     _install_fake_ray_runner(monkeypatch, runner)
 

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import gc
+import sys
+import types
+from collections.abc import Iterator
+
+import pyarrow as pa
+import pytest
+
+import duckdb
+
+
+class _FakeRayRunner:
+    def __init__(self, tables: list[pa.Table]) -> None:
+        self.tables = tables
+        self.calls: list[tuple[duckdb.DuckDBPyRelation, int | None]] = []
+        self.closed_iterators = 0
+
+    def run_iter_tables(
+        self, relation: duckdb.DuckDBPyRelation, results_buffer_size: int | None = None
+    ) -> Iterator[pa.Table]:
+        self.calls.append((relation, results_buffer_size))
+        try:
+            yield from self.tables
+        finally:
+            self.closed_iterators += 1
+
+
+def _install_fake_ray_runner(monkeypatch: pytest.MonkeyPatch, runner: _FakeRayRunner) -> None:
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    runners = types.ModuleType("duckdb.runners")
+    runners.set_runner_ray = lambda *_args, **_kwargs: runner
+    monkeypatch.setitem(sys.modules, "duckdb.runners", runners)
+
+
+def _two_column_relation() -> duckdb.DuckDBPyRelation:
+    return duckdb.connect().sql("SELECT 999::BIGINT AS value, 'local'::VARCHAR AS label")
+
+
+def _two_column_tables() -> list[pa.Table]:
+    return [
+        pa.table({"c0": pa.array([1, 2], pa.int64()), "c1": ["one", "two"]}),
+        pa.table({"c0": pa.array([3], pa.int64()), "c1": ["three"]}),
+    ]
+
+
+def test_distributed_row_cursor_is_shared_across_fetch_methods(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    assert relation.fetchone() == (1, "one")
+    assert relation.fetchmany(1) == [(2, "two")]
+    assert relation.fetchall() == [(3, "three")]
+
+    assert len(runner.calls) == 1
+    assert runner.calls[0][1] == 1
+    assert runner.closed_iterators == 1
+
+
+def test_distributed_execute_preserves_result_for_later_consumption(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    relation.execute()
+
+    assert relation.fetchall() == [
+        (1, "one"),
+        (2, "two"),
+        (3, "three"),
+    ]
+    assert len(runner.calls) == 1
+
+
+def test_distributed_numpy_and_pandas_use_relation_names(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    numpy_result = _two_column_relation().fetchnumpy()
+    assert list(numpy_result) == ["value", "label"]
+    assert numpy_result["value"].tolist() == [1, 2, 3]
+    assert numpy_result["label"].tolist() == ["one", "two", "three"]
+
+    frame = _two_column_relation().df()
+    assert frame.to_dict(orient="list") == {
+        "value": [1, 2, 3],
+        "label": ["one", "two", "three"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("consumer", "result_kind", "deprecated"),
+    [
+        ("fetchdf", "frame", False),
+        ("to_df", "frame", False),
+        ("arrow", "reader", False),
+        ("fetch_arrow_table", "table", True),
+        ("fetch_record_batch", "reader", True),
+        ("fetch_arrow_reader", "reader", True),
+    ],
+)
+def test_distributed_consumer_aliases(monkeypatch, consumer, result_kind, deprecated):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    if deprecated:
+        with pytest.warns(DeprecationWarning):
+            result = getattr(_two_column_relation(), consumer)()
+    else:
+        result = getattr(_two_column_relation(), consumer)()
+
+    if result_kind == "frame":
+        assert result.to_dict(orient="list") == {
+            "value": [1, 2, 3],
+            "label": ["one", "two", "three"],
+        }
+    else:
+        if result_kind == "reader":
+            result = result.read_all()
+        assert result.to_pydict() == {
+            "value": [1, 2, 3],
+            "label": ["one", "two", "three"],
+        }
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("consumer", "module_name", "converter_name"),
+    [
+        ("torch", "torch", "from_numpy"),
+        ("tf", "tensorflow", "convert_to_tensor"),
+    ],
+)
+def test_distributed_tensor_consumers_receive_numpy_results(monkeypatch, consumer, module_name, converter_name):
+    runner = _FakeRayRunner([pa.table({"c0": pa.array([1, 2, 3], pa.int64())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+    framework = types.ModuleType(module_name)
+    setattr(framework, converter_name, lambda array: array.tolist())
+    monkeypatch.setitem(sys.modules, module_name, framework)
+    relation = duckdb.connect().sql("SELECT 999::BIGINT AS value")
+
+    assert getattr(relation, consumer)() == {"value": [1, 2, 3]}
+    assert len(runner.calls) == 1
+
+
+def test_distributed_polars_eager_and_lazy(monkeypatch):
+    pytest.importorskip("polars")
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    eager = _two_column_relation().pl()
+    lazy_relation = _two_column_relation()
+    lazy = lazy_relation.pl(lazy=True).collect()
+
+    expected = [
+        {"value": 1, "label": "one"},
+        {"value": 2, "label": "two"},
+        {"value": 3, "label": "three"},
+    ]
+    assert eager.to_dicts() == expected
+    assert lazy.to_dicts() == expected
+    assert len(runner.calls) == 2
+
+
+def test_distributed_df_chunks_preserve_cursor_state(monkeypatch):
+    first = pa.table(
+        {
+            "c0": pa.array(range(3000), pa.int64()),
+            "c1": [f"row-{index}" for index in range(3000)],
+        }
+    )
+    runner = _FakeRayRunner([first])
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    first_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
+    second_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
+    third_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
+
+    assert first_chunk["value"].tolist() == list(range(2048))
+    assert second_chunk["value"].tolist() == list(range(2048, 3000))
+    assert third_chunk.empty
+    assert len(runner.calls) == 1
+
+
+def test_distributed_arrow_table_and_reader_stream_partitions(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    table = _two_column_relation().to_arrow_table(batch_size=1)
+    assert table.schema.names == ["value", "label"]
+    assert table.to_pydict() == {
+        "value": [1, 2, 3],
+        "label": ["one", "two", "three"],
+    }
+
+    reader = _two_column_relation().to_arrow_reader(batch_size=2)
+    assert [batch.num_rows for batch in reader] == [2, 1]
+
+
+def test_distributed_arrow_capsule_protocol(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    reader = pa.RecordBatchReader.from_stream(_two_column_relation())
+    assert reader.read_all().to_pydict() == {
+        "value": [1, 2, 3],
+        "label": ["one", "two", "three"],
+    }
+
+
+def test_distributed_result_rejects_switching_cursor_modes(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    assert relation.fetchone() == (1, "one")
+    with pytest.raises(duckdb.InvalidInputException, match="partially consumed row result"):
+        relation.to_arrow_table()
+
+
+def test_distributed_result_preserves_duplicate_names(monkeypatch):
+    table = pa.Table.from_arrays([pa.array([10]), pa.array([20])], names=["c0", "c1"])
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS a, 2::BIGINT AS a")
+    result = relation.to_arrow_table()
+
+    assert result.schema.names == ["a", "a"]
+    assert result.column(0).to_pylist() == [10]
+    assert result.column(1).to_pylist() == [20]
+
+
+def test_distributed_empty_result_keeps_schema(monkeypatch):
+    runner = _FakeRayRunner([])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    row_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
+    assert row_relation.fetchall() == []
+
+    arrow_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
+    result = arrow_relation.to_arrow_table()
+    assert result.schema.names == ["name"]
+    assert result.schema.types == [pa.string()]
+    assert result.num_rows == 0
+
+
+def test_distributed_result_rejects_partition_schema_mismatch(monkeypatch):
+    runner = _FakeRayRunner([pa.table({"c0": ["wrong type"]})])
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(duckdb.InvalidInputException, match="cannot be safely cast to BIGINT"):
+        relation.fetchall()
+
+
+def test_distributed_result_close_closes_runner_iterator(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    assert relation.fetchone() == (1, "one")
+    relation.close()
+
+    assert runner.closed_iterators == 1
+    with pytest.raises(duckdb.InvalidInputException, match="result closed"):
+        relation.fetchall()
+
+
+def test_distributed_partial_result_lifecycle_stress(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    row_iterations = 32
+    for index in range(row_iterations):
+        relation = _two_column_relation()
+        assert relation.fetchone() == (1, "one")
+        if index % 2 == 0:
+            relation.close()
+        del relation
+
+    arrow_iterations = 32
+    for index in range(arrow_iterations):
+        relation = _two_column_relation()
+        reader = relation.to_arrow_reader(batch_size=1)
+        assert reader.read_next_batch().to_pydict() == {
+            "value": [1],
+            "label": ["one"],
+        }
+        if index % 2 == 0:
+            reader.close()
+        del reader
+        del relation
+
+    gc.collect()
+
+    assert len(runner.calls) == row_iterations + arrow_iterations
+    assert runner.closed_iterators == row_iterations + arrow_iterations
+
+
+def test_distributed_len_and_shape_use_runner(monkeypatch):
+    runner = _FakeRayRunner([pa.table({"c0": pa.array([3], pa.int64())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    relation = _two_column_relation()
+    assert len(relation) == 3
+    assert relation.shape == (3, 2)
+    assert len(runner.calls) == 2
+
+
+def test_distributed_repr_uses_common_result_source(monkeypatch):
+    runner = _FakeRayRunner([pa.table({"c0": pa.array([41, 42], pa.int64())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    output = repr(duckdb.connect().sql("SELECT 999::BIGINT AS value"))
+
+    assert "41" in output
+    assert "42" in output
+    assert "999" not in output
+    assert len(runner.calls) == 1
+    assert "LIMIT 10000" in runner.calls[0][0].sql_query().upper()

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -486,6 +486,55 @@ def test_distributed_result_accepts_lossless_arrow_extension_types(
 
 
 @pytest.mark.parametrize(
+    ("partition_query", "relation_query", "expected"),
+    [
+        (
+            "SELECT ['{\"ray\": true}'::JSON] AS c0",
+            "SELECT ['{\"local\": true}'::JSON] AS value",
+            ['{"ray": true}'],
+        ),
+        ("SELECT ['10101'::BIT] AS c0", "SELECT ['111'::BIT] AS value", ["10101"]),
+        (
+            "SELECT [123456789012345678901234567890::BIGNUM] AS c0",
+            "SELECT [1::BIGNUM] AS value",
+            ["123456789012345678901234567890"],
+        ),
+        (
+            "SELECT {'json_value': '{\"ray\": true}'::JSON} AS c0",
+            "SELECT {'json_value': '{\"local\": true}'::JSON} AS value",
+            {"json_value": '{"ray": true}'},
+        ),
+        (
+            "SELECT ['{\"ray\": true}'::JSON]::JSON[1] AS c0",
+            "SELECT ['{\"local\": true}'::JSON]::JSON[1] AS value",
+            ('{"ray": true}',),
+        ),
+        (
+            "SELECT map(['key'], ['{\"ray\": true}'::JSON]) AS c0",
+            "SELECT map(['key'], ['{\"local\": true}'::JSON]) AS value",
+            {"key": '{"ray": true}'},
+        ),
+    ],
+)
+def test_distributed_result_normalizes_nested_lossless_arrow_extension_storage(
+    monkeypatch, partition_query, relation_query, expected
+):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    producer = duckdb.connect()
+    producer.execute("SET arrow_lossless_conversion = true")
+    producer.execute("SET arrow_large_buffer_size = true")
+    table = producer.sql(partition_query).to_arrow_table()
+
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+    consumer = duckdb.connect()
+    consumer.execute("SET arrow_lossless_conversion = true")
+
+    assert consumer.sql(relation_query).fetchone() == (expected,)
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
     "query",
     [
         "SELECT 'red'::ENUM('red', 'blue') AS value",
@@ -526,6 +575,19 @@ def test_distributed_result_rejects_untransportable_types_before_starting_runner
             "SELECT ['local'::VARCHAR] AS value",
             pa.table({"c0": pa.array([["distributed"]], pa.large_list(pa.large_string()))}),
             [(["distributed"],)],
+        ),
+        (
+            "SELECT ['local'::VARCHAR] AS value",
+            pa.table(
+                {
+                    "c0": pa.ListViewArray.from_arrays(
+                        pa.array([0, 1], pa.int32()),
+                        pa.array([2, 3], pa.int32()),
+                        pa.array(["first", "second", "third", "fourth"], pa.large_string()),
+                    )
+                }
+            ),
+            [(["first", "second"],), (["second", "third", "fourth"],)],
         ),
     ],
 )

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -55,6 +55,38 @@ def _two_column_tables() -> list[pa.Table]:
     ]
 
 
+def _assert_typed_empty_bulk_result(result, consumer: str) -> None:
+    if consumer == "fetchdf":
+        assert result.empty
+        assert list(result.columns) == ["value"]
+        assert str(result.dtypes["value"]) == "int64"
+    else:
+        assert list(result) == ["value"]
+        assert result["value"].tolist() == []
+        assert str(result["value"].dtype) == "int64"
+
+
+@pytest.mark.parametrize("consumer", ["fetchdf", "fetchnumpy"])
+def test_local_bulk_result_preserves_schema_after_row_cursor_exhaustion(monkeypatch, consumer):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    assert relation.fetchmany(2) == [(1,)]
+
+    _assert_typed_empty_bulk_result(getattr(relation, consumer)(), consumer)
+
+
+@pytest.mark.parametrize("consumer", ["fetchdf", "fetchnumpy"])
+def test_distributed_bulk_result_preserves_schema_after_row_cursor_exhaustion(monkeypatch, consumer):
+    runner = _FakeRayRunner([pa.table({"c0": pa.array([1], pa.int64())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT 999::BIGINT AS value")
+
+    assert relation.fetchmany(2) == [(1,)]
+
+    _assert_typed_empty_bulk_result(getattr(relation, consumer)(), consumer)
+
+
 def test_distributed_row_cursor_is_shared_across_fetch_methods(monkeypatch):
     runner = _FakeRayRunner(_two_column_tables())
     _install_fake_ray_runner(monkeypatch, runner)

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -30,11 +30,18 @@ class _FakeRayRunner:
             self.closed_iterators += 1
 
 
-def _install_fake_ray_runner(monkeypatch: pytest.MonkeyPatch, runner: object) -> None:
+def _install_fake_ray_runner(monkeypatch: pytest.MonkeyPatch, runner: object) -> list[tuple[object, bool]]:
     monkeypatch.setenv("VANE_RUNNER", "ray")
     runners = types.ModuleType("duckdb.runners")
-    runners.set_runner_ray = lambda *_args, **_kwargs: runner
+    factory_calls: list[tuple[object, bool]] = []
+
+    def set_runner_ray(address=None, noop_if_initialized=False):
+        factory_calls.append((address, noop_if_initialized))
+        return runner
+
+    runners.set_runner_ray = set_runner_ray
     monkeypatch.setitem(sys.modules, "duckdb.runners", runners)
+    return factory_calls
 
 
 def _two_column_relation() -> duckdb.DuckDBPyRelation:
@@ -380,6 +387,94 @@ def test_distributed_result_rejects_safe_but_noncanonical_partition_type(monkeyp
 
     with pytest.raises(duckdb.InvalidInputException, match="has Arrow type int32, expected int64"):
         relation.fetchall()
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 1::HUGEINT AS value",
+        "SELECT 1::UHUGEINT AS value",
+        "SELECT '00112233-4455-6677-8899-aabbccddeeff'::UUID AS value",
+        "SELECT '10101'::BIT AS value",
+        "SELECT '12:34:56+02:00'::TIMETZ AS value",
+        "SELECT '{\"key\": 1}'::JSON AS value",
+        "SELECT [1::HUGEINT] AS value",
+    ],
+)
+def test_distributed_result_rejects_lossy_types_before_starting_runner(monkeypatch, query):
+    runner = _FakeRayRunner([])
+    factory_calls = _install_fake_ray_runner(monkeypatch, runner)
+
+    with pytest.raises(
+        duckdb.NotImplementedException,
+        match="cannot preserve result type.*arrow_lossless_conversion",
+    ):
+        duckdb.connect().sql(query).fetchall()
+
+    assert factory_calls == []
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize(
+    ("partition_query", "relation_query", "expected"),
+    [
+        ("SELECT 1::HUGEINT AS c0", "SELECT 999::HUGEINT AS value", "1"),
+        ("SELECT 1::UHUGEINT AS c0", "SELECT 999::UHUGEINT AS value", "1"),
+        (
+            "SELECT '00112233-4455-6677-8899-aabbccddeeff'::UUID AS c0",
+            "SELECT 'ffffffff-ffff-ffff-ffff-ffffffffffff'::UUID AS value",
+            "00112233-4455-6677-8899-aabbccddeeff",
+        ),
+        ("SELECT '10101'::BIT AS c0", "SELECT '111'::BIT AS value", "10101"),
+        (
+            "SELECT '{\"key\": 1}'::JSON AS c0",
+            "SELECT '{\"local\": true}'::JSON AS value",
+            '{"key": 1}',
+        ),
+        (
+            "SELECT '12:34:56+02:00'::TIMETZ AS c0",
+            "SELECT '01:02:03+01:00'::TIMETZ AS value",
+            "12:34:56+02:00",
+        ),
+    ],
+)
+def test_distributed_result_accepts_lossless_arrow_extension_types(
+    monkeypatch, partition_query, relation_query, expected
+):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = duckdb.connect()
+    connection.execute("SET arrow_lossless_conversion = true")
+    table = connection.sql(partition_query).to_arrow_table()
+
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    assert str(connection.sql(relation_query).fetchone()[0]) == expected
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT 'red'::ENUM('red', 'blue') AS value",
+        "SELECT 42::VARIANT AS value",
+        "SELECT sum(i) EXPORT_STATE AS value FROM range(3) t(i)",
+    ],
+)
+def test_distributed_result_rejects_untransportable_types_before_starting_runner_even_when_lossless(monkeypatch, query):
+    connection = duckdb.connect()
+    connection.execute("SET arrow_lossless_conversion = true")
+    runner = _FakeRayRunner([])
+    factory_calls = _install_fake_ray_runner(monkeypatch, runner)
+
+    with pytest.raises(
+        duckdb.NotImplementedException,
+        match="cannot preserve result type.*Arrow transport",
+    ):
+        connection.sql(query).fetchall()
+
+    assert factory_calls == []
+    assert runner.calls == []
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -30,7 +30,7 @@ class _FakeRayRunner:
             self.closed_iterators += 1
 
 
-def _install_fake_ray_runner(monkeypatch: pytest.MonkeyPatch, runner: _FakeRayRunner) -> None:
+def _install_fake_ray_runner(monkeypatch: pytest.MonkeyPatch, runner: object) -> None:
     monkeypatch.setenv("VANE_RUNNER", "ray")
     runners = types.ModuleType("duckdb.runners")
     runners.set_runner_ray = lambda *_args, **_kwargs: runner
@@ -69,12 +69,76 @@ def test_distributed_execute_preserves_result_for_later_consumption(monkeypatch)
 
     relation.execute()
 
+    assert len(runner.calls) == 1
     assert relation.fetchall() == [
         (1, "one"),
         (2, "two"),
         (3, "three"),
     ]
     assert len(runner.calls) == 1
+
+
+def test_distributed_execute_starts_runner_and_close_releases_iterator(monkeypatch):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    relation.execute()
+
+    assert len(runner.calls) == 1
+    assert runner.closed_iterators == 0
+
+    relation.close()
+
+    assert runner.closed_iterators == 1
+
+
+def test_distributed_execute_reports_runner_start_error(monkeypatch):
+    class _StartFailRunner:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_iter_tables(self, _relation, results_buffer_size=None):
+            self.calls += 1
+            raise RuntimeError("runner failed before first partition")
+            yield  # pragma: no cover
+
+    runner = _StartFailRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    with pytest.raises(RuntimeError, match="runner failed before first partition"):
+        relation.execute()
+
+    assert runner.calls == 1
+
+
+def test_distributed_result_reports_midstream_runner_error(monkeypatch):
+    class _MidstreamFailRunner:
+        def __init__(self) -> None:
+            self.closed_iterators = 0
+
+        def run_iter_tables(self, _relation, results_buffer_size=None):
+            del results_buffer_size
+            try:
+                yield pa.table({"c0": pa.array([1], pa.int64())})
+                raise RuntimeError("runner failed after first partition")
+            finally:
+                self.closed_iterators += 1
+
+    runner = _MidstreamFailRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(duckdb.InvalidInputException, match="runner failed after first partition"):
+        relation.fetchall()
+
+    assert runner.closed_iterators == 1
+
+    with pytest.raises(duckdb.InvalidInputException, match="runner failed after first partition"):
+        relation.fetchall()
+
+    assert runner.closed_iterators == 1
 
 
 def test_distributed_numpy_and_pandas_use_relation_names(monkeypatch):
@@ -181,11 +245,20 @@ def test_distributed_df_chunks_preserve_cursor_state(monkeypatch):
     first_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
     second_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
     third_chunk = relation.fetch_df_chunk(vectors_per_chunk=1)
+    fourth_chunk = relation.fetch_df_chunk(vectors_per_chunk=100)
+    fifth_chunk = relation.fetch_df_chunk(vectors_per_chunk=0)
 
     assert first_chunk["value"].tolist() == list(range(2048))
     assert second_chunk["value"].tolist() == list(range(2048, 3000))
     assert third_chunk.empty
+    assert fourth_chunk.empty
+    assert fifth_chunk.empty
+    assert list(fourth_chunk.columns) == ["value", "label"]
     assert len(runner.calls) == 1
+
+    relation.close()
+    with pytest.raises(duckdb.InvalidInputException, match="result closed"):
+        relation.fetch_df_chunk()
 
 
 def test_distributed_arrow_table_and_reader_stream_partitions(monkeypatch):
@@ -201,6 +274,46 @@ def test_distributed_arrow_table_and_reader_stream_partitions(monkeypatch):
 
     reader = _two_column_relation().to_arrow_reader(batch_size=2)
     assert [batch.num_rows for batch in reader] == [2, 1]
+
+
+@pytest.mark.parametrize("consumer", ["to_arrow_reader", "to_arrow_table"])
+def test_local_arrow_consumers_reject_zero_batch_size_without_consuming_result(monkeypatch, consumer):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = duckdb.connect()
+    connection.execute("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(RuntimeError, match="Approximate Batch Size of Record Batch MUST be higher than 0"):
+        getattr(connection, consumer)(batch_size=0)
+
+    assert connection.fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize("consumer", ["to_arrow_reader", "to_arrow_table"])
+def test_fresh_local_relation_arrow_consumers_reject_zero_batch_size_without_consuming_result(monkeypatch, consumer):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(RuntimeError, match="Approximate Batch Size of Record Batch MUST be higher than 0"):
+        getattr(relation, consumer)(batch_size=0)
+
+    assert relation.fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize("consumer", ["to_arrow_reader", "to_arrow_table"])
+def test_distributed_arrow_consumers_reject_zero_batch_size_without_consuming_result(monkeypatch, consumer):
+    runner = _FakeRayRunner(_two_column_tables())
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = _two_column_relation()
+
+    with pytest.raises(RuntimeError, match="Approximate Batch Size of Record Batch MUST be higher than 0"):
+        getattr(relation, consumer)(batch_size=0)
+
+    assert relation.fetchall() == [
+        (1, "one"),
+        (2, "two"),
+        (3, "three"),
+    ]
+    assert len(runner.calls) == 1
 
 
 def test_distributed_arrow_capsule_protocol(monkeypatch):
@@ -241,10 +354,10 @@ def test_distributed_empty_result_keeps_schema(monkeypatch):
     runner = _FakeRayRunner([])
     _install_fake_ray_runner(monkeypatch, runner)
 
-    row_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
+    row_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name")
     assert row_relation.fetchall() == []
 
-    arrow_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name WHERE FALSE")
+    arrow_relation = duckdb.connect().sql("SELECT NULL::VARCHAR AS name")
     result = arrow_relation.to_arrow_table()
     assert result.schema.names == ["name"]
     assert result.schema.types == [pa.string()]
@@ -256,8 +369,85 @@ def test_distributed_result_rejects_partition_schema_mismatch(monkeypatch):
     _install_fake_ray_runner(monkeypatch, runner)
     relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
 
-    with pytest.raises(duckdb.InvalidInputException, match="cannot be safely cast to BIGINT"):
+    with pytest.raises(duckdb.InvalidInputException, match="has Arrow type string, expected int64"):
         relation.fetchall()
+
+
+def test_distributed_result_rejects_safe_but_noncanonical_partition_type(monkeypatch):
+    runner = _FakeRayRunner([pa.table({"c0": pa.array([1], pa.int32())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(duckdb.InvalidInputException, match="has Arrow type int32, expected int64"):
+        relation.fetchall()
+
+
+@pytest.mark.parametrize(
+    ("query", "table", "expected"),
+    [
+        (
+            "SELECT 'local'::VARCHAR AS value",
+            pa.table({"c0": pa.array(["distributed"], pa.large_string())}),
+            [("distributed",)],
+        ),
+        (
+            "SELECT 'local'::BLOB AS value",
+            pa.table({"c0": pa.array([b"distributed"], pa.large_binary())}),
+            [(b"distributed",)],
+        ),
+        (
+            "SELECT ['local'::VARCHAR] AS value",
+            pa.table({"c0": pa.array([["distributed"]], pa.large_list(pa.large_string()))}),
+            [(["distributed"],)],
+        ),
+    ],
+)
+def test_distributed_result_normalizes_only_arrow_offset_widths(monkeypatch, query, table, expected):
+    runner = _FakeRayRunner([table])
+    _install_fake_ray_runner(monkeypatch, runner)
+
+    assert duckdb.connect().sql(query).fetchall() == expected
+
+
+def test_distributed_partition_error_is_terminal_and_closes_iterator(monkeypatch):
+    runner = _FakeRayRunner(
+        [
+            pa.table({"c0": ["bad"]}),
+            pa.table({"c0": pa.array([22], pa.int64())}),
+        ]
+    )
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT 1::BIGINT AS value")
+
+    with pytest.raises(duckdb.InvalidInputException, match="has Arrow type string, expected int64"):
+        relation.fetchall()
+
+    assert runner.closed_iterators == 1
+
+    with pytest.raises(duckdb.InvalidInputException, match="has Arrow type string, expected int64"):
+        relation.fetchall()
+
+    assert runner.closed_iterators == 1
+
+
+def test_distributed_runner_error_does_not_fall_back_to_local(monkeypatch):
+    class _UnsupportedPlanRunner:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_iter_tables(self, _relation, results_buffer_size=None):
+            self.calls += 1
+            raise NotImplementedError("unsupported distributed plan")
+            yield  # pragma: no cover
+
+    runner = _UnsupportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    relation = duckdb.connect().sql("SELECT source_id FROM pragma_version()")
+
+    with pytest.raises(NotImplementedError, match="unsupported distributed plan"):
+        relation.fetchone()
+
+    assert runner.calls == 1
 
 
 def test_distributed_result_close_closes_runner_iterator(monkeypatch):

--- a/tests/fast/test_distributed_show.py
+++ b/tests/fast/test_distributed_show.py
@@ -31,8 +31,8 @@ def test_relation_show_materializes_through_ray(monkeypatch, capsys):
     monkeypatch.delenv("VANE_RUNNER", raising=False)
     runner = _FakeRayRunner(
         [
-            pa.table({"value": [41]}),
-            pa.table({"value": [42]}),
+            pa.table({"value": pa.array([41], pa.int32())}),
+            pa.table({"value": pa.array([42], pa.int32())}),
         ]
     )
     _install_fake_ray_runner(monkeypatch, runner)
@@ -64,7 +64,7 @@ def test_relation_show_uses_local_execution(monkeypatch, capsys):
 
 def test_relation_show_preserves_duplicate_column_names(monkeypatch, capsys):
     monkeypatch.setenv("VANE_RUNNER", "")
-    table = pa.Table.from_arrays([pa.array([10]), pa.array([20])], names=["a", "a"])
+    table = pa.Table.from_arrays([pa.array([10], pa.int32()), pa.array([20], pa.int32())], names=["a", "a"])
     runner = _FakeRayRunner([table])
     _install_fake_ray_runner(monkeypatch, runner)
 
@@ -83,7 +83,7 @@ def test_relation_show_handles_empty_distributed_result(monkeypatch, capsys):
     _install_fake_ray_runner(monkeypatch, runner)
 
     connection = duckdb.connect()
-    connection.sql("SELECT NULL::VARCHAR AS name WHERE FALSE").show()
+    connection.sql("SELECT NULL::VARCHAR AS name").show()
 
     output = capsys.readouterr().out
     assert "name" in output

--- a/tests/fast/test_distributed_show.py
+++ b/tests/fast/test_distributed_show.py
@@ -83,7 +83,7 @@ def test_relation_show_handles_empty_distributed_result(monkeypatch, capsys):
     _install_fake_ray_runner(monkeypatch, runner)
 
     connection = duckdb.connect()
-    connection.sql("SELECT NULL::VARCHAR AS name").show()
+    connection.sql("SELECT NULL::VARCHAR AS name WHERE FALSE").show()
 
     output = capsys.readouterr().out
     assert "name" in output

--- a/tests/fast/test_expression_cls_sql.py
+++ b/tests/fast/test_expression_cls_sql.py
@@ -354,7 +354,7 @@ def test_vane_cls_sql_explain_resolves_actor_backend_from_current_runner(monkeyp
             return f"{self.prefix}{text}"
 
     vane.attach_function(Prefixer("p:"), connection=conn, alias="prefixer_sql", parameters=["VARCHAR"])
-    plan = conn.sql("EXPLAIN SELECT prefixer_sql('x'::VARCHAR)").fetchall()
+    plan = conn.execute("EXPLAIN SELECT prefixer_sql('x'::VARCHAR)").fetchall()
     text = "\n".join(str(row) for row in plan)
 
     assert "ray_actor" in text
@@ -382,7 +382,7 @@ def test_vane_cls_batch_sql_explain_resolves_actor_backend_from_current_runner(m
         input_names=["value"],
         parameters=["INTEGER"],
     )
-    plan = conn.sql("EXPLAIN SELECT score_sql(1::INTEGER)").fetchall()
+    plan = conn.execute("EXPLAIN SELECT score_sql(1::INTEGER)").fetchall()
     text = "\n".join(str(row) for row in plan)
 
     assert "ray_actor" in text

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -87,3 +87,105 @@ def test_run_distributed_plan_end_to_end_on_ray_local(tmp_path):
         assert actor is not None
     except Exception:
         pass
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
+    from duckdb import runners
+
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = duckdb.connect()
+    path = tmp_path / "ray_relation_result_consumers.parquet"
+    connection.execute(
+        f"""
+        COPY (
+            SELECT
+                i::BIGINT AS value,
+                ('row-' || i::VARCHAR)::VARCHAR AS label
+            FROM range(6) AS t(i)
+        ) TO '{path}' (FORMAT PARQUET)
+        """
+    )
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    query = f"SELECT value, label FROM read_parquet('{path}') ORDER BY value"
+
+    row_relation = connection.sql(query)
+    assert row_relation.fetchone() == (0, "row-0")
+    assert row_relation.fetchmany(2) == [(1, "row-1"), (2, "row-2")]
+    assert row_relation.fetchall() == [
+        (3, "row-3"),
+        (4, "row-4"),
+        (5, "row-5"),
+    ]
+
+    table = connection.sql(query).to_arrow_table(batch_size=2)
+    assert table.schema.names == ["value", "label"]
+    assert table.to_pydict() == {
+        "value": list(range(6)),
+        "label": [f"row-{index}" for index in range(6)],
+    }
+
+    reader = connection.sql(query).to_arrow_reader(batch_size=2)
+    assert [batch.num_rows for batch in reader] == [2, 2, 2]
+
+    partial_relation = connection.sql(query)
+    assert partial_relation.fetchone() == (0, "row-0")
+    partial_relation.close()
+    with pytest.raises(duckdb.InvalidInputException, match="result closed"):
+        partial_relation.fetchall()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_complex_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
+    from duckdb import runners
+
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = duckdb.connect()
+    facts_path = tmp_path / "ray_relation_result_facts.parquet"
+    dimensions_path = tmp_path / "ray_relation_result_dimensions.parquet"
+    connection.execute(
+        f"""
+        COPY (
+            SELECT
+                (i % 3)::BIGINT AS group_id,
+                (i + 1)::BIGINT AS amount
+            FROM range(12) AS t(i)
+        ) TO '{facts_path}' (FORMAT PARQUET)
+        """
+    )
+    connection.execute(
+        f"""
+        COPY (
+            SELECT *
+            FROM (VALUES (0, 10), (1, 100), (2, 1000)) AS t(group_id, weight)
+        ) TO '{dimensions_path}' (FORMAT PARQUET)
+        """
+    )
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    query = f"""
+        SELECT
+            facts.group_id,
+            count(*)::BIGINT AS row_count,
+            sum(facts.amount * dimensions.weight)::BIGINT AS weighted_sum
+        FROM read_parquet('{facts_path}') AS facts
+        JOIN read_parquet('{dimensions_path}') AS dimensions USING (group_id)
+        GROUP BY facts.group_id
+        ORDER BY facts.group_id
+    """
+    expected_rows = [
+        (0, 4, 220),
+        (1, 4, 2600),
+        (2, 4, 30000),
+    ]
+
+    assert connection.sql(query).fetchall() == expected_rows
+
+    table = connection.sql(query).to_arrow_reader(batch_size=2).read_all()
+    assert table.to_pylist() == [
+        {"group_id": group_id, "row_count": row_count, "weighted_sum": weighted_sum}
+        for group_id, row_count, weighted_sum in expected_rows
+    ]

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -108,6 +108,7 @@ def test_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
         """
     )
 
+    monkeypatch.setenv("VANE_RUNNER", "ray")
     runners.set_runner_ray(noop_if_initialized=True)
     query = f"SELECT value, label FROM read_parquet('{path}') ORDER BY value"
 
@@ -145,6 +146,7 @@ def test_lossless_relation_result_types_on_ray_local(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     connection = duckdb.connect()
     connection.execute("SET arrow_lossless_conversion = true")
+    monkeypatch.setenv("VANE_RUNNER", "ray")
     runners.set_runner_ray(noop_if_initialized=True)
 
     row = connection.sql("""
@@ -194,6 +196,7 @@ def test_complex_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
         """
     )
 
+    monkeypatch.setenv("VANE_RUNNER", "ray")
     runners.set_runner_ray(noop_if_initialized=True)
     query = f"""
         SELECT

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -139,6 +139,35 @@ def test_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")
 @pytest.mark.usefixtures("ray_local")
+def test_lossless_relation_result_types_on_ray_local(monkeypatch):
+    from duckdb import runners
+
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = duckdb.connect()
+    connection.execute("SET arrow_lossless_conversion = true")
+    runners.set_runner_ray(noop_if_initialized=True)
+
+    row = connection.sql("""
+        SELECT
+            1::HUGEINT AS huge_value,
+            1::UHUGEINT AS uhuge_value,
+            '00112233-4455-6677-8899-aabbccddeeff'::UUID AS uuid_value,
+            '10101'::BIT AS bit_value,
+            '12:34:56+02:00'::TIMETZ AS time_value,
+            '{"key": 1}'::JSON AS json_value
+    """).fetchone()
+
+    assert row is not None
+    assert row[0] == 1
+    assert row[1] == 1
+    assert str(row[2]) == "00112233-4455-6677-8899-aabbccddeeff"
+    assert row[3] == "10101"
+    assert row[4].utcoffset().total_seconds() == 2 * 60 * 60
+    assert row[5] == '{"key": 1}'
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
 def test_complex_relation_result_consumers_on_ray_local(tmp_path, monkeypatch):
     from duckdb import runners
 

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -146,6 +146,7 @@ def test_lossless_relation_result_types_on_ray_local(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     connection = duckdb.connect()
     connection.execute("SET arrow_lossless_conversion = true")
+    connection.execute("SET TimeZone = 'America/New_York'")
     monkeypatch.setenv("VANE_RUNNER", "ray")
     runners.set_runner_ray(noop_if_initialized=True)
 
@@ -156,7 +157,9 @@ def test_lossless_relation_result_types_on_ray_local(monkeypatch):
             '00112233-4455-6677-8899-aabbccddeeff'::UUID AS uuid_value,
             '10101'::BIT AS bit_value,
             '12:34:56+02:00'::TIMETZ AS time_value,
-            '{"key": 1}'::JSON AS json_value
+            TIMESTAMPTZ '2024-01-01 12:00:00+00' AS timestamp_tz_value,
+            '{"key": 1}'::JSON AS json_value,
+            union_value(v := 'distributed'::VARCHAR) AS union_value
     """).fetchone()
 
     assert row is not None
@@ -165,7 +168,9 @@ def test_lossless_relation_result_types_on_ray_local(monkeypatch):
     assert str(row[2]) == "00112233-4455-6677-8899-aabbccddeeff"
     assert row[3] == "10101"
     assert row[4].utcoffset().total_seconds() == 2 * 60 * 60
-    assert row[5] == '{"key": 1}'
+    assert row[5].isoformat() == "2024-01-01T07:00:00-05:00"
+    assert row[6] == '{"key": 1}'
+    assert row[7] == "distributed"
 
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")


### PR DESCRIPTION
## Summary

- introduce a backend-neutral `DuckDBPyResultSource` shared by local `QueryResult` objects and Ray-produced Arrow partition streams
- route row, NumPy/Pandas, tensor, Arrow, Polars, shape/length, and display consumers through one cursor and lifecycle implementation
- preserve relation schemas and duplicate names while validating each distributed partition against canonical Arrow types
- make partial consumption, explicit close, destruction, startup failures, schema errors, and mid-stream runner failures deterministic and terminal
- keep the Ray runner strict: distributed errors are surfaced and never silently fall back to local execution

This branch is rebuilt directly on the current `upstream/main` and intentionally excludes runner configuration, FTE, relation serialization, pivot, and other work already present upstream.

## Related issue

close: #190

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public consumer APIs are unchanged; this provides distributed execution parity and a stricter existing Ray failure contract.

## Validation

- `scripts/format root --changed`
- incremental Release native install with `SKBUILD_BUILD_DIR="$PWD/build/python-release"`, `SKBUILD_CMAKE_BUILD_TYPE=Release`, and `uv pip install . --no-build-isolation`
- `python -m pytest tests/fast/test_distributed_result_consumers.py tests/fast/test_distributed_show.py` — 42 passed
- `python -m pytest tests/fast/test_ray_cpp_bindings.py -k ray_backed_result_partition_concurrent_materialization` — 2 passed
- `python -m pytest tests/fast/test_ray_real_integration.py -k relation_result_consumers` — 2 passed
- `scripts/run_release_tests.sh` — passed
- `scripts/run_fast_tests.sh` — passed, including 5,383 non-Ray tests, 80 shared-cluster Ray tests, real-Ray result consumers, and test-owned Ray fault-injection shards

Environment: Linux, Python 3.12, Release native build, local Ray cluster, default 2 GiB test object store.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

## Follow-up

- #192 tracks connection-bound runner policy and consistent statement routing across `execute()` and `sql()`. It is intentionally outside this focused PR.
