### PR TITLE
[feat](packaging) Add video and image optional dependency extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Install the `vane-ai` package from PyPI:
 pip install vane-ai
 ```
 
+Optional features are provided as extras:
+
+```bash
+pip install 'vane-ai[openai]'   # OpenAI provider (anthropic / google / transformers / vllm likewise)
+pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
+pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
+```
+
+The `video` extra installs `decord` on Linux x86-64 only, matching the platforms covered by its prebuilt wheels.
+
 For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/data/quickstart/installation).
 
 ### Quick Start

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
 ```
 
-The `video` extra installs `decord` on Linux x86-64 only, matching the platforms covered by its prebuilt wheels.
+The `video` extra installs `decord` on Linux x86-64, Vane's currently supported native platform. decord itself publishes no wheels for modern Python on macOS or for any ARM platform; if Vane adds Windows support later, decord's existing `win_amd64` wheel can be enabled explicitly.
 
 For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/data/quickstart/installation).
 

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -17,20 +17,33 @@ Usage::
 
 from __future__ import annotations
 
+import importlib
 import os
 import threading
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
+from types import ModuleType
 from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
-from PIL import Image  # type: ignore[import-not-found]
 
 from duckdb.datasource import DataSource, DataSourceTask
+
+
+def _import_video_dependency(module_name: str, package_name: str) -> ModuleType:
+    """Import an optional video dependency, reporting the extra to install on failure."""
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        hint = "Please `pip install 'vane-ai[video]'` to use the video data source."
+        if package_name == "decord":
+            hint += " The video extra installs decord on Linux x86-64 only."
+        raise ImportError(f"The video data source requires the '{package_name}' package. {hint}") from exc
+
 
 # The generic datasource keeps its historical 10 MiB default. The aligned
 # video benchmark explicitly supplies Ray Data's 128 MiB soft block target.
