### PR TITLE
[fix](ray) Isolate result poller failures

### DIFF
--- a/duckdb/runners/ray/runner.py
+++ b/duckdb/runners/ray/runner.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 
 
 _RAY_RUNNERS: weakref.WeakSet[RayRunner] = weakref.WeakSet()
-_RAY_RUNNERS_LOCK = threading.Lock()
+# WeakSet operations may allocate and synchronously run DuckDB connection
+# finalizers, which re-enter notify_connection_closed() on the same thread.
+_RAY_RUNNERS_LOCK = threading.RLock()
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 
 

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1691,6 +1691,86 @@ void register_ray_bindings(py::module_ &mod) {
 	    "Verify RayTaskResultHandle records the current Python handle worker_id at completion time.");
 
 	m.def(
+	    "_ray_task_result_poller_batch_for_test",
+	    [](py::list handles, int timeout_ms) {
+		    using namespace duckdb::distributed;
+		    using namespace duckdb::distributed::python::ray;
+
+		    if (timeout_ms <= 0) {
+			    throw pybind11::value_error("timeout_ms must be positive");
+		    }
+
+		    struct PollOutcome {
+			    bool terminal = false;
+			    bool is_error = false;
+			    string error;
+			    bool has_output = false;
+			    string worker_id;
+		    };
+
+		    std::vector<std::unique_ptr<RayTaskResultHandle>> task_handles;
+		    task_handles.reserve(handles.size());
+		    for (size_t index = 0; index < handles.size(); ++index) {
+			    auto handle = pybind11::reinterpret_borrow<pybind11::object>(handles[index]);
+			    task_handles.push_back(make_uniq<RayTaskResultHandle>(
+			        TaskContext::from_node_context(0, index + 1, index), std::move(handle),
+			        make_worker_id("worker-original-" + std::to_string(index)),
+			        "poller-test." + std::to_string(index)));
+		    }
+
+		    std::vector<PollOutcome> outcomes(task_handles.size());
+		    {
+			    pybind11::gil_scoped_release release;
+			    size_t remaining = task_handles.size();
+			    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+			    while (remaining > 0 && std::chrono::steady_clock::now() < deadline) {
+				    bool had_progress = false;
+				    for (size_t index = 0; index < task_handles.size(); ++index) {
+					    auto &outcome = outcomes[index];
+					    if (outcome.terminal) {
+						    continue;
+					    }
+					    auto polled = task_handles[index]->poll();
+					    if (!polled.first) {
+						    continue;
+					    }
+					    outcome.terminal = true;
+					    remaining--;
+					    had_progress = true;
+					    if (polled.second.is_err()) {
+						    outcome.is_error = true;
+						    outcome.error = polled.second.error().what();
+					    } else {
+						    auto payload = std::move(polled.second).value();
+						    outcome.has_output = payload.first;
+						    if (payload.second.worker_id()) {
+							    outcome.worker_id = *payload.second.worker_id();
+						    }
+					    }
+					    task_handles[index]->AckPollResult();
+				    }
+				    if (!had_progress && remaining > 0) {
+					    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+				    }
+			    }
+		    }
+
+		    pybind11::list result;
+		    for (const auto &outcome : outcomes) {
+			    pybind11::dict item;
+			    item["terminal"] = outcome.terminal;
+			    item["is_error"] = outcome.is_error;
+			    item["error"] = outcome.error;
+			    item["has_output"] = outcome.has_output;
+			    item["worker_id"] = outcome.worker_id;
+			    result.append(std::move(item));
+		    }
+		    return result;
+	    },
+	    py::arg("handles"), py::arg("timeout_ms") = 2000,
+	    "Poll multiple RayTaskResultHandle instances through the shared native poller.");
+
+	m.def(
 	    "python_task_result_handle_for_test",
 	    [](py::object handle) {
 		    using namespace duckdb::distributed;

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -17,11 +17,13 @@
 #include <duckdb/common/arrow/arrow_converter.hpp>
 #include <duckdb/common/arrow/arrow.hpp>
 #include <duckdb/common/arrow/arrow_type_extension.hpp>
-#include <thread>
-#include <mutex>
-#include <unordered_map>
 #include <atomic>
 #include <cstdint>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace py = pybind11;
 using namespace duckdb::distributed::python::ray;
@@ -511,6 +513,7 @@ struct RayTaskPollState {
 	duckdb::distributed::python::ray::SafePyObject handle;
 	duckdb::distributed::python::ray::RayTaskResultHandle::WorkerId worker_id;
 	duckdb::distributed::python::ray::RayTaskResultHandle::TaskContext task_context;
+	std::string fte_task_id;
 	std::shared_ptr<duckdb::distributed::UnboundedChannelState<
 	    duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>>>>
 	    result_state;
@@ -561,6 +564,107 @@ private:
 		thread_ = std::thread([this]() { Run(); });
 	}
 
+	static std::string TaskFailureMessage(const std::shared_ptr<RayTaskPollState> &state, const std::string &operation,
+	                                      const std::string &detail) {
+		std::string message = "Ray task result polling failed operation=" + operation;
+		if (state && !state->fte_task_id.empty()) {
+			message += " task_id=" + state->fte_task_id;
+		} else if (state) {
+			message += " poller_id=" + std::to_string(state->id);
+		}
+		return message + ": " + detail;
+	}
+
+	void ReportBatchFailure(const std::string &operation, const std::string &detail) {
+		auto diagnostic = "operation=" + operation + " error=" + detail;
+		if (diagnostic == last_batch_failure_) {
+			return;
+		}
+		last_batch_failure_ = diagnostic;
+		std::cerr << "[vane-ray-result-poller] " << diagnostic << std::endl;
+	}
+
+	void ClearBatchFailure() {
+		last_batch_failure_.clear();
+	}
+
+	static std::vector<size_t> DecodeReadyIndices(const py::list &ready_indices, size_t active_count) {
+		std::vector<size_t> decoded;
+		decoded.reserve(ready_indices.size());
+		std::unordered_set<size_t> seen;
+		size_t result_position = 0;
+		for (auto raw_index : ready_indices) {
+			auto index_obj = py::reinterpret_borrow<py::object>(raw_index);
+			if (py::isinstance<py::bool_>(index_obj) || !py::isinstance<py::int_>(index_obj)) {
+				throw duckdb::InvalidInputException("batch_wait_ready index at position " +
+				                                    std::to_string(result_position) + " must be an integer");
+			}
+			auto signed_index = index_obj.cast<int64_t>();
+			if (signed_index < 0) {
+				throw duckdb::InvalidInputException("batch_wait_ready index at position " +
+				                                    std::to_string(result_position) + " must be non-negative");
+			}
+			auto index = static_cast<size_t>(signed_index);
+			if (index >= active_count) {
+				throw duckdb::InvalidInputException("batch_wait_ready index " + std::to_string(index) +
+				                                    " is out of range for " + std::to_string(active_count) +
+				                                    " active handles");
+			}
+			if (!seen.insert(index).second) {
+				throw duckdb::InvalidInputException("batch_wait_ready returned duplicate index " +
+				                                    std::to_string(index));
+			}
+			decoded.push_back(index);
+			result_position++;
+		}
+		return decoded;
+	}
+
+	bool PollOneUnderGIL(const std::shared_ptr<RayTaskPollState> &state, const std::string &batch_failure) {
+		if (!state || state->done_sent.load()) {
+			return false;
+		}
+		std::string operation = "read handle";
+		try {
+			if (!state->handle.has_value()) {
+				return SendError(state, operation, "RayTaskResultHandle missing handle");
+			}
+			py::object handle_obj = state->handle.get();
+			operation = "handle.done";
+			if (!handle_obj.attr("done")().cast<bool>()) {
+				return false;
+			}
+			return ProcessDoneUnderGIL(state);
+		} catch (const py::error_already_set &e) {
+			auto detail = std::string(e.what());
+			if (!batch_failure.empty()) {
+				detail += "; batch_fallback_cause=" + batch_failure;
+			}
+			return SendError(state, operation, detail);
+		} catch (const std::exception &e) {
+			auto detail = std::string(e.what());
+			if (!batch_failure.empty()) {
+				detail += "; batch_fallback_cause=" + batch_failure;
+			}
+			return SendError(state, operation, detail);
+		} catch (...) {
+			auto detail = std::string("unknown exception");
+			if (!batch_failure.empty()) {
+				detail += "; batch_fallback_cause=" + batch_failure;
+			}
+			return SendError(state, operation, detail);
+		}
+	}
+
+	bool PollIndividuallyUnderGIL(const std::vector<std::shared_ptr<RayTaskPollState>> &states,
+	                              const std::string &batch_failure) {
+		bool had_progress = false;
+		for (const auto &state : states) {
+			had_progress = PollOneUnderGIL(state, batch_failure) || had_progress;
+		}
+		return had_progress;
+	}
+
 	void Run() {
 		while (!stop_.load()) {
 			if (!RayTaskPythonRuntimeUsable()) {
@@ -576,55 +680,110 @@ private:
 				}
 			}
 			if (snapshot.empty()) {
+				ClearBatchFailure();
 				std::this_thread::sleep_for(std::chrono::milliseconds(5));
 				continue;
 			}
 
 			bool had_progress = false;
-
+			std::string operation = "acquire Python GIL";
 			try {
-				// Single GIL acquisition per polling cycle (was: N times per cycle)
+				// Keep one GIL acquisition per cycle. The batch helper remains
+				// the fast path, while an isolated per-handle path recovers from
+				// helper and result-contract failures.
 				PythonGILWrapper gil;
-
-				// Batch-check which handles are ready using Python helper
-				// This replaces N individual done() calls with one batch call
+				operation = "build handle batch";
 				py::list handles_list;
-				std::vector<size_t> active_indices;
-				for (size_t i = 0; i < snapshot.size(); ++i) {
-					auto &state = snapshot[i];
+				std::vector<std::shared_ptr<RayTaskPollState>> active_states;
+				active_states.reserve(snapshot.size());
+				for (auto &state : snapshot) {
 					if (!state || state->done_sent.load()) {
 						continue;
 					}
 					if (!state->handle.has_value()) {
-						SendError(state, "RayTaskResultHandle missing handle");
+						had_progress =
+						    SendError(state, "read handle", "RayTaskResultHandle missing handle") || had_progress;
 						continue;
 					}
-					handles_list.append(state->handle.get());
-					active_indices.push_back(i);
+					try {
+						handles_list.append(state->handle.get());
+						active_states.push_back(state);
+					} catch (const py::error_already_set &e) {
+						had_progress = SendError(state, "read handle", e.what()) || had_progress;
+					} catch (const std::exception &e) {
+						had_progress = SendError(state, "read handle", e.what()) || had_progress;
+					} catch (...) {
+						had_progress = SendError(state, "read handle", "unknown exception") || had_progress;
+					}
 				}
 
-				if (!active_indices.empty()) {
-					// Call batch_wait_ready() - single Python call replaces N done() calls
-					auto driver_mod = py::module_::import("duckdb.runners.ray.driver");
-					py::object batch_wait_fn = driver_mod.attr("batch_wait_ready");
-					py::list ready_indices = batch_wait_fn(handles_list);
+				if (!active_states.empty()) {
+					std::vector<size_t> ready_positions;
+					bool batch_succeeded = false;
+					std::string batch_failure;
+					try {
+						operation = "import duckdb.runners.ray.driver";
+						auto driver_mod = py::module_::import("duckdb.runners.ray.driver");
+						operation = "resolve batch_wait_ready";
+						py::object batch_wait_fn = driver_mod.attr("batch_wait_ready");
+						operation = "batch_wait_ready";
+						py::object ready_result = batch_wait_fn(handles_list);
+						operation = "decode batch_wait_ready result";
+						if (!py::isinstance<py::list>(ready_result)) {
+							throw duckdb::InvalidInputException("batch_wait_ready result must be a list");
+						}
+						ready_positions =
+						    DecodeReadyIndices(py::reinterpret_borrow<py::list>(ready_result), active_states.size());
+						batch_succeeded = true;
+						ClearBatchFailure();
+					} catch (const py::error_already_set &e) {
+						auto detail = std::string(e.what());
+						batch_failure = operation + ": " + detail;
+						ReportBatchFailure(operation, detail);
+					} catch (const std::exception &e) {
+						auto detail = std::string(e.what());
+						batch_failure = operation + ": " + detail;
+						ReportBatchFailure(operation, detail);
+					} catch (...) {
+						batch_failure = operation + ": unknown exception";
+						ReportBatchFailure(operation, "unknown exception");
+					}
 
-					// Process only the ready (done) handles
-					for (auto py_idx : ready_indices) {
-						size_t ready_pos = py_idx.cast<size_t>();
-						if (ready_pos >= active_indices.size())
-							continue;
-						size_t snap_idx = active_indices[ready_pos];
-						auto &state = snapshot[snap_idx];
-						if (state && !state->done_sent.load()) {
-							ProcessDoneUnderGIL(state);
-							had_progress = true;
+					if (!batch_succeeded) {
+						had_progress = PollIndividuallyUnderGIL(active_states, batch_failure) || had_progress;
+					} else {
+						for (auto ready_position : ready_positions) {
+							auto &state = active_states[ready_position];
+							try {
+								had_progress = ProcessDoneUnderGIL(state) || had_progress;
+							} catch (const py::error_already_set &e) {
+								had_progress = SendError(state, "process ready handle", e.what()) || had_progress;
+							} catch (const std::exception &e) {
+								had_progress = SendError(state, "process ready handle", e.what()) || had_progress;
+							} catch (...) {
+								had_progress =
+								    SendError(state, "process ready handle", "unknown exception") || had_progress;
+							}
 						}
 					}
 				}
-			} catch (const py::error_already_set &) {
-				// Best-effort done notification; continue polling other tasks.
-			} catch (const std::exception &) {
+			} catch (const py::error_already_set &e) {
+				auto detail = std::string(e.what());
+				ReportBatchFailure(operation, detail);
+				for (const auto &state : snapshot) {
+					had_progress = SendError(state, operation, detail) || had_progress;
+				}
+			} catch (const std::exception &e) {
+				auto detail = std::string(e.what());
+				ReportBatchFailure(operation, detail);
+				for (const auto &state : snapshot) {
+					had_progress = SendError(state, operation, detail) || had_progress;
+				}
+			} catch (...) {
+				ReportBatchFailure(operation, "unknown exception");
+				for (const auto &state : snapshot) {
+					had_progress = SendError(state, operation, "unknown exception") || had_progress;
+				}
 			}
 
 			// Clean up done tasks
@@ -648,22 +807,22 @@ private:
 		}
 	}
 
-	void SendError(const std::shared_ptr<RayTaskPollState> &state, const string &msg) {
-		if (state->done_sent.exchange(true)) {
-			return;
+	bool SendError(const std::shared_ptr<RayTaskPollState> &state, const string &operation, const string &detail) {
+		if (!state || state->done_sent.exchange(true)) {
+			return false;
 		}
-		// ALWAYS log task errors to stderr
-		duckdb::distributed::DuckDBError err(msg);
+		duckdb::distributed::DuckDBError err(TaskFailureMessage(state, operation, detail));
 		duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>> res =
 		    duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>>::err(err);
 		if (state->result_state) {
 			state->result_state->send(std::move(res));
 		}
+		return true;
 	}
 
-	void SendOutput(const std::shared_ptr<RayTaskPollState> &state, duckdb::distributed::MaterializedOutput output) {
-		if (state->done_sent.exchange(true)) {
-			return;
+	bool SendOutput(const std::shared_ptr<RayTaskPollState> &state, duckdb::distributed::MaterializedOutput output) {
+		if (!state || state->done_sent.exchange(true)) {
+			return false;
 		}
 		// Final task completion is routed through the FTE query result path.
 		if (state->result_state) {
@@ -671,60 +830,72 @@ private:
 			    duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>>::ok(
 			        std::make_pair(true, std::move(output))));
 		}
+		return true;
 	}
 
-	void SendNoOutput(const std::shared_ptr<RayTaskPollState> &state) {
-		if (state->done_sent.exchange(true)) {
-			return;
+	bool SendNoOutput(const std::shared_ptr<RayTaskPollState> &state) {
+		if (!state || state->done_sent.exchange(true)) {
+			return false;
 		}
 		if (state->result_state) {
 			state->result_state->send(
 			    duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>>::ok(
 			        std::make_pair(false, duckdb::distributed::MaterializedOutput())));
 		}
+		return true;
 	}
 
-	// ProcessDoneUnderGIL: handles a task that batch_wait_ready() reported as done.
+	// ProcessDoneUnderGIL: handles a task that batch_wait_ready() or the
+	// per-handle fallback confirmed as done.
 	// GIL is already held by the caller.
-	void ProcessDoneUnderGIL(const std::shared_ptr<RayTaskPollState> &state) {
+	bool ProcessDoneUnderGIL(const std::shared_ptr<RayTaskPollState> &state) {
 		if (!state || state->done_sent.load()) {
-			return;
+			return false;
 		}
+		std::string operation = "read handle";
 		try {
 			if (!state->handle.has_value()) {
-				SendError(state, "RayTaskResultHandle missing handle");
-				return;
+				return SendError(state, operation, "RayTaskResultHandle missing handle");
 			}
 			py::object handle_obj = state->handle.get();
 
+			operation = "handle.get_result_sync";
 			py::object result = handle_obj.attr("get_result_sync")();
+			operation = "decode task result";
 			RayTaskResult task_result = result.cast<RayTaskResult>();
 			if (task_result.tag == RayTaskResult::Tag::Success) {
+				operation = "materialize result partitions";
 				std::vector<::duckdb::distributed::ResultPartitionRef> partitions;
 				partitions.reserve(task_result.parts.size());
 				for (auto &part_obj : task_result.parts) {
 					py::object part = part_obj.get();
 					partitions.push_back(BuildResultPartitionFromPyObject(part));
 				}
+				operation = "build materialized output";
 				auto current_worker_id = WorkerIdFromPythonHandle(handle_obj, state->worker_id);
 				std::vector<duckdb::distributed::NodeID> node_ids(state->task_context.node_ids().begin(),
 				                                                  state->task_context.node_ids().end());
 				::duckdb::distributed::MaterializedOutput mat_output(std::move(partitions), current_worker_id,
 				                                                     std::move(node_ids));
 				mat_output.set_flight_port(task_result.flight_port);
+				operation = "apply exchange sink metadata";
 				ApplyExchangeSinkInstanceToMaterializedOutput(mat_output, task_result.ExchangeSinkInstanceObject());
-				SendOutput(state, std::move(mat_output));
+				operation = "publish task output";
+				return SendOutput(state, std::move(mat_output));
 			} else if (task_result.tag == RayTaskResult::Tag::NoOutput) {
-				SendNoOutput(state);
+				operation = "publish no-output result";
+				return SendNoOutput(state);
 			} else if (task_result.tag == RayTaskResult::Tag::WorkerDied) {
-				SendError(state, "worker died");
+				return SendError(state, "task completion", "worker died");
 			} else {
-				SendError(state, "worker unavailable");
+				return SendError(state, "task completion", "worker unavailable");
 			}
 		} catch (const py::error_already_set &e) {
-			SendError(state, e.what());
+			return SendError(state, operation, e.what());
 		} catch (const std::exception &e) {
-			SendError(state, e.what());
+			return SendError(state, operation, e.what());
+		} catch (...) {
+			return SendError(state, operation, "unknown exception");
 		}
 	}
 
@@ -733,6 +904,7 @@ private:
 	std::atomic<bool> stop_ {false};
 	std::atomic<uint64_t> next_id_ {1};
 	std::thread thread_;
+	std::string last_batch_failure_;
 };
 
 } // namespace
@@ -749,6 +921,7 @@ RayTaskResultHandle::RayTaskResultHandle(TaskContext task_context, py::object ha
 	poll_state_->handle = SafePyObject(std::move(handle));
 	poll_state_->worker_id = worker_id;
 	poll_state_->task_context = task_context;
+	poll_state_->fte_task_id = fte_task_id_;
 	poll_state_->result_state = std::make_shared<duckdb::distributed::UnboundedChannelState<
 	    duckdb::distributed::DuckDBResult<std::pair<bool, duckdb::distributed::MaterializedOutput>>>>();
 	RayTaskResultPoller::Get().Register(poll_state_);

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -580,6 +580,145 @@ def test_ray_task_result_handle_uses_refreshed_worker_id_and_nested_sink_query_i
     assert handle.release_calls == 1
 
 
+class _PollerTestHandle:
+    def __init__(
+        self,
+        name,
+        *,
+        done_error=None,
+        result_error=None,
+        ready_after=1,
+    ):
+        self.worker_id = f"worker-{name}"
+        self.done_error = done_error
+        self.result_error = result_error
+        self.ready_after = ready_after
+        self.done_calls = 0
+
+    def done(self):
+        if self.done_error is not None:
+            raise self.done_error
+        self.done_calls += 1
+        return self.done_calls >= self.ready_after
+
+    def get_result_sync(self):
+        if self.result_error is not None:
+            raise self.result_error
+        return duckdb.ray_cxx.RayTaskResult.success([], [], None, 5010, None)
+
+
+def _poll_with_shared_ray_task_result_poller(*handles):
+    return duckdb.ray_cxx._ray_task_result_poller_batch_for_test(list(handles), timeout_ms=5000)
+
+
+def _assert_successful_poller_outcome(outcome, worker_id):
+    assert outcome == {
+        "terminal": True,
+        "is_error": False,
+        "error": "",
+        "has_output": True,
+        "worker_id": worker_id,
+    }
+
+
+def test_ray_task_result_poller_isolates_handle_done_failure_and_recovers():
+    healthy = _PollerTestHandle("healthy", ready_after=3)
+    outcomes = _poll_with_shared_ray_task_result_poller(
+        _PollerTestHandle("broken", done_error=RuntimeError("injected done failure")),
+        healthy,
+    )
+
+    assert outcomes[0]["terminal"] is True
+    assert outcomes[0]["is_error"] is True
+    assert "operation=handle.done" in outcomes[0]["error"]
+    assert "task_id=poller-test.0" in outcomes[0]["error"]
+    assert "injected done failure" in outcomes[0]["error"]
+    _assert_successful_poller_outcome(outcomes[1], "worker-healthy")
+    assert healthy.done_calls >= 3
+
+    recovery = _poll_with_shared_ray_task_result_poller(_PollerTestHandle("recovery"))
+    _assert_successful_poller_outcome(recovery[0], "worker-recovery")
+
+
+def test_ray_task_result_poller_falls_back_after_batch_helper_failure(monkeypatch, capfd):
+    from duckdb.runners.ray import driver
+
+    def fail_batch_wait(_handles):
+        raise RuntimeError("injected batch helper failure")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(driver, "batch_wait_ready", fail_batch_wait)
+        outcomes = _poll_with_shared_ray_task_result_poller(
+            _PollerTestHandle("first", ready_after=3),
+            _PollerTestHandle("second", ready_after=4),
+        )
+
+    _assert_successful_poller_outcome(outcomes[0], "worker-first")
+    _assert_successful_poller_outcome(outcomes[1], "worker-second")
+    stderr = capfd.readouterr().err
+    assert "operation=batch_wait_ready" in stderr
+    assert "injected batch helper failure" in stderr
+    assert stderr.count("[vane-ray-result-poller]") == 1
+
+    recovery = _poll_with_shared_ray_task_result_poller(_PollerTestHandle("recovery"))
+    _assert_successful_poller_outcome(recovery[0], "worker-recovery")
+
+
+def test_ray_task_result_poller_falls_back_after_driver_import_failure(monkeypatch, capfd):
+    with monkeypatch.context() as patch:
+        patch.setitem(sys.modules, "duckdb.runners.ray.driver", None)
+        outcomes = _poll_with_shared_ray_task_result_poller(_PollerTestHandle("healthy"))
+
+    _assert_successful_poller_outcome(outcomes[0], "worker-healthy")
+    stderr = capfd.readouterr().err
+    assert "operation=import duckdb.runners.ray.driver" in stderr
+    assert "duckdb.runners.ray.driver" in stderr
+
+    recovery = _poll_with_shared_ray_task_result_poller(_PollerTestHandle("recovery"))
+    _assert_successful_poller_outcome(recovery[0], "worker-recovery")
+
+
+@pytest.mark.parametrize(
+    ("ready_indices", "error_fragment"),
+    [
+        pytest.param(["invalid"], "must be an integer", id="non-integer"),
+        pytest.param([-1], "must be non-negative", id="negative"),
+        pytest.param([1], "out of range", id="out-of-range"),
+        pytest.param([0, 0], "duplicate", id="duplicate"),
+    ],
+)
+def test_ray_task_result_poller_falls_back_after_invalid_ready_indices(
+    monkeypatch,
+    capfd,
+    ready_indices,
+    error_fragment,
+):
+    from duckdb.runners.ray import driver
+
+    with monkeypatch.context() as patch:
+        patch.setattr(driver, "batch_wait_ready", lambda _handles: ready_indices)
+        outcomes = _poll_with_shared_ray_task_result_poller(_PollerTestHandle("healthy"))
+
+    _assert_successful_poller_outcome(outcomes[0], "worker-healthy")
+    stderr = capfd.readouterr().err
+    assert "operation=decode batch_wait_ready result" in stderr
+    assert error_fragment in stderr
+
+
+def test_ray_task_result_poller_isolates_per_handle_completion_failure():
+    outcomes = _poll_with_shared_ray_task_result_poller(
+        _PollerTestHandle("broken", result_error=RuntimeError("injected completion failure")),
+        _PollerTestHandle("healthy"),
+    )
+
+    assert outcomes[0]["terminal"] is True
+    assert outcomes[0]["is_error"] is True
+    assert "operation=handle.get_result_sync" in outcomes[0]["error"]
+    assert "task_id=poller-test.0" in outcomes[0]["error"]
+    assert "injected completion failure" in outcomes[0]["error"]
+    _assert_successful_poller_outcome(outcomes[1], "worker-healthy")
+
+
 def test_flight_exchange_source_reads_only_selected_retry_attempt_data(tmp_path):
     result = duckdb.ray_cxx.flight_exchange_selected_attempt_dataplane_for_test(str(tmp_path))
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6570,6 +6570,34 @@ def test_ray_runner_close_is_terminal_and_idempotent(monkeypatch):
     assert ray_runner._closed is True
 
 
+def test_connection_close_notification_reenters_runner_registry_lock(monkeypatch):
+    from duckdb.runners.ray import runner as runner_module
+
+    target_session_id = "reentrant-session"
+    calls = []
+
+    class _LiveRunner:
+        def close_session(self, session_id):
+            calls.append(session_id)
+
+    monkeypatch.setattr(runner_module, "_RAY_RUNNERS", {_LiveRunner()})
+    registry_lock = runner_module._RAY_RUNNERS_LOCK
+
+    registry_lock.acquire()
+    try:
+        reacquired = registry_lock.acquire(blocking=False)
+        assert reacquired, "connection finalizers must be able to re-enter the runner registry lock"
+        if reacquired:
+            registry_lock.release()
+    finally:
+        registry_lock.release()
+
+    with registry_lock:
+        runner_module.notify_connection_closed(target_session_id)
+
+    assert calls.count(target_session_id) == 1
+
+
 def test_connection_close_notification_attempts_every_live_runner(monkeypatch):
     from duckdb.runners.ray import runner as runner_module
 


### PR DESCRIPTION
## Summary

- Keep the batched `batch_wait_ready` path as the fast path, and fall back to polling handles independently when driver import, helper execution, or ready-index validation fails.
- Turn malformed-handle and per-handle completion failures into task-local terminal errors containing the operation, task identity, and original exception, so one bad result handle cannot stall unrelated queries.
- Keep the process-global poller reusable after failures and add fault-injection coverage for import errors, helper errors, malformed indices, completion failures, delayed healthy handles, and recovery.
- Make the local RayRunner registry lock reentrant so WeakSet allocations can safely run synchronous DuckDB connection finalizers without deadlocking the same thread.

## Related issue

close: #76

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change only hardens internal Ray result-poller and connection-close lifecycle handling and adds private test coverage.

## Validation

- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- Result-poller fault-injection tests — 8 passed; repeated 10 times, 80 passed
- Adjacent RayRunner lifecycle/notification tests on Python 3.14 — repeated 100 times, 300 passed
- Controlled WeakSet/GC finalizer reentry reproduction — completes after previously deadlocking and exiting 139
- `scripts/run_release_tests.sh` on Python 3.12 — 396 passed, 1 skipped; Ray shard 7 passed
- `scripts/run_release_tests.sh` on Python 3.14 — 396 passed, 1 skipped; Ray shard 7 passed
- `scripts/run_fast_tests.sh` — non-Ray 5724 passed; shared-Ray 82 passed; all runnable owner-Ray tests passed
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
