### PR TITLE
[fix](video) Bound remote reads and preserve source identity

### DIFF
--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -17,13 +17,17 @@ Usage::
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import logging
 import os
+import tempfile
 import threading
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from itertools import repeat
+from contextlib import contextmanager
+from itertools import islice, repeat
 from types import ModuleType
 from typing import Any, cast
 
@@ -49,9 +53,47 @@ def _import_video_dependency(module_name: str, package_name: str) -> ModuleType:
 # video benchmark explicitly supplies Ray Data's 128 MiB soft block target.
 _DEFAULT_MAX_PARTITION_BYTES = int(os.environ.get("VANE_VIDEO_MAX_PARTITION_BYTES", str(10 * 1024 * 1024)))
 _DEFAULT_VIDEO_SOURCE_UDF_MEMORY_BYTES = 512 * 1024**2
+_DEFAULT_MAX_REMOTE_VIDEO_BYTES = int(os.environ.get("VANE_VIDEO_MAX_REMOTE_BYTES", str(8 * 1024**3)))
+_DEFAULT_MAX_SOURCE_FRAME_BYTES = int(os.environ.get("VANE_VIDEO_MAX_SOURCE_FRAME_BYTES", str(128 * 1024**2)))
+_REMOTE_VIDEO_READ_CHUNK_BYTES = 8 * 1024**2
+_VIDEO_DECODER_MEMORY_HEADROOM_BYTES = 128 * 1024**2
+_DEFAULT_MAX_SOURCE_PATH_BYTES = 4096
+_SOURCE_ID_BYTES = hashlib.sha256().digest_size * 2
+_ARROW_STRING_OFFSET_BYTES = np.dtype(np.int32).itemsize
+_FRAME_INDEX_BYTES = np.dtype(np.int64).itemsize
+_ARROW_STRING_DATA_MAX_BYTES = int(np.iinfo(np.int32).max)
 # Ray Data read/map tasks use one CPU by default. Keep the decode/resize
 # worker at that width unless the caller explicitly requests otherwise.
 _VIDEO_RESIZE_THREADS = max(1, int(os.environ.get("VANE_VIDEO_RESIZE_THREADS", "1")))
+# A fixed single Decord thread keeps its native buffering inside the declared
+# source-task working-set headroom.
+_VIDEO_DECODE_THREADS = 1
+# Decord 0.6 exposes FFmpeg's padded RGB row as extra channels when the row
+# width is not 32-byte aligned. RGB rows are aligned when pixels are a
+# multiple of 32, after which Pillow applies the exact requested width.
+_VIDEO_DECODE_WIDTH_ALIGNMENT = 32
+_VIDEO_ERROR_MODES = frozenset({"raise", "skip"})
+_LOGGER = logging.getLogger(__name__)
+
+
+class VideoReadError(RuntimeError):
+    """A failure associated with one input video."""
+
+    def __init__(self, video_path: str, message: str):
+        self.video_path = str(video_path)
+        self.message = str(message)
+        super().__init__(self.video_path, self.message)
+
+    def __str__(self) -> str:
+        return f"Failed to read video {self.video_path!r}: {self.message}"
+
+
+class RemoteVideoTooLargeError(VideoReadError):
+    """A remote video exceeded its configured per-file disk bound."""
+
+
+class SourceFrameTooLargeError(VideoReadError):
+    """A decoded source frame exceeded its configured working-set bound."""
 
 
 def _read_bool_env(name: str, default: bool) -> bool:
@@ -258,14 +300,99 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool]:
     return kwargs
 
 
-def _read_s3_bytes(s3_path: str) -> bytes:
-    """Read a file from S3 into memory via PyArrow's S3FileSystem."""
+def _video_source_identity(video_path: str) -> tuple[str, str]:
+    """Return a stable provenance path and collision-resistant source ID."""
+    if video_path.startswith("s3://"):
+        object_path = video_path[len("s3://") :]
+        bucket, separator, key = object_path.partition("/")
+        if not bucket or not separator or not key:
+            raise ValueError(f"invalid S3 video path: {video_path!r}")
+        canonical_path = f"s3://{bucket.lower()}/{key}"
+    else:
+        # Resolve components in filesystem order.  Lexically collapsing
+        # ``link/..`` before following ``link`` can identify a different file
+        # from the one the decoder opens.
+        canonical_path = os.path.realpath(video_path)
+    source_id = hashlib.sha256(canonical_path.encode("utf-8")).hexdigest()
+    return canonical_path, source_id
+
+
+def _video_source_path_bytes(video_path: str) -> int:
+    canonical_path, _ = _video_source_identity(video_path)
+    return len(canonical_path.encode("utf-8"))
+
+
+def _max_video_source_path_bytes(video_paths: list[str]) -> int:
+    return max((_video_source_path_bytes(path) for path in video_paths), default=0)
+
+
+def _safe_video_suffix(video_path: str) -> str:
+    suffix = os.path.splitext(video_path)[1]
+    if len(suffix) > 16 or not suffix[1:].isalnum():
+        return ""
+    return suffix
+
+
+def _s3_filesystem() -> Any:
     import pyarrow.fs as pa_fs
 
