### PR TITLE
[fix](ray) Keep result collectors query-local

### DIFF
--- a/external/duckdb/src/include/duckdb/main/client_context.hpp
+++ b/external/duckdb/src/include/duckdb/main/client_context.hpp
@@ -65,6 +65,9 @@ struct PendingQueryParameters {
 	optional_ptr<case_insensitive_map_t<BoundParameterData>> parameters;
 	//! Whether a stream/buffer-managed result should be allowed
 	QueryParameters query_parameters;
+	//! Query-local callback used to create a materialized result collector.
+	//! Takes precedence over the connection-level callback without modifying connection state.
+	get_result_collector_t get_result_collector = nullptr;
 };
 
 //! The ClientContext holds information relevant to the current client session

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -587,9 +587,15 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 
 	// Decide how to get the result collector.
 	get_result_collector_t get_collector = PhysicalResultCollector::GetResultCollector;
-	auto &client_config = ClientConfig::GetConfig(*this);
-	if (!stream_result && client_config.get_result_collector) {
-		get_collector = client_config.get_result_collector;
+	if (!stream_result) {
+		if (parameters.get_result_collector) {
+			get_collector = parameters.get_result_collector;
+		} else {
+			auto &client_config = ClientConfig::GetConfig(*this);
+			if (client_config.get_result_collector) {
+				get_collector = client_config.get_result_collector;
+			}
+		}
 	}
 	statement_data.output_type =
 	    stream_result ? QueryResultOutputType::ALLOW_STREAMING : QueryResultOutputType::FORCE_MATERIALIZED;

--- a/external/duckdb/test/api/test_pending_query.cpp
+++ b/external/duckdb/test/api/test_pending_query.cpp
@@ -3,9 +3,35 @@
 
 #include <thread>
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/execution/operator/helper/physical_result_collector.hpp"
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/client_context_state.hpp"
 
 using namespace duckdb;
 using namespace std;
+
+namespace {
+
+get_result_collector_t CountingResultCollector(idx_t &calls) {
+	return [&calls](ClientContext &context, PreparedStatementData &data) -> PhysicalOperator & {
+		calls++;
+		return PhysicalResultCollector::GetResultCollector(context, data);
+	};
+}
+
+class FailNextQueryEndState : public ClientContextState {
+public:
+	bool fail_next = false;
+
+	void QueryEnd(ClientContext &, optional_ptr<ErrorData>) override {
+		if (fail_next) {
+			fail_next = false;
+			throw InvalidInputException("injected query teardown failure");
+		}
+	}
+};
+
+} // namespace
 
 TEST_CASE("Test Pending Query API", "[api][.]") {
 	DuckDB db;
@@ -111,6 +137,106 @@ TEST_CASE("Test Pending Query API", "[api][.]") {
 		auto pending_query = con.PendingQuery("SELCT 32;");
 		REQUIRE(pending_query->HasError());
 		REQUIRE(duckdb::StringUtil::Contains(pending_query->GetError(), "SYNTAX_ERROR"));
+	}
+}
+
+TEST_CASE("Pending query result collector overrides are query-local", "[api][result-collector]") {
+	idx_t connection_collector_calls = 0;
+	idx_t query_collector_calls = 0;
+	DuckDB db;
+	Connection con(db);
+	auto &client_config = ClientConfig::GetConfig(*con.context);
+	client_config.get_result_collector = CountingResultCollector(connection_collector_calls);
+
+	auto require_local_query = [&](int value, idx_t expected_connection_calls) {
+		auto result = con.Query("SELECT " + to_string(value));
+		REQUIRE(CHECK_COLUMN(result, 0, {value}));
+		REQUIRE(connection_collector_calls == expected_connection_calls);
+	};
+
+	require_local_query(41, 1);
+
+	PendingQueryParameters parameters;
+	parameters.get_result_collector = CountingResultCollector(query_collector_calls);
+
+	SECTION("success") {
+		auto pending_query = con.PendingQuery("SELECT 42", parameters);
+		REQUIRE(!pending_query->HasError());
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 1);
+
+		auto result = pending_query->Execute();
+		REQUIRE(CHECK_COLUMN(result, 0, {42}));
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 1);
+	}
+
+	SECTION("planning failure") {
+		auto pending_query = con.PendingQuery("SELECT missing_column", parameters);
+		REQUIRE(pending_query->HasError());
+		REQUIRE(StringUtil::Contains(pending_query->GetError(), "missing_column"));
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 0);
+
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 0);
+	}
+
+	SECTION("collector initialization failure") {
+		parameters.get_result_collector = [&query_collector_calls](ClientContext &,
+		                                                           PreparedStatementData &) -> PhysicalOperator & {
+			query_collector_calls++;
+			throw InvalidInputException("injected result collector failure");
+		};
+
+		auto pending_query = con.PendingQuery("SELECT 42", parameters);
+		REQUIRE(pending_query->HasError());
+		REQUIRE(StringUtil::Contains(pending_query->GetError(), "injected result collector failure"));
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 1);
+
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 1);
+	}
+
+	SECTION("execution failure") {
+		auto pending_query = con.PendingQuery(
+		    "SELECT concat(SUM(i)::VARCHAR, 'invalid')::INTEGER FROM range(100000) tbl(i)", parameters);
+		REQUIRE(!pending_query->HasError());
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 1);
+
+		auto result = pending_query->Execute();
+		REQUIRE(result->HasError());
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 1);
+	}
+
+	SECTION("cancellation") {
+		auto pending_query = con.PendingQuery("SELECT SUM(i) FROM range(1000000000) tbl(i)", parameters);
+		REQUIRE(!pending_query->HasError());
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 1);
+
+		con.Interrupt();
+		auto result = pending_query->Execute();
+		REQUIRE(result->HasError());
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 1);
+	}
+
+	SECTION("teardown failure") {
+		auto state = make_shared_ptr<FailNextQueryEndState>();
+		con.context->registered_state->Insert("fail_query_end", state);
+		auto pending_query = con.PendingQuery("SELECT 42", parameters);
+		REQUIRE(!pending_query->HasError());
+		REQUIRE(connection_collector_calls == 1);
+		REQUIRE(query_collector_calls == 1);
+
+		state->fail_next = true;
+		REQUIRE_THROWS_WITH(pending_query->Execute(), Catch::Matchers::Contains("injected query teardown failure"));
+		require_local_query(43, 2);
+		REQUIRE(query_collector_calls == 1);
 	}
 }
 

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1964,6 +1964,13 @@ struct PyPhysicalPlanWrapperRunner {
 			} plan_guard(prepared_data->physical_plan);
 
 			PendingQueryParameters parameters;
