### PR TITLE
[fix](ray) Fence FTE fragment state and worker pressure

### DIFF
--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte.dynamic_inputs import strip_fte_dynamic_context
 from duckdb.runners.fte.fte_attempts import (
     ExecutionClassTransition,
     FinishedAttempt,
@@ -56,7 +59,7 @@ from duckdb.runners.fte.fte_update_batch import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from duckdb.runners.fte.fte_events import FteWorkerCommand
     from duckdb.runners.fte.fte_exchange import ExchangeSinkHandle, FteExchangeTracker
@@ -81,6 +84,16 @@ class FteWorkerControlFailure(RuntimeError):
             f"FTE worker {self.worker_id or '<unknown>'} failed during "
             f"{self.method_name} for {self.attempt_id}: {cause}"
         )
+
+
+@dataclass(frozen=True)
+class FtePartitionPlacementSnapshot:
+    partition: FteTaskPartition
+    generation: int
+    memory_requirement_bytes: int | None
+    execution_class: FteTaskExecutionClass
+    node_requirements: NodeRequirements | None
+    node_requirements_wait_started_at: float | None
 
 
 class FteWorkerReservationUnavailable(RuntimeError):
@@ -146,6 +159,10 @@ class FteTaskPartition:
         self.execution_ready_deferred = False
         self.node_wait_started_at: float | None = None
         self.no_matching_node_started_at: float | None = None
+        self._placement_generation = 0
+
+    def _invalidate_placement(self) -> None:
+        self._placement_generation += 1
 
     @property
     def state(self) -> FtePartitionState:
@@ -184,6 +201,7 @@ class FteTaskPartition:
         if self.running_attempts:
             raise RuntimeError(f"partition {self.task_id} already has a running attempt")
 
+        self._invalidate_placement()
         attempt_number = self.next_attempt_number()
         attempt_id = FteTaskAttemptId(self.task_id, attempt_number)
         request = self.descriptor.to_create_task_request(
@@ -214,6 +232,12 @@ class FteTaskPartition:
     def mark_waiting_for_node(self) -> None:
         if self.node_wait_started_at is None:
             self.node_wait_started_at = time.time()
+            self._invalidate_placement()
+
+    def clear_waiting_for_node(self) -> None:
+        if self.node_wait_started_at is not None:
+            self.node_wait_started_at = None
+            self._invalidate_placement()
 
     def mark_no_matching_node(self) -> float:
         if self.no_matching_node_started_at is None:
@@ -224,14 +248,20 @@ class FteTaskPartition:
         self.no_matching_node_started_at = None
 
     def mark_ready_for_execution(self) -> None:
+        if self.ready_for_scheduling and not self.execution_ready_deferred:
+            return
         self.ready_for_scheduling = True
         self.execution_ready_deferred = False
+        self._invalidate_placement()
 
     def defer_ready_for_execution(self) -> None:
         if self.finished or self.failed or self.running_attempts:
             return
+        if not self.ready_for_scheduling and self.execution_ready_deferred:
+            return
         self.ready_for_scheduling = False
         self.execution_ready_deferred = True
+        self._invalidate_placement()
 
     def seal(self) -> FteTaskExecutionClass | None:
         if self.finished or self.failed:
@@ -256,6 +286,7 @@ class FteTaskPartition:
                 f"from {self.execution_class.value} to {new_class.value}"
             )
         self.execution_class = new_class
+        self._invalidate_placement()
         return True
 
     def mark_attempt_finished(
@@ -268,6 +299,7 @@ class FteTaskPartition:
         running = self.running_attempts.pop(attempt.attempt_id, None)
         if running is None:
             return False
+        self._invalidate_placement()
         task_stats = self.running_task_stats.pop(attempt.attempt_id, None)
         self.finished = True
         self.failed = False
@@ -303,6 +335,7 @@ class FteTaskPartition:
         running = self.running_attempts.pop(attempt.attempt_id, None)
         if running is None:
             return None
+        self._invalidate_placement()
         self.running_task_stats.pop(attempt.attempt_id, None)
 
         self.failure_observed = True
@@ -339,6 +372,7 @@ class FteTaskPartition:
         running = self.running_attempts.pop(attempt.attempt_id, None)
         if running is None:
             return None
+        self._invalidate_placement()
 
         self.failure_observed = True
         self.failures.append(error)
@@ -420,6 +454,7 @@ class FteFragmentExecution:
         execution_class_transition_callback: Callable[[list[ExecutionClassTransition]], None] | None = None,
         execution_admission_callback: Callable[[FteTaskPartition], bool] | None = None,
         attempt_admission_callback: Callable[[FteTaskPartition], bool] | None = None,
+        attempt_admission_abandon_callback: Callable[[FteTaskPartition], None] | None = None,
         worker_reservation_callback: Callable[[FteTaskPartition], bool] | None = None,
         descriptor_storage: TaskDescriptorStorage | None = None,
         max_attempts: int = 4,
@@ -449,6 +484,7 @@ class FteFragmentExecution:
         self.execution_class_transition_callback = execution_class_transition_callback
         self.execution_admission_callback = execution_admission_callback
         self.attempt_admission_callback = attempt_admission_callback
+        self.attempt_admission_abandon_callback = attempt_admission_abandon_callback
         self.worker_reservation_callback = worker_reservation_callback
         self.descriptor_storage = descriptor_storage if descriptor_storage is not None else TaskDescriptorStorage()
         self.max_attempts = int(max_attempts)
@@ -491,11 +527,22 @@ class FteFragmentExecution:
         partition_id: int,
         node_requirements: NodeRequirements | None = None,
     ) -> FteTaskPartition:
+        with self._state_lock:
+            return self._add_partition_locked(partition_id, node_requirements)
+
+    def _add_partition_locked(
+        self,
+        partition_id: int,
+        node_requirements: NodeRequirements | None = None,
+    ) -> FteTaskPartition:
+        if not self._state_lock_owned_by_current_thread():
+            raise RuntimeError("FTE partition mutation requires the fragment state lock")
         partition_id = _check_non_negative("partition_id", partition_id)
         existing = self.partitions.get(partition_id)
         if existing is not None:
             if existing.node_requirements is None and node_requirements is not None:
                 existing.node_requirements = node_requirements
+                existing._invalidate_placement()
             return existing
         task_id = FteTaskId(self.query_id, self.fragment_execution_id, partition_id)
         sink_handle = self.exchange.add_sink(partition_id) if self.exchange is not None else None
@@ -525,6 +572,185 @@ class FteFragmentExecution:
         self.descriptor_storage.put(task_id, descriptor)
         return partition
 
+    def merge_submission_metadata(
+        self,
+        *,
+        task_context_info: Mapping[str, Any] | None,
+        exchange_sink_instance: Any,
+        dynamic_scan_sources: set[str],
+        dynamic_exchange_sources: set[str],
+    ) -> None:
+        dynamic_scan_sources = {str(source) for source in dynamic_scan_sources}
+        dynamic_exchange_sources = {str(source) for source in dynamic_exchange_sources}
+        submitted_task_context_info = dict(task_context_info or {})
+        with self._state_lock:
+            if not self.task_context_info and submitted_task_context_info:
+                self.task_context_info = dict(submitted_task_context_info)
+            if exchange_sink_instance is not None:
+                self.task_context_info["exchange_sink_instance"] = exchange_sink_instance
+            self.source_node_ids.update(dynamic_scan_sources)
+            self.source_node_ids.update(dynamic_exchange_sources)
+            self.dynamic_scan_source_node_ids.update(dynamic_scan_sources)
+            self.dynamic_exchange_source_node_ids.update(dynamic_exchange_sources)
+            self.context = strip_fte_dynamic_context(
+                self.context,
+                self.dynamic_scan_source_node_ids,
+                self.dynamic_exchange_source_node_ids,
+            )
+            for partition in self.partitions.values():
+                descriptor = partition.descriptor
+                descriptor.source_node_ids.update(dynamic_scan_sources)
+                descriptor.source_node_ids.update(dynamic_exchange_sources)
+                descriptor.dynamic_scan_source_node_ids.update(dynamic_scan_sources)
+                descriptor.dynamic_exchange_source_node_ids.update(dynamic_exchange_sources)
+                descriptor.context = strip_fte_dynamic_context(
+                    descriptor.context,
+                    descriptor.dynamic_scan_source_node_ids,
+                    descriptor.dynamic_exchange_source_node_ids,
+                )
+                if not descriptor.task_context_info and submitted_task_context_info:
+                    descriptor.task_context_info = dict(submitted_task_context_info)
+                if descriptor.exchange_sink_instance is None and exchange_sink_instance is not None:
+                    descriptor.exchange_sink_instance = exchange_sink_instance
+
+    def get_partition(self, partition_id: int) -> FteTaskPartition | None:
+        with self._state_lock:
+            return self.partitions.get(int(partition_id))
+
+    def partition_scheduling_requirements(
+        self,
+        partition_id: int,
+    ) -> tuple[int | None, FteTaskExecutionClass, NodeRequirements | None] | None:
+        with self._state_lock:
+            partition = self.partitions.get(int(partition_id))
+            if partition is None:
+                return None
+            return (
+                partition.memory_requirement_bytes,
+                FteTaskExecutionClass.coerce(partition.execution_class),
+                partition.node_requirements,
+            )
+
+    def partition_attempt_is_running(
+        self,
+        partition_id: int,
+        attempt_id: FteTaskAttemptId | str | Mapping[str, Any],
+    ) -> bool:
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        with self._state_lock:
+            partition = self.partitions.get(int(partition_id))
+            return bool(
+                partition is not None
+                and any(running.attempt_id == attempt for running in partition.running_attempts.values())
+            )
+
+    def _placement_snapshot_locked(
+        self,
+        partition_id: int,
+        *,
+        expected_partition: FteTaskPartition | None = None,
+        expected_generation: int | None = None,
+    ) -> FtePartitionPlacementSnapshot | None:
+        if not self._state_lock_owned_by_current_thread():
+            raise RuntimeError("FTE placement snapshot requires the fragment state lock")
+        partition = self.partitions.get(int(partition_id))
+        if partition is None or (expected_partition is not None and partition is not expected_partition):
+            return None
+        if expected_generation is not None and partition._placement_generation != int(expected_generation):
+            return None
+        if partition.running_attempts or partition.finished or partition.failed:
+            return None
+        return FtePartitionPlacementSnapshot(
+            partition=partition,
+            generation=partition._placement_generation,
+            memory_requirement_bytes=partition.memory_requirement_bytes,
+            execution_class=partition.execution_class,
+            node_requirements=partition.node_requirements,
+            node_requirements_wait_started_at=partition.node_wait_started_at,
+        )
+
+    @contextmanager
+    def partition_placement(
+        self,
+        partition_id: int,
+        *,
+        expected_partition: FteTaskPartition | None = None,
+    ) -> Iterator[FtePartitionPlacementSnapshot | None]:
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                snapshot = self._placement_snapshot_locked(
+                    partition_id,
+                    expected_partition=expected_partition,
+                )
+            yield snapshot
+
+    def mark_partition_waiting_for_node(
+        self,
+        snapshot: FtePartitionPlacementSnapshot,
+    ) -> FtePartitionPlacementSnapshot | None:
+        with self._state_lock:
+            current = self._placement_snapshot_locked(
+                snapshot.partition.task_id.partition_id,
+                expected_partition=snapshot.partition,
+                expected_generation=snapshot.generation,
+            )
+            if current is None:
+                return None
+            current.partition.mark_waiting_for_node()
+            return self._placement_snapshot_locked(
+                current.partition.task_id.partition_id,
+                expected_partition=current.partition,
+            )
+
+    def commit_partition_placement(self, snapshot: FtePartitionPlacementSnapshot) -> bool:
+        with self._state_lock:
+            return (
+                self._placement_snapshot_locked(
+                    snapshot.partition.task_id.partition_id,
+                    expected_partition=snapshot.partition,
+                    expected_generation=snapshot.generation,
+                )
+                is not None
+            )
+
+    def record_partition_placement_unavailable(
+        self,
+        snapshot: FtePartitionPlacementSnapshot,
+        *,
+        has_matching_node: bool,
+    ) -> tuple[bool, float]:
+        with self._state_lock:
+            current = self._placement_snapshot_locked(
+                snapshot.partition.task_id.partition_id,
+                expected_partition=snapshot.partition,
+                expected_generation=snapshot.generation,
+            )
+            if current is None:
+                return False, 0.0
+            if has_matching_node:
+                current.partition.reset_no_matching_node()
+                return True, 0.0
+            return True, current.partition.mark_no_matching_node()
+
+    def defer_partition_after_placement_rejection(
+        self,
+        snapshot: FtePartitionPlacementSnapshot,
+        *,
+        defer_execution: bool,
+    ) -> bool:
+        with self._state_lock:
+            current = self._placement_snapshot_locked(
+                snapshot.partition.task_id.partition_id,
+                expected_partition=snapshot.partition,
+                expected_generation=snapshot.generation,
+            )
+            if current is None:
+                return False
+            current.partition.clear_waiting_for_node()
+            if defer_execution:
+                current.partition.defer_ready_for_execution()
+            return True
+
     def _base_sink_instance_for_partition(self) -> Any:
         if self.exchange is not None:
             return None
