### PR TITLE
[fix](ray) Keep COPY registration off the driver event loop

### DIFF
--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -86,6 +86,28 @@ class _DeferredQueryAllocationTeardown:
     reason: str
 
 
+class _PlanStartupOwnership:
+    """Hand registered resources to exactly one startup or cancellation path."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._owner = "caller"
+
+    def claim_for_worker(self) -> bool:
+        with self._lock:
+            if self._owner != "caller":
+                return False
+            self._owner = "worker"
+            return True
+
+    def cancel_before_worker_claim(self) -> bool:
+        with self._lock:
+            if self._owner != "caller":
+                return False
+            self._owner = "cancelled"
+            return True
+
+
 def _progress_topology_init_timeout_s() -> float:
     value = float(
         os.environ.get(
@@ -3168,13 +3190,54 @@ class RayQueryDriverActor:
             plan,
             expected_plan_id=plan_id,
         )
-        await asyncio.to_thread(
-            self._run_plan_sync,
-            plan,
-            plan_id,
-            graph,
-            allocation,
+        startup_ownership = _PlanStartupOwnership()
+        startup = asyncio.create_task(
+            asyncio.to_thread(
+                self._run_plan_sync_with_ownership,
+                plan,
+                plan_id,
+                graph,
+                allocation,
+                startup_ownership,
+            ),
+            name=f"vane-plan-startup:{plan_id}",
         )
+        try:
+            await asyncio.shield(startup)
+        except asyncio.CancelledError as cancellation_error:
+            if startup_ownership.cancel_before_worker_claim():
+                startup.cancel()
+                await asyncio.gather(startup, return_exceptions=True)
+                try:
+                    await asyncio.to_thread(
+                        self._teardown_plan_resources,
+                        plan_id,
+                        str(graph.query_id),
+                        drop_fragments=False,
+                    )
+                except BaseException as teardown_error:
+                    raise RuntimeError(
+                        f"query plan {plan_id} was cancelled before startup and teardown failed: "
+                        f"{type(teardown_error).__name__}: {teardown_error}"
+                    ) from teardown_error
+            else:
+                try:
+                    await asyncio.shield(startup)
+                except BaseException as startup_error:
+                    raise startup_error from cancellation_error
+                try:
+                    await asyncio.to_thread(
+                        self._teardown_plan_resources,
+                        plan_id,
+                        str(graph.query_id),
+                        drop_fragments=True,
+                    )
+                except BaseException as teardown_error:
+                    raise RuntimeError(
+                        f"query plan {plan_id} was cancelled during startup and teardown failed: "
+                        f"{type(teardown_error).__name__}: {teardown_error}"
+                    ) from teardown_error
+            raise
 
     def _prepare_plan_sync(
         self,
@@ -3235,6 +3298,24 @@ class RayQueryDriverActor:
                     f"teardown={type(teardown_error).__name__}: {teardown_error}"
                 ) from start_error
             raise
+
+    def _run_plan_sync_with_ownership(
+        self,
+        plan: Any,
+        plan_id: str,
+        graph: Any,
+        allocation: Any,
+        startup_ownership: _PlanStartupOwnership,
+    ) -> None:
+        """Start only after atomically claiming the registered resources."""
+        if not startup_ownership.claim_for_worker():
+            return
+        self._run_plan_sync(
+            plan,
+            plan_id,
+            graph,
+            allocation,
+        )
 
     async def run_copy_plan(
         self,

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -68,6 +68,24 @@ class CopyPlanOutcome:
     final_progress_snapshot: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class _PreparedQueryResourceRegistration:
+    """Immutable registration input prepared away from the actor owner loop."""
+
+    graph: Any
+    node_capacities: tuple[Any, ...]
+    capacity_snapshot_started_at: float
+
+
+@dataclass(frozen=True)
+class _DeferredQueryAllocationTeardown:
+    """Generation-fenced fragment teardown discovered during a local commit."""
+
+    query_id: str
+    generation: int
+    reason: str
+
+
 def _progress_topology_init_timeout_s() -> float:
     value = float(
         os.environ.get(
@@ -900,6 +918,12 @@ class RayQueryDriverActor:
         self._query_graphs: dict[str, Any] = {}
         self._query_allocations: dict[str, Any] = {}
         self._query_node_capacities: tuple[Any, ...] = ()
+        self._query_allocation_teardowns_pending: dict[
+            str,
+            _DeferredQueryAllocationTeardown,
+        ] = {}
+        self._query_allocation_teardowns_claimed: set[str] = set()
+        self._query_allocation_teardown_futures: set[asyncio.Future[Any]] = set()
         self._query_task_lease_requests: dict[str, dict[str, Any]] = {}
         self._query_output_lease_requests: dict[str, dict[str, Any]] = {}
         self._query_task_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
@@ -1217,6 +1241,10 @@ class RayQueryDriverActor:
                 self._driver_shutdown_started = True
                 plan_runner = self.plan_runner
             await self.stop_query_resource_maintenance()
+            self._ensure_query_allocation_teardown_state()
+            teardown_futures = tuple(self._query_allocation_teardown_futures)
+            if teardown_futures:
+                await asyncio.gather(*teardown_futures, return_exceptions=True)
             if plan_runner is not None:
                 await asyncio.to_thread(plan_runner.shutdown)
             self._driver_shutdown_complete = True
@@ -1262,12 +1290,29 @@ class RayQueryDriverActor:
             heartbeat_timeout_s=heartbeat_timeout,
         )
 
-    def _synchronize_query_allocations(self) -> None:
+    def _ensure_query_allocation_teardown_state(self) -> None:
+        if not hasattr(self, "_query_allocation_teardowns_pending"):
+            self._query_allocation_teardowns_pending = {}
+        if not hasattr(self, "_query_allocation_teardowns_claimed"):
+            self._query_allocation_teardowns_claimed = set()
+        if not hasattr(self, "_query_allocation_teardown_futures"):
+            self._query_allocation_teardown_futures = set()
+
+    def _synchronize_query_allocations(
+        self,
+    ) -> tuple[_DeferredQueryAllocationTeardown, ...]:
+        """Commit local allocation state and return teardown work.
+
+        The caller owns ``_query_resource_lock``. Returned work may perform
+        remote calls and must run only after that lock is released.
+        """
         from duckdb.runners.ray.query_execution_graph import QueryAllocation
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
+        self._ensure_query_allocation_teardown_state()
         snapshot = self._query_resource_coordinator.snapshot()
         coordinator_queries = snapshot["queries"]
+        deferred_teardowns = dict(self._query_allocation_teardowns_pending)
         terminal_errors = getattr(self, "_query_terminal_errors", None)
         if terminal_errors is None:
             terminal_errors = {}
@@ -1301,24 +1346,93 @@ class RayQueryDriverActor:
                     )
                     terminal_errors[query_id] = reason
                     manager.cancel("ray_actor_placement_lost")
-                    try:
-                        self._drop_query_fragments_after_admission_fence_sync(
-                            query_id,
-                            release_resources=False,
-                        )
-                    except BaseException as exc:
-                        terminal_errors[query_id] = (
-                            f"{reason}; fragment cancellation failed: {type(exc).__name__}: {exc}"
-                        )
+                    teardown = _DeferredQueryAllocationTeardown(
+                        query_id=query_id,
+                        generation=allocation.generation,
+                        reason=reason,
+                    )
+                    self._query_allocation_teardowns_pending[query_id] = teardown
+                    deferred_teardowns[query_id] = teardown
+        return tuple(deferred_teardowns[query_id] for query_id in sorted(deferred_teardowns))
 
-    def _refresh_query_capacity(self) -> Any:
-        capacities = self._read_query_node_capacities()
+    def _run_query_allocation_teardowns(
+        self,
+        teardowns: tuple[_DeferredQueryAllocationTeardown, ...],
+    ) -> None:
+        """Run remote fragment teardown after releasing resource-state locks."""
+        self._ensure_query_allocation_teardown_state()
+        for teardown in teardowns:
+            query_id = teardown.query_id
+            with self._query_resource_lock:
+                if self._query_allocation_teardowns_pending.get(query_id) != teardown:
+                    continue
+                if query_id in self._query_allocation_teardowns_claimed:
+                    continue
+                self._query_allocation_teardowns_claimed.add(query_id)
+            succeeded = False
+            try:
+                self._drop_query_fragments_after_admission_fence_sync(
+                    query_id,
+                    release_resources=False,
+                )
+                succeeded = True
+            except BaseException as exc:
+                with self._query_resource_lock:
+                    if (
+                        self._query_allocation_teardowns_pending.get(query_id) == teardown
+                        and query_id in self._query_graphs
+                    ):
+                        self._query_terminal_errors[query_id] = (
+                            f"{teardown.reason}; fragment cancellation failed: {type(exc).__name__}: {exc}"
+                        )
+            finally:
+                with self._query_resource_lock:
+                    self._query_allocation_teardowns_claimed.discard(query_id)
+                    if succeeded and self._query_allocation_teardowns_pending.get(query_id) == teardown:
+                        self._query_allocation_teardowns_pending.pop(query_id, None)
+
+    def _schedule_query_allocation_teardowns(
+        self,
+        teardowns: tuple[_DeferredQueryAllocationTeardown, ...],
+    ) -> None:
+        """Submit teardown work without adding a post-commit cancellation point."""
+        if not teardowns:
+            return
+        self._ensure_query_allocation_teardown_state()
+        future = asyncio.get_running_loop().run_in_executor(
+            None,
+            self._run_query_allocation_teardowns,
+            teardowns,
+        )
+        self._query_allocation_teardown_futures.add(future)
+
+        def _retire(done: asyncio.Future[Any]) -> None:
+            self._query_allocation_teardown_futures.discard(done)
+            if not done.cancelled():
+                done.exception()
+
+        future.add_done_callback(_retire)
+
+    def _apply_query_capacity_snapshot(
+        self,
+        capacities: tuple[Any, ...],
+        *,
+        snapshot_started_at: float,
+    ) -> Any:
+        """Apply a complete GCS snapshot while the caller owns the state lock.
+
+        Request start time orders overlapping reads so a slow older request
+        cannot overwrite a later request that already committed.
+        """
         if not capacities:
             raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
+        last_snapshot_started_at = float(getattr(self, "_query_resource_last_capacity_refresh_at", 0.0))
+        cached_capacities = tuple(getattr(self, "_query_node_capacities", ()))
+        if cached_capacities and float(snapshot_started_at) < last_snapshot_started_at:
+            return self._sum_node_capacity(cached_capacities)
         self._query_resource_coordinator.update_node_capacities(capacities)
         self._query_node_capacities = capacities
-        self._query_resource_last_capacity_refresh_at = time.monotonic()
-        self._synchronize_query_allocations()
+        self._query_resource_last_capacity_refresh_at = float(snapshot_started_at)
         return self._sum_node_capacity(capacities)
 
     @staticmethod
@@ -1353,46 +1467,55 @@ class RayQueryDriverActor:
                 capacities = self._read_query_node_capacities()
             except BaseException as exc:
                 capacity_error = exc
-                capacities = tuple(self._query_node_capacities)
+                capacities = ()
         capacities = tuple(capacities)
-        if not capacities:
-            if capacity_error is not None:
-                raise RuntimeError(
-                    f"failed to refresh Ray capacity and no cached snapshot exists: {capacity_error}"
-                ) from capacity_error
+        if capacity_error is None and not capacities:
             raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
 
-        with self._query_resource_lock:
-            self._query_resource_coordinator.update_node_capacities(
-                capacities,
-                now=timestamp,
-            )
-            self._query_node_capacities = capacities
-            if capacity_error is None:
-                self._query_resource_last_capacity_refresh_at = timestamp
-            self._synchronize_query_allocations()
+        deferred_teardowns: list[_DeferredQueryAllocationTeardown] = []
+        try:
+            with self._query_resource_lock:
+                if capacity_error is None:
+                    self._apply_query_capacity_snapshot(
+                        capacities,
+                        snapshot_started_at=timestamp,
+                    )
+                else:
+                    cached_capacities = tuple(self._query_node_capacities)
+                    if not cached_capacities:
+                        raise RuntimeError(
+                            f"failed to refresh Ray capacity and no cached snapshot exists: {capacity_error}"
+                        ) from capacity_error
+                    self._query_resource_coordinator.update_node_capacities(
+                        cached_capacities,
+                        now=timestamp,
+                    )
+                deferred_teardowns.extend(self._synchronize_query_allocations())
 
-            observed_usage: dict[str, ResourceVector] = {}
-            generations: dict[str, int] = {}
-            for query_id in sorted(self._query_graphs):
-                manager = get_query_resource_manager(query_id)
-                observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
-                generations[query_id] = self._query_allocations[query_id].generation
-            self._query_resource_coordinator.refresh_queries(
-                observed_usage_by_query=observed_usage,
-                generations=generations,
-                now=timestamp,
-            )
-            expired = self._query_resource_coordinator.expire_queries(now=timestamp)
-            if expired:
-                raise RuntimeError("active query resource heartbeats expired unexpectedly: " + ", ".join(expired))
-            self._synchronize_query_allocations()
-            self._query_resource_last_maintenance_at = timestamp
-            return {
-                "query_count": len(observed_usage),
-                "capacity_cached": capacity_error is not None,
-                "capacity_error": "" if capacity_error is None else str(capacity_error),
-            }
+                observed_usage: dict[str, ResourceVector] = {}
+                generations: dict[str, int] = {}
+                for query_id in sorted(self._query_graphs):
+                    manager = get_query_resource_manager(query_id)
+                    observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
+                    generations[query_id] = self._query_allocations[query_id].generation
+                self._query_resource_coordinator.refresh_queries(
+                    observed_usage_by_query=observed_usage,
+                    generations=generations,
+                    now=timestamp,
+                )
+                expired = self._query_resource_coordinator.expire_queries(now=timestamp)
+                if expired:
+                    raise RuntimeError("active query resource heartbeats expired unexpectedly: " + ", ".join(expired))
+                deferred_teardowns.extend(self._synchronize_query_allocations())
+                self._query_resource_last_maintenance_at = timestamp
+                result = {
+                    "query_count": len(observed_usage),
+                    "capacity_cached": capacity_error is not None,
+                    "capacity_error": "" if capacity_error is None else str(capacity_error),
+                }
+        finally:
+            self._run_query_allocation_teardowns(tuple(deferred_teardowns))
+        return result
 
     def _start_query_resource_maintenance(self) -> None:
         task = self._query_resource_maintenance_task
@@ -2558,26 +2681,91 @@ class RayQueryDriverActor:
         self._run_query_resource_admission_pumps(query_id)
         return {"cancelled": True, "released": bool(released)}
 
-    def _register_query_resources(self, plan: Any) -> tuple[Any, Any]:
+    def _prepare_query_resource_registration(
+        self,
+        plan: Any,
+        expected_plan_id: str | None = None,
+    ) -> _PreparedQueryResourceRegistration:
         from duckdb.runners.ray.query_graph_builder import (
-            build_query_demand,
             build_query_execution_graph,
-        )
-        from duckdb.runners.ray.query_resource_runtime import (
-            register_query_graph,
-            release_query_resource_manager,
         )
 
         metadata = plan.collect_execution_stages(conn=self._duckdb_conn)
         graph = build_query_execution_graph(metadata)
         plan_id = str(plan.idx())
+        if expected_plan_id is not None and plan_id != expected_plan_id:
+            raise ValueError(
+                f"physical plan query_id changed during registration: "
+                f"prepared={expected_plan_id!r} registration={plan_id!r}"
+            )
         if graph.query_id != plan_id:
             raise ValueError(f"execution graph query_id mismatch: graph={graph.query_id!r} plan={plan_id!r}")
+        capacity_snapshot_started_at = time.monotonic()
+        capacities = self._read_query_node_capacities()
+        if not capacities:
+            raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
+        return _PreparedQueryResourceRegistration(
+            graph=graph,
+            node_capacities=tuple(capacities),
+            capacity_snapshot_started_at=capacity_snapshot_started_at,
+        )
 
+    async def _register_query_resources(
+        self,
+        plan: Any,
+        *,
+        expected_plan_id: str | None = None,
+    ) -> tuple[Any, Any]:
+        """Prepare registration off-loop, then atomically publish local state."""
+        self._ensure_query_resource_admission_state()
+        owner_loop = self._query_resource_admission_loop
+        running_loop = asyncio.get_running_loop()
+        if owner_loop is None:
+            self._query_resource_admission_loop = running_loop
+        elif owner_loop is not running_loop:
+            raise RuntimeError("query resource registration must run on the admission owner loop")
+
+        prepared = await asyncio.to_thread(
+            self._prepare_query_resource_registration,
+            plan,
+            expected_plan_id,
+        )
+        deferred_teardowns: list[_DeferredQueryAllocationTeardown] = []
+        try:
+            result = self._commit_query_resource_registration(
+                prepared,
+                deferred_teardowns=deferred_teardowns,
+            )
+        finally:
+            self._schedule_query_allocation_teardowns(
+                tuple(deferred_teardowns),
+            )
+        return result
+
+    def _commit_query_resource_registration(
+        self,
+        prepared: _PreparedQueryResourceRegistration,
+        *,
+        deferred_teardowns: list[_DeferredQueryAllocationTeardown],
+    ) -> tuple[Any, Any]:
+        from duckdb.runners.ray.query_graph_builder import build_query_demand
+        from duckdb.runners.ray.query_resource_runtime import (
+            register_query_graph,
+            release_query_resource_manager,
+        )
+
+        graph = prepared.graph
         with self._query_resource_lock:
             if graph.query_id in self._query_graphs:
                 raise ValueError(f"query graph is already registered: {graph.query_id}")
-            cluster_capacity = self._refresh_query_capacity()
+            self._ensure_query_allocation_teardown_state()
+            if graph.query_id in self._query_allocation_teardowns_pending:
+                raise RuntimeError(f"query {graph.query_id} still has a pending allocation-loss teardown")
+            cluster_capacity = self._apply_query_capacity_snapshot(
+                prepared.node_capacities,
+                snapshot_started_at=prepared.capacity_snapshot_started_at,
+            )
+            deferred_teardowns.extend(self._synchronize_query_allocations())
             demand = build_query_demand(
                 graph,
                 cluster_capacity,
@@ -2585,7 +2773,7 @@ class RayQueryDriverActor:
             allocation = self._query_resource_coordinator.register_query(demand)
             manager_registered = False
             try:
-                self._synchronize_query_allocations()
+                deferred_teardowns.extend(self._synchronize_query_allocations())
                 manager = register_query_graph(
                     graph,
                     allocation,
@@ -2601,9 +2789,7 @@ class RayQueryDriverActor:
                     )
                 self._query_graphs[graph.query_id] = graph
                 self._query_allocations[graph.query_id] = allocation
-                self._run_on_query_resource_admission_loop_sync(
-                    lambda: self._open_query_resource_admission(graph.query_id)
-                )
+                self._open_query_resource_admission(graph.query_id)
                 return graph, allocation
             except BaseException as registration_error:
                 cleanup_errors: list[BaseException] = []
@@ -2629,7 +2815,7 @@ class RayQueryDriverActor:
                 except BaseException as exc:
                     cleanup_errors.append(exc)
                 try:
-                    self._synchronize_query_allocations()
+                    deferred_teardowns.extend(self._synchronize_query_allocations())
                 except BaseException as exc:
                     cleanup_errors.append(exc)
                 if cleanup_errors:
@@ -2697,33 +2883,37 @@ class RayQueryDriverActor:
                     f"failed to fence query resource release for {query_key}: {type(exc).__name__}: {exc}"
                 ) from exc
         cleanup_errors: list[BaseException] = []
-        with self._query_resource_lock:
-            allocation = self._query_allocations.get(query_key)
-            try:
-                release_query_resource_manager(query_key, reason=reason)
-            except BaseException as exc:
-                cleanup_errors.append(exc)
-            if allocation is not None:
+        deferred_teardowns: tuple[_DeferredQueryAllocationTeardown, ...] = ()
+        try:
+            with self._query_resource_lock:
+                allocation = self._query_allocations.get(query_key)
                 try:
-                    released = self._query_resource_coordinator.release_query(
-                        query_key,
-                        allocation.generation,
-                    )
-                    if not released:
-                        cleanup_errors.append(
-                            RuntimeError(
-                                f"coordinator allocation was already absent for query {query_key} "
-                                f"at generation {allocation.generation}"
-                            )
-                        )
+                    release_query_resource_manager(query_key, reason=reason)
                 except BaseException as exc:
                     cleanup_errors.append(exc)
-            self._query_graphs.pop(query_key, None)
-            self._query_allocations.pop(query_key, None)
-            try:
-                self._synchronize_query_allocations()
-            except BaseException as exc:
-                cleanup_errors.append(exc)
+                if allocation is not None:
+                    try:
+                        released = self._query_resource_coordinator.release_query(
+                            query_key,
+                            allocation.generation,
+                        )
+                        if not released:
+                            cleanup_errors.append(
+                                RuntimeError(
+                                    f"coordinator allocation was already absent for query {query_key} "
+                                    f"at generation {allocation.generation}"
+                                )
+                            )
+                    except BaseException as exc:
+                        cleanup_errors.append(exc)
+                self._query_graphs.pop(query_key, None)
+                self._query_allocations.pop(query_key, None)
+                try:
+                    deferred_teardowns = self._synchronize_query_allocations()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+        finally:
+            self._run_query_allocation_teardowns(deferred_teardowns)
         if cleanup_errors:
             raise RuntimeError(
                 f"query resource cleanup for {query_key} had "
@@ -2973,13 +3163,24 @@ class RayQueryDriverActor:
     ) -> None:
         """Run a plan without blocking the driver actor's control event loop."""
         _set_global_event_loop(asyncio.get_running_loop())
