### PR TITLE
[fix](ray) Remove elastic GPU allocation

### DIFF
--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -22,6 +22,36 @@ from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 _EPSILON = 1e-9
 
 
+class ElasticGpuDemandError(ValueError):
+    code = "ELASTIC_GPU_UNSUPPORTED"
+
+    def __init__(
+        self,
+        query_id: str,
+        minimum_gpu: float,
+        desired_gpu: float,
+    ) -> None:
+        self.query_id = str(query_id)
+        self.minimum_gpu = float(minimum_gpu)
+        self.desired_gpu = float(desired_gpu)
+        super().__init__(self.query_id, self.minimum_gpu, self.desired_gpu)
+
+    def __str__(self) -> str:
+        return (
+            f"query {self.query_id} GPU resources cannot be elastic: "
+            f"minimum={self.minimum_gpu:g}, desired={self.desired_gpu:g}"
+        )
+
+    def to_dict(self) -> dict[str, str | float]:
+        return {
+            "code": self.code,
+            "query_id": self.query_id,
+            "resource": "gpu",
+            "minimum": self.minimum_gpu,
+            "desired": self.desired_gpu,
+        }
+
+
 def _sum_resources(resources: Sequence[ResourceVector]) -> ResourceVector:
     total = ResourceVector()
     for item in resources:
@@ -100,6 +130,12 @@ class QueryDemand:
         if not self.minimum.fits_within(self.desired):
             exceeded = self.minimum.exceeded_dimensions(self.desired)
             raise ValueError(f"minimum query demand exceeds desired demand for {', '.join(exceeded)}")
+        if not math.isclose(self.minimum.gpu, self.desired.gpu, rel_tol=0.0, abs_tol=_EPSILON):
+            raise ElasticGpuDemandError(
+                query_id=query_id,
+                minimum_gpu=self.minimum.gpu,
+                desired_gpu=self.desired.gpu,
+            )
         weight = float(self.weight)
         if not math.isfinite(weight) or weight <= 0:
             raise ValueError("weight must be finite and > 0")
@@ -445,30 +481,32 @@ class ClusterQueryResourceCoordinator:
             if query_id not in pinned_query_ids:
                 actor_ok = True
                 new_actor_placements: list[ActorPlacement] = []
-                for bundle in state.demand.actor_bundles:
-                    node_id = self._place_bundle(bundle.resources, trial_remaining)
+                for actor_bundle in state.demand.actor_bundles:
+                    node_id = self._place_bundle(actor_bundle.resources, trial_remaining)
                     if node_id is None:
                         actor_ok = False
                         break
                     new_actor_placements.append(
                         ActorPlacement(
-                            stage_id=bundle.stage_id,
-                            actor_index=bundle.actor_index,
+                            stage_id=actor_bundle.stage_id,
+                            actor_index=actor_bundle.actor_index,
                             node_id=node_id,
                         )
                     )
-                    trial_allocations[node_id] = trial_allocations.get(node_id, ResourceVector()) + bundle.resources
+                    trial_allocations[node_id] = (
+                        trial_allocations.get(node_id, ResourceVector()) + actor_bundle.resources
+                    )
                 if not actor_ok:
                     continue
                 actor_placements_by_query[query_id] = tuple(new_actor_placements)
 
             task_ok = True
-            for bundle in state.demand.task_bundles:
-                node_id = self._place_bundle(bundle, trial_remaining)
+            for task_bundle in state.demand.task_bundles:
+                node_id = self._place_bundle(task_bundle, trial_remaining)
                 if node_id is None:
                     task_ok = False
                     break
-                trial_allocations[node_id] = trial_allocations.get(node_id, ResourceVector()) + bundle
+                trial_allocations[node_id] = trial_allocations.get(node_id, ResourceVector()) + task_bundle
             if not task_ok:
                 continue
 
@@ -480,8 +518,8 @@ class ClusterQueryResourceCoordinator:
         extra_capacity = _sum_resources(list(remaining.values()))
         extras = self._weighted_drf_extras(admitted, extra_capacity, total_capacity)
 
-        # Place the aggregate DRF result onto concrete nodes. Each dimension is
-        # divisible; indivisible actor bundles were already placed above.
+        # Place the aggregate DRF result onto concrete nodes. GPU demand is
+        # fixed in the bundles above; only CPU and memory extras are divisible.
         for state in admitted:
             query_id = state.demand.query_id
             extra = extras.get(query_id, ResourceVector())
@@ -546,7 +584,7 @@ class ClusterQueryResourceCoordinator:
         remaining: dict[str, ResourceVector],
     ) -> dict[str, ResourceVector] | None:
         if request.gpu > _EPSILON:
