### PR TITLE
[fix](ray) Propagate FTE worker reservation callback failures

### DIFF
--- a/duckdb/runners/ray/fragment_worker_placement.py
+++ b/duckdb/runners/ray/fragment_worker_placement.py
@@ -44,6 +44,7 @@ class FteWorkerPlacementMixin:
         # Supplied by the other mixins on the composed Ray worker handle.
         _bind_fte_scheduler_handlers: Any
         _fte_worker_placement_manager: Any
+        _handles_for_worker_reservation_completed_event: Any
         worker_id: Any
 
     def _select_fte_worker(
@@ -95,6 +96,26 @@ class FteWorkerPlacementMixin:
                 future.reservation_generation,
                 worker_id,
                 error=error,
+            )
+        )
+
+    def _handle_fte_worker_reservation_callback_error(
+        self,
+        future: FteWorkerReservationFuture,
+        error: BaseException,
+    ) -> None:
+        callback_failure = RuntimeError(f"FTE worker reservation completion callback failed: {error}")
+        callback_failure.__cause__ = error
+        # Dispatch itself may be what failed, so enter the generation-fenced
+        # completion handler directly instead of trying to enqueue another event.
+        self._handles_for_worker_reservation_completed_event(
+            WorkerReservationCompleted(
+                future.query_id,
+                future.fragment_execution_id,
+                future.fragment_id,
+                future.partition_id,
+                future.reservation_generation,
+                error=callback_failure,
             )
         )
 
@@ -250,6 +271,7 @@ class FteWorkerPlacementMixin:
                     node_requirements=placement.node_requirements,
                     node_requirements_wait_started_at=placement.node_requirements_wait_started_at,
                     on_done=self._enqueue_fte_worker_reservation_completion,
