### PR TITLE
[fix](udf) Restore socket timeout after subprocess handshake

### DIFF
--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -389,21 +389,24 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
 
     def _recv_expected(self, expected: tuple[int, ...], *, timeout_s: float | None = None) -> tuple[int, bytes]:
         sock = self._require_socket()
+        timeout_overridden = False
         restore_timeout = None
         if timeout_s is not None and hasattr(sock, "settimeout") and hasattr(sock, "gettimeout"):
             restore_timeout = sock.gettimeout()
             sock.settimeout(max(0.0, float(timeout_s)))
+            timeout_overridden = True
         try:
-            msg_type, payload = _recv_message(sock)
+            try:
+                msg_type, payload = _recv_message(sock)
+            finally:
+                if timeout_overridden:
+                    try:
+                        sock.settimeout(restore_timeout)
+                    except Exception:
+                        pass
         except Exception as exc:
             self._mark_broken(f"UDF subprocess communication failed: {exc}", actor_lost=True)
             raise RuntimeError(self._broken_error) from exc
-        finally:
-            if restore_timeout is not None:
-                try:
-                    sock.settimeout(restore_timeout)
-                except Exception:
-                    pass
         if msg_type not in expected:
             self._mark_broken(f"UDF subprocess sent unexpected message type {msg_type:#x}", actor_lost=True)
             raise RuntimeError(self._broken_error)

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import socket
 import struct
 import sys
 import threading
@@ -5227,6 +5228,66 @@ def test_subprocess_ref_bundle_consumer_can_start_when_output_budget_full(monkey
         executor.close(kill=True)
         for ref in refs:
             ref.release()
+
+
+def _timeout_test_executor(subprocess_exec, sock):
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._closed = False
+    executor._broken_error = None
+    executor._sock = sock
+    return executor
+
+
+@pytest.mark.parametrize("initial_timeout", [None, 5.0, 0.0], ids=["blocking", "finite", "nonblocking"])
+@pytest.mark.parametrize("handshake_result", ["ready", "error"])
+def test_recv_expected_restores_socket_timeout_after_handshake(monkeypatch, initial_timeout, handshake_result):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    parent_sock, child_sock = socket.socketpair()
+    parent_sock.settimeout(initial_timeout)
+    executor = _timeout_test_executor(subprocess_exec, parent_sock)
+    msg_type = subprocess_exec._MSG_READY if handshake_result == "ready" else subprocess_exec._MSG_ERROR
+
+    def receive(sock):
+        assert sock.gettimeout() == 2.0
+        return msg_type, b"payload"
+
+    monkeypatch.setattr(subprocess_exec, "_recv_message", receive)
+    try:
+        assert executor._recv_expected(
+            (subprocess_exec._MSG_READY, subprocess_exec._MSG_ERROR),
+            timeout_s=2.0,
+        ) == (msg_type, b"payload")
+        assert parent_sock.gettimeout() == initial_timeout
+    finally:
+        parent_sock.close()
+        child_sock.close()
+
+
+def test_recv_expected_restores_socket_timeout_before_marking_broken(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    parent_sock, child_sock = socket.socketpair()
+    executor = _timeout_test_executor(subprocess_exec, parent_sock)
+
+    def fail_receive(_sock):
+        raise OSError("connection reset")
+
+    def mark_broken(error: str, *, actor_lost: bool = False) -> None:
+        del actor_lost
+        assert parent_sock.gettimeout() is None
+        executor._broken_error = error
+        parent_sock.close()
+
+    monkeypatch.setattr(subprocess_exec, "_recv_message", fail_receive)
+    executor._mark_broken = mark_broken
+
+    try:
+        with pytest.raises(RuntimeError, match="connection reset"):
+            executor._recv_expected((subprocess_exec._MSG_READY,), timeout_s=2.0)
+    finally:
+        parent_sock.close()
+        child_sock.close()
 
 
 class _FakeControlSocket:


### PR DESCRIPTION
PR description

  ## Summary

  Fix the UDF subprocess control socket leaking its temporary handshake timeout
  into normal task communication.

  `_recv_expected` previously used `None` both as the default sentinel and as a
  valid timeout value for a blocking socket. As a result, sockets that started in
  blocking mode were not restored after the handshake.

  This change:

  - tracks timeout overrides independently from the previous timeout value;
  - restores blocking, finite-timeout, and non-blocking socket modes;
  - restores the timeout before broken-executor cleanup closes the socket;
  - adds regression coverage using real socket pairs for successful, worker-error,
    and transport-error paths.

  There are no public API, protocol, dependency, or configuration changes.

  ## Related issue

  close: #65

  ## Documentation impact

  - [x] No user-facing documentation update is required.
  - [ ] Documentation is updated in this PR or in a linked website PR.
  - [ ] <!-- docs-follow-up --> A follow-up issue is required in
        `AstroVela/vane-website`.

  ## Validation

  - `ruff check duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py`
  - `ruff format --check duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py`
  - `python -m py_compile duckdb/execution/udf_subprocess.py tests/fast/test_udf_executor_lifecycle.py`
  - Targeted exact-method harness: 8 timeout and failure-path scenarios passed.
  - Full pytest suite was not run locally because a built `_duckdb` native
    extension was not available in the local environment. CI is expected to run
    the repository test suite.

  ## Checklist

  - [x] The change is focused and includes tests or a reason tests are unnecessary.
  - [x] Public behavior and compatibility impact are documented.
  - [x] New dependencies, copied code, model assets, and datasets have compatible
        licenses and are recorded where required.
  - [x] No credentials, private endpoints, personal paths, generated data, model
        weights, or build artifacts are included.
  - [x] Security implications of UDFs, serialization, remote code, network access,
        and untrusted input have been considered.
  - [ ] Native changes were compiled; Python-only, documentation, and workflow
        changes passed relevant checks.

  The final item is left unchecked because the full repository pytest suite could
  not be run in the local environment.