### PR TITLE
[fix](tests) Isolate session-close callback assertions

### DIFF
--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6573,7 +6573,11 @@ def test_ray_runner_close_is_terminal_and_idempotent(monkeypatch):
 def test_connection_close_notification_attempts_every_live_runner(monkeypatch):
     from duckdb.runners.ray import runner as runner_module
 
+    target_session_id = "session-a"
     calls = []
+
+    def runners_called_for(session_id):
+        return sorted(name for name, called_session_id in calls if called_session_id == session_id)
 
     class _LiveRunner:
         def __init__(self, name, *, fail):
@@ -6582,30 +6586,27 @@ def test_connection_close_notification_attempts_every_live_runner(monkeypatch):
 
         def close_session(self, session_id):
             calls.append((self.name, session_id))
-            if self.fail:
+            if self.fail and session_id == target_session_id:
                 raise RuntimeError(f"planned close failure on {self.name}")
 
     failing = _LiveRunner("runner-a", fail=True)
     succeeding = _LiveRunner("runner-b", fail=False)
     monkeypatch.setattr(runner_module, "_RAY_RUNNERS", {failing, succeeding})
 
-    with pytest.raises(RuntimeError, match="planned close failure on runner-a"):
-        runner_module.notify_connection_closed("session-a")
+    # A connection finalized by another test may notify the process-global
+    # runner registry while this monkeypatch is active.
+    runner_module.notify_connection_closed("unrelated-session")
+    assert runners_called_for("unrelated-session") == ["runner-a", "runner-b"]
 
-    assert sorted(calls) == [
-        ("runner-a", "session-a"),
-        ("runner-b", "session-a"),
-    ]
+    with pytest.raises(RuntimeError, match="planned close failure on runner-a"):
+        runner_module.notify_connection_closed(target_session_id)
+
+    assert runners_called_for(target_session_id) == ["runner-a", "runner-b"]
 
     failing.fail = False
-    runner_module.notify_connection_closed("session-a")
+    runner_module.notify_connection_closed(target_session_id)
 
-    assert sorted(calls) == [
-        ("runner-a", "session-a"),
-        ("runner-a", "session-a"),
-        ("runner-b", "session-a"),
-        ("runner-b", "session-a"),
-    ]
+    assert runners_called_for(target_session_id) == ["runner-a", "runner-a", "runner-b", "runner-b"]
 
 
 def test_ray_runner_session_start_and_close_are_serialized(monkeypatch):


### PR DESCRIPTION
## Summary

- Scope the fake runner's planned failure to the target `session-a` notification.
- Assert calls per session and explicitly exercise an unrelated session-close callback.
- Preserve production behavior and the all-runners-attempted/error-propagation contract while removing Python 3.14 finalization-order dependence.

## Related issue

close: #212

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change is limited to an internal regression test and does not alter public behavior.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Python 3.14.6 target test with warnings as errors: passed
- Python 3.14.6 target test repeated 100 times: 100 passed
- Python 3.14.6 `scripts/run_release_tests.sh`: 387 non-Ray passed; 7 real-Ray passed
- Python 3.12.3 `scripts/run_release_tests.sh`: 387 non-Ray passed; 7 real-Ray passed
- Python 3.12.3 `scripts/run_fast_tests.sh`: 5712 non-Ray passed; 85 shared-Ray passed; all 6 runnable test-owned-cluster cases passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.