+                    on_done_error=self._handle_fte_worker_reservation_callback_error,
                 )
             except BaseException:
                 release_fte_partition_submission(*key)

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -8,7 +8,7 @@ import hashlib
 import math
 import threading
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from duckdb.runners.fte import (
@@ -43,8 +43,6 @@ from duckdb.runners.ray.fte_scheduler_config import (
 from duckdb.runners.ray.ray_env import collect_vane_env_overrides
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from duckdb.runners.fte import FteFragmentExecution, NodeRequirements
     from duckdb.runners.ray.fragment_worker_client import RayWorkerActorHandle
 
@@ -1765,6 +1763,17 @@ class FteWorkerReservation:
         self.attempt_id = str(attempt_id)
 
 
+_FteWorkerReservationDoneCallback = Callable[["FteWorkerReservationFuture"], None]
+_FteWorkerReservationCallbackErrorHandler = Callable[
+    ["FteWorkerReservationFuture", BaseException],
+    None,
+]
+_FteWorkerReservationCallback = tuple[
+    _FteWorkerReservationDoneCallback,
+    _FteWorkerReservationCallbackErrorHandler | None,
+]
+
+
 class FteWorkerReservationFuture:
     def __init__(
         self,
@@ -1795,7 +1804,7 @@ class FteWorkerReservationFuture:
         self._cancelled = False
         self._result: FteWorkerReservation | None = None
         self._exception: BaseException | None = None
-        self._callbacks: list[Callable[[FteWorkerReservationFuture], None]] = []
+        self._callbacks: list[_FteWorkerReservationCallback] = []
 
     def done(self) -> bool:
         with self._lock:
@@ -1825,15 +1834,21 @@ class FteWorkerReservationFuture:
         with self._lock:
             self.blocked_reason = str(blocked_reason or "")
 
-    def add_done_callback(self, callback: Callable[[FteWorkerReservationFuture], None]) -> None:
+    def add_done_callback(
+        self,
+        callback: _FteWorkerReservationDoneCallback,
+        *,
+        on_error: _FteWorkerReservationCallbackErrorHandler | None = None,
+    ) -> None:
+        registered_callback = (callback, on_error)
         run_now = False
         with self._lock:
             if self._done:
                 run_now = True
             else:
-                self._callbacks.append(callback)
+                self._callbacks.append(registered_callback)
         if run_now:
-            self._run_callback(callback)
+            self._run_callback(*registered_callback)
 
     def set_result(self, reservation: FteWorkerReservation) -> bool:
         callbacks = self._complete(result=reservation)
@@ -1856,7 +1871,7 @@ class FteWorkerReservationFuture:
         result: FteWorkerReservation | None = None,
         exception: BaseException | None = None,
         cancelled: bool = False,
-    ) -> list[Callable[[FteWorkerReservationFuture], None]]:
+    ) -> list[_FteWorkerReservationCallback]:
         with self._lock:
             if self._done:
                 return []
@@ -1868,15 +1883,24 @@ class FteWorkerReservationFuture:
             self._callbacks.clear()
         return callbacks
 
-    def _run_callbacks(self, callbacks: list[Callable[[FteWorkerReservationFuture], None]]) -> None:
-        for callback in callbacks:
-            self._run_callback(callback)
+    def _run_callbacks(
+        self,
+        callbacks: list[_FteWorkerReservationCallback],
+    ) -> None:
+        for callback, on_error in callbacks:
+            self._run_callback(callback, on_error)
 
-    def _run_callback(self, callback: Callable[[FteWorkerReservationFuture], None]) -> None:
+    def _run_callback(
+        self,
+        callback: _FteWorkerReservationDoneCallback,
+        on_error: _FteWorkerReservationCallbackErrorHandler | None,
+    ) -> None:
         try:
             callback(self)
-        except Exception:
-            pass
+        except Exception as exc:
+            if on_error is None:
+                raise
+            on_error(self, exc)
 
 
 def _fte_partition_owner(query_id: str, fragment_id: str, partition_id: int) -> Any | None:
@@ -1899,7 +1923,8 @@ class FteWorkerPlacementManager:
         execution_class: FteTaskExecutionClass | str | None = None,
         node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
         node_requirements_wait_started_at: float | None = None,
-        on_done: Callable[[FteWorkerReservationFuture], None] | None = None,
+        on_done: _FteWorkerReservationDoneCallback | None = None,
+        on_done_error: _FteWorkerReservationCallbackErrorHandler | None = None,
     ) -> tuple[FteWorkerReservationFuture, bool]:
         query_id = str(query_id)
         fragment_id = str(fragment_id)
@@ -1926,7 +1951,7 @@ class FteWorkerPlacementManager:
             )
             _FTE_PENDING_WORKER_RESERVATIONS[key] = future
         if on_done is not None:
