### PR TITLE
[fix](ray) Make worker snapshot refresh single-flight

### DIFF
--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -38,86 +38,120 @@ def _persistent_worker_runtime_env(env_vars: dict[str, str]) -> dict[str, Any]:
     return {"env_vars": runtime_env_vars}
 
 
+def _cleanup_started_workers(
+    actors: list[tuple[dict[str, Any], str, Any]],
+    worker_handles: list[RayWorkerActorHandle],
+) -> list[str]:
+    errors = []
+    cleaned_actor_ids = set()
+    for worker_handle in reversed(worker_handles):
+        actor = worker_handle.actor_handle
+        try:
+            worker_handle.abort_shutdown()
+            cleaned_actor_ids.add(id(actor))
+        except BaseException as exc:
+            errors.append(f"{worker_handle.worker_id}: {exc}")
+
+    for _node, worker_id, actor in reversed(actors):
+        if id(actor) in cleaned_actor_ids:
+            continue
+        try:
+            ray.kill(actor, no_restart=True)
+        except BaseException as exc:
+            errors.append(f"{worker_id}: {exc}")
+    return errors
+
+
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
+    ACTOR_STARTUP_TIMEOUT = 120
     env_overrides = _collect_vane_env_overrides()
     actors = []
-    for node in ray.nodes():
-        base_worker_id = str(node.get("NodeManagerAddress") or node.get("NodeID") or "")
-        if (
-            "Resources" in node
-            and "CPU" in node["Resources"]
-            and "memory" in node["Resources"]
-            and node["Resources"]["CPU"] > 0
-            and node["Resources"]["memory"] > 0
-            and base_worker_id
-        ):
-            worker_id = base_worker_id
-            if worker_id in existing_worker_ids:
-                continue
-            worker_env = dict(env_overrides)
-            worker_env["VANE_WORKER_ID"] = worker_id
-            worker_env["VANE_WORKER_INDEX"] = "0"
-            memory_layout = build_ray_node_memory_layout(int(node["Resources"]["memory"]))
-            # max_concurrency limits how many control/execute RPCs can queue
-            # inside the actor. FTE backpressure is handled by task
-            # status/split-queue feedback and the shared DuckDB TaskScheduler.
-            #
-            # The persistent actor is a node-local execution container, not a
-            # Ray CPU/GPU lease. Vane admission accounts for native fragments
-            # and Ray-backed UDFs, so reserving the node's full CPU/GPU capacity
-            # here would prevent those child Ray workloads from being scheduled.
-            _actor_max_conc = int(os.environ.get("VANE_RAY_ACTOR_MAX_CONCURRENCY", "256"))
-            actor = RayWorkerActor.options(  # type: ignore[attr-defined]
-                max_concurrency=_actor_max_conc,
-                memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
-                runtime_env=_persistent_worker_runtime_env(worker_env),
-                scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                    node_id=node["NodeID"],
-                    soft=False,
-                ),
-            ).remote(
-                num_cpus=int(node["Resources"]["CPU"]),
-                num_gpus=int(node["Resources"].get("GPU", 0)),
-                duckdb_memory_bytes=memory_layout.worker_duckdb_memory_bytes,
-                task_heap_capacity_bytes=memory_layout.task_heap_capacity_bytes,
+    worker_handles = []
+    try:
+        for node in ray.nodes():
+            base_worker_id = str(node.get("NodeManagerAddress") or node.get("NodeID") or "")
+            if (
+                "Resources" in node
+                and "CPU" in node["Resources"]
+                and "memory" in node["Resources"]
+                and node["Resources"]["CPU"] > 0
+                and node["Resources"]["memory"] > 0
+                and base_worker_id
+            ):
+                worker_id = base_worker_id
+                if worker_id in existing_worker_ids:
+                    continue
+                worker_env = dict(env_overrides)
+                worker_env["VANE_WORKER_ID"] = worker_id
+                worker_env["VANE_WORKER_INDEX"] = "0"
+                memory_layout = build_ray_node_memory_layout(int(node["Resources"]["memory"]))
+                # max_concurrency limits how many control/execute RPCs can queue
+                # inside the actor. FTE backpressure is handled by task
+                # status/split-queue feedback and the shared DuckDB TaskScheduler.
+                #
+                # The persistent actor is a node-local execution container, not a
+                # Ray CPU/GPU lease. Vane admission accounts for native fragments
+                # and Ray-backed UDFs, so reserving the node's full CPU/GPU capacity
+                # here would prevent those child Ray workloads from being scheduled.
+                _actor_max_conc = int(os.environ.get("VANE_RAY_ACTOR_MAX_CONCURRENCY", "256"))
+                actor = RayWorkerActor.options(
+                    max_concurrency=_actor_max_conc,
+                    memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
+                    runtime_env=_persistent_worker_runtime_env(worker_env),
+                    scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                        node_id=node["NodeID"],
+                        soft=False,
+                    ),
+                ).remote(
+                    num_cpus=int(node["Resources"]["CPU"]),
+                    num_gpus=int(node["Resources"].get("GPU", 0)),
+                    duckdb_memory_bytes=memory_layout.worker_duckdb_memory_bytes,
+                    task_heap_capacity_bytes=memory_layout.task_heap_capacity_bytes,
+                )
+                actors.append((node, worker_id, actor))
+
+        # Pre-warm: wait for all actors to be fully initialized before returning.
+        # This absorbs the ~2.5s actor cold-start so the first task dispatch is fast.
+        # Matches upstream Vane's start_ray_workers() pattern.
+        warmup_refs = [actor.ping.remote() for _, _, actor in actors]
+        # Nested distributed execution may call start_ray_workers() from inside a
+        # Ray actor. Let actor startup proceed asynchronously there and rely on the
+        # first task submission for backpressure.
+        if not _is_ray_worker_context():
+            try:
+                resolve_object_refs_blocking(warmup_refs, timeout=ACTOR_STARTUP_TIMEOUT)
+            except ray.exceptions.GetTimeoutError as exc:
+                raise RuntimeError(f"Failed to warm up Worker actors within {ACTOR_STARTUP_TIMEOUT}s") from exc
+
+        handles = []
+        for node, worker_id, actor in actors:
+            actor_handle = RayWorkerActorHandle(
+                actor,
+                worker_id=worker_id,
+                node_id=str(node["NodeID"]),
+                memory_capacity_bytes=build_ray_node_memory_layout(
+                    int(node["Resources"]["memory"])
+                ).task_heap_capacity_bytes,
             )