-        await asyncio.to_thread(self._run_plan_sync, plan)
+        plan, plan_id = await asyncio.to_thread(self._prepare_plan_sync, plan)
+        graph, allocation = await self._register_query_resources(
+            plan,
+            expected_plan_id=plan_id,
+        )
+        await asyncio.to_thread(
+            self._run_plan_sync,
+            plan,
+            plan_id,
+            graph,
+            allocation,
+        )
 
-    def _run_plan_sync(
+    def _prepare_plan_sync(
         self,
         plan: duckdb.ray_cxx.PyLogicalPlan,
-    ) -> None:
-        """Blocking plan startup executed by ``run_plan`` on an owned worker thread."""
+    ) -> tuple[Any, str]:
+        """Prepare a physical plan on an owned worker thread."""
         _apply_env_overrides(self._env_overrides)
 
         if os.environ.get("VANE_WORKER") == "1":
@@ -2990,12 +3191,19 @@ class RayQueryDriverActor:
 
         self._ensure_duckdb_conn()
 
-        plan = plan.to_physical_plan(self._duckdb_conn)
-        graph = None
-        plan_id = str(plan.idx())
+        physical_plan = plan.to_physical_plan(self._duckdb_conn)
+        return physical_plan, str(physical_plan.idx())
+
+    def _run_plan_sync(
+        self,
+        plan: Any,
+        plan_id: str,
+        graph: Any,
+        allocation: Any,
+    ) -> None:
+        """Start an already registered streaming plan on a worker thread."""
         plan_runner_started = False
         try:
-            graph, allocation = self._register_query_resources(plan)
             udf_actors = self._precreate_udf_actors(plan, graph, allocation)
             if udf_actors:
                 self._active_udf_actors_by_plan[plan_id] = list(udf_actors)
@@ -3044,7 +3252,10 @@ class RayQueryDriverActor:
         plan_execution: asyncio.Task[Any] | None = None
         startup_tasks: list[asyncio.Task[Any]] = []
         try:
-            graph, allocation = self._register_query_resources(plan)
+            graph, allocation = await self._register_query_resources(
+                plan,
+                expected_plan_id=plan_id,
+            )
             udf_actors = await asyncio.to_thread(
                 self._precreate_udf_actors,
                 plan,

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -12,11 +13,14 @@ import pytest
 import duckdb
 from duckdb._ray_cxx import validate_plan_serialization_for_submission
 from duckdb._ray_errors import RemoteRayException
+from duckdb.runners.ray.cluster_resource_coordinator import NodeCapacity
 from duckdb.runners.ray.query_execution_graph import (
     ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
+    QueryExecutionGraph,
     ResourceVector,
+    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
@@ -59,11 +63,24 @@ class _FakePhysicalPlan:
         return self._metadata
 
 
+class _RegistrationOnlyIdxPhysicalPlan(_FakePhysicalPlan):
+    def __init__(self, query_id, metadata, events):
+        super().__init__(query_id, metadata, events)
+        self.idx_calls = 0
+
+    def idx(self):
+        self.idx_calls += 1
+        if self.idx_calls > 2:
+            raise RuntimeError("physical plan idx was re-entered after registration")
+        return super().idx()
+
+
 class _FakeCoordinator:
     def __init__(self, events):
         self._events = events
         self.released = []
         self.allocations = {}
+        self.capacity_updates = []
 
     def register_query(self, demand):
         self._events.append("coordinator_register")
@@ -88,6 +105,10 @@ class _FakeCoordinator:
         )
         self.allocations[demand.query_id] = allocation
         return allocation
+
+    def update_node_capacities(self, capacities):
+        self.capacity_updates.append(tuple(capacities))
+        return None
 
     def release_query(self, query_id, generation):
         self.released.append((query_id, generation))
@@ -164,12 +185,20 @@ def _runner(events, coordinator):
     runner._plan_query_ids = {}
     runner._leased_result_partition_refs = {}
     runner._result_partition_ref_counters = {}
-    runner._refresh_query_capacity = lambda: ResourceVector(
+    node_resources = ResourceVector(
         cpu=8,
         gpu=1,
         heap_bytes=16 * _GIB,
         object_store_bytes=4 * _GIB,
     )
+
+    def _read_node_capacities():
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            asyncio.get_running_loop()
+        events.append("capacity")
+        return (NodeCapacity("node-a", node_resources),)
+
+    runner._read_query_node_capacities = _read_node_capacities
     runner._ensure_duckdb_conn = lambda: runner._duckdb_conn
     runner._precreate_vllm_actors = lambda plan: events.append("vllm_ready") or []
     runner._get_plan_runner = lambda: SimpleNamespace(run_plan=lambda plan, conn: "stream")
@@ -216,6 +245,7 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
     assert events == [
         "physical_plan",
         "collect_graph",
+        "capacity",
         "coordinator_register",
         "actors_created",
         "vllm_ready",
@@ -225,6 +255,30 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
     manager = get_query_resource_manager(query_id)
     assert manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]["actor_ready"] is True
     assert runner.curr_streams[query_id] == "stream"
+
+
+def test_run_plan_does_not_read_physical_plan_id_after_registration():
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    runner._precreate_udf_actors = lambda *_args: []
+    runner._mark_query_actor_stages_ready = lambda _graph: None
+    query_id = "query-single-use-plan-id"
+    physical_plan = _RegistrationOnlyIdxPhysicalPlan(
+        query_id,
+        _metadata(query_id),
+        events,
+    )
+
+    asyncio.run(
+        runner_cls.run_plan(
+            runner,
+            _FakeLogicalPlan(physical_plan, events),
+        )
+    )
+
+    assert physical_plan.idx_calls == 2
+    assert runner._plan_query_ids[query_id] == query_id
 
 
 def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initialization_fails():
@@ -248,6 +302,320 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
     assert coordinator.released == [(query_id, 7)]
     assert query_id not in runner.curr_plans
     assert "plan_runner" not in events
+
+
+def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_is_delayed(
+    monkeypatch,
+):
+    from duckdb.runners.ray import driver as driver_module
+    from duckdb.runners.ray.query_resource_runtime import register_query_graph
+
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    runner._query_resource_lock = threading.Lock()
+    runner._read_query_node_capacities = lambda: runner_cls._read_query_node_capacities()
+    runner._precreate_udf_actors = lambda *_args: []
+    runner._precreate_vllm_actors = lambda *_args: []
+    runner._get_plan_runner = lambda: SimpleNamespace(
+        run_copy_plan=lambda _plan, _conn: {"rows_copied": 1},
+    )
+    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._build_local_progress_snapshot = lambda query_id, _started_at: {
+        "query_id": query_id,
+        "state": "FINISHED",
+    }
+    runner._teardown_plan_resources = lambda *_args, **_kwargs: None
+    runner._open_query_resource_admission = lambda _query_id: None
+
+    streaming_query_id = "query-streaming-admission"
+    streaming_stage = StageResourceSpec(
+        query_id=streaming_query_id,
+        stage_id=f"stage:{streaming_query_id}:udf",
+        physical_node_id="node:streaming:udf",
+        stage_kind="udf",
+        backend="ray_task",
+        input_stage_ids=(),
+        per_task=ResourceVector(cpu=1, heap_bytes=128),
+        target_output_block_bytes=64,
+        generator_buffer_blocks=1,
+        max_concurrency=None,
+    )
+    streaming_graph = QueryExecutionGraph(
+        query_id=streaming_query_id,
+        plan_digest="sha256:streaming-admission",
+        stages=(streaming_stage,),
+        terminal_stage_ids=(streaming_stage.stage_id,),
+    )
+    streaming_resources = ResourceVector(
+        cpu=2,
+        heap_bytes=4096,
+        object_store_bytes=4096,
+    )
+    streaming_allocation = QueryAllocation(
+        resources=streaming_resources,
+        node_allocations=(
+            NodeResourceAllocation(
+                node_id="node-a",
+                resources=streaming_resources,
+            ),
+        ),
+        actor_placements=(),
+        generation=1,
+    )
+    streaming_manager = register_query_graph(
+        streaming_graph,
+        streaming_allocation,
+    )
+    streaming_manager.update_stage_state(
+        streaming_stage.stage_id,
+        runnable=True,
+        actor_ready=True,
+    )
+    coordinator.allocations[streaming_query_id] = streaming_allocation
+    runner._query_graphs[streaming_query_id] = streaming_graph
+    runner._query_allocations[streaming_query_id] = streaming_allocation
+
+    nodes_started = threading.Event()
+    nodes_release = threading.Event()
+
+    def _delayed_nodes():
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            asyncio.get_running_loop()
+        assert runner._query_resource_lock.acquire(blocking=False)
+        runner._query_resource_lock.release()
+        nodes_started.set()
+        assert nodes_release.wait(timeout=2.0)
+        return [
+            {
+                "Alive": True,
+                "NodeID": "node-a",
+                "Resources": {
+                    "CPU": 32.0,
+                    "GPU": 4.0,
+                    "memory": 64 * _GIB,
+                    "object_store_memory": 32 * _GIB,
+                },
+            }
+        ]
+
+    monkeypatch.setattr(driver_module.ray, "nodes", _delayed_nodes)
+    copy_query_id = "query-copy-delayed-capacity"
+    copy_plan = _FakePhysicalPlan(
+        copy_query_id,
+        _metadata(copy_query_id),
+        events,
+    )
+    lease_request = {
+        "request_id": "request:streaming-during-copy",
+        "query_id": streaming_query_id,
+        "stage_id": streaming_stage.stage_id,
+        "task_id": "task:streaming-during-copy",
+        "attempt_id": "attempt:streaming-during-copy",
+        "node_id": None,
+        "retained_input_bytes": 0,
+        "resources": {
+            "cpu": 1.0,
+            "gpu": 0.0,
+            "heap_bytes": 128,
+            "object_store_bytes": 0,
+        },
+    }
+
+    async def _run_concurrently():
+        copy_task = asyncio.create_task(
+            runner_cls.run_copy_plan(
+                runner,
+                _FakeLogicalPlan(copy_plan, events),
+            )
+        )
+        try:
+            assert await asyncio.to_thread(nodes_started.wait, 1.0)
+            started_at = time.monotonic()
+            lease = await asyncio.wait_for(
+                runner_cls.acquire_query_task_lease(runner, lease_request),
+                timeout=0.25,
+            )
+            assert time.monotonic() - started_at < 0.25
+            assert lease["granted"] is True
+            assert copy_task.done() is False
+            released = await asyncio.wait_for(
+                runner_cls.release_query_task_lease(
+                    runner,
+                    lease_request["request_id"],
+                    lease["lease"]["lease_id"],
+                    lease["lease"]["attempt_id"],
+                ),
+                timeout=0.25,
+            )
+            assert released == {"released": True}
+            nodes_release.set()
+            return await asyncio.wait_for(copy_task, timeout=1.0)
+        finally:
+            nodes_release.set()
+
+    outcome = asyncio.run(_run_concurrently())
+
+    assert outcome.result == {"rows_copied": 1}
+    assert outcome.final_progress_snapshot == {
+        "query_id": copy_query_id,
+        "state": "FINISHED",
+    }
+
+
+def test_registration_does_not_overwrite_a_newer_capacity_snapshot():
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    older = NodeCapacity(
+        "node-old",
+        ResourceVector(
+            cpu=2,
+            heap_bytes=2 * _GIB,
+            object_store_bytes=1 * _GIB,
+        ),
+    )
+    newer = NodeCapacity(
+        "node-new",
+        ResourceVector(
+            cpu=8,
+            heap_bytes=8 * _GIB,
+            object_store_bytes=4 * _GIB,
+        ),
+    )
+    runner._query_node_capacities = (newer,)
+    runner._query_resource_last_capacity_refresh_at = 20.0
+
+    capacity = runner_cls._apply_query_capacity_snapshot(
+        runner,
+        (older,),
+        snapshot_started_at=10.0,
+    )
+
+    assert capacity == newer.resources
+    assert runner._query_node_capacities == (newer,)
+    assert runner._query_resource_last_capacity_refresh_at == 20.0
+    assert coordinator.capacity_updates == []
+
+
+def test_pending_allocation_teardown_fences_query_id_reuse_until_remote_drop_finishes():
+    from duckdb.runners.ray.driver import (
+        _DeferredQueryAllocationTeardown,
+        _PreparedQueryResourceRegistration,
+    )
+    from duckdb.runners.ray.query_graph_builder import build_query_execution_graph
+
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    runner._query_resource_lock = threading.Lock()
+    runner._open_query_resource_admission = lambda _query_id: None
+    query_id = "query-generation-fence"
+    graph = build_query_execution_graph(_metadata(query_id))
+    node = NodeCapacity(
+        "node-a",
+        ResourceVector(
+            cpu=8,
+            gpu=1,
+            heap_bytes=16 * _GIB,
+            object_store_bytes=4 * _GIB,
+        ),
+    )
+    teardown = _DeferredQueryAllocationTeardown(
+        query_id=query_id,
+        generation=3,
+        reason="old generation lost actor placement",
+    )
+    runner._query_allocation_teardowns_pending = {query_id: teardown}
+    runner._query_allocation_teardowns_claimed = set()
+    runner._query_allocation_teardown_futures = set()
+    runner._query_terminal_errors = {}
+    drop_started = threading.Event()
+    allow_drop = threading.Event()
+
+    def _drop_query_fragments(actual_query_id, *, release_resources):
+        assert actual_query_id == query_id
+        assert release_resources is False
+        drop_started.set()
+        assert allow_drop.wait(timeout=2.0)
+
+    runner._drop_query_fragments_after_admission_fence_sync = _drop_query_fragments
+    worker = threading.Thread(
+        target=runner_cls._run_query_allocation_teardowns,
+        args=(runner, (teardown,)),
+    )
+    worker.start()
+    assert drop_started.wait(timeout=1.0)
+
+    prepared = _PreparedQueryResourceRegistration(
+        graph=graph,
+        node_capacities=(node,),
+        capacity_snapshot_started_at=time.monotonic(),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="pending allocation-loss teardown"):
+            runner_cls._commit_query_resource_registration(
+                runner,
+                prepared,
+                deferred_teardowns=[],
+            )
+    finally:
+        allow_drop.set()
+        worker.join(timeout=1.0)
+    assert not worker.is_alive()
+    assert query_id not in runner._query_allocation_teardowns_pending
+
+    registered_graph, allocation = runner_cls._commit_query_resource_registration(
+        runner,
+        prepared,
+        deferred_teardowns=[],
+    )
+    assert registered_graph is graph
+    assert allocation.generation == 7
+
+
+def test_failed_allocation_teardown_remains_retryable():
+    from duckdb.runners.ray.driver import _DeferredQueryAllocationTeardown
+
+    events: list[str] = []
+    runner_cls, runner = _runner(events, _FakeCoordinator(events))
+    query_id = "query-teardown-retry"
+    teardown = _DeferredQueryAllocationTeardown(
+        query_id=query_id,
+        generation=4,
+        reason="old generation lost actor placement",
+    )
+    runner._query_allocation_teardowns_pending = {query_id: teardown}
+    runner._query_allocation_teardowns_claimed = set()
+    runner._query_allocation_teardown_futures = set()
+    runner._query_graphs = {query_id: object()}
+    runner._query_allocations = {
+        query_id: SimpleNamespace(generation=teardown.generation + 1),
+    }
+    runner._query_terminal_errors = {query_id: teardown.reason}
+    attempts = 0
+
+    def _drop_query_fragments(_query_id, *, release_resources):
+        nonlocal attempts
+        assert release_resources is False
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient remote teardown failure")
+
+    runner._drop_query_fragments_after_admission_fence_sync = _drop_query_fragments
+
+    runner_cls._run_query_allocation_teardowns(runner, (teardown,))
+    assert runner._query_allocation_teardowns_pending == {query_id: teardown}
+    assert "transient remote teardown failure" in runner._query_terminal_errors[query_id]
+
+    runner._query_graphs = {}
+    runner._query_allocations = {}
+    retry = runner_cls._synchronize_query_allocations(runner)
+    assert retry == (teardown,)
+    runner_cls._run_query_allocation_teardowns(runner, retry)
+
+    assert attempts == 2
+    assert runner._query_allocation_teardowns_pending == {}
 
 
 @pytest.mark.parametrize("entrypoint", ["run_plan", "run_copy_plan"])
@@ -427,12 +795,18 @@ def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
     runner._query_graphs = {query_id: graph}
     runner._query_allocations = {query_id: allocation}
     runner._query_terminal_errors = {}
-    runner._get_plan_runner = lambda: SimpleNamespace(
-        drop_query_fragments=lambda actual_query_id: dropped.append(actual_query_id)
-    )
+    runner._query_resource_lock = threading.Lock()
+
+    def _drop_query_fragments(actual_query_id):
+        assert runner._query_resource_lock.acquire(blocking=False)
+        runner._query_resource_lock.release()
+        dropped.append(actual_query_id)
+
+    runner._get_plan_runner = lambda: SimpleNamespace(drop_query_fragments=_drop_query_fragments)
 
     coordinator.update_node_capacities((NodeCapacity("node-b", node_resources),))
-    runner_cls._synchronize_query_allocations(runner)
+    teardowns = runner_cls._synchronize_query_allocations(runner)
+    runner_cls._run_query_allocation_teardowns(runner, teardowns)
 
     snapshot = manager.snapshot()
     assert snapshot["cancelled"] is True

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
@@ -279,6 +280,149 @@ def test_run_plan_does_not_read_physical_plan_id_after_registration():
 
     assert physical_plan.idx_calls == 2
     assert runner._plan_query_ids[query_id] == query_id
+
+
+def test_run_plan_cancellation_releases_registration_before_startup_worker_claim():
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    query_id = "query-cancelled-before-startup"
+    physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
+    blocker_started = threading.Event()
+    blocker_release = threading.Event()
+    startup_entered = threading.Event()
+    executor = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="vane-test-saturated",
+    )
+
+    runner._precreate_udf_actors = lambda *_args: startup_entered.set() or []
+    runner._mark_query_actor_stages_ready = lambda _graph: None
+
+    async def _exercise() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(executor)
+        registration_complete = asyncio.Event()
+        blocker_future = None
+        register_query_resources = runner_cls._register_query_resources
+
+        def _occupy_default_executor() -> None:
+            blocker_started.set()
+            assert blocker_release.wait(timeout=2.0)
+
+        async def _register_then_saturate(
+            plan,
+            *,
+            expected_plan_id=None,
+        ):
+            nonlocal blocker_future
+            registered = await register_query_resources(
+                runner,
+                plan,
+                expected_plan_id=expected_plan_id,
+            )
+            blocker_future = loop.run_in_executor(
+                None,
+                _occupy_default_executor,
+            )
+            while not blocker_started.is_set():
+                await asyncio.sleep(0)
+            registration_complete.set()
+            return registered
+
+        runner._register_query_resources = _register_then_saturate
+        run_plan = asyncio.create_task(
+            runner_cls.run_plan(
+                runner,
+                _FakeLogicalPlan(physical_plan, events),
+            )
+        )
+        try:
+            await asyncio.wait_for(
+                registration_complete.wait(),
+                timeout=1.0,
+            )
+            await asyncio.sleep(0)
+            assert startup_entered.is_set() is False
+            run_plan.cancel()
+            await asyncio.sleep(0)
+            blocker_release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(run_plan, timeout=1.0)
+            assert blocker_future is not None
+            await blocker_future
+        finally:
+            blocker_release.set()
+
+    try:
+        asyncio.run(_exercise())
+    finally:
+        blocker_release.set()
+        executor.shutdown(wait=True)
+
+    with pytest.raises(KeyError, match="query graph is not registered"):
+        get_query_resource_manager(query_id)
+    assert startup_entered.is_set() is False
+    assert coordinator.released == [(query_id, 7)]
+    assert query_id not in runner._query_graphs
+    assert query_id not in runner._query_allocations
+
+
+def test_run_plan_cancellation_after_startup_claim_tears_down_once():
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    query_id = "query-cancelled-after-startup-claim"
+    physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
+    startup_claimed = threading.Event()
+    startup_release = threading.Event()
+    fragment_drops: list[str] = []
+
+    def _precreate_udf_actors(*_args):
+        startup_claimed.set()
+        assert startup_release.wait(timeout=2.0)
+        return []
+
+    def _drop_query_fragments(actual_query_id: str) -> None:
+        fragment_drops.append(actual_query_id)
+        runner._release_query_resources(
+            actual_query_id,
+            reason="test_cancelled_during_startup",
+        )
+
+    runner._precreate_udf_actors = _precreate_udf_actors
+    runner._wait_for_udf_actors_ready = lambda _actors: None
+    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._drop_query_fragments_sync = _drop_query_fragments
+
+    async def _exercise() -> None:
+        run_plan = asyncio.create_task(
+            runner_cls.run_plan(
+                runner,
+                _FakeLogicalPlan(physical_plan, events),
+            )
+        )
+        try:
+            while not startup_claimed.is_set():
+                await asyncio.sleep(0)
+            run_plan.cancel()
+            startup_release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(run_plan, timeout=1.0)
+        finally:
+            startup_release.set()
+
+    asyncio.run(_exercise())
+
+    with pytest.raises(KeyError, match="query graph is not registered"):
+        get_query_resource_manager(query_id)
+    assert fragment_drops == [query_id]
+    assert coordinator.released == [(query_id, 7)]
+    assert query_id not in runner.curr_plans
+    assert query_id not in runner.curr_streams
+    assert query_id not in runner._plan_query_ids
+    assert query_id not in runner._query_graphs
+    assert query_id not in runner._query_allocations
 
 
 def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initialization_fails():

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -942,7 +942,7 @@ def test_query_teardown_cleans_local_state_when_coordinator_lease_expired():
         runner._query_resource_coordinator = coordinator
         runner._query_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
-        runner._synchronize_query_allocations = lambda: None
+        runner._synchronize_query_allocations = lambda: ()
 
         with pytest.raises(
             RuntimeError,
@@ -991,7 +991,7 @@ def test_fragment_drop_waits_for_fte_admission_pump_before_registry_drop(monkeyp
         runner._query_resource_coordinator = _CoordinatorStub()
         runner._query_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
-        runner._synchronize_query_allocations = lambda: None
+        runner._synchronize_query_allocations = lambda: ()
 
         drain_entered = threading.Event()
         release_drain = threading.Event()
@@ -1070,7 +1070,7 @@ def test_fragment_drop_keeps_query_resources_when_local_fte_registry_cannot_quie
         runner._query_resource_coordinator = coordinator
         runner._query_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
-        runner._synchronize_query_allocations = lambda: None
+        runner._synchronize_query_allocations = lambda: ()
         runner._get_plan_runner = lambda: SimpleNamespace(
             drop_query_fragments=lambda _query_id: None,
         )
@@ -1122,7 +1122,7 @@ def test_fragment_drop_retains_query_owner_while_remote_teardown_is_incomplete(m
         runner._query_resource_coordinator = coordinator
         runner._query_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
-        runner._synchronize_query_allocations = lambda: None
+        runner._synchronize_query_allocations = lambda: ()
         runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
 
         class _PlanRunner:
@@ -1268,6 +1268,9 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
     released: list[tuple[str, int]] = []
 
     class _Coordinator:
+        def update_node_capacities(self, _capacities):
+            return None
+
         def register_query(self, demand):
             assert demand == "demand"
             return allocation
@@ -1296,20 +1299,21 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
     runner._query_graphs = {}
     runner._query_allocations = {}
     runner._query_resource_coordinator = _Coordinator()
-    runner._refresh_query_capacity = lambda: ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
-    runner._synchronize_query_allocations = lambda: None
+    capacity = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
+    runner._read_query_node_capacities = lambda: (SimpleNamespace(resources=capacity),)
+    runner._synchronize_query_allocations = lambda: ()
 
-    def fail_open(_callback):
+    def fail_open(_query_id):
         raise RuntimeError("injected owner-loop open failure")
 
-    runner._run_on_query_resource_admission_loop_sync = fail_open
+    runner._open_query_resource_admission = fail_open
     plan = SimpleNamespace(
         collect_execution_stages=lambda conn: object(),
         idx=lambda: query_id,
     )
 
     with pytest.raises(RuntimeError, match="injected owner-loop open failure"):
-        runner_cls._register_query_resources(runner, plan)
+        asyncio.run(runner_cls._register_query_resources(runner, plan))
 
     with pytest.raises(KeyError):
         get_query_resource_manager(query_id)

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -156,6 +156,14 @@ def _make_local_query_driver_actor():
     return cls, runner
 
 
+def _query_registration_stub(query_id: str):
+    async def _register(_self, _plan, *, expected_plan_id=None):
+        del expected_plan_id
+        return SimpleNamespace(query_id=query_id, stages=()), object()
+
+    return _register
+
+
 def test_driver_env_override_applies_duckdb_execution_width(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     statements = []
@@ -281,7 +289,7 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (SimpleNamespace(query_id="copy-plan", stages=()), object()),
+        _query_registration_stub("copy-plan"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
@@ -324,10 +332,7 @@ def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monke
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(query_id="copy-query-terminal", stages=()),
-            object(),
-        ),
+        _query_registration_stub("copy-query-terminal"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
 
@@ -360,10 +365,7 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(query_id="copy-progress-contract-failure", stages=()),
-            object(),
-        ),
+        _query_registration_stub("copy-progress-contract-failure"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
     monkeypatch.setattr(
@@ -428,10 +430,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(query_id="copy-startup-order", stages=()),
-            object(),
-        ),
+        _query_registration_stub("copy-startup-order"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", mark_actor_stages)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
@@ -489,13 +488,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(
-                query_id="copy-plan-before-startup-barriers",
-                stages=(),
-            ),
-            object(),
-        ),
+        _query_registration_stub("copy-plan-before-startup-barriers"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", mark_actor_stages)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
@@ -545,10 +538,7 @@ def test_query_driver_copy_plan_failure_interrupts_startup_barriers(monkeypatch)
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(query_id="copy-plan-startup-failure", stages=()),
-            object(),
-        ),
+        _query_registration_stub("copy-plan-startup-failure"),
     )
     monkeypatch.setattr(
         cls,
@@ -612,13 +602,7 @@ def test_query_driver_copy_startup_barrier_failure_tears_down_plan(
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(
-                query_id=f"copy-{failing_barrier}-barrier-failure",
-                stages=(),
-            ),
-            object(),
-        ),
+        _query_registration_stub(f"copy-{failing_barrier}-barrier-failure"),
     )
     monkeypatch.setattr(
         cls,
@@ -808,7 +792,7 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (SimpleNamespace(query_id="stream-plan", stages=()), object()),
+        _query_registration_stub("stream-plan"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
@@ -850,10 +834,7 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        lambda _self, _plan: (
-            SimpleNamespace(query_id="failed-query", stages=()),
-            object(),
-        ),
+        _query_registration_stub("failed-query"),
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_udf_actors)


### PR DESCRIPTION
## Summary

- route normal plans and COPY through one async query-resource registration path
- prepare execution graphs and Ray/GCS capacity snapshots on worker threads, then atomically commit local resource state on the admission owner loop
- keep resource locks out of remote fragment teardown, with retryable generation fencing and stale-capacity protection
- cover delayed `ray.nodes()` alongside an active streaming UDF admission RPC and assert bounded driver latency

## Testing

- `python -m pytest tests/fast/test_driver_query_graph_registration.py tests/fast/test_driver_query_leases.py tests/fast/test_ray_result_contract.py tests/fast/test_driver_udf_precreate.py -q` (`157 passed`)
- `scripts/run_release_tests.sh` (`307 passed, 1 skipped`; Ray shard `7 passed`)
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/run_fast_tests.sh` was attempted in the shared local virtualenv; unrelated catalog and distributed-result failures reproduce on a clean `upstream/main` worktree with the same stale native `_duckdb` artifact

Closes #84