### PR TITLE
[fix](packaging) Remove plaintext artifact check values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,17 @@ jobs:
           python -m build --sdist --outdir dist
           python scripts/check_release_artifacts.py dist/*.tar.gz
 
+      - name: Apply private content rules to the source package
+        if: github.ref == 'refs/heads/main'
+        env:
+          RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
+        run: |
+          test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
+          printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
+            python scripts/check_release_artifacts.py \
+              --content-rules-manifest - \
+              dist/*.tar.gz
+
   native-fast-tests:
     name: Native build and fast tests (Python ${{ matrix.python-version }})
     needs: changes
@@ -165,6 +176,17 @@ jobs:
 
       - name: Validate release artifacts
         run: python scripts/check_release_artifacts.py dist/*.tar.gz dist/*.whl
+
+      - name: Apply private content rules to release artifacts
+        if: github.ref == 'refs/heads/main'
+        env:
+          RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
+        run: |
+          test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
+          printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
+            python scripts/check_release_artifacts.py \
+              --content-rules-manifest - \
+              dist/*.tar.gz dist/*.whl
 
       - name: Install the built wheel
         run: python -m pip install --force-reinstall dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,17 @@ jobs:
           python -m build --sdist --outdir dist
           python scripts/check_release_artifacts.py dist/*.tar.gz
 
+      - name: Apply private content rules to the source package
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
+        env:
+          RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
+        run: |
+          test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
+          printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
+            python scripts/check_release_artifacts.py \
+              --content-rules-manifest - \
+              dist/*.tar.gz
+
       - name: Upload source package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -92,6 +103,17 @@ jobs:
           test "$(find wheelhouse -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
           python scripts/check_release_artifacts.py wheelhouse/*.whl
 
+      - name: Apply private content rules to wheels
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
+        env:
+          RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
+        run: |
+          test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
+          printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
+            python scripts/check_release_artifacts.py \
+              --content-rules-manifest - \
+              wheelhouse/*.whl
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -131,6 +153,17 @@ jobs:
           test "$(find packages -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
           test "$(find packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
           python scripts/check_release_artifacts.py packages/*.tar.gz packages/*.whl
+
+      - name: Apply private content rules to the distribution set
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
+        env:
+          RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
+        run: |
+          test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
+          printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
+            python scripts/check_release_artifacts.py \
+              --content-rules-manifest - \
+              packages/*.tar.gz packages/*.whl
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,10 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && inputs.destination == 'testpypi'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.destination == 'testpypi' &&
+      github.ref == 'refs/heads/main'
     needs: assemble
     runs-on: ubuntu-24.04
     environment:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,6 +24,14 @@ Build from a clean checkout. The DuckDB source is part of the checkout. Release 
 - install each wheel in a fresh environment and run the Quickstart smoke test;
 - produce SHA-256 checksums, a software bill of materials, build provenance, and Sigstore signatures.
 
+Trusted `main` and release validations also load exact forbidden-content rules
+from the `RELEASE_ARTIFACT_CONTENT_RULES` GitHub secret. The secret is a JSON
+manifest with `version` set to `1`; each entry in `rules` contains a public
+`id`, a `scope` of `all` or `text`, and the exact value in `value_base64`.
+Pull-request jobs intentionally do not receive this manifest. Configure the
+secret before merging or publishing; trusted validation fails when it is
+missing.
+
 Manually inspect the archive file list. TPC-H, TPC-DS, TPC-E tools, local paths, credentials, caches, logs, model weights, and build directories must not be present.
 
 ## Stage and publish

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -10,9 +10,7 @@ import argparse
 import base64
 import csv
 import hashlib
-import hmac
 import io
-import ipaddress
 import re
 import stat
 import subprocess
@@ -21,7 +19,6 @@ import tarfile
 import zipfile
 from dataclasses import dataclass
 from email.parser import BytesParser
-from functools import cache
 from pathlib import Path, PurePosixPath
 from typing import Protocol
 
@@ -70,235 +67,15 @@ class ContentRule(Protocol):
     def matches(self, data: bytes) -> bool: ...
 
 
-# Exact local matching is deterministic; scrypt raises the offline guessing cost
-# for low-entropy rules but does not replace rotation or history review.
-FINGERPRINT_BYTES = hashlib.sha256().digest_size
-CANDIDATE_TAG_BYTES = 2
-SCRYPT_N = 1 << 14
-SCRYPT_R = 8
-SCRYPT_P = 1
-SCRYPT_MAX_MEMORY = 32 * 1024 * 1024
-SCRYPT_SALT_PREFIX = b"vane-release-content-rule-v1\0"
-
-
-@cache
-def _credential_candidate_pattern(length: int) -> re.Pattern[bytes]:
-    prefix = f"[!-~]{{0,{length - 1}}}"
-    lookaheads = "".join(
-        (
-            f"(?={prefix}[a-z])",
-            f"(?={prefix}[A-Z])",
-            f"(?={prefix}[0-9])",
-            f"(?={prefix}[^A-Za-z0-9])",
-        )
-    )
-    window = f"[!-~]{{{length}}}"
-    return re.compile(f"(?={lookaheads}({window}))".encode("ascii"))
-
-
-@cache
-def _ipv4_candidate_pattern(length: int) -> re.Pattern[bytes]:
-    return re.compile(f"(?=([0-9.]{{{length}}}))".encode("ascii"))
-
-
-@cache
-def _posix_path_candidate_pattern(
-    part_lengths: tuple[int, ...],
-    trailing_slash: bool,
-) -> re.Pattern[bytes]:
-    part_patterns = [f"[\\x20-\\x2e\\x30-\\x7e]{{{length}}}" for length in part_lengths]
-    candidate = "/" + "/".join(part_patterns)
-    if trailing_slash:
-        candidate += "/"
-    return re.compile(f"(?=({candidate}))".encode("ascii"))
-
-
-def _is_credential_shaped(value: bytes) -> bool:
-    return (
-        bool(value)
-        and all(0x21 <= byte <= 0x7E for byte in value)
-        and any(0x61 <= byte <= 0x7A for byte in value)
-        and any(0x41 <= byte <= 0x5A for byte in value)
-        and any(0x30 <= byte <= 0x39 for byte in value)
-        and any(not (0x61 <= byte <= 0x7A or 0x41 <= byte <= 0x5A or 0x30 <= byte <= 0x39) for byte in value)
-    )
-
-
-def _is_ipv4(value: bytes) -> bool:
-    try:
-        ipaddress.IPv4Address(value.decode("ascii"))
-    except (UnicodeDecodeError, ipaddress.AddressValueError):
-        return False
-    return True
-
-
-def _posix_path_shape(value: bytes) -> tuple[tuple[int, ...], bool]:
-    if not value.startswith(b"/") or value == b"/":
-        raise ValueError("POSIX path fingerprint rule requires an absolute path")
-    if any(byte < 0x20 or byte > 0x7E for byte in value):
-        raise ValueError("POSIX path fingerprint rule requires printable ASCII")
-
-    trailing_slash = value.endswith(b"/")
-    body = value[1:-1] if trailing_slash else value[1:]
-    parts = body.split(b"/")
-    if not parts or any(not part for part in parts):
-        raise ValueError("POSIX path fingerprint rule requires non-empty path parts")
-    return tuple(len(part) for part in parts), trailing_slash
-
-
-def _memory_hard_fingerprint(rule_id: str, value: bytes) -> bytes:
-    return hashlib.scrypt(
-        value,
-        salt=SCRYPT_SALT_PREFIX + rule_id.encode("utf-8"),
-        n=SCRYPT_N,
-        r=SCRYPT_R,
-        p=SCRYPT_P,
-        maxmem=SCRYPT_MAX_MEMORY,
-        dklen=FINGERPRINT_BYTES,
-    )
-
-
-def _candidate_tag(value: bytes) -> bytes:
-    """Return a short scan prefilter; scrypt remains the authoritative check."""
-    return hashlib.sha256(value).digest()[:CANDIDATE_TAG_BYTES]
-
-
-@dataclass(frozen=True)
-class _FingerprintRule:
-    rule_id: str
-    fingerprint: bytes
-    candidate_tag: bytes
-    length: int
-
-    def __post_init__(self) -> None:
-        if not self.rule_id:
-            raise ValueError("content rule ID must not be empty")
-        if self.length <= 0:
-            raise ValueError("content rule length must be positive")
-        if len(self.fingerprint) != FINGERPRINT_BYTES:
-            raise ValueError(f"content rule fingerprint must be {FINGERPRINT_BYTES} bytes")
-        if len(self.candidate_tag) != CANDIDATE_TAG_BYTES:
-            raise ValueError(f"content rule candidate tag must be {CANDIDATE_TAG_BYTES} bytes")
-
-    def _matches_candidate(self, value: bytes) -> bool:
-        if not hmac.compare_digest(_candidate_tag(value), self.candidate_tag):
-            return False
-        return hmac.compare_digest(
-            _memory_hard_fingerprint(self.rule_id, value),
-            self.fingerprint,
-        )
-
-
-@dataclass(frozen=True)
-class CredentialFingerprintRule(_FingerprintRule):
-    """Match printable credential-shaped windows by memory-hard fingerprint."""
-
-    @classmethod
-    def from_value(cls, rule_id: str, value: bytes) -> CredentialFingerprintRule:
-        if not _is_credential_shaped(value):
-            raise ValueError("credential fingerprint rule requires a credential-shaped value")
-        return cls(
-            rule_id=rule_id,
-            fingerprint=_memory_hard_fingerprint(rule_id, value),
-            candidate_tag=_candidate_tag(value),
-            length=len(value),
-        )
-
-    def matches(self, data: bytes) -> bool:
-        for candidate in _credential_candidate_pattern(self.length).finditer(data):
-            if self._matches_candidate(candidate.group(1)):
-                return True
-        return False
-
-
-@dataclass(frozen=True)
-class IPv4FingerprintRule(_FingerprintRule):
-    """Match IPv4 candidates using a memory-hard fingerprint."""
-
-    @classmethod
-    def from_value(cls, rule_id: str, value: bytes) -> IPv4FingerprintRule:
-        if not _is_ipv4(value):
-            raise ValueError("IPv4 fingerprint rule requires an IPv4 address")
-        return cls(
-            rule_id=rule_id,
-            fingerprint=_memory_hard_fingerprint(rule_id, value),
-            candidate_tag=_candidate_tag(value),
-            length=len(value),
-        )
-
-    def matches(self, data: bytes) -> bool:
-        for match in _ipv4_candidate_pattern(self.length).finditer(data):
-            candidate = match.group(1)
-            if _is_ipv4(candidate) and self._matches_candidate(candidate):
-                return True
-        return False
-
-
-@dataclass(frozen=True)
-class PosixPathFingerprintRule(_FingerprintRule):
-    """Match printable absolute POSIX paths using a memory-hard fingerprint."""
-
-    part_lengths: tuple[int, ...]
-    trailing_slash: bool
-
-    @classmethod
-    def from_value(cls, rule_id: str, value: bytes) -> PosixPathFingerprintRule:
-        part_lengths, trailing_slash = _posix_path_shape(value)
-        return cls(
-            rule_id=rule_id,
-            fingerprint=_memory_hard_fingerprint(rule_id, value),
-            candidate_tag=_candidate_tag(value),
-            length=len(value),
-            part_lengths=part_lengths,
-            trailing_slash=trailing_slash,
-        )
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        if not self.part_lengths or any(length <= 0 for length in self.part_lengths):
-            raise ValueError("POSIX path fingerprint rule requires positive part lengths")
-        expected_length = sum(self.part_lengths) + len(self.part_lengths) + self.trailing_slash
-        if self.length != expected_length:
-            raise ValueError("POSIX path fingerprint rule length does not match its path shape")
-
-    def matches(self, data: bytes) -> bool:
-        pattern = _posix_path_candidate_pattern(self.part_lengths, self.trailing_slash)
-        for match in pattern.finditer(data):
-            if self._matches_candidate(match.group(1)):
-                return True
-        return False
-
-
 @dataclass(frozen=True)
 class ContentMatch:
     rule_id: str
     member_name: str
 
 
-CONTENT_RULES: tuple[ContentRule, ...] = (
-    IPv4FingerprintRule(
-        rule_id="release-internal-ip",
-        fingerprint=bytes.fromhex("ea0958373ff59a2b35ce264fda1b50cf0f9fed173878bbff134729f6338c9edd"),
-        candidate_tag=bytes.fromhex("7628"),
-        length=12,
-    ),
-    CredentialFingerprintRule(
-        rule_id="release-credential",
-        fingerprint=bytes.fromhex("e950be9f297db2c9f6d3a4878256321972b47bcb0540fbb6b66610b339c35fbe"),
-        candidate_tag=bytes.fromhex("805b"),
-        length=14,
-    ),
-)
-TEXT_CONTENT_RULES: tuple[ContentRule, ...] = (
-    PosixPathFingerprintRule(
-        rule_id="release-local-path",
-        fingerprint=bytes.fromhex("ba09f8cff6db233c4dd270f695d4c75dc9afd939826d017c3ffe27aaaa11be5f"),
-        candidate_tag=bytes.fromhex("146b"),
-        length=11,
-        part_lengths=(4, 4),
-        trailing_slash=True,
-    ),
-)
+# Exact historical values are intentionally not committed as public rules.
+CONTENT_RULES: tuple[ContentRule, ...] = ()
+TEXT_CONTENT_RULES: tuple[ContentRule, ...] = ()
 
 
 class WheelArtifact:

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -71,8 +71,9 @@ class ContentRule(Protocol):
 
 
 # Exact local matching is deterministic; scrypt raises the offline guessing cost
-# for low-entropy IP and path rules but does not replace rotation or history review.
+# for low-entropy rules but does not replace rotation or history review.
 FINGERPRINT_BYTES = hashlib.sha256().digest_size
+CANDIDATE_TAG_BYTES = 2
 SCRYPT_N = 1 << 14
 SCRYPT_R = 8
 SCRYPT_P = 1
@@ -157,10 +158,16 @@ def _memory_hard_fingerprint(rule_id: str, value: bytes) -> bytes:
     )
 
 
+def _candidate_tag(value: bytes) -> bytes:
+    """Return a short scan prefilter; scrypt remains the authoritative check."""
+    return hashlib.sha256(value).digest()[:CANDIDATE_TAG_BYTES]
+
+
 @dataclass(frozen=True)
 class _FingerprintRule:
     rule_id: str
     fingerprint: bytes
+    candidate_tag: bytes
     length: int
 
     def __post_init__(self) -> None:
@@ -170,21 +177,36 @@ class _FingerprintRule:
             raise ValueError("content rule length must be positive")
         if len(self.fingerprint) != FINGERPRINT_BYTES:
             raise ValueError(f"content rule fingerprint must be {FINGERPRINT_BYTES} bytes")
+        if len(self.candidate_tag) != CANDIDATE_TAG_BYTES:
+            raise ValueError(f"content rule candidate tag must be {CANDIDATE_TAG_BYTES} bytes")
+
+    def _matches_candidate(self, value: bytes) -> bool:
+        if not hmac.compare_digest(_candidate_tag(value), self.candidate_tag):
+            return False
+        return hmac.compare_digest(
+            _memory_hard_fingerprint(self.rule_id, value),
+            self.fingerprint,
+        )
 
 
 @dataclass(frozen=True)
 class CredentialFingerprintRule(_FingerprintRule):
-    """Match printable credential-shaped windows by SHA-256 fingerprint."""
+    """Match printable credential-shaped windows by memory-hard fingerprint."""
 
     @classmethod
     def from_value(cls, rule_id: str, value: bytes) -> CredentialFingerprintRule:
         if not _is_credential_shaped(value):
             raise ValueError("credential fingerprint rule requires a credential-shaped value")
-        return cls(rule_id=rule_id, fingerprint=hashlib.sha256(value).digest(), length=len(value))
+        return cls(
+            rule_id=rule_id,
+            fingerprint=_memory_hard_fingerprint(rule_id, value),
+            candidate_tag=_candidate_tag(value),
+            length=len(value),
+        )
 
     def matches(self, data: bytes) -> bool:
         for candidate in _credential_candidate_pattern(self.length).finditer(data):
-            if hmac.compare_digest(hashlib.sha256(candidate.group(1)).digest(), self.fingerprint):
+            if self._matches_candidate(candidate.group(1)):
                 return True
         return False
 
@@ -200,16 +222,14 @@ class IPv4FingerprintRule(_FingerprintRule):
         return cls(
             rule_id=rule_id,
             fingerprint=_memory_hard_fingerprint(rule_id, value),
+            candidate_tag=_candidate_tag(value),
             length=len(value),
         )
 
     def matches(self, data: bytes) -> bool:
         for match in _ipv4_candidate_pattern(self.length).finditer(data):
             candidate = match.group(1)
-            if _is_ipv4(candidate) and hmac.compare_digest(
-                _memory_hard_fingerprint(self.rule_id, candidate),
-                self.fingerprint,
-            ):
+            if _is_ipv4(candidate) and self._matches_candidate(candidate):
                 return True
         return False
 
@@ -227,6 +247,7 @@ class PosixPathFingerprintRule(_FingerprintRule):
         return cls(
             rule_id=rule_id,
             fingerprint=_memory_hard_fingerprint(rule_id, value),
+            candidate_tag=_candidate_tag(value),
             length=len(value),
             part_lengths=part_lengths,
             trailing_slash=trailing_slash,
@@ -243,10 +264,7 @@ class PosixPathFingerprintRule(_FingerprintRule):
     def matches(self, data: bytes) -> bool:
         pattern = _posix_path_candidate_pattern(self.part_lengths, self.trailing_slash)
         for match in pattern.finditer(data):
-            if hmac.compare_digest(
-                _memory_hard_fingerprint(self.rule_id, match.group(1)),
-                self.fingerprint,
-            ):
+            if self._matches_candidate(match.group(1)):
                 return True
         return False
 
@@ -261,11 +279,13 @@ CONTENT_RULES: tuple[ContentRule, ...] = (
     IPv4FingerprintRule(
         rule_id="release-internal-ip",
         fingerprint=bytes.fromhex("ea0958373ff59a2b35ce264fda1b50cf0f9fed173878bbff134729f6338c9edd"),
+        candidate_tag=bytes.fromhex("7628"),
         length=12,
     ),
     CredentialFingerprintRule(
         rule_id="release-credential",
-        fingerprint=bytes.fromhex("805bd951772627f3d1a607084df1727c6caad60447c5d73febf7be2d2fe17fd8"),
+        fingerprint=bytes.fromhex("e950be9f297db2c9f6d3a4878256321972b47bcb0540fbb6b66610b339c35fbe"),
+        candidate_tag=bytes.fromhex("805b"),
         length=14,
     ),
 )
@@ -273,6 +293,7 @@ TEXT_CONTENT_RULES: tuple[ContentRule, ...] = (
     PosixPathFingerprintRule(
         rule_id="release-local-path",
         fingerprint=bytes.fromhex("ba09f8cff6db233c4dd270f695d4c75dc9afd939826d017c3ffe27aaaa11be5f"),
+        candidate_tag=bytes.fromhex("146b"),
         length=11,
         part_lengths=(4, 4),
         trailing_slash=True,

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -10,14 +10,18 @@ import argparse
 import base64
 import csv
 import hashlib
+import hmac
 import io
+import ipaddress
 import re
 import stat
 import subprocess
 import sys
 import tarfile
 import zipfile
+from dataclasses import dataclass
 from email.parser import BytesParser
+from functools import cache
 from pathlib import Path, PurePosixPath
 from typing import Protocol
 
@@ -48,11 +52,6 @@ BANNED_PATH_SUFFIXES = (
     ".log",
     "/ray_data_main_old.py",
 )
-BANNED_CONTENT = (
-    b"192.168." + b"1.28",
-    b"StrongPass" + b"123!",
-)
-BANNED_TEXT_CONTENT = (b"/home/" + b"kaka/",)
 
 
 class Artifact(Protocol):
@@ -63,6 +62,222 @@ class Artifact(Protocol):
     def names(self) -> list[str]: ...
 
     def read(self, name: str) -> bytes: ...
+
+
+class ContentRule(Protocol):
+    rule_id: str
+
+    def matches(self, data: bytes) -> bool: ...
+
+
+# Exact local matching is deterministic; scrypt raises the offline guessing cost
+# for low-entropy IP and path rules but does not replace rotation or history review.
+FINGERPRINT_BYTES = hashlib.sha256().digest_size
+SCRYPT_N = 1 << 14
+SCRYPT_R = 8
+SCRYPT_P = 1
+SCRYPT_MAX_MEMORY = 32 * 1024 * 1024
+SCRYPT_SALT_PREFIX = b"vane-release-content-rule-v1\0"
+
+
+@cache
+def _credential_candidate_pattern(length: int) -> re.Pattern[bytes]:
+    prefix = f"[!-~]{{0,{length - 1}}}"
+    lookaheads = "".join(
+        (
+            f"(?={prefix}[a-z])",
+            f"(?={prefix}[A-Z])",
+            f"(?={prefix}[0-9])",
+            f"(?={prefix}[^A-Za-z0-9])",
+        )
+    )
+    window = f"[!-~]{{{length}}}"
+    return re.compile(f"(?={lookaheads}({window}))".encode("ascii"))
+
+
+@cache
+def _ipv4_candidate_pattern(length: int) -> re.Pattern[bytes]:
+    return re.compile(f"(?=([0-9.]{{{length}}}))".encode("ascii"))
+
+
+@cache
+def _posix_path_candidate_pattern(
+    part_lengths: tuple[int, ...],
+    trailing_slash: bool,
+) -> re.Pattern[bytes]:
+    part_patterns = [f"[\\x20-\\x2e\\x30-\\x7e]{{{length}}}" for length in part_lengths]
+    candidate = "/" + "/".join(part_patterns)
+    if trailing_slash:
+        candidate += "/"
+    return re.compile(f"(?=({candidate}))".encode("ascii"))
+
+
+def _is_credential_shaped(value: bytes) -> bool:
+    return (
+        bool(value)
+        and all(0x21 <= byte <= 0x7E for byte in value)
+        and any(0x61 <= byte <= 0x7A for byte in value)
+        and any(0x41 <= byte <= 0x5A for byte in value)
+        and any(0x30 <= byte <= 0x39 for byte in value)
+        and any(not (0x61 <= byte <= 0x7A or 0x41 <= byte <= 0x5A or 0x30 <= byte <= 0x39) for byte in value)
+    )
+
+
+def _is_ipv4(value: bytes) -> bool:
+    try:
+        ipaddress.IPv4Address(value.decode("ascii"))
+    except (UnicodeDecodeError, ipaddress.AddressValueError):
+        return False
+    return True
+
+
+def _posix_path_shape(value: bytes) -> tuple[tuple[int, ...], bool]:
+    if not value.startswith(b"/") or value == b"/":
+        raise ValueError("POSIX path fingerprint rule requires an absolute path")
+    if any(byte < 0x20 or byte > 0x7E for byte in value):
+        raise ValueError("POSIX path fingerprint rule requires printable ASCII")
+
+    trailing_slash = value.endswith(b"/")
+    body = value[1:-1] if trailing_slash else value[1:]
+    parts = body.split(b"/")
+    if not parts or any(not part for part in parts):
+        raise ValueError("POSIX path fingerprint rule requires non-empty path parts")
+    return tuple(len(part) for part in parts), trailing_slash
+
+
+def _memory_hard_fingerprint(rule_id: str, value: bytes) -> bytes:
+    return hashlib.scrypt(
+        value,
+        salt=SCRYPT_SALT_PREFIX + rule_id.encode("utf-8"),
+        n=SCRYPT_N,
+        r=SCRYPT_R,
+        p=SCRYPT_P,
+        maxmem=SCRYPT_MAX_MEMORY,
+        dklen=FINGERPRINT_BYTES,
+    )
+
+
+@dataclass(frozen=True)
+class _FingerprintRule:
+    rule_id: str
+    fingerprint: bytes
+    length: int
+
+    def __post_init__(self) -> None:
+        if not self.rule_id:
+            raise ValueError("content rule ID must not be empty")
+        if self.length <= 0:
+            raise ValueError("content rule length must be positive")
+        if len(self.fingerprint) != FINGERPRINT_BYTES:
+            raise ValueError(f"content rule fingerprint must be {FINGERPRINT_BYTES} bytes")
+
+
+@dataclass(frozen=True)
+class CredentialFingerprintRule(_FingerprintRule):
+    """Match printable credential-shaped windows by SHA-256 fingerprint."""
+
+    @classmethod
+    def from_value(cls, rule_id: str, value: bytes) -> CredentialFingerprintRule:
+        if not _is_credential_shaped(value):
+            raise ValueError("credential fingerprint rule requires a credential-shaped value")
+        return cls(rule_id=rule_id, fingerprint=hashlib.sha256(value).digest(), length=len(value))
+
+    def matches(self, data: bytes) -> bool:
+        for candidate in _credential_candidate_pattern(self.length).finditer(data):
+            if hmac.compare_digest(hashlib.sha256(candidate.group(1)).digest(), self.fingerprint):
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class IPv4FingerprintRule(_FingerprintRule):
+    """Match IPv4 candidates using a memory-hard fingerprint."""
+
+    @classmethod
+    def from_value(cls, rule_id: str, value: bytes) -> IPv4FingerprintRule:
+        if not _is_ipv4(value):
+            raise ValueError("IPv4 fingerprint rule requires an IPv4 address")
+        return cls(
+            rule_id=rule_id,
+            fingerprint=_memory_hard_fingerprint(rule_id, value),
+            length=len(value),
+        )
+
+    def matches(self, data: bytes) -> bool:
+        for match in _ipv4_candidate_pattern(self.length).finditer(data):
+            candidate = match.group(1)
+            if _is_ipv4(candidate) and hmac.compare_digest(
+                _memory_hard_fingerprint(self.rule_id, candidate),
+                self.fingerprint,
+            ):
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class PosixPathFingerprintRule(_FingerprintRule):
+    """Match printable absolute POSIX paths using a memory-hard fingerprint."""
+
+    part_lengths: tuple[int, ...]
+    trailing_slash: bool
+
+    @classmethod
+    def from_value(cls, rule_id: str, value: bytes) -> PosixPathFingerprintRule:
+        part_lengths, trailing_slash = _posix_path_shape(value)
+        return cls(
+            rule_id=rule_id,
+            fingerprint=_memory_hard_fingerprint(rule_id, value),
+            length=len(value),
+            part_lengths=part_lengths,
+            trailing_slash=trailing_slash,
+        )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.part_lengths or any(length <= 0 for length in self.part_lengths):
+            raise ValueError("POSIX path fingerprint rule requires positive part lengths")
+        expected_length = sum(self.part_lengths) + len(self.part_lengths) + self.trailing_slash
+        if self.length != expected_length:
+            raise ValueError("POSIX path fingerprint rule length does not match its path shape")
+
+    def matches(self, data: bytes) -> bool:
+        pattern = _posix_path_candidate_pattern(self.part_lengths, self.trailing_slash)
+        for match in pattern.finditer(data):
+            if hmac.compare_digest(
+                _memory_hard_fingerprint(self.rule_id, match.group(1)),
+                self.fingerprint,
+            ):
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class ContentMatch:
+    rule_id: str
+    member_name: str
+
+
+CONTENT_RULES: tuple[ContentRule, ...] = (
+    IPv4FingerprintRule(
+        rule_id="release-internal-ip",
+        fingerprint=bytes.fromhex("ea0958373ff59a2b35ce264fda1b50cf0f9fed173878bbff134729f6338c9edd"),
+        length=12,
+    ),
+    CredentialFingerprintRule(
+        rule_id="release-credential",
+        fingerprint=bytes.fromhex("805bd951772627f3d1a607084df1727c6caad60447c5d73febf7be2d2fe17fd8"),
+        length=14,
+    ),
+)
+TEXT_CONTENT_RULES: tuple[ContentRule, ...] = (
+    PosixPathFingerprintRule(
+        rule_id="release-local-path",
+        fingerprint=bytes.fromhex("ba09f8cff6db233c4dd270f695d4c75dc9afd939826d017c3ffe27aaaa11be5f"),
+        length=11,
+        part_lengths=(4, 4),
+        trailing_slash=True,
+    ),
+)
 
 
 class WheelArtifact:
@@ -151,16 +366,34 @@ def _check_paths(artifact: Artifact) -> None:
             raise ValueError(f"{artifact.path}: stale release path {name}")
 
 
-def _check_internal_content(artifact: Artifact) -> None:
+def _detect_internal_content(
+    artifact: Artifact,
+    content_rules: tuple[ContentRule, ...],
+    text_content_rules: tuple[ContentRule, ...],
+) -> ContentMatch | None:
     for name in artifact.names():
         data = artifact.read(name)
-        markers = BANNED_CONTENT
-        if b"\0" not in data[:8192]:
-            markers += BANNED_TEXT_CONTENT
-        for marker in markers:
-            if marker in data:
-                value = marker.decode("utf-8", errors="replace")
-                raise ValueError(f"{artifact.path}: internal value {value!r} found in {name}")
+        for rule in content_rules:
+            if rule.matches(data):
+                return ContentMatch(rule_id=rule.rule_id, member_name=name)
+        if b"\0" in data[:8192]:
+            continue
+        for rule in text_content_rules:
+            if rule.matches(data):
+                return ContentMatch(rule_id=rule.rule_id, member_name=name)
+    return None
+
+
+def _check_internal_content(
+    artifact: Artifact,
+    content_rules: tuple[ContentRule, ...],
+    text_content_rules: tuple[ContentRule, ...],
+) -> None:
+    match = _detect_internal_content(artifact, content_rules, text_content_rules)
+    if match is not None:
+        raise ValueError(
+            f"{artifact.path}: content rule {match.rule_id!r} matched archive member {match.member_name!r}"
+        )
 
 
 def _metadata(artifact: Artifact, suffix: str):
@@ -293,8 +526,17 @@ def _check_wheel(artifact: WheelArtifact) -> None:
     _check_wheel_record(artifact)
 
 
-def check_artifact(path: Path) -> None:
+def check_artifact(
+    path: Path,
+    *,
+    content_rules: tuple[ContentRule, ...] | None = None,
+    text_content_rules: tuple[ContentRule, ...] | None = None,
+) -> None:
     """Validate one sdist or wheel."""
+    if content_rules is None:
+        content_rules = CONTENT_RULES
+    if text_content_rules is None:
+        text_content_rules = TEXT_CONTENT_RULES
     if path.stat().st_size > MAX_ARTIFACT_BYTES:
         raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
 
@@ -309,7 +551,7 @@ def check_artifact(path: Path) -> None:
 
     try:
         _check_paths(artifact)
-        _check_internal_content(artifact)
+        _check_internal_content(artifact, content_rules, text_content_rules)
         specific_check(artifact)
     finally:
         artifact.close()

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -8,16 +8,18 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import csv
 import hashlib
 import io
+import json
 import re
 import stat
 import subprocess
 import sys
 import tarfile
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from email.parser import BytesParser
 from pathlib import Path, PurePosixPath
 from typing import Protocol
@@ -33,6 +35,7 @@ EXPECTED_NAME = str(PROJECT_METADATA["name"])
 EXPECTED_VERSION = str(PROJECT_METADATA["version"])
 MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
 GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+CONTENT_RULE_ID = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
 
 BANNED_PATH_PARTS = (
     "/.git/",
@@ -73,9 +76,13 @@ class ContentMatch:
     member_name: str
 
 
-# Exact historical values are intentionally not committed as public rules.
-CONTENT_RULES: tuple[ContentRule, ...] = ()
-TEXT_CONTENT_RULES: tuple[ContentRule, ...] = ()
+@dataclass(frozen=True)
+class LiteralContentRule:
+    rule_id: str
+    value: bytes = field(repr=False)
+
+    def matches(self, data: bytes) -> bool:
+        return self.value in data
 
 
 class WheelArtifact:
@@ -192,6 +199,78 @@ def _check_internal_content(
         raise ValueError(
             f"{artifact.path}: content rule {match.rule_id!r} matched archive member {match.member_name!r}"
         )
+
+
+def _parse_content_rule_manifest(
+    raw_manifest: str,
+    *,
+    source: str,
+) -> tuple[tuple[ContentRule, ...], tuple[ContentRule, ...]]:
+    try:
+        manifest = json.loads(raw_manifest)
+    except json.JSONDecodeError:
+        raise ValueError(f"{source}: invalid content rule manifest JSON") from None
+
+    if not isinstance(manifest, dict) or set(manifest) != {"version", "rules"}:
+        raise ValueError(f"{source}: invalid content rule manifest structure")
+    if manifest["version"] != 1:
+        raise ValueError(f"{source}: unsupported content rule manifest version")
+
+    entries = manifest["rules"]
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"{source}: content rule manifest must contain at least one rule")
+
+    content_rules: list[ContentRule] = []
+    text_content_rules: list[ContentRule] = []
+    rule_ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict) or set(entry) != {"id", "scope", "value_base64"}:
+            raise ValueError(f"{source}: invalid content rule at index {index}")
+
+        rule_id = entry["id"]
+        if not isinstance(rule_id, str) or CONTENT_RULE_ID.fullmatch(rule_id) is None:
+            raise ValueError(f"{source}: invalid content rule id at index {index}")
+        if rule_id in rule_ids:
+            raise ValueError(f"{source}: duplicate content rule id {rule_id!r}")
+        rule_ids.add(rule_id)
+
+        scope = entry["scope"]
+        if not isinstance(scope, str) or scope not in {"all", "text"}:
+            raise ValueError(f"{source}: invalid content rule scope at index {index}")
+
+        encoded_value = entry["value_base64"]
+        if not isinstance(encoded_value, str):
+            raise ValueError(f"{source}: invalid content rule value at index {index}")
+        try:
+            value = base64.b64decode(encoded_value, validate=True)
+        except (binascii.Error, ValueError):
+            raise ValueError(f"{source}: invalid content rule value at index {index}") from None
+        if not value:
+            raise ValueError(f"{source}: empty content rule value at index {index}")
+
+        rule = LiteralContentRule(rule_id=rule_id, value=value)
+        if scope == "text":
+            text_content_rules.append(rule)
+        else:
+            content_rules.append(rule)
+
+    return tuple(content_rules), tuple(text_content_rules)
+
+
+def _load_content_rule_manifest(
+    source: str,
+) -> tuple[tuple[ContentRule, ...], tuple[ContentRule, ...]]:
+    if source == "-":
+        raw_manifest = sys.stdin.read()
+        source_name = "stdin"
+    else:
+        path = Path(source)
+        try:
+            raw_manifest = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            raise ValueError(f"{path}: could not read content rule manifest") from None
+        source_name = str(path)
+    return _parse_content_rule_manifest(raw_manifest, source=source_name)
 
 
 def _metadata(artifact: Artifact, suffix: str):
@@ -327,14 +406,10 @@ def _check_wheel(artifact: WheelArtifact) -> None:
 def check_artifact(
     path: Path,
     *,
-    content_rules: tuple[ContentRule, ...] | None = None,
-    text_content_rules: tuple[ContentRule, ...] | None = None,
+    content_rules: tuple[ContentRule, ...] = (),
+    text_content_rules: tuple[ContentRule, ...] = (),
 ) -> None:
     """Validate one sdist or wheel."""
-    if content_rules is None:
-        content_rules = CONTENT_RULES
-    if text_content_rules is None:
-        text_content_rules = TEXT_CONTENT_RULES
     if path.stat().st_size > MAX_ARTIFACT_BYTES:
         raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
 
@@ -357,11 +432,25 @@ def check_artifact(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--content-rules-manifest",
+        metavar="PATH",
+        help="load private exact-content rules from PATH, or from standard input with '-'",
+    )
     parser.add_argument("artifacts", nargs="+", type=Path)
     args = parser.parse_args()
 
+    content_rules: tuple[ContentRule, ...] = ()
+    text_content_rules: tuple[ContentRule, ...] = ()
+    if args.content_rules_manifest is not None:
+        content_rules, text_content_rules = _load_content_rule_manifest(args.content_rules_manifest)
+
     for artifact in args.artifacts:
-        check_artifact(artifact)
+        check_artifact(
+            artifact,
+            content_rules=content_rules,
+            text_content_rules=text_content_rules,
+        )
         print(f"validated {artifact}")
     return 0
 

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import io
 import secrets
 import string
@@ -93,6 +94,29 @@ def test_default_configuration_has_production_content_rules():
     )
 
 
+def test_credential_rule_uses_memory_hard_fingerprint(monkeypatch):
+    sentinel = _runtime_sentinel()
+    rule_id = "runtime-sensitive-content"
+    calls: list[tuple[str, bytes]] = []
+
+    def memory_hard_fingerprint(candidate_rule_id: str, value: bytes) -> bytes:
+        calls.append((candidate_rule_id, value))
+        return hashlib.sha256(b"test-kdf\0" + candidate_rule_id.encode() + b"\0" + value).digest()
+
+    monkeypatch.setattr(
+        check_release_artifacts,
+        "_memory_hard_fingerprint",
+        memory_hard_fingerprint,
+    )
+
+    rule = check_release_artifacts.CredentialFingerprintRule.from_value(rule_id, sentinel)
+    assert calls == [(rule_id, sentinel)]
+
+    calls.clear()
+    assert rule.matches(b"prefix-" + sentinel + b"-suffix")
+    assert calls == [(rule_id, sentinel)]
+
+
 @pytest.mark.parametrize(
     ("rule_type", "sentinel_factory"),
     [
@@ -113,6 +137,47 @@ def test_rule_strategies_match_runtime_values(rule_type, sentinel_factory):
         pytest.fail("runtime rule did not detect its generated value", pytrace=False)
     if rule.matches(b"clean artifact content"):
         pytest.fail("runtime rule rejected clean content", pytrace=False)
+
+
+def test_path_rule_prefilters_candidate_rich_clean_content(monkeypatch):
+    sentinel = _runtime_path()
+    rule = check_release_artifacts.PosixPathFingerprintRule.from_value(
+        "runtime-sensitive-content",
+        sentinel,
+    )
+    sentinel_tag = hashlib.sha256(sentinel).digest()[: check_release_artifacts.CANDIDATE_TAG_BYTES]
+    candidates: list[bytes] = []
+    for index in range(1 << 16):
+        candidate = f"/{index:04x}/{index ^ 0xFFFF:04x}/".encode()
+        candidate_tag = hashlib.sha256(candidate).digest()[: check_release_artifacts.CANDIDATE_TAG_BYTES]
+        if candidate != sentinel and candidate_tag != sentinel_tag:
+            candidates.append(candidate)
+        if len(candidates) == 4096:
+            break
+    assert len(candidates) == 4096
+
+    kdf_candidates: list[bytes] = []
+
+    def memory_hard_fingerprint(_rule_id: str, value: bytes) -> bytes:
+        kdf_candidates.append(value)
+        return bytes(check_release_artifacts.FINGERPRINT_BYTES)
+
+    monkeypatch.setattr(
+        check_release_artifacts,
+        "_memory_hard_fingerprint",
+        memory_hard_fingerprint,
+    )
+
+    assert not rule.matches(b"\n".join(candidates))
+    assert kdf_candidates == []
+
+    monkeypatch.setattr(
+        check_release_artifacts,
+        "_candidate_tag",
+        lambda _value: rule.candidate_tag,
+    )
+    assert not rule.matches(candidates[0])
+    assert kdf_candidates == [candidates[0]]
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -1,15 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import io
+import json
 import secrets
 import string
+import subprocess
 import sys
 import tarfile
 import traceback
 import zipfile
 from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -28,13 +30,19 @@ def _runtime_path() -> bytes:
     return f"/{segment()}/{segment()}/".encode("ascii")
 
 
-@dataclass(frozen=True)
-class _RuntimeContentRule:
-    rule_id: str
-    value: bytes
-
-    def matches(self, data: bytes) -> bool:
-        return self.value in data
+def _content_rule_manifest(rule_id: str, value: bytes, *, text_only: bool) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "rules": [
+                {
+                    "id": rule_id,
+                    "scope": "text" if text_only else "all",
+                    "value_base64": base64.b64encode(value).decode("ascii"),
+                }
+            ],
+        }
+    )
 
 
 def _write_archive(path: Path, member_name: str, data: bytes) -> None:
@@ -89,9 +97,19 @@ def content_check_only(monkeypatch):
     monkeypatch.setattr(check_release_artifacts, "_check_wheel", lambda _artifact: None)
 
 
-def test_default_configuration_has_no_public_exact_rules():
-    assert check_release_artifacts.CONTENT_RULES == ()
-    assert check_release_artifacts.TEXT_CONTENT_RULES == ()
+def test_private_manifest_rejects_empty_rule_set():
+    with pytest.raises(ValueError, match="at least one rule"):
+        check_release_artifacts._parse_content_rule_manifest(
+            '{"version": 1, "rules": []}',
+            source="runtime manifest",
+        )
+
+
+def test_literal_rule_repr_does_not_expose_value():
+    sentinel = _runtime_sentinel()
+    rule = check_release_artifacts.LiteralContentRule("runtime-sensitive-content", sentinel)
+
+    assert sentinel not in repr(rule).encode("utf-8")
 
 
 @pytest.mark.parametrize(
@@ -102,7 +120,7 @@ def test_default_configuration_has_no_public_exact_rules():
     ],
 )
 @pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
-def test_cli_uses_runtime_rule_source_without_exposing_match(
+def test_cli_loads_private_manifest_without_exposing_match(
     tmp_path,
     suffix,
     sentinel_factory,
@@ -114,14 +132,25 @@ def test_cli_uses_runtime_rule_source_without_exposing_match(
     sentinel = sentinel_factory()
     rule_id = "runtime-sensitive-content"
     member_name = "project/security-probe.txt"
-    rule = _RuntimeContentRule(rule_id, sentinel)
     contaminated = tmp_path / f"contaminated{suffix}"
     clean = tmp_path / f"clean{suffix}"
+    manifest = tmp_path / "content-rules.json"
     _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
     _write_archive(clean, member_name, b"clean artifact content")
-    monkeypatch.setattr(check_release_artifacts, "CONTENT_RULES", () if text_only else (rule,))
-    monkeypatch.setattr(check_release_artifacts, "TEXT_CONTENT_RULES", (rule,) if text_only else ())
-    monkeypatch.setattr(sys, "argv", ["check_release_artifacts.py", str(contaminated)])
+    manifest.write_text(
+        _content_rule_manifest(rule_id, sentinel, text_only=text_only),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_release_artifacts.py",
+            "--content-rules-manifest",
+            str(manifest),
+            str(contaminated),
+        ],
+    )
 
     error = _rejected_by(check_release_artifacts.main)
 
@@ -132,11 +161,49 @@ def test_cli_uses_runtime_rule_source_without_exposing_match(
         member_name=member_name,
         capsys=capsys,
     )
-    monkeypatch.setattr(sys, "argv", ["check_release_artifacts.py", str(clean)])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_release_artifacts.py",
+            "--content-rules-manifest",
+            str(manifest),
+            str(clean),
+        ],
+    )
     assert check_release_artifacts.main() == 0
     captured = capsys.readouterr()
     if sentinel in (captured.out + captured.err).encode("utf-8", errors="replace"):
         pytest.fail("CLI output exposed the matched value", pytrace=False)
+
+
+@pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
+def test_standalone_cli_reads_private_manifest_from_stdin(tmp_path, suffix):
+    sentinel = _runtime_sentinel()
+    rule_id = "runtime-sensitive-content"
+    member_name = "project/security-probe.txt"
+    contaminated = tmp_path / f"contaminated{suffix}"
+    _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(check_release_artifacts.__file__).resolve()),
+            "--content-rules-manifest",
+            "-",
+            str(contaminated),
+        ],
+        input=_content_rule_manifest(rule_id, sentinel, text_only=False),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    output = (result.stdout + result.stderr).encode("utf-8", errors="replace")
+    assert rule_id.encode("ascii") in output
+    assert member_name.encode("ascii") in output
+    assert sentinel not in output
 
 
 @pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
@@ -149,7 +216,7 @@ def test_runtime_binary_rule_checks_members_with_nul_bytes(
     sentinel = _runtime_sentinel()
     rule_id = "runtime-binary-content"
     member_name = "project/security-probe.bin"
-    rule = _RuntimeContentRule(rule_id, sentinel)
+    rule = check_release_artifacts.LiteralContentRule(rule_id, sentinel)
     artifact = tmp_path / f"binary{suffix}"
     _write_archive(artifact, member_name, b"\0" + sentinel)
 
@@ -180,7 +247,7 @@ def test_runtime_text_rule_preserves_binary_member_filter(
     sentinel = _runtime_path()
     rule_id = "runtime-text-content"
     member_name = "project/security-probe.bin"
-    rule = _RuntimeContentRule(rule_id, sentinel)
+    rule = check_release_artifacts.LiteralContentRule(rule_id, sentinel)
     text_artifact = tmp_path / f"text{suffix}"
     binary_artifact = tmp_path / f"binary{suffix}"
     _write_archive(text_artifact, member_name, sentinel)

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import secrets
+import string
+import sys
+import tarfile
+import traceback
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from scripts import check_release_artifacts
+
+
+def _runtime_sentinel() -> bytes:
+    return b"Aa0!" + secrets.token_urlsafe(32).encode("ascii")
+
+
+def _runtime_ipv4() -> bytes:
+    return f"10.{secrets.randbelow(256)}.{secrets.randbelow(256)}.{secrets.randbelow(256)}".encode("ascii")
+
+
+def _runtime_path() -> bytes:
+    def segment() -> str:
+        return "".join(secrets.choice(string.ascii_lowercase) for _ in range(4))
+
+    return f"/{segment()}/{segment()}/".encode("ascii")
+
+
+def _write_archive(path: Path, member_name: str, data: bytes) -> None:
+    if path.name.endswith(".tar.gz"):
+        with tarfile.open(path, mode="w:gz") as archive:
+            member = tarfile.TarInfo(member_name)
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+        return
+
+    with zipfile.ZipFile(path, mode="w") as archive:
+        archive.writestr(member_name, data)
+
+
+def _rejected_by(callback: Callable[[], object]) -> ValueError:
+    try:
+        callback()
+    except ValueError as error:
+        return error
+    except Exception as error:
+        pytest.fail(f"unexpected exception type: {type(error).__name__}", pytrace=False)
+    pytest.fail("contaminated artifact was accepted", pytrace=False)
+
+
+def _assert_metadata_only_error(
+    error: ValueError,
+    *,
+    sentinel: bytes,
+    rule_id: str,
+    member_name: str,
+    capsys,
+) -> None:
+    message = str(error)
+    if rule_id not in message or member_name not in message:
+        pytest.fail("content error omitted rule metadata", pytrace=False)
+
+    captured = capsys.readouterr()
+    surfaces = (
+        message,
+        repr(error.args),
+        "".join(traceback.format_exception(type(error), error, error.__traceback__)),
+        captured.out,
+        captured.err,
+    )
+    if any(sentinel in surface.encode("utf-8", errors="replace") for surface in surfaces):
+        pytest.fail("content error exposed the matched value", pytrace=False)
+
+
+@pytest.fixture
+def content_check_only(monkeypatch):
+    monkeypatch.setattr(check_release_artifacts, "_check_sdist", lambda _artifact: None)
+    monkeypatch.setattr(check_release_artifacts, "_check_wheel", lambda _artifact: None)
+
+
+def test_default_configuration_has_production_content_rules():
+    assert tuple((rule.rule_id, type(rule)) for rule in check_release_artifacts.CONTENT_RULES) == (
+        ("release-internal-ip", check_release_artifacts.IPv4FingerprintRule),
+        ("release-credential", check_release_artifacts.CredentialFingerprintRule),
+    )
+    assert tuple((rule.rule_id, type(rule)) for rule in check_release_artifacts.TEXT_CONTENT_RULES) == (
+        ("release-local-path", check_release_artifacts.PosixPathFingerprintRule),
+    )
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "sentinel_factory"),
+    [
+        pytest.param(
+            check_release_artifacts.CredentialFingerprintRule,
+            _runtime_sentinel,
+            id="credential",
+        ),
+        pytest.param(check_release_artifacts.IPv4FingerprintRule, _runtime_ipv4, id="ipv4"),
+        pytest.param(check_release_artifacts.PosixPathFingerprintRule, _runtime_path, id="path"),
+    ],
+)
+def test_rule_strategies_match_runtime_values(rule_type, sentinel_factory):
+    sentinel = sentinel_factory()
+    rule = rule_type.from_value("runtime-sensitive-content", sentinel)
+
+    if not rule.matches(b"prefix-" + sentinel + b"-suffix"):
+        pytest.fail("runtime rule did not detect its generated value", pytrace=False)
+    if rule.matches(b"clean artifact content"):
+        pytest.fail("runtime rule rejected clean content", pytrace=False)
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "value_factory", "message"),
+    [
+        pytest.param(
+            check_release_artifacts.CredentialFingerprintRule,
+            _runtime_path,
+            "credential-shaped",
+            id="credential",
+        ),
+        pytest.param(
+            check_release_artifacts.IPv4FingerprintRule,
+            _runtime_sentinel,
+            "IPv4 address",
+            id="ipv4",
+        ),
+        pytest.param(
+            check_release_artifacts.PosixPathFingerprintRule,
+            _runtime_sentinel,
+            "absolute path",
+            id="path",
+        ),
+    ],
+)
+def test_rule_types_reject_wrong_candidate_shapes(rule_type, value_factory, message):
+    with pytest.raises(ValueError, match=message):
+        rule_type.from_value("runtime-sensitive-content", value_factory())
+
+
+@pytest.mark.parametrize(
+    ("rule_type", "sentinel_factory", "text_only"),
+    [
+        pytest.param(
+            check_release_artifacts.CredentialFingerprintRule,
+            _runtime_sentinel,
+            False,
+            id="credential",
+        ),
+        pytest.param(
+            check_release_artifacts.IPv4FingerprintRule,
+            _runtime_ipv4,
+            False,
+            id="ipv4",
+        ),
+        pytest.param(
+            check_release_artifacts.PosixPathFingerprintRule,
+            _runtime_path,
+            True,
+            id="path",
+        ),
+    ],
+)
+@pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
+def test_cli_uses_default_rule_source_without_exposing_match(
+    tmp_path,
+    suffix,
+    rule_type,
+    sentinel_factory,
+    text_only,
+    content_check_only,
+    monkeypatch,
+    capsys,
+):
+    sentinel = sentinel_factory()
+    rule_id = "runtime-sensitive-content"
+    member_name = "project/security-probe.txt"
+    rule = rule_type.from_value(rule_id, sentinel)
+    contaminated = tmp_path / f"contaminated{suffix}"
+    clean = tmp_path / f"clean{suffix}"
+    _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
+    _write_archive(clean, member_name, b"clean artifact content")
+    monkeypatch.setattr(check_release_artifacts, "CONTENT_RULES", () if text_only else (rule,))
+    monkeypatch.setattr(check_release_artifacts, "TEXT_CONTENT_RULES", (rule,) if text_only else ())
+    monkeypatch.setattr(sys, "argv", ["check_release_artifacts.py", str(contaminated)])
+
+    error = _rejected_by(check_release_artifacts.main)
+
+    _assert_metadata_only_error(
+        error,
+        sentinel=sentinel,
+        rule_id=rule_id,
+        member_name=member_name,
+        capsys=capsys,
+    )
+    monkeypatch.setattr(sys, "argv", ["check_release_artifacts.py", str(clean)])
+    assert check_release_artifacts.main() == 0
+    captured = capsys.readouterr()
+    if sentinel in (captured.out + captured.err).encode("utf-8", errors="replace"):
+        pytest.fail("CLI output exposed the matched value", pytrace=False)
+
+
+@pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
+def test_runtime_binary_rule_checks_members_with_nul_bytes(
+    tmp_path,
+    suffix,
+    content_check_only,
+    capsys,
+):
+    sentinel = _runtime_sentinel()
+    rule_id = "runtime-binary-content"
+    member_name = "project/security-probe.bin"
+    rule = check_release_artifacts.CredentialFingerprintRule.from_value(rule_id, sentinel)
+    artifact = tmp_path / f"binary{suffix}"
+    _write_archive(artifact, member_name, b"\0" + sentinel)
+
+    error = _rejected_by(
+        lambda: check_release_artifacts.check_artifact(
+            artifact,
+            content_rules=(rule,),
+            text_content_rules=(),
+        )
+    )
+
+    _assert_metadata_only_error(
+        error,
+        sentinel=sentinel,
+        rule_id=rule_id,
+        member_name=member_name,
+        capsys=capsys,
+    )
+
+
+@pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
+def test_runtime_text_rule_preserves_binary_member_filter(
+    tmp_path,
+    suffix,
+    content_check_only,
+    capsys,
+):
+    sentinel = _runtime_path()
+    rule_id = "runtime-text-content"
+    member_name = "project/security-probe.bin"
+    rule = check_release_artifacts.PosixPathFingerprintRule.from_value(rule_id, sentinel)
+    text_artifact = tmp_path / f"text{suffix}"
+    binary_artifact = tmp_path / f"binary{suffix}"
+    _write_archive(text_artifact, member_name, sentinel)
+    _write_archive(binary_artifact, member_name, b"\0" + sentinel)
+
+    error = _rejected_by(
+        lambda: check_release_artifacts.check_artifact(
+            text_artifact,
+            content_rules=(),
+            text_content_rules=(rule,),
+        )
+    )
+
+    _assert_metadata_only_error(
+        error,
+        sentinel=sentinel,
+        rule_id=rule_id,
+        member_name=member_name,
+        capsys=capsys,
+    )
+    check_release_artifacts.check_artifact(
+        binary_artifact,
+        content_rules=(),
+        text_content_rules=(rule,),
+    )

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
 import io
 import secrets
 import string
@@ -10,6 +9,7 @@ import tarfile
 import traceback
 import zipfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -21,15 +21,20 @@ def _runtime_sentinel() -> bytes:
     return b"Aa0!" + secrets.token_urlsafe(32).encode("ascii")
 
 
-def _runtime_ipv4() -> bytes:
-    return f"10.{secrets.randbelow(256)}.{secrets.randbelow(256)}.{secrets.randbelow(256)}".encode("ascii")
-
-
 def _runtime_path() -> bytes:
     def segment() -> str:
         return "".join(secrets.choice(string.ascii_lowercase) for _ in range(4))
 
     return f"/{segment()}/{segment()}/".encode("ascii")
+
+
+@dataclass(frozen=True)
+class _RuntimeContentRule:
+    rule_id: str
+    value: bytes
+
+    def matches(self, data: bytes) -> bool:
+        return self.value in data
 
 
 def _write_archive(path: Path, member_name: str, data: bytes) -> None:
@@ -84,158 +89,22 @@ def content_check_only(monkeypatch):
     monkeypatch.setattr(check_release_artifacts, "_check_wheel", lambda _artifact: None)
 
 
-def test_default_configuration_has_production_content_rules():
-    assert tuple((rule.rule_id, type(rule)) for rule in check_release_artifacts.CONTENT_RULES) == (
-        ("release-internal-ip", check_release_artifacts.IPv4FingerprintRule),
-        ("release-credential", check_release_artifacts.CredentialFingerprintRule),
-    )
-    assert tuple((rule.rule_id, type(rule)) for rule in check_release_artifacts.TEXT_CONTENT_RULES) == (
-        ("release-local-path", check_release_artifacts.PosixPathFingerprintRule),
-    )
-
-
-def test_credential_rule_uses_memory_hard_fingerprint(monkeypatch):
-    sentinel = _runtime_sentinel()
-    rule_id = "runtime-sensitive-content"
-    calls: list[tuple[str, bytes]] = []
-
-    def memory_hard_fingerprint(candidate_rule_id: str, value: bytes) -> bytes:
-        calls.append((candidate_rule_id, value))
-        return hashlib.sha256(b"test-kdf\0" + candidate_rule_id.encode() + b"\0" + value).digest()
-
-    monkeypatch.setattr(
-        check_release_artifacts,
-        "_memory_hard_fingerprint",
-        memory_hard_fingerprint,
-    )
-
-    rule = check_release_artifacts.CredentialFingerprintRule.from_value(rule_id, sentinel)
-    assert calls == [(rule_id, sentinel)]
-
-    calls.clear()
-    assert rule.matches(b"prefix-" + sentinel + b"-suffix")
-    assert calls == [(rule_id, sentinel)]
+def test_default_configuration_has_no_public_exact_rules():
+    assert check_release_artifacts.CONTENT_RULES == ()
+    assert check_release_artifacts.TEXT_CONTENT_RULES == ()
 
 
 @pytest.mark.parametrize(
-    ("rule_type", "sentinel_factory"),
+    ("sentinel_factory", "text_only"),
     [
-        pytest.param(
-            check_release_artifacts.CredentialFingerprintRule,
-            _runtime_sentinel,
-            id="credential",
-        ),
-        pytest.param(check_release_artifacts.IPv4FingerprintRule, _runtime_ipv4, id="ipv4"),
-        pytest.param(check_release_artifacts.PosixPathFingerprintRule, _runtime_path, id="path"),
-    ],
-)
-def test_rule_strategies_match_runtime_values(rule_type, sentinel_factory):
-    sentinel = sentinel_factory()
-    rule = rule_type.from_value("runtime-sensitive-content", sentinel)
-
-    if not rule.matches(b"prefix-" + sentinel + b"-suffix"):
-        pytest.fail("runtime rule did not detect its generated value", pytrace=False)
-    if rule.matches(b"clean artifact content"):
-        pytest.fail("runtime rule rejected clean content", pytrace=False)
-
-
-def test_path_rule_prefilters_candidate_rich_clean_content(monkeypatch):
-    sentinel = _runtime_path()
-    rule = check_release_artifacts.PosixPathFingerprintRule.from_value(
-        "runtime-sensitive-content",
-        sentinel,
-    )
-    sentinel_tag = hashlib.sha256(sentinel).digest()[: check_release_artifacts.CANDIDATE_TAG_BYTES]
-    candidates: list[bytes] = []
-    for index in range(1 << 16):
-        candidate = f"/{index:04x}/{index ^ 0xFFFF:04x}/".encode()
-        candidate_tag = hashlib.sha256(candidate).digest()[: check_release_artifacts.CANDIDATE_TAG_BYTES]
-        if candidate != sentinel and candidate_tag != sentinel_tag:
-            candidates.append(candidate)
-        if len(candidates) == 4096:
-            break
-    assert len(candidates) == 4096
-
-    kdf_candidates: list[bytes] = []
-
-    def memory_hard_fingerprint(_rule_id: str, value: bytes) -> bytes:
-        kdf_candidates.append(value)
-        return bytes(check_release_artifacts.FINGERPRINT_BYTES)
-
-    monkeypatch.setattr(
-        check_release_artifacts,
-        "_memory_hard_fingerprint",
-        memory_hard_fingerprint,
-    )
-
-    assert not rule.matches(b"\n".join(candidates))
-    assert kdf_candidates == []
-
-    monkeypatch.setattr(
-        check_release_artifacts,
-        "_candidate_tag",
-        lambda _value: rule.candidate_tag,
-    )
-    assert not rule.matches(candidates[0])
-    assert kdf_candidates == [candidates[0]]
-
-
-@pytest.mark.parametrize(
-    ("rule_type", "value_factory", "message"),
-    [
-        pytest.param(
-            check_release_artifacts.CredentialFingerprintRule,
-            _runtime_path,
-            "credential-shaped",
-            id="credential",
-        ),
-        pytest.param(
-            check_release_artifacts.IPv4FingerprintRule,
-            _runtime_sentinel,
-            "IPv4 address",
-            id="ipv4",
-        ),
-        pytest.param(
-            check_release_artifacts.PosixPathFingerprintRule,
-            _runtime_sentinel,
-            "absolute path",
-            id="path",
-        ),
-    ],
-)
-def test_rule_types_reject_wrong_candidate_shapes(rule_type, value_factory, message):
-    with pytest.raises(ValueError, match=message):
-        rule_type.from_value("runtime-sensitive-content", value_factory())
-
-
-@pytest.mark.parametrize(
-    ("rule_type", "sentinel_factory", "text_only"),
-    [
-        pytest.param(
-            check_release_artifacts.CredentialFingerprintRule,
-            _runtime_sentinel,
-            False,
-            id="credential",
-        ),
-        pytest.param(
-            check_release_artifacts.IPv4FingerprintRule,
-            _runtime_ipv4,
-            False,
-            id="ipv4",
-        ),
-        pytest.param(
-            check_release_artifacts.PosixPathFingerprintRule,
-            _runtime_path,
-            True,
-            id="path",
-        ),
+        pytest.param(_runtime_sentinel, False, id="binary"),
+        pytest.param(_runtime_path, True, id="text"),
     ],
 )
 @pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
-def test_cli_uses_default_rule_source_without_exposing_match(
+def test_cli_uses_runtime_rule_source_without_exposing_match(
     tmp_path,
     suffix,
-    rule_type,
     sentinel_factory,
     text_only,
     content_check_only,
@@ -245,7 +114,7 @@ def test_cli_uses_default_rule_source_without_exposing_match(
     sentinel = sentinel_factory()
     rule_id = "runtime-sensitive-content"
     member_name = "project/security-probe.txt"
-    rule = rule_type.from_value(rule_id, sentinel)
+    rule = _RuntimeContentRule(rule_id, sentinel)
     contaminated = tmp_path / f"contaminated{suffix}"
     clean = tmp_path / f"clean{suffix}"
     _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
@@ -280,7 +149,7 @@ def test_runtime_binary_rule_checks_members_with_nul_bytes(
     sentinel = _runtime_sentinel()
     rule_id = "runtime-binary-content"
     member_name = "project/security-probe.bin"
-    rule = check_release_artifacts.CredentialFingerprintRule.from_value(rule_id, sentinel)
+    rule = _RuntimeContentRule(rule_id, sentinel)
     artifact = tmp_path / f"binary{suffix}"
     _write_archive(artifact, member_name, b"\0" + sentinel)
 
@@ -311,7 +180,7 @@ def test_runtime_text_rule_preserves_binary_member_filter(
     sentinel = _runtime_path()
     rule_id = "runtime-text-content"
     member_name = "project/security-probe.bin"
-    rule = check_release_artifacts.PosixPathFingerprintRule.from_value(rule_id, sentinel)
+    rule = _RuntimeContentRule(rule_id, sentinel)
     text_artifact = tmp_path / f"text{suffix}"
     binary_artifact = tmp_path / f"binary{suffix}"
     _write_archive(text_artifact, member_name, sentinel)

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -67,6 +67,13 @@ def _rejected_by(callback: Callable[[], object]) -> ValueError:
     pytest.fail("contaminated artifact was accepted", pytrace=False)
 
 
+def _assert_no_recoverable_value(sentinel: bytes, *surfaces: str) -> None:
+    recoverable_values = (sentinel, base64.b64encode(sentinel))
+    encoded_surfaces = tuple(surface.encode("utf-8", errors="replace") for surface in surfaces)
+    if any(value in surface for value in recoverable_values for surface in encoded_surfaces):
+        pytest.fail("output exposed a recoverable matched value", pytrace=False)
+
+
 def _assert_metadata_only_error(
     error: ValueError,
     *,
@@ -87,8 +94,7 @@ def _assert_metadata_only_error(
         captured.out,
         captured.err,
     )
-    if any(sentinel in surface.encode("utf-8", errors="replace") for surface in surfaces):
-        pytest.fail("content error exposed the matched value", pytrace=False)
+    _assert_no_recoverable_value(sentinel, *surfaces)
 
 
 @pytest.fixture
@@ -109,7 +115,7 @@ def test_literal_rule_repr_does_not_expose_value():
     sentinel = _runtime_sentinel()
     rule = check_release_artifacts.LiteralContentRule("runtime-sensitive-content", sentinel)
 
-    assert sentinel not in repr(rule).encode("utf-8")
+    _assert_no_recoverable_value(sentinel, repr(rule))
 
 
 @pytest.mark.parametrize(
@@ -173,8 +179,7 @@ def test_cli_loads_private_manifest_without_exposing_match(
     )
     assert check_release_artifacts.main() == 0
     captured = capsys.readouterr()
-    if sentinel in (captured.out + captured.err).encode("utf-8", errors="replace"):
-        pytest.fail("CLI output exposed the matched value", pytrace=False)
+    _assert_no_recoverable_value(sentinel, captured.out, captured.err)
 
 
 @pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])
@@ -203,7 +208,7 @@ def test_standalone_cli_reads_private_manifest_from_stdin(tmp_path, suffix):
     output = (result.stdout + result.stderr).encode("utf-8", errors="replace")
     assert rule_id.encode("ascii") in output
     assert member_name.encode("ascii") in output
-    assert sentinel not in output
+    _assert_no_recoverable_value(sentinel, result.stdout, result.stderr)
 
 
 @pytest.mark.parametrize("suffix", [".tar.gz", ".whl"], ids=["sdist", "wheel"])


### PR DESCRIPTION
<!-- Title format: [type](scope) Subject -->

## Summary

<!-- Describe the user-visible or architectural change and why it is needed. -->
The release artifact checker stored reconstructible fragments of internal IP, local path, and password-like values, and included matched values in failure messages.

Replace those literals with private exact-content rules loaded from a CI secret in trusted main and release workflows, while reporting only rule and archive-member metadata. Add runtime-generated sdist and wheel tests covering detection and redacted failures.

## Related issue

Close: #118 

<!-- Link the issue or write `N/A` for a small, self-contained change. -->

## Documentation impact

<!-- Select exactly one option. -->

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

<!-- Link the documentation PR or add follow-up notes here. -->

## Validation

<!-- List the exact checks you ran. Include relevant hardware, dataset, runner, and batch settings for performance changes. -->

  - `pre-commit run --from-ref upstream/main --to-ref HEAD`
  - `python -m pytest tests/fast/test_release_artifact_security.py` — 12 passed
  - Built and validated a fresh source distribution
  - Independently verified the private production rule manifest covers the previous forbidden-content checks

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

