### PR TITLE
[fix](udf) Enforce callable cache and materialized batches

### DIFF
--- a/duckdb/execution/_common.py
+++ b/duckdb/execution/_common.py
@@ -18,10 +18,22 @@ if TYPE_CHECKING:
 
 _UDF_CALLABLE_CACHE_LOCK = threading.Lock()
 _UDF_CALLABLE_CACHE: OrderedDict[str, Any] = OrderedDict()
-_UDF_CALLABLE_CACHE_STATS = {
+_UDF_CALLABLE_STATS = {
     "python_udf_callable_cache_hit": 0,
     "python_udf_callable_cache_miss": 0,
     "python_udf_callable_cache_bypass": 0,
+    "python_udf_callable_load_map_native": 0,
+    "python_udf_callable_load_map_arrow": 0,
+    "python_udf_callable_load_map_batches": 0,
+    "python_udf_callable_load_map_batches_rows": 0,
+    "python_udf_callable_load_flat_map": 0,
+}
+_UDF_CALLABLE_LOAD_STATS = {
+    ("map", "native"): "python_udf_callable_load_map_native",
+    ("map", "arrow"): "python_udf_callable_load_map_arrow",
+    ("map_batches", ""): "python_udf_callable_load_map_batches",
+    ("map_batches_rows", ""): "python_udf_callable_load_map_batches_rows",
+    ("flat_map", ""): "python_udf_callable_load_flat_map",
 }
 _TRUTHY_FALSE_VALUES = ("", "0", "false", "no", "off")
 
@@ -30,14 +42,12 @@ _TRUTHY_FALSE_VALUES = ("", "0", "false", "no", "off")
 
 
 def ensure_table(rows: Any) -> pa.Table:
-    """Coerce various Arrow types to pa.Table."""
+    """Coerce a materialized Arrow batch to ``pa.Table``."""
     if isinstance(rows, pa.Table):
         return rows
     if isinstance(rows, pa.RecordBatch):
         return pa.Table.from_batches([rows])
-    if isinstance(rows, pa.RecordBatchReader):
-        return pa.Table.from_batches(list(rows))
-    raise TypeError("rows must be a pyarrow Table, RecordBatch, or RecordBatchReader")
+    raise TypeError("rows must be a pyarrow Table or RecordBatch")
 
 
 def estimate_table_bytes(table: pa.Table) -> int:
@@ -62,7 +72,18 @@ def load_udf_from_payload(payload: dict[str, Any]) -> Any:
     from duckdb import pickle as duckdb_pickle
 
     function_pickle = _payload_pickle_bytes(payload)
+    _record_udf_callable_load(payload)
     return duckdb_pickle.loads(function_pickle)
+
+
+def _record_udf_callable_load(payload: dict[str, Any]) -> None:
+    call_mode = str(payload.get("call_mode") or "")
+    scalar_udf_type = str(payload.get("scalar_udf_type") or "native") if call_mode == "map" else ""
+    stat_name = _UDF_CALLABLE_LOAD_STATS.get((call_mode, scalar_udf_type))
+    if stat_name is None:
+        return
+    with _UDF_CALLABLE_CACHE_LOCK:
+        _UDF_CALLABLE_STATS[stat_name] += 1
 
 
 def _payload_pickle_bytes(payload: dict[str, Any]) -> bytes:
@@ -108,14 +129,14 @@ def clear_udf_callable_cache() -> None:
     """Clear the process-local UDF callable cache."""
     with _UDF_CALLABLE_CACHE_LOCK:
         _UDF_CALLABLE_CACHE.clear()
-        for key in _UDF_CALLABLE_CACHE_STATS:
-            _UDF_CALLABLE_CACHE_STATS[key] = 0
+        for key in _UDF_CALLABLE_STATS:
+            _UDF_CALLABLE_STATS[key] = 0
 
 
 def udf_callable_cache_stats() -> dict[str, int]:
-    """Return process-local callable cache counters."""
+    """Return process-local callable cache and deserialization counters."""
     with _UDF_CALLABLE_CACHE_LOCK:
-        return dict(_UDF_CALLABLE_CACHE_STATS)
+        return dict(_UDF_CALLABLE_STATS)
 
 
 def callable_cache_enabled(payload: dict[str, Any]) -> bool:
@@ -128,13 +149,13 @@ def load_udf_from_payload_cached(payload: dict[str, Any], max_entries: int | Non
     """Deserialize a UDF callable with a process-local LRU cache."""
     if payload.get("side_effects"):
         with _UDF_CALLABLE_CACHE_LOCK:
-            _UDF_CALLABLE_CACHE_STATS["python_udf_callable_cache_bypass"] += 1
+            _UDF_CALLABLE_STATS["python_udf_callable_cache_bypass"] += 1
         return load_udf_from_payload(payload)
     if max_entries is None:
         max_entries = 64
     if max_entries <= 0:
         with _UDF_CALLABLE_CACHE_LOCK:
-            _UDF_CALLABLE_CACHE_STATS["python_udf_callable_cache_bypass"] += 1
+            _UDF_CALLABLE_STATS["python_udf_callable_cache_bypass"] += 1
         return load_udf_from_payload(payload)
 
     key = udf_cache_key(payload)
@@ -142,7 +163,7 @@ def load_udf_from_payload_cached(payload: dict[str, Any], max_entries: int | Non
         if key in _UDF_CALLABLE_CACHE:
             cached = _UDF_CALLABLE_CACHE[key]
             _UDF_CALLABLE_CACHE.move_to_end(key)
-            _UDF_CALLABLE_CACHE_STATS["python_udf_callable_cache_hit"] += 1
+            _UDF_CALLABLE_STATS["python_udf_callable_cache_hit"] += 1
             return cached
 
     udf = load_udf_from_payload(payload)
@@ -150,10 +171,10 @@ def load_udf_from_payload_cached(payload: dict[str, Any], max_entries: int | Non
         if key in _UDF_CALLABLE_CACHE:
             cached = _UDF_CALLABLE_CACHE[key]
             _UDF_CALLABLE_CACHE.move_to_end(key)
-            _UDF_CALLABLE_CACHE_STATS["python_udf_callable_cache_hit"] += 1
+            _UDF_CALLABLE_STATS["python_udf_callable_cache_hit"] += 1
             return cached
         _UDF_CALLABLE_CACHE[key] = udf
-        _UDF_CALLABLE_CACHE_STATS["python_udf_callable_cache_miss"] += 1
+        _UDF_CALLABLE_STATS["python_udf_callable_cache_miss"] += 1
         while len(_UDF_CALLABLE_CACHE) > max_entries:
             _UDF_CALLABLE_CACHE.popitem(last=False)
     return udf

--- a/duckdb/execution/_udf_runtime.py
+++ b/duckdb/execution/_udf_runtime.py
@@ -118,12 +118,12 @@ _RETURN_NULL = int(PythonExceptionHandling.RETURN_NULL)
 
 
 def _coerce_scalar_array(output: Any, expected_rows: int) -> pa.Array:
+    if isinstance(output, pa.RecordBatchReader):
+        raise TypeError("map UDF output must be materialized; RecordBatchReader is not supported")
     if isinstance(output, pa.Table):
         table = output
     elif isinstance(output, pa.RecordBatch):
         table = pa.Table.from_batches([output])
-    elif isinstance(output, pa.RecordBatchReader):
-        table = pa.Table.from_batches(list(output))
     else:
         table = pa.Table.from_arrays([output], names=["_udf_out"])
 
@@ -242,15 +242,13 @@ def _iter_output_tables(result: Any) -> Iterable[pa.Table]:
     if result is None:
         return
 
+    if isinstance(result, pa.RecordBatchReader):
+        raise TypeError("UDF output must be materialized; RecordBatchReader is not supported")
     if isinstance(result, pa.Table):
         yield result
         return
     if isinstance(result, pa.RecordBatch):
         yield pa.Table.from_batches([result])
-        return
-    if isinstance(result, pa.RecordBatchReader):
-        for rb in result:
-            yield pa.Table.from_batches([rb])
         return
     if isinstance(result, dict):
         yield pa.table(result)
@@ -263,7 +261,7 @@ def _iter_output_tables(result: Any) -> Iterable[pa.Table]:
             yield from _iter_output_tables(item)
         return
 
-    raise TypeError("udf output must be Table/RecordBatch/RecordBatchReader/dict, or an iterable yielding those types")
+    raise TypeError("udf output must be Table/RecordBatch/dict, or an iterable yielding those types")
 
 
 def _iter_table_row_dicts(table: pa.Table) -> Iterable[dict[str, Any]]:
@@ -468,7 +466,11 @@ class UDFExecutor:
         if raw_input_names:
             self._input_names = list(raw_input_names)
 
-        self._map_fn = _load_runtime_callable(payload)
+        self._map_fn = _load_runtime_callable(
+            payload,
+            cache_callable=cache_callable,
+            cache_max_entries=cache_max_entries,
+        )
         self._mode = self._call_mode
         self._is_map_batches = self._call_mode == "map_batches"
         self._is_map_batches_rows = self._call_mode == "map_batches_rows"
@@ -550,7 +552,9 @@ class UDFExecutor:
                     yield table
             return
         except TypeError as exc:
-            raise TypeError(f"map_batches UDF must return pa.Table or Iterator[pa.Table], got {type(result)}") from exc
+            raise TypeError(
+                f"map_batches UDF must return pa.Table or Iterator[pa.Table], got {type(result)}: {exc}"
+            ) from exc
 
     def _coerce_row_preserving_batch_output(self, result: Any, expected_rows: int) -> pa.Table:
         if isinstance(result, pa.Table):
@@ -559,6 +563,10 @@ class UDFExecutor:
             table = pa.Table.from_batches([result])
         elif isinstance(result, dict):
             table = pa.table(result)
+        elif isinstance(result, pa.RecordBatchReader):
+            raise TypeError(
+                "row-preserving map_batches UDF output must be materialized; RecordBatchReader is not supported"
+            )
         elif isinstance(result, Iterable) and not isinstance(result, (str, bytes, bytearray)):
             raise TypeError("row-preserving map_batches UDF must return a single pa.Table, not an iterator")
         else:
@@ -712,6 +720,8 @@ class UDFExecutor:
                 result = self._map_fn(row_dict)
                 if result is None:
                     continue
+                if isinstance(result, pa.RecordBatchReader):
+                    raise TypeError("flat_map UDF output must be row dictionaries; RecordBatchReader is not supported")
                 if isinstance(result, dict):
                     yield from append_output_row(result)
                 else:
@@ -760,6 +770,8 @@ class UDFExecutor:
                     outputs.append(None)
                     continue
                 raise
+            if isinstance(result, pa.RecordBatchReader):
+                raise TypeError("map UDF output must be scalar; RecordBatchReader is not supported")
             if self._default_null_handling() and result is None:
                 raise ValueError(_NULL_HANDLING_ERROR)
             outputs.append(result)

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -97,6 +97,17 @@ def _pickle_function(fn):
     return cloudpickle.dumps(fn)
 
 
+def _record_batch_reader_with_pull_counter():
+    pulls = []
+    batch = pa.record_batch({"x": [1]})
+
+    def batches():
+        pulls.append(batch)
+        yield batch
+
+    return pa.RecordBatchReader.from_batches(batch.schema, batches()), pulls
+
+
 def _unsupported_local_map_payload(fn, **extra):
     payload = {
         "function_pickle": _pickle_function(fn),
@@ -1522,6 +1533,51 @@ def test_unified_executor_routes_subprocess_scalar_native():
         assert executor.take_ready_result() is None
     finally:
         executor.close()
+
+
+def test_udf_runtime_rejects_record_batch_reader_input_without_consuming_it():
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    def identity(table):
+        return table
+
+    reader, pulls = _record_batch_reader_with_pull_counter()
+    executor = UDFExecutor(_subprocess_map_payload(identity))
+
+    with pytest.raises(TypeError, match="rows must be a pyarrow Table or RecordBatch"):
+        executor.submit(reader)
+
+    assert pulls == []
+
+
+@pytest.mark.parametrize(
+    ("call_mode", "scalar_udf_type"),
+    [
+        ("map", "native"),
+        ("map", "arrow"),
+        ("map_batches", None),
+        ("map_batches_rows", None),
+        ("flat_map", None),
+    ],
+)
+def test_udf_runtime_rejects_record_batch_reader_output_without_consuming_it(call_mode, scalar_udf_type):
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    def identity(value):
+        return value
+
+    if call_mode == "map":
+        payload = _subprocess_scalar_payload(identity, scalar_udf_type=scalar_udf_type)
+    else:
+        payload = _subprocess_map_payload(identity, call_mode=call_mode)
+    executor = UDFExecutor(payload)
+    reader, pulls = _record_batch_reader_with_pull_counter()
+    executor._map_fn = lambda *_args: reader
+
+    with pytest.raises(TypeError, match="RecordBatchReader is not supported"):
+        executor.submit(pa.table({"x": [1]}))
+
+    assert pulls == []
 
 
 def test_udf_runtime_map_batches_stream_output_buffers_compute_subbatches_until_submit_flush():
@@ -4623,8 +4679,69 @@ def test_callable_cache_reuses_deserialized_callable(monkeypatch):
         "python_udf_callable_cache_hit": 1,
         "python_udf_callable_cache_miss": 1,
         "python_udf_callable_cache_bypass": 0,
+        "python_udf_callable_load_map_native": 1,
+        "python_udf_callable_load_map_arrow": 0,
+        "python_udf_callable_load_map_batches": 0,
+        "python_udf_callable_load_map_batches_rows": 0,
+        "python_udf_callable_load_flat_map": 0,
     }
     common.clear_udf_callable_cache()
+
+
+@pytest.mark.parametrize(
+    ("call_mode", "scalar_udf_type", "load_stat"),
+    [
+        ("map", "native", "python_udf_callable_load_map_native"),
+        ("map", "arrow", "python_udf_callable_load_map_arrow"),
+        ("map_batches", None, "python_udf_callable_load_map_batches"),
+        ("map_batches_rows", None, "python_udf_callable_load_map_batches_rows"),
+        ("flat_map", None, "python_udf_callable_load_flat_map"),
+    ],
+)
+def test_runtime_callable_cache_contract_applies_to_every_udf_type(
+    monkeypatch,
+    call_mode,
+    scalar_udf_type,
+    load_stat,
+):
+    import duckdb.execution._common as common
+    from duckdb import pickle as duckdb_pickle
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    common.clear_udf_callable_cache()
+    calls = []
+
+    def udf(value):
+        return value
+
+    def fake_loads(data):
+        calls.append(data)
+        return udf
+
+    monkeypatch.setattr(duckdb_pickle, "loads", fake_loads)
+    payload = {
+        "function_pickle": f"{call_mode}-{scalar_udf_type}".encode(),
+        "call_mode": call_mode,
+        "execution_backend": "subprocess_task",
+    }
+    if scalar_udf_type is not None:
+        payload["scalar_udf_type"] = scalar_udf_type
+
+    try:
+        UDFExecutor(payload, cache_callable=True, cache_max_entries=8)
+        UDFExecutor(payload, cache_callable=True, cache_max_entries=8)
+
+        stats = common.udf_callable_cache_stats()
+        load_stats = {name: count for name, count in stats.items() if name.startswith("python_udf_callable_load_")}
+
+        assert calls == [payload["function_pickle"]]
+        assert stats["python_udf_callable_cache_hit"] == 1
+        assert stats["python_udf_callable_cache_miss"] == 1
+        assert stats["python_udf_callable_cache_bypass"] == 0
+        assert load_stats[load_stat] == 1
+        assert sum(load_stats.values()) == 1
+    finally:
+        common.clear_udf_callable_cache()
 
 
 def test_local_shm_budget_manager_input_lease_is_diagnostic_only(monkeypatch):


### PR DESCRIPTION
## Summary

- honor `cache_callable` and `cache_max_entries` for scalar, batch, row-preserving batch, and flat-map runtimes
- record process-local callable deserialization counters for all five supported UDF execution types
- remove `RecordBatchReader` support from the UDF runtime contract and reject readers before pulling any batch

## Design

The UDF runtime already documents materialized `pa.Table` input and `pa.Table | Iterator[pa.Table]` batch output. A `RecordBatchReader` is therefore intentionally unsupported instead of being silently materialized or retained through a compatibility path. Core DuckDB Arrow reader APIs and the separate vLLM executor are unchanged.

Because readers are rejected without consumption, the regression coverage asserts zero pulls for both input and every UDF output type. This replaces the streaming-memory test requested by the original acceptance criteria with the stronger unsupported-input invariant.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files duckdb/execution/_common.py duckdb/execution/_udf_runtime.py tests/fast/test_udf_executor_lifecycle.py`
- `python -m pytest tests/fast/test_udf_executor_lifecycle.py` (`220 passed`)
- `scripts/run_release_tests.sh` (`303 passed, 1 skipped`; real-Ray shard `7 passed`)
- two consecutive clean code-review passes after the final fix

Fixes #103