### PR TITLE
[fix](relation) preserve catalog qualification in insert_into and create

### DIFF
--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -1883,7 +1883,7 @@ DuckDBPyRelation &DuckDBPyRelation::Execute() {
 void DuckDBPyRelation::InsertInto(const string &table) {
 	AssertRelation();
 	auto parsed_info = QualifiedName::Parse(table);
-	auto insert = rel->InsertRel(parsed_info.schema, parsed_info.name);
+	auto insert = rel->InsertRel(parsed_info.catalog, parsed_info.schema, parsed_info.name);
 	PyExecuteRelation(insert);
 }
 
@@ -1946,7 +1946,7 @@ void DuckDBPyRelation::Insert(const py::object &params) const {
 void DuckDBPyRelation::Create(const string &table) {
 	AssertRelation();
 	auto parsed_info = QualifiedName::Parse(table);
-	auto create = rel->CreateRel(parsed_info.schema, parsed_info.name, false);
+	auto create = rel->CreateRel(parsed_info.catalog, parsed_info.schema, parsed_info.name, false);
 	PyExecuteRelation(create);
 }
 

--- a/tests/fast/api/test_insert_into.py
+++ b/tests/fast/api/test_insert_into.py
@@ -27,3 +27,58 @@ class TestInsertInto:
         con.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
         rel.insert_into("t")
         assert con.execute("select * from t").fetchall() == [(1,)]
+
+    def test_insert_into_catalog_qualification(self):
+        """insert_into must preserve catalog qualification when writing to a catalog-qualified table name."""
+        import pandas as pd
+
+        con = duckdb.connect()
+        con.execute("ATTACH ':memory:' AS cat_a")
+        con.execute("ATTACH ':memory:' AS cat_b")
+        con.execute("CREATE TABLE cat_a.main.t (x INT)")
+        con.execute("CREATE TABLE cat_b.main.t (x INT)")
+        con.execute("INSERT INTO cat_a.main.t VALUES (42)")
+
+        rel = con.from_df(pd.DataFrame({"x": [99]}))
+        rel.insert_into("cat_b.main.t")
+
+        results_a = con.execute("SELECT * FROM cat_a.main.t").fetchall()
+        results_b = con.execute("SELECT * FROM cat_b.main.t").fetchall()
+        assert results_a == [(42,)], f"cat_a.main.t should be [(42,)] but got {results_a}"
+        assert results_b == [(99,)], f"cat_b.main.t should be [(99,)] but got {results_b}"
+
+    def test_insert_into_catalog_quoted_identifiers(self):
+        """insert_into must preserve catalog qualification with quoted identifiers."""
+        import pandas as pd
+
+        con = duckdb.connect()
+        con.execute("ATTACH ':memory:' AS \"my.catalog\"")
+        con.execute("ATTACH ':memory:' AS other_cat")
+        con.execute('CREATE TABLE "my.catalog".main.t (x INT)')
+        con.execute("CREATE TABLE other_cat.main.t (x INT)")
+
+        rel = con.from_df(pd.DataFrame({"x": [77]}))
+        rel.insert_into('"my.catalog".main.t')
+
+        results_a = con.execute('SELECT * FROM "my.catalog".main.t').fetchall()
+        results_b = con.execute("SELECT * FROM other_cat.main.t").fetchall()
+        assert results_a == [(77,)], f'"my.catalog".main.t should be [(77,)] but got {results_a}'
+        assert results_b == [], f"other_cat.main.t should be [] but got {results_b}"
+
+    def test_create_catalog_qualification(self):
+        """create must preserve catalog qualification when creating a table with a catalog-qualified name."""
+        import pandas as pd
+
+        con = duckdb.connect()
+        con.execute("ATTACH ':memory:' AS cat_a")
+        con.execute("ATTACH ':memory:' AS cat_b")
+        con.execute("CREATE TABLE cat_a.main.t (x INT)")
+        con.execute("INSERT INTO cat_a.main.t VALUES (42)")
+
+        rel = con.from_df(pd.DataFrame({"x": [55]}))
+        rel.create("cat_b.main.t")
+
+        results_a = con.execute("SELECT * FROM cat_a.main.t").fetchall()
+        results_b = con.execute("SELECT * FROM cat_b.main.t").fetchall()
+        assert results_a == [(42,)], f"cat_a.main.t should be [(42,)] but got {results_a}"
+        assert results_b == [(55,)], f"cat_b.main.t should be [(55,)] but got {results_b}"


### PR DESCRIPTION
## Problem

`insert_into` and `create` could discard the catalog portion of a multi-part name such as `catalog.schema.table`, causing writes to target the wrong database when same-named tables exist in different catalogs.

## Root cause

In `src/duckdb_py/pyrelation.cpp`, both `InsertInto` and `Create` used `QualifiedName::Parse()` which correctly extracts catalog, schema, and name, but then only forwarded schema + name to `InsertRel`/`CreateRel`, dropping the catalog.

## Fix

Use the three-argument overloads (`InsertRel(catalog, schema, name)` and `CreateRel(catalog, schema, name, temporary)`) that preserve the catalog parameter.

## Changes

- `src/duckdb_py/pyrelation.cpp`: Pass `parsed_info.catalog` to `InsertRel` and `CreateRel`
- `tests/fast/api/test_insert_into.py`: Add tests for catalog-qualified insert_into and create with two attached catalogs and quoted identifiers

Closes #108