### PR TITLE
[feat](ai) Support image inputs in ai_prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 
 - Public governance, contribution, security, release, provenance, and third-party documentation.
 - Release artifact validation and a reproducible native dependency license bundle.
+- Added three-argument SQL `ai_prompt` overloads for per-row `BLOB` and
+  `BLOB[]` image inputs. NULL and empty image inputs fall back to text-only
+  prompting, while the existing text-only signatures remain unchanged.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 - Public governance, contribution, security, release, provenance, and third-party documentation.
 - Release artifact validation and a reproducible native dependency license bundle.
 - Added three-argument SQL `ai_prompt` overloads for per-row `BLOB` and
-  `BLOB[]` image inputs. NULL and empty image inputs fall back to text-only
-  prompting, while the existing text-only signatures remain unchanged.
+  `BLOB[]` image inputs. NULL, zero-length BLOB, and empty BLOB[] inputs fall
+  back to text-only prompting, while the existing text-only signatures remain
+  unchanged.
 
 ### Changed
 

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/function/scalar/udf_functions.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb_python/pybind11/gil_wrapper.hpp"
 #include "duckdb_python/python_objects.hpp"
@@ -127,11 +128,13 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
                                           vector<unique_ptr<Expression>> &arguments, AISQLKind kind) {
 	auto options_index = OptionsArgumentIndex(kind, arguments.size());
 	auto image_input = kind == AISQLKind::PROMPT && arguments.size() == 3;
-	if (arguments[0]->return_type.id() != LogicalTypeId::VARCHAR) {
+	auto input_type_id = arguments[0]->return_type.id();
+	if (input_type_id != LogicalTypeId::VARCHAR && !(image_input && input_type_id == LogicalTypeId::SQLNULL)) {
 		throw BinderException("ai SQL input argument must be VARCHAR");
 	}
 	if (image_input && arguments[1]->return_type != LogicalType::BLOB &&
-	    arguments[1]->return_type != LogicalType::LIST(LogicalType::BLOB)) {
+	    arguments[1]->return_type != LogicalType::LIST(LogicalType::BLOB) &&
+	    arguments[1]->return_type.id() != LogicalTypeId::SQLNULL) {
 		throw BinderException("ai_prompt image argument must be BLOB or BLOB[]");
 	}
 
@@ -165,17 +168,29 @@ static void AISQLExecute(DataChunk &, ExpressionState &, Vector &) {
 	    "ai SQL functions can only be used in a projection and must be planned as UDF operators");
 }
 
+static unique_ptr<Expression> LowerAISQLImageExpressionUDF(FunctionBindExpressionInput &input) {
+	if (!input.children.empty() && input.children[0]->IsFoldable()) {
+		Value prompt;
+		if (ExpressionExecutor::TryEvaluateScalar(input.context, *input.children[0], prompt) && prompt.IsNull()) {
+			if (!input.bind_data) {
+				throw BinderException("registered expression UDF is missing bind payload");
+			}
+			auto &registered_data = input.bind_data->Cast<UDFFunctionData>();
+			return make_uniq<BoundConstantExpression>(Value(registered_data.return_type));
+		}
+	}
+	return LowerRegisteredExpressionUDFPreservingFoldableNulls(input);
+}
+
 static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bind, bool include_image_inputs) {
 	auto base = ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
 	                           LogicalType::INVALID, FunctionStability::VOLATILE);
-	base.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	base.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
+	base.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
 	set.AddFunction(std::move(base));
 
 	auto with_options = ScalarFunction({LogicalType::VARCHAR, LogicalType::ANY}, LogicalType::ANY, AISQLExecute, bind,
 	                                   nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
-	with_options.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	with_options.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
+	with_options.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
 	set.AddFunction(std::move(with_options));
 
 	if (!include_image_inputs) {
@@ -185,14 +200,14 @@ static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bin
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::BLOB, LogicalType::ANY}, LogicalType::ANY, AISQLExecute,
 	                   bind, nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
 	with_image.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	with_image.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
+	with_image.SetBindExpressionCallback(LowerAISQLImageExpressionUDF);
 	set.AddFunction(std::move(with_image));
 
 	auto with_images = ScalarFunction({LogicalType::VARCHAR, LogicalType::LIST(LogicalType::BLOB), LogicalType::ANY},
 	                                  LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
 	                                  LogicalType::INVALID, FunctionStability::VOLATILE);
 	with_images.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-	with_images.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
+	with_images.SetBindExpressionCallback(LowerAISQLImageExpressionUDF);
 	set.AddFunction(std::move(with_images));
 }
 

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -168,12 +168,14 @@ static void AISQLExecute(DataChunk &, ExpressionState &, Vector &) {
 static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bind, bool include_image_inputs) {
 	auto base = ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
 	                           LogicalType::INVALID, FunctionStability::VOLATILE);
-	base.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	base.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	base.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
 	set.AddFunction(std::move(base));
 
 	auto with_options = ScalarFunction({LogicalType::VARCHAR, LogicalType::ANY}, LogicalType::ANY, AISQLExecute, bind,
 	                                   nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
-	with_options.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	with_options.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	with_options.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
 	set.AddFunction(std::move(with_options));
 
 	if (!include_image_inputs) {
@@ -182,13 +184,15 @@ static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bin
 	auto with_image =
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::BLOB, LogicalType::ANY}, LogicalType::ANY, AISQLExecute,
 	                   bind, nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
-	with_image.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	with_image.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	with_image.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
 	set.AddFunction(std::move(with_image));
 
 	auto with_images = ScalarFunction({LogicalType::VARCHAR, LogicalType::LIST(LogicalType::BLOB), LogicalType::ANY},
 	                                  LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
 	                                  LogicalType::INVALID, FunctionStability::VOLATILE);
-	with_images.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	with_images.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	with_images.SetBindExpressionCallback(LowerRegisteredExpressionUDFPreservingFoldableNulls);
 	set.AddFunction(std::move(with_images));
 }
 

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -60,14 +60,34 @@ static py::object DictGetOrNone(const py::dict &dict, const char *key) {
 	return py::reinterpret_borrow<py::object>(dict[py_key]);
 }
 