-            return None
+            raise AssertionError("divisible placement received fixed GPU resources")
         trial_remaining = dict(remaining)
         allocations = {node_id: ResourceVector() for node_id in remaining}
         for field_name in ("cpu", "heap_bytes", "object_store_bytes"):
@@ -700,6 +738,7 @@ class ClusterQueryResourceCoordinator:
 __all__ = [
     "ActorResourceBundle",
     "ClusterQueryResourceCoordinator",
+    "ElasticGpuDemandError",
     "NodeCapacity",
     "QueryDemand",
     "read_ray_node_capacities",

--- a/duckdb/runners/ray/query_execution_graph.py
+++ b/duckdb/runners/ray/query_execution_graph.py
@@ -78,7 +78,12 @@ class ResourceVector:
         underflow = [name for name, value in values.items() if value < 0]
         if underflow:
             raise ValueError(f"resource subtraction underflow: {', '.join(underflow)}")
-        return ResourceVector(**values)
+        return ResourceVector(
+            cpu=values["cpu"],
+            gpu=values["gpu"],
+            heap_bytes=int(values["heap_bytes"]),
+            object_store_bytes=int(values["object_store_bytes"]),
+        )
 
     def scale(self, factor: float) -> ResourceVector:
         factor = float(factor)
@@ -300,8 +305,7 @@ class StageResourceSpec:
     generator_buffer_blocks: int
     max_concurrency: int | None
     resident_per_actor: ResourceVector = field(default_factory=ResourceVector)
-    actor_min_size: int = 0
-    actor_max_size: int = 0
+    actor_pool_size: int = 0
     actor_prefetch_depth: int = 1
     spill_mode: str = "streaming"
 
@@ -317,8 +321,7 @@ class StageResourceSpec:
         "generator_buffer_blocks",
         "max_concurrency",
         "resident_per_actor",
-        "actor_min_size",
-        "actor_max_size",
+        "actor_pool_size",
         "actor_prefetch_depth",
         "spill_mode",
     )
@@ -344,8 +347,7 @@ class StageResourceSpec:
             "generator_buffer_blocks": int(self.generator_buffer_blocks),
             "max_concurrency": None if self.max_concurrency is None else int(self.max_concurrency),
             "resident_per_actor": self.resident_per_actor.to_dict(),
-            "actor_min_size": int(self.actor_min_size),
-            "actor_max_size": int(self.actor_max_size),
+            "actor_pool_size": int(self.actor_pool_size),
             "actor_prefetch_depth": int(self.actor_prefetch_depth),
             "spill_mode": self.spill_mode,
         }
@@ -367,8 +369,7 @@ class StageResourceSpec:
             generator_buffer_blocks=int(values["generator_buffer_blocks"]),
             max_concurrency=None if max_concurrency is None else int(max_concurrency),
             resident_per_actor=ResourceVector.from_dict(values["resident_per_actor"]),
-            actor_min_size=int(values["actor_min_size"]),
-            actor_max_size=int(values["actor_max_size"]),
+            actor_pool_size=int(values["actor_pool_size"]),
             actor_prefetch_depth=int(values["actor_prefetch_depth"]),
             spill_mode=str(values["spill_mode"]),
         )
@@ -495,14 +496,11 @@ class QueryExecutionGraph:
             if process_resources.heap_bytes <= 0:
                 raise ValueError(f"Ray stage {stage.stage_id} must request non-zero heap_bytes")
 
-        actor_min = int(stage.actor_min_size)
-        actor_max = int(stage.actor_max_size)
+        actor_pool_size = int(stage.actor_pool_size)
         actor_prefetch_depth = int(stage.actor_prefetch_depth)
         if stage.backend == "ray_actor":
-            if actor_min <= 0:
-                raise ValueError(f"ray_actor stage {stage.stage_id} actor_min_size must be > 0")
-            if actor_max < actor_min:
-                raise ValueError(f"ray_actor stage {stage.stage_id} actor_max_size must be >= actor_min_size")
+            if actor_pool_size <= 0:
+                raise ValueError(f"ray_actor stage {stage.stage_id} actor_pool_size must be > 0")
             if actor_prefetch_depth <= 0:
                 raise ValueError(f"ray_actor stage {stage.stage_id} actor_prefetch_depth must be > 0")
             if stage.max_concurrency is not None:
@@ -511,8 +509,8 @@ class QueryExecutionGraph:
                 raise ValueError(
                     f"ray_actor stage {stage.stage_id} invocation resources may only contain object-store bytes"
                 )
-        elif actor_min != 0 or actor_max != 0:
-            raise ValueError(f"actor bounds are only valid for ray_actor stages: {stage.stage_id}")
+        elif actor_pool_size != 0:
+            raise ValueError(f"actor_pool_size is only valid for ray_actor stages: {stage.stage_id}")
         elif actor_prefetch_depth != 1:
             raise ValueError(f"actor_prefetch_depth is only configurable for ray_actor stages: {stage.stage_id}")
         elif not stage.resident_per_actor.is_zero():