@@ -532,6 +758,10 @@ class FteFragmentExecution:
 
     def _state_lock_owned_by_current_thread(self) -> bool:
         is_owned = getattr(self._state_lock, "_is_owned", None)
+        return bool(is_owned()) if callable(is_owned) else False
+
+    def _attempt_scheduling_lock_owned_by_current_thread(self) -> bool:
+        is_owned = getattr(self._attempt_scheduling_lock, "_is_owned", None)
         return bool(is_owned()) if callable(is_owned) else False
 
     def apply_assignment_result(self, result: AssignmentResult) -> FragmentExecutionMutationResult:
@@ -543,7 +773,7 @@ class FteFragmentExecution:
             try:
                 with self._state_lock:
                     for info in result.partitions_added:
-                        self.add_partition(info.partition_id, info.node_requirements)
+                        self._add_partition_locked(info.partition_id, info.node_requirements)
                 for update in self._coalesce_partition_updates(result.partition_updates):
                     attempt = self.update_partition(update)
                     if attempt is not None:
@@ -677,11 +907,34 @@ class FteFragmentExecution:
 
             with self._state_lock:
                 current = self.partitions.get(int(partition_id))
-                if current is not partition or not self._partition_ready_to_schedule(partition):
-                    return None
-                if not self._partition_matches_execution_class(partition, execution_class):
-                    return None
-                return self._create_attempt_after_admission(partition)
+                placement_is_current = (
+                    current is partition
+                    and self._partition_ready_to_schedule(partition)
+                    and self._partition_matches_execution_class(partition, execution_class)
+                )
+                if not placement_is_current:
+                    reservation_callback = None
+                else:
+                    reservation_callback = self.worker_reservation_callback
+            if not placement_is_current:
+                if self.attempt_admission_abandon_callback is not None:
+                    self.attempt_admission_abandon_callback(partition)
+                return None
+            if reservation_callback is None:
+                with self._state_lock:
+                    current = self.partitions.get(int(partition_id))
+                    placement_is_current = not (
+                        current is not partition
+                        or not self._partition_ready_to_schedule(partition)
+                        or not self._partition_matches_execution_class(partition, execution_class)
+                    )
+                    if placement_is_current:
+                        return self._create_attempt_after_admission(partition)
+                if self.attempt_admission_abandon_callback is not None:
+                    self.attempt_admission_abandon_callback(partition)
+                return None
+            reservation_callback(partition)
+            return None
 
     @staticmethod
     def _transition_from_partition(partition: FteTaskPartition) -> ExecutionClassTransition:
@@ -1236,6 +1489,17 @@ class FteFragmentExecution:
             }
 
     def start_attempt_with_worker(self, partition: FteTaskPartition) -> ScheduledAttempt:
+        with self._attempt_scheduling_lock:
+            with self._state_lock:
+                return self._start_attempt_with_worker_locked(partition)
+
+    def _start_attempt_with_worker_locked(self, partition: FteTaskPartition) -> ScheduledAttempt:
+        if not self._attempt_scheduling_lock_owned_by_current_thread():
+            raise RuntimeError("FTE attempt mutation requires the attempt scheduling lock")
+        if not self._state_lock_owned_by_current_thread():
+            raise RuntimeError("FTE attempt mutation requires the fragment state lock")
+        if self.partitions.get(partition.task_id.partition_id) is not partition:
+            raise ValueError(f"partition {partition.task_id} does not belong to this fragment execution")
         worker_id, worker = self._select_worker(partition)
         sink_instance = None
         if self.exchange is not None:
@@ -1282,10 +1546,10 @@ class FteFragmentExecution:
             command.worker.record_fte_task_started(command.attempt_id, command.request)
             return
         if isinstance(command, FteAddSplitsCommand):