@@ -194,7 +207,7 @@ def _wait_for_memory() -> None:
     IMPORTANT: Only call at task START (before a new video). Never call
     mid-decode or mid-yield — that deadlocks the DuckDB push pipeline.
     """
-    import psutil  # type: ignore[import-untyped]
+    psutil = _import_video_dependency("psutil", "psutil")
 
     def has_capacity(mem: Any) -> bool:
         if _MEM_MIN_AVAILABLE_BYTES > 0 and mem.available >= _MEM_MIN_AVAILABLE_BYTES:
@@ -275,7 +288,7 @@ def _constant_string_array(value: str, count: int) -> pa.Array:
 
 
 def _open_decord_reader(video_path: str) -> Any:
-    from decord import VideoReader  # type: ignore[import-not-found]
+    VideoReader = _import_video_dependency("decord", "decord").VideoReader
 
     if video_path.startswith("s3://"):
         import io as _io
@@ -289,7 +302,8 @@ def _resize_rgb_frame(
     width: int,
     height: int,
 ) -> npt.NDArray[np.uint8]:
-    pil_image = Image.fromarray(frame)
+    pil_image_module = _import_video_dependency("PIL.Image", "pillow")
+    pil_image = pil_image_module.fromarray(frame)
     return np.array(pil_image.resize((width, height)))
 
 

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -41,7 +41,7 @@ def _import_video_dependency(module_name: str, package_name: str) -> ModuleType:
     except ImportError as exc:
         hint = "Please `pip install 'vane-ai[video]'` to use the video data source."
         if package_name == "decord":
-            hint += " The video extra installs decord on Linux x86-64 only."
+            hint += " The video extra installs decord on Linux x86-64, Vane's currently supported video platform."
         raise ImportError(f"The video data source requires the '{package_name}' package. {hint}") from exc
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,14 @@ transformers = [
 vllm = [
     "vllm; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]
+image = [ # ndarray image inputs for AI providers
+    "pillow>=10",
+]
+video = [ # video data source; decord ships prebuilt wheels for Linux x86-64 only
+    "pillow>=10",
+    "psutil>=5.9",
+    "decord>=0.6; platform_system == 'Linux' and platform_machine == 'x86_64'",
+]
 all = [ # Cloud providers and dataframe/filesystem integrations; local model runtimes stay opt-in.
     "anthropic",
     "google-genai",
@@ -81,6 +89,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "openai",
     "pandas",  # used for pandas dataframes
     "adbc-driver-manager", # for the adbc driver
+    "pillow>=10", # used for image inputs and video frames
 ]
 
 ######################################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ vllm = [
 image = [ # ndarray image inputs for AI providers
     "pillow>=10",
 ]
-video = [ # video data source; decord ships prebuilt wheels for Linux x86-64 only
+video = [ # video data source; decord is gated to Vane's supported native platform (it lacks modern macOS/ARM wheels)
     "pillow>=10",
     "psutil>=5.9",
     "decord>=0.6; platform_system == 'Linux' and platform_machine == 'x86_64'",

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -134,7 +134,7 @@ def test_image_extra_installs_pillow():
 def test_video_extra_installs_video_dependencies():
     selected = _requirements_for_extra("video")
     assert {"pillow", "psutil"} <= selected
-    if sys.platform == "linux" and platform.machine() == "x86_64":
+    if platform.system() == "Linux" and platform.machine() == "x86_64":
         assert "decord" in selected
 
 

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import platform
 import subprocess
 import sys
 from importlib.metadata import distribution, metadata, requires, version
@@ -124,3 +125,24 @@ def test_sdist_tree_uses_injected_source_id(tmp_path, monkeypatch):
     )
 
     assert _expected_duckdb_source_id(tmp_path) == expected
+
+
+def test_image_extra_installs_pillow():
+    assert _requirements_for_extra("image") == {"pillow"}
+
+
+def test_video_extra_installs_video_dependencies():
+    selected = _requirements_for_extra("video")
+    assert {"pillow", "psutil"} <= selected
+    if sys.platform == "linux" and platform.machine() == "x86_64":
+        assert "decord" in selected
+
+
+def test_base_distribution_keeps_video_dependencies_optional():
+    base_requirements = set()
+    for raw_requirement in requires("vane-ai") or []:
+        requirement = Requirement(raw_requirement)
+        if requirement.marker is None or requirement.marker.evaluate({"extra": ""}):
+            base_requirements.add(canonicalize_name(requirement.name))
+
+    assert {"pillow", "psutil", "decord"}.isdisjoint(base_requirements)

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -134,8 +134,8 @@ def test_image_extra_installs_pillow():
 def test_video_extra_installs_video_dependencies():
     selected = _requirements_for_extra("video")
     assert {"pillow", "psutil"} <= selected
-    if platform.system() == "Linux" and platform.machine() == "x86_64":
-        assert "decord" in selected
+    supports_decord = platform.system() == "Linux" and platform.machine() == "x86_64"
+    assert ("decord" in selected) is supports_decord
 
 
 def test_base_distribution_keeps_video_dependencies_optional():

--- a/tests/fast/test_video_optional_deps.py
+++ b/tests/fast/test_video_optional_deps.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import numpy as np
+import pytest
+
+from duckdb.datasource import video_reader
+
+
+def test_missing_decord_error_names_video_extra(monkeypatch):
+    monkeypatch.setitem(sys.modules, "decord", None)
+    with pytest.raises(ImportError, match=r"vane-ai\[video\]") as exc_info:
+        video_reader._open_decord_reader("nonexistent.mp4")
+    assert "decord" in str(exc_info.value)
+    assert "Linux x86-64" in str(exc_info.value)
+
+
+def test_missing_pillow_error_names_video_extra(monkeypatch):
+    monkeypatch.setitem(sys.modules, "PIL.Image", None)
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+    with pytest.raises(ImportError, match=r"vane-ai\[video\]") as exc_info:
+        video_reader._resize_rgb_frame(frame, width=1, height=1)
+    assert "pillow" in str(exc_info.value)
+
+
+def test_missing_psutil_error_names_video_extra(monkeypatch):
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    with pytest.raises(ImportError, match=r"vane-ai\[video\]"):
+        video_reader._wait_for_memory()
+
+
+def test_provider_ndarray_without_pillow_names_image_extra(monkeypatch):
+    pytest.importorskip("openai")
+    from vane.ai.providers.openai import OpenAIPrompter
+
+    monkeypatch.setitem(sys.modules, "PIL", None)
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+    with pytest.raises(ImportError, match=r"vane-ai\[image\]"):
+        OpenAIPrompter._process_ndarray(None, frame)

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor
-from vane.ai.provider import Provider
+from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -208,7 +208,10 @@ class AnthropicPrompter:
     def _process_ndarray(self, arr: Any) -> dict[str, Any]:
         import io
 
-        from PIL import Image
+        try:
+            from PIL import Image
+        except ImportError as exc:
+            raise ProviderImportError("image", function="ndarray image input") from exc
 
         img = Image.fromarray(arr)
         buf = io.BytesIO()

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
-from vane.ai.provider import Provider
+from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
 
 if TYPE_CHECKING:
@@ -374,7 +374,11 @@ class GooglePrompter:
         import io
 
         from google.genai import types
-        from PIL import Image
+
+        try:
+            from PIL import Image
+        except ImportError as exc:
+            raise ProviderImportError("image", function="ndarray image input") from exc
 
         img = Image.fromarray(arr)
         buf = io.BytesIO()

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -22,7 +22,7 @@ import pyarrow as pa
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
-from vane.ai.provider import Provider
+from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
 
 if TYPE_CHECKING:
@@ -489,7 +489,10 @@ class OpenAIPrompter:
         import base64
         import io
 
-        from PIL import Image
+        try:
+            from PIL import Image
+        except ImportError as exc:
+            raise ProviderImportError("image", function="ndarray image input") from exc
 
         img = Image.fromarray(arr)
         buf = io.BytesIO()


### PR DESCRIPTION
## Summary

Implements the complete optional dependency story for the video data source, plus a shared `image` extra for the ndarray image paths in AI providers.

- Add `video = ["pillow>=10", "psutil>=5.9", "decord>=0.6; platform_system == 'Linux' and platform_machine == 'x86_64'"]`. decord is gated with the same environment marker as the existing `vllm` extra: the marker matches Vane's currently supported native platform (Linux x86-64). The dependency-side constraint is that decord 0.6.0 publishes no wheels for modern Python on macOS and none for any ARM platform, and has no sdist, so an unmarked extra would make `pip install 'vane-ai[video]'` unresolvable there. decord's existing `win_amd64` wheel can be enabled explicitly if Vane adds Windows support.
- Add `image = ["pillow>=10"]` as a shared extra for the ndarray→image conversion sites in the OpenAI/Anthropic/Google providers. Provider extras stay SDK-only; the conversion sites raise `ProviderImportError("image")` with the exact install command. The main pipeline that feeds ndarrays into prompts (video frames) already has Pillow via the `video` extra.
- Make all three optional imports in `video_reader.py` (PIL / psutil / decord) lazy through one helper that names the exact extra on failure; the decord message states the platform bound explicitly. The base import stays light and the base install gains no new dependencies (asserted by a new metadata test). With the static imports gone, the `# type: ignore` comments they carried are no longer needed.
- `all` gains `pillow` only, consistent with its existing note that heavy/platform-gated runtimes stay opt-in.
- Document the extras in the README installation section.

## Related issue

Closes #72.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

README installation section now documents the `image`/`video` extras and the

## Validation

- Rebased onto `59b9aaec`; the typing annotations from #189 are preserved (the lazy-import change subsumes their `# type: ignore` comments).
- New metadata tests extend the existing `_requirements_for_extra` pattern i_metadata.py`; the decord assertion is platform-aware so it passes on anyrunner. A base-install test asserts pillow/psutil/decord stay out of the default dependency set.
- New `tests/fast/test_video_optional_deps.py` covers the error messages forlus the provider `image` path, simulating missing dependenciesdeterministically via `sys.modules` blocking — the tests pass regardless of which optional packages the environment has installed (relevant now that CI's test dependencies include pillow).
- Local verification on this host: `ruff check` / `ruff format --check` clean, `py_compile` on all touched files, `tomllib` parse of `pyproject.toml`. Test execution is deferred to CI: this host is macOS arm64, which the native build does not currently target, so the fast-test suite cannot run locally. Python-only change, no native rebuild required.          
## Checklist

- [x] The change is focused and includes regression coverage.                                                                                                                       - [x] Public behavior and native compatibility impact are documented. (New ohavior change for existing installs.)
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. (Declared optional extras only — pillow (MIT-CMU), psutil (BSD-3-Clause), decord (Apache-2.0); nothing is vendored, matching how existclared.)
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network accave been considered. (Import-error paths only; no new code executesthird-party input.)
- [x] Native changes were compiled; affected native, Python, release, formatting, and lint checks passed. (No native changes; formatting and lint verified locally, tests via CI.)