-            actors.append((node, worker_id, actor))
-
-    # Pre-warm: wait for all actors to be fully initialized before returning.
-    # This absorbs the ~2.5s actor cold-start so the first task dispatch is fast.
-    # Matches upstream Vane's start_ray_workers() pattern.
-    ACTOR_STARTUP_TIMEOUT = 120
-    warmup_refs = [actor.ping.remote() for _, _, actor in actors]
-    # Nested distributed execution may call start_ray_workers() from inside a
-    # Ray actor. Let actor startup proceed asynchronously there and rely on the
-    # first task submission for backpressure.
-    if not _is_ray_worker_context():
-        try:
-            resolve_object_refs_blocking(warmup_refs, timeout=ACTOR_STARTUP_TIMEOUT)
-        except ray.exceptions.GetTimeoutError:
-            raise RuntimeError(f"Failed to warm up Worker actors within {ACTOR_STARTUP_TIMEOUT}s")
-
-    handles = []
-    for node, worker_id, actor in actors:
-        actor_handle = RayWorkerActorHandle(
-            actor,
-            worker_id=worker_id,
-            node_id=str(node["NodeID"]),
-            memory_capacity_bytes=build_ray_node_memory_layout(
-                int(node["Resources"]["memory"])
-            ).task_heap_capacity_bytes,
-        )
-        handles.append(
-            RayWorkerRuntime(
-                worker_id,
-                actor_handle,
-                int(node["Resources"]["CPU"]),
-                int(node["Resources"].get("GPU", 0)),
-                int(node["Resources"]["memory"]),
+            worker_handles.append(actor_handle)
+            handles.append(
+                RayWorkerRuntime(
+                    worker_id,
+                    actor_handle,
+                    int(node["Resources"]["CPU"]),
+                    int(node["Resources"].get("GPU", 0)),
+                    int(node["Resources"]["memory"]),
+                )
             )
-        )
 
-    return handles
+        return handles
+    except BaseException as startup_error:
+        cleanup_errors = _cleanup_started_workers(actors, worker_handles)
+        if cleanup_errors:
+            raise RuntimeError(
+                f"Ray worker startup failed: {startup_error}; actor cleanup failed: {'; '.join(cleanup_errors)}"
+            ) from startup_error
+        raise
 
 
 def try_autoscale(bundles: list[dict[str, int]]) -> None:

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -20,6 +20,23 @@ using duckdb::distributed::WorkerSnapshot;
 
 static constexpr auto REFRESH_INTERVAL = std::chrono::seconds(5);
 
+static std::vector<std::string> AbortWorkers(const std::vector<std::shared_ptr<RayWorkerRuntime>> &workers) {
+	std::vector<std::string> errors;
+	for (auto &worker : workers) {
+		const auto worker_id = worker && worker->Id() ? *worker->Id() : std::string("<unknown>");
+		try {
+			if (worker) {
+				worker->AbortShutdown();
+			}
+		} catch (const std::exception &ex) {
+			errors.push_back(worker_id + ": " + ex.what());
+		} catch (...) {
+			errors.push_back(worker_id + ": unknown abort error");
+		}
+	}
+	return errors;
+}
+
 static bool IsUnselectedFteHandle(const RayWorkerRuntime::TaskResultHandleType &handle,
                                   const RayWorkerRuntime::QueryStatus *finished_status) {
 	if (!finished_status || finished_status->selected_attempt_task_ids.empty()) {
@@ -476,12 +493,24 @@ void RayWorkerManager::rethrow_submission_error(const string &query_id) {
 }
 
 DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager::worker_snapshots() const {
+	// State locks and refresh waits must never retain the GIL. The creator
+	// reacquires it only around Python/Ray startup and actor cleanup.
+	if (PyGILState_Check()) {
+		py::gil_scoped_release release;
+		return WorkerSnapshotsWithoutGIL();
+	}
+	return WorkerSnapshotsWithoutGIL();
+}
+
+RayWorkerManager::WorkerSnapshotResult RayWorkerManager::WorkerSnapshotsWithoutGIL() const {
 	OperationGuard operation(*this);
 	if (!operation) {
 		return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
 		    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
-	bool should_refresh = false;
+	std::promise<WorkerSnapshotResult> refresh_completion;
+	std::shared_ptr<WorkerRefreshFlight> refresh;
+	bool refresh_creator = false;
 	std::vector<string> existing_ids;
 	{
 		lock_guard<mutex> guard(mutex_);
@@ -489,19 +518,49 @@ DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager:
 			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
 			    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 		}
-		should_refresh = !state_.last_refresh.first ||
-		                 (std::chrono::steady_clock::now() - state_.last_refresh.second) > REFRESH_INTERVAL;
-		if (should_refresh) {
+		const bool should_refresh = !state_.last_refresh.first ||
+		                            (std::chrono::steady_clock::now() - state_.last_refresh.second) > REFRESH_INTERVAL;
+		if (!should_refresh) {
+			std::vector<duckdb::distributed::WorkerSnapshot> snapshots;
+			snapshots.reserve(state_.ray_workers.size());
+			for (auto &kv : state_.ray_workers) {
+				snapshots.emplace_back(kv.first, kv.second->TotalNumCpus(), kv.second->TotalNumGpus(),
+				                       kv.second->TotalMemoryBytes());
+			}
+			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::ok(std::move(snapshots));
+		}
+		if (state_.worker_refresh) {
+			refresh = state_.worker_refresh;
+		} else {
 			existing_ids.reserve(state_.ray_workers.size());
 			for (auto &kv : state_.ray_workers) {
 				if (kv.first) {
 					existing_ids.push_back(*kv.first);
 				}
 			}
+			auto result = refresh_completion.get_future().share();
+			refresh = std::make_shared<WorkerRefreshFlight>(std::move(result));
+			state_.worker_refresh = refresh;
+			refresh_creator = true;
 		}
 	}
 
-	if (should_refresh) {
+	if (!refresh_creator) {
+		try {
+			return refresh->result.get();
+		} catch (const std::exception &ex) {
+			return WorkerSnapshotResult::err(
+			    DuckDBError::internal_error(string("worker refresh synchronization failed: ") + ex.what()));
+		} catch (...) {
+			return WorkerSnapshotResult::err(
+			    DuckDBError::internal_error("worker refresh synchronization failed: unknown exception"));
+		}
+	}
+
+	WorkerSnapshotResult refresh_result;
+	std::vector<std::shared_ptr<RayWorkerRuntime>> new_workers;
+	bool worker_creation_succeeded = false;
+	{
 		duckdb::PythonGILWrapper gil;
 		try {
 			py::module_ worker_pool_obj = py::module_::import("duckdb.runners.ray.worker_pool");
@@ -511,73 +570,134 @@ DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> RayWorkerManager:
 			try {
 				workers_iter = py_workers_obj.cast<py::iterable>();
 			} catch (const py::cast_error &e) {
-				return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(DuckDBError::external_error(
-				    string("start_ray_workers must return an iterable of RayWorkerRuntime: ") + e.what()));
+				throw std::runtime_error(string("start_ray_workers must return an iterable of RayWorkerRuntime: ") +
+				                         e.what());
 			}
 
-			std::vector<std::shared_ptr<RayWorkerRuntime>> new_workers;
+			string worker_validation_error;
 			for (auto item : workers_iter) {
-				auto worker = item.cast<std::shared_ptr<RayWorkerRuntime>>();
+				std::shared_ptr<RayWorkerRuntime> worker;
+				try {
+					worker = item.cast<std::shared_ptr<RayWorkerRuntime>>();
+				} catch (const py::cast_error &e) {
+					if (worker_validation_error.empty()) {
+						worker_validation_error = e.what();
+					}
+					continue;
+				}
 				if (!worker) {
-					return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-					    DuckDBError::invalid_state_error("start_ray_workers returned null RayWorkerRuntime"));
+					if (worker_validation_error.empty()) {
+						worker_validation_error = "start_ray_workers returned null RayWorkerRuntime";
+					}
+					continue;
 				}
 				auto worker_id = worker->Id();
-				if (!worker_id) {
-					return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-					    DuckDBError::invalid_state_error("start_ray_workers returned worker without id"));
-				}
 				new_workers.push_back(std::move(worker));
+				if (!worker_id || worker_id->empty()) {
+					if (worker_validation_error.empty()) {
+						worker_validation_error = "start_ray_workers returned worker without id";
+					}
+					continue;
+				}
+			}
+			if (!worker_validation_error.empty()) {
+				throw std::runtime_error(std::move(worker_validation_error));
+			}
+			worker_creation_succeeded = true;
+		} catch (const py::error_already_set &e) {
+			refresh_result = WorkerSnapshotResult::err(
+			    DuckDBError::external_error(string("refresh_workers python error: ") + e.what()));
+		} catch (const std::exception &e) {
+			refresh_result = WorkerSnapshotResult::err(
+			    DuckDBError::external_error(string("refresh_workers exception: ") + e.what()));
+		} catch (...) {
+			refresh_result =
+			    WorkerSnapshotResult::err(DuckDBError::external_error("refresh_workers unknown exception"));
+		}
+	}
+
+	if (worker_creation_succeeded) {
+		try {
+			std::unordered_set<string> worker_ids;
+			std::vector<std::pair<WorkerId, std::shared_ptr<RayWorkerRuntime>>> new_entries;
+			new_entries.reserve(new_workers.size());
+			for (auto &worker : new_workers) {
+				const auto &worker_id = *worker->Id();
+				if (!worker_ids.insert(worker_id).second) {
+					throw std::runtime_error("start_ray_workers returned duplicate worker id: " + worker_id);
+				}
+				new_entries.emplace_back(duckdb::distributed::make_worker_id(worker_id), worker);
 			}
 
-			bool reject_new_workers = false;
 			{
 				lock_guard<mutex> guard(mutex_);
 				if (state_.shutdown_started) {
-					reject_new_workers = true;
+					refresh_result = WorkerSnapshotResult::err(
+					    DuckDBError::invalid_state_error("Ray worker manager shut down during worker refresh"));
 				} else {
-					for (auto &worker : new_workers) {
-						state_.ray_workers.emplace(duckdb::distributed::make_worker_id(*worker->Id()), worker);
+					auto updated_workers = state_.ray_workers;
+					for (auto &entry : new_entries) {
+						if (updated_workers.find(entry.first) != updated_workers.end()) {
+							throw std::runtime_error("start_ray_workers returned existing worker id: " + *entry.first);
+						}
+						auto inserted = updated_workers.emplace(entry.first, entry.second);
+						if (!inserted.second) {
+							throw std::runtime_error("failed to stage worker id: " + *entry.first);
+						}
 					}
+
+					std::vector<duckdb::distributed::WorkerSnapshot> snapshots;
+					snapshots.reserve(updated_workers.size());
+					for (auto &kv : updated_workers) {
+						snapshots.emplace_back(kv.first, kv.second->TotalNumCpus(), kv.second->TotalNumGpus(),
+						                       kv.second->TotalMemoryBytes());
+					}
+					state_.ray_workers.swap(updated_workers);
 					state_.last_refresh = std::make_pair(true, std::chrono::steady_clock::now());
+					refresh_result = WorkerSnapshotResult::ok(std::move(snapshots));
 				}
 			}
-			if (reject_new_workers) {
-				for (auto &worker : new_workers) {
-					try {
-						worker->AbortShutdown();
-					} catch (...) {
-					}
-				}
-				return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-				    DuckDBError::invalid_state_error("Ray worker manager shut down during worker refresh"));
-			}
-		} catch (const py::error_already_set &e) {
-			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-			    DuckDBError::external_error(string("refresh_workers python error: ") + e.what()));
-		} catch (const std::exception &e) {
-			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-			    DuckDBError::external_error(string("refresh_workers exception: ") + e.what()));
+		} catch (const std::exception &ex) {
+			refresh_result = WorkerSnapshotResult::err(
+			    DuckDBError::external_error(string("refresh_workers commit failed: ") + ex.what()));
 		} catch (...) {
-			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-			    DuckDBError::external_error("refresh_workers unknown exception"));
+			refresh_result = WorkerSnapshotResult::err(
+			    DuckDBError::external_error("refresh_workers commit failed: unknown exception"));
 		}
 	}
 
-	std::vector<duckdb::distributed::WorkerSnapshot> snapshots;
-	{
-		lock_guard<mutex> guard(mutex_);
-		if (state_.shutdown_started) {
-			return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::err(
-			    DuckDBError::invalid_state_error("Ray worker manager is shut down"));
-		}
-		snapshots.reserve(state_.ray_workers.size());
-		for (auto &kv : state_.ray_workers) {
-			snapshots.emplace_back(kv.first, kv.second->TotalNumCpus(), kv.second->TotalNumGpus(),
-			                       kv.second->TotalMemoryBytes());
+	if (refresh_result.is_err() && !new_workers.empty()) {
+		try {
+			auto cleanup_errors = AbortWorkers(new_workers);
+			if (!cleanup_errors.empty()) {
+				string message = refresh_result.error().what();
+				for (auto &error : cleanup_errors) {
+					message += "; worker refresh cleanup failed: " + error;
+				}
+				refresh_result = WorkerSnapshotResult::err(DuckDBError::external_error(std::move(message)));
+			}
+		} catch (const std::exception &ex) {
+			refresh_result = WorkerSnapshotResult::err(DuckDBError::external_error(
+			    string(refresh_result.error().what()) + "; worker refresh cleanup failed: " + ex.what()));
+		} catch (...) {
+			refresh_result = WorkerSnapshotResult::err(DuckDBError::external_error(
+			    string(refresh_result.error().what()) + "; worker refresh cleanup failed: unknown exception"));
 		}
 	}
-	return DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>::ok(std::move(snapshots));
+
+	try {
+		refresh_completion.set_value(refresh_result);
+	} catch (...) {
+		// The creator owns the only promise. Its destructor makes the shared
+		// future ready with broken_promise if publication unexpectedly fails.
+	}
+	{
+		lock_guard<mutex> guard(mutex_);
+		if (state_.worker_refresh == refresh) {
+			state_.worker_refresh.reset();
+		}
+	}
+	return refresh_result;
 }
 
 DuckDBResult<void> RayWorkerManager::shutdown() {

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <chrono>
+#include <future>
 #include <memory>
 
 #include <vector>
@@ -52,9 +53,19 @@ public:
 	std::unordered_map<string, std::unordered_map<string, idx_t>> fragment_stats_by_worker() const;
 
 private:
+	using WorkerSnapshotResult = DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>>;
+
+	struct WorkerRefreshFlight {
+		explicit WorkerRefreshFlight(std::shared_future<WorkerSnapshotResult> result_p) : result(std::move(result_p)) {
+		}
+
+		std::shared_future<WorkerSnapshotResult> result;
+	};
+
 	struct State {
 		std::unordered_map<WorkerId, std::shared_ptr<RayWorkerRuntime>, WorkerIdHash, WorkerIdEqual> ray_workers;
 		std::pair<bool, std::chrono::steady_clock::time_point> last_refresh;
+		std::shared_ptr<WorkerRefreshFlight> worker_refresh;
 		std::unordered_map<string, std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>>>
 		    fte_result_handles_by_query;
 		std::unordered_map<string, std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>>>
@@ -92,6 +103,7 @@ private:
 
 	bool BeginOperation() const;
 	void EndOperation() const;
+	WorkerSnapshotResult WorkerSnapshotsWithoutGIL() const;
 	static string QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks);
 	void StoreFteResultHandles(const string &query_id,
 	                           std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>> handles);

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2310,6 +2310,351 @@ def test_ray_worker_manager_integration(monkeypatch):
     assert dummy_worker_handle.fte_cleanup_query_calls == ["query-lifecycle"]
 
 
+def test_ray_worker_manager_worker_snapshot_refresh_is_single_flight(monkeypatch):
+    thread_count = 8
+    caller_barrier = threading.Barrier(thread_count)
+    start_condition = threading.Condition()
+    start_calls = []
+    created_handles = []
+
+    class DummyRayWorkerHandle:
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            return None
+
+    def start_ray_workers(existing_ids):
+        with start_condition:
+            start_calls.append(tuple(existing_ids))
+            start_condition.notify_all()
+            # The old implementation lets every caller enter this function.
+            # A single-flight implementation times out here with one creator
+            # while the other callers wait for its result.
+            start_condition.wait_for(lambda: len(start_calls) == thread_count, timeout=0.5)
+        handle = DummyRayWorkerHandle()
+        created_handles.append(handle)
+        return [duckdb.ray_cxx.RayWorkerRuntime("worker-shared", handle, 1.0, 0.0, 1024)]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    outcomes = []
+    errors = []
+
+    def snapshot():
+        try:
+            caller_barrier.wait(timeout=5)
+            outcomes.append(manager.worker_snapshots())
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=snapshot, daemon=True) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert [thread for thread in threads if thread.is_alive()] == []
+    assert errors == []
+    assert len(start_calls) == 1
+    assert len(created_handles) == 1
+    assert len(outcomes) == thread_count
+    assert (
+        outcomes
+        == [
+            [
+                {
+                    "worker_id": "worker-shared",
+                    "num_cpus": 1.0,
+                    "num_gpus": 0.0,
+                    "available_num_cpus": 1.0,
+                    "available_num_gpus": 0.0,
+                    "total_memory_bytes": 1024,
+                    "available_memory_bytes": 1024,
+                }
+            ]
+        ]
+        * thread_count
+    )
+    manager.shutdown()
+
+
+def test_ray_worker_manager_failed_snapshot_refresh_is_shared_and_retryable(monkeypatch):
+    thread_count = 6
+    caller_barrier = threading.Barrier(thread_count)
+    start_condition = threading.Condition()
+    start_calls = []
+
+    class DummyRayWorkerHandle:
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            return None
+
+    def start_ray_workers(existing_ids):
+        with start_condition:
+            start_calls.append(tuple(existing_ids))
+            call_number = len(start_calls)
+            start_condition.notify_all()
+            if call_number == 1:
+                start_condition.wait_for(lambda: len(start_calls) == thread_count, timeout=0.5)
+        if call_number == 1:
+            raise RuntimeError("planned shared refresh failure")
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-retry",
+                DummyRayWorkerHandle(),
+                1.0,
+                0.0,
+                1024,
+            )
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    errors = []
+
+    def snapshot():
+        try:
+            caller_barrier.wait(timeout=5)
+            manager.worker_snapshots()
+        except BaseException as exc:
+            errors.append(str(exc))
+
+    threads = [threading.Thread(target=snapshot, daemon=True) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert [thread for thread in threads if thread.is_alive()] == []
+    assert len(start_calls) == 1
+    assert len(errors) == thread_count
+    assert all("planned shared refresh failure" in error for error in errors)
+    assert len(set(errors)) == 1
+
+    snapshots = manager.worker_snapshots()
+    assert [snapshot["worker_id"] for snapshot in snapshots] == ["worker-retry"]
+    assert start_calls == [(), ()]
+    manager.shutdown()
+
+
+def test_ray_worker_manager_rejects_and_cleans_duplicate_refresh_workers(monkeypatch):
+    start_calls = []
+    aborted = []
+
+    class DummyRayWorkerHandle:
+        def __init__(self, label):
+            self.label = label
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            aborted.append(self.label)
+            if self.label == "first":
+                raise RuntimeError("planned first abort failure")
+
+    def start_ray_workers(existing_ids):
+        start_calls.append(tuple(existing_ids))
+        if len(start_calls) == 1:
+            return [
+                duckdb.ray_cxx.RayWorkerRuntime(
+                    "worker-duplicate",
+                    DummyRayWorkerHandle("first"),
+                    1.0,
+                    0.0,
+                    1024,
+                ),
+                duckdb.ray_cxx.RayWorkerRuntime(
+                    "worker-duplicate",
+                    DummyRayWorkerHandle("second"),
+                    1.0,
+                    0.0,
+                    1024,
+                ),
+            ]
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-recovered",
+                DummyRayWorkerHandle("recovered"),
+                1.0,
+                0.0,
+                1024,
+            )
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+
+    with pytest.raises(Exception, match="duplicate worker id: worker-duplicate") as exc_info:
+        manager.worker_snapshots()
+
+    assert sorted(aborted) == ["first", "second"]
+    assert "worker refresh cleanup failed: worker-duplicate" in str(exc_info.value)
+    assert "planned first abort failure" in str(exc_info.value)
+    snapshots = manager.worker_snapshots()
+    assert [snapshot["worker_id"] for snapshot in snapshots] == ["worker-recovered"]
+    assert start_calls == [(), ()]
+    manager.shutdown()
+
+
+def test_ray_worker_manager_cleans_all_runtimes_after_invalid_refresh_entry(monkeypatch):
+    aborted = []
+
+    class DummyRayWorkerHandle:
+        def __init__(self, label):
+            self.label = label
+
+        def abort_shutdown(self):
+            aborted.append(self.label)
+
+    def start_ray_workers(_existing_ids):
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-before-invalid",
+                DummyRayWorkerHandle("before"),
+                1.0,
+                0.0,
+                1024,
+            ),
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "",
+                DummyRayWorkerHandle("empty-id"),
+                1.0,
+                0.0,
+                1024,
+            ),
+            object(),
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-after-invalid",
+                DummyRayWorkerHandle("after"),
+                1.0,
+                0.0,
+                1024,
+            ),
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+
+    with pytest.raises(Exception, match="refresh_workers exception"):
+        manager.worker_snapshots()
+
+    assert sorted(aborted) == ["after", "before", "empty-id"]
+    manager.shutdown()
+
+
+def test_ray_worker_manager_snapshot_refresh_shutdown_has_no_deadlock(monkeypatch):
+    caller_barrier = threading.Barrier(2)
+    refresh_entered = threading.Event()
+    release_refresh = threading.Event()
+    start_calls = []
+    aborted = []
+
+    class DummyRayWorkerHandle:
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            aborted.append("worker-racing-shutdown")
+
+    def start_ray_workers(existing_ids):
+        start_calls.append(tuple(existing_ids))
+        refresh_entered.set()
+        assert release_refresh.wait(timeout=10)
+        return [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-racing-shutdown",
+                DummyRayWorkerHandle(),
+                1.0,
+                0.0,
+                1024,
+            )
+        ]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    snapshot_errors = []
+
+    def snapshot():
+        try:
+            caller_barrier.wait(timeout=5)
+            manager.worker_snapshots()
+        except BaseException as exc:
+            snapshot_errors.append(str(exc))
+
+    snapshot_threads = [threading.Thread(target=snapshot, daemon=True) for _ in range(2)]
+    for thread in snapshot_threads:
+        thread.start()
+    assert refresh_entered.wait(timeout=5)
+
+    shutdown_errors = []
+
+    def shutdown():
+        try:
+            manager.shutdown()
+        except BaseException as exc:
+            shutdown_errors.append(str(exc))
+
+    shutdown_thread = threading.Thread(target=shutdown, daemon=True)
+    shutdown_thread.start()
+
+    shutdown_state_error = None
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            manager.try_autoscale([])
+        except BaseException as exc:
+            shutdown_state_error = str(exc)
+            break
+        time.sleep(0.001)
+
+    assert shutdown_thread.is_alive()
+
+    release_refresh.set()
+    for thread in snapshot_threads:
+        thread.join(timeout=10)
+    shutdown_thread.join(timeout=10)
+
+    assert [thread for thread in [*snapshot_threads, shutdown_thread] if thread.is_alive()] == []
+    assert shutdown_state_error is not None
+    assert "shut down" in shutdown_state_error
+    assert shutdown_errors == []
+    assert start_calls == [()]
+    assert len(snapshot_errors) == 2
+    assert all("shut down during worker refresh" in error for error in snapshot_errors)
+    assert aborted == ["worker-racing-shutdown"]
+
+
 def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypatch):
     calls = []
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -8230,6 +8230,73 @@ def test_start_ray_workers_skips_blocking_warmup_inside_ray_worker(monkeypatch):
     assert get_calls == []
 
 