-            command.worker.record_fte_splits_added(command.attempt_id, len(command.splits))
-            command.worker.record_fte_split_bytes_added(
+            command.worker.record_fte_splits_added(
                 command.attempt_id,
-                sum(_estimated_payload_bytes(split) for split in command.splits),
+                len(command.splits),
+                split_bytes=sum(_estimated_payload_bytes(split) for split in command.splits),
             )
 
     def worker_control_failure_for_command(

--- a/duckdb/runners/ray/fragment_registry.py
+++ b/duckdb/runners/ray/fragment_registry.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from duckdb.runners.fte import (
     FteTaskAttemptId,
     FteTaskExecutionClass,
+    FteTaskId,
 )
 from duckdb.runners.fte.fte_scheduler import FteSchedulerRegistry
 
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from duckdb.runners.fte.fte_scheduler import FteAttemptStatusWatcher
     from duckdb.runners.ray.fragment_worker_client import RayWorkerActorHandle
     from duckdb.runners.ray.fte_fragment_scheduler import FteWorkerReservationFuture
+
+
+_PressureKey = TypeVar("_PressureKey")
 
 
 @dataclass(frozen=True)
@@ -115,14 +119,31 @@ class _FteSchedulingDelayer:
 class _FteWorkerPressure:
     def __init__(self) -> None:
         self.running_attempts: set[str] = set()
+        # Compact every task's terminal attempts into one monotonic watermark.
+        # This keeps late ACK rejection exact without retaining one tombstone
+        # for every retry for the lifetime of the query.
+        self.terminal_attempt_id_by_task: dict[str, int] = {}
         self.reserved_partitions: set[tuple[str, str, int]] = set()
         self.split_counts_by_attempt: dict[str, int] = {}
         self.split_bytes_by_attempt: dict[str, int] = {}
+        self.pending_split_counts_by_attempt: dict[str, int] = {}
+        self.pending_split_bytes_by_attempt: dict[str, int] = {}
         self.memory_bytes_by_attempt: dict[str, int] = {}
         self.memory_bytes_by_reservation: dict[tuple[str, str, int], int] = {}
         self.execution_class_by_attempt: dict[str, str] = {}
         self.execution_class_by_reservation: dict[tuple[str, str, int], str] = {}
         self.last_seen_at = time.time()
+
+    def attempt_is_terminal(self, attempt_id: FteTaskAttemptId) -> bool:
+        terminal_attempt_id = self.terminal_attempt_id_by_task.get(str(attempt_id.task_id))
+        return terminal_attempt_id is not None and int(attempt_id.attempt_id) <= terminal_attempt_id
+
+    def record_terminal_attempt(self, attempt_id: FteTaskAttemptId) -> None:
+        task_key = str(attempt_id.task_id)
+        self.terminal_attempt_id_by_task[task_key] = max(
+            int(attempt_id.attempt_id),
+            self.terminal_attempt_id_by_task.get(task_key, -1),
+        )
 
     def score(self) -> int:
         return (
@@ -137,8 +158,8 @@ class _FteWorkerPressure:
 
     @staticmethod
     def _memory_bytes_for_class(
-        memory_by_key: dict[str, int],
-        execution_class_by_key: dict[str, str],
+        memory_by_key: dict[_PressureKey, int],
+        execution_class_by_key: dict[_PressureKey, str],
         execution_class: FteTaskExecutionClass,
     ) -> int:
         return sum(
@@ -183,6 +204,7 @@ class _FteWorkerPressure:
         )
         return {
             "running_attempt_count": len(self.running_attempts),
+            "terminal_attempt_count": len(self.terminal_attempt_id_by_task),
             "reserved_partition_count": len(self.reserved_partitions),
             "assigned_split_count": sum(self.split_counts_by_attempt.values()),
             "assigned_split_bytes": sum(self.split_bytes_by_attempt.values()),
@@ -212,35 +234,51 @@ class _FteWorkerPressure:
         def owned_attempt(attempt: str) -> bool:
             return FteTaskAttemptId.parse(attempt).query_id == query_id
 
-        self.running_attempts = {attempt for attempt in self.running_attempts if not owned_attempt(attempt)}
-        self.reserved_partitions = {
-            reservation for reservation in self.reserved_partitions if reservation[0] != query_id
-        }
-        self.split_counts_by_attempt = {
-            attempt: count for attempt, count in self.split_counts_by_attempt.items() if not owned_attempt(attempt)
-        }
-        self.split_bytes_by_attempt = {
-            attempt: count for attempt, count in self.split_bytes_by_attempt.items() if not owned_attempt(attempt)
-        }
-        self.memory_bytes_by_attempt = {
-            attempt: count for attempt, count in self.memory_bytes_by_attempt.items() if not owned_attempt(attempt)
-        }
-        self.memory_bytes_by_reservation = {
-            reservation: count
-            for reservation, count in self.memory_bytes_by_reservation.items()
-            if reservation[0] != query_id
-        }
-        self.execution_class_by_attempt = {
-            attempt: execution_class
-            for attempt, execution_class in self.execution_class_by_attempt.items()
-            if not owned_attempt(attempt)
-        }
-        self.execution_class_by_reservation = {
-            reservation: execution_class
-            for reservation, execution_class in self.execution_class_by_reservation.items()
-            if reservation[0] != query_id
-        }
-        self.last_seen_at = time.time()
+        with _FTE_REGISTRY_LOCK:
+            self.running_attempts = {attempt for attempt in self.running_attempts if not owned_attempt(attempt)}
+            self.terminal_attempt_id_by_task = {
+                task: attempt_id
+                for task, attempt_id in self.terminal_attempt_id_by_task.items()
+                if FteTaskId.parse(task).query_id != query_id
+            }
+            self.reserved_partitions = {
+                reservation for reservation in self.reserved_partitions if reservation[0] != query_id
+            }
+            self.split_counts_by_attempt = {
+                attempt: count for attempt, count in self.split_counts_by_attempt.items() if not owned_attempt(attempt)
+            }
+            self.split_bytes_by_attempt = {
+                attempt: count for attempt, count in self.split_bytes_by_attempt.items() if not owned_attempt(attempt)
+            }
+            self.pending_split_counts_by_attempt = {
+                attempt: count
+                for attempt, count in self.pending_split_counts_by_attempt.items()
+                if not owned_attempt(attempt)
+            }
+            self.pending_split_bytes_by_attempt = {
+                attempt: count
+                for attempt, count in self.pending_split_bytes_by_attempt.items()
+                if not owned_attempt(attempt)
+            }
+            self.memory_bytes_by_attempt = {
+                attempt: count for attempt, count in self.memory_bytes_by_attempt.items() if not owned_attempt(attempt)
+            }
+            self.memory_bytes_by_reservation = {
+                reservation: count
+                for reservation, count in self.memory_bytes_by_reservation.items()
+                if reservation[0] != query_id
+            }
+            self.execution_class_by_attempt = {
+                attempt: execution_class
+                for attempt, execution_class in self.execution_class_by_attempt.items()
+                if not owned_attempt(attempt)
+            }
+            self.execution_class_by_reservation = {
+                reservation: execution_class
+                for reservation, execution_class in self.execution_class_by_reservation.items()
+                if reservation[0] != query_id
+            }
+            self.last_seen_at = time.time()
 
 
 @dataclass

--- a/duckdb/runners/ray/fragment_worker_placement.py
+++ b/duckdb/runners/ray/fragment_worker_placement.py
@@ -14,6 +14,7 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_REGISTRY_LOCK,
     _FTE_SCHEDULERS,
 )
+from duckdb.runners.ray.fragment_submission_window import release_fte_partition_submission
 from duckdb.runners.ray.fragment_worker_reservations import (
     cancel_fte_worker_reservation_future,
     fte_partition_owner,
@@ -39,6 +40,12 @@ if TYPE_CHECKING:
 
 
 class FteWorkerPlacementMixin:
+    if TYPE_CHECKING:
+        # Supplied by the other mixins on the composed Ray worker handle.
+        _bind_fte_scheduler_handlers: Any
+        _fte_worker_placement_manager: Any
+        worker_id: Any
+
     def _select_fte_worker(
         self,
         *,
@@ -94,27 +101,29 @@ class FteWorkerPlacementMixin:
     def _record_fte_worker_reservation_unavailable(
         self,
         future: FteWorkerReservationFuture,
-        partition: Any | None,
+        fragment_execution: FteFragmentExecution,
+        placement: Any,
         *,
         node_requirements: NodeRequirements | Mapping[str, Any] | None,
         node_requirements_wait_started_at: float | None,
-    ) -> None:
-        if partition is None:
-            cancel_fte_worker_reservation_future(future)
-            return
+    ) -> bool:
         has_matching_node = _node_requirements_have_candidates(
             available_fte_workers(self, self.worker_id),
             node_requirements,
             node_requirements_wait_started_at=node_requirements_wait_started_at,
         )
-        if not has_matching_node:
-            no_matching_period = partition.mark_no_matching_node()
-            if no_matching_period > _fte_allowed_no_matching_node_period_s():
-                raise RuntimeError(
-                    f"No nodes available to run query {future.query_id}/{future.fragment_id}/{future.partition_id}"
-                )
-        else:
-            partition.reset_no_matching_node()
+        current, no_matching_period = fragment_execution.record_partition_placement_unavailable(
+            placement,
+            has_matching_node=has_matching_node,
+        )
+        if not current:
+            cancel_fte_worker_reservation_future(future)
+            return False
+        if not has_matching_node and no_matching_period > _fte_allowed_no_matching_node_period_s():
+            raise RuntimeError(
+                f"No nodes available to run query {future.query_id}/{future.fragment_id}/{future.partition_id}"
+            )
+        return True
 
     def _try_complete_fte_worker_reservation_future(
         self,
@@ -130,63 +139,82 @@ class FteWorkerPlacementMixin:
         if fragment_execution is None or partition is None:
             cancel_fte_worker_reservation_future(future)
             return False
-        if partition.running_attempt is not None or partition.finished or partition.failed:
-            cancel_fte_worker_reservation_future(future)
-            return False
-        memory_requirement_bytes = partition.memory_requirement_bytes
-        execution_class = partition.execution_class
-        node_requirements = partition.node_requirements
-        node_requirements_wait_started_at = partition.node_wait_started_at or future.node_requirements_wait_started_at
-        try:
-            if not fte_worker_reservation_future_is_current(future):
+        with fragment_execution.partition_placement(
+            future.partition_id,
+            expected_partition=partition,
+        ) as placement:
+            if placement is None:
+                cancel_fte_worker_reservation_future(future)
                 return False
-            reservation = self._fte_worker_placement_manager.acquire(
-                query_id=future.query_id,
-                fragment_id=future.fragment_id,
-                partition_id=future.partition_id,
-                memory_requirement_bytes=memory_requirement_bytes,
-                execution_class=execution_class,
-                node_requirements=node_requirements,
-                node_requirements_wait_started_at=node_requirements_wait_started_at,
+            memory_requirement_bytes = placement.memory_requirement_bytes
+            execution_class = placement.execution_class
+            node_requirements = placement.node_requirements
+            node_requirements_wait_started_at = (
+                placement.node_requirements_wait_started_at or future.node_requirements_wait_started_at
             )
-        except FteWorkerReservationUnavailable as exc:
-            if exc.blocked_reason not in {"", "node_capacity"}:
-                # QRM did not grant this descriptor.  Return it to the passive
-                # execution queue; keeping a reservation future here would
-                # recreate the one-waiter-per-logical-partition failure mode.
-                cancel_fte_worker_reservation_future(
-                    future,
-                    allow_next_submission=False,
-                )
-                partition.node_wait_started_at = None
-                partition.defer_ready_for_execution()
-                return False
             try:
-                self._record_fte_worker_reservation_unavailable(
-                    future,
-                    partition,
+                if not fte_worker_reservation_future_is_current(future):
+                    return False
+                reservation = self._fte_worker_placement_manager.acquire(
+                    query_id=future.query_id,
+                    fragment_id=future.fragment_id,
+                    partition_id=future.partition_id,
+                    memory_requirement_bytes=memory_requirement_bytes,
+                    execution_class=execution_class,
                     node_requirements=node_requirements,
                     node_requirements_wait_started_at=node_requirements_wait_started_at,
                 )
-            except RuntimeError as exc:
-                if raise_on_no_matching_timeout:
+            except FteWorkerReservationUnavailable as exc:
+                if exc.blocked_reason not in {"", "node_capacity"}:
+                    # QRM did not grant this descriptor.  Return it to the passive
+                    # execution queue; keeping a reservation future here would
+                    # recreate the one-waiter-per-logical-partition failure mode.
+                    fragment_execution.defer_partition_after_placement_rejection(
+                        placement,
+                        defer_execution=True,
+                    )
+                    cancel_fte_worker_reservation_future(
+                        future,
+                        allow_next_submission=False,
+                    )
+                    return False
+                try:
+                    current = self._record_fte_worker_reservation_unavailable(
+                        future,
+                        fragment_execution,
+                        placement,
+                        node_requirements=node_requirements,
+                        node_requirements_wait_started_at=node_requirements_wait_started_at,
+                    )
+                    if not current:
+                        return False
+                except RuntimeError as exc:
+                    if raise_on_no_matching_timeout:
+                        cancel_fte_worker_reservation_future(future)
+                        raise
+                    future.set_exception(exc)
+                    return True
+                return False
+            except Exception as exc:
+                if fragment_execution.commit_partition_placement(placement):
+                    future.set_exception(exc)
+                    return True
+                cancel_fte_worker_reservation_future(future)
+                return False
+            future_is_current = fte_worker_reservation_future_is_current(future)
+            placement_is_current = fragment_execution.commit_partition_placement(placement)
+            if not future_is_current or not placement_is_current:
+                FteWorkerPlacementManager.release_owner(
+                    query_id=future.query_id,
+                    fragment_id=future.fragment_id,
+                    partition_id=future.partition_id,
+                    terminal=False,
+                )
+                if future_is_current:
                     cancel_fte_worker_reservation_future(future)
-                    raise
-                future.set_exception(exc)
-                return True
-            return False
-        except Exception as exc:
-            future.set_exception(exc)
+                return False
+            future.set_result(reservation)
             return True
-        if not fte_worker_reservation_future_is_current(future):
-            FteWorkerPlacementManager.release_owner(
-                query_id=future.query_id,
-                fragment_id=future.fragment_id,
-                partition_id=future.partition_id,
-            )
-            return False
-        future.set_result(reservation)
-        return True
 
     def _request_fte_worker_reservation_for_partition(
         self,
@@ -200,17 +228,35 @@ class FteWorkerPlacementMixin:
             str(fragment_id),
             int(partition.task_id.partition_id),
         )
-        future, created = self._fte_worker_placement_manager.request_async(
-            query_id=key[0],
-            fragment_execution_id=fragment_execution.fragment_execution_id,
-            fragment_id=key[1],
-            partition_id=key[2],
-            memory_requirement_bytes=partition.memory_requirement_bytes,
-            execution_class=partition.execution_class,
-            node_requirements=partition.node_requirements,
-            node_requirements_wait_started_at=partition.node_wait_started_at,
-            on_done=self._enqueue_fte_worker_reservation_completion,
-        )
+        with fragment_execution.partition_placement(
+            key[2],
+            expected_partition=partition,
+        ) as placement:
+            if placement is None:
+                release_fte_partition_submission(*key)
+                return False
+            placement = fragment_execution.mark_partition_waiting_for_node(placement)
+            if placement is None:
+                release_fte_partition_submission(*key)
+                return False
+            try:
+                future, created = self._fte_worker_placement_manager.request_async(
+                    query_id=key[0],
+                    fragment_execution_id=fragment_execution.fragment_execution_id,
+                    fragment_id=key[1],
+                    partition_id=key[2],
+                    memory_requirement_bytes=placement.memory_requirement_bytes,
+                    execution_class=placement.execution_class,
+                    node_requirements=placement.node_requirements,
+                    node_requirements_wait_started_at=placement.node_requirements_wait_started_at,
+                    on_done=self._enqueue_fte_worker_reservation_completion,
+                )
+            except BaseException:
+                release_fte_partition_submission(*key)
+                raise
+            if not fragment_execution.commit_partition_placement(placement):
+                cancel_fte_worker_reservation_future(future)
+                return False
         if not created:
             return True
         return self._try_complete_fte_worker_reservation_future(
@@ -231,23 +277,50 @@ class FteWorkerPlacementMixin:
         self,
         query_id: str,
         fragment_id: str,
-        partition,
+        partition: Any,
         *,
         fragment_execution: FteFragmentExecution | None = None,
     ) -> None:
-        if not _admit_fte_partition_node_wait(query_id, partition, fragment_execution):
+        if fragment_execution is None:
             return
-        partition.mark_waiting_for_node()
-        try:
-            self._fte_worker_placement_manager.acquire(
-                query_id=str(query_id),
-                fragment_id=str(fragment_id),
-                partition_id=int(partition.task_id.partition_id),
-                memory_requirement_bytes=partition.memory_requirement_bytes,
-                execution_class=partition.execution_class,
-                node_requirements=partition.node_requirements,
-                node_requirements_wait_started_at=partition.node_wait_started_at,
-            )
-        except FteWorkerReservationUnavailable as exc:
-            if exc.blocked_reason not in {"", "node_capacity"}:
-                partition.node_wait_started_at = None
+        partition_id = int(partition.task_id.partition_id)
+        with fragment_execution.partition_placement(
+            partition_id,
+            expected_partition=partition,
+        ) as placement:
+            if placement is None:
+                return
+            if not _admit_fte_partition_node_wait(query_id, placement.partition, fragment_execution):
+                return
+            placement = fragment_execution.mark_partition_waiting_for_node(placement)
+            if placement is None:
+                release_fte_partition_submission(
+                    query_id,
+                    fragment_id,
+                    partition_id,
+                )
+                return
+            try:
+                self._fte_worker_placement_manager.acquire(
+                    query_id=str(query_id),
+                    fragment_id=str(fragment_id),
+                    partition_id=partition_id,
+                    memory_requirement_bytes=placement.memory_requirement_bytes,
+                    execution_class=placement.execution_class,
+                    node_requirements=placement.node_requirements,
+                    node_requirements_wait_started_at=placement.node_requirements_wait_started_at,
+                )
+            except FteWorkerReservationUnavailable as exc:
+                if exc.blocked_reason not in {"", "node_capacity"}:
+                    fragment_execution.defer_partition_after_placement_rejection(
+                        placement,
+                        defer_execution=False,
+                    )
+                return
+            if not fragment_execution.commit_partition_placement(placement):
+                FteWorkerPlacementManager.release_owner(
+                    query_id=str(query_id),
+                    fragment_id=str(fragment_id),
+                    partition_id=partition_id,
+                    terminal=False,
+                )

--- a/duckdb/runners/ray/fragment_worker_pressure_accounting.py
+++ b/duckdb/runners/ray/fragment_worker_pressure_accounting.py
@@ -130,8 +130,9 @@ class FteWorkerPressureAccountingMixin:
             self._fte_pressure.last_seen_at = time.time()
             return True
 
-    def record_fte_task_started(self, attempt_id: Any, request: Mapping[str, Any]) -> None:
-        key = attempt_key(attempt_id)
+    def record_fte_task_started(self, attempt_id: Any, request: Mapping[str, Any]) -> bool:
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        key = str(attempt)
         memory_requirement = request.get("memory_requirement_bytes")
         task_class = FteTaskExecutionClass.coerce(request.get("execution_class"))
         try:
@@ -139,15 +140,22 @@ class FteWorkerPressureAccountingMixin:
         except (TypeError, ValueError):
             memory_requirement_bytes = 0
         with _FTE_REGISTRY_LOCK:
+            if self._fte_pressure.attempt_is_terminal(attempt) or key in self._fte_pressure.running_attempts:
+                return False
             self._fte_pressure.running_attempts.add(key)
             self._fte_pressure.execution_class_by_attempt[key] = task_class.value
-            self._fte_pressure.split_counts_by_attempt[key] = initial_split_count(request)
-            self._fte_pressure.split_bytes_by_attempt[key] = initial_split_bytes(request)
+            self._fte_pressure.split_counts_by_attempt[key] = initial_split_count(
+                request
+            ) + self._fte_pressure.pending_split_counts_by_attempt.pop(key, 0)
+            self._fte_pressure.split_bytes_by_attempt[key] = initial_split_bytes(
+                request
+            ) + self._fte_pressure.pending_split_bytes_by_attempt.pop(key, 0)
             if memory_requirement_bytes > 0:
                 self._fte_pressure.memory_bytes_by_attempt[key] = memory_requirement_bytes
             else:
                 self._fte_pressure.memory_bytes_by_attempt.pop(key, None)
             self._fte_pressure.last_seen_at = time.time()
+            return True
 
     def record_fte_task_started_from_reservation(
         self,
@@ -156,47 +164,76 @@ class FteWorkerPressureAccountingMixin:
         partition_id: int,
         attempt_id: Any,
         request: Mapping[str, Any],
-    ) -> None:
+    ) -> bool:
         """Move reservation pressure to running without exposing free capacity."""
 
         reservation_key = partition_reservation_key(query_id, fragment_id, partition_id)
         with _FTE_REGISTRY_LOCK:
+            if not self.record_fte_task_started(attempt_id, request):
+                return False
             self._fte_pressure.reserved_partitions.discard(reservation_key)
             self._fte_pressure.memory_bytes_by_reservation.pop(reservation_key, None)
             self._fte_pressure.execution_class_by_reservation.pop(reservation_key, None)
-            self.record_fte_task_started(attempt_id, request)
+            return True
 
-    def record_fte_splits_added(self, attempt_id: Any, split_count: int) -> None:
-        key = attempt_key(attempt_id)
+    def record_fte_splits_added(
+        self,
+        attempt_id: Any,
+        split_count: int,
+        *,
+        split_bytes: int | None = None,
+    ) -> bool:
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        key = str(attempt)
+        added_split_count = max(0, int(split_count))
+        added_split_bytes = None if split_bytes is None else max(0, int(split_bytes))
         with _FTE_REGISTRY_LOCK:
-            self._fte_pressure.running_attempts.add(key)
-            self._fte_pressure.split_counts_by_attempt[key] = self._fte_pressure.split_counts_by_attempt.get(
-                key, 0
-            ) + max(0, int(split_count))
+            if self._fte_pressure.attempt_is_terminal(attempt):
+                return False
+            if key not in self._fte_pressure.running_attempts:
+                self._fte_pressure.pending_split_counts_by_attempt[key] = (
+                    self._fte_pressure.pending_split_counts_by_attempt.get(key, 0) + added_split_count
+                )
+                if added_split_bytes is not None:
+                    self._fte_pressure.pending_split_bytes_by_attempt[key] = (
+                        self._fte_pressure.pending_split_bytes_by_attempt.get(key, 0) + added_split_bytes
+                    )
+                self._fte_pressure.last_seen_at = time.time()
+                return True
+            self._fte_pressure.split_counts_by_attempt[key] = (
+                self._fte_pressure.split_counts_by_attempt.get(key, 0) + added_split_count
+            )
+            if added_split_bytes is not None:
+                self._fte_pressure.split_bytes_by_attempt[key] = (
+                    self._fte_pressure.split_bytes_by_attempt.get(key, 0) + added_split_bytes
+                )
             self._fte_pressure.last_seen_at = time.time()
+            return True
 
-    def record_fte_split_bytes_added(self, attempt_id: Any, split_bytes: int) -> None:
+    def record_fte_split_bytes_added(self, attempt_id: Any, split_bytes: int) -> bool:
         key = attempt_key(attempt_id)
         with _FTE_REGISTRY_LOCK:
-            self._fte_pressure.running_attempts.add(key)
+            if key not in self._fte_pressure.running_attempts:
+                return False
             self._fte_pressure.split_bytes_by_attempt[key] = self._fte_pressure.split_bytes_by_attempt.get(
                 key, 0
             ) + max(0, int(split_bytes))
             self._fte_pressure.last_seen_at = time.time()
+            return True
 
     def _record_fte_task_pressure_complete(self, attempt_id: Any, *, drain: bool) -> None:
-        key = attempt_key(attempt_id)
+        attempt = FteTaskAttemptId.coerce(attempt_id)
+        key = str(attempt)
         with _FTE_REGISTRY_LOCK:
+            self._fte_pressure.record_terminal_attempt(attempt)
             self._fte_pressure.running_attempts.discard(key)
             self._fte_pressure.split_counts_by_attempt.pop(key, None)
             self._fte_pressure.split_bytes_by_attempt.pop(key, None)
+            self._fte_pressure.pending_split_counts_by_attempt.pop(key, None)
+            self._fte_pressure.pending_split_bytes_by_attempt.pop(key, None)
             self._fte_pressure.memory_bytes_by_attempt.pop(key, None)
             self._fte_pressure.execution_class_by_attempt.pop(key, None)
             self._fte_pressure.last_seen_at = time.time()
-        try:
-            FteTaskAttemptId.coerce(attempt_id)
-        except Exception:
-            return
         if drain:
             request_fte_pending_task_drain()
 

--- a/duckdb/runners/ray/fragment_worker_reservations.py
+++ b/duckdb/runners/ray/fragment_worker_reservations.py
@@ -25,7 +25,7 @@ def pending_fte_worker_reservation_partition(future: Any) -> tuple[Any | None, A
         fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((future.query_id, future.fragment_id))
     if fragment_execution is None:
         return None, None
-    return fragment_execution, fragment_execution.partitions.get(future.partition_id)
+    return fragment_execution, fragment_execution.get_partition(future.partition_id)
 
 
 def pending_fte_worker_reservation_future(
@@ -43,12 +43,13 @@ def cancel_fte_worker_reservation_future(
     *,
     allow_next_submission: bool = True,
 ) -> None:
+    key = future.key
     with _FTE_REGISTRY_LOCK:
-        if _FTE_PENDING_WORKER_RESERVATIONS.get(future.key) is future:
-            _FTE_PENDING_WORKER_RESERVATIONS.pop(future.key, None)
-    release_fte_partition_task_waiter(future.key)
+        if _FTE_PENDING_WORKER_RESERVATIONS.get(key) is future:
+            _FTE_PENDING_WORKER_RESERVATIONS.pop(key, None)
+    release_fte_partition_task_waiter(key)
     release_fte_partition_submission(
-        *future.key,
+        *key,
         allow_next=allow_next_submission,
     )
     future.cancel()

--- a/duckdb/runners/ray/fragment_worker_selection.py
+++ b/duckdb/runners/ray/fragment_worker_selection.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from duckdb.runners.ray.fragment_registry import _FTE_WORKER_HANDLES
+from duckdb.runners.ray.fragment_registry import (
+    _FTE_REGISTRY_LOCK,
+    _FTE_WORKER_HANDLES,
+)
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _filter_workers_for_node_requirements,
     _fte_worker_has_memory_capacity,
@@ -25,16 +28,18 @@ def available_fte_workers(
     exclude: set[str] | None = None,
 ) -> list[Any]:
     exclude = exclude or set()
-    workers = [
-        handle
-        for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
-        if handle is not None and str(worker_id) not in exclude and handle._fte_healthy
-    ]
-    if (
-        current_worker not in workers
-        and (not current_worker_id or str(current_worker_id) not in exclude)
-        and current_worker._fte_healthy
-    ):
+    with _FTE_REGISTRY_LOCK:
+        workers = [
+            handle
+            for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
+            if handle is not None and str(worker_id) not in exclude and handle._fte_healthy
+        ]
+        include_current_worker = (
+            current_worker not in workers
+            and (not current_worker_id or str(current_worker_id) not in exclude)
+            and current_worker._fte_healthy
+        )
+    if include_current_worker:
         workers.append(current_worker)
     return workers
 

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -33,6 +33,7 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_REGISTRY_LOCK,
     _FTE_SCHEDULERS,
 )
+from duckdb.runners.ray.fragment_submission_window import release_fte_partition_submission
 from duckdb.runners.ray.fragment_worker_context import (
     fragment_id_for_task,
     resource_identity_from_context,
@@ -194,44 +195,29 @@ class FteWorkerSubmissionMixin:
         query_id = str(item["query_id"])
         fragment_id = str(item["fragment_id"])
         key = (query_id, fragment_id)
+
+        def merge_existing(existing: FteFragmentExecution) -> FteFragmentExecution:
+            existing.merge_submission_metadata(
+                task_context_info=item.get("task_context_info"),
+                exchange_sink_instance=item.get("exchange_sink_instance"),
+                dynamic_scan_sources=dynamic_scan_sources,
+                dynamic_exchange_sources=dynamic_exchange_sources,
+            )
+            with _FTE_REGISTRY_LOCK:
+                if fte_registry_query_is_closing(query_id) or _FTE_FRAGMENT_EXECUTIONS.get(key) is not existing:
+                    raise RuntimeError(
+                        f"FTE fragment registry changed while merging metadata: {query_id}/{fragment_id}"
+                    )
+                self._fte_fragment_executions[key] = existing
+            return existing
+
         with _FTE_REGISTRY_LOCK:
             if fte_registry_query_is_closing(query_id):
                 raise RuntimeError(f"FTE query registry is closing: {query_id}")
             _FTE_SCHEDULERS.get_or_create(query_id)
             existing = _FTE_FRAGMENT_EXECUTIONS.get(key)
-            if existing is not None:
-                if not existing.task_context_info and item.get("task_context_info"):
-                    existing.task_context_info = dict(item["task_context_info"])
-                if item.get("exchange_sink_instance") is not None:
-                    existing.task_context_info["exchange_sink_instance"] = item.get("exchange_sink_instance")
-                existing.source_node_ids.update(dynamic_scan_sources)
-                existing.source_node_ids.update(dynamic_exchange_sources)
-                existing.dynamic_scan_source_node_ids.update(dynamic_scan_sources)
-                existing.dynamic_exchange_source_node_ids.update(dynamic_exchange_sources)
-                existing.context = _strip_fte_dynamic_context(
-                    existing.context,
-                    existing.dynamic_scan_source_node_ids,
-                    existing.dynamic_exchange_source_node_ids,
-                )
-                for partition in existing.partitions.values():
-                    partition.descriptor.source_node_ids.update(dynamic_scan_sources)
-                    partition.descriptor.source_node_ids.update(dynamic_exchange_sources)
-                    partition.descriptor.dynamic_scan_source_node_ids.update(dynamic_scan_sources)
-                    partition.descriptor.dynamic_exchange_source_node_ids.update(dynamic_exchange_sources)
-                    partition.descriptor.context = _strip_fte_dynamic_context(
-                        partition.descriptor.context,
-                        partition.descriptor.dynamic_scan_source_node_ids,
-                        partition.descriptor.dynamic_exchange_source_node_ids,
-                    )
-                    if not partition.descriptor.task_context_info and item.get("task_context_info"):
-                        partition.descriptor.task_context_info = dict(item["task_context_info"])
-                    if (
-                        partition.descriptor.exchange_sink_instance is None
-                        and item.get("exchange_sink_instance") is not None
-                    ):
-                        partition.descriptor.exchange_sink_instance = item.get("exchange_sink_instance")
-                self._fte_fragment_executions[key] = existing
-                return existing
+        if existing is not None:
+            return merge_existing(existing)
 
         fragment_execution_context = _strip_fte_dynamic_context(
             item.get("context"),
@@ -299,6 +285,11 @@ class FteWorkerSubmissionMixin:
         def request_worker_reservation(partition: Any) -> bool:
             fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
             if fragment_execution is None:
+                release_fte_partition_submission(
+                    query_id,
+                    fragment_id,
+                    partition.task_id.partition_id,
+                )
                 return False
             return self._request_fte_worker_reservation_for_partition(
                 query_id,
@@ -315,6 +306,11 @@ class FteWorkerSubmissionMixin:
             execution_class_transition_callback=apply_execution_class_transitions,
             execution_admission_callback=admit_execution,
             attempt_admission_callback=admit_attempt,
+            attempt_admission_abandon_callback=lambda partition: release_fte_partition_submission(
+                query_id,
+                fragment_id,
+                partition.task_id.partition_id,
+            ),
             worker_reservation_callback=request_worker_reservation,
             context=fragment_execution_context,
             fragment_plan=item.get("fragment_plan"),
@@ -340,9 +336,12 @@ class FteWorkerSubmissionMixin:
                 raise RuntimeError(f"FTE query registry is closing: {query_id}")
             existing = _FTE_FRAGMENT_EXECUTIONS.get(key)
             if existing is not None:
-                self._fte_fragment_executions[key] = existing
-                return existing
-            _FTE_FRAGMENT_EXECUTIONS[key] = fragment_execution
+                registered = existing
+            else:
+                _FTE_FRAGMENT_EXECUTIONS[key] = fragment_execution
+                registered = fragment_execution
+        if registered is not fragment_execution:
+            return merge_existing(registered)
         self._fte_fragment_executions[key] = fragment_execution
         return fragment_execution
 

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -809,18 +809,18 @@ def _drop_fte_registry_for_query(query_id: str) -> None:
         _FTE_FRAGMENT_PROGRESS_TOPOLOGY_BUILDS.difference_update(
             {key for key in _FTE_FRAGMENT_PROGRESS_TOPOLOGY_BUILDS if key[0] == query_id}
         )
-        for key in list(_FTE_WORKER_RESERVATION_GENERATIONS):
-            if key[0] == query_id:
-                _FTE_WORKER_RESERVATION_GENERATIONS.pop(key, None)
-        for key in list(_FTE_PENDING_WORKER_RESERVATIONS):
-            if key[0] == query_id:
-                future = _FTE_PENDING_WORKER_RESERVATIONS.pop(key, None)
+        for reservation_key in list(_FTE_WORKER_RESERVATION_GENERATIONS):
+            if reservation_key[0] == query_id:
+                _FTE_WORKER_RESERVATION_GENERATIONS.pop(reservation_key, None)
+        for reservation_key in list(_FTE_PENDING_WORKER_RESERVATIONS):
+            if reservation_key[0] == query_id:
+                future = _FTE_PENDING_WORKER_RESERVATIONS.pop(reservation_key, None)
                 if future is not None:
                     pending_worker_reservation_futures.append(future)
         _FTE_RESULT_HANDLES_BY_QUERY.pop(query_id, None)
-        for key in list(_FTE_SEQUENCES):
-            if key[0] == query_id:
-                _FTE_SEQUENCES.pop(key, None)
+        for sequence_key in list(_FTE_SEQUENCES):
+            if sequence_key[0] == query_id:
+                _FTE_SEQUENCES.pop(sequence_key, None)
         for key in list(_FTE_FRAGMENT_STATES):
             if key[0] == query_id:
                 _FTE_FRAGMENT_STATES.pop(key, None)
@@ -1156,13 +1156,13 @@ def _write_sink_has_input(fragment_execution: Any) -> tuple[bool, bool]:
 
 
 def _sync_write_sink_stage_for_fragment(fragment_execution: Any) -> str | None:
-    if not _is_write_sink_fragment(fragment_execution):
-        return None
-
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-    resource_query_id, stage_id = resource_identity_from_context(fragment_execution.context)
-    has_input, all_terminal = _write_sink_has_input(fragment_execution)
+    with fragment_execution._state_lock:
+        if not _is_write_sink_fragment(fragment_execution):
+            return None
+        resource_query_id, stage_id = resource_identity_from_context(fragment_execution.context)
+        has_input, all_terminal = _write_sink_has_input(fragment_execution)
     get_query_resource_manager(resource_query_id).update_stage_state(
         stage_id,
         runnable=has_input,
@@ -1545,39 +1545,6 @@ def _fte_worker_selection_key(
     )
 
 
-def _fte_partition_memory_requirement_bytes(owner_key: tuple[str, str, int]) -> int | None:
-    fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((owner_key[0], owner_key[1]))
-    if fragment_execution is None:
-        return None
-    partition = fragment_execution.partitions.get(owner_key[2])
-    if partition is None:
-        return None
-    memory_requirement = partition.memory_requirement_bytes
-    if memory_requirement is None:
-        return None
-    return _memory_requirement_bytes(memory_requirement)
-
-
-def _fte_partition_execution_class(owner_key: tuple[str, str, int]) -> FteTaskExecutionClass:
-    fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((owner_key[0], owner_key[1]))
-    if fragment_execution is None:
-        return FteTaskExecutionClass.STANDARD
-    partition = fragment_execution.partitions.get(owner_key[2])
-    if partition is None:
-        return FteTaskExecutionClass.STANDARD
-    return FteTaskExecutionClass.coerce(partition.execution_class)
-
-
-def _fte_partition_node_requirements(owner_key: tuple[str, str, int]) -> NodeRequirements | None:
-    fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((owner_key[0], owner_key[1]))
-    if fragment_execution is None:
-        return None
-    partition = fragment_execution.partitions.get(owner_key[2])
-    if partition is None:
-        return None
-    return partition.node_requirements
-
-
 def _select_replacement_fte_worker(
     exclude_worker_id: str | set[str],
     *,
@@ -1591,11 +1558,12 @@ def _select_replacement_fte_worker(
         if isinstance(exclude_worker_id, str)
         else {str(worker_id) for worker_id in exclude_worker_id}
     )
-    candidates = [
-        handle
-        for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
-        if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
-    ]
+    with _FTE_REGISTRY_LOCK:
+        candidates = [
+            handle
+            for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
+            if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
+        ]
     if not candidates:
         return None
     candidates = _filter_workers_for_node_requirements(
@@ -1638,11 +1606,12 @@ def _has_replacement_fte_worker(
         if isinstance(exclude_worker_id, str)
         else {str(worker_id) for worker_id in exclude_worker_id}
     )
-    candidates = [
-        handle
-        for worker_id, handle in _FTE_WORKER_HANDLES.items()
-        if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
-    ]
+    with _FTE_REGISTRY_LOCK:
+        candidates = [
+            handle
+            for worker_id, handle in _FTE_WORKER_HANDLES.items()
+            if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
+        ]
     return bool(
         _filter_workers_for_node_requirements(
             candidates,
@@ -2143,30 +2112,48 @@ class FteWorkerPlacementManager:
         fragment_id: str,
         partition_id: int,
         terminal: bool | None = None,
+        expected_owner: RayWorkerActorHandle | None = None,
     ) -> RayWorkerActorHandle | None:
         query_id = str(query_id)
         fragment_id = str(fragment_id)
         partition_id = int(partition_id)
+        owner_key = (query_id, fragment_id, partition_id)
+        fragment_execution = None
+        waiter_identity = None
         with _FTE_REGISTRY_LOCK:
-            owner = _FTE_PARTITION_OWNERS.pop((query_id, fragment_id, partition_id), None)
-            lease_record = _FTE_PARTITION_TASK_LEASES.pop((query_id, fragment_id, partition_id), None)
+            current_owner = _FTE_PARTITION_OWNERS.get(owner_key)
+            if expected_owner is not None and current_owner is not expected_owner:
+                return None
+            owner = _FTE_PARTITION_OWNERS.pop(owner_key, None)
+            lease_record = _FTE_PARTITION_TASK_LEASES.pop(owner_key, None)
+            waiter_identity = _FTE_PARTITION_TASK_WAITERS.pop(owner_key, None)
+            for stage_key, partition_key in list(_FTE_STAGE_SUBMISSION_PROBES.items()):
+                if partition_key == owner_key:
+                    _FTE_STAGE_SUBMISSION_PROBES.pop(stage_key, None)
+            for stage_key, blocked in list(_FTE_STAGE_SUBMISSION_BLOCKS.items()):
+                if blocked[2] == owner_key:
+                    _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
             if terminal is None and lease_record is not None:
-                _, task_lease = lease_record
                 fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
-                partition = None if fragment_execution is None else fragment_execution.partitions.get(partition_id)
-                terminal = bool(
-                    partition is not None
-                    and any(
-                        str(running.attempt_id) == task_lease.attempt_id
-                        for running in partition.running_attempts.values()
-                    )
+        if terminal is None and lease_record is not None:
+            _, task_lease = lease_record
+            terminal = bool(
+                fragment_execution is not None
+                and fragment_execution.partition_attempt_is_running(
+                    partition_id,
+                    task_lease.attempt_id,
                 )
-        release_fte_partition_task_waiter((query_id, fragment_id, partition_id))
-        release_fte_partition_submission(
-            query_id,
-            fragment_id,
-            partition_id,
-        )
+            )
+        if waiter_identity is not None:
+            from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+            try:
+                get_query_resource_manager(waiter_identity[0]).remove_task_waiter(
+                    waiter_identity[1],
+                    waiter_identity[2],
+                )
+            except KeyError:
+                pass
         try:
             if owner is not None:
                 owner.release_fte_partition_reservation(query_id, fragment_id, partition_id)
@@ -2259,6 +2246,13 @@ def _mark_fte_worker_failed(
     handles_to_kill: list[RayWorkerActorHandle] = []
     pending_worker_reservation_futures_to_cancel: list[FteWorkerReservationFuture] = []
     retryable_by_owner_key: dict[tuple[str, str, int], bool] = {}
+    failed_owner_items: list[
+        tuple[
+            tuple[str, str, int],
+            RayWorkerActorHandle,
+            FteFragmentExecution | None,
+        ]
+    ] = []
     with _FTE_REGISTRY_LOCK:
         for failed_worker_id in sorted(failed_worker_ids):
             failed_handle = _FTE_WORKER_HANDLES.pop(failed_worker_id, None)
@@ -2271,46 +2265,56 @@ def _mark_fte_worker_failed(
                 continue
             if str(owner.worker_id) not in failed_worker_ids:
                 continue
-            memory_requirement_bytes = _fte_partition_memory_requirement_bytes(owner_key)
-            execution_class = _fte_partition_execution_class(owner_key)
-            node_requirements = _fte_partition_node_requirements(owner_key)
-            wait_started_at = time.time()
-            replacement = _select_replacement_fte_worker(
-                failed_worker_ids,
-                memory_requirement_bytes=memory_requirement_bytes,
-                execution_class=execution_class,
-                node_requirements=node_requirements,
-                node_requirements_wait_started_at=wait_started_at,
+            failed_owner_items.append(
+                (
+                    owner_key,
+                    owner,
+                    _FTE_FRAGMENT_EXECUTIONS.get((owner_key[0], owner_key[1])),
+                )
             )
-            if replacement is None:
-                future = _FTE_PENDING_WORKER_RESERVATIONS.pop(owner_key, None)
-                if future is not None:
-                    pending_worker_reservation_futures_to_cancel.append(future)
-                FteWorkerPlacementManager.release_owner(
-                    query_id=owner_key[0],
-                    fragment_id=owner_key[1],
-                    partition_id=owner_key[2],
-                )
-                retryable_by_owner_key[owner_key] = _has_replacement_fte_worker(
-                    failed_worker_ids,
-                    node_requirements=node_requirements,
-                    node_requirements_wait_started_at=wait_started_at,
-                )
-            else:
-                retryable_by_owner_key[owner_key] = True
-                future = _FTE_PENDING_WORKER_RESERVATIONS.pop(owner_key, None)
-                if future is not None:
-                    pending_worker_reservation_futures_to_cancel.append(future)
-                FteWorkerPlacementManager.release_owner(
-                    query_id=owner_key[0],
-                    fragment_id=owner_key[1],
-                    partition_id=owner_key[2],
-                )
+            future = _FTE_PENDING_WORKER_RESERVATIONS.pop(owner_key, None)
+            if future is not None:
+                pending_worker_reservation_futures_to_cancel.append(future)
         fragment_execution_items = [
             item
             for item in _FTE_FRAGMENT_EXECUTIONS.items()
             if query_id_filter is None or item[0][0] == query_id_filter
         ]
+
+    for owner_key, owner, fragment_execution in failed_owner_items:
+        scheduling_requirements = None
+        if fragment_execution is not None:
+            with _FTE_REGISTRY_LOCK:
+                fragment_is_current = _FTE_FRAGMENT_EXECUTIONS.get((owner_key[0], owner_key[1])) is fragment_execution
+            if fragment_is_current:
+                scheduling_requirements = fragment_execution.partition_scheduling_requirements(
+                    owner_key[2],
+                )
+        if scheduling_requirements is None:
+            memory_requirement_bytes = None
+            execution_class = FteTaskExecutionClass.STANDARD
+            node_requirements = None
+        else:
+            memory_requirement_bytes, execution_class, node_requirements = scheduling_requirements
+        wait_started_at = time.time()
+        replacement = _select_replacement_fte_worker(
+            failed_worker_ids,
+            memory_requirement_bytes=memory_requirement_bytes,
+            execution_class=execution_class,
+            node_requirements=node_requirements,
+            node_requirements_wait_started_at=wait_started_at,
+        )
+        retryable_by_owner_key[owner_key] = replacement is not None or _has_replacement_fte_worker(
+            failed_worker_ids,
+            node_requirements=node_requirements,
+            node_requirements_wait_started_at=wait_started_at,
+        )
+        FteWorkerPlacementManager.release_owner(
+            query_id=owner_key[0],
+            fragment_id=owner_key[1],
+            partition_id=owner_key[2],
+            expected_owner=owner,
+        )
 
     for handle in handles_to_kill:
         try:

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -14,8 +14,12 @@ import duckdb
 
 ray = pytest.importorskip("ray")
 
+import duckdb.runners.ray.fragment_worker_commands as worker_commands_mod
+import duckdb.runners.ray.fragment_worker_placement as worker_placement_mod
+import duckdb.runners.ray.fragment_worker_selection as worker_selection_mod
 import duckdb.runners.ray.fragment_worker_submission as fragment_submission_mod
 import duckdb.runners.ray.fragment_worker_task_control as task_control_mod
+import duckdb.runners.ray.fte_fragment_scheduler as fte_fragment_scheduler_mod
 import duckdb.runners.ray.worker as worker_mod
 import duckdb.runners.ray.worker_handle as worker_handle_mod
 from duckdb.runners.common import QueryDeadlineExceeded
@@ -30,7 +34,12 @@ from duckdb.runners.ray.fte import (
     NodeRequirements,
     PartitionInfo,
 )
-from duckdb.runners.ray.fte_events import TaskStatusChanged, WorkerReservationCompleted
+from duckdb.runners.ray.fte_events import (
+    FteAddSplitsCommand,
+    FteCreateTaskCommand,
+    TaskStatusChanged,
+    WorkerReservationCompleted,
+)
 from duckdb.runners.ray.query_execution_graph import (
     NodeResourceAllocation,
     QueryAllocation,
@@ -2055,6 +2064,15 @@ def test_fte_drop_query_clears_fte_registry_and_worker_pressure(monkeypatch):
             )
         ]
     )
+    handle0.record_fte_task_terminal(
+        {
+            "query_id": "query-drop",
+            "fragment_execution_id": 99,
+            "partition_id": 0,
+            "attempt_id": 0,
+        },
+        drain=False,
+    )
 
     before = handle0.fte_registry_stats()
     assert before["fragment_execution_count"] == 2
@@ -2070,6 +2088,7 @@ def test_fte_drop_query_clears_fte_registry_and_worker_pressure(monkeypatch):
         "FteCreateTaskCommand": 1,
     }
     assert sum(worker["running_attempt_count"] for worker in before["workers"].values()) == 2
+    assert sum(worker["terminal_attempt_count"] for worker in before["workers"].values()) == 1
 
     assert handle0.fte_drop_query("query-drop") == {
         "tasks_removed": 1,
@@ -2088,6 +2107,7 @@ def test_fte_drop_query_clears_fte_registry_and_worker_pressure(monkeypatch):
         "FteCreateTaskCommand": 1,
     }
     assert sum(worker["running_attempt_count"] for worker in after["workers"].values()) == 1
+    assert sum(worker["terminal_attempt_count"] for worker in after["workers"].values()) == 0
     assert all(
         "query-drop" not in attempt
         for worker in (handle0, handle1)
@@ -2739,6 +2759,883 @@ def test_fte_owner_selection_uses_worker_split_pressure(monkeypatch):
     assert handle0.fte_pressure_stats()["assigned_split_bytes"] == len(b"p0")
     assert handle1.fte_pressure_stats()["assigned_split_bytes"] == len(b"p1")
     assert handle0.fte_registry_stats()["partition_owner_count"] == 2
+
+
+def test_fte_terminal_pressure_rejects_late_attempt_updates():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-terminal-pressure",
+    )
+    attempt = {
+        "query_id": "query-terminal-pressure",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    request = {
+        "execution_class": "standard",
+        "initial_splits": {},
+        "memory_requirement_bytes": 64,
+    }
+
+    assert handle.record_fte_task_started(attempt, request) is True
+    assert handle.record_fte_splits_added(attempt, 1, split_bytes=16) is True
+    handle.record_fte_task_terminal(attempt, drain=False)
+
+    assert handle.record_fte_task_started(attempt, request) is False
+    assert handle.record_fte_splits_added(attempt, 1, split_bytes=128) is False
+    assert handle.record_fte_split_bytes_added(attempt, 256) is False
+    stats = handle.fte_pressure_stats()
+    assert stats["running_attempt_count"] == 0
+    assert stats["assigned_split_count"] == 0
+    assert stats["assigned_split_bytes"] == 0
+    assert stats["assigned_memory_bytes"] == 0
+    assert stats["score"] == 0
+
+
+def test_fte_split_ack_before_create_ack_is_merged_into_running_pressure(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-create-add-ack-order",
+    )
+    query_id = "query-create-add-ack-order"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    scheduled = partition.start_attempt(
+        worker_id=handle.worker_id,
+        remote_handle=handle,
+    )
+    request = {
+        **scheduled.request,
+        "initial_splits": {
+            "7": ({"sequence_id": 0, "kind": "scan_task", "data": b"base"},),
+        },
+    }
+    handle.reserve_fte_partition(
+        query_id,
+        fragment_id,
+        0,
+        memory_requirement_bytes=64,
+        execution_class="standard",
+    )
+    create_command = FteCreateTaskCommand(
+        query_id=query_id,
+        fragment_id=fragment_id,
+        worker_id=handle.worker_id,
+        worker=handle,
+        attempt_id=scheduled.attempt_id,
+        partition_id=0,
+        request=request,
+    )
+    add_command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=fragment_id,
+        worker_id=handle.worker_id,
+        worker=handle,
+        attempt_id=scheduled.attempt_id,
+        source_node_id="7",
+        splits=(
+            {"sequence_id": 1, "kind": "scan_task", "data": b"a"},
+            {"sequence_id": 2, "kind": "scan_task", "data": b"bc"},
+        ),
+    )
+    create_rpc_completed = threading.Event()
+    release_create_ack = threading.Event()
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create(query_id)
+
+    def execute(command):
+        if isinstance(command, FteCreateTaskCommand):
+            create_rpc_completed.set()
+            assert release_create_ack.wait(2.0)
+        else:
+            assert create_rpc_completed.wait(2.0)
+
+    monkeypatch.setattr(scheduler.worker_command_executor, "execute", execute)
+    monkeypatch.setattr(
+        worker_commands_mod,
+        "fte_partition_task_lease_payload",
+        lambda *_args, **_kwargs: {},
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        create_ack = executor.submit(
+            handle._execute_fte_fragment_execution_worker_commands,
+            stage,
+            [create_command],
+        )
+        assert create_rpc_completed.wait(2.0)
+        add_ack = executor.submit(
+            handle._execute_fte_fragment_execution_worker_commands,
+            stage,
+            [add_command],
+        )
+        add_ack.result(timeout=2.0)
+
+        attempt_key = str(scheduled.attempt_id)
+        assert handle._fte_pressure.pending_split_counts_by_attempt == {attempt_key: 2}
+        pending_split_bytes = handle._fte_pressure.pending_split_bytes_by_attempt[attempt_key]
+        assert pending_split_bytes > 0
+        assert handle.fte_pressure_stats()["running_attempt_count"] == 0
+
+        release_create_ack.set()
+        create_ack.result(timeout=2.0)
+
+    stats = handle.fte_pressure_stats()
+    assert stats["running_attempt_count"] == 1
+    assert stats["reserved_partition_count"] == 0
+    assert stats["assigned_split_count"] == 3
+    assert stats["assigned_split_bytes"] == 4 + pending_split_bytes
+    assert stats["assigned_memory_bytes"] == 64
+    assert handle._fte_pressure.pending_split_counts_by_attempt == {}
+    assert handle._fte_pressure.pending_split_bytes_by_attempt == {}
+
+
+def test_fte_terminal_pressure_compacts_retry_tombstones_by_task():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-terminal-pressure-compaction",
+    )
+    task = {
+        "query_id": "query-terminal-pressure-compaction",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+    }
+    request = {
+        "execution_class": "standard",
+        "initial_splits": {},
+        "memory_requirement_bytes": 64,
+    }
+
+    for attempt_id in range(10_000):
+        handle.record_fte_task_terminal(
+            {**task, "attempt_id": attempt_id},
+            drain=False,
+        )
+
+    task_key = "query-terminal-pressure-compaction.0.0"
+    assert handle._fte_pressure.terminal_attempt_id_by_task == {task_key: 9_999}
+    assert handle.fte_pressure_stats()["terminal_attempt_count"] == 1
+    assert handle.record_fte_task_started({**task, "attempt_id": 9_999}, request) is False
+    assert handle.record_fte_splits_added({**task, "attempt_id": 9_999}, 1) is False
+    assert handle.record_fte_task_started({**task, "attempt_id": 10_000}, request) is True
+
+
+def test_fte_late_ack_for_terminal_attempt_does_not_touch_retry_pressure():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-retry-pressure",
+    )
+    old_attempt = {
+        "query_id": "query-retry-pressure",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    retry_attempt = {
+        **old_attempt,
+        "attempt_id": 1,
+    }
+    request = {
+        "execution_class": "standard",
+        "initial_splits": {},
+        "memory_requirement_bytes": 64,
+    }
+
+    assert handle.record_fte_task_started(old_attempt, request) is True
+    handle.record_fte_task_terminal(old_attempt, drain=False)
+    assert handle.record_fte_task_started(retry_attempt, request) is True
+    assert handle.record_fte_splits_added(retry_attempt, 2, split_bytes=32) is True
+
+    assert handle.record_fte_splits_added(old_attempt, 10, split_bytes=1024) is False
+    stats = handle.fte_pressure_stats()
+    assert stats["running_attempt_count"] == 1
+    assert stats["assigned_split_count"] == 2
+    assert stats["assigned_split_bytes"] == 32
+    assert stats["assigned_memory_bytes"] == 64
+
+
+def test_fte_late_create_ack_does_not_clear_retry_reservation():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-retry-reservation",
+    )
+    query_id = "query-retry-reservation"
+    fragment_id = f"{query_id}:node:7"
+    old_attempt = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    request = {
+        "execution_class": "standard",
+        "initial_splits": {},
+        "memory_requirement_bytes": 128,
+    }
+
+    assert handle.record_fte_task_started(old_attempt, request) is True
+    handle.record_fte_task_terminal(old_attempt, drain=False)
+    handle.reserve_fte_partition(
+        query_id,
+        fragment_id,
+        0,
+        memory_requirement_bytes=128,
+        execution_class="standard",
+    )
+
+    assert (
+        handle.record_fte_task_started_from_reservation(
+            query_id,
+            fragment_id,
+            0,
+            old_attempt,
+            request,
+        )
+        is False
+    )
+    stats = handle.fte_pressure_stats()
+    assert stats["running_attempt_count"] == 0
+    assert stats["terminal_attempt_count"] == 1
+    assert stats["reserved_partition_count"] == 1
+    assert stats["reserved_memory_bytes"] == 128
+    assert stats["score"] == 1024
+
+
+def test_fte_add_splits_ack_after_task_finish_does_not_revive_pressure():
+    rpc_started = threading.Event()
+    release_rpc = threading.Event()
+
+    class _BlockingFuture:
+        def __init__(self, value):
+            self.value = value
+
+        def result(self, timeout=None):
+            assert release_rpc.wait(timeout)
+            return self.value
+
+    class _BlockingObjectRef:
+        def __init__(self, value):
+            self._future = _BlockingFuture(value)
+
+        def future(self):
+            return self._future
+
+    class _BlockingAddSplits:
+        def remote(self, task_id, source_node_id, splits, dependency=None):
+            rpc_started.set()
+            return _BlockingObjectRef(
+                _FakeActor._control_status(
+                    "fte_add_splits",
+                    task_id,
+                    version=2,
+                )
+            )
+
+    query_id = "query-late-add-splits-ack"
+    fragment_id = f"{query_id}:node:7"
+    actor = _FakeActor()
+    actor.fte_add_splits = _BlockingAddSplits()
+    handle = RayWorkerActorHandle(
+        actor,
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-late-add-splits-ack",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        task_memory_bytes=64,
+    )
+
+    finished_partition = stage.add_partition(0)
+    finished_attempt = finished_partition.start_attempt(
+        worker_id=handle.worker_id,
+        remote_handle=handle,
+    )
+    assert handle.record_fte_task_started(finished_attempt.attempt_id, finished_attempt.request) is True
+
+    retry_partition = stage.add_partition(1)
+    failed_attempt = retry_partition.start_attempt(
+        worker_id=handle.worker_id,
+        remote_handle=handle,
+    )
+    assert handle.record_fte_task_started(failed_attempt.attempt_id, failed_attempt.request) is True
+    assert stage.task_failed(failed_attempt.attempt_id, "retry", schedule_retry=False) is None
+    retry_attempt = retry_partition.start_attempt(
+        worker_id=handle.worker_id,
+        remote_handle=handle,
+    )
+    assert retry_attempt.attempt_id.attempt_id == 1
+    assert handle.record_fte_task_started(retry_attempt.attempt_id, retry_attempt.request) is True
+    assert handle.record_fte_splits_added(retry_attempt.attempt_id, 2, split_bytes=32) is True
+
+    command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=fragment_id,
+        worker_id=handle.worker_id,
+        worker=handle,
+        attempt_id=finished_attempt.attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"late"},),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        command_execution = executor.submit(
+            handle._execute_fte_fragment_execution_worker_commands,
+            stage,
+            [command],
+        )
+        try:
+            assert rpc_started.wait(2.0)
+            assert stage.task_finished(finished_attempt.attempt_id) is True
+
+            before_ack = handle.fte_pressure_stats()
+            assert before_ack["running_attempt_count"] == 1
+            assert before_ack["terminal_attempt_count"] == 2
+            assert before_ack["assigned_split_count"] == 2
+            assert before_ack["assigned_split_bytes"] == 32
+            assert before_ack["assigned_memory_bytes"] == 64
+        finally:
+            release_rpc.set()
+        command_execution.result(timeout=2.0)
+
+    after_ack = handle.fte_pressure_stats()
+    assert after_ack["running_attempt_count"] == 1
+    assert after_ack["terminal_attempt_count"] == 2
+    assert after_ack["assigned_split_count"] == 2
+    assert after_ack["assigned_split_bytes"] == 32
+    assert after_ack["assigned_memory_bytes"] == 64
+    assert handle._fte_pressure.running_attempts == {str(retry_attempt.attempt_id)}
+
+
+def test_fte_pressure_drop_query_serializes_with_other_query_start():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-drop-pressure-race",
+    )
+    query_a_attempt = {
+        "query_id": "query-drop-pressure-a",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    query_b_attempt = {
+        "query_id": "query-drop-pressure-b",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    request = {
+        "execution_class": "standard",
+        "initial_splits": {},
+        "memory_requirement_bytes": 64,
+    }
+    assert handle.record_fte_task_started(query_a_attempt, request) is True
+
+    drop_iteration_started = threading.Event()
+    query_b_start_entered = threading.Event()
+
+    class _BlockingAttemptSet(set):
+        def __iter__(self):
+            snapshot = tuple(set.__iter__(self))
+            drop_iteration_started.set()
+            assert query_b_start_entered.wait(2.0)
+            return iter(snapshot)
+
+    handle._fte_pressure.running_attempts = _BlockingAttemptSet(handle._fte_pressure.running_attempts)
+
+    def start_query_b():
+        query_b_start_entered.set()
+        return handle.record_fte_task_started(query_b_attempt, request)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        dropped = executor.submit(handle._fte_pressure.drop_query, "query-drop-pressure-a")
+        assert drop_iteration_started.wait(2.0)
+        started = executor.submit(start_query_b)
+        dropped.result(timeout=2.0)
+        assert started.result(timeout=2.0) is True
+
+    stats = handle.fte_pressure_stats()
+    assert stats["running_attempt_count"] == 1
+    assert stats["assigned_memory_bytes"] == 64
+    assert handle._fte_pressure.running_attempts == {str(FteTaskAttemptId.coerce(query_b_attempt))}
+
+
+def test_fte_existing_fragment_metadata_merge_serializes_with_partition_add(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-metadata-merge",
+    )
+    query_id = "query-metadata-merge"
+    fragment_id = f"{query_id}:node:7"
+    key = (query_id, fragment_id)
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        context={"scan_task_nodes": "7,8"},
+        task_memory_bytes=64,
+    )
+    first = stage.add_partition(0)
+    merge_iteration_started = threading.Event()
+    add_entered = threading.Event()
+
+    class _LockCheckingPartitions(dict):
+        def values(self):
+            assert stage._state_lock_owned_by_current_thread()
+            is_registry_lock_owned = getattr(fragment_submission_mod._FTE_REGISTRY_LOCK, "_is_owned", None)
+            assert callable(is_registry_lock_owned) and not is_registry_lock_owned()
+            merge_iteration_started.set()
+            assert add_entered.wait(2.0)
+            return super().values()
+
+    stage.partitions = _LockCheckingPartitions(stage.partitions)
+    monkeypatch.setitem(fragment_submission_mod._FTE_FRAGMENT_EXECUTIONS, key, stage)
+
+    def merge_metadata():
+        return handle._get_or_create_fte_fragment_execution(
+            {
+                "query_id": query_id,
+                "fragment_id": fragment_id,
+                "task_context_info": {"metadata": "merged"},
+                "exchange_sink_instance": {"sink": "merged"},
+            },
+            dynamic_scan_sources={"7"},
+            dynamic_exchange_sources={"8"},
+        )
+
+    def add_partition():
+        add_entered.set()
+        return stage.add_partition(1)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        merged = executor.submit(merge_metadata)
+        assert merge_iteration_started.wait(2.0)
+        added = executor.submit(add_partition)
+        assert merged.result(timeout=2.0) is stage
+        second = added.result(timeout=2.0)
+
+    assert first.descriptor.source_node_ids == {"7", "8"}
+    assert second.descriptor.source_node_ids == {"7", "8"}
+    assert second.descriptor.task_context_info == {
+        "metadata": "merged",
+        "exchange_sink_instance": {"sink": "merged"},
+    }
+    assert second.descriptor.exchange_sink_instance == {"sink": "merged"}
+
+
+def test_available_fte_workers_snapshots_registry_before_concurrent_removal(monkeypatch):
+    iteration_started = threading.Event()
+    removal_started = threading.Event()
+
+    class _Worker:
+        _fte_healthy = True
+
+        def __init__(self, worker_id):
+            self.worker_id = worker_id
+
+    class _LockCheckingRegistry(dict):
+        def items(self):
+            is_owned = getattr(worker_selection_mod._FTE_REGISTRY_LOCK, "_is_owned", None)
+            assert callable(is_owned) and is_owned()
+            iteration_started.set()
+            assert removal_started.wait(2.0)
+            return super().items()
+
+    worker_a = _Worker("worker-a")
+    worker_b = _Worker("worker-b")
+    registry = _LockCheckingRegistry({"worker-a": worker_a, "worker-b": worker_b})
+    monkeypatch.setattr(worker_selection_mod, "_FTE_WORKER_HANDLES", registry)
+
+    def remove_worker():
+        removal_started.set()
+        with worker_selection_mod._FTE_REGISTRY_LOCK:
+            registry.pop("worker-b")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        snapshot = executor.submit(
+            worker_selection_mod.available_fte_workers,
+            worker_a,
+            worker_a.worker_id,
+        )
+        assert iteration_started.wait(2.0)
+        removal = executor.submit(remove_worker)
+        workers = snapshot.result(timeout=2.0)
+        removal.result(timeout=2.0)
+
+    assert workers == [worker_a, worker_b]
+    assert registry == {"worker-a": worker_a}
+
+
+def test_fte_node_wait_placement_rechecks_terminal_partition_after_admission(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-placement-terminal",
+    )
+    query_id = "query-placement-terminal"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        context={
+            "resource_query_id": query_id,
+            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+        },
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    next_partition = stage.add_partition(1)
+    _register_test_query_graph(query_id, [fragment_id])
+    monkeypatch.setitem(
+        worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
+        (query_id, fragment_id),
+        stage,
+    )
+    admission_started = threading.Event()
+    terminal_committed = threading.Event()
+    reservation_calls = []
+
+    class _PlacementManager:
+        def acquire(self, **kwargs):
+            reservation_calls.append(kwargs)
+            return object()
+
+    handle._fte_worker_placement_manager = _PlacementManager()
+
+    real_admit = worker_placement_mod._admit_fte_partition_node_wait
+
+    def admit(*args, **kwargs):
+        admitted = real_admit(*args, **kwargs)
+        assert admitted is True
+        admission_started.set()
+        assert terminal_committed.wait(2.0)
+        return admitted
+
+    monkeypatch.setattr(worker_placement_mod, "_admit_fte_partition_node_wait", admit)
+
+    def finish_partition():
+        assert admission_started.wait(2.0)
+        with stage._state_lock:
+            partition.finished = True
+            partition._invalidate_placement()
+        terminal_committed.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        placement = executor.submit(
+            handle._try_reserve_fte_partition_for_node_wait,
+            query_id,
+            fragment_id,
+            partition,
+            fragment_execution=stage,
+        )
+        finished = executor.submit(finish_partition)
+        placement.result(timeout=2.0)
+        finished.result(timeout=2.0)
+
+    assert partition.finished is True
+    assert partition.node_wait_started_at is None
+    assert reservation_calls == []
+    assert fte_fragment_scheduler_mod.fte_submission_window_snapshot()["probes"] == {}
+    assert (
+        fte_fragment_scheduler_mod.admit_fte_partition_submission(
+            query_id,
+            fragment_id,
+            next_partition.task_id.partition_id,
+        )
+        is True
+    )
+    assert (
+        fte_fragment_scheduler_mod.release_fte_partition_submission(
+            query_id,
+            fragment_id,
+            next_partition.task_id.partition_id,
+        )
+        is True
+    )
+
+
+def test_fte_ready_attempt_releases_admission_when_partition_finishes_before_handoff(monkeypatch):
+    query_id = "query-ready-attempt-terminal"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        context={
+            "resource_query_id": query_id,
+            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+        },
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    next_partition = stage.add_partition(1)
+    with stage._state_lock:
+        partition.mark_ready_for_execution()
+    _register_test_query_graph(query_id, [fragment_id])
+    monkeypatch.setitem(
+        worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
+        (query_id, fragment_id),
+        stage,
+    )
+    admission_started = threading.Event()
+    terminal_committed = threading.Event()
+    reservation_calls = []
+
+    def admit(candidate):
+        admitted = fte_fragment_scheduler_mod._admit_fte_partition_node_wait(
+            query_id,
+            candidate,
+            stage,
+        )
+        assert admitted is True
+        admission_started.set()
+        assert terminal_committed.wait(2.0)
+        return admitted
+
+    stage.attempt_admission_callback = admit
+    stage.attempt_admission_abandon_callback = lambda candidate: (
+        fte_fragment_scheduler_mod.release_fte_partition_submission(
+            query_id,
+            fragment_id,
+            candidate.task_id.partition_id,
+        )
+    )
+    stage.worker_reservation_callback = lambda candidate: reservation_calls.append(candidate) or True
+
+    def finish_partition():
+        assert admission_started.wait(2.0)
+        with stage._state_lock:
+            partition.finished = True
+            partition._invalidate_placement()
+        terminal_committed.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        scheduled = executor.submit(stage.schedule_next_pending_partition)
+        finished = executor.submit(finish_partition)
+        assert scheduled.result(timeout=2.0) is None
+        finished.result(timeout=2.0)
+
+    assert reservation_calls == []
+    assert fte_fragment_scheduler_mod.fte_submission_window_snapshot()["probes"] == {}
+    assert (
+        fte_fragment_scheduler_mod.admit_fte_partition_submission(
+            query_id,
+            fragment_id,
+            next_partition.task_id.partition_id,
+        )
+        is True
+    )
+    assert (
+        fte_fragment_scheduler_mod.release_fte_partition_submission(
+            query_id,
+            fragment_id,
+            next_partition.task_id.partition_id,
+        )
+        is True
+    )
+
+
+def test_fte_async_reservation_releases_admission_for_terminal_partition(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-async-reservation-terminal",
+    )
+    query_id = "query-async-reservation-terminal"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        context={
+            "resource_query_id": query_id,
+            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+        },
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    _register_test_query_graph(query_id, [fragment_id])
+    monkeypatch.setitem(
+        worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
+        (query_id, fragment_id),
+        stage,
+    )
+    assert (
+        fte_fragment_scheduler_mod.admit_fte_partition_submission(
+            query_id,
+            fragment_id,
+            partition.task_id.partition_id,
+        )
+        is True
+    )
+    with stage._state_lock:
+        partition.finished = True
+        partition._invalidate_placement()
+
+    assert (
+        handle._request_fte_worker_reservation_for_partition(
+            query_id,
+            fragment_id,
+            stage,
+            partition,
+        )
+        is False
+    )
+    assert fte_fragment_scheduler_mod.fte_submission_window_snapshot()["probes"] == {}
+
+
+def test_fte_node_wait_placement_releases_reservation_when_partition_finishes_before_commit(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-placement-rollback",
+    )
+    query_id = "query-placement-rollback"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    reservation_started = threading.Event()
+    terminal_committed = threading.Event()
+    releases = []
+
+    class _PlacementManager:
+        def acquire(self, **_kwargs):
+            reservation_started.set()
+            assert terminal_committed.wait(2.0)
+            return object()
+
+    handle._fte_worker_placement_manager = _PlacementManager()
+    monkeypatch.setattr(worker_placement_mod, "_admit_fte_partition_node_wait", lambda *_args: True)
+    monkeypatch.setattr(
+        worker_placement_mod.FteWorkerPlacementManager,
+        "release_owner",
+        lambda **kwargs: releases.append(kwargs),
+    )
+
+    def finish_partition():
+        assert reservation_started.wait(2.0)
+        with stage._state_lock:
+            partition.finished = True
+            partition._invalidate_placement()
+        terminal_committed.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        placement = executor.submit(
+            handle._try_reserve_fte_partition_for_node_wait,
+            query_id,
+            fragment_id,
+            partition,
+            fragment_execution=stage,
+        )
+        finished = executor.submit(finish_partition)
+        placement.result(timeout=2.0)
+        finished.result(timeout=2.0)
+
+    assert partition.finished is True
+    assert len(releases) == 1
+    assert releases[0] == {
+        "query_id": query_id,
+        "fragment_id": fragment_id,
+        "partition_id": 0,
+        "terminal": False,
+    }
+
+
+def test_fte_async_placement_releases_reservation_when_partition_finishes_before_commit(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-async-placement-rollback",
+    )
+    query_id = "query-async-placement-rollback"
+    fragment_id = f"{query_id}:node:7"
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        context={
+            "resource_query_id": query_id,
+            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+        },
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    monkeypatch.setitem(
+        fragment_submission_mod._FTE_FRAGMENT_EXECUTIONS,
+        (query_id, fragment_id),
+        stage,
+    )
+    future, created = handle._fte_worker_placement_manager.request_async(
+        query_id=query_id,
+        fragment_execution_id=stage.fragment_execution_id,
+        fragment_id=fragment_id,
+        partition_id=0,
+        memory_requirement_bytes=64,
+        execution_class=partition.execution_class,
+    )
+    assert created is True
+    reservation_started = threading.Event()
+    terminal_committed = threading.Event()
+    releases = []
+
+    def acquire(**_kwargs):
+        reservation_started.set()
+        assert terminal_committed.wait(2.0)
+        return object()
+
+    monkeypatch.setattr(handle._fte_worker_placement_manager, "acquire", acquire)
+    monkeypatch.setattr(
+        worker_placement_mod.FteWorkerPlacementManager,
+        "release_owner",
+        lambda **kwargs: releases.append(kwargs),
+    )
+
+    def finish_partition():
+        assert reservation_started.wait(2.0)
+        with stage._state_lock:
+            partition.finished = True
+            partition._invalidate_placement()
+        terminal_committed.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        placement = executor.submit(
+            handle._try_complete_fte_worker_reservation_future,
+            future,
+            partition=partition,
+        )
+        finished = executor.submit(finish_partition)
+        assert placement.result(timeout=2.0) is False
+        finished.result(timeout=2.0)
+
+    assert future.cancelled() is True
+    assert releases == [
+        {
+            "query_id": query_id,
+            "fragment_id": fragment_id,
+            "partition_id": 0,
+            "terminal": False,
+        }
+    ]
 
 
 def test_fte_registry_stats_reports_query_stage_partition_metrics(monkeypatch):
@@ -5034,6 +5931,92 @@ def test_fte_worker_failure_retry_preserves_registered_heap(monkeypatch):
     assert high_memory.fte_pressure_stats()["assigned_memory_bytes"] == 0
 
 
+def test_fte_worker_failure_does_not_invert_attempt_start_lock_order(monkeypatch):
+    failure_holds_registry = threading.Event()
+    start_holds_state = threading.Event()
+    failure_reads_state_without_registry = threading.Event()
+    query_id = "query-worker-failure-start-race"
+    fragment_id = f"{query_id}:node:7"
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="failed-start-race",
+    )
+    replacement = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="replacement-start-race",
+    )
+    stage = None
+
+    def select_replacement(_partition):
+        assert stage is not None
+        assert stage._state_lock_owned_by_current_thread()
+        start_holds_state.set()
+        assert failure_holds_registry.wait(2.0)
+        with fte_fragment_scheduler_mod._FTE_REGISTRY_LOCK:
+            fte_fragment_scheduler_mod._FTE_PARTITION_OWNERS[owner_key] = replacement
+            return replacement.worker_id, replacement
+
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=fragment_id,
+        worker_selector=select_replacement,
+        task_memory_bytes=64,
+    )
+    partition = stage.add_partition(0)
+    owner_key = (query_id, fragment_id, 0)
+
+    class _BlockingOwnerRegistry(dict):
+        def items(self):
+            is_owned = getattr(fte_fragment_scheduler_mod._FTE_REGISTRY_LOCK, "_is_owned", None)
+            assert callable(is_owned) and is_owned()
+            failure_holds_registry.set()
+            assert start_holds_state.wait(2.0)
+            return super().items()
+
+    monkeypatch.setattr(
+        fte_fragment_scheduler_mod,
+        "_FTE_PARTITION_OWNERS",
+        _BlockingOwnerRegistry({owner_key: failed}),
+    )
+    monkeypatch.setitem(
+        fte_fragment_scheduler_mod._FTE_FRAGMENT_EXECUTIONS,
+        (query_id, fragment_id),
+        stage,
+    )
+    original_requirements = stage.partition_scheduling_requirements
+
+    def observed_requirements(partition_id):
+        is_owned = getattr(fte_fragment_scheduler_mod._FTE_REGISTRY_LOCK, "_is_owned", None)
+        assert callable(is_owned) and not is_owned()
+        failure_reads_state_without_registry.set()
+        return original_requirements(partition_id)
+
+    monkeypatch.setattr(stage, "partition_scheduling_requirements", observed_requirements)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        failure = executor.submit(
+            fte_fragment_scheduler_mod._mark_fte_worker_failed,
+            failed.worker_id,
+            "worker lost during attempt start",
+            query_id_filter=query_id,
+            failed_worker_ids_override={failed.worker_id},
+        )
+        assert failure_holds_registry.wait(2.0)
+        attempt = executor.submit(stage.start_attempt_with_worker, partition)
+
+        scheduled = attempt.result(timeout=2.0)
+        assert failure.result(timeout=2.0) == []
+
+    assert failure_reads_state_without_registry.is_set()
+    assert scheduled.worker_id == replacement.worker_id
+    assert partition.running_attempt is not None
+    assert partition.running_attempt.remote_handle is replacement
+    assert fte_fragment_scheduler_mod._FTE_PARTITION_OWNERS[owner_key] is replacement
+
+
 def test_fte_worker_failure_replays_descriptor_on_new_owner(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,
@@ -6988,14 +7971,18 @@ def test_worker_pressure_drop_uses_exact_query_identity():
     parent_reservation = partition_reservation_key("q", "q:node:1", 0)
     child_reservation = partition_reservation_key("q|child", "q|child:node:1", 0)
     pressure.running_attempts.update({parent_attempt, child_attempt})
+    pressure.terminal_attempt_id_by_task.update({"q.0.0": 0, "q.child.0.0": 0})
     pressure.split_counts_by_attempt.update({parent_attempt: 1, child_attempt: 2})
+    pressure.pending_split_counts_by_attempt.update({parent_attempt: 3, child_attempt: 4})
     pressure.reserved_partitions.update({parent_reservation, child_reservation})
     pressure.memory_bytes_by_reservation.update({parent_reservation: 10, child_reservation: 20})
 
     pressure.drop_query("q")
 
     assert pressure.running_attempts == {child_attempt}
+    assert pressure.terminal_attempt_id_by_task == {"q.child.0.0": 0}
     assert pressure.split_counts_by_attempt == {child_attempt: 2}
+    assert pressure.pending_split_counts_by_attempt == {child_attempt: 4}
     assert pressure.reserved_partitions == {child_reservation}
     assert pressure.memory_bytes_by_reservation == {child_reservation: 20}
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -492,6 +493,35 @@ def test_fte_write_sink_updates_registered_stage_state_instead_of_registering_an
         assert manager.snapshot()["stages"][stage_id]["runnable"] is True
         assert fragment_id == f"{query_id}:node:sink"
     finally:
+        _cleanup_fte_query(query_id)
+
+
+def test_fte_write_sink_stage_snapshot_owns_fragment_state_lock():
+    query_id = "q-write-sink-stage-lock"
+    clear_query_resource_managers()
+    _manager, _stage_id = _register_fte_query(query_id, "sink", partitions=1, task_slots=1)
+    stage, _fragment_id = _install_fte_fragment(
+        query_id,
+        "sink",
+        partitions=1,
+        context={
+            "node_id": "sink",
+            "copy_output_base": "",
+            "copy_output_run_id": "run-write-lock",
+            "copy_output_remote_base": "/tmp/out-lock.parquet",
+        },
+    )
+
+    class _LockCheckingPartitions(dict):
+        def values(self):
+            assert stage._state_lock_owned_by_current_thread()
+            return super().values()
+
+    stage.partitions = _LockCheckingPartitions(stage.partitions)
+    try:
+        fte_fragment_scheduler._sync_write_sink_stage_for_fragment(stage)
+    finally:
+        stage.partitions = dict(stage.partitions)
         _cleanup_fte_query(query_id)
 
 
@@ -1712,10 +1742,7 @@ class _FakeLiveWorker:
     def record_fte_task_started(self, _attempt_id, _request):
         return None
 
-    def record_fte_splits_added(self, _attempt_id, _split_count):
-        return None
-
-    def record_fte_split_bytes_added(self, _attempt_id, _split_bytes):
+    def record_fte_splits_added(self, _attempt_id, _split_count, *, split_bytes=None):
         return None
 
     def record_fte_task_terminal(self, _attempt_id):
@@ -1803,6 +1830,64 @@ def test_fte_worker_command_outbox_pop_owns_attempt_scheduling_lock():
     assert acquired_during_copy is False
     assert popped == ["first"]
     assert stage._worker_command_outbox == []
+
+
+def test_fte_add_partition_owns_state_lock_and_is_idempotent_under_concurrency():
+    class _LockCheckingExchange:
+        def __init__(self):
+            self.stage = None
+            self.created_sink_count = 0
+
+        def add_sink(self, partition_id):
+            assert self.stage is not None
+            assert self.stage._state_lock_owned_by_current_thread()
+            assert partition_id == 0
+            self.created_sink_count += 1
+            return object()
+
+    exchange = _LockCheckingExchange()
+    stage = FteFragmentExecution(
+        "query-concurrent-add",
+        0,
+        fragment_id="query-concurrent-add:node:1",
+        exchange=exchange,
+        task_memory_bytes=1,
+    )
+    exchange.stage = stage
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        partitions = list(executor.map(stage.add_partition, [0] * 8))
+
+    assert len({id(partition) for partition in partitions}) == 1
+    assert stage.partitions == {0: partitions[0]}
+    assert exchange.created_sink_count == 1
+
+
+def test_fte_start_attempt_with_worker_owns_mutation_locks():
+    worker = _FakeLiveWorker("worker-lock-contract")
+    lock_ownership = {}
+    stage = None
+
+    def select_worker(_partition):
+        assert stage is not None
+        lock_ownership["scheduling"] = stage._attempt_scheduling_lock_owned_by_current_thread()
+        lock_ownership["state"] = stage._state_lock_owned_by_current_thread()
+        return worker
+
+    stage = FteFragmentExecution(
+        "query-start-lock-contract",
+        0,
+        fragment_id="query-start-lock-contract:node:1",
+        worker_selector=select_worker,
+        task_memory_bytes=1,
+    )
+    partition = stage.add_partition(0)
+
+    scheduled = stage.start_attempt_with_worker(partition)
+
+    assert lock_ownership == {"scheduling": True, "state": True}
+    assert scheduled.worker_id == worker.worker_id
+    assert partition.running_attempt is not None
 
 
 def test_fte_two_query_fragment_callbacks_do_not_cross_state_locks():
@@ -1940,6 +2025,40 @@ def test_fte_worker_command_executor_requires_single_ordered_enqueue_protocol():
 
     with pytest.raises(RuntimeError, match="enqueue_fte_add_splits"):
         FteWorkerCommandExecutor().execute(command)
+
+
+def test_fte_add_splits_command_success_accounts_count_and_bytes_atomically():
+    class _Worker:
+        def __init__(self):
+            self.calls = []
+
+        def record_fte_splits_added(self, attempt_id, split_count, *, split_bytes=None):
+            self.calls.append((str(FteTaskAttemptId.coerce(attempt_id)), split_count, split_bytes))
+
+        def record_fte_split_bytes_added(self, *_args, **_kwargs):
+            raise AssertionError("split bytes must be accounted with the split batch")
+
+    worker = _Worker()
+    attempt_id = FteTaskAttemptId(FteTaskId("q", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id="q",
+        fragment_id="q:node:scan",
+        worker_id="worker-a",
+        worker=worker,
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=(
+            {"sequence_id": 1, "kind": "scan_task", "size_bytes": 7},
+            {"sequence_id": 2, "kind": "scan_task", "size_bytes": 11},
+        ),
+    )
+    stage = _fte_fragment_execution("q", 0, fragment_id="q:node:scan")
+
+    stage.handle_worker_command_success(command)
+
+    assert len(worker.calls) == 1
+    assert worker.calls[0][:2] == (str(attempt_id), 2)
+    assert worker.calls[0][2] > 0
 
 
 def test_fte_fragment_execution_requires_fragment_registration_protocol():


### PR DESCRIPTION
## Summary

- Make public `FteFragmentExecution` mutation paths own their state locking and use placement generations to reject stale reservation results.
- Fence terminal and stale task acknowledgements with a per-task high-water mark, preventing delayed create/start/split ACKs from resurrecting worker pressure or clearing retry reservations.
- Snapshot the worker registry under its lock, then perform worker selection and failure cleanup outside that critical section to avoid concurrent dictionary mutation and preserve lock ordering.
- Add deterministic regression coverage for concurrent partition mutation, delayed ACK/retry ordering, reservation rollback, registry removal, and worker-failure/attempt-start interleavings.

## Related issue

close: #89

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Internal scheduler, placement, and worker-pressure behavior only; no documentation changes are required.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files <changed files>` — all hooks passed, including Ruff and mypy
- `python -m pytest -q tests/fast/test_ray_fte.py tests/fast/test_ray_fragment_submission.py` — 330 passed
- `scripts/run_release_tests.sh` — 307 passed, 1 skipped; real-Ray shard 7 passed
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