-            future.add_done_callback(on_done)
+            future.add_done_callback(on_done, on_error=on_done_error)
         return future, True
 
     def acquire(

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -4363,6 +4363,108 @@ def test_fte_worker_reservation_completion_is_atomic_with_pending_drain(monkeypa
     assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0, 1]
 
 
+@pytest.mark.parametrize("failure_point", ["bind", "enqueue"])
+def test_fte_worker_reservation_callback_failure_fails_query_and_releases_resources(
+    monkeypatch,
+    failure_point,
+):
+    query_id = f"query-reservation-callback-{failure_point}"
+    actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    running = handle.pop_fte_result_handles(query_id)
+    assert len(running) == 1
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+    failure = RuntimeError(f"planned reservation callback {failure_point} failure")
+
+    if failure_point == "bind":
+
+        def fail_completion_bind(_scheduler):
+            raise failure
+
+        monkeypatch.setattr(handle, "_bind_fte_scheduler_handlers", fail_completion_bind)
+    else:
+        original_enqueue = scheduler.enqueue
+
+        def fail_completion_enqueue(event, *, priority=False):
+            if isinstance(event, WorkerReservationCompleted):
+                raise failure
+            return original_enqueue(event, priority=priority)
+
+        monkeypatch.setattr(scheduler, "enqueue", fail_completion_enqueue)
+
+    handle.record_fte_task_terminal(running[0].task_id)
+
+    fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, pending_key[1])]
+    stats = scheduler.stats()
+    assert pending_future.done() is True
+    assert pending_key not in worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS
+    assert pending_key not in worker_handle_mod._FTE_PARTITION_OWNERS
+    assert pending_key not in worker_handle_mod._FTE_PARTITION_TASK_LEASES
+    assert fragment_execution.partitions[pending_key[2]].running_attempt is None
+    assert stats.state == "FAILED"
+    assert stats.queued_events == 0
+    assert stats.failure_reason == (
+        f"FTE worker reservation failed: FTE worker reservation completion callback failed: {failure}"
+    )
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
+def test_fte_worker_reservation_callback_failure_ignores_replacement_generation(monkeypatch):
+    query_id = "query-reservation-callback-stale"
+    actor, handle, pending_key, old_future = _submit_strict_worker_reservation_pending_pair(
+        monkeypatch,
+        query_id,
+    )
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+
+    def fail_completion_bind(_scheduler):
+        callback_entered.set()
+        assert release_callback.wait(5.0)
+        raise RuntimeError("planned stale reservation callback failure")
+
+    monkeypatch.setattr(handle, "_bind_fte_scheduler_handlers", fail_completion_bind)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        completion = executor.submit(
+            old_future.set_result,
+            _completed_test_reservation(old_future, handle),
+        )
+        assert callback_entered.wait(5.0)
+        try:
+            with worker_handle_mod._FTE_REGISTRY_LOCK:
+                removed_future = worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS.pop(pending_key)
+                fragment_execution = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, pending_key[1])]
+            partition = fragment_execution.partitions[pending_key[2]]
+            new_future, created = handle._fte_worker_placement_manager.request_async(
+                query_id=query_id,
+                fragment_execution_id=fragment_execution.fragment_execution_id,
+                fragment_id=pending_key[1],
+                partition_id=pending_key[2],
+                memory_requirement_bytes=partition.memory_requirement_bytes,
+                execution_class=partition.execution_class,
+                node_requirements=partition.node_requirements,
+                node_requirements_wait_started_at=partition.node_wait_started_at,
+                on_done=handle._enqueue_fte_worker_reservation_completion,
+                on_done_error=handle._handle_fte_worker_reservation_callback_error,
+            )
+        finally:
+            release_callback.set()
+        assert completion.result(timeout=5.0) is True
+
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get(query_id)
+    assert scheduler is not None
+    assert removed_future is old_future
+    assert created is True
+    assert new_future.reservation_generation == old_future.reservation_generation + 1
+    assert worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS[pending_key] is new_future
+    assert scheduler.stats().state == "RUNNING"
+    assert scheduler.stats().queued_events == 0
+    assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
+
+
 def test_fte_failed_worker_reservation_blocks_concurrent_retry(monkeypatch):
     query_id = "query-reservation-failure-race"
     actor, handle, pending_key, pending_future = _submit_strict_worker_reservation_pending_pair(


### PR DESCRIPTION
## Summary

- Stop silently swallowing exceptions raised while dispatching completed FTE
  worker reservations.
- Route callback failures through generation-fenced reservation cleanup so the
  current pending reservation, worker ownership, and QRM task lease are
  released before the affected query is failed.
- Ignore failures from stale reservation generations so they cannot disrupt a
  replacement reservation.
- Add deterministic coverage for scheduler-handler binding failures, event
  enqueue failures, and stale-generation races.

## Related issue

close: #88

#222 completes the remaining #88 acceptance criteria after #171 and #215.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal Ray FTE failure handling without changing the public API.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files duckdb/runners/ray/fragment_worker_placement.py duckdb/runners/ray/fte_fragment_scheduler.py tests/fast/test_ray_fragment_submission.py`
- `python -m pytest -q tests/fast/test_ray_fte_event_scheduler.py tests/fast/test_ray_fte.py tests/fast/test_ray_fragment_submission.py`
  (`382 passed`)
- `scripts/run_release_tests.sh`
  (`392 passed, 1 skipped`; real-Ray shard: `7 passed`)
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

This is a Python-only change; no native rebuild was required.