+@pytest.mark.parametrize(
+    ("warmup_error", "error_match"),
+    [
+        (RuntimeError("planned warmup failure"), "planned warmup failure"),
+        (ray.exceptions.GetTimeoutError("planned warmup timeout"), "Failed to warm up Worker actors within 120s"),
+    ],
+)
+def test_start_ray_workers_cleans_up_actors_after_warmup_failure(monkeypatch, warmup_error, error_match):
+    killed = []
+
+    class _FakePingMethod:
+        def remote(self):
+            return "warmup-ref"
+
+    class _FakeActorHandle:
+        def __init__(self, node_id):
+            self.node_id = node_id
+            self.ping = _FakePingMethod()
+
+    class _FakeActorFactory:
+        def __init__(self):
+            self.node_id = None
+
+        def options(self, **kwargs):
+            self.node_id = kwargs["scheduling_strategy"][1]["node_id"]
+            return self
+
+        def remote(self, **_kwargs):
+            return _FakeActorHandle(self.node_id)
+
+    monkeypatch.setattr(worker_handle_mod, "_is_ray_worker_context", lambda: False)
+    monkeypatch.setattr(worker_handle_mod, "_collect_vane_env_overrides", dict)
+    monkeypatch.setattr(worker_handle_mod, "RayWorkerActor", _FakeActorFactory())
+    monkeypatch.setattr(
+        worker_handle_mod.ray,
+        "nodes",
+        lambda: [
+            {
+                "NodeID": node_id,
+                "NodeManagerAddress": address,
+                "Resources": {"CPU": 4.0, "memory": 1024.0, "GPU": 0.0},
+            }
+            for node_id, address in (("node-a", "10.0.0.1"), ("node-b", "10.0.0.2"))
+        ],
+    )
+    monkeypatch.setattr(
+        worker_handle_mod.ray.util.scheduling_strategies,
+        "NodeAffinitySchedulingStrategy",
+        lambda **kwargs: ("node-affinity", kwargs),
+    )
+    monkeypatch.setattr(
+        worker_handle_mod,
+        "resolve_object_refs_blocking",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(warmup_error),
+    )
+    monkeypatch.setattr(
+        worker_handle_mod.ray,
+        "kill",
+        lambda actor, *, no_restart=True: killed.append((actor.node_id, no_restart)),
+    )
+
+    with pytest.raises(RuntimeError, match=error_match):
+        worker_handle_mod.start_ray_workers(existing_worker_ids=[])
+
+    assert sorted(killed) == [("node-a", True), ("node-b", True)]
+
+
 def test_worker_session_connection_rejects_reopen_after_close(monkeypatch):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)