-    fs = pa_fs.S3FileSystem(**_s3_filesystem_kwargs())
-    obj_path = s3_path[len("s3://") :]
-    with fs.open_input_file(obj_path) as f:
-        return f.read()
+    return pa_fs.S3FileSystem(**_s3_filesystem_kwargs())
+
+
+@contextmanager
+def _materialize_video_path(
+    video_path: str,
+    *,
+    max_remote_video_bytes: int,
+    remote_temp_dir: str | None,
+) -> Iterator[str]:
+    """Yield a local decoder path while keeping remote heap use constant."""
+    if not video_path.startswith("s3://"):
+        yield video_path
+        return
+    if max_remote_video_bytes <= 0:
+        raise ValueError("max_remote_video_bytes must be positive")
+
+    canonical_path, _ = _video_source_identity(video_path)
+    object_path = canonical_path[len("s3://") :]
+    fs = _s3_filesystem()
+    file_info = fs.get_file_info(object_path)
+    object_size_value = file_info.size
+    object_size = None if object_size_value is None else int(object_size_value)
+    if object_size is not None and object_size >= 0 and object_size > max_remote_video_bytes:
+        raise RemoteVideoTooLargeError(
+            canonical_path,
+            f"remote object size {object_size} exceeds limit {max_remote_video_bytes}",
+        )
+
+    temporary = tempfile.NamedTemporaryFile(
+        mode="wb",
+        prefix="vane-video-",
+        suffix=_safe_video_suffix(object_path),
+        dir=remote_temp_dir,
+        delete=False,
+    )
+    local_path = temporary.name
+    try:
+        with temporary, fs.open_input_file(object_path) as source:
+            copied_bytes = 0
+            while True:
+                chunk = source.read(_REMOTE_VIDEO_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                copied_bytes += len(chunk)
+                if copied_bytes > max_remote_video_bytes:
+                    raise RemoteVideoTooLargeError(
+                        canonical_path,
+                        f"remote object exceeded limit {max_remote_video_bytes} while downloading",
+                    )
+                temporary.write(chunk)
+        yield local_path
+    finally:
+        try:
+            os.unlink(local_path)
+        except FileNotFoundError:
+            pass
 
 
 def _build_frame_array(frames: npt.ArrayLike) -> pa.ExtensionArray:
@@ -275,26 +402,41 @@ def _build_frame_array(frames: npt.ArrayLike) -> pa.ExtensionArray:
     return pa.FixedShapeTensorArray.from_numpy_ndarray(frame_array)
 
 
-def _int64_array(values: list[int]) -> pa.Array:
+def _int64_array(values: npt.ArrayLike) -> pa.Array:
     array = np.ascontiguousarray(values, dtype=np.int64)
     return pa.Array.from_buffers(pa.int64(), len(array), [None, pa.py_buffer(array)])
 
 
 def _constant_string_array(value: str, count: int) -> pa.Array:
+    if count < 0:
+        raise ValueError("constant string array count must be non-negative")
     encoded = value.encode("utf-8")
+    data_bytes = len(encoded) * count
+    if count > _ARROW_STRING_DATA_MAX_BYTES or data_bytes > _ARROW_STRING_DATA_MAX_BYTES:
+        raise ValueError(
+            f"constant string array requires {data_bytes} data bytes, "
+            f"exceeding Arrow's {_ARROW_STRING_DATA_MAX_BYTES}-byte UTF-8 offset limit"
+        )
     offsets: npt.NDArray[np.int32] = np.arange(count + 1, dtype=np.int32) * len(encoded)
     data = encoded * count
     return pa.Array.from_buffers(pa.string(), count, [None, pa.py_buffer(offsets), pa.py_buffer(data)])
 
 
-def _open_decord_reader(video_path: str) -> Any:
+def _open_decord_reader(video_path: str, *, width: int, height: int) -> Any:
     VideoReader = _import_video_dependency("decord", "decord").VideoReader
+    return VideoReader(
+        video_path,
+        width=int(width),
+        height=int(height),
+        num_threads=_VIDEO_DECODE_THREADS,
+    )
 
-    if video_path.startswith("s3://"):
-        import io as _io
 
-        return VideoReader(_io.BytesIO(_read_s3_bytes(video_path)))
-    return VideoReader(video_path)
+def _video_decoder_dimensions(*, width: int, height: int) -> tuple[int, int]:
+    decoder_width = ((int(width) + _VIDEO_DECODE_WIDTH_ALIGNMENT - 1) // _VIDEO_DECODE_WIDTH_ALIGNMENT) * (
+        _VIDEO_DECODE_WIDTH_ALIGNMENT
+    )
+    return decoder_width, int(height)
 
 
 def _resize_rgb_frame(
@@ -324,6 +466,16 @@ def _resize_frame_batch(
         return list(executor.map(_resize_rgb_frame, frames, repeat(width), repeat(height)))
 
 
+def _source_frame_bytes_from_shape(frame: Any) -> int | None:
+    shape = getattr(frame, "shape", None)
+    if shape is None:
+        return None
+    frame_bytes = 1
+    for dimension in shape:
+        frame_bytes *= int(dimension)
+    return frame_bytes
+
+
 def _decode_video_batches(
     video_path: str,
     *,
@@ -331,42 +483,85 @@ def _decode_video_batches(
     width: int,
     max_partition_bytes: int,
     max_frames: int | None = None,
+    max_remote_video_bytes: int = _DEFAULT_MAX_REMOTE_VIDEO_BYTES,
+    max_source_frame_bytes: int = _DEFAULT_MAX_SOURCE_FRAME_BYTES,
+    max_source_path_bytes: int | None = None,
+    remote_temp_dir: str | None = None,
 ) -> Iterator[pa.RecordBatch]:
     if max_frames is not None and max_frames <= 0:
         return
+    if height <= 0 or width <= 0:
+        raise ValueError("height and width must be positive")
+    if max_remote_video_bytes <= 0:
+        raise ValueError("max_remote_video_bytes must be positive")
+    if max_source_frame_bytes <= 0:
+        raise ValueError("max_source_frame_bytes must be positive")
 
-    open_start = time.perf_counter()
-    reader = _open_decord_reader(video_path)
-    open_s = time.perf_counter() - open_start
-    vname = os.path.basename(video_path)
-    batch_size = _video_source_udf_output_batch_size(height, width, max_partition_bytes)
+    source_path, source_id = _video_source_identity(video_path)
+    source_path_bytes = len(source_path.encode("utf-8"))
+    if max_source_path_bytes is None:
+        max_source_path_bytes = source_path_bytes
+    else:
+        max_source_path_bytes = int(max_source_path_bytes)
+        if max_source_path_bytes < source_path_bytes:
+            raise ValueError(
+                f"max_source_path_bytes {max_source_path_bytes} is smaller than canonical path size {source_path_bytes}"
+            )
 
+    decoder_width, decoder_height = _video_decoder_dimensions(width=width, height=height)
+    decoded_frame_bytes = decoder_height * decoder_width * 3
+    if decoded_frame_bytes > max_source_frame_bytes:
+        raise SourceFrameTooLargeError(
+            source_path,
+            f"bounded decoder frame size {decoded_frame_bytes} exceeds limit {max_source_frame_bytes}",
+        )
+
+    batch_size = _video_source_udf_output_batch_size(
+        height,
+        width,
+        max_partition_bytes,
+        max_source_path_bytes=max_source_path_bytes,
+    )
     resized: npt.NDArray[np.uint8] = np.empty((batch_size, height, width, 3), dtype=np.uint8)
-    raw_frames: list[npt.NDArray[np.uint8]] = []
-    indices: list[int] = []
+    pending_frames: list[npt.NDArray[np.uint8]] = []
+    pending_indices: list[int] = []
+    indices: npt.NDArray[np.int64] = np.empty(batch_size, dtype=np.int64)
     count = 0
     decode_s = 0.0
+    resize_s = 0.0
+    open_s = 0.0
     batch_start = time.perf_counter()
-    resize_executor = ThreadPoolExecutor(max_workers=_VIDEO_RESIZE_THREADS) if _VIDEO_RESIZE_THREADS > 1 else None
+    resize_executor: ThreadPoolExecutor | None = None
+    resize_window_size = max(1, min(_VIDEO_RESIZE_THREADS, batch_size))
 
-    def emit_resized_batch() -> Iterator[pa.RecordBatch]:
-        nonlocal resized, count, raw_frames, indices, decode_s, batch_start, open_s
-        current_count = count
+    def resize_pending_frames() -> None:
+        nonlocal count, pending_frames, pending_indices, resize_s
+        if not pending_frames:
+            return
 
         resize_start = time.perf_counter()
-        resized_frames = _resize_frame_batch(raw_frames, width=width, height=height, executor=resize_executor)
-        resize_s = time.perf_counter() - resize_start
+        resized_frames = _resize_frame_batch(
+            pending_frames,
+            width=width,
+            height=height,
+            executor=resize_executor,
+        )
+        resize_s += time.perf_counter() - resize_start
+        if len(resized_frames) != len(pending_indices):
+            raise RuntimeError("video resize returned a different number of frames")
 
-        for out_idx, resized_frame in enumerate(resized_frames):
-            resized[out_idx] = resized_frame
+        for frame_index, resized_frame in zip(pending_indices, resized_frames, strict=True):
+            resized[count] = resized_frame
+            indices[count] = frame_index
+            count += 1
+        pending_frames = []
+        pending_indices = []
 
+    def emit_resized_batch(*, allocate_next: bool) -> Iterator[pa.RecordBatch]:
+        nonlocal resized, count, indices, decode_s, resize_s, batch_start, open_s
+        current_count = count
         flush_start = time.perf_counter()
-        batch = _flush_frame_batch(vname, resized, indices, current_count)
-        # FixedShapeTensorArray retains a zero-copy reference to ``resized``.
-        # Transfer ownership of that buffer to the emitted Arrow batch before
-        # the generator can resume; reusing it would mutate already published
-        # blocks while Ray serializes or downstream operators consume them.
-        resized = np.empty((batch_size, height, width, 3), dtype=np.uint8)
+        batch = _flush_frame_batch(source_id, source_path, resized, indices, current_count)
         flush_s = time.perf_counter() - flush_start
         total_s = time.perf_counter() - batch_start
         _emit_reader_timing(
@@ -380,48 +575,173 @@ def _decode_video_batches(
             flush_s=flush_s,
         )
         yield batch
-
-        raw_frames = []
-        indices = []
+        del batch
+        if allocate_next:
+            # The emitted Arrow batch owns the old zero-copy NumPy buffer.
+            resized = np.empty((batch_size, height, width, 3), dtype=np.uint8)
+            indices = np.empty(batch_size, dtype=np.int64)
         count = 0
         decode_s = 0.0
+        resize_s = 0.0
         open_s = 0.0
         batch_start = time.perf_counter()
 
-    try:
-        for frame_idx, frame in enumerate(reader):
-            if max_frames is not None and frame_idx >= max_frames:
-                break
-            decode_start = time.perf_counter()
-            arr = frame.asnumpy()
-            decode_s += time.perf_counter() - decode_start
-            raw_frames.append(arr)
-            indices.append(frame_idx)
-            count += 1
+    open_start = time.perf_counter()
+    with _materialize_video_path(
+        source_path,
+        max_remote_video_bytes=max_remote_video_bytes,
+        remote_temp_dir=remote_temp_dir,
+    ) as decoder_path:
+        # Bound Decord's materialized frame shape at reader construction rather
+        # than discovering an oversized frame after iteration begins. The
+        # aligned width also avoids Decord exposing FFmpeg row padding as
+        # additional channels for narrow RGB output.
+        reader = _open_decord_reader(
+            decoder_path,
+            width=decoder_width,
+            height=decoder_height,
+        )
+        open_s = time.perf_counter() - open_start
+        if _VIDEO_RESIZE_THREADS > 1:
+            resize_executor = ThreadPoolExecutor(max_workers=_VIDEO_RESIZE_THREADS)
+        try:
+            frames = reader if max_frames is None else islice(reader, max_frames)
+            for frame_idx, frame in enumerate(frames):
+                shape_frame_bytes = _source_frame_bytes_from_shape(frame)
+                if shape_frame_bytes is not None and shape_frame_bytes > max_source_frame_bytes:
+                    raise SourceFrameTooLargeError(
+                        source_path,
+                        f"source frame size {shape_frame_bytes} exceeds limit {max_source_frame_bytes}",
+                    )
+                decode_start = time.perf_counter()
+                array = frame.asnumpy()
+                decode_s += time.perf_counter() - decode_start
+                if array.nbytes > max_source_frame_bytes:
+                    raise SourceFrameTooLargeError(
+                        source_path,
+                        f"source frame size {array.nbytes} exceeds limit {max_source_frame_bytes}",
+                    )
+                pending_frames.append(array)
+                pending_indices.append(frame_idx)
+                del array
+                del frame
 
-            if count >= batch_size:
-                yield from emit_resized_batch()
-        if count > 0:
-            yield from emit_resized_batch()
-    finally:
-        if resize_executor is not None:
-            resize_executor.shutdown()
+                remaining_batch_rows = batch_size - count
+                pending_limit = min(resize_window_size, remaining_batch_rows)
+                if len(pending_frames) >= pending_limit:
+                    resize_pending_frames()
+                if count >= batch_size:
+                    yield from emit_resized_batch(allocate_next=True)
+
+            resize_pending_frames()
+            if count > 0:
+                yield from emit_resized_batch(allocate_next=False)
+        finally:
+            if resize_executor is not None:
+                resize_executor.shutdown()
+            del reader
 
 
 def _flush_frame_batch(
-    vname: str,
+    source_id: str,
+    video_path: str,
     resized: npt.NDArray[np.uint8],
-    indices: list[int],
+    indices: npt.ArrayLike,
     count: int,
 ) -> pa.RecordBatch:
-    frame_arr = _build_frame_array(resized[:count])
+    frame_indices = np.ascontiguousarray(indices, dtype=np.int64)
+    if frame_indices.ndim != 1 or len(frame_indices) < count:
+        raise ValueError("frame indices must be a one-dimensional array covering every frame")
+    if count < len(frame_indices):
+        frame_indices = frame_indices[:count].copy()
+    else:
+        frame_indices = frame_indices[:count]
+    frame_values = resized[:count]
+    if count < len(resized):
+        # Arrow retains the NumPy owner of a zero-copy slice. Compact a short
+        # tail so coalescing tails from many files cannot pin one full output
+        # allocation per file.
+        frame_values = frame_values.copy()
+    frame_arr = _build_frame_array(frame_values)
     return pa.record_batch(
         {
-            "video_path": _constant_string_array(vname, count),
-            "frame_index": _int64_array(indices),
+            "source_id": _constant_string_array(source_id, count),
+            "video_path": _constant_string_array(video_path, count),
+            "frame_index": _int64_array(frame_indices),
             "frame": frame_arr,
         }
     )
+
+
+def _validate_video_error_mode(on_error: str) -> str:
+    if on_error not in _VIDEO_ERROR_MODES:
+        choices = ", ".join(sorted(_VIDEO_ERROR_MODES))
+        raise ValueError(f"on_error must be one of: {choices}; got {on_error!r}")
+    return on_error
+
+
+def _is_decord_error(exc: Exception) -> bool:
+    """Return whether *exc* is one of Decord's direct Exception subclasses."""
+    try:
+        decord_base = importlib.import_module("decord._ffi.base")
+    except ImportError:
+        return False
+    return any(
+        isinstance(error_type, type) and isinstance(exc, error_type)
+        for error_type in (
+            getattr(decord_base, "DECORDError", None),
+            getattr(decord_base, "DECORDLimitReachedError", None),
+        )
+    )
+
+
+def _decode_video_with_policy(
+    video_path: str,
+    *,
+    height: int,
+    width: int,
+    max_partition_bytes: int,
+    max_frames: int | None,
+    max_remote_video_bytes: int,
+    max_source_frame_bytes: int,
+    remote_temp_dir: str | None,
+    on_error: str,
+    max_source_path_bytes: int | None = None,
+) -> Iterator[pa.RecordBatch]:
+    _validate_video_error_mode(on_error)
+    try:
+        yield from _decode_video_batches(
+            video_path,
+            height=height,
+            width=width,
+            max_partition_bytes=max_partition_bytes,
+            max_frames=max_frames,
+            max_remote_video_bytes=max_remote_video_bytes,
+            max_source_frame_bytes=max_source_frame_bytes,
+            max_source_path_bytes=max_source_path_bytes,
+            remote_temp_dir=remote_temp_dir,
+        )
+    except Exception as exc:
+        if not isinstance(exc, (OSError, RuntimeError, ValueError)) and not _is_decord_error(exc):
+            raise
+        if isinstance(exc, VideoReadError):
+            error = exc
+        else:
+            try:
+                source_path, _ = _video_source_identity(video_path)
+            except ValueError:
+                source_path = video_path
+            error = VideoReadError(source_path, f"{type(exc).__name__}: {exc}")
+        if on_error == "raise":
+            if error is exc:
+                raise
+            raise error from exc
+        _LOGGER.warning(
+            "Skipping unreadable video source=%r error_type=%s error=%s",
+            error.video_path,
+            type(exc).__name__,
+            exc,
+        )
 
 
 def _sql_string_literal(value: str) -> str:
@@ -444,11 +764,123 @@ def _video_source_udf_videos_per_task(frame_limit: int | None, path_count: int) 
     return _read_int_env("VANE_VIDEO_SOURCE_UDF_VIDEOS_PER_TASK", 1, minimum=1)
 
 
-def _video_source_udf_output_batch_size(height: int, width: int, max_partition_bytes: int) -> int:
-    frame_bytes = max(1, int(height) * int(width) * 3)
+def _video_max_output_rows(max_source_path_bytes: int) -> int:
+    max_source_path_bytes = int(max_source_path_bytes)
+    if max_source_path_bytes < 0:
+        raise ValueError("max_source_path_bytes must be non-negative")
+    if max_source_path_bytes > _ARROW_STRING_DATA_MAX_BYTES:
+        raise ValueError(
+            f"canonical video path requires {max_source_path_bytes} bytes, "
+            f"exceeding Arrow's {_ARROW_STRING_DATA_MAX_BYTES}-byte UTF-8 offset limit"
+        )
+    path_limit = (
+        _ARROW_STRING_DATA_MAX_BYTES
+        if max_source_path_bytes == 0
+        else _ARROW_STRING_DATA_MAX_BYTES // max_source_path_bytes
+    )
+    return min(
+        _ARROW_STRING_DATA_MAX_BYTES // _SOURCE_ID_BYTES,
+        path_limit,
+    )
+
+
+def _video_output_row_bytes(*, height: int, width: int, max_source_path_bytes: int) -> int:
+    if height <= 0 or width <= 0:
+        raise ValueError("height and width must be positive")
+    if max_source_path_bytes < 0:
+        raise ValueError("max_source_path_bytes must be non-negative")
+    frame_bytes = int(height) * int(width) * 3
+    return (
+        frame_bytes
+        + _SOURCE_ID_BYTES
+        + int(max_source_path_bytes)
+        # Coalescing file tails can leave one Arrow chunk per row. Charge both
+        # the row offset and each chunk's terminal offset for both strings.
+        + 4 * _ARROW_STRING_OFFSET_BYTES
+        + _FRAME_INDEX_BYTES
+    )
+
+
+def _video_output_batch_bytes(
+    row_count: int,
+    *,
+    height: int,
+    width: int,
+    max_source_path_bytes: int,
+) -> int:
+    row_count = int(row_count)
+    if row_count < 0:
+        raise ValueError("row_count must be non-negative")
+    max_rows = _video_max_output_rows(max_source_path_bytes)
+    if row_count > max_rows:
+        raise ValueError(
+            f"video output batch has {row_count} rows, exceeding Arrow's UTF-8 offset limit of {max_rows} rows"
+        )
+    row_bytes = _video_output_row_bytes(
+        height=height,
+        width=width,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+    return row_count * row_bytes
+
+
+def _video_source_udf_output_batch_size(
+    height: int,
+    width: int,
+    max_partition_bytes: int,
+    *,
+    max_source_path_bytes: int = _DEFAULT_MAX_SOURCE_PATH_BYTES,
+) -> int:
+    if max_partition_bytes <= 0:
+        raise ValueError("max_partition_bytes must be positive")
+    row_bytes = _video_output_row_bytes(
+        height=height,
+        width=width,
+        max_source_path_bytes=max_source_path_bytes,
+    )
     # Ray Data's block target is soft: the row that first crosses the target
     # is retained in the emitted block.
-    return max(1, int(max_partition_bytes) // frame_bytes + 1)
+    target_rows = max(1, int(max_partition_bytes) // row_bytes + 1)
+    return min(target_rows, _video_max_output_rows(max_source_path_bytes))
+
+
+def _video_source_peak_memory_bytes(
+    *,
+    height: int,
+    width: int,
+    max_partition_bytes: int,
+    max_source_frame_bytes: int,
+    max_source_path_bytes: int = _DEFAULT_MAX_SOURCE_PATH_BYTES,
+    output_batch_size: int | None = None,
+) -> int:
+    """Return the bounded source-task working set used for Ray admission."""
+    frame_bytes = max(1, int(height) * int(width) * 3)
+    decode_batch_size = _video_source_udf_output_batch_size(
+        height,
+        width,
+        max_partition_bytes,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+    transport_batch_size = decode_batch_size if output_batch_size is None else max(1, int(output_batch_size))
+    output_bytes = _video_output_batch_bytes(
+        max(decode_batch_size, transport_batch_size),
+        height=height,
+        width=width,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+    resize_window_size = max(1, min(_VIDEO_RESIZE_THREADS, decode_batch_size))
+    resize_window_bytes = resize_window_size * (int(max_source_frame_bytes) + frame_bytes)
+    # Decord still owns the current decoded frame while ``asnumpy()`` copies it.
+    # That overlap is separate from the NumPy frames retained by the resize
+    # window and scales with the configured source-frame limit.
+    decoder_copy_overlap_bytes = int(max_source_frame_bytes)
+    return (
+        _REMOTE_VIDEO_READ_CHUNK_BYTES
+        + _VIDEO_DECODER_MEMORY_HEADROOM_BYTES
+        + 2 * output_bytes
+        + resize_window_bytes
+        + decoder_copy_overlap_bytes
+    )
 
 
 def _coalesce_video_frame_batches(
@@ -494,6 +926,8 @@ def _video_source_udf_kwargs(
     height: int = 640,
     width: int = 480,
     max_partition_bytes: int = _DEFAULT_MAX_PARTITION_BYTES,
+    max_source_frame_bytes: int = _DEFAULT_MAX_SOURCE_FRAME_BYTES,
+    max_source_path_bytes: int = _DEFAULT_MAX_SOURCE_PATH_BYTES,
     frame_limit: int | None = None,
     path_count: int = 1,
     pre_grouped_paths: bool = False,
@@ -503,8 +937,19 @@ def _video_source_udf_kwargs(
     execution_backend = _video_source_udf_backend()
     output_batch_size = _read_int_env(
         "VANE_VIDEO_SOURCE_UDF_OUTPUT_BATCH_SIZE",
-        _video_source_udf_output_batch_size(height, width, max_partition_bytes),
+        _video_source_udf_output_batch_size(
+            height,
+            width,
+            max_partition_bytes,
+            max_source_path_bytes=max_source_path_bytes,
+        ),
         minimum=1,
+    )
+    output_batch_bytes = _video_output_batch_bytes(
+        output_batch_size,
+        height=height,
+        width=width,
+        max_source_path_bytes=max_source_path_bytes,
     )
     udf_kwargs: dict[str, object] = {
         "execution_backend": execution_backend,
@@ -513,10 +958,11 @@ def _video_source_udf_kwargs(
         # Ray Data's target_max_block_size is a soft threshold: the row that
         # crosses it remains in the block.  Vane's runtime byte limit is a
         # hard pre-append limit, so leaving both values at 128 MiB would split
-        # a Ray-compatible 110-frame block back to 109 frames.  Row count is
-        # the semantic flush boundary here; this larger guard only prevents a
-        # second byte-based split of that already bounded output batch.
-        "output_target_max_bytes": max(int(max_partition_bytes) * 2, 1),
+        # a Ray-compatible soft-target block at its hard byte boundary. Row
+        # count is the semantic flush boundary here; this larger guard only
+        # prevents a second byte-based split of that already bounded output
+        # batch.
+        "output_target_max_bytes": max(int(max_partition_bytes) * 2, output_batch_bytes, 1),
         # One compute batch is one Ray-compatible read-task descriptor.  Its
         # final short block must be published before the next descriptor is
         # evaluated, just like Ray Data finalizes a block builder per read
@@ -526,10 +972,19 @@ def _video_source_udf_kwargs(
         "cpus": _video_source_udf_cpus(),
     }
     if execution_backend == "ray_task":
-        udf_kwargs["memory_bytes"] = (
+        configured_memory_bytes = (
             _read_optional_positive_int_env("VANE_VIDEO_SOURCE_UDF_MEMORY_BYTES")
             or _DEFAULT_VIDEO_SOURCE_UDF_MEMORY_BYTES
         )
+        peak_memory_bytes = _video_source_peak_memory_bytes(
+            height=height,
+            width=width,
+            max_partition_bytes=max_partition_bytes,
+            max_source_frame_bytes=max_source_frame_bytes,
+            max_source_path_bytes=max_source_path_bytes,
+            output_batch_size=output_batch_size,
+        )
+        udf_kwargs["memory_bytes"] = max(configured_memory_bytes, peak_memory_bytes)
     if schema is not None:
         udf_kwargs["schema"] = schema
     return udf_kwargs
@@ -565,18 +1020,28 @@ def _video_frame_source_manifest_sql(source: VideoFrameSource) -> str:
     if not source.paths:
         return (
             "select []::VARCHAR[] as video_paths, 0::BIGINT as height, 0::BIGINT as width, "
-            "0::BIGINT as max_partition_bytes, NULL::BIGINT as frame_limit where false"
+            "0::BIGINT as max_partition_bytes, NULL::BIGINT as frame_limit, "
+            "0::BIGINT as max_remote_video_bytes, 0::BIGINT as max_source_frame_bytes, "
+            "0::BIGINT as max_source_path_bytes, "
+            "'raise'::VARCHAR as on_error, NULL::VARCHAR as remote_temp_dir where false"
         )
 
     frame_limit_sql = "NULL" if source.frame_limit is None else str(max(0, int(source.frame_limit)))
+    remote_temp_dir_sql = "NULL" if source.remote_temp_dir is None else _sql_string_literal(source.remote_temp_dir)
     path_groups = _video_source_path_groups(source)
+    max_source_path_bytes = _max_video_source_path_bytes(source.paths)
     rows = ", ".join(
         "("
-        f"list_value({', '.join(_sql_string_literal(path) for path in paths)}), "
+        f"list_value({', '.join(_sql_string_literal(_video_source_identity(path)[0]) for path in paths)}), "
         f"{int(source.height)}, "
         f"{int(source.width)}, "
         f"{int(source.max_partition_bytes)}, "
-        f"{frame_limit_sql}"
+        f"{frame_limit_sql}, "
+        f"{int(source.max_remote_video_bytes)}, "
+        f"{int(source.max_source_frame_bytes)}, "
+        f"{max_source_path_bytes}, "
+        f"{_sql_string_literal(source.on_error)}, "
+        f"{remote_temp_dir_sql}"
         ")"
         for paths in path_groups
     )
@@ -586,8 +1051,16 @@ def _video_frame_source_manifest_sql(source: VideoFrameSource) -> str:
         "height::BIGINT as height, "
         "width::BIGINT as width, "
         "max_partition_bytes::BIGINT as max_partition_bytes, "
-        "frame_limit::BIGINT as frame_limit "
-        f"from (values {rows}) as manifest(video_paths, height, width, max_partition_bytes, frame_limit)"
+        "frame_limit::BIGINT as frame_limit, "
+        "max_remote_video_bytes::BIGINT as max_remote_video_bytes, "
+        "max_source_frame_bytes::BIGINT as max_source_frame_bytes, "
+        "max_source_path_bytes::BIGINT as max_source_path_bytes, "
+        "on_error::VARCHAR as on_error, "
+        "remote_temp_dir::VARCHAR as remote_temp_dir "
+        f"from (values {rows}) as manifest("
+        "video_paths, height, width, max_partition_bytes, frame_limit, "
+        "max_remote_video_bytes, max_source_frame_bytes, max_source_path_bytes, "
+        "on_error, remote_temp_dir)"
     )
 
 
@@ -618,19 +1091,55 @@ def _video_frame_source_map_batches(table: pa.Table) -> Iterator[pa.Table]:
     widths = table.column("width").to_pylist()
     max_partition_bytes_values = table.column("max_partition_bytes").to_pylist()
     frame_limits = table.column("frame_limit").to_pylist()
+    max_remote_video_bytes_values = table.column("max_remote_video_bytes").to_pylist()
+    max_source_frame_bytes_values = table.column("max_source_frame_bytes").to_pylist()
+    max_source_path_bytes_values = table.column("max_source_path_bytes").to_pylist()
+    on_error_values = table.column("on_error").to_pylist()
+    remote_temp_dir_values = table.column("remote_temp_dir").to_pylist()
     remaining = _manifest_frame_limit(frame_limits)
 
     for row_idx, paths in enumerate(path_groups):
         height = _manifest_int_value(heights, row_idx, "height")
         width = _manifest_int_value(widths, row_idx, "width")
         max_partition_bytes = _manifest_int_value(max_partition_bytes_values, row_idx, "max_partition_bytes")
-        target_rows = _video_source_udf_output_batch_size(height, width, max_partition_bytes)
+        max_remote_video_bytes = _manifest_int_value(
+            max_remote_video_bytes_values,
+            row_idx,
+            "max_remote_video_bytes",
+        )
+        max_source_frame_bytes = _manifest_int_value(
+            max_source_frame_bytes_values,
+            row_idx,
+            "max_source_frame_bytes",
+        )
+        max_source_path_bytes = _manifest_int_value(
+            max_source_path_bytes_values,
+            row_idx,
+            "max_source_path_bytes",
+        )
+        on_error_value = on_error_values[row_idx]
+        if on_error_value is None:
+            raise ValueError("VideoFrameSource manifest column 'on_error' cannot be NULL")
+        on_error = _validate_video_error_mode(str(on_error_value))
+        remote_temp_dir_value = remote_temp_dir_values[row_idx]
+        remote_temp_dir = None if remote_temp_dir_value is None else str(remote_temp_dir_value)
+        target_rows = _video_source_udf_output_batch_size(
+            height,
+            width,
+            max_partition_bytes,
+            max_source_path_bytes=max_source_path_bytes,
+        )
 
         def decode_group(
             paths: list[str | None] = paths,
             height: int = height,
             width: int = width,
             max_partition_bytes: int = max_partition_bytes,
+            max_remote_video_bytes: int = max_remote_video_bytes,
+            max_source_frame_bytes: int = max_source_frame_bytes,
+            max_source_path_bytes: int = max_source_path_bytes,
+            on_error: str = on_error,
+            remote_temp_dir: str | None = remote_temp_dir,
         ) -> Iterator[pa.RecordBatch]:
             nonlocal remaining
             for path in paths:
@@ -643,12 +1152,17 @@ def _video_frame_source_map_batches(table: pa.Table) -> Iterator[pa.Table]:
                 _wait_for_memory()
                 _decode_semaphore.acquire()
                 try:
-                    for batch in _decode_video_batches(
+                    for batch in _decode_video_with_policy(
                         path,
                         height=height,
                         width=width,
                         max_partition_bytes=max_partition_bytes,
                         max_frames=max_frames,
+                        max_remote_video_bytes=max_remote_video_bytes,
+                        max_source_frame_bytes=max_source_frame_bytes,
+                        max_source_path_bytes=max_source_path_bytes,
+                        remote_temp_dir=remote_temp_dir,
+                        on_error=on_error,
                     ):
                         if remaining is not None:
                             if batch.num_rows > remaining:
@@ -674,11 +1188,19 @@ class VideoFrameTask(DataSourceTask):
         height: int,
         width: int,
         max_partition_bytes: int = _DEFAULT_MAX_PARTITION_BYTES,
+        max_remote_video_bytes: int = _DEFAULT_MAX_REMOTE_VIDEO_BYTES,
+        max_source_frame_bytes: int = _DEFAULT_MAX_SOURCE_FRAME_BYTES,
+        on_error: str = "raise",
+        remote_temp_dir: str | None = None,
     ):
         self.video_path = video_path
         self.height = height
         self.width = width
         self.max_partition_bytes = max_partition_bytes
+        self.max_remote_video_bytes = max_remote_video_bytes
+        self.max_source_frame_bytes = max_source_frame_bytes
+        self.on_error = _validate_video_error_mode(on_error)
+        self.remote_temp_dir = remote_temp_dir
 
     def execute(self) -> Iterator[pa.RecordBatch]:
         """Decode video frames with decord, yielding batches of ~10MB.
@@ -695,22 +1217,29 @@ class VideoFrameTask(DataSourceTask):
             _decode_semaphore.release()
 
     def _execute_inner(self) -> Iterator[pa.RecordBatch]:
-        yield from _decode_video_batches(
+        yield from _decode_video_with_policy(
             self.video_path,
             height=self.height,
             width=self.width,
             max_partition_bytes=self.max_partition_bytes,
+            max_frames=None,
+            max_remote_video_bytes=self.max_remote_video_bytes,
+            max_source_frame_bytes=self.max_source_frame_bytes,
+            max_source_path_bytes=None,
+            remote_temp_dir=self.remote_temp_dir,
+            on_error=self.on_error,
         )
 
     def _flush(
         self,
-        vname: str,
+        source_id: str,
+        video_path: str,
         resized: npt.NDArray[np.uint8],
-        indices: list[int],
+        indices: npt.ArrayLike,
         count: int,
     ) -> pa.RecordBatch:
         """Build a RecordBatch from the accumulated frame buffer."""
-        return _flush_frame_batch(vname, resized, indices, count)
+        return _flush_frame_batch(source_id, video_path, resized, indices, count)
 
 
 class LimitedVideoFrameTask(DataSourceTask):
@@ -723,12 +1252,20 @@ class LimitedVideoFrameTask(DataSourceTask):
         width: int,
         max_frames: int,
         max_partition_bytes: int = _DEFAULT_MAX_PARTITION_BYTES,
+        max_remote_video_bytes: int = _DEFAULT_MAX_REMOTE_VIDEO_BYTES,
+        max_source_frame_bytes: int = _DEFAULT_MAX_SOURCE_FRAME_BYTES,
+        on_error: str = "raise",
+        remote_temp_dir: str | None = None,
     ):
         self.paths = paths
         self.height = height
         self.width = width
         self.max_frames = max_frames
         self.max_partition_bytes = max_partition_bytes
+        self.max_remote_video_bytes = max_remote_video_bytes
+        self.max_source_frame_bytes = max_source_frame_bytes
+        self.on_error = _validate_video_error_mode(on_error)
+        self.remote_temp_dir = remote_temp_dir
 
     def execute(self) -> Iterator[pa.RecordBatch]:
         _wait_for_memory()
@@ -743,12 +1280,17 @@ class LimitedVideoFrameTask(DataSourceTask):
         for path in self.paths:
             if remaining <= 0:
                 break
-            for batch in _decode_video_batches(
+            for batch in _decode_video_with_policy(
                 path,
                 height=self.height,
                 width=self.width,
                 max_partition_bytes=self.max_partition_bytes,
                 max_frames=remaining,
+                max_remote_video_bytes=self.max_remote_video_bytes,
+                max_source_frame_bytes=self.max_source_frame_bytes,
+                max_source_path_bytes=None,
+                remote_temp_dir=self.remote_temp_dir,
+                on_error=self.on_error,
             ):
                 remaining -= batch.num_rows
                 yield batch
@@ -760,7 +1302,15 @@ class VideoFrameSource(DataSource):
     """DataSource that streams video frames from local or S3 video files.
 
     Each video file becomes an independent task. Frames are decoded using
-    decord and resized to (height, width). Output batches are ~10MB each.
+    decord and resized to (height, width). Output rows contain the canonical
+    ``video_path``, its SHA-256 ``source_id``, ``frame_index``, and the frame
+    tensor. S3 objects are copied to a bounded task-local temporary file before
+    decoding.
+
+    ``on_error="raise"`` fails the query on an unreadable file.
+    ``on_error="skip"`` keeps frames emitted before the error, skips the
+    remainder of that file, and continues with the next file. Frames that
+    decord recovers without raising are considered successfully decoded.
     """
 
     def __init__(
@@ -771,12 +1321,38 @@ class VideoFrameSource(DataSource):
         max_partition_bytes: int = _DEFAULT_MAX_PARTITION_BYTES,
         frame_limit: int | None = None,
         read_task_count: int | None = None,
+        max_remote_video_bytes: int = _DEFAULT_MAX_REMOTE_VIDEO_BYTES,
+        max_source_frame_bytes: int = _DEFAULT_MAX_SOURCE_FRAME_BYTES,
+        on_error: str = "raise",
+        remote_temp_dir: str | None = None,
     ):
         self.paths = paths
-        self.height = height
-        self.width = width
-        self.max_partition_bytes = max_partition_bytes
+        self.height = int(height)
+        self.width = int(width)
+        self.max_partition_bytes = int(max_partition_bytes)
         self.frame_limit = frame_limit
+        self.max_remote_video_bytes = int(max_remote_video_bytes)
+        self.max_source_frame_bytes = int(max_source_frame_bytes)
+        self.on_error = _validate_video_error_mode(on_error)
+        self.remote_temp_dir = None if remote_temp_dir is None else os.fspath(remote_temp_dir)
+        if self.height <= 0 or self.width <= 0:
+            raise ValueError("height and width must be positive")
+        if self.max_partition_bytes <= 0:
+            raise ValueError("max_partition_bytes must be positive")
+        if self.max_remote_video_bytes <= 0:
+            raise ValueError("max_remote_video_bytes must be positive")
+        if self.max_source_frame_bytes <= 0:
+            raise ValueError("max_source_frame_bytes must be positive")
+        decoder_width, decoder_height = _video_decoder_dimensions(
+            width=self.width,
+            height=self.height,
+        )
+        decoded_frame_bytes = decoder_height * decoder_width * 3
+        if decoded_frame_bytes > self.max_source_frame_bytes:
+            raise ValueError(
+                f"bounded decoder frame size {decoded_frame_bytes} exceeds "
+                f"max_source_frame_bytes {self.max_source_frame_bytes}"
+            )
         if read_task_count is not None and int(read_task_count) <= 0:
             raise ValueError("read_task_count must be positive")
         self.read_task_count = None if read_task_count is None else int(read_task_count)
@@ -784,6 +1360,7 @@ class VideoFrameSource(DataSource):
     @property
     def schema(self) -> dict[str, object]:
         return {
+            "source_id": "VARCHAR",
             "video_path": "VARCHAR",
             "frame_index": "BIGINT",
             "frame": {"kind": "tensor", "dtype": "UINT8", "shape": [self.height, self.width, 3]},
@@ -797,6 +1374,10 @@ class VideoFrameSource(DataSource):
                 width=self.width,
                 max_frames=max(0, self.frame_limit),
                 max_partition_bytes=self.max_partition_bytes,
+                max_remote_video_bytes=self.max_remote_video_bytes,
+                max_source_frame_bytes=self.max_source_frame_bytes,
+                on_error=self.on_error,
+                remote_temp_dir=self.remote_temp_dir,
             )
             return
         for path in self.paths:
@@ -805,6 +1386,10 @@ class VideoFrameSource(DataSource):
                 height=self.height,
                 width=self.width,
                 max_partition_bytes=self.max_partition_bytes,
+                max_remote_video_bytes=self.max_remote_video_bytes,
+                max_source_frame_bytes=self.max_source_frame_bytes,
+                on_error=self.on_error,
+                remote_temp_dir=self.remote_temp_dir,
             )
 
     def to_udf_relation(self, con: Any) -> Any:
@@ -815,10 +1400,13 @@ class VideoFrameSource(DataSource):
             height=self.height,
             width=self.width,
             max_partition_bytes=self.max_partition_bytes,
+            max_source_frame_bytes=self.max_source_frame_bytes,
+            max_source_path_bytes=_max_video_source_path_bytes(self.paths),
             frame_limit=self.frame_limit,
             path_count=len(_video_source_path_groups(self)),
             pre_grouped_paths=True,
             schema={
+                "source_id": duckdb.sqltypes.VARCHAR,
                 "video_path": duckdb.sqltypes.VARCHAR,
                 "frame_index": duckdb.sqltypes.BIGINT,
                 "frame": duckdb.tensor_type(duckdb.sqltypes.UTINYINT, (self.height, self.width, 3)),

--- a/tests/fast/test_video_optional_deps.py
+++ b/tests/fast/test_video_optional_deps.py
@@ -12,7 +12,7 @@ from duckdb.datasource import video_reader
 def test_missing_decord_error_names_video_extra(monkeypatch):
     monkeypatch.setitem(sys.modules, "decord", None)
     with pytest.raises(ImportError, match=r"vane-ai\[video\]") as exc_info:
-        video_reader._open_decord_reader("nonexistent.mp4")
+        video_reader._open_decord_reader("nonexistent.mp4", width=32, height=32)
     assert "decord" in str(exc_info.value)
     assert "Linux x86-64" in str(exc_info.value)
 

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import io
+import logging
+from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
@@ -17,8 +19,9 @@ from duckdb.datasource.video_reader import (
     _coalesce_video_frame_batches,
     _decode_video_batches,
     _flush_frame_batch,
-    _read_s3_bytes,
+    _materialize_video_path,
     _resize_frame_batch,
+    _s3_filesystem,
     _split_video_path_groups,
     _video_frame_source_manifest_sql,
     _video_frame_source_map_batches,
@@ -50,6 +53,9 @@ def recording_s3_filesystem(monkeypatch):
         def __init__(self, **kwargs):
             recorded["kwargs"] = kwargs
 
+        def get_file_info(self, _path):
+            return type("FileInfo", (), {"size": len(b"video-bytes")})()
+
         def open_input_file(self, path):
             recorded["path"] = path
             return io.BytesIO(b"video-bytes")
@@ -63,16 +69,247 @@ def _clear_s3_environment(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_video_s3_reader_uses_default_aws_sdk_chain(monkeypatch, recording_s3_filesystem):
+def test_video_s3_reader_uses_default_aws_sdk_chain(
+    monkeypatch,
+    recording_s3_filesystem,
+    tmp_path,
+):
     _clear_s3_environment(monkeypatch)
 
-    result = _read_s3_bytes("s3://media-bucket/clips/example.mp4")
+    with _materialize_video_path(
+        "s3://media-bucket/clips/example.mp4",
+        max_remote_video_bytes=1024,
+        remote_temp_dir=str(tmp_path),
+    ) as local_path:
+        result = Path(local_path).read_bytes()
 
     assert result == b"video-bytes"
     assert recording_s3_filesystem == {
         "kwargs": {},
         "path": "media-bucket/clips/example.mp4",
     }
+
+
+def test_remote_video_materialization_reads_bounded_chunks_and_cleans_up(monkeypatch, tmp_path):
+    import pyarrow.fs as pa_fs
+
+    import duckdb.datasource.video_reader as video_reader
+
+    chunk_bytes = video_reader._REMOTE_VIDEO_READ_CHUNK_BYTES
+    object_size = 2 * chunk_bytes + 17
+    read_sizes = []
+
+    class LazyRemoteFile:
+        def __init__(self):
+            self.remaining = object_size
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, size=-1):
+            read_sizes.append(size)
+            assert 0 < size <= chunk_bytes
+            count = min(size, self.remaining)
+            self.remaining -= count
+            return b"x" * count
+
+    class FakeFileInfo:
+        size = object_size
+
+    class FakeS3FileSystem:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_file_info(self, path):
+            assert path == "media-bucket/clips/example.mp4"
+            return FakeFileInfo()
+
+        def open_input_file(self, path):
+            assert path == "media-bucket/clips/example.mp4"
+            return LazyRemoteFile()
+
+    monkeypatch.setattr(pa_fs, "S3FileSystem", FakeS3FileSystem)
+
+    with video_reader._materialize_video_path(
+        "s3://media-bucket/clips/example.mp4",
+        max_remote_video_bytes=object_size,
+        remote_temp_dir=str(tmp_path),
+    ) as local_path:
+        assert Path(local_path).stat().st_size == object_size
+        assert Path(local_path).parent == tmp_path
+
+    assert read_sizes == [chunk_bytes, chunk_bytes, chunk_bytes, chunk_bytes]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_remote_video_materialization_rejects_oversized_stream_and_cleans_up(monkeypatch, tmp_path):
+    import pyarrow.fs as pa_fs
+
+    import duckdb.datasource.video_reader as video_reader
+
+    limit = 1024
+
+    class GrowingRemoteFile:
+        def __init__(self):
+            self.read_count = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, size=-1):
+            assert size == video_reader._REMOTE_VIDEO_READ_CHUNK_BYTES
+            self.read_count += 1
+            return b"x" * limit if self.read_count <= 2 else b""
+
+    class UnknownSizeFileInfo:
+        size = -1
+
+    class FakeS3FileSystem:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_file_info(self, _path):
+            return UnknownSizeFileInfo()
+
+        def open_input_file(self, _path):
+            return GrowingRemoteFile()
+
+    monkeypatch.setattr(pa_fs, "S3FileSystem", FakeS3FileSystem)
+
+    with pytest.raises(video_reader.RemoteVideoTooLargeError, match="exceeded limit 1024"):
+        with video_reader._materialize_video_path(
+            "s3://media-bucket/clips/example.mp4",
+            max_remote_video_bytes=limit,
+            remote_temp_dir=str(tmp_path),
+        ):
+            pytest.fail("oversized remote video should not be yielded")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_remote_video_materialization_allows_unknown_size_metadata(monkeypatch, tmp_path):
+    import duckdb.datasource.video_reader as video_reader
+
+    class UnknownSizeFileInfo:
+        size = None
+
+    class FakeS3FileSystem:
+        def get_file_info(self, _path):
+            return UnknownSizeFileInfo()
+
+        def open_input_file(self, _path):
+            return io.BytesIO(b"video-bytes")
+
+    monkeypatch.setattr(video_reader, "_s3_filesystem", FakeS3FileSystem)
+
+    with video_reader._materialize_video_path(
+        "s3://media-bucket/clips/example.mp4",
+        max_remote_video_bytes=1024,
+        remote_temp_dir=str(tmp_path),
+    ) as local_path:
+        assert Path(local_path).read_bytes() == b"video-bytes"
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_video_source_identity_distinguishes_same_basename_sources():
+    import duckdb.datasource.video_reader as video_reader
+
+    path_a, source_id_a = video_reader._video_source_identity("s3://bucket-a/train/clip.mp4")
+    path_b, source_id_b = video_reader._video_source_identity("s3://bucket-b/eval/clip.mp4")
+
+    assert path_a == "s3://bucket-a/train/clip.mp4"
+    assert path_b == "s3://bucket-b/eval/clip.mp4"
+    assert len(source_id_a) == 64
+    assert len(source_id_b) == 64
+    assert source_id_a != source_id_b
+
+
+def test_video_source_identity_preserves_s3_object_key_semantics():
+    import duckdb.datasource.video_reader as video_reader
+
+    path, _ = video_reader._video_source_identity("s3://MEDIA-BUCKET/a//../clip.mp4")
+
+    assert path == "s3://media-bucket/a//../clip.mp4"
+
+
+def test_video_source_identity_resolves_symlink_before_parent_component(tmp_path):
+    import duckdb.datasource.video_reader as video_reader
+
+    decoded_root = tmp_path / "decoded"
+    decoded_dir = decoded_root / "nested"
+    decoded_dir.mkdir(parents=True)
+    decoded_video = decoded_root / "clip.mp4"
+    decoded_video.touch()
+    direct_video = tmp_path / "clip.mp4"
+    direct_video.touch()
+    link = tmp_path / "link"
+    link.symlink_to(decoded_dir, target_is_directory=True)
+
+    canonical_path, source_id = video_reader._video_source_identity(str(link / ".." / "clip.mp4"))
+    direct_path, direct_source_id = video_reader._video_source_identity(str(direct_video))
+
+    assert canonical_path == str(decoded_video.resolve())
+    assert direct_path == str(direct_video.resolve())
+    assert source_id != direct_source_id
+
+
+def test_video_decode_opens_the_resolved_local_source(monkeypatch, tmp_path):
+    import duckdb.datasource.video_reader as video_reader
+
+    decoded_root = tmp_path / "decoded"
+    decoded_dir = decoded_root / "nested"
+    decoded_dir.mkdir(parents=True)
+    decoded_video = decoded_root / "clip.mp4"
+    decoded_video.touch()
+    link = tmp_path / "link"
+    link.symlink_to(decoded_dir, target_is_directory=True)
+    input_path = str(link / ".." / "clip.mp4")
+    opened_paths = []
+
+    def fake_open_decoder(path, **_kwargs):
+        opened_paths.append(path)
+        return []
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+
+    assert (
+        list(
+            _decode_video_batches(
+                input_path,
+                height=2,
+                width=2,
+                max_partition_bytes=1024,
+            )
+        )
+        == []
+    )
+    assert opened_paths == [str(decoded_video.resolve())]
+
+
+def test_video_read_errors_are_pickle_safe():
+    import pickle
+
+    import duckdb.datasource.video_reader as video_reader
+
+    for error_type in (
+        video_reader.VideoReadError,
+        video_reader.RemoteVideoTooLargeError,
+        video_reader.SourceFrameTooLargeError,
+    ):
+        error = error_type("s3://bucket/clip.mp4", "test failure")
+        restored = pickle.loads(pickle.dumps(error))
+
+        assert type(restored) is error_type
+        assert restored.video_path == error.video_path
+        assert restored.message == error.message
+        assert str(restored) == str(error)
 
 
 @pytest.mark.parametrize(
@@ -96,7 +333,7 @@ def test_video_s3_reader_leaves_profile_and_role_credentials_to_sdk(
     for name, value in credential_env.items():
         monkeypatch.setenv(name, value)
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {}
 
@@ -107,7 +344,7 @@ def test_video_s3_reader_leaves_static_session_credentials_to_sdk(monkeypatch, r
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "temporary-secret-key")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "temporary-session-token")
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {}
 
@@ -129,7 +366,7 @@ def test_video_s3_reader_leaves_partial_static_credentials_to_sdk(
     for name, value in partial_credentials.items():
         monkeypatch.setenv(name, value)
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {}
 
@@ -144,7 +381,7 @@ def test_video_s3_reader_passes_custom_https_endpoint_and_region(
     monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test:9443/prefix")
     monkeypatch.setenv(region_env, "eu-west-1")
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {
         "endpoint_override": "objects.example.test:9443",
@@ -179,7 +416,7 @@ def test_video_s3_reader_normalizes_endpoint_override(
     _clear_s3_environment(monkeypatch)
     monkeypatch.setenv("AWS_ENDPOINT_URL", endpoint_url)
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == expected_kwargs
 
@@ -191,7 +428,7 @@ def test_video_s3_reader_does_not_enable_anonymous_mode_when_explicitly_disabled
     _clear_s3_environment(monkeypatch)
     monkeypatch.setenv("S3FS_ANON", "false")
 
-    _read_s3_bytes("s3://media-bucket/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {}
 
@@ -202,7 +439,7 @@ def test_video_s3_reader_uses_anonymous_mode_only_when_explicit(monkeypatch, rec
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ignored-access-key")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ignored-secret-key")
 
-    _read_s3_bytes("s3://public-media/example.mp4")
+    _s3_filesystem()
 
     assert recording_s3_filesystem["kwargs"] == {"anonymous": True}
 
@@ -240,10 +477,104 @@ def test_video_frame_source_manifest_groups_paths_like_ray_read_tasks():
     assert [len(group) for group in _split_video_path_groups(source.paths, 4)] == [3, 3, 3, 2]
     assert sql.count("list_value(") == 4
     assert "video_paths::VARCHAR[]" in sql
+    assert "max_remote_video_bytes::BIGINT" in sql
+    assert "max_source_frame_bytes::BIGINT" in sql
+    assert "max_source_path_bytes::BIGINT" in sql
+    assert "on_error::VARCHAR" in sql
+
+
+@pytest.mark.parametrize("on_error", ["", "ignore", "warn"])
+def test_video_frame_source_rejects_unknown_error_mode(on_error):
+    with pytest.raises(ValueError, match="on_error must be one of: raise, skip"):
+        VideoFrameSource(["a.avi"], on_error=on_error)
+
+
+def test_video_frame_source_rejects_decoder_frame_above_cap():
+    with pytest.raises(
+        ValueError,
+        match="bounded decoder frame size 384 exceeds max_source_frame_bytes 383",
+    ):
+        VideoFrameSource(
+            ["a.avi"],
+            height=4,
+            width=4,
+            max_source_frame_bytes=383,
+        )
 
 
 def test_video_source_uses_ray_soft_block_row_boundary():
-    assert _video_source_udf_output_batch_size(640, 640, 128 * 1024**2) == 110
+    assert _video_source_udf_output_batch_size(640, 640, 128 * 1024**2) == 109
+
+
+def test_video_source_batch_size_accounts_for_provenance_columns():
+    import duckdb.datasource.video_reader as video_reader
+
+    target_bytes = 1024
+    max_source_path_bytes = 100
+    batch_size = _video_source_udf_output_batch_size(
+        1,
+        1,
+        target_bytes,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+
+    assert batch_size == 6
+    assert (
+        video_reader._video_output_batch_bytes(
+            batch_size - 1,
+            height=1,
+            width=1,
+            max_source_path_bytes=max_source_path_bytes,
+        )
+        <= target_bytes
+    )
+    assert (
+        video_reader._video_output_batch_bytes(
+            batch_size,
+            height=1,
+            width=1,
+            max_source_path_bytes=max_source_path_bytes,
+        )
+        > target_bytes
+    )
+    below_target = _flush_frame_batch(
+        "s" * video_reader._SOURCE_ID_BYTES,
+        "p" * max_source_path_bytes,
+        np.zeros((batch_size - 1, 1, 1, 3), dtype=np.uint8),
+        np.arange(batch_size - 1, dtype=np.int64),
+        batch_size - 1,
+    )
+    crossing_target = _flush_frame_batch(
+        "s" * video_reader._SOURCE_ID_BYTES,
+        "p" * max_source_path_bytes,
+        np.zeros((batch_size, 1, 1, 3), dtype=np.uint8),
+        np.arange(batch_size, dtype=np.int64),
+        batch_size,
+    )
+    assert below_target.nbytes <= target_bytes
+    assert crossing_target.nbytes > target_bytes
+
+
+def test_video_source_batch_size_respects_arrow_string_offset_limit():
+    import duckdb.datasource.video_reader as video_reader
+
+    max_source_path_bytes = 1024
+    expected_limit = video_reader._ARROW_STRING_DATA_MAX_BYTES // max_source_path_bytes
+
+    assert (
+        _video_source_udf_output_batch_size(
+            1,
+            1,
+            10**15,
+            max_source_path_bytes=max_source_path_bytes,
+        )
+        == expected_limit
+    )
+    with pytest.raises(ValueError, match="exceeding Arrow's .* UTF-8 offset limit"):
+        video_reader._constant_string_array(
+            "x" * max_source_path_bytes,
+            expected_limit + 1,
+        )
 
 
 def test_video_source_transport_does_not_resplit_ray_soft_block(monkeypatch):
@@ -257,7 +588,7 @@ def test_video_source_transport_does_not_resplit_ray_soft_block(monkeypatch):
         max_partition_bytes=target_bytes,
     )
 
-    assert kwargs["output_batch_size"] == 110
+    assert kwargs["output_batch_size"] == 109
     assert kwargs["output_target_max_bytes"] == 2 * target_bytes
     assert kwargs["preserve_compute_batch_boundaries"] is True
 
@@ -289,23 +620,283 @@ def test_video_decode_batches_do_not_mutate_emitted_arrow_buffers(monkeypatch):
             self._value = value
 
         def asnumpy(self):
-            return np.full((2, 2, 3), self._value, dtype=np.uint8)
+            return np.full((2, 32, 3), self._value, dtype=np.uint8)
 
-    monkeypatch.setattr(video_reader, "_open_decord_reader", lambda _path: [FakeFrame(i) for i in range(5)])
+    monkeypatch.setattr(
+        video_reader,
+        "_open_decord_reader",
+        lambda _path, **_kwargs: [FakeFrame(i) for i in range(5)],
+    )
     monkeypatch.setattr(video_reader, "_VIDEO_RESIZE_THREADS", 1)
+    source_path, _ = video_reader._video_source_identity("clip.avi")
+    max_partition_bytes = video_reader._video_output_batch_bytes(
+        1,
+        height=2,
+        width=2,
+        max_source_path_bytes=len(source_path.encode("utf-8")),
+    )
 
     batches = list(
         _decode_video_batches(
             "clip.avi",
             height=2,
             width=2,
-            # One 12-byte frame reaches the soft target, so each batch has 2 rows.
-            max_partition_bytes=12,
+            # One complete output row reaches the soft target, so the crossing
+            # row makes each full batch contain two rows.
+            max_partition_bytes=max_partition_bytes,
         )
     )
 
     values = [batch.column("frame").to_numpy_ndarray()[:, 0, 0, 0].tolist() for batch in batches]
     assert values == [[0, 1], [2, 3], [4]]
+    expected_path, expected_source_id = video_reader._video_source_identity("clip.avi")
+    assert batches[0].column("video_path").to_pylist() == [expected_path, expected_path]
+    assert batches[0].column("source_id").to_pylist() == [expected_source_id, expected_source_id]
+
+
+def test_video_decoder_uses_one_thread_for_bounded_native_buffering(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    calls = []
+
+    class FakeVideoReader:
+        def __init__(self, path, *, width, height, num_threads):
+            calls.append((path, width, height, num_threads))
+
+    class FakeDecordModule:
+        VideoReader = FakeVideoReader
+
+    monkeypatch.setattr(video_reader, "_import_video_dependency", lambda *_args: FakeDecordModule)
+
+    reader = video_reader._open_decord_reader("clip.avi", width=320, height=180)
+
+    assert isinstance(reader, FakeVideoReader)
+    assert calls == [("clip.avi", 320, 180, 1)]
+
+
+def test_video_decode_aligns_narrow_decord_output_before_exact_resize(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        shape = (2, 32, 3)
+
+        def asnumpy(self):
+            return np.zeros(self.shape, dtype=np.uint8)
+
+    calls = []
+
+    def fake_open_decoder(path, **kwargs):
+        calls.append((path, kwargs))
+        return [FakeFrame()]
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+
+    batches = list(
+        _decode_video_batches(
+            "clip.avi",
+            height=2,
+            width=2,
+            max_partition_bytes=1024,
+            max_source_frame_bytes=2 * 32 * 3,
+        )
+    )
+
+    source_path, _ = video_reader._video_source_identity("clip.avi")
+    assert calls == [(source_path, {"width": 32, "height": 2})]
+    assert batches[0].column("frame").type.shape == [2, 2, 3]
+
+
+def test_video_decode_does_not_advance_reader_past_frame_limit(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        shape = (2, 32, 3)
+
+        def asnumpy(self):
+            return np.zeros(self.shape, dtype=np.uint8)
+
+    class BoundaryReader:
+        def __init__(self):
+            self.next_calls = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.next_calls += 1
+            if self.next_calls == 1:
+                return FakeFrame()
+            pytest.fail("decoder advanced beyond max_frames")
+
+    reader = BoundaryReader()
+    monkeypatch.setattr(video_reader, "_open_decord_reader", lambda _path, **_kwargs: reader)
+
+    batches = list(
+        video_reader._decode_video_batches(
+            "clip.avi",
+            height=2,
+            width=2,
+            max_partition_bytes=1024,
+            max_frames=1,
+        )
+    )
+
+    assert sum(batch.num_rows for batch in batches) == 1
+    assert reader.next_calls == 1
+
+
+def test_remote_video_decode_uses_temporary_path_and_preserves_remote_identity(
+    monkeypatch,
+    recording_s3_filesystem,
+    tmp_path,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        def asnumpy(self):
+            return np.zeros((2, 32, 3), dtype=np.uint8)
+
+    decoder_paths = []
+
+    def fake_open_decoder(path, **kwargs):
+        assert kwargs == {"width": 32, "height": 2}
+        decoder_path = Path(path)
+        assert decoder_path.is_file()
+        decoder_paths.append(decoder_path)
+        return [FakeFrame()]
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+
+    batches = list(
+        _decode_video_batches(
+            "s3://media-bucket/clips/example.mp4",
+            height=2,
+            width=2,
+            max_partition_bytes=1024,
+            max_remote_video_bytes=1024,
+            remote_temp_dir=str(tmp_path),
+        )
+    )
+
+    source_path, source_id = video_reader._video_source_identity("s3://media-bucket/clips/example.mp4")
+    assert len(decoder_paths) == 1
+    assert not decoder_paths[0].exists()
+    assert batches[0].column("video_path").to_pylist() == [source_path]
+    assert batches[0].column("source_id").to_pylist() == [source_id]
+    assert recording_s3_filesystem["path"] == "media-bucket/clips/example.mp4"
+
+
+def test_remote_video_decode_cleans_temporary_path_when_consumer_stops_early(
+    monkeypatch,
+    recording_s3_filesystem,
+    tmp_path,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        def asnumpy(self):
+            return np.zeros((2, 32, 3), dtype=np.uint8)
+
+    decoder_paths = []
+
+    def fake_open_decoder(path, **kwargs):
+        assert kwargs == {"width": 32, "height": 2}
+        decoder_paths.append(Path(path))
+        return [FakeFrame(), FakeFrame(), FakeFrame()]
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+    source_path, _ = video_reader._video_source_identity("s3://media-bucket/clips/example.mp4")
+    max_partition_bytes = video_reader._video_output_batch_bytes(
+        1,
+        height=2,
+        width=2,
+        max_source_path_bytes=len(source_path.encode("utf-8")),
+    )
+    batches = _decode_video_batches(
+        "s3://media-bucket/clips/example.mp4",
+        height=2,
+        width=2,
+        max_partition_bytes=max_partition_bytes,
+        max_remote_video_bytes=1024,
+        remote_temp_dir=str(tmp_path),
+    )
+
+    first = next(batches)
+    assert first.num_rows == 2
+    assert decoder_paths[0].is_file()
+
+    batches.close()
+
+    assert not decoder_paths[0].exists()
+
+
+def test_video_decode_keeps_raw_resize_window_bounded(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        def __init__(self, value):
+            self._value = value
+
+        def asnumpy(self):
+            return np.full((4, 32, 3), self._value, dtype=np.uint8)
+
+    resize_window_sizes = []
+
+    def fake_resize(frames, *, width, height, executor=None):
+        del executor
+        resize_window_sizes.append(len(frames))
+        return [np.full((height, width, 3), frame[0, 0, 0], dtype=np.uint8) for frame in frames]
+
+    monkeypatch.setattr(
+        video_reader,
+        "_open_decord_reader",
+        lambda _path, **_kwargs: [FakeFrame(i) for i in range(10)],
+    )
+    monkeypatch.setattr(video_reader, "_resize_frame_batch", fake_resize)
+    monkeypatch.setattr(video_reader, "_VIDEO_RESIZE_THREADS", 3)
+    source_path, _ = video_reader._video_source_identity("clip.avi")
+    max_partition_bytes = video_reader._video_output_batch_bytes(
+        8,
+        height=2,
+        width=2,
+        max_source_path_bytes=len(source_path.encode("utf-8")),
+    )
+
+    batches = list(
+        _decode_video_batches(
+            "clip.avi",
+            height=2,
+            width=2,
+            max_partition_bytes=max_partition_bytes,
+        )
+    )
+
+    assert [batch.num_rows for batch in batches] == [9, 1]
+    assert resize_window_sizes
+    assert max(resize_window_sizes) <= 3
+
+
+def test_video_decode_rejects_frame_bound_before_opening_decoder(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    def fail_open(*_args, **_kwargs):
+        pytest.fail("decoder must not open when its requested frame exceeds the cap")
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fail_open)
+
+    with pytest.raises(
+        video_reader.SourceFrameTooLargeError,
+        match="bounded decoder frame size 384 exceeds limit 383",
+    ):
+        list(
+            _decode_video_batches(
+                "clip.avi",
+                height=4,
+                width=4,
+                max_partition_bytes=1024,
+                max_source_frame_bytes=383,
+            )
+        )
 
 
 def test_datasource_schema_supports_fixed_shape_tensor_entries():
@@ -324,6 +915,7 @@ def test_video_frame_source_schema_declares_typed_frame_not_blob():
     source = VideoFrameSource(["a.avi"], height=4, width=5)
 
     assert source.schema == {
+        "source_id": "VARCHAR",
         "video_path": "VARCHAR",
         "frame_index": "BIGINT",
         "frame": {"kind": "tensor", "dtype": "UINT8", "shape": [4, 5, 3]},
@@ -419,11 +1011,85 @@ def test_video_source_udf_memory_is_stage_specific(monkeypatch):
     monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_BACKEND", "ray_task")
     monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_MEMORY_BYTES", "268435456")
     monkeypatch.setenv("VANE_UDF_TASK_HEAP_BYTES", "1073741824")
+    monkeypatch.delenv("VANE_VIDEO_SOURCE_UDF_OUTPUT_BATCH_SIZE", raising=False)
 
-    assert video_reader._video_source_udf_kwargs()["memory_bytes"] == 268435456
+    expected_peak = video_reader._video_source_peak_memory_bytes(
+        height=640,
+        width=480,
+        max_partition_bytes=10 * 1024**2,
+        max_source_frame_bytes=128 * 1024**2,
+    )
+    assert video_reader._video_source_udf_kwargs()["memory_bytes"] == expected_peak
 
     monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_BACKEND", "subprocess_task")
     assert "memory_bytes" not in video_reader._video_source_udf_kwargs()
+
+
+def test_video_source_udf_memory_covers_large_output_partition(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_BACKEND", "ray_task")
+    monkeypatch.delenv("VANE_VIDEO_SOURCE_UDF_MEMORY_BYTES", raising=False)
+    monkeypatch.delenv("VANE_VIDEO_SOURCE_UDF_OUTPUT_BATCH_SIZE", raising=False)
+    max_partition_bytes = 128 * 1024**2
+    expected_peak = video_reader._video_source_peak_memory_bytes(
+        height=640,
+        width=640,
+        max_partition_bytes=max_partition_bytes,
+        max_source_frame_bytes=128 * 1024**2,
+    )
+
+    kwargs = video_reader._video_source_udf_kwargs(
+        height=640,
+        width=640,
+        max_partition_bytes=max_partition_bytes,
+    )
+
+    assert expected_peak > 512 * 1024**2
+    assert kwargs["memory_bytes"] == expected_peak
+
+
+def test_video_source_peak_memory_accounts_for_provenance_and_decord_copy_overlap(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    monkeypatch.setattr(video_reader, "_VIDEO_RESIZE_THREADS", 2)
+    height = 2
+    width = 3
+    frame_bytes = height * width * 3
+    max_partition_bytes = 500
+    max_source_frame_bytes = 1000
+    max_source_path_bytes = 10
+    decode_batch_size = video_reader._video_source_udf_output_batch_size(
+        height,
+        width,
+        max_partition_bytes,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+    transport_batch_size = 7
+
+    peak_bytes = video_reader._video_source_peak_memory_bytes(
+        height=height,
+        width=width,
+        max_partition_bytes=max_partition_bytes,
+        max_source_frame_bytes=max_source_frame_bytes,
+        max_source_path_bytes=max_source_path_bytes,
+        output_batch_size=transport_batch_size,
+    )
+    output_bytes = video_reader._video_output_batch_bytes(
+        transport_batch_size,
+        height=height,
+        width=width,
+        max_source_path_bytes=max_source_path_bytes,
+    )
+
+    assert decode_batch_size == 5
+    assert peak_bytes == (
+        video_reader._REMOTE_VIDEO_READ_CHUNK_BYTES
+        + video_reader._VIDEO_DECODER_MEMORY_HEADROOM_BYTES
+        + 2 * output_bytes
+        + 2 * (max_source_frame_bytes + frame_bytes)
+        + max_source_frame_bytes
+    )
 
 
 def test_video_source_udf_memory_must_be_positive(monkeypatch):
@@ -442,7 +1108,7 @@ def test_video_frame_source_map_batches_reads_manifest(monkeypatch):
     calls = []
     frames = np.arange(2 * 8 * 9 * 3, dtype=np.uint8).reshape(2, 8, 9, 3)
 
-    def fake_decode(video_path, *, height, width, max_partition_bytes, max_frames=None):
+    def fake_decode(video_path, *, height, width, max_partition_bytes, max_frames=None, **_kwargs):
         calls.append((video_path, height, width, max_partition_bytes, max_frames))
         yield pa.record_batch(
             {
@@ -461,6 +1127,14 @@ def test_video_frame_source_map_batches_reads_manifest(monkeypatch):
             "width": [9, 9],
             "max_partition_bytes": [1024, 1024],
             "frame_limit": pa.array([None, None], type=pa.int64()),
+            "max_remote_video_bytes": [4096, 4096],
+            "max_source_frame_bytes": [2048, 2048],
+            "max_source_path_bytes": [
+                video_reader._video_source_path_bytes("a.avi"),
+                video_reader._video_source_path_bytes("b.avi"),
+            ],
+            "on_error": ["raise", "raise"],
+            "remote_temp_dir": pa.array([None, None], type=pa.string()),
         }
     )
 
@@ -483,7 +1157,7 @@ def test_video_frame_source_map_batches_honors_global_frame_limit(monkeypatch):
 
     calls = []
 
-    def fake_decode(video_path, *, height, width, max_partition_bytes, max_frames=None):
+    def fake_decode(video_path, *, height, width, max_partition_bytes, max_frames=None, **_kwargs):
         calls.append((video_path, max_frames))
         row_count = min(2, max_frames if max_frames is not None else 2)
         if row_count > 0:
@@ -505,6 +1179,16 @@ def test_video_frame_source_map_batches_honors_global_frame_limit(monkeypatch):
             "width": [9],
             "max_partition_bytes": [1024],
             "frame_limit": pa.array([3], type=pa.int64()),
+            "max_remote_video_bytes": [4096],
+            "max_source_frame_bytes": [2048],
+            "max_source_path_bytes": [
+                max(
+                    video_reader._video_source_path_bytes("a.avi"),
+                    video_reader._video_source_path_bytes("b.avi"),
+                )
+            ],
+            "on_error": ["raise"],
+            "remote_temp_dir": pa.array([None], type=pa.string()),
         }
     )
 
@@ -512,6 +1196,108 @@ def test_video_frame_source_map_batches_honors_global_frame_limit(monkeypatch):
 
     assert calls == [("a.avi", 3), ("b.avi", 1)]
     assert sum(table.num_rows for table in tables) == 3
+
+
+def test_video_frame_source_map_batches_skips_bad_file_and_continues(
+    monkeypatch,
+    caplog,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    frames = np.zeros((2, 2, 2, 3), dtype=np.uint8)
+
+    class FakeDecordError(Exception):
+        pass
+
+    class FakeDecordLimitReachedError(Exception):
+        pass
+
+    class FakeDecordBase:
+        DECORDError = FakeDecordError
+        DECORDLimitReachedError = FakeDecordLimitReachedError
+
+    real_import_module = video_reader.importlib.import_module
+
+    def fake_import_module(module_name, *args, **kwargs):
+        if module_name == "decord._ffi.base":
+            return FakeDecordBase
+        return real_import_module(module_name, *args, **kwargs)
+
+    def fake_decode(video_path, **_kwargs):
+        source_path, source_id = video_reader._video_source_identity(video_path)
+        row_count = 1 if video_path == "bad.avi" else 2
+        yield pa.record_batch(
+            {
+                "source_id": [source_id] * row_count,
+                "video_path": [source_path] * row_count,
+                "frame_index": list(range(row_count)),
+                "frame": pa.FixedShapeTensorArray.from_numpy_ndarray(frames[:row_count]),
+            }
+        )
+        if video_path == "bad.avi":
+            raise FakeDecordError("corrupt video")
+
+    monkeypatch.setattr(video_reader.importlib, "import_module", fake_import_module)
+    assert video_reader._is_decord_error(FakeDecordError("corrupt"))
+    assert video_reader._is_decord_error(FakeDecordLimitReachedError("recovery limit"))
+    monkeypatch.setattr(video_reader, "_wait_for_memory", lambda: None)
+    monkeypatch.setattr(video_reader, "_decode_video_batches", fake_decode)
+    manifest = pa.table(
+        {
+            "video_paths": pa.array([["bad.avi", "good.avi"]], type=pa.list_(pa.string())),
+            "height": [2],
+            "width": [2],
+            "max_partition_bytes": [1024],
+            "frame_limit": pa.array([None], type=pa.int64()),
+            "max_remote_video_bytes": [4096],
+            "max_source_frame_bytes": [2048],
+            "max_source_path_bytes": [
+                max(
+                    video_reader._video_source_path_bytes("bad.avi"),
+                    video_reader._video_source_path_bytes("good.avi"),
+                )
+            ],
+            "on_error": ["skip"],
+            "remote_temp_dir": pa.array([None], type=pa.string()),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger=video_reader.__name__):
+        tables = list(_video_frame_source_map_batches(manifest))
+
+    bad_path, _ = video_reader._video_source_identity("bad.avi")
+    good_path, _ = video_reader._video_source_identity("good.avi")
+    assert [table.column("video_path").to_pylist() for table in tables] == [[bad_path, good_path, good_path]]
+    assert f"Skipping unreadable video source={bad_path!r}" in caplog.text
+
+
+def test_video_read_error_mode_raise_wraps_file_failure(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    def fake_decode(_video_path, **_kwargs):
+        raise OSError("corrupt video")
+        yield
+
+    monkeypatch.setattr(video_reader, "_decode_video_batches", fake_decode)
+
+    with pytest.raises(video_reader.VideoReadError, match="corrupt video") as raised:
+        list(
+            video_reader._decode_video_with_policy(
+                "bad.avi",
+                height=2,
+                width=2,
+                max_partition_bytes=1024,
+                max_frames=None,
+                max_remote_video_bytes=4096,
+                max_source_frame_bytes=2048,
+                remote_temp_dir=None,
+                on_error="raise",
+            )
+        )
+
+    assert isinstance(raised.value.__cause__, OSError)
+    expected_path, _ = video_reader._video_source_identity("bad.avi")
+    assert raised.value.video_path == expected_path
 
 
 def test_resize_frame_batch_preserves_order_and_uses_configured_threads(monkeypatch):
@@ -533,10 +1319,30 @@ def test_resize_frame_batch_preserves_order_and_uses_configured_threads(monkeypa
 def test_flush_frame_batch_uses_fixed_shape_tensor_for_frames():
     resized = np.arange(2 * 2 * 3 * 3, dtype=np.uint8).reshape(2, 2, 3, 3)
 
-    batch = _flush_frame_batch("clip.avi", resized, [5, 6], 2)
+    batch = _flush_frame_batch("source-1", "clips/clip.avi", resized, [5, 6], 2)
     frame = batch.column("frame")
 
-    assert batch.column("video_path").to_pylist() == ["clip.avi", "clip.avi"]
+    assert batch.column("source_id").to_pylist() == ["source-1", "source-1"]
+    assert batch.column("video_path").to_pylist() == ["clips/clip.avi", "clips/clip.avi"]
     assert batch.column("frame_index").to_pylist() == [5, 6]
     assert frame.type == pa.fixed_shape_tensor(pa.uint8(), (2, 3, 3))
     np.testing.assert_array_equal(frame.to_numpy_ndarray(), resized)
+
+
+def test_flush_frame_batch_compacts_partial_output_buffer():
+    import gc
+    import weakref
+
+    resized = np.zeros((100, 2, 3, 3), dtype=np.uint8)
+    full_buffer_ref = weakref.ref(resized)
+    indices = np.arange(100, dtype=np.int64)
+    full_indices_ref = weakref.ref(indices)
+
+    batch = _flush_frame_batch("source-1", "clips/clip.avi", resized, indices, 1)
+    del resized
+    del indices
+    gc.collect()
+
+    assert batch.num_rows == 1
+    assert full_buffer_ref() is None
+    assert full_indices_ref() is None


### PR DESCRIPTION
Closes #97

## Summary

- Stream S3 objects to task-local seekable temporary files in fixed 8 MiB chunks, enforce a per-file compressed-object cap before and during transfer, and clean up on success, failure, or early iterator close.
- Replace basename identity with a canonical source path plus full SHA-256 `source_id`; local paths use `realpath`, while S3 object-key semantics are preserved.
- Bound decoder output at Decord construction time, use one decoder thread, enforce an aligned RGB frame cap before source materialization/open, keep resize concurrency bounded, and compact partial buffers.
- Size output batches, transport guards, and Ray memory reservations from the complete Arrow row footprint: frame, `source_id`, canonical path, both string-offset buffers, and `frame_index`, including Arrow 32-bit string-data limits.
- Add per-file `on_error="raise" | "skip"` behavior. Skip mode retains already emitted frames, drops the rest of the bad file, and continues with unrelated inputs.
- Carry all limits and policies through source objects, SQL manifests, map workers, and legacy task execution.

There is intentionally no full-object `BytesIO` path, basename-identity fallback, or compatibility branch.

## Public behavior

`VideoFrameSource` output now includes:

- `source_id`: SHA-256 of the canonical source path
- `video_path`: canonical source path
- `frame_index`
- `frame`

New controls are `max_remote_video_bytes` (default 8 GiB), `max_source_frame_bytes` (default 128 MiB), `on_error` (default `raise`), and `remote_temp_dir`.

## Validation

Final HEAD `5e46e2da`, rebased onto upstream `main` at `3097c97b`:

- focused video/optional-dependency tests: 63 passed, 1 dependency skip
- release suite: 414 passed, 1 artifact-only skip; real-Ray shard 7 passed
- full non-Ray fast shard: 5749 passed; one known unrelated GC-timing flaky tracked by #217 and then 10/10 passed in independent pytest processes
- shared-cluster Ray shard: 86 passed, 10 dependency/GPU skips
- test-owned Ray clusters: 6 passed, 1 dependency skip
- real Decord 0.6 smoke: 1x1, 3x2, 17x1, 33x7, 48x48, and 320x180 outputs passed
- formatting, pre-commit checks, mypy, `git diff --check`, boundary/property checks, and early-generator-close cleanup checks passed

The implementation was reviewed to a clean pass twice after the fixes; all three inline review findings are addressed and resolved.