@@ -663,18 +661,20 @@ class QueryExecutionGraph:
             ):
                 raise ValueError(f"stage {stage.stage_id} maximum task does not fit any allocated Ray node")
             if stage.backend == "ray_actor":
-                actor_minimum = placement_commitment.scale(stage.actor_min_size)
-                exceeded_actor = actor_minimum.exceeded_dimensions(capacity)
+                actor_pool = placement_commitment.scale(stage.actor_pool_size)
+                exceeded_actor = actor_pool.exceeded_dimensions(capacity)
                 if require_full_minimum and exceeded_actor:
                     raise ValueError(
-                        f"stage {stage.stage_id} actor minimum exceeds query allocation for {', '.join(exceeded_actor)}"
+                        f"stage {stage.stage_id} actor pool exceeds query allocation for {', '.join(exceeded_actor)}"
                     )
                 placements = [
                     placement for placement in allocation.actor_placements if placement.stage_id == stage.stage_id
                 ]
-                if require_full_minimum and len(placements) != stage.actor_min_size:
-                    raise ValueError(f"stage {stage.stage_id} requires exactly {stage.actor_min_size} actor placements")
-                expected_indices = set(range(stage.actor_min_size))
+                if require_full_minimum and len(placements) != stage.actor_pool_size:
+                    raise ValueError(
+                        f"stage {stage.stage_id} requires exactly {stage.actor_pool_size} actor placements"
+                    )
+                expected_indices = set(range(stage.actor_pool_size))
                 placement_indices = {placement.actor_index for placement in placements}
                 if placements and placement_indices != expected_indices:
                     raise ValueError(f"stage {stage.stage_id} actor placement indices must be contiguous from zero")

--- a/duckdb/runners/ray/query_graph_builder.py
+++ b/duckdb/runners/ray/query_graph_builder.py
@@ -232,8 +232,7 @@ def _udf_stage(
             )
         )
         max_concurrency = None
