### PR TITLE
[fix](datasource) Use stable distributed factory identities

### DIFF
--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -80,7 +80,7 @@ def _ensure_python_datasource_runtime() -> None:
 
 
 def _release_datasource_factories_for_query(query_id: str) -> int:
-    import _duckdb
+    import _duckdb  # type: ignore[import-not-found]
 
     return int(_duckdb._release_datasource_factories_for_query(str(query_id)))
 

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -900,16 +900,22 @@ class RayWorkerActor:
             fte_result = await self._get_fte_task_manager().drop_query(query_id)
             fragments_removed = self.drop_query_fragments(query_id)
         finally:
-            drain_results = await asyncio.gather(
+            native_drain_result, flight_drain_result = await asyncio.gather(
                 self._wait_worker_native_executions_for_query(query_id),
                 _wait_flight_shuffle_executions_for_query(query_id),
                 return_exceptions=True,
             )
-            drain_errors = [result for result in drain_results if isinstance(result, BaseException)]
+            drain_errors = [
+                result for result in (native_drain_result, flight_drain_result) if isinstance(result, BaseException)
+            ]
+            if not isinstance(native_drain_result, BaseException):
+                try:
+                    _release_datasource_factories_for_query(query_id)
+                except Exception as error:
+                    drain_errors.append(error)
             if drain_errors:
                 details = "; ".join(f"{type(error).__name__}: {error}" for error in drain_errors)
-                raise RuntimeError(f"failed to drain native executions for {query_id}: {details}") from drain_errors[0]
-            _release_datasource_factories_for_query(query_id)
+                raise RuntimeError(f"failed to prepare query teardown for {query_id}: {details}") from drain_errors[0]
         if interrupt_errors:
             raise RuntimeError(
                 f"failed to interrupt {len(interrupt_errors)} native execution(s) for {query_id}: "

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -79,6 +79,18 @@ def _ensure_python_datasource_runtime() -> None:
     import duckdb.datasource  # noqa: F401
 
 
+def _release_datasource_factories_for_query(query_id: str) -> int:
+    import _duckdb
+
+    return int(_duckdb._release_datasource_factories_for_query(str(query_id)))
+
+
+def _clear_datasource_factory_registry() -> None:
+    import _duckdb
+
+    _duckdb._clear_datasource_factory_registry()
+
+
 def _chaos_worker_loss_matches(task_id: FteTaskAttemptId) -> bool:
     if not _env_flag_enabled("VANE_FTE_CHAOS_KILL_WORKER_ON_RUNNING"):
         return False
@@ -897,6 +909,7 @@ class RayWorkerActor:
             if drain_errors:
                 details = "; ".join(f"{type(error).__name__}: {error}" for error in drain_errors)
                 raise RuntimeError(f"failed to drain native executions for {query_id}: {details}") from drain_errors[0]
+            _release_datasource_factories_for_query(query_id)
         if interrupt_errors:
             raise RuntimeError(
                 f"failed to interrupt {len(interrupt_errors)} native execution(s) for {query_id}: "
@@ -1184,6 +1197,7 @@ class RayWorkerActor:
                 hint="Ensure the C++ ray extension is built with Flight service lifecycle support.",
             )
             shutdown_flight()
+            _clear_datasource_factory_registry()
             self._shutdown_complete = True
 
     @ray.method(concurrency_group="control")

--- a/external/duckdb/src/function/table/datasource_scan.cpp
+++ b/external/duckdb/src/function/table/datasource_scan.cpp
@@ -20,7 +20,8 @@ static const string DATASOURCE_PREFIX = "datasource://";
 // Global produce_stream callback — set once from Python module init,
 // used to restore the callback on workers after deserialization.
 static std::atomic<datasource_produce_stream_t> g_global_produce_stream {nullptr};
-static std::atomic<datasource_set_worker_source_t> g_global_worker_source_callback {nullptr};
+static std::atomic<datasource_acquire_source_t> g_global_acquire_source {nullptr};
+static std::atomic<datasource_release_source_t> g_global_release_source {nullptr};
 static std::atomic<datasource_get_schema_t> g_global_get_schema {nullptr};
 
 static datasource_produce_stream_t RequireProduceStream(datasource_produce_stream_t callback) {
@@ -105,6 +106,16 @@ static unique_ptr<FunctionData> DataSourceScanBind(ClientContext &context, Table
 
 // ── Init Global ────────────────────────────────────────────────────
 
+DataSourceScanGlobalState::~DataSourceScanGlobalState() {
+	if (!release_source_on_destroy || !release_source) {
+		return;
+	}
+	try {
+		release_source(pickled_source.c_str(), pickled_source.size());
+	} catch (...) { // Destructors must not propagate callback failures.
+	}
+}
+
 static unique_ptr<GlobalTableFunctionState> DataSourceScanInitGlobal(ClientContext &context,
                                                                      TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<DataSourceScanBindData>();
@@ -112,14 +123,25 @@ static unique_ptr<GlobalTableFunctionState> DataSourceScanInitGlobal(ClientConte
 	result->total_tasks = bind_data.pickled_tasks.size();
 	result->next_task_idx = 0;
 
-	// On a worker, set the pickled_source so ProduceStream can lazily create factories.
-	auto worker_source_cb = g_global_worker_source_callback.load();
-	if (!bind_data.pickled_source.empty() && !worker_source_cb) {
-		throw InvalidInputException("Python datasource runtime is not initialized on this Ray worker; missing "
-		                            "datasource worker source callback");
+	// Acquire one process-local factory owner for this execution. Local scan
+	// ownership follows the global state; distributed ownership follows the
+	// logical query and is released only after worker executions are drained.
+	auto acquire_source = g_global_acquire_source.load();
+	auto release_source = g_global_release_source.load();
+	if (!bind_data.pickled_source.empty() && (!acquire_source || !release_source)) {
+		throw InvalidInputException(
+		    "Python datasource runtime is not initialized on this Ray worker; missing datasource source callbacks");
 	}
-	if (worker_source_cb && !bind_data.pickled_source.empty()) {
-		worker_source_cb(bind_data.pickled_source.c_str(), bind_data.pickled_source.size());
+	if (acquire_source && release_source && !bind_data.pickled_source.empty()) {
+		if (bind_data.query_id.empty()) {
+			result->release_source = release_source;
+			result->pickled_source = bind_data.pickled_source;
+		}
+		acquire_source(bind_data.pickled_source.c_str(), bind_data.pickled_source.size(), bind_data.query_id.c_str(),
+		               bind_data.query_id.size());
+		if (bind_data.query_id.empty()) {
+			result->release_source_on_destroy = true;
+		}
 	}
 
 	// Restore arrow_table on worker nodes (type_info is not picklable).
@@ -235,12 +257,14 @@ static void DataSourceScanSerialize(Serializer &serializer, const optional_ptr<F
 	auto &bind_data = bind_data_p->Cast<DataSourceScanBindData>();
 	serializer.WriteProperty(100, "pickled_tasks", bind_data.pickled_tasks);
 	serializer.WriteProperty(101, "pickled_source", bind_data.pickled_source);
+	serializer.WriteProperty(102, "query_id", bind_data.query_id);
 }
 
 static unique_ptr<FunctionData> DataSourceScanDeserialize(Deserializer &deserializer, TableFunction &function) {
 	auto result = make_uniq<DataSourceScanBindData>();
 	result->pickled_tasks = deserializer.ReadProperty<vector<string>>(100, "pickled_tasks");
 	result->pickled_source = deserializer.ReadProperty<string>(101, "pickled_source");
+	result->query_id = deserializer.ReadProperty<string>(102, "query_id");
 	// Restore produce_stream from global callback (set by Python module on load)
 	result->produce_stream = g_global_produce_stream.load();
 	RequireProduceStream(result->produce_stream);
@@ -273,8 +297,12 @@ datasource_produce_stream_t DataSourceScanFunction::GetGlobalProduceStream() {
 	return g_global_produce_stream.load();
 }
 
-void DataSourceScanFunction::SetGlobalWorkerSourceCallback(datasource_set_worker_source_t callback) {
-	g_global_worker_source_callback.store(callback);
+void DataSourceScanFunction::SetGlobalAcquireSource(datasource_acquire_source_t callback) {
+	g_global_acquire_source.store(callback);
+}
+
+void DataSourceScanFunction::SetGlobalReleaseSource(datasource_release_source_t callback) {
+	g_global_release_source.store(callback);
 }
 
 void DataSourceScanFunction::SetGlobalGetSchema(datasource_get_schema_t callback) {

--- a/external/duckdb/src/function/table/datasource_scan.cpp
+++ b/external/duckdb/src/function/table/datasource_scan.cpp
@@ -89,17 +89,13 @@ static unique_ptr<FunctionData> DataSourceScanBind(ClientContext &context, Table
 		throw InvalidInputException(
 		    "Python datasource runtime is not initialized in this process; missing datasource schema callback");
 	}
-	ArrowSchema arrow_schema;
-	get_schema(pickled_source.c_str(), pickled_source.size(), &arrow_schema);
+	ArrowSchemaWrapper arrow_schema;
+	get_schema(pickled_source.c_str(), pickled_source.size(), &arrow_schema.arrow_schema);
 
 	// Parse Arrow schema into DuckDB types
-	ArrowTableFunction::PopulateArrowTableSchema(context, result->arrow_table, arrow_schema);
+	ArrowTableFunction::PopulateArrowTableSchema(context, result->arrow_table, arrow_schema.arrow_schema);
 	names = result->arrow_table.GetNames();
 	return_types = result->arrow_table.GetTypes();
-
-	if (arrow_schema.release) {
-		arrow_schema.release(&arrow_schema);
-	}
 
 	return std::move(result);
 }
@@ -123,25 +119,13 @@ static unique_ptr<GlobalTableFunctionState> DataSourceScanInitGlobal(ClientConte
 	result->total_tasks = bind_data.pickled_tasks.size();
 	result->next_task_idx = 0;
 
-	// Acquire one process-local factory owner for this execution. Local scan
-	// ownership follows the global state; distributed ownership follows the
-	// logical query and is released only after worker executions are drained.
+	// Resolve ownership callbacks before restoring schema, but do not acquire
+	// until schema restoration has passed every fallible initialization step.
 	auto acquire_source = g_global_acquire_source.load();
 	auto release_source = g_global_release_source.load();
 	if (!bind_data.pickled_source.empty() && (!acquire_source || !release_source)) {
 		throw InvalidInputException(
 		    "Python datasource runtime is not initialized on this Ray worker; missing datasource source callbacks");
-	}
-	if (acquire_source && release_source && !bind_data.pickled_source.empty()) {
-		if (bind_data.query_id.empty()) {
-			result->release_source = release_source;
-			result->pickled_source = bind_data.pickled_source;
-		}
-		acquire_source(bind_data.pickled_source.c_str(), bind_data.pickled_source.size(), bind_data.query_id.c_str(),
-		               bind_data.query_id.size());
-		if (bind_data.query_id.empty()) {
-			result->release_source_on_destroy = true;
-		}
 	}
 
 	// Restore arrow_table on worker nodes (type_info is not picklable).
@@ -151,14 +135,26 @@ static unique_ptr<GlobalTableFunctionState> DataSourceScanInitGlobal(ClientConte
 			throw InvalidInputException(
 			    "Python datasource runtime is not initialized on this Ray worker; missing datasource schema callback");
 		}
-		ArrowSchema arrow_schema;
-		get_schema_cb(bind_data.pickled_source.c_str(), bind_data.pickled_source.size(), &arrow_schema);
+		ArrowSchemaWrapper arrow_schema;
+		get_schema_cb(bind_data.pickled_source.c_str(), bind_data.pickled_source.size(), &arrow_schema.arrow_schema);
 		// Reset to empty so AddColumn's emplace() succeeds
 		const_cast<DataSourceScanBindData &>(bind_data).arrow_table = ArrowTableSchema();
 		ArrowTableFunction::PopulateArrowTableSchema(
-		    context, const_cast<DataSourceScanBindData &>(bind_data).arrow_table, arrow_schema);
-		if (arrow_schema.release) {
-			arrow_schema.release(&arrow_schema);
+		    context, const_cast<DataSourceScanBindData &>(bind_data).arrow_table, arrow_schema.arrow_schema);
+	}
+
+	// Acquire one process-local factory owner for this execution. Local scan
+	// ownership follows the global state; distributed ownership follows the
+	// logical query and is released only after worker executions are drained.
+	if (acquire_source && release_source && !bind_data.pickled_source.empty()) {
+		if (bind_data.query_id.empty()) {
+			result->release_source = release_source;
+			result->pickled_source = bind_data.pickled_source;
+		}
+		acquire_source(bind_data.pickled_source.c_str(), bind_data.pickled_source.size(), bind_data.query_id.c_str(),
+		               bind_data.query_id.size());
+		if (bind_data.query_id.empty()) {
+			result->release_source_on_destroy = true;
 		}
 	}
 

--- a/external/duckdb/src/include/duckdb/function/table/datasource_scan.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/datasource_scan.hpp
@@ -27,17 +27,24 @@ namespace duckdb {
 //!   4. Export via _export_to_c into the ArrowArrayStream
 typedef void (*datasource_produce_stream_t)(const char *pickled_task, idx_t pickled_len, ArrowArrayStream *out_stream);
 
-//! C callback type: given pickled DataSource bytes, produce the Arrow schema
+//! C callback type: given a serialized logical source package, produce the Arrow schema
 typedef void (*datasource_get_schema_t)(const char *pickled_source, idx_t pickled_len, ArrowSchema *out_schema);
 
-//! C callback type: set the pickled source for worker-side factory recovery
-typedef void (*datasource_set_worker_source_t)(const char *pickled_source, idx_t pickled_len);
+//! C callback types: acquire/release the process-local factory for a logical source.
+//! Acquire must complete before ProduceStream is called. An empty query_id is
+//! released with the scan global state; a non-empty query_id transfers release
+//! ownership to the distributed query teardown path.
+typedef void (*datasource_acquire_source_t)(const char *pickled_source, idx_t pickled_len, const char *query_id,
+                                            idx_t query_id_len);
+typedef void (*datasource_release_source_t)(const char *pickled_source, idx_t pickled_len);
 
 struct DataSourceScanBindData : public TableFunctionData, public ExtensionFileListProvider {
 	//! Pickled DataSourceTask objects, one per task
 	vector<string> pickled_tasks;
-	//! Pickled DataSource object (for schema extraction on deserialize)
+	//! Serialized logical source package (for schema extraction on workers)
 	string pickled_source;
+	//! Distributed query owner. Empty for ordinary connection-local scans.
+	string query_id;
 	//! Callback to produce ArrowArrayStream from a pickled task
 	datasource_produce_stream_t produce_stream;
 	//! Arrow schema metadata
@@ -47,6 +54,7 @@ struct DataSourceScanBindData : public TableFunctionData, public ExtensionFileLi
 		auto result = make_uniq<DataSourceScanBindData>();
 		result->pickled_tasks = pickled_tasks;
 		result->pickled_source = pickled_source;
+		result->query_id = query_id;
 		result->produce_stream = produce_stream;
 		result->arrow_table = arrow_table;
 		return std::move(result);
@@ -60,10 +68,16 @@ struct DataSourceScanBindData : public TableFunctionData, public ExtensionFileLi
 };
 
 struct DataSourceScanGlobalState : public GlobalTableFunctionState {
+	~DataSourceScanGlobalState() override;
+
 	//! Next task index (atomic for thread-safe work-stealing)
 	atomic<idx_t> next_task_idx {0};
 	//! Total tasks
 	idx_t total_tasks = 0;
+	//! Connection-local source ownership acquired for this execution.
+	datasource_release_source_t release_source = nullptr;
+	string pickled_source;
+	bool release_source_on_destroy = false;
 
 	idx_t MaxThreads() const override {
 		return total_tasks;
@@ -86,8 +100,9 @@ struct DataSourceScanFunction {
 	static void SetGlobalProduceStream(datasource_produce_stream_t callback);
 	//! Get the global produce_stream callback (returns nullptr if not set)
 	static datasource_produce_stream_t GetGlobalProduceStream();
-	//! Register a global set_worker_source callback
-	static void SetGlobalWorkerSourceCallback(datasource_set_worker_source_t callback);
+	//! Register global source ownership callbacks.
+	static void SetGlobalAcquireSource(datasource_acquire_source_t callback);
+	static void SetGlobalReleaseSource(datasource_release_source_t callback);
 	//! Register a global get_schema callback for worker schema restoration
 	static void SetGlobalGetSchema(datasource_get_schema_t callback);
 };

--- a/src/duckdb_py/datasource_function.cpp
+++ b/src/duckdb_py/datasource_function.cpp
@@ -5,8 +5,13 @@
 #include "duckdb_python/pybind11/gil_wrapper.hpp"
 
 #include "duckdb/common/arrow/arrow.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 #include "duckdb_python/pyconnection/pyconnection.hpp"
+
+#include <algorithm>
+#include <condition_variable>
+#include <unordered_set>
 
 namespace py = pybind11;
 
@@ -16,107 +21,151 @@ namespace duckdb {
 static string PyBytesToString(const py::object &obj) {
 	char *buf = nullptr;
 	Py_ssize_t len = 0;
-	PyBytes_AsStringAndSize(obj.ptr(), &buf, &len);
+	if (PyBytes_AsStringAndSize(obj.ptr(), &buf, &len) != 0) {
+		throw py::error_already_set();
+	}
 	return string(buf, static_cast<size_t>(len));
 }
 
-// ── Global registry ────────────────────────────────────────────────
-// Factories must outlive the DuckDB plan execution. We store them in a
-// global map keyed by pointer value. The Python read_datasource() function
-// also holds a reference to prevent GC on the Python side.
-static std::mutex g_factory_mutex;
-static std::unordered_map<uintptr_t, shared_ptr<DataSourceStreamFactory>> g_factory_registry;
+// Every serialized datasource payload starts with a versioned, process-
+// independent source identity. Both source and task blobs carry the same ID.
+static constexpr char DATASOURCE_PAYLOAD_MAGIC[] = {'V', 'D', 'S', '1'};
+static constexpr idx_t DATASOURCE_PAYLOAD_MAGIC_SIZE = sizeof(DATASOURCE_PAYLOAD_MAGIC);
+static constexpr idx_t DATASOURCE_SOURCE_ID_SIZE = BaseUUID::STRING_SIZE;
+static constexpr idx_t DATASOURCE_PAYLOAD_HEADER_SIZE = DATASOURCE_PAYLOAD_MAGIC_SIZE + DATASOURCE_SOURCE_ID_SIZE;
 
-static void RegisterFactory(shared_ptr<DataSourceStreamFactory> factory) {
-	auto key = reinterpret_cast<uintptr_t>(factory.get());
-	std::lock_guard<std::mutex> lock(g_factory_mutex);
-	g_factory_registry[key] = std::move(factory);
+struct ParsedDataSourcePayload {
+	string source_id;
+	const char *payload;
+	idx_t payload_len;
+};
+
+static ParsedDataSourcePayload ParseDataSourcePayload(const char *data, idx_t len, const char *kind) {
+	if (len <= DATASOURCE_PAYLOAD_HEADER_SIZE) {
+		throw InvalidInputException("Serialized datasource %s is too short", kind);
+	}
+	if (memcmp(data, DATASOURCE_PAYLOAD_MAGIC, DATASOURCE_PAYLOAD_MAGIC_SIZE) != 0) {
+		throw InvalidInputException("Serialized datasource %s has an invalid payload header", kind);
+	}
+	string source_id(data + DATASOURCE_PAYLOAD_MAGIC_SIZE, DATASOURCE_SOURCE_ID_SIZE);
+	hugeint_t parsed_uuid;
+	if (!UUID::FromString(source_id, parsed_uuid, true)) {
+		throw InvalidInputException("Serialized datasource %s has an invalid source ID", kind);
+	}
+	return {std::move(source_id), data + DATASOURCE_PAYLOAD_HEADER_SIZE, len - DATASOURCE_PAYLOAD_HEADER_SIZE};
 }
 
-void ClearDataSourceFactoryRegistry() {
-	std::lock_guard<std::mutex> lock(g_factory_mutex);
-	g_factory_registry.clear();
+static string EncodeDataSourcePayload(const string &source_id, const string &payload) {
+	string result;
+	result.reserve(DATASOURCE_PAYLOAD_HEADER_SIZE + payload.size());
+	result.append(DATASOURCE_PAYLOAD_MAGIC, DATASOURCE_PAYLOAD_MAGIC_SIZE);
+	result.append(source_id);
+	result.append(payload);
+	return result;
+}
+
+static py::object LoadArrowSchema(const ParsedDataSourcePayload &source) {
+	auto cloudpickle = py::module::import("cloudpickle");
+	auto source_package = cloudpickle.attr("loads")(py::bytes(source.payload, source.payload_len));
+	if (!py::isinstance<py::tuple>(source_package)) {
+		throw InvalidInputException("Serialized datasource source package must be a tuple");
+	}
+	auto package_tuple = py::reinterpret_borrow<py::tuple>(source_package);
+	if (package_tuple.size() != 2) {
+		throw InvalidInputException(
+		    "Serialized datasource source package must contain source identity bytes and Arrow schema");
+	}
+	if (!py::isinstance<py::bytes>(package_tuple[0])) {
+		throw InvalidInputException("Serialized datasource source identity must be bytes");
+	}
+	return py::reinterpret_borrow<py::object>(package_tuple[1]);
+}
+
+// ── Process-local registry ─────────────────────────────────────────
+// Entries are keyed by the stable source UUID embedded in the distributed
+// plan. Local scans are reference-counted per global state; distributed scans
+// are owned idempotently by their logical query until worker query teardown.
+struct DataSourceFactoryRegistryEntry {
+	explicit DataSourceFactoryRegistryEntry(string source)
+	    : pickled_source(std::move(source)), loading(true), local_owner_count(0) {
+	}
+
+	string pickled_source;
+	shared_ptr<DataSourceStreamFactory> factory;
+	std::condition_variable ready;
+	string load_error;
+	bool loading;
+	idx_t local_owner_count;
+	std::unordered_set<string> query_owners;
+};
+
+static std::mutex g_factory_mutex;
+static std::unordered_map<string, shared_ptr<DataSourceFactoryRegistryEntry>> g_factory_registry;
+static std::atomic<idx_t> g_factory_creation_count {0};
+static string g_last_created_source_id;
+
+static void VerifyMatchingSource(const DataSourceFactoryRegistryEntry &entry, const char *pickled_source,
+                                 idx_t pickled_len, const string &source_id) {
+	if (entry.pickled_source.size() == pickled_len &&
+	    memcmp(entry.pickled_source.data(), pickled_source, pickled_len) == 0) {
+		return;
+	}
+	throw InvalidInputException("Datasource source ID collision for '%s'", source_id);
+}
+
+static void FailFactoryLoad(const string &source_id, const shared_ptr<DataSourceFactoryRegistryEntry> &entry,
+                            const string &error) {
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		entry->load_error = error;
+		entry->loading = false;
+		auto current = g_factory_registry.find(source_id);
+		if (current != g_factory_registry.end() && current->second == entry) {
+			g_factory_registry.erase(current);
+		}
+	}
+	entry->ready.notify_all();
+}
+
+static void AddFactoryOwner(DataSourceFactoryRegistryEntry &entry, const string &query_id) {
+	if (query_id.empty()) {
+		entry.local_owner_count++;
+	} else {
+		entry.query_owners.insert(query_id);
+	}
+}
+
+static idx_t FactoryOwnerCount(const DataSourceFactoryRegistryEntry &entry) {
+	return entry.local_owner_count + entry.query_owners.size();
+}
+
+static bool HasFactoryOwners(const DataSourceFactoryRegistryEntry &entry) {
+	return entry.local_owner_count > 0 || !entry.query_owners.empty();
 }
 
 // ── ProduceStream ──────────────────────────────────────────────────
 // C callback called by datasource_scan GetData/InitLocal from pipeline threads.
-// pickled_task blob layout: [factory_ptr: 8 bytes][pickled task bytes]
-//
-// On a Ray worker the factory_ptr from the driver is invalid. In that case
-// we lazily recreate the factory from the pickled DataSource embedded in
-// pickled_source (stored in the companion global g_pickled_source_for_worker).
-
-// Global pickled_source for worker-side factory recovery.
-// Set by InitGlobal before any GetData call.
-static std::mutex g_worker_source_mutex;
-static string g_worker_pickled_source;
-
-void DataSourceStreamFactory::SetWorkerPickledSource(const char *pickled_source, idx_t pickled_len) {
-	std::lock_guard<std::mutex> lock(g_worker_source_mutex);
-	g_worker_pickled_source.assign(pickled_source, pickled_len);
-}
+// pickled_task blob layout: [magic/version][source UUID][pickled task bytes]
 
 void DataSourceStreamFactory::ProduceStream(const char *pickled_task, idx_t pickled_len, ArrowArrayStream *out_stream) {
-	if (pickled_len < sizeof(uintptr_t)) {
-		throw InternalException("DataSourceStreamFactory::ProduceStream: pickled_task too short");
-	}
-	uintptr_t factory_ptr;
-	memcpy(&factory_ptr, pickled_task, sizeof(uintptr_t));
-
-	DataSourceStreamFactory *factory = nullptr;
-	{
-		std::lock_guard<std::mutex> lock(g_factory_mutex);
-		auto it = g_factory_registry.find(factory_ptr);
-		if (it != g_factory_registry.end()) {
-			factory = it->second.get();
-		}
-	}
-
-	const char *task_bytes = pickled_task + sizeof(uintptr_t);
-	idx_t task_len = pickled_len - sizeof(uintptr_t);
-
+	auto task = ParseDataSourcePayload(pickled_task, pickled_len, "task");
 	PythonGILWrapper acquire;
 
-	// If factory not found (worker process), create one from pickled_source
+	shared_ptr<DataSourceStreamFactory> factory;
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		auto entry = g_factory_registry.find(task.source_id);
+		if (entry != g_factory_registry.end() && !entry->second->loading && HasFactoryOwners(*entry->second)) {
+			factory = entry->second->factory;
+		}
+	}
 	if (!factory) {
-		string pickled_source_copy;
-		{
-			std::lock_guard<std::mutex> lock(g_worker_source_mutex);
-			pickled_source_copy = g_worker_pickled_source;
-		}
-
-		if (pickled_source_copy.size() < sizeof(uintptr_t)) {
-			throw InternalException("ProduceStream: no factory and no worker pickled_source available");
-		}
-
-		// Extract the pickled DataSource (skip the stale factory_ptr prefix)
-		const char *source_bytes = pickled_source_copy.data() + sizeof(uintptr_t);
-		idx_t source_len = pickled_source_copy.size() - sizeof(uintptr_t);
-
-		auto cloudpickle = py::module::import("cloudpickle");
-		auto source_obj = cloudpickle.attr("loads")(py::bytes(source_bytes, source_len));
-
-		// Reconstruct Arrow schema from the DataSource
-		auto schema_dict = py::cast<py::dict>(source_obj.attr("schema"));
-		auto ds_module = py::module::import("duckdb.datasource");
-		auto arrow_schema = ds_module.attr("_schema_to_arrow")(schema_dict);
-
-		// Create and register a new factory
-		auto new_factory = make_shared_ptr<DataSourceStreamFactory>(source_obj, arrow_schema, vector<string> {});
-		uintptr_t new_factory_ptr = reinterpret_cast<uintptr_t>(new_factory.get());
-		RegisterFactory(new_factory);
-		factory = new_factory.get();
-
-		// Update the worker pickled_source with the new factory pointer
-		{
-			std::lock_guard<std::mutex> lock(g_worker_source_mutex);
-			memcpy(&g_worker_pickled_source[0], &new_factory_ptr, sizeof(uintptr_t));
-		}
+		throw InvalidInputException("Datasource source '%s' is not acquired for this query", task.source_id);
 	}
 
 	// 1. Unpickle the task
 	auto cloudpickle = py::module::import("cloudpickle");
-	auto task_obj = cloudpickle.attr("loads")(py::bytes(task_bytes, task_len));
+	auto task_obj = cloudpickle.attr("loads")(py::bytes(task.payload, task.payload_len));
 
 	// 2. Call task.execute() to get a generator of RecordBatches
 	auto generator = task_obj.attr("execute")();
@@ -131,40 +180,144 @@ void DataSourceStreamFactory::ProduceStream(const char *pickled_task, idx_t pick
 
 // ── GetSchema ──────────────────────────────────────────────────────
 // C callback called by datasource_scan Bind to get the Arrow schema.
-// pickled_source blob layout: [factory_ptr: 8 bytes][pickled DataSource bytes]
+// pickled_source blob layout: [magic/version][source UUID][pickled source bytes]
 
 void DataSourceStreamFactory::GetSchema(const char *pickled_source, idx_t pickled_len, ArrowSchema *out_schema) {
-	if (pickled_len < sizeof(uintptr_t)) {
-		throw InternalException("DataSourceStreamFactory::GetSchema: pickled_source too short");
-	}
-	uintptr_t factory_ptr;
-	memcpy(&factory_ptr, pickled_source, sizeof(uintptr_t));
+	auto source = ParseDataSourcePayload(pickled_source, pickled_len, "source");
+	PythonGILWrapper acquire;
 
-	DataSourceStreamFactory *factory = nullptr;
+	shared_ptr<DataSourceFactoryRegistryEntry> entry;
 	{
 		std::lock_guard<std::mutex> lock(g_factory_mutex);
-		auto it = g_factory_registry.find(factory_ptr);
-		if (it != g_factory_registry.end()) {
-			factory = it->second.get();
+		auto current = g_factory_registry.find(source.source_id);
+		if (current != g_factory_registry.end()) {
+			VerifyMatchingSource(*current->second, pickled_source, pickled_len, source.source_id);
+			entry = current->second;
 		}
 	}
 
+	if (entry) {
+		py::gil_scoped_release release;
+		std::unique_lock<std::mutex> lock(g_factory_mutex);
+		entry->ready.wait(lock, [&entry] { return !entry->loading; });
+	}
+
+	shared_ptr<DataSourceStreamFactory> factory;
+	if (entry) {
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		if (!entry->load_error.empty()) {
+			throw InvalidInputException("Failed to initialize datasource source '%s': %s", source.source_id,
+			                            entry->load_error);
+		}
+		factory = entry->factory;
+	}
+	auto arrow_schema = factory ? factory->arrow_schema : LoadArrowSchema(source);
+	arrow_schema.attr("_export_to_c")(reinterpret_cast<uintptr_t>(out_schema));
+}
+
+// ── Source ownership ───────────────────────────────────────────────
+
+void DataSourceStreamFactory::AcquireSource(const char *pickled_source, idx_t pickled_len, const char *query_id,
+                                            idx_t query_id_len) {
+	auto source = ParseDataSourcePayload(pickled_source, pickled_len, "source");
+	string query_owner(query_id, query_id_len);
 	PythonGILWrapper acquire;
 
-	if (factory) {
-		factory->arrow_schema.attr("_export_to_c")(reinterpret_cast<uintptr_t>(out_schema));
-	} else {
-		// Worker process: reconstruct schema from pickled DataSource
-		const char *source_bytes = pickled_source + sizeof(uintptr_t);
-		idx_t source_len = pickled_len - sizeof(uintptr_t);
+	shared_ptr<DataSourceFactoryRegistryEntry> entry;
+	bool load_factory = false;
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		auto current = g_factory_registry.find(source.source_id);
+		if (current == g_factory_registry.end()) {
+			entry = make_shared_ptr<DataSourceFactoryRegistryEntry>(string(pickled_source, pickled_len));
+			g_factory_registry.emplace(source.source_id, entry);
+			load_factory = true;
+		} else {
+			entry = current->second;
+			VerifyMatchingSource(*entry, pickled_source, pickled_len, source.source_id);
+			if (!entry->loading) {
+				if (!entry->factory) {
+					throw InternalException("Datasource source '%s' has no registered factory", source.source_id);
+				}
+				AddFactoryOwner(*entry, query_owner);
+				return;
+			}
+		}
+	}
 
-		auto cloudpickle = py::module::import("cloudpickle");
-		auto source_obj = cloudpickle.attr("loads")(py::bytes(source_bytes, source_len));
+	if (!load_factory) {
+		{
+			// Schema deserialization may temporarily release the GIL. Do not
+			// hold it while another query initializes the same logical source.
+			py::gil_scoped_release release;
+			std::unique_lock<std::mutex> lock(g_factory_mutex);
+			entry->ready.wait(lock, [&entry] { return !entry->loading; });
+		}
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		if (!entry->load_error.empty()) {
+			throw InvalidInputException("Failed to initialize datasource source '%s': %s", source.source_id,
+			                            entry->load_error);
+		}
+		auto current = g_factory_registry.find(source.source_id);
+		if (current == g_factory_registry.end() || current->second != entry || !entry->factory) {
+			throw InternalException("Datasource source '%s' disappeared during initialization", source.source_id);
+		}
+		AddFactoryOwner(*entry, query_owner);
+		return;
+	}
 
-		auto schema_dict = py::cast<py::dict>(source_obj.attr("schema"));
-		auto ds_module = py::module::import("duckdb.datasource");
-		auto arrow_schema = ds_module.attr("_schema_to_arrow")(schema_dict);
-		arrow_schema.attr("_export_to_c")(reinterpret_cast<uintptr_t>(out_schema));
+	try {
+		auto arrow_schema = LoadArrowSchema(source);
+		auto factory = make_shared_ptr<DataSourceStreamFactory>(std::move(arrow_schema));
+		{
+			std::lock_guard<std::mutex> lock(g_factory_mutex);
+			auto current = g_factory_registry.find(source.source_id);
+			if (current == g_factory_registry.end() || current->second != entry) {
+				throw InternalException("Datasource source '%s' disappeared during initialization", source.source_id);
+			}
+			entry->factory = std::move(factory);
+			AddFactoryOwner(*entry, query_owner);
+			entry->loading = false;
+			g_factory_creation_count.fetch_add(1);
+		}
+		entry->ready.notify_all();
+	} catch (std::exception &ex) {
+		FailFactoryLoad(source.source_id, entry, ex.what());
+		throw;
+	} catch (...) {
+		FailFactoryLoad(source.source_id, entry, "unknown factory initialization error");
+		throw;
+	}
+}
+
+void DataSourceStreamFactory::ReleaseSource(const char *pickled_source, idx_t pickled_len) noexcept {
+	try {
+		auto source = ParseDataSourcePayload(pickled_source, pickled_len, "source");
+		if (!Py_IsInitialized() || PythonIsFinalizing()) {
+			return;
+		}
+		PythonGILWrapper acquire;
+		shared_ptr<DataSourceFactoryRegistryEntry> released_entry;
+		{
+			std::lock_guard<std::mutex> lock(g_factory_mutex);
+			auto current = g_factory_registry.find(source.source_id);
+			if (current == g_factory_registry.end()) {
+				return;
+			}
+			auto &entry = *current->second;
+			VerifyMatchingSource(entry, pickled_source, pickled_len, source.source_id);
+			if (entry.loading || entry.local_owner_count == 0) {
+				return;
+			}
+			entry.local_owner_count--;
+			if (!HasFactoryOwners(entry)) {
+				released_entry = std::move(current->second);
+				g_factory_registry.erase(current);
+			}
+		}
+		// released_entry is destroyed before the GIL wrapper.
+	} catch (...) {
+		// Called from a global-state destructor: release must never throw.
 	}
 }
 
@@ -193,28 +346,27 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 		throw InvalidInputException("DataSource returned no tasks");
 	}
 
-	// 3. Create and register the factory
-	auto factory = make_shared_ptr<DataSourceStreamFactory>(source, arrow_schema, std::move(pickled_tasks));
-	uintptr_t factory_ptr = reinterpret_cast<uintptr_t>(factory.get());
-	RegisterFactory(factory);
+	// 3. Assign one stable logical source ID. It is serialized with the plan
+	// and is therefore identical in the driver and every worker process.
+	auto source_id = UUID::ToString(UUID::GenerateRandomUUID());
 
-	// 4. Build pickled_tasks list: each blob = [factory_ptr][pickled_task_bytes]
+	// 4. Build pickled_tasks list: each blob = [version][source ID][task]
 	vector<Value> task_values;
-	for (auto &pt : factory->pickled_tasks) {
-		string prefixed;
-		prefixed.resize(sizeof(uintptr_t) + pt.size());
-		memcpy(&prefixed[0], &factory_ptr, sizeof(uintptr_t));
-		memcpy(&prefixed[sizeof(uintptr_t)], pt.data(), pt.size());
+	for (auto &pickled_task : pickled_tasks) {
+		auto prefixed = EncodeDataSourcePayload(source_id, pickled_task);
 		task_values.push_back(Value::BLOB(const_data_ptr_cast(prefixed.data()), prefixed.size()));
 	}
 	auto task_list = Value::LIST(LogicalType::BLOB, std::move(task_values));
 
-	// 5. Build pickled_source: [factory_ptr][pickled DataSource bytes]
-	auto pickled_source_obj = PyBytesToString(cloudpickle.attr("dumps")(source));
-	string pickled_source_prefixed;
-	pickled_source_prefixed.resize(sizeof(uintptr_t) + pickled_source_obj.size());
-	memcpy(&pickled_source_prefixed[0], &factory_ptr, sizeof(uintptr_t));
-	memcpy(&pickled_source_prefixed[sizeof(uintptr_t)], pickled_source_obj.data(), pickled_source_obj.size());
+	// 5. Build pickled_source:
+	// [version][source ID][pickled (pickled DataSource, Arrow schema)].
+	// The source bytes remain part of the collision-checked identity payload,
+	// while workers can load the schema without instantiating the DataSource or
+	// invoking source.schema again.
+	auto pickled_source_identity = cloudpickle.attr("dumps")(source);
+	auto source_package = py::make_tuple(pickled_source_identity, arrow_schema);
+	auto pickled_source_obj = PyBytesToString(cloudpickle.attr("dumps")(source_package));
+	auto pickled_source_prefixed = EncodeDataSourcePayload(source_id, pickled_source_obj);
 
 	// 6. Build datasource_scan(produce_ptr, get_schema_ptr, pickled_source, pickled_tasks)
 	vector<Value> params;
@@ -229,9 +381,100 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 	// TryBindRelation() which triggers DataSourceScanBind → GetSchema callback,
 	// which needs the GIL to call arrow_schema._export_to_c().
 	auto rel = connection.TableFunction("datasource_scan", std::move(params));
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		g_last_created_source_id = source_id;
+	}
 
-	// Return as DuckDBPyRelation — factory stays alive in g_factory_registry
 	return make_uniq<DuckDBPyRelation>(rel->Alias(name));
+}
+
+void ClearDataSourceFactoryRegistry() {
+	PythonGILWrapper acquire;
+	std::unordered_map<string, shared_ptr<DataSourceFactoryRegistryEntry>> released_entries;
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		released_entries.swap(g_factory_registry);
+		g_last_created_source_id.clear();
+	}
+	// released_entries is destroyed before the GIL wrapper.
+}
+
+idx_t ReleaseDataSourceFactoriesForQuery(const string &query_id) {
+	if (query_id.empty()) {
+		throw InvalidInputException("Datasource distributed query ID must not be empty");
+	}
+	PythonGILWrapper acquire;
+	vector<shared_ptr<DataSourceFactoryRegistryEntry>> released_entries;
+	idx_t released_owners = 0;
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		released_entries.reserve(g_factory_registry.size());
+		for (auto entry = g_factory_registry.begin(); entry != g_factory_registry.end();) {
+			if (entry->second->query_owners.erase(query_id) == 0) {
+				entry++;
+				continue;
+			}
+			released_owners++;
+			if (HasFactoryOwners(*entry->second)) {
+				entry++;
+				continue;
+			}
+			released_entries.push_back(std::move(entry->second));
+			entry = g_factory_registry.erase(entry);
+		}
+	}
+	// released_entries is destroyed before the GIL wrapper.
+	return released_owners;
+}
+
+py::dict DataSourceFactoryRegistryStateForTest() {
+	D_ASSERT(py::gil_check());
+	vector<string> source_ids;
+	std::unordered_set<string> query_id_set;
+	idx_t owner_count = 0;
+	idx_t local_owner_count = 0;
+	idx_t query_owner_count = 0;
+	idx_t factory_count = 0;
+	idx_t registry_size = 0;
+	string last_created_source_id;
+	{
+		std::lock_guard<std::mutex> lock(g_factory_mutex);
+		registry_size = g_factory_registry.size();
+		source_ids.reserve(registry_size);
+		for (auto &item : g_factory_registry) {
+			source_ids.push_back(item.first);
+			owner_count += FactoryOwnerCount(*item.second);
+			local_owner_count += item.second->local_owner_count;
+			query_owner_count += item.second->query_owners.size();
+			query_id_set.insert(item.second->query_owners.begin(), item.second->query_owners.end());
+			factory_count += item.second->factory ? 1 : 0;
+		}
+		last_created_source_id = g_last_created_source_id;
+	}
+	std::sort(source_ids.begin(), source_ids.end());
+
+	py::list py_source_ids;
+	for (auto &source_id : source_ids) {
+		py_source_ids.append(source_id);
+	}
+	vector<string> query_ids(query_id_set.begin(), query_id_set.end());
+	std::sort(query_ids.begin(), query_ids.end());
+	py::list py_query_ids;
+	for (auto &query_id : query_ids) {
+		py_query_ids.append(query_id);
+	}
+	py::dict result;
+	result["registry_size"] = registry_size;
+	result["factory_count"] = factory_count;
+	result["owner_count"] = owner_count;
+	result["local_owner_count"] = local_owner_count;
+	result["query_owner_count"] = query_owner_count;
+	result["factory_creation_count"] = g_factory_creation_count.load();
+	result["source_ids"] = std::move(py_source_ids);
+	result["query_ids"] = std::move(py_query_ids);
+	result["last_created_source_id"] = std::move(last_created_source_id);
+	return result;
 }
 
 // ── RegisterDataSourceGlobalCallbacks ──────────────────────────────
@@ -239,7 +482,8 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 
 void RegisterDataSourceGlobalCallbacks() {
 	DataSourceScanFunction::SetGlobalProduceStream(&DataSourceStreamFactory::ProduceStream);
-	DataSourceScanFunction::SetGlobalWorkerSourceCallback(&DataSourceStreamFactory::SetWorkerPickledSource);
+	DataSourceScanFunction::SetGlobalAcquireSource(&DataSourceStreamFactory::AcquireSource);
+	DataSourceScanFunction::SetGlobalReleaseSource(&DataSourceStreamFactory::ReleaseSource);
 	DataSourceScanFunction::SetGlobalGetSchema(&DataSourceStreamFactory::GetSchema);
 }
 

--- a/src/duckdb_py/datasource_function.cpp
+++ b/src/duckdb_py/datasource_function.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 #include "duckdb_python/pyconnection/pyconnection.hpp"
+#include "duckdb_python/python_dependency.hpp"
 
 #include <algorithm>
 #include <condition_variable>
@@ -381,15 +382,22 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 	// TryBindRelation() which triggers DataSourceScanBind → GetSchema callback,
 	// which needs the GIL to call arrow_schema._export_to_c().
 	auto rel = connection.TableFunction("datasource_scan", std::move(params));
+	auto aliased_rel = rel->Alias(name);
+	auto dependency = make_uniq<ExternalDependency>();
+	dependency->AddDependency("datasource", PythonDependencyItem::Create(source));
+	aliased_rel->AddExternalDependency(std::move(dependency));
 	{
 		std::lock_guard<std::mutex> lock(g_factory_mutex);
 		g_last_created_source_id = source_id;
 	}
 
-	return make_uniq<DuckDBPyRelation>(rel->Alias(name));
+	return make_uniq<DuckDBPyRelation>(std::move(aliased_rel));
 }
 
 void ClearDataSourceFactoryRegistry() {
+	if (!Py_IsInitialized() || PythonIsFinalizing()) {
+		return;
+	}
 	PythonGILWrapper acquire;
 	std::unordered_map<string, shared_ptr<DataSourceFactoryRegistryEntry>> released_entries;
 	{
@@ -401,6 +409,9 @@ void ClearDataSourceFactoryRegistry() {
 }
 
 idx_t ReleaseDataSourceFactoriesForQuery(const string &query_id) {
+	if (!Py_IsInitialized() || PythonIsFinalizing()) {
+		return 0;
+	}
 	if (query_id.empty()) {
 		throw InvalidInputException("Datasource distributed query ID must not be empty");
 	}

--- a/src/duckdb_py/datasource_function.hpp
+++ b/src/duckdb_py/datasource_function.hpp
@@ -15,35 +15,35 @@ namespace duckdb {
 //! Lives in the Python binding layer (pybind11 allowed here).
 //! Core datasource_scan.cpp only sees C function pointers.
 struct DataSourceStreamFactory {
-	//! Keep the DataSource Python object alive
-	py::object datasource_obj;
-	//! Pickled task bytes — one per task
-	vector<string> pickled_tasks;
 	//! Arrow schema (PyArrow Schema object, kept alive)
 	py::object arrow_schema;
 
-	DataSourceStreamFactory(py::object datasource, py::object schema, vector<string> tasks)
-	    : datasource_obj(std::move(datasource)), pickled_tasks(std::move(tasks)), arrow_schema(std::move(schema)) {
+	explicit DataSourceStreamFactory(py::object schema) : arrow_schema(std::move(schema)) {
 	}
 
 	//! C callback: unpickle task → task.execute() → RecordBatchReader → _export_to_c
 	//! Called from pipeline threads — each call creates an independent stream.
-	//! The factory pointer is passed indirectly: the pickled_task bytes include a
-	//! prefix with the factory pointer (see ProduceStreamWithFactory).
 	static void ProduceStream(const char *pickled_task, idx_t pickled_len, ArrowArrayStream *out_stream);
 
-	//! C callback: export the cached Arrow schema to ArrowSchema
+	//! C callback: export the serialized or cached Arrow schema to ArrowSchema
 	static void GetSchema(const char *pickled_source, idx_t pickled_len, ArrowSchema *out_schema);
 
-	//! Set the worker-side pickled source for factory recovery (C callback for datasource_set_worker_source_t)
-	static void SetWorkerPickledSource(const char *pickled_source, idx_t pickled_len);
+	//! Acquire/release one query execution owner for the logical source.
+	static void AcquireSource(const char *pickled_source, idx_t pickled_len, const char *query_id, idx_t query_id_len);
+	static void ReleaseSource(const char *pickled_source, idx_t pickled_len) noexcept;
 };
 
 //! Clear all factory references to prevent segfault during Python shutdown.
 //! Must be called before Python interpreter finalizes.
 void ClearDataSourceFactoryRegistry();
 
-//! Register global callbacks (ProduceStream, SetWorkerPickledSource) on DataSourceScanFunction.
+//! Release every source owned by a completed distributed query.
+idx_t ReleaseDataSourceFactoriesForQuery(const string &query_id);
+
+//! Return process-local registry diagnostics used by lifecycle regression tests.
+py::dict DataSourceFactoryRegistryStateForTest();
+
+//! Register global callbacks on DataSourceScanFunction.
 //! Call once from Python module init.
 void RegisterDataSourceGlobalCallbacks();
 

--- a/src/duckdb_py/duckdb_python.cpp
+++ b/src/duckdb_py/duckdb_python.cpp
@@ -1120,6 +1120,9 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) { // NOLINT
 
 	// Register global callbacks for datasource_scan (needed for distributed workers)
 	duckdb::RegisterDataSourceGlobalCallbacks();
+	m.def("_datasource_factory_registry_state_for_test", &duckdb::DataSourceFactoryRegistryStateForTest);
+	m.def("_clear_datasource_factory_registry", &duckdb::ClearDataSourceFactoryRegistry);
+	m.def("_release_datasource_factories_for_query", &duckdb::ReleaseDataSourceFactoriesForQuery, py::arg("query_id"));
 
 	py::enum_<duckdb::ExplainType>(m, "ExplainType")
 	    .value("STANDARD", duckdb::ExplainType::EXPLAIN_STANDARD)

--- a/src/duckdb_py/ray/CMakeLists.txt
+++ b/src/duckdb_py/ray/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(python_ray OBJECT ray_module.cpp task.cpp worker.cpp
 
 target_include_directories(
   python_ray
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..
           ${CMAKE_SOURCE_DIR}/external/duckdb/third_party/yyjson/include)
 
 target_link_libraries(python_ray PRIVATE _duckdb_dependencies)

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -3,6 +3,27 @@
 
 // Included by ray_module.cpp inside namespace duckdb.
 
+static void AssignDataSourceQueryOwner(duckdb::PhysicalOperator &op, const string &query_id) {
+	if (query_id.empty()) {
+		return;
+	}
+	if (op.type == duckdb::PhysicalOperatorType::TABLE_SCAN) {
+		auto &scan = op.Cast<duckdb::PhysicalTableScan>();
+		auto *bind_data = dynamic_cast<duckdb::DataSourceScanBindData *>(scan.bind_data.get());
+		if (bind_data) {
+			if (!bind_data->query_id.empty() && bind_data->query_id != query_id) {
+				throw duckdb::InvalidInputException(
+				    "Datasource scan query ownership mismatch: existing='%s', requested='%s'", bind_data->query_id,
+				    query_id);
+			}
+			bind_data->query_id = query_id;
+		}
+	}
+	for (auto &child : op.children) {
+		AssignDataSourceQueryOwner(child.get(), query_id);
+	}
+}
+
 struct PyPhysicalPlanWrapper {
 	static constexpr uint64_t INIT_MAGIC = 0x445046504C414E31ULL;
 	uint64_t init_magic_;
@@ -94,6 +115,9 @@ struct PyPhysicalPlanWrapper {
 
 		plan_ =
 		    std::make_shared<duckdb::distributed::DistributedPhysicalPlan>(idx, effective_query_id, physical_plan, cfg);
+		if (physical_plan && physical_plan->HasRoot()) {
+			AssignDataSourceQueryOwner(physical_plan->Root(), effective_query_id);
+		}
 	}
 
 	// Materialize deferred serialized_root_ into the plan's PhysicalPlan.
@@ -134,6 +158,7 @@ struct PyPhysicalPlanWrapper {
 			auto *root_ptr = root_op.get();
 			physical_plan->TakeOwnership(std::move(root_op));
 			physical_plan->SetRoot(*root_ptr);
+			AssignDataSourceQueryOwner(*root_ptr, idx());
 		}
 		// Keep connection alive to ensure allocator validity
 		worker_connection_ = conn_obj;
@@ -207,6 +232,9 @@ struct PyPhysicalPlanWrapper {
 	      query_id_(p ? p->query_id() : string()), plan_(std::move(p)), arrow_schema_(py::none()),
 	      udf_registrations_(py::none()), udf_actor_handles_(py::none()), connection_snapshot_(py::none()),
 	      serialized_root_() {
+		if (plan_ && plan_->physical_plan() && plan_->physical_plan()->HasRoot()) {
+			AssignDataSourceQueryOwner(plan_->physical_plan()->Root(), query_id_);
+		}
 	}
 
 	bool IsInitialized() const {
@@ -1439,6 +1467,13 @@ struct PyPhysicalPlanWrapperRunner {
 		} catch (...) {
 			teardown_error = std::current_exception();
 		}
+		try {
+			ReleaseDataSourceFactoriesForQuery(query_id);
+		} catch (...) {
+			if (!teardown_error) {
+				teardown_error = std::current_exception();
+			}
+		}
 		CleanupQueryPythonReplayState(query_id);
 		if (teardown_error) {
 			std::rethrow_exception(teardown_error);
@@ -1827,6 +1862,7 @@ struct PyPhysicalPlanWrapperRunner {
 		if (!physical_plan || !physical_plan->HasRoot()) {
 			throw py::value_error("Physical plan is missing or has no root operator");
 		}
+		AssignDataSourceQueryOwner(physical_plan->Root(), plan_id);
 
 		if (scan_task_map && !scan_task_map->empty()) {
 			string error;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -7,6 +7,7 @@
 #include "worker.hpp"
 #include "worker_manager.hpp"
 #include "safe_pyobject.hpp"
+#include "datasource_function.hpp"
 
 #include "duckdb_python/pyrelation.hpp"
 #include "duckdb_python/pyconnection/pyconnection.hpp"
@@ -84,6 +85,7 @@ static inline int DuckdbGetEnvIntMs(const char *name) {
 #include <duckdb/execution/operator/projection/physical_tableinout_function.hpp>
 #include <duckdb/execution/operator/projection/physical_udf_inout.hpp>
 #include <duckdb/function/scalar/udf_functions.hpp>
+#include <duckdb/function/table/datasource_scan.hpp>
 #include <duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp>
 #include <duckdb/execution/operator/helper/physical_result_collector.hpp>
 #include <duckdb/execution/operator/projection/physical_projection.hpp>

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import gc
 import os
 import time
 import uuid
+import weakref
 from collections.abc import Iterator
 
 import _duckdb
@@ -146,6 +148,75 @@ class FailingSource(DataSource):
 
     def get_tasks(self) -> Iterator[DataSourceTask]:
         yield FailingTask()
+
+
+class SourceKeepaliveProbe(DataSource):
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    @property
+    def schema(self) -> dict[str, str]:
+        return {"value": "BIGINT"}
+
+    def get_tasks(self) -> Iterator[DataSourceTask]:
+        class SourceKeepaliveTask(DataSourceTask):
+            def __init__(self, path: str) -> None:
+                self.path = path
+
+            def execute(self) -> Iterator[pa.RecordBatch]:
+                with open(self.path, encoding="utf-8") as source_file:
+                    value = int(source_file.read())
+                yield pa.record_batch({"value": pa.array([value], type=pa.int64())})
+
+        yield SourceKeepaliveTask(self.path)
+
+    def __del__(self) -> None:
+        try:
+            os.unlink(self.path)
+        except FileNotFoundError:
+            pass
+
+
+def test_datasource_relation_keeps_source_alive_until_relation_is_released(duckdb_conn, tmp_path):
+    source_path = tmp_path / "source-keepalive.txt"
+    source_path.write_text("42", encoding="utf-8")
+    source = SourceKeepaliveProbe(str(source_path))
+    source_ref = weakref.ref(source)
+
+    relation = read_datasource(source, con=duckdb_conn)
+    del source
+    gc.collect()
+
+    assert source_ref() is not None
+    assert source_path.exists()
+    assert relation.fetchall() == [(42,)]
+
+    del relation
+    gc.collect()
+    assert source_ref() is None
+    assert not source_path.exists()
+
+
+def test_ray_runner_keeps_source_alive_until_distributed_scan_finishes(ray_runner, duckdb_conn, tmp_path):
+    source_path = tmp_path / "distributed-source-keepalive.txt"
+    source_path.write_text("43", encoding="utf-8")
+    source = SourceKeepaliveProbe(str(source_path))
+    source_ref = weakref.ref(source)
+
+    relation = read_datasource(source, con=duckdb_conn, limit=1)
+    del source
+    gc.collect()
+
+    assert source_ref() is not None
+    assert source_path.exists()
+    result = _collect_tables(ray_runner, relation)
+    assert result.num_rows == 1
+    assert result.column(0).to_pylist() == [43]
+
+    del relation
+    gc.collect()
+    assert source_ref() is None
+    assert not source_path.exists()
 
 
 def test_datasource_factory_registry_churn_returns_to_baseline(duckdb_conn):

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import os
 import time
+import uuid
 from collections.abc import Iterator
 
+import _duckdb
 import pyarrow as pa
 import pytest
 
@@ -59,6 +61,169 @@ def _collect_tables(runner, relation, timeout_s: float = 60.0) -> pa.Table:
     return pa.concat_tables(parts)
 
 
+def _datasource_registry_state() -> dict:
+    return dict(_duckdb._datasource_factory_registry_state_for_test())
+
+
+class RegistryProbeTask(DataSourceTask):
+    def __init__(self, value: int) -> None:
+        self.value = int(value)
+
+    def execute(self) -> Iterator[pa.RecordBatch]:
+        import _duckdb
+
+        state = dict(_duckdb._datasource_factory_registry_state_for_test())
+        source_ids = list(state["source_ids"])
+        if len(source_ids) != 1:
+            raise RuntimeError(f"expected one active datasource source, found {source_ids!r}")
+        query_ids = list(state["query_ids"])
+        yield pa.record_batch(
+            {
+                "value": pa.array([self.value], type=pa.int64()),
+                "source_id": pa.array([source_ids[0]], type=pa.string()),
+                "query_id": pa.array([query_ids[0] if query_ids else ""], type=pa.string()),
+                "registry_size": pa.array([state["registry_size"]], type=pa.int64()),
+                "owner_count": pa.array([state["owner_count"]], type=pa.int64()),
+                "factory_creation_count": pa.array([state["factory_creation_count"]], type=pa.int64()),
+            }
+        )
+
+
+class RegistryProbeSource(DataSource):
+    def __init__(self, values: list[int]) -> None:
+        self.values = [int(value) for value in values]
+
+    @property
+    def schema(self) -> dict[str, str]:
+        return {
+            "value": "BIGINT",
+            "source_id": "VARCHAR",
+            "query_id": "VARCHAR",
+            "registry_size": "BIGINT",
+            "owner_count": "BIGINT",
+            "factory_creation_count": "BIGINT",
+        }
+
+    def get_tasks(self) -> Iterator[DataSourceTask]:
+        for value in self.values:
+            yield RegistryProbeTask(value)
+
+
+class StreamingTask(DataSourceTask):
+    def execute(self) -> Iterator[pa.RecordBatch]:
+        for value in range(3):
+            yield pa.record_batch({"value": pa.array([value], type=pa.int64())})
+
+
+class StreamingSource(DataSource):
+    @property
+    def schema(self) -> dict[str, str]:
+        return {"value": "BIGINT"}
+
+    def get_tasks(self) -> Iterator[DataSourceTask]:
+        yield StreamingTask()
+
+
+class SchemaCallTrackingSource(StreamingSource):
+    schema_calls = 0
+
+    @property
+    def schema(self) -> dict[str, str]:
+        type(self).schema_calls += 1
+        return super().schema
+
+
+class FailingTask(DataSourceTask):
+    def execute(self) -> Iterator[pa.RecordBatch]:
+        raise RuntimeError("datasource task failed")
+        yield  # pragma: no cover
+
+
+class FailingSource(DataSource):
+    @property
+    def schema(self) -> dict[str, str]:
+        return {"value": "BIGINT"}
+
+    def get_tasks(self) -> Iterator[DataSourceTask]:
+        yield FailingTask()
+
+
+def test_datasource_factory_registry_churn_returns_to_baseline(duckdb_conn):
+    baseline = _datasource_registry_state()
+    assert baseline["registry_size"] == 0
+    assert baseline["factory_count"] == 0
+    assert baseline["owner_count"] == 0
+
+    source_ids: set[str] = set()
+    previous_creation_count = baseline["factory_creation_count"]
+    for value in range(64):
+        relation = read_datasource(RegistryProbeSource([value]), con=duckdb_conn)
+        after_bind = _datasource_registry_state()
+        driver_source_id = after_bind["last_created_source_id"]
+        assert str(uuid.UUID(driver_source_id)) == driver_source_id
+        assert after_bind["registry_size"] == baseline["registry_size"]
+
+        assert relation.fetchall() == [
+            (
+                value,
+                driver_source_id,
+                "",
+                1,
+                1,
+                previous_creation_count + 1,
+            )
+        ]
+        source_ids.add(driver_source_id)
+        previous_creation_count += 1
+
+        after_query = _datasource_registry_state()
+        assert after_query["registry_size"] == baseline["registry_size"]
+        assert after_query["factory_count"] == baseline["factory_count"]
+        assert after_query["owner_count"] == baseline["owner_count"]
+        assert after_query["factory_creation_count"] == previous_creation_count
+
+    assert len(source_ids) == 64
+
+
+def test_datasource_factory_owner_released_when_stream_finishes(duckdb_conn):
+    baseline = _datasource_registry_state()
+    relation = read_datasource(StreamingSource(), con=duckdb_conn)
+
+    assert relation.fetchone() == (0,)
+    active = _datasource_registry_state()
+    assert active["registry_size"] == baseline["registry_size"] + 1
+    assert active["factory_count"] == baseline["factory_count"] + 1
+    assert active["local_owner_count"] == baseline["local_owner_count"] + 1
+
+    assert relation.fetchall() == [(1,), (2,)]
+    finished = _datasource_registry_state()
+    assert finished["registry_size"] == baseline["registry_size"]
+    assert finished["factory_count"] == baseline["factory_count"]
+    assert finished["owner_count"] == baseline["owner_count"]
+
+
+def test_datasource_schema_is_evaluated_once(duckdb_conn):
+    SchemaCallTrackingSource.schema_calls = 0
+
+    relation = read_datasource(SchemaCallTrackingSource(), con=duckdb_conn)
+    assert SchemaCallTrackingSource.schema_calls == 1
+    assert relation.fetchall() == [(0,), (1,), (2,)]
+    assert SchemaCallTrackingSource.schema_calls == 1
+
+
+def test_datasource_factory_owner_released_when_query_fails(duckdb_conn):
+    baseline = _datasource_registry_state()
+    relation = read_datasource(FailingSource(), con=duckdb_conn)
+
+    with pytest.raises(Exception, match="datasource task failed"):
+        relation.fetchall()
+
+    finished = _datasource_registry_state()
+    assert finished["registry_size"] == baseline["registry_size"]
+    assert finished["factory_count"] == baseline["factory_count"]
+    assert finished["owner_count"] == baseline["owner_count"]
+
+
 def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb_conn):
     driver_pid = os.getpid()
 
@@ -67,13 +232,30 @@ def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb
             self.task_id = int(task_id)
 
         def execute(self) -> Iterator[pa.RecordBatch]:
+            import _duckdb
+
             worker_id = os.getenv("VANE_WORKER_ID", "").strip() or os.getenv("VANE_FTE_WORKER_ID", "").strip()
+            registry = dict(_duckdb._datasource_factory_registry_state_for_test())
+            source_ids = list(registry["source_ids"])
+            if len(source_ids) != 1:
+                raise RuntimeError(f"expected one active datasource source, found {source_ids!r}")
+            query_ids = list(registry["query_ids"])
+            if len(query_ids) != 1:
+                raise RuntimeError(f"expected one datasource query owner, found {query_ids!r}")
             yield pa.record_batch(
                 {
                     "task_id": pa.array([self.task_id], type=pa.int64()),
                     "driver_pid": pa.array([driver_pid], type=pa.int64()),
                     "execute_pid": pa.array([os.getpid()], type=pa.int64()),
                     "worker_id": pa.array([worker_id], type=pa.string()),
+                    "source_id": pa.array([source_ids[0]], type=pa.string()),
+                    "query_id": pa.array([query_ids[0]], type=pa.string()),
+                    "registry_size": pa.array([registry["registry_size"]], type=pa.int64()),
+                    "owner_count": pa.array([registry["owner_count"]], type=pa.int64()),
+                    "factory_creation_count": pa.array(
+                        [registry["factory_creation_count"]],
+                        type=pa.int64(),
+                    ),
                 }
             )
 
@@ -85,19 +267,50 @@ def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb
                 "driver_pid": "BIGINT",
                 "execute_pid": "BIGINT",
                 "worker_id": "VARCHAR",
+                "source_id": "VARCHAR",
+                "query_id": "VARCHAR",
+                "registry_size": "BIGINT",
+                "owner_count": "BIGINT",
+                "factory_creation_count": "BIGINT",
             }
 
         def get_tasks(self) -> Iterator[DataSourceTask]:
             for task_id in range(4):
                 yield ExecutionLocationTask(task_id)
 
-    source = ExecutionLocationSource()
-    relation = read_datasource(source, con=duckdb_conn)
+    source_ids: set[str] = set()
+    query_ids: set[str] = set()
+    creation_counts_by_run: list[dict[int, int]] = []
+    for _ in range(2):
+        relation = read_datasource(ExecutionLocationSource(), con=duckdb_conn)
+        driver_state = _datasource_registry_state()
+        driver_source_id = driver_state["last_created_source_id"]
+        assert str(uuid.UUID(driver_source_id)) == driver_source_id
+        assert driver_state["registry_size"] == 0
 
-    table = _collect_tables(ray_runner, relation)
-    rows = sorted(zip(*[column.to_pylist() for column in table.columns], strict=True), key=lambda row: row[0])
+        table = _collect_tables(ray_runner, relation)
+        rows = sorted(zip(*[column.to_pylist() for column in table.columns], strict=True), key=lambda row: row[0])
 
-    assert [row[0] for row in rows] == [0, 1, 2, 3]
-    assert all(row[1] == driver_pid for row in rows)
-    assert all(row[2] != driver_pid for row in rows)
-    assert all(row[3] for row in rows)
+        assert [row[0] for row in rows] == [0, 1, 2, 3]
+        assert all(row[1] == driver_pid for row in rows)
+        assert all(row[2] != driver_pid for row in rows)
+        assert all(row[3] for row in rows)
+        assert {row[4] for row in rows} == {driver_source_id}
+        assert len({row[5] for row in rows}) == 1
+        assert all(row[6] == 1 for row in rows)
+        assert all(row[7] == 1 for row in rows)
+
+        creation_counts_by_pid: dict[int, set[int]] = {}
+        for row in rows:
+            creation_counts_by_pid.setdefault(row[2], set()).add(row[8])
+        assert all(len(counts) == 1 for counts in creation_counts_by_pid.values())
+
+        source_ids.add(driver_source_id)
+        query_ids.add(rows[0][5])
+        creation_counts_by_run.append({pid: next(iter(counts)) for pid, counts in creation_counts_by_pid.items()})
+
+    assert len(source_ids) == 2
+    assert len(query_ids) == 2
+    shared_worker_pids = creation_counts_by_run[0].keys() & creation_counts_by_run[1].keys()
+    for pid in shared_worker_pids:
+        assert creation_counts_by_run[1][pid] == creation_counts_by_run[0][pid] + 1

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2415,6 +2415,77 @@ def test_worker_drop_query_releases_datasource_after_fragment_cleanup_failure(mo
     ]
 
 
+@pytest.mark.parametrize(
+    ("failed_barrier", "expect_release"),
+    [
+        pytest.param("flight", True, id="flight-failure"),
+        pytest.param("native", False, id="native-failure"),
+    ],
+)
+def test_worker_drop_query_releases_datasource_only_after_native_drain(monkeypatch, failed_barrier, expect_release):
+    events: list[str] = []
+
+    class TaskManager:
+        async def drop_query(self, query_id):
+            assert query_id == "query-drop"
+            events.append("cancel")
+            return {"removed": 2, "canceled": 1}
+
+    class DummyWorker:
+        @staticmethod
+        def _get_fte_task_manager():
+            return TaskManager()
+
+        @staticmethod
+        def drop_query_fragments(query_id):
+            assert query_id == "query-drop"
+            events.append("fragments")
+            return 3
+
+        @staticmethod
+        def _close_worker_native_query(query_id):
+            assert query_id == "query-drop"
+            events.append("native-close")
+            return []
+
+        @staticmethod
+        async def _wait_worker_native_executions_for_query(query_id):
+            assert query_id == "query-drop"
+            events.append("worker-wait")
+            if failed_barrier == "native":
+                raise RuntimeError("native drain failed")
+
+    async def wait_for_flight(query_id):
+        assert query_id == "query-drop"
+        events.append("flight-wait")
+        if failed_barrier == "flight":
+            raise RuntimeError("flight drain failed")
+
+    monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", lambda _query_id: events.append("close"))
+    monkeypatch.setattr(worker_mod, "_wait_flight_shuffle_executions_for_query", wait_for_flight)
+    monkeypatch.setattr(
+        worker_mod,
+        "_release_datasource_factories_for_query",
+        lambda _query_id: events.append("datasource-release"),
+    )
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(RuntimeError, match=f"{failed_barrier} drain failed"):
+        asyncio.run(actor_class.fte_prepare_drop_query(DummyWorker(), "query-drop"))
+
+    expected_events = [
+        "close",
+        "native-close",
+        "cancel",
+        "fragments",
+        "worker-wait",
+        "flight-wait",
+    ]
+    if expect_release:
+        expected_events.append("datasource-release")
+    assert events == expected_events
+
+
 def test_fte_control_rpc_retries_transient_failure(monkeypatch):
     monkeypatch.setenv("VANE_FTE_CONTROL_RPC_MAX_ATTEMPTS", "2")
     monkeypatch.setenv("VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S", "0")

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2317,10 +2317,16 @@ def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypa
         assert query_id == "query-drop"
         events.append("retire")
 
+    def release_datasource_factories(query_id):
+        assert query_id == "query-drop"
+        events.append("datasource-release")
+        return 2
+
     monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", close)
     monkeypatch.setattr(worker_mod, "_wait_flight_shuffle_executions_for_query", wait_for_executions)
     monkeypatch.setattr(worker_mod, "_drain_flight_shuffle_for_query", drain)
     monkeypatch.setattr(worker_mod, "_retire_flight_shuffle_query", retire)
+    monkeypatch.setattr(worker_mod, "_release_datasource_factories_for_query", release_datasource_factories)
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
 
     prepare_result = asyncio.run(actor_class.fte_prepare_drop_query(DummyWorker(), "query-drop"))
@@ -2335,6 +2341,7 @@ def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypa
         "fragments",
         "worker-wait",
         "flight-wait",
+        "datasource-release",
         "drain",
         "retire",
         "native-retire",
@@ -2347,6 +2354,65 @@ def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypa
         "flight_shuffle_storage_entries_removed": 5,
         "flight_shuffle_cleanup_errors": 0,
     }
+
+
+def test_worker_drop_query_releases_datasource_after_fragment_cleanup_failure(monkeypatch):
+    events: list[str] = []
+
+    class TaskManager:
+        async def drop_query(self, query_id):
+            assert query_id == "query-drop"
+            events.append("cancel")
+            return {"removed": 2, "canceled": 1}
+
+    class DummyWorker:
+        @staticmethod
+        def _get_fte_task_manager():
+            return TaskManager()
+
+        @staticmethod
+        def drop_query_fragments(query_id):
+            assert query_id == "query-drop"
+            events.append("fragments")
+            raise RuntimeError("fragment cleanup failed")
+
+        @staticmethod
+        def _close_worker_native_query(query_id):
+            assert query_id == "query-drop"
+            events.append("native-close")
+            return []
+
+        @staticmethod
+        async def _wait_worker_native_executions_for_query(query_id):
+            assert query_id == "query-drop"
+            events.append("worker-wait")
+
+    monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", lambda _query_id: events.append("close"))
+
+    async def wait_for_executions(query_id):
+        assert query_id == "query-drop"
+        events.append("flight-wait")
+
+    monkeypatch.setattr(worker_mod, "_wait_flight_shuffle_executions_for_query", wait_for_executions)
+    monkeypatch.setattr(
+        worker_mod,
+        "_release_datasource_factories_for_query",
+        lambda _query_id: events.append("datasource-release"),
+    )
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(RuntimeError, match="fragment cleanup failed"):
+        asyncio.run(actor_class.fte_prepare_drop_query(DummyWorker(), "query-drop"))
+
+    assert events == [
+        "close",
+        "native-close",
+        "cancel",
+        "fragments",
+        "worker-wait",
+        "flight-wait",
+        "datasource-release",
+    ]
 
 
 def test_fte_control_rpc_retries_transient_failure(monkeypatch):

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -209,6 +209,11 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
             )
         ),
     )
+    monkeypatch.setattr(
+        worker_module,
+        "_clear_datasource_factory_registry",
+        lambda: events.append("datasource-registry-cleared"),
+    )
 
     actor_class._prepare_worker_runtime_shutdown(actor)
     native_thread.join(timeout=5)
@@ -228,7 +233,7 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
 
     actor_class._finish_worker_runtime_shutdown(actor)
     assert actor._shutdown_complete is True
-    assert events[-1] == "flight-stopped"
+    assert events[-2:] == ["flight-stopped", "datasource-registry-cleared"]
     with pytest.raises(RuntimeError, match="shutting down"):
         actor_class._begin_worker_native_execution(actor, "query-a")
     with pytest.raises(RuntimeError, match="shutting down"):


### PR DESCRIPTION
## Summary

- replace process-local pointer keys with strict, versioned `VDS1` payloads carrying a stable source UUID across driver and workers
- cache one schema-only stream factory per logical source and coordinate concurrent initialization without holding the GIL while waiting
- track connection-local and distributed-query ownership, releasing factories after query drains and clearing the registry at worker-session shutdown
- remove the worker fallback that repeatedly unpickled and registered datasource factories per task
- add local churn/failure lifecycle coverage plus real multi-process Ray assertions for stable source/query IDs and once-per-worker factory creation

Serialized datasource plans now use the new strict payload format intentionally; there is no compatibility fallback for the former pointer-prefixed format.

## Related issue

close: #81

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- Release incremental native install with `SKBUILD_BUILD_DIR=$PWD/build/python-release`, `SKBUILD_CMAKE_BUILD_TYPE=Release`, and `uv pip install . --no-build-isolation`
- `python -m pytest tests/fast/test_datasource_distributed_scan.py tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_worker_lifecycle.py` (181 passed)
- `scripts/run_release_tests.sh` (304 passed, 1 skipped; real-Ray shard 7 passed)
- `scripts/run_fast_tests.sh` (main shard 5461 passed; shared-Ray shard 80 passed; all runnable test-owned Ray fault scenarios passed)
- `scripts/format workspace --changed`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No new dependencies or copied assets are introduced.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. Payload headers and UUIDs are validated strictly, and source-ID collisions require exact payload equality.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.