### PR TITLE
[fix](ray) Isolate connection sessions in shared runtime

### DIFF
--- a/benchmarking/tpch/run_tpch_duckdb_ray_relapi.py
+++ b/benchmarking/tpch/run_tpch_duckdb_ray_relapi.py
@@ -172,23 +172,6 @@ def run_query_distributed_with_timeout(parquet_folder, qnum, threads, timeout, r
     if proc.is_alive():
         proc.kill()
         proc.join(timeout=5)
-        # Kill stuck query driver actor so ray.shutdown() won't hang
-        try:
-            import ray as _ray
-
-            for actor_name in ("ray-query-driver-actor",):
-                try:
-                    actor = _ray.get_actor(actor_name, namespace="vane")
-                except Exception:
-                    continue
-                _ray.kill(actor, no_restart=True)
-                print(
-                    f"  [diag] killed stuck actor '{actor_name}' after subprocess timeout",
-                    flush=True,
-                )
-                break
-        except Exception:
-            pass
         return "TIMEOUT", timeout, f"subprocess killed after {timeout}s"
 
     if not queue.empty():

--- a/benchmarking/tpch/run_tpch_vane_ray_relapi.py
+++ b/benchmarking/tpch/run_tpch_vane_ray_relapi.py
@@ -169,23 +169,6 @@ def run_query_distributed_with_timeout(parquet_folder, qnum, threads, timeout, r
     if proc.is_alive():
         proc.kill()
         proc.join(timeout=5)
-        # Kill stuck query driver actor so ray.shutdown() won't hang
-        try:
-            import ray as _ray
-
-            for actor_name in ("ray-query-driver-actor",):
-                try:
-                    actor = _ray.get_actor(actor_name, namespace="vane")
-                except Exception:
-                    continue
-                _ray.kill(actor, no_restart=True)
-                print(
-                    f"  [diag] killed stuck actor '{actor_name}' after subprocess timeout",
-                    flush=True,
-                )
-                break
-        except Exception:
-            pass
         return "TIMEOUT", timeout, f"subprocess killed after {timeout}s"
 
     if not queue.empty():

--- a/duckdb/execution/udf.py
+++ b/duckdb/execution/udf.py
@@ -23,6 +23,8 @@ _ALLOWED_OPTIONS = frozenset(
         "actor_node_ids",
         "actor_dispatch_indices",
         "local_actor_pool",
+        "query_driver_handle",
+        "session_config",
     }
 )
 

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -284,13 +284,13 @@ def _build_actor_runtime_env(ray_options: dict[str, Any] | None) -> dict[str, An
     return runtime_env
 
 
-def _actor_class(max_restarts: int, max_task_retries: int):
+def _actor_class(max_restarts: int, max_task_retries: int) -> Any:
     return _actor_runtime_class(max_restarts, max_task_retries)
 
 
 class UDFActorPool(_UDFActorPoolBase):
     @staticmethod
-    def _actor_class(max_restarts: int, max_task_retries: int):
+    def _actor_class(max_restarts: int, max_task_retries: int) -> Any:
         return _actor_class(max_restarts, max_task_retries)
 
     @staticmethod
@@ -315,10 +315,10 @@ class UDFActorPool(_UDFActorPoolBase):
 
 
 def _apply_actor_node_options(
-    actors: UDFActorPool,
+    actors: _UDFActorPoolBase,
     *,
     options: dict[str, Any],
-) -> UDFActorPool:
+) -> _UDFActorPoolBase:
     return _apply_actor_node_options_impl(
         actors,
         options=options,
@@ -333,7 +333,7 @@ def ensure_actor_pools_for_plan(
     query_driver_handle: Any,
     session_config: dict[str, str],
     conn: Any = None,
-) -> tuple[list[UDFActorPool], dict[str, Any]]:
+) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _ensure_actor_pools_for_plan_impl(
         plan,
         conn=conn,
@@ -358,7 +358,7 @@ def ensure_actor_pools_for_nodes(
     query_driver_handle: Any,
     session_config: dict[str, str],
     set_handles: Any = None,
-) -> tuple[list[UDFActorPool], dict[str, Any]]:
+) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _ensure_actor_pools_for_nodes_impl(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
@@ -383,7 +383,7 @@ def prepare_actor_pools_for_plan(
     query_driver_handle: Any,
     session_config: dict[str, str],
     conn: Any = None,
-) -> tuple[list[UDFActorPool], dict[str, Any]]:
+) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _prepare_actor_pools_for_plan_impl(
         plan,
         conn=conn,
@@ -401,7 +401,7 @@ def prepare_actor_pools_for_plan(
     )
 
 
-def wait_for_actor_pools_ready(actor_pools: list[UDFActorPool]) -> None:
+def wait_for_actor_pools_ready(actor_pools: list[_UDFActorPoolBase]) -> None:
     _wait_for_actor_pools_ready_impl(actor_pools)
 
 
@@ -416,7 +416,7 @@ class RemoteUDFExecutor(
 ):
     def __init__(
         self,
-        actors: UDFActorPool,
+        actors: _UDFActorPoolBase,
         payload: dict[str, Any],
         *,
         query_driver_handle: Any,
@@ -545,7 +545,7 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
     def submit(self, _args: pa.Table) -> None:
         raise RuntimeError("RayTaskUDFExecutor.submit() direct submit path has been removed; use submit_with_id()")
 
-    def submit_with_id(self, submit_id: int, args: pa.Table):
+    def submit_with_id(self, submit_id: int, args: pa.Table) -> TaskLeaseObjectRefGenerator:
         seq = _next_ray_task_debug_seq()
         table = _ensure_table(args)
         if _ray_task_should_log(seq):
@@ -568,7 +568,14 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
             ),
         )
 
-    def submit_ref_bundle_with_id(self, submit_id: int, block_refs, slices, metadata, names):
+    def submit_ref_bundle_with_id(
+        self,
+        submit_id: int,
+        block_refs: Any,
+        slices: Any,
+        metadata: Any,
+        names: Any,
+    ) -> TaskLeaseObjectRefGenerator:
         seq = _next_ray_task_debug_seq()
         if _ray_task_should_log(seq):
             _ray_task_debug_log(
@@ -596,7 +603,13 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
             ),
         )
 
-    def submit_ref_bundle(self, _block_refs, _slices, _metadata, _names) -> None:
+    def submit_ref_bundle(
+        self,
+        _block_refs: Any,
+        _slices: Any,
+        _metadata: Any,
+        _names: Any,
+    ) -> None:
         raise RuntimeError(
             "RayTaskUDFExecutor.submit_ref_bundle() direct ref-bundle submit path has been removed; "
             "use submit_ref_bundle_with_id()"
@@ -643,7 +656,7 @@ def _streaming_task_payload(payload: dict[str, Any]) -> dict[str, Any]:
 def _iter_materialized_task_outputs(
     payload: dict[str, Any],
     tables: list[pa.Table] | tuple[pa.Table, ...],
-):
+) -> Iterator[Any]:
     """Yield direct block/metadata pairs for materialized Ray task input."""
     validate_task_runtime_node(payload)
     stream_payload = _streaming_task_payload(payload)
@@ -654,7 +667,7 @@ def _iter_materialized_task_outputs(
     configure_loaded_torch_threads()
     output_index = 0
 
-    def emit(output: pa.Table):
+    def emit(output: pa.Table) -> Iterator[tuple[pa.Table, Any]]:
         nonlocal output_index
         for block in iter_bounded_stream_blocks(_ensure_table(output), stream_payload):
             metadata = make_stream_block_metadata(
@@ -741,9 +754,9 @@ def _build_bundle_stream_remote(
         ray_options,
     )
 
-    @ray.remote(**task_options)
+    @ray.remote(**task_options)  # type: ignore[untyped-decorator]
     @_with_explicit_session_runtime_env(session_runtime_env_vars)
-    def run_bundle_stream(payload: dict[str, Any], tables: list[pa.Table]):
+    def run_bundle_stream(payload: dict[str, Any], tables: list[pa.Table]) -> Iterator[Any]:
         seq = _next_ray_task_debug_seq()
         log_task = _ray_task_should_log(seq)
         start = time.perf_counter()
@@ -782,7 +795,13 @@ def _build_bundle_stream_remote(
     return run_bundle_stream
 
 
-def _iter_ref_bundle_task_outputs(payload: dict[str, Any], blocks, slices, metadata, names):
+def _iter_ref_bundle_task_outputs(
+    payload: dict[str, Any],
+    blocks: Any,
+    slices: Any,
+    metadata: Any,
+    names: Any,
+) -> Iterator[Any]:
     validate_task_runtime_node(payload)
     seq = _next_ray_task_debug_seq()
     log_task = _ray_task_should_log(seq)
@@ -819,7 +838,7 @@ def _iter_ref_bundle_task_outputs(payload: dict[str, Any], blocks, slices, metad
         output_count = 0
         output_rows = 0
 
-        def emit_output(output: pa.Table):
+        def emit_output(output: pa.Table) -> Iterator[tuple[pa.Table, Any]]:
             nonlocal output_count, output_rows
             for output_table in iter_bounded_stream_blocks(_ensure_table(output), stream_payload):
                 output_rows += output_table.num_rows
@@ -890,9 +909,15 @@ def _build_ref_bundle_stream_remote(
         ray_options,
     )
 
-    @ray.remote(**task_options)
+    @ray.remote(**task_options)  # type: ignore[untyped-decorator]
     @_with_explicit_session_runtime_env(session_runtime_env_vars)
-    def run_ref_bundle_stream(*blocks, payload: dict[str, Any], slices, metadata, names):
+    def run_ref_bundle_stream(
+        *blocks: Any,
+        payload: dict[str, Any],
+        slices: Any,
+        metadata: Any,
+        names: Any,
+    ) -> Iterator[Any]:
         try:
             yield from _iter_ref_bundle_task_outputs(payload, blocks, slices, metadata, names)
         except Exception as exc:

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import sys
 import threading
 import time
 from collections import deque
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import pyarrow as pa
@@ -103,12 +105,38 @@ from duckdb.execution.udf_task_admission import (
 )
 from duckdb.execution.udf_threading import configure_loaded_torch_threads
 from duckdb.execution.unified_executor import UDFExecutor
+from duckdb.runners.ray.ray_env import (
+    build_session_runtime_env_vars,
+    install_explicit_session_runtime_env,
+    scrub_shared_runtime_session_env,
+)
 
 DEFAULT_UDF_OUTPUT_TARGET_MAX_BYTES = 128 * 1024 * 1024
 DEFAULT_GENERATOR_BACKPRESSURE_NUM_OBJECTS = RAY_UDF_GENERATOR_BACKPRESSURE_OBJECTS
 DEFAULT_GENERATOR_STREAM_BUFFER_BLOCKS = RAY_UDF_STREAM_BUFFER_BLOCKS
 
 _RAY_TASK_DEBUG_SEQ = 0
+
+
+def _with_explicit_session_runtime_env(
+    session_runtime_env_vars: dict[str, str],
+) -> Callable[[Callable[..., Iterator[Any]]], Callable[..., Iterator[Any]]]:
+    """Install one task session for every call, including reused Ray workers."""
+    explicit_carrier = {str(key): str(value) for key, value in session_runtime_env_vars.items()}
+
+    def _decorate(generator_fn: Callable[..., Iterator[Any]]) -> Callable[..., Iterator[Any]]:
+        @functools.wraps(generator_fn)
+        def _wrapped(*args: Any, **kwargs: Any) -> Iterator[Any]:
+            try:
+                os.environ.update(explicit_carrier)
+                install_explicit_session_runtime_env()
+                yield from generator_fn(*args, **kwargs)
+            finally:
+                scrub_shared_runtime_session_env()
+
+        return _wrapped
+
+    return _decorate
 
 
 def _next_ray_task_debug_seq() -> int:
@@ -302,12 +330,16 @@ def ensure_actor_pools_for_plan(
     plan: Any,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     conn: Any = None,
 ) -> tuple[list[UDFActorPool], dict[str, Any]]:
     return _ensure_actor_pools_for_plan_impl(
         plan,
         conn=conn,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         actor_pool_cls=UDFActorPool,
         is_vane_worker_process=_is_vane_worker_process,
         requires_actor_pool_fn=_requires_actor_pool_impl,
@@ -323,11 +355,15 @@ def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     set_handles: Any = None,
 ) -> tuple[list[UDFActorPool], dict[str, Any]]:
     return _ensure_actor_pools_for_nodes_impl(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         set_handles=set_handles,
         actor_pool_cls=UDFActorPool,
         is_vane_worker_process=_is_vane_worker_process,
@@ -344,12 +380,16 @@ def prepare_actor_pools_for_plan(
     plan: Any,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     conn: Any = None,
 ) -> tuple[list[UDFActorPool], dict[str, Any]]:
     return _prepare_actor_pools_for_plan_impl(
         plan,
         conn=conn,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         actor_pool_cls=UDFActorPool,
         is_vane_worker_process=_is_vane_worker_process,
         requires_actor_pool_fn=_requires_actor_pool_impl,
@@ -378,10 +418,15 @@ class RemoteUDFExecutor(
         self,
         actors: UDFActorPool,
         payload: dict[str, Any],
+        *,
+        query_driver_handle: Any,
     ) -> None:
         self._actors_obj = actors
         self._payload = payload
-        self._initialize_task_admission(payload)
+        self._initialize_task_admission(
+            payload,
+            driver=query_driver_handle,
+        )
         self.actors = actors.actors
         # Actor readiness lifecycle:
         # - _pending_ready_refs tracks __ray_ready__ refs waiting to resolve.
@@ -444,13 +489,22 @@ def _build_ray_actor_executor(payload: dict[str, Any], options: dict[str, Any]) 
 
     pre_created_handles = options.get("actor_handles")
     if pre_created_handles is not None:
+        query_driver_handle = options.get("query_driver_handle")
+        if query_driver_handle is None:
+            raise RuntimeError("Ray actor UDF executor requires an explicit query driver handle")
+        if "session_config" not in options:
+            raise RuntimeError("Ray actor UDF executor requires explicit Vane session config")
         actors = UDFActorPool._from_handles(
             pre_created_handles,
             payload=payload,
             actor_dispatch_indices=options.get("actor_dispatch_indices"),
         )
         actors = _apply_actor_node_options(actors, options=options)
-        return RemoteUDFExecutor(actors, payload)
+        return RemoteUDFExecutor(
+            actors,
+            payload,
+            query_driver_handle=query_driver_handle,
+        )
 
     raise RuntimeError(
         "build_ray_executor requires pre-created actor handles. Ray UDF named actor pools have been removed."
@@ -463,12 +517,17 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
         payload: dict[str, Any],
         run_bundle_stream: Any,
         run_ref_bundle_stream: Any,
+        *,
+        query_driver_handle: Any,
     ) -> None:
         self.payload = payload
         self.run_bundle_stream = run_bundle_stream
         self.run_ref_bundle_stream = run_ref_bundle_stream
         self._finished_submitting = False
-        self._initialize_task_admission(payload)
+        self._initialize_task_admission(
+            payload,
+            driver=query_driver_handle,
+        )
         _ray_payload_requires_block_stream(payload)
         _ray_task_debug_log(
             "executor_init",
@@ -670,6 +729,7 @@ def _build_bundle_stream_remote(
     memory_bytes: int,
     max_retries: int,
     ray_options: dict[str, Any],
+    session_runtime_env_vars: dict[str, str],
 ) -> Any:
     import ray
 
@@ -682,6 +742,7 @@ def _build_bundle_stream_remote(
     )
 
     @ray.remote(**task_options)
+    @_with_explicit_session_runtime_env(session_runtime_env_vars)
     def run_bundle_stream(payload: dict[str, Any], tables: list[pa.Table]):
         seq = _next_ray_task_debug_seq()
         log_task = _ray_task_should_log(seq)
@@ -817,6 +878,7 @@ def _build_ref_bundle_stream_remote(
     memory_bytes: int,
     max_retries: int,
     ray_options: dict[str, Any],
+    session_runtime_env_vars: dict[str, str],
 ) -> Any:
     import ray
 
@@ -829,6 +891,7 @@ def _build_ref_bundle_stream_remote(
     )
 
     @ray.remote(**task_options)
+    @_with_explicit_session_runtime_env(session_runtime_env_vars)
     def run_ref_bundle_stream(*blocks, payload: dict[str, Any], slices, metadata, names):
         try:
             yield from _iter_ref_bundle_task_outputs(payload, blocks, slices, metadata, names)
@@ -848,7 +911,18 @@ def _build_ray_task_executor(payload: dict[str, Any], options: dict[str, Any]) -
     _ray_payload_requires_block_stream(payload)
     if not ray.is_initialized():
         raise RuntimeError("Ray task UDF execution requires an initialized RayRunner runtime")
+    query_driver_handle = options.get("query_driver_handle")
+    if query_driver_handle is None:
+        raise RuntimeError("Ray task UDF executor requires an explicit query driver handle")
+    if "session_config" not in options:
+        raise RuntimeError("Ray task UDF executor requires explicit Vane session config")
     ray_options = dict(options.get("ray_options") or {})
+    runtime_env = dict(ray_options.get("runtime_env") or {})
+    env_vars = dict(runtime_env.get("env_vars") or {})
+    session_runtime_env_vars = build_session_runtime_env_vars(dict(options["session_config"]))
+    env_vars.update(session_runtime_env_vars)
+    runtime_env["env_vars"] = env_vars
+    ray_options["runtime_env"] = runtime_env
     num_cpus = _payload_num_cpus(payload)
     num_gpus = _payload_num_gpus(payload)
     memory_bytes = ray_udf_task_memory_bytes(payload)
@@ -865,6 +939,7 @@ def _build_ray_task_executor(payload: dict[str, Any], options: dict[str, Any]) -
             memory_bytes,
             max_retries,
             ray_options,
+            session_runtime_env_vars,
         ),
         _build_ref_bundle_stream_remote(
             num_cpus,
@@ -872,7 +947,9 @@ def _build_ray_task_executor(payload: dict[str, Any], options: dict[str, Any]) -
             memory_bytes,
             max_retries,
             ray_options,
+            session_runtime_env_vars,
         ),
+        query_driver_handle=query_driver_handle,
     )
 
 

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -274,9 +274,17 @@ def _shutdown_owned_actors(ray: Any, actors_obj: Any) -> None:
     if not bool(getattr(actors_obj, "_owns_actors", False)):
         return
     actors = list(getattr(actors_obj, "actors", []))
-    for actor in actors:
-        ray.kill(actor, no_restart=True)
-    actors_obj.actors = []
+    errors: list[str] = []
+    remaining_actors: list[Any] = []
+    for actor_index, actor in enumerate(actors):
+        try:
+            ray.kill(actor, no_restart=True)
+        except BaseException as exc:
+            errors.append(f"actor-{actor_index}: {type(exc).__name__}: {exc}")
+            remaining_actors.append(actor)
+    actors_obj.actors = remaining_actors
+    if errors:
+        raise RuntimeError("failed to shut down UDF actor pool: " + "; ".join(errors))
 
 
 def _resolve_actor_pool_init_refs(ray: Any, actors_obj: Any) -> None:
@@ -297,14 +305,24 @@ def _resolve_actor_pool_init_refs(ray: Any, actors_obj: Any) -> None:
         else:
             resolve_object_refs_blocking(refs, timeout=timeout_s)
     except Exception as exc:
-        _shutdown_owned_actors(ray, actors_obj)
         if _is_timeout_error(exc):
             timeout_desc = "query deadline" if timeout_s is None else f"{timeout_s:.3f}s"
-            raise RuntimeError(
+            readiness_error = RuntimeError(
                 "UDF actor pool initialization timed out "
                 f"after {timeout_desc} while waiting for {len(refs)} actor init refs"
+            )
+        else:
+            readiness_error = RuntimeError(f"UDF actor pool initialization failed: {type(exc).__name__}: {exc}")
+        try:
+            _shutdown_owned_actors(ray, actors_obj)
+        except BaseException as cleanup_error:
+            raise _OwnedUDFActorPoolsError(
+                "UDF actor pool initialization failed and actor cleanup also failed: "
+                f"initialization={readiness_error}; cleanup={type(cleanup_error).__name__}: {cleanup_error}",
+                owned_actor_pools=[actors_obj],
+                creation_error=readiness_error,
             ) from exc
-        raise RuntimeError(f"UDF actor pool initialization failed: {type(exc).__name__}: {exc}") from exc
+        raise readiness_error from exc
     actors_obj._confirmed_ready.update(range(len(actors)))
 
 
@@ -561,16 +579,23 @@ def wait_for_actor_pools_ready(actor_pools: list[UDFActorPoolBase]) -> None:
         for actors_obj in actor_pools:
             _resolve_actor_pool_init_refs(ray, actors_obj)
     except BaseException as readiness_error:
-        cleanup_errors = []
+        cleanup_errors: list[str] = []
+        remaining_owned: list[UDFActorPoolBase] = []
         for actors_obj in reversed(actor_pools):
             try:
                 actors_obj.shutdown()
             except BaseException as cleanup_error:
-                cleanup_errors.append(cleanup_error)
+                cleanup_errors.append(f"{type(cleanup_error).__name__}: {cleanup_error}")
+                remaining_owned.append(actors_obj)
         if cleanup_errors:
-            raise RuntimeError(
-                f"UDF actor readiness failed and cleanup also failed: {cleanup_errors[0]}"
+            creation_error = getattr(readiness_error, "creation_error", readiness_error)
+            raise _OwnedUDFActorPoolsError(
+                "UDF actor readiness failed and cleanup also failed: " + "; ".join(cleanup_errors),
+                owned_actor_pools=list(reversed(remaining_owned)),
+                creation_error=creation_error,
             ) from readiness_error
+        if isinstance(readiness_error, _OwnedUDFActorPoolsError):
+            raise readiness_error.creation_error
         raise
 
 

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 from duckdb.runners.ray.safe_get import (
     configured_ray_get_timeout_s,
     resolve_object_refs_blocking,
@@ -26,6 +27,21 @@ from duckdb.execution.udf_threading import (
     ray_actor_thread_env,
     ray_actor_thread_policy,
 )
+
+
+class _OwnedUDFActorPoolsError(RuntimeError):
+    """Carry actor pools whose teardown must remain retryable by the driver."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        owned_actor_pools: list[Any],
+        creation_error: BaseException,
+    ) -> None:
+        super().__init__(message)
+        self.owned_actor_pools = list(owned_actor_pools)
+        self.creation_error = creation_error
 
 
 def _with_actor_thread_env(
@@ -120,9 +136,25 @@ class UDFActorPoolBase:
         payload_ref = ray.put(payload)
         self._payload_ref = payload_ref
 
-        self.actors = [Actor.options(**actor_options[idx]).remote() for idx in range(concurrency)]
-
-        self._init_refs = [a.init_payload.remote(payload_ref) for a in self.actors]
+        self.actors: list[Any] = []
+        self._init_refs: list[Any] = []
+        try:
+            for actor_index in range(concurrency):
+                self.actors.append(Actor.options(**actor_options[actor_index]).remote())
+            for actor in self.actors:
+                self._init_refs.append(actor.init_payload.remote(payload_ref))
+        except BaseException as creation_error:
+            try:
+                self.shutdown()
+            except BaseException as cleanup_error:
+                raise _OwnedUDFActorPoolsError(
+                    "UDF actor pool creation failed and partial actor cleanup also failed: "
+                    f"creation={type(creation_error).__name__}: {creation_error}; "
+                    f"cleanup={type(cleanup_error).__name__}: {cleanup_error}",
+                    owned_actor_pools=[self],
+                    creation_error=creation_error,
+                ) from creation_error
+            raise
         self._confirmed_ready: set[int] = set()
 
     @staticmethod
@@ -185,9 +217,17 @@ class UDFActorPoolBase:
 
         import ray
 
-        for actor in self.actors:
-            ray.kill(actor, no_restart=True)
-        self.actors = []
+        errors: list[str] = []
+        remaining_actors: list[Any] = []
+        for actor_index, actor in enumerate(self.actors):
+            try:
+                ray.kill(actor, no_restart=True)
+            except BaseException as exc:
+                errors.append(f"actor-{actor_index}: {type(exc).__name__}: {exc}")
+                remaining_actors.append(actor)
+        self.actors = remaining_actors
+        if errors:
+            raise RuntimeError("failed to shut down UDF actor pool: " + "; ".join(errors))
 
 
 def apply_actor_node_options(
@@ -273,6 +313,8 @@ def ensure_actor_pools_for_plan(
     conn: Any = None,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
     requires_actor_pool_fn: Callable[[dict[str, Any]], bool],
@@ -286,6 +328,8 @@ def ensure_actor_pools_for_plan(
     return ensure_actor_pools_for_nodes(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         set_handles=lambda actor_handles_map: plan.set_udf_actor_handles(actor_handles_map, conn=conn),
         actor_pool_cls=actor_pool_cls,
         is_vane_worker_process=is_vane_worker_process,
@@ -303,6 +347,8 @@ def prepare_actor_pools_for_plan(
     conn: Any = None,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
     requires_actor_pool_fn: Callable[[dict[str, Any]], bool],
@@ -323,6 +369,8 @@ def prepare_actor_pools_for_plan(
     return _create_actor_pools_for_nodes(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         set_handles=lambda actor_handles_map: plan.set_udf_actor_handles(actor_handles_map, conn=conn),
         actor_pool_cls=actor_pool_cls,
         is_vane_worker_process=is_vane_worker_process,
@@ -340,6 +388,8 @@ def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     set_handles: Callable[[dict[str, Any]], None] | None = None,
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
@@ -353,6 +403,8 @@ def ensure_actor_pools_for_nodes(
     return _create_actor_pools_for_nodes(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
+        query_driver_handle=query_driver_handle,
+        session_config=session_config,
         set_handles=set_handles,
         actor_pool_cls=actor_pool_cls,
         is_vane_worker_process=is_vane_worker_process,
@@ -370,6 +422,8 @@ def _create_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    session_config: dict[str, str],
     set_handles: Callable[[dict[str, Any]], None] | None,
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
@@ -386,6 +440,10 @@ def _create_actor_pools_for_nodes(
 
     if not udf_nodes:
         return [], {}
+    if query_driver_handle is None:
+        raise ValueError("Ray UDF executor preparation requires an explicit query driver handle")
+    normalized_session_config = {str(key): str(value) for key, value in session_config.items()}
+    session_runtime_env_vars = build_session_runtime_env_vars(normalized_session_config)
 
     import ray
 
@@ -398,6 +456,17 @@ def _create_actor_pools_for_nodes(
     try:
         for node in udf_nodes:
             raw_payload = node.get("payload") or {}
+            backend = str(raw_payload.get("execution_backend") or "").strip().lower()
+            if backend not in {"ray_task", "ray_actor", "subprocess_task", "subprocess_actor"}:
+                continue
+            node_id = str(node["node_id"])
+            executor_options = {
+                "session_config": normalized_session_config,
+            }
+            actor_handles_map[node_id] = executor_options
+            if backend in {"subprocess_task", "subprocess_actor"}:
+                continue
+            executor_options["query_driver_handle"] = query_driver_handle
             if not requires_actor_pool_fn(raw_payload):
                 continue
             payload = normalize_actor_pool_payload(raw_payload)
@@ -406,7 +475,6 @@ def _create_actor_pools_for_nodes(
             if not requires_actor_pool_fn(payload):
                 continue
 
-            node_id = str(node["node_id"])
             stage_id = str(payload.get("stage_id") or "").strip()
             if not stage_id:
                 raise RuntimeError(f"Ray actor UDF node {node_id} is missing stage_id")
@@ -419,7 +487,12 @@ def _create_actor_pools_for_nodes(
                     f"got {len(assigned_node_ids)}"
                 )
             cpus = resolve_actor_num_cpus(payload)
-            ray_options = {"num_cpus": cpus}
+            ray_options = {
+                "num_cpus": cpus,
+                "runtime_env": {
+                    "env_vars": session_runtime_env_vars,
+                },
+            }
 
             stateful_options: dict[str, int] = {}
             if payload.get("stateful"):
@@ -441,25 +514,37 @@ def _create_actor_pools_for_nodes(
                 _resolve_actor_pool_init_refs(ray, actors_obj)
             actor_node_ids = list(assigned_node_ids)
             actor_dispatch_indices = set(range(len(actors_obj.actors)))
-            actor_handles_map[node_id] = build_udf_executor_options(
-                actor_handles=list(actors_obj.actors),
-                actor_node_ids=actor_node_ids,
-                actor_dispatch_indices=actor_dispatch_indices,
+            executor_options.update(
+                build_udf_executor_options(
+                    actor_handles=list(actors_obj.actors),
+                    actor_node_ids=actor_node_ids,
+                    actor_dispatch_indices=actor_dispatch_indices,
+                )
             )
 
         if actor_handles_map and set_handles is not None:
             set_handles(actor_handles_map)
     except BaseException as execution_error:
-        cleanup_errors = []
+        for actors_obj in getattr(execution_error, "owned_actor_pools", ()):
+            if actors_obj not in created:
+                created.append(actors_obj)
+        cleanup_errors: list[BaseException] = []
+        remaining_owned: list[UDFActorPoolBase] = []
         for actors_obj in reversed(created):
             try:
                 actors_obj.shutdown()
             except BaseException as cleanup_error:
                 cleanup_errors.append(cleanup_error)
+                remaining_owned.append(actors_obj)
         if cleanup_errors:
-            raise RuntimeError(
-                f"UDF actor pool creation failed and cleanup also failed: {cleanup_errors[0]}"
+            creation_error = getattr(execution_error, "creation_error", execution_error)
+            raise _OwnedUDFActorPoolsError(
+                f"UDF actor pool creation failed and cleanup also failed: {cleanup_errors[0]}",
+                owned_actor_pools=list(reversed(remaining_owned)),
+                creation_error=creation_error,
             ) from execution_error
+        if isinstance(execution_error, _OwnedUDFActorPoolsError):
+            raise execution_error.creation_error
         raise
 
     return created, actor_handles_map

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -29,6 +29,7 @@ from duckdb.execution.udf_ray_stream_protocol import (
     validate_task_runtime_node,
 )
 from duckdb.execution.udf_threading import configure_ray_actor_loaded_torch_threads
+from duckdb.runners.ray.ray_env import install_explicit_session_runtime_env
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
 
@@ -104,6 +105,7 @@ def _actor_class(
     @ray.remote(max_restarts=max_restarts, max_task_retries=max_task_retries, max_concurrency=1)
     class UDFActor:
         def __init__(self) -> None:
+            install_explicit_session_runtime_env()
             # No-arg constructor avoids Ray warning about constructor arguments
             # in the object store with max_restarts>0 (ray#53727).
             # Payload is injected via init_payload() immediately after creation.

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import time
+from collections.abc import Iterator
 from typing import Any
 
 import pyarrow as pa
@@ -97,7 +98,7 @@ def _payload_requires_ray_block_stream(payload: dict[str, Any] | None) -> bool:
 def _actor_class(
     max_restarts: int,
     max_task_retries: int,
-):
+) -> Any:
     import ray
 
     # UDFExecutor and user callables are not thread-safe. QRM may pre-admit a
@@ -109,8 +110,8 @@ def _actor_class(
             # No-arg constructor avoids Ray warning about constructor arguments
             # in the object store with max_restarts>0 (ray#53727).
             # Payload is injected via init_payload() immediately after creation.
-            self._payload = None
-            self.executor = None  # lazy init on first streaming submission
+            self._payload: dict[str, Any] | None = None
+            self.executor: RuntimeUDFExecutor | None = None  # lazy init on first streaming submission
 
         def init_payload(self, payload: dict[str, Any]) -> None:
             """Inject payload after construction to avoid Ray object-store GC issues."""
@@ -121,22 +122,26 @@ def _actor_class(
                 runtime_payload = dict(self._payload)
                 runtime_payload["stream_output"] = True
                 runtime_payload["prebatched_input"] = False
-                self.executor = RuntimeUDFExecutor(runtime_payload)
+                executor = RuntimeUDFExecutor(runtime_payload)
+                self.executor = executor
                 configure_ray_actor_loaded_torch_threads(self._payload)
                 if _eager_actor_warm_up_enabled(self._payload):
-                    self.executor.warm_up()
+                    executor.warm_up()
                 _actor_debug_log("executor_init_done", self._payload, path="init_payload")
 
-        def _ensure_executor(self, effective_payload: dict[str, Any]) -> None:
-            if self.executor is not None:
-                return
+        def _ensure_executor(self, effective_payload: dict[str, Any]) -> RuntimeUDFExecutor:
+            executor = self.executor
+            if executor is not None:
+                return executor
             if self._payload is None:
                 self._payload = dict(effective_payload)
             runtime_payload = dict(self._payload)
             runtime_payload["stream_output"] = True
             runtime_payload["prebatched_input"] = False
-            self.executor = RuntimeUDFExecutor(runtime_payload)
+            executor = RuntimeUDFExecutor(runtime_payload)
+            self.executor = executor
             configure_ray_actor_loaded_torch_threads(self._payload)
+            return executor
 
         def _run_row_preserving_batch(
             self,
@@ -148,13 +153,13 @@ def _actor_class(
                 split_row_preserving_input,
             )
 
-            self._ensure_executor(effective_payload)
+            executor = self._ensure_executor(effective_payload)
             args, passthrough = split_row_preserving_input(effective_payload, table)
             if args.num_rows == 0:
                 output = _empty_output_table_from_payload(effective_payload)
                 return fuse_row_preserving_output(effective_payload, passthrough, output)
-            self.executor.submit(args)
-            outputs = self.executor.drain_outputs()
+            executor.submit(args)
+            outputs = executor.drain_outputs()
             if len(outputs) != 1:
                 raise RuntimeError("map_batches_rows actor produced %d outputs, expected exactly 1" % len(outputs))
             return fuse_row_preserving_output(
@@ -167,12 +172,13 @@ def _actor_class(
             self,
             args: pa.Table,
             effective_payload: dict[str, Any],
-        ):
+        ) -> Iterator[Any]:
             _payload_requires_ray_block_stream(effective_payload)
             validate_task_runtime_node(effective_payload)
-            if self.executor is None:
+            executor = self.executor
+            if executor is None:
                 _actor_debug_log("executor_init_start", effective_payload, path="run_block_stream")
-                self._ensure_executor(effective_payload)
+                executor = self._ensure_executor(effective_payload)
                 _actor_debug_log("executor_init_done", effective_payload, path="run_block_stream")
             args = _ensure_table(args)
             _actor_debug_log(
@@ -183,7 +189,7 @@ def _actor_class(
             )
             output_count = 0
 
-            def emit(table: pa.Table):
+            def emit(table: pa.Table) -> Iterator[Any]:
                 nonlocal output_count
                 for block in iter_bounded_stream_blocks(_ensure_table(table), effective_payload):
                     yield block
@@ -195,7 +201,7 @@ def _actor_class(
                     output_count += 1
 
             if str(effective_payload.get("call_mode") or "") == "map":
-                table = execute_scalar_map_layout(effective_payload, args, self.executor)
+                table = execute_scalar_map_layout(effective_payload, args, executor)
                 yield from emit(table)
                 _actor_debug_log(
                     "run_block_stream_submit_done",
@@ -213,7 +219,7 @@ def _actor_class(
                     outputs=1,
                 )
                 return
-            for result in self.executor.iter_submit(args):
+            for result in executor.iter_submit(args):
                 table = _ensure_table(result)
                 _actor_debug_log(
                     "run_block_stream_output",
@@ -237,7 +243,7 @@ def _actor_class(
             self,
             args: pa.Table,
             payload: dict[str, Any] | None = None,
-        ):
+        ) -> Iterator[Any]:
             effective_payload = dict(self._payload or {})
             if payload is not None:
                 effective_payload.update(payload)
@@ -250,12 +256,12 @@ def _actor_class(
 
         def run_ref_bundle_stream(
             self,
-            *blocks,
+            *blocks: Any,
             payload: dict[str, Any] | None = None,
-            slices=None,
-            metadata=None,
-            names=None,
-        ):
+            slices: Any = None,
+            metadata: Any = None,
+            names: Any = None,
+        ) -> Iterator[Any]:
             base_payload = payload or self._payload or {}
             try:
                 _actor_debug_log(

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -1516,6 +1516,19 @@ def ensure_local_subprocess_actor_pools_for_nodes(
                 raise ValueError("GPU resources require a Ray UDF backend")
             executor_options = dict(node.get("executor_options") or {})
             session_config = _normalize_session_config_option(executor_options)
+            existing_pool = executor_options.get("local_actor_pool")
+            if existing_pool is not None:
+                existing_pool_size = _validate_local_actor_pool_contract(existing_pool)
+                if existing_pool_size != pool_size:
+                    raise ValueError(
+                        "pre-created local_actor_pool size does not match the UDF actor_number: "
+                        f"pool_size={existing_pool_size} actor_number={pool_size}"
+                    )
+                existing_session_config = getattr(existing_pool, "session_config", None)
+                if existing_session_config != session_config:
+                    raise ValueError("pre-created local_actor_pool belongs to a different Vane session")
+                actor_options_map[node_id] = executor_options
+                continue
             pool_name = f"local-subprocess-actor-{identity}-{node_id}"
             pool_kwargs: dict[str, Any] = {"name": pool_name}
             if session_config is not None:
@@ -1625,6 +1638,8 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 )
             actor_pool_size = _validate_local_actor_pool_contract(actor_pool)
             _validate_stateful_local_actor_contract(payload, actor_pool_size)
+            if getattr(actor_pool, "session_config", None) != session_config:
+                raise ValueError("local_actor_pool belongs to a different Vane session")
             worker_pids = actor_pool.worker_pids()
             self._actor_pool = actor_pool
             self._pool_size = actor_pool_size

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -18,6 +18,7 @@ import threading
 import time
 import weakref
 from collections import deque
+from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
@@ -60,6 +61,7 @@ from duckdb.execution.udf_threading import (
     worker_thread_env as _worker_thread_env,
 )
 from duckdb.execution.unified_executor import UDFExecutor as BaseUDFExecutor
+from duckdb.runners.ray.ray_env import build_explicit_session_process_env
 
 _MSG_READY = 0x01
 _MSG_SUBMIT = 0x02
@@ -295,7 +297,13 @@ def _read_ipc_from_shm(shm: shared_memory.SharedMemory, size: int | None = None)
 class _SingleSubprocessExecutor(BaseUDFExecutor):
     """Run Python UDFs in one long-lived worker subprocess."""
 
-    def __init__(self, payload: dict[str, Any], *, worker_env: dict[str, str] | None = None) -> None:
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        *,
+        worker_env: dict[str, str] | None = None,
+        session_config: Mapping[str, Any] | None = None,
+    ) -> None:
         if payload is None:
             raise ValueError("UDF payload is required")
 
@@ -309,6 +317,9 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._wakeup_error: BaseException | None = None
         self._ref_bundle_output = payload_requests_local_ref_bundle_output(payload)
         self._worker_env = dict(worker_env or {})
+        self._session_config = (
+            None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
+        )
         self._active_input_leases: set[int] = set()
         self._active_input_leases_lock = threading.Lock()
         self._active_output_grants: set[int] = set()
@@ -349,7 +360,11 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                 str(payload_size),
                 data_shm.name,
             ]
-            env = dict(os.environ)
+            env = (
+                dict(os.environ)
+                if self._session_config is None
+                else build_explicit_session_process_env(self._session_config)
+            )
             env.update(self._worker_env)
             env["PYTHONUNBUFFERED"] = "1"
             proc = subprocess.Popen(
@@ -892,8 +907,26 @@ def _worker_env_for_pool_index(payload: dict[str, Any], worker_idx: int, pool_si
     return env
 
 
-def _payload_task_key(payload: dict[str, Any]) -> str:
-    return hashlib.sha256(duckdb_pickle.dumps(payload)).hexdigest()
+def _normalize_session_config_option(options: Mapping[str, Any]) -> dict[str, str] | None:
+    if "session_config" not in options:
+        return None
+    raw_config = options["session_config"]
+    if not isinstance(raw_config, Mapping):
+        raise TypeError("UDF executor session_config must be a mapping")
+    return {str(key): str(value) for key, value in raw_config.items()}
+
+
+def _payload_task_key(
+    payload: dict[str, Any],
+    session_config: Mapping[str, Any] | None = None,
+) -> str:
+    identity = (
+        payload,
+        None
+        if session_config is None
+        else tuple(sorted((str(key), str(value)) for key, value in session_config.items())),
+    )
+    return hashlib.sha256(duckdb_pickle.dumps(identity)).hexdigest()
 
 
 class _PooledTaskWorker:
@@ -909,10 +942,14 @@ class _TaskWorkerPool:
         key: str,
         payload: dict[str, Any],
         pool_size: int,
+        session_config: Mapping[str, Any] | None = None,
     ) -> None:
         self.runtime = runtime
         self.key = key
         self.payload = dict(payload)
+        self.session_config = (
+            None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
+        )
         self.pool_size = max(1, int(pool_size))
         self.ref_count = 0
         self.closing = False
@@ -971,6 +1008,7 @@ class _TaskWorkerPool:
         worker = _SingleSubprocessExecutor(
             self.payload,
             worker_env=_worker_env_for_pool_index(self.payload, worker_idx, self.pool_size),
+            session_config=self.session_config,
         )
         return _PooledTaskWorker(worker)
 
@@ -1061,14 +1099,20 @@ class _GlobalSubprocessTaskRuntime:
         self.total_workers = 0
         self.closed = False
 
-    def acquire_pool(self, payload: dict[str, Any], pool_size: int) -> _TaskWorkerPool:
-        key = _payload_task_key(payload)
+    def acquire_pool(
+        self,
+        payload: dict[str, Any],
+        pool_size: int,
+        *,
+        session_config: Mapping[str, Any] | None = None,
+    ) -> _TaskWorkerPool:
+        key = _payload_task_key(payload, session_config)
         with self.cond:
             if self.closed:
                 raise RuntimeError("global subprocess task runtime is closed")
             pool = self.pools.get(key)
             if pool is None:
-                pool = _TaskWorkerPool(self, key, payload, pool_size)
+                pool = _TaskWorkerPool(self, key, payload, pool_size, session_config)
                 self.pools[key] = pool
             pool.acquire_ref()
             return pool
@@ -1205,8 +1249,18 @@ atexit.register(_shutdown_global_task_runtime)
 class LocalSubprocessActorPool:
     """Shared subprocess actor pool for one local UDF node."""
 
-    def __init__(self, payload: dict[str, Any], pool_size: int, *, name: str | None = None) -> None:
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        pool_size: int,
+        *,
+        name: str | None = None,
+        session_config: Mapping[str, Any] | None = None,
+    ) -> None:
         self.payload = dict(payload)
+        self.session_config = (
+            None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
+        )
         self.pool_size = max(1, int(pool_size))
         self.name = str(name or "")
         self._closed = False
@@ -1226,6 +1280,7 @@ class LocalSubprocessActorPool:
                     _SingleSubprocessExecutor(
                         self.payload,
                         worker_env=_worker_env_for_pool_index(self.payload, worker_idx, self.pool_size),
+                        session_config=self.session_config,
                     )
                 )
             self._executor = ThreadPoolExecutor(
@@ -1459,12 +1514,16 @@ def ensure_local_subprocess_actor_pools_for_nodes(
             _validate_stateful_local_actor_contract(raw_payload, pool_size)
             if float(raw_payload.get("gpus") or 0.0) > 0.0:
                 raise ValueError("GPU resources require a Ray UDF backend")
+            executor_options = dict(node.get("executor_options") or {})
+            session_config = _normalize_session_config_option(executor_options)
             pool_name = f"local-subprocess-actor-{identity}-{node_id}"
-            pool = LocalSubprocessActorPool(raw_payload, pool_size, name=pool_name)
+            pool_kwargs: dict[str, Any] = {"name": pool_name}
+            if session_config is not None:
+                pool_kwargs["session_config"] = session_config
+            pool = LocalSubprocessActorPool(raw_payload, pool_size, **pool_kwargs)
             created.append(pool)
-            actor_options_map[node_id] = {
-                "local_actor_pool": pool,
-            }
+            executor_options["local_actor_pool"] = pool
+            actor_options_map[node_id] = executor_options
 
         if actor_options_map and set_handles is not None:
             set_handles(actor_options_map)
@@ -1488,6 +1547,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
 
     def __init__(self, payload: dict[str, Any], options: dict[str, Any] | None = None) -> None:
         options = dict(options or {})
+        session_config = _normalize_session_config_option(options)
         self._subprocess_mode = _payload_subprocess_mode(payload)
         self._pool_size = _payload_subprocess_pool_size(payload, self._subprocess_mode)
         if payload.get("stateful"):
@@ -1538,7 +1598,11 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
 
             if self._subprocess_mode == "task":
                 self._task_runtime = _global_task_runtime()
-                self._task_pool = self._task_runtime.acquire_pool(payload, self._pool_size)
+                self._task_pool = self._task_runtime.acquire_pool(
+                    payload,
+                    self._pool_size,
+                    session_config=session_config,
+                )
                 self._initialize_admission(self._task_pool.create_admission_authority())
                 with self._task_runtime.cond:
                     task_pool_ref_count = self._task_pool.ref_count

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -7,7 +7,7 @@ import os
 import threading
 import uuid
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeAlias
 
 from duckdb.execution.udf_admission import (
     AdmissionExecutorMixin,
@@ -55,7 +55,7 @@ def ray_udf_task_resource_spec(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-TaskAdmission = AdmissionLease
+TaskAdmission: TypeAlias = AdmissionLease
 
 
 class TaskAdmissionController:
@@ -82,7 +82,7 @@ class TaskAdmissionController:
         self._error: BaseException | None = None
         self._wakeup: Callable[[], None] | None = None
 
-    def _driver_actor(self):
+    def _driver_actor(self) -> Any:
         return self._driver
 
     def register_wakeup(self, callback: Callable[[], None]) -> None:

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -61,12 +61,14 @@ TaskAdmission = AdmissionLease
 class TaskAdmissionController:
     """One-lookahead, non-blocking query task-lease admission."""
 
-    def __init__(self, payload: dict[str, Any], *, driver: Any | None = None) -> None:
+    def __init__(self, payload: dict[str, Any], *, driver: Any) -> None:
         self._payload = dict(payload)
         self._query_id = str(self._payload.get("query_id") or "").strip()
         self._stage_id = str(self._payload.get("stage_id") or "").strip()
         if not self._query_id or not self._stage_id:
             raise ValueError("distributed Ray UDF task admission requires query_id and stage_id")
+        if driver is None:
+            raise ValueError("distributed Ray UDF task admission requires an explicit query driver handle")
         self._resources = ray_udf_task_resource_spec(self._payload)
         self._driver = driver
         self._executor_id = uuid.uuid4().hex
@@ -81,19 +83,6 @@ class TaskAdmissionController:
         self._wakeup: Callable[[], None] | None = None
 
     def _driver_actor(self):
-        if self._driver is not None:
-            return self._driver
-        import ray
-
-        from duckdb.runners.ray.driver import (
-            RAY_QUERY_DRIVER_ACTOR_NAME,
-            RAY_QUERY_DRIVER_ACTOR_NAMESPACE,
-        )
-
-        self._driver = ray.get_actor(
-            RAY_QUERY_DRIVER_ACTOR_NAME,
-            namespace=RAY_QUERY_DRIVER_ACTOR_NAMESPACE,
-        )
         return self._driver
 
     def register_wakeup(self, callback: Callable[[], None]) -> None:
@@ -256,7 +245,7 @@ class TaskAdmissionExecutorMixin(AdmissionExecutorMixin):
         self,
         payload: dict[str, Any],
         *,
-        driver: Any | None = None,
+        driver: Any,
     ) -> None:
         authority = TaskAdmissionController(payload, driver=driver)
         self._task_admission = authority

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -517,7 +517,10 @@ class RayLocalVLLMExecutor(LocalVLLMExecutor):
 
 class RemoteVLLMExecutor(VLLMExecutor):
     def __init__(self, llm_actors: LLMActors, pool_name: str | None = None):
-        self.router_actor = llm_actors.router_actor
+        router_actor = llm_actors.router_actor
+        if router_actor is None:
+            raise ValueError("RemoteVLLMExecutor requires a router actor")
+        self.router_actor = router_actor
         resolve_object_refs_blocking(self.router_actor.report_start.remote())
 
         self.llm_actors = llm_actors.llm_actors

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -11,11 +11,13 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
+from collections.abc import Mapping
 from numbers import Integral, Real
 from typing import Any
 
 import pyarrow as pa
 
+from duckdb.runners.ray.ray_env import build_session_runtime_env_vars, install_explicit_session_runtime_env
 from duckdb.runners.ray.safe_get import configured_ray_get_timeout_s, resolve_object_refs_blocking
 
 # ---------------------------------------------------------------------------
@@ -484,6 +486,30 @@ class LocalVLLMExecutor(VLLMExecutor):
 
 
 class RayLocalVLLMExecutor(LocalVLLMExecutor):
+    def __init__(
+        self,
+        model: str,
+        engine_args: dict[str, Any],
+        generate_args: dict[str, Any],
+        on_error: str = "raise",
+        use_threading: bool = True,
+        engine_init_timeout_s: float | None = None,
+        force_background_thread: bool = False,
+        *,
+        _install_session_runtime_env: bool = False,
+    ):
+        if _install_session_runtime_env:
+            install_explicit_session_runtime_env()
+        super().__init__(
+            model,
+            engine_args,
+            generate_args,
+            on_error=on_error,
+            use_threading=use_threading,
+            engine_init_timeout_s=engine_init_timeout_s,
+            force_background_thread=force_background_thread,
+        )
+
     # Ray actor calls are awaitable, while the in-process executor exposes a blocking method.
     async def wait_for_result(self, executor_id: str | None = None) -> bool:  # type: ignore[override]
         return await asyncio.to_thread(self._wait_for_result_blocking, executor_id)
@@ -792,7 +818,16 @@ class RemoteVLLMExecutor(VLLMExecutor):
 
 
 class PrefixRouter:
-    def __init__(self, llm_actors: list[Any], _load_balance_threshold: int, _max_recent_prefixes: int = 8):
+    def __init__(
+        self,
+        llm_actors: list[Any],
+        _load_balance_threshold: int,
+        _max_recent_prefixes: int = 8,
+        *,
+        _install_session_runtime_env: bool = False,
+    ):
+        if _install_session_runtime_env:
+            install_explicit_session_runtime_env()
         self.llm_actors = llm_actors
         self.unfinished_actors = 0
 
@@ -808,6 +843,21 @@ class PrefixRouter:
                 resolve_object_refs_blocking(actor.finished_submitting.remote())
 
 
+class _OwnedLLMActorPoolsError(RuntimeError):
+    """Carry vLLM pools whose teardown must remain retryable by the driver."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        owned_actor_pools: list[Any],
+        creation_error: BaseException,
+    ) -> None:
+        super().__init__(message)
+        self.owned_actor_pools = list(owned_actor_pools)
+        self.creation_error = creation_error
+
+
 class LLMActors:
     def __init__(
         self,
@@ -820,39 +870,68 @@ class LLMActors:
         load_balance_threshold: int,
         name_prefix: str | None = None,
         engine_init_timeout_s: float | None = None,
+        session_config: Mapping[str, Any] | None = None,
     ):
         import ray
 
         LocalVLLMExecutorActor = ray.remote(num_gpus=gpus_per_actor, max_restarts=4)(RayLocalVLLMExecutor)
         PrefixRouterActor = ray.remote(PrefixRouter)
+        normalized_session_config = (
+            None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
+        )
+        install_session_env = normalized_session_config is not None
+        actor_runtime_env = (
+            None
+            if normalized_session_config is None
+            else {"env_vars": build_session_runtime_env_vars(normalized_session_config)}
+        )
 
-        if name_prefix:
-            llm_names = [f"{name_prefix}-llm-{i}" for i in range(concurrency)]
-            self.llm_actors = [
-                LocalVLLMExecutorActor.options(name=llm_name).remote(
-                    model,
-                    engine_args,
-                    generate_args,
-                    on_error,
-                    engine_init_timeout_s=engine_init_timeout_s,
+        self.llm_actors: list[Any] = []
+        self.router_actor: Any | None = None
+        try:
+            for actor_index in range(concurrency):
+                actor_options: dict[str, Any] = {}
+                if name_prefix:
+                    actor_options["name"] = f"{name_prefix}-llm-{actor_index}"
+                if actor_runtime_env is not None:
+                    actor_options["runtime_env"] = actor_runtime_env
+                actor_factory = (
+                    LocalVLLMExecutorActor.options(**actor_options) if actor_options else LocalVLLMExecutorActor
                 )
-                for llm_name in llm_names
-            ]
-            self.router_actor = PrefixRouterActor.options(name=f"{name_prefix}-router").remote(
-                self.llm_actors, load_balance_threshold
+                self.llm_actors.append(
+                    actor_factory.remote(
+                        model,
+                        engine_args,
+                        generate_args,
+                        on_error,
+                        engine_init_timeout_s=engine_init_timeout_s,
+                        _install_session_runtime_env=install_session_env,
+                    )
+                )
+
+            router_options: dict[str, Any] = {}
+            if name_prefix:
+                router_options["name"] = f"{name_prefix}-router"
+            if actor_runtime_env is not None:
+                router_options["runtime_env"] = actor_runtime_env
+            router_factory = PrefixRouterActor.options(**router_options) if router_options else PrefixRouterActor
+            self.router_actor = router_factory.remote(
+                self.llm_actors,
+                load_balance_threshold,
+                _install_session_runtime_env=install_session_env,
             )
-        else:
-            self.llm_actors = [
-                LocalVLLMExecutorActor.remote(
-                    model,
-                    engine_args,
-                    generate_args,
-                    on_error,
-                    engine_init_timeout_s=engine_init_timeout_s,
-                )
-                for _ in range(concurrency)
-            ]
-            self.router_actor = PrefixRouterActor.remote(self.llm_actors, load_balance_threshold)
+        except BaseException as creation_error:
+            try:
+                self.shutdown()
+            except BaseException as cleanup_error:
+                raise _OwnedLLMActorPoolsError(
+                    "vLLM actor pool creation failed and partial actor cleanup also failed: "
+                    f"creation={type(creation_error).__name__}: {creation_error}; "
+                    f"cleanup={type(cleanup_error).__name__}: {cleanup_error}",
+                    owned_actor_pools=[self],
+                    creation_error=creation_error,
+                ) from creation_error
+            raise
 
     @classmethod
     def _from_handles(cls, llm_actors: list[Any], router_actor: Any) -> LLMActors:
@@ -860,6 +939,29 @@ class LLMActors:
         instance.llm_actors = llm_actors
         instance.router_actor = router_actor
         return instance
+
+    def shutdown(self) -> None:
+        import ray
+
+        errors: list[str] = []
+        if self.router_actor is not None:
+            try:
+                ray.kill(self.router_actor, no_restart=True)
+            except BaseException as exc:
+                errors.append(f"router: {type(exc).__name__}: {exc}")
+            else:
+                self.router_actor = None
+
+        remaining_llm_actors: list[Any] = []
+        for actor_index, actor in enumerate(self.llm_actors):
+            try:
+                ray.kill(actor, no_restart=True)
+            except BaseException as exc:
+                errors.append(f"llm-{actor_index}: {type(exc).__name__}: {exc}")
+                remaining_llm_actors.append(actor)
+        self.llm_actors = remaining_llm_actors
+        if errors:
+            raise RuntimeError("failed to shut down vLLM actor pool: " + "; ".join(errors))
 
     @classmethod
     def get_or_create_named(
@@ -874,6 +976,7 @@ class LLMActors:
         load_balance_threshold: int,
         name_prefix: str,
         engine_init_timeout_s: float | None = None,
+        session_config: Mapping[str, Any] | None = None,
     ) -> LLMActors:
         import ray
 
@@ -899,11 +1002,16 @@ class LLMActors:
         if found == expected:
             return cls._from_handles(llm_actors, router_actor)
         if found:
-            raise RuntimeError(
+            creation_error = RuntimeError(
                 f"Named vLLM actor pool '{name_prefix}' partially available: "
                 f"found={found} missing={len(missing)} expected={expected} "
                 f"missing_names={', '.join(missing)}"
             )
+            raise _OwnedLLMActorPoolsError(
+                str(creation_error),
+                owned_actor_pools=[cls._from_handles(llm_actors, router_actor)],
+                creation_error=creation_error,
+            ) from creation_error
 
         return cls(
             model=model,
@@ -915,6 +1023,7 @@ class LLMActors:
             load_balance_threshold=load_balance_threshold,
             name_prefix=name_prefix,
             engine_init_timeout_s=engine_init_timeout_s,
+            session_config=session_config,
         )
 
     @classmethod
@@ -1063,7 +1172,12 @@ def _is_ray_worker() -> bool:
         return False
 
 
-def ensure_named_vllm_pools_for_plan(plan: Any, conn: Any = None) -> tuple[list[LLMActors], dict[str, Any]]:
+def ensure_named_vllm_pools_for_plan(
+    plan: Any,
+    conn: Any = None,
+    *,
+    session_config: Mapping[str, Any],
+) -> tuple[list[LLMActors], dict[str, Any]]:
     """Pre-create named Ray actor pools for vLLM nodes in a distributed plan.
 
     Called on the driver before task dispatch so that workers find actors
@@ -1087,35 +1201,62 @@ def ensure_named_vllm_pools_for_plan(plan: Any, conn: Any = None) -> tuple[list[
     if not ray.is_initialized():
         raise RuntimeError("Ray vLLM actor creation requires an initialized RayRunner runtime")
 
+    normalized_session_config = {str(key): str(value) for key, value in session_config.items()}
     created: list[LLMActors] = []
-    for node in vllm_nodes:
-        pool_name = str(node["pool_name"])
-        model = str(node.get("model", ""))
+    try:
+        for node in vllm_nodes:
+            pool_name = str(node["pool_name"])
+            model = str(node.get("model", ""))
 
-        # Parse options through normalize_options to get clean defaults.
-        raw_opts = node.get("options")
-        opts = normalize_options(raw_opts)
+            # Parse options through normalize_options to get clean defaults.
+            raw_opts = node.get("options")
+            opts = normalize_options(raw_opts)
 
-        engine_args = _apply_engine_defaults(dict(opts.get("engine_args") or {}))
-        generate_args = dict(opts.get("generate_args") or {})
-        on_error = str(opts.get("on_error", "raise"))
-        gpus_per_actor = opts["gpus_per_actor"]
-        concurrency = max(1, int(opts.get("concurrency", 1)))
-        load_balance_threshold = max(0, int(opts.get("load_balance_threshold", 32)))
-        engine_init_timeout_s = _vllm_engine_init_timeout_s(opts.get("engine_init_timeout_s"))
+            engine_args = _apply_engine_defaults(dict(opts.get("engine_args") or {}))
+            generate_args = dict(opts.get("generate_args") or {})
+            on_error = str(opts.get("on_error", "raise"))
+            gpus_per_actor = opts["gpus_per_actor"]
+            concurrency = max(1, int(opts.get("concurrency", 1)))
+            load_balance_threshold = max(0, int(opts.get("load_balance_threshold", 32)))
+            engine_init_timeout_s = _vllm_engine_init_timeout_s(opts.get("engine_init_timeout_s"))
 
-        actors_obj = LLMActors.get_or_create_named(
-            model=model,
-            engine_args=engine_args,
-            generate_args=generate_args,
-            on_error=on_error,
-            gpus_per_actor=gpus_per_actor,
-            concurrency=concurrency,
-            load_balance_threshold=load_balance_threshold,
-            name_prefix=pool_name,
-            engine_init_timeout_s=engine_init_timeout_s,
-        )
-        created.append(actors_obj)
+            actors_obj = LLMActors.get_or_create_named(
+                model=model,
+                engine_args=engine_args,
+                generate_args=generate_args,
+                on_error=on_error,
+                gpus_per_actor=gpus_per_actor,
+                concurrency=concurrency,
+                load_balance_threshold=load_balance_threshold,
+                name_prefix=pool_name,
+                engine_init_timeout_s=engine_init_timeout_s,
+                session_config=normalized_session_config,
+            )
+            created.append(actors_obj)
+    except BaseException as execution_error:
+        for actors_obj in getattr(execution_error, "owned_actor_pools", ()):
+            if actors_obj not in created:
+                created.append(actors_obj)
+        cleanup_errors: list[str] = []
+        remaining_owned: list[LLMActors] = []
+        for actors_obj in created:
+            try:
+                actors_obj.shutdown()
+            except BaseException as exc:
+                cleanup_errors.append(f"{type(exc).__name__}: {exc}")
+                remaining_owned.append(actors_obj)
+        if cleanup_errors:
+            creation_error = getattr(execution_error, "creation_error", execution_error)
+            raise _OwnedLLMActorPoolsError(
+                "vLLM plan actor creation failed and prior pool cleanup also failed: "
+                f"creation={type(creation_error).__name__}: {creation_error}; "
+                f"cleanup={'; '.join(cleanup_errors)}",
+                owned_actor_pools=remaining_owned,
+                creation_error=creation_error,
+            ) from execution_error
+        if isinstance(execution_error, _OwnedLLMActorPoolsError):
+            raise execution_error.creation_error
+        raise
 
     return created, {}
 

--- a/duckdb/runners/ray/aws_credentials.py
+++ b/duckdb/runners/ray/aws_credentials.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from typing import Any
+
+
+def resolve_aws_credentials_from_environment() -> dict[str, Any]:
+    """Resolve one standard AWS credential chain in this isolated process."""
+    from botocore.session import Session  # type: ignore[import-not-found]
+
+    session = Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError("AWS credential resolver found no credentials")
+    frozen = credentials.get_frozen_credentials()
+    if not frozen.access_key or not frozen.secret_key:
+        raise RuntimeError("AWS credential resolver returned incomplete credentials")
+
+    resolved = {
+        "AWS_ACCESS_KEY_ID": frozen.access_key,
+        "AWS_SECRET_ACCESS_KEY": frozen.secret_key,
+    }
+    if frozen.token:
+        resolved["AWS_SESSION_TOKEN"] = frozen.token
+    region = os.environ.get("AWS_REGION") or session.get_config_variable("region")
+    if region:
+        resolved["AWS_REGION"] = str(region)
+
+    result: dict[str, Any] = {"credentials": resolved}
+    expiration = getattr(credentials, "_expiry_time", None)
+    if isinstance(expiration, datetime):
+        result["expiration_epoch_s"] = expiration.timestamp()
+    return result
+
+
+def _write_result(result: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(result, sort_keys=True, separators=(",", ":")))
+
+
+def main() -> None:
+    _write_result(resolve_aws_credentials_from_environment())
+
+
+if __name__ == "__main__":
+    main()

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -9,6 +9,7 @@ import os
 import sys
 import threading
 import time
+import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -36,12 +37,16 @@ from duckdb.runners.fte import (
 )
 from duckdb.runners.progress import ProgressRenderer, progress_enabled
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
-from duckdb.runners.ray.ray_env import collect_vane_env_overrides
+from duckdb.runners.ray.ray_env import collect_vane_env_overrides, scrub_shared_runtime_session_env
 from duckdb.runners.ray.safe_get import QueryDeadlineExceeded, resolve_object_refs_blocking
 from duckdb.runners.ray.worker import WorkerTaskMetadata
 
 _LEASE_REQUEST_REPLAY_CAPACITY = 65_536
+_SESSION_CLOSE_REPLAY_CAPACITY = 65_536
+_CLIENT_DETACH_REPLAY_CAPACITY = 65_536
 _DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S = 60.0
+RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
+RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -106,6 +111,54 @@ class _PlanStartupOwnership:
                 return False
             self._owner = "cancelled"
             return True
+
+
+@dataclass
+class _DriverSession:
+    owner_id: str
+    config: dict[str, str]
+    connection: Any
+    s3_config: dict[str, str]
+    plan_ids: set[str] = field(default_factory=set)
+    lock: threading.RLock = field(default_factory=threading.RLock)
+    operation_lock: threading.Lock = field(default_factory=threading.Lock)
+    closing: bool = False
+    close_in_progress: bool = False
+    closed: bool = False
+    active_operations: int = 0
+    condition: threading.Condition = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.condition = threading.Condition(self.lock)
+
+
+def _normalize_session_config(config: Mapping[str, Any]) -> dict[str, str]:
+    if not isinstance(config, Mapping):
+        raise TypeError("Vane session config must be a mapping")
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in config.items():
+        key = str(raw_key)
+        if not key:
+            raise ValueError("Vane session config keys must not be empty")
+        if raw_value is None:
+            raise ValueError(f"Vane session config value must not be None: {key}")
+        normalized[key] = str(raw_value)
+    return normalized
+
+
+async def _to_thread_with_owned_side_effects(callback: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Do not expose cancellation until a thread-owned mutation has finished."""
+    thread_task = asyncio.create_task(asyncio.to_thread(callback, *args, **kwargs))
+    cancellation: asyncio.CancelledError | None = None
+    while not thread_task.done():
+        try:
+            await asyncio.shield(thread_task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+    result = thread_task.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
 
 
 def _progress_topology_init_timeout_s() -> float:
@@ -175,12 +228,18 @@ def _safe_remote_error_message(exc: BaseException) -> str:
     return f"{type(exc).__name__} from remote Ray task"
 
 
-def _ray_progress_snapshot_or_none(runner: Any, plan_id: Any, started_at: float) -> dict[str, Any] | None:
+def _ray_progress_snapshot_or_none(
+    runner: Any,
+    owner_id: str,
+    session_id: str,
+    plan_id: Any,
+    started_at: float,
+) -> dict[str, Any] | None:
     # Short hard timeout: progress must never stall query execution or pin the
     # driver actor long enough to block UDF lease admission/release.
     try:
         return resolve_object_refs_blocking(
-            runner.progress_snapshot.remote(plan_id, started_at),
+            runner.progress_snapshot.remote(owner_id, session_id, plan_id, started_at),
             timeout=0.1,
         )
     except Exception:
@@ -190,13 +249,28 @@ def _ray_progress_snapshot_or_none(runner: Any, plan_id: Any, started_at: float)
 class _RayProgressSession:
     """Drive best-effort progress updates from synchronous Ray waits."""
 
-    def __init__(self, runner: Any, plan_id: Any, started_at: float) -> None:
+    def __init__(
+        self,
+        runner: Any,
+        owner_id: str,
+        session_id: str,
+        plan_id: Any,
+        started_at: float,
+    ) -> None:
         self._renderer = None
         self._renderer_failed = False
         self._finished = False
         try:
             if progress_enabled():
-                self._renderer = ProgressRenderer(lambda: _ray_progress_snapshot_or_none(runner, plan_id, started_at))
+                self._renderer = ProgressRenderer(
+                    lambda: _ray_progress_snapshot_or_none(
+                        runner,
+                        owner_id,
+                        session_id,
+                        plan_id,
+                        started_at,
+                    )
+                )
         except Exception:
             self._renderer_failed = True
 
@@ -330,15 +404,6 @@ def shutdown_background_event_loop(timeout_s: float = 5.0) -> None:
 
 def _collect_vane_env_overrides() -> dict[str, str]:
     return collect_vane_env_overrides()
-
-
-def _apply_env_overrides(env_overrides: Mapping[str, str | None] | None) -> None:
-    if not env_overrides:
-        return
-    for key, value in env_overrides.items():
-        if value is None:
-            continue
-        os.environ[key] = str(value)
 
 
 def _apply_duckdb_thread_setting(conn: Any) -> None:
@@ -903,10 +968,6 @@ def batch_wait_ready(handles: list[Any]) -> list[int]:
     return [index for index, handle in enumerate(handles) if handle.done()]
 
 
-RAY_QUERY_DRIVER_ACTOR_NAMESPACE = "vane"
-RAY_QUERY_DRIVER_ACTOR_NAME = "ray-query-driver-actor"
-
-
 def _udf_test_hooks_enabled() -> bool:
     value = os.environ.get("VANE_ENABLE_UDF_TEST_HOOKS", "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
@@ -918,12 +979,26 @@ def _udf_test_hooks_enabled() -> bool:
 class RayQueryDriverActor:
     def __init__(
         self,
-        env_overrides: dict[str, str] | None,
+        runtime_config: dict[str, str],
         duckdb_memory_bytes: int,
     ) -> None:
+        scrub_shared_runtime_session_env()
         duckdb_memory_bytes = int(duckdb_memory_bytes)
         if duckdb_memory_bytes <= 0:
             raise ValueError("Ray driver duckdb_memory_bytes must be positive")
+        self._runtime_config = _normalize_session_config(runtime_config)
+        self._client_ids: set[str] = set()
+        self._detaching_client_ids: set[str] = set()
+        self._detached_client_results = BoundedReplayMap[str, bool](capacity=_CLIENT_DETACH_REPLAY_CAPACITY)
+        self._client_detach_lock = asyncio.Lock()
+        self._sessions: dict[str, _DriverSession] = {}
+        self._closed_session_owners = BoundedReplayMap[str, str](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
+        self._session_lock = threading.RLock()
+        self._plan_session_ids: dict[str, str] = {}
+        self._plan_connections: dict[str, Any] = {}
+        self._plan_teardown_condition = threading.Condition(self._session_lock)
+        self._plan_teardowns_in_progress: set[str] = set()
+        self._driver_handle = ray.get_runtime_context().current_actor
         # Avoid referencing C++ types at import time; store opaque plan objects and
         # lazily instantiate the plan runner when first required.
         self.curr_plans: dict[str, Any] = {}
@@ -936,6 +1011,7 @@ class RayQueryDriverActor:
         self._active_udf_actors: list[Any] = []
         self._active_udf_actors_by_plan: dict[str, list[Any]] = {}
         self._active_vllm_actors: list[Any] = []
+        self._active_vllm_actors_by_plan: dict[str, list[Any]] = {}
         self._query_resource_lock = threading.RLock()
         self._query_graphs: dict[str, Any] = {}
         self._query_allocations: dict[str, Any] = {}
@@ -982,8 +1058,6 @@ class RayQueryDriverActor:
         self._driver_shutdown_started = False
         self._driver_shutdown_complete = False
         self._driver_duckdb_memory_bytes = duckdb_memory_bytes
-        self._env_overrides = env_overrides or {}
-        _apply_env_overrides(self._env_overrides)
 
         self._query_resource_coordinator = self._create_query_resource_coordinator()
 
@@ -1053,9 +1127,15 @@ class RayQueryDriverActor:
             plan_runner = None
         execution_query_ids.update(remembered_execution_query_ids)
         pending_execution_teardowns.setdefault(str(query_id), set()).update(execution_query_ids)
+        resource_query_id = str(query_id)
+        teardown_query_ids = sorted(
+            execution_query_id for execution_query_id in execution_query_ids if execution_query_id != resource_query_id
+        )
         successful_execution_query_ids: set[str] = set()
         if plan_runner is not None:
-            for execution_query_id in sorted(execution_query_ids):
+            # The resource query owns query-scoped replay and datasource state.
+            # Drain every internal execution before releasing that outer owner.
+            for execution_query_id in teardown_query_ids:
                 try:
                     plan_runner.drop_query_fragments(execution_query_id)
                 except BaseException as exc:
@@ -1066,11 +1146,21 @@ class RayQueryDriverActor:
             fte_query_remote_teardown_blockers,
         )
 
-        teardown_blockers_by_query: dict[str, tuple[str, ...]] = {}
-        for execution_query_id in sorted(execution_query_ids):
-            blockers = fte_query_remote_teardown_blockers(execution_query_id)
-            if blockers:
-                teardown_blockers_by_query[execution_query_id] = blockers
+        teardown_blockers_by_query = {
+            execution_query_id: blockers
+            for execution_query_id in teardown_query_ids
+            if (blockers := fte_query_remote_teardown_blockers(execution_query_id))
+        }
+        if plan_runner is not None and not errors and not teardown_blockers_by_query:
+            try:
+                plan_runner.drop_query_fragments(resource_query_id)
+            except BaseException as exc:
+                errors.append(exc)
+            else:
+                successful_execution_query_ids.add(resource_query_id)
+        blockers = fte_query_remote_teardown_blockers(resource_query_id)
+        if blockers:
+            teardown_blockers_by_query[resource_query_id] = blockers
         pending_for_query = pending_execution_teardowns[str(query_id)]
         pending_for_query.difference_update(
             execution_query_id
@@ -1194,10 +1284,16 @@ class RayQueryDriverActor:
 
     async def progress_snapshot(
         self,
-        query_id: str,
+        owner_id: str,
+        session_id: str,
+        plan_id: str,
         started_at: float | None = None,
     ) -> dict[str, Any]:
         """Build one local-only progress view without blocking actor admission."""
+        self._require_plan_session(owner_id, session_id, plan_id)
+        query_id = self._plan_query_ids.get(str(plan_id))
+        if not query_id:
+            raise RuntimeError(f"query plan {plan_id} is missing its registered query resource owner")
         self._ensure_progress_snapshot_state()
         key = (
             str(query_id),
@@ -1240,21 +1336,129 @@ class RayQueryDriverActor:
 
         import duckdb
         from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
-        from duckdb.runners.ray.worker import _configure_duckdb_s3
 
         self._duckdb_conn = duckdb.connect()
         _apply_duckdb_thread_setting(self._duckdb_conn)
         apply_duckdb_memory_limit(self._duckdb_conn, self._driver_duckdb_memory_bytes)
-        _configure_duckdb_s3(self._duckdb_conn)
         return self._duckdb_conn
 
-    def ping(self) -> bool:
+    def _require_owner(self, owner_id: str) -> None:
+        owner_key = str(owner_id).strip()
+        with self._session_lock:
+            if owner_key not in self._client_ids or owner_key in self._detaching_client_ids:
+                raise PermissionError("Ray query runtime operation requires an attached client owner")
+
+    def attach_client(self, owner_id: str, runtime_config: dict[str, str]) -> bool:
+        owner_key = str(owner_id).strip()
+        if not owner_key:
+            raise ValueError("Ray query runtime owner_id must not be empty")
+        normalized_config = _normalize_session_config(runtime_config)
+        with self._session_lock:
+            if self._driver_shutdown_started:
+                raise RuntimeError("Ray query runtime is shutting down")
+            if owner_key in self._detaching_client_ids or owner_key in self._detached_client_results:
+                raise RuntimeError("Ray query runtime owner identity was already detached")
+            if normalized_config != self._runtime_config:
+                raise RuntimeError("Ray query runtime configuration differs from the existing job runtime")
+            self._client_ids.add(owner_key)
+        return True
+
+    def _require_session(
+        self,
+        owner_id: str,
+        session_id: str,
+        *,
+        allow_closing: bool = False,
+    ) -> _DriverSession:
+        self._require_owner(owner_id)
+        session_key = str(session_id).strip()
+        if not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        with self._session_lock:
+            session = self._sessions.get(session_key)
+        if session is None:
+            raise RuntimeError(f"Vane session is not open: {session_key}")
+        if session.owner_id != str(owner_id).strip():
+            raise PermissionError("Vane session operation requires its owning runtime client")
+        with session.condition:
+            if session.closed:
+                raise RuntimeError(f"Vane session is closed: {session_key}")
+            if session.closing and not allow_closing:
+                raise RuntimeError(f"Vane session is closing: {session_key}")
+        return session
+
+    def _require_plan_session(self, owner_id: str, session_id: str, plan_id: str) -> _DriverSession:
+        session = self._require_session(owner_id, session_id)
+        plan_key = str(plan_id)
+        with self._session_lock:
+            plan_session_id = self._plan_session_ids.get(plan_key)
+        with session.condition:
+            owns_plan = plan_key in session.plan_ids
+        if plan_session_id != str(session_id) or not owns_plan:
+            raise PermissionError("query plan does not belong to the requested Vane session")
+        return session
+
+    @staticmethod
+    def _begin_session_operation(session: _DriverSession, session_id: str) -> None:
+        with session.condition:
+            if session.closed:
+                raise RuntimeError(f"Vane session is closed: {session_id}")
+            if session.closing:
+                raise RuntimeError(f"Vane session is closing: {session_id}")
+            session.active_operations += 1
+
+    @staticmethod
+    def _end_session_operation(session: _DriverSession) -> None:
+        with session.condition:
+            if session.active_operations <= 0:
+                raise RuntimeError("Vane session operation accounting underflow")
+            session.active_operations -= 1
+            session.condition.notify_all()
+
+    def open_session(self, owner_id: str, session_id: str, config: dict[str, str]) -> bool:
+        self._require_owner(owner_id)
+        owner_key = str(owner_id).strip()
+        session_key = str(session_id).strip()
+        if not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        normalized_config = _normalize_session_config(config)
+        with self._session_lock:
+            if owner_key not in self._client_ids or owner_key in self._detaching_client_ids:
+                raise PermissionError("Ray query runtime operation requires an attached client owner")
+            if self._driver_shutdown_started:
+                raise RuntimeError("Ray query runtime is shutting down")
+            if session_key in self._closed_session_owners:
+                raise RuntimeError(f"Vane session identity was already closed: {session_key}")
+            existing = self._sessions.get(session_key)
+            if existing is not None:
+                if existing.owner_id != owner_key or existing.config != normalized_config:
+                    raise RuntimeError(f"Vane session identity collision: {session_key}")
+                return False
+            session_connection = self._ensure_duckdb_conn().cursor()
+            self._sessions[session_key] = _DriverSession(
+                owner_id=owner_key,
+                config=normalized_config,
+                connection=session_connection,
+                s3_config={},
+            )
+        return True
+
+    def _validate_plan_session(self, session_id: str, plan: Any, session: _DriverSession) -> None:
+        plan_session_id = str(plan.session_id()).strip()
+        if plan_session_id != str(session_id):
+            raise ValueError(f"logical plan session mismatch: plan={plan_session_id!r} requested={str(session_id)!r}")
+        plan_config = _normalize_session_config(plan.session_config())
+        if plan_config != session.config:
+            raise ValueError(f"logical plan session config changed after session open: {session_id}")
+
+    def ping(self, owner_id: str) -> bool:
         """Health-check: returns True if the actor is alive."""
+        self._require_owner(owner_id)
         if self._driver_shutdown_started:
             raise RuntimeError("Ray query driver is shutting down")
         return True
 
-    async def shutdown(self) -> None:
+    async def _shutdown_runtime(self) -> None:
         """Stop background maintenance and gracefully drain every worker actor."""
         async with self._driver_shutdown_lock:
             if self._driver_shutdown_complete:
@@ -1268,8 +1472,107 @@ class RayQueryDriverActor:
             if teardown_futures:
                 await asyncio.gather(*teardown_futures, return_exceptions=True)
             if plan_runner is not None:
-                await asyncio.to_thread(plan_runner.shutdown)
+                await _to_thread_with_owned_side_effects(plan_runner.shutdown)
             self._driver_shutdown_complete = True
+
+    async def detach_client(self, owner_id: str) -> bool:
+        owner_key = str(owner_id).strip()
+        if not owner_key:
+            raise ValueError("Ray query runtime owner_id must not be empty")
+        async with self._client_detach_lock:
+            with self._session_lock:
+                detached_result = self._detached_client_results.get(owner_key)
+                if detached_result is not None:
+                    return detached_result
+                if owner_key not in self._client_ids:
+                    raise PermissionError("Ray query runtime operation requires an attached client owner")
+                self._detaching_client_ids.add(owner_key)
+                session_ids = [
+                    session_id for session_id, session in self._sessions.items() if session.owner_id == owner_key
+                ]
+            try:
+                for session_id in session_ids:
+                    await self._close_session_for_owner(owner_key, session_id)
+                with self._session_lock:
+                    self._client_ids.remove(owner_key)
+                    last_owner = not self._client_ids
+                    if last_owner:
+                        with self._plan_runner_lifecycle_lock:
+                            self._driver_shutdown_started = True
+                if last_owner:
+                    await self._shutdown_runtime()
+            except BaseException:
+                with self._session_lock:
+                    self._client_ids.add(owner_key)
+                    self._detaching_client_ids.discard(owner_key)
+                raise
+            with self._session_lock:
+                self._detaching_client_ids.discard(owner_key)
+                self._detached_client_results[owner_key] = last_owner
+            return last_owner
+
+    async def close_session(self, owner_id: str, session_id: str) -> None:
+        self._require_owner(owner_id)
+        owner_key = str(owner_id).strip()
+        await self._close_session_for_owner(owner_key, session_id)
+
+    async def _close_session_for_owner(self, owner_key: str, session_id: str) -> None:
+        session_key = str(session_id).strip()
+        if not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        with self._session_lock:
+            session = self._sessions.get(session_key)
+            closed_owner = self._closed_session_owners.get(session_key)
+            if session is None and closed_owner is None:
+                self._closed_session_owners[session_key] = owner_key
+                return
+        if session is None:
+            if closed_owner != owner_key:
+                raise PermissionError("Vane session operation requires its owning runtime client")
+            return
+        if session.owner_id != owner_key:
+            raise PermissionError("Vane session operation requires its owning runtime client")
+        with session.condition:
+            if session.closed:
+                return
+            session.closing = True
+
+        def _close() -> None:
+            with session.condition:
+                while session.close_in_progress:
+                    session.condition.wait()
+                if session.closed:
+                    return
+                session.close_in_progress = True
+            try:
+                with session.condition:
+                    while session.active_operations > 0:
+                        session.condition.wait()
+                    if session.closed:
+                        return
+                    plan_ids = tuple(session.plan_ids)
+                for plan_id in plan_ids:
+                    self._cleanup_finished_plan(plan_id)
+                with session.condition:
+                    if session.plan_ids:
+                        raise RuntimeError(f"Vane session still owns query plans after teardown: {session_key}")
+                plan_runner = self.plan_runner
+                if plan_runner is not None:
+                    plan_runner.close_session(session_key)
+                session.connection.close()
+                with self._session_lock:
+                    current = self._sessions.get(session_key)
+                    if current is session:
+                        self._closed_session_owners[session_key] = owner_key
+                        self._sessions.pop(session_key, None)
+                with session.condition:
+                    session.closed = True
+            finally:
+                with session.condition:
+                    session.close_in_progress = False
+                    session.condition.notify_all()
+
+        await _to_thread_with_owned_side_effects(_close)
 
     @staticmethod
     def _sum_node_capacity(node_capacities: tuple[Any, ...]) -> Any:
@@ -2706,13 +3009,14 @@ class RayQueryDriverActor:
     def _prepare_query_resource_registration(
         self,
         plan: Any,
+        query_connection: Any,
         expected_plan_id: str | None = None,
     ) -> _PreparedQueryResourceRegistration:
         from duckdb.runners.ray.query_graph_builder import (
             build_query_execution_graph,
         )
 
-        metadata = plan.collect_execution_stages(conn=self._duckdb_conn)
+        metadata = plan.collect_execution_stages(conn=query_connection)
         graph = build_query_execution_graph(metadata)
         plan_id = str(plan.idx())
         if expected_plan_id is not None and plan_id != expected_plan_id:
@@ -2736,6 +3040,7 @@ class RayQueryDriverActor:
         self,
         plan: Any,
         *,
+        query_connection: Any,
         expected_plan_id: str | None = None,
     ) -> tuple[Any, Any]:
         """Prepare registration off-loop, then atomically publish local state."""
@@ -2747,9 +3052,10 @@ class RayQueryDriverActor:
         elif owner_loop is not running_loop:
             raise RuntimeError("query resource registration must run on the admission owner loop")
 
-        prepared = await asyncio.to_thread(
+        prepared = await _to_thread_with_owned_side_effects(
             self._prepare_query_resource_registration,
             plan,
+            query_connection,
             expected_plan_id,
         )
         deferred_teardowns: list[_DeferredQueryAllocationTeardown] = []
@@ -2815,7 +3121,20 @@ class RayQueryDriverActor:
                 return graph, allocation
             except BaseException as registration_error:
                 cleanup_errors: list[BaseException] = []
-                if manager_registered:
+                coordinator_released = False
+                try:
+                    released = self._query_resource_coordinator.release_query(
+                        graph.query_id,
+                        allocation.generation,
+                    )
+                    coordinator_released = True
+                    if not released:
+                        cleanup_errors.append(
+                            RuntimeError("coordinator allocation disappeared during query registration rollback")
+                        )
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+                if coordinator_released and manager_registered:
                     try:
                         release_query_resource_manager(
                             graph.query_id,
@@ -2823,19 +3142,12 @@ class RayQueryDriverActor:
                         )
                     except BaseException as exc:
                         cleanup_errors.append(exc)
-                self._query_graphs.pop(graph.query_id, None)
-                self._query_allocations.pop(graph.query_id, None)
-                try:
-                    released = self._query_resource_coordinator.release_query(
-                        graph.query_id,
-                        allocation.generation,
-                    )
-                    if not released:
-                        cleanup_errors.append(
-                            RuntimeError("coordinator allocation disappeared during query registration rollback")
-                        )
-                except BaseException as exc:
-                    cleanup_errors.append(exc)
+                if coordinator_released:
+                    self._query_graphs.pop(graph.query_id, None)
+                    self._query_allocations.pop(graph.query_id, None)
+                else:
+                    self._query_graphs[graph.query_id] = graph
+                    self._query_allocations[graph.query_id] = allocation
                 try:
                     deferred_teardowns.extend(self._synchronize_query_allocations())
                 except BaseException as exc:
@@ -2909,16 +3221,14 @@ class RayQueryDriverActor:
         try:
             with self._query_resource_lock:
                 allocation = self._query_allocations.get(query_key)
-                try:
-                    release_query_resource_manager(query_key, reason=reason)
-                except BaseException as exc:
-                    cleanup_errors.append(exc)
+                coordinator_released = allocation is None
                 if allocation is not None:
                     try:
                         released = self._query_resource_coordinator.release_query(
                             query_key,
                             allocation.generation,
                         )
+                        coordinator_released = True
                         if not released:
                             cleanup_errors.append(
                                 RuntimeError(
@@ -2928,8 +3238,13 @@ class RayQueryDriverActor:
                             )
                     except BaseException as exc:
                         cleanup_errors.append(exc)
-                self._query_graphs.pop(query_key, None)
-                self._query_allocations.pop(query_key, None)
+                if coordinator_released:
+                    try:
+                        release_query_resource_manager(query_key, reason=reason)
+                    except BaseException as exc:
+                        cleanup_errors.append(exc)
+                    self._query_graphs.pop(query_key, None)
+                    self._query_allocations.pop(query_key, None)
                 try:
                     deferred_teardowns = self._synchronize_query_allocations()
                 except BaseException as exc:
@@ -2943,10 +3258,22 @@ class RayQueryDriverActor:
                 + "; ".join(f"{type(exc).__name__}: {exc}" for exc in cleanup_errors)
             ) from cleanup_errors[0]
 
-    def query_resource_snapshot(self, query_id: str) -> dict[str, Any]:
+    def query_resource_snapshot(
+        self,
+        owner_id: str,
+        session_id: str,
+        query_id: str,
+    ) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_runtime import query_resource_manager_snapshot
 
+        session = self._require_session(owner_id, session_id)
         query_key = str(query_id or "").strip()
+        with session.condition:
+            plan_ids = tuple(session.plan_ids)
+        with self._session_lock:
+            owned_query_ids = {self._plan_query_ids.get(plan_id) for plan_id in plan_ids}
+        if query_key not in owned_query_ids:
+            raise PermissionError("query resources do not belong to the requested Vane session")
         coordinator = self._query_resource_coordinator.snapshot()
         return {
             "manager": query_resource_manager_snapshot(query_key),
@@ -2959,7 +3286,7 @@ class RayQueryDriverActor:
             },
         }
 
-    def get_test_udf_actor_handle(self, plan_id: str, udf_name: str) -> Any:
+    def get_test_udf_actor_handle(self, owner_id: str, plan_id: str, udf_name: str) -> Any:
         """Return one query-owned stateful actor for deterministic fault tests.
 
         This hook is deliberately environment-gated and lives on the Driver;
@@ -2971,6 +3298,11 @@ class RayQueryDriverActor:
             )
 
         plan_key = str(plan_id)
+        with self._session_lock:
+            session_id = self._plan_session_ids.get(plan_key)
+        if session_id is None:
+            raise RuntimeError(f"query plan is not active: {plan_key}")
+        self._require_plan_session(owner_id, session_id, plan_key)
         pools = self._active_udf_actors_by_plan.get(plan_key)
         if pools is None:
             raise RuntimeError(f"no active UDF actor pools found for plan {plan_key!r}")
@@ -2996,12 +3328,6 @@ class RayQueryDriverActor:
             )
         return actors[0]
 
-    def install_env_overrides(self, env_overrides: dict[str, str] | None) -> None:
-        self._env_overrides = env_overrides or {}
-        _apply_env_overrides(self._env_overrides)
-        if self._duckdb_conn is not None:
-            _apply_duckdb_thread_setting(self._duckdb_conn)
-
     def _get_plan_runner(self) -> Any:
         with self._plan_runner_lifecycle_lock:
             if self._driver_shutdown_started:
@@ -3015,21 +3341,43 @@ class RayQueryDriverActor:
                 self.plan_runner.warm_up()
             return self.plan_runner
 
-    def _precreate_udf_actors(self, plan: Any, graph: Any, allocation: Any) -> list[Any]:
+    def _precreate_udf_actors(
+        self,
+        plan: Any,
+        graph: Any,
+        allocation: Any,
+        *,
+        query_connection: Any,
+        session_config: dict[str, str],
+    ) -> list[Any]:
         """Create Ray actors and inject handles without waiting for model init."""
         from duckdb.execution.udf_ray import prepare_actor_pools_for_plan
 
+        plan_id = str(plan.idx())
         actor_node_ids_by_stage = {
             stage.stage_id: allocation.actor_node_ids_for_stage(stage.stage_id)
             for stage in graph.stages
             if stage.backend == "ray_actor"
         }
-        created, _ = prepare_actor_pools_for_plan(
-            plan,
-            actor_node_ids_by_stage=actor_node_ids_by_stage,
-            conn=self._duckdb_conn,
-        )
+        try:
+            created, _ = prepare_actor_pools_for_plan(
+                plan,
+                actor_node_ids_by_stage=actor_node_ids_by_stage,
+                query_driver_handle=self._driver_handle,
+                session_config=session_config,
+                conn=query_connection,
+            )
+        except BaseException as creation_error:
+            owned_pools = list(getattr(creation_error, "owned_actor_pools", ()))
+            for pool in owned_pools:
+                if all(existing is not pool for existing in self._active_udf_actors):
+                    self._active_udf_actors.append(pool)
+            if owned_pools:
+                self._active_udf_actors_by_plan[plan_id] = owned_pools
+            raise
         self._active_udf_actors.extend(created)
+        if created:
+            self._active_udf_actors_by_plan[plan_id] = list(created)
         return created
 
     @staticmethod
@@ -3038,30 +3386,104 @@ class RayQueryDriverActor:
 
         wait_for_actor_pools_ready(actor_pools)
 
-    def _precreate_vllm_actors(self, plan: Any) -> list[Any]:
+    def _precreate_vllm_actors(
+        self,
+        plan: Any,
+        *,
+        query_connection: Any,
+        session_config: dict[str, str],
+    ) -> list[Any]:
         """Pre-create Ray actor pools for vLLM nodes on the driver."""
         from duckdb.execution.vllm import ensure_named_vllm_pools_for_plan
 
-        created, _ = ensure_named_vllm_pools_for_plan(plan, conn=self._duckdb_conn)
+        plan_id = str(plan.idx())
+        try:
+            created, _ = ensure_named_vllm_pools_for_plan(
+                plan,
+                conn=query_connection,
+                session_config=session_config,
+            )
+        except BaseException as creation_error:
+            owned_pools = list(getattr(creation_error, "owned_actor_pools", ()))
+            for pool in owned_pools:
+                if all(existing is not pool for existing in self._active_vllm_actors):
+                    self._active_vllm_actors.append(pool)
+            if owned_pools:
+                self._active_vllm_actors_by_plan[plan_id] = owned_pools
+            raise
         self._active_vllm_actors.extend(created)
+        if created:
+            self._active_vllm_actors_by_plan[plan_id] = list(created)
         return created
 
     def _cleanup_udf_actor_pools(self, plan_id: str) -> None:
-        pools = self._active_udf_actors_by_plan.pop(str(plan_id), [])
+        plan_key = str(plan_id)
+        pools = list(self._active_udf_actors_by_plan.get(plan_key, ()))
         if not pools:
             return
         errors: list[str] = []
+        remaining_pools: list[Any] = []
         for pool in pools:
             try:
                 pool.shutdown()
             except BaseException as exc:
                 errors.append(f"{type(exc).__name__}: {exc}")
-            try:
-                self._active_udf_actors.remove(pool)
-            except ValueError:
-                pass
+                remaining_pools.append(pool)
+            else:
+                try:
+                    self._active_udf_actors.remove(pool)
+                except ValueError:
+                    pass
+        if remaining_pools:
+            self._active_udf_actors_by_plan[plan_key] = remaining_pools
+        else:
+            self._active_udf_actors_by_plan.pop(plan_key, None)
         if errors:
             raise RuntimeError(f"failed to shut down {len(errors)} query-owned UDF actor pool(s): " + "; ".join(errors))
+
+    def _cleanup_vllm_actor_pools(self, plan_id: str) -> None:
+        plan_key = str(plan_id)
+        pools = list(self._active_vllm_actors_by_plan.get(plan_key, ()))
+        if not pools:
+            return
+        errors: list[str] = []
+        remaining_pools: list[Any] = []
+        for pool in pools:
+            try:
+                pool.shutdown()
+            except BaseException as exc:
+                errors.append(f"{type(exc).__name__}: {exc}")
+                remaining_pools.append(pool)
+            else:
+                try:
+                    self._active_vllm_actors.remove(pool)
+                except ValueError:
+                    pass
+        if remaining_pools:
+            self._active_vllm_actors_by_plan[plan_key] = remaining_pools
+        else:
+            self._active_vllm_actors_by_plan.pop(plan_key, None)
+        if errors:
+            raise RuntimeError(
+                f"failed to shut down {len(errors)} query-owned vLLM actor pool(s): " + "; ".join(errors)
+            )
+
+    def _release_plan_session_state(self, plan_id: str) -> None:
+        plan_key = str(plan_id)
+        with self._session_lock:
+            session_id = self._plan_session_ids.get(plan_key)
+            query_connection = self._plan_connections.get(plan_key)
+            session = self._sessions.get(session_id) if session_id is not None else None
+        if query_connection is not None:
+            query_connection.close()
+        with self._session_lock:
+            if self._plan_session_ids.get(plan_key) == session_id:
+                self._plan_session_ids.pop(plan_key, None)
+            if self._plan_connections.get(plan_key) is query_connection:
+                self._plan_connections.pop(plan_key, None)
+        if session is not None:
+            with session.condition:
+                session.plan_ids.discard(plan_key)
 
     def _teardown_plan_resources(
         self,
@@ -3070,23 +3492,64 @@ class RayQueryDriverActor:
         *,
         drop_fragments: bool,
     ) -> None:
+        plan_key = str(plan_id)
+        with self._plan_teardown_condition:
+            while plan_key in self._plan_teardowns_in_progress:
+                self._plan_teardown_condition.wait()
+            if plan_key not in self._plan_session_ids:
+                return
+            self._plan_teardowns_in_progress.add(plan_key)
+        try:
+            self._teardown_plan_resources_once(
+                plan_key,
+                query_id,
+                drop_fragments=drop_fragments,
+            )
+        finally:
+            with self._plan_teardown_condition:
+                self._plan_teardowns_in_progress.discard(plan_key)
+                self._plan_teardown_condition.notify_all()
+
+    def _teardown_plan_resources_once(
+        self,
+        plan_id: str,
+        query_id: str,
+        *,
+        drop_fragments: bool,
+    ) -> None:
         errors: list[BaseException] = []
-        retain_query_owner = False
         self.curr_plans.pop(plan_id, None)
         self.curr_streams.pop(plan_id, None)
-        leased_refs = getattr(self, "_leased_result_partition_refs", None)
-        if leased_refs is not None:
-            records = leased_refs.pop(str(plan_id), {})
-            for _, output_lease_owner in records.values():
+        with self._plan_teardown_condition:
+            leased_refs = getattr(self, "_leased_result_partition_refs", None)
+            records = {} if leased_refs is None else dict(leased_refs.get(str(plan_id), {}))
+        if records:
+            for release_token, record in records.items():
+                _, output_lease_owner = record
                 try:
                     output_lease_owner.release()
                 except BaseException as exc:
                     errors.append(exc)
-        counters = getattr(self, "_result_partition_ref_counters", None)
-        if counters is not None:
-            counters.pop(str(plan_id), None)
+                else:
+                    with self._plan_teardown_condition:
+                        current_refs = self._leased_result_partition_refs.get(str(plan_id))
+                        if current_refs is not None and current_refs.get(release_token) is record:
+                            current_refs.pop(release_token, None)
+                            if not current_refs:
+                                self._leased_result_partition_refs.pop(str(plan_id), None)
+        with self._plan_teardown_condition:
+            leased_refs = getattr(self, "_leased_result_partition_refs", None)
+            remaining_refs = None if leased_refs is None else leased_refs.get(str(plan_id))
+            if not remaining_refs:
+                counters = getattr(self, "_result_partition_ref_counters", None)
+                if counters is not None:
+                    counters.pop(str(plan_id), None)
         try:
             self._cleanup_udf_actor_pools(str(plan_id))
+        except BaseException as exc:
+            errors.append(exc)
+        try:
+            self._cleanup_vllm_actor_pools(str(plan_id))
         except BaseException as exc:
             errors.append(exc)
         query_key = str(query_id or "").strip()
@@ -3101,16 +3564,7 @@ class RayQueryDriverActor:
                     )
             except BaseException as exc:
                 errors.append(exc)
-                retain_query_owner = isinstance(
-                    exc,
-                    QueryTeardownOwnershipError,
-                )
         if errors:
-            if not retain_query_owner:
-                self._plan_query_ids.pop(plan_id, None)
-                terminal_errors = getattr(self, "_query_terminal_errors", None)
-                if terminal_errors is not None:
-                    terminal_errors.pop(str(query_id or ""), None)
             raise RuntimeError(
                 f"query plan {plan_id} teardown failed: " + "; ".join(f"{type(exc).__name__}: {exc}" for exc in errors)
             ) from errors[0]
@@ -3118,6 +3572,7 @@ class RayQueryDriverActor:
         terminal_errors = getattr(self, "_query_terminal_errors", None)
         if terminal_errors is not None:
             terminal_errors.pop(str(query_id or ""), None)
+        self._release_plan_session_state(plan_id)
 
     def _cleanup_finished_plan(self, plan_id: str) -> None:
         query_id = self._plan_query_ids.get(plan_id, "")
@@ -3145,117 +3600,253 @@ class RayQueryDriverActor:
 
     def _lease_result_partition_ref(
         self,
+        session: _DriverSession,
+        session_id: str,
         plan_id: str,
         object_ref: Any,
         output_lease_owner: Any,
     ) -> str:
-        if not hasattr(self, "_leased_result_partition_refs"):
-            self._leased_result_partition_refs = {}
-        if not hasattr(self, "_result_partition_ref_counters"):
-            self._result_partition_ref_counters = {}
         plan_key = str(plan_id)
-        next_id = int(self._result_partition_ref_counters.get(plan_key, 0))
-        self._result_partition_ref_counters[plan_key] = next_id + 1
-        release_token = str(next_id)
-        self._leased_result_partition_refs.setdefault(plan_key, {})[release_token] = (
-            object_ref,
-            output_lease_owner,
-        )
-        return release_token
+        with session.condition:
+            if session.closing or session.closed:
+                raise RuntimeError(f"Vane session closed while publishing query result: {session_id}")
+            with self._plan_teardown_condition:
+                if plan_key in self._plan_teardowns_in_progress or self._plan_session_ids.get(plan_key) != str(
+                    session_id
+                ):
+                    raise RuntimeError(f"query plan closed while publishing result: {plan_key}")
+                if not hasattr(self, "_leased_result_partition_refs"):
+                    self._leased_result_partition_refs = {}
+                if not hasattr(self, "_result_partition_ref_counters"):
+                    self._result_partition_ref_counters = {}
+                output_lease_owner.transition_to("external_consumer")
+                next_id = int(self._result_partition_ref_counters.get(plan_key, 0))
+                self._result_partition_ref_counters[plan_key] = next_id + 1
+                release_token = str(next_id)
+                self._leased_result_partition_refs.setdefault(plan_key, {})[release_token] = (
+                    object_ref,
+                    output_lease_owner,
+                )
+                return release_token
 
-    def release_result_partition_ref(self, plan_id: str, release_token: str) -> None:
-        if not hasattr(self, "_leased_result_partition_refs"):
-            self._leased_result_partition_refs = {}
-        refs = self._leased_result_partition_refs.get(str(plan_id))
-        if not refs:
+    def release_result_partition_ref(
+        self,
+        owner_id: str,
+        session_id: str,
+        plan_id: str,
+        release_token: str,
+    ) -> None:
+        owner_key = str(owner_id).strip()
+        session_key = str(session_id).strip()
+        if not owner_key:
+            raise ValueError("Ray query runtime owner_id must not be empty")
+        if not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        plan_key = str(plan_id)
+        with self._session_lock:
+            session = self._sessions.get(session_key)
+            closed_owner = self._closed_session_owners.get(session_key)
+            plan_session_id = self._plan_session_ids.get(plan_key)
+        if session is None:
+            if closed_owner is None:
+                raise RuntimeError(f"Vane session is not open: {session_key}")
+            if closed_owner != owner_key:
+                raise PermissionError("Vane session operation requires its owning runtime client")
             return
-        record = refs.pop(str(release_token), None)
-        if record is not None:
+        if session.owner_id != owner_key:
+            raise PermissionError("Vane session operation requires its owning runtime client")
+        if plan_session_id is None:
+            return
+        if plan_session_id != session_key:
+            raise PermissionError("query plan does not belong to the requested Vane session")
+        with self._plan_teardown_condition:
+            if plan_key in self._plan_teardowns_in_progress:
+                return
+            current_plan_session_id = self._plan_session_ids.get(plan_key)
+            if current_plan_session_id is None:
+                return
+            if current_plan_session_id != session_key:
+                raise PermissionError("query plan does not belong to the requested Vane session")
+            if not hasattr(self, "_leased_result_partition_refs"):
+                self._leased_result_partition_refs = {}
+            refs = self._leased_result_partition_refs.get(plan_key)
+            if not refs:
+                return
+            token_key = str(release_token)
+            record = refs.get(token_key)
+            if record is None:
+                return
             _, output_lease_owner = record
             output_lease_owner.release()
-        if not refs:
-            self._leased_result_partition_refs.pop(str(plan_id), None)
+            if refs.get(token_key) is record:
+                refs.pop(token_key, None)
+                if not refs:
+                    self._leased_result_partition_refs.pop(plan_key, None)
 
-    async def close_plan(self, plan_id: str) -> None:
-        await asyncio.to_thread(self._cleanup_finished_plan, plan_id)
+    async def close_plan(self, owner_id: str, session_id: str, plan_id: str) -> None:
+        self._require_plan_session(owner_id, session_id, plan_id)
+        await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
 
     async def run_plan(
         self,
+        owner_id: str,
+        session_id: str,
         plan: duckdb.ray_cxx.PyLogicalPlan,
     ) -> None:
         """Run a plan without blocking the driver actor's control event loop."""
+        session = self._require_session(owner_id, session_id)
+        self._validate_plan_session(session_id, plan, session)
         _set_global_event_loop(asyncio.get_running_loop())
-        plan, plan_id = await asyncio.to_thread(self._prepare_plan_sync, plan)
-        graph, allocation = await self._register_query_resources(
-            plan,
-            expected_plan_id=plan_id,
-        )
-        startup_ownership = _PlanStartupOwnership()
-        startup = asyncio.create_task(
-            asyncio.to_thread(
-                self._run_plan_sync_with_ownership,
-                plan,
-                plan_id,
-                graph,
-                allocation,
-                startup_ownership,
-            ),
-            name=f"vane-plan-startup:{plan_id}",
-        )
+        plan_id = str(plan.idx())
+        self._begin_session_operation(session, session_id)
         try:
-            await asyncio.shield(startup)
-        except asyncio.CancelledError as cancellation_error:
-            if startup_ownership.cancel_before_worker_claim():
-                startup.cancel()
-                await asyncio.gather(startup, return_exceptions=True)
+            try:
+                plan, plan_id, query_connection = await _to_thread_with_owned_side_effects(
+                    self._prepare_plan_sync,
+                    session_id,
+                    session,
+                    plan,
+                )
+            except asyncio.CancelledError as cancellation_error:
                 try:
-                    await asyncio.to_thread(
+                    await _to_thread_with_owned_side_effects(
                         self._teardown_plan_resources,
                         plan_id,
-                        str(graph.query_id),
+                        "",
                         drop_fragments=False,
                     )
+                except asyncio.CancelledError:
+                    pass
                 except BaseException as teardown_error:
                     raise RuntimeError(
-                        f"query plan {plan_id} was cancelled before startup and teardown failed: "
+                        f"query plan {plan_id} was cancelled during preparation and teardown failed: "
                         f"{type(teardown_error).__name__}: {teardown_error}"
                     ) from teardown_error
-            else:
+                raise cancellation_error
+
+            self._plan_query_ids[plan_id] = plan_id
+            try:
+                graph, allocation = await self._register_query_resources(
+                    plan,
+                    query_connection=query_connection,
+                    expected_plan_id=plan_id,
+                )
+            except BaseException as registration_error:
                 try:
-                    await asyncio.shield(startup)
-                except BaseException as startup_error:
-                    raise startup_error from cancellation_error
-                try:
-                    await asyncio.to_thread(
+                    await _to_thread_with_owned_side_effects(
                         self._teardown_plan_resources,
                         plan_id,
-                        str(graph.query_id),
-                        drop_fragments=True,
+                        plan_id,
+                        drop_fragments=False,
                     )
+                except asyncio.CancelledError:
+                    pass
                 except BaseException as teardown_error:
                     raise RuntimeError(
-                        f"query plan {plan_id} was cancelled during startup and teardown failed: "
-                        f"{type(teardown_error).__name__}: {teardown_error}"
-                    ) from teardown_error
-            raise
+                        f"query plan {plan_id} registration failed and teardown also failed: "
+                        f"registration={type(registration_error).__name__}: {registration_error}; "
+                        f"teardown={type(teardown_error).__name__}: {teardown_error}"
+                    ) from registration_error
+                raise
+            self._plan_query_ids[plan_id] = str(graph.query_id)
+
+            startup_ownership = _PlanStartupOwnership()
+            startup = asyncio.create_task(
+                asyncio.to_thread(
+                    self._run_plan_sync_with_ownership,
+                    plan,
+                    plan_id,
+                    graph,
+                    allocation,
+                    query_connection,
+                    session.config,
+                    startup_ownership,
+                ),
+                name=f"vane-plan-startup:{plan_id}",
+            )
+            try:
+                await asyncio.shield(startup)
+            except asyncio.CancelledError as cancellation_error:
+                if startup_ownership.cancel_before_worker_claim():
+                    startup.cancel()
+                    await asyncio.gather(startup, return_exceptions=True)
+                    try:
+                        await _to_thread_with_owned_side_effects(
+                            self._teardown_plan_resources,
+                            plan_id,
+                            str(graph.query_id),
+                            drop_fragments=False,
+                        )
+                    except asyncio.CancelledError:
+                        pass
+                    except BaseException as teardown_error:
+                        raise RuntimeError(
+                            f"query plan {plan_id} was cancelled before startup and teardown failed: "
+                            f"{type(teardown_error).__name__}: {teardown_error}"
+                        ) from teardown_error
+                else:
+                    try:
+                        await asyncio.shield(startup)
+                    except BaseException as startup_error:
+                        raise startup_error from cancellation_error
+                    try:
+                        await _to_thread_with_owned_side_effects(
+                            self._teardown_plan_resources,
+                            plan_id,
+                            str(graph.query_id),
+                            drop_fragments=True,
+                        )
+                    except asyncio.CancelledError:
+                        pass
+                    except BaseException as teardown_error:
+                        raise RuntimeError(
+                            f"query plan {plan_id} was cancelled during startup and teardown failed: "
+                            f"{type(teardown_error).__name__}: {teardown_error}"
+                        ) from teardown_error
+                raise
+        finally:
+            self._end_session_operation(session)
 
     def _prepare_plan_sync(
         self,
+        session_id: str,
+        session: _DriverSession,
         plan: duckdb.ray_cxx.PyLogicalPlan,
-    ) -> tuple[Any, str]:
+    ) -> tuple[Any, str, Any]:
         """Prepare a physical plan on an owned worker thread."""
-        _apply_env_overrides(self._env_overrides)
-
         if os.environ.get("VANE_WORKER") == "1":
             raise RuntimeError(
                 "RayQueryDriverActor.run_plan() called inside a Worker Worker. "
                 "Nested distributed execution is not supported."
             )
+        with session.operation_lock:
+            logical_plan = plan
+            plan_id = str(logical_plan.idx())
+            query_connection = session.connection.cursor()
+            with self._session_lock:
+                if self._sessions.get(str(session_id)) is not session:
+                    query_connection.close()
+                    raise RuntimeError(f"Vane session closed during query startup: {session_id}")
+                if plan_id in self._plan_session_ids:
+                    query_connection.close()
+                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
+                session.plan_ids.add(plan_id)
+                self._plan_session_ids[plan_id] = str(session_id)
+                self._plan_connections[plan_id] = query_connection
 
-        self._ensure_duckdb_conn()
-
-        physical_plan = plan.to_physical_plan(self._duckdb_conn)
-        return physical_plan, str(physical_plan.idx())
+            try:
+                physical_plan = logical_plan.to_physical_plan(query_connection)
+                physical_plan_id = str(physical_plan.idx())
+                if physical_plan_id != plan_id:
+                    raise RuntimeError(
+                        f"logical/physical query plan identity changed: logical={plan_id!r} "
+                        f"physical={physical_plan_id!r}"
+                    )
+                self._validate_plan_session(session_id, physical_plan, session)
+            except BaseException:
+                self._release_plan_session_state(plan_id)
+                raise
+        return physical_plan, plan_id, query_connection
 
     def _run_plan_sync(
         self,
@@ -3263,20 +3854,32 @@ class RayQueryDriverActor:
         plan_id: str,
         graph: Any,
         allocation: Any,
+        query_connection: Any,
+        session_config: Mapping[str, str],
     ) -> None:
         """Start an already registered streaming plan on a worker thread."""
         plan_runner_started = False
         try:
-            udf_actors = self._precreate_udf_actors(plan, graph, allocation)
+            udf_actors = self._precreate_udf_actors(
+                plan,
+                graph,
+                allocation,
+                query_connection=query_connection,
+                session_config=session_config,
+            )
             if udf_actors:
                 self._active_udf_actors_by_plan[plan_id] = list(udf_actors)
-            self._precreate_vllm_actors(plan)
+            self._precreate_vllm_actors(
+                plan,
+                query_connection=query_connection,
+                session_config=session_config,
+            )
 
             self.curr_plans[plan_id] = plan
-            self._plan_query_ids[plan_id] = graph.query_id
+            self._plan_query_ids[plan_id] = str(graph.query_id)
             plan_runner = self._get_plan_runner()
             plan_runner_started = True
-            self.curr_streams[plan_id] = plan_runner.run_plan(plan, self._duckdb_conn)
+            self.curr_streams[plan_id] = plan_runner.run_plan(plan, query_connection)
             # Native FTE execution is intentionally started before the actor
             # readiness fence opens.  It can initialize DuckDB's real
             # Fragment/Pipeline topology, but its Ray-actor UDF dispatcher
@@ -3284,7 +3887,7 @@ class RayQueryDriverActor:
             self._wait_for_udf_actors_ready(udf_actors)
             self._mark_query_actor_stages_ready(graph)
         except BaseException as start_error:
-            query_id = "" if graph is None else str(graph.query_id)
+            query_id = self._plan_query_ids.get(plan_id, "")
             try:
                 self._teardown_plan_resources(
                     plan_id,
@@ -3305,6 +3908,8 @@ class RayQueryDriverActor:
         plan_id: str,
         graph: Any,
         allocation: Any,
+        query_connection: Any,
+        session_config: Mapping[str, str],
         startup_ownership: _PlanStartupOwnership,
     ) -> None:
         """Start only after atomically claiming the registered resources."""
@@ -3315,19 +3920,57 @@ class RayQueryDriverActor:
             plan_id,
             graph,
             allocation,
+            query_connection,
+            session_config,
         )
 
     async def run_copy_plan(
         self,
+        owner_id: str,
+        session_id: str,
         plan: Any,
     ) -> CopyPlanOutcome:
         """Run COPY and capture its final progress state before teardown."""
-        _apply_env_overrides(self._env_overrides)
+        session = self._require_session(owner_id, session_id)
+        self._validate_plan_session(session_id, plan, session)
+        self._begin_session_operation(session, session_id)
+        try:
+            return await self._run_copy_plan_for_session(session_id, session, plan)
+        finally:
+            self._end_session_operation(session)
 
-        self._ensure_duckdb_conn()
-
-        plan = plan.to_physical_plan(self._duckdb_conn)
-        plan_id = str(plan.idx())
+    async def _run_copy_plan_for_session(
+        self,
+        session_id: str,
+        session: _DriverSession,
+        plan: Any,
+    ) -> CopyPlanOutcome:
+        logical_plan = plan
+        plan_id = str(logical_plan.idx())
+        with session.lock:
+            query_connection = session.connection.cursor()
+            with self._session_lock:
+                if self._sessions.get(str(session_id)) is not session:
+                    query_connection.close()
+                    raise RuntimeError(f"Vane session closed during COPY startup: {session_id}")
+                if plan_id in self._plan_session_ids:
+                    query_connection.close()
+                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
+                session.plan_ids.add(plan_id)
+                self._plan_session_ids[plan_id] = str(session_id)
+                self._plan_connections[plan_id] = query_connection
+            try:
+                plan = logical_plan.to_physical_plan(query_connection)
+                physical_plan_id = str(plan.idx())
+                if physical_plan_id != plan_id:
+                    raise RuntimeError(
+                        f"logical/physical query plan identity changed: logical={plan_id!r} "
+                        f"physical={physical_plan_id!r}"
+                    )
+                self._validate_plan_session(session_id, plan, session)
+            except BaseException:
+                self._release_plan_session_state(plan_id)
+                raise
         graph = None
         plan_runner_started = False
         plan_execution: asyncio.Task[Any] | None = None
@@ -3335,24 +3978,31 @@ class RayQueryDriverActor:
         try:
             graph, allocation = await self._register_query_resources(
                 plan,
+                query_connection=query_connection,
                 expected_plan_id=plan_id,
             )
-            udf_actors = await asyncio.to_thread(
+            self._plan_query_ids[plan_id] = str(graph.query_id)
+            udf_actors = await _to_thread_with_owned_side_effects(
                 self._precreate_udf_actors,
                 plan,
                 graph,
                 allocation,
+                query_connection=query_connection,
+                session_config=session.config,
             )
-            if udf_actors:
-                self._active_udf_actors_by_plan[plan_id] = list(udf_actors)
-            await asyncio.to_thread(self._precreate_vllm_actors, plan)
+            await _to_thread_with_owned_side_effects(
+                self._precreate_vllm_actors,
+                plan,
+                query_connection=query_connection,
+                session_config=session.config,
+            )
             plan_runner = self._get_plan_runner()
             plan_runner_started = True
             plan_execution = asyncio.create_task(
                 asyncio.to_thread(
                     plan_runner.run_copy_plan,
                     plan,
-                    self._duckdb_conn,
+                    query_connection,
                 ),
                 name=f"vane-copy-plan:{plan_id}",
             )
@@ -3400,15 +4050,18 @@ class RayQueryDriverActor:
             self._mark_query_actor_stages_ready(graph)
             result = await plan_execution
         except BaseException as execution_error:
-            query_id = "" if graph is None else str(graph.query_id)
+            query_id = self._plan_query_ids.get(plan_id, "")
             teardown_error: BaseException | None = None
             try:
-                await asyncio.to_thread(
+                await _to_thread_with_owned_side_effects(
                     self._teardown_plan_resources,
                     plan_id,
                     query_id,
                     drop_fragments=plan_runner_started,
                 )
+            except asyncio.CancelledError:
+                # The owned teardown finished before cancellation was exposed.
+                pass
             except BaseException as error:
                 teardown_error = error
             # Teardown interrupts the native runner. Always retrieve its
@@ -3431,7 +4084,7 @@ class RayQueryDriverActor:
         query_id = str(graph.query_id)
         _log_copy_result_debug(query_id, result)
         if query_id in getattr(self, "_query_terminal_errors", {}):
-            await asyncio.to_thread(
+            await _to_thread_with_owned_side_effects(
                 self._finish_terminal_query,
                 plan_id,
                 query_id,
@@ -3444,12 +4097,14 @@ class RayQueryDriverActor:
             )
         except BaseException as progress_error:
             try:
-                await asyncio.to_thread(
+                await _to_thread_with_owned_side_effects(
                     self._teardown_plan_resources,
                     plan_id,
                     query_id,
                     drop_fragments=True,
                 )
+            except asyncio.CancelledError:
+                raise progress_error
             except BaseException as teardown_error:
                 raise RuntimeError(
                     f"COPY query plan {plan_id} progress finalization failed and teardown also failed: "
@@ -3457,7 +4112,7 @@ class RayQueryDriverActor:
                     f"teardown={type(teardown_error).__name__}: {teardown_error}"
                 ) from progress_error
             raise
-        await asyncio.to_thread(
+        await _to_thread_with_owned_side_effects(
             self._teardown_plan_resources,
             plan_id,
             query_id,
@@ -3470,6 +4125,8 @@ class RayQueryDriverActor:
 
     async def get_next_partition(
         self,
+        owner_id: str,
+        session_id: str,
         plan_id: str,
         release_owner: Any | None = None,
     ) -> RayMaterializedResult | None:
@@ -3479,6 +4136,7 @@ class RayQueryDriverActor:
             RayMaterializedResult,
         )
 
+        session = self._require_plan_session(owner_id, session_id, plan_id)
         if plan_id not in self.curr_streams:
             raise ValueError(f"Plan {plan_id} not found in DriverPlanRunner")
 
@@ -3486,7 +4144,7 @@ class RayQueryDriverActor:
         if not query_id:
             raise RuntimeError(f"Plan {plan_id} is missing its registered query resource owner")
         if query_id in getattr(self, "_query_terminal_errors", {}):
-            await asyncio.to_thread(
+            await _to_thread_with_owned_side_effects(
                 self._finish_terminal_query,
                 str(plan_id),
                 query_id,
@@ -3516,30 +4174,30 @@ class RayQueryDriverActor:
 
                 next_item = await asyncio.to_thread(_safe_blocking_next)
             except (StopIteration, StopAsyncIteration):
-                await asyncio.to_thread(self._cleanup_finished_plan, plan_id)
+                await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
                 return None
             except RuntimeError as e:
                 # pybind11 wraps StopIteration in RuntimeError
                 if "StopIteration" in str(e):
-                    await asyncio.to_thread(self._cleanup_finished_plan, plan_id)
+                    await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
                     return None
                 raise
         finally:
             manager.set_external_consumer_waiting(False)
         if query_id in getattr(self, "_query_terminal_errors", {}):
-            await asyncio.to_thread(
+            await _to_thread_with_owned_side_effects(
                 self._finish_terminal_query,
                 str(plan_id),
                 query_id,
             )
         if next_item is None:
-            await asyncio.to_thread(self._cleanup_finished_plan, plan_id)
+            await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
             return None
 
         if isinstance(next_item, RayMaterializedResult):
             return next_item
         if isinstance(next_item, WorkerTaskMetadata):
-            await asyncio.to_thread(self._cleanup_finished_plan, plan_id)
+            await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
             return None
 
         if hasattr(next_item, "object_ref"):
@@ -3547,12 +4205,17 @@ class RayQueryDriverActor:
             output_lease_owner = next_item.lease_owner
             if not callable(getattr(output_lease_owner, "transition_to", None)):
                 raise TypeError("metadata-aware Ray result is missing its output lease owner")
-            output_lease_owner.transition_to("external_consumer")
-            release_token = self._lease_result_partition_ref(
-                str(plan_id),
-                object_ref,
-                output_lease_owner,
-            )
+            try:
+                release_token = self._lease_result_partition_ref(
+                    session,
+                    session_id,
+                    str(plan_id),
+                    object_ref,
+                    output_lease_owner,
+                )
+            except BaseException:
+                output_lease_owner.release()
+                raise
             metadata_accessor = PartitionMetadataAccessor.from_metadata_list(
                 [PartitionMetadata(next_item.num_rows, next_item.size_bytes)]
             )
@@ -3561,6 +4224,8 @@ class RayQueryDriverActor:
                 metadatas=metadata_accessor,
                 metadata_idx=0,
                 release_owner=release_owner,
+                release_owner_id=str(owner_id),
+                release_session_id=str(session_id),
                 release_plan_id=str(plan_id),
                 release_token=release_token,
             )
@@ -3629,13 +4294,30 @@ def _maybe_set_distributed_cluster_capacity() -> None:
 
 
 class RayQueryDriverClient:
-    """Client wrapper for the Ray query driver actor."""
+    """Client attachment to the Ray Job-scoped Vane runtime actor."""
 
     def __init__(self) -> None:
+        self._owner_id = uuid.uuid4().hex
+        self._opened_sessions: dict[str, dict[str, str]] = {}
+        self._uncertain_sessions: dict[str, dict[str, str]] = {}
+        self._opening_session_ids: set[str] = set()
+        self._closing_session_ids: set[str] = set()
+        self._closed_session_ids = BoundedReplayMap[str, bool](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
+        self._session_closes_in_progress: set[str] = set()
+        self._session_condition = threading.Condition()
+        self._client_closing = False
+        self._client_close_in_progress = False
         try:
-            self._ray_gcs_address = ray.get_runtime_context().gcs_address
+            runtime_context = ray.get_runtime_context()
+            self._ray_gcs_address = runtime_context.gcs_address
+            job_id_obj = runtime_context.get_job_id()
         except Exception:
             self._ray_gcs_address = None
+            raise RuntimeError("Ray runtime context is missing the current job identity") from None
+        job_id_hex = getattr(job_id_obj, "hex", None)
+        job_id = str(job_id_hex() if callable(job_id_hex) else job_id_obj).strip()
+        if not job_id:
+            raise RuntimeError("Ray runtime context returned an empty job identity")
         _maybe_set_distributed_cluster_capacity()
         from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 
@@ -3648,50 +4330,170 @@ class RayQueryDriverClient:
             raise RuntimeError("Ray head node has no positive logical memory capacity")
         head_memory_layout = build_ray_node_memory_layout(head_memory_bytes)
         driver_duckdb_memory_bytes = head_memory_layout.driver_duckdb_reserve_bytes
-        env_overrides = _collect_vane_env_overrides()
+        runtime_config = _normalize_session_config(_collect_vane_env_overrides())
         scheduling = ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
             node_id=head_node_id,
             soft=False,
         )
         runner_options = {
-            "name": RAY_QUERY_DRIVER_ACTOR_NAME,
-            "namespace": RAY_QUERY_DRIVER_ACTOR_NAMESPACE,
+            "name": f"{RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX}{job_id}",
+            "namespace": RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
+            "get_if_exists": True,
             "scheduling_strategy": scheduling,
             "memory": driver_duckdb_memory_bytes,
             # RayQueryDriverActor must receive PYTHONPATH/env overrides at actor
             # creation time; constructor args are too late for module import.
-            "runtime_env": {"env_vars": env_overrides},
+            "runtime_env": {"env_vars": runtime_config},
         }
-        self.runner = RayQueryDriverActor.options(  # type: ignore[attr-defined]
-            get_if_exists=True,
-            **runner_options,
-        ).remote(env_overrides, driver_duckdb_memory_bytes)
+        self.runner = RayQueryDriverActor.options(**runner_options).remote(  # type: ignore[attr-defined]
+            runtime_config,
+            driver_duckdb_memory_bytes,
+        )
 
-        # Health-check: verify the actor is alive.  If a stale actor from a
-        # previous session is returned by get_if_exists, the ping will fail
-        # and we recreate the actor from scratch.
         try:
-            resolve_object_refs_blocking(self.runner.ping.remote(), timeout=300)
-        except Exception:
+            attach_ref = self.runner.attach_client.remote(self._owner_id, runtime_config)
+            resolve_object_refs_blocking(
+                attach_ref,
+                timeout=300,
+            )
+            resolve_object_refs_blocking(
+                self.runner.ping.remote(self._owner_id),
+                timeout=300,
+            )
+        except BaseException:
+            runner = self.runner
+            self.runner = None
             try:
-                ray.kill(self.runner)
-            except Exception:
+                last_owner = bool(
+                    resolve_object_refs_blocking(
+                        runner.detach_client.remote(self._owner_id),
+                        timeout=300,
+                        honor_query_deadline=False,
+                    )
+                )
+                if last_owner:
+                    ray.kill(runner, no_restart=True)
+            except BaseException:
                 pass
-            self.runner = RayQueryDriverActor.options(  # type: ignore[attr-defined]
-                get_if_exists=False,
-                **runner_options,
-            ).remote(env_overrides, driver_duckdb_memory_bytes)
-            # Verify the fresh actor is alive
-            resolve_object_refs_blocking(self.runner.ping.remote(), timeout=300)
+            raise
 
-        resolve_object_refs_blocking(self.runner.install_env_overrides.remote(env_overrides))
+    def _ensure_session(self, plan: Any) -> tuple[str, dict[str, str]]:
+        session_id = str(plan.session_id()).strip()
+        if not session_id:
+            raise ValueError("distributed logical plan is missing its Vane session identity")
+        session_config = _normalize_session_config(plan.session_config())
+        with self._session_condition:
+            while True:
+                runner = getattr(self, "runner", None)
+                if runner is None or self._client_closing:
+                    raise RuntimeError("Ray query runtime client is closed")
+                if session_id in self._closed_session_ids:
+                    raise RuntimeError(f"Vane session is closed: {session_id}")
+                if session_id in self._closing_session_ids:
+                    raise RuntimeError(f"Vane session is closing: {session_id}")
+                existing = self._opened_sessions.get(session_id)
+                if existing is not None:
+                    if existing != session_config:
+                        raise RuntimeError(f"Vane session config changed after open: {session_id}")
+                    return session_id, session_config
+                uncertain = self._uncertain_sessions.get(session_id)
+                if uncertain is not None and uncertain != session_config:
+                    raise RuntimeError(f"Vane session config changed after an ambiguous open: {session_id}")
+                if session_id not in self._opening_session_ids:
+                    self._opening_session_ids.add(session_id)
+                    break
+                self._session_condition.wait()
+        try:
+            resolve_object_refs_blocking(
+                runner.open_session.remote(self._owner_id, session_id, session_config),
+                timeout=300,
+            )
+        except BaseException:
+            with self._session_condition:
+                self._opening_session_ids.remove(session_id)
+                self._uncertain_sessions[session_id] = session_config
+                self._session_condition.notify_all()
+            raise
+        with self._session_condition:
+            self._opening_session_ids.remove(session_id)
+            self._opened_sessions[session_id] = session_config
+            self._uncertain_sessions.pop(session_id, None)
+            closing = self._client_closing or session_id in self._closing_session_ids
+            self._session_condition.notify_all()
+        if closing:
+            raise RuntimeError(f"Vane session closed while it was opening: {session_id}")
+        return session_id, session_config
+
+    def close_session(self, session_id: str) -> None:
+        session_key = str(session_id).strip()
+        if not session_key:
+            return
+        with self._session_condition:
+            if self._client_closing:
+                return
+            if session_key in self._closed_session_ids:
+                return
+            self._closing_session_ids.add(session_key)
+            while session_key in self._opening_session_ids or session_key in self._session_closes_in_progress:
+                self._session_condition.wait()
+            if self._client_closing:
+                self._closing_session_ids.discard(session_key)
+                self._session_condition.notify_all()
+                return
+            if session_key not in self._opened_sessions and session_key not in self._uncertain_sessions:
+                self._closed_session_ids[session_key] = True
+                self._closing_session_ids.discard(session_key)
+                self._session_condition.notify_all()
+                return
+            runner = getattr(self, "runner", None)
+            if runner is None:
+                self._opened_sessions.pop(session_key, None)
+                self._uncertain_sessions.pop(session_key, None)
+                self._closed_session_ids[session_key] = True
+                self._closing_session_ids.discard(session_key)
+                self._session_condition.notify_all()
+                return
+            self._session_closes_in_progress.add(session_key)
+        try:
+            resolve_object_refs_blocking(
+                runner.close_session.remote(self._owner_id, session_key),
+                timeout=300,
+                honor_query_deadline=False,
+            )
+        except BaseException:
+            with self._session_condition:
+                self._session_closes_in_progress.remove(session_key)
+                self._session_condition.notify_all()
+            raise
+        with self._session_condition:
+            self._session_closes_in_progress.remove(session_key)
+            self._opened_sessions.pop(session_key, None)
+            self._uncertain_sessions.pop(session_key, None)
+            self._closed_session_ids[session_key] = True
+            self._closing_session_ids.discard(session_key)
+            self._session_condition.notify_all()
 
     def close(self) -> None:
-        runner = getattr(self, "runner", None)
-        if runner is None:
-            return
-        self.runner = None
+        with self._session_condition:
+            while self._client_close_in_progress:
+                self._session_condition.wait()
+            runner = getattr(self, "runner", None)
+            if runner is None:
+                return
+            self._client_close_in_progress = True
+            self._client_closing = True
+            while self._opening_session_ids or self._session_closes_in_progress:
+                self._session_condition.wait()
         if not ray.is_initialized():
+            with self._session_condition:
+                self.runner = None
+                self._opened_sessions.clear()
+                self._uncertain_sessions.clear()
+                self._closing_session_ids.clear()
+                self._closed_session_ids.clear()
+                self._client_closing = False
+                self._client_close_in_progress = False
+                self._session_condition.notify_all()
             return
         try:
             current_gcs_address = ray.get_runtime_context().gcs_address
@@ -3702,24 +4504,40 @@ class RayQueryDriverClient:
             and current_gcs_address is not None
             and current_gcs_address != self._ray_gcs_address
         ):
+            with self._session_condition:
+                self.runner = None
+                self._opened_sessions.clear()
+                self._uncertain_sessions.clear()
+                self._closing_session_ids.clear()
+                self._closed_session_ids.clear()
+                self._client_closing = False
+                self._client_close_in_progress = False
+                self._session_condition.notify_all()
             return
         try:
-            resolve_object_refs_blocking(
-                runner.shutdown.remote(),
-                timeout=300,
-                honor_query_deadline=False,
+            last_owner = bool(
+                resolve_object_refs_blocking(
+                    runner.detach_client.remote(self._owner_id),
+                    timeout=300,
+                    honor_query_deadline=False,
+                )
             )
-        except Exception:
-            pass
-        try:
-            ray.kill(runner, no_restart=True)
-        except TypeError:
-            try:
-                ray.kill(runner)
-            except Exception:
-                pass
-        except Exception:
-            pass
+            if last_owner:
+                ray.kill(runner, no_restart=True)
+        except BaseException:
+            with self._session_condition:
+                self._client_close_in_progress = False
+                self._session_condition.notify_all()
+            raise
+        with self._session_condition:
+            self.runner = None
+            self._opened_sessions.clear()
+            self._uncertain_sessions.clear()
+            self._closing_session_ids.clear()
+            self._closed_session_ids.clear()
+            self._client_closing = False
+            self._client_close_in_progress = False
+            self._session_condition.notify_all()
 
     shutdown = close
 
@@ -3729,9 +4547,29 @@ class RayQueryDriverClient:
         if runner is None:
             raise RuntimeError("Ray query Driver is closed")
         return resolve_object_refs_blocking(
-            runner.get_test_udf_actor_handle.remote(str(plan_id), str(udf_name)),
+            runner.get_test_udf_actor_handle.remote(
+                self._owner_id,
+                str(plan_id),
+                str(udf_name),
+            ),
             timeout=30,
         )
+
+    @staticmethod
+    def _cancel_and_settle_remote_call(future: Any) -> None:
+        """Wait for an async actor mutation to stop before local ownership moves on."""
+        try:
+            ray.cancel(future, force=False)
+        except BaseException:
+            pass
+        try:
+            resolve_object_refs_blocking(
+                future,
+                timeout=300,
+                honor_query_deadline=False,
+            )
+        except BaseException:
+            pass
 
     def stream_plan(
         self,
@@ -3744,16 +4582,43 @@ class RayQueryDriverClient:
 
         _t_stream_start = _time.time()
 
-        env_overrides = _collect_vane_env_overrides()
-        resolve_object_refs_blocking(self.runner.install_env_overrides.remote(env_overrides))
-        plan_id = plan.idx()
-        resolve_object_refs_blocking(self.runner.run_plan.remote(plan))
-        progress = _RayProgressSession(self.runner, plan_id, _t_stream_start)
+        session_id, _ = self._ensure_session(plan)
+        plan_id = str(plan.idx())
+        run_future = self.runner.run_plan.remote(self._owner_id, session_id, plan)
+        try:
+            resolve_object_refs_blocking(run_future)
+        except BaseException:
+            self._cancel_and_settle_remote_call(run_future)
+            try:
+                resolve_object_refs_blocking(
+                    self.runner.close_plan.remote(
+                        self._owner_id,
+                        session_id,
+                        plan_id,
+                    ),
+                    timeout=30,
+                    honor_query_deadline=False,
+                )
+            except BaseException:
+                pass
+            raise
+        progress = _RayProgressSession(
+            self.runner,
+            self._owner_id,
+            session_id,
+            plan_id,
+            _t_stream_start,
+        )
 
         completed = False
         try:
             while True:
-                partition_future = self.runner.get_next_partition.remote(plan_id, self.runner)
+                partition_future = self.runner.get_next_partition.remote(
+                    self._owner_id,
+                    session_id,
+                    plan_id,
+                    self.runner,
+                )
                 materialized_result = progress.resolve(partition_future)
                 if materialized_result is None:
                     completed = True
@@ -3764,7 +4629,15 @@ class RayQueryDriverClient:
         finally:
             try:
                 if not completed:
-                    resolve_object_refs_blocking(self.runner.close_plan.remote(plan_id), timeout=30)
+                    resolve_object_refs_blocking(
+                        self.runner.close_plan.remote(
+                            self._owner_id,
+                            session_id,
+                            plan_id,
+                        ),
+                        timeout=30,
+                        honor_query_deadline=False,
+                    )
             finally:
                 progress.finish(final_state="FINISHED" if completed else None)
 
@@ -3777,18 +4650,42 @@ class RayQueryDriverClient:
 
         _t0 = _time.time()
 
-        env_overrides = _collect_vane_env_overrides()
-        resolve_object_refs_blocking(self.runner.install_env_overrides.remote(env_overrides))
-
         try:
+            session_id, _ = self._ensure_session(plan)
             plan_id = str(plan.idx())
-            future = self.runner.run_copy_plan.remote(plan)
-            progress = _RayProgressSession(self.runner, plan_id, _t0)
+            future = self.runner.run_copy_plan.remote(
+                self._owner_id,
+                session_id,
+                plan,
+            )
+            progress = _RayProgressSession(
+                self.runner,
+                self._owner_id,
+                session_id,
+                plan_id,
+                _t0,
+            )
             completed = False
             outcome = None
             final_progress_snapshot = None
             try:
-                outcome = progress.resolve(future)
+                try:
+                    outcome = progress.resolve(future)
+                except BaseException:
+                    self._cancel_and_settle_remote_call(future)
+                    try:
+                        resolve_object_refs_blocking(
+                            self.runner.close_plan.remote(
+                                self._owner_id,
+                                session_id,
+                                plan_id,
+                            ),
+                            timeout=30,
+                            honor_query_deadline=False,
+                        )
+                    except BaseException:
+                        pass
+                    raise
                 if not isinstance(outcome, CopyPlanOutcome):
                     raise TypeError(f"Ray COPY returned {type(outcome).__name__}, expected CopyPlanOutcome")
                 final_progress_snapshot = outcome.final_progress_snapshot

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -106,10 +106,27 @@ def _runtime_error_contains(error: BaseException, error_type: type[BaseException
 
 
 def _runtime_error_is_wait_timeout(error: BaseException) -> bool:
+    candidates = _runtime_error_candidates(error)
+    ray_task_error_type = getattr(ray.exceptions, "RayTaskError", None)
+    if isinstance(ray_task_error_type, type) and any(
+        isinstance(candidate, ray_task_error_type) for candidate in candidates
+    ):
+        # A completed actor RPC can itself raise TimeoutError. That mutation
+        # failed terminally and must be retried with a new ObjectRef rather than
+        # mistaken for an ambiguous local wait on the existing ObjectRef.
+        return False
+    if any(getattr(candidate, "remote_exception_type", None) for candidate in candidates):
+        return False
     return any(
-        isinstance(candidate, TimeoutError)
-        or type(candidate).__name__ in {"GetTimeoutError", "FutureTimeoutError"}
-        for candidate in _runtime_error_candidates(error)
+        isinstance(candidate, TimeoutError) or type(candidate).__name__ in {"GetTimeoutError", "FutureTimeoutError"}
+        for candidate in candidates
+    )
+
+
+def _runtime_actor_is_unavailable(error: BaseException) -> bool:
+    actor_error_type = getattr(ray.exceptions, "RayActorError", None)
+    return isinstance(actor_error_type, type) and any(
+        isinstance(candidate, actor_error_type) for candidate in _runtime_error_candidates(error)
     )
 
 
@@ -203,6 +220,15 @@ def _normalize_session_config(config: Mapping[str, Any]) -> dict[str, str]:
             raise ValueError(f"Vane session config value must not be None: {key}")
         normalized[key] = str(raw_value)
     return normalized
+
+
+def _ray_runtime_job_id(runtime_context: Any) -> str:
+    job_id_obj = runtime_context.get_job_id()
+    job_id_hex = getattr(job_id_obj, "hex", None)
+    job_id = str(job_id_hex() if callable(job_id_hex) else job_id_obj).strip()
+    if not job_id:
+        raise RuntimeError("Ray runtime context returned an empty job identity")
+    return job_id
 
 
 async def _to_thread_with_owned_side_effects(callback: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
@@ -4471,14 +4497,10 @@ class RayQueryDriverClient:
         try:
             runtime_context = ray.get_runtime_context()
             self._ray_gcs_address = runtime_context.gcs_address
-            job_id_obj = runtime_context.get_job_id()
+            self._ray_job_id = _ray_runtime_job_id(runtime_context)
         except Exception:
             self._ray_gcs_address = None
             raise RuntimeError("Ray runtime context is missing the current job identity") from None
-        job_id_hex = getattr(job_id_obj, "hex", None)
-        job_id = str(job_id_hex() if callable(job_id_hex) else job_id_obj).strip()
-        if not job_id:
-            raise RuntimeError("Ray runtime context returned an empty job identity")
         _maybe_set_distributed_cluster_capacity()
         from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 
@@ -4497,7 +4519,7 @@ class RayQueryDriverClient:
             soft=False,
         )
         runner_options = {
-            "name": f"{RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX}{job_id}",
+            "name": f"{RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX}{self._ray_job_id}",
             "namespace": RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
             "get_if_exists": True,
             "scheduling_strategy": scheduling,
@@ -4546,16 +4568,28 @@ class RayQueryDriverClient:
         if not ray.is_initialized():
             return True
         try:
-            current_gcs_address = ray.get_runtime_context().gcs_address
+            runtime_context = ray.get_runtime_context()
+            current_gcs_address = runtime_context.gcs_address
         except Exception:
             return False
-        return (
+        if (
             self._ray_gcs_address is not None
             and current_gcs_address is not None
             and current_gcs_address != self._ray_gcs_address
-        )
+        ):
+            return True
+        try:
+            return _ray_runtime_job_id(runtime_context) != self._ray_job_id
+        except Exception:
+            # A context lookup failure is not proof that the old runtime was
+            # replaced; let the actor RPC produce the actionable error.
+            return False
 
     def _detach_after_failed_attach(self, runner: Any, attach_error: BaseException) -> None:
+        # A failed actor process cannot retain an owner, including constructor
+        # failures that must not be classified as a replaceable old runtime.
+        if _runtime_actor_is_unavailable(attach_error):
+            return
         cleanup_error: BaseException | None = None
         cleanup_deadline = time.monotonic() + _RUNTIME_ATTACH_CLEANUP_TIMEOUT_S
         detach_ref: Any | None = None
@@ -4574,7 +4608,7 @@ class RayQueryDriverClient:
             except BaseException as error:
                 if (
                     _runtime_error_contains(error, PermissionError)
-                    or _runtime_actor_is_being_replaced(error)
+                    or _runtime_actor_is_unavailable(error)
                     or self._runtime_is_unavailable_or_replaced()
                 ):
                     return
@@ -4845,9 +4879,7 @@ class RayQueryDriverClient:
             )
         except BaseException as teardown_error:
             settled_detail = (
-                ""
-                if settled_error is None
-                else f"; settled={type(settled_error).__name__}: {settled_error}"
+                "" if settled_error is None else f"; settled={type(settled_error).__name__}: {settled_error}"
             )
             raise RuntimeError(
                 f"Ray query plan {plan_id} failed and teardown also failed: "

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -3123,12 +3123,10 @@ class RayQueryDriverActor:
 
         metadata = plan.collect_execution_stages(conn=query_connection)
         graph = build_query_execution_graph(metadata)
-        plan_id = str(plan.idx())
-        if expected_plan_id is not None and plan_id != expected_plan_id:
-            raise ValueError(
-                f"physical plan query_id changed during registration: "
-                f"prepared={expected_plan_id!r} registration={plan_id!r}"
-            )
+        # The session preparation step already compared the logical and
+        # physical IDs. Reuse that immutable identity after handing the plan to
+        # the registration thread instead of re-entering the physical wrapper.
+        plan_id = str(plan.idx()) if expected_plan_id is None else str(expected_plan_id)
         if graph.query_id != plan_id:
             raise ValueError(f"execution graph query_id mismatch: graph={graph.query_id!r} plan={plan_id!r}")
         capacity_snapshot_started_at = time.monotonic()
@@ -3838,6 +3836,7 @@ class RayQueryDriverActor:
                     session_id,
                     session,
                     plan,
+                    plan_id,
                 )
             except asyncio.CancelledError as cancellation_error:
                 try:
@@ -3944,6 +3943,7 @@ class RayQueryDriverActor:
         session_id: str,
         session: _DriverSession,
         plan: duckdb.ray_cxx.PyLogicalPlan,
+        plan_id: str,
     ) -> tuple[Any, str, Any]:
         """Prepare a physical plan on an owned worker thread."""
         if os.environ.get("VANE_WORKER") == "1":
@@ -3953,7 +3953,6 @@ class RayQueryDriverActor:
             )
         with session.operation_lock:
             logical_plan = plan
-            plan_id = str(logical_plan.idx())
             query_connection = session.connection.cursor()
             with self._session_lock:
                 if self._sessions.get(str(session_id)) is not session:
@@ -4006,7 +4005,7 @@ class RayQueryDriverActor:
         graph: Any,
         allocation: Any,
         query_connection: Any,
-        session_config: Mapping[str, str],
+        session_config: dict[str, str],
     ) -> None:
         """Start an already registered streaming plan on a worker thread."""
         plan_runner_started = False
@@ -4060,7 +4059,7 @@ class RayQueryDriverActor:
         graph: Any,
         allocation: Any,
         query_connection: Any,
-        session_config: Mapping[str, str],
+        session_config: dict[str, str],
         startup_ownership: _PlanStartupOwnership,
     ) -> None:
         """Start only after atomically claiming the registered resources."""
@@ -4108,6 +4107,7 @@ class RayQueryDriverActor:
                 session_id,
                 session,
                 logical_plan,
+                plan_id,
             )
             self._plan_query_ids[plan_id] = plan_id
             graph, allocation = await self._register_query_resources(
@@ -4262,9 +4262,9 @@ class RayQueryDriverActor:
         session_id: str,
         session: _DriverSession,
         logical_plan: Any,
+        plan_id: str,
     ) -> tuple[Any, Any]:
         """Build a COPY plan on an owned thread without blocking actor control RPCs."""
-        plan_id = str(logical_plan.idx())
         with session.operation_lock:
             query_connection = session.connection.cursor()
             with self._session_lock:

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -11,6 +11,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Mapping
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -118,7 +119,8 @@ def _runtime_error_is_wait_timeout(error: BaseException) -> bool:
     if any(getattr(candidate, "remote_exception_type", None) for candidate in candidates):
         return False
     return any(
-        isinstance(candidate, TimeoutError) or type(candidate).__name__ in {"GetTimeoutError", "FutureTimeoutError"}
+        isinstance(candidate, (TimeoutError, FutureTimeoutError))
+        or type(candidate).__name__ in {"GetTimeoutError", "FutureTimeoutError"}
         for candidate in candidates
     )
 

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -45,6 +45,10 @@ _LEASE_REQUEST_REPLAY_CAPACITY = 65_536
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 _CLIENT_DETACH_REPLAY_CAPACITY = 65_536
 _DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S = 60.0
+_RUNTIME_ATTACH_TIMEOUT_S = 300.0
+_RUNTIME_ATTACH_RETRY_INTERVAL_S = 0.05
+_RUNTIME_ATTACH_CLEANUP_ATTEMPTS = 3
+_RUNTIME_ATTACH_CLEANUP_TIMEOUT_S = 300.0
 RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
 RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
 
@@ -63,6 +67,61 @@ class QueryTeardownOwnershipError(RuntimeError):
 
 class QueryFteRegistryQuiesceError(QueryTeardownOwnershipError):
     """Local FTE threads still own query state; teardown must remain retryable."""
+
+
+class RayRuntimeShuttingDownError(RuntimeError):
+    """The named job runtime cannot accept a new owner while it exits."""
+
+
+class VaneSessionOpenRejectedError(RuntimeError):
+    """A session-open request was rejected before the actor recorded it."""
+
+
+def _runtime_error_candidates(error: BaseException) -> list[BaseException]:
+    candidates: list[BaseException] = [error]
+    candidate_ids = {id(error)}
+    candidate_index = 0
+    while candidate_index < len(candidates) and candidate_index < 16:
+        candidate = candidates[candidate_index]
+        candidate_index += 1
+        converted = getattr(candidate, "as_instanceof_cause", None)
+        if callable(converted):
+            try:
+                converted_cause = converted()
+            except BaseException:
+                converted_cause = None
+            if isinstance(converted_cause, BaseException) and id(converted_cause) not in candidate_ids:
+                candidate_ids.add(id(converted_cause))
+                candidates.append(converted_cause)
+        for attribute in ("cause", "__cause__"):
+            cause = getattr(candidate, attribute, None)
+            if isinstance(cause, BaseException) and id(cause) not in candidate_ids:
+                candidate_ids.add(id(cause))
+                candidates.append(cause)
+    return candidates
+
+
+def _runtime_error_contains(error: BaseException, error_type: type[BaseException]) -> bool:
+    return any(isinstance(candidate, error_type) for candidate in _runtime_error_candidates(error))
+
+
+def _runtime_error_is_wait_timeout(error: BaseException) -> bool:
+    return any(
+        isinstance(candidate, TimeoutError)
+        or type(candidate).__name__ in {"GetTimeoutError", "FutureTimeoutError"}
+        for candidate in _runtime_error_candidates(error)
+    )
+
+
+def _runtime_actor_is_being_replaced(error: BaseException) -> bool:
+    candidates = _runtime_error_candidates(error)
+    if any(isinstance(candidate, RayRuntimeShuttingDownError) for candidate in candidates):
+        return True
+    actor_error_type = getattr(ray.exceptions, "RayActorError", None)
+    return isinstance(actor_error_type, type) and any(
+        isinstance(candidate, actor_error_type) and not bool(getattr(candidate, "actor_init_failed", False))
+        for candidate in candidates
+    )
 
 
 @dataclass(frozen=True)
@@ -1355,7 +1414,7 @@ class RayQueryDriverActor:
         normalized_config = _normalize_session_config(runtime_config)
         with self._session_lock:
             if self._driver_shutdown_started:
-                raise RuntimeError("Ray query runtime is shutting down")
+                raise RayRuntimeShuttingDownError("Ray query runtime is shutting down")
             if owner_key in self._detaching_client_ids or owner_key in self._detached_client_results:
                 raise RuntimeError("Ray query runtime owner identity was already detached")
             if normalized_config != self._runtime_config:
@@ -1415,7 +1474,7 @@ class RayQueryDriverActor:
             session.active_operations -= 1
             session.condition.notify_all()
 
-    def open_session(self, owner_id: str, session_id: str, config: dict[str, str]) -> bool:
+    async def open_session(self, owner_id: str, session_id: str, config: dict[str, str]) -> bool:
         self._require_owner(owner_id)
         owner_key = str(owner_id).strip()
         session_key = str(session_id).strip()
@@ -1426,15 +1485,32 @@ class RayQueryDriverActor:
             if owner_key not in self._client_ids or owner_key in self._detaching_client_ids:
                 raise PermissionError("Ray query runtime operation requires an attached client owner")
             if self._driver_shutdown_started:
-                raise RuntimeError("Ray query runtime is shutting down")
+                raise VaneSessionOpenRejectedError("Ray query runtime is shutting down")
             if session_key in self._closed_session_owners:
-                raise RuntimeError(f"Vane session identity was already closed: {session_key}")
+                raise VaneSessionOpenRejectedError(f"Vane session identity was already closed: {session_key}")
             existing = self._sessions.get(session_key)
             if existing is not None:
                 if existing.owner_id != owner_key or existing.config != normalized_config:
-                    raise RuntimeError(f"Vane session identity collision: {session_key}")
+                    raise VaneSessionOpenRejectedError(f"Vane session identity collision: {session_key}")
                 return False
-            session_connection = self._ensure_duckdb_conn().cursor()
+
+        session_connection = self._ensure_duckdb_conn().cursor()
+        with self._session_lock:
+            if owner_key not in self._client_ids or owner_key in self._detaching_client_ids:
+                session_connection.close()
+                raise PermissionError("Ray query runtime operation requires an attached client owner")
+            if bool(getattr(self, "_driver_shutdown_started")):
+                session_connection.close()
+                raise VaneSessionOpenRejectedError("Ray query runtime is shutting down")
+            if session_key in self._closed_session_owners:
+                session_connection.close()
+                raise VaneSessionOpenRejectedError(f"Vane session identity was already closed: {session_key}")
+            existing = self._sessions.get(session_key)
+            if existing is not None:
+                session_connection.close()
+                if existing.owner_id != owner_key or existing.config != normalized_config:
+                    raise VaneSessionOpenRejectedError(f"Vane session identity collision: {session_key}")
+                return False
             self._sessions[session_key] = _DriverSession(
                 owner_id=owner_key,
                 config=normalized_config,
@@ -1457,6 +1533,11 @@ class RayQueryDriverActor:
         if self._driver_shutdown_started:
             raise RuntimeError("Ray query driver is shutting down")
         return True
+
+    def runtime_replacement_ready(self) -> bool:
+        """Return whether a new client may retire this drained named runtime."""
+        with self._session_lock:
+            return self._driver_shutdown_complete and not self._client_ids
 
     async def _shutdown_runtime(self) -> None:
         """Stop background maintenance and gracefully drain every worker actor."""
@@ -1548,8 +1629,6 @@ class RayQueryDriverActor:
                 with session.condition:
                     while session.active_operations > 0:
                         session.condition.wait()
-                    if session.closed:
-                        return
                     plan_ids = tuple(session.plan_ids)
                 for plan_id in plan_ids:
                     self._cleanup_finished_plan(plan_id)
@@ -3106,7 +3185,7 @@ class RayQueryDriverActor:
                     graph,
                     allocation,
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
-                    on_change=lambda query_id=graph.query_id: self._signal_query_resource_change(query_id),
+                    on_change=lambda: self._signal_query_resource_change(graph.query_id),
                 )
                 manager_registered = True
                 for stage in graph.stages:
@@ -3619,7 +3698,8 @@ class RayQueryDriverActor:
                     self._leased_result_partition_refs = {}
                 if not hasattr(self, "_result_partition_ref_counters"):
                     self._result_partition_ref_counters = {}
-                output_lease_owner.transition_to("external_consumer")
+                if not output_lease_owner.transition_to("external_consumer"):
+                    raise RuntimeError(f"query result lease was released before external publication: plan={plan_key}")
                 next_id = int(self._result_partition_ref_counters.get(plan_key, 0))
                 self._result_partition_ref_counters[plan_key] = next_id + 1
                 release_token = str(next_id)
@@ -3684,8 +3764,34 @@ class RayQueryDriverActor:
                     self._leased_result_partition_refs.pop(plan_key, None)
 
     async def close_plan(self, owner_id: str, session_id: str, plan_id: str) -> None:
-        self._require_plan_session(owner_id, session_id, plan_id)
-        await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_id)
+        owner_key = str(owner_id).strip()
+        session_key = str(session_id).strip()
+        plan_key = str(plan_id)
+        if not owner_key:
+            raise ValueError("Ray query runtime owner_id must not be empty")
+        if not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        with self._session_lock:
+            session = self._sessions.get(session_key)
+            closed_owner = self._closed_session_owners.get(session_key)
+            plan_session_id = self._plan_session_ids.get(plan_key)
+        if session is None:
+            if closed_owner is None:
+                raise RuntimeError(f"Vane session is not open: {session_key}")
+            if closed_owner != owner_key:
+                raise PermissionError("Vane session operation requires its owning runtime client")
+            return
+        if session.owner_id != owner_key:
+            raise PermissionError("Vane session operation requires its owning runtime client")
+        with session.condition:
+            owns_plan = plan_key in session.plan_ids
+        if plan_session_id is None and not owns_plan:
+            return
+        if plan_session_id is not None and plan_session_id != session_key:
+            raise PermissionError("query plan does not belong to the requested Vane session")
+        if plan_session_id is None or not owns_plan:
+            raise RuntimeError(f"query plan ownership state is inconsistent: {plan_key}")
+        await _to_thread_with_owned_side_effects(self._cleanup_finished_plan, plan_key)
 
     async def run_plan(
         self,
@@ -3835,7 +3941,26 @@ class RayQueryDriverActor:
                 self._plan_connections[plan_id] = query_connection
 
             try:
-                physical_plan = logical_plan.to_physical_plan(query_connection)
+                from duckdb.runners.ray.worker import (
+                    _configure_duckdb_s3,
+                    _refresh_effective_duckdb_s3_config,
+                )
+
+                use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
+                refreshed_s3_config = _refresh_effective_duckdb_s3_config(
+                    session.config,
+                    session.s3_config,
+                    use_session_credentials=use_session_credentials,
+                )
+                session.s3_config = _configure_duckdb_s3(
+                    query_connection,
+                    refreshed_s3_config,
+                    use_session_credentials=use_session_credentials,
+                )
+                physical_plan = logical_plan.to_physical_plan(
+                    query_connection,
+                    session.s3_config,
+                )
                 physical_plan_id = str(physical_plan.idx())
                 if physical_plan_id != plan_id:
                     raise RuntimeError(
@@ -3947,35 +4072,18 @@ class RayQueryDriverActor:
     ) -> CopyPlanOutcome:
         logical_plan = plan
         plan_id = str(logical_plan.idx())
-        with session.lock:
-            query_connection = session.connection.cursor()
-            with self._session_lock:
-                if self._sessions.get(str(session_id)) is not session:
-                    query_connection.close()
-                    raise RuntimeError(f"Vane session closed during COPY startup: {session_id}")
-                if plan_id in self._plan_session_ids:
-                    query_connection.close()
-                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
-                session.plan_ids.add(plan_id)
-                self._plan_session_ids[plan_id] = str(session_id)
-                self._plan_connections[plan_id] = query_connection
-            try:
-                plan = logical_plan.to_physical_plan(query_connection)
-                physical_plan_id = str(plan.idx())
-                if physical_plan_id != plan_id:
-                    raise RuntimeError(
-                        f"logical/physical query plan identity changed: logical={plan_id!r} "
-                        f"physical={physical_plan_id!r}"
-                    )
-                self._validate_plan_session(session_id, plan, session)
-            except BaseException:
-                self._release_plan_session_state(plan_id)
-                raise
         graph = None
         plan_runner_started = False
         plan_execution: asyncio.Task[Any] | None = None
         startup_tasks: list[asyncio.Task[Any]] = []
         try:
+            plan, query_connection = await _to_thread_with_owned_side_effects(
+                self._prepare_copy_plan_sync,
+                session_id,
+                session,
+                logical_plan,
+            )
+            self._plan_query_ids[plan_id] = plan_id
             graph, allocation = await self._register_query_resources(
                 plan,
                 query_connection=query_connection,
@@ -4090,7 +4198,7 @@ class RayQueryDriverActor:
                 query_id,
             )
         try:
-            final_progress_snapshot = await asyncio.to_thread(
+            final_progress_snapshot = await _to_thread_with_owned_side_effects(
                 self._build_local_progress_snapshot,
                 query_id,
                 None,
@@ -4122,6 +4230,59 @@ class RayQueryDriverActor:
             result=result,
             final_progress_snapshot=final_progress_snapshot,
         )
+
+    def _prepare_copy_plan_sync(
+        self,
+        session_id: str,
+        session: _DriverSession,
+        logical_plan: Any,
+    ) -> tuple[Any, Any]:
+        """Build a COPY plan on an owned thread without blocking actor control RPCs."""
+        plan_id = str(logical_plan.idx())
+        with session.operation_lock:
+            query_connection = session.connection.cursor()
+            with self._session_lock:
+                if self._sessions.get(str(session_id)) is not session:
+                    query_connection.close()
+                    raise RuntimeError(f"Vane session closed during COPY startup: {session_id}")
+                if plan_id in self._plan_session_ids:
+                    query_connection.close()
+                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
+                session.plan_ids.add(plan_id)
+                self._plan_session_ids[plan_id] = str(session_id)
+                self._plan_connections[plan_id] = query_connection
+            try:
+                from duckdb.runners.ray.worker import (
+                    _configure_duckdb_s3,
+                    _refresh_effective_duckdb_s3_config,
+                )
+
+                use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
+                refreshed_s3_config = _refresh_effective_duckdb_s3_config(
+                    session.config,
+                    session.s3_config,
+                    use_session_credentials=use_session_credentials,
+                )
+                session.s3_config = _configure_duckdb_s3(
+                    query_connection,
+                    refreshed_s3_config,
+                    use_session_credentials=use_session_credentials,
+                )
+                plan = logical_plan.to_physical_plan(
+                    query_connection,
+                    session.s3_config,
+                )
+                physical_plan_id = str(plan.idx())
+                if physical_plan_id != plan_id:
+                    raise RuntimeError(
+                        f"logical/physical query plan identity changed: logical={plan_id!r} "
+                        f"physical={physical_plan_id!r}"
+                    )
+                self._validate_plan_session(session_id, plan, session)
+            except BaseException:
+                self._release_plan_session_state(plan_id)
+                raise
+        return plan, query_connection
 
     async def get_next_partition(
         self,
@@ -4345,39 +4506,127 @@ class RayQueryDriverClient:
             # creation time; constructor args are too late for module import.
             "runtime_env": {"env_vars": runtime_config},
         }
-        self.runner = RayQueryDriverActor.options(**runner_options).remote(  # type: ignore[attr-defined]
-            runtime_config,
-            driver_duckdb_memory_bytes,
+        attach_deadline = time.monotonic() + _RUNTIME_ATTACH_TIMEOUT_S
+        while True:
+            runner = RayQueryDriverActor.options(**runner_options).remote(  # type: ignore[attr-defined]
+                runtime_config,
+                driver_duckdb_memory_bytes,
+            )
+            self.runner = runner
+            try:
+                attach_ref = runner.attach_client.remote(self._owner_id, runtime_config)
+                resolve_object_refs_blocking(
+                    attach_ref,
+                    timeout=300,
+                )
+                break
+            except BaseException as error:
+                self.runner = None
+                replacing_runtime = _runtime_actor_is_being_replaced(error)
+                if not replacing_runtime:
+                    self._detach_after_failed_attach(runner, error)
+                    raise
+                try:
+                    replacement_ready = bool(
+                        resolve_object_refs_blocking(
+                            runner.runtime_replacement_ready.remote(),
+                            timeout=300,
+                            honor_query_deadline=False,
+                        )
+                    )
+                    if replacement_ready:
+                        ray.kill(runner, no_restart=True)
+                except BaseException:
+                    pass
+                if time.monotonic() >= attach_deadline:
+                    raise TimeoutError("timed out waiting for the previous Ray query runtime to exit") from error
+                time.sleep(_RUNTIME_ATTACH_RETRY_INTERVAL_S)
+
+    def _runtime_is_unavailable_or_replaced(self) -> bool:
+        if not ray.is_initialized():
+            return True
+        try:
+            current_gcs_address = ray.get_runtime_context().gcs_address
+        except Exception:
+            return False
+        return (
+            self._ray_gcs_address is not None
+            and current_gcs_address is not None
+            and current_gcs_address != self._ray_gcs_address
         )
 
-        try:
-            attach_ref = self.runner.attach_client.remote(self._owner_id, runtime_config)
-            resolve_object_refs_blocking(
-                attach_ref,
-                timeout=300,
-            )
-            resolve_object_refs_blocking(
-                self.runner.ping.remote(self._owner_id),
-                timeout=300,
-            )
-        except BaseException:
-            runner = self.runner
-            self.runner = None
+    def _detach_after_failed_attach(self, runner: Any, attach_error: BaseException) -> None:
+        cleanup_error: BaseException | None = None
+        cleanup_deadline = time.monotonic() + _RUNTIME_ATTACH_CLEANUP_TIMEOUT_S
+        detach_ref: Any | None = None
+        terminal_failures = 0
+        while time.monotonic() < cleanup_deadline:
             try:
+                if detach_ref is None:
+                    detach_ref = runner.detach_client.remote(self._owner_id)
                 last_owner = bool(
                     resolve_object_refs_blocking(
-                        runner.detach_client.remote(self._owner_id),
-                        timeout=300,
+                        detach_ref,
+                        timeout=max(0.0, cleanup_deadline - time.monotonic()),
                         honor_query_deadline=False,
                     )
                 )
-                if last_owner:
+            except BaseException as error:
+                if (
+                    _runtime_error_contains(error, PermissionError)
+                    or _runtime_actor_is_being_replaced(error)
+                    or self._runtime_is_unavailable_or_replaced()
+                ):
+                    return
+                cleanup_error = error
+                if _runtime_error_is_wait_timeout(error):
+                    time.sleep(_RUNTIME_ATTACH_RETRY_INTERVAL_S)
+                    continue
+                terminal_failures += 1
+                if terminal_failures >= _RUNTIME_ATTACH_CLEANUP_ATTEMPTS:
+                    break
+                # The detach method failed and restored owner state. Retry the
+                # idempotent mutation with a new RPC. Ambiguous waits keep
+                # resolving the original ObjectRef instead.
+                detach_ref = None
+                time.sleep(_RUNTIME_ATTACH_RETRY_INTERVAL_S)
+                continue
+            if last_owner:
+                try:
                     ray.kill(runner, no_restart=True)
-            except BaseException:
-                pass
-            raise
+                except BaseException:
+                    # The actor is drained and has no owners. A later attach can
+                    # retire it through runtime_replacement_ready().
+                    pass
+            return
+        assert cleanup_error is not None
+        raise RuntimeError(
+            "Ray query runtime attach failed and owner detach could not be confirmed: "
+            f"attach={type(attach_error).__name__}: {attach_error}; "
+            f"detach={type(cleanup_error).__name__}: {cleanup_error}"
+        ) from attach_error
 
-    def _ensure_session(self, plan: Any) -> tuple[str, dict[str, str]]:
+    def _complete_session_close_locally(self, session_key: str) -> None:
+        with self._session_condition:
+            self._session_closes_in_progress.discard(session_key)
+            self._opened_sessions.pop(session_key, None)
+            self._uncertain_sessions.pop(session_key, None)
+            self._closed_session_ids[session_key] = True
+            self._closing_session_ids.discard(session_key)
+            self._session_condition.notify_all()
+
+    def _complete_client_close_locally(self) -> None:
+        with self._session_condition:
+            self.runner = None
+            self._opened_sessions.clear()
+            self._uncertain_sessions.clear()
+            self._closing_session_ids.clear()
+            self._closed_session_ids.clear()
+            self._client_closing = False
+            self._client_close_in_progress = False
+            self._session_condition.notify_all()
+
+    def _ensure_session(self, plan: Any) -> tuple[str, dict[str, str], Any]:
         session_id = str(plan.session_id()).strip()
         if not session_id:
             raise ValueError("distributed logical plan is missing its Vane session identity")
@@ -4395,7 +4644,7 @@ class RayQueryDriverClient:
                 if existing is not None:
                     if existing != session_config:
                         raise RuntimeError(f"Vane session config changed after open: {session_id}")
-                    return session_id, session_config
+                    return session_id, session_config, runner
                 uncertain = self._uncertain_sessions.get(session_id)
                 if uncertain is not None and uncertain != session_config:
                     raise RuntimeError(f"Vane session config changed after an ambiguous open: {session_id}")
@@ -4408,10 +4657,12 @@ class RayQueryDriverClient:
                 runner.open_session.remote(self._owner_id, session_id, session_config),
                 timeout=300,
             )
-        except BaseException:
+        except BaseException as error:
+            rejected_without_open = _runtime_error_contains(error, VaneSessionOpenRejectedError)
             with self._session_condition:
                 self._opening_session_ids.remove(session_id)
-                self._uncertain_sessions[session_id] = session_config
+                if not rejected_without_open:
+                    self._uncertain_sessions[session_id] = session_config
                 self._session_condition.notify_all()
             raise
         with self._session_condition:
@@ -4422,15 +4673,13 @@ class RayQueryDriverClient:
             self._session_condition.notify_all()
         if closing:
             raise RuntimeError(f"Vane session closed while it was opening: {session_id}")
-        return session_id, session_config
+        return session_id, session_config, runner
 
     def close_session(self, session_id: str) -> None:
         session_key = str(session_id).strip()
         if not session_key:
             return
         with self._session_condition:
-            if self._client_closing:
-                return
             if session_key in self._closed_session_ids:
                 return
             self._closing_session_ids.add(session_key)
@@ -4447,31 +4696,27 @@ class RayQueryDriverClient:
                 return
             runner = getattr(self, "runner", None)
             if runner is None:
-                self._opened_sessions.pop(session_key, None)
-                self._uncertain_sessions.pop(session_key, None)
-                self._closed_session_ids[session_key] = True
-                self._closing_session_ids.discard(session_key)
-                self._session_condition.notify_all()
+                self._complete_session_close_locally(session_key)
                 return
             self._session_closes_in_progress.add(session_key)
+        if self._runtime_is_unavailable_or_replaced():
+            self._complete_session_close_locally(session_key)
+            return
         try:
             resolve_object_refs_blocking(
                 runner.close_session.remote(self._owner_id, session_key),
                 timeout=300,
                 honor_query_deadline=False,
             )
-        except BaseException:
+        except BaseException as error:
+            if self._runtime_is_unavailable_or_replaced() or _runtime_actor_is_being_replaced(error):
+                self._complete_session_close_locally(session_key)
+                return
             with self._session_condition:
                 self._session_closes_in_progress.remove(session_key)
                 self._session_condition.notify_all()
             raise
-        with self._session_condition:
-            self._session_closes_in_progress.remove(session_key)
-            self._opened_sessions.pop(session_key, None)
-            self._uncertain_sessions.pop(session_key, None)
-            self._closed_session_ids[session_key] = True
-            self._closing_session_ids.discard(session_key)
-            self._session_condition.notify_all()
+        self._complete_session_close_locally(session_key)
 
     def close(self) -> None:
         with self._session_condition:
@@ -4484,35 +4729,8 @@ class RayQueryDriverClient:
             self._client_closing = True
             while self._opening_session_ids or self._session_closes_in_progress:
                 self._session_condition.wait()
-        if not ray.is_initialized():
-            with self._session_condition:
-                self.runner = None
-                self._opened_sessions.clear()
-                self._uncertain_sessions.clear()
-                self._closing_session_ids.clear()
-                self._closed_session_ids.clear()
-                self._client_closing = False
-                self._client_close_in_progress = False
-                self._session_condition.notify_all()
-            return
-        try:
-            current_gcs_address = ray.get_runtime_context().gcs_address
-        except Exception:
-            current_gcs_address = None
-        if (
-            self._ray_gcs_address is not None
-            and current_gcs_address is not None
-            and current_gcs_address != self._ray_gcs_address
-        ):
-            with self._session_condition:
-                self.runner = None
-                self._opened_sessions.clear()
-                self._uncertain_sessions.clear()
-                self._closing_session_ids.clear()
-                self._closed_session_ids.clear()
-                self._client_closing = False
-                self._client_close_in_progress = False
-                self._session_condition.notify_all()
+        if self._runtime_is_unavailable_or_replaced():
+            self._complete_client_close_locally()
             return
         try:
             last_owner = bool(
@@ -4524,20 +4742,15 @@ class RayQueryDriverClient:
             )
             if last_owner:
                 ray.kill(runner, no_restart=True)
-        except BaseException:
+        except BaseException as error:
+            if self._runtime_is_unavailable_or_replaced() or _runtime_actor_is_being_replaced(error):
+                self._complete_client_close_locally()
+                return
             with self._session_condition:
                 self._client_close_in_progress = False
                 self._session_condition.notify_all()
             raise
-        with self._session_condition:
-            self.runner = None
-            self._opened_sessions.clear()
-            self._uncertain_sessions.clear()
-            self._closing_session_ids.clear()
-            self._closed_session_ids.clear()
-            self._client_closing = False
-            self._client_close_in_progress = False
-            self._session_condition.notify_all()
+        self._complete_client_close_locally()
 
     shutdown = close
 
@@ -4556,7 +4769,7 @@ class RayQueryDriverClient:
         )
 
     @staticmethod
-    def _cancel_and_settle_remote_call(future: Any) -> None:
+    def _cancel_and_settle_remote_call(future: Any) -> BaseException | None:
         """Wait for an async actor mutation to stop before local ownership moves on."""
         try:
             ray.cancel(future, force=False)
@@ -4568,8 +4781,79 @@ class RayQueryDriverClient:
                 timeout=300,
                 honor_query_deadline=False,
             )
-        except BaseException:
-            pass
+        except BaseException as error:
+            return error
+        return None
+
+    def _client_detach_completed_for_runner(
+        self,
+        runner: Any,
+        error: BaseException,
+    ) -> bool:
+        with self._session_condition:
+            while self._client_close_in_progress:
+                self._session_condition.wait()
+            if getattr(self, "runner", None) is not runner:
+                return True
+            # detach_client removes the owner only after every owned session and
+            # plan was closed. A retryable post-detach actor-kill failure leaves
+            # the local handle in place, so PermissionError is still terminal
+            # for this plan teardown.
+            return self._client_closing and _runtime_error_contains(error, PermissionError)
+
+    def _close_plan_after_stream(
+        self,
+        runner: Any,
+        *,
+        session_id: str,
+        plan_id: str,
+    ) -> None:
+        try:
+            resolve_object_refs_blocking(
+                runner.close_plan.remote(
+                    self._owner_id,
+                    session_id,
+                    plan_id,
+                ),
+                timeout=300,
+                honor_query_deadline=False,
+            )
+        except BaseException as error:
+            if (
+                self._client_detach_completed_for_runner(runner, error)
+                or self._runtime_is_unavailable_or_replaced()
+                or _runtime_actor_is_being_replaced(error)
+            ):
+                return
+            raise
+
+    def _teardown_failed_plan(
+        self,
+        runner: Any,
+        future: Any,
+        *,
+        session_id: str,
+        plan_id: str,
+        operation_error: BaseException,
+    ) -> None:
+        settled_error = self._cancel_and_settle_remote_call(future)
+        try:
+            self._close_plan_after_stream(
+                runner,
+                session_id=session_id,
+                plan_id=plan_id,
+            )
+        except BaseException as teardown_error:
+            settled_detail = (
+                ""
+                if settled_error is None
+                else f"; settled={type(settled_error).__name__}: {settled_error}"
+            )
+            raise RuntimeError(
+                f"Ray query plan {plan_id} failed and teardown also failed: "
+                f"operation={type(operation_error).__name__}: {operation_error}"
+                f"{settled_detail}; teardown={type(teardown_error).__name__}: {teardown_error}"
+            ) from operation_error
 
     def stream_plan(
         self,
@@ -4582,28 +4866,22 @@ class RayQueryDriverClient:
 
         _t_stream_start = _time.time()
 
-        session_id, _ = self._ensure_session(plan)
+        session_id, _, runner = self._ensure_session(plan)
         plan_id = str(plan.idx())
-        run_future = self.runner.run_plan.remote(self._owner_id, session_id, plan)
+        run_future = runner.run_plan.remote(self._owner_id, session_id, plan)
         try:
             resolve_object_refs_blocking(run_future)
-        except BaseException:
-            self._cancel_and_settle_remote_call(run_future)
-            try:
-                resolve_object_refs_blocking(
-                    self.runner.close_plan.remote(
-                        self._owner_id,
-                        session_id,
-                        plan_id,
-                    ),
-                    timeout=30,
-                    honor_query_deadline=False,
-                )
-            except BaseException:
-                pass
+        except BaseException as operation_error:
+            self._teardown_failed_plan(
+                runner,
+                run_future,
+                session_id=session_id,
+                plan_id=plan_id,
+                operation_error=operation_error,
+            )
             raise
         progress = _RayProgressSession(
-            self.runner,
+            runner,
             self._owner_id,
             session_id,
             plan_id,
@@ -4613,11 +4891,11 @@ class RayQueryDriverClient:
         completed = False
         try:
             while True:
-                partition_future = self.runner.get_next_partition.remote(
+                partition_future = runner.get_next_partition.remote(
                     self._owner_id,
                     session_id,
                     plan_id,
-                    self.runner,
+                    runner,
                 )
                 materialized_result = progress.resolve(partition_future)
                 if materialized_result is None:
@@ -4629,14 +4907,10 @@ class RayQueryDriverClient:
         finally:
             try:
                 if not completed:
-                    resolve_object_refs_blocking(
-                        self.runner.close_plan.remote(
-                            self._owner_id,
-                            session_id,
-                            plan_id,
-                        ),
-                        timeout=30,
-                        honor_query_deadline=False,
+                    self._close_plan_after_stream(
+                        runner,
+                        session_id=session_id,
+                        plan_id=plan_id,
                     )
             finally:
                 progress.finish(final_state="FINISHED" if completed else None)
@@ -4651,15 +4925,15 @@ class RayQueryDriverClient:
         _t0 = _time.time()
 
         try:
-            session_id, _ = self._ensure_session(plan)
+            session_id, _, runner = self._ensure_session(plan)
             plan_id = str(plan.idx())
-            future = self.runner.run_copy_plan.remote(
+            future = runner.run_copy_plan.remote(
                 self._owner_id,
                 session_id,
                 plan,
             )
             progress = _RayProgressSession(
-                self.runner,
+                runner,
                 self._owner_id,
                 session_id,
                 plan_id,
@@ -4671,20 +4945,14 @@ class RayQueryDriverClient:
             try:
                 try:
                     outcome = progress.resolve(future)
-                except BaseException:
-                    self._cancel_and_settle_remote_call(future)
-                    try:
-                        resolve_object_refs_blocking(
-                            self.runner.close_plan.remote(
-                                self._owner_id,
-                                session_id,
-                                plan_id,
-                            ),
-                            timeout=30,
-                            honor_query_deadline=False,
-                        )
-                    except BaseException:
-                        pass
+                except BaseException as operation_error:
+                    self._teardown_failed_plan(
+                        runner,
+                        future,
+                        session_id=session_id,
+                        plan_id=plan_id,
+                        operation_error=operation_error,
+                    )
                     raise
                 if not isinstance(outcome, CopyPlanOutcome):
                     raise TypeError(f"Ray COPY returned {type(outcome).__name__}, expected CopyPlanOutcome")

--- a/duckdb/runners/ray/fragment_worker_client.py
+++ b/duckdb/runners/ray/fragment_worker_client.py
@@ -87,6 +87,15 @@ class RayWorkerActorHandle(
         with _FTE_REGISTRY_LOCK:
             _FTE_WORKER_HANDLES[worker_id] = self
 
+    def close_session(self, session_id: str) -> None:
+        from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
+
+        resolve_object_refs_blocking(
+            self.actor_handle.close_session.remote(str(session_id)),
+            timeout=30,
+            honor_query_deadline=False,
+        )
+
     @staticmethod
     def _fte_task_handle_cls() -> type[Any]:
         # Lazy import to avoid a module import cycle with driver.py.

--- a/duckdb/runners/ray/fragment_worker_client.py
+++ b/duckdb/runners/ray/fragment_worker_client.py
@@ -88,13 +88,23 @@ class RayWorkerActorHandle(
             _FTE_WORKER_HANDLES[worker_id] = self
 
     def close_session(self, session_id: str) -> None:
+        import ray
+
+        from duckdb.runners.ray.driver import _runtime_error_contains
         from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
-        resolve_object_refs_blocking(
-            self.actor_handle.close_session.remote(str(session_id)),
-            timeout=30,
-            honor_query_deadline=False,
-        )
+        try:
+            resolve_object_refs_blocking(
+                self.actor_handle.close_session.remote(str(session_id)),
+                timeout=30,
+                honor_query_deadline=False,
+            )
+        except BaseException as error:
+            actor_error_type = getattr(ray.exceptions, "RayActorError", None)
+            if isinstance(actor_error_type, type) and _runtime_error_contains(error, actor_error_type):
+                # A dead worker process cannot retain this session's connection.
+                return
+            raise
 
     @staticmethod
     def _fte_task_handle_cls() -> type[Any]:

--- a/duckdb/runners/ray/partition_metadata.py
+++ b/duckdb/runners/ray/partition_metadata.py
@@ -29,6 +29,8 @@ class RayMaterializedResult(MaterializedResult):
         metadatas: PartitionMetadataAccessor | None = None,
         metadata_idx: int | None = None,
         release_owner: Any | None = None,
+        release_owner_id: str | None = None,
+        release_session_id: str | None = None,
         release_plan_id: str | None = None,
         release_token: str | None = None,
     ):
@@ -36,6 +38,8 @@ class RayMaterializedResult(MaterializedResult):
         self._metadatas = metadatas
         self._metadata_idx = metadata_idx
         self._release_owner = release_owner
+        self._release_owner_id = release_owner_id
+        self._release_session_id = release_session_id
         self._release_plan_id = release_plan_id
         self._release_token = release_token
         self._released = False
@@ -69,9 +73,13 @@ class RayMaterializedResult(MaterializedResult):
     def close(self) -> None:
         if self._released:
             return
-        self._released = True
         if self._release_owner is None:
+            self._released = True
             return
+        if self._release_owner_id is None:
+            raise TypeError("release_owner_id is required when release_owner is set")
+        if self._release_session_id is None:
+            raise TypeError("release_session_id is required when release_owner is set")
         if self._release_plan_id is None:
             raise TypeError("release_plan_id is required when release_owner is set")
         if self._release_token is None:
@@ -80,7 +88,13 @@ class RayMaterializedResult(MaterializedResult):
         remote = release_method.remote
         if not callable(remote):
             raise TypeError("release_owner.release_result_partition_ref.remote must be callable")
-        remote(self._release_plan_id, self._release_token)
+        remote(
+            self._release_owner_id,
+            self._release_session_id,
+            self._release_plan_id,
+            self._release_token,
+        )
+        self._released = True
 
 
 class PartitionMetadataAccessor:

--- a/duckdb/runners/ray/partition_metadata.py
+++ b/duckdb/runners/ray/partition_metadata.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 import ray
 
-from duckdb.runners.common import MaterializedResult, PartitionMetadata
+from duckdb.runners.common import MaterializedResult
+from duckdb.runners.common import PartitionMetadata as PartitionMetadata
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
 if TYPE_CHECKING:

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -10,7 +10,6 @@ from typing import Any
 from duckdb.runners.ray.query_execution_graph import QueryAllocation, QueryExecutionGraph
 from duckdb.runners.ray.query_resource_manager import QueryResourceManager
 
-
 _LOCK = threading.RLock()
 _MANAGERS: dict[str, QueryResourceManager] = {}
 
@@ -64,10 +63,13 @@ def release_query_resource_manager(query_id: str, *, reason: str) -> dict[str, A
     if not query_key:
         return {"released": False, "task_lease_count": 0, "output_lease_count": 0}
     with _LOCK:
-        manager = _MANAGERS.pop(query_key, None)
+        manager = _MANAGERS.get(query_key)
     if manager is None:
         return {"released": False, "task_lease_count": 0, "output_lease_count": 0}
     released = manager.cancel(reason)
+    with _LOCK:
+        if _MANAGERS.get(query_key) is manager:
+            _MANAGERS.pop(query_key, None)
     return {"released": True, **released}
 
 

--- a/duckdb/runners/ray/ray_env.py
+++ b/duckdb/runners/ray/ray_env.py
@@ -3,38 +3,131 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import os
+from collections.abc import Mapping
+from typing import Any
 
 from duckdb._vane_session import ensure_vane_session_dir
 
-_OPTIONAL_ENV_KEYS = (
-    "S3FS_ANON",
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SESSION_TOKEN",
-    "AWS_PROFILE",
-    "AWS_REGION",
-    "AWS_DEFAULT_REGION",
-    "AWS_ENDPOINT_URL",
-    "RAY_ADDRESS",
+_JOB_DUCKDB_ENV_KEYS = (
+    "DUCKDB_DISTRIBUTED_DEBUG",
+    "DUCKDB_FLIGHT_PORT",
+    "DUCKDB_SHUFFLE_DIRS",
 )
+
+_SENSITIVE_ENV_MARKERS = (
+    "ACCESS_KEY",
+    "API_KEY",
+    "AUTH",
+    "CREDENTIAL",
+    "ENDPOINT",
+    "PASSWORD",
+    "PRIVATE_KEY",
+    "SECRET",
+    "SESSION",
+    "TOKEN",
+    "URL",
+)
+
+_SESSION_ENV_PREFIXES = (
+    "AWS_",
+    "DUCKDB_",
+    "S3FS_",
+)
+
+_SESSION_ENV_PAYLOAD_KEY = "VANE_INTERNAL_SESSION_ENV_PAYLOAD"
+
+
+def _is_session_environment_key(key: str) -> bool:
+    normalized_key = str(key).upper()
+    if normalized_key in _JOB_DUCKDB_ENV_KEYS:
+        return False
+    if normalized_key.startswith(_SESSION_ENV_PREFIXES):
+        return True
+    return normalized_key.startswith("VANE_") and any(marker in normalized_key for marker in _SENSITIVE_ENV_MARKERS)
+
+
+def session_environment_overrides(config: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        str(key): str(value)
+        for key, value in config.items()
+        if _is_session_environment_key(str(key)) and str(key) not in {"VANE_SESSION_DIR", _SESSION_ENV_PAYLOAD_KEY}
+    }
+
+
+def build_explicit_session_process_env(
+    config: Mapping[str, Any],
+    *,
+    base_env: Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    """Build a child-process environment containing exactly one session context."""
+    source = os.environ if base_env is None else base_env
+    environment = {
+        str(key): str(value)
+        for key, value in source.items()
+        if not _is_session_environment_key(str(key)) or str(key) == "VANE_SESSION_DIR"
+    }
+    environment.update(session_environment_overrides(config))
+    return environment
+
+
+def scrub_shared_runtime_session_env() -> None:
+    """Remove inherited connection/session values before shared runtime use."""
+    for key in tuple(os.environ):
+        if _is_session_environment_key(key) and key != "VANE_SESSION_DIR":
+            os.environ.pop(key, None)
+
+
+def build_session_runtime_env_vars(config: Mapping[str, Any]) -> dict[str, str]:
+    """Encode one explicit session context for a dedicated task/actor process."""
+    overrides = session_environment_overrides(config)
+    payload = json.dumps(overrides, sort_keys=True, separators=(",", ":")).encode()
+    return {
+        _SESSION_ENV_PAYLOAD_KEY: base64.urlsafe_b64encode(payload).decode(),
+    }
+
+
+def install_explicit_session_runtime_env() -> None:
+    """Scrub inherited values, then install exactly one encoded session context."""
+    encoded_payload = os.environ.pop(_SESSION_ENV_PAYLOAD_KEY, "")
+    if not encoded_payload:
+        raise RuntimeError("Vane session runtime environment is missing its explicit payload")
+    try:
+        decoded = base64.urlsafe_b64decode(encoded_payload.encode())
+        raw_overrides = json.loads(decoded)
+    except Exception as exc:
+        raise RuntimeError("Vane session runtime environment payload is invalid") from exc
+    if not isinstance(raw_overrides, dict):
+        raise RuntimeError("Vane session runtime environment payload must contain a mapping")
+    overrides = session_environment_overrides(raw_overrides)
+    if overrides != raw_overrides:
+        raise RuntimeError("Vane session runtime environment payload contains unmanaged keys")
+    scrub_shared_runtime_session_env()
+    os.environ.update(overrides)
 
 
 def collect_vane_env_overrides() -> dict[str, str]:
+    """Collect immutable Ray Job runtime environment.
+
+    Connection/session credentials are carried in the logical-plan session
+    snapshot and must never be installed in a shared runtime process.
+    """
     ensure_vane_session_dir()
 
-    overrides = {key: value for key, value in os.environ.items() if key.startswith("VANE_")}
+    overrides = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith("VANE_") and not _is_session_environment_key(key)
+    }
     for key in ("PYTHONPATH", "PYTHONWARNINGS"):
         value = os.environ.get(key)
         if value:
             overrides[key] = value
-    for key in _OPTIONAL_ENV_KEYS:
+    overrides["VANE_SESSION_DIR"] = ensure_vane_session_dir()
+    for key in _JOB_DUCKDB_ENV_KEYS:
         value = os.environ.get(key)
         if value is not None:
-            overrides[key] = value
-    for key, value in os.environ.items():
-        if key in overrides:
-            continue
-        if key.startswith(("AWS_", "DUCKDB_", "S3FS_", "VANE_")):
             overrides[key] = value
     return overrides

--- a/duckdb/runners/ray/runner.py
+++ b/duckdb/runners/ray/runner.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import os
+import threading
 import uuid
+import weakref
 from typing import TYPE_CHECKING, Any
 
 from duckdb._ray_cxx import require_ray_cxx_attr
@@ -13,6 +15,7 @@ from duckdb._vane_session import ensure_vane_session_dir
 
 configure_ray_progress_logging_defaults()
 
+from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.driver import RayQueryDriverClient
 from duckdb.runners.runner import Runner
 
@@ -22,6 +25,31 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     import duckdb
+
+
+_RAY_RUNNERS: weakref.WeakSet[RayRunner] = weakref.WeakSet()
+_RAY_RUNNERS_LOCK = threading.Lock()
+_SESSION_CLOSE_REPLAY_CAPACITY = 65_536
+
+
+def notify_connection_closed(session_id: str) -> None:
+    """Close one logical Vane session on every live local RayRunner."""
+    session_key = str(session_id).strip()
+    if not session_key:
+        raise ValueError("Vane session_id must not be empty")
+    with _RAY_RUNNERS_LOCK:
+        runners = tuple(_RAY_RUNNERS)
+    errors: list[BaseException] = []
+    for runner in runners:
+        try:
+            runner.close_session(session_key)
+        except BaseException as exc:
+            errors.append(exc)
+    if errors:
+        raise RuntimeError(
+            f"failed to close Vane session {session_key} on {len(errors)} local Ray runner(s): "
+            + "; ".join(f"{type(exc).__name__}: {exc}" for exc in errors)
+        ) from errors[0]
 
 
 def _configure_scan_task_backlog_env(max_task_backlog: int | None) -> None:
@@ -69,15 +97,53 @@ class RayRunner(Runner):
             )
 
         self.query_driver_client: RayQueryDriverClient | None = None
+        self._session_ids: set[str] = set()
+        self._closed_session_ids = BoundedReplayMap[str, bool](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
+        self._session_lock = threading.RLock()
+        self._closed = False
+        with _RAY_RUNNERS_LOCK:
+            _RAY_RUNNERS.add(self)
 
     def close(self) -> None:
-        if self.query_driver_client is not None:
-            try:
-                self.query_driver_client.close()
-            finally:
-                self.query_driver_client = None
+        with self._session_lock:
+            if self._closed:
+                return
+            client = self.query_driver_client
+            if client is not None:
+                client.close()
+            self.query_driver_client = None
+            self._session_ids.clear()
+            self._closed_session_ids.clear()
+            self._closed = True
+        with _RAY_RUNNERS_LOCK:
+            _RAY_RUNNERS.discard(self)
 
     shutdown = close
+
+    def close_session(self, session_id: str) -> None:
+        session_key = str(session_id).strip()
+        with self._session_lock:
+            self._closed_session_ids[session_key] = True
+            if session_key not in self._session_ids:
+                return
+            client = self.query_driver_client
+            if client is not None:
+                client.close_session(session_key)
+            self._session_ids.remove(session_key)
+
+    def _client_for_session(self, session_id: str) -> RayQueryDriverClient:
+        session_key = str(session_id).strip()
+        with self._session_lock:
+            if self._closed:
+                raise RuntimeError("RayRunner is closed")
+            if session_key in self._closed_session_ids:
+                raise RuntimeError(f"Vane session is closed: {session_key}")
+            client = self.query_driver_client
+            if client is None:
+                client = RayQueryDriverClient()
+                self.query_driver_client = client
+            self._session_ids.add(session_key)
+            return client
 
     def run_iter(
         self, relation: duckdb.DuckDBPyRelation, results_buffer_size: int | None = None
@@ -90,12 +156,12 @@ class RayRunner(Runner):
         )
 
         logical_plan = PyLogicalPlan.from_duckdb_relation(relation, query_id)
+        session_id = str(logical_plan.session_id())
 
-        if self.query_driver_client is None:
-            self.query_driver_client = RayQueryDriverClient()
+        client = self._client_for_session(session_id)
 
         # Send PyLogicalPlan to Driver — Driver will create physical plan
-        yield from self.query_driver_client.stream_plan(
+        yield from client.stream_plan(
             logical_plan,
         )
 
@@ -109,12 +175,12 @@ class RayRunner(Runner):
         query_id = str(uuid.uuid4())
 
         logical_plan = PyLogicalPlan.from_duckdb_relation(relation, query_id)
+        session_id = str(logical_plan.session_id())
 
-        if self.query_driver_client is None:
-            self.query_driver_client = RayQueryDriverClient()
+        client = self._client_for_session(session_id)
 
         # Send PyLogicalPlan to Driver — Driver will create physical plan
-        return self.query_driver_client.run_copy_plan(logical_plan)
+        return client.run_copy_plan(logical_plan)
 
     def run_iter_tables(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[pa.Table]:
         for result in self.run_iter(relation, results_buffer_size=results_buffer_size):

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -5,11 +5,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import math
 import os
+import subprocess
 import sys
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, NamedTuple, cast
 
 import ray
@@ -32,9 +35,52 @@ from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.fte_scheduler_config import _fte_control_rpc_timeout_s
-from duckdb.runners.ray.ray_env import scrub_shared_runtime_session_env
+from duckdb.runners.ray.ray_env import build_explicit_session_process_env, scrub_shared_runtime_session_env
 
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
+_AWS_CREDENTIAL_RESOLVER_TIMEOUT_S = 120
+_AWS_CREDENTIAL_REFRESH_AT_KEY = "__vane_aws_credential_refresh_at_epoch_s"
+_AWS_CREDENTIAL_PROVIDER_KEYS = (
+    "AWS_CONFIG_FILE",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_PROFILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+)
+_DUCKDB_S3_SESSION_KEYS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_DEFAULT_REGION",
+    "AWS_ENDPOINT_URL",
+    "AWS_REGION",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+)
+
+
+async def _to_thread_with_owned_side_effects(
+    callback: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Do not expose cancellation until a thread-owned mutation has finished."""
+    thread_task = asyncio.create_task(asyncio.to_thread(callback, *args, **kwargs))
+    cancellation: asyncio.CancelledError | None = None
+    while not thread_task.done():
+        try:
+            await asyncio.shield(thread_task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+    result = thread_task.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
 
 
 def _fte_applied_control_status(
@@ -101,6 +147,16 @@ def _register_query_python_replay_state(query_id: str, plan: Any) -> bool:
         hint="Ensure the C++ ray extension is built with query replay lifecycle support.",
     )
     return bool(register(str(query_id), plan))
+
+
+def _plan_resource_query_id(plan: Any) -> str:
+    resource_query_id = getattr(plan, "resource_query_id", None)
+    if not callable(resource_query_id):
+        raise TypeError("distributed physical plan is missing resource_query_id()")
+    query_id = str(resource_query_id()).strip()
+    if not query_id:
+        raise ValueError("distributed physical plan resource_query_id must not be empty")
+    return query_id
 
 
 def _cleanup_query_python_replay_state(query_id: str) -> None:
@@ -336,7 +392,124 @@ def _normalize_stats_for_ray(stats_payload: Any) -> list[int]:
     return []
 
 
-def _configure_duckdb_s3(conn: Any, config: Mapping[str, str]) -> None:
+def _resolve_session_aws_credentials(config: Mapping[str, str]) -> tuple[dict[str, str], float | None]:
+    """Resolve one session credential chain without mutating shared process state."""
+    environment = build_explicit_session_process_env(config)
+    environment["VANE_RUNNER"] = "local"
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "duckdb.runners.ray.aws_credentials"],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=_AWS_CREDENTIAL_RESOLVER_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("DuckDB AWS session credential resolver timed out") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(f"DuckDB AWS session credential resolver failed with exit code {completed.returncode}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("DuckDB AWS session credential resolver returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("DuckDB AWS session credential resolver returned a non-mapping payload")
+    raw_credentials = payload.get("credentials")
+    if not isinstance(raw_credentials, dict):
+        raise RuntimeError("DuckDB AWS session credential resolver returned invalid credentials")
+    credentials = {
+        str(key): str(value)
+        for key, value in raw_credentials.items()
+        if str(key) in _DUCKDB_S3_SESSION_KEYS and value is not None
+    }
+    if not credentials.get("AWS_ACCESS_KEY_ID") or not credentials.get("AWS_SECRET_ACCESS_KEY"):
+        raise RuntimeError("DuckDB AWS session credential resolver returned incomplete credentials")
+    expiration_epoch_s = None
+    raw_expiration = payload.get("expiration_epoch_s")
+    if raw_expiration is not None:
+        try:
+            expiration_epoch_s = float(raw_expiration)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("DuckDB AWS session credential resolver returned an invalid expiration") from exc
+        if not math.isfinite(expiration_epoch_s):
+            raise RuntimeError("DuckDB AWS session credential resolver returned a non-finite expiration")
+    return credentials, expiration_epoch_s
+
+
+def _effective_duckdb_s3_config(
+    config: Mapping[str, str],
+    *,
+    use_session_credentials: bool = True,
+) -> dict[str, str]:
+    normalized = {str(key): str(value) for key, value in config.items()}
+    effective = {key: normalized[key] for key in _DUCKDB_S3_SESSION_KEYS if normalized.get(key, "").strip()}
+    if not use_session_credentials:
+        return {
+            key: value
+            for key, value in effective.items()
+            if key not in {"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"}
+        }
+    refresh_at = normalized.get(_AWS_CREDENTIAL_REFRESH_AT_KEY, "").strip()
+    if refresh_at:
+        effective[_AWS_CREDENTIAL_REFRESH_AT_KEY] = refresh_at
+    access_key = effective.get("AWS_ACCESS_KEY_ID")
+    secret_key = effective.get("AWS_SECRET_ACCESS_KEY")
+    session_token = effective.get("AWS_SESSION_TOKEN")
+    has_static_credentials = bool(access_key and secret_key)
+    if bool(access_key) != bool(secret_key) or (session_token and not has_static_credentials):
+        raise ValueError("AWS static session credentials must provide both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
+    needs_credential_chain = any(normalized.get(key, "").strip() for key in _AWS_CREDENTIAL_PROVIDER_KEYS)
+    if not has_static_credentials and needs_credential_chain:
+        resolved, expiration_epoch_s = _resolve_session_aws_credentials(normalized)
+        resolved.update(effective)
+        effective = resolved
+        if expiration_epoch_s is not None:
+            resolved_at = time.time()
+            refresh_at_epoch_s = resolved_at + max(0.0, expiration_epoch_s - resolved_at) * 0.8
+            effective[_AWS_CREDENTIAL_REFRESH_AT_KEY] = repr(refresh_at_epoch_s)
+    return effective
+
+
+def _refresh_effective_duckdb_s3_config(
+    config: Mapping[str, str],
+    effective_config: Mapping[str, str],
+    *,
+    use_session_credentials: bool = True,
+) -> dict[str, str]:
+    normalized = {str(key): str(value) for key, value in config.items()}
+    if not use_session_credentials:
+        return _effective_duckdb_s3_config(
+            normalized,
+            use_session_credentials=False,
+        )
+    has_static_credentials = bool(
+        normalized.get("AWS_ACCESS_KEY_ID", "").strip() and normalized.get("AWS_SECRET_ACCESS_KEY", "").strip()
+    )
+    needs_credential_chain = any(normalized.get(key, "").strip() for key in _AWS_CREDENTIAL_PROVIDER_KEYS)
+    current = {str(key): str(value) for key, value in effective_config.items()}
+    if has_static_credentials or not needs_credential_chain:
+        return _effective_duckdb_s3_config(normalized)
+    refresh_at = current.get(_AWS_CREDENTIAL_REFRESH_AT_KEY)
+    if refresh_at is None:
+        if current.get("AWS_ACCESS_KEY_ID") and current.get("AWS_SECRET_ACCESS_KEY"):
+            return current
+        return _effective_duckdb_s3_config(normalized)
+    try:
+        refresh_at_epoch_s = float(refresh_at)
+    except ValueError:
+        return _effective_duckdb_s3_config(normalized)
+    if math.isfinite(refresh_at_epoch_s) and time.time() < refresh_at_epoch_s:
+        return current
+    return _effective_duckdb_s3_config(normalized)
+
+
+def _configure_duckdb_s3(
+    conn: Any,
+    config: Mapping[str, str],
+    *,
+    use_session_credentials: bool = True,
+) -> dict[str, str]:
     """Configure one DuckDB context from explicit session AWS settings.
 
     Shared driver/worker processes must not read session credentials from their
@@ -345,14 +518,18 @@ def _configure_duckdb_s3(conn: Any, config: Mapping[str, str]) -> None:
     """
     from urllib.parse import urlparse
 
-    endpoint_url = str(config.get("AWS_ENDPOINT_URL", "")).strip()
-    access_key = str(config.get("AWS_ACCESS_KEY_ID", "")).strip()
-    secret_key = str(config.get("AWS_SECRET_ACCESS_KEY", "")).strip()
-    session_token = str(config.get("AWS_SESSION_TOKEN", "")).strip()
-    region = str(config.get("AWS_REGION") or config.get("AWS_DEFAULT_REGION") or "").strip()
+    effective_config = _effective_duckdb_s3_config(
+        config,
+        use_session_credentials=use_session_credentials,
+    )
+    endpoint_url = str(effective_config.get("AWS_ENDPOINT_URL", "")).strip()
+    access_key = str(effective_config.get("AWS_ACCESS_KEY_ID", "")).strip()
+    secret_key = str(effective_config.get("AWS_SECRET_ACCESS_KEY", "")).strip()
+    session_token = str(effective_config.get("AWS_SESSION_TOKEN", "")).strip()
+    region = str(effective_config.get("AWS_REGION") or effective_config.get("AWS_DEFAULT_REGION") or "").strip()
 
-    if not any((endpoint_url, access_key, secret_key, session_token, region)):
-        return  # nothing to configure
+    if use_session_credentials and not any((endpoint_url, access_key, secret_key, session_token, region)):
+        return effective_config
 
     try:
         conn.execute("LOAD httpfs")
@@ -364,12 +541,18 @@ def _configure_duckdb_s3(conn: Any, config: Mapping[str, str]) -> None:
 
     if region:
         conn.execute(f"SET s3_region='{_q(region)}'")
-    if access_key:
-        conn.execute(f"SET s3_access_key_id='{_q(access_key)}'")
-    if secret_key:
-        conn.execute(f"SET s3_secret_access_key='{_q(secret_key)}'")
-    if session_token:
-        conn.execute(f"SET s3_session_token='{_q(session_token)}'")
+    if use_session_credentials:
+        if access_key:
+            conn.execute(f"SET s3_access_key_id='{_q(access_key)}'")
+        if secret_key:
+            conn.execute(f"SET s3_secret_access_key='{_q(secret_key)}'")
+    else:
+        conn.execute("SET s3_access_key_id=''")
+        conn.execute("SET s3_secret_access_key=''")
+    # Task cursors inherit settings from the long-lived session connection.
+    # Always overwrite the token so a refresh from temporary credentials to
+    # credentials without a token cannot retain the previous value.
+    conn.execute(f"SET s3_session_token='{_q(session_token)}'")
     if endpoint_url:
         parse_target = endpoint_url
         if "://" not in parse_target and not parse_target.startswith("//"):
@@ -390,6 +573,7 @@ def _configure_duckdb_s3(conn: Any, config: Mapping[str, str]) -> None:
     conn.execute("SET http_retries=10")
     conn.execute("SET http_retry_wait_ms=100")
     conn.execute("SET http_retry_backoff=1.5")
+    return effective_config
 
 
 def _configure_ray_worker_conn(conn: Any, duckdb_memory_bytes: int) -> None:
@@ -549,6 +733,8 @@ class RayWorkerActor:
         self._shared_conn: Any | None = None
         self._shared_conn_lock = threading.Lock()
         self._session_connections: dict[str, tuple[dict[str, str], Any]] = {}
+        self._session_s3_configs: dict[str, dict[str, str]] = {}
+        self._session_operation_locks: dict[str, threading.Lock] = {}
         self._closed_session_ids = BoundedReplayMap[str, bool](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
         self._session_connections_lock = threading.RLock()
         self._shutdown_lock = threading.RLock()
@@ -659,7 +845,7 @@ class RayWorkerActor:
                 existing += 1
                 continue
             query_id = str(entry.get("query_id", "")).strip()
-            _register_query_python_replay_state(query_id, plan)
+            _register_query_python_replay_state(_plan_resource_query_id(plan), plan)
             self._plan_fragments[fragment_id] = plan
             self._fragment_query_ids[fragment_id] = query_id
             self._query_fragments.setdefault(query_id, set()).add(fragment_id)
@@ -972,6 +1158,7 @@ class RayWorkerActor:
             self._fragment_lookup_misses += 1
             raise ValueError(f"PlanFragment not found in actor registry: {fragment_id}")
 
+        _register_query_python_replay_state(_plan_resource_query_id(fragment_plan), fragment_plan)
         self._plan_fragments[fragment_id] = fragment_plan
         self._fragment_query_ids[fragment_id] = resolved_query_id
         self._query_fragments.setdefault(resolved_query_id, set()).add(fragment_id)
@@ -1002,12 +1189,59 @@ class RayWorkerActor:
             self._shared_conn = conn
             return conn
 
-    def _get_session_conn(self, session_id: str, config: Mapping[str, str]) -> Any:
+    def _get_session_operation_lock(
+        self,
+        session_id: str,
+        *,
+        allow_closed: bool = False,
+    ) -> threading.Lock:
+        with self._session_connections_lock:
+            if not allow_closed:
+                if self._shutdown_started:
+                    raise RuntimeError("Ray worker runtime is shutting down")
+                if session_id in self._closed_session_ids:
+                    raise RuntimeError(f"Ray worker Vane session is closed: {session_id}")
+            operation_locks = getattr(self, "_session_operation_locks", None)
+            if operation_locks is None:
+                operation_locks = {}
+                self._session_operation_locks = operation_locks
+            operation_lock = operation_locks.get(session_id)
+            if operation_lock is None:
+                operation_lock = threading.Lock()
+                operation_locks[session_id] = operation_lock
+            return operation_lock
+
+    def _get_session_conn(
+        self,
+        session_id: str,
+        config: Mapping[str, str],
+        *,
+        use_session_credentials: bool = True,
+    ) -> Any:
         session_key = str(session_id).strip()
         if not session_key:
             raise ValueError("Ray worker execution requires a Vane session_id")
         normalized_config = {str(key): str(value) for key, value in config.items()}
+        operation_lock = self._get_session_operation_lock(session_key)
+        with operation_lock:
+            return self._get_session_conn_locked(
+                session_key,
+                normalized_config,
+                use_session_credentials=use_session_credentials,
+            )
+
+    def _get_session_conn_locked(
+        self,
+        session_key: str,
+        normalized_config: dict[str, str],
+        *,
+        use_session_credentials: bool,
+    ) -> Any:
         with self._session_connections_lock:
+            session_s3_configs = getattr(self, "_session_s3_configs", None)
+            if session_s3_configs is None:
+                session_s3_configs = {}
+                self._session_s3_configs = session_s3_configs
             if self._shutdown_started:
                 raise RuntimeError("Ray worker runtime is shutting down")
             if session_key in self._closed_session_ids:
@@ -1018,34 +1252,109 @@ class RayWorkerActor:
                 if existing_config != normalized_config:
                     raise RuntimeError(f"Ray worker Vane session config changed: {session_key}")
                 return connection
-            connection = self._get_shared_conn().cursor()
+
+        connection = self._get_shared_conn().cursor()
+        try:
+            effective_s3_config = _configure_duckdb_s3(
+                connection,
+                normalized_config,
+                use_session_credentials=use_session_credentials,
+            )
+        except BaseException as config_error:
             try:
-                _configure_duckdb_s3(connection, normalized_config)
-            except BaseException as config_error:
-                try:
-                    connection.close()
-                except BaseException as close_error:
-                    raise RuntimeError(
-                        f"Ray worker Vane session {session_key} configuration failed and "
-                        f"its connection could not be closed: {type(close_error).__name__}: {close_error}"
-                    ) from config_error
-                raise
-            self._session_connections[session_key] = (normalized_config, connection)
-            return connection
+                connection.close()
+            except BaseException as close_error:
+                raise RuntimeError(
+                    f"Ray worker Vane session {session_key} configuration failed and "
+                    f"its connection could not be closed: {type(close_error).__name__}: {close_error}"
+                ) from config_error
+            raise
+
+        try:
+            with self._session_connections_lock:
+                if self._shutdown_started:
+                    raise RuntimeError("Ray worker runtime is shutting down")
+                if session_key in self._closed_session_ids:
+                    raise RuntimeError(f"Ray worker Vane session is closed: {session_key}")
+                existing = self._session_connections.get(session_key)
+                if existing is not None:
+                    raise RuntimeError(f"Ray worker Vane session opened outside its operation lock: {session_key}")
+                self._session_connections[session_key] = (normalized_config, connection)
+                session_s3_configs[session_key] = effective_s3_config
+                return connection
+        except BaseException as state_error:
+            try:
+                connection.close()
+            except BaseException as close_error:
+                raise RuntimeError(
+                    f"Ray worker Vane session {session_key} changed while opening and "
+                    f"its connection could not be closed: {type(close_error).__name__}: {close_error}"
+                ) from state_error
+            raise
+
+    def _refresh_session_s3_config(
+        self,
+        session_id: str,
+        session_config: dict[str, str],
+        connection: Any,
+        *,
+        use_session_credentials: bool,
+    ) -> dict[str, str]:
+        operation_lock = self._get_session_operation_lock(session_id)
+        with operation_lock:
+            with self._session_connections_lock:
+                if self._shutdown_started:
+                    raise RuntimeError("Ray worker runtime is shutting down")
+                if session_id in self._closed_session_ids:
+                    raise RuntimeError(f"Ray worker Vane session is closed: {session_id}")
+                record = self._session_connections.get(session_id)
+                if record is None or record[1] is not connection:
+                    raise RuntimeError(f"Ray worker Vane session closed during task startup: {session_id}")
+                effective_s3_config = dict(self._session_s3_configs.get(session_id, session_config))
+            effective_s3_config = _refresh_effective_duckdb_s3_config(
+                session_config,
+                effective_s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            with self._session_connections_lock:
+                if self._shutdown_started:
+                    raise RuntimeError("Ray worker runtime is shutting down")
+                if session_id in self._closed_session_ids:
+                    raise RuntimeError(f"Ray worker Vane session is closed: {session_id}")
+                record = self._session_connections.get(session_id)
+                if record is None or record[1] is not connection:
+                    raise RuntimeError(f"Ray worker Vane session closed during task startup: {session_id}")
+                self._session_s3_configs[session_id] = effective_s3_config
+            return effective_s3_config
 
     @ray.method(concurrency_group="control")
-    def close_session(self, session_id: str) -> None:
+    async def close_session(self, session_id: str) -> None:
         session_key = str(session_id).strip()
         if not session_key:
             raise ValueError("Ray worker close_session requires a Vane session_id")
-        with self._session_connections_lock:
-            self._closed_session_ids[session_key] = True
-            record = self._session_connections.get(session_key)
-            if record is not None:
+
+        def _close() -> None:
+            operation_lock = self._get_session_operation_lock(session_key, allow_closed=True)
+            with self._session_connections_lock:
+                self._closed_session_ids[session_key] = True
+            with operation_lock:
+                with self._session_connections_lock:
+                    record = self._session_connections.get(session_key)
+                if record is None:
+                    with self._session_connections_lock:
+                        operation_locks = getattr(self, "_session_operation_locks", {})
+                        if operation_locks.get(session_key) is operation_lock:
+                            operation_locks.pop(session_key, None)
+                    return
                 _, connection = record
                 connection.close()
-                if self._session_connections.get(session_key) is record:
-                    self._session_connections.pop(session_key, None)
+                with self._session_connections_lock:
+                    if self._session_connections.get(session_key) is record:
+                        self._session_connections.pop(session_key, None)
+                        getattr(self, "_session_s3_configs", {}).pop(session_key, None)
+                        getattr(self, "_session_operation_locks", {}).pop(session_key, None)
+
+        await _to_thread_with_owned_side_effects(_close)
 
     def _begin_worker_native_execution(self, query_id: str) -> None:
         query_id = str(query_id or "").strip()
@@ -1218,6 +1527,8 @@ class RayWorkerActor:
                 with session_connections_lock:
                     if getattr(self, "_session_connections", {}).get(session_id) is not record:
                         continue
+                    if record is None:
+                        continue
                     _, session_connection = record
                     try:
                         session_connection.close()
@@ -1226,6 +1537,7 @@ class RayWorkerActor:
                     else:
                         if self._session_connections.get(session_id) is record:
                             self._session_connections.pop(session_id, None)
+                            getattr(self, "_session_s3_configs", {}).pop(session_id, None)
             with shared_conn_lock:
                 conn = getattr(self, "_shared_conn", None)
             if conn is not None:
@@ -1296,16 +1608,45 @@ class RayWorkerActor:
     ) -> Any:
         session_id = str(plan.session_id()).strip()
         session_config = {str(key): str(value) for key, value in dict(plan.session_config()).items()}
-        conn = self._get_session_conn(session_id, session_config)
-        cursor = conn.cursor()
+        has_explicit_s3_credentials = getattr(plan, "has_explicit_s3_credentials", None)
+        if not callable(has_explicit_s3_credentials):
+            raise TypeError("distributed physical plan is missing has_explicit_s3_credentials()")
+        use_session_credentials = not bool(has_explicit_s3_credentials())
+        conn = self._get_session_conn(
+            session_id,
+            session_config,
+            use_session_credentials=use_session_credentials,
+        )
+        effective_s3_config = self._refresh_session_s3_config(
+            session_id,
+            session_config,
+            conn,
+            use_session_credentials=use_session_credentials,
+        )
+        cursor = None
         cursor_registered = False
         debug_context = dict(debug_context or {})
         start = time.monotonic()
 
         try:
-            _configure_duckdb_s3(cursor, session_config)
-            query_admitted = self._register_native_cursor(cursor, native_query_id)
-            cursor_registered = True
+            with self._session_connections_lock:
+                if self._shutdown_started:
+                    raise RuntimeError("Ray worker runtime is shutting down")
+                if session_id in self._closed_session_ids:
+                    raise RuntimeError(f"Ray worker Vane session is closed: {session_id}")
+                record = self._session_connections.get(session_id)
+                if record is None or record[1] is not conn:
+                    raise RuntimeError(f"Ray worker Vane session closed during task startup: {session_id}")
+                cursor = conn.cursor()
+                query_admitted = self._register_native_cursor(cursor, native_query_id)
+                cursor_registered = True
+            if not query_admitted:
+                raise RuntimeError(f"native query is closing: {native_query_id}")
+            effective_s3_config = _configure_duckdb_s3(
+                cursor,
+                effective_s3_config,
+                use_session_credentials=use_session_credentials,
+            )
             _ray_worker_memory_log(
                 "native_execute_start",
                 **debug_context,
@@ -1314,8 +1655,6 @@ class RayWorkerActor:
                 has_exchange_sink_instance=exchange_sink_instance is not None,
                 has_dynamic_filter_domains=bool(dynamic_filter_domains),
             )
-            if not query_admitted:
-                raise RuntimeError(f"native query is closing: {native_query_id}")
             plan_runner = self._get_plan_runner()
             scan_task_arg = scan_task_map or None
             result = plan_runner.execute_native(
@@ -1330,6 +1669,7 @@ class RayWorkerActor:
                 dynamic_filter_domains or None,
                 native_progress_callback,
                 debug_context or None,
+                effective_s3_config,
             )
             _ray_worker_memory_log(
                 "native_execute_done",
@@ -1348,7 +1688,8 @@ class RayWorkerActor:
             raise
         finally:
             try:
-                cursor.close()
+                if cursor is not None:
+                    cursor.close()
             except Exception:
                 pass
             finally:

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -30,7 +30,11 @@ from duckdb.runners.fte import (
 from duckdb.runners.fte.debug_memory import describe_result_payload, log_debug, process_memory_snapshot
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
+from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.fte_scheduler_config import _fte_control_rpc_timeout_s
+from duckdb.runners.ray.ray_env import scrub_shared_runtime_session_env
+
+_SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 
 
 def _fte_applied_control_status(
@@ -89,6 +93,22 @@ def _clear_datasource_factory_registry() -> None:
     import _duckdb
 
     _duckdb._clear_datasource_factory_registry()
+
+
+def _register_query_python_replay_state(query_id: str, plan: Any) -> bool:
+    register = require_ray_cxx_attr(
+        "_register_query_python_replay_state",
+        hint="Ensure the C++ ray extension is built with query replay lifecycle support.",
+    )
+    return bool(register(str(query_id), plan))
+
+
+def _cleanup_query_python_replay_state(query_id: str) -> None:
+    cleanup = require_ray_cxx_attr(
+        "_cleanup_query_python_replay_state",
+        hint="Ensure the C++ ray extension is built with query replay lifecycle support.",
+    )
+    cleanup(str(query_id))
 
 
 def _chaos_worker_loss_matches(task_id: FteTaskAttemptId) -> bool:
@@ -316,24 +336,22 @@ def _normalize_stats_for_ray(stats_payload: Any) -> list[int]:
     return []
 
 
-def _configure_duckdb_s3(conn: Any) -> None:
-    """Configure S3 settings on a DuckDB connection from AWS environment variables.
+def _configure_duckdb_s3(conn: Any, config: Mapping[str, str]) -> None:
+    """Configure one DuckDB context from explicit session AWS settings.
 
-    Ray actors create bare ``duckdb.connect()`` instances that lack S3 endpoint
-    and credential settings.  The standard ``AWS_*`` env vars *are* propagated
-    to workers, but DuckDB does not automatically map ``AWS_ENDPOINT_URL`` to
-    its ``s3_endpoint`` setting, causing S3 reads to go to the real AWS instead
-    of a local MinIO / compatible store.
+    Shared driver/worker processes must not read session credentials from their
+    process environment. The caller owns the immutable connection-session
+    snapshot.
     """
     from urllib.parse import urlparse
 
-    endpoint_url = os.environ.get("AWS_ENDPOINT_URL", "").strip()
-    access_key = os.environ.get("AWS_ACCESS_KEY_ID", "").strip()
-    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip()
-    session_token = os.environ.get("AWS_SESSION_TOKEN", "").strip()
-    region = (os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "").strip()
+    endpoint_url = str(config.get("AWS_ENDPOINT_URL", "")).strip()
+    access_key = str(config.get("AWS_ACCESS_KEY_ID", "")).strip()
+    secret_key = str(config.get("AWS_SECRET_ACCESS_KEY", "")).strip()
+    session_token = str(config.get("AWS_SESSION_TOKEN", "")).strip()
+    region = str(config.get("AWS_REGION") or config.get("AWS_DEFAULT_REGION") or "").strip()
 
-    if not endpoint_url and not access_key:
+    if not any((endpoint_url, access_key, secret_key, session_token, region)):
         return  # nothing to configure
 
     try:
@@ -344,50 +362,34 @@ def _configure_duckdb_s3(conn: Any) -> None:
     def _q(s: str) -> str:
         return s.replace("'", "''")
 
-    # Use GLOBAL so cursors (which create new ClientContexts) inherit settings.
     if region:
-        conn.execute(f"SET GLOBAL s3_region='{_q(region)}'")
+        conn.execute(f"SET s3_region='{_q(region)}'")
     if access_key:
-        conn.execute(f"SET GLOBAL s3_access_key_id='{_q(access_key)}'")
+        conn.execute(f"SET s3_access_key_id='{_q(access_key)}'")
     if secret_key:
-        conn.execute(f"SET GLOBAL s3_secret_access_key='{_q(secret_key)}'")
+        conn.execute(f"SET s3_secret_access_key='{_q(secret_key)}'")
     if session_token:
-        conn.execute(f"SET GLOBAL s3_session_token='{_q(session_token)}'")
+        conn.execute(f"SET s3_session_token='{_q(session_token)}'")
     if endpoint_url:
-        parsed = urlparse(endpoint_url)
+        parse_target = endpoint_url
+        if "://" not in parse_target and not parse_target.startswith("//"):
+            parse_target = f"//{parse_target}"
+        parsed = urlparse(parse_target)
         endpoint = parsed.netloc or parsed.path
         use_ssl = parsed.scheme == "https"
-        conn.execute(f"SET GLOBAL s3_endpoint='{_q(endpoint)}'")
-        conn.execute(f"SET GLOBAL s3_use_ssl={'true' if use_ssl else 'false'}")
-        conn.execute("SET GLOBAL s3_url_style='path'")
+        conn.execute(f"SET s3_endpoint='{_q(endpoint)}'")
+        conn.execute(f"SET s3_use_ssl={'true' if use_ssl else 'false'}")
+        conn.execute("SET s3_url_style='path'")
 
     # Keep-alive MUST stay enabled: disabling it creates a new TCP connection
     # per S3 request, which exhausts ephemeral ports via TIME_WAIT buildup
     # (55K+ TIME_WAIT sockets observed with keep_alive=false).
-    conn.execute("SET GLOBAL http_keep_alive=true")
+    conn.execute("SET http_keep_alive=true")
     # Increase retries to handle transient connection failures during
     # concurrent S3 access from many DuckDB threads.
-    conn.execute("SET GLOBAL http_retries=10")
-    conn.execute("SET GLOBAL http_retry_wait_ms=100")
-    conn.execute("SET GLOBAL http_retry_backoff=1.5")
-
-    # Create an explicit S3 secret so that credentials are available to the
-    # DuckDB secret manager even when internal code paths use a null FileOpener.
-    if endpoint_url and access_key and secret_key:
-        use_ssl_str = "true" if (urlparse(endpoint_url).scheme == "https") else "false"
-        endpoint_host = urlparse(endpoint_url).netloc or urlparse(endpoint_url).path
-        region_val = region or "us-east-1"
-        conn.execute(f"""
-            CREATE SECRET IF NOT EXISTS __vane_s3 (
-                TYPE S3,
-                KEY_ID '{_q(access_key)}',
-                SECRET '{_q(secret_key)}',
-                ENDPOINT '{_q(endpoint_host)}',
-                REGION '{_q(region_val)}',
-                USE_SSL {use_ssl_str},
-                URL_STYLE 'path'
-            )
-        """)
+    conn.execute("SET http_retries=10")
+    conn.execute("SET http_retry_wait_ms=100")
+    conn.execute("SET http_retry_backoff=1.5")
 
 
 def _configure_ray_worker_conn(conn: Any, duckdb_memory_bytes: int) -> None:
@@ -398,10 +400,6 @@ def _configure_ray_worker_conn(conn: Any, duckdb_memory_bytes: int) -> None:
             conn.execute(f"SET threads={int(duckdb_threads)}")
         except Exception:
             pass
-    try:
-        _configure_duckdb_s3(conn)
-    except Exception:
-        pass
     try:
         conn.execute("SET local_exchange_streaming=true")
     except Exception:
@@ -435,15 +433,6 @@ def _warm_up_python_native_dependencies() -> None:
         __import__("pyarrow.parquet")
     except Exception:
         pass
-
-
-def _apply_env_overrides(env_overrides: Mapping[str, str | None] | None) -> None:
-    if not env_overrides:
-        return
-    for key, value in env_overrides.items():
-        if value is None:
-            continue
-        os.environ[key] = str(value)
 
 
 def _copy_output_info_from_context(context: dict[str, Any] | None) -> dict[str, str] | None:
@@ -502,22 +491,19 @@ class RayWorkerActor:
         num_gpus: int,
         duckdb_memory_bytes: int,
         task_heap_capacity_bytes: int,
-        env_overrides: dict[str, str] | None = None,
     ) -> None:
+        scrub_shared_runtime_session_env()
         duckdb_memory_bytes = int(duckdb_memory_bytes)
         task_heap_capacity_bytes = int(task_heap_capacity_bytes)
         if duckdb_memory_bytes <= 0:
             raise ValueError("Ray worker duckdb_memory_bytes must be positive")
         if task_heap_capacity_bytes <= 0:
             raise ValueError("Ray worker task_heap_capacity_bytes must be positive")
-        self._env_overrides = env_overrides or {}
         self._node_id = str(ray.get_runtime_context().get_node_id() or "").strip()
         if not self._node_id:
             raise RuntimeError("Ray worker runtime context is missing node_id")
         self._duckdb_memory_bytes = duckdb_memory_bytes
         self._task_heap_capacity_bytes = task_heap_capacity_bytes
-        _apply_env_overrides(self._env_overrides)
-        os.environ["VANE_WORKER"] = "1"
         try:
             loop = asyncio.get_running_loop()
             set_event_loop(loop)
@@ -562,6 +548,9 @@ class RayWorkerActor:
         # with actor creation instead of blocking the first task.
         self._shared_conn: Any | None = None
         self._shared_conn_lock = threading.Lock()
+        self._session_connections: dict[str, tuple[dict[str, str], Any]] = {}
+        self._closed_session_ids = BoundedReplayMap[str, bool](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
+        self._session_connections_lock = threading.RLock()
         self._shutdown_lock = threading.RLock()
         self._native_execution_condition = threading.Condition()
         self._native_execution_count = 0
@@ -591,10 +580,9 @@ class RayWorkerActor:
                 raise RuntimeError("Ray worker runtime is shutting down")
 
     @ray.method(concurrency_group="control")
-    def install_env_overrides(self, env_overrides: dict[str, str] | None) -> None:
+    def ping(self) -> bool:
         self._ensure_worker_runtime_running()
-        self._env_overrides = env_overrides or {}
-        _apply_env_overrides(self._env_overrides)
+        return True
 
     @ray.method(concurrency_group="control")
     async def register_fragments(self, fragments: list[dict[str, Any]]) -> dict[str, int]:
@@ -670,8 +658,9 @@ class RayWorkerActor:
                     )
                 existing += 1
                 continue
-            self._plan_fragments[fragment_id] = plan
             query_id = str(entry.get("query_id", "")).strip()
+            _register_query_python_replay_state(query_id, plan)
+            self._plan_fragments[fragment_id] = plan
             self._fragment_query_ids[fragment_id] = query_id
             self._query_fragments.setdefault(query_id, set()).add(fragment_id)
             registered += 1
@@ -932,6 +921,7 @@ class RayWorkerActor:
         flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
         _retire_flight_shuffle_query(query_id)
         self._retire_worker_native_query(query_id)
+        _cleanup_query_python_replay_state(query_id)
         return {
             "flight_shuffle_registry_entries_removed": int(flight_shuffle_cleanup["registry_entries_removed"]),
             "flight_shuffle_storage_entries_removed": int(flight_shuffle_cleanup["storage_entries_removed"]),
@@ -1011,6 +1001,51 @@ class RayWorkerActor:
             self._configure_conn(conn)
             self._shared_conn = conn
             return conn
+
+    def _get_session_conn(self, session_id: str, config: Mapping[str, str]) -> Any:
+        session_key = str(session_id).strip()
+        if not session_key:
+            raise ValueError("Ray worker execution requires a Vane session_id")
+        normalized_config = {str(key): str(value) for key, value in config.items()}
+        with self._session_connections_lock:
+            if self._shutdown_started:
+                raise RuntimeError("Ray worker runtime is shutting down")
+            if session_key in self._closed_session_ids:
+                raise RuntimeError(f"Ray worker Vane session is closed: {session_key}")
+            existing = self._session_connections.get(session_key)
+            if existing is not None:
+                existing_config, connection = existing
+                if existing_config != normalized_config:
+                    raise RuntimeError(f"Ray worker Vane session config changed: {session_key}")
+                return connection
+            connection = self._get_shared_conn().cursor()
+            try:
+                _configure_duckdb_s3(connection, normalized_config)
+            except BaseException as config_error:
+                try:
+                    connection.close()
+                except BaseException as close_error:
+                    raise RuntimeError(
+                        f"Ray worker Vane session {session_key} configuration failed and "
+                        f"its connection could not be closed: {type(close_error).__name__}: {close_error}"
+                    ) from config_error
+                raise
+            self._session_connections[session_key] = (normalized_config, connection)
+            return connection
+
+    @ray.method(concurrency_group="control")
+    def close_session(self, session_id: str) -> None:
+        session_key = str(session_id).strip()
+        if not session_key:
+            raise ValueError("Ray worker close_session requires a Vane session_id")
+        with self._session_connections_lock:
+            self._closed_session_ids[session_key] = True
+            record = self._session_connections.get(session_key)
+            if record is not None:
+                _, connection = record
+                connection.close()
+                if self._session_connections.get(session_key) is record:
+                    self._session_connections.pop(session_key, None)
 
     def _begin_worker_native_execution(self, query_id: str) -> None:
         query_id = str(query_id or "").strip()
@@ -1141,6 +1176,12 @@ class RayWorkerActor:
                 self._shared_conn_lock = shared_conn_lock
             with shared_conn_lock:
                 conn = getattr(self, "_shared_conn", None)
+            session_connections_lock = getattr(self, "_session_connections_lock", None)
+            if session_connections_lock is None:
+                session_connections_lock = threading.RLock()
+                self._session_connections_lock = session_connections_lock
+            with session_connections_lock:
+                session_connections = list(getattr(self, "_session_connections", {}).items())
             if conn is not None:
                 try:
                     conn.interrupt()
@@ -1173,6 +1214,18 @@ class RayWorkerActor:
                 native_drained = self._native_execution_count == 0
             if not native_drained:
                 raise RuntimeError("; ".join(errors))
+            for session_id, record in session_connections:
+                with session_connections_lock:
+                    if getattr(self, "_session_connections", {}).get(session_id) is not record:
+                        continue
+                    _, session_connection = record
+                    try:
+                        session_connection.close()
+                    except Exception as exc:
+                        errors.append(f"close DuckDB session connection {session_id}: {exc}")
+                    else:
+                        if self._session_connections.get(session_id) is record:
+                            self._session_connections.pop(session_id, None)
             with shared_conn_lock:
                 conn = getattr(self, "_shared_conn", None)
             if conn is not None:
@@ -1241,21 +1294,26 @@ class RayWorkerActor:
         debug_context: dict[str, Any] | None = None,
         native_query_id: str = "",
     ) -> Any:
-        conn = self._get_shared_conn()
+        session_id = str(plan.session_id()).strip()
+        session_config = {str(key): str(value) for key, value in dict(plan.session_config()).items()}
+        conn = self._get_session_conn(session_id, session_config)
         cursor = conn.cursor()
-        query_admitted = self._register_native_cursor(cursor, native_query_id)
+        cursor_registered = False
         debug_context = dict(debug_context or {})
         start = time.monotonic()
-        _ray_worker_memory_log(
-            "native_execute_start",
-            **debug_context,
-            scan_task_map_count=len(scan_task_map or {}),
-            exchange_source_task_map_count=len(exchange_source_task_map or {}),
-            has_exchange_sink_instance=exchange_sink_instance is not None,
-            has_dynamic_filter_domains=bool(dynamic_filter_domains),
-        )
 
         try:
+            _configure_duckdb_s3(cursor, session_config)
+            query_admitted = self._register_native_cursor(cursor, native_query_id)
+            cursor_registered = True
+            _ray_worker_memory_log(
+                "native_execute_start",
+                **debug_context,
+                scan_task_map_count=len(scan_task_map or {}),
+                exchange_source_task_map_count=len(exchange_source_task_map or {}),
+                has_exchange_sink_instance=exchange_sink_instance is not None,
+                has_dynamic_filter_domains=bool(dynamic_filter_domains),
+            )
             if not query_admitted:
                 raise RuntimeError(f"native query is closing: {native_query_id}")
             plan_runner = self._get_plan_runner()
@@ -1294,7 +1352,8 @@ class RayWorkerActor:
             except Exception:
                 pass
             finally:
-                self._unregister_native_cursor(cursor)
+                if cursor_registered:
+                    self._unregister_native_cursor(cursor)
 
     @staticmethod
     async def _await_fragment_registration(registration_result: Any | None) -> None:
@@ -1316,7 +1375,6 @@ class RayWorkerActor:
         debug_context: dict[str, Any] | None = None,
     ) -> Any:
         """Run a plan on worker and return a Ray-serializable result tuple."""
-        _apply_env_overrides(self._env_overrides)
         debug_context = dict(debug_context or {})
 
         copy_output_info = _copy_output_info_from_context(context)

--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -24,7 +24,7 @@ RayWorkerRuntime: Any = require_ray_cxx_attr(
 )
 
 
-def _persistent_worker_runtime_env() -> dict[str, dict[str, str]]:
+def _persistent_worker_runtime_env(env_vars: dict[str, str]) -> dict[str, Any]:
     """Keep the node's accelerator visibility in a zero-GPU Ray actor.
 
     Ray 2.53 through 2.55 clear accelerator visibility for actors that do not
@@ -32,7 +32,10 @@ def _persistent_worker_runtime_env() -> dict[str, dict[str, str]]:
     2.56 and later preserve it by default, but accepting the switch keeps the
     behavior stable across the supported Ray range.
     """
-    return {"env_vars": {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"}}
+    runtime_env_vars = dict(env_vars)
+    runtime_env_vars["RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO"] = "0"
+    runtime_env_vars["VANE_WORKER"] = "1"
+    return {"env_vars": runtime_env_vars}
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
@@ -67,7 +70,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
             actor = RayWorkerActor.options(  # type: ignore[attr-defined]
                 max_concurrency=_actor_max_conc,
                 memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
-                runtime_env=_persistent_worker_runtime_env(),
+                runtime_env=_persistent_worker_runtime_env(worker_env),
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node["NodeID"],
                     soft=False,
@@ -77,7 +80,6 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
                 num_gpus=int(node["Resources"].get("GPU", 0)),
                 duckdb_memory_bytes=memory_layout.worker_duckdb_memory_bytes,
                 task_heap_capacity_bytes=memory_layout.task_heap_capacity_bytes,
-                env_overrides=worker_env,
             )
             actors.append((node, worker_id, actor))
 
@@ -85,7 +87,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
     # This absorbs the ~2.5s actor cold-start so the first task dispatch is fast.
     # Matches upstream Vane's start_ray_workers() pattern.
     ACTOR_STARTUP_TIMEOUT = 120
-    warmup_refs = [actor.install_env_overrides.remote(None) for _, _, actor in actors]
+    warmup_refs = [actor.ping.remote() for _, _, actor in actors]
     # Nested distributed execution may call start_ray_workers() from inside a
     # Ray actor. Let actor startup proceed asynchronously there and rely on the
     # first task submission for backpressure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ license-files = [
 keywords = ["Vane", "DuckDB", "Ray", "Distributed", "Database", "SQL", "OLAP"]
 requires-python = ">=3.10,<3.15"
 dependencies = [
+    "botocore>=1.34,<2",
     "cloudpickle>=3.1.2,<4",
     "numpy",
     "pyarrow",

--- a/src/duckdb_py/datasource_function.cpp
+++ b/src/duckdb_py/datasource_function.cpp
@@ -391,7 +391,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 		g_last_created_source_id = source_id;
 	}
 
-	return make_uniq<DuckDBPyRelation>(std::move(aliased_rel));
+	return CreateRelation(std::move(aliased_rel));
 }
 
 void ClearDataSourceFactoryRegistry() {

--- a/src/duckdb_py/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/src/duckdb_py/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -154,6 +154,17 @@ private:
 	unique_ptr<DuckDBPyRelation> result;
 };
 
+struct VaneSessionContext {
+	VaneSessionContext(string id_p, py::dict config_p) : id(std::move(id_p)), config(std::move(config_p)) {
+	}
+
+	string id;
+	py::dict config;
+	mutex lock;
+	idx_t connection_count = 1;
+	bool ray_session_opened = false;
+};
+
 struct DuckDBPyConnection : public enable_shared_from_this<DuckDBPyConnection> {
 private:
 	class Cursors {
@@ -177,6 +188,8 @@ public:
 	string connection_database = ":memory:";
 	bool connection_read_only = false;
 	py::dict connection_config = py::dict();
+	shared_ptr<VaneSessionContext> vane_session;
+	bool vane_session_attached = false;
 	//! MemoryFileSystem used to temporarily store file-like objects for reading
 	shared_ptr<ModifiedMemoryFileSystem> internal_object_filesystem;
 	case_insensitive_map_t<unique_ptr<ExternalDependency>> registered_functions;
@@ -363,6 +376,12 @@ public:
 	static shared_ptr<DuckDBPyConnection> Connect(const py::object &database, bool read_only, const py::dict &config);
 	void SetConnectionBootstrapConfig(const string &database, bool read_only, const py::dict &config);
 	py::dict ExportConnectionBootstrapConfig() const;
+	void InitializeVaneSession();
+	void InheritVaneSession(const DuckDBPyConnection &owner);
+	const string &GetVaneSessionId() const;
+	py::dict ExportVaneSessionConfig() const;
+	void MarkVaneRaySessionOpened();
+	void ReleaseVaneSession();
 
 	static vector<Value> TransformPythonParamList(const py::handle &params);
 	static case_insensitive_map_t<BoundParameterData> TransformPythonParamDict(const py::dict &params);

--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -548,6 +548,13 @@ static void RegisterVaneScalarFunctionAtomically(
 } // namespace
 
 DuckDBPyConnection::~DuckDBPyConnection() {
+	if (!PythonIsFinalizing()) {
+		try {
+			PythonGILWrapper gil;
+			ReleaseVaneSession();
+		} catch (...) { // NOLINT
+		}
+	}
 	try {
 		py::gil_scoped_release gil;
 		// Release any structures that do not need to hold the GIL here
@@ -2656,13 +2663,16 @@ int DuckDBPyConnection::GetRowcount() {
 void DuckDBPyConnection::Close() {
 	con.SetResult(nullptr);
 	D_ASSERT(py::gil_check());
-	py::gil_scoped_release release;
-	con.SetConnection(nullptr);
-	con.SetDatabase(nullptr);
-	// https://peps.python.org/pep-0249/#Connection.close
-	cursors.ClearCursors();
-	registered_functions.clear();
-	registered_function_catalog_types.clear();
+	{
+		py::gil_scoped_release release;
+		con.SetConnection(nullptr);
+		con.SetDatabase(nullptr);
+		// https://peps.python.org/pep-0249/#Connection.close
+		cursors.ClearCursors();
+		registered_functions.clear();
+		registered_function_catalog_types.clear();
+	}
+	ReleaseVaneSession();
 }
 
 void DuckDBPyConnection::Interrupt() {
@@ -2785,6 +2795,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Cursor() {
 	res->con.SetDatabase(con);
 	res->con.SetConnection(make_uniq<Connection>(res->con.GetDatabase()));
 	res->SetConnectionBootstrapConfig(connection_database, connection_read_only, connection_config);
+	res->InheritVaneSession(*this);
 	res->distributed_python_udf_registrations = distributed_python_udf_registrations;
 	res->applied_distributed_python_udf_digests = applied_distributed_python_udf_digests;
 	cursors.AddCursor(res);
@@ -2910,6 +2921,101 @@ py::dict DuckDBPyConnection::ExportConnectionBootstrapConfig() const {
 	result[py::str("read_only")] = py::bool_(connection_read_only);
 	result[py::str("config")] = CopyPyDict(connection_config);
 	return result;
+}
+
+static bool IsVaneSessionEnvironmentKey(const string &name) {
+	return StringUtil::StartsWith(name, "AWS_") || StringUtil::StartsWith(name, "DUCKDB_") ||
+	       StringUtil::StartsWith(name, "S3FS_") || StringUtil::StartsWith(name, "VANE_");
+}
+
+void DuckDBPyConnection::InitializeVaneSession() {
+	auto uuid_module = py::module_::import("uuid");
+	auto session_id = py::str(uuid_module.attr("uuid4")().attr("hex")).cast<string>();
+	if (session_id.empty()) {
+		throw InternalException("Failed to generate Vane connection session identity");
+	}
+
+	py::dict captured;
+	auto environ = py::module_::import("os").attr("environ");
+	auto environ_dict = py::module_::import("builtins").attr("dict")(environ).cast<py::dict>();
+	for (auto item : environ_dict) {
+		auto key = py::str(item.first).cast<string>();
+		if (!IsVaneSessionEnvironmentKey(key)) {
+			continue;
+		}
+		captured[py::str(key)] = py::str(item.second);
+	}
+	vane_session = make_shared_ptr<VaneSessionContext>(std::move(session_id), std::move(captured));
+	vane_session_attached = true;
+}
+
+void DuckDBPyConnection::InheritVaneSession(const DuckDBPyConnection &owner) {
+	if (!owner.vane_session || !owner.vane_session_attached) {
+		throw InternalException("Cannot inherit missing Vane connection session");
+	}
+	vane_session = owner.vane_session;
+	{
+		lock_guard<mutex> guard(vane_session->lock);
+		if (vane_session->connection_count == 0) {
+			throw InternalException("Cannot inherit closed Vane connection session");
+		}
+		vane_session->connection_count++;
+	}
+	vane_session_attached = true;
+}
+
+const string &DuckDBPyConnection::GetVaneSessionId() const {
+	if (!vane_session || vane_session->id.empty()) {
+		throw InternalException("DuckDB connection is missing its Vane session identity");
+	}
+	return vane_session->id;
+}
+
+py::dict DuckDBPyConnection::ExportVaneSessionConfig() const {
+	if (!vane_session) {
+		throw InternalException("DuckDB connection is missing its Vane session configuration");
+	}
+	lock_guard<mutex> guard(vane_session->lock);
+	if (!vane_session_attached || vane_session->connection_count == 0) {
+		throw InternalException("DuckDB connection Vane session is closed");
+	}
+	return CopyPyDict(vane_session->config);
+}
+
+void DuckDBPyConnection::MarkVaneRaySessionOpened() {
+	if (!vane_session) {
+		throw InternalException("DuckDB connection is missing its Vane session identity");
+	}
+	lock_guard<mutex> guard(vane_session->lock);
+	if (!vane_session_attached || vane_session->connection_count == 0) {
+		throw InternalException("DuckDB connection Vane session is closed");
+	}
+	vane_session->ray_session_opened = true;
+}
+
+void DuckDBPyConnection::ReleaseVaneSession() {
+	if (!vane_session_attached) {
+		return;
+	}
+	if (!vane_session) {
+		throw InternalException("DuckDB connection is missing its attached Vane session");
+	}
+	lock_guard<mutex> guard(vane_session->lock);
+	if (vane_session->connection_count == 0) {
+		throw InternalException("DuckDB connection Vane session reference count underflow");
+	}
+	if (vane_session->connection_count > 1) {
+		vane_session->connection_count--;
+		vane_session_attached = false;
+		return;
+	}
+	if (vane_session->ray_session_opened && !vane_session->id.empty() && !PythonIsFinalizing()) {
+		py::module_::import("duckdb.runners.ray.runner").attr("notify_connection_closed")(py::str(vane_session->id));
+		vane_session->ray_session_opened = false;
+	}
+	vane_session->connection_count = 0;
+	vane_session->config = py::dict();
+	vane_session_attached = false;
 }
 
 static bool HasJupyterProgressBarDependencies() {
@@ -3041,6 +3147,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Connect(const py::object &dat
 
 	auto res = FetchOrCreateInstance(database, config);
 	res->SetConnectionBootstrapConfig(database, read_only, config_options);
+	res->InitializeVaneSession();
 	auto &client_context = *res->con.GetConnection().context;
 	SetDefaultConfigArguments(client_context);
 	return res;

--- a/src/duckdb_py/python_udf_actor_resources.cpp
+++ b/src/duckdb_py/python_udf_actor_resources.cpp
@@ -95,6 +95,13 @@ static py::dict BuildUDFNode(idx_t node_id, UDFFunctionData &bind_data, ClientCo
 	py::dict meta;
 	meta[py::str("node_id")] = py::int_(node_id);
 	meta[py::str("payload")] = payload_obj;
+	if (bind_data.actor_handles) {
+		auto *boxed_options = static_cast<py::object *>(bind_data.actor_handles.get());
+		if (!py::isinstance<py::dict>(*boxed_options)) {
+			throw InvalidInputException("udf executor options must be a dict");
+		}
+		meta[py::str("executor_options")] = py::reinterpret_borrow<py::dict>(*boxed_options);
+	}
 	if (py::isinstance<py::dict>(payload_obj)) {
 		auto payload_dict = py::reinterpret_borrow<py::dict>(payload_obj);
 		auto get = payload_dict.attr("get");
@@ -234,7 +241,7 @@ private:
 		pybind11::list subprocess_nodes;
 		for (idx_t node_id = 0; node_id < bind_nodes.size(); node_id++) {
 			auto *bind_data = bind_nodes[node_id];
-			if (!bind_data || bind_data->actor_handles) {
+			if (!bind_data) {
 				continue;
 			}
 			string backend;
@@ -243,7 +250,7 @@ private:
 			}
 			if (backend == "subprocess_actor") {
 				subprocess_nodes.append(BuildUDFNode(node_id, *bind_data, context));
-			} else if (backend == "ray_actor") {
+			} else if (backend == "ray_actor" && !bind_data->actor_handles) {
 				throw InvalidInputException("ray_actor UDF execution requires driver-precreated actor handles from a "
 				                            "registered query allocation; "
 				                            "execute the relation through RayRunner");

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -3,24 +3,27 @@
 
 // Included by ray_module.cpp inside namespace duckdb.
 
-static void AssignDataSourceQueryOwner(duckdb::PhysicalOperator &op, const string &query_id) {
-	if (query_id.empty()) {
-		return;
-	}
+static void AssignDataSourceQueryOwner(duckdb::PhysicalOperator &op, const string &query_id,
+                                       bool allow_unacquired_rebind = false) {
 	if (op.type == duckdb::PhysicalOperatorType::TABLE_SCAN) {
 		auto &scan = op.Cast<duckdb::PhysicalTableScan>();
 		auto *bind_data = dynamic_cast<duckdb::DataSourceScanBindData *>(scan.bind_data.get());
 		if (bind_data) {
+			if (query_id.empty()) {
+				throw duckdb::InternalException("Datasource scan requires a non-empty resource query owner");
+			}
 			if (!bind_data->query_id.empty() && bind_data->query_id != query_id) {
-				throw duckdb::InvalidInputException(
-				    "Datasource scan query ownership mismatch: existing='%s', requested='%s'", bind_data->query_id,
-				    query_id);
+				if (!allow_unacquired_rebind) {
+					throw duckdb::InvalidInputException(
+					    "Datasource scan query ownership mismatch: existing='%s', requested='%s'", bind_data->query_id,
+					    query_id);
+				}
 			}
 			bind_data->query_id = query_id;
 		}
 	}
 	for (auto &child : op.children) {
-		AssignDataSourceQueryOwner(child.get(), query_id);
+		AssignDataSourceQueryOwner(child.get(), query_id, allow_unacquired_rebind);
 	}
 }
 
@@ -35,6 +38,7 @@ struct PyPhysicalPlanWrapper {
 	duckdb::shared_ptr<duckdb::ClientContext>
 	    client_context_; // Keep driver-side context alive when built from relation
 	string query_id_;
+	string resource_query_id_;
 	std::shared_ptr<duckdb::distributed::DistributedPhysicalPlan> plan_;
 	py::object arrow_schema_;        // Arrow schema for type information
 	py::object udf_registrations_;   // Connection-local Python UDF registrations captured from the source relation
@@ -116,7 +120,7 @@ struct PyPhysicalPlanWrapper {
 		plan_ =
 		    std::make_shared<duckdb::distributed::DistributedPhysicalPlan>(idx, effective_query_id, physical_plan, cfg);
 		if (physical_plan && physical_plan->HasRoot()) {
-			AssignDataSourceQueryOwner(physical_plan->Root(), effective_query_id);
+			AssignDataSourceQueryOwner(physical_plan->Root(), resource_query_id_);
 		}
 	}
 
@@ -158,7 +162,10 @@ struct PyPhysicalPlanWrapper {
 			auto *root_ptr = root_op.get();
 			physical_plan->TakeOwnership(std::move(root_op));
 			physical_plan->SetRoot(*root_ptr);
-			AssignDataSourceQueryOwner(*root_ptr, idx());
+			// The root was just deserialized and cannot have acquired a process-
+			// local datasource factory yet, so replacing its serialized source
+			// plan owner with the explicit resource query owner is safe.
+			AssignDataSourceQueryOwner(*root_ptr, resource_query_id_, true);
 		}
 		// Keep connection alive to ensure allocator validity
 		worker_connection_ = conn_obj;
@@ -195,13 +202,12 @@ struct PyPhysicalPlanWrapper {
 	PyPhysicalPlanWrapper clone(py::object conn_obj) const {
 		PyPhysicalPlanWrapper result;
 		result.query_id_ = idx();
+		result.resource_query_id_ = resource_query_id_;
 		result.udf_registrations_ = udf_registrations_;
 		result.udf_actor_handles_ = udf_actor_handles_;
 		result.connection_snapshot_ = connection_snapshot_;
 		result.serialized_root_ = serialize_root_for_clone();
 		result.ensure_plan_identity();
-		RememberQueryUDFRegistrations(result.query_id_, result.udf_registrations_);
-		RememberQueryUDFActorHandles(result.query_id_, result.udf_actor_handles_);
 		if (!conn_obj.is_none()) {
 			result.materialize_deferred_root(conn_obj);
 		}
@@ -210,8 +216,8 @@ struct PyPhysicalPlanWrapper {
 
 	PyPhysicalPlanWrapper()
 	    : init_magic_(INIT_MAGIC), worker_connection_(py::none()), client_context_(nullptr), query_id_(),
-	      plan_(nullptr), arrow_schema_(py::none()), udf_registrations_(py::none()), udf_actor_handles_(py::none()),
-	      connection_snapshot_(py::none()), serialized_root_() {
+	      resource_query_id_(), plan_(nullptr), arrow_schema_(py::none()), udf_registrations_(py::none()),
+	      udf_actor_handles_(py::none()), connection_snapshot_(py::none()), serialized_root_() {
 		// Create a minimal placeholder DistributedPhysicalPlan directly (avoid using from_logical_plan_builder).
 		try {
 			uint16_t idx = duckdb::distributed::get_query_idx_counter().fetch_add(1);
@@ -229,11 +235,26 @@ struct PyPhysicalPlanWrapper {
 	}
 	explicit PyPhysicalPlanWrapper(std::shared_ptr<duckdb::distributed::DistributedPhysicalPlan> p)
 	    : init_magic_(INIT_MAGIC), worker_connection_(py::none()), client_context_(nullptr),
-	      query_id_(p ? p->query_id() : string()), plan_(std::move(p)), arrow_schema_(py::none()),
-	      udf_registrations_(py::none()), udf_actor_handles_(py::none()), connection_snapshot_(py::none()),
-	      serialized_root_() {
+	      query_id_(p ? p->query_id() : string()), resource_query_id_(query_id_), plan_(std::move(p)),
+	      arrow_schema_(py::none()), udf_registrations_(py::none()), udf_actor_handles_(py::none()),
+	      connection_snapshot_(py::none()), serialized_root_() {
 		if (plan_ && plan_->physical_plan() && plan_->physical_plan()->HasRoot()) {
-			AssignDataSourceQueryOwner(plan_->physical_plan()->Root(), query_id_);
+			AssignDataSourceQueryOwner(plan_->physical_plan()->Root(), resource_query_id_);
+		}
+	}
+
+	PyPhysicalPlanWrapper(std::shared_ptr<duckdb::distributed::DistributedPhysicalPlan> p, string resource_query_id)
+	    : init_magic_(INIT_MAGIC), worker_connection_(py::none()), client_context_(nullptr),
+	      query_id_(p ? p->query_id() : string()), resource_query_id_(std::move(resource_query_id)),
+	      plan_(std::move(p)), arrow_schema_(py::none()), udf_registrations_(py::none()),
+	      udf_actor_handles_(py::none()), connection_snapshot_(py::none()), serialized_root_() {
+		if (resource_query_id_.empty()) {
+			throw duckdb::InternalException("DistributedPhysicalPlan requires a non-empty resource_query_id");
+		}
+		if (plan_ && plan_->physical_plan() && plan_->physical_plan()->HasRoot()) {
+			// WorkerTask plans are unexecuted copies. Their serialized source
+			// plan ID may differ from the resource query that owns teardown.
+			AssignDataSourceQueryOwner(plan_->physical_plan()->Root(), resource_query_id_, true);
 		}
 	}
 
@@ -255,6 +276,21 @@ struct PyPhysicalPlanWrapper {
 			}
 		}
 		return query_id_;
+	}
+
+	string resource_query_id() const {
+		if (!IsInitialized()) {
+			return string();
+		}
+		return resource_query_id_;
+	}
+
+	string session_id() const {
+		return VaneSessionIdFromSnapshot(connection_snapshot_);
+	}
+
+	py::dict session_config() const {
+		return VaneSessionConfigFromSnapshot(connection_snapshot_);
 	}
 
 	size_t num_partitions() const {
@@ -871,7 +907,6 @@ struct PyPhysicalPlanWrapper {
 
 		if (!handles_map.empty()) {
 			udf_actor_handles_ = handles_map;
-			RememberQueryUDFActorHandles(query_id_, udf_actor_handles_);
 		}
 
 		auto physical_plan = plan_->physical_plan();
@@ -951,6 +986,7 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj) const
 
 	auto plan_wrapper = PyPhysicalPlanWrapper(distributed_plan);
 	plan_wrapper.query_id_ = query_id_;
+	plan_wrapper.resource_query_id_ = query_id_;
 	plan_wrapper.worker_connection_ = planning_conn;
 	plan_wrapper.client_context_ = conn_wrapper.con.GetConnection().context;
 	plan_wrapper.udf_registrations_ = udf_registrations_;
@@ -958,7 +994,6 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj) const
 	auto validate_serialization =
 	    py::module_::import("duckdb._ray_cxx").attr("validate_plan_serialization_for_submission");
 	validate_serialization(py::cast(plan_wrapper));
-	RememberQueryUDFRegistrations(plan_wrapper.query_id_, plan_wrapper.udf_registrations_);
 	return plan_wrapper;
 }
 
@@ -1656,6 +1691,16 @@ struct PyPhysicalPlanWrapperRunner {
 		}
 	}
 
+	void close_session(const string &session_id) {
+		if (!ray_worker_manager_) {
+			throw std::runtime_error("Vane session lifecycle requires the Ray worker manager");
+		}
+		auto result = ray_worker_manager_->close_session(session_id);
+		if (result.is_err()) {
+			throw std::runtime_error(result.error().what());
+		}
+	}
+
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const {
 		if (ray_worker_manager_) {
 			return ray_worker_manager_->fragment_stats_by_worker();
@@ -1679,7 +1724,8 @@ struct PyPhysicalPlanWrapperRunner {
 	                                                duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
 	                                                    duckdb::distributed::python::ray::SafePyObject()) {
 		using namespace duckdb::distributed;
-		RememberQueryConnectionSnapshot(plan.idx(), plan.connection_snapshot_);
+		RegisterQueryPythonReplayState(plan.idx(), plan.udf_registrations_, plan.udf_actor_handles_,
+		                               plan.connection_snapshot_);
 		auto run_state = std::make_shared<PlanRunState>();
 		run_state->client_context = client_context;
 		run_state->py_conn_keepalive = std::move(py_conn_keepalive);
@@ -1781,7 +1827,8 @@ struct PyPhysicalPlanWrapperRunner {
 	                         duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
 	                             duckdb::distributed::python::ray::SafePyObject()) {
 		using namespace duckdb::distributed;
-		RememberQueryConnectionSnapshot(plan.idx(), plan.connection_snapshot_);
+		RegisterQueryPythonReplayState(plan.idx(), plan.udf_registrations_, plan.udf_actor_handles_,
+		                               plan.connection_snapshot_);
 		(void)py_conn_keepalive;
 		auto copy_started = std::chrono::steady_clock::now();
 		idx_t cleanup_ms = 0;
@@ -1815,7 +1862,6 @@ struct PyPhysicalPlanWrapperRunner {
 			auto cleanup_started = std::chrono::steady_clock::now();
 			try {
 				drop_query_fragments(plan.idx());
-				CleanupQueryPythonReplayState(plan.idx());
 			} catch (...) {
 				cleanup_error = std::current_exception();
 			}
@@ -1996,6 +2042,7 @@ struct PyPhysicalPlanWrapperRunner {
 	// Core implementation of execute_native that works with a raw PhysicalPlan pointer
 	py::object execute_native_impl(
 	    py::object conn_obj, std::shared_ptr<duckdb::PhysicalPlan> physical_plan, const string &plan_id,
+	    const string &resource_query_id,
 	    const std::unordered_map<idx_t, duckdb::distributed::ScanTaskDescriptor> *scan_task_map,
 	    const std::unordered_map<idx_t, duckdb::distributed::ExchangeSourceTaskDescriptor> *exchange_source_task_map =
 	        nullptr,
@@ -2027,7 +2074,7 @@ struct PyPhysicalPlanWrapperRunner {
 		if (!physical_plan || !physical_plan->HasRoot()) {
 			throw py::value_error("Physical plan is missing or has no root operator");
 		}
-		AssignDataSourceQueryOwner(physical_plan->Root(), plan_id);
+		AssignDataSourceQueryOwner(physical_plan->Root(), resource_query_id);
 
 		if (scan_task_map && !scan_task_map->empty()) {
 			string error;
@@ -2537,9 +2584,6 @@ struct PyPhysicalPlanWrapperRunner {
 
 	// Execute physical plan using DuckDB's native Executor (DistributedPhysicalPlan version)
 	py::object execute_native(py::object conn_obj, const PyPhysicalPlanWrapper &plan) {
-		auto cleanup = [&]() {
-			CleanupQueryPythonReplayState(plan.idx());
-		};
 		try {
 			auto &mutable_plan = const_cast<PyPhysicalPlanWrapper &>(plan);
 			py::object exec_conn = ResolveConnectionForSnapshot(conn_obj, plan.connection_snapshot_);
@@ -2551,12 +2595,11 @@ struct PyPhysicalPlanWrapperRunner {
 				throw py::value_error("DistributedPhysicalPlan is missing underlying physical plan");
 			}
 
-			auto result = execute_native_impl(exec_conn, plan.plan_->physical_plan(), plan.idx(), nullptr, nullptr,
-			                                  nullptr, nullptr, nullptr, nullptr, py::none(), py::none());
-			cleanup();
+			auto result =
+			    execute_native_impl(exec_conn, plan.plan_->physical_plan(), plan.idx(), plan.resource_query_id_,
+			                        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, py::none(), py::none());
 			return result;
 		} catch (...) {
-			cleanup();
 			throw;
 		}
 	}
@@ -2570,6 +2613,7 @@ static py::dict DescribeNativeProgress(py::object conn_obj, const PyPhysicalPlan
 	py::object exec_conn = ResolveConnectionForSnapshot(conn_obj, plan.connection_snapshot_);
 	PyPhysicalPlanWrapper topology_plan;
 	topology_plan.query_id_ = plan.idx();
+	topology_plan.resource_query_id_ = plan.resource_query_id_;
 	topology_plan.udf_registrations_ = plan.udf_registrations_;
 	topology_plan.udf_actor_handles_ = plan.udf_actor_handles_;
 	topology_plan.connection_snapshot_ = plan.connection_snapshot_;

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -846,7 +846,11 @@ struct PyPhysicalPlanWrapper {
 		if (!physical_plan || !physical_plan->HasRoot())
 			return result;
 
-		// Need query_id for pool name construction.
+		// The pool identity must include the connection session. Query IDs are
+		// normally unique, but they are caller-provided at this binding boundary;
+		// allowing the same query ID from another session to attach to an
+		// existing named actor would reuse that actor's session environment.
+		auto session_id = VaneSessionIdFromSnapshot(connection_snapshot_);
 		auto query_id = plan_->query_id();
 		if (query_id.empty()) {
 			query_id = std::to_string(plan_->idx());
@@ -869,8 +873,9 @@ struct PyPhysicalPlanWrapper {
 				idx_t node_id = vllm_counter++;
 
 				// Build pool name using the same sanitization as VLLMProjectNode.
+				auto safe_session = duckdb::distributed::SanitizePoolComponent(session_id);
 				auto safe_query = duckdb::distributed::SanitizePoolComponent(query_id);
-				auto pool_name = "duckdb_vllm_" + safe_query + "_" + std::to_string(node_id);
+				auto pool_name = "duckdb_vllm_" + safe_session + "_" + safe_query + "_" + std::to_string(node_id);
 
 				// Inject pool name into operator options so the translator
 				// propagates it to VLLMProjectNode → produce_tasks.

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -50,11 +50,11 @@ struct PyPhysicalPlanWrapper {
 		return plan_ && plan_->physical_plan() && plan_->physical_plan()->HasRoot();
 	}
 
-	void ensure_connection_snapshot(py::object conn_obj) const {
+	void ensure_connection_snapshot(py::object conn_obj, bool apply_session_config = true) const {
 		if (connection_snapshot_.is_none()) {
 			return;
 		}
-		ApplyConnectionSnapshot(conn_obj, connection_snapshot_);
+		ApplyConnectionSnapshot(conn_obj, connection_snapshot_, apply_session_config);
 	}
 
 	void apply_udf_actor_handles() {
@@ -126,14 +126,14 @@ struct PyPhysicalPlanWrapper {
 
 	// Materialize deferred serialized_root_ into the plan's PhysicalPlan.
 	// Requires a DuckDB connection for deserialization context.
-	void materialize_deferred_root(py::object conn_obj) {
+	void materialize_deferred_root(py::object conn_obj, bool apply_session_config = true) {
 		if (serialized_root_.empty())
 			return;
 		if (has_root())
 			return; // Already has a root
 
 		ensure_plan_identity();
-		ensure_connection_snapshot(conn_obj);
+		ensure_connection_snapshot(conn_obj, apply_session_config);
 
 		auto &py_conn = ExtractPyConnectionWrapper(conn_obj);
 		auto &db_conn = py_conn.con.GetConnection();
@@ -291,6 +291,10 @@ struct PyPhysicalPlanWrapper {
 
 	py::dict session_config() const {
 		return VaneSessionConfigFromSnapshot(connection_snapshot_);
+	}
+
+	bool has_explicit_s3_credentials() const {
+		return HasExplicitS3CredentialsFromSnapshot(connection_snapshot_);
 	}
 
 	size_t num_partitions() const {
@@ -934,7 +938,7 @@ struct PyPhysicalPlanWrapper {
 	}
 };
 
-PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj) const {
+PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj, py::object effective_session_config) const {
 	if (conn_obj.is_none()) {
 		throw duckdb::InternalException("Connection is required for to_physical_plan");
 	}
@@ -950,7 +954,11 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj) const
 
 	py::object planning_conn = ResolveConnectionForSnapshot(conn_obj, connection_snapshot_);
 	auto &conn_wrapper = ExtractPyConnectionWrapper(planning_conn);
-	ApplyConnectionSnapshot(planning_conn, connection_snapshot_);
+	// Resolved environment/profile credentials are the session baseline. Replay
+	// the source connection last so an explicit SET on that connection keeps
+	// DuckDB's normal explicit-config-over-environment precedence.
+	ApplyEffectiveVaneSessionConfig(conn_wrapper.con.GetConnection(), effective_session_config);
+	ApplyConnectionSnapshot(planning_conn, connection_snapshot_, effective_session_config.is_none());
 	if (!udf_registrations_.is_none()) {
 		conn_wrapper.ApplyDistributedPythonUDFRegistrations(udf_registrations_);
 	}
@@ -1724,7 +1732,7 @@ struct PyPhysicalPlanWrapperRunner {
 	                                                duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
 	                                                    duckdb::distributed::python::ray::SafePyObject()) {
 		using namespace duckdb::distributed;
-		RegisterQueryPythonReplayState(plan.idx(), plan.udf_registrations_, plan.udf_actor_handles_,
+		RegisterQueryPythonReplayState(plan.resource_query_id_, plan.udf_registrations_, plan.udf_actor_handles_,
 		                               plan.connection_snapshot_);
 		auto run_state = std::make_shared<PlanRunState>();
 		run_state->client_context = client_context;
@@ -1827,7 +1835,7 @@ struct PyPhysicalPlanWrapperRunner {
 	                         duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
 	                             duckdb::distributed::python::ray::SafePyObject()) {
 		using namespace duckdb::distributed;
-		RegisterQueryPythonReplayState(plan.idx(), plan.udf_registrations_, plan.udf_actor_handles_,
+		RegisterQueryPythonReplayState(plan.resource_query_id_, plan.udf_registrations_, plan.udf_actor_handles_,
 		                               plan.connection_snapshot_);
 		(void)py_conn_keepalive;
 		auto copy_started = std::chrono::steady_clock::now();

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -20,8 +20,9 @@ struct PyLogicalPlan {
 
 	string session_id() const;
 	py::dict session_config() const;
+	bool has_explicit_s3_credentials() const;
 
-	PyPhysicalPlanWrapper to_physical_plan(py::object conn_obj) const;
+	PyPhysicalPlanWrapper to_physical_plan(py::object conn_obj, py::object effective_session_config) const;
 };
 
 static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::Relation> &rel) {
@@ -127,6 +128,50 @@ static py::dict VaneSessionConfigFromSnapshot(const py::object &snapshot_obj) {
 		throw duckdb::InvalidInputException("Connection snapshot Vane session config must be a dict");
 	}
 	return CopyPyDict(session[py::str("config")].cast<py::dict>());
+}
+
+static bool HasExplicitS3CredentialsFromSnapshot(const py::object &snapshot_obj) {
+	if (snapshot_obj.is_none() || !py::isinstance<py::dict>(snapshot_obj)) {
+		throw duckdb::InvalidInputException("Connection snapshot is missing the required Vane session");
+	}
+	auto snapshot = snapshot_obj.cast<py::dict>();
+	if (!snapshot.contains(py::str("settings")) || !py::isinstance<py::list>(snapshot[py::str("settings")])) {
+		return false;
+	}
+	bool has_access_key = false;
+	bool has_secret_key = false;
+	bool has_session_token = false;
+	string access_key;
+	string secret_key;
+	string session_token;
+	for (auto item : snapshot[py::str("settings")].cast<py::list>()) {
+		if (!py::isinstance<py::dict>(item)) {
+			continue;
+		}
+		auto setting = py::reinterpret_borrow<py::dict>(item);
+		if (!setting.contains(py::str("name")) || !setting.contains(py::str("value"))) {
+			continue;
+		}
+		auto name = duckdb::StringUtil::Lower(py::str(setting[py::str("name")]).cast<string>());
+		if (name == "s3_access_key_id") {
+			has_access_key = true;
+			access_key = py::str(setting[py::str("value")]).cast<string>();
+		} else if (name == "s3_secret_access_key") {
+			has_secret_key = true;
+			secret_key = py::str(setting[py::str("value")]).cast<string>();
+		} else if (name == "s3_session_token") {
+			has_session_token = true;
+			session_token = py::str(setting[py::str("value")]).cast<string>();
+		}
+	}
+	const bool has_access_key_value = !access_key.empty();
+	const bool has_secret_key_value = !secret_key.empty();
+	if (has_access_key != has_secret_key || has_access_key_value != has_secret_key_value ||
+	    (has_session_token && !session_token.empty() && !has_access_key_value)) {
+		throw duckdb::InvalidInputException(
+		    "Explicit DuckDB S3 credentials must set both s3_access_key_id and s3_secret_access_key");
+	}
+	return has_access_key;
 }
 
 static bool IsDefaultBootstrapSnapshot(const py::object &bootstrap_obj) {
@@ -249,6 +294,7 @@ struct ConnectionSettingRecord {
 	string name;
 	string value;
 	string input_type;
+	string scope;
 };
 
 static bool ShouldSkipConnectionSettingSnapshot(const string &name, const string &input_type) {
@@ -273,6 +319,15 @@ static bool IsNumericConnectionSettingType(const string &input_type) {
 	    "USMALLINT", "UINTEGER", "UBIGINT", "FLOAT",  "DOUBLE",  "DECIMAL",
 	};
 	return numeric_types.find(duckdb::StringUtil::Upper(input_type)) != numeric_types.end();
+}
+
+static bool IsVaneSessionBaselineConnectionSetting(const string &name) {
+	static const std::unordered_set<string> names {
+	    "http_keep_alive",  "http_retries", "http_retry_backoff", "http_retry_wait_ms",
+	    "s3_access_key_id", "s3_endpoint",  "s3_region",          "s3_secret_access_key",
+	    "s3_session_token", "s3_url_style", "s3_use_ssl",
+	};
+	return names.find(duckdb::StringUtil::Lower(name)) != names.end();
 }
 
 static string QuoteSQLStringLiteral(const string &value) {
@@ -349,8 +404,7 @@ static string VaneSessionConfigValue(const py::dict &config, const char *key) {
 	return py::str(config[py_key]).cast<string>();
 }
 
-static void ApplyVaneSessionConfig(duckdb::Connection &conn, const py::object &snapshot_obj) {
-	auto config = VaneSessionConfigFromSnapshot(snapshot_obj);
+static void ApplyVaneSessionConfigValues(duckdb::Connection &conn, const py::dict &config) {
 	auto endpoint_url = VaneSessionConfigValue(config, "AWS_ENDPOINT_URL");
 	auto access_key = VaneSessionConfigValue(config, "AWS_ACCESS_KEY_ID");
 	auto secret_key = VaneSessionConfigValue(config, "AWS_SECRET_ACCESS_KEY");
@@ -373,7 +427,7 @@ static void ApplyVaneSessionConfig(duckdb::Connection &conn, const py::object &s
 	if (!secret_key.empty()) {
 		ExecuteSnapshotQuery(conn, "SET s3_secret_access_key=" + QuoteSQLStringLiteral(secret_key));
 	}
-	if (!session_token.empty()) {
+	if (!access_key.empty() || !secret_key.empty() || !session_token.empty()) {
 		ExecuteSnapshotQuery(conn, "SET s3_session_token=" + QuoteSQLStringLiteral(session_token));
 	}
 	if (!endpoint_url.empty()) {
@@ -386,6 +440,20 @@ static void ApplyVaneSessionConfig(duckdb::Connection &conn, const py::object &s
 	ExecuteSnapshotQuery(conn, "SET http_retries=10");
 	ExecuteSnapshotQuery(conn, "SET http_retry_wait_ms=100");
 	ExecuteSnapshotQuery(conn, "SET http_retry_backoff=1.5");
+}
+
+static void ApplyVaneSessionConfig(duckdb::Connection &conn, const py::object &snapshot_obj) {
+	ApplyVaneSessionConfigValues(conn, VaneSessionConfigFromSnapshot(snapshot_obj));
+}
+
+static void ApplyEffectiveVaneSessionConfig(duckdb::Connection &conn, const py::object &config_obj) {
+	if (config_obj.is_none()) {
+		return;
+	}
+	if (!py::isinstance<py::dict>(config_obj)) {
+		throw duckdb::InvalidInputException("Effective Vane session config must be a dict");
+	}
+	ApplyVaneSessionConfigValues(conn, config_obj.cast<py::dict>());
 }
 
 static std::vector<string> QueryLoadedExtensionNames(DuckDBPyConnection &conn_wrapper) {
@@ -412,7 +480,7 @@ static std::vector<string> QueryLoadedExtensionNames(DuckDBPyConnection &conn_wr
 
 static std::vector<ConnectionSettingRecord> QueryConnectionSettings(DuckDBPyConnection &conn_wrapper) {
 	std::vector<ConnectionSettingRecord> settings;
-	auto result = ExecuteSnapshotQuery(conn_wrapper.con.GetConnection(), "SELECT name, value, input_type "
+	auto result = ExecuteSnapshotQuery(conn_wrapper.con.GetConnection(), "SELECT name, value, input_type, scope "
 	                                                                     "FROM duckdb_settings() "
 	                                                                     "ORDER BY name");
 	auto &collection = result->Collection();
@@ -422,12 +490,14 @@ static std::vector<ConnectionSettingRecord> QueryConnectionSettings(DuckDBPyConn
 		auto name_val = row.GetValue(0);
 		auto value_val = row.GetValue(1);
 		auto input_type_val = row.GetValue(2);
-		if (name_val.IsNull() || input_type_val.IsNull()) {
+		auto scope_val = row.GetValue(3);
+		if (name_val.IsNull() || input_type_val.IsNull() || scope_val.IsNull()) {
 			continue;
 		}
 		record.name = name_val.ToString();
 		record.value = value_val.IsNull() ? string() : value_val.ToString();
 		record.input_type = input_type_val.ToString();
+		record.scope = scope_val.ToString();
 		settings.push_back(std::move(record));
 	}
 	return settings;
@@ -449,17 +519,14 @@ static void TryLoadSnapshotExtension(DuckDBPyConnection &conn_wrapper, const str
 }
 
 static bool VaneRaySessionLifecycleEnabled() {
-	auto environ = py::module_::import("os").attr("environ");
-	auto runner = py::str(environ.attr("get")(py::str("VANE_RUNNER"), py::str(""))).cast<string>();
+	auto duckdb_module = py::module_::import("duckdb");
+	auto runner = py::str(duckdb_module.attr("vane_runners_cpp").attr("get_or_infer_runner_type")()).cast<string>();
 	duckdb::StringUtil::Trim(runner);
 	runner = duckdb::StringUtil::Lower(runner);
-	return runner.empty() || runner == "ray";
+	return runner == "ray";
 }
 
 static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
-	if (VaneRaySessionLifecycleEnabled()) {
-		conn_wrapper.MarkVaneRaySessionOpened();
-	}
 	auto bootstrap_obj = conn_wrapper.ExportConnectionBootstrapConfig();
 	auto loaded_extensions = QueryLoadedExtensionNames(conn_wrapper);
 	auto source_settings = QueryConnectionSettings(conn_wrapper);
@@ -488,7 +555,10 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 		}
 		auto lower_name = duckdb::StringUtil::Lower(record.name);
 		auto entry = default_setting_values.find(lower_name);
-		if (entry != default_setting_values.end() && entry->second == record.value) {
+		auto explicitly_local_session_override =
+		    duckdb::StringUtil::Lower(record.scope) == "local" && IsVaneSessionBaselineConnectionSetting(record.name);
+		if (!explicitly_local_session_override && entry != default_setting_values.end() &&
+		    entry->second == record.value) {
 			continue;
 		}
 		py::dict setting_obj;
@@ -509,10 +579,14 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 	}
 	snapshot_obj[py::str("extensions")] = std::move(extensions_obj);
 	snapshot_obj[py::str("settings")] = std::move(settings_obj);
+	if (VaneRaySessionLifecycleEnabled()) {
+		conn_wrapper.MarkVaneRaySessionOpened();
+	}
 	return snapshot_obj;
 }
 
-static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snapshot_obj) {
+static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snapshot_obj,
+                                    bool apply_session_config = true) {
 	if (snapshot_obj.is_none()) {
 		return;
 	}
@@ -534,7 +608,9 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 			}
 		}
 	}
-	ApplyVaneSessionConfig(conn_wrapper.con.GetConnection(), snapshot_obj);
+	if (apply_session_config) {
+		ApplyVaneSessionConfig(conn_wrapper.con.GetConnection(), snapshot_obj);
+	}
 
 	if (!snapshot.contains(py::str("settings"))) {
 		return;
@@ -576,6 +652,10 @@ string PyLogicalPlan::session_id() const {
 
 py::dict PyLogicalPlan::session_config() const {
 	return VaneSessionConfigFromSnapshot(connection_snapshot_);
+}
+
+bool PyLogicalPlan::has_explicit_s3_credentials() const {
+	return HasExplicitS3CredentialsFromSnapshot(connection_snapshot_);
 }
 
 enum class QueryPythonReplayField : uint8_t {

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -18,6 +18,9 @@ struct PyLogicalPlan {
 		return query_id_;
 	}
 
+	string session_id() const;
+	py::dict session_config() const;
+
 	PyPhysicalPlanWrapper to_physical_plan(py::object conn_obj) const;
 };
 
@@ -90,6 +93,40 @@ static py::object LookupBootstrapSnapshot(const py::object &snapshot_obj) {
 		return py::none();
 	}
 	return bootstrap_obj;
+}
+
+static py::dict LookupVaneSessionSnapshot(const py::object &snapshot_obj) {
+	if (snapshot_obj.is_none() || !py::isinstance<py::dict>(snapshot_obj)) {
+		throw duckdb::InvalidInputException("Connection snapshot is missing the required Vane session");
+	}
+	auto snapshot = snapshot_obj.cast<py::dict>();
+	if (!snapshot.contains(py::str("vane_session")) || !py::isinstance<py::dict>(snapshot[py::str("vane_session")])) {
+		throw duckdb::InvalidInputException("Connection snapshot is missing the required Vane session");
+	}
+	return snapshot[py::str("vane_session")].cast<py::dict>();
+}
+
+static string VaneSessionIdFromSnapshot(const py::object &snapshot_obj) {
+	auto session = LookupVaneSessionSnapshot(snapshot_obj);
+	if (!session.contains(py::str("id")) || session[py::str("id")].is_none()) {
+		throw duckdb::InvalidInputException("Connection snapshot Vane session is missing id");
+	}
+	auto session_id = py::str(session[py::str("id")]).cast<string>();
+	if (session_id.empty()) {
+		throw duckdb::InvalidInputException("Connection snapshot Vane session id must not be empty");
+	}
+	return session_id;
+}
+
+static py::dict VaneSessionConfigFromSnapshot(const py::object &snapshot_obj) {
+	auto session = LookupVaneSessionSnapshot(snapshot_obj);
+	if (!session.contains(py::str("config")) || session[py::str("config")].is_none()) {
+		throw duckdb::InvalidInputException("Connection snapshot Vane session is missing config");
+	}
+	if (!py::isinstance<py::dict>(session[py::str("config")])) {
+		throw duckdb::InvalidInputException("Connection snapshot Vane session config must be a dict");
+	}
+	return CopyPyDict(session[py::str("config")].cast<py::dict>());
 }
 
 static bool IsDefaultBootstrapSnapshot(const py::object &bootstrap_obj) {
@@ -188,12 +225,25 @@ static py::object ResolveConnectionForSnapshot(py::object conn_obj, const py::ob
 	return CreateConnectionFromBootstrapSnapshot(bootstrap_obj);
 }
 
-static std::mutex g_query_udf_registrations_lock;
-static std::unordered_map<string, duckdb::distributed::python::ray::SafePyObject> g_query_udf_registrations;
-static std::mutex g_query_udf_actor_handles_lock;
-static std::unordered_map<string, duckdb::distributed::python::ray::SafePyObject> g_query_udf_actor_handles;
-static std::mutex g_query_connection_snapshots_lock;
-static std::unordered_map<string, duckdb::distributed::python::ray::SafePyObject> g_query_connection_snapshots;
+struct QueryPythonReplayState {
+	string session_id;
+	duckdb::distributed::python::ray::SafePyObject session_config;
+	duckdb::distributed::python::ray::SafePyObject udf_registrations;
+	duckdb::distributed::python::ray::SafePyObject udf_actor_handles;
+	duckdb::distributed::python::ray::SafePyObject connection_snapshot;
+
+	QueryPythonReplayState(string session_id_p, py::object session_config_p, py::object udf_registrations_p,
+	                       py::object udf_actor_handles_p, py::object connection_snapshot_p)
+	    : session_id(std::move(session_id_p)),
+	      session_config(duckdb::distributed::python::ray::SafePyObject(std::move(session_config_p))),
+	      udf_registrations(duckdb::distributed::python::ray::SafePyObject(std::move(udf_registrations_p))),
+	      udf_actor_handles(duckdb::distributed::python::ray::SafePyObject(std::move(udf_actor_handles_p))),
+	      connection_snapshot(duckdb::distributed::python::ray::SafePyObject(std::move(connection_snapshot_p))) {
+	}
+};
+
+static std::mutex g_query_python_replay_states_lock;
+static std::unordered_map<string, std::unique_ptr<QueryPythonReplayState>> g_query_python_replay_states;
 
 struct ConnectionSettingRecord {
 	string name;
@@ -291,6 +341,53 @@ static void ConfigureConnectionForS3Endpoint(duckdb::Connection &conn, const str
 	                               "URL_STYLE 'path')");
 }
 
+static string VaneSessionConfigValue(const py::dict &config, const char *key) {
+	auto py_key = py::str(key);
+	if (!config.contains(py_key) || config[py_key].is_none()) {
+		return string();
+	}
+	return py::str(config[py_key]).cast<string>();
+}
+
+static void ApplyVaneSessionConfig(duckdb::Connection &conn, const py::object &snapshot_obj) {
+	auto config = VaneSessionConfigFromSnapshot(snapshot_obj);
+	auto endpoint_url = VaneSessionConfigValue(config, "AWS_ENDPOINT_URL");
+	auto access_key = VaneSessionConfigValue(config, "AWS_ACCESS_KEY_ID");
+	auto secret_key = VaneSessionConfigValue(config, "AWS_SECRET_ACCESS_KEY");
+	auto session_token = VaneSessionConfigValue(config, "AWS_SESSION_TOKEN");
+	auto region = VaneSessionConfigValue(config, "AWS_REGION");
+	if (region.empty()) {
+		region = VaneSessionConfigValue(config, "AWS_DEFAULT_REGION");
+	}
+	if (endpoint_url.empty() && access_key.empty() && secret_key.empty() && session_token.empty() && region.empty()) {
+		return;
+	}
+
+	ExecuteSnapshotQuery(conn, "LOAD httpfs");
+	if (!region.empty()) {
+		ExecuteSnapshotQuery(conn, "SET s3_region=" + QuoteSQLStringLiteral(region));
+	}
+	if (!access_key.empty()) {
+		ExecuteSnapshotQuery(conn, "SET s3_access_key_id=" + QuoteSQLStringLiteral(access_key));
+	}
+	if (!secret_key.empty()) {
+		ExecuteSnapshotQuery(conn, "SET s3_secret_access_key=" + QuoteSQLStringLiteral(secret_key));
+	}
+	if (!session_token.empty()) {
+		ExecuteSnapshotQuery(conn, "SET s3_session_token=" + QuoteSQLStringLiteral(session_token));
+	}
+	if (!endpoint_url.empty()) {
+		ExecuteSnapshotQuery(conn,
+		                     "SET s3_endpoint=" + QuoteSQLStringLiteral(StripS3EndpointSchemeForDuckDB(endpoint_url)));
+		ExecuteSnapshotQuery(conn, string("SET s3_use_ssl=") + (S3EndpointUsesSSL(endpoint_url) ? "true" : "false"));
+		ExecuteSnapshotQuery(conn, "SET s3_url_style='path'");
+	}
+	ExecuteSnapshotQuery(conn, "SET http_keep_alive=true");
+	ExecuteSnapshotQuery(conn, "SET http_retries=10");
+	ExecuteSnapshotQuery(conn, "SET http_retry_wait_ms=100");
+	ExecuteSnapshotQuery(conn, "SET http_retry_backoff=1.5");
+}
+
 static std::vector<string> QueryLoadedExtensionNames(DuckDBPyConnection &conn_wrapper) {
 	std::vector<string> extensions;
 	auto result =
@@ -351,7 +448,18 @@ static void TryLoadSnapshotExtension(DuckDBPyConnection &conn_wrapper, const str
 	ExecuteSnapshotQuery(conn, "LOAD " + extension_name);
 }
 
+static bool VaneRaySessionLifecycleEnabled() {
+	auto environ = py::module_::import("os").attr("environ");
+	auto runner = py::str(environ.attr("get")(py::str("VANE_RUNNER"), py::str(""))).cast<string>();
+	duckdb::StringUtil::Trim(runner);
+	runner = duckdb::StringUtil::Lower(runner);
+	return runner.empty() || runner == "ray";
+}
+
 static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
+	if (VaneRaySessionLifecycleEnabled()) {
+		conn_wrapper.MarkVaneRaySessionOpened();
+	}
 	auto bootstrap_obj = conn_wrapper.ExportConnectionBootstrapConfig();
 	auto loaded_extensions = QueryLoadedExtensionNames(conn_wrapper);
 	auto source_settings = QueryConnectionSettings(conn_wrapper);
@@ -391,11 +499,11 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 	}
 
 	bool has_bootstrap = !IsDefaultBootstrapSnapshot(bootstrap_obj);
-	if (!has_bootstrap && py::len(extensions_obj) == 0 && py::len(settings_obj) == 0) {
-		return py::none();
-	}
-
 	py::dict snapshot_obj;
+	py::dict session_obj;
+	session_obj[py::str("id")] = py::str(conn_wrapper.GetVaneSessionId());
+	session_obj[py::str("config")] = conn_wrapper.ExportVaneSessionConfig();
+	snapshot_obj[py::str("vane_session")] = std::move(session_obj);
 	if (has_bootstrap) {
 		snapshot_obj[py::str("bootstrap")] = NormalizeBootstrapSnapshot(bootstrap_obj);
 	}
@@ -426,6 +534,7 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 			}
 		}
 	}
+	ApplyVaneSessionConfig(conn_wrapper.con.GetConnection(), snapshot_obj);
 
 	if (!snapshot.contains(py::str("settings"))) {
 		return;
@@ -461,109 +570,100 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 	}
 }
 
-static void RememberQueryUDFRegistrations(const string &query_id, const py::object &registrations) {
-	if (query_id.empty() || registrations.is_none()) {
-		return;
+string PyLogicalPlan::session_id() const {
+	return VaneSessionIdFromSnapshot(connection_snapshot_);
+}
+
+py::dict PyLogicalPlan::session_config() const {
+	return VaneSessionConfigFromSnapshot(connection_snapshot_);
+}
+
+enum class QueryPythonReplayField : uint8_t {
+	UDFRegistrations,
+	UDFActorHandles,
+	ConnectionSnapshot,
+};
+
+static py::object LookupQueryPythonReplayState(const string &query_id, QueryPythonReplayField field) {
+	if (query_id.empty()) {
+		return py::none();
 	}
-	std::lock_guard<std::mutex> guard(g_query_udf_registrations_lock);
-	g_query_udf_registrations[query_id] = duckdb::distributed::python::ray::SafePyObject(registrations);
+	std::lock_guard<std::mutex> guard(g_query_python_replay_states_lock);
+	auto entry = g_query_python_replay_states.find(query_id);
+	if (entry == g_query_python_replay_states.end()) {
+		return py::none();
+	}
+	switch (field) {
+	case QueryPythonReplayField::UDFRegistrations:
+		return entry->second->udf_registrations.get();
+	case QueryPythonReplayField::UDFActorHandles:
+		return entry->second->udf_actor_handles.get();
+	case QueryPythonReplayField::ConnectionSnapshot:
+		return entry->second->connection_snapshot.get();
+	default:
+		throw duckdb::InternalException("Unknown query Python replay field");
+	}
+}
+
+static bool RegisterQueryPythonReplayState(const string &query_id, const py::object &udf_registrations,
+                                           const py::object &udf_actor_handles, const py::object &connection_snapshot) {
+	if (query_id.empty()) {
+		throw duckdb::InternalException("Query Python replay state requires a non-empty query_id");
+	}
+	auto session_id = VaneSessionIdFromSnapshot(connection_snapshot);
+	py::object session_config = VaneSessionConfigFromSnapshot(connection_snapshot);
+	std::lock_guard<std::mutex> guard(g_query_python_replay_states_lock);
+	auto entry = g_query_python_replay_states.find(query_id);
+	if (entry == g_query_python_replay_states.end()) {
+		g_query_python_replay_states.emplace(query_id, std::make_unique<QueryPythonReplayState>(
+		                                                   std::move(session_id), std::move(session_config),
+		                                                   py::reinterpret_borrow<py::object>(udf_registrations),
+		                                                   py::reinterpret_borrow<py::object>(udf_actor_handles),
+		                                                   py::reinterpret_borrow<py::object>(connection_snapshot)));
+		return true;
+	}
+	auto &state = *entry->second;
+	if (state.session_id != session_id || !PythonObjectsEqual(state.session_config.get(), session_config)) {
+		throw duckdb::InvalidInputException("Query " + query_id + " was registered with a different Vane session");
+	}
+	if (!PythonObjectsEqual(state.connection_snapshot.get(), connection_snapshot)) {
+		throw duckdb::InvalidInputException("Query " + query_id +
+		                                    " was registered with a different connection snapshot");
+	}
+	if (!PythonObjectsEqual(state.udf_registrations.get(), udf_registrations)) {
+		throw duckdb::InvalidInputException("Query " + query_id +
+		                                    " was registered with different Python UDF registrations");
+	}
+	if (!PythonObjectsEqual(state.udf_actor_handles.get(), udf_actor_handles)) {
+		throw duckdb::InvalidInputException("Query " + query_id +
+		                                    " was registered with different Python UDF actor handles");
+	}
+	return false;
 }
 
 static py::object LookupQueryUDFRegistrations(const string &query_id) {
-	if (query_id.empty()) {
-		return py::none();
-	}
-	std::lock_guard<std::mutex> guard(g_query_udf_registrations_lock);
-	auto entry = g_query_udf_registrations.find(query_id);
-	if (entry == g_query_udf_registrations.end()) {
-		return py::none();
-	}
-	return entry->second.get();
-}
-
-static void ForgetQueryUDFRegistrations(const string &query_id) {
-	if (query_id.empty()) {
-		return;
-	}
-	std::lock_guard<std::mutex> guard(g_query_udf_registrations_lock);
-	g_query_udf_registrations.erase(query_id);
-}
-
-static void RememberQueryConnectionSnapshot(const string &query_id, const py::object &snapshot) {
-	if (query_id.empty() || snapshot.is_none()) {
-		return;
-	}
-	std::lock_guard<std::mutex> guard(g_query_connection_snapshots_lock);
-	g_query_connection_snapshots[query_id] = duckdb::distributed::python::ray::SafePyObject(snapshot);
+	return LookupQueryPythonReplayState(query_id, QueryPythonReplayField::UDFRegistrations);
 }
 
 static py::object LookupQueryConnectionSnapshot(const string &query_id) {
-	if (query_id.empty()) {
-		return py::none();
-	}
-	std::lock_guard<std::mutex> guard(g_query_connection_snapshots_lock);
-	auto entry = g_query_connection_snapshots.find(query_id);
-	if (entry == g_query_connection_snapshots.end()) {
-		return py::none();
-	}
-	return entry->second.get();
-}
-
-static void ForgetQueryConnectionSnapshot(const string &query_id) {
-	if (query_id.empty()) {
-		return;
-	}
-	std::lock_guard<std::mutex> guard(g_query_connection_snapshots_lock);
-	g_query_connection_snapshots.erase(query_id);
-}
-
-static void RememberQueryUDFActorHandles(const string &query_id, const py::object &handles_map) {
-	if (query_id.empty() || handles_map.is_none()) {
-		return;
-	}
-	std::lock_guard<std::mutex> guard(g_query_udf_actor_handles_lock);
-	g_query_udf_actor_handles[query_id] = duckdb::distributed::python::ray::SafePyObject(handles_map);
+	return LookupQueryPythonReplayState(query_id, QueryPythonReplayField::ConnectionSnapshot);
 }
 
 static py::object LookupQueryUDFActorHandles(const string &query_id) {
-	if (query_id.empty()) {
-		return py::none();
-	}
-	std::lock_guard<std::mutex> guard(g_query_udf_actor_handles_lock);
-	auto entry = g_query_udf_actor_handles.find(query_id);
-	if (entry == g_query_udf_actor_handles.end()) {
-		return py::none();
-	}
-	return entry->second.get();
-}
-
-static void ForgetQueryUDFActorHandles(const string &query_id) {
-	if (query_id.empty()) {
-		return;
-	}
-	std::lock_guard<std::mutex> guard(g_query_udf_actor_handles_lock);
-	g_query_udf_actor_handles.erase(query_id);
+	return LookupQueryPythonReplayState(query_id, QueryPythonReplayField::UDFActorHandles);
 }
 
 static void CleanupQueryPythonReplayState(const string &query_id) {
-	ForgetQueryUDFRegistrations(query_id);
-	ForgetQueryUDFActorHandles(query_id);
-	ForgetQueryConnectionSnapshot(query_id);
+	if (query_id.empty()) {
+		return;
+	}
+	std::lock_guard<std::mutex> guard(g_query_python_replay_states_lock);
+	g_query_python_replay_states.erase(query_id);
 }
 
 static void CleanupAllQueryPythonReplayState() {
-	{
-		std::lock_guard<std::mutex> guard(g_query_udf_registrations_lock);
-		g_query_udf_registrations.clear();
-	}
-	{
-		std::lock_guard<std::mutex> guard(g_query_udf_actor_handles_lock);
-		g_query_udf_actor_handles.clear();
-	}
-	{
-		std::lock_guard<std::mutex> guard(g_query_connection_snapshots_lock);
-		g_query_connection_snapshots.clear();
-	}
+	std::lock_guard<std::mutex> guard(g_query_python_replay_states_lock);
+	g_query_python_replay_states.clear();
 }
 
 static duckdb::unique_ptr<duckdb::LogicalOperator>

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -414,8 +414,8 @@ void register_ray_bindings(py::module_ &mod) {
 	// Wraps a raw PhysicalPlan in a DistributedPhysicalPlan for unified execution.
 	m.def(
 	    "_create_physical_plan_from_capsule",
-	    [](py::capsule capsule, py::object query_id_obj, py::object udf_registrations_obj,
-	       py::object udf_actor_handles_obj, py::object connection_snapshot_obj) {
+	    [](py::capsule capsule, py::object query_id_obj, py::object resource_query_id_obj,
+	       py::object udf_registrations_obj, py::object udf_actor_handles_obj, py::object connection_snapshot_obj) {
 		    auto *plan_ptr = static_cast<std::shared_ptr<duckdb::PhysicalPlan> *>(capsule.get_pointer());
 		    if (!plan_ptr || !*plan_ptr) {
 			    return PyPhysicalPlanWrapper();
@@ -429,21 +429,31 @@ void register_ray_bindings(py::module_ &mod) {
 		    if (query_id.empty()) {
 			    throw duckdb::InternalException("_create_physical_plan_from_capsule requires a non-empty query_id");
 		    }
+		    if (resource_query_id_obj.is_none()) {
+			    throw duckdb::InternalException(
+			        "_create_physical_plan_from_capsule requires a non-empty resource_query_id");
+		    }
+		    auto resource_query_id = resource_query_id_obj.cast<string>();
+		    if (resource_query_id.empty()) {
+			    throw duckdb::InternalException(
+			        "_create_physical_plan_from_capsule requires a non-empty resource_query_id");
+		    }
 		    auto cfg = std::make_shared<duckdb::distributed::DuckDBExecutionConfig>(
 		        duckdb::distributed::DuckDBExecutionConfig::from_env());
 		    auto distributed_plan =
 		        std::make_shared<duckdb::distributed::DistributedPhysicalPlan>(idx, query_id, *plan_ptr, cfg);
-		    auto result = PyPhysicalPlanWrapper(distributed_plan);
+		    auto result = PyPhysicalPlanWrapper(distributed_plan, resource_query_id);
 		    result.query_id_ = query_id;
 		    result.udf_registrations_ = udf_registrations_obj;
 		    result.udf_actor_handles_ = udf_actor_handles_obj;
 		    result.connection_snapshot_ = connection_snapshot_obj;
-		    RememberQueryUDFRegistrations(result.query_id_, result.udf_registrations_);
-		    RememberQueryUDFActorHandles(result.query_id_, result.udf_actor_handles_);
+		    (void)VaneSessionIdFromSnapshot(result.connection_snapshot_);
+		    (void)VaneSessionConfigFromSnapshot(result.connection_snapshot_);
 		    return result;
 	    },
-	    py::arg("capsule"), py::arg("query_id") = py::none(), py::arg("udf_registrations") = py::none(),
-	    py::arg("udf_actor_handles") = py::none(), py::arg("connection_snapshot") = py::none(),
+	    py::arg("capsule"), py::arg("query_id") = py::none(), py::arg("resource_query_id") = py::none(),
+	    py::arg("udf_registrations") = py::none(), py::arg("udf_actor_handles") = py::none(),
+	    py::arg("connection_snapshot") = py::none(),
 	    "Internal helper to create PyPhysicalPlanWrapper from C++ capsule");
 
 	m.def(
@@ -457,6 +467,23 @@ void register_ray_bindings(py::module_ &mod) {
 	m.def(
 	    "_lookup_query_connection_snapshot",
 	    [](const string &query_id) { return LookupQueryConnectionSnapshot(query_id); }, py::arg("query_id"));
+
+	m.def(
+	    "_register_query_python_replay_state",
+	    [](const string &query_id, const PyPhysicalPlanWrapper &plan) {
+		    if (query_id.empty()) {
+			    throw duckdb::InternalException("Query Python replay registration requires a non-empty query_id");
+		    }
+		    // The resource query owns this lifecycle. A retried FTE task can carry a
+		    // physical plan created under a different source plan identifier.
+		    return RegisterQueryPythonReplayState(query_id, plan.udf_registrations_, plan.udf_actor_handles_,
+		                                          plan.connection_snapshot_);
+	    },
+	    py::arg("query_id"), py::arg("plan"));
+
+	m.def(
+	    "_cleanup_query_python_replay_state", [](const string &query_id) { CleanupQueryPythonReplayState(query_id); },
+	    py::arg("query_id"));
 
 	m.def(
 	    "begin_flight_shuffle_query_execution",
@@ -561,6 +588,9 @@ void register_ray_bindings(py::module_ &mod) {
 
 	py::class_<PyPhysicalPlanWrapper>(m, "DistributedPhysicalPlan")
 	    .def("idx", &PyPhysicalPlanWrapper::idx)
+	    .def("resource_query_id", &PyPhysicalPlanWrapper::resource_query_id)
+	    .def("session_id", &PyPhysicalPlanWrapper::session_id)
+	    .def("session_config", &PyPhysicalPlanWrapper::session_config)
 	    .def("has_root", &PyPhysicalPlanWrapper::has_root)
 	    .def("clone", &PyPhysicalPlanWrapper::clone, py::arg("conn") = py::none())
 	    .def("num_partitions", &PyPhysicalPlanWrapper::num_partitions)
@@ -583,20 +613,20 @@ void register_ray_bindings(py::module_ &mod) {
 		        // or deferred root must always carry a non-empty payload.
 		        if (!p.has_root()) {
 			        if (!p.serialized_root_.empty()) {
-				        return py::make_tuple(true, py::bytes(p.serialized_root_), p.query_id_, p.udf_registrations_,
-				                              p.udf_actor_handles_, p.connection_snapshot_);
+				        return py::make_tuple(true, py::bytes(p.serialized_root_), p.query_id_, p.resource_query_id_,
+				                              p.udf_registrations_, p.udf_actor_handles_, p.connection_snapshot_);
 			        }
-			        return py::make_tuple(false, py::bytes(""), p.query_id_, p.udf_registrations_, p.udf_actor_handles_,
-			                              p.connection_snapshot_);
+			        return py::make_tuple(false, py::bytes(""), p.query_id_, p.resource_query_id_, p.udf_registrations_,
+			                              p.udf_actor_handles_, p.connection_snapshot_);
 		        }
 
 		        auto serialized_root = p.serialize_root_for_clone();
-		        return py::make_tuple(true, py::bytes(serialized_root), p.query_id_, p.udf_registrations_,
-		                              p.udf_actor_handles_, p.connection_snapshot_);
+		        return py::make_tuple(true, py::bytes(serialized_root), p.query_id_, p.resource_query_id_,
+		                              p.udf_registrations_, p.udf_actor_handles_, p.connection_snapshot_);
 	        },
 	        // __setstate__: store deferred bytes for later deserialization
 	        [](py::tuple t) {
-		        if (t.size() < 2 || t.size() > 6) {
+		        if (t.size() != 7) {
 			        throw duckdb::InternalException("Invalid state for PyPhysicalPlanWrapper pickle");
 		        }
 		        bool has_data = t[0].cast<bool>();
@@ -610,25 +640,21 @@ void register_ray_bindings(py::module_ &mod) {
 			        throw duckdb::InternalException(
 			            "Invalid PyPhysicalPlanWrapper pickle: absent root carries serialized data");
 		        }
-		        string query_id;
-		        if (t.size() >= 3) {
-			        query_id = t[2].cast<string>();
-		        }
+		        string query_id = t[2].cast<string>();
 
 		        PyPhysicalPlanWrapper result;
 		        result.query_id_ = std::move(query_id);
-		        if (t.size() >= 4) {
-			        result.udf_registrations_ = t[3];
+		        result.resource_query_id_ = t[3].cast<string>();
+		        if (result.resource_query_id_.empty()) {
+			        throw duckdb::InternalException(
+			            "Invalid PyPhysicalPlanWrapper pickle: resource_query_id must not be empty");
 		        }
-		        if (t.size() >= 5) {
-			        result.udf_actor_handles_ = t[4];
-		        }
-		        if (t.size() >= 6) {
-			        result.connection_snapshot_ = t[5];
-		        }
+		        result.udf_registrations_ = t[4];
+		        result.udf_actor_handles_ = t[5];
+		        result.connection_snapshot_ = t[6];
+		        (void)VaneSessionIdFromSnapshot(result.connection_snapshot_);
+		        (void)VaneSessionConfigFromSnapshot(result.connection_snapshot_);
 		        result.ensure_plan_identity();
-		        RememberQueryUDFRegistrations(result.query_id_, result.udf_registrations_);
-		        RememberQueryUDFActorHandles(result.query_id_, result.udf_actor_handles_);
 
 		        if (has_data) {
 			        result.serialized_root_ = std::move(data_str);
@@ -673,6 +699,29 @@ void register_ray_bindings(py::module_ &mod) {
 	    },
 	    py::arg("has_plan") = false, py::arg("query_id") = py::none(),
 	    "Create a worker task with explicit plan/query-id presence for native tests.");
+
+	m.def(
+	    "_make_worker_task_from_plan_for_test",
+	    [](const PyPhysicalPlanWrapper &plan, const string &execution_query_id, const string &resource_query_id) {
+		    if (!plan.plan_ || !plan.plan_->physical_plan() || !plan.plan_->physical_plan()->HasRoot()) {
+			    throw duckdb::InternalException("test worker task requires a physical plan with a root");
+		    }
+		    if (execution_query_id.empty() || resource_query_id.empty()) {
+			    throw duckdb::InternalException(
+			        "test worker task requires non-empty execution_query_id and resource_query_id");
+		    }
+		    auto config = std::make_shared<duckdb::distributed::DuckDBExecutionConfig>(
+		        duckdb::distributed::DuckDBExecutionConfig::from_env());
+		    std::unordered_map<string, string> context {
+		        {"query_id", execution_query_id},
+		        {"resource_query_id", resource_query_id},
+		    };
+		    duckdb::distributed::WorkerTask task(duckdb::distributed::TaskContext(), plan.plan_->physical_plan(),
+		                                         std::move(config), std::move(context), "WorkerTaskFromPlanForTest");
+		    return RayWorkerTask(std::move(task));
+	    },
+	    py::arg("plan"), py::arg("execution_query_id"), py::arg("resource_query_id"),
+	    "Create a worker task from a physical plan with distinct execution and resource query IDs.");
 
 	m.def(
 	    "_submission_error_owner_query_id_for_test",
@@ -722,6 +771,8 @@ void register_ray_bindings(py::module_ &mod) {
 		                }
 	                })
 	    .def("idx", &PyLogicalPlan::idx)
+	    .def("session_id", &PyLogicalPlan::session_id)
+	    .def("session_config", &PyLogicalPlan::session_config)
 	    .def("to_physical_plan", &PyLogicalPlan::to_physical_plan, py::arg("conn") = py::none())
 	    .def(py::pickle(
 	        [](const PyLogicalPlan &p) {
@@ -737,7 +788,7 @@ void register_ray_bindings(py::module_ &mod) {
 		                              p.connection_snapshot_);
 	        },
 	        [](py::tuple t) {
-		        if (t.size() < 2 || t.size() > 4)
+		        if (t.size() != 4)
 			        throw duckdb::InternalException("Invalid state for PyLogicalPlan");
 		        string query_id = py::cast<string>(t[0]);
 		        py::bytes serialized_bytes = py::cast<py::bytes>(t[1]);
@@ -748,12 +799,10 @@ void register_ray_bindings(py::module_ &mod) {
 		        PyLogicalPlan plan;
 		        plan.query_id_ = std::move(query_id);
 		        plan.serialized_logical_plan_ = std::move(serialized_plan);
-		        if (t.size() >= 3) {
-			        plan.udf_registrations_ = t[2];
-		        }
-		        if (t.size() >= 4) {
-			        plan.connection_snapshot_ = t[3];
-		        }
+		        plan.udf_registrations_ = t[2];
+		        plan.connection_snapshot_ = t[3];
+		        (void)VaneSessionIdFromSnapshot(plan.connection_snapshot_);
+		        (void)VaneSessionConfigFromSnapshot(plan.connection_snapshot_);
 		        return plan;
 	        }));
 
@@ -915,6 +964,7 @@ void register_ray_bindings(py::module_ &mod) {
 	        },
 	        py::arg("file_infos"), py::arg("copy_spec"), py::arg("staging_root"), py::arg("conn") = py::none())
 	    .def("drop_query_fragments", &PyPhysicalPlanWrapperRunner::drop_query_fragments, py::arg("query_id"))
+	    .def("close_session", &PyPhysicalPlanWrapperRunner::close_session, py::arg("session_id"))
 	    .def("warm_up", &PyPhysicalPlanWrapperRunner::warm_up)
 	    .def("shutdown",
 	         [](PyPhysicalPlanWrapperRunner &self) {
@@ -1161,9 +1211,6 @@ void register_ray_bindings(py::module_ &mod) {
 			        auto &plan = plan_obj.cast<PyPhysicalPlanWrapper &>();
 			        PyPhysicalPlanWrapper *exec_plan = &plan;
 			        PyPhysicalPlanWrapper deferred_exec_plan;
-			        auto cleanup = [&]() {
-				        CleanupQueryPythonReplayState(exec_plan->idx());
-			        };
 
 			        try {
 				        py::object exec_conn = ResolveConnectionForSnapshot(conn_obj, plan.connection_snapshot_);
@@ -1176,6 +1223,7 @@ void register_ray_bindings(py::module_ &mod) {
 					        // holding an executed plan whose destructor runs after the
 					        // cursor is closed, causing use-after-free crashes.
 					        deferred_exec_plan.query_id_ = plan.query_id_;
+					        deferred_exec_plan.resource_query_id_ = plan.resource_query_id_;
 					        deferred_exec_plan.udf_registrations_ = plan.udf_registrations_;
 					        deferred_exec_plan.udf_actor_handles_ = plan.udf_actor_handles_;
 					        deferred_exec_plan.connection_snapshot_ = plan.connection_snapshot_;
@@ -1192,14 +1240,12 @@ void register_ray_bindings(py::module_ &mod) {
 				        exec_plan->ensure_connection_snapshot(exec_conn);
 				        exec_plan->apply_udf_actor_handles();
 				        auto result = self.execute_native_impl(
-				            exec_conn, exec_plan->plan_->physical_plan(), plan.idx(), scan_task_map_ptr,
-				            exchange_source_task_map_ptr, exchange_sink_instance_task_ptr,
+				            exec_conn, exec_plan->plan_->physical_plan(), plan.idx(), plan.resource_query_id_,
+				            scan_task_map_ptr, exchange_source_task_map_ptr, exchange_sink_instance_task_ptr,
 				            fte_scan_source_queue_map_ptr, fte_exchange_source_queue_map_ptr, copy_output_info_ptr,
 				            dynamic_filter_domains_obj, native_progress_callback_obj, runtime_context_obj);
-				        cleanup();
 				        return result;
 			        } catch (...) {
-				        cleanup();
 				        throw;
 			        }
 		        }

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -591,6 +591,7 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def("resource_query_id", &PyPhysicalPlanWrapper::resource_query_id)
 	    .def("session_id", &PyPhysicalPlanWrapper::session_id)
 	    .def("session_config", &PyPhysicalPlanWrapper::session_config)
+	    .def("has_explicit_s3_credentials", &PyPhysicalPlanWrapper::has_explicit_s3_credentials)
 	    .def("has_root", &PyPhysicalPlanWrapper::has_root)
 	    .def("clone", &PyPhysicalPlanWrapper::clone, py::arg("conn") = py::none())
 	    .def("num_partitions", &PyPhysicalPlanWrapper::num_partitions)
@@ -773,7 +774,9 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def("idx", &PyLogicalPlan::idx)
 	    .def("session_id", &PyLogicalPlan::session_id)
 	    .def("session_config", &PyLogicalPlan::session_config)
-	    .def("to_physical_plan", &PyLogicalPlan::to_physical_plan, py::arg("conn") = py::none())
+	    .def("has_explicit_s3_credentials", &PyLogicalPlan::has_explicit_s3_credentials)
+	    .def("to_physical_plan", &PyLogicalPlan::to_physical_plan, py::arg("conn") = py::none(),
+	         py::arg("effective_session_config") = py::none())
 	    .def(py::pickle(
 	        [](const PyLogicalPlan &p) {
 		        if (p.serialized_logical_plan_.empty()) {
@@ -982,7 +985,8 @@ void register_ray_bindings(py::module_ &mod) {
 	           py::object exchange_source_task_obj, py::object copy_output_info_obj,
 	           py::object exchange_sink_instance_obj, py::object fte_scan_source_queues_obj,
 	           py::object fte_exchange_source_queues_obj, py::object dynamic_filter_domains_obj,
-	           py::object native_progress_callback_obj, py::object runtime_context_obj) {
+	           py::object native_progress_callback_obj, py::object runtime_context_obj,
+	           py::object effective_session_config_obj) {
 		        string plan_type_name = py::str(py::type::of(plan_obj).attr("__name__")).cast<string>();
 		        std::unordered_map<idx_t, duckdb::distributed::ScanTaskDescriptor> scan_task_map;
 		        bool has_scan_task_map = false;
@@ -1214,6 +1218,11 @@ void register_ray_bindings(py::module_ &mod) {
 
 			        try {
 				        py::object exec_conn = ResolveConnectionForSnapshot(conn_obj, plan.connection_snapshot_);
+				        // Install refreshed session credentials as a baseline
+				        // before replaying explicit source-connection settings.
+				        ApplyEffectiveVaneSessionConfig(ExtractPyConnectionWrapper(exec_conn).con.GetConnection(),
+				                                        effective_session_config_obj);
+				        const bool apply_snapshot_session_config = effective_session_config_obj.is_none();
 				        // Handle deferred deserialization (from pickle round-trip)
 				        if (!plan.has_root() && !plan.serialized_root_.empty()) {
 					        // Materialize into a temporary wrapper so any physical-plan
@@ -1229,7 +1238,7 @@ void register_ray_bindings(py::module_ &mod) {
 					        deferred_exec_plan.connection_snapshot_ = plan.connection_snapshot_;
 					        deferred_exec_plan.serialized_root_ = plan.serialized_root_;
 					        deferred_exec_plan.worker_connection_ = exec_conn;
-					        deferred_exec_plan.materialize_deferred_root(exec_conn);
+					        deferred_exec_plan.materialize_deferred_root(exec_conn, apply_snapshot_session_config);
 					        exec_plan = &deferred_exec_plan;
 				        }
 
@@ -1237,7 +1246,7 @@ void register_ray_bindings(py::module_ &mod) {
 					        throw py::value_error("PyPhysicalPlanWrapper has no root after deserialization");
 				        }
 				        exec_plan->worker_connection_ = exec_conn;
-				        exec_plan->ensure_connection_snapshot(exec_conn);
+				        exec_plan->ensure_connection_snapshot(exec_conn, apply_snapshot_session_config);
 				        exec_plan->apply_udf_actor_handles();
 				        auto result = self.execute_native_impl(
 				            exec_conn, exec_plan->plan_->physical_plan(), plan.idx(), plan.resource_query_id_,
@@ -1259,7 +1268,7 @@ void register_ray_bindings(py::module_ &mod) {
 	        py::arg("exchange_sink_instance") = py::none(), py::arg("fte_scan_source_queues") = py::none(),
 	        py::arg("fte_exchange_source_queues") = py::none(), py::arg("dynamic_filter_domains") = py::none(),
 	        py::arg("native_progress_callback") = py::none(), py::arg("runtime_context") = py::none(),
-	        "Execute physical plan using DuckDB's native Executor");
+	        py::arg("effective_session_config") = py::none(), "Execute physical plan using DuckDB's native Executor");
 
 	// Merge multiple raw-bytes ScanTaskDescriptors into one.
 	// Each descriptor may contain multiple files; the merged result is a single

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -1021,10 +1021,15 @@ py::object RayWorkerTask::Plan() const {
 	if (!plan_ref->HasRoot()) {
 		throw duckdb::InternalException("RayWorkerTask::Plan received a present physical plan without a root");
 	}
+	auto resource_query_id_entry = task_context.find("resource_query_id");
+	if (resource_query_id_entry == task_context.end() || resource_query_id_entry->second.empty()) {
+		throw duckdb::InternalException("RayWorkerTask::Plan requires non-empty task context resource_query_id");
+	}
 	py::object query_id_obj = py::str(query_id_entry->second);
-	auto udf_registrations_obj = ray_cxx.attr("_lookup_query_udf_registrations")(query_id_obj);
-	auto udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(query_id_obj);
-	auto connection_snapshot_obj = ray_cxx.attr("_lookup_query_connection_snapshot")(query_id_obj);
+	py::object resource_query_id_obj = py::str(resource_query_id_entry->second);
+	auto udf_registrations_obj = ray_cxx.attr("_lookup_query_udf_registrations")(resource_query_id_obj);
+	auto udf_actor_handles_obj = ray_cxx.attr("_lookup_query_udf_actor_handles")(resource_query_id_obj);
+	auto connection_snapshot_obj = ray_cxx.attr("_lookup_query_connection_snapshot")(resource_query_id_obj);
 
 	// Keep ownership locally until the capsule is fully constructed. Capsule
 	// construction can allocate and raise before its destructor callback owns
@@ -1034,7 +1039,8 @@ py::object RayWorkerTask::Plan() const {
 	                         [](void *ptr) { delete static_cast<std::shared_ptr<duckdb::PhysicalPlan> *>(ptr); });
 	plan_copy.release();
 	auto create_fn = ray_cxx.attr("_create_physical_plan_from_capsule");
-	return create_fn(plan_capsule, query_id_obj, udf_registrations_obj, udf_actor_handles_obj, connection_snapshot_obj);
+	return create_fn(plan_capsule, query_id_obj, resource_query_id_obj, udf_registrations_obj, udf_actor_handles_obj,
+	                 connection_snapshot_obj);
 }
 
 py::dict RayWorkerTask::Inputs() const {

--- a/src/duckdb_py/ray/worker.cpp
+++ b/src/duckdb_py/ray/worker.cpp
@@ -237,6 +237,14 @@ std::unordered_map<std::string, duckdb::idx_t> RayWorkerRuntime::FragmentStats()
 	return stats;
 }
 
+void RayWorkerRuntime::CloseSession(const string &session_id) {
+	if (session_id.empty()) {
+		throw duckdb::InvalidInputException("Ray worker close session requires a non-empty session_id");
+	}
+	duckdb::PythonGILWrapper gil;
+	ray_worker_handle_.attr("close_session")(session_id);
+}
+
 void RayWorkerRuntime::PrepareShutdown() {
 	duckdb::PythonGILWrapper gil;
 	ray_worker_handle_.attr("prepare_shutdown")();

--- a/src/duckdb_py/ray/worker.hpp
+++ b/src/duckdb_py/ray/worker.hpp
@@ -61,6 +61,7 @@ public:
 	std::vector<RayTaskResultHandle> PopFteResultHandles(const string &query_id);
 	void PrepareDropQuery(const string &query_id);
 	void CleanupQuery(const string &query_id);
+	void CloseSession(const string &session_id);
 	std::unordered_map<string, idx_t> FragmentStats() const;
 
 	void PrepareShutdown();

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -583,9 +583,10 @@ DuckDBResult<void> RayWorkerManager::shutdown() {
 		std::unique_lock<mutex> guard(mutex_);
 		if (state_.shutdown_started) {
 			shutdown_cv_.wait(guard, [&]() { return state_.shutdown_finished; });
-			if (!state_.shutdown_error.empty()) {
-				return DuckDBResult<void>::err(DuckDBError::external_error(state_.shutdown_error));
-			}
+			// The caller that performed shutdown already received the aggregated
+			// error. Every worker was either finished or force-terminated and all
+			// manager-owned state was released, so a retry observes the completed
+			// terminal state instead of replaying an unrecoverable error forever.
 			return DuckDBResult<void>::ok();
 		}
 		state_.shutdown_started = true;
@@ -654,12 +655,49 @@ DuckDBResult<void> RayWorkerManager::shutdown() {
 	}
 	{
 		lock_guard<mutex> guard(mutex_);
-		state_.shutdown_error = error_message;
 		state_.shutdown_finished = true;
 	}
 	shutdown_cv_.notify_all();
 	if (!error_message.empty()) {
 		return DuckDBResult<void>::err(DuckDBError::external_error(std::move(error_message)));
+	}
+	return DuckDBResult<void>::ok();
+}
+
+DuckDBResult<void> RayWorkerManager::close_session(const string &session_id) {
+	if (session_id.empty()) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker session_id is empty"));
+	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
+	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
+	{
+		lock_guard<mutex> guard(mutex_);
+		workers.reserve(state_.ray_workers.size());
+		for (auto &entry : state_.ray_workers) {
+			workers.push_back(entry.second);
+		}
+	}
+	std::vector<std::string> errors;
+	for (auto &worker : workers) {
+		const auto worker_id = worker->Id() ? *worker->Id() : std::string("<unknown>");
+		try {
+			worker->CloseSession(session_id);
+		} catch (const std::exception &ex) {
+			errors.push_back(worker_id + ": " + ex.what());
+		} catch (...) {
+			errors.push_back(worker_id + ": unknown close-session error");
+		}
+	}
+	if (!errors.empty()) {
+		std::string message =
+		    "Failed to close Ray worker session " + session_id + " with " + std::to_string(errors.size()) + " error(s)";
+		for (const auto &error : errors) {
+			message += "; " + error;
+		}
+		return DuckDBResult<void>::err(DuckDBError::external_error(std::move(message)));
 	}
 	return DuckDBResult<void>::ok();
 }

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -54,12 +54,15 @@ void RayWorkerManager::EndOperation() const {
 std::string
 duckdb::distributed::python::ray::SubmissionErrorOwnerQueryId(const std::vector<duckdb::distributed::WorkerTask> &tasks,
                                                               const std::string &execution_query_id) {
+	if (tasks.empty()) {
+		return execution_query_id;
+	}
 	std::string resource_query_id;
 	for (const auto &task : tasks) {
 		const auto &context = task.context();
 		auto it = context.find("resource_query_id");
 		if (it == context.end() || it->second.empty()) {
-			continue;
+			throw std::runtime_error("FTE submit task requires a non-empty resource_query_id");
 		}
 		if (resource_query_id.empty()) {
 			resource_query_id = it->second;
@@ -69,7 +72,7 @@ duckdb::distributed::python::ray::SubmissionErrorOwnerQueryId(const std::vector<
 			throw std::runtime_error("FTE submit batch contains multiple resource_query_id values");
 		}
 	}
-	return resource_query_id.empty() ? execution_query_id : resource_query_id;
+	return resource_query_id;
 }
 
 std::string RayWorkerManager::QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks) {

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -48,6 +48,7 @@ public:
 
 	void drop_query_fragments(const string &query_id);
 	void rethrow_submission_error(const string &query_id);
+	DuckDBResult<void> close_session(const string &session_id);
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const;
 
 private:
@@ -61,7 +62,6 @@ private:
 		idx_t active_operations = 0;
 		bool shutdown_started = false;
 		bool shutdown_finished = false;
-		std::string shutdown_error;
 	};
 
 	class OperationGuard {

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -295,6 +295,54 @@ def test_datasource_factory_owner_released_when_query_fails(duckdb_conn):
     assert finished["owner_count"] == baseline["owner_count"]
 
 
+def test_datasource_worker_plan_uses_resource_query_owner_when_execution_id_differs(duckdb_conn):
+    source_plan_id = "query-datasource-source-plan"
+    resource_query_id = "query-datasource-resource-owner"
+    execution_query_id = f"{resource_query_id}:stage:retry"
+    relation = read_datasource(RegistryProbeSource([41]), con=duckdb_conn)
+    logical_plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, source_plan_id)
+    source_plan = logical_plan.to_physical_plan(duckdb_conn)
+    assert source_plan.idx() == source_plan_id
+    assert source_plan.resource_query_id() == source_plan_id
+
+    duckdb.ray_cxx._register_query_python_replay_state(resource_query_id, source_plan)
+    worker_connection = duckdb.connect()
+    worker_source_plan = None
+    task = None
+    worker_plan = None
+    result = None
+    try:
+        worker_source_plan = source_plan.clone(worker_connection)
+        task = duckdb.ray_cxx._make_worker_task_from_plan_for_test(
+            worker_source_plan,
+            execution_query_id,
+            resource_query_id,
+        )
+        worker_plan = task.plan()
+        assert worker_plan.idx() == execution_query_id
+        assert worker_plan.resource_query_id() == resource_query_id
+
+        result = duckdb.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            worker_connection,
+            worker_plan,
+        )
+        assert result.completion_status == "ok"
+        assert result.partition_payloads[0].column(0).to_pylist() == [41]
+        assert result.partition_payloads[0].column(2).to_pylist() == [resource_query_id]
+
+        active = _datasource_registry_state()
+        assert active["query_ids"] == [resource_query_id]
+        assert execution_query_id not in active["query_ids"]
+    finally:
+        result = None
+        worker_plan = None
+        task = None
+        worker_source_plan = None
+        worker_connection.close()
+        _duckdb._release_datasource_factories_for_query(resource_query_id)
+        duckdb.ray_cxx._cleanup_query_python_replay_state(resource_query_id)
+
+
 def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb_conn):
     driver_pid = os.getpid()
 

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -336,7 +336,7 @@ def test_run_plan_does_not_read_physical_plan_id_after_registration():
     events: list[str] = []
     coordinator = _FakeCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
-    runner._precreate_udf_actors = lambda *_args: []
+    runner._precreate_udf_actors = lambda *_args, **_kwargs: []
     runner._mark_query_actor_stages_ready = lambda _graph: None
     query_id = "query-single-use-plan-id"
     physical_plan = _RegistrationOnlyIdxPhysicalPlan(
@@ -348,6 +348,8 @@ def test_run_plan_does_not_read_physical_plan_id_after_registration():
     asyncio.run(
         runner_cls.run_plan(
             runner,
+            _OWNER_ID,
+            _SESSION_ID,
             _FakeLogicalPlan(physical_plan, events),
         )
     )
@@ -370,7 +372,7 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         thread_name_prefix="vane-test-saturated",
     )
 
-    runner._precreate_udf_actors = lambda *_args: startup_entered.set() or []
+    runner._precreate_udf_actors = lambda *_args, **_kwargs: startup_entered.set() or []
     runner._mark_query_actor_stages_ready = lambda _graph: None
 
     async def _exercise() -> None:
@@ -387,12 +389,14 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         async def _register_then_saturate(
             plan,
             *,
+            query_connection,
             expected_plan_id=None,
         ):
             nonlocal blocker_future
             registered = await register_query_resources(
                 runner,
                 plan,
+                query_connection=query_connection,
                 expected_plan_id=expected_plan_id,
             )
             blocker_future = loop.run_in_executor(
@@ -408,6 +412,8 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         run_plan = asyncio.create_task(
             runner_cls.run_plan(
                 runner,
+                _OWNER_ID,
+                _SESSION_ID,
                 _FakeLogicalPlan(physical_plan, events),
             )
         )
@@ -452,7 +458,7 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
     startup_release = threading.Event()
     fragment_drops: list[str] = []
 
-    def _precreate_udf_actors(*_args):
+    def _precreate_udf_actors(*_args, **_kwargs):
         startup_claimed.set()
         assert startup_release.wait(timeout=2.0)
         return []
@@ -473,6 +479,8 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
         run_plan = asyncio.create_task(
             runner_cls.run_plan(
                 runner,
+                _OWNER_ID,
+                _SESSION_ID,
                 _FakeLogicalPlan(physical_plan, events),
             )
         )
@@ -542,8 +550,8 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     runner_cls, runner = _runner(events, coordinator)
     runner._query_resource_lock = threading.Lock()
     runner._read_query_node_capacities = lambda: runner_cls._read_query_node_capacities()
-    runner._precreate_udf_actors = lambda *_args: []
-    runner._precreate_vllm_actors = lambda *_args: []
+    runner._precreate_udf_actors = lambda *_args, **_kwargs: []
+    runner._precreate_vllm_actors = lambda *_args, **_kwargs: []
     runner._get_plan_runner = lambda: SimpleNamespace(
         run_copy_plan=lambda _plan, _conn: {"rows_copied": 1},
     )
@@ -653,6 +661,8 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
         copy_task = asyncio.create_task(
             runner_cls.run_copy_plan(
                 runner,
+                _OWNER_ID,
+                _SESSION_ID,
                 _FakeLogicalPlan(copy_plan, events),
             )
         )

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -29,6 +29,19 @@ from duckdb.runners.ray.query_resource_runtime import (
 )
 
 _GIB = 1024**3
+_OWNER_ID = "query-graph-test-owner"
+_SESSION_ID = "query-graph-test-session"
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.closed = False
+
+    def cursor(self):
+        return _FakeConnection()
+
+    def close(self):
+        self.closed = True
 
 
 class _FakeLogicalPlan:
@@ -40,6 +53,15 @@ class _FakeLogicalPlan:
         assert conn is not None
         self._events.append("physical_plan")
         return self._physical_plan
+
+    def idx(self):
+        return self._physical_plan.idx()
+
+    def session_id(self):
+        return _SESSION_ID
+
+    def session_config(self):
+        return {}
 
 
 class _ValidatingLogicalPlan(_FakeLogicalPlan):
@@ -57,6 +79,12 @@ class _FakePhysicalPlan:
 
     def idx(self):
         return self._query_id
+
+    def session_id(self):
+        return _SESSION_ID
+
+    def session_config(self):
+        return {}
 
     def collect_execution_stages(self, conn=None):
         assert conn is not None
@@ -168,12 +196,27 @@ def _clean_query_runtime():
 
 
 def _runner(events, coordinator):
-    from duckdb.runners.ray.driver import RayQueryDriverActor
+    from duckdb.runners.ray.driver import BoundedReplayMap, RayQueryDriverActor, _DriverSession
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     runner = object.__new__(runner_cls)
-    runner._duckdb_conn = object()
-    runner._env_overrides = {}
+    runner._duckdb_conn = _FakeConnection()
+    runner._client_ids = {_OWNER_ID}
+    runner._detaching_client_ids = set()
+    runner._detached_client_results = BoundedReplayMap(capacity=65_536)
+    runner._session_lock = threading.RLock()
+    runner._closed_session_owners = BoundedReplayMap(capacity=65_536)
+    runner._plan_session_ids = {}
+    runner._plan_connections = {}
+    runner._plan_teardown_condition = threading.Condition(runner._session_lock)
+    runner._plan_teardowns_in_progress = set()
+    runner._sessions = {
+        _SESSION_ID: _DriverSession(
+            owner_id=_OWNER_ID,
+            config={},
+            connection=runner._duckdb_conn.cursor(),
+        )
+    }
     runner._query_resource_coordinator = coordinator
     runner._query_resource_lock = threading.RLock()
     runner._query_allocations = {}
@@ -181,6 +224,7 @@ def _runner(events, coordinator):
     runner._active_udf_actors = []
     runner._active_udf_actors_by_plan = {}
     runner._active_vllm_actors = []
+    runner._active_vllm_actors_by_plan = {}
     runner.curr_plans = {}
     runner.curr_streams = {}
     runner._plan_query_ids = {}
@@ -201,7 +245,7 @@ def _runner(events, coordinator):
 
     runner._read_query_node_capacities = _read_node_capacities
     runner._ensure_duckdb_conn = lambda: runner._duckdb_conn
-    runner._precreate_vllm_actors = lambda plan: events.append("vllm_ready") or []
+    runner._precreate_vllm_actors = lambda plan, *, query_connection, session_config: events.append("vllm_ready") or []
     runner._get_plan_runner = lambda: SimpleNamespace(run_plan=lambda plan, conn: "stream")
     return runner_cls, runner
 
@@ -213,16 +257,33 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
     query_id = "query-driver-order"
     physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
 
-    def _precreate(plan, graph, allocation):
+    def _precreate(plan, graph, allocation, *, query_connection, session_config):
+        assert query_connection is not None
+        assert session_config == {}
         assert graph.query_id == query_id
         assert allocation.actor_node_ids_for_stage(f"stage:{query_id}:node:1:udf") == ("node-a",)
         manager = get_query_resource_manager(query_id)
         actor_stage = manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]
         assert actor_stage["actor_ready"] is False
         events.append("actors_created")
-        return [SimpleNamespace(shutdown=lambda: None)]
+        pool = SimpleNamespace(shutdown=lambda: None)
+        runner._active_udf_actors.append(pool)
+        runner._active_udf_actors_by_plan[query_id] = [pool]
+        return [pool]
 
     runner._precreate_udf_actors = _precreate
+    vllm_pool = SimpleNamespace(shutdown=lambda: None)
+
+    def _precreate_vllm(plan, *, query_connection, session_config):
+        assert plan is physical_plan
+        assert query_connection is not None
+        assert session_config == {}
+        events.append("vllm_ready")
+        runner._active_vllm_actors.append(vllm_pool)
+        runner._active_vllm_actors_by_plan[query_id] = [vllm_pool]
+        return [vllm_pool]
+
+    runner._precreate_vllm_actors = _precreate_vllm
 
     def _wait_for_ready(_actor_pools):
         manager = get_query_resource_manager(query_id)
@@ -241,7 +302,14 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
 
     runner._get_plan_runner = lambda: SimpleNamespace(run_plan=_run_plan)
 
-    asyncio.run(runner_cls.run_plan(runner, _FakeLogicalPlan(physical_plan, events)))
+    asyncio.run(
+        runner_cls.run_plan(
+            runner,
+            _OWNER_ID,
+            _SESSION_ID,
+            _FakeLogicalPlan(physical_plan, events),
+        )
+    )
 
     assert events == [
         "physical_plan",
@@ -256,6 +324,7 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
     manager = get_query_resource_manager(query_id)
     assert manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]["actor_ready"] is True
     assert runner.curr_streams[query_id] == "stream"
+    assert runner._active_vllm_actors_by_plan[query_id] == [vllm_pool]
 
 
 def test_run_plan_does_not_read_physical_plan_id_after_registration():
@@ -432,14 +501,23 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
     query_id = "query-driver-rollback"
     physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
 
-    def _fail_precreate(plan, graph, allocation):
+    def _fail_precreate(plan, graph, allocation, *, query_connection, session_config):
+        assert query_connection is not None
+        assert session_config == {}
         events.append("actors_initializing")
         raise RuntimeError("model initialization failed")
 
     runner._precreate_udf_actors = _fail_precreate
 
     with pytest.raises(RuntimeError, match="model initialization failed"):
-        asyncio.run(runner_cls.run_plan(runner, _FakeLogicalPlan(physical_plan, events)))
+        asyncio.run(
+            runner_cls.run_plan(
+                runner,
+                _OWNER_ID,
+                _SESSION_ID,
+                _FakeLogicalPlan(physical_plan, events),
+            )
+        )
 
     with pytest.raises(KeyError, match="query graph is not registered"):
         get_query_resource_manager(query_id)
@@ -774,7 +852,12 @@ def test_driver_rejects_non_serializable_plan_before_query_registration(entrypoi
         RuntimeError,
         match=f"distributed physical plan serialization preflight failed for query_id={query_id}",
     ) as exc_info:
-        coroutine = getattr(runner_cls, entrypoint)(runner, _ValidatingLogicalPlan(physical_plan, events))
+        coroutine = getattr(runner_cls, entrypoint)(
+            runner,
+            _OWNER_ID,
+            _SESSION_ID,
+            _ValidatingLogicalPlan(physical_plan, events),
+        )
         asyncio.run(coroutine)
 
     assert isinstance(exc_info.value, RemoteRayException)

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -49,8 +49,9 @@ class _FakeLogicalPlan:
         self._physical_plan = physical_plan
         self._events = events
 
-    def to_physical_plan(self, conn):
+    def to_physical_plan(self, conn, effective_session_config):
         assert conn is not None
+        assert effective_session_config == {}
         self._events.append("physical_plan")
         return self._physical_plan
 
@@ -63,10 +64,13 @@ class _FakeLogicalPlan:
     def session_config(self):
         return {}
 
+    def has_explicit_s3_credentials(self):
+        return False
+
 
 class _ValidatingLogicalPlan(_FakeLogicalPlan):
-    def to_physical_plan(self, conn):
-        physical_plan = super().to_physical_plan(conn)
+    def to_physical_plan(self, conn, effective_session_config):
+        physical_plan = super().to_physical_plan(conn, effective_session_config)
         validate_plan_serialization_for_submission(physical_plan)
         return physical_plan
 
@@ -215,6 +219,7 @@ def _runner(events, coordinator):
             owner_id=_OWNER_ID,
             config={},
             connection=runner._duckdb_conn.cursor(),
+            s3_config={},
         )
     }
     runner._query_resource_coordinator = coordinator

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -1313,13 +1313,209 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="injected owner-loop open failure"):
-        asyncio.run(runner_cls._register_query_resources(runner, plan))
+        asyncio.run(
+            runner_cls._register_query_resources(
+                runner,
+                plan,
+                query_connection=object(),
+            )
+        )
 
     with pytest.raises(KeyError):
         get_query_resource_manager(query_id)
     assert released == [(query_id, allocation.generation)]
     assert runner._query_graphs == {}
     assert runner._query_allocations == {}
+
+
+def test_query_registration_retains_failed_coordinator_release_for_retry(monkeypatch):
+    import duckdb.runners.ray.query_graph_builder as graph_builder
+    from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+    query_id = "query-registration-release-retry"
+    graph = _graph(query_id)
+    allocation = _allocation()
+
+    class _Coordinator:
+        def __init__(self):
+            self.release_calls = 0
+
+        def update_node_capacities(self, _capacities):
+            return None
+
+        def register_query(self, _demand):
+            return allocation
+
+        def release_query(self, released_query_id, generation):
+            assert released_query_id == query_id
+            assert generation == allocation.generation
+            self.release_calls += 1
+            if self.release_calls == 1:
+                raise RuntimeError("planned coordinator release failure")
+            return True
+
+    monkeypatch.setattr(graph_builder, "build_query_execution_graph", lambda _metadata: graph)
+    monkeypatch.setattr(graph_builder, "build_query_demand", lambda _graph, _capacity: "demand")
+
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    runner._query_resource_lock = threading.RLock()
+    runner._query_graphs = {}
+    runner._query_allocations = {}
+    runner._query_resource_coordinator = _Coordinator()
+    capacity = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
+    runner._read_query_node_capacities = lambda: (SimpleNamespace(resources=capacity),)
+    runner._synchronize_query_allocations = lambda: ()
+    runner._open_query_resource_admission = lambda _query_id: (_ for _ in ()).throw(
+        RuntimeError("planned registration failure")
+    )
+    runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
+    plan = SimpleNamespace(
+        collect_execution_stages=lambda conn: object(),
+        idx=lambda: query_id,
+    )
+
+    with pytest.raises(RuntimeError, match="planned coordinator release failure"):
+        asyncio.run(
+            runner_cls._register_query_resources(
+                runner,
+                plan,
+                query_connection=object(),
+            )
+        )
+
+    assert runner._query_graphs == {query_id: graph}
+    assert runner._query_allocations == {query_id: allocation}
+    assert get_query_resource_manager(query_id) is not None
+
+    runner_cls._release_query_resources(
+        runner,
+        query_id,
+        reason="registration_cleanup_retry",
+    )
+
+    assert runner._query_resource_coordinator.release_calls == 2
+    assert runner._query_graphs == {}
+    assert runner._query_allocations == {}
+    with pytest.raises(KeyError):
+        get_query_resource_manager(query_id)
+
+
+def test_query_resource_registry_retains_manager_when_cancel_raises():
+    from duckdb.runners.ray import query_resource_runtime as runtime
+
+    query_id = "query-manager-cancel-retry"
+
+    class _Manager:
+        def __init__(self):
+            self.cancel_calls = 0
+
+        def cancel(self, _reason):
+            self.cancel_calls += 1
+            if self.cancel_calls == 1:
+                raise RuntimeError("planned manager cancel failure")
+            return {
+                "task_lease_count": 0,
+                "output_lease_count": 0,
+            }
+
+    manager = _Manager()
+    with runtime._LOCK:
+        runtime._MANAGERS[query_id] = manager
+    try:
+        with pytest.raises(RuntimeError, match="planned manager cancel failure"):
+            runtime.release_query_resource_manager(
+                query_id,
+                reason="first_attempt",
+            )
+
+        with runtime._LOCK:
+            assert runtime._MANAGERS[query_id] is manager
+
+        assert runtime.release_query_resource_manager(
+            query_id,
+            reason="retry",
+        ) == {
+            "released": True,
+            "task_lease_count": 0,
+            "output_lease_count": 0,
+        }
+        with runtime._LOCK:
+            assert query_id not in runtime._MANAGERS
+    finally:
+        with runtime._LOCK:
+            runtime._MANAGERS.pop(query_id, None)
+
+
+def test_query_teardown_retries_manager_after_coordinator_release():
+    from duckdb.runners.ray import query_resource_runtime as runtime
+
+    query_id = "query-manager-teardown-retry"
+    graph = _graph(query_id)
+    allocation = _allocation()
+
+    class _Manager:
+        def __init__(self):
+            self.cancel_calls = 0
+
+        def cancel(self, _reason):
+            self.cancel_calls += 1
+            if self.cancel_calls == 1:
+                raise RuntimeError("planned manager cancel failure")
+            return {
+                "task_lease_count": 0,
+                "output_lease_count": 0,
+            }
+
+    class _Coordinator:
+        def __init__(self):
+            self.release_calls = []
+
+        def release_query(self, released_query_id, generation):
+            self.release_calls.append((released_query_id, generation))
+            return True
+
+        def snapshot(self):
+            return {"queries": {}}
+
+    manager = _Manager()
+    runner_cls, runner = _runner(None)
+    coordinator = _Coordinator()
+    runner._query_resource_lock = threading.RLock()
+    runner._query_resource_coordinator = coordinator
+    runner._query_graphs = {query_id: graph}
+    runner._query_allocations = {query_id: allocation}
+    runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
+    with runtime._LOCK:
+        runtime._MANAGERS[query_id] = manager
+    try:
+        with pytest.raises(RuntimeError, match="planned manager cancel failure"):
+            runner_cls._release_query_resources(
+                runner,
+                query_id,
+                reason="first_attempt",
+            )
+
+        assert coordinator.release_calls == [(query_id, allocation.generation)]
+        assert runner._query_graphs == {}
+        assert runner._query_allocations == {}
+        with runtime._LOCK:
+            assert runtime._MANAGERS[query_id] is manager
+
+        runner_cls._release_query_resources(
+            runner,
+            query_id,
+            reason="retry",
+        )
+
+        assert coordinator.release_calls == [(query_id, allocation.generation)]
+        with runtime._LOCK:
+            assert query_id not in runtime._MANAGERS
+    finally:
+        with runtime._LOCK:
+            runtime._MANAGERS.pop(query_id, None)
 
 
 def test_background_query_teardown_fences_new_admission_before_table_purge():

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -22,6 +22,9 @@ class _FakePlan:
         self._nodes = nodes
         self.set_calls = []
 
+    def idx(self):
+        return "test-plan"
+
     def collect_udf_nodes(self, conn=None):
         return self._nodes
 
@@ -73,9 +76,9 @@ def test_drop_resource_query_closes_owned_internal_fte_queries(monkeypatch):
     runner._drop_query_fragments_sync("q-drop-owned")
 
     assert dropped_fragments == [
-        "q-drop-owned",
         "q-drop-owned_orderby_range",
         "q-drop-owned_orderby_sample",
+        "q-drop-owned",
     ]
 
 
@@ -115,22 +118,81 @@ def test_drop_resource_query_remembers_failed_internal_teardown_after_registry_l
     with pytest.raises(QueryTeardownOwnershipError, match="pending_execution_queries"):
         runner._drop_query_fragments_sync(resource_query_id)
 
-    assert runner._query_pending_execution_teardowns == {resource_query_id: {execution_query_id}}
+    assert runner._query_pending_execution_teardowns == {
+        resource_query_id: {
+            execution_query_id,
+            resource_query_id,
+        }
+    }
     assert released_queries == []
 
     runner._drop_query_fragments_sync(resource_query_id)
 
     assert calls == [
-        resource_query_id,
+        execution_query_id,
         execution_query_id,
         resource_query_id,
-        execution_query_id,
     ]
     assert runner._query_pending_execution_teardowns == {}
     assert released_queries == ["released"]
 
 
-def test_driver_actor_shutdown_reaches_plan_runner_once():
+def test_drop_resource_query_keeps_outer_owner_until_internal_blockers_clear(monkeypatch):
+    import duckdb.runners.ray.fte_fragment_scheduler as fte_scheduler
+    from duckdb.runners.ray.driver import QueryTeardownOwnershipError, RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    runner._query_pending_execution_teardowns = {}
+    runner._release_query_resources = lambda *_args, **_kwargs: released_queries.append("released")
+
+    resource_query_id = "q-drop-blocked"
+    execution_query_id = f"{resource_query_id}_stage"
+    monkeypatch.setattr(
+        fte_scheduler,
+        "fte_execution_query_ids_for_resource",
+        lambda _query_id: (execution_query_id,),
+    )
+    monkeypatch.setattr(fte_scheduler, "_drop_fte_registry_for_query", lambda _query_id: None)
+
+    blocked = True
+
+    def teardown_blockers(query_id):
+        if blocked and query_id == execution_query_id:
+            return ("active_execution=1",)
+        return ()
+
+    monkeypatch.setattr(fte_scheduler, "fte_query_remote_teardown_blockers", teardown_blockers)
+
+    calls: list[str] = []
+    released_queries: list[str] = []
+    runner._get_plan_runner = lambda: SimpleNamespace(drop_query_fragments=calls.append)
+
+    with pytest.raises(QueryTeardownOwnershipError, match="active_execution=1"):
+        runner._drop_query_fragments_sync(resource_query_id)
+
+    assert calls == [execution_query_id]
+    assert runner._query_pending_execution_teardowns == {
+        resource_query_id: {
+            execution_query_id,
+            resource_query_id,
+        }
+    }
+    assert released_queries == []
+
+    blocked = False
+    runner._drop_query_fragments_sync(resource_query_id)
+
+    assert calls == [
+        execution_query_id,
+        execution_query_id,
+        resource_query_id,
+    ]
+    assert runner._query_pending_execution_teardowns == {}
+    assert released_queries == ["released"]
+
+
+def test_driver_actor_runtime_shutdown_reaches_plan_runner_once():
     from duckdb.runners.ray.driver import RayQueryDriverActor
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
@@ -148,8 +210,8 @@ def test_driver_actor_shutdown_reaches_plan_runner_once():
     runner.stop_query_resource_maintenance = stop_maintenance
 
     async def shutdown_twice():
-        await runner_cls.shutdown(runner)
-        await runner_cls.shutdown(runner)
+        await runner_cls._shutdown_runtime(runner)
+        await runner_cls._shutdown_runtime(runner)
 
     asyncio.run(shutdown_twice())
 
@@ -158,22 +220,49 @@ def test_driver_actor_shutdown_reaches_plan_runner_once():
     assert runner._driver_shutdown_complete is True
 
 
-def test_driver_client_close_gracefully_shuts_down_before_kill(monkeypatch):
+def test_driver_actor_rejects_detach_from_non_owner():
+    from duckdb.runners.ray.driver import BoundedReplayMap, RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    runner._client_ids = {"owner-a"}
+    runner._detaching_client_ids = set()
+    runner._detached_client_results = BoundedReplayMap(capacity=65_536)
+    runner._client_detach_lock = asyncio.Lock()
+    runner._sessions = {}
+    runner._session_lock = threading.RLock()
+
+    with pytest.raises(PermissionError, match="attached client owner"):
+        asyncio.run(runner_cls.detach_client(runner, "owner-b"))
+
+
+def test_driver_client_close_detaches_and_kills_last_job_runtime(monkeypatch):
     from duckdb.runners.ray import driver as driver_module
 
     events: list[str] = []
-    shutdown_ref = object()
+    detach_ref = object()
 
-    class ShutdownMethod:
+    class DetachMethod:
         @staticmethod
-        def remote():
-            events.append("shutdown-rpc")
-            return shutdown_ref
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            events.append("detach-rpc")
+            return detach_ref
 
-    actor = SimpleNamespace(shutdown=ShutdownMethod())
+    actor = SimpleNamespace(detach_client=DetachMethod())
     client = object.__new__(driver_module.RayQueryDriverClient)
     client.runner = actor
+    client._owner_id = "owner-a"
     client._ray_gcs_address = "gcs-a"
+    client._opened_sessions = {}
+    client._uncertain_sessions = {}
+    client._opening_session_ids = set()
+    client._closing_session_ids = set()
+    client._closed_session_ids = driver_module.BoundedReplayMap(capacity=65_536)
+    client._session_closes_in_progress = set()
+    client._session_condition = threading.Condition()
+    client._client_closing = False
+    client._client_close_in_progress = False
 
     monkeypatch.setattr(driver_module.ray, "is_initialized", lambda: True)
     monkeypatch.setattr(
@@ -183,9 +272,10 @@ def test_driver_client_close_gracefully_shuts_down_before_kill(monkeypatch):
     )
 
     def resolve(ref, **kwargs):
-        assert ref is shutdown_ref
+        assert ref is detach_ref
         assert kwargs == {"timeout": 300, "honor_query_deadline": False}
-        events.append("shutdown-complete")
+        events.append("detach-complete")
+        return True
 
     def kill(target, *, no_restart):
         assert target is actor
@@ -198,10 +288,10 @@ def test_driver_client_close_gracefully_shuts_down_before_kill(monkeypatch):
     client.close()
 
     assert client.runner is None
-    assert events == ["shutdown-rpc", "shutdown-complete", "kill"]
+    assert events == ["detach-rpc", "detach-complete", "kill"]
 
 
-def test_precreate_udf_actors_skips_non_actor_backend(monkeypatch):
+def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     from duckdb.runners.ray.driver import RayQueryDriverActor
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
@@ -210,15 +300,23 @@ def test_precreate_udf_actors_skips_non_actor_backend(monkeypatch):
         plan,
         *,
         actor_node_ids_by_stage,
+        query_driver_handle,
+        session_config,
         conn=None,
     ):
         assert actor_node_ids_by_stage == {}
+        assert query_driver_handle is driver_handle
+        assert session_config == {"AWS_ACCESS_KEY_ID": "session-access-key"}
+        assert conn is query_connection
         created = []
         handles_map = {}
         for node in plan.collect_udf_nodes(conn=conn):
             payload = node.get("payload") or {}
-            if payload.get("execution_backend") != "ray_actor":
-                continue
+            if payload.get("execution_backend") in {"ray_task", "ray_actor"}:
+                handles_map[str(node["node_id"])] = {
+                    "query_driver_handle": query_driver_handle,
+                    "session_config": dict(session_config),
+                }
         if handles_map:
             plan.set_udf_actor_handles(handles_map, conn=conn)
         return created, handles_map
@@ -227,7 +325,12 @@ def test_precreate_udf_actors_skips_non_actor_backend(monkeypatch):
     fake_mod.prepare_actor_pools_for_plan = _fake_prepare_actor_pools_for_plan
     monkeypatch.setitem(sys.modules, "duckdb.execution.udf_ray", fake_mod)
 
-    runner = SimpleNamespace(_duckdb_conn=object(), _active_udf_actors=[])
+    driver_handle = object()
+    runner = SimpleNamespace(
+        _driver_handle=driver_handle,
+        _active_udf_actors=[],
+    )
+    query_connection = object()
 
     plan = _FakePlan(
         [
@@ -249,10 +352,23 @@ def test_precreate_udf_actors_skips_non_actor_backend(monkeypatch):
         plan,
         SimpleNamespace(stages=()),
         SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+        query_connection=query_connection,
+        session_config={"AWS_ACCESS_KEY_ID": "session-access-key"},
     )
 
     assert created == []
-    assert plan.set_calls == []
+    assert plan.set_calls == [
+        {
+            "handles_map": {
+                "7": {
+                    "query_driver_handle": driver_handle,
+                    "session_config": {
+                        "AWS_ACCESS_KEY_ID": "session-access-key",
+                    },
+                }
+            },
+        }
+    ]
 
 
 def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
@@ -267,7 +383,11 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
     fake_mod.prepare_actor_pools_for_plan = _fake_prepare_actor_pools_for_plan
     monkeypatch.setitem(sys.modules, "duckdb.execution.udf_ray", fake_mod)
 
-    runner = SimpleNamespace(_duckdb_conn=object(), _active_udf_actors=[])
+    runner = SimpleNamespace(
+        _driver_handle=object(),
+        _duckdb_conn=object(),
+        _active_udf_actors=[],
+    )
 
     plan = _FakePlan(
         [
@@ -286,10 +406,85 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
         plan,
         SimpleNamespace(stages=()),
         SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+        query_connection=object(),
+        session_config={},
     )
 
     assert created == []
     assert plan.set_calls == []
+
+
+@pytest.mark.parametrize(
+    ("module_name", "factory_name", "method_name", "active_attr", "by_plan_attr"),
+    [
+        (
+            "duckdb.execution.udf_ray",
+            "prepare_actor_pools_for_plan",
+            "_precreate_udf_actors",
+            "_active_udf_actors",
+            "_active_udf_actors_by_plan",
+        ),
+        (
+            "duckdb.execution.vllm",
+            "ensure_named_vllm_pools_for_plan",
+            "_precreate_vllm_actors",
+            "_active_vllm_actors",
+            "_active_vllm_actors_by_plan",
+        ),
+    ],
+)
+def test_precreate_retains_partially_created_actor_pool_for_teardown(
+    monkeypatch,
+    module_name,
+    factory_name,
+    method_name,
+    active_attr,
+    by_plan_attr,
+):
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    pool = object()
+    creation_error = RuntimeError("partial actor cleanup failed")
+    creation_error.owned_actor_pools = [pool]
+
+    def _fail(*_args, **_kwargs):
+        raise creation_error
+
+    fake_mod = types.ModuleType(module_name)
+    setattr(fake_mod, factory_name, _fail)
+    monkeypatch.setitem(sys.modules, module_name, fake_mod)
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = SimpleNamespace(
+        _driver_handle=object(),
+        **{
+            active_attr: [],
+            by_plan_attr: {},
+        },
+    )
+    plan = _FakePlan([])
+
+    with pytest.raises(RuntimeError, match="partial actor cleanup failed"):
+        method = getattr(runner_cls, method_name)
+        if method_name == "_precreate_udf_actors":
+            method(
+                runner,
+                plan,
+                SimpleNamespace(stages=()),
+                SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+                query_connection=object(),
+                session_config={},
+            )
+        else:
+            method(
+                runner,
+                plan,
+                query_connection=object(),
+                session_config={},
+            )
+
+    assert getattr(runner, active_attr) == [pool]
+    assert getattr(runner, by_plan_attr) == {"test-plan": [pool]}
 
 
 def test_driver_udf_actor_handle_hook_is_disabled_by_default(monkeypatch):
@@ -300,7 +495,7 @@ def test_driver_udf_actor_handle_hook_is_disabled_by_default(monkeypatch):
     runner = runner_cls.__new__(runner_cls)
 
     with pytest.raises(RuntimeError, match="VANE_ENABLE_UDF_TEST_HOOKS=1"):
-        runner_cls.get_test_udf_actor_handle(runner, "plan-7", "stateful_counter")
+        runner_cls.get_test_udf_actor_handle(runner, "owner-a", "plan-7", "stateful_counter")
 
 
 def test_stateful_actor_loss_error_includes_stable_query_context():
@@ -495,6 +690,8 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=object(),
+        session_config={},
         conn=object(),
     )
 
@@ -560,27 +757,31 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
         ]
     )
 
+    query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=query_driver_handle,
+        session_config={},
         conn=object(),
     )
 
     assert len(created) == 1
-    assert calls == [
-        {
-            "payload": {
-                "udf_name": "decode_images",
-                "execution_backend": "ray_actor",
-                "stage_id": "stage:test:actor",
-            },
-            "concurrency": 2,
-            "gpus_per_actor": 0.0,
-            "actor_node_ids": ["node-a", "node-b"],
-            "ray_options": {"num_cpus": 1.0},
-        }
-    ]
+    assert len(calls) == 1
+    assert calls[0]["payload"] == {
+        "udf_name": "decode_images",
+        "execution_backend": "ray_actor",
+        "stage_id": "stage:test:actor",
+    }
+    assert calls[0]["concurrency"] == 2
+    assert calls[0]["gpus_per_actor"] == 0.0
+    assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
+    assert calls[0]["ray_options"]["num_cpus"] == 1.0
+    from duckdb.runners.ray import ray_env
+
+    assert calls[0]["ray_options"]["runtime_env"]["env_vars"] == ray_env.build_session_runtime_env_vars({})
     assert handles_map["7"]["actor_handles"] == ["actor-0", "actor-1"]
+    assert handles_map["7"]["query_driver_handle"] is query_driver_handle
     assert "ray_actor_pool_name" not in handles_map["7"]
     assert plan.set_calls == [
         {
@@ -646,6 +847,8 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:stateful": ("node-a",)},
+        query_driver_handle=object(),
+        session_config={},
         conn=object(),
     )
 
@@ -731,6 +934,8 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:retry-policy": ("node-a",)},
+        query_driver_handle=object(),
+        session_config={},
         conn=object(),
     )
 
@@ -832,24 +1037,70 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
     created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=object(),
+        session_config={},
         set_handles=inject,
     )
 
     assert len(created) == 1
-    assert calls == [
-        {
-            "payload": {
-                "udf_name": "decode_images",
-                "execution_backend": "ray_actor",
-                "stage_id": "stage:test:actor",
-            },
-            "concurrency": 2,
-            "gpus_per_actor": 0.0,
-            "actor_node_ids": ["node-a", "node-b"],
-            "ray_options": {"num_cpus": 1.0},
-        }
-    ]
+    assert len(calls) == 1
+    assert calls[0]["payload"] == {
+        "udf_name": "decode_images",
+        "execution_backend": "ray_actor",
+        "stage_id": "stage:test:actor",
+    }
+    assert calls[0]["concurrency"] == 2
+    assert calls[0]["gpus_per_actor"] == 0.0
+    assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
+    assert calls[0]["ray_options"]["num_cpus"] == 1.0
+    from duckdb.runners.ray import ray_env
+
+    assert calls[0]["ray_options"]["runtime_env"]["env_vars"] == ray_env.build_session_runtime_env_vars({})
     assert handles_map["9"]["actor_handles"] == ["actor-0", "actor-1"]
+    assert injected == [handles_map]
+
+
+def test_ray_plan_injects_session_context_for_explicit_subprocess_backends(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.is_initialized = lambda: True
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
+
+    nodes = [
+        {
+            "node_id": 3,
+            "payload": {
+                "execution_backend": "subprocess_task",
+            },
+        },
+        {
+            "node_id": 4,
+            "payload": {
+                "execution_backend": "subprocess_actor",
+            },
+        },
+    ]
+    session_config = {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "VANE_AUTH_HEADER": "session-auth",
+    }
+    injected = []
+
+    created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
+        nodes,
+        actor_node_ids_by_stage={},
+        query_driver_handle=object(),
+        session_config=session_config,
+        set_handles=injected.append,
+    )
+
+    assert created == []
+    assert handles_map == {
+        "3": {"session_config": session_config},
+        "4": {"session_config": session_config},
+    }
     assert injected == [handles_map]
 
 
@@ -915,6 +1166,8 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
         actor_node_ids_by_stage={
             "stage:test:deferred-ready": ("node-a", "node-b"),
         },
+        query_driver_handle=object(),
+        session_config={},
     )
 
     assert resolved == []
@@ -949,6 +1202,136 @@ def test_udf_actor_pool_shutdown_accepts_query_owned_kill_flag(monkeypatch):
 
     assert killed == [{"actor": "actor-0", "no_restart": True}]
     assert pool.actors == []
+
+
+def test_udf_actor_pool_constructor_cleans_partial_actor_creation(monkeypatch):
+    import duckdb.execution.udf_ray_actor_pool as actor_pool_mod
+
+    killed = []
+    fake_ray = types.SimpleNamespace(
+        put=lambda payload: ("payload-ref", payload),
+        kill=lambda actor, no_restart=True: killed.append((actor, no_restart)),
+    )
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+
+    class _ActorFactory:
+        calls = 0
+
+        @classmethod
+        def options(cls, **_options):
+            class _BoundActor:
+                @staticmethod
+                def remote():
+                    actor_index = cls.calls
+                    cls.calls += 1
+                    if actor_index == 1:
+                        raise RuntimeError("planned actor creation failure")
+                    return f"actor-{actor_index}"
+
+            return _BoundActor
+
+    class _Pool(actor_pool_mod.UDFActorPoolBase):
+        @staticmethod
+        def _actor_class(_max_restarts, _max_task_retries):
+            return _ActorFactory
+
+        @staticmethod
+        def _resolve_actor_num_cpus(_payload):
+            return 1
+
+        @staticmethod
+        def _resolve_actor_memory_bytes(_payload):
+            return 1
+
+        @staticmethod
+        def _build_actor_runtime_env(_ray_options):
+            return {}
+
+        @staticmethod
+        def _normalize_actor_node_ids(node_ids, *, expected_count):
+            assert len(node_ids) == expected_count
+            return list(node_ids)
+
+    with pytest.raises(RuntimeError, match="planned actor creation failure"):
+        _Pool(
+            payload={},
+            concurrency=2,
+            gpus_per_actor=0,
+            actor_node_ids=["a" * 56, "b" * 56],
+        )
+
+    assert killed == [("actor-0", True)]
+
+
+def test_udf_actor_pool_constructor_exposes_partial_actor_when_cleanup_fails(monkeypatch):
+    import duckdb.execution.udf_ray_actor_pool as actor_pool_mod
+
+    fail_kill = True
+
+    def _kill(_actor, *, no_restart):
+        assert no_restart is True
+        if fail_kill:
+            raise RuntimeError("planned actor cleanup failure")
+
+    fake_ray = types.SimpleNamespace(
+        put=lambda payload: ("payload-ref", payload),
+        kill=_kill,
+    )
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+
+    class _ActorFactory:
+        calls = 0
+
+        @classmethod
+        def options(cls, **_options):
+            class _BoundActor:
+                @staticmethod
+                def remote():
+                    actor_index = cls.calls
+                    cls.calls += 1
+                    if actor_index == 1:
+                        raise RuntimeError("planned actor creation failure")
+                    return f"actor-{actor_index}"
+
+            return _BoundActor
+
+    class _Pool(actor_pool_mod.UDFActorPoolBase):
+        @staticmethod
+        def _actor_class(_max_restarts, _max_task_retries):
+            return _ActorFactory
+
+        @staticmethod
+        def _resolve_actor_num_cpus(_payload):
+            return 1
+
+        @staticmethod
+        def _resolve_actor_memory_bytes(_payload):
+            return 1
+
+        @staticmethod
+        def _build_actor_runtime_env(_ray_options):
+            return {}
+
+        @staticmethod
+        def _normalize_actor_node_ids(node_ids, *, expected_count):
+            assert len(node_ids) == expected_count
+            return list(node_ids)
+
+    with pytest.raises(RuntimeError, match="partial actor cleanup also failed") as exc_info:
+        _Pool(
+            payload={},
+            concurrency=2,
+            gpus_per_actor=0,
+            actor_node_ids=["a" * 56, "b" * 56],
+        )
+
+    owned_pools = exc_info.value.owned_actor_pools
+    assert len(owned_pools) == 1
+    assert owned_pools[0].actors == ["actor-0"]
+
+    fail_kill = False
+    owned_pools[0].shutdown()
+    assert owned_pools[0].actors == []
 
 
 def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snapshot(monkeypatch):
@@ -1004,6 +1387,8 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=object(),
+        session_config={},
         conn=object(),
     )
 
@@ -1012,7 +1397,7 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
     assert handles_map["7"]["actor_handles"] == ["actor-0", "actor-1"]
 
 
-def test_ensure_actor_pools_for_plan_skips_python_udf_payload(monkeypatch):
+def test_ensure_actor_pools_for_plan_publishes_driver_handle_for_ray_task(monkeypatch):
     import duckdb.execution.udf_ray as udf_ray
 
     calls = []
@@ -1054,14 +1439,23 @@ def test_ensure_actor_pools_for_plan_skips_python_udf_payload(monkeypatch):
         ]
     )
 
+    query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={},
+        query_driver_handle=query_driver_handle,
+        session_config={},
         conn=object(),
     )
 
     assert created == []
-    assert handles_map == {}
+    assert handles_map == {
+        "9": {
+            "query_driver_handle": query_driver_handle,
+            "session_config": {},
+        }
+    }
+    assert plan.set_calls == [{"handles_map": handles_map}]
     assert calls == []
 
 
@@ -1078,6 +1472,8 @@ def test_ensure_actor_pools_for_plan_propagates_collect_errors(monkeypatch):
         udf_ray.ensure_actor_pools_for_plan(
             _BadPlan(),
             actor_node_ids_by_stage={},
+            query_driver_handle=object(),
+            session_config={},
             conn=object(),
         )
 
@@ -1121,6 +1517,8 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
         udf_ray.ensure_actor_pools_for_plan(
             plan,
             actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+            query_driver_handle=object(),
+            session_config={},
             conn=object(),
         )
     assert plan.set_calls == []
@@ -1242,11 +1640,14 @@ def test_physical_plan_structured_executor_options_reach_udf_builder(monkeypatch
     con = duckdb.connect()
     try:
         plan = _build_simple_ray_udf_plan(con)
+        query_driver_handle = object()
         plan.set_udf_actor_handles(
             {
                 "0": {
                     "actor_handles": ["actor-0"],
                     "actor_node_ids": ["node-a"],
+                    "query_driver_handle": query_driver_handle,
+                    "session_config": {},
                 }
             },
             conn=con,
@@ -1261,6 +1662,8 @@ def test_physical_plan_structured_executor_options_reach_udf_builder(monkeypatch
     assert all(call["payload_execution_backend"] == "ray_actor" for call in build_calls)
     assert build_calls[0]["options"]["actor_handles"] == ["actor-0"]
     assert build_calls[0]["options"]["actor_node_ids"] == ["node-a"]
+    assert build_calls[0]["options"]["query_driver_handle"] is query_driver_handle
+    assert build_calls[0]["options"]["session_config"] == {}
     assert table.column(0).to_pylist() == [2, 3]
 
 
@@ -1367,6 +1770,7 @@ def test_execute_native_udf_cleanup_does_not_deadlock_with_gil_held():
                 "0": {
                     "actor_handles": ["actor-0"],
                     "actor_node_ids": ["node-a"],
+                    "query_driver_handle": object(),
                 }
             },
             conn=con,
@@ -1471,6 +1875,8 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=object(),
+        session_config={},
     )
 
     assert len(created) == 1
@@ -1548,6 +1954,8 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
     _, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        query_driver_handle=object(),
+        session_config={},
     )
 
     assert [ref for ref, _timeout in fake_ray.future_calls] == init_refs

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -351,6 +351,8 @@ def test_actor_gpu_reservation_follows_resolved_backend(
         pools, _ = udf_ray.ensure_actor_pools_for_nodes(
             nodes,
             actor_node_ids_by_stage={stage_id: ("node-a",)},
+            query_driver_handle=object(),
+            session_config={},
         )
 
     assert len(pools) == 1
@@ -460,6 +462,8 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
     pools, _ = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
         actor_node_ids_by_stage={stage_id: ("node-a", "node-a", "node-a")},
+        query_driver_handle=object(),
+        session_config={},
     )
 
     assert len(pools) == 1

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -117,12 +117,13 @@ def test_ray_task_remote_keeps_options_available_for_lease_node_affinity():
     from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
     import duckdb.execution.udf_ray as fur
+    from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 
     for builder in (
         fur._build_bundle_stream_remote,
         fur._build_ref_bundle_stream_remote,
     ):
-        remote_fn = builder(1.0, 0.0, 2 * _GIB, 2, {})
+        remote_fn = builder(1.0, 0.0, 2 * _GIB, 2, {}, build_session_runtime_env_vars({}))
         scheduled = remote_fn.options(
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 node_id=_NODE_ID,
@@ -143,9 +144,34 @@ def test_ray_task_executor_requires_runner_owned_ray_runtime(monkeypatch):
         fur._build_ray_task_executor(_distributed_payload(), {})
 
 
+def test_ray_task_executor_requires_explicit_query_driver_handle(monkeypatch):
+    import ray
+
+    import duckdb.execution.udf_ray as fur
+
+    monkeypatch.setattr(ray, "is_initialized", lambda: True)
+
+    with pytest.raises(RuntimeError, match="explicit query driver handle"):
+        fur._build_ray_task_executor(
+            _distributed_payload(),
+            {
+                "max_task_retries": None,
+            },
+        )
+
+
 def test_ray_udf_rejects_unknown_options_without_compatibility_branches():
     import duckdb.execution.udf as udf
 
+    query_driver_handle = object()
+    assert (
+        udf.normalize_options(
+            {
+                "query_driver_handle": query_driver_handle,
+            }
+        )["query_driver_handle"]
+        is query_driver_handle
+    )
     with pytest.raises(ValueError, match="unknown UDF executor options: ray_address"):
         udf.normalize_options({"ray_address": "auto"})
     with pytest.raises(TypeError, match="must be a dict"):
@@ -205,6 +231,7 @@ def test_task_executor_consumes_pregranted_admission_with_exact_resources(monkey
         payload,
         run_bundle_stream=object(),
         run_ref_bundle_stream=object(),
+        query_driver_handle=object(),
     )
     admission = SimpleNamespace(
         driver=object(),
@@ -249,6 +276,7 @@ def test_task_submission_starts_immediately_from_pregranted_lease(monkeypatch):
         _distributed_payload(),
         run_bundle_stream=_Remote(),
         run_ref_bundle_stream=_Remote(),
+        query_driver_handle=object(),
     )
     lease = {
         "query_id": "q1",

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -195,6 +195,41 @@ def test_local_plan_snapshot_does_not_open_a_ray_session(monkeypatch):
     assert closed_session_ids == []
 
 
+@pytest.mark.parametrize(
+    ("configured_runner", "environment_runner", "expects_close"),
+    [
+        ("ray", "local", True),
+        ("local", "ray", False),
+    ],
+)
+def test_plan_snapshot_uses_configured_runner_for_session_lifecycle(
+    monkeypatch,
+    configured_runner,
+    environment_runner,
+    expects_close,
+):
+    ray_cxx = _require_ray_cxx()
+    closed_session_ids = []
+    monkeypatch.setenv("VANE_RUNNER", environment_runner)
+    monkeypatch.setattr(
+        duckdb.vane_runners_cpp,
+        "get_or_infer_runner_type",
+        lambda: configured_runner,
+    )
+    monkeypatch.setattr(
+        "duckdb.runners.ray.runner.notify_connection_closed",
+        closed_session_ids.append,
+    )
+
+    connection = duckdb.connect()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "configured-runner-session")
+    session_id = plan.session_id()
+
+    connection.close()
+
+    assert closed_session_ids == ([session_id] if expects_close else [])
+
+
 def test_deserialized_plan_rejects_missing_session_config():
     ray_cxx = _require_ray_cxx()
     connection = duckdb.connect()
@@ -374,3 +409,204 @@ def test_pickled_physical_plan_replays_bootstrap_and_runtime_connection_snapshot
 
     assert table.column(0).to_pylist() == ["snapshot-test"]
     assert table.column(1).to_pylist() == ["UTC"]
+
+
+def test_effective_session_config_reaches_nondefault_bootstrap_connection(tmp_path):
+    ray_cxx = _require_ray_cxx()
+    database_path = str(tmp_path / "session-bootstrap.duckdb")
+    source_conn = duckdb.connect(database_path)
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute("SET GLOBAL s3_access_key_id='source-placeholder-key'")
+    relation = source_conn.sql("SELECT CAST(current_setting('s3_access_key_id') AS VARCHAR) AS access_key")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "snapshot-effective-session-config",
+    )
+    effective_config = {
+        "AWS_ACCESS_KEY_ID": "resolved-profile-key",
+        "AWS_SECRET_ACCESS_KEY": "resolved-profile-secret",
+    }
+
+    physical_plan = logical_plan.to_physical_plan(
+        duckdb.connect(),
+        effective_session_config=effective_config,
+    )
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        duckdb.connect().cursor(),
+        restored_plan,
+        effective_session_config=effective_config,
+    )
+
+    assert _table_from_native_result(result).column(0).to_pylist() == ["resolved-profile-key"]
+
+
+def test_explicit_connection_s3_settings_override_effective_session_config():
+    ray_cxx = _require_ray_cxx()
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute("SET s3_access_key_id='explicit-key'")
+    source_conn.execute("SET s3_secret_access_key='explicit-secret'")
+    source_conn.execute("SET s3_session_token=''")
+    relation = source_conn.sql(
+        "SELECT current_setting('s3_access_key_id') AS access_key, "
+        "current_setting('s3_secret_access_key') AS secret_key, "
+        "current_setting('s3_session_token') AS session_token"
+    )
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "snapshot-explicit-s3-precedence",
+    )
+    assert logical_plan.has_explicit_s3_credentials() is True
+    effective_config = {
+        "AWS_ACCESS_KEY_ID": "environment-key",
+        "AWS_SECRET_ACCESS_KEY": "environment-secret",
+        "AWS_SESSION_TOKEN": "environment-token",
+    }
+
+    planning_conn = duckdb.connect()
+    physical_plan = logical_plan.to_physical_plan(
+        planning_conn,
+        effective_session_config=effective_config,
+    )
+    assert physical_plan.has_explicit_s3_credentials() is True
+    assert planning_conn.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "explicit-key"
+
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+    worker_cursor = duckdb.connect().cursor()
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        worker_cursor,
+        restored_plan,
+        effective_session_config=effective_config,
+    )
+
+    table = _table_from_native_result(result)
+    assert table.column(0).to_pylist() == ["explicit-key"]
+    assert table.column(1).to_pylist() == ["explicit-secret"]
+    assert table.column(2).to_pylist() == [""]
+    assert worker_cursor.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "explicit-key"
+    assert worker_cursor.execute("SELECT current_setting('s3_session_token')").fetchone()[0] == ""
+
+
+def test_connection_snapshot_requires_both_explicit_s3_credential_settings():
+    ray_cxx = _require_ray_cxx()
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute("SET s3_access_key_id='explicit-key'")
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-partial-explicit-s3",
+    )
+
+    with pytest.raises(
+        Exception,
+        match="must set both s3_access_key_id and s3_secret_access_key",
+    ):
+        logical_plan.has_explicit_s3_credentials()
+
+
+@pytest.mark.parametrize(
+    ("access_key", "secret_key"),
+    [
+        ("explicit-key", ""),
+        ("", "explicit-secret"),
+    ],
+)
+def test_connection_snapshot_rejects_explicit_s3_key_pair_with_one_empty_value(
+    access_key,
+    secret_key,
+):
+    ray_cxx = _require_ray_cxx()
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute(f"SET s3_access_key_id='{access_key}'")
+    source_conn.execute(f"SET s3_secret_access_key='{secret_key}'")
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-empty-partial-explicit-s3",
+    )
+
+    with pytest.raises(
+        Exception,
+        match="must set both s3_access_key_id and s3_secret_access_key",
+    ):
+        logical_plan.has_explicit_s3_credentials()
+
+
+def test_connection_snapshot_rejects_explicit_s3_session_token_without_key_pair():
+    ray_cxx = _require_ray_cxx()
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute("SET s3_session_token='explicit-token'")
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-partial-explicit-s3-token",
+    )
+
+    with pytest.raises(
+        Exception,
+        match="must set both s3_access_key_id and s3_secret_access_key",
+    ):
+        logical_plan.has_explicit_s3_credentials()
+
+
+def test_connection_snapshot_recognizes_explicit_empty_s3_credentials():
+    ray_cxx = _require_ray_cxx()
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    source_conn.execute("SET s3_access_key_id=''")
+    source_conn.execute("SET s3_secret_access_key=''")
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-empty-explicit-s3",
+    )
+
+    assert logical_plan.has_explicit_s3_credentials() is True
+
+
+def test_effective_session_config_overrides_stale_captured_environment(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "stale-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "stale-secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "stale-token")
+
+    source_conn = duckdb.connect()
+    source_conn.execute("LOAD httpfs")
+    relation = source_conn.sql(
+        "SELECT current_setting('s3_access_key_id') AS access_key, "
+        "current_setting('s3_secret_access_key') AS secret_key, "
+        "current_setting('s3_session_token') AS session_token"
+    )
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "snapshot-refreshed-s3-precedence",
+    )
+    effective_config = {
+        "AWS_ACCESS_KEY_ID": "refreshed-key",
+        "AWS_SECRET_ACCESS_KEY": "refreshed-secret",
+        "AWS_SESSION_TOKEN": "refreshed-token",
+    }
+
+    planning_conn = duckdb.connect()
+    physical_plan = logical_plan.to_physical_plan(
+        planning_conn,
+        effective_session_config=effective_config,
+    )
+    assert planning_conn.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "refreshed-key"
+
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+    worker_cursor = duckdb.connect().cursor()
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        worker_cursor,
+        restored_plan,
+        effective_session_config=effective_config,
+    )
+
+    table = _table_from_native_result(result)
+    assert table.column(0).to_pylist() == ["refreshed-key"]
+    assert table.column(1).to_pylist() == ["refreshed-secret"]
+    assert table.column(2).to_pylist() == ["refreshed-token"]

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import pickle
 
 import pytest
@@ -23,6 +24,287 @@ def _table_from_native_result(result):
     if len(payloads) == 1:
         return payloads[0]
     return pa.concat_tables(payloads)
+
+
+def test_logical_plan_captures_connection_scoped_vane_session(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+
+    monkeypatch.setenv("AWS_REVIEW_SESSION_SECRET_75", "session-a-secret")
+    connection_a = duckdb.connect()
+    cursor_a = connection_a.cursor()
+
+    monkeypatch.delenv("AWS_REVIEW_SESSION_SECRET_75")
+    connection_b = duckdb.connect()
+
+    plan_a = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection_a.sql("SELECT 1"), "session-a")
+    cursor_plan_a = ray_cxx.PyLogicalPlan.from_duckdb_relation(cursor_a.sql("SELECT 1"), "session-a-cursor")
+    plan_b = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection_b.sql("SELECT 1"), "session-b")
+
+    assert plan_a.session_id()
+    assert plan_a.session_id() == cursor_plan_a.session_id()
+    assert plan_a.session_id() != plan_b.session_id()
+    assert plan_a.session_config()["AWS_REVIEW_SESSION_SECRET_75"] == "session-a-secret"
+    assert "AWS_REVIEW_SESSION_SECRET_75" not in plan_b.session_config()
+
+    restored_plan = pickle.loads(pickle.dumps(plan_a.to_physical_plan(duckdb.connect())))
+    assert restored_plan.session_id() == plan_a.session_id()
+    assert restored_plan.session_config() == plan_a.session_config()
+
+
+def test_datasource_relation_retains_connection_scoped_vane_session(monkeypatch):
+    from duckdb.datasource import DataSource, DataSourceTask, read_datasource
+
+    ray_cxx = _require_ray_cxx()
+
+    class SnapshotTask(DataSourceTask):
+        def execute(self):
+            return iter(())
+
+    class SnapshotSource(DataSource):
+        @property
+        def schema(self):
+            return {"value": "INTEGER"}
+
+        def get_tasks(self):
+            return iter((SnapshotTask(),))
+
+    monkeypatch.setenv("AWS_DATASOURCE_SESSION_SECRET_75", "datasource-secret")
+    connection = duckdb.connect()
+    relation = read_datasource(SnapshotSource(), con=connection)
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "datasource-session")
+
+    assert plan.session_id()
+    assert plan.session_config()["AWS_DATASOURCE_SESSION_SECRET_75"] == "datasource-secret"
+
+
+def test_session_aws_settings_replay_only_on_the_target_connection_context(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://minio-a.internal:9000")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "session-a-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "session-a-secret")
+    connection_a = duckdb.connect()
+    plan_a = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection_a.sql("SELECT 1"), "session-a-settings")
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://minio-b.internal:9443")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "session-b-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "session-b-secret")
+    connection_b = duckdb.connect()
+    plan_b = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection_b.sql("SELECT 1"), "session-b-settings")
+
+    for key in ("AWS_ENDPOINT_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
+        monkeypatch.delenv(key)
+    target_root = duckdb.connect()
+    target_a = target_root.cursor()
+    target_b = target_root.cursor()
+
+    plan_a.to_physical_plan(target_a)
+    plan_b.to_physical_plan(target_b)
+
+    assert target_a.execute("SELECT current_setting('s3_endpoint')").fetchone()[0] == "minio-a.internal:9000"
+    assert target_a.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "session-a-key"
+    assert target_a.execute("SELECT current_setting('s3_use_ssl')").fetchone()[0] is False
+    assert target_b.execute("SELECT current_setting('s3_endpoint')").fetchone()[0] == "minio-b.internal:9443"
+    assert target_b.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "session-b-key"
+    assert target_b.execute("SELECT current_setting('s3_use_ssl')").fetchone()[0] is True
+
+
+def test_cursor_plan_marks_owning_connection_session_for_close(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    closed_session_ids = []
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setattr(
+        "duckdb.runners.ray.runner.notify_connection_closed",
+        closed_session_ids.append,
+    )
+
+    connection = duckdb.connect()
+    cursor = connection.cursor()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(cursor.sql("SELECT 1"), "cursor-session-close")
+    session_id = plan.session_id()
+
+    cursor.close()
+    assert closed_session_ids == []
+
+    connection.close()
+    assert closed_session_ids == [session_id]
+
+
+def test_cursor_keeps_vane_session_alive_after_root_connection_is_collected(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    closed_session_ids = []
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setattr(
+        "duckdb.runners.ray.runner.notify_connection_closed",
+        closed_session_ids.append,
+    )
+
+    connection = duckdb.connect()
+    cursor = connection.cursor()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(cursor.sql("SELECT 1"), "cursor-session-gc")
+    session_id = plan.session_id()
+
+    del connection
+    gc.collect()
+    assert closed_session_ids == []
+
+    cursor.close()
+    assert closed_session_ids == [session_id]
+
+
+def test_connection_close_notification_failure_remains_retryable(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    closed_session_ids = []
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def _notify(session_id):
+        closed_session_ids.append(session_id)
+        if len(closed_session_ids) == 1:
+            raise RuntimeError("planned session close notification failure")
+
+    monkeypatch.setattr(
+        "duckdb.runners.ray.runner.notify_connection_closed",
+        _notify,
+    )
+
+    connection = duckdb.connect()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "session-close-retry")
+    session_id = plan.session_id()
+
+    with pytest.raises(RuntimeError, match="planned session close notification failure"):
+        connection.close()
+    connection.close()
+
+    assert closed_session_ids == [session_id, session_id]
+
+
+def test_local_plan_snapshot_does_not_open_a_ray_session(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    closed_session_ids = []
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    monkeypatch.setattr(
+        "duckdb.runners.ray.runner.notify_connection_closed",
+        closed_session_ids.append,
+    )
+
+    connection = duckdb.connect()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "local-session")
+
+    assert plan.session_id()
+    connection.close()
+    assert closed_session_ids == []
+
+
+def test_deserialized_plan_rejects_missing_session_config():
+    ray_cxx = _require_ray_cxx()
+    connection = duckdb.connect()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "missing-session-config")
+    state = list(plan.__getstate__())
+    state[3] = {"vane_session": {"id": plan.session_id()}}
+
+    malformed_plan = ray_cxx.PyLogicalPlan.__new__(ray_cxx.PyLogicalPlan)
+    with pytest.raises(Exception, match="Vane session is missing config"):
+        malformed_plan.__setstate__(tuple(state))
+
+
+def test_plan_pickles_reject_pre_session_state_shapes():
+    ray_cxx = _require_ray_cxx()
+    connection = duckdb.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "strict-session-state")
+    logical_state = logical_plan.__getstate__()
+    malformed_logical = ray_cxx.PyLogicalPlan.__new__(ray_cxx.PyLogicalPlan)
+
+    with pytest.raises(Exception, match="Invalid state for PyLogicalPlan"):
+        malformed_logical.__setstate__(logical_state[:3])
+
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    physical_state = physical_plan.__getstate__()
+    malformed_physical = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+
+    with pytest.raises(Exception, match="Invalid state for PyPhysicalPlanWrapper pickle"):
+        malformed_physical.__setstate__(physical_state[:6])
+
+    missing_resource_owner = list(physical_state)
+    missing_resource_owner[3] = ""
+    with pytest.raises(Exception, match="resource_query_id must not be empty"):
+        malformed_physical.__setstate__(tuple(missing_resource_owner))
+
+
+def test_physical_plan_replay_state_has_query_lifecycle(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    query_id = "query-replay-lifecycle"
+
+    monkeypatch.setenv("AWS_QUERY_REPLAY_SECRET", "session-a")
+    connection_a = duckdb.connect()
+    plan_a = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection_a.sql("SELECT 1"),
+        "plan-replay-source-a",
+    ).to_physical_plan(duckdb.connect())
+
+    monkeypatch.setenv("AWS_QUERY_REPLAY_SECRET", "session-b")
+    connection_b = duckdb.connect()
+    plan_b = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection_b.sql("SELECT 1"),
+        "plan-replay-source-b",
+    ).to_physical_plan(duckdb.connect())
+
+    restored_plan_a = pickle.loads(pickle.dumps(plan_a))
+    assert restored_plan_a.idx() != query_id
+    assert restored_plan_a.resource_query_id() == plan_a.idx()
+    assert ray_cxx._lookup_query_connection_snapshot(query_id) is None
+
+    try:
+        assert ray_cxx._register_query_python_replay_state(query_id, restored_plan_a) is True
+        assert ray_cxx._register_query_python_replay_state(query_id, restored_plan_a) is False
+        assert (
+            ray_cxx._lookup_query_connection_snapshot(query_id)["vane_session"]["config"]["AWS_QUERY_REPLAY_SECRET"]
+            == "session-a"
+        )
+
+        with pytest.raises(Exception, match="different Vane session"):
+            ray_cxx._register_query_python_replay_state(query_id, plan_b)
+    finally:
+        ray_cxx._cleanup_query_python_replay_state(query_id)
+
+    assert ray_cxx._lookup_query_connection_snapshot(query_id) is None
+
+
+def test_query_replay_state_rejects_different_python_runtime_fields():
+    ray_cxx = _require_ray_cxx()
+    connection = duckdb.connect()
+    source_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection.sql("SELECT 1"),
+        "plan-replay-runtime-fields",
+    ).to_physical_plan(duckdb.connect())
+    source_state = list(source_plan.__getstate__())
+
+    def plan_with(*, registrations, actor_handles):
+        state = list(source_state)
+        state[4] = registrations
+        state[5] = actor_handles
+        plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+        plan.__setstate__(tuple(state))
+        return plan
+
+    registrations_query_id = "query-replay-registration-conflict"
+    registrations_a = plan_with(registrations=[{"digest": "a"}], actor_handles=None)
+    registrations_b = plan_with(registrations=[{"digest": "b"}], actor_handles=None)
+    try:
+        assert ray_cxx._register_query_python_replay_state(registrations_query_id, registrations_a) is True
+        with pytest.raises(Exception, match="different Python UDF registrations"):
+            ray_cxx._register_query_python_replay_state(registrations_query_id, registrations_b)
+    finally:
+        ray_cxx._cleanup_query_python_replay_state(registrations_query_id)
+
+    handles_query_id = "query-replay-actor-handle-conflict"
+    handles_a = plan_with(registrations=None, actor_handles={"node": {"handle": "a"}})
+    handles_b = plan_with(registrations=None, actor_handles={"node": {"handle": "b"}})
+    try:
+        assert ray_cxx._register_query_python_replay_state(handles_query_id, handles_a) is True
+        with pytest.raises(Exception, match="different Python UDF actor handles"):
+            ray_cxx._register_query_python_replay_state(handles_query_id, handles_b)
+    finally:
+        ray_cxx._cleanup_query_python_replay_state(handles_query_id)
 
 
 def test_logical_plan_replays_connection_snapshot_on_to_physical_plan():

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -51,6 +51,32 @@ def test_logical_plan_captures_connection_scoped_vane_session(monkeypatch):
     assert restored_plan.session_config() == plan_a.session_config()
 
 
+def test_vllm_named_actor_pool_identity_includes_connection_session():
+    ray_cxx = _require_ray_cxx()
+    connection_a = duckdb.connect()
+    connection_b = duckdb.connect()
+    query_id = "reused-query-id"
+    options = '{"use_ray":true}'
+
+    plan_a = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection_a.sql(f"SELECT vllm('hello', 'test-model', '{options}')"),
+        query_id,
+    ).to_physical_plan(connection_a)
+    plan_b = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection_b.sql(f"SELECT vllm('hello', 'test-model', '{options}')"),
+        query_id,
+    ).to_physical_plan(connection_b)
+
+    nodes_a = plan_a.collect_vllm_nodes(conn=connection_a)
+    nodes_b = plan_b.collect_vllm_nodes(conn=connection_b)
+
+    assert len(nodes_a) == 1
+    assert len(nodes_b) == 1
+    assert nodes_a[0]["pool_name"] != nodes_b[0]["pool_name"]
+    assert plan_a.session_id() in nodes_a[0]["pool_name"]
+    assert plan_b.session_id() in nodes_b[0]["pool_name"]
+
+
 def test_datasource_relation_retains_connection_scoped_vane_session(monkeypatch):
     from duckdb.datasource import DataSource, DataSourceTask, read_datasource
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2706,6 +2706,10 @@ def test_ray_worker_manager_shutdown_aborts_all_actors_after_prepare_error(monke
         "worker-failing",
     ]
 
+    manager.shutdown()
+
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "abort", "abort"]
+
 
 def test_ray_worker_manager_shutdown_finishes_all_actors_after_finish_error(monkeypatch):
     calls: list[tuple[str, str]] = []
@@ -2759,6 +2763,10 @@ def test_ray_worker_manager_shutdown_finishes_all_actors_after_finish_error(monk
         "worker-clean",
         "worker-failing",
     ]
+
+    manager.shutdown()
+
+    assert [phase for phase, _ in calls] == ["prepare", "prepare", "finish", "finish"]
 
 
 def test_ray_worker_manager_worker_snapshots_fail_fast(monkeypatch):

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -127,7 +127,7 @@ def test_worker_task_plan_rejects_present_plan_without_root():
 @pytest.mark.parametrize(
     ("execution_query_id", "resource_query_id", "expected"),
     [
-        ("query-root", None, "query-root"),
+        ("query-root", "query-root", "query-root"),
         ("query-root:orderby:sample", "query-root", "query-root"),
     ],
 )
@@ -143,6 +143,14 @@ def test_submission_error_is_owned_by_outer_resource_query(
         )
         == expected
     )
+
+
+def test_submission_error_rejects_missing_resource_query_owner():
+    with pytest.raises(RuntimeError, match="requires a non-empty resource_query_id"):
+        duckdb.ray_cxx._submission_error_owner_query_id_for_test(
+            "query-root",
+            None,
+        )
 
 
 @pytest.mark.parametrize("manager_kind", ["python-backend", "ray-worker-manager"])

--- a/tests/fast/test_ray_env.py
+++ b/tests/fast/test_ray_env.py
@@ -133,13 +133,16 @@ def test_session_runtime_setup_scrubs_inheritance_then_installs_explicit_context
     }
 
     carrier = build_session_runtime_env_vars(config)
-    os.environ.update(carrier)
-    install_explicit_session_runtime_env()
+    try:
+        os.environ.update(carrier)
+        install_explicit_session_runtime_env()
 
-    assert "AWS_SECRET_ACCESS_KEY" not in os.environ
-    assert os.environ["AWS_ACCESS_KEY_ID"] == "session-key"
-    assert os.environ["DUCKDB_ISSUE75_SESSION_SECRET"] == "session-duckdb-secret"
-    assert os.environ["VANE_AUTH_HEADER"] == "session-auth"
-    assert os.environ["VANE_RUNNER"] == "job-runner"
-    assert os.environ["VANE_SESSION_DIR"] == "/tmp/vane-job-session"
-    assert all(key not in os.environ for key in carrier)
+        assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+        assert os.environ["AWS_ACCESS_KEY_ID"] == "session-key"
+        assert os.environ["DUCKDB_ISSUE75_SESSION_SECRET"] == "session-duckdb-secret"
+        assert os.environ["VANE_AUTH_HEADER"] == "session-auth"
+        assert os.environ["VANE_RUNNER"] == "job-runner"
+        assert os.environ["VANE_SESSION_DIR"] == "/tmp/vane-job-session"
+        assert all(key not in os.environ for key in carrier)
+    finally:
+        scrub_shared_runtime_session_env()

--- a/tests/fast/test_ray_env.py
+++ b/tests/fast/test_ray_env.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 
 import os
 
+from duckdb.runners.ray.ray_env import (
+    build_explicit_session_process_env,
+    build_session_runtime_env_vars,
+    collect_vane_env_overrides,
+    install_explicit_session_runtime_env,
+    scrub_shared_runtime_session_env,
+    session_environment_overrides,
+)
 from duckdb.runners.ray.runner import (
     _configure_scan_task_backlog_env,
 )
-from duckdb.runners.ray.ray_env import collect_vane_env_overrides
 
 
 def test_ray_runner_does_not_inject_udf_stage_count_env(monkeypatch):
@@ -34,6 +41,13 @@ def test_collect_vane_env_overrides_excludes_app_benchmark_env(monkeypatch):
     for key in app_env_keys:
         monkeypatch.setenv(key, f"value-for-{key}")
     monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setenv("VANE_OPENAI_API_KEY", "session-api-key")
+    monkeypatch.setenv("VANE_PRIVATE_KEY_PATH", "/tmp/session-private-key")
+    monkeypatch.setenv("VANE_AUTH_HEADER", "session-auth-header")
+    monkeypatch.setenv("VANE_S3_ENDPOINT", "http://session-endpoint")
+    monkeypatch.setenv("VANE_SERVICE_URL", "https://session-service")
+    monkeypatch.setenv("DUCKDB_SHUFFLE_DIRS", "file:///tmp/vane-shuffle")
+    monkeypatch.setenv("DUCKDB_ISSUE75_SESSION_SECRET", "session-duckdb-secret")
     monkeypatch.setenv("AWS_ENDPOINT_URL", "http://127.0.0.1:9000")
     monkeypatch.setenv("RAY_ADDRESS", "auto")
 
@@ -42,5 +56,90 @@ def test_collect_vane_env_overrides_excludes_app_benchmark_env(monkeypatch):
     for key in app_env_keys:
         assert key not in overrides
     assert overrides["VANE_RUNNER"] == "ray"
-    assert overrides["AWS_ENDPOINT_URL"] == "http://127.0.0.1:9000"
-    assert overrides["RAY_ADDRESS"] == "auto"
+    assert "VANE_OPENAI_API_KEY" not in overrides
+    assert "VANE_PRIVATE_KEY_PATH" not in overrides
+    assert "VANE_AUTH_HEADER" not in overrides
+    assert "VANE_S3_ENDPOINT" not in overrides
+    assert "VANE_SERVICE_URL" not in overrides
+    assert overrides["DUCKDB_SHUFFLE_DIRS"] == "file:///tmp/vane-shuffle"
+    assert "DUCKDB_ISSUE75_SESSION_SECRET" not in overrides
+    assert "AWS_ENDPOINT_URL" not in overrides
+    assert "RAY_ADDRESS" not in overrides
+
+
+def test_shared_runtime_setup_scrubs_inherited_session_environment(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "inherited-aws-key")
+    monkeypatch.setenv("DUCKDB_ISSUE75_SESSION_SECRET", "inherited-duckdb-secret")
+    monkeypatch.setenv("DUCKDB_SHUFFLE_DIRS", "file:///tmp/vane-shuffle")
+    monkeypatch.setenv("VANE_OPENAI_API_KEY", "inherited-vane-key")
+    monkeypatch.setenv("VANE_SERVICE_URL", "https://inherited-service")
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setenv("VANE_SESSION_DIR", "/tmp/vane-job-session")
+
+    scrub_shared_runtime_session_env()
+
+    assert "AWS_ACCESS_KEY_ID" not in os.environ
+    assert "DUCKDB_ISSUE75_SESSION_SECRET" not in os.environ
+    assert os.environ["DUCKDB_SHUFFLE_DIRS"] == "file:///tmp/vane-shuffle"
+    assert "VANE_OPENAI_API_KEY" not in os.environ
+    assert "VANE_SERVICE_URL" not in os.environ
+    assert os.environ["VANE_RUNNER"] == "ray"
+    assert os.environ["VANE_SESSION_DIR"] == "/tmp/vane-job-session"
+
+
+def test_explicit_session_process_env_replaces_inherited_managed_values():
+    environment = build_explicit_session_process_env(
+        {
+            "AWS_ACCESS_KEY_ID": "session-key",
+            "VANE_AUTH_HEADER": "session-auth",
+        },
+        base_env={
+            "AWS_SECRET_ACCESS_KEY": "inherited-secret",
+            "DUCKDB_ISSUE75_SESSION_SECRET": "inherited-duckdb-secret",
+            "VANE_AUTH_HEADER": "inherited-auth",
+            "VANE_RUNNER": "ray",
+            "VANE_SESSION_DIR": "/tmp/vane-job-session",
+            "PATH": "/usr/bin",
+        },
+    )
+
+    assert environment == {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "VANE_AUTH_HEADER": "session-auth",
+        "VANE_RUNNER": "ray",
+        "VANE_SESSION_DIR": "/tmp/vane-job-session",
+        "PATH": "/usr/bin",
+    }
+
+
+def test_session_runtime_setup_scrubs_inheritance_then_installs_explicit_context(monkeypatch):
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "inherited-secret")
+    monkeypatch.setenv("DUCKDB_ISSUE75_SESSION_SECRET", "inherited-duckdb-secret")
+    monkeypatch.setenv("VANE_AUTH_HEADER", "inherited-auth")
+    monkeypatch.setenv("VANE_RUNNER", "job-runner")
+    monkeypatch.setenv("VANE_SESSION_DIR", "/tmp/vane-job-session")
+    config = {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "DUCKDB_ISSUE75_SESSION_SECRET": "session-duckdb-secret",
+        "VANE_AUTH_HEADER": "session-auth",
+        "VANE_RUNNER": "session-runner",
+        "VANE_SESSION_DIR": "/tmp/vane-connection-session",
+    }
+
+    assert session_environment_overrides(config) == {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "DUCKDB_ISSUE75_SESSION_SECRET": "session-duckdb-secret",
+        "VANE_AUTH_HEADER": "session-auth",
+    }
+
+    carrier = build_session_runtime_env_vars(config)
+    os.environ.update(carrier)
+    install_explicit_session_runtime_env()
+
+    assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "session-key"
+    assert os.environ["DUCKDB_ISSUE75_SESSION_SECRET"] == "session-duckdb-secret"
+    assert os.environ["VANE_AUTH_HEADER"] == "session-auth"
+    assert os.environ["VANE_RUNNER"] == "job-runner"
+    assert os.environ["VANE_SESSION_DIR"] == "/tmp/vane-job-session"
+    assert all(key not in os.environ for key in carrier)

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import os
 import subprocess
 import sys
 import threading
@@ -8133,6 +8134,10 @@ def test_register_fragments_awaits_plan_refs_without_ray_get(monkeypatch):
     )
 
     class _Plan:
+        @staticmethod
+        def resource_query_id():
+            return "query-resource"
+
         def has_root(self):
             return True
 
@@ -8154,7 +8159,7 @@ def test_register_fragments_awaits_plan_refs_without_ray_get(monkeypatch):
     assert plan_ref.awaited
     assert actor._plan_fragments["query-1:node:1"] is resolved_plan
     assert actor._query_fragments == {"query-1": {"query-1:node:1"}}
-    assert replay_registrations == [("query-1", resolved_plan)]
+    assert replay_registrations == [("query-resource", resolved_plan)]
 
 
 def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
@@ -8229,6 +8234,7 @@ def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
     actor._session_connections = {}
+    actor._session_operation_locks = {}
     actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
     actor._session_connections_lock = threading.RLock()
     actor._shutdown_started = False
@@ -8243,7 +8249,12 @@ def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
             return _SessionConnection()
 
     actor._get_shared_conn = lambda: _SharedConnection()
-    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", lambda *_args: None)
+
+    def _configure(_connection, config, *, use_session_credentials):
+        assert use_session_credentials is True
+        return dict(config)
+
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", _configure)
 
     session_connection = actor_cls._get_session_conn(
         actor,
@@ -8259,7 +8270,7 @@ def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
         is session_connection
     )
 
-    actor_cls.close_session(actor, "session-a")
+    asyncio.run(actor_cls.close_session(actor, "session-a"))
 
     assert closed == ["session"]
     with pytest.raises(RuntimeError, match="Vane session is closed"):
@@ -8268,6 +8279,159 @@ def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
             "session-a",
             {"AWS_ACCESS_KEY_ID": "key-a"},
         )
+    assert actor._session_operation_locks == {}
+
+
+def test_worker_handle_session_close_treats_dead_actor_as_terminal(monkeypatch):
+    close_ref = object()
+    calls = []
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(session_id):
+            calls.append(session_id)
+            return close_ref
+
+    worker_handle = object.__new__(_ProductionRayWorkerActorHandle)
+    worker_handle.actor_handle = SimpleNamespace(close_session=_CloseMethod())
+
+    import duckdb.runners.ray.safe_get as safe_get
+
+    monkeypatch.setattr(
+        safe_get,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ray.exceptions.RayActorError(error_msg="worker exited")),
+    )
+
+    worker_handle.close_session("session-a")
+
+    assert calls == ["session-a"]
+
+
+def test_worker_session_connection_open_is_single_flight(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._session_connections = {}
+    actor._session_s3_configs = {}
+    actor._session_operation_locks = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    configure_started = threading.Event()
+    configure_release = threading.Event()
+    created_connections = []
+    results = []
+    errors = []
+
+    class _SessionConnection:
+        def close(self):
+            raise AssertionError("single-flight session connection must not be discarded")
+
+    class _SharedConnection:
+        def cursor(self):
+            connection = _SessionConnection()
+            created_connections.append(connection)
+            return connection
+
+    def _configure(_connection, config, *, use_session_credentials):
+        assert use_session_credentials is True
+        configure_started.set()
+        assert configure_release.wait(timeout=1.0)
+        return dict(config)
+
+    actor._get_shared_conn = lambda: _SharedConnection()
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", _configure)
+
+    def _open():
+        try:
+            results.append(actor_cls._get_session_conn(actor, "session-a", {"AWS_PROFILE": "analytics"}))
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_open)
+    second = threading.Thread(target=_open)
+    first.start()
+    assert configure_started.wait(timeout=1.0)
+    second.start()
+    time.sleep(0.01)
+    assert len(created_connections) == 1
+    configure_release.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert results == [created_connections[0], created_connections[0]]
+
+
+def test_worker_session_credential_refresh_is_single_flight(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    connection = object()
+    actor._session_connections = {"session-a": ({"AWS_PROFILE": "analytics"}, connection)}
+    actor._session_s3_configs = {
+        "session-a": {
+            "AWS_ACCESS_KEY_ID": "old-key",
+            "AWS_SECRET_ACCESS_KEY": "old-secret",
+            worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "0",
+        }
+    }
+    actor._session_operation_locks = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    resolver_started = threading.Event()
+    resolver_release = threading.Event()
+    resolver_calls = []
+    results = []
+    errors = []
+
+    def _resolve(config):
+        resolver_calls.append(dict(config))
+        resolver_started.set()
+        assert resolver_release.wait(timeout=1.0)
+        return (
+            {
+                "AWS_ACCESS_KEY_ID": "new-key",
+                "AWS_SECRET_ACCESS_KEY": "new-secret",
+            },
+            200.0,
+        )
+
+    monkeypatch.setattr(worker_mod, "_resolve_session_aws_credentials", _resolve)
+    monkeypatch.setattr(worker_mod.time, "time", lambda: 100.0)
+
+    def _refresh():
+        try:
+            results.append(
+                actor_cls._refresh_session_s3_config(
+                    actor,
+                    "session-a",
+                    {"AWS_PROFILE": "analytics"},
+                    connection,
+                    use_session_credentials=True,
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_refresh)
+    second = threading.Thread(target=_refresh)
+    first.start()
+    assert resolver_started.wait(timeout=1.0)
+    second.start()
+    time.sleep(0.01)
+    assert len(resolver_calls) == 1
+    resolver_release.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert len(resolver_calls) == 1
+    assert [result["AWS_ACCESS_KEY_ID"] for result in results] == ["new-key", "new-key"]
 
 
 def test_worker_session_configuration_failure_closes_unpublished_connection(monkeypatch):
@@ -8288,10 +8452,15 @@ def test_worker_session_configuration_failure_closes_unpublished_connection(monk
             return _SessionConnection()
 
     actor._get_shared_conn = lambda: _SharedConnection()
+
+    def _fail_configuration(_connection, _config, *, use_session_credentials):
+        assert use_session_credentials is True
+        raise RuntimeError("planned session configuration failure")
+
     monkeypatch.setattr(
         worker_mod,
         "_configure_duckdb_s3",
-        lambda *_args: (_ for _ in ()).throw(RuntimeError("planned session configuration failure")),
+        _fail_configuration,
     )
 
     with pytest.raises(RuntimeError, match="planned session configuration failure"):
@@ -8303,6 +8472,168 @@ def test_worker_session_configuration_failure_closes_unpublished_connection(monk
 
     assert closed == ["session"]
     assert actor._session_connections == {}
+
+
+def test_worker_session_close_wins_race_with_credential_resolution(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._session_connections = {}
+    actor._session_s3_configs = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    resolution_started = threading.Event()
+    resolution_release = threading.Event()
+    closed = []
+    open_errors = []
+
+    class _SessionConnection:
+        def close(self):
+            closed.append("session")
+
+    class _SharedConnection:
+        def cursor(self):
+            return _SessionConnection()
+
+    def _delayed_config(_connection, config, *, use_session_credentials):
+        assert use_session_credentials is True
+        resolution_started.set()
+        assert resolution_release.wait(timeout=1.0)
+        return dict(config)
+
+    actor._get_shared_conn = lambda: _SharedConnection()
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", _delayed_config)
+
+    def _open():
+        try:
+            actor_cls._get_session_conn(actor, "session-a", {"AWS_PROFILE": "analytics"})
+        except BaseException as exc:
+            open_errors.append(exc)
+
+    open_thread = threading.Thread(target=_open)
+    open_thread.start()
+    assert resolution_started.wait(timeout=1.0)
+
+    close_errors = []
+
+    def _close():
+        try:
+            asyncio.run(actor_cls.close_session(actor, "session-a"))
+        except BaseException as exc:
+            close_errors.append(exc)
+
+    close_thread = threading.Thread(target=_close)
+    close_thread.start()
+    for _ in range(100):
+        if "session-a" in actor._closed_session_ids:
+            break
+        time.sleep(0.001)
+    assert close_thread.is_alive()
+    resolution_release.set()
+    open_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not open_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert close_errors == []
+    assert len(open_errors) == 1
+    assert isinstance(open_errors[0], RuntimeError)
+    assert "Vane session is closed" in str(open_errors[0])
+    assert closed == ["session"]
+    assert actor._session_connections == {}
+    assert actor._session_s3_configs == {}
+
+
+def test_worker_session_close_wins_race_with_credential_refresh(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._session_operation_locks = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    refresh_started = threading.Event()
+    refresh_release = threading.Event()
+    closed = []
+    refresh_errors = []
+    close_errors = []
+
+    class _SessionConnection:
+        def close(self):
+            closed.append("session")
+
+    connection = _SessionConnection()
+    session_config = {"AWS_PROFILE": "analytics"}
+    actor._session_connections = {
+        "session-a": (
+            session_config,
+            connection,
+        ),
+    }
+    actor._session_s3_configs = {
+        "session-a": {
+            "AWS_ACCESS_KEY_ID": "old-key",
+            "AWS_SECRET_ACCESS_KEY": "old-secret",
+        },
+    }
+
+    def _delayed_refresh(_config, _effective, *, use_session_credentials):
+        assert use_session_credentials is True
+        refresh_started.set()
+        assert refresh_release.wait(timeout=1.0)
+        return {
+            "AWS_ACCESS_KEY_ID": "new-key",
+            "AWS_SECRET_ACCESS_KEY": "new-secret",
+        }
+
+    monkeypatch.setattr(
+        worker_mod,
+        "_refresh_effective_duckdb_s3_config",
+        _delayed_refresh,
+    )
+
+    def _refresh():
+        try:
+            actor_cls._refresh_session_s3_config(
+                actor,
+                "session-a",
+                session_config,
+                connection,
+                use_session_credentials=True,
+            )
+        except BaseException as exc:
+            refresh_errors.append(exc)
+
+    refresh_thread = threading.Thread(target=_refresh)
+    refresh_thread.start()
+    assert refresh_started.wait(timeout=1.0)
+
+    def _close():
+        try:
+            asyncio.run(actor_cls.close_session(actor, "session-a"))
+        except BaseException as exc:
+            close_errors.append(exc)
+
+    close_thread = threading.Thread(target=_close)
+    close_thread.start()
+    for _ in range(100):
+        if "session-a" in actor._closed_session_ids:
+            break
+        time.sleep(0.001)
+    assert close_thread.is_alive()
+
+    refresh_release.set()
+    refresh_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not refresh_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert close_errors == []
+    assert len(refresh_errors) == 1
+    assert "Vane session is closed" in str(refresh_errors[0])
+    assert closed == ["session"]
+    assert actor._session_connections == {}
+    assert actor._session_s3_configs == {}
+    assert actor._session_operation_locks == {}
 
 
 def test_worker_session_close_keeps_connection_retryable_after_failure():
@@ -8323,20 +8654,83 @@ def test_worker_session_close_keeps_connection_retryable_after_failure():
     actor._session_connections = {"session-a": record}
 
     with pytest.raises(RuntimeError, match="planned close failure"):
-        actor_cls.close_session(actor, "session-a")
+        asyncio.run(actor_cls.close_session(actor, "session-a"))
 
     assert actor._session_connections["session-a"] is record
     assert "session-a" in actor._closed_session_ids
 
-    actor_cls.close_session(actor, "session-a")
+    asyncio.run(actor_cls.close_session(actor, "session-a"))
 
     assert close_calls == ["close", "close"]
+    assert "session-a" not in actor._session_connections
+
+
+def test_worker_session_close_does_not_block_actor_event_loop():
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    close_started = threading.Event()
+    close_release = threading.Event()
+
+    class _SessionConnection:
+        def close(self):
+            close_started.set()
+            assert close_release.wait(timeout=1.0)
+
+    actor._session_connections = {"session-a": ({}, _SessionConnection())}
+
+    async def _close_without_blocking_loop():
+        close_task = asyncio.create_task(actor_cls.close_session(actor, "session-a"))
+        assert await asyncio.to_thread(close_started.wait, 1.0)
+        await asyncio.wait_for(asyncio.sleep(0), timeout=0.1)
+        assert close_task.done() is False
+        close_release.set()
+        await asyncio.wait_for(close_task, timeout=1.0)
+
+    asyncio.run(_close_without_blocking_loop())
+
+    assert "session-a" not in actor._session_connections
+
+
+def test_worker_session_close_cancellation_waits_for_owned_teardown():
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    close_started = threading.Event()
+    close_release = threading.Event()
+
+    class _SessionConnection:
+        def close(self):
+            close_started.set()
+            assert close_release.wait(timeout=1.0)
+
+    actor._session_connections = {"session-a": ({}, _SessionConnection())}
+
+    async def _cancel_close():
+        close_task = asyncio.create_task(actor_cls.close_session(actor, "session-a"))
+        assert await asyncio.to_thread(close_started.wait, 1.0)
+        close_task.cancel()
+        await asyncio.sleep(0.01)
+        assert close_task.done() is False
+        close_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+    asyncio.run(_cancel_close())
+
     assert "session-a" not in actor._session_connections
 
 
 def test_execute_native_task_configuration_failure_closes_unregistered_cursor(monkeypatch):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._session_connections_lock = threading.RLock()
+    actor._session_s3_configs = {}
+    actor._session_operation_locks = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._shutdown_started = False
     actor._native_execution_condition = threading.Condition()
     actor._active_native_cursors = set()
     actor._native_cursor_query_ids = {}
@@ -8348,11 +8742,36 @@ def test_execute_native_task_configuration_failure_closes_unregistered_cursor(mo
             closed.append("cursor")
 
     cursor = _Cursor()
-    actor._get_session_conn = lambda *_args: SimpleNamespace(cursor=lambda: cursor)
+    session_conn = SimpleNamespace(cursor=lambda: cursor)
+    actor._session_connections = {
+        "session-a": (
+            {
+                "AWS_ACCESS_KEY_ID": "key-a",
+                "AWS_SECRET_ACCESS_KEY": "secret-a",
+            },
+            session_conn,
+        ),
+    }
+
+    def _get_session_conn(session_id, config, *, use_session_credentials):
+        assert session_id == "session-a"
+        assert config == {
+            "AWS_ACCESS_KEY_ID": "key-a",
+            "AWS_SECRET_ACCESS_KEY": "secret-a",
+        }
+        assert use_session_credentials is True
+        return session_conn
+
+    actor._get_session_conn = _get_session_conn
+
+    def _fail_configuration(_connection, _config, *, use_session_credentials):
+        assert use_session_credentials is True
+        raise RuntimeError("planned query cursor configuration failure")
+
     monkeypatch.setattr(
         worker_mod,
         "_configure_duckdb_s3",
-        lambda *_args: (_ for _ in ()).throw(RuntimeError("planned query cursor configuration failure")),
+        _fail_configuration,
     )
 
     class _Plan:
@@ -8362,7 +8781,14 @@ def test_execute_native_task_configuration_failure_closes_unregistered_cursor(mo
 
         @staticmethod
         def session_config():
-            return {"AWS_ACCESS_KEY_ID": "key-a"}
+            return {
+                "AWS_ACCESS_KEY_ID": "key-a",
+                "AWS_SECRET_ACCESS_KEY": "secret-a",
+            }
+
+        @staticmethod
+        def has_explicit_s3_credentials():
+            return False
 
     with pytest.raises(RuntimeError, match="planned query cursor configuration failure"):
         actor_cls._execute_native_task(actor, _Plan(), None, native_query_id="query-a")
@@ -8375,6 +8801,11 @@ def test_execute_native_task_configuration_failure_closes_unregistered_cursor(mo
 def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._session_connections_lock = threading.RLock()
+    actor._session_s3_configs = {}
+    actor._session_operation_locks = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._shutdown_started = False
     actor._native_execution_condition = threading.Condition()
     actor._active_native_cursors = set()
     actor._native_cursor_query_ids = {}
@@ -8409,6 +8840,7 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
             dynamic_filter_domains,
             native_progress_callback,
             runtime_context,
+            effective_session_config,
         ):
             calls.append(
                 (
@@ -8423,6 +8855,7 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
                     dynamic_filter_domains,
                     native_progress_callback,
                     runtime_context,
+                    effective_session_config,
                 )
             )
             return "ok"
@@ -8432,20 +8865,46 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
             return "session-a"
 
         def session_config(self):
-            return {"AWS_ACCESS_KEY_ID": "session-a-key"}
+            return {
+                "AWS_ACCESS_KEY_ID": "session-a-key",
+                "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+            }
+
+        def has_explicit_s3_credentials(self):
+            return False
 
     shared_conn = _FakeConn()
-    actor._get_session_conn = lambda session_id, config: (
-        shared_conn if (session_id, config) == ("session-a", {"AWS_ACCESS_KEY_ID": "session-a-key"}) else None
-    )
+    actor._session_connections = {
+        "session-a": (
+            {
+                "AWS_ACCESS_KEY_ID": "session-a-key",
+                "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+            },
+            shared_conn,
+        ),
+    }
+
+    def _get_session_conn(session_id, config, *, use_session_credentials):
+        assert (session_id, config) == (
+            "session-a",
+            {
+                "AWS_ACCESS_KEY_ID": "session-a-key",
+                "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+            },
+        )
+        assert use_session_credentials is True
+        return shared_conn
+
+    actor._get_session_conn = _get_session_conn
     actor._get_plan_runner = lambda: _FakePlanRunner()
     plan_object = _FakePlan()
     configured = []
-    monkeypatch.setattr(
-        worker_mod,
-        "_configure_duckdb_s3",
-        lambda cursor, config: configured.append((cursor, dict(config))),
-    )
+
+    def _configure(cursor, config, *, use_session_credentials):
+        configured.append((cursor, dict(config), use_session_credentials))
+        return dict(config)
+
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", _configure)
 
     dynamic_domains = {"df0": {"column": "id", "single_value": 7}}
     result = actor_cls._execute_native_task(
@@ -8460,7 +8919,16 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
     )
 
     assert result == "ok"
-    assert configured == [(shared_conn.cursor_obj, {"AWS_ACCESS_KEY_ID": "session-a-key"})]
+    assert configured == [
+        (
+            shared_conn.cursor_obj,
+            {
+                "AWS_ACCESS_KEY_ID": "session-a-key",
+                "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+            },
+            True,
+        )
+    ]
     assert len(calls) == 1
     (
         _,
@@ -8474,6 +8942,7 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
         dynamic_filter_domains,
         native_progress_callback,
         runtime_context,
+        effective_session_config,
     ) = calls[0]
     assert plan is plan_object
     assert scan_task_arg == {"1": b"scan"}
@@ -8489,9 +8958,13 @@ def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
     assert dynamic_filter_domains == dynamic_domains
     assert native_progress_callback is None
     assert runtime_context == {"query_id": "q1", "fragment_id": "f1", "task_id": "q1.2.3.4"}
+    assert effective_session_config == {
+        "AWS_ACCESS_KEY_ID": "session-a-key",
+        "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+    }
 
 
-def test_configure_duckdb_s3_applies_secret_only_to_connection_context():
+def test_configure_duckdb_s3_applies_static_credentials_only_to_connection_context():
     statements = []
 
     class _FakeConnection:
@@ -8500,11 +8973,16 @@ def test_configure_duckdb_s3_applies_secret_only_to_connection_context():
 
     worker_mod._configure_duckdb_s3(
         _FakeConnection(),
-        {"AWS_SECRET_ACCESS_KEY": "secret'value"},
+        {
+            "AWS_ACCESS_KEY_ID": "access-key",
+            "AWS_SECRET_ACCESS_KEY": "secret'value",
+        },
     )
 
     assert statements[0] == "LOAD httpfs"
+    assert "SET s3_access_key_id='access-key'" in statements
     assert "SET s3_secret_access_key='secret''value'" in statements
+    assert "SET s3_session_token=''" in statements
     assert all("SET GLOBAL" not in statement for statement in statements)
 
 
@@ -8524,9 +9002,262 @@ def test_configure_duckdb_s3_preserves_scheme_less_endpoint_authority():
     assert "SET s3_use_ssl=false" in statements
 
 
+@pytest.mark.parametrize(
+    "provider_config",
+    [
+        {"AWS_PROFILE": "analytics"},
+        {
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/analytics",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/aws/token",
+        },
+    ],
+)
+def test_configure_duckdb_s3_resolves_session_credential_chain_outside_shared_worker(
+    monkeypatch,
+    provider_config,
+):
+    statements = []
+    resolver_calls = []
+
+    class _FakeConnection:
+        def execute(self, statement):
+            statements.append(statement)
+
+    def _resolve(config):
+        resolver_calls.append(dict(config))
+        return (
+            {
+                "AWS_ACCESS_KEY_ID": "resolved-key",
+                "AWS_SECRET_ACCESS_KEY": "resolved-secret",
+                "AWS_SESSION_TOKEN": "resolved-token",
+                "AWS_REGION": "us-west-2",
+            },
+            None,
+        )
+
+    monkeypatch.setattr(worker_mod, "_resolve_session_aws_credentials", _resolve)
+
+    effective_config = worker_mod._configure_duckdb_s3(
+        _FakeConnection(),
+        provider_config,
+    )
+
+    assert resolver_calls == [provider_config]
+    assert effective_config == {
+        "AWS_ACCESS_KEY_ID": "resolved-key",
+        "AWS_SECRET_ACCESS_KEY": "resolved-secret",
+        "AWS_SESSION_TOKEN": "resolved-token",
+        "AWS_REGION": "us-west-2",
+    }
+    assert "SET s3_access_key_id='resolved-key'" in statements
+    assert "SET s3_secret_access_key='resolved-secret'" in statements
+    assert "SET s3_session_token='resolved-token'" in statements
+    assert "SET s3_region='us-west-2'" in statements
+
+
+@pytest.mark.parametrize(
+    "partial_credentials",
+    [
+        {"AWS_ACCESS_KEY_ID": "partial-key"},
+        {"AWS_SECRET_ACCESS_KEY": "partial-secret"},
+        {"AWS_SESSION_TOKEN": "partial-token"},
+    ],
+)
+def test_session_credentials_reject_incomplete_static_values(monkeypatch, partial_credentials):
+    resolver_calls = []
+    monkeypatch.setattr(
+        worker_mod,
+        "_resolve_session_aws_credentials",
+        lambda config: resolver_calls.append(dict(config)),
+    )
+
+    with pytest.raises(ValueError, match="must provide both"):
+        worker_mod._effective_duckdb_s3_config(partial_credentials)
+
+    assert resolver_calls == []
+
+
+def test_session_credential_resolver_uses_only_explicit_child_environment(monkeypatch):
+    monkeypatch.setenv("AWS_PROFILE", "shared-process-profile")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "shared-process-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "shared-process-secret")
+    calls = []
+
+    def _run(command, **kwargs):
+        calls.append((command, kwargs))
+        assert kwargs["env"]["AWS_PROFILE"] == "connection-profile"
+        assert kwargs["env"]["AWS_WEB_IDENTITY_TOKEN_FILE"] == "/session/token"
+        assert "AWS_ACCESS_KEY_ID" not in kwargs["env"]
+        assert "AWS_SECRET_ACCESS_KEY" not in kwargs["env"]
+        assert kwargs["env"]["VANE_RUNNER"] == "local"
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                '{"credentials":{"AWS_ACCESS_KEY_ID":"resolved-key",'
+                '"AWS_SECRET_ACCESS_KEY":"resolved-secret",'
+                '"AWS_SESSION_TOKEN":"resolved-token"},'
+                '"expiration_epoch_s":1234.5}'
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(worker_mod.subprocess, "run", _run)
+
+    credentials, expiration_epoch_s = worker_mod._resolve_session_aws_credentials(
+        {
+            "AWS_PROFILE": "connection-profile",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/session/token",
+        }
+    )
+
+    assert credentials == {
+        "AWS_ACCESS_KEY_ID": "resolved-key",
+        "AWS_SECRET_ACCESS_KEY": "resolved-secret",
+        "AWS_SESSION_TOKEN": "resolved-token",
+    }
+    assert expiration_epoch_s == 1234.5
+    assert calls[0][0] == [sys.executable, "-m", "duckdb.runners.ray.aws_credentials"]
+    assert calls[0][1]["capture_output"] is True
+    assert calls[0][1]["check"] is False
+    assert calls[0][1]["text"] is True
+    assert calls[0][1]["timeout"] == 120
+    assert os.environ["AWS_PROFILE"] == "shared-process-profile"
+    assert os.environ["AWS_ACCESS_KEY_ID"] == "shared-process-key"
+    assert os.environ["AWS_SECRET_ACCESS_KEY"] == "shared-process-secret"
+
+
+def test_session_credential_resolver_loads_profile_in_real_child_process(tmp_path):
+    credentials_file = tmp_path / "credentials"
+    credentials_file.write_text(
+        "[analytics]\n"
+        "aws_access_key_id=profile-key\n"
+        "aws_secret_access_key=profile-secret\n"
+        "aws_session_token=profile-token\n",
+        encoding="utf-8",
+    )
+
+    credentials, expiration_epoch_s = worker_mod._resolve_session_aws_credentials(
+        {
+            "AWS_EC2_METADATA_DISABLED": "true",
+            "AWS_PROFILE": "analytics",
+            "AWS_REGION": "us-east-2",
+            "AWS_SHARED_CREDENTIALS_FILE": str(credentials_file),
+        }
+    )
+
+    assert credentials == {
+        "AWS_ACCESS_KEY_ID": "profile-key",
+        "AWS_REGION": "us-east-2",
+        "AWS_SECRET_ACCESS_KEY": "profile-secret",
+        "AWS_SESSION_TOKEN": "profile-token",
+    }
+    assert expiration_epoch_s is None
+
+
+def test_session_credential_chain_refreshes_before_expiration(monkeypatch):
+    now = [100.0]
+    resolver_calls = []
+
+    def _resolve(config):
+        resolver_calls.append(dict(config))
+        suffix = len(resolver_calls)
+        return (
+            {
+                "AWS_ACCESS_KEY_ID": f"key-{suffix}",
+                "AWS_SECRET_ACCESS_KEY": f"secret-{suffix}",
+            },
+            200.0 + suffix * 100.0,
+        )
+
+    monkeypatch.setattr(worker_mod, "_resolve_session_aws_credentials", _resolve)
+    monkeypatch.setattr(worker_mod.time, "time", lambda: now[0])
+
+    config = {"AWS_PROFILE": "analytics"}
+    effective = worker_mod._effective_duckdb_s3_config(config)
+    assert effective["AWS_ACCESS_KEY_ID"] == "key-1"
+
+    now[0] = 259.9
+    assert worker_mod._refresh_effective_duckdb_s3_config(config, effective) == effective
+    assert len(resolver_calls) == 1
+
+    now[0] = 260.0
+    refreshed = worker_mod._refresh_effective_duckdb_s3_config(config, effective)
+    assert refreshed["AWS_ACCESS_KEY_ID"] == "key-2"
+    assert len(resolver_calls) == 2
+
+
+def test_nonexpiring_session_credential_chain_is_resolved_once(monkeypatch):
+    resolver_calls = []
+
+    def _resolve(config):
+        resolver_calls.append(dict(config))
+        return (
+            {
+                "AWS_ACCESS_KEY_ID": "profile-key",
+                "AWS_SECRET_ACCESS_KEY": "profile-secret",
+            },
+            None,
+        )
+
+    monkeypatch.setattr(worker_mod, "_resolve_session_aws_credentials", _resolve)
+    config = {"AWS_PROFILE": "analytics"}
+
+    effective = worker_mod._refresh_effective_duckdb_s3_config(config, {})
+    refreshed = worker_mod._refresh_effective_duckdb_s3_config(config, effective)
+
+    assert refreshed == effective
+    assert resolver_calls == [config]
+
+
+def test_explicit_duckdb_credentials_skip_profile_resolution_and_discard_cached_profile_credentials(monkeypatch):
+    resolver_calls = []
+    monkeypatch.setattr(
+        worker_mod,
+        "_resolve_session_aws_credentials",
+        lambda config: resolver_calls.append(dict(config)),
+    )
+    config = {
+        "AWS_ACCESS_KEY_ID": "incomplete-environment-key",
+        "AWS_PROFILE": "unavailable-profile",
+        "AWS_ENDPOINT_URL": "https://s3.example.test",
+    }
+    cached = {
+        "AWS_ACCESS_KEY_ID": "stale-profile-key",
+        "AWS_SECRET_ACCESS_KEY": "stale-profile-secret",
+        "AWS_SESSION_TOKEN": "stale-profile-token",
+        "AWS_ENDPOINT_URL": "https://s3.example.test",
+        worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "9999999999",
+    }
+    statements = []
+
+    class _FakeConnection:
+        def execute(self, statement):
+            statements.append(statement)
+
+    effective = worker_mod._refresh_effective_duckdb_s3_config(
+        config,
+        cached,
+        use_session_credentials=False,
+    )
+    configured = worker_mod._configure_duckdb_s3(
+        _FakeConnection(),
+        effective,
+        use_session_credentials=False,
+    )
+
+    assert effective == {"AWS_ENDPOINT_URL": "https://s3.example.test"}
+    assert configured == effective
+    assert "SET s3_access_key_id=''" in statements
+    assert "SET s3_secret_access_key=''" in statements
+    assert "SET s3_session_token=''" in statements
+    assert resolver_calls == []
+
+
 def test_execute_native_task_uses_session_database_for_fte():
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._session_connections_lock = threading.RLock()
+    actor._session_s3_configs = {}
     actor._native_execution_condition = threading.Condition()
     actor._active_native_cursors = set()
     actor._native_cursor_query_ids = {}
@@ -8549,6 +9280,7 @@ def test_execute_native_task_uses_session_database_for_fte():
             closed.append("conn")
 
     shared_conn = _FakeConn()
+    actor._session_connections = {"session-a": ({}, shared_conn)}
 
     class _FakePlan:
         def session_id(self):
@@ -8557,7 +9289,10 @@ def test_execute_native_task_uses_session_database_for_fte():
         def session_config(self):
             return {}
 
-    actor._get_session_conn = lambda session_id, config: (
+        def has_explicit_s3_credentials(self):
+            return False
+
+    actor._get_session_conn = lambda session_id, config, *, use_session_credentials: (
         shared_conn if (session_id, config) == ("session-a", {}) else None
     )
 
@@ -8575,6 +9310,7 @@ def test_execute_native_task_uses_session_database_for_fte():
             _dynamic_filter_domains,
             _native_progress_callback,
             _runtime_context,
+            _effective_session_config,
         ):
             calls.append((cursor, fte_scan_source_queues, fte_exchange_source_queues))
             return "ok"

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 
 import pytest
 
@@ -2322,11 +2323,16 @@ def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypa
         events.append("datasource-release")
         return 2
 
+    def cleanup_replay(query_id):
+        assert query_id == "query-drop"
+        events.append("replay-cleanup")
+
     monkeypatch.setattr(worker_mod, "_close_flight_shuffle_query", close)
     monkeypatch.setattr(worker_mod, "_wait_flight_shuffle_executions_for_query", wait_for_executions)
     monkeypatch.setattr(worker_mod, "_drain_flight_shuffle_for_query", drain)
     monkeypatch.setattr(worker_mod, "_retire_flight_shuffle_query", retire)
     monkeypatch.setattr(worker_mod, "_release_datasource_factories_for_query", release_datasource_factories)
+    monkeypatch.setattr(worker_mod, "_cleanup_query_python_replay_state", cleanup_replay)
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
 
     prepare_result = asyncio.run(actor_class.fte_prepare_drop_query(DummyWorker(), "query-drop"))
@@ -2345,6 +2351,7 @@ def test_worker_drop_query_uses_separate_execution_and_storage_barriers(monkeypa
         "drain",
         "retire",
         "native-retire",
+        "replay-cleanup",
     ]
     assert result == {
         "tasks_removed": 2,
@@ -8118,6 +8125,12 @@ def test_register_fragments_awaits_plan_refs_without_ray_get(monkeypatch):
         "get",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("ray.get must not be used")),
     )
+    replay_registrations = []
+    monkeypatch.setattr(
+        worker_mod,
+        "_register_query_python_replay_state",
+        lambda query_id, plan: replay_registrations.append((query_id, plan)) or True,
+    )
 
     class _Plan:
         def has_root(self):
@@ -8141,6 +8154,7 @@ def test_register_fragments_awaits_plan_refs_without_ray_get(monkeypatch):
     assert plan_ref.awaited
     assert actor._plan_fragments["query-1:node:1"] is resolved_plan
     assert actor._query_fragments == {"query-1": {"query-1:node:1"}}
+    assert replay_registrations == [("query-1", resolved_plan)]
 
 
 def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
@@ -8148,13 +8162,13 @@ def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
     option_calls = []
     remote_calls = []
 
-    class _FakeInstalledMethod:
+    class _FakePingMethod:
         def remote(self, *_args, **_kwargs):
             return "warmup-ref"
 
     class _FakeActorHandle:
         def __init__(self):
-            self.install_env_overrides = _FakeInstalledMethod()
+            self.ping = _FakePingMethod()
 
     class _FakeActorFactory:
         def options(self, **kwargs):
@@ -8195,19 +8209,170 @@ def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
     assert len(runtimes) == 1
     assert option_calls[0]["memory"] == 358
     assert option_calls[0]["runtime_env"] == {
-        "env_vars": {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"},
+        "env_vars": {
+            "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
+            "VANE_WORKER": "1",
+            "VANE_WORKER_ID": "10.0.0.1",
+            "VANE_WORKER_INDEX": "0",
+        },
     }
     assert "num_cpus" not in option_calls[0]
     assert "num_gpus" not in option_calls[0]
     assert len(remote_calls) == 1
-    assert remote_calls[0]["env_overrides"]["VANE_WORKER_ID"] == "10.0.0.1"
-    assert remote_calls[0]["env_overrides"]["VANE_WORKER_INDEX"] == "0"
+    assert "env_overrides" not in remote_calls[0]
     assert remote_calls[0]["duckdb_memory_bytes"] == 256
     assert remote_calls[0]["task_heap_capacity_bytes"] == 615
     assert get_calls == []
 
 
-def test_execute_native_task_passes_exchange_and_sink_inputs():
+def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._session_connections = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    closed = []
+
+    class _SessionConnection:
+        def close(self):
+            closed.append("session")
+
+    class _SharedConnection:
+        def cursor(self):
+            return _SessionConnection()
+
+    actor._get_shared_conn = lambda: _SharedConnection()
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", lambda *_args: None)
+
+    session_connection = actor_cls._get_session_conn(
+        actor,
+        "session-a",
+        {"AWS_ACCESS_KEY_ID": "key-a"},
+    )
+    assert (
+        actor_cls._get_session_conn(
+            actor,
+            "session-a",
+            {"AWS_ACCESS_KEY_ID": "key-a"},
+        )
+        is session_connection
+    )
+
+    actor_cls.close_session(actor, "session-a")
+
+    assert closed == ["session"]
+    with pytest.raises(RuntimeError, match="Vane session is closed"):
+        actor_cls._get_session_conn(
+            actor,
+            "session-a",
+            {"AWS_ACCESS_KEY_ID": "key-a"},
+        )
+
+
+def test_worker_session_configuration_failure_closes_unpublished_connection(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._session_connections = {}
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    actor._shutdown_started = False
+    closed = []
+
+    class _SessionConnection:
+        def close(self):
+            closed.append("session")
+
+    class _SharedConnection:
+        def cursor(self):
+            return _SessionConnection()
+
+    actor._get_shared_conn = lambda: _SharedConnection()
+    monkeypatch.setattr(
+        worker_mod,
+        "_configure_duckdb_s3",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("planned session configuration failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="planned session configuration failure"):
+        actor_cls._get_session_conn(
+            actor,
+            "session-a",
+            {"AWS_ACCESS_KEY_ID": "key-a"},
+        )
+
+    assert closed == ["session"]
+    assert actor._session_connections == {}
+
+
+def test_worker_session_close_keeps_connection_retryable_after_failure():
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=65_536)
+    actor._session_connections_lock = threading.RLock()
+    close_calls = []
+
+    class _SessionConnection:
+        def close(self):
+            close_calls.append("close")
+            if len(close_calls) == 1:
+                raise RuntimeError("planned close failure")
+
+    connection = _SessionConnection()
+    record = ({}, connection)
+    actor._session_connections = {"session-a": record}
+
+    with pytest.raises(RuntimeError, match="planned close failure"):
+        actor_cls.close_session(actor, "session-a")
+
+    assert actor._session_connections["session-a"] is record
+    assert "session-a" in actor._closed_session_ids
+
+    actor_cls.close_session(actor, "session-a")
+
+    assert close_calls == ["close", "close"]
+    assert "session-a" not in actor._session_connections
+
+
+def test_execute_native_task_configuration_failure_closes_unregistered_cursor(monkeypatch):
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_cls)
+    actor._native_execution_condition = threading.Condition()
+    actor._active_native_cursors = set()
+    actor._native_cursor_query_ids = {}
+    actor._closing_native_queries = set()
+    closed = []
+
+    class _Cursor:
+        def close(self):
+            closed.append("cursor")
+
+    cursor = _Cursor()
+    actor._get_session_conn = lambda *_args: SimpleNamespace(cursor=lambda: cursor)
+    monkeypatch.setattr(
+        worker_mod,
+        "_configure_duckdb_s3",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("planned query cursor configuration failure")),
+    )
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {"AWS_ACCESS_KEY_ID": "key-a"}
+
+    with pytest.raises(RuntimeError, match="planned query cursor configuration failure"):
+        actor_cls._execute_native_task(actor, _Plan(), None, native_query_id="query-a")
+
+    assert closed == ["cursor"]
+    assert actor._active_native_cursors == set()
+    assert actor._native_cursor_query_ids == {}
+
+
+def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
     actor._native_execution_condition = threading.Condition()
@@ -8262,14 +8427,30 @@ def test_execute_native_task_passes_exchange_and_sink_inputs():
             )
             return "ok"
 
+    class _FakePlan:
+        def session_id(self):
+            return "session-a"
+
+        def session_config(self):
+            return {"AWS_ACCESS_KEY_ID": "session-a-key"}
+
     shared_conn = _FakeConn()
-    actor._get_shared_conn = lambda: shared_conn
+    actor._get_session_conn = lambda session_id, config: (
+        shared_conn if (session_id, config) == ("session-a", {"AWS_ACCESS_KEY_ID": "session-a-key"}) else None
+    )
     actor._get_plan_runner = lambda: _FakePlanRunner()
+    plan_object = _FakePlan()
+    configured = []
+    monkeypatch.setattr(
+        worker_mod,
+        "_configure_duckdb_s3",
+        lambda cursor, config: configured.append((cursor, dict(config))),
+    )
 
     dynamic_domains = {"df0": {"column": "id", "single_value": 7}}
     result = actor_cls._execute_native_task(
         actor,
-        "fake-plan",
+        plan_object,
         {"1": b"scan"},
         copy_output_info={"base": "", "run_id": "run-native", "remote_base": "/tmp/out"},
         exchange_source_task_map={"9": b"exchange-binding"},
@@ -8279,6 +8460,7 @@ def test_execute_native_task_passes_exchange_and_sink_inputs():
     )
 
     assert result == "ok"
+    assert configured == [(shared_conn.cursor_obj, {"AWS_ACCESS_KEY_ID": "session-a-key"})]
     assert len(calls) == 1
     (
         _,
@@ -8293,7 +8475,7 @@ def test_execute_native_task_passes_exchange_and_sink_inputs():
         native_progress_callback,
         runtime_context,
     ) = calls[0]
-    assert plan == "fake-plan"
+    assert plan is plan_object
     assert scan_task_arg == {"1": b"scan"}
     assert exchange_source_task_arg == {"9": b"exchange-binding"}
     assert copy_output_info == {"base": "", "run_id": "run-native", "remote_base": "/tmp/out"}
@@ -8309,7 +8491,40 @@ def test_execute_native_task_passes_exchange_and_sink_inputs():
     assert runtime_context == {"query_id": "q1", "fragment_id": "f1", "task_id": "q1.2.3.4"}
 
 
-def test_execute_native_task_uses_shared_database_for_fte():
+def test_configure_duckdb_s3_applies_secret_only_to_connection_context():
+    statements = []
+
+    class _FakeConnection:
+        def execute(self, statement):
+            statements.append(statement)
+
+    worker_mod._configure_duckdb_s3(
+        _FakeConnection(),
+        {"AWS_SECRET_ACCESS_KEY": "secret'value"},
+    )
+
+    assert statements[0] == "LOAD httpfs"
+    assert "SET s3_secret_access_key='secret''value'" in statements
+    assert all("SET GLOBAL" not in statement for statement in statements)
+
+
+def test_configure_duckdb_s3_preserves_scheme_less_endpoint_authority():
+    statements = []
+
+    class _FakeConnection:
+        def execute(self, statement):
+            statements.append(statement)
+
+    worker_mod._configure_duckdb_s3(
+        _FakeConnection(),
+        {"AWS_ENDPOINT_URL": "minio.internal:9000"},
+    )
+
+    assert "SET s3_endpoint='minio.internal:9000'" in statements
+    assert "SET s3_use_ssl=false" in statements
+
+
+def test_execute_native_task_uses_session_database_for_fte():
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
     actor._native_execution_condition = threading.Condition()
@@ -8334,7 +8549,17 @@ def test_execute_native_task_uses_shared_database_for_fte():
             closed.append("conn")
 
     shared_conn = _FakeConn()
-    actor._get_shared_conn = lambda: shared_conn
+
+    class _FakePlan:
+        def session_id(self):
+            return "session-a"
+
+        def session_config(self):
+            return {}
+
+    actor._get_session_conn = lambda session_id, config: (
+        shared_conn if (session_id, config) == ("session-a", {}) else None
+    )
 
     class _FakePlanRunner:
         def execute_native(
@@ -8361,7 +8586,7 @@ def test_execute_native_task_uses_shared_database_for_fte():
     exchange_queues = {"2": object()}
     result = actor_cls._execute_native_task(
         actor,
-        "fake-plan",
+        _FakePlan(),
         None,
         fte_scan_source_queues=scan_queues,
         fte_exchange_source_queues=exchange_queues,

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -9256,7 +9256,9 @@ def test_explicit_duckdb_credentials_skip_profile_resolution_and_discard_cached_
 def test_execute_native_task_uses_session_database_for_fte():
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
+    actor._shutdown_started = False
     actor._session_connections_lock = threading.RLock()
+    actor._closed_session_ids = worker_mod.BoundedReplayMap(capacity=16)
     actor._session_s3_configs = {}
     actor._native_execution_condition = threading.Condition()
     actor._active_native_cursors = set()

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -594,8 +594,8 @@ def test_real_ray_actor_kill_replays_native_dynamic_scan_on_replacement(monkeypa
     assert len(descriptors) == 1
     descriptor = bytes(descriptors[0])
 
-    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60, {})
-    actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60, {})
+    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60)
+    actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60)
     handle0 = RayWorkerActorHandle(actor0, memory_capacity_bytes=1 << 60, worker_id="worker-native-a")
     handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-native-b")
 
@@ -692,8 +692,8 @@ def test_real_ray_full_query_worker_loss_uses_retry_output(monkeypatch, tmp_path
     assert len(descriptors) == 1
     descriptor = bytes(descriptors[0])
 
-    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60, {})
-    actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60, {})
+    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60)
+    actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(1, 0, 1 << 30, 1 << 60)
     handle0 = RayWorkerActorHandle(actor0, memory_capacity_bytes=1 << 60, worker_id="worker-full-a")
     handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-full-b")
 
@@ -802,7 +802,7 @@ def test_real_ray_host_loss_replays_all_owned_full_query_outputs(monkeypatch, tm
     )
     _register_fault_query([task_a, task_b])
 
-    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(2, 0, 1 << 30, 1 << 60, {})
+    actor0 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(2, 0, 1 << 30, 1 << 60)
     handle0 = RayWorkerActorHandle(actor0, memory_capacity_bytes=1 << 60, worker_id="worker-host-a")
 
     try:
@@ -832,7 +832,7 @@ def test_real_ray_host_loss_replays_all_owned_full_query_outputs(monkeypatch, tm
         else:
             raise AssertionError("host-loss native scans did not enter blocked RUNNING state")
 
-        actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(2, 0, 1 << 30, 1 << 60, {})
+        actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(2, 0, 1 << 30, 1 << 60)
         handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-host-b")
         ray.kill(actor0, no_restart=True)
 

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -81,12 +81,68 @@ def test_run_distributed_plan_end_to_end_on_ray_local(tmp_path):
     expected_rows = {(x, x * 10, x + x * 10) for x in range(n)}
     assert set(rows) == expected_rows
 
-    # Some Ray setups do not expose named actors through the same namespace.
+    client = runner.query_driver_client
+    assert client is not None
+    assert ray.get(client.runner.ping.remote(client._owner_id)) is True
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_two_connections_share_job_runtime_and_close_independently(monkeypatch, tmp_path):
+    import os
+
+    import pyarrow as pa
+
+    from duckdb import runners as _runners
+    from duckdb.runners.ray.driver import RayQueryDriverClient
+
+    _runners.set_runner_ray(noop_if_initialized=True)
+    runner = _runners.get_or_create_runner()
+
+    session_secret_key = "AWS_ISSUE75_SESSION_SECRET"
+    path = tmp_path / "ray_two_sessions.parquet"
+    duckdb.sql(f"COPY (SELECT i::INTEGER AS value FROM range(8) AS t(i)) TO '{path}' (FORMAT PARQUET)")
+
+    monkeypatch.setenv(session_secret_key, "connection-a")
+    connection_a = duckdb.connect()
+    monkeypatch.setenv(session_secret_key, "connection-b")
+    connection_b = duckdb.connect()
+    monkeypatch.delenv(session_secret_key)
+
+    def read_session_secret(table):
+        secret = os.environ.get(session_secret_key)
+        return pa.table({"secret": [secret] * table.num_rows})
+
+    relation_a = connection_a.sql(f"SELECT * FROM read_parquet('{path}')").map_batches(
+        read_session_secret,
+        schema={"secret": duckdb.sqltypes.VARCHAR},
+        execution_backend="ray_task",
+    )
+    relation_b = connection_b.sql(f"SELECT * FROM read_parquet('{path}')").map_batches(
+        read_session_secret,
+        schema={"secret": duckdb.sqltypes.VARCHAR},
+        execution_backend="ray_task",
+    )
+
+    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_a))) == {("connection-a",)}
+    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_b))) == {("connection-b",)}
+
+    runtime_client = runner.query_driver_client
+    assert runtime_client is not None
+    peer_client = RayQueryDriverClient()
     try:
-        actor = ray.get_actor("ray-query-driver-actor", namespace="vane")
-        assert actor is not None
-    except Exception:
-        pass
+        assert runtime_client.runner._actor_id == peer_client.runner._actor_id
+    finally:
+        peer_client.close()
+
+    connection_a.close()
+    relation_b_after_close = connection_b.sql(f"SELECT * FROM read_parquet('{path}')").map_batches(
+        read_session_secret,
+        schema={"secret": duckdb.sqltypes.VARCHAR},
+        execution_backend="ray_task",
+    )
+    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_b_after_close))) == {("connection-b",)}
+    connection_b.close()
 
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pickle
+import threading
 from typing import Any
 
 import pytest
@@ -296,8 +297,13 @@ def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, 
         def idx(self) -> str:
             return "remote-error-plan"
 
+        def session_id(self) -> str:
+            return "remote-error-session"
+
+        def session_config(self) -> dict[str, str]:
+            return {}
+
     class Runner:
-        install_env_overrides = SuccessMethod()
         close_plan = SuccessMethod()
         progress_snapshot = SuccessMethod()
 
@@ -311,6 +317,16 @@ def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, 
 
     for failure_path in ("preflight", "stream", "copy"):
         client = object.__new__(driver.RayQueryDriverClient)
+        client._owner_id = "remote-error-owner"
+        client._opened_sessions = {"remote-error-session": {}}
+        client._uncertain_sessions = {}
+        client._opening_session_ids = set()
+        client._closing_session_ids = set()
+        client._closed_session_ids = driver.BoundedReplayMap(capacity=65_536)
+        client._session_closes_in_progress = set()
+        client._session_condition = threading.Condition()
+        client._client_closing = False
+        client._client_close_in_progress = False
         client.runner = Runner(failure_path)
         with pytest.raises(RuntimeError) as exc_info:
             if failure_path == "copy":

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6455,6 +6455,15 @@ def test_runtime_wait_timeout_classifier_rejects_completed_remote_timeout():
     assert not driver._runtime_error_is_wait_timeout(restored_remote_timeout)
 
 
+def test_runtime_wait_timeout_classifier_accepts_pre311_future_timeout(monkeypatch):
+    class _Pre311FutureTimeoutError(Exception):
+        pass
+
+    monkeypatch.setattr(driver, "FutureTimeoutError", _Pre311FutureTimeoutError)
+
+    assert driver._runtime_error_is_wait_timeout(_Pre311FutureTimeoutError("ObjectRef is still pending"))
+
+
 def test_failed_attach_cleanup_skips_detach_for_actor_init_failure():
     class _DetachMethod:
         @staticmethod

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 import time
 import uuid
@@ -124,20 +125,74 @@ class _FakeOutputLeaseOwner:
         return True
 
 
+_TEST_RUNTIME_OWNER_ID = "test-runtime-owner"
+_TEST_SESSION_ID = "test-vane-session"
+_TEST_SESSION_CONFIG: dict[str, str] = {}
+
+
 class _FakePhysicalPlanWithoutPlanAttr:
-    def __init__(self, plan_id: str = "fake-plan") -> None:
+    def __init__(
+        self,
+        plan_id: str = "fake-plan",
+        *,
+        session_id: str = _TEST_SESSION_ID,
+        session_config: dict[str, str] | None = None,
+    ) -> None:
         self._plan_id = plan_id
+        self._session_id = session_id
+        self._session_config = dict(_TEST_SESSION_CONFIG if session_config is None else session_config)
 
     def idx(self) -> str:
         return self._plan_id
+
+    def session_id(self) -> str:
+        return self._session_id
+
+    def session_config(self) -> dict[str, str]:
+        return dict(self._session_config)
 
 
 class _FakeLogicalPlan:
     def __init__(self, physical_plan: _FakePhysicalPlanWithoutPlanAttr) -> None:
         self.physical_plan = physical_plan
 
+    def idx(self) -> str:
+        return self.physical_plan.idx()
+
     def to_physical_plan(self, _conn):
         return self.physical_plan
+
+    def session_id(self) -> str:
+        return self.physical_plan.session_id()
+
+    def session_config(self) -> dict[str, str]:
+        return self.physical_plan.session_config()
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursors: list[_FakeConnection] = []
+        self.closed = False
+
+    def cursor(self) -> _FakeConnection:
+        cursor = _FakeConnection()
+        self.cursors.append(cursor)
+        return cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _initialize_test_query_driver_client(client, opened_sessions=None):
+    client._opened_sessions = dict(opened_sessions or {})
+    client._uncertain_sessions = {}
+    client._opening_session_ids = set()
+    client._closing_session_ids = set()
+    client._closed_session_ids = driver.BoundedReplayMap(capacity=65_536)
+    client._session_closes_in_progress = set()
+    client._session_condition = threading.Condition()
+    client._client_closing = False
+    client._client_close_in_progress = False
 
 
 def _make_local_query_driver_actor():
@@ -147,37 +202,106 @@ def _make_local_query_driver_actor():
     runner.curr_plans = {}
     runner._plan_query_ids = {}
     runner._query_terminal_errors = {}
-    runner._env_overrides = {}
-    runner._duckdb_conn = object()
+    runner._duckdb_conn = _FakeConnection()
     runner.plan_runner = None
     runner._active_udf_actors = []
     runner._active_udf_actors_by_plan = {}
     runner._active_vllm_actors = []
+    runner._active_vllm_actors_by_plan = {}
+    runner._plan_runner_lifecycle_lock = threading.RLock()
+    runner._driver_shutdown_started = False
+    runner._client_ids = {_TEST_RUNTIME_OWNER_ID}
+    runner._detaching_client_ids = set()
+    runner._detached_client_results = driver.BoundedReplayMap(capacity=65_536)
+    runner._client_detach_lock = asyncio.Lock()
+    runner._session_lock = threading.RLock()
+    runner._closed_session_owners = driver.BoundedReplayMap(capacity=65_536)
+    runner._plan_session_ids = {}
+    runner._plan_connections = {}
+    runner._plan_teardown_condition = threading.Condition(runner._session_lock)
+    runner._plan_teardowns_in_progress = set()
+    session_connection = runner._duckdb_conn.cursor()
+    runner._sessions = {
+        _TEST_SESSION_ID: driver._DriverSession(
+            owner_id=_TEST_RUNTIME_OWNER_ID,
+            config=dict(_TEST_SESSION_CONFIG),
+            connection=session_connection,
+            s3_config={},
+        )
+    }
+    runner._test_session_connection = session_connection
     return cls, runner
 
 
 def _query_registration_stub(query_id: str):
-    async def _register(_self, _plan, *, expected_plan_id=None):
-        del expected_plan_id
+    async def _register(
+        _self,
+        _plan,
+        *,
+        query_connection,
+        expected_plan_id=None,
+    ):
+        del query_connection, expected_plan_id
         return SimpleNamespace(query_id=query_id, stages=()), object()
 
     return _register
 
 
-def test_driver_env_override_applies_duckdb_execution_width(monkeypatch):
-    cls, runner = _make_local_query_driver_actor()
+def _run_actor_copy_plan(runner, plan):
+    return runner.run_copy_plan(
+        _TEST_RUNTIME_OWNER_ID,
+        _TEST_SESSION_ID,
+        plan,
+    )
+
+
+def _run_actor_stream_plan(runner, plan):
+    return runner.run_plan(
+        _TEST_RUNTIME_OWNER_ID,
+        _TEST_SESSION_ID,
+        plan,
+    )
+
+
+def test_driver_connection_applies_duckdb_execution_width(monkeypatch):
     statements = []
 
     class _Connection:
         def execute(self, statement):
             statements.append(statement)
 
-    runner._duckdb_conn = _Connection()
     monkeypatch.setenv("VANE_DUCKDB_THREADS", "7")
 
-    cls.install_env_overrides(runner, {"VANE_DUCKDB_THREADS": "7"})
+    driver._apply_duckdb_thread_setting(_Connection())
 
     assert statements == ["SET threads=7"]
+
+
+def test_driver_constructor_scrubs_inherited_session_environment(monkeypatch):
+    cls = driver.RayQueryDriverActor.__ray_metadata__.modified_class
+    monkeypatch.setenv("AWS_ISSUE75_INHERITED_SECRET", "inherited-aws")
+    monkeypatch.setenv("DUCKDB_ISSUE75_INHERITED_SECRET", "inherited-duckdb")
+    monkeypatch.setenv("VANE_ISSUE75_INHERITED_SECRET", "inherited-vane")
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(current_actor=object()),
+    )
+    monkeypatch.setattr(driver.asyncio, "get_running_loop", object)
+    monkeypatch.setattr(driver, "set_event_loop", lambda _loop: None)
+    monkeypatch.setattr(driver, "_set_global_event_loop", lambda _loop: None)
+    monkeypatch.setattr(cls, "_create_query_resource_coordinator", lambda _self: object())
+    monkeypatch.setattr(cls, "_ensure_duckdb_conn", lambda _self: object())
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: object())
+    monkeypatch.setattr(cls, "_start_query_resource_maintenance", lambda _self: None)
+
+    cls({}, 1)
+
+    assert "AWS_ISSUE75_INHERITED_SECRET" not in os.environ
+    assert "DUCKDB_ISSUE75_INHERITED_SECRET" not in os.environ
+    assert "VANE_ISSUE75_INHERITED_SECRET" not in os.environ
+    assert os.environ["VANE_RUNNER"] == "ray"
 
 
 def _bind_test_query_resource_owner(
@@ -226,7 +350,16 @@ def _bind_test_query_resource_owner(
     )
     manager.update_stage_state(stage.stage_id, runnable=True)
     runner._plan_query_ids[str(plan_id)] = query_id
+    runner._plan_session_ids[str(plan_id)] = _TEST_SESSION_ID
+    runner._sessions[_TEST_SESSION_ID].plan_ids.add(str(plan_id))
     return manager
+
+
+def _bind_test_plan_session(runner, plan_id: str, *, query_id: str | None = None) -> None:
+    plan_key = str(plan_id)
+    runner._plan_session_ids[plan_key] = _TEST_SESSION_ID
+    runner._plan_query_ids[plan_key] = str(plan_key if query_id is None else query_id)
+    runner._sessions[_TEST_SESSION_ID].plan_ids.add(plan_key)
 
 
 def _fake_task_context_info(task_id):
@@ -261,8 +394,96 @@ def test_ray_progress_snapshot_timeout_returns_none(monkeypatch):
 
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", _fake_get)
 
-    assert driver._ray_progress_snapshot_or_none(_FakeRunner(), "plan-id", 123.0) is None
+    assert (
+        driver._ray_progress_snapshot_or_none(
+            _FakeRunner(),
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "plan-id",
+            123.0,
+        )
+        is None
+    )
     assert timeouts == [0.1]
+
+
+def test_owned_thread_side_effect_finishes_before_cancellation_is_exposed():
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _mutate():
+        started.set()
+        assert release.wait(timeout=1.0)
+        finished.set()
+
+    async def _cancel():
+        task = asyncio.create_task(driver._to_thread_with_owned_side_effects(_mutate))
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert started.is_set()
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_cancel())
+    assert finished.is_set()
+
+
+def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr("cancelled-plan"))
+    started = threading.Event()
+    release = threading.Event()
+    events = []
+
+    def _start(_self, session_id, session, plan):
+        assert session_id == _TEST_SESSION_ID
+        assert plan is logical_plan
+        started.set()
+        assert release.wait(timeout=1.0)
+        with runner._session_lock:
+            runner._plan_session_ids["cancelled-plan"] = session_id
+            session.plan_ids.add("cancelled-plan")
+        events.append("started")
+
+    def _cleanup(_self, plan_id):
+        events.append(("cleanup", plan_id))
+        with runner._session_lock:
+            runner._plan_session_ids.pop(plan_id, None)
+            runner._sessions[_TEST_SESSION_ID].plan_ids.discard(plan_id)
+
+    monkeypatch.setattr(cls, "_run_plan_sync", _start)
+    monkeypatch.setattr(cls, "_cleanup_finished_plan", _cleanup)
+
+    async def _cancel():
+        task = asyncio.create_task(_run_actor_stream_plan(runner, logical_plan))
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert started.is_set()
+
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_cancel())
+
+    assert events == ["started", ("cleanup", "cancelled-plan")]
+    assert "cancelled-plan" not in runner._plan_session_ids
+    assert "cancelled-plan" not in runner._sessions[_TEST_SESSION_ID].plan_ids
 
 
 def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(monkeypatch):
@@ -277,14 +498,25 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
             captured["conn"] = conn
             return {"ok": True}
 
-    def _precreate_udf_actors(_self, _plan, _graph, _allocation):
+    def _precreate_udf_actors(
+        _self,
+        _plan,
+        _graph,
+        _allocation,
+        *,
+        query_connection,
+        session_config,
+    ):
+        assert query_connection is runner._test_session_connection.cursors[-1]
+        assert session_config == _TEST_SESSION_CONFIG
+        assert runner._plan_query_ids["copy-plan"] == "copy-plan"
         with pytest.raises(RuntimeError, match="no running event loop"):
             asyncio.get_running_loop()
         captured["actor_init_thread"] = threading.current_thread().name
         return []
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", _precreate_udf_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda _self, _plan: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -304,13 +536,13 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
 
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", _final_progress_snapshot)
 
-    outcome = asyncio.run(runner.run_copy_plan(logical_plan))
+    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert isinstance(outcome, driver.CopyPlanOutcome)
     assert outcome.result == {"ok": True}
     assert outcome.final_progress_snapshot == {"query_id": "copy-plan", "state": "FINISHED"}
     assert captured["plan"] is physical_plan
-    assert captured["conn"] is runner._duckdb_conn
+    assert captured["conn"] is runner._test_session_connection.cursors[-1]
     assert captured["actor_init_thread"].startswith("asyncio_")
     assert captured["lifecycle"] == ["snapshot", "teardown"]
 
@@ -326,8 +558,8 @@ def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monke
             runner._query_terminal_errors["copy-query-terminal"] = "fixed Ray actor placement was lost"
             return {"ok": True}
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: [])
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -343,7 +575,7 @@ def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monke
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     with pytest.raises(RuntimeError, match="fixed Ray actor placement was lost"):
-        asyncio.run(runner.run_copy_plan(logical_plan))
+        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_calls == [
         ("copy-plan-terminal", "copy-query-terminal", True),
@@ -359,8 +591,8 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
         def run_copy_plan(self, _plan, _conn):
             return {"ok": True}
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: [])
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -380,7 +612,7 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
     )
 
     with pytest.raises(RuntimeError, match="invalid progress topology"):
-        asyncio.run(runner.run_copy_plan(logical_plan))
+        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_calls == [
         (
@@ -423,9 +655,9 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
         events.append("actor-stage-open")
         actor_stage_open.set()
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: ["actor-pool"])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -441,7 +673,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
         wait_for_topology,
     )
 
-    outcome = asyncio.run(runner.run_copy_plan(logical_plan))
+    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert outcome.result == {"ok": True}
     open_index = events.index("actor-stage-open")
@@ -481,9 +713,9 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
     def mark_actor_stages(_self, _graph):
         events.append("actor-stage-open")
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: ["actor-pool"])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -504,7 +736,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
         daemon=True,
     )
     release_thread.start()
-    outcome = asyncio.run(runner.run_copy_plan(logical_plan))
+    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
     release_thread.join(timeout=2.0)
 
     assert outcome.result == {"rows_copied": 0}
@@ -531,9 +763,9 @@ def test_query_driver_copy_plan_failure_interrupts_startup_barriers(monkeypatch)
     def teardown(*_args, **_kwargs):
         teardown_started.set()
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: ["actor-pool"])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_until_teardown)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -553,7 +785,7 @@ def test_query_driver_copy_plan_failure_interrupts_startup_barriers(monkeypatch)
     )
 
     with pytest.raises(ValueError, match="native plan startup failed"):
-        asyncio.run(runner.run_copy_plan(logical_plan))
+        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_started.is_set()
     assert marked_ready == []
@@ -595,9 +827,9 @@ def test_query_driver_copy_startup_barrier_failure_tears_down_plan(
     def teardown(*_args, **_kwargs):
         teardown_started.set()
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: ["actor-pool"])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -617,7 +849,7 @@ def test_query_driver_copy_startup_barrier_failure_tears_down_plan(
     )
 
     with pytest.raises(error_type, match=message):
-        asyncio.run(runner.run_copy_plan(logical_plan))
+        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_started.is_set()
     assert marked_ready == []
@@ -670,7 +902,7 @@ def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot
     )
 
     class _Runner:
-        install_env_overrides = _RemoteMethod(lambda: _Ref(None))
+        open_session = _RemoteMethod(lambda: _Ref(True))
         run_copy_plan = _RemoteMethod(lambda: _Ref(outcome, timeouts=2))
         progress_snapshot = _RemoteMethod(lambda: _Ref(running_snapshot))
 
@@ -692,8 +924,9 @@ def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot
 
     monkeypatch.setattr(driver, "ProgressRenderer", _Renderer)
     monkeypatch.setattr(driver, "progress_enabled", lambda: True)
-    monkeypatch.setattr(driver, "_collect_vane_env_overrides", dict)
     client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client)
     client.runner = _Runner()
 
     result = client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-plan"))
@@ -735,14 +968,14 @@ def test_ray_query_driver_client_stream_waits_through_progress_session(monkeypat
     partition_ref = object()
 
     class _Runner:
-        install_env_overrides = _RemoteMethod(None)
+        open_session = _RemoteMethod(True)
         run_plan = _RemoteMethod(None)
         get_next_partition = _RemoteMethod(partition_ref)
 
     class _ProgressSession:
         instances = []
 
-        def __init__(self, runner, plan_id, started_at):
+        def __init__(self, runner, owner_id, session_id, plan_id, started_at):
             self.resolved = []
             self.finish_calls = []
             self.__class__.instances.append(self)
@@ -755,8 +988,9 @@ def test_ray_query_driver_client_stream_waits_through_progress_session(monkeypat
             self.finish_calls.append(kwargs)
 
     monkeypatch.setattr(driver, "_RayProgressSession", _ProgressSession)
-    monkeypatch.setattr(driver, "_collect_vane_env_overrides", dict)
     client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client)
     client.runner = _Runner()
 
     assert list(client.stream_plan(_FakePhysicalPlanWithoutPlanAttr("stream-plan"))) == []
@@ -765,6 +999,135 @@ def test_ray_query_driver_client_stream_waits_through_progress_session(monkeypat
     assert len(progress.resolved) == 1
     assert progress.resolved[0].future().result() is partition_ref
     assert progress.finish_calls == [{"final_state": "FINISHED"}]
+
+
+def test_ray_query_driver_client_stream_start_failure_cancels_and_retries_close(monkeypatch):
+    run_future = object()
+    close_future = object()
+    resolved = []
+    cancelled = []
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    runner = SimpleNamespace(
+        run_plan=_RemoteMethod(run_future),
+        close_plan=_RemoteMethod(close_future),
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = runner
+
+    def _resolve(ref, **kwargs):
+        resolved.append((ref, kwargs))
+        if ref is run_future:
+            raise RuntimeError("planned stream startup failure")
+        assert ref is close_future
+        return None
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "cancel", lambda ref, *, force: cancelled.append((ref, force)))
+
+    plan = _FakePhysicalPlanWithoutPlanAttr("failed-stream-start")
+    with pytest.raises(RuntimeError, match="planned stream startup failure"):
+        list(client.stream_plan(plan))
+
+    assert cancelled == [(run_future, False)]
+    assert runner.close_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "failed-stream-start",
+        )
+    ]
+    assert resolved == [
+        (run_future, {}),
+        (
+            run_future,
+            {
+                "timeout": 300,
+                "honor_query_deadline": False,
+            },
+        ),
+        (
+            close_future,
+            {
+                "timeout": 30,
+                "honor_query_deadline": False,
+            },
+        ),
+    ]
+
+
+def test_ray_query_driver_client_copy_failure_cancels_and_settles(monkeypatch):
+    copy_future = object()
+    close_future = object()
+    resolved = []
+    cancelled = []
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_copy_plan=_RemoteMethod(copy_future),
+        close_plan=_RemoteMethod(close_future),
+    )
+
+    def _resolve(ref, **kwargs):
+        resolved.append((ref, kwargs))
+        if ref is copy_future:
+            raise RuntimeError("planned COPY failure")
+        assert ref is close_future
+        return None
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "cancel", lambda ref, *, force: cancelled.append((ref, force)))
+
+    with pytest.raises(RuntimeError, match="planned COPY failure"):
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("failed-copy"))
+
+    assert cancelled == [(copy_future, False)]
+    assert resolved == [
+        (copy_future, {}),
+        (
+            copy_future,
+            {
+                "timeout": 300,
+                "honor_query_deadline": False,
+            },
+        ),
+        (
+            close_future,
+            {
+                "timeout": 30,
+                "honor_query_deadline": False,
+            },
+        ),
+    ]
+    assert client.runner.close_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "failed-copy",
+        )
+    ]
 
 
 def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypatch):
@@ -780,14 +1143,25 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
             captured["conn"] = conn
             return stream
 
-    def _precreate_udf_actors(_self, _plan, _graph, _allocation):
+    def _precreate_udf_actors(
+        _self,
+        _plan,
+        _graph,
+        _allocation,
+        *,
+        query_connection,
+        session_config,
+    ):
+        assert query_connection is runner._test_session_connection.cursors[-1]
+        assert session_config == _TEST_SESSION_CONFIG
+        assert runner._plan_query_ids["stream-plan"] == "stream-plan"
         with pytest.raises(RuntimeError, match="no running event loop"):
             asyncio.get_running_loop()
         captured["startup_thread"] = threading.current_thread().name
         return []
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", _precreate_udf_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda _self, _plan: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -801,10 +1175,10 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
         lambda _self, _query_id, reason, **_kwargs: None,
     )
 
-    asyncio.run(runner.run_plan(logical_plan))
+    asyncio.run(_run_actor_stream_plan(runner, logical_plan))
 
     assert captured["plan"] is physical_plan
-    assert captured["conn"] is runner._duckdb_conn
+    assert captured["conn"] is runner._test_session_connection.cursors[-1]
     assert captured["startup_thread"].startswith("asyncio_")
     assert runner.curr_plans["stream-plan"] is physical_plan
     assert runner.curr_streams["stream-plan"] is stream
@@ -828,8 +1202,8 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
         calls.append(("fragments", query_id))
         raise RuntimeError("fragment cleanup failed")
 
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args: [])
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args: [])
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
@@ -841,7 +1215,7 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
     monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
 
     with pytest.raises(RuntimeError, match="failed to start and teardown also failed") as exc_info:
-        asyncio.run(runner.run_plan(logical_plan))
+        asyncio.run(_run_actor_stream_plan(runner, logical_plan))
 
     message = str(exc_info.value)
     assert "submission failed" in message
@@ -853,34 +1227,61 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
     ]
     assert "failed-plan" not in runner.curr_plans
     assert "failed-plan" not in runner.curr_streams
+    assert runner._plan_query_ids["failed-plan"] == "failed-query"
+    assert runner._plan_session_ids["failed-plan"] == _TEST_SESSION_ID
+
+    monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", lambda *_args: None)
+    monkeypatch.setattr(cls, "_drop_query_fragments_sync", lambda *_args: None)
+    cls._cleanup_finished_plan(runner, "failed-plan")
+
     assert "failed-plan" not in runner._plan_query_ids
+    assert "failed-plan" not in runner._plan_session_ids
 
 
 def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     plan_id = "teardown-plan"
     calls = []
+    attempts = {
+        "output": 0,
+        "actors": 0,
+        "vllm": 0,
+        "fragments": 0,
+    }
 
     class _OutputOwner:
         def release(self):
             calls.append("output")
-            raise RuntimeError("output release failed")
+            attempts["output"] += 1
+            if attempts["output"] == 1:
+                raise RuntimeError("output release failed")
 
     runner.curr_plans[plan_id] = object()
     runner.curr_streams[plan_id] = _DummyStream([])
-    runner._plan_query_ids[plan_id] = "teardown-query"
+    _bind_test_plan_session(runner, plan_id, query_id="teardown-query")
     runner._leased_result_partition_refs = {plan_id: {"0": (object(), _OutputOwner())}}
     runner._result_partition_ref_counters = {plan_id: 1}
 
     def _cleanup_actors(_self, actual_plan_id):
         calls.append(f"actors:{actual_plan_id}")
-        raise RuntimeError("actor release failed")
+        attempts["actors"] += 1
+        if attempts["actors"] == 1:
+            raise RuntimeError("actor release failed")
+
+    def _cleanup_vllm_actors(_self, actual_plan_id):
+        calls.append(f"vllm:{actual_plan_id}")
+        attempts["vllm"] += 1
+        if attempts["vllm"] == 1:
+            raise RuntimeError("vllm actor release failed")
 
     def _drop_fragments(_self, query_id):
         calls.append(f"fragments:{query_id}")
-        raise RuntimeError("fragment release failed")
+        attempts["fragments"] += 1
+        if attempts["fragments"] == 1:
+            raise RuntimeError("fragment release failed")
 
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_actors)
+    monkeypatch.setattr(cls, "_cleanup_vllm_actor_pools", _cleanup_vllm_actors)
     monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
 
     with pytest.raises(RuntimeError, match="teardown failed") as exc_info:
@@ -893,17 +1294,78 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
 
     assert "output release failed" in str(exc_info.value)
     assert "actor release failed" in str(exc_info.value)
+    assert "vllm actor release failed" in str(exc_info.value)
     assert "fragment release failed" in str(exc_info.value)
     assert calls == [
         "output",
         "actors:teardown-plan",
+        "vllm:teardown-plan",
         "fragments:teardown-query",
     ]
     assert plan_id not in runner.curr_plans
     assert plan_id not in runner.curr_streams
+    assert runner._plan_query_ids[plan_id] == "teardown-query"
+    assert plan_id in runner._plan_session_ids
+    assert list(runner._leased_result_partition_refs[plan_id]) == ["0"]
+    assert runner._result_partition_ref_counters == {plan_id: 1}
+
+    cls._teardown_plan_resources(
+        runner,
+        plan_id,
+        "teardown-query",
+        drop_fragments=True,
+    )
+
+    assert calls == [
+        "output",
+        "actors:teardown-plan",
+        "vllm:teardown-plan",
+        "fragments:teardown-query",
+        "output",
+        "actors:teardown-plan",
+        "vllm:teardown-plan",
+        "fragments:teardown-query",
+    ]
     assert plan_id not in runner._plan_query_ids
+    assert plan_id not in runner._plan_session_ids
     assert runner._leased_result_partition_refs == {}
     assert runner._result_partition_ref_counters == {}
+
+
+@pytest.mark.parametrize(
+    ("cleanup_method", "active_attr", "by_plan_attr"),
+    [
+        ("_cleanup_udf_actor_pools", "_active_udf_actors", "_active_udf_actors_by_plan"),
+        ("_cleanup_vllm_actor_pools", "_active_vllm_actors", "_active_vllm_actors_by_plan"),
+    ],
+)
+def test_query_actor_pool_cleanup_retains_failed_pool_for_retry(cleanup_method, active_attr, by_plan_attr):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "actor-cleanup-retry"
+
+    class _Pool:
+        def __init__(self):
+            self.attempts = 0
+
+        def shutdown(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("transient actor cleanup failure")
+
+    pool = _Pool()
+    setattr(runner, active_attr, [pool])
+    setattr(runner, by_plan_attr, {plan_id: [pool]})
+
+    with pytest.raises(RuntimeError, match="transient actor cleanup failure"):
+        getattr(cls, cleanup_method)(runner, plan_id)
+
+    assert getattr(runner, active_attr) == [pool]
+    assert getattr(runner, by_plan_attr) == {plan_id: [pool]}
+
+    getattr(cls, cleanup_method)(runner, plan_id)
+
+    assert getattr(runner, active_attr) == []
+    assert getattr(runner, by_plan_attr) == {}
 
 
 def test_teardown_fence_failure_retains_retryable_query_ownership(monkeypatch):
@@ -937,6 +1399,597 @@ def test_teardown_fence_failure_retains_retryable_query_ownership(monkeypatch):
         assert get_query_resource_manager(query_id) is manager
     finally:
         release_query_resource_manager(query_id, reason="test_complete")
+
+
+def test_concurrent_plan_teardown_runs_owned_cleanup_once(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "concurrent-teardown"
+    query_id = "concurrent-teardown-query"
+    _bind_test_plan_session(runner, plan_id, query_id=query_id)
+    runner.curr_plans[plan_id] = object()
+    runner.curr_streams[plan_id] = _DummyStream([])
+    cleanup_started = threading.Event()
+    cleanup_release = threading.Event()
+    cleanup_calls = []
+    errors = []
+
+    def _drop_fragments(_self, actual_query_id):
+        cleanup_calls.append(actual_query_id)
+        cleanup_started.set()
+        cleanup_release.wait(timeout=1.0)
+
+    monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
+
+    def _cleanup():
+        try:
+            cls._cleanup_finished_plan(runner, plan_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_cleanup)
+    second = threading.Thread(target=_cleanup)
+    first.start()
+    assert cleanup_started.wait(timeout=1.0)
+    second.start()
+    cleanup_release.set()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert cleanup_calls == [query_id]
+    assert plan_id not in runner._plan_session_ids
+
+
+def test_close_session_does_not_deadlock_with_plan_teardown(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "close-during-teardown"
+    query_id = "close-during-teardown-query"
+    _bind_test_plan_session(runner, plan_id, query_id=query_id)
+    runner.curr_plans[plan_id] = object()
+    runner.curr_streams[plan_id] = _DummyStream([])
+    cleanup_started = threading.Event()
+    cleanup_release = threading.Event()
+    close_cleanup_started = threading.Event()
+    cleanup_entries = 0
+    cleanup_entries_lock = threading.Lock()
+    cleanup_calls = []
+    errors = []
+
+    def _drop_fragments(_self, actual_query_id):
+        cleanup_calls.append(actual_query_id)
+        cleanup_started.set()
+        cleanup_release.wait(timeout=1.0)
+
+    original_cleanup_finished_plan = cls._cleanup_finished_plan
+
+    def _tracked_cleanup_finished_plan(self, actual_plan_id):
+        nonlocal cleanup_entries
+        with cleanup_entries_lock:
+            cleanup_entries += 1
+            if cleanup_entries == 2:
+                close_cleanup_started.set()
+        return original_cleanup_finished_plan(self, actual_plan_id)
+
+    async def _run_inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
+    monkeypatch.setattr(cls, "_cleanup_finished_plan", _tracked_cleanup_finished_plan)
+    monkeypatch.setattr(asyncio, "to_thread", _run_inline)
+
+    def _cleanup():
+        try:
+            cls._cleanup_finished_plan(runner, plan_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def _close():
+        try:
+            asyncio.run(
+                cls.close_session(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    _TEST_SESSION_ID,
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    cleanup_thread = threading.Thread(target=_cleanup, daemon=True)
+    close_thread = threading.Thread(target=_close, daemon=True)
+    cleanup_thread.start()
+    assert cleanup_started.wait(timeout=1.0)
+    close_thread.start()
+    assert close_cleanup_started.wait(timeout=1.0)
+    cleanup_release.set()
+    cleanup_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not cleanup_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert errors == []
+    assert cleanup_calls == [query_id]
+    assert runner._closed_session_owners.get(_TEST_SESSION_ID) == _TEST_RUNTIME_OWNER_ID
+    assert _TEST_SESSION_ID not in runner._sessions
+
+
+def test_session_close_waits_until_query_connection_is_closed():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "close-during-query-connection-release"
+    _bind_test_plan_session(runner, plan_id, query_id="")
+    query_close_started = threading.Event()
+    query_close_release = threading.Event()
+    errors = []
+
+    class _BlockingQueryConnection:
+        def close(self):
+            query_close_started.set()
+            assert query_close_release.wait(timeout=1.0)
+
+    runner._plan_connections[plan_id] = _BlockingQueryConnection()
+
+    def _teardown():
+        try:
+            cls._cleanup_finished_plan(runner, plan_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def _close_session():
+        try:
+            asyncio.run(
+                cls.close_session(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    _TEST_SESSION_ID,
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    teardown_thread = threading.Thread(target=_teardown, daemon=True)
+    close_thread = threading.Thread(target=_close_session, daemon=True)
+    teardown_thread.start()
+    assert query_close_started.wait(timeout=1.0)
+    close_thread.start()
+    for _ in range(100):
+        with runner._sessions[_TEST_SESSION_ID].condition:
+            if runner._sessions[_TEST_SESSION_ID].closing:
+                break
+        time.sleep(0.001)
+
+    assert close_thread.is_alive()
+    assert runner._test_session_connection.closed is False
+
+    query_close_release.set()
+    teardown_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not teardown_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert errors == []
+    assert runner._test_session_connection.closed is True
+
+
+def test_close_session_waits_for_active_copy_operation():
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    cls._begin_session_copy(session, _TEST_SESSION_ID)
+
+    async def _close_after_copy_finishes():
+        close_task = asyncio.create_task(
+            cls.close_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+            )
+        )
+        for _ in range(100):
+            if session.closing:
+                break
+            await asyncio.sleep(0)
+        assert session.closing is True
+        assert close_task.done() is False
+        with pytest.raises(RuntimeError, match="Vane session is closing"):
+            cls._begin_session_copy(session, _TEST_SESSION_ID)
+        cls._end_session_copy(session)
+        await asyncio.wait_for(close_task, timeout=1.0)
+
+    asyncio.run(_close_after_copy_finishes())
+
+    assert session.closed is True
+    assert runner._test_session_connection.closed is True
+    assert _TEST_SESSION_ID not in runner._sessions
+
+
+def test_detach_fences_new_session_work_and_replays_result():
+    cls, runner = _make_local_query_driver_actor()
+    runner._client_ids.add("other-owner")
+    session = runner._sessions[_TEST_SESSION_ID]
+    cls._begin_session_copy(session, _TEST_SESSION_ID)
+
+    async def _detach_after_copy_finishes():
+        detach_task = asyncio.create_task(
+            cls.detach_client(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+            )
+        )
+        for _ in range(100):
+            if _TEST_RUNTIME_OWNER_ID in runner._detaching_client_ids:
+                break
+            await asyncio.sleep(0)
+        assert _TEST_RUNTIME_OWNER_ID in runner._detaching_client_ids
+        with pytest.raises(PermissionError, match="attached client owner"):
+            cls.open_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                "late-session",
+                {},
+            )
+        cls._end_session_copy(session)
+        assert await asyncio.wait_for(detach_task, timeout=1.0) is False
+        assert await cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID) is False
+
+    asyncio.run(_detach_after_copy_finishes())
+
+    assert _TEST_RUNTIME_OWNER_ID not in runner._client_ids
+    assert _TEST_SESSION_ID not in runner._sessions
+    assert runner._detached_client_results[_TEST_RUNTIME_OWNER_ID] is False
+
+
+def test_open_session_revalidates_owner_inside_registry_lock(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    runner._sessions = {}
+    runner._client_ids.add("other-owner")
+    normalize_started = threading.Event()
+    normalize_release = threading.Event()
+    open_errors = []
+
+    def _delayed_normalize(config):
+        normalize_started.set()
+        assert normalize_release.wait(timeout=1.0)
+        return dict(config)
+
+    monkeypatch.setattr(driver, "_normalize_session_config", _delayed_normalize)
+
+    def _open():
+        try:
+            cls.open_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                "late-session",
+                {},
+            )
+        except BaseException as exc:
+            open_errors.append(exc)
+
+    open_thread = threading.Thread(target=_open)
+    open_thread.start()
+    assert normalize_started.wait(timeout=1.0)
+
+    assert asyncio.run(cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID)) is False
+    normalize_release.set()
+    open_thread.join(timeout=1.0)
+
+    assert not open_thread.is_alive()
+    assert len(open_errors) == 1
+    assert isinstance(open_errors[0], PermissionError)
+    assert "late-session" not in runner._sessions
+
+
+def test_last_owner_detach_retries_runtime_shutdown_failure():
+    cls, runner = _make_local_query_driver_actor()
+    runner._sessions = {}
+    shutdown_calls = []
+
+    async def _shutdown_runtime():
+        shutdown_calls.append("shutdown")
+        if len(shutdown_calls) == 1:
+            raise RuntimeError("planned shutdown failure")
+
+    runner._shutdown_runtime = _shutdown_runtime
+
+    async def _detach_with_retry():
+        with pytest.raises(RuntimeError, match="planned shutdown failure"):
+            await cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID)
+        assert _TEST_RUNTIME_OWNER_ID in runner._client_ids
+        assert _TEST_RUNTIME_OWNER_ID not in runner._detaching_client_ids
+        assert await cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID) is True
+        assert await cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID) is True
+
+    asyncio.run(_detach_with_retry())
+
+    assert shutdown_calls == ["shutdown", "shutdown"]
+    assert _TEST_RUNTIME_OWNER_ID not in runner._client_ids
+    assert runner._detached_client_results[_TEST_RUNTIME_OWNER_ID] is True
+
+
+def test_driver_sessions_keep_config_and_close_lifecycle_independent():
+    cls, runner = _make_local_query_driver_actor()
+    session_b_config = {"AWS_ACCESS_KEY_ID": "session-b-key"}
+
+    assert cls.open_session(
+        runner,
+        _TEST_RUNTIME_OWNER_ID,
+        "session-b",
+        session_b_config,
+    )
+    session_b_config["AWS_ACCESS_KEY_ID"] = "mutated-after-open"
+
+    assert runner._sessions[_TEST_SESSION_ID].config == {}
+    assert runner._sessions["session-b"].config == {"AWS_ACCESS_KEY_ID": "session-b-key"}
+
+    asyncio.run(
+        cls.close_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+        )
+    )
+    asyncio.run(
+        cls.close_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+        )
+    )
+
+    assert _TEST_SESSION_ID not in runner._sessions
+    assert cls._require_session(runner, _TEST_RUNTIME_OWNER_ID, "session-b").config == {
+        "AWS_ACCESS_KEY_ID": "session-b-key"
+    }
+
+    runner._client_ids.add("other-runtime-owner")
+    with pytest.raises(PermissionError, match="owning runtime client"):
+        cls._require_session(runner, "other-runtime-owner", "session-b")
+
+
+def test_close_unknown_session_tombstones_ambiguous_open():
+    cls, runner = _make_local_query_driver_actor()
+    session_id = "ambiguous-open-session"
+
+    asyncio.run(
+        cls.close_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            session_id,
+        )
+    )
+
+    assert runner._closed_session_owners[session_id] == _TEST_RUNTIME_OWNER_ID
+    with pytest.raises(RuntimeError, match="identity was already closed"):
+        cls.open_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            session_id,
+            {},
+        )
+
+    runner._client_ids.add("other-runtime-owner")
+    with pytest.raises(PermissionError, match="owning runtime client"):
+        asyncio.run(
+            cls.close_session(
+                runner,
+                "other-runtime-owner",
+                session_id,
+            )
+        )
+
+
+def test_close_plan_cancellation_waits_for_owned_teardown():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "cancelled-close-plan"
+    _bind_test_plan_session(runner, plan_id, query_id="")
+    cleanup_started = threading.Event()
+    cleanup_release = threading.Event()
+    cleanup_finished = threading.Event()
+
+    def _cleanup(actual_plan_id):
+        assert actual_plan_id == plan_id
+        cleanup_started.set()
+        assert cleanup_release.wait(timeout=1.0)
+        cleanup_finished.set()
+
+    runner._cleanup_finished_plan = _cleanup
+
+    async def _cancel_close():
+        close_task = asyncio.create_task(
+            cls.close_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
+        assert await asyncio.to_thread(cleanup_started.wait, 1.0)
+        close_task.cancel()
+        await asyncio.sleep(0.01)
+        assert close_task.done() is False
+        cleanup_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+    asyncio.run(_cancel_close())
+
+    assert cleanup_finished.is_set()
+
+
+@pytest.mark.parametrize(
+    "first_owner",
+    [_TEST_RUNTIME_OWNER_ID, "other-runtime-owner"],
+)
+def test_two_runtime_clients_keep_session_config_and_close_order_independent(first_owner):
+    cls, runner = _make_local_query_driver_actor()
+    other_owner = "other-runtime-owner"
+    runner._sessions = {}
+    runner._client_ids.add(other_owner)
+    sessions = {
+        _TEST_RUNTIME_OWNER_ID: ("session-a", {"AWS_ACCESS_KEY_ID": "session-a-key"}),
+        other_owner: ("session-b", {"AWS_ACCESS_KEY_ID": "session-b-key"}),
+    }
+
+    for owner_id, (session_id, config) in sessions.items():
+        assert cls.open_session(runner, owner_id, session_id, config) is True
+
+    first_session_id, _ = sessions[first_owner]
+    surviving_owner = other_owner if first_owner == _TEST_RUNTIME_OWNER_ID else _TEST_RUNTIME_OWNER_ID
+    surviving_session_id, surviving_config = sessions[surviving_owner]
+
+    assert asyncio.run(cls.detach_client(runner, first_owner)) is False
+
+    assert first_session_id not in runner._sessions
+    surviving_session = cls._require_session(runner, surviving_owner, surviving_session_id)
+    assert surviving_session.config == surviving_config
+    with pytest.raises(PermissionError, match="attached client owner"):
+        cls._require_session(runner, first_owner, surviving_session_id)
+
+    asyncio.run(cls.close_session(runner, surviving_owner, surviving_session_id))
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
+def test_driver_rejects_active_plan_identity_collision(copy_plan):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    plan_id = "duplicate-plan"
+    runner._plan_session_ids[plan_id] = "other-session"
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return plan_id
+
+    existing_cursor_count = len(session.connection.cursors)
+    with pytest.raises(RuntimeError, match="query plan identity is already active"):
+        if copy_plan:
+            asyncio.run(
+                cls._run_copy_plan_for_session(
+                    runner,
+                    _TEST_SESSION_ID,
+                    session,
+                    _LogicalPlan(),
+                )
+            )
+        else:
+            cls._run_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+            )
+
+    assert len(session.connection.cursors) == existing_cursor_count + 1
+    assert session.connection.cursors[-1].closed is True
+    assert plan_id not in session.plan_ids
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
+def test_driver_rejects_logical_to_physical_plan_identity_change(copy_plan):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    physical_plan = _FakePhysicalPlanWithoutPlanAttr("physical-plan")
+
+    class _ChangedIdentityLogicalPlan:
+        @staticmethod
+        def idx():
+            return "logical-plan"
+
+        @staticmethod
+        def to_physical_plan(_connection):
+            return physical_plan
+
+    existing_cursor_count = len(session.connection.cursors)
+    with pytest.raises(RuntimeError, match="logical/physical query plan identity changed"):
+        if copy_plan:
+            asyncio.run(
+                cls._run_copy_plan_for_session(
+                    runner,
+                    _TEST_SESSION_ID,
+                    session,
+                    _ChangedIdentityLogicalPlan(),
+                )
+            )
+        else:
+            cls._run_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _ChangedIdentityLogicalPlan(),
+            )
+
+    assert len(session.connection.cursors) == existing_cursor_count + 1
+    assert session.connection.cursors[-1].closed is True
+    assert session.plan_ids == set()
+    assert runner._plan_session_ids == {}
+    assert runner._plan_connections == {}
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
+@pytest.mark.parametrize(
+    ("physical_session_id", "physical_session_config"),
+    [
+        ("other-session", _TEST_SESSION_CONFIG),
+        (_TEST_SESSION_ID, {"AWS_ACCESS_KEY_ID": "other-key"}),
+    ],
+)
+def test_driver_revalidates_physical_plan_session(
+    copy_plan,
+    physical_session_id,
+    physical_session_config,
+):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    physical_plan = _FakePhysicalPlanWithoutPlanAttr(
+        "physical-session-plan",
+        session_id=physical_session_id,
+        session_config=physical_session_config,
+    )
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return "physical-session-plan"
+
+        @staticmethod
+        def session_id():
+            return _TEST_SESSION_ID
+
+        @staticmethod
+        def session_config():
+            return dict(_TEST_SESSION_CONFIG)
+
+        @staticmethod
+        def to_physical_plan(_connection):
+            return physical_plan
+
+    existing_cursor_count = len(session.connection.cursors)
+    with pytest.raises(ValueError, match="session mismatch|session config changed"):
+        if copy_plan:
+            asyncio.run(
+                cls.run_copy_plan(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    _TEST_SESSION_ID,
+                    _LogicalPlan(),
+                )
+            )
+        else:
+            asyncio.run(
+                cls.run_plan(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    _TEST_SESSION_ID,
+                    _LogicalPlan(),
+                )
+            )
+
+    assert len(session.connection.cursors) == existing_cursor_count + 1
+    assert session.connection.cursors[-1].closed is True
+    assert session.plan_ids == set()
+    assert session.active_copy_operations == 0
+    assert runner._plan_session_ids == {}
+    assert runner._plan_connections == {}
 
 
 def test_normalize_native_task_result_preserves_schema_and_stats():
@@ -2053,7 +3106,14 @@ def test_get_next_partition_wraps_metadata_aware_fragment(monkeypatch):
         classmethod(lambda _cls, meta: _LocalMetadataAccessor(meta)),
     )
 
-    result = asyncio.run(cls.get_next_partition(runner, plan_id))
+    result = asyncio.run(
+        cls.get_next_partition(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+        )
+    )
 
     assert result is not None
     assert result.partition_ref() is payload
@@ -2085,9 +3145,15 @@ def test_get_next_partition_leases_and_releases_metadata_aware_fragment(monkeypa
         def __init__(self):
             self.release_result_partition_ref = _FakeRemoteMethod(self._release)
 
-        def _release(self, owner_plan_id, release_token):
-            released.append((owner_plan_id, release_token))
-            return cls.release_result_partition_ref(runner, owner_plan_id, release_token)
+        def _release(self, owner_id, session_id, owner_plan_id, release_token):
+            released.append((owner_id, session_id, owner_plan_id, release_token))
+            return cls.release_result_partition_ref(
+                runner,
+                owner_id,
+                session_id,
+                owner_plan_id,
+                release_token,
+            )
 
     class _LocalMetadataAccessor:
         def __init__(self, metadatas):
@@ -2106,6 +3172,8 @@ def test_get_next_partition_leases_and_releases_metadata_aware_fragment(monkeypa
     result = asyncio.run(
         cls.get_next_partition(
             runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
             plan_id,
             release_owner=_FakeReleaseOwner(),
         )
@@ -2113,7 +3181,7 @@ def test_get_next_partition_leases_and_releases_metadata_aware_fragment(monkeypa
 
     assert result is not None
     assert result.partition() is payload
-    assert released == [(plan_id, "0")]
+    assert released == [(_TEST_RUNTIME_OWNER_ID, _TEST_SESSION_ID, plan_id, "0")]
     assert output_owner.released is True
     assert runner._leased_result_partition_refs == {}
 
@@ -2141,12 +3209,20 @@ def test_get_next_partition_releases_by_lease_id_not_object_ref(monkeypatch):
         def __init__(self):
             self.release_result_partition_ref = _FakeRemoteMethod(self._release)
 
-        def _release(self, owner_plan_id, release_token):
+        def _release(self, owner_id, session_id, owner_plan_id, release_token):
+            assert owner_id == _TEST_RUNTIME_OWNER_ID
+            assert session_id == _TEST_SESSION_ID
             assert owner_plan_id == plan_id
             assert release_token is not payload
             assert isinstance(release_token, str)
             released.append(release_token)
-            return cls.release_result_partition_ref(runner, owner_plan_id, release_token)
+            return cls.release_result_partition_ref(
+                runner,
+                owner_id,
+                session_id,
+                owner_plan_id,
+                release_token,
+            )
 
     class _LocalMetadataAccessor:
         def __init__(self, metadatas):
@@ -2165,6 +3241,8 @@ def test_get_next_partition_releases_by_lease_id_not_object_ref(monkeypatch):
     result = asyncio.run(
         cls.get_next_partition(
             runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
             plan_id,
             release_owner=_FakeReleaseOwner(),
         )
@@ -2174,6 +3252,97 @@ def test_get_next_partition_releases_by_lease_id_not_object_ref(monkeypatch):
     assert result.partition() is payload
     assert released == ["0"]
     assert output_owner.released is True
+    assert runner._leased_result_partition_refs == {}
+
+
+def test_late_result_release_is_idempotent_after_plan_and_session_close():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "late-result-release"
+    _bind_test_plan_session(runner, plan_id, query_id="")
+    runner.curr_plans[plan_id] = object()
+    runner.curr_streams[plan_id] = _DummyStream([])
+    release_calls = []
+
+    class _OutputOwner:
+        def release(self):
+            release_calls.append("release")
+
+    runner._leased_result_partition_refs = {
+        plan_id: {
+            "0": (object(), _OutputOwner()),
+        }
+    }
+    runner._result_partition_ref_counters = {plan_id: 1}
+
+    cls._cleanup_finished_plan(runner, plan_id)
+    cls.release_result_partition_ref(
+        runner,
+        _TEST_RUNTIME_OWNER_ID,
+        _TEST_SESSION_ID,
+        plan_id,
+        "0",
+    )
+    asyncio.run(
+        cls.close_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+        )
+    )
+    cls.release_result_partition_ref(
+        runner,
+        _TEST_RUNTIME_OWNER_ID,
+        _TEST_SESSION_ID,
+        plan_id,
+        "0",
+    )
+
+    assert release_calls == ["release"]
+    with pytest.raises(PermissionError, match="owning runtime client"):
+        cls.release_result_partition_ref(
+            runner,
+            "other-runtime-owner",
+            _TEST_SESSION_ID,
+            plan_id,
+            "0",
+        )
+
+
+def test_result_release_failure_retains_lease_for_retry():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "retry-result-release"
+    _bind_test_plan_session(runner, plan_id, query_id="")
+    attempts = []
+
+    class _OutputOwner:
+        def release(self):
+            attempts.append("release")
+            if len(attempts) == 1:
+                raise RuntimeError("transient release failure")
+
+    record = (object(), _OutputOwner())
+    runner._leased_result_partition_refs = {plan_id: {"0": record}}
+
+    with pytest.raises(RuntimeError, match="transient release failure"):
+        cls.release_result_partition_ref(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+            "0",
+        )
+
+    assert runner._leased_result_partition_refs[plan_id]["0"] is record
+
+    cls.release_result_partition_ref(
+        runner,
+        _TEST_RUNTIME_OWNER_ID,
+        _TEST_SESSION_ID,
+        plan_id,
+        "0",
+    )
+
+    assert attempts == ["release", "release"]
     assert runner._leased_result_partition_refs == {}
 
 
@@ -2187,7 +3356,14 @@ def test_get_next_partition_rejects_unleased_arrow_payload():
     runner.curr_plans[plan_id] = object()
 
     with pytest.raises(TypeError, match="expected metadata-aware fragment"):
-        asyncio.run(cls.get_next_partition(runner, plan_id))
+        asyncio.run(
+            cls.get_next_partition(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
 
 
 def test_get_next_partition_rejects_non_metadata_aware_fragment():
@@ -2198,7 +3374,14 @@ def test_get_next_partition_rejects_non_metadata_aware_fragment():
     runner.curr_plans[plan_id] = object()
 
     with pytest.raises(TypeError, match="expected metadata-aware fragment"):
-        asyncio.run(cls.get_next_partition(runner, plan_id))
+        asyncio.run(
+            cls.get_next_partition(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
 
 
 def test_get_next_partition_surfaces_terminal_actor_placement_loss_before_delivery():
@@ -2219,7 +3402,14 @@ def test_get_next_partition_surfaces_terminal_actor_placement_loss_before_delive
     runner._teardown_plan_resources = _teardown
 
     with pytest.raises(RuntimeError, match="fixed Ray actor placement was lost"):
-        asyncio.run(cls.get_next_partition(runner, plan_id))
+        asyncio.run(
+            cls.get_next_partition(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
 
     assert teardown_calls == [(plan_id, query_id, True)]
     assert runner.curr_streams[plan_id].items == [undelivered]
@@ -2247,7 +3437,14 @@ def test_get_next_partition_waits_for_teardown_without_blocking_event_loop():
     runner._drop_query_fragments_sync = _slow_drop_query_fragments
 
     async def _consume_to_completion():
-        consume_task = asyncio.create_task(cls.get_next_partition(runner, plan_id))
+        consume_task = asyncio.create_task(
+            cls.get_next_partition(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
         assert await asyncio.to_thread(cleanup_started.wait, 1.0)
         assert consume_task.done() is False
 
@@ -2273,6 +3470,8 @@ def test_get_next_partition_waits_for_teardown_without_blocking_event_loop():
 def test_close_plan_runs_blocking_teardown_off_actor_event_loop():
     cls, runner = _make_local_query_driver_actor()
     cleanup_threads = []
+    runner._sessions[_TEST_SESSION_ID].plan_ids.add("plan-close")
+    runner._plan_session_ids["plan-close"] = _TEST_SESSION_ID
 
     def _cleanup(plan_id):
         assert plan_id == "plan-close"
@@ -2283,7 +3482,12 @@ def test_close_plan_runs_blocking_teardown_off_actor_event_loop():
     runner._cleanup_finished_plan = _cleanup
 
     async def _close():
-        await cls.close_plan(runner, "plan-close")
+        await cls.close_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "plan-close",
+        )
 
     asyncio.run(_close())
 
@@ -2328,6 +3532,7 @@ def test_progress_snapshot_build_runs_off_actor_event_loop(monkeypatch):
     from duckdb.runners.ray import fte_fragment_scheduler
 
     cls, runner = _make_local_query_driver_actor()
+    _bind_test_plan_session(runner, "query-progress")
     build_started = threading.Event()
     build_release = threading.Event()
 
@@ -2362,7 +3567,13 @@ def test_progress_snapshot_build_runs_off_actor_event_loop(monkeypatch):
         watchdog.start()
         try:
             started_at = time.monotonic()
-            progress_call = cls.progress_snapshot(runner, "query-progress", 0.0)
+            progress_call = cls.progress_snapshot(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                "query-progress",
+                0.0,
+            )
             call_elapsed = time.monotonic() - started_at
 
             assert call_elapsed < 0.05
@@ -2384,6 +3595,7 @@ def test_progress_snapshot_build_runs_off_actor_event_loop(monkeypatch):
 
 def test_progress_snapshot_returns_cached_value_while_refresh_runs():
     cls, runner = _make_local_query_driver_actor()
+    _bind_test_plan_session(runner, "query-cache-progress")
     refresh_started = threading.Event()
     refresh_release = threading.Event()
     build_count = 0
@@ -2400,9 +3612,23 @@ def test_progress_snapshot_returns_cached_value_while_refresh_runs():
     runner._build_local_progress_snapshot = _snapshot
 
     async def _read_cached_during_refresh():
-        first = await cls.progress_snapshot(runner, "query-cache-progress", 0.0)
+        first = await cls.progress_snapshot(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "query-cache-progress",
+            0.0,
+        )
         await asyncio.sleep(0)
-        second_call = asyncio.create_task(cls.progress_snapshot(runner, "query-cache-progress", 0.0))
+        second_call = asyncio.create_task(
+            cls.progress_snapshot(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                "query-cache-progress",
+                0.0,
+            )
+        )
         assert await asyncio.to_thread(refresh_started.wait, 1.0)
         second = await asyncio.wait_for(second_call, timeout=0.1)
         assert runner._progress_snapshot_builds
@@ -2421,6 +3647,7 @@ def test_progress_snapshot_returns_cached_value_while_refresh_runs():
 
 def test_progress_snapshot_state_is_cancelled_and_dropped_with_query():
     cls, runner = _make_local_query_driver_actor()
+    _bind_test_plan_session(runner, "query-drop-progress")
     build_started = threading.Event()
     build_release = threading.Event()
 
@@ -2432,7 +3659,15 @@ def test_progress_snapshot_state_is_cancelled_and_dropped_with_query():
     runner._build_local_progress_snapshot = _slow_snapshot
 
     async def _drop_active_snapshot():
-        progress = asyncio.create_task(cls.progress_snapshot(runner, "query-drop-progress", 0.0))
+        progress = asyncio.create_task(
+            cls.progress_snapshot(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                "query-drop-progress",
+                0.0,
+            )
+        )
         assert await asyncio.to_thread(build_started.wait, 1.0)
         cls._drop_progress_snapshot_state(runner, "query-drop-progress")
         with pytest.raises(asyncio.CancelledError):
@@ -4328,60 +5563,899 @@ def test_wait_fte_query_respects_timeout_after_finished_status_during_drain(monk
         manager.shutdown()
 
 
-def test_ray_query_driver_client_retries_stale_named_actor_with_get_if_exists(monkeypatch):
+def test_worker_manager_close_session_attempts_every_worker_before_retry(monkeypatch):
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    calls = []
+
+    class _SessionWorker:
+        def __init__(self, worker_id, *, fail):
+            self.worker_id = worker_id
+            self.fail = fail
+
+        def close_session(self, session_id):
+            calls.append((self.worker_id, session_id))
+            if self.fail:
+                raise RuntimeError(f"planned close failure on {self.worker_id}")
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            return None
+
+    first = _SessionWorker("worker-a", fail=True)
+    second = _SessionWorker("worker-b", fail=False)
+    monkeypatch.setattr(
+        ray_worker_handle,
+        "start_ray_workers",
+        lambda _existing_ids: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-a", first, 1.0, 0.0, 1024),
+            duckdb.ray_cxx.RayWorkerRuntime("worker-b", second, 1.0, 0.0, 1024),
+        ],
+    )
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+    try:
+        runner.warm_up()
+        with pytest.raises(Exception, match="planned close failure on worker-a"):
+            runner.close_session("session-a")
+
+        assert sorted(calls) == [
+            ("worker-a", "session-a"),
+            ("worker-b", "session-a"),
+        ]
+
+        first.fail = False
+        runner.close_session("session-a")
+
+        assert sorted(calls) == [
+            ("worker-a", "session-a"),
+            ("worker-a", "session-a"),
+            ("worker-b", "session-a"),
+            ("worker-b", "session-a"),
+        ]
+    finally:
+        runner.shutdown()
+
+
+def test_ray_query_driver_clients_attach_to_job_runtime(monkeypatch):
     class _FakeMethod:
         def __init__(self, label):
             self.label = label
+            self.calls = []
 
         def remote(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
             return (self.label, args, kwargs)
 
     class _FakeHandle:
         def __init__(self, name):
             self.name = name
+            self.attach_client = _FakeMethod(("attach", name))
             self.ping = _FakeMethod(("ping", name))
-            self.install_env_overrides = _FakeMethod(("install_env_overrides", name))
 
-    handles = [_FakeHandle("stale"), _FakeHandle("fresh")]
+    handle = _FakeHandle("job-runtime")
     option_calls = []
-    kill_calls = []
+    remote_calls = []
 
     def _fake_options(**kwargs):
         option_calls.append(kwargs)
 
         class _Factory:
-            def remote(self, env_overrides, duckdb_memory_bytes):
-                assert env_overrides == {}
+            def remote(self, runtime_config, duckdb_memory_bytes):
+                assert runtime_config == {"PYTHONPATH": "/vane"}
                 assert duckdb_memory_bytes == 50
-                return handles.pop(0)
+                remote_calls.append((runtime_config, duckdb_memory_bytes, handle))
+                return handle
 
         return _Factory()
 
-    def _fake_ray_get(token, **_kwargs):
-        if token[0] == ("ping", "stale"):
-            raise RuntimeError("stale actor")
-
-    def _fake_ray_kill(handle, no_restart=False):
-        kill_calls.append((handle.name, no_restart))
-
     monkeypatch.setattr(driver, "_maybe_set_distributed_cluster_capacity", lambda: None)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(
+            gcs_address="gcs-a",
+            get_job_id=lambda: "job-a",
+        ),
+    )
     monkeypatch.setattr(
         driver,
         "get_head_node",
         lambda: {"NodeID": "a" * 56, "Resources": {"memory": 1_000}},
     )
-    monkeypatch.setattr(driver, "_collect_vane_env_overrides", dict)
+    monkeypatch.setattr(driver, "_collect_vane_env_overrides", lambda: {"PYTHONPATH": "/vane"})
     monkeypatch.setattr(driver.RayQueryDriverActor, "options", _fake_options)
-    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _fake_ray_get)
-    monkeypatch.setattr(driver.ray, "kill", _fake_ray_kill)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", lambda *_args, **_kwargs: True)
 
-    runner = driver.RayQueryDriverClient()
+    client_a = driver.RayQueryDriverClient()
+    client_b = driver.RayQueryDriverClient()
 
-    assert runner.runner.name == "fresh"
+    assert client_a.runner is handle
+    assert client_b.runner is handle
+    assert client_a._owner_id != client_b._owner_id
     assert len(option_calls) == 2
-    assert option_calls[0]["name"] == "ray-query-driver-actor"
-    assert option_calls[0]["namespace"] == "vane"
+    assert option_calls[0]["name"] == option_calls[1]["name"]
+    assert option_calls[0]["name"].startswith("vane-query-runtime-")
+    assert all(options["namespace"] == "vane" for options in option_calls)
+    assert all(options["get_if_exists"] is True for options in option_calls)
     assert option_calls[0]["memory"] == 50
-    assert option_calls[0]["get_if_exists"] is True
-    assert option_calls[1]["get_if_exists"] is False
-    assert kill_calls == [("stale", False)]
+    assert option_calls[0]["runtime_env"]["env_vars"] == {"PYTHONPATH": "/vane"}
+    assert option_calls[1]["runtime_env"]["env_vars"] == {"PYTHONPATH": "/vane"}
+    assert remote_calls[0][:2] == ({"PYTHONPATH": "/vane"}, 50)
+    assert remote_calls[1][:2] == ({"PYTHONPATH": "/vane"}, 50)
+    assert handle.attach_client.calls == [
+        ((client_a._owner_id, {"PYTHONPATH": "/vane"}), {}),
+        ((client_b._owner_id, {"PYTHONPATH": "/vane"}), {}),
+    ]
+    assert handle.ping.calls == [
+        ((client_a._owner_id,), {}),
+        ((client_b._owner_id,), {}),
+    ]
+
+
+def test_ray_runner_creates_one_driver_client_for_concurrent_sessions(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    created = []
+
+    class _FakeClient:
+        def __init__(self):
+            created.append(self)
+
+    ray_runner = object.__new__(runner_module.RayRunner)
+    ray_runner.query_driver_client = None
+    ray_runner._session_ids = set()
+    ray_runner._closed_session_ids = runner_module.BoundedReplayMap(capacity=65_536)
+    ray_runner._session_lock = threading.RLock()
+    ray_runner._closed = False
+    monkeypatch.setattr(runner_module, "RayQueryDriverClient", _FakeClient)
+
+    clients = []
+
+    def _get_client(session_id):
+        clients.append(ray_runner._client_for_session(session_id))
+
+    first = threading.Thread(target=_get_client, args=("session-a",))
+    second = threading.Thread(target=_get_client, args=("session-b",))
+    first.start()
+    second.start()
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+
+    assert len(created) == 1
+    assert clients == [created[0], created[0]]
+    assert ray_runner._session_ids == {"session-a", "session-b"}
+
+
+def test_ray_runner_close_before_session_registration_is_terminal(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    ray_runner = object.__new__(runner_module.RayRunner)
+    ray_runner.query_driver_client = None
+    ray_runner._session_ids = set()
+    ray_runner._closed_session_ids = runner_module.BoundedReplayMap(capacity=65_536)
+    ray_runner._session_lock = threading.RLock()
+    ray_runner._closed = False
+    monkeypatch.setattr(
+        runner_module,
+        "RayQueryDriverClient",
+        lambda: (_ for _ in ()).throw(AssertionError("closed session must not create a client")),
+    )
+
+    ray_runner.close_session("session-a")
+
+    with pytest.raises(RuntimeError, match="Vane session is closed"):
+        ray_runner._client_for_session("session-a")
+    assert set(ray_runner._closed_session_ids) == {"session-a"}
+
+
+def test_ray_runner_close_is_terminal_and_idempotent(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    closed_clients = []
+
+    class _FakeClient:
+        def close(self):
+            closed_clients.append(self)
+
+    ray_runner = object.__new__(runner_module.RayRunner)
+    original_client = _FakeClient()
+    ray_runner.query_driver_client = original_client
+    ray_runner._session_ids = {"session-a"}
+    ray_runner._closed_session_ids = runner_module.BoundedReplayMap(capacity=65_536)
+    ray_runner._session_lock = threading.RLock()
+    ray_runner._closed = False
+    with runner_module._RAY_RUNNERS_LOCK:
+        runner_module._RAY_RUNNERS.add(ray_runner)
+    monkeypatch.setattr(runner_module, "RayQueryDriverClient", _FakeClient)
+
+    ray_runner.close()
+    ray_runner.close()
+
+    with runner_module._RAY_RUNNERS_LOCK:
+        assert ray_runner not in runner_module._RAY_RUNNERS
+
+    with pytest.raises(RuntimeError, match="RayRunner is closed"):
+        ray_runner._client_for_session("session-b")
+    assert closed_clients == [original_client]
+    assert ray_runner._session_ids == set()
+    assert ray_runner._closed is True
+
+
+def test_connection_close_notification_attempts_every_live_runner(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    calls = []
+
+    class _LiveRunner:
+        def __init__(self, name, *, fail):
+            self.name = name
+            self.fail = fail
+
+        def close_session(self, session_id):
+            calls.append((self.name, session_id))
+            if self.fail:
+                raise RuntimeError(f"planned close failure on {self.name}")
+
+    failing = _LiveRunner("runner-a", fail=True)
+    succeeding = _LiveRunner("runner-b", fail=False)
+    monkeypatch.setattr(runner_module, "_RAY_RUNNERS", {failing, succeeding})
+
+    with pytest.raises(RuntimeError, match="planned close failure on runner-a"):
+        runner_module.notify_connection_closed("session-a")
+
+    assert sorted(calls) == [
+        ("runner-a", "session-a"),
+        ("runner-b", "session-a"),
+    ]
+
+    failing.fail = False
+    runner_module.notify_connection_closed("session-a")
+
+    assert sorted(calls) == [
+        ("runner-a", "session-a"),
+        ("runner-a", "session-a"),
+        ("runner-b", "session-a"),
+        ("runner-b", "session-a"),
+    ]
+
+
+def test_ray_runner_session_start_and_close_are_serialized(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    client_init_started = threading.Event()
+    client_init_release = threading.Event()
+    close_started = threading.Event()
+
+    class _FakeClient:
+        def __init__(self):
+            client_init_started.set()
+            assert client_init_release.wait(timeout=1.0)
+
+        def close(self):
+            close_started.set()
+
+    ray_runner = object.__new__(runner_module.RayRunner)
+    ray_runner.query_driver_client = None
+    ray_runner._session_ids = set()
+    ray_runner._closed_session_ids = runner_module.BoundedReplayMap(capacity=65_536)
+    ray_runner._session_lock = threading.RLock()
+    ray_runner._closed = False
+    monkeypatch.setattr(runner_module, "RayQueryDriverClient", _FakeClient)
+
+    session_thread = threading.Thread(
+        target=ray_runner._client_for_session,
+        args=("session-a",),
+        daemon=True,
+    )
+    close_thread = threading.Thread(target=ray_runner.close, daemon=True)
+    session_thread.start()
+    assert client_init_started.wait(timeout=1.0)
+    close_thread.start()
+    try:
+        assert close_started.wait(timeout=0.05) is False
+    finally:
+        client_init_release.set()
+    session_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not session_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert close_started.is_set()
+    assert ray_runner._closed is True
+
+
+def test_ray_query_driver_client_serializes_first_session_open_with_close(monkeypatch):
+    open_started = threading.Event()
+    open_release = threading.Event()
+    events = []
+
+    class _OpenMethod:
+        @staticmethod
+        def remote(owner_id, session_id, config):
+            events.append(("open", owner_id, session_id, config))
+            open_started.set()
+            assert open_release.wait(timeout=1.0)
+            return "open-ref"
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(owner_id, session_id):
+            events.append(("close", owner_id, session_id))
+            return "close-ref"
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {"AWS_ACCESS_KEY_ID": "key-a"}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    _initialize_test_query_driver_client(client)
+    client.runner = SimpleNamespace(
+        open_session=_OpenMethod(),
+        close_session=_CloseMethod(),
+    )
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref)
+    open_errors = []
+    close_errors = []
+
+    def _open():
+        try:
+            client._ensure_session(_Plan())
+        except BaseException as exc:
+            open_errors.append(exc)
+
+    def _close():
+        try:
+            client.close_session("session-a")
+        except BaseException as exc:
+            close_errors.append(exc)
+
+    open_thread = threading.Thread(target=_open)
+    close_thread = threading.Thread(target=_close)
+    open_thread.start()
+    assert open_started.wait(timeout=1.0)
+    close_thread.start()
+    for _ in range(100):
+        with client._session_condition:
+            if "session-a" in client._closing_session_ids:
+                break
+        time.sleep(0.001)
+    open_release.set()
+    open_thread.join(timeout=1.0)
+    close_thread.join(timeout=1.0)
+
+    assert not open_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert len(open_errors) == 1
+    assert "closed while it was opening" in str(open_errors[0])
+    assert close_errors == []
+    assert events == [
+        ("open", "owner-a", "session-a", {"AWS_ACCESS_KEY_ID": "key-a"}),
+        ("close", "owner-a", "session-a"),
+    ]
+    assert client._opened_sessions == {}
+    assert client._opening_session_ids == set()
+    assert client._closing_session_ids == set()
+
+
+def test_ray_query_driver_client_closes_session_after_ambiguous_open_failure(monkeypatch):
+    open_ref = object()
+    close_ref = object()
+    close_calls = []
+
+    class _OpenMethod:
+        @staticmethod
+        def remote(*_args):
+            return open_ref
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(owner_id, session_id):
+            close_calls.append((owner_id, session_id))
+            return close_ref
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {"AWS_ACCESS_KEY_ID": "key-a"}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    _initialize_test_query_driver_client(client)
+    client.runner = SimpleNamespace(
+        open_session=_OpenMethod(),
+        close_session=_CloseMethod(),
+    )
+
+    def _resolve(ref, **_kwargs):
+        if ref is open_ref:
+            raise FutureTimeoutError("ambiguous open timeout")
+        assert ref is close_ref
+        return None
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    with pytest.raises(FutureTimeoutError, match="ambiguous open timeout"):
+        client._ensure_session(_Plan())
+
+    assert client._opened_sessions == {}
+    assert client._uncertain_sessions == {
+        "session-a": {
+            "AWS_ACCESS_KEY_ID": "key-a",
+        }
+    }
+
+    client.close_session("session-a")
+
+    assert close_calls == [("owner-a", "session-a")]
+    assert client._uncertain_sessions == {}
+    assert client._closing_session_ids == set()
+
+
+def test_ray_query_driver_client_detach_supersedes_session_close_waiting_on_open(monkeypatch):
+    open_started = threading.Event()
+    open_release = threading.Event()
+    detach_started = threading.Event()
+    detach_release = threading.Event()
+    events = []
+
+    class _OpenMethod:
+        @staticmethod
+        def remote(owner_id, session_id, config):
+            events.append(("open", owner_id, session_id, config))
+            open_started.set()
+            assert open_release.wait(timeout=1.0)
+            return "open-ref"
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(owner_id, session_id):
+            events.append(("close", owner_id, session_id))
+            return "close-ref"
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            events.append(("detach", owner_id))
+            detach_started.set()
+            assert detach_release.wait(timeout=1.0)
+            return "detach-ref"
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {"AWS_ACCESS_KEY_ID": "key-a"}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client)
+    client.runner = SimpleNamespace(
+        open_session=_OpenMethod(),
+        close_session=_CloseMethod(),
+        detach_client=_DetachMethod(),
+    )
+
+    def _resolve(ref, **_kwargs):
+        return False if ref == "detach-ref" else ref
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    errors = []
+
+    def _run(call):
+        try:
+            call()
+        except BaseException as exc:
+            errors.append(exc)
+
+    open_thread = threading.Thread(target=_run, args=(lambda: client._ensure_session(_Plan()),))
+    session_close_thread = threading.Thread(target=_run, args=(lambda: client.close_session("session-a"),))
+    client_close_thread = threading.Thread(target=_run, args=(client.close,))
+    open_thread.start()
+    assert open_started.wait(timeout=1.0)
+    session_close_thread.start()
+    for _ in range(100):
+        with client._session_condition:
+            if "session-a" in client._closing_session_ids:
+                break
+        time.sleep(0.001)
+    client_close_thread.start()
+    open_release.set()
+    assert detach_started.wait(timeout=1.0)
+
+    session_close_thread.join(timeout=1.0)
+    assert not session_close_thread.is_alive()
+    assert not any(event[0] == "close" for event in events)
+
+    detach_release.set()
+    open_thread.join(timeout=1.0)
+    client_close_thread.join(timeout=1.0)
+
+    assert not open_thread.is_alive()
+    assert not client_close_thread.is_alive()
+    assert len(errors) == 1
+    assert "closed while it was opening" in str(errors[0])
+    assert events == [
+        ("open", "owner-a", "session-a", {"AWS_ACCESS_KEY_ID": "key-a"}),
+        ("detach", "owner-a"),
+    ]
+    assert client.runner is None
+    assert client._opened_sessions == {}
+    assert client._closing_session_ids == set()
+
+
+def test_ray_query_driver_client_session_close_failure_stays_fenced_and_retryable(monkeypatch):
+    close_calls = []
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(owner_id, session_id):
+            close_calls.append((owner_id, session_id))
+            return len(close_calls)
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = SimpleNamespace(close_session=_CloseMethod())
+
+    def _resolve(ref, **_kwargs):
+        if ref == 1:
+            raise RuntimeError("planned session close failure")
+        return None
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    with pytest.raises(RuntimeError, match="planned session close failure"):
+        client.close_session("session-a")
+
+    assert client._opened_sessions == {"session-a": {}}
+    assert client._closing_session_ids == {"session-a"}
+    with pytest.raises(RuntimeError, match="Vane session is closing"):
+        client._ensure_session(_Plan())
+
+    client.close_session("session-a")
+
+    assert close_calls == [("owner-a", "session-a"), ("owner-a", "session-a")]
+    assert client._opened_sessions == {}
+    assert client._closing_session_ids == set()
+
+
+@pytest.mark.parametrize("failed_ref", ["attach", "ping"])
+@pytest.mark.parametrize("failure_type", [RuntimeError, KeyboardInterrupt])
+def test_ray_query_driver_client_detaches_when_initialization_fails(monkeypatch, failed_ref, failure_type):
+    events = []
+
+    class _FakeMethod:
+        def __init__(self, operation):
+            self.operation = operation
+
+        def remote(self, *args):
+            events.append((self.operation, *args))
+            return self.operation
+
+    class _FakeHandle:
+        attach_client = _FakeMethod("attach")
+        ping = _FakeMethod("ping")
+        detach_client = _FakeMethod("detach")
+
+    handle = _FakeHandle()
+
+    class _Factory:
+        @staticmethod
+        def remote(_runtime_config, _duckdb_memory_bytes):
+            return handle
+
+    monkeypatch.setattr(driver, "_maybe_set_distributed_cluster_capacity", lambda: None)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(
+            gcs_address="gcs-a",
+            get_job_id=lambda: "job-a",
+        ),
+    )
+    monkeypatch.setattr(
+        driver,
+        "get_head_node",
+        lambda: {"NodeID": "a" * 56, "Resources": {"memory": 1_000}},
+    )
+    monkeypatch.setattr(driver, "_collect_vane_env_overrides", lambda: {})
+    monkeypatch.setattr(driver.RayQueryDriverActor, "options", lambda **_kwargs: _Factory())
+
+    def resolve(ref, **kwargs):
+        events.append(("resolve", ref, kwargs))
+        if ref == failed_ref:
+            raise failure_type(f"planned {failed_ref} failure")
+        return True
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(
+        driver.ray,
+        "kill",
+        lambda actor, *, no_restart: events.append(("kill", actor, no_restart)),
+    )
+
+    with pytest.raises(failure_type, match=f"planned {failed_ref} failure"):
+        driver.RayQueryDriverClient()
+
+    attach_event = next(event for event in events if event[0] == "attach")
+    detach_event = next(event for event in events if event[0] == "detach")
+    assert attach_event[1] == detach_event[1]
+    if failed_ref == "ping":
+        ping_event = next(event for event in events if event[0] == "ping")
+        assert attach_event[1] == ping_event[1]
+    else:
+        assert all(event[0] != "ping" for event in events)
+    assert ("kill", handle, True) in events
+
+
+@pytest.mark.parametrize("close_order", [(0, 1), (1, 0)])
+def test_ray_query_driver_client_close_keeps_shared_runtime_until_last_owner(monkeypatch, close_order):
+    events = []
+
+    class _FakeMethod:
+        def __init__(self, operation, actor_name):
+            self.operation = operation
+            self.actor_name = actor_name
+
+        def remote(self, owner_id):
+            events.append((self.operation, self.actor_name, owner_id))
+            return (self.operation, self.actor_name)
+
+    class _FakeHandle:
+        def __init__(self, name):
+            self.name = name
+            self.ping = _FakeMethod("ping", name)
+            self.detach_client = _FakeMethod("detach", name)
+
+    shared_handle = _FakeHandle("job-runtime")
+    clients = []
+    for index in range(2):
+        client = object.__new__(driver.RayQueryDriverClient)
+        client._owner_id = f"owner-{index}"
+        client._ray_gcs_address = "gcs-a"
+        _initialize_test_query_driver_client(client)
+        client.runner = shared_handle
+        clients.append(client)
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+
+    def resolve(ref, **_kwargs):
+        events.append(("resolve", *ref))
+        if ref[0] == "detach":
+            detach_count = sum(event[0] == "detach" for event in events)
+            return detach_count == 2
+        return True
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(
+        driver.ray,
+        "kill",
+        lambda actor, *, no_restart: events.append(("kill", actor.name, no_restart)),
+    )
+
+    first, second = close_order
+    clients[first].close()
+
+    assert clients[first].runner is None
+    assert clients[second].runner is not None
+    ping_ref = clients[second].runner.ping.remote(clients[second]._owner_id)
+    assert resolve(ping_ref) is True
+
+    clients[second].close()
+
+    assert events == [
+        ("detach", "job-runtime", f"owner-{first}"),
+        ("resolve", "detach", "job-runtime"),
+        ("ping", "job-runtime", f"owner-{second}"),
+        ("resolve", "ping", "job-runtime"),
+        ("detach", "job-runtime", f"owner-{second}"),
+        ("resolve", "detach", "job-runtime"),
+        ("kill", "job-runtime", True),
+    ]
+
+
+def test_ray_query_driver_client_close_remains_retryable_after_detach_failure(monkeypatch):
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            return "detach-ref"
+
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = runner
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("planned detach failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="planned detach failure"):
+        client.close()
+
+    assert client.runner is runner
+    assert client._opened_sessions == {"session-a": {}}
+    assert client._client_closing is True
+
+
+def test_ray_query_driver_client_close_remains_retryable_after_kill_failure(monkeypatch):
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            return "detach-ref"
+
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = runner
+    kill_calls = []
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", lambda *_args, **_kwargs: True)
+
+    def _kill(actor, *, no_restart):
+        assert actor is runner
+        assert no_restart is True
+        kill_calls.append(actor)
+        if len(kill_calls) == 1:
+            raise RuntimeError("planned kill failure")
+
+    monkeypatch.setattr(driver.ray, "kill", _kill)
+
+    with pytest.raises(RuntimeError, match="planned kill failure"):
+        client.close()
+
+    assert client.runner is runner
+    assert client._opened_sessions == {"session-a": {}}
+    assert client._client_closing is True
+
+    client.close()
+
+    assert client.runner is None
+    assert client._opened_sessions == {}
+    assert client._client_closing is False
+    assert kill_calls == [runner, runner]
+
+
+def test_ray_query_driver_client_concurrent_close_detaches_once(monkeypatch):
+    detach_calls: list[str] = []
+    kill_calls = []
+    detach_started = threading.Event()
+    allow_detach = threading.Event()
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            detach_calls.append(owner_id)
+            return "detach-ref"
+
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = runner
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+
+    def _resolve(*_args, **_kwargs):
+        detach_started.set()
+        assert allow_detach.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(
+        driver.ray,
+        "kill",
+        lambda actor, *, no_restart: kill_calls.append((actor, no_restart)),
+    )
+
+    errors: list[BaseException] = []
+
+    def _close() -> None:
+        try:
+            client.close()
+        except BaseException as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=_close)
+    second = threading.Thread(target=_close)
+    first.start()
+    assert detach_started.wait(timeout=5)
+    second.start()
+    allow_detach.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert detach_calls == ["owner-a"]
+    assert kill_calls == [(runner, True)]
+    assert client.runner is None
+
+
+def test_ray_query_driver_client_close_before_open_is_terminal():
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    _initialize_test_query_driver_client(client)
+    client.runner = SimpleNamespace()
+
+    client.close_session("session-a")
+
+    assert set(client._closed_session_ids) == {"session-a"}
+    with pytest.raises(RuntimeError, match="Vane session is closed"):
+        client._ensure_session(_Plan())

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6413,17 +6413,17 @@ def test_ray_query_driver_client_retires_drained_named_runtime_before_retry(monk
 
 
 def test_runtime_replacement_classifier_rejects_permanent_actor_init_failure():
-    assert driver._runtime_actor_is_being_replaced(
-        driver.ray.exceptions.RayActorError(
-            error_msg="actor disappeared before attach",
-        )
+    actor_loss = driver.ray.exceptions.RayActorError(
+        error_msg="actor disappeared before attach",
     )
-    assert not driver._runtime_actor_is_being_replaced(
-        driver.ray.exceptions.RayActorError(
-            error_msg="actor constructor failed",
-            actor_init_failed=True,
-        )
+    actor_init_failure = driver.ray.exceptions.RayActorError(
+        error_msg="actor constructor failed",
+        actor_init_failed=True,
     )
+    assert driver._runtime_actor_is_unavailable(actor_loss)
+    assert driver._runtime_actor_is_unavailable(actor_init_failure)
+    assert driver._runtime_actor_is_being_replaced(actor_loss)
+    assert not driver._runtime_actor_is_being_replaced(actor_init_failure)
 
     class _WrappedShutdown(RuntimeError):
         @staticmethod
@@ -6432,6 +6432,38 @@ def test_runtime_replacement_classifier_rejects_permanent_actor_init_failure():
 
     wrapped_shutdown = _WrappedShutdown()
     assert driver._runtime_actor_is_being_replaced(wrapped_shutdown)
+
+
+def test_runtime_wait_timeout_classifier_rejects_completed_remote_timeout():
+    local_wait_timeout = FutureTimeoutError("ObjectRef is still pending")
+    remote_method_timeout = driver.ray.exceptions.RayTaskError(
+        "detach_client",
+        "remote detach timeout",
+        TimeoutError("remote detach timeout"),
+    )
+    restored_remote_timeout = TimeoutError("transported remote detach timeout")
+    restored_remote_timeout.remote_exception_type = "builtins.TimeoutError"
+
+    assert driver._runtime_error_is_wait_timeout(local_wait_timeout)
+    assert not driver._runtime_error_is_wait_timeout(remote_method_timeout)
+    assert not driver._runtime_error_is_wait_timeout(restored_remote_timeout)
+
+
+def test_failed_attach_cleanup_skips_detach_for_actor_init_failure():
+    class _DetachMethod:
+        @staticmethod
+        def remote(_owner_id):
+            raise AssertionError("a failed actor process cannot retain an attached owner")
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    attach_error = driver.ray.exceptions.RayActorError(
+        error_msg="actor constructor failed",
+        actor_init_failed=True,
+    )
+
+    client._detach_after_failed_attach(runner, attach_error)
 
 
 def test_ray_runner_creates_one_driver_client_for_concurrent_sessions(monkeypatch):
@@ -6960,16 +6992,18 @@ def test_ray_query_driver_client_session_close_failure_stays_fenced_and_retryabl
 
 
 @pytest.mark.parametrize(
-    ("ray_initialized", "current_gcs_address"),
+    ("ray_initialized", "current_gcs_address", "current_job_id"),
     [
-        (False, "gcs-a"),
-        (True, "gcs-b"),
+        (False, "gcs-a", "job-a"),
+        (True, "gcs-b", "job-a"),
+        (True, "gcs-a", "job-b"),
     ],
 )
 def test_ray_query_driver_client_session_close_is_terminal_after_runtime_changes(
     monkeypatch,
     ray_initialized,
     current_gcs_address,
+    current_job_id,
 ):
     class _CloseMethod:
         @staticmethod
@@ -6979,6 +7013,7 @@ def test_ray_query_driver_client_session_close_is_terminal_after_runtime_changes
     client = object.__new__(driver.RayQueryDriverClient)
     client._owner_id = "owner-a"
     client._ray_gcs_address = "gcs-a"
+    client._ray_job_id = "job-a"
     _initialize_test_query_driver_client(client, {"session-a": {}})
     client.runner = SimpleNamespace(close_session=_CloseMethod())
 
@@ -6986,7 +7021,10 @@ def test_ray_query_driver_client_session_close_is_terminal_after_runtime_changes
     monkeypatch.setattr(
         driver.ray,
         "get_runtime_context",
-        lambda: SimpleNamespace(gcs_address=current_gcs_address),
+        lambda: SimpleNamespace(
+            gcs_address=current_gcs_address,
+            get_job_id=lambda: current_job_id,
+        ),
     )
 
     client.close_session("session-a")

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -151,6 +151,9 @@ class _FakePhysicalPlanWithoutPlanAttr:
     def session_config(self) -> dict[str, str]:
         return dict(self._session_config)
 
+    def has_explicit_s3_credentials(self) -> bool:
+        return False
+
 
 class _FakeLogicalPlan:
     def __init__(self, physical_plan: _FakePhysicalPlanWithoutPlanAttr) -> None:
@@ -159,7 +162,7 @@ class _FakeLogicalPlan:
     def idx(self) -> str:
         return self.physical_plan.idx()
 
-    def to_physical_plan(self, _conn):
+    def to_physical_plan(self, _conn, _effective_session_config):
         return self.physical_plan
 
     def session_id(self) -> str:
@@ -168,16 +171,24 @@ class _FakeLogicalPlan:
     def session_config(self) -> dict[str, str]:
         return self.physical_plan.session_config()
 
+    def has_explicit_s3_credentials(self) -> bool:
+        return self.physical_plan.has_explicit_s3_credentials()
+
 
 class _FakeConnection:
     def __init__(self) -> None:
         self.cursors: list[_FakeConnection] = []
+        self.statements: list[str] = []
         self.closed = False
 
     def cursor(self) -> _FakeConnection:
         cursor = _FakeConnection()
         self.cursors.append(cursor)
         return cursor
+
+    def execute(self, statement: str) -> _FakeConnection:
+        self.statements.append(statement)
+        return self
 
     def close(self) -> None:
         self.closed = True
@@ -486,6 +497,69 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
     assert "cancelled-plan" not in runner._sessions[_TEST_SESSION_ID].plan_ids
 
 
+def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    physical_plan = _FakePhysicalPlanWithoutPlanAttr("slow-stream-startup")
+    startup_started = threading.Event()
+    startup_release = threading.Event()
+
+    class _BlockingLogicalPlan(_FakeLogicalPlan):
+        def to_physical_plan(self, _conn, _effective_session_config):
+            startup_started.set()
+            assert startup_release.wait(timeout=1.0)
+            return physical_plan
+
+    class _PlanRunner:
+        @staticmethod
+        def run_plan(_plan, _conn):
+            return _DummyStream([])
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(
+        cls,
+        "_register_query_resources",
+        lambda _self, _plan, *, query_connection: (
+            SimpleNamespace(query_id="slow-stream-startup", stages=()),
+            object(),
+        ),
+    )
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+
+    def _cleanup(_self, plan_id):
+        runner.curr_plans.pop(plan_id, None)
+        runner.curr_streams.pop(plan_id, None)
+        cls._release_plan_session_state(runner, plan_id)
+
+    monkeypatch.setattr(cls, "_cleanup_finished_plan", _cleanup)
+
+    async def _close_during_startup():
+        run_task = asyncio.create_task(_run_actor_stream_plan(runner, _BlockingLogicalPlan(physical_plan)))
+        assert await asyncio.to_thread(startup_started.wait, 1.0)
+        close_task = asyncio.create_task(
+            cls.close_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+            )
+        )
+        for _ in range(100):
+            if runner._sessions[_TEST_SESSION_ID].closing:
+                break
+            await asyncio.sleep(0)
+        assert runner._sessions[_TEST_SESSION_ID].closing is True
+        await asyncio.wait_for(asyncio.sleep(0), timeout=0.1)
+        assert close_task.done() is False
+        startup_release.set()
+        await asyncio.wait_for(run_task, timeout=1.0)
+        await asyncio.wait_for(close_task, timeout=1.0)
+
+    asyncio.run(_close_during_startup())
+
+    assert _TEST_SESSION_ID not in runner._sessions
+
+
 def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-plan")
@@ -621,6 +695,65 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
             True,
         )
     ]
+
+
+def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-progress-cancellation"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    snapshot_started = threading.Event()
+    snapshot_release = threading.Event()
+    snapshot_finished = threading.Event()
+    teardown_calls = []
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            return {"ok": True}
+
+    def _build_snapshot(_self, query_id, _started_at):
+        assert query_id == plan_id
+        snapshot_started.set()
+        assert snapshot_release.wait(timeout=1.0)
+        snapshot_finished.set()
+        return {"query_id": query_id}
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        assert snapshot_finished.is_set()
+        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(
+        cls,
+        "_register_query_resources",
+        lambda _self, _plan, *, query_connection: (
+            SimpleNamespace(query_id=plan_id, stages=()),
+            object(),
+        ),
+    )
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", _build_snapshot)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    async def _cancel_during_snapshot():
+        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        assert await asyncio.to_thread(snapshot_started.wait, 1.0)
+        copy_task.cancel()
+        await asyncio.sleep(0.01)
+        assert copy_task.done() is False
+        assert teardown_calls == []
+        snapshot_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await copy_task
+
+    asyncio.run(_cancel_during_snapshot())
+
+    assert teardown_calls == [(plan_id, plan_id, True)]
+    assert runner._sessions[_TEST_SESSION_ID].active_operations == 0
+    assert plan_id not in runner._plan_session_ids
 
 
 def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(monkeypatch):
@@ -1001,6 +1134,46 @@ def test_ray_query_driver_client_stream_waits_through_progress_session(monkeypat
     assert progress.finish_calls == [{"final_state": "FINISHED"}]
 
 
+def test_ray_query_driver_client_stream_keeps_captured_runner_during_concurrent_close(monkeypatch):
+    run_ref = object()
+    partition_ref = object()
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+
+    class _RunMethod:
+        @staticmethod
+        def remote(*_args):
+            client.runner = None
+            return run_ref
+
+    class _NextMethod:
+        calls = []
+
+        @classmethod
+        def remote(cls, *args):
+            cls.calls.append(args)
+            return partition_ref
+
+    runner = SimpleNamespace(
+        run_plan=_RunMethod(),
+        get_next_partition=_NextMethod(),
+    )
+    client.runner = runner
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", lambda ref, **_kwargs: None)
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+
+    assert list(client.stream_plan(_FakePhysicalPlanWithoutPlanAttr("stream-plan"))) == []
+    assert _NextMethod.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "stream-plan",
+            runner,
+        )
+    ]
+
+
 def test_ray_query_driver_client_stream_start_failure_cancels_and_retries_close(monkeypatch):
     run_future = object()
     close_future = object()
@@ -1059,11 +1232,84 @@ def test_ray_query_driver_client_stream_start_failure_cancels_and_retries_close(
         (
             close_future,
             {
-                "timeout": 30,
+                "timeout": 300,
                 "honor_query_deadline": False,
             },
         ),
     ]
+
+
+def test_ray_query_driver_client_stream_start_reports_teardown_failure(monkeypatch):
+    run_future = object()
+    close_future = object()
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+
+        def remote(self, *_args):
+            return self.result
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_plan=_RemoteMethod(run_future),
+        close_plan=_RemoteMethod(close_future),
+    )
+    client._runtime_is_unavailable_or_replaced = lambda: False
+
+    def _resolve(ref, **_kwargs):
+        if ref is run_future:
+            raise RuntimeError("planned stream startup failure")
+        assert ref is close_future
+        raise RuntimeError("planned stream teardown failure")
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "cancel", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="failed and teardown also failed") as error:
+        list(client.stream_plan(_FakePhysicalPlanWithoutPlanAttr("failed-stream-cleanup")))
+
+    assert "planned stream startup failure" in str(error.value)
+    assert "planned stream teardown failure" in str(error.value)
+
+
+def test_ray_query_driver_client_stream_failure_accepts_concurrent_detach_cleanup(monkeypatch):
+    run_future = object()
+    close_future = object()
+
+    class _RunMethod:
+        @staticmethod
+        def remote(*_args):
+            client.runner = None
+            return run_future
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(*_args):
+            return close_future
+
+    runner = SimpleNamespace(
+        run_plan=_RunMethod(),
+        close_plan=_CloseMethod(),
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = runner
+
+    def _resolve(ref, **_kwargs):
+        if ref is run_future:
+            raise RuntimeError("planned stream startup failure")
+        assert ref is close_future
+        raise PermissionError("runtime owner was detached")
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "cancel", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="planned stream startup failure"):
+        list(client.stream_plan(_FakePhysicalPlanWithoutPlanAttr("detached-stream-cleanup")))
 
 
 def test_ray_query_driver_client_copy_failure_cancels_and_settles(monkeypatch):
@@ -1116,7 +1362,7 @@ def test_ray_query_driver_client_copy_failure_cancels_and_settles(monkeypatch):
         (
             close_future,
             {
-                "timeout": 30,
+                "timeout": 300,
                 "honor_query_deadline": False,
             },
         ),
@@ -1575,7 +1821,7 @@ def test_session_close_waits_until_query_connection_is_closed():
 def test_close_session_waits_for_active_copy_operation():
     cls, runner = _make_local_query_driver_actor()
     session = runner._sessions[_TEST_SESSION_ID]
-    cls._begin_session_copy(session, _TEST_SESSION_ID)
+    cls._begin_session_operation(session, _TEST_SESSION_ID)
 
     async def _close_after_copy_finishes():
         close_task = asyncio.create_task(
@@ -1592,8 +1838,8 @@ def test_close_session_waits_for_active_copy_operation():
         assert session.closing is True
         assert close_task.done() is False
         with pytest.raises(RuntimeError, match="Vane session is closing"):
-            cls._begin_session_copy(session, _TEST_SESSION_ID)
-        cls._end_session_copy(session)
+            cls._begin_session_operation(session, _TEST_SESSION_ID)
+        cls._end_session_operation(session)
         await asyncio.wait_for(close_task, timeout=1.0)
 
     asyncio.run(_close_after_copy_finishes())
@@ -1607,7 +1853,7 @@ def test_detach_fences_new_session_work_and_replays_result():
     cls, runner = _make_local_query_driver_actor()
     runner._client_ids.add("other-owner")
     session = runner._sessions[_TEST_SESSION_ID]
-    cls._begin_session_copy(session, _TEST_SESSION_ID)
+    cls._begin_session_operation(session, _TEST_SESSION_ID)
 
     async def _detach_after_copy_finishes():
         detach_task = asyncio.create_task(
@@ -1622,13 +1868,13 @@ def test_detach_fences_new_session_work_and_replays_result():
             await asyncio.sleep(0)
         assert _TEST_RUNTIME_OWNER_ID in runner._detaching_client_ids
         with pytest.raises(PermissionError, match="attached client owner"):
-            cls.open_session(
+            await cls.open_session(
                 runner,
                 _TEST_RUNTIME_OWNER_ID,
                 "late-session",
                 {},
             )
-        cls._end_session_copy(session)
+        cls._end_session_operation(session)
         assert await asyncio.wait_for(detach_task, timeout=1.0) is False
         assert await cls.detach_client(runner, _TEST_RUNTIME_OWNER_ID) is False
 
@@ -1656,11 +1902,13 @@ def test_open_session_revalidates_owner_inside_registry_lock(monkeypatch):
 
     def _open():
         try:
-            cls.open_session(
-                runner,
-                _TEST_RUNTIME_OWNER_ID,
-                "late-session",
-                {},
+            asyncio.run(
+                cls.open_session(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    "late-session",
+                    {},
+                )
             )
         except BaseException as exc:
             open_errors.append(exc)
@@ -1677,6 +1925,31 @@ def test_open_session_revalidates_owner_inside_registry_lock(monkeypatch):
     assert len(open_errors) == 1
     assert isinstance(open_errors[0], PermissionError)
     assert "late-session" not in runner._sessions
+
+
+def test_open_session_defers_credential_resolution_until_plan_preparation(monkeypatch):
+    from duckdb.runners.ray import worker as worker_module
+
+    cls, runner = _make_local_query_driver_actor()
+    runner._sessions = {}
+    monkeypatch.setattr(
+        worker_module,
+        "_effective_duckdb_s3_config",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("session open must not resolve credentials")),
+    )
+
+    assert (
+        asyncio.run(
+            cls.open_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                "deferred-credential-session",
+                {"AWS_PROFILE": "analytics"},
+            )
+        )
+        is True
+    )
+    assert runner._sessions["deferred-credential-session"].s3_config == {}
 
 
 def test_last_owner_detach_retries_runtime_shutdown_failure():
@@ -1708,18 +1981,26 @@ def test_last_owner_detach_retries_runtime_shutdown_failure():
 
 def test_driver_sessions_keep_config_and_close_lifecycle_independent():
     cls, runner = _make_local_query_driver_actor()
-    session_b_config = {"AWS_ACCESS_KEY_ID": "session-b-key"}
+    session_b_config = {
+        "AWS_ACCESS_KEY_ID": "session-b-key",
+        "AWS_SECRET_ACCESS_KEY": "session-b-secret",
+    }
 
-    assert cls.open_session(
-        runner,
-        _TEST_RUNTIME_OWNER_ID,
-        "session-b",
-        session_b_config,
+    assert asyncio.run(
+        cls.open_session(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            "session-b",
+            session_b_config,
+        )
     )
     session_b_config["AWS_ACCESS_KEY_ID"] = "mutated-after-open"
 
     assert runner._sessions[_TEST_SESSION_ID].config == {}
-    assert runner._sessions["session-b"].config == {"AWS_ACCESS_KEY_ID": "session-b-key"}
+    assert runner._sessions["session-b"].config == {
+        "AWS_ACCESS_KEY_ID": "session-b-key",
+        "AWS_SECRET_ACCESS_KEY": "session-b-secret",
+    }
 
     asyncio.run(
         cls.close_session(
@@ -1738,7 +2019,8 @@ def test_driver_sessions_keep_config_and_close_lifecycle_independent():
 
     assert _TEST_SESSION_ID not in runner._sessions
     assert cls._require_session(runner, _TEST_RUNTIME_OWNER_ID, "session-b").config == {
-        "AWS_ACCESS_KEY_ID": "session-b-key"
+        "AWS_ACCESS_KEY_ID": "session-b-key",
+        "AWS_SECRET_ACCESS_KEY": "session-b-secret",
     }
 
     runner._client_ids.add("other-runtime-owner")
@@ -1760,11 +2042,13 @@ def test_close_unknown_session_tombstones_ambiguous_open():
 
     assert runner._closed_session_owners[session_id] == _TEST_RUNTIME_OWNER_ID
     with pytest.raises(RuntimeError, match="identity was already closed"):
-        cls.open_session(
-            runner,
-            _TEST_RUNTIME_OWNER_ID,
-            session_id,
-            {},
+        asyncio.run(
+            cls.open_session(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                session_id,
+                {},
+            )
         )
 
     runner._client_ids.add("other-runtime-owner")
@@ -1816,6 +2100,42 @@ def test_close_plan_cancellation_waits_for_owned_teardown():
     assert cleanup_finished.is_set()
 
 
+def test_close_plan_is_idempotent_after_plan_teardown():
+    cls, runner = _make_local_query_driver_actor()
+    cleanup_calls = []
+    runner._cleanup_finished_plan = lambda plan_id: cleanup_calls.append(plan_id)
+
+    asyncio.run(
+        cls.close_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "already-closed-plan",
+        )
+    )
+
+    assert cleanup_calls == []
+
+
+def test_close_plan_rejects_plan_from_another_session():
+    cls, runner = _make_local_query_driver_actor()
+    runner._plan_session_ids["other-session-plan"] = "other-session"
+    cleanup_calls = []
+    runner._cleanup_finished_plan = lambda plan_id: cleanup_calls.append(plan_id)
+
+    with pytest.raises(PermissionError, match="does not belong"):
+        asyncio.run(
+            cls.close_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                "other-session-plan",
+            )
+        )
+
+    assert cleanup_calls == []
+
+
 @pytest.mark.parametrize(
     "first_owner",
     [_TEST_RUNTIME_OWNER_ID, "other-runtime-owner"],
@@ -1826,12 +2146,24 @@ def test_two_runtime_clients_keep_session_config_and_close_order_independent(fir
     runner._sessions = {}
     runner._client_ids.add(other_owner)
     sessions = {
-        _TEST_RUNTIME_OWNER_ID: ("session-a", {"AWS_ACCESS_KEY_ID": "session-a-key"}),
-        other_owner: ("session-b", {"AWS_ACCESS_KEY_ID": "session-b-key"}),
+        _TEST_RUNTIME_OWNER_ID: (
+            "session-a",
+            {
+                "AWS_ACCESS_KEY_ID": "session-a-key",
+                "AWS_SECRET_ACCESS_KEY": "session-a-secret",
+            },
+        ),
+        other_owner: (
+            "session-b",
+            {
+                "AWS_ACCESS_KEY_ID": "session-b-key",
+                "AWS_SECRET_ACCESS_KEY": "session-b-secret",
+            },
+        ),
     }
 
     for owner_id, (session_id, config) in sessions.items():
-        assert cls.open_session(runner, owner_id, session_id, config) is True
+        assert asyncio.run(cls.open_session(runner, owner_id, session_id, config)) is True
 
     first_session_id, _ = sessions[first_owner]
     surviving_owner = other_owner if first_owner == _TEST_RUNTIME_OWNER_ID else _TEST_RUNTIME_OWNER_ID
@@ -1885,6 +2217,212 @@ def test_driver_rejects_active_plan_identity_collision(copy_plan):
 
 
 @pytest.mark.parametrize("copy_plan", [False, True])
+def test_driver_applies_session_s3_config_to_query_cursor(copy_plan):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    session.config = {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "AWS_SECRET_ACCESS_KEY": "session-secret",
+        "AWS_REGION": "us-east-2",
+    }
+    session.s3_config = dict(session.config)
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return "s3-config-plan"
+
+        @staticmethod
+        def has_explicit_s3_credentials():
+            return False
+
+        @staticmethod
+        def to_physical_plan(_connection, effective_session_config):
+            assert effective_session_config == session.s3_config
+            raise RuntimeError("planned stop after query cursor configuration")
+
+    with pytest.raises(RuntimeError, match="planned stop after query cursor configuration"):
+        if copy_plan:
+            asyncio.run(
+                cls._run_copy_plan_for_session(
+                    runner,
+                    _TEST_SESSION_ID,
+                    session,
+                    _LogicalPlan(),
+                )
+            )
+        else:
+            cls._run_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+            )
+
+    query_connection = session.connection.cursors[-1]
+    assert "SET s3_access_key_id='session-key'" in query_connection.statements
+    assert "SET s3_secret_access_key='session-secret'" in query_connection.statements
+    assert "SET s3_region='us-east-2'" in query_connection.statements
+    assert query_connection.closed is True
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
+def test_driver_explicit_s3_settings_bypass_and_clear_session_credentials(monkeypatch, copy_plan):
+    from duckdb.runners.ray import worker as worker_module
+
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    session.config = {
+        "AWS_ACCESS_KEY_ID": "incomplete-environment-key",
+        "AWS_PROFILE": "unavailable-profile",
+    }
+    session.s3_config = {
+        "AWS_ACCESS_KEY_ID": "stale-profile-key",
+        "AWS_SECRET_ACCESS_KEY": "stale-profile-secret",
+        "AWS_SESSION_TOKEN": "stale-profile-token",
+    }
+    monkeypatch.setattr(
+        worker_module,
+        "_resolve_session_aws_credentials",
+        lambda _config: (_ for _ in ()).throw(AssertionError("explicit DuckDB credentials must skip resolution")),
+    )
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return "explicit-s3-config-plan"
+
+        @staticmethod
+        def has_explicit_s3_credentials():
+            return True
+
+        @staticmethod
+        def to_physical_plan(_connection, effective_session_config):
+            assert effective_session_config == {}
+            raise RuntimeError("planned stop after explicit S3 baseline reset")
+
+    with pytest.raises(RuntimeError, match="planned stop after explicit S3 baseline reset"):
+        if copy_plan:
+            asyncio.run(
+                cls._run_copy_plan_for_session(
+                    runner,
+                    _TEST_SESSION_ID,
+                    session,
+                    _LogicalPlan(),
+                )
+            )
+        else:
+            cls._run_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+            )
+
+    query_connection = session.connection.cursors[-1]
+    assert "SET s3_access_key_id=''" in query_connection.statements
+    assert "SET s3_secret_access_key=''" in query_connection.statements
+    assert "SET s3_session_token=''" in query_connection.statements
+    assert query_connection.closed is True
+
+
+def test_copy_session_refresh_does_not_block_actor_loop(monkeypatch):
+    from duckdb.runners.ray import worker as worker_module
+
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    refresh_started = threading.Event()
+    refresh_release = threading.Event()
+
+    def _delayed_refresh(config, effective_config, *, use_session_credentials):
+        assert use_session_credentials is True
+        refresh_started.set()
+        assert refresh_release.wait(timeout=1.0)
+        return dict(effective_config)
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return "slow-copy-session-refresh"
+
+        @staticmethod
+        def has_explicit_s3_credentials():
+            return False
+
+        @staticmethod
+        def to_physical_plan(_connection, _effective_session_config):
+            raise RuntimeError("planned stop after COPY session refresh")
+
+    monkeypatch.setattr(worker_module, "_refresh_effective_duckdb_s3_config", _delayed_refresh)
+
+    async def _refresh_while_serving_control_requests():
+        copy_task = asyncio.create_task(
+            cls._run_copy_plan_for_session(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+            )
+        )
+        try:
+            assert await asyncio.to_thread(refresh_started.wait, 1.0)
+            assert cls.ping(runner, _TEST_RUNTIME_OWNER_ID) is True
+        finally:
+            refresh_release.set()
+        with pytest.raises(RuntimeError, match="planned stop after COPY session refresh"):
+            await asyncio.wait_for(copy_task, timeout=1.0)
+
+    asyncio.run(_refresh_while_serving_control_requests())
+
+
+def test_copy_resource_registration_does_not_block_actor_loop(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    registration_started = threading.Event()
+    registration_release = threading.Event()
+    plan_id = "slow-copy-resource-registration"
+
+    def _delayed_registration(_self, _plan, *, query_connection):
+        assert query_connection is runner._test_session_connection.cursors[-1]
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            asyncio.get_running_loop()
+        registration_started.set()
+        assert registration_release.wait(timeout=1.0)
+        raise RuntimeError("planned stop after COPY resource registration")
+
+    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+        assert actual_plan_id == plan_id
+        assert drop_fragments is False
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_register_query_resources", _delayed_registration)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    async def _register_while_serving_control_requests():
+        copy_task = asyncio.create_task(
+            cls._run_copy_plan_for_session(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id)),
+            )
+        )
+        try:
+            assert await asyncio.to_thread(registration_started.wait, 1.0)
+            assert cls.ping(runner, _TEST_RUNTIME_OWNER_ID) is True
+        finally:
+            registration_release.set()
+        with pytest.raises(RuntimeError, match="planned stop after COPY resource registration"):
+            await asyncio.wait_for(copy_task, timeout=1.0)
+
+    asyncio.run(_register_while_serving_control_requests())
+
+    assert plan_id not in session.plan_ids
+    assert plan_id not in runner._plan_session_ids
+    assert runner._test_session_connection.cursors[-1].closed is True
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
 def test_driver_rejects_logical_to_physical_plan_identity_change(copy_plan):
     cls, runner = _make_local_query_driver_actor()
     session = runner._sessions[_TEST_SESSION_ID]
@@ -1896,7 +2434,11 @@ def test_driver_rejects_logical_to_physical_plan_identity_change(copy_plan):
             return "logical-plan"
 
         @staticmethod
-        def to_physical_plan(_connection):
+        def has_explicit_s3_credentials():
+            return False
+
+        @staticmethod
+        def to_physical_plan(_connection, _effective_session_config):
             return physical_plan
 
     existing_cursor_count = len(session.connection.cursors)
@@ -1960,7 +2502,11 @@ def test_driver_revalidates_physical_plan_session(
             return dict(_TEST_SESSION_CONFIG)
 
         @staticmethod
-        def to_physical_plan(_connection):
+        def has_explicit_s3_credentials():
+            return False
+
+        @staticmethod
+        def to_physical_plan(_connection, _effective_session_config):
             return physical_plan
 
     existing_cursor_count = len(session.connection.cursors)
@@ -1987,7 +2533,7 @@ def test_driver_revalidates_physical_plan_session(
     assert len(session.connection.cursors) == existing_cursor_count + 1
     assert session.connection.cursors[-1].closed is True
     assert session.plan_ids == set()
-    assert session.active_copy_operations == 0
+    assert session.active_operations == 0
     assert runner._plan_session_ids == {}
     assert runner._plan_connections == {}
 
@@ -3183,6 +3729,42 @@ def test_get_next_partition_leases_and_releases_metadata_aware_fragment(monkeypa
     assert result.partition() is payload
     assert released == [(_TEST_RUNTIME_OWNER_ID, _TEST_SESSION_ID, plan_id, "0")]
     assert output_owner.released is True
+    assert runner._leased_result_partition_refs == {}
+
+
+def test_get_next_partition_rejects_result_with_released_output_lease():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "plan-released-lease"
+    _bind_test_query_resource_owner(runner, plan_id)
+    payload = object()
+    transition_calls = []
+    release_calls = []
+
+    class _ReleasedOutputLeaseOwner:
+        def transition_to(self, state):
+            transition_calls.append(state)
+            return False
+
+        def release(self):
+            release_calls.append("release")
+            return False
+
+    fragment = duckdb.ray_cxx.RayResultPartitionRef(payload, 7, 99, _ReleasedOutputLeaseOwner())
+    runner.curr_streams[plan_id] = _DummyStream([fragment])
+    runner.curr_plans[plan_id] = object()
+
+    with pytest.raises(RuntimeError, match="released before external publication"):
+        asyncio.run(
+            cls.get_next_partition(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
+
+    assert transition_calls == ["external_consumer"]
+    assert release_calls == ["release"]
     assert runner._leased_result_partition_refs == {}
 
 
@@ -5693,10 +6275,163 @@ def test_ray_query_driver_clients_attach_to_job_runtime(monkeypatch):
         ((client_a._owner_id, {"PYTHONPATH": "/vane"}), {}),
         ((client_b._owner_id, {"PYTHONPATH": "/vane"}), {}),
     ]
-    assert handle.ping.calls == [
-        ((client_a._owner_id,), {}),
-        ((client_b._owner_id,), {}),
-    ]
+    assert handle.ping.calls == []
+
+
+def test_ray_query_driver_client_retries_named_runtime_that_is_shutting_down(monkeypatch):
+    class _FakeMethod:
+        def __init__(self, label):
+            self.label = label
+            self.calls = []
+
+        def remote(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self.label
+
+    class _FakeHandle:
+        def __init__(self, name):
+            self.name = name
+            self.attach_client = _FakeMethod(("attach", name))
+            self.ping = _FakeMethod(("ping", name))
+            self.detach_client = _FakeMethod(("detach", name))
+
+    closing_handle = _FakeHandle("closing-runtime")
+    replacement_handle = _FakeHandle("replacement-runtime")
+    handles = iter((closing_handle, replacement_handle))
+    created = []
+
+    class _Factory:
+        @staticmethod
+        def remote(_runtime_config, _duckdb_memory_bytes):
+            handle = next(handles)
+            created.append(handle)
+            return handle
+
+    monkeypatch.setattr(driver, "_maybe_set_distributed_cluster_capacity", lambda: None)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(
+            gcs_address="gcs-a",
+            get_job_id=lambda: "job-a",
+        ),
+    )
+    monkeypatch.setattr(
+        driver,
+        "get_head_node",
+        lambda: {"NodeID": "a" * 56, "Resources": {"memory": 1_000}},
+    )
+    monkeypatch.setattr(driver, "_collect_vane_env_overrides", lambda: {})
+    monkeypatch.setattr(driver.RayQueryDriverActor, "options", lambda **_kwargs: _Factory())
+    monkeypatch.setattr(driver.time, "sleep", lambda _seconds: None)
+
+    def _resolve(ref, **_kwargs):
+        if ref == ("attach", "closing-runtime"):
+            raise driver.RayRuntimeShuttingDownError("Ray query runtime is shutting down")
+        return True
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    client = driver.RayQueryDriverClient()
+
+    assert created == [closing_handle, replacement_handle]
+    assert client.runner is replacement_handle
+    assert len(closing_handle.attach_client.calls) == 1
+    assert len(replacement_handle.attach_client.calls) == 1
+    assert len(replacement_handle.ping.calls) == 0
+
+
+def test_ray_query_driver_client_retires_drained_named_runtime_before_retry(monkeypatch):
+    class _FakeMethod:
+        def __init__(self, label):
+            self.label = label
+            self.calls = []
+
+        def remote(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return self.label
+
+    class _FakeHandle:
+        def __init__(self, name):
+            self.name = name
+            self.attach_client = _FakeMethod(("attach", name))
+            self.runtime_replacement_ready = _FakeMethod(("replacement-ready", name))
+
+    closing_handle = _FakeHandle("closing-runtime")
+    replacement_handle = _FakeHandle("replacement-runtime")
+    active_handle = closing_handle
+    created = []
+    killed = []
+
+    class _Factory:
+        @staticmethod
+        def remote(_runtime_config, _duckdb_memory_bytes):
+            created.append(active_handle)
+            return active_handle
+
+    monkeypatch.setattr(driver, "_maybe_set_distributed_cluster_capacity", lambda: None)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(
+            gcs_address="gcs-a",
+            get_job_id=lambda: "job-a",
+        ),
+    )
+    monkeypatch.setattr(
+        driver,
+        "get_head_node",
+        lambda: {"NodeID": "a" * 56, "Resources": {"memory": 1_000}},
+    )
+    monkeypatch.setattr(driver, "_collect_vane_env_overrides", lambda: {})
+    monkeypatch.setattr(driver.RayQueryDriverActor, "options", lambda **_kwargs: _Factory())
+    monkeypatch.setattr(driver.time, "sleep", lambda _seconds: None)
+
+    def _resolve(ref, **_kwargs):
+        if ref == ("attach", "closing-runtime"):
+            raise driver.RayRuntimeShuttingDownError("Ray query runtime is shutting down")
+        if ref == ("replacement-ready", "closing-runtime"):
+            return True
+        return True
+
+    def _kill(actor, *, no_restart):
+        nonlocal active_handle
+        assert actor is closing_handle
+        assert no_restart is True
+        killed.append(actor)
+        active_handle = replacement_handle
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(driver.ray, "kill", _kill)
+
+    client = driver.RayQueryDriverClient()
+
+    assert created == [closing_handle, replacement_handle]
+    assert killed == [closing_handle]
+    assert client.runner is replacement_handle
+    assert len(closing_handle.runtime_replacement_ready.calls) == 1
+
+
+def test_runtime_replacement_classifier_rejects_permanent_actor_init_failure():
+    assert driver._runtime_actor_is_being_replaced(
+        driver.ray.exceptions.RayActorError(
+            error_msg="actor disappeared before attach",
+        )
+    )
+    assert not driver._runtime_actor_is_being_replaced(
+        driver.ray.exceptions.RayActorError(
+            error_msg="actor constructor failed",
+            actor_init_failed=True,
+        )
+    )
+
+    class _WrappedShutdown(RuntimeError):
+        @staticmethod
+        def as_instanceof_cause():
+            return driver.RayRuntimeShuttingDownError("Ray query runtime is shutting down")
+
+    wrapped_shutdown = _WrappedShutdown()
+    assert driver._runtime_actor_is_being_replaced(wrapped_shutdown)
 
 
 def test_ray_runner_creates_one_driver_client_for_concurrent_sessions(monkeypatch):
@@ -5901,10 +6636,17 @@ def test_ray_query_driver_client_serializes_first_session_open_with_close(monkey
 
     client = object.__new__(driver.RayQueryDriverClient)
     client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
     _initialize_test_query_driver_client(client)
     client.runner = SimpleNamespace(
         open_session=_OpenMethod(),
         close_session=_CloseMethod(),
+    )
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
     )
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref)
     open_errors = []
@@ -5977,10 +6719,17 @@ def test_ray_query_driver_client_closes_session_after_ambiguous_open_failure(mon
 
     client = object.__new__(driver.RayQueryDriverClient)
     client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
     _initialize_test_query_driver_client(client)
     client.runner = SimpleNamespace(
         open_session=_OpenMethod(),
         close_session=_CloseMethod(),
+    )
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
     )
 
     def _resolve(ref, **_kwargs):
@@ -6006,6 +6755,54 @@ def test_ray_query_driver_client_closes_session_after_ambiguous_open_failure(mon
     assert close_calls == [("owner-a", "session-a")]
     assert client._uncertain_sessions == {}
     assert client._closing_session_ids == set()
+
+
+def test_ray_query_driver_client_does_not_close_session_after_rejected_open(monkeypatch):
+    open_ref = object()
+
+    class _OpenMethod:
+        @staticmethod
+        def remote(*_args):
+            return open_ref
+
+    class _CloseMethod:
+        @staticmethod
+        def remote(*_args):
+            raise AssertionError("an unrecorded rejected session must not receive a close RPC")
+
+    class _Plan:
+        @staticmethod
+        def session_id():
+            return "session-a"
+
+        @staticmethod
+        def session_config():
+            return {}
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    _initialize_test_query_driver_client(client)
+    client.runner = SimpleNamespace(
+        open_session=_OpenMethod(),
+        close_session=_CloseMethod(),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            driver.VaneSessionOpenRejectedError("Vane session identity collision")
+        ),
+    )
+
+    with pytest.raises(driver.VaneSessionOpenRejectedError, match="identity collision"):
+        client._ensure_session(_Plan())
+
+    assert client._opened_sessions == {}
+    assert client._uncertain_sessions == {}
+
+    client.close_session("session-a")
+
+    assert set(client._closed_session_ids) == {"session-a"}
 
 
 def test_ray_query_driver_client_detach_supersedes_session_close_waiting_on_open(monkeypatch):
@@ -6130,8 +6927,15 @@ def test_ray_query_driver_client_session_close_failure_stays_fenced_and_retryabl
 
     client = object.__new__(driver.RayQueryDriverClient)
     client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
     _initialize_test_query_driver_client(client, {"session-a": {}})
     client.runner = SimpleNamespace(close_session=_CloseMethod())
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
 
     def _resolve(ref, **_kwargs):
         if ref == 1:
@@ -6155,9 +6959,82 @@ def test_ray_query_driver_client_session_close_failure_stays_fenced_and_retryabl
     assert client._closing_session_ids == set()
 
 
-@pytest.mark.parametrize("failed_ref", ["attach", "ping"])
+@pytest.mark.parametrize(
+    ("ray_initialized", "current_gcs_address"),
+    [
+        (False, "gcs-a"),
+        (True, "gcs-b"),
+    ],
+)
+def test_ray_query_driver_client_session_close_is_terminal_after_runtime_changes(
+    monkeypatch,
+    ray_initialized,
+    current_gcs_address,
+):
+    class _CloseMethod:
+        @staticmethod
+        def remote(_owner_id, _session_id):
+            raise AssertionError("stale Ray runtime must not receive a session-close RPC")
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = SimpleNamespace(close_session=_CloseMethod())
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: ray_initialized)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address=current_gcs_address),
+    )
+
+    client.close_session("session-a")
+
+    assert client._opened_sessions == {}
+    assert client._uncertain_sessions == {}
+    assert client._closing_session_ids == set()
+    assert client._session_closes_in_progress == set()
+    assert set(client._closed_session_ids) == {"session-a"}
+
+
+def test_ray_query_driver_client_session_close_is_terminal_after_runtime_actor_loss(monkeypatch):
+    class _CloseMethod:
+        @staticmethod
+        def remote(_owner_id, _session_id):
+            return "close-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = SimpleNamespace(close_session=_CloseMethod())
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            driver.ray.exceptions.RayActorError(error_msg="runtime actor exited")
+        ),
+    )
+
+    client.close_session("session-a")
+
+    assert client._opened_sessions == {}
+    assert client._uncertain_sessions == {}
+    assert client._closing_session_ids == set()
+    assert client._session_closes_in_progress == set()
+    assert set(client._closed_session_ids) == {"session-a"}
+
+
 @pytest.mark.parametrize("failure_type", [RuntimeError, KeyboardInterrupt])
-def test_ray_query_driver_client_detaches_when_initialization_fails(monkeypatch, failed_ref, failure_type):
+def test_ray_query_driver_client_detaches_when_attach_is_ambiguous(monkeypatch, failure_type):
     events = []
 
     class _FakeMethod:
@@ -6199,8 +7076,8 @@ def test_ray_query_driver_client_detaches_when_initialization_fails(monkeypatch,
 
     def resolve(ref, **kwargs):
         events.append(("resolve", ref, kwargs))
-        if ref == failed_ref:
-            raise failure_type(f"planned {failed_ref} failure")
+        if ref == "attach":
+            raise failure_type("planned attach failure")
         return True
 
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", resolve)
@@ -6210,18 +7087,161 @@ def test_ray_query_driver_client_detaches_when_initialization_fails(monkeypatch,
         lambda actor, *, no_restart: events.append(("kill", actor, no_restart)),
     )
 
-    with pytest.raises(failure_type, match=f"planned {failed_ref} failure"):
+    with pytest.raises(failure_type, match="planned attach failure"):
         driver.RayQueryDriverClient()
 
     attach_event = next(event for event in events if event[0] == "attach")
     detach_event = next(event for event in events if event[0] == "detach")
     assert attach_event[1] == detach_event[1]
-    if failed_ref == "ping":
-        ping_event = next(event for event in events if event[0] == "ping")
-        assert attach_event[1] == ping_event[1]
-    else:
-        assert all(event[0] != "ping" for event in events)
+    assert all(event[0] != "ping" for event in events)
     assert ("kill", handle, True) in events
+
+
+def test_ray_query_driver_client_retries_detach_after_ambiguous_attach(monkeypatch):
+    detach_calls = []
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            detach_calls.append(owner_id)
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    resolve_attempts = 0
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(driver.time, "sleep", lambda _seconds: None)
+
+    def _resolve(ref, **kwargs):
+        nonlocal resolve_attempts
+        assert ref == "detach-ref"
+        assert kwargs["honor_query_deadline"] is False
+        resolve_attempts += 1
+        if resolve_attempts == 1:
+            raise RuntimeError("transient detach failure")
+        return False
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    client._detach_after_failed_attach(runner, RuntimeError("ambiguous attach"))
+
+    assert detach_calls == ["owner-a", "owner-a"]
+    assert resolve_attempts == 2
+
+
+def test_ray_query_driver_client_reuses_ambiguous_detach_ref_after_timeout(monkeypatch):
+    detach_calls = []
+    resolve_attempts = 0
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            detach_calls.append(owner_id)
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(driver.time, "sleep", lambda _seconds: None)
+
+    def _resolve(ref, **kwargs):
+        nonlocal resolve_attempts
+        assert ref == "detach-ref"
+        assert kwargs["honor_query_deadline"] is False
+        resolve_attempts += 1
+        if resolve_attempts == 1:
+            raise FutureTimeoutError("ambiguous detach timeout")
+        return False
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    client._detach_after_failed_attach(runner, RuntimeError("ambiguous attach"))
+
+    assert detach_calls == ["owner-a"]
+    assert resolve_attempts == 2
+
+
+def test_ray_query_driver_client_preserves_attach_error_when_detach_was_not_needed(monkeypatch):
+    class _WrappedPermissionError(RuntimeError):
+        @staticmethod
+        def as_instanceof_cause():
+            return PermissionError("owner was never attached")
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(_WrappedPermissionError()),
+    )
+
+    client._detach_after_failed_attach(runner, RuntimeError("ambiguous attach"))
+
+
+def test_ray_query_driver_client_reports_unconfirmed_detach_after_ambiguous_attach(monkeypatch):
+    detach_calls = []
+
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            detach_calls.append(owner_id)
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    runner = SimpleNamespace(detach_client=_DetachMethod())
+    attach_error = RuntimeError("ambiguous attach")
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(driver.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("persistent detach failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="owner detach could not be confirmed") as error:
+        client._detach_after_failed_attach(runner, attach_error)
+
+    assert error.value.__cause__ is attach_error
+    assert detach_calls == ["owner-a"] * driver._RUNTIME_ATTACH_CLEANUP_ATTEMPTS
 
 
 @pytest.mark.parametrize("close_order", [(0, 1), (1, 0)])
@@ -6329,6 +7349,40 @@ def test_ray_query_driver_client_close_remains_retryable_after_detach_failure(mo
     assert client._client_closing is True
 
 
+def test_ray_query_driver_client_close_is_terminal_when_ray_stops_during_detach(monkeypatch):
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = SimpleNamespace(detach_client=_DetachMethod())
+    initialized = iter((True, False))
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: next(initialized))
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("Ray is not initialized")),
+    )
+
+    client.close()
+
+    assert client.runner is None
+    assert client._opened_sessions == {}
+    assert client._client_closing is False
+    assert client._client_close_in_progress is False
+
+
 def test_ray_query_driver_client_close_remains_retryable_after_kill_failure(monkeypatch):
     class _DetachMethod:
         @staticmethod
@@ -6374,6 +7428,41 @@ def test_ray_query_driver_client_close_remains_retryable_after_kill_failure(monk
     assert client._opened_sessions == {}
     assert client._client_closing is False
     assert kill_calls == [runner, runner]
+
+
+def test_ray_query_driver_client_close_is_terminal_after_runtime_actor_loss(monkeypatch):
+    class _DetachMethod:
+        @staticmethod
+        def remote(owner_id):
+            assert owner_id == "owner-a"
+            return "detach-ref"
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = "owner-a"
+    client._ray_gcs_address = "gcs-a"
+    _initialize_test_query_driver_client(client, {"session-a": {}})
+    client.runner = SimpleNamespace(detach_client=_DetachMethod())
+
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        driver.ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(gcs_address="gcs-a"),
+    )
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            driver.ray.exceptions.RayActorError(error_msg="runtime actor exited")
+        ),
+    )
+
+    client.close()
+
+    assert client.runner is None
+    assert client._opened_sessions == {}
+    assert client._client_closing is False
+    assert client._client_close_in_progress is False
 
 
 def test_ray_query_driver_client_concurrent_close_detaches_once(monkeypatch):

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -455,24 +455,30 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
     release = threading.Event()
     events = []
 
-    def _start(_self, session_id, session, plan):
-        assert session_id == _TEST_SESSION_ID
-        assert plan is logical_plan
+    def _start(
+        _self,
+        plan,
+        plan_id,
+        _graph,
+        _allocation,
+        _query_connection,
+        _session_config,
+    ):
+        assert plan is logical_plan.physical_plan
+        assert plan_id == "cancelled-plan"
         started.set()
         assert release.wait(timeout=1.0)
-        with runner._session_lock:
-            runner._plan_session_ids["cancelled-plan"] = session_id
-            session.plan_ids.add("cancelled-plan")
         events.append("started")
 
-    def _cleanup(_self, plan_id):
+    def _cleanup(_self, plan_id, query_id, *, drop_fragments):
+        assert query_id == "cancelled-plan"
+        assert drop_fragments is True
         events.append(("cleanup", plan_id))
-        with runner._session_lock:
-            runner._plan_session_ids.pop(plan_id, None)
-            runner._sessions[_TEST_SESSION_ID].plan_ids.discard(plan_id)
+        cls._release_plan_session_state(runner, plan_id)
 
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub("cancelled-plan"))
     monkeypatch.setattr(cls, "_run_plan_sync", _start)
-    monkeypatch.setattr(cls, "_cleanup_finished_plan", _cleanup)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _cleanup)
 
     async def _cancel():
         task = asyncio.create_task(_run_actor_stream_plan(runner, logical_plan))
@@ -520,10 +526,7 @@ def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypat
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan, *, query_connection: (
-            SimpleNamespace(query_id="slow-stream-startup", stages=()),
-            object(),
-        ),
+        _query_registration_stub("slow-stream-startup"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
 
@@ -729,10 +732,7 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan, *, query_connection: (
-            SimpleNamespace(query_id=plan_id, stages=()),
-            object(),
-        ),
+        _query_registration_stub(plan_id),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", _build_snapshot)
@@ -2195,20 +2195,20 @@ def test_driver_rejects_active_plan_identity_collision(copy_plan):
     existing_cursor_count = len(session.connection.cursors)
     with pytest.raises(RuntimeError, match="query plan identity is already active"):
         if copy_plan:
-            asyncio.run(
-                cls._run_copy_plan_for_session(
-                    runner,
-                    _TEST_SESSION_ID,
-                    session,
-                    _LogicalPlan(),
-                )
-            )
-        else:
-            cls._run_plan_sync(
+            cls._prepare_copy_plan_sync(
                 runner,
                 _TEST_SESSION_ID,
                 session,
                 _LogicalPlan(),
+                plan_id,
+            )
+        else:
+            cls._prepare_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+                plan_id,
             )
 
     assert len(session.connection.cursors) == existing_cursor_count + 1
@@ -2243,20 +2243,20 @@ def test_driver_applies_session_s3_config_to_query_cursor(copy_plan):
 
     with pytest.raises(RuntimeError, match="planned stop after query cursor configuration"):
         if copy_plan:
-            asyncio.run(
-                cls._run_copy_plan_for_session(
-                    runner,
-                    _TEST_SESSION_ID,
-                    session,
-                    _LogicalPlan(),
-                )
-            )
-        else:
-            cls._run_plan_sync(
+            cls._prepare_copy_plan_sync(
                 runner,
                 _TEST_SESSION_ID,
                 session,
                 _LogicalPlan(),
+                "s3-config-plan",
+            )
+        else:
+            cls._prepare_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+                "s3-config-plan",
             )
 
     query_connection = session.connection.cursors[-1]
@@ -2303,20 +2303,20 @@ def test_driver_explicit_s3_settings_bypass_and_clear_session_credentials(monkey
 
     with pytest.raises(RuntimeError, match="planned stop after explicit S3 baseline reset"):
         if copy_plan:
-            asyncio.run(
-                cls._run_copy_plan_for_session(
-                    runner,
-                    _TEST_SESSION_ID,
-                    session,
-                    _LogicalPlan(),
-                )
-            )
-        else:
-            cls._run_plan_sync(
+            cls._prepare_copy_plan_sync(
                 runner,
                 _TEST_SESSION_ID,
                 session,
                 _LogicalPlan(),
+                "explicit-s3-config-plan",
+            )
+        else:
+            cls._prepare_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _LogicalPlan(),
+                "explicit-s3-config-plan",
             )
 
     query_connection = session.connection.cursors[-1]
@@ -2382,8 +2382,14 @@ def test_copy_resource_registration_does_not_block_actor_loop(monkeypatch):
     registration_release = threading.Event()
     plan_id = "slow-copy-resource-registration"
 
-    def _delayed_registration(_self, _plan, *, query_connection):
+    def _delayed_registration(
+        _self,
+        _plan,
+        query_connection,
+        expected_plan_id=None,
+    ):
         assert query_connection is runner._test_session_connection.cursors[-1]
+        assert expected_plan_id == plan_id
         with pytest.raises(RuntimeError, match="no running event loop"):
             asyncio.get_running_loop()
         registration_started.set()
@@ -2395,7 +2401,7 @@ def test_copy_resource_registration_does_not_block_actor_loop(monkeypatch):
         assert drop_fragments is False
         cls._release_plan_session_state(runner, actual_plan_id)
 
-    monkeypatch.setattr(cls, "_register_query_resources", _delayed_registration)
+    monkeypatch.setattr(cls, "_prepare_query_resource_registration", _delayed_registration)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     async def _register_while_serving_control_requests():
@@ -2444,20 +2450,20 @@ def test_driver_rejects_logical_to_physical_plan_identity_change(copy_plan):
     existing_cursor_count = len(session.connection.cursors)
     with pytest.raises(RuntimeError, match="logical/physical query plan identity changed"):
         if copy_plan:
-            asyncio.run(
-                cls._run_copy_plan_for_session(
-                    runner,
-                    _TEST_SESSION_ID,
-                    session,
-                    _ChangedIdentityLogicalPlan(),
-                )
-            )
-        else:
-            cls._run_plan_sync(
+            cls._prepare_copy_plan_sync(
                 runner,
                 _TEST_SESSION_ID,
                 session,
                 _ChangedIdentityLogicalPlan(),
+                "logical-plan",
+            )
+        else:
+            cls._prepare_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                _ChangedIdentityLogicalPlan(),
+                "logical-plan",
             )
 
     assert len(session.connection.cursors) == existing_cursor_count + 1

--- a/tests/fast/test_ray_worker_cuda_visibility.py
+++ b/tests/fast/test_ray_worker_cuda_visibility.py
@@ -39,7 +39,6 @@ def test_ray_worker_init_preserves_node_cuda_visibility(monkeypatch, visible_dev
         num_gpus=2,
         duckdb_memory_bytes=128 * 1024**2,
         task_heap_capacity_bytes=128 * 1024**2,
-        env_overrides={},
     )
 
     assert worker_mod.os.environ["CUDA_VISIBLE_DEVICES"] == visible_devices
@@ -51,6 +50,9 @@ def test_ray_worker_init_preserves_node_cuda_visibility(monkeypatch, visible_dev
 def test_zero_gpu_ray_worker_preserves_non_contiguous_node_cuda_visibility(monkeypatch):
     visible_devices = "2,5"
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible_devices)
+    monkeypatch.setenv("AWS_ISSUE75_INHERITED_SECRET", "inherited-aws")
+    monkeypatch.setenv("DUCKDB_ISSUE75_INHERITED_SECRET", "inherited-duckdb")
+    monkeypatch.setenv("VANE_ISSUE75_INHERITED_SECRET", "inherited-vane")
     # Exercise the legacy Ray behavior even when this test runs on Ray 2.56+.
     # The persistent worker's runtime_env must opt back into preservation.
     monkeypatch.setenv("RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO", "1")
@@ -74,21 +76,29 @@ def test_zero_gpu_ray_worker_preserves_non_contiguous_node_cuda_visibility(monke
                 return (
                     worker_mod.os.environ.get("CUDA_VISIBLE_DEVICES"),
                     ray.get_runtime_context().get_accelerator_ids(),
+                    worker_mod.os.environ.get("AWS_ISSUE75_INHERITED_SECRET"),
+                    worker_mod.os.environ.get("DUCKDB_ISSUE75_INHERITED_SECRET"),
+                    worker_mod.os.environ.get("VANE_ISSUE75_INHERITED_SECRET"),
                 )
 
         probe_cls = ray.remote(concurrency_groups={"execute": 128, "control": 512})(CudaVisibilityProbe)
-        actor = probe_cls.options(runtime_env=_persistent_worker_runtime_env()).remote(
+        actor = probe_cls.options(runtime_env=_persistent_worker_runtime_env({})).remote(
             num_cpus=1,
             num_gpus=2,
             duckdb_memory_bytes=128 * 1024**2,
             task_heap_capacity_bytes=128 * 1024**2,
-            env_overrides={},
         )
 
-        observed_devices, assigned_accelerators = ray.get(actor.cuda_visibility.remote(), timeout=60)
+        observed_devices, assigned_accelerators, inherited_aws, inherited_duckdb, inherited_vane = ray.get(
+            actor.cuda_visibility.remote(),
+            timeout=60,
+        )
 
         assert observed_devices == visible_devices
         assert not assigned_accelerators.get("GPU")
+        assert inherited_aws is None
+        assert inherited_duckdb is None
+        assert inherited_vane is None
     finally:
         if actor is not None:
             ray.kill(actor, no_restart=True)

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -421,16 +421,15 @@ def test_actor_task_manager_creation_is_rejected_after_shutdown_starts():
 def test_actor_session_connection_creation_is_rejected_after_shutdown_starts():
     from duckdb.runners.ray import worker as worker_module
 
-    class DummyActor:
-        _shutdown_started = True
-        _session_connections_lock = threading.RLock()
-        _session_connections: dict[str, object] = {}
-        _closed_session_ids = worker_module.BoundedReplayMap(capacity=16)
-
     actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._shutdown_started = True
+    actor._session_connections_lock = threading.RLock()
+    actor._session_connections = {}
+    actor._closed_session_ids = worker_module.BoundedReplayMap(capacity=16)
 
     with pytest.raises(RuntimeError, match="shutting down"):
-        actor_class._get_session_conn(DummyActor(), "session-a", {})
+        actor_class._get_session_conn(actor, "session-a", {})
 
 
 def test_actor_shutdown_retries_failed_session_connection_close():

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -166,6 +166,11 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
             assert native_finished.is_set()
             events.append("connection-close")
 
+    class SessionConnection:
+        def close(self):
+            assert native_finished.is_set()
+            events.append("session-connection-close")
+
     class TaskManager:
         def shutdown(self):
             events.append("tasks-canceled")
@@ -173,6 +178,7 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
     class DummyActor:
         _shutdown_lock = threading.Lock()
         _shared_conn_lock = threading.Lock()
+        _session_connections_lock = threading.RLock()
         _native_execution_condition = threading.Condition()
         _native_execution_count = 1
         _native_execution_counts_by_query = {"query-a": 1}
@@ -181,6 +187,7 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
         _shutdown_prepared = False
         _shutdown_complete = False
         _shared_conn = Connection()
+        _session_connections = {"session-a": ({}, SessionConnection())}
         _fte_task_manager = TaskManager()
 
     actor = DummyActor()
@@ -228,6 +235,7 @@ def test_actor_shutdown_joins_native_threads_before_closing_runtime(monkeypatch)
         "connection-interrupt",
         "cursor-interrupt",
         "native-finished",
+        "session-connection-close",
         "connection-close",
     ]
 
@@ -408,3 +416,62 @@ def test_actor_task_manager_creation_is_rejected_after_shutdown_starts():
 
     with pytest.raises(RuntimeError, match="shutting down"):
         actor_class._get_fte_task_manager(DummyActor())
+
+
+def test_actor_session_connection_creation_is_rejected_after_shutdown_starts():
+    from duckdb.runners.ray import worker as worker_module
+
+    class DummyActor:
+        _shutdown_started = True
+        _session_connections_lock = threading.RLock()
+        _session_connections: dict[str, object] = {}
+        _closed_session_ids = worker_module.BoundedReplayMap(capacity=16)
+
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        actor_class._get_session_conn(DummyActor(), "session-a", {})
+
+
+def test_actor_shutdown_retries_failed_session_connection_close():
+    from duckdb.runners.ray import worker as worker_module
+
+    class SessionConnection:
+        close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("planned session connection close failure")
+
+    session_connection = SessionConnection()
+
+    class DummyActor:
+        _shutdown_lock = threading.RLock()
+        _shared_conn_lock = threading.Lock()
+        _session_connections_lock = threading.RLock()
+        _native_execution_condition = threading.Condition()
+        _native_execution_count = 0
+        _native_execution_counts_by_query: dict[str, int] = {}
+        _active_native_cursors: set[object] = set()
+        _native_cursor_query_ids: dict[object, str] = {}
+        _closing_native_queries: set[str] = set()
+        _shutdown_started = False
+        _shutdown_prepared = False
+        _shutdown_complete = False
+        _shared_conn = None
+        _session_connections = {"session-a": ({}, session_connection)}
+        _fte_task_manager = None
+
+    actor = DummyActor()
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(RuntimeError, match="planned session connection close failure"):
+        actor_class._prepare_worker_runtime_shutdown(actor)
+
+    assert actor._session_connections == {"session-a": ({}, session_connection)}
+    actor_class._prepare_worker_runtime_shutdown(actor)
+
+    assert actor._session_connections == {}
+    assert actor._shutdown_prepared is True
+    assert session_connection.close_calls == 2

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -594,6 +594,46 @@ def test_udf_actor_pool_init_failure_preserves_root_cause():
         actor_pool_mod._resolve_actor_pool_init_refs(FakeRay(), actors_obj)
 
 
+def test_udf_actor_pool_init_cleanup_retains_only_failed_handles_for_retry():
+    import duckdb.execution.udf_ray_actor_pool as actor_pool_mod
+
+    class FakeRay:
+        def __init__(self):
+            self.killed = []
+
+        def kill(self, actor, **kwargs):
+            self.killed.append((actor, kwargs))
+            if actor == "actor-0":
+                raise RuntimeError("planned cleanup failure")
+
+    class FakeRef:
+        def future(self):
+            class _Future:
+                def result(self, timeout=None):
+                    raise TypeError(f"invalid init ObjectRef, timeout={timeout}")
+
+            return _Future()
+
+    fake_ray = FakeRay()
+    actors_obj = types.SimpleNamespace(
+        actors=["actor-0", "actor-1"],
+        _init_refs=[FakeRef(), FakeRef()],
+        _confirmed_ready=set(),
+        _owns_actors=True,
+    )
+
+    with pytest.raises(actor_pool_mod._OwnedUDFActorPoolsError) as exc_info:
+        actor_pool_mod._resolve_actor_pool_init_refs(fake_ray, actors_obj)
+
+    assert "UDF actor pool initialization failed: TypeError" in str(exc_info.value.creation_error)
+    assert exc_info.value.owned_actor_pools == [actors_obj]
+    assert actors_obj.actors == ["actor-0"]
+    assert fake_ray.killed == [
+        ("actor-0", {"no_restart": True}),
+        ("actor-1", {"no_restart": True}),
+    ]
+
+
 def test_local_vllm_submit_fails_fast_when_engine_init_deadline_expires():
     import duckdb.execution.vllm as vllm
 
@@ -1651,6 +1691,152 @@ def test_ensure_local_subprocess_actor_pools_for_nodes_injects_with_callback(mon
         }
     }
     assert injected == [handles_map]
+
+
+def test_ensure_local_subprocess_actor_pools_for_nodes_reuses_injected_pool(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    session_config = {"AWS_ACCESS_KEY_ID": "session-key"}
+
+    class ExistingPool:
+        pool_size = 2
+
+        def __init__(self):
+            self.session_config = session_config
+
+        def submit(self, *_args, **_kwargs):
+            raise AssertionError("submit should not be called")
+
+        def create_admission_authority(self):
+            raise AssertionError("admission should not be used")
+
+        def stats(self):
+            return {}
+
+        def cancel_output_grants(self):
+            pass
+
+        def first_proc(self):
+            return None
+
+        def worker_pids(self):
+            return ()
+
+    existing_pool = ExistingPool()
+    nodes = [
+        {
+            "node_id": 4,
+            "payload": {
+                "execution_backend": "subprocess_actor",
+                "actor_number": 2,
+                "function_pickle": b"unused",
+                "call_mode": "map_batches",
+            },
+            "executor_options": {
+                "session_config": session_config,
+                "local_actor_pool": existing_pool,
+            },
+        }
+    ]
+    monkeypatch.setattr(
+        subprocess_exec,
+        "LocalSubprocessActorPool",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not create a duplicate pool")),
+    )
+
+    created, handles_map = subprocess_exec.ensure_local_subprocess_actor_pools_for_nodes(nodes)
+
+    assert created == []
+    assert handles_map == {
+        "4": {
+            "session_config": session_config,
+            "local_actor_pool": existing_pool,
+        }
+    }
+
+
+def test_ensure_local_subprocess_actor_pools_rejects_implicit_cross_session_reuse():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    class ExistingPool:
+        pool_size = 1
+        session_config = {"AWS_ACCESS_KEY_ID": "session-a-key"}
+
+        def submit(self, *_args, **_kwargs):
+            raise AssertionError("submit should not be called")
+
+        def create_admission_authority(self):
+            raise AssertionError("admission should not be used")
+
+        def stats(self):
+            return {}
+
+        def cancel_output_grants(self):
+            pass
+
+        def first_proc(self):
+            return None
+
+        def worker_pids(self):
+            return ()
+
+    nodes = [
+        {
+            "node_id": 4,
+            "payload": {
+                "execution_backend": "subprocess_actor",
+                "actor_number": 1,
+                "function_pickle": b"unused",
+                "call_mode": "map_batches",
+            },
+            "executor_options": {
+                "local_actor_pool": ExistingPool(),
+            },
+        }
+    ]
+
+    with pytest.raises(ValueError, match="belongs to a different Vane session"):
+        subprocess_exec.ensure_local_subprocess_actor_pools_for_nodes(nodes)
+
+
+def test_subprocess_actor_executor_rejects_cross_session_pool_attachment():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    class ExistingPool:
+        pool_size = 1
+        session_config = {"AWS_ACCESS_KEY_ID": "session-a-key"}
+
+        def submit(self, *_args, **_kwargs):
+            raise AssertionError("submit should not be called")
+
+        def create_admission_authority(self):
+            raise AssertionError("admission should not be used")
+
+        def stats(self):
+            return {}
+
+        def cancel_output_grants(self):
+            pass
+
+        def first_proc(self):
+            return None
+
+        def worker_pids(self):
+            return ()
+
+    payload = {
+        "execution_backend": "subprocess_actor",
+        "actor_number": 1,
+        "function_pickle": b"unused",
+        "call_mode": "map_batches",
+    }
+    options = {
+        "local_actor_pool": ExistingPool(),
+        "session_config": {"AWS_ACCESS_KEY_ID": "session-b-key"},
+    }
+
+    with pytest.raises(ValueError, match="belongs to a different Vane session"):
+        subprocess_exec.UDFExecutor(payload, options)
 
 
 def test_ensure_local_subprocess_actor_pools_for_plan_propagates_collection_errors():

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -1145,12 +1145,207 @@ def test_vllm_router_waits_for_actor_finished_refs(monkeypatch):
     assert observed == ["finish-0", "finish-1"]
 
 
+def test_vllm_query_owned_actors_receive_explicit_session_environment(monkeypatch):
+    import duckdb.execution.vllm as vllm
+    from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
+
+    creations = []
+
+    class FakeActorFactory:
+        def __init__(self, actor_class, options=None):
+            self.actor_class = actor_class
+            self.actor_options = dict(options or {})
+
+        def options(self, **options):
+            return FakeActorFactory(self.actor_class, options)
+
+        def remote(self, *args, **kwargs):
+            handle = f"{self.actor_class.__name__}-{len(creations)}"
+            creations.append((self.actor_class, self.actor_options, args, kwargs, handle))
+            return handle
+
+    class FakeRay(types.ModuleType):
+        def __init__(self):
+            super().__init__("ray")
+            self.killed = []
+
+        def remote(self, *args, **options):
+            if args:
+                assert len(args) == 1
+                assert not options
+                return FakeActorFactory(args[0])
+            return lambda actor_class: FakeActorFactory(actor_class, options)
+
+        def kill(self, actor, *, no_restart):
+            self.killed.append((actor, no_restart))
+
+    fake_ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    session_config = {
+        "AWS_ACCESS_KEY_ID": "session-key",
+        "DUCKDB_CUSTOM_SESSION": "session-value",
+        "UNMANAGED": "ignored",
+    }
+
+    actors = vllm.LLMActors(
+        model="model",
+        engine_args={},
+        generate_args={},
+        on_error="raise",
+        gpus_per_actor=1,
+        concurrency=2,
+        load_balance_threshold=32,
+        name_prefix="query-pool",
+        session_config=session_config,
+    )
+
+    expected_runtime_env = {"env_vars": build_session_runtime_env_vars(session_config)}
+    assert [creation[1] for creation in creations] == [
+        {"name": "query-pool-llm-0", "runtime_env": expected_runtime_env},
+        {"name": "query-pool-llm-1", "runtime_env": expected_runtime_env},
+        {"name": "query-pool-router", "runtime_env": expected_runtime_env},
+    ]
+    assert creations[0][3]["_install_session_runtime_env"] is True
+    assert creations[1][3]["_install_session_runtime_env"] is True
+    assert creations[2][3]["_install_session_runtime_env"] is True
+
+    actors.shutdown()
+
+    assert fake_ray.killed == [
+        ("PrefixRouter-2", True),
+        ("RayLocalVLLMExecutor-0", True),
+        ("RayLocalVLLMExecutor-1", True),
+    ]
+    assert actors.router_actor is None
+    assert actors.llm_actors == []
+
+
+def test_vllm_actor_entrypoints_install_explicit_session_environment(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    events = []
+
+    monkeypatch.setattr(vllm, "install_explicit_session_runtime_env", lambda: events.append("install"))
+    monkeypatch.setattr(vllm.LocalVLLMExecutor, "__init__", lambda *_args, **_kwargs: events.append("executor"))
+
+    vllm.RayLocalVLLMExecutor(
+        "model",
+        {},
+        {},
+        _install_session_runtime_env=True,
+    )
+    vllm.PrefixRouter([], 32, _install_session_runtime_env=True)
+
+    assert events == ["install", "executor", "install"]
+
+
+def test_vllm_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    class FakeRay(types.ModuleType):
+        def __init__(self):
+            super().__init__("ray")
+            self.attempts = []
+            self.fail_once = {"llm-0"}
+
+        def kill(self, actor, *, no_restart):
+            self.attempts.append((actor, no_restart))
+            if actor in self.fail_once:
+                self.fail_once.remove(actor)
+                raise RuntimeError("transient kill failure")
+
+    fake_ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    actors = vllm.LLMActors._from_handles(["llm-0", "llm-1"], "router")
+
+    with pytest.raises(RuntimeError, match="transient kill failure"):
+        actors.shutdown()
+
+    assert actors.router_actor is None
+    assert actors.llm_actors == ["llm-0"]
+
+    actors.shutdown()
+
+    assert actors.llm_actors == []
+    assert fake_ray.attempts == [
+        ("router", True),
+        ("llm-0", True),
+        ("llm-1", True),
+        ("llm-0", True),
+    ]
+
+
+def test_udf_actor_shutdown_retains_failed_handles_for_retry(monkeypatch):
+    from duckdb.execution.udf_ray_actor_pool import UDFActorPoolBase
+
+    class FakeRay(types.ModuleType):
+        def __init__(self):
+            super().__init__("ray")
+            self.attempts = []
+            self.fail_once = {"actor-0"}
+
+        def kill(self, actor, *, no_restart):
+            self.attempts.append((actor, no_restart))
+            if actor in self.fail_once:
+                self.fail_once.remove(actor)
+                raise RuntimeError("transient kill failure")
+
+    fake_ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    actors = UDFActorPoolBase.__new__(UDFActorPoolBase)
+    actors._owns_actors = True
+    actors.actors = ["actor-0", "actor-1"]
+
+    with pytest.raises(RuntimeError, match="transient kill failure"):
+        actors.shutdown()
+
+    assert actors.actors == ["actor-0"]
+
+    actors.shutdown()
+
+    assert actors.actors == []
+    assert fake_ray.attempts == [
+        ("actor-0", True),
+        ("actor-1", True),
+        ("actor-0", True),
+    ]
+
+
+def test_ray_task_session_environment_is_reinstalled_for_reused_worker(monkeypatch):
+    import os
+
+    import duckdb.execution.udf_ray as udf_ray
+    from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
+
+    stale_key = "AWS_ISSUE75_STALE_TASK_SECRET"
+    session_key = "AWS_ISSUE75_CURRENT_TASK_SECRET"
+    monkeypatch.setenv(stale_key, "stale")
+    carrier = build_session_runtime_env_vars({session_key: "current"})
+
+    @udf_ray._with_explicit_session_runtime_env(carrier)
+    def _stream():
+        assert stale_key not in os.environ
+        assert os.environ[session_key] == "current"
+        yield "value"
+        raise AssertionError("closing the generator must not resume its body")
+
+    for _ in range(2):
+        stream = _stream()
+        assert next(stream) == "value"
+        stream.close()
+
+        assert stale_key not in os.environ
+        assert session_key not in os.environ
+        assert all(key not in os.environ for key in carrier)
+
+
 def test_vllm_named_actor_pool_partial_lookup_fails_without_creation_fallback(monkeypatch):
     import duckdb.execution.vllm as vllm
 
     class FakeRay:
         def __init__(self):
             self.lookups: list[str] = []
+            self.killed: list[str] = []
 
         def get_actor(self, name):
             self.lookups.append(name)
@@ -1158,13 +1353,18 @@ def test_vllm_named_actor_pool_partial_lookup_fails_without_creation_fallback(mo
                 return f"actor:{name}"
             raise ValueError(name)
 
+        def kill(self, actor, *, no_restart):
+            assert no_restart is True
+            self.killed.append(actor)
+
     def fail_create(*_args, **_kwargs):
         raise AssertionError("partial named vLLM pool must not fall back to actor creation")
 
-    monkeypatch.setitem(sys.modules, "ray", FakeRay())
+    fake_ray = FakeRay()
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
     monkeypatch.setattr(vllm.LLMActors, "__init__", fail_create)
 
-    with pytest.raises(RuntimeError, match="partially available|incomplete"):
+    with pytest.raises(RuntimeError, match="partially available|incomplete") as exc_info:
         vllm.LLMActors.get_or_create_named(
             model="model",
             engine_args={},
@@ -1175,6 +1375,11 @@ def test_vllm_named_actor_pool_partial_lookup_fails_without_creation_fallback(mo
             load_balance_threshold=32,
             name_prefix="pool",
         )
+
+    owned_pools = exc_info.value.owned_actor_pools
+    assert len(owned_pools) == 1
+    owned_pools[0].shutdown()
+    assert fake_ray.killed == ["actor:pool-router", "actor:pool-llm-0"]
 
 
 def test_vllm_ray_execution_requires_runner_owned_runtime(monkeypatch):
@@ -1391,11 +1596,11 @@ def test_ensure_local_subprocess_actor_pools_for_nodes_injects_with_callback(mon
     injected = []
 
     class FakeLocalActorPool:
-        def __init__(self, payload, pool_size, *, name=None):
+        def __init__(self, payload, pool_size, *, name=None, session_config=None):
             self.payload = payload
             self.pool_size = pool_size
             self.name = name
-            created_args.append((payload, pool_size, name))
+            created_args.append((payload, pool_size, name, session_config))
 
         def shutdown(self, *, kill=False):
             pass
@@ -1409,6 +1614,11 @@ def test_ensure_local_subprocess_actor_pools_for_nodes_injects_with_callback(mon
                 "actor_number": 2,
                 "function_pickle": b"unused",
                 "call_mode": "map_batches",
+            },
+            "executor_options": {
+                "session_config": {
+                    "AWS_ACCESS_KEY_ID": "session-key",
+                },
             },
         },
         {
@@ -1433,7 +1643,13 @@ def test_ensure_local_subprocess_actor_pools_for_nodes_injects_with_callback(mon
     assert len(created) == 1
     assert created_args[0][1] == 2
     assert created_args[0][2] == "local-subprocess-actor-direct-plan-4"
-    assert handles_map == {"4": {"local_actor_pool": created[0]}}
+    assert created_args[0][3] == {"AWS_ACCESS_KEY_ID": "session-key"}
+    assert handles_map == {
+        "4": {
+            "local_actor_pool": created[0],
+            "session_config": {"AWS_ACCESS_KEY_ID": "session-key"},
+        }
+    }
     assert injected == [handles_map]
 
 
@@ -3480,7 +3696,8 @@ def test_local_subprocess_actor_pool_rolls_back_created_workers_on_worker_init_f
 
     created: list[FakeWorker] = []
 
-    def fake_worker(payload, *, worker_env=None):
+    def fake_worker(payload, *, worker_env=None, session_config=None):
+        assert session_config is None
         if len(created) == 1:
             raise RuntimeError("worker init failed")
         worker = FakeWorker(f"w{len(created)}")
@@ -3515,7 +3732,8 @@ def test_local_subprocess_actor_pool_rolls_back_created_workers_on_thread_pool_i
     class FakeWorker:
         _proc = None
 
-        def __init__(self, payload, *, worker_env=None):
+        def __init__(self, payload, *, worker_env=None, session_config=None):
+            assert session_config is None
             self.name = f"w{len(created)}"
             created.append(self.name)
 
@@ -3921,6 +4139,98 @@ def test_subprocess_task_shared_payload_pool_keeps_worker_slots_global(monkeypat
         assert observed_stats["active_workers"] == 1
         assert observed_stats["total_workers"] == 1
         assert len(pids) == 1
+    finally:
+        executor_a.close(kill=True)
+        executor_b.close(kill=True)
+        subprocess_exec._shutdown_global_task_runtime()
+
+
+def test_subprocess_task_pool_identity_includes_session_config():
+    from duckdb.execution.udf_subprocess import _payload_task_key
+
+    payload = {
+        "execution_backend": "subprocess_task",
+        "udf_worker_slots": 1,
+        "function_pickle": b"same-function",
+    }
+
+    first = _payload_task_key(payload, {"AWS_ACCESS_KEY_ID": "session-a"})
+    second = _payload_task_key(payload, {"AWS_ACCESS_KEY_ID": "session-b"})
+    reordered = _payload_task_key(
+        payload,
+        {
+            "VANE_AUTH_HEADER": "auth",
+            "AWS_ACCESS_KEY_ID": "session-a",
+        },
+    )
+    reordered_again = _payload_task_key(
+        payload,
+        {
+            "AWS_ACCESS_KEY_ID": "session-a",
+            "VANE_AUTH_HEADER": "auth",
+        },
+    )
+
+    assert first != second
+    assert reordered == reordered_again
+
+
+def test_subprocess_task_workers_receive_exact_session_environment(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    subprocess_exec._shutdown_global_task_runtime()
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "inherited-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "inherited-secret")
+    monkeypatch.setenv("VANE_AUTH_HEADER", "inherited-auth")
+
+    def read_session_environment(table):
+        import os
+
+        row_count = table.num_rows
+        return pa.table(
+            {
+                "access_key": [os.environ.get("AWS_ACCESS_KEY_ID", "<missing>")] * row_count,
+                "secret_key": [os.environ.get("AWS_SECRET_ACCESS_KEY", "<missing>")] * row_count,
+                "auth_header": [os.environ.get("VANE_AUTH_HEADER", "<missing>")] * row_count,
+            }
+        )
+
+    payload = _subprocess_map_payload(read_session_environment)
+    executor_a = subprocess_exec.UDFExecutor(
+        payload,
+        options={
+            "session_config": {
+                "AWS_ACCESS_KEY_ID": "session-a",
+                "VANE_AUTH_HEADER": "auth-a",
+            }
+        },
+    )
+    executor_b = subprocess_exec.UDFExecutor(
+        payload,
+        options={
+            "session_config": {
+                "AWS_ACCESS_KEY_ID": "session-b",
+            }
+        },
+    )
+    try:
+        assert executor_a._task_pool is not executor_b._task_pool
+        _submit_with_admission(executor_a, pa.table({"x": [1]}), submit_id=191)
+        _submit_with_admission(executor_b, pa.table({"x": [2]}), submit_id=192)
+
+        result_a = _wait_for_results(executor_a, 1, timeout_s=10.0)[0][2]
+        result_b = _wait_for_results(executor_b, 1, timeout_s=10.0)[0][2]
+
+        assert result_a.to_pydict() == {
+            "access_key": ["session-a"],
+            "secret_key": ["<missing>"],
+            "auth_header": ["auth-a"],
+        }
+        assert result_b.to_pydict() == {
+            "access_key": ["session-b"],
+            "secret_key": ["<missing>"],
+            "auth_header": ["<missing>"],
+        }
     finally:
         executor_a.close(kill=True)
         executor_b.close(kill=True)
@@ -4525,6 +4835,7 @@ def _ray_task_executor(*, stream_result="stream-ref", ref_stream_result="ref-str
         },
         run_stream,
         run_ref_stream,
+        query_driver_handle=object(),
     )
     return executor, run_stream, run_ref_stream
 

--- a/tests/fast/test_udf_ray_actor_row_preserving.py
+++ b/tests/fast/test_udf_ray_actor_row_preserving.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from typing import Any
@@ -76,9 +77,13 @@ def fake_ray(monkeypatch: pytest.MonkeyPatch) -> _FakeRayModule:
     # Load the actor runtime and its runner dependencies against real Ray.
     # The fake only needs to replace Ray while the actor class itself runs.
     import duckdb.execution.udf_ray_actor_runtime  # noqa: F401
+    from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 
     module = _FakeRayModule()
     monkeypatch.setitem(sys.modules, "ray", module)
+    monkeypatch.setenv("VANE_ISSUE75_INHERITED_SECRET", "inherited-secret")
+    for key, value in build_session_runtime_env_vars({"AWS_ISSUE75_ACTOR_SESSION": "actor-session"}).items():
+        monkeypatch.setenv(key, value)
     return module
 
 
@@ -115,6 +120,13 @@ def test_actor_block_stream_rows_mode_fuses_passthrough(fake_ray):
         "keep": ["a", "b", "c"],
         "y": [2, 3, 4],
     }
+
+
+def test_actor_constructor_installs_only_explicit_session_environment(fake_ray):
+    _make_actor(_rows_payload(_AddOne))
+
+    assert "VANE_ISSUE75_INHERITED_SECRET" not in os.environ
+    assert os.environ["AWS_ISSUE75_ACTOR_SESSION"] == "actor-session"
 
 
 def test_actor_ref_bundle_block_stream_rows_mode_fuses_passthrough(fake_ray):

--- a/tests/fast/test_udf_ray_ready.py
+++ b/tests/fast/test_udf_ray_ready.py
@@ -62,7 +62,11 @@ def _executor(actors, *, dispatch_indices=None, payload=None, node_ids=None):
         actor_node_ids=node_ids or ["node-a"] * len(actors),
         actor_dispatch_indices=(set(range(len(actors))) if dispatch_indices is None else dispatch_indices),
     )
-    return RemoteUDFExecutor(pool, payload or _payload())
+    return RemoteUDFExecutor(
+        pool,
+        payload or _payload(),
+        query_driver_handle=object(),
+    )
 
 
 def _run_after_lease(executor, monkeypatch, *, actor_index=0):
@@ -208,10 +212,46 @@ def test_existing_actor_handles_require_explicit_dispatch_eligibility():
         actor_dispatch_indices=set(),
     )
     executor = __import__("duckdb.execution.udf_ray", fromlist=["RemoteUDFExecutor"]).RemoteUDFExecutor(
-        pool, _payload()
+        pool,
+        _payload(),
+        query_driver_handle=object(),
     )
     assert executor._ready_actor_indices == []
     assert executor._actor_init_errors[0] == "ray actor does not expose __ray_ready__ readiness probe"
+
+
+def test_actor_executor_uses_explicit_query_driver_handle():
+    from duckdb.execution.udf_ray import _build_ray_actor_executor
+
+    actor = _Actor()
+    query_driver_handle = object()
+    options = {
+        "actor_handles": [actor],
+        "actor_node_ids": ["node-a"],
+        "actor_dispatch_indices": [0],
+    }
+
+    with pytest.raises(RuntimeError, match="explicit query driver handle"):
+        _build_ray_actor_executor(_payload(), options)
+
+    with pytest.raises(RuntimeError, match="explicit Vane session config"):
+        _build_ray_actor_executor(
+            _payload(),
+            {
+                **options,
+                "query_driver_handle": query_driver_handle,
+            },
+        )
+
+    executor = _build_ray_actor_executor(
+        _payload(),
+        {
+            **options,
+            "query_driver_handle": query_driver_handle,
+            "session_config": {},
+        },
+    )
+    assert executor._task_admission._driver is query_driver_handle
 
 
 def test_actor_executor_options_reject_missing_or_invalid_coordinator_identity():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -59,6 +59,11 @@ def _payload():
     }
 
 
+def test_task_admission_requires_explicit_query_driver_handle():
+    with pytest.raises(ValueError, match="query driver handle"):
+        TaskAdmissionController(_payload(), driver=None)
+
+
 def _grant(request):
     return {
         "granted": True,


### PR DESCRIPTION
## Summary

- Share one job-scoped Ray driver runtime while tracking connection owners with attach/detach semantics and shutting it down only after the last owner closes.
- Keep configuration and environment snapshots in per-connection sessions, scrub managed variables from the shared runtime, and explicitly propagate session credentials to workers, UDF executors, subprocesses, and vLLM actors.
- Use one query-scoped replay/resource lifecycle. Replay state, UDF registrations, actor handles, and datasource ownership follow the outer resource query ID; nested execution queries are torn down first and failed cleanup remains retryable.
- Preserve the public runner/relation API. Internal plan serialization intentionally uses the new strict format without compatibility or fallback paths.

## Related issue

close: #75

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public API is unchanged; this corrects internal ownership and isolation semantics.

## Validation

- Incremental native Release build with `SKBUILD_BUILD_DIR=$PWD/build/python-release uv pip install . --no-build-isolation`
- Targeted session/Ray regression suite: 657 passed, 4 deselected
- Final `tests/fast/test_ray_result_contract.py`: 170 passed
- `scripts/run_fast_tests.sh`
  - non-Ray shard: 5689 passed, 30 skipped, 103 deselected, 9 xfailed
  - shared-Ray shard: 85 passed, 9 skipped, 5737 deselected
  - all runnable test-owned Ray cluster shards passed; vLLM and multi-node-only cases skipped when unavailable
- `scripts/run_release_tests.sh`
  - base gate: 387 passed, 1 skipped, 11 deselected
  - real-Ray gate: 7 passed, 392 deselected
- GitHub Required CI on `3e166622`
  - source packages and native/build/release jobs passed on Python 3.10–3.14
  - both non-Ray, shared-Ray, and isolated-Ray fast-test shards passed
- `pre-commit run --show-diff-on-failure --color=never --from-ref upstream/main --to-ref HEAD`
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. `botocore>=1.34,<2` is added for
      isolated AWS provider-chain credential resolution (Apache-2.0).
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.