-static py::object OptionsToPython(ClientContext &context, vector<unique_ptr<Expression>> &arguments) {
-	if (arguments.size() == 1) {
+static idx_t OptionsArgumentIndex(AISQLKind kind, idx_t argument_count) {
+	if (kind == AISQLKind::EMBED) {
+		if (argument_count == 1) {
+			return argument_count;
+		}
+		if (argument_count == 2) {
+			return 1;
+		}
+		throw BinderException("ai_embed requires one or two arguments");
+	}
+	if (argument_count == 1) {
+		return argument_count;
+	}
+	if (argument_count == 2) {
+		return 1;
+	}
+	if (argument_count == 3) {
+		return 2;
+	}
+	throw BinderException("ai_prompt requires one, two, or three arguments");
+}
+
+static py::object OptionsToPython(ClientContext &context, vector<unique_ptr<Expression>> &arguments,
+                                  idx_t options_index) {
+	if (options_index >= arguments.size()) {
 		return py::none();
 	}
-	if (arguments.size() != 2) {
-		throw BinderException("ai SQL functions require one or two arguments");
-	}
-	auto &options_arg = *arguments[1];
+	auto &options_arg = *arguments[options_index];
 	ThrowIfNotConstant(options_arg, "options");
 	auto options = EvaluateConstant(context, options_arg);
 	if (options.IsNull()) {
@@ -76,14 +96,14 @@ static py::object OptionsToPython(ClientContext &context, vector<unique_ptr<Expr
 	return PythonObject::FromValue(options, options.type(), context.GetClientProperties());
 }
 
-static Value BuildAISQLPayload(ClientContext &context, AISQLKind kind, const py::object &py_options) {
+static Value BuildAISQLPayload(ClientContext &context, AISQLKind kind, const py::object &py_options, bool image_input) {
 	auto sql_module = py::module_::import("vane.ai._sql");
 	auto expression_helpers = py::module_::import("vane._expression_udf");
 	auto normalize_schema = expression_helpers.attr("_normalize_schema");
 
 	auto builder = kind == AISQLKind::PROMPT ? sql_module.attr("build_ai_prompt_sql_spec")
 	                                         : sql_module.attr("build_ai_embed_sql_spec");
-	auto spec = py::cast<py::dict>(builder(py_options));
+	auto spec = py::cast<py::dict>(kind == AISQLKind::PROMPT ? builder(py_options, image_input) : builder(py_options));
 	auto name = py::cast<string>(spec[py::str("name")]);
 	auto udf = py::cast<py::function>(spec[py::str("function")]);
 	auto input_names = ParseInputNames(py::reinterpret_borrow<py::object>(spec[py::str("input_names")]));
@@ -105,23 +125,26 @@ static Value BuildAISQLPayload(ClientContext &context, AISQLKind kind, const py:
 
 static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction &bound_function,
                                           vector<unique_ptr<Expression>> &arguments, AISQLKind kind) {
-	if (arguments.empty() || arguments.size() > 2) {
-		throw BinderException("ai SQL functions require one or two arguments");
-	}
+	auto options_index = OptionsArgumentIndex(kind, arguments.size());
+	auto image_input = kind == AISQLKind::PROMPT && arguments.size() == 3;
 	if (arguments[0]->return_type.id() != LogicalTypeId::VARCHAR) {
 		throw BinderException("ai SQL input argument must be VARCHAR");
+	}
+	if (image_input && arguments[1]->return_type != LogicalType::BLOB &&
+	    arguments[1]->return_type != LogicalType::LIST(LogicalType::BLOB)) {
+		throw BinderException("ai_prompt image argument must be BLOB or BLOB[]");
 	}
 
 	Value payload;
 	{
 		PythonGILWrapper acquire;
-		auto py_options = OptionsToPython(context, arguments);
-		payload = BuildAISQLPayload(context, kind, py_options);
+		auto py_options = OptionsToPython(context, arguments, options_index);
+		payload = BuildAISQLPayload(context, kind, py_options, image_input);
 	}
 	auto return_type = udf_helpers::ResolvePayloadReturnType(payload);
 	bound_function.SetReturnType(return_type);
-	if (arguments.size() == 2) {
-		Function::EraseArgument(bound_function, arguments, 1);
+	if (options_index < arguments.size()) {
+		Function::EraseArgument(bound_function, arguments, options_index);
 	}
 	bound_function.SetExtraFunctionInfo(make_shared_ptr<RegisteredUDFFunctionInfo>(payload));
 	return make_uniq<UDFFunctionData>(std::move(payload), std::move(return_type));
@@ -142,29 +165,44 @@ static void AISQLExecute(DataChunk &, ExpressionState &, Vector &) {
 	    "ai SQL functions can only be used in a projection and must be planned as UDF operators");
 }
 
-static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bind) {
+static void AddAISQLFunctions(ScalarFunctionSet &set, bind_scalar_function_t bind, bool include_image_inputs) {
 	auto base = ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
 	                           LogicalType::INVALID, FunctionStability::VOLATILE);
 	base.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
 	set.AddFunction(std::move(base));
 
 	auto with_options = ScalarFunction({LogicalType::VARCHAR, LogicalType::ANY}, LogicalType::ANY, AISQLExecute, bind,
-	                                   nullptr, nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+	                                   nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
 	with_options.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
 	set.AddFunction(std::move(with_options));
+
+	if (!include_image_inputs) {
+		return;
+	}
+	auto with_image =
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::BLOB, LogicalType::ANY}, LogicalType::ANY, AISQLExecute,
+	                   bind, nullptr, nullptr, nullptr, LogicalType::INVALID, FunctionStability::VOLATILE);
+	with_image.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	set.AddFunction(std::move(with_image));
+
+	auto with_images = ScalarFunction({LogicalType::VARCHAR, LogicalType::LIST(LogicalType::BLOB), LogicalType::ANY},
+	                                  LogicalType::ANY, AISQLExecute, bind, nullptr, nullptr, nullptr,
+	                                  LogicalType::INVALID, FunctionStability::VOLATILE);
+	with_images.SetBindExpressionCallback(LowerRegisteredExpressionUDF);
+	set.AddFunction(std::move(with_images));
 }
 
 } // namespace
 
 ScalarFunctionSet AISQLFunction::GetPromptFunctions() {
 	ScalarFunctionSet set("ai_prompt");
-	AddAISQLFunctions(set, AISQLPromptBind);
+	AddAISQLFunctions(set, AISQLPromptBind, true);
 	return set;
 }
 
 ScalarFunctionSet AISQLFunction::GetEmbedFunctions() {
 	ScalarFunctionSet set("ai_embed");
-	AddAISQLFunctions(set, AISQLEmbedBind);
+	AddAISQLFunctions(set, AISQLEmbedBind, false);
 	return set;
 }
 

--- a/src/duckdb_py/ai_sql_functions.cpp
+++ b/src/duckdb_py/ai_sql_functions.cpp
@@ -34,6 +34,11 @@ static Value EvaluateConstant(ClientContext &context, Expression &arg) {
 	return ExpressionExecutor::EvaluateScalar(context, arg);
 }
 
+static bool IsFoldableNull(ClientContext &context, const Expression &arg) {
+	Value value;
+	return arg.IsFoldable() && ExpressionExecutor::TryEvaluateScalar(context, arg, value) && value.IsNull();
+}
+
 static vector<string> ParseInputNames(const py::object &input_names) {
 	if (!py::isinstance<py::list>(input_names) && !py::isinstance<py::tuple>(input_names)) {
 		throw BinderException("ai SQL helper returned invalid input_names");
@@ -137,6 +142,12 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 	    arguments[1]->return_type.id() != LogicalTypeId::SQLNULL) {
 		throw BinderException("ai_prompt image argument must be BLOB or BLOB[]");
 	}
+	if (image_input && IsFoldableNull(context, *arguments[0])) {
+		auto return_type = LogicalType::VARCHAR;
+		bound_function.SetReturnType(return_type);
+		// A NULL payload is a local bind-state marker consumed by the image lowerer.
+		return make_uniq<UDFFunctionData>(Value(LogicalType::SQLNULL), std::move(return_type));
+	}
 
 	Value payload;
 	{
@@ -169,15 +180,12 @@ static void AISQLExecute(DataChunk &, ExpressionState &, Vector &) {
 }
 
 static unique_ptr<Expression> LowerAISQLImageExpressionUDF(FunctionBindExpressionInput &input) {
-	if (!input.children.empty() && input.children[0]->IsFoldable()) {
-		Value prompt;
-		if (ExpressionExecutor::TryEvaluateScalar(input.context, *input.children[0], prompt) && prompt.IsNull()) {
-			if (!input.bind_data) {
-				throw BinderException("registered expression UDF is missing bind payload");
-			}
-			auto &registered_data = input.bind_data->Cast<UDFFunctionData>();
-			return make_uniq<BoundConstantExpression>(Value(registered_data.return_type));
-		}
+	if (!input.bind_data) {
+		throw BinderException("registered expression UDF is missing bind payload");
+	}
+	auto &registered_data = input.bind_data->Cast<UDFFunctionData>();
+	if (registered_data.payload.IsNull()) {
+		return make_uniq<BoundConstantExpression>(Value(registered_data.return_type));
 	}
 	return LowerRegisteredExpressionUDFPreservingFoldableNulls(input);
 }

--- a/src/duckdb_py/include/duckdb_python/python_udf_utils.hpp
+++ b/src/duckdb_py/include/duckdb_python/python_udf_utils.hpp
@@ -19,6 +19,7 @@
 namespace duckdb {
 
 unique_ptr<Expression> LowerRegisteredExpressionUDF(FunctionBindExpressionInput &input);
+unique_ptr<Expression> LowerRegisteredExpressionUDFPreservingFoldableNulls(FunctionBindExpressionInput &input);
 
 Value BuildPythonUDFPayload(
     const string &name, const py::function &udf, const py::object &schema, const shared_ptr<DuckDBPyType> &return_type,

--- a/src/duckdb_py/python_udf_utils.cpp
+++ b/src/duckdb_py/python_udf_utils.cpp
@@ -279,7 +279,8 @@ static Value PayloadWithAddedOrUpdatedFields(const Value &payload, child_list_t<
 }
 } // namespace
 
-unique_ptr<Expression> LowerRegisteredExpressionUDF(FunctionBindExpressionInput &input) {
+static unique_ptr<Expression> LowerRegisteredExpressionUDFInternal(FunctionBindExpressionInput &input,
+                                                                   bool preserve_foldable_nulls) {
 	if (!input.bind_data) {
 		throw BinderException("registered expression UDF is missing bind payload");
 	}
@@ -296,12 +297,31 @@ unique_ptr<Expression> LowerRegisteredExpressionUDF(FunctionBindExpressionInput 
 	children.push_back(make_uniq<BoundConstantExpression>(registered_data.payload));
 
 	FunctionBinder binder(input.context);
+	if (preserve_foldable_nulls) {
+		// The catalog-based binder replaces a function call with a NULL constant
+		// before invoking UDFBind when any foldable argument is NULL. AI image
+		// arguments use NULL to mean "no image", so bind the sole internal udf
+		// overload directly and let the UDF operator receive that row value.
+		auto functions = UDFFunction::GetFunctions();
+		auto function = functions.GetFunctionByOffset(0);
+		function.name = UDFFunction::Name;
+		return binder.BindScalarFunction(std::move(function), std::move(children));
+	}
+
 	ErrorData error;
 	auto lowered = binder.BindScalarFunction(DEFAULT_SCHEMA, UDFFunction::Name, std::move(children), error);
 	if (!lowered) {
 		error.Throw();
 	}
 	return lowered;
+}
+
+unique_ptr<Expression> LowerRegisteredExpressionUDF(FunctionBindExpressionInput &input) {
+	return LowerRegisteredExpressionUDFInternal(input, false);
+}
+
+unique_ptr<Expression> LowerRegisteredExpressionUDFPreservingFoldableNulls(FunctionBindExpressionInput &input) {
+	return LowerRegisteredExpressionUDFInternal(input, true);
 }
 
 Value BuildPythonUDFPayload(

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2603,6 +2603,110 @@ class TestMultimodalPromptBatch:
             "response:gamma",
         ]
 
+    def test_prompt_batch_propagates_null_prompts_when_requested(self):
+        """NULL prompts stay local while other rows retain their execution path."""
+        from vane.ai.functions import _PromptBatch
+
+        captured_messages = []
+        captured_batches = []
+
+        class DualPathPrompter:
+            def prompt_batch(self, texts):
+                captured_batches.append(texts)
+                return [f"batch:{text}" for text in texts]
+
+            async def prompt(self, msgs):
+                captured_messages.append(msgs)
+                return f"multimodal:{msgs[0]}"
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.instantiate.return_value = DualPathPrompter()
+
+        batch = _PromptBatch(
+            mock_descriptor,
+            "text",
+            "response",
+            image_columns=["image"],
+            propagate_null_prompts=True,
+        )
+        table = pa.table(
+            {
+                "text": pa.array([None, "Text only", "With image"], type=pa.string()),
+                "image": pa.array([b"ignored", None, b"\x89PNG"], type=pa.binary()),
+            }
+        )
+        result = batch(table)
+
+        assert captured_batches == [["Text only"]]
+        assert captured_messages == [("With image", b"\x89PNG")]
+        assert result.column("response").to_pylist() == [
+            None,
+            "batch:Text only",
+            "multimodal:With image",
+        ]
+
+    def test_prompt_batch_does_not_instantiate_for_only_null_prompts(self):
+        """An all-NULL propagated batch does not initialize a provider."""
+        from vane.ai.functions import _PromptBatch
+
+        mock_descriptor = MagicMock()
+        batch = _PromptBatch(
+            mock_descriptor,
+            "text",
+            "response",
+            image_columns=["image"],
+            propagate_null_prompts=True,
+        )
+        table = pa.table(
+            {
+                "text": pa.array([None], type=pa.string()),
+                "image": pa.array([b"\x89PNG"], type=pa.binary()),
+            }
+        )
+
+        result = batch(table)
+
+        mock_descriptor.instantiate.assert_not_called()
+        assert result.column("response").to_pylist() == [None]
+
+    def test_prompt_batch_treats_zero_length_bytes_as_empty_images(self):
+        """Zero-length BLOBs and BLOB[] elements remain safely batchable."""
+        from vane.ai.functions import _PromptBatch
+
+        captured_batches = []
+
+        class VLLMLikePrompter:
+            def prompt_batch(self, texts):
+                captured_batches.append(texts)
+                return [f"response:{text}" for text in texts]
+
+            async def prompt(self, _msgs):
+                raise AssertionError("empty image values must not use the multimodal path")
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.instantiate.return_value = VLLMLikePrompter()
+
+        batch = _PromptBatch(
+            mock_descriptor,
+            "text",
+            "response",
+            image_columns=["image", "images"],
+        )
+        table = pa.table(
+            {
+                "text": ["empty blob", "empty list item"],
+                "image": pa.array([b"", None], type=pa.binary()),
+                "images": pa.array([None, [b"", None]], type=pa.list_(pa.binary())),
+            }
+        )
+        result = batch(table)
+
+        assert captured_batches == [["empty blob", "empty list item"]]
+        assert result.column("response").to_pylist() == [
+            "response:empty blob",
+            "response:empty list item",
+        ]
+
     def test_prompt_batch_no_image_columns_text_only(self):
         """Without image_columns, behavior is identical to original."""
         from vane.ai.functions import _PromptBatch

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -367,6 +367,17 @@ class TestVLLMProvider:
         mock_prompter.prompt_batch.assert_called_once_with(["hi", "hey"])
         assert result.column("response").to_pylist() == ["Hello!", "World!"]
 
+    def test_prompter_rejects_multimodal_parts(self):
+        """The native vLLM adapter must not silently discard image parts."""
+        import asyncio
+
+        from vane.ai.providers.vllm import VLLMPrompter
+
+        prompter = VLLMPrompter(model="test")
+
+        with pytest.raises(ValueError, match="multimodal prompt parts are not supported"):
+            asyncio.run(prompter.prompt(("Describe this", b"\x89PNG\r\n\x1a\n")))
+
     def test_system_message_formatting(self):
         """VLLMPrompter prepends system message to prompts."""
         from vane.ai.providers.vllm import VLLMPrompter
@@ -2496,6 +2507,49 @@ class TestMultimodalPromptBatch:
         batch(table)
 
         assert len(captured_messages[0]) == 3  # text + 2 images
+
+    def test_prompt_batch_expands_image_lists_without_using_text_batch_api(self):
+        """BLOB[] values become ordered image parts and skip NULL elements."""
+        from vane.ai.functions import _PromptBatch
+
+        captured_messages = []
+
+        class DualPathPrompter:
+            def prompt_batch(self, texts):
+                raise AssertionError("text-only batch API must not receive image inputs")
+
+            async def prompt(self, msgs):
+                captured_messages.append(msgs)
+                return "ok"
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.instantiate.return_value = DualPathPrompter()
+
+        batch = _PromptBatch(
+            mock_descriptor,
+            "text",
+            "response",
+            image_columns=["images"],
+        )
+        table = pa.table(
+            {
+                "text": ["Compare these", "No images"],
+                "images": pa.array(
+                    [
+                        [b"\x89PNG\r\n\x1a\n", None, b"\xff\xd8\xff"],
+                        None,
+                    ],
+                    type=pa.list_(pa.binary()),
+                ),
+            }
+        )
+        result = batch(table)
+
+        assert captured_messages == [
+            ("Compare these", b"\x89PNG\r\n\x1a\n", b"\xff\xd8\xff"),
+            ("No images",),
+        ]
+        assert result.column("response").to_pylist() == ["ok", "ok"]
 
     def test_prompt_batch_no_image_columns_text_only(self):
         """Without image_columns, behavior is identical to original."""

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2508,19 +2508,21 @@ class TestMultimodalPromptBatch:
 
         assert len(captured_messages[0]) == 3  # text + 2 images
 
-    def test_prompt_batch_expands_image_lists_without_using_text_batch_api(self):
-        """BLOB[] values become ordered image parts and skip NULL elements."""
+    def test_prompt_batch_partitions_image_lists_and_preserves_row_order(self):
+        """Only rows with actual images use the multimodal prompt path."""
         from vane.ai.functions import _PromptBatch
 
         captured_messages = []
+        captured_batches = []
 
         class DualPathPrompter:
             def prompt_batch(self, texts):
-                raise AssertionError("text-only batch API must not receive image inputs")
+                captured_batches.append(texts)
+                return [f"batch:{text}" for text in texts]
 
             async def prompt(self, msgs):
                 captured_messages.append(msgs)
-                return "ok"
+                return f"multimodal:{msgs[0]}"
 
         mock_descriptor = MagicMock()
         mock_descriptor.instantiate.return_value = DualPathPrompter()
@@ -2533,11 +2535,12 @@ class TestMultimodalPromptBatch:
         )
         table = pa.table(
             {
-                "text": ["Compare these", "No images"],
+                "text": ["Compare these", "No images", "Empty images"],
                 "images": pa.array(
                     [
                         [b"\x89PNG\r\n\x1a\n", None, b"\xff\xd8\xff"],
                         None,
+                        [],
                     ],
                     type=pa.list_(pa.binary()),
                 ),
@@ -2547,9 +2550,58 @@ class TestMultimodalPromptBatch:
 
         assert captured_messages == [
             ("Compare these", b"\x89PNG\r\n\x1a\n", b"\xff\xd8\xff"),
-            ("No images",),
         ]
-        assert result.column("response").to_pylist() == ["ok", "ok"]
+        assert captured_batches == [["No images", "Empty images"]]
+        assert result.column("response").to_pylist() == [
+            "multimodal:Compare these",
+            "batch:No images",
+            "batch:Empty images",
+        ]
+
+    def test_prompt_batch_uses_text_batch_api_when_all_image_parts_are_empty(self):
+        """NULL, empty lists, and NULL list elements remain safely batchable."""
+        from vane.ai.functions import _PromptBatch
+
+        captured_batches = []
+
+        class VLLMLikePrompter:
+            def prompt_batch(self, texts):
+                captured_batches.append(texts)
+                return [f"response:{text}" for text in texts]
+
+            async def prompt(self, _msgs):
+                raise AssertionError("text-only rows must not use the shared single-row executor")
+
+        mock_descriptor = MagicMock()
+        mock_descriptor.instantiate.return_value = VLLMLikePrompter()
+
+        batch = _PromptBatch(
+            mock_descriptor,
+            "text",
+            "response",
+            image_columns=["images"],
+        )
+        table = pa.table(
+            {
+                "text": ["alpha", "beta", "gamma"],
+                "images": pa.array(
+                    [
+                        None,
+                        [],
+                        [None],
+                    ],
+                    type=pa.list_(pa.binary()),
+                ),
+            }
+        )
+        result = batch(table)
+
+        assert captured_batches == [["alpha", "beta", "gamma"]]
+        assert result.column("response").to_pylist() == [
+            "response:alpha",
+            "response:beta",
+            "response:gamma",
+        ]
 
     def test_prompt_batch_no_image_columns_text_only(self):
         """Without image_columns, behavior is identical to original."""

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -62,6 +62,12 @@ class MockPrompter:
     def prompt_batch(self, text: list[str]) -> list[str]:
         return [f"{self._prefix}:{item}" for item in text]
 
+    async def prompt(self, messages: tuple[object, ...]) -> str:
+        text = str(messages[0]) if messages else ""
+        images = [part.hex() for part in messages[1:] if isinstance(part, bytes)]
+        image_suffix = f":images={','.join(images)}" if images else ""
+        return f"{self._prefix}:{text}{image_suffix}"
+
 
 @dataclass
 class MockPrompterDescriptor(PrompterDescriptor):
@@ -247,6 +253,32 @@ def test_ai_prompt_options_survive_logical_plan_pickle_to_fresh_connection():
     assert udf_node["payload"]["ai_dimensions"] is None
     assert udf_node["payload"]["function_pickle_size_bytes"] > 0
     assert 0 < len(serialized) < 1_000_000
+
+
+def test_ai_prompt_image_input_survives_plan_round_trip_as_row_data():
+    image_hex = "89504e470d0a1a0a49535355453138524f5744415441"
+    image_bytes = bytes.fromhex(image_hex)
+    source = vane.connect()
+    relation = source.sql(f"""
+        SELECT ai_prompt(
+            prompt,
+            image,
+            struct_pack(provider := 'mock_ai_sql', model := 'round-trip-vision', concurrency := 1)
+        ) AS response
+        FROM (
+            VALUES ('describe', from_hex('{image_hex}'))
+        ) AS t(prompt, image)
+    """)
+
+    _, target, physical, _ = _round_trip_ai_plan(relation)
+    udf_node = physical.collect_udf_nodes()[0]
+    table = _execute_ai_physical_plan(target, physical)
+    payload = udf_node["payload"]
+
+    assert table.column(0).to_pylist() == [f"round-trip-vision:describe:images={image_hex}"]
+    assert payload["input_names"] == ["messages", "images"]
+    assert payload["scalar_arg_count"] == 2
+    assert image_bytes not in payload["function_pickle"]
 
 
 def test_ai_embed_fixed_dimensions_survive_round_trip():
@@ -448,6 +480,58 @@ def test_ai_prompt_sql_with_mock_provider():
     assert rows == [("topic:alpha",), ("topic:beta",)]
 
 
+def test_ai_prompt_sql_with_single_image_blob_and_null_image():
+    conn = vane.connect()
+
+    rows = conn.sql("""
+        SELECT id, ai_prompt(
+            prompt,
+            image,
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+        FROM (
+            VALUES
+                (1, 'alpha', from_hex('89504e470d0a1a0a')),
+                (2, 'beta', NULL::BLOB)
+        ) AS t(id, prompt, image)
+        ORDER BY id
+    """).fetchall()
+
+    assert rows == [
+        (1, "vision-model:alpha:images=89504e470d0a1a0a"),
+        (2, "vision-model:beta"),
+    ]
+
+
+def test_ai_prompt_sql_with_image_blob_list():
+    conn = vane.connect()
+
+    rows = conn.sql("""
+        SELECT id, ai_prompt(
+            prompt,
+            images,
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+        FROM (
+            VALUES
+                (
+                    1,
+                    'compare',
+                    [from_hex('89504e47'), NULL, from_hex('ffd8ff')]::BLOB[]
+                ),
+                (2, 'empty', []::BLOB[]),
+                (3, 'null', NULL::BLOB[])
+        ) AS t(id, prompt, images)
+        ORDER BY id
+    """).fetchall()
+
+    assert rows == [
+        (1, "vision-model:compare:images=89504e47,ffd8ff"),
+        (2, "vision-model:empty"),
+        (3, "vision-model:null"),
+    ]
+
+
 def test_ai_embed_sql_with_mock_provider_and_dimensions():
     conn = vane.connect()
 
@@ -527,6 +611,21 @@ def test_ai_sql_helper_builds_prompt_spec_without_execution():
 
     assert spec["name"] == "ai_prompt"
     assert spec["input_names"] == ["messages"]
+    assert spec["schema"] == {"response": "VARCHAR"}
+    assert spec["actor_number"] == 1
+    assert spec["gpus"] == 0
+
+
+def test_ai_sql_helper_builds_multimodal_prompt_spec_without_execution():
+    from vane.ai._sql import build_ai_prompt_sql_spec
+
+    spec = build_ai_prompt_sql_spec(
+        {"provider": "mock_ai_sql", "concurrency": 1},
+        image_input=True,
+    )
+
+    assert spec["name"] == "ai_prompt"
+    assert spec["input_names"] == ["messages", "images"]
     assert spec["schema"] == {"response": "VARCHAR"}
     assert spec["actor_number"] == 1
     assert spec["gpus"] == 0

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -480,6 +480,55 @@ def test_ai_prompt_sql_with_mock_provider():
     assert rows == [("topic:alpha",), ("topic:beta",)]
 
 
+@pytest.mark.parametrize("null_image", ["NULL::BLOB", "NULL::BLOB[]"])
+def test_ai_prompt_sql_with_literal_null_image(null_image):
+    conn = vane.connect()
+
+    relation = conn.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            {null_image},
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+    """)
+
+    assert [str(dtype) for dtype in relation.types] == ["VARCHAR"]
+    assert relation.fetchall() == [("vision-model:describe",)]
+
+    _, target, physical, _ = _round_trip_ai_plan(relation)
+    table = _execute_ai_physical_plan(target, physical)
+    assert table.column(0).to_pylist() == ["vision-model:describe"]
+
+
+def test_ai_prompt_sql_with_null_options_uses_default_provider(monkeypatch):
+    monkeypatch.setitem(provider_registry.PROVIDERS, "openai", lambda name=None, **options: MockProvider())
+    conn = vane.connect()
+
+    relation = conn.sql("""
+        SELECT ai_prompt(
+            'describe',
+            from_hex('89504e47'),
+            NULL
+        ) AS response
+    """)
+
+    assert [str(dtype) for dtype in relation.types] == ["VARCHAR"]
+    assert relation.fetchall() == [("topic:describe:images=89504e47",)]
+
+
+def test_ai_prompt_literal_null_image_still_validates_provider():
+    conn = vane.connect()
+
+    with pytest.raises(Exception, match="Provider 'does_not_exist' is not supported"):
+        conn.sql("""
+            SELECT ai_prompt(
+                'describe',
+                NULL::BLOB,
+                struct_pack(provider := 'does_not_exist')
+            )
+        """).fetchall()
+
+
 def test_ai_prompt_sql_with_single_image_blob_and_null_image():
     conn = vane.connect()
 

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -569,6 +569,36 @@ def test_ai_prompt_literal_null_prompt_skips_nonconstant_options():
     assert rows == [(None,)]
 
 
+@pytest.mark.parametrize(
+    "image_expression",
+    [
+        "from_hex('89504e47')",
+        "[from_hex('89504e47')]::BLOB[]",
+    ],
+)
+def test_ai_prompt_image_input_propagates_column_null_prompt(image_expression):
+    conn = vane.connect()
+
+    rows = conn.sql(f"""
+        SELECT id, ai_prompt(
+            prompt,
+            image,
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+        FROM (
+            VALUES
+                (1, NULL::VARCHAR, {image_expression}),
+                (2, 'alpha', {image_expression})
+        ) AS t(id, prompt, image)
+        ORDER BY id
+    """).fetchall()
+
+    assert rows == [
+        (1, None),
+        (2, "vision-model:alpha:images=89504e47"),
+    ]
+
+
 @pytest.mark.parametrize("null_image", ["NULL", "NULL::BLOB", "NULL::BLOB[]"])
 def test_ai_prompt_sql_with_literal_null_image(null_image):
     conn = vane.connect()
@@ -668,6 +698,27 @@ def test_ai_prompt_sql_with_image_blob_list():
         (2, "vision-model:empty"),
         (3, "vision-model:null"),
     ]
+
+
+@pytest.mark.parametrize(
+    "empty_image",
+    [
+        "''::BLOB",
+        "[''::BLOB]::BLOB[]",
+    ],
+)
+def test_ai_prompt_sql_treats_zero_length_image_as_empty(empty_image):
+    conn = vane.connect()
+
+    rows = conn.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            {empty_image},
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+    """).fetchall()
+
+    assert rows == [("vision-model:describe",)]
 
 
 def test_ai_embed_sql_with_mock_provider_and_dimensions():

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -507,7 +507,14 @@ def test_ai_sql_text_signatures_preserve_legacy_null_propagation(monkeypatch, ex
 
 
 @pytest.mark.parametrize("null_prompt", ["NULL", "NULL::VARCHAR"])
-def test_ai_prompt_image_input_propagates_literal_null_prompt(null_prompt):
+def test_ai_prompt_image_input_propagates_literal_null_prompt(monkeypatch, null_prompt):
+    provider_calls = []
+
+    def recording_provider(name=None, **options):
+        provider_calls.append((name, options))
+        return MockProvider()
+
+    monkeypatch.setitem(provider_registry.PROVIDERS, "mock_ai_sql", recording_provider)
     conn = vane.connect()
 
     relation = conn.sql(f"""
@@ -518,13 +525,48 @@ def test_ai_prompt_image_input_propagates_literal_null_prompt(null_prompt):
         ) AS response
     """)
 
+    assert provider_calls == []
     assert [str(dtype) for dtype in relation.types] == ["VARCHAR"]
     assert relation.fetchall() == [(None,)]
+    assert provider_calls == []
 
     _, target, physical, _ = _round_trip_ai_plan(relation)
     assert physical.collect_udf_nodes() == []
     table = _execute_ai_physical_plan(target, physical)
     assert table.column(0).to_pylist() == [None]
+    assert provider_calls == []
+
+
+def test_ai_prompt_literal_null_prompt_skips_invalid_provider():
+    conn = vane.connect()
+
+    relation = conn.sql("""
+        SELECT ai_prompt(
+            NULL,
+            from_hex('89504e47'),
+            struct_pack(provider := 'does_not_exist')
+        ) AS response
+    """)
+
+    assert [str(dtype) for dtype in relation.types] == ["VARCHAR"]
+    assert relation.fetchall() == [(None,)]
+
+
+def test_ai_prompt_literal_null_prompt_skips_nonconstant_options():
+    conn = vane.connect()
+
+    rows = conn.sql("""
+        SELECT ai_prompt(
+            NULL,
+            image,
+            struct_pack(provider := provider_name)
+        ) AS response
+        FROM (
+            VALUES (from_hex('89504e47'), 'does_not_exist')
+        ) AS t(image, provider_name)
+    """).fetchall()
+
+    assert rows == [(None,)]
 
 
 @pytest.mark.parametrize("null_image", ["NULL", "NULL::BLOB", "NULL::BLOB[]"])

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -480,7 +480,54 @@ def test_ai_prompt_sql_with_mock_provider():
     assert rows == [("topic:alpha",), ("topic:beta",)]
 
 
-@pytest.mark.parametrize("null_image", ["NULL::BLOB", "NULL::BLOB[]"])
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "ai_prompt(NULL, struct_pack(provider := 'mock_ai_sql', concurrency := 1))",
+        "ai_prompt(NULL::VARCHAR, struct_pack(provider := 'mock_ai_sql', concurrency := 1))",
+        "ai_embed(NULL, struct_pack(provider := 'mock_ai_sql', dimensions := 4, concurrency := 1))",
+        "ai_embed(NULL::VARCHAR, struct_pack(provider := 'mock_ai_sql', dimensions := 4, concurrency := 1))",
+        "ai_prompt('alpha', NULL)",
+        "ai_embed('abc', NULL)",
+    ],
+)
+def test_ai_sql_text_signatures_preserve_legacy_null_propagation(monkeypatch, expression):
+    provider_calls = []
+
+    def recording_provider(name=None, **options):
+        provider_calls.append((name, options))
+        return MockProvider()
+
+    monkeypatch.setitem(provider_registry.PROVIDERS, "mock_ai_sql", recording_provider)
+    monkeypatch.setitem(provider_registry.PROVIDERS, "openai", recording_provider)
+    conn = vane.connect()
+
+    assert conn.sql(f"SELECT {expression} AS result").fetchall() == [(None,)]
+    assert provider_calls == []
+
+
+@pytest.mark.parametrize("null_prompt", ["NULL", "NULL::VARCHAR"])
+def test_ai_prompt_image_input_propagates_literal_null_prompt(null_prompt):
+    conn = vane.connect()
+
+    relation = conn.sql(f"""
+        SELECT ai_prompt(
+            {null_prompt},
+            from_hex('89504e47'),
+            struct_pack(provider := 'mock_ai_sql', model := 'vision-model', concurrency := 1)
+        ) AS response
+    """)
+
+    assert [str(dtype) for dtype in relation.types] == ["VARCHAR"]
+    assert relation.fetchall() == [(None,)]
+
+    _, target, physical, _ = _round_trip_ai_plan(relation)
+    assert physical.collect_udf_nodes() == []
+    table = _execute_ai_physical_plan(target, physical)
+    assert table.column(0).to_pylist() == [None]
+
+
+@pytest.mark.parametrize("null_image", ["NULL", "NULL::BLOB", "NULL::BLOB[]"])
 def test_ai_prompt_sql_with_literal_null_image(null_image):
     conn = vane.connect()
 

--- a/tests/slow/test_expression_udf_ray_chain.py
+++ b/tests/slow/test_expression_udf_ray_chain.py
@@ -428,13 +428,17 @@ try:
         con = vane.connect()
         parquet_path = Path(tmp_dir) / "ai_options.parquet"
         con.execute(
-            f"COPY (SELECT value::VARCHAR AS chunk FROM range(4) t(value)) "
-            f"TO '{parquet_path}' (FORMAT PARQUET)"
+            "COPY ("
+            "SELECT value::VARCHAR AS chunk, "
+            "CASE WHEN value % 2 = 0 THEN from_hex('89504e47') ELSE NULL::BLOB END AS image "
+            "FROM range(4) t(value)"
+            f") TO '{parquet_path}' (FORMAT PARQUET)"
         )
         source = f"read_parquet('{parquet_path}')"
         prompt_relation = con.sql(f'''
             SELECT chunk, ai_prompt(
                 chunk,
+                image,
                 struct_pack(
                     provider := 'mock_ai_sql',
                     model := 'ray-model',
@@ -466,7 +470,13 @@ try:
 
         prompt_rows = sorted(zip(prompt.column(0).to_pylist(), prompt.column(1).to_pylist()))
         embedding_rows = sorted(zip(embedding.column(0).to_pylist(), embedding.column(1).to_pylist()))
-        assert prompt_rows == [(str(value), f"ray-model:{value}") for value in range(4)]
+        assert prompt_rows == [
+            (
+                str(value),
+                f"ray-model:{value}:images=89504e47" if value % 2 == 0 else f"ray-model:{value}",
+            )
+            for value in range(4)
+        ]
         assert [len(vector) for _, vector in embedding_rows] == [5, 5, 5, 5]
         assert all(abs(float(np.linalg.norm(vector)) - 1.0) < 1e-6 for _, vector in embedding_rows)
         print("AI_RAY_OPTIONS provider=mock_ai_sql model=ray-model dimensions=5 concurrency=3")

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -171,6 +171,7 @@ def build_ai_prompt_sql_spec(
         "response",
         udf_opts.max_api_concurrency,
         image_columns=["images"] if image_input else None,
+        propagate_null_prompts=image_input,
         max_retries=resolved_max_retries,
         on_error=udf_opts.on_error,
     )

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -146,7 +146,11 @@ def _normalize_sql_options(options: dict[str, Any] | None) -> dict[str, Any]:
     return opts
 
 
-def build_ai_prompt_sql_spec(options: dict[str, Any] | None = None) -> dict[str, Any]:
+def build_ai_prompt_sql_spec(
+    options: dict[str, Any] | None = None,
+    image_input: bool = False,
+) -> dict[str, Any]:
+    """Build the row-preserving SQL prompt UDF specification."""
     opts = _normalize_sql_options(options)
     provider = opts.pop("provider", "openai")
     model = opts.pop("model", None)
@@ -166,6 +170,7 @@ def build_ai_prompt_sql_spec(options: dict[str, Any] | None = None) -> dict[str,
         "messages",
         "response",
         udf_opts.max_api_concurrency,
+        image_columns=["images"] if image_input else None,
         max_retries=resolved_max_retries,
         on_error=udf_opts.on_error,
     )
@@ -176,7 +181,7 @@ def build_ai_prompt_sql_spec(options: dict[str, Any] | None = None) -> dict[str,
         "provider": descriptor.get_provider(),
         "model": descriptor.get_model(),
         "return_type": "VARCHAR",
-        "input_names": ["messages"],
+        "input_names": ["messages", "images"] if image_input else ["messages"],
         "schema": {"response": "VARCHAR"},
         "batch_size": batch_size if batch_size is not None else _resolve_ai_batch_size(udf_opts),
         "row_preserving": True,

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -577,20 +577,32 @@ class _PromptBatch:
                     parts.append(val)
             return tuple(parts)
 
-        # Use batch API if available (e.g. vLLM's continuous batching)
-        has_images = bool(self._image_columns)
-        if not has_images and hasattr(self._prompter, "prompt_batch"):
-            results = _retry_call(
-                self._prompter.prompt_batch,
-                texts,
+        row_messages = [build_messages(idx) for idx in range(len(texts))]
+        results: list[Any] = [None] * len(texts)
+
+        # Keep text-only rows on the batch API (e.g. vLLM's continuous
+        # batching), even when other rows in the Arrow batch contain images.
+        prompt_batch = getattr(self._prompter, "prompt_batch", None)
+        if callable(prompt_batch):
+            text_indices = [idx for idx, messages in enumerate(row_messages) if len(messages) == 1]
+            prompt_indices = [idx for idx, messages in enumerate(row_messages) if len(messages) > 1]
+        else:
+            text_indices = []
+            prompt_indices = list(range(len(texts)))
+
+        if text_indices:
+            text_results = _retry_call(
+                prompt_batch,
+                [texts[idx] for idx in text_indices],
                 max_retries=self._max_retries,
                 on_error=self._on_error,
             )
-            if results is None:
-                results = [None] * len(texts)
+            if text_results is None:
+                text_results = [None] * len(text_indices)
             if self._return_format is not None:
-                results = [self._serialize_result(r) for r in results]
-            return pa.table({self._output_column: results})
+                text_results = [self._serialize_result(result) for result in text_results]
+            for idx, result in zip(text_indices, text_results, strict=True):
+                results[idx] = result
 
         max_retries = self._max_retries
         on_error = self._on_error
@@ -601,30 +613,31 @@ class _PromptBatch:
 
                 async def limited(idx: int) -> str | None:
                     async with sem:
-                        msgs = build_messages(idx) if has_images else (texts[idx],)
                         result = await _retry_call_async(
                             self._prompter.prompt,
-                            msgs,
+                            row_messages[idx],
                             max_retries=max_retries,
                             on_error=on_error,
                         )
                         return self._serialize_result(result) if self._return_format else result
 
-                return await asyncio.gather(*(limited(i) for i in range(len(texts))))
+                return await asyncio.gather(*(limited(idx) for idx in prompt_indices))
 
             async def single(idx: int) -> str | None:
-                msgs = build_messages(idx) if has_images else (texts[idx],)
                 result = await _retry_call_async(
                     self._prompter.prompt,
-                    msgs,
+                    row_messages[idx],
                     max_retries=max_retries,
                     on_error=on_error,
                 )
                 return self._serialize_result(result) if self._return_format else result
 
-            return await asyncio.gather(*(single(i) for i in range(len(texts))))
+            return await asyncio.gather(*(single(idx) for idx in prompt_indices))
 
-        results = _run_async(run_all())
+        if prompt_indices:
+            prompt_results = _run_async(run_all())
+            for idx, result in zip(prompt_indices, prompt_results, strict=True):
+                results[idx] = result
         return pa.table({self._output_column: results})
 
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -519,7 +519,7 @@ class _PromptBatch:
     When ``return_format`` is set, responses are serialized to JSON strings.
     When ``image_columns`` is set, image data from those columns is packed
     alongside text into multimodal message tuples. List-valued image cells are
-    expanded in order and NULL image values are skipped.
+    expanded in order and NULL or zero-length image values are skipped.
     """
 
     def __init__(
@@ -530,6 +530,7 @@ class _PromptBatch:
         max_api_concurrency: int | None = None,
         return_format: Any | None = None,
         image_columns: list[str] | None = None,
+        propagate_null_prompts: bool = False,
         max_retries: int = 3,
         on_error: _OnError = "raise",
     ) -> None:
@@ -539,6 +540,7 @@ class _PromptBatch:
         self._max_api_concurrency = max_api_concurrency
         self._return_format = return_format
         self._image_columns = image_columns or []
+        self._propagate_null_prompts = propagate_null_prompts
         self._max_retries = max_retries
         self._on_error: _OnError = on_error
         self._prompter = None  # lazy: instantiate on first __call__
@@ -559,36 +561,47 @@ class _PromptBatch:
         return json.dumps(result, default=str)
 
     def __call__(self, table: pa.Table) -> pa.Table:
+        texts = table.column(self._column).to_pylist()
+        active_indices = [idx for idx, text in enumerate(texts) if not (self._propagate_null_prompts and text is None)]
+        results: list[Any] = [None] * len(texts)
+        if self._propagate_null_prompts and not active_indices:
+            return pa.table({self._output_column: pa.array(results, type=pa.string())})
+
         if self._prompter is None:
             self._prompter = self._descriptor.instantiate()
-        texts = table.column(self._column).to_pylist()
         texts = [t if t is not None else "" for t in texts]
 
         # Build per-row message tuples (text + optional image columns)
         image_lists: list[list[Any]] = [table.column(col_name).to_pylist() for col_name in self._image_columns]
+
+        def has_image_data(value: Any) -> bool:
+            if value is None:
+                return False
+            if isinstance(value, (bytes, bytearray, memoryview)):
+                return len(value) > 0
+            return True
 
         def build_messages(idx: int) -> tuple[Any, ...]:
             parts: list[Any] = [texts[idx]]
             for img_col in image_lists:
                 val = img_col[idx]
                 if isinstance(val, list):
-                    parts.extend(item for item in val if item is not None)
-                elif val is not None:
+                    parts.extend(item for item in val if has_image_data(item))
+                elif has_image_data(val):
                     parts.append(val)
             return tuple(parts)
 
         row_messages = [build_messages(idx) for idx in range(len(texts))]
-        results: list[Any] = [None] * len(texts)
 
         # Keep text-only rows on the batch API (e.g. vLLM's continuous
         # batching), even when other rows in the Arrow batch contain images.
         prompt_batch = getattr(self._prompter, "prompt_batch", None)
         if callable(prompt_batch):
-            text_indices = [idx for idx, messages in enumerate(row_messages) if len(messages) == 1]
-            prompt_indices = [idx for idx, messages in enumerate(row_messages) if len(messages) > 1]
+            text_indices = [idx for idx in active_indices if len(row_messages[idx]) == 1]
+            prompt_indices = [idx for idx in active_indices if len(row_messages[idx]) > 1]
         else:
             text_indices = []
-            prompt_indices = list(range(len(texts)))
+            prompt_indices = active_indices
 
         if text_indices:
             text_results = _retry_call(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -518,7 +518,8 @@ class _PromptBatch:
     Supports both plain text and structured output (Pydantic models).
     When ``return_format`` is set, responses are serialized to JSON strings.
     When ``image_columns`` is set, image data from those columns is packed
-    alongside text into multimodal message tuples.
+    alongside text into multimodal message tuples. List-valued image cells are
+    expanded in order and NULL image values are skipped.
     """
 
     def __init__(
@@ -570,12 +571,15 @@ class _PromptBatch:
             parts: list[Any] = [texts[idx]]
             for img_col in image_lists:
                 val = img_col[idx]
-                if val is not None:
+                if isinstance(val, list):
+                    parts.extend(item for item in val if item is not None)
+                elif val is not None:
                     parts.append(val)
             return tuple(parts)
 
         # Use batch API if available (e.g. vLLM's continuous batching)
-        if hasattr(self._prompter, "prompt_batch"):
+        has_images = bool(self._image_columns)
+        if not has_images and hasattr(self._prompter, "prompt_batch"):
             results = _retry_call(
                 self._prompter.prompt_batch,
                 texts,
@@ -588,7 +592,6 @@ class _PromptBatch:
                 results = [self._serialize_result(r) for r in results]
             return pa.table({self._output_column: results})
 
-        has_images = bool(self._image_columns)
         max_retries = self._max_retries
         on_error = self._on_error
 

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -243,6 +243,8 @@ class VLLMPrompter:
         allows the wrapper classes in ``functions.py`` to use the
         standard ``asyncio.gather`` pattern.
         """
+        if len(messages) != 1 or not isinstance(messages[0], str):
+            raise ValueError("vLLM provider only supports one text prompt; multimodal prompt parts are not supported")
         text = str(messages[0]) if messages else ""
         formatted = self._format_prompt(text)
 


### PR DESCRIPTION
## Summary

- Add three-argument SQL `ai_prompt(message, image, options)` overloads for
  per-row `BLOB` and `BLOB[]` image data, reusing the existing multimodal
  `_PromptBatch` path for both local and Ray execution.
- Keep image bytes as UDF data inputs rather than serialized function metadata,
  and preserve row order when a batch mixes text-only and image-bearing rows.
- Define deterministic compatibility behavior: NULL or empty image values fall
  back to text-only prompting, literal NULL image arguments are accepted, and
  the existing text-only `ai_prompt`/`ai_embed` NULL semantics remain unchanged.
- Short-circuit a foldable NULL prompt before parsing options or constructing a
  provider, and reject unsupported vLLM multimodal calls explicitly.
- Cover SQL binding/lowering, mock-provider message parts, NULL behavior,
  logical-plan round trips, local/Ray execution, and text-only compatibility.

## Why

SQL-first multimodal pipelines currently have to cross into Python, call
`vane.ai.prompt(..., image_columns=...)`, and register the resulting Relation
before returning to SQL. This change exposes the already-supported multimodal
provider path directly through `ai_prompt` while keeping image payloads as
ordinary Relation columns.

The SQL registration and lowering path previously only understood the message
column plus constant options. Supporting nullable image inputs also requires
preventing DuckDB's foldable-NULL shortcut from discarding the image overload,
without changing NULL propagation for the pre-existing text-only signatures.

## User impact

Users can now write:

```sql
SELECT ai_prompt(
    prompt,
    image_blob,
    struct_pack(provider := 'openai', model := '...')
)
FROM evidence;
```

The second argument may be `BLOB` or `BLOB[]`. NULL and empty image values use
the text-only path. Providers that do not support multimodal input continue to
fail clearly instead of silently associating a response with the wrong row.

## Related issue

Closes #18

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The new overloads and NULL/empty-image behavior are documented in
`CHANGELOG.md`.

## Validation

- `scripts/format root --changed`
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `python -m pytest tests/ai/test_expression_ai_sql.py` — 54 passed
- Targeted `_PromptBatch` and vLLM regression tests in
  `tests/ai/test_ai_functions.py` — passed
- `VANE_PROGRESS=0 scripts/run_release_tests.sh` — 272 non-Ray and 5 Ray tests
  passed

## Checklist

- [x] The change is focused, and tests cover the changed behavior.
- [x] Public behavior and compatibility implications are documented.
- [x] No new dependency, bundled asset, or license obligation is introduced.
- [x] No credentials, private endpoints, customer data, or sensitive artifacts
      are included.
- [x] Security and trust-boundary implications were considered.
- [x] Native changes were compiled using the incremental Release build.