+			// Force a parallel result collector for this query only. This enables multi-threaded pipeline
+			// execution for UDF-heavy workloads without changing the connection's collector callback.
+			parameters.get_result_collector = [](duckdb::ClientContext &,
+			                                     duckdb::PreparedStatementData &data) -> duckdb::PhysicalOperator & {
+				auto &physical_plan = *data.physical_plan;
+				return physical_plan.Make<duckdb::PhysicalMaterializedCollector>(data, true);
+			};
 			std::unique_ptr<QueryResult> query_result;
 			vector<PipelineProgressSnapshot> stable_pipeline_snapshots;
 			try {
@@ -1971,15 +1978,6 @@ struct PyPhysicalPlanWrapperRunner {
 				const auto native_progress_env_ms = DuckdbGetEnvIntMs("VANE_NATIVE_PROGRESS_INTERVAL_MS");
 				const auto native_progress_ms =
 				    has_native_progress_callback ? (native_progress_env_ms > 0 ? native_progress_env_ms : 500) : 0;
-				auto &client_config = duckdb::ClientConfig::GetConfig(context);
-				// Force parallel result collector by providing a custom get_result_collector
-				// callback that always creates PhysicalMaterializedCollector(parallel=true).
-				// This enables multi-threaded pipeline execution for UDF-heavy workloads.
-				client_config.get_result_collector =
-				    [](duckdb::ClientContext &, duckdb::PreparedStatementData &data) -> duckdb::PhysicalOperator & {
-					auto &physical_plan = *data.physical_plan;
-					return physical_plan.Make<duckdb::PhysicalMaterializedCollector>(data, true);
-				};
 
 				py::gil_scoped_release release;
 				auto pending = context.PendingQueryPreparedStatementNoRebind(string("external_plan:") + plan_id,

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -85,6 +85,7 @@ static inline int DuckdbGetEnvIntMs(const char *name) {
 #include <duckdb/execution/operator/projection/physical_udf_inout.hpp>
 #include <duckdb/function/scalar/udf_functions.hpp>
 #include <duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp>
+#include <duckdb/execution/operator/helper/physical_result_collector.hpp>
 #include <duckdb/execution/operator/projection/physical_projection.hpp>
 #include <duckdb/planner/expression/bound_reference_expression.hpp>
 #include <duckdb/common/arrow/arrow_converter.hpp>
@@ -137,9 +138,54 @@ protected:
 	}
 };
 
+class CountingResultCollectorForTest {
+public:
+	CountingResultCollectorForTest() : calls(make_shared_ptr<std::atomic<idx_t>>(0)) {
+	}
+
+	PhysicalOperator &operator()(ClientContext &context, PreparedStatementData &data) const {
+		calls->fetch_add(1, std::memory_order_relaxed);
+		return PhysicalResultCollector::GetResultCollector(context, data);
+	}
+
+	shared_ptr<std::atomic<idx_t>> calls;
+};
+
 void register_ray_bindings(py::module_ &mod) {
 	auto m = mod.def_submodule("ray_cxx");
 	m.doc() = "C++ Ray execution bindings (experimental)";
+	m.def(
+	    "_install_counting_result_collector_for_test",
+	    [](py::object conn_obj) {
+		    auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
+		    auto &context = *conn_wrapper.con.GetConnection().context;
+		    ClientConfig::GetConfig(context).get_result_collector = CountingResultCollectorForTest();
+	    },
+	    py::arg("conn"), "Install a connection-level result collector that counts materialized queries.");
+	m.def(
+	    "_connection_result_collector_calls_for_test",
+	    [](py::object conn_obj) {
+		    auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
+		    auto &context = *conn_wrapper.con.GetConnection().context;
+		    auto &callback = ClientConfig::GetConfig(context).get_result_collector;
+		    auto collector = callback.target<CountingResultCollectorForTest>();
+		    if (!collector) {
+			    throw InternalException("The counting result collector is no longer installed");
+		    }
+		    return collector->calls->load(std::memory_order_relaxed);
+	    },
+	    py::arg("conn"), "Return the number of materialized queries observed by the test collector.");
+	m.def(
+	    "_execute_materialized_int64_for_test",
+	    [](py::object conn_obj, const string &query) {
+		    auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
+		    auto result = conn_wrapper.con.GetConnection().Query(query);
+		    if (result->HasError()) {
+			    throw InvalidInputException(result->GetError());
+		    }
+		    return result->GetValue<int64_t>(0, 0);
+	    },
+	    py::arg("conn"), py::arg("query"), "Execute a materialized query and return its first BIGINT value.");
 	m.def("shutdown_local_flight_service", []() {
 		auto result = []() {
 			py::gil_scoped_release release;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -33,6 +33,24 @@ def _make_test_physical_plan(con=None):
     ).to_physical_plan(con)
 
 
+def test_execute_native_keeps_result_collector_query_local():
+    con = duckdb.connect()
+    cursor = con.cursor()
+    local_sql = "SELECT sum(i)::BIGINT FROM range(32) tbl(i)"
+    plan = _make_test_physical_plan(cursor)
+    duckdb.ray_cxx._install_counting_result_collector_for_test(cursor)
+
+    before = duckdb.ray_cxx._execute_materialized_int64_for_test(cursor, local_sql)
+    assert duckdb.ray_cxx._connection_result_collector_calls_for_test(cursor) == 1
+
+    result = duckdb.ray_cxx.DistributedPhysicalPlanRunner().execute_native(cursor, plan)
+
+    assert result.completion_status == "ok"
+    assert duckdb.ray_cxx._connection_result_collector_calls_for_test(cursor) == 1
+    assert duckdb.ray_cxx._execute_materialized_int64_for_test(cursor, local_sql) == before
+    assert duckdb.ray_cxx._connection_result_collector_calls_for_test(cursor) == 2
+
+
 def test_physical_plan_pickle_propagates_non_serializable_operator_error():
     plan = duckdb.ray_cxx._make_non_serializable_physical_plan_for_test("query-non-serializable")
 


### PR DESCRIPTION
## Summary

- add a query-local materialized result collector override to `PendingQueryParameters`, ahead of the legacy connection-level callback
- use the query-local override for native distributed execution so the connection callback is never mutated
- cover success, planning and collector initialization failures, execution failure, cancellation, teardown failure, and same-connection local/distributed/local behavior
- verify that an existing custom connection callback remains installed and observes only local materialized queries

## Tests

- `build/native-cxx20/test/unittest [result-collector]` — 54 assertions passed
- `.venv/bin/python -m pytest -q tests/fast/test_ray_cpp_bindings.py::test_execute_native_keeps_result_collector_query_local` — passed
- `scripts/run_release_tests.sh` — 304 non-Ray tests and 7 real-Ray tests passed
- CPU-only `scripts/run_fast_tests.sh` profile — 5,238 non-Ray tests and 77 shared-Ray tests passed; one test-owned Ray process reported PASS but exited before its pytest summary on the aggregate run, and the complete owner-Ray phase then passed on an isolated rerun (6 passed, 2 multi-node skips)
- pre-commit hooks for all changed files — passed

Fixes #82