### PR DESCRIPTION
## Summary

- Serialize stale Ray worker refreshes behind one shared future, so concurrent callers reuse one creator result instead of creating duplicate actors.
- Keep the manager mutex out of Python/Ray startup, future waits, and actor cleanup; release the GIL before manager locking/waiting to preserve an acyclic shutdown lock order.
- Make Python actor startup and C++ refresh commit transactional, aborting every created actor on startup, validation, duplicate-ID, commit, or shutdown-race failure.
- Add barrier-based concurrency, shared failure/retry, cleanup, and shutdown deadlock regression coverage.

The public runner and relation APIs are unchanged.

## Related issue

close: #78

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- Release incremental native build with `SKBUILD_BUILD_DIR=build/python-release uv pip install . --no-build-isolation`
- Related manager/startup tests: 17 passed
- Single-flight/failure/shutdown concurrency tests: 10 repeated runs, 30 passed
- `scripts/run_release_tests.sh`: 392 passed + 7 real-Ray passed
- `scripts/run_fast_tests.sh shared-ray`: 85 passed, 17 skipped
- `scripts/run_fast_tests.sh owner-ray`: 6 passed, 3 capability skips
- Non-Ray fast suite: 5,510 passed; the unrelated zero-duration `test_fte_no_matching_node_period_expiry_fails_query` timing edge flaked once and passed immediately in isolation (the same full shard also passed cleanly in an earlier run)
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.