-        actor_min = actor_size
-        actor_max = actor_size
+        actor_pool_size = actor_size
         resident_per_actor = ResourceVector(
             cpu=cpu,
             gpu=gpu,
@@ -242,8 +241,7 @@ def _udf_stage(
         invocation_resources = ResourceVector(object_store_bytes=input_window)
     else:
         max_concurrency = None
-        actor_min = 0
-        actor_max = 0
+        actor_pool_size = 0
         actor_prefetch_depth = 1
         resident_per_actor = ResourceVector()
         invocation_resources = ResourceVector(
@@ -264,8 +262,7 @@ def _udf_stage(
         generator_buffer_blocks=retention_blocks,
         max_concurrency=max_concurrency,
         resident_per_actor=resident_per_actor,
-        actor_min_size=actor_min,
-        actor_max_size=actor_max,
+        actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
         spill_mode="streaming",
     )
@@ -438,20 +435,18 @@ def build_query_demand(
     fte_tasks: list[ResourceVector] = []
     ray_tasks: list[ResourceVector] = []
     downstream_fte_tasks: list[ResourceVector] = []
-    desired_gpu = 0.0
     stage_by_id = {stage.stage_id: stage for stage in graph.stages}
     for stage in graph.stages:
         commitment = _task_commitment(stage)
         if stage.backend == "ray_actor":
-            actor_bundle = stage.resident_per_actor + commitment
-            desired_gpu += stage.resident_per_actor.gpu * stage.actor_max_size
+            actor_commitment = stage.resident_per_actor + commitment
             actor_bundles.extend(
                 ActorResourceBundle(
                     stage_id=stage.stage_id,
                     actor_index=actor_index,
-                    resources=actor_bundle,
+                    resources=actor_commitment,
                 )
-                for actor_index in range(stage.actor_min_size)
+                for actor_index in range(stage.actor_pool_size)
             )
         elif stage.backend == "ray_task":
             ray_tasks.append(commitment)
@@ -469,8 +464,8 @@ def build_query_demand(
         if stage_id in downstream_fte_stage_ids
     )
     minimum = ResourceVector()
-    for bundle in actor_bundles:
-        minimum = minimum + bundle.resources
+    for required_actor in actor_bundles:
+        minimum = minimum + required_actor.resources
     task_bundles = tuple(
         bundle
         # Reserve the nested Ray process before its parent FTE bundle.  The
@@ -488,14 +483,13 @@ def build_query_demand(
         )
         if not bundle.is_zero()
     )
-    for bundle in task_bundles:
-        minimum = minimum + bundle
+    for task_bundle in task_bundles:
+        minimum = minimum + task_bundle
     desired = ResourceVector(
         cpu=cluster_capacity.cpu,
-        # GPU task commitments are indivisible task bundles just like their
-        # CPU/heap commitments. Keep enough GPU allocation for the minimum
-        # runnable task set in addition to any fixed actor residency.
-        gpu=min(cluster_capacity.gpu, max(desired_gpu, minimum.gpu)),
+        # GPU commitments remain fixed indivisible bundles. Only CPU and
+        # memory headroom participate in elastic DRF allocation.
+        gpu=minimum.gpu,
         heap_bytes=cluster_capacity.heap_bytes,
         object_store_bytes=cluster_capacity.object_store_bytes,
     )

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -836,10 +836,10 @@ class QueryResourceManager:
             evaluations = self._evaluate_waiting_tasks_locked()
             owned_fatal = [item for item in evaluations if item.fatal and item.key in candidate_keys]
             if owned_fatal:
-                selected = min(owned_fatal, key=lambda item: item.rank)
-                return selected.request, TaskGrant(
+                fatal_selected = min(owned_fatal, key=lambda item: item.rank)
+                return fatal_selected.request, TaskGrant(
                     False,
-                    blocked_reason=selected.reason or "fatal_task_admission",
+                    blocked_reason=fatal_selected.reason or "fatal_task_admission",
                     fatal=True,
                 )
             selected = self._select_waiting_task_evaluation_locked(evaluations)
@@ -1619,7 +1619,7 @@ class QueryResourceManager:
         """Cap a soft share by tasks that can coexist under every hard dimension."""
         concurrency = self._stage_concurrency_cap(spec)
         if spec.backend == "ray_actor":
-            concurrency = spec.actor_min_size
+            concurrency = spec.actor_pool_size
         hard_bound = math.inf if concurrency is None else int(concurrency)
         commitment = self._task_commitment(spec)
         for resource_field in _RESOURCE_FIELDS:
@@ -1759,7 +1759,7 @@ class QueryResourceManager:
 
     def _preferred_liveness_stage_locked(self) -> str | None:
         if self._waiting_task_inputs:
-            candidates: list[str] = []
+            waiting_candidates: list[str] = []
             for stage_id in self.graph.reverse_topological_stage_ids():
                 for request, _ in self._waiting_task_inputs.values():
                     if str(request.stage_id) != stage_id:
@@ -1769,18 +1769,18 @@ class QueryResourceManager:
                         hypothetical=True,
                     )
                     if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
-                        candidates.append(stage_id)
+                        waiting_candidates.append(stage_id)
                         break
-            if not candidates:
+            if not waiting_candidates:
                 return None
             starving = [
                 stage_id
-                for stage_id in candidates
+                for stage_id in waiting_candidates
                 if self._stages[stage_id].queued_input_bytes > 0
                 and self._active_task_count_for_stage_locked(stage_id) == 0
             ]
-            return (starving or candidates)[0]
-        candidates: list[str] = []
+            return (starving or waiting_candidates)[0]
+        runnable_candidates: list[str] = []
         for stage_id in self.graph.reverse_topological_stage_ids():
             stage = self._stages[stage_id]
             if not stage.runnable or stage.completed:
@@ -1798,15 +1798,15 @@ class QueryResourceManager:
                 hypothetical=True,
             )
             if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
-                candidates.append(stage_id)
-        if not candidates:
+                runnable_candidates.append(stage_id)
+        if not runnable_candidates:
             return None
         starving = [
             stage_id
-            for stage_id in candidates
+            for stage_id in runnable_candidates
             if self._stages[stage_id].queued_input_bytes > 0 and self._active_task_count_for_stage_locked(stage_id) == 0
         ]
-        return (starving or candidates)[0]
+        return (starving or runnable_candidates)[0]
 
     def _grant_task_locked(
         self,
@@ -1854,7 +1854,7 @@ class QueryResourceManager:
             else:
                 self._queued_actor_slot_leases.setdefault(actor_slot, deque()).append(lease.lease_id)
         if plan.new_credit is not None:
-            credit = _ContinuationCredit(
+            new_credit = _ContinuationCredit(
                 credit_id=uuid.uuid4().hex,
                 parent_task_lease_id=lease.lease_id,
                 parent_stage_id=lease.stage_id,
@@ -1864,20 +1864,20 @@ class QueryResourceManager:
                 resources=plan.new_credit.resources,
                 allocation_generation=self.allocation.generation,
             )
-            self._continuation_credits[credit.credit_id] = credit
-            self._continuation_credit_by_parent[lease.lease_id] = credit.credit_id
+            self._continuation_credits[new_credit.credit_id] = new_credit
+            self._continuation_credit_by_parent[lease.lease_id] = new_credit.credit_id
         elif plan.borrowed_credit_id is not None:
-            credit = self._continuation_credits.get(plan.borrowed_credit_id)
+            borrowed_credit = self._continuation_credits.get(plan.borrowed_credit_id)
             if (
-                credit is None
-                or not credit.parent_active
-                or credit.borrowed_by_task_lease_id is not None
-                or lease.stage_id not in credit.eligible_stage_ids
-                or credit.node_id != lease.node_id
+                borrowed_credit is None
+                or not borrowed_credit.parent_active
+                or borrowed_credit.borrowed_by_task_lease_id is not None
+                or lease.stage_id not in borrowed_credit.eligible_stage_ids
+                or borrowed_credit.node_id != lease.node_id
             ):
                 raise RuntimeError("continuation credit changed during atomic task admission")
-            credit.borrowed_by_task_lease_id = lease.lease_id
-            self._continuation_credit_by_borrower[lease.lease_id] = credit.credit_id
+            borrowed_credit.borrowed_by_task_lease_id = lease.lease_id
+            self._continuation_credit_by_borrower[lease.lease_id] = borrowed_credit.credit_id
         self._waiting_task_inputs.pop((lease.task_id, lease.attempt_id), None)
         self._recompute_stage_queued_input_locked(lease.stage_id)
         self._started_stage_ids.add(lease.stage_id)
@@ -2483,8 +2483,6 @@ class QueryResourceManager:
         outputs_by_idle_credit: dict[str, int] = {}
         for output in self._output_leases.values():
             if node_id is not None and output.node_id != node_id:
-                continue
-            if stage_id is not None and output.producer_stage_id != stage_id:
                 continue
             credit_id = output.continuation_credit_id
             credit = self._continuation_credits.get(credit_id or "")

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import pickle
 from types import SimpleNamespace
 
 import pytest
@@ -9,11 +10,12 @@ from duckdb.runners.ray import cluster_resource_coordinator as coordinator_modul
 from duckdb.runners.ray.cluster_resource_coordinator import (
     ActorResourceBundle,
     ClusterQueryResourceCoordinator,
+    ElasticGpuDemandError,
     NodeCapacity,
     QueryDemand,
     read_ray_node_capacities,
 )
-from duckdb.runners.ray.query_execution_graph import ResourceVector
+from duckdb.runners.ray.query_execution_graph import ActorPlacement, ResourceVector
 
 
 def _r(
@@ -320,6 +322,82 @@ def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
     assert allocation.resources == _r(cpu=3, heap=300, store=400)
 
 
+def test_query_demand_rejects_elastic_gpu_headroom_before_registration():
+    minimum = _r(cpu=1, gpu=1, heap=100)
+
+    with pytest.raises(
+        ElasticGpuDemandError,
+        match=r"GPU resources cannot be elastic: minimum=1, desired=4",
+    ) as raised:
+        _demand(
+            "elastic-gpu",
+            minimum=minimum,
+            desired=_r(cpu=4, gpu=4, heap=400),
+            actor_bundles=(minimum,),
+        )
+
+    assert raised.value.to_dict() == {
+        "code": "ELASTIC_GPU_UNSUPPORTED",
+        "query_id": "elastic-gpu",
+        "resource": "gpu",
+        "minimum": 1.0,
+        "desired": 4.0,
+    }
+    restored = pickle.loads(pickle.dumps(raised.value))
+    assert isinstance(restored, ElasticGpuDemandError)
+    assert str(restored) == str(raised.value)
+    assert restored.to_dict() == raised.value.to_dict()
+
+
+def test_fixed_gpu_bundle_receives_only_divisible_cpu_and_memory_headroom():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("gpu-node", cpu=4, gpu=1, heap=400, store=400),),
+    )
+    fixed_gpu_bundle = _r(cpu=1, gpu=1, heap=100)
+    desired = _r(cpu=4, gpu=1, heap=400, store=400)
+
+    allocation = coordinator.register_query(
+        _demand(
+            "fixed-gpu",
+            minimum=fixed_gpu_bundle,
+            desired=desired,
+            actor_bundles=(fixed_gpu_bundle,),
+        ),
+        now=0,
+    )
+
+    assert allocation.resources == desired
+    assert allocation.actor_placements == (ActorPlacement(stage_id="stage:actor", actor_index=0, node_id="gpu-node"),)
+
+
+def test_fractional_gpu_actor_bundles_are_placed_whole_on_heterogeneous_nodes():
+    coordinator = ClusterQueryResourceCoordinator(
+        (
+            _node("half-gpu", cpu=2, gpu=0.5, heap=200),
+            _node("quarter-gpu", cpu=1, gpu=0.25, heap=100),
+        )
+    )
+    bundle = _r(cpu=1, gpu=0.25, heap=100)
+    fixed_pool = bundle.scale(3)
+
+    allocation = coordinator.register_query(
+        _demand(
+            "fractional-gpu",
+            minimum=fixed_pool,
+            desired=fixed_pool,
+            actor_bundles=(bundle, bundle, bundle),
+        ),
+        now=0,
+    )
+
+    assert allocation.resources == fixed_pool
+    assert allocation.actor_placements == (
+        ActorPlacement(stage_id="stage:actor", actor_index=0, node_id="quarter-gpu"),
+        ActorPlacement(stage_id="stage:actor", actor_index=1, node_id="half-gpu"),
+        ActorPlacement(stage_id="stage:actor", actor_index=2, node_id="half-gpu"),
+    )
+
+
 def test_indivisible_gpu_actor_bundle_must_fit_one_node_not_cluster_aggregate():
     coordinator = ClusterQueryResourceCoordinator(
         (
@@ -392,7 +470,7 @@ def test_actor_bundle_resources_must_be_part_of_query_minimum():
         )
 
 
-def test_gpu_actor_minima_use_priority_then_fifo_without_partial_bundle_grants():
+def test_gpu_actor_pools_use_priority_then_fifo_without_partial_bundle_grants():
     coordinator = ClusterQueryResourceCoordinator(
         (
             _node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),
@@ -415,7 +493,7 @@ def test_gpu_actor_minima_use_priority_then_fifo_without_partial_bundle_grants()
     assert sum(snapshot[query_id]["allocation"]["resources"]["gpu"] for query_id in snapshot) == 2
 
 
-def test_running_gpu_actor_minimum_is_not_preempted_by_later_high_priority_query():
+def test_running_gpu_actor_pool_is_not_preempted_by_later_high_priority_query():
     coordinator = ClusterQueryResourceCoordinator((_node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),))
     bundle = _r(cpu=1, gpu=1, heap=100)
     low = coordinator.register_query(

--- a/tests/fast/test_query_execution_graph.py
+++ b/tests/fast/test_query_execution_graph.py
@@ -50,8 +50,7 @@ def _stage(
     target_output_block_bytes: int = 16 * MIB,
     generator_buffer_blocks: int = 2,
     max_concurrency: int | None = None,
-    actor_min_size: int = 0,
-    actor_max_size: int = 0,
+    actor_pool_size: int = 0,
     actor_prefetch_depth: int = 1,
     spill_mode: str = "streaming",
 ) -> StageResourceSpec:
@@ -78,8 +77,7 @@ def _stage(
         generator_buffer_blocks=generator_buffer_blocks,
         max_concurrency=max_concurrency,
         resident_per_actor=resident,
-        actor_min_size=actor_min_size,
-        actor_max_size=actor_max_size,
+        actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
         spill_mode=spill_mode,
     )
@@ -148,8 +146,7 @@ def test_graph_orders_stages_deterministically_and_preserves_one_stage_identity_
         backend="ray_actor",
         per_task=_resources(cpu=1, gpu=1, heap_bytes=1024 * MIB),
         max_concurrency=None,
-        actor_min_size=1,
-        actor_max_size=1,
+        actor_pool_size=1,
     )
     graph = _graph(gpu_udf, scan, cpu_udf, terminals=(gpu_udf.stage_id,))
 
@@ -191,8 +188,7 @@ def test_graph_identifies_downstream_fte_slots_after_non_fte_boundaries():
         inputs=(post_task_fte.stage_id,),
         backend="ray_actor",
         per_task=_resources(gpu=1),
-        actor_min_size=1,
-        actor_max_size=1,
+        actor_pool_size=1,
     )
     post_actor_fte = _stage(
         "stage:fragment-3:post-actor-fte",
@@ -289,8 +285,7 @@ def test_graph_rejects_zero_heap_for_every_ray_python_process(backend):
         "stage:fragment-1:udf",
         backend=backend,
         per_task=_resources(heap_bytes=0),
-        actor_min_size=1 if backend == "ray_actor" else 0,
-        actor_max_size=1 if backend == "ray_actor" else 0,
+        actor_pool_size=1 if backend == "ray_actor" else 0,
     )
 
     with pytest.raises(ValueError, match="non-zero heap_bytes"):
@@ -310,17 +305,15 @@ def test_graph_rejects_ray_stage_without_cpu_or_gpu_scheduling_resources():
 @pytest.mark.parametrize(
     "changes, message",
     [
-        ({"actor_min_size": 0, "actor_max_size": 1}, "actor_min_size"),
-        ({"actor_min_size": 2, "actor_max_size": 1}, "actor_max_size"),
-        ({"actor_min_size": 1, "actor_max_size": 1, "max_concurrency": 1}, "concurrency is owned"),
+        ({"actor_pool_size": 0}, "actor_pool_size"),
+        ({"actor_pool_size": 1, "max_concurrency": 1}, "concurrency is owned"),
     ],
 )
-def test_graph_rejects_invalid_actor_bounds(changes, message):
+def test_graph_rejects_invalid_actor_pool(changes, message):
     params = {
         "backend": "ray_actor",
         "max_concurrency": None,
-        "actor_min_size": 1,
-        "actor_max_size": 1,
+        "actor_pool_size": 1,
         **changes,
     }
     stage = _stage("stage:fragment-1:gpu-udf", **params)
@@ -329,12 +322,11 @@ def test_graph_rejects_invalid_actor_bounds(changes, message):
         _graph(stage, terminals=(stage.stage_id,))
 
 
-def test_graph_rejects_actor_bounds_on_non_actor_stage():
+def test_graph_rejects_actor_pool_on_non_actor_stage():
     stage = _stage(
         "stage:fragment-1:udf",
         backend="ray_task",
-        actor_min_size=1,
-        actor_max_size=1,
+        actor_pool_size=1,
     )
 
     with pytest.raises(ValueError, match="only valid for ray_actor"):
@@ -345,8 +337,7 @@ def test_graph_rejects_invalid_actor_prefetch_depth():
     actor = _stage(
         "stage:fragment-1:gpu-udf",
         backend="ray_actor",
-        actor_min_size=1,
-        actor_max_size=1,
+        actor_pool_size=1,
         actor_prefetch_depth=0,
     )
     with pytest.raises(ValueError, match="actor_prefetch_depth"):
@@ -501,8 +492,7 @@ def test_allocation_rejects_cumulative_actor_placements_on_one_node():
         target_output_block_bytes=10,
         generator_buffer_blocks=2,
         max_concurrency=None,
-        actor_min_size=2,
-        actor_max_size=2,
+        actor_pool_size=2,
     )
     graph = _graph(actor, terminals=(actor.stage_id,))
     per_node = _resources(cpu=1, gpu=1, heap_bytes=100, object_store_bytes=30)

--- a/tests/fast/test_query_graph_builder.py
+++ b/tests/fast/test_query_graph_builder.py
@@ -115,8 +115,7 @@ def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():
     assert gpu_udf.resident_per_actor == ResourceVector(cpu=1, gpu=1, heap_bytes=3 * GIB)
     assert gpu_udf.per_task == ResourceVector(object_store_bytes=128 * MIB)
     assert gpu_udf.max_concurrency is None
-    assert gpu_udf.actor_min_size == 1
-    assert gpu_udf.actor_max_size == 1
+    assert gpu_udf.actor_pool_size == 1
     assert gpu_udf.actor_prefetch_depth == 2
 
 
@@ -238,7 +237,7 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_reserves_actor_minima_and_downstream_fte_progress_slot():
+def test_query_demand_reserves_fixed_actor_pool_and_downstream_fte_progress_slot():
     graph = build_query_execution_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
@@ -288,6 +287,24 @@ def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():
     assert demand.desired.gpu == 2
     assert demand.actor_bundles[0].resources.gpu == 1
     assert demand.task_bundles[0].gpu == 1
+
+
+def test_query_demand_reserves_every_fractional_gpu_actor_in_fixed_pool():
+    metadata = _metadata()
+    actor_payload = metadata["nodes"][2]["udf_payload"]
+    actor_payload["actor_pool_size"] = 3
+    actor_payload["gpus"] = 0.25
+    graph = build_query_execution_graph(metadata, env={})
+    cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
+
+    demand = build_query_demand(graph, cluster)
+    actor_stage = graph.stage_by_id(udf_stage_id_for_node("query-7", "3"))
+
+    assert actor_stage.actor_pool_size == 3
+    assert [bundle.actor_index for bundle in demand.actor_bundles] == [0, 1, 2]
+    assert all(bundle.resources.gpu == 0.25 for bundle in demand.actor_bundles)
+    assert demand.minimum.gpu == 0.75
+    assert demand.desired.gpu == demand.minimum.gpu
 
 
 def test_fragment_identity_maps_directly_to_pre_registered_fte_stage():

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -44,8 +44,7 @@ def _stage(
     blocks=2,
     concurrency=100,
     backend="ray_task",
-    actor_min=0,
-    actor_max=0,
+    actor_pool_size=0,
     actor_prefetch_depth=1,
     resident=None,
     stage_kind="udf",
@@ -73,8 +72,7 @@ def _stage(
         generator_buffer_blocks=blocks,
         max_concurrency=concurrency if backend == "ray_worker" else None,
         resident_per_actor=resident_resources,
-        actor_min_size=actor_min,
-        actor_max_size=actor_max,
+        actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
         spill_mode="streaming",
     )
@@ -99,7 +97,7 @@ def _manager(
         ActorPlacement(stage_id=stage.stage_id, actor_index=actor_index, node_id="node-a")
         for stage in stages
         if stage.backend == "ray_actor"
-        for actor_index in range(stage.actor_min_size)
+        for actor_index in range(stage.actor_pool_size)
     )
     allocation = _allocation(
         allocation_resources,
@@ -142,8 +140,7 @@ def test_task_admission_requires_runnable_registered_stage_and_ready_actor():
         resources=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
         concurrency=1,
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(actor, resources=_r(cpu=2, gpu=1, heap=500, store=500))
 
@@ -167,8 +164,7 @@ def test_actor_task_leases_own_distinct_concrete_actor_slots():
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
         concurrency=None,
-        actor_min=2,
-        actor_max=2,
+        actor_pool_size=2,
     )
     manager = _manager(
         actor,
@@ -207,8 +203,7 @@ def test_actor_prefetch_depth_queues_one_call_per_concrete_actor():
         resources=_r(store=40),
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
-        actor_min=2,
-        actor_max=2,
+        actor_pool_size=2,
         actor_prefetch_depth=2,
     )
     manager = _manager(
@@ -262,8 +257,7 @@ def test_idle_actor_resident_resources_remain_charged_to_query_and_node():
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
         concurrency=None,
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         actor,
@@ -294,8 +288,7 @@ def test_soft_reservation_only_divides_each_dimension_among_stages_that_need_it(
         target=0,
         blocks=0,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         *cpu_stages,
@@ -330,8 +323,7 @@ def test_stage_minimum_commitments_are_protected_before_shared_heap_borrowing():
         target=0,
         blocks=0,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         *cpu_stages,
@@ -357,8 +349,7 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_stage_capacity():
         blocks=0,
         concurrency=None,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     cpu_stage = _stage(
         "stage:f:cpu",
@@ -1478,8 +1469,7 @@ def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
         target=0,
         blocks=0,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         parent,
@@ -1525,8 +1515,7 @@ def test_ray_task_placement_preserves_combined_fte_and_pinned_actor_reservations
         target=2,
         blocks=1,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         producer,
@@ -1614,8 +1603,7 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
         target=1,
         blocks=1,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         producer,
@@ -1674,8 +1662,7 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
         target=0,
         blocks=0,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
         actor_prefetch_depth=3,
     )
     downstream = _stage(
@@ -1777,8 +1764,7 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
         target=1,
         blocks=1,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     # actor resident + invocation, one Ray task credit, the invoking FTE task,
     # and one downstream FTE progress slot: this is the registered minimum.
@@ -1858,8 +1844,7 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
         target=0,
         blocks=0,
         backend="ray_actor",
-        actor_min=1,
-        actor_max=1,
+        actor_pool_size=1,
     )
     manager = _manager(
         parent,


### PR DESCRIPTION
## Summary

- collapse the internal Ray actor minimum/maximum model into the physical `actor_pool_size`, making every actor in the pool a required indivisible resource bundle
- keep GPU demand fixed at the minimum bundle total while CPU, heap, and object-store headroom continue through weighted DRF
- reject unsupported elastic GPU demand with a structured, pickle-safe `ElasticGpuDemandError`, and assert that fixed GPU resources never reach the divisible placer
- cover fixed GPU plus elastic CPU/memory, fractional GPU actor pools, heterogeneous nodes, serialization, placement validation, and resource-manager accounting

The public UDF `actor_pool_size` API is unchanged. The internal execution-graph replay schema now contains only `actor_pool_size`; the removed actor min/max schema has no compatibility reader or fallback.

## Related issue

close: #87

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal query-resource accounting and diagnostics only.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `python -m pytest tests/fast/test_cluster_resource_coordinator.py tests/fast/test_query_execution_graph.py tests/fast/test_query_graph_builder.py tests/fast/test_query_resource_manager.py tests/fast/test_ray_remote_exceptions.py -q` (154 passed)
- `scripts/run_release_tests.sh` (387 passed, 1 skipped, 11 deselected; 7 real-Ray tests passed, 392 deselected)
- `VANE_FAST_TEST_NON_RAY_SHARD_COUNT=2 VANE_FAST_TEST_NON_RAY_SHARD_INDEX=0 scripts/run_fast_tests.sh non-ray` (2846 passed, 12 skipped, 5 xfailed)
- `VANE_FAST_TEST_NON_RAY_SHARD_COUNT=2 VANE_FAST_TEST_NON_RAY_SHARD_INDEX=1 scripts/run_fast_tests.sh non-ray` (2846 passed, 13 skipped, 3 xfailed, 1 xpassed)
- `scripts/run_fast_tests.sh shared-ray` (85 passed, 10 skipped, 5740 deselected)
- `scripts/run_fast_tests.sh owner-ray` (6 passed, 3 environment-dependent skips)
- deterministic stress check: 500 randomized heterogeneous placements and 64 concurrent registrations passed
- two consecutive post-fix review rounds found no remaining issues, including lock-boundary and deadlock review

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
