### PR TITLE
[fix](udf) Scope subprocess cancellation and shutdown

### DIFF
--- a/duckdb/execution/_udf_runtime.py
+++ b/duckdb/execution/_udf_runtime.py
@@ -443,6 +443,7 @@ class UDFExecutor:
             raise ValueError("UDF payload is required")
         self._queue: deque[pa.Table] = deque()
         self._finished_submitting = False
+        self._closed = False
         self._call_mode = str(payload.get("call_mode") or "")
         if self._call_mode not in ("map_batches", "map_batches_rows", "flat_map", "map"):
             raise ValueError("UDF payload.call_mode must be one of: map_batches, map_batches_rows, flat_map, map")
@@ -874,6 +875,16 @@ class UDFExecutor:
         if self._is_map_batches:
             self._execute_map_batches_compute_batches(self._flush_map_batches_compute_batches())
         self._finished_submitting = True
+
+    def close(self) -> None:
+        """Flush buffered work and deterministically release the loaded callable."""
+        if self._closed:
+            return
+        try:
+            self.finished_submitting()
+        finally:
+            self._closed = True
+            self._map_fn = None
 
     def all_tasks_finished(self) -> bool:
         return self._finished_submitting and not self._queue

--- a/duckdb/execution/ref_bundle.py
+++ b/duckdb/execution/ref_bundle.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from itertools import count
 from multiprocessing import resource_tracker as _resource_tracker
 from multiprocessing import shared_memory
-from typing import Any
+from typing import Any, Protocol
 
 import pyarrow as pa
 
@@ -46,6 +46,10 @@ _local_shm_budget_reserved_bytes = 0
 _local_shm_budget_pending_output_bytes = 0
 _local_shm_refs_created = 0
 _local_shm_refs_released = 0
+
+
+class _CancellationFlag(Protocol):
+    def is_set(self) -> bool: ...
 
 
 @dataclass
@@ -320,11 +324,24 @@ class LocalShmBudgetManager:
             soft_limit = max(soft_limit, min(limit, requested))
             return usage + requested <= soft_limit
 
-    def acquire_allocation(self, size: int, *, name: str = "", block: bool = True) -> int:
+    def acquire_allocation(
+        self,
+        size: int,
+        *,
+        name: str = "",
+        block: bool = True,
+        cancel_event: _CancellationFlag | None = None,
+    ) -> int:
         requested = max(0, int(size))
         if requested <= 0:
             return 0
         with self._cond:
+
+            def _raise_if_cancelled_locked() -> None:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise RuntimeError(f"local_shm allocation cancelled: {name or '-'}")
+
+            _raise_if_cancelled_locked()
             limit = self._limit_locked()
             if limit <= 0:
                 return 0
@@ -339,9 +356,11 @@ class LocalShmBudgetManager:
                     limit_bytes=limit,
                 )
                 self._cond.wait()
+                _raise_if_cancelled_locked()
                 limit = self._limit_locked()
                 if limit <= 0:
                     return 0
+            _raise_if_cancelled_locked()
             if not block and self._usage_locked() > 0 and self._usage_locked() + requested > limit:
                 _shm_debug_log(
                     "budget_overcommit",
@@ -572,7 +591,7 @@ class LocalShmBudgetManager:
         size: int,
         *,
         name: str = "",
-        cancel_event: threading.Event | None = None,
+        cancel_event: _CancellationFlag | None = None,
     ) -> int:
         requested = max(0, int(size))
         if requested <= 0:
@@ -639,7 +658,7 @@ class LocalShmBudgetManager:
         name: str = "",
         priority: str = "producer",
         input_lease_id: int | None = None,
-        cancel_event: threading.Event | None = None,
+        cancel_event: _CancellationFlag | None = None,
     ) -> int:
         requested = max(0, int(size))
         if requested <= 0:
@@ -805,7 +824,7 @@ def request_local_shm_output_grant(
     name: str = "",
     priority: str = "producer",
     input_lease_id: int | None = None,
-    cancel_event: threading.Event | None = None,
+    cancel_event: _CancellationFlag | None = None,
 ) -> int:
     return _LOCAL_SHM_BUDGET_MANAGER.request_output_grant(
         size,
@@ -852,11 +871,22 @@ def can_admit_local_shm_ref_output_submit(size: int, *, projected_output_bytes: 
     )
 
 
-def _acquire_local_shm_ref_budget(size: int, *, name: str = "", block: bool = True) -> int:
+def _acquire_local_shm_ref_budget(
+    size: int,
+    *,
+    name: str = "",
+    block: bool = True,
+    cancel_event: _CancellationFlag | None = None,
+) -> int:
     requested = max(0, int(size))
     if requested <= 0:
         return 0
-    return _LOCAL_SHM_BUDGET_MANAGER.acquire_allocation(requested, name=name, block=block)
+    return _LOCAL_SHM_BUDGET_MANAGER.acquire_allocation(
+        requested,
+        name=name,
+        block=block,
+        cancel_event=cancel_event,
+    )
 
 
 def wake_local_shm_ref_budget_waiters() -> None:
@@ -867,7 +897,7 @@ def claim_local_shm_ref_output_budget(
     size: int,
     *,
     name: str = "",
-    cancel_event: threading.Event | None = None,
+    cancel_event: _CancellationFlag | None = None,
 ) -> int:
     requested = max(0, int(size))
     if requested <= 0:
@@ -1059,6 +1089,7 @@ class LocalShmBlockRef:
         shm: shared_memory.SharedMemory | None = None,
         budget_bytes: int | None = None,
         track: bool = False,
+        cancel_event: _CancellationFlag | None = None,
     ) -> None:
         self.name = str(name)
         self.size = int(size)
@@ -1069,7 +1100,14 @@ class LocalShmBlockRef:
         if not self.owner:
             self._budget_bytes = 0
         elif budget_bytes is None:
-            self._budget_bytes = _acquire_local_shm_ref_budget(self.size, name=self.name)
+            if cancel_event is None:
+                self._budget_bytes = _acquire_local_shm_ref_budget(self.size, name=self.name)
+            else:
+                self._budget_bytes = _acquire_local_shm_ref_budget(
+                    self.size,
+                    name=self.name,
+                    cancel_event=cancel_event,
+                )
         else:
             self._budget_bytes = max(0, int(budget_bytes))
         self._finalizer = weakref.finalize(
@@ -1170,11 +1208,22 @@ def _cleanup_local_shm_ref(
         raise cleanup_error
 
 
-def make_local_shm_ref_bundle_result(table: pa.Table):
+def make_local_shm_ref_bundle_result(
+    table: pa.Table,
+    *,
+    cancel_event: _CancellationFlag | None = None,
+):
     table = _ensure_table(table)
     ipc_bytes = _arrow_table_to_ipc_bytes(table)
     required = _IPC_HEADER_SIZE + len(ipc_bytes)
-    budget_bytes = _acquire_local_shm_ref_budget(required, name="local-shm-result")
+    if cancel_event is None:
+        budget_bytes = _acquire_local_shm_ref_budget(required, name="local-shm-result")
+    else:
+        budget_bytes = _acquire_local_shm_ref_budget(
+            required,
+            name="local-shm-result",
+            cancel_event=cancel_event,
+        )
     shm = None
     try:
         shm = _create_shm(required, track=False)
@@ -1302,6 +1351,7 @@ def make_local_shm_ref_bundle_result_from_descriptor(
     descriptor: dict[str, Any],
     *,
     block_on_budget: bool = True,
+    cancel_event: _CancellationFlag | None = None,
 ):
     refs_in = list(descriptor.get("block_refs") or [])
     metadata_in = list(descriptor.get("metadata") or [{} for _ in refs_in])
@@ -1338,12 +1388,18 @@ def make_local_shm_ref_bundle_result_from_descriptor(
                             size - budget_bytes,
                             name=name,
                             block=block_on_budget,
+                            cancel_event=cancel_event,
                         )
                     except Exception:
                         _release_local_shm_ref_budget(budget_bytes, name=name)
                         raise
             else:
-                budget_bytes = _acquire_local_shm_ref_budget(size, name=name, block=block_on_budget)
+                budget_bytes = _acquire_local_shm_ref_budget(
+                    size,
+                    name=name,
+                    block=block_on_budget,
+                    cancel_event=cancel_event,
+                )
             shm = None
             try:
                 shm = _open_existing_shm(name, track=False)

--- a/duckdb/execution/ref_bundle.py
+++ b/duckdb/execution/ref_bundle.py
@@ -10,6 +10,7 @@ import os
 import sys
 import threading
 import weakref
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from itertools import count
 from multiprocessing import resource_tracker as _resource_tracker
@@ -41,7 +42,7 @@ _shm_debug_lock = threading.Lock()
 _shm_debug_seq = 0
 _local_shm_budget_cond = threading.Condition()
 _local_shm_budget_wakeup_lock = threading.Lock()
-_local_shm_budget_wakeup_callbacks: set[Any] = set()
+_local_shm_budget_wakeup_callbacks: set[Callable[[], None]] = set()
 _local_shm_budget_reserved_bytes = 0
 _local_shm_budget_pending_output_bytes = 0
 _local_shm_refs_created = 0
@@ -179,7 +180,7 @@ def _local_shm_ref_budget_limit_bytes() -> int:
         raise ValueError(f"VANE_LOCAL_SHM_REF_BUDGET_BYTES is not a valid byte size: {raw!r}") from exc
 
 
-def _make_local_shm_ref_budget_limit_factory():
+def _make_local_shm_ref_budget_limit_factory() -> Callable[[], int]:
     auto_limit_bytes: int | None = None
     auto_limit_lock = threading.Lock()
 
@@ -225,7 +226,7 @@ def _notify_local_shm_budget_wakeup_callbacks() -> None:
     raise RuntimeError(f"local_shm budget wakeup callbacks failed: {message}") from errors[0]
 
 
-def register_local_shm_ref_budget_wakeup(callback: Any):
+def register_local_shm_ref_budget_wakeup(callback: Callable[[], None]) -> Callable[[], None]:
     with _local_shm_budget_wakeup_lock:
         _local_shm_budget_wakeup_callbacks.add(callback)
 
@@ -237,7 +238,7 @@ def register_local_shm_ref_budget_wakeup(callback: Any):
 
 
 class LocalShmBudgetManager:
-    def __init__(self, *, limit_factory: Any | None = None) -> None:
+    def __init__(self, *, limit_factory: Callable[[], int] | None = None) -> None:
         self._cond = threading.Condition()
         self._limit_factory = limit_factory or _make_local_shm_ref_budget_limit_factory()
         self._allocated_bytes = 0
@@ -931,37 +932,47 @@ def _arrow_table_from_ipc_bytes(data: bytes) -> pa.Table:
     return reader.read_all()
 
 
+def _require_shm_buffer(shm: shared_memory.SharedMemory) -> memoryview[int]:
+    buffer = shm.buf
+    if buffer is None:
+        raise RuntimeError(f"shared memory segment {shm.name!r} is closed")
+    return buffer
+
+
 def _write_ipc_to_shm(shm: shared_memory.SharedMemory, ipc_bytes: bytes) -> int:
+    buffer = _require_shm_buffer(shm)
     required = _IPC_HEADER_SIZE + len(ipc_bytes)
-    if required > len(shm.buf):
+    if required > len(buffer):
         raise BufferError("shared memory segment is too small for Arrow IPC payload")
-    shm.buf[:_IPC_HEADER_SIZE] = len(ipc_bytes).to_bytes(_IPC_HEADER_SIZE, "little")
-    shm.buf[_IPC_HEADER_SIZE:required] = ipc_bytes
+    buffer[:_IPC_HEADER_SIZE] = len(ipc_bytes).to_bytes(_IPC_HEADER_SIZE, "little")
+    buffer[_IPC_HEADER_SIZE:required] = ipc_bytes
     return required
 
 
 def _read_ipc_from_shm(shm: shared_memory.SharedMemory, size: int | None = None) -> bytes:
-    if len(shm.buf) < _IPC_HEADER_SIZE:
+    buffer = _require_shm_buffer(shm)
+    if len(buffer) < _IPC_HEADER_SIZE:
         raise BufferError("shared memory segment is too small for Arrow IPC header")
-    ipc_size = int.from_bytes(shm.buf[:_IPC_HEADER_SIZE], "little")
+    ipc_size = int.from_bytes(buffer[:_IPC_HEADER_SIZE], "little")
     required = _IPC_HEADER_SIZE + ipc_size
-    if required > len(shm.buf):
+    if required > len(buffer):
         raise BufferError(
-            f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(shm.buf)}"
+            f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(buffer)}"
         )
     if size is not None and required > size:
         raise BufferError(f"shared memory IPC payload exceeds descriptor size: required={required} size={size}")
-    return bytes(shm.buf[_IPC_HEADER_SIZE:required])
+    return bytes(buffer[_IPC_HEADER_SIZE:required])
 
 
 def _ipc_payload_bounds(shm: shared_memory.SharedMemory, size: int | None = None) -> tuple[int, int]:
-    if len(shm.buf) < _IPC_HEADER_SIZE:
+    buffer = _require_shm_buffer(shm)
+    if len(buffer) < _IPC_HEADER_SIZE:
         raise BufferError("shared memory segment is too small for Arrow IPC header")
-    ipc_size = int.from_bytes(shm.buf[:_IPC_HEADER_SIZE], "little")
+    ipc_size = int.from_bytes(buffer[:_IPC_HEADER_SIZE], "little")
     required = _IPC_HEADER_SIZE + ipc_size
-    if required > len(shm.buf):
+    if required > len(buffer):
         raise BufferError(
-            f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(shm.buf)}"
+            f"shared memory IPC payload exceeds local mapping: required={required} capacity={len(buffer)}"
         )
     if size is not None and required > size:
         raise BufferError(f"shared memory IPC payload exceeds descriptor size: required={required} size={size}")
@@ -1024,7 +1035,7 @@ def _arrow_table_from_local_shm_zero_copy(name: str, size: int) -> pa.Table:
     owner: _LocalShmBufferOwner | None = None
     try:
         start, end = _ipc_payload_bounds(shm, size)
-        address = ctypes.addressof(ctypes.c_char.from_buffer(shm.buf, start))
+        address = ctypes.addressof(ctypes.c_char.from_buffer(_require_shm_buffer(shm), start))
         owner = _LocalShmBufferOwner(shm)
         buffer = pa.foreign_buffer(address, end - start, base=owner)
         table = pa.ipc.open_stream(pa.BufferReader(buffer)).read_all()
@@ -1051,11 +1062,19 @@ def _unlink_shared_memory_name(name: str) -> None:
         shm.close()
 
 
-def _untrack_shm(shm: shared_memory.SharedMemory) -> shared_memory.SharedMemory:
-    name = shm._name
-    if not name:
-        shm.close()
+def _posix_shm_name(shm: shared_memory.SharedMemory) -> str:
+    name = getattr(shm, "_name", None)
+    if not isinstance(name, str) or not name:
         raise RuntimeError("shared memory handle is missing its POSIX name")
+    return name
+
+
+def _untrack_shm(shm: shared_memory.SharedMemory) -> shared_memory.SharedMemory:
+    try:
+        name = _posix_shm_name(shm)
+    except Exception:
+        shm.close()
+        raise
     _resource_tracker.unregister(name, "shared_memory")
     return shm
 
@@ -1074,7 +1093,10 @@ def _unlink_shm(shm: shared_memory.SharedMemory, *, track: bool) -> None:
     if track:
         shm.unlink()
         return
-    shared_memory._posixshmem.shm_unlink(shm._name)
+    posix_shmem = getattr(shared_memory, "_posixshmem", None)
+    if posix_shmem is None:
+        raise RuntimeError("multiprocessing.shared_memory has no POSIX unlink implementation")
+    posix_shmem.shm_unlink(_posix_shm_name(shm))
 
 
 class LocalShmBlockRef:
@@ -1212,7 +1234,7 @@ def make_local_shm_ref_bundle_result(
     table: pa.Table,
     *,
     cancel_event: _CancellationFlag | None = None,
-):
+) -> tuple[str, list[LocalShmBlockRef], list[dict[str, Any]], list[str]]:
     table = _ensure_table(table)
     ipc_bytes = _arrow_table_to_ipc_bytes(table)
     required = _IPC_HEADER_SIZE + len(ipc_bytes)
@@ -1280,7 +1302,7 @@ def make_local_shm_ref_bundle_descriptor(table: pa.Table, *, grant_id: int | Non
             "ipc_size_bytes": int(required),
             "shm_name": shm.name,
         }
-        descriptor = {
+        descriptor: dict[str, Any] = {
             "block_refs": [
                 {
                     "provider": LOCAL_SHM_PROVIDER,
@@ -1352,7 +1374,7 @@ def make_local_shm_ref_bundle_result_from_descriptor(
     *,
     block_on_budget: bool = True,
     cancel_event: _CancellationFlag | None = None,
-):
+) -> tuple[str, list[LocalShmBlockRef], list[dict[str, Any]], list[str]]:
     refs_in = list(descriptor.get("block_refs") or [])
     metadata_in = list(descriptor.get("metadata") or [{} for _ in refs_in])
     if len(refs_in) != len(metadata_in):

--- a/duckdb/execution/udf_lifecycle.py
+++ b/duckdb/execution/udf_lifecycle.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral task cancellation primitives for UDF executors."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+
+
+class ExecutionCancelledError(RuntimeError):
+    """Raised when one logical UDF execution scope is cancelled."""
+
+
+class ExecutionCancellationScope:
+    """One immutable executor/task generation with event-driven cancellation."""
+
+    def __init__(self, owner_id: str, generation: int) -> None:
+        parsed_owner_id = str(owner_id).strip()
+        if not parsed_owner_id:
+            raise ValueError("execution cancellation owner_id must be non-empty")
+        parsed_generation = int(generation)
+        if parsed_generation <= 0:
+            raise ValueError("execution cancellation generation must be positive")
+        self.owner_id = parsed_owner_id
+        self.generation = parsed_generation
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._cancel_reason = ""
+        self._finished = False
+        self._next_callback_id = 0
+        self._cancel_wakeups: dict[int, Callable[[], None]] = {}
+
+    @property
+    def identity(self) -> tuple[str, int]:
+        return self.owner_id, self.generation
+
+    @property
+    def cancel_reason(self) -> str:
+        with self._lock:
+            return self._cancel_reason
+
+    @property
+    def finished(self) -> bool:
+        with self._lock:
+            return self._finished
+
+    def is_set(self) -> bool:
+        """Match ``threading.Event``'s cancellation predicate."""
+        return self._event.is_set()
+
+    def raise_if_cancelled(self, operation: str = "UDF execution") -> None:
+        if not self.is_set():
+            return
+        reason = self.cancel_reason or "cancelled"
+        raise ExecutionCancelledError(f"{operation} cancelled: {reason}")
+
+    def register_cancel_wakeup(self, callback: Callable[[], None]) -> Callable[[], None]:
+        """Wake one blocking authority when this scope is cancelled."""
+        if not callable(callback):
+            raise TypeError("execution cancellation wakeup must be callable")
+        callback_id: int | None = None
+        wake_now = False
+        with self._lock:
+            if self._event.is_set():
+                wake_now = True
+            elif not self._finished:
+                self._next_callback_id += 1
+                callback_id = self._next_callback_id
+                self._cancel_wakeups[callback_id] = callback
+        if wake_now:
+            callback()
+
+        def unregister() -> None:
+            if callback_id is None:
+                return
+            with self._lock:
+                self._cancel_wakeups.pop(callback_id, None)
+
+        return unregister
+
+    def cancel(self, reason: str = "cancelled") -> bool:
+        """Cancel this generation exactly once and wake every registered wait."""
+        wakeups: list[Callable[[], None]] = []
+        with self._lock:
+            if self._finished or self._event.is_set():
+                return False
+            self._cancel_reason = str(reason).strip() or "cancelled"
+            self._event.set()
+            wakeups = list(self._cancel_wakeups.values())
+            self._cancel_wakeups.clear()
+        for wakeup in wakeups:
+            try:
+                wakeup()
+            except Exception:
+                # Cancellation must remain observable even if a diagnostic
+                # wakeup fails. The blocked owner also checks ``is_set()``.
+                pass
+        return True
+
+    def finish(self) -> None:
+        """Retire a completed generation so later owner close cannot affect it."""
+        with self._lock:
+            self._finished = True
+            self._cancel_wakeups.clear()
+
+
+__all__ = ["ExecutionCancellationScope", "ExecutionCancelledError"]

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -136,7 +136,10 @@ def _subprocess_debug_enabled() -> bool:
 def _subprocess_debug_log(message: str) -> None:
     if not _subprocess_debug_enabled():
         return
-    print(f"[vane-udf-worker-slots pid={os.getpid()}] {message}", file=sys.stderr, flush=True)
+    try:
+        print(f"[vane-udf-worker-slots pid={os.getpid()}] {message}", file=sys.stderr, flush=True)
+    except Exception:
+        pass
 
 
 def _debug_submit_log_every() -> int:
@@ -302,6 +305,14 @@ def _read_ipc_from_shm(shm: shared_memory.SharedMemory, size: int | None = None)
     return bytes(buf[_IPC_HEADER.size : required])
 
 
+class _SubprocessStartupCancelledError(RuntimeError):
+    pass
+
+
+class _SubprocessStartupCleanupError(RuntimeError):
+    pass
+
+
 class _SingleSubprocessExecutor(BaseUDFExecutor):
     """Run Python UDFs in one long-lived worker subprocess."""
 
@@ -311,6 +322,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         *,
         worker_env: dict[str, str] | None = None,
         session_config: Mapping[str, Any] | None = None,
+        startup_observer: Callable[[_SingleSubprocessExecutor], None] | None = None,
     ) -> None:
         if payload is None:
             raise ValueError("UDF payload is required")
@@ -332,6 +344,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._active_execution_scope: ExecutionCancellationScope | None = None
         self._worker_lifetime_scope = ExecutionCancellationScope(f"subprocess-worker:{id(self)}", 1)
         self._close_lock = threading.Lock()
+        self._startup_cancel_requested = threading.Event()
         self._active_input_leases: dict[int, ExecutionCancellationScope] = {}
         self._active_input_leases_lock = threading.Lock()
         self._active_output_grants: dict[int, ExecutionCancellationScope] = {}
@@ -342,7 +355,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._sock: socket.socket | None = None
         self._proc: subprocess.Popen[bytes] | None = None
 
-        self._start_worker(payload)
+        self._start_worker(payload, startup_observer=startup_observer)
         self._finalizer = weakref.finalize(
             self,
             _cleanup_subprocess_executor,
@@ -352,7 +365,12 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             self._data_shm,
         )
 
-    def _start_worker(self, payload: dict[str, Any]) -> None:
+    def _start_worker(
+        self,
+        payload: dict[str, Any],
+        *,
+        startup_observer: Callable[[_SingleSubprocessExecutor], None] | None = None,
+    ) -> None:
         payload_bytes = duckdb_pickle.dumps(payload)
         payload_size = _IPC_HEADER.size + len(payload_bytes)
         payload_shm = _create_shm(max(payload_size, 4096), track=False)
@@ -401,27 +419,63 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._data_shm = data_shm
         self._sock = parent_sock
         self._proc = proc
+        try:
+            if startup_observer is not None:
+                startup_observer(self)
+            self._raise_if_startup_cancelled()
+            msg_type, payload_data = self._recv_expected(
+                (_MSG_READY, _MSG_ERROR),
+                timeout_s=_subprocess_control_timeout_s(),
+            )
+            if msg_type == _MSG_ERROR:
+                self._mark_broken(payload_data.decode("utf-8", errors="replace"))
+                raise RuntimeError(self._broken_error)
+            self._raise_if_startup_cancelled()
 
-        msg_type, payload_data = self._recv_expected(
-            (_MSG_READY, _MSG_ERROR),
-            timeout_s=_subprocess_control_timeout_s(),
-        )
-        if msg_type == _MSG_ERROR:
-            self._mark_broken(payload_data.decode("utf-8", errors="replace"))
-            raise RuntimeError(self._broken_error)
+            # The worker has loaded the payload. The parent no longer needs this shm.
+            self._close_payload_shm()
+        except BaseException as startup_error:
+            cancel_requested = self._startup_cancel_requested.is_set()
+            if isinstance(startup_error, _SubprocessStartupCleanupError):
+                raise
+            if self._closed:
+                if cancel_requested:
+                    raise _SubprocessStartupCancelledError(
+                        "UDF subprocess worker startup was cancelled"
+                    ) from startup_error
+                raise
+            try:
+                self.close(kill=True)
+            except BaseException as cleanup_error:
+                raise _SubprocessStartupCleanupError(
+                    f"UDF subprocess worker startup failed: {type(startup_error).__name__}: {startup_error}; "
+                    f"cleanup failed: {type(cleanup_error).__name__}: {cleanup_error}"
+                ) from startup_error
+            if cancel_requested:
+                raise _SubprocessStartupCancelledError("UDF subprocess worker startup was cancelled") from startup_error
+            raise
 
-        # The worker has loaded the payload. The parent no longer needs this shm.
-        self._close_payload_shm()
+    def _raise_if_startup_cancelled(self) -> None:
+        cancel_requested = getattr(self, "_startup_cancel_requested", None)
+        if not self._closed and (cancel_requested is None or not cancel_requested.is_set()):
+            return
+        try:
+            self.close(kill=True)
+        except BaseException as exc:
+            raise _SubprocessStartupCleanupError(
+                f"UDF subprocess worker startup cancellation cleanup failed: {exc}"
+            ) from exc
+        raise _SubprocessStartupCancelledError("UDF subprocess worker startup was cancelled")
 
     def _recv_expected(self, expected: tuple[int, ...], *, timeout_s: float | None = None) -> tuple[int, bytes]:
         sock = self._require_socket()
         timeout_overridden = False
         restore_timeout = None
-        if timeout_s is not None and hasattr(sock, "settimeout") and hasattr(sock, "gettimeout"):
-            restore_timeout = sock.gettimeout()
-            sock.settimeout(max(0.0, float(timeout_s)))
-            timeout_overridden = True
         try:
+            if timeout_s is not None and hasattr(sock, "settimeout") and hasattr(sock, "gettimeout"):
+                restore_timeout = sock.gettimeout()
+                sock.settimeout(max(0.0, float(timeout_s)))
+                timeout_overridden = True
             try:
                 msg_type, payload = _recv_message(sock)
             finally:
@@ -431,6 +485,9 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                     except Exception:
                         pass
         except Exception as exc:
+            cancel_requested = getattr(self, "_startup_cancel_requested", None)
+            if cancel_requested is not None and cancel_requested.is_set():
+                raise _SubprocessStartupCancelledError(f"UDF subprocess worker startup was cancelled: {exc}") from exc
             self._mark_broken(f"UDF subprocess communication failed: {exc}", actor_lost=True)
             raise RuntimeError(self._broken_error) from exc
         if msg_type not in expected:
@@ -476,16 +533,59 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             if self._active_execution_scope is not None:
                 raise RuntimeError("UDF subprocess worker already has an active execution scope")
             self._active_execution_scope = scope
-        unregister = scope.register_cancel_wakeup(lambda: self._cancel_scope_resources(scope, cancel_scope=False))
+        unregister: Callable[[], None] | None = None
+        cancel_cleanup_lock = threading.Lock()
+        cancel_cleanup_errors: list[BaseException] = []
+        result: Any | None = None
+        result_ready = False
+
+        def cleanup_cancelled_scope() -> None:
+            # ExecutionCancellationScope deliberately keeps cancellation
+            # observable when a wakeup raises. Preserve that wakeup failure
+            # here so the worker cannot be returned to a pool as reusable.
+            with cancel_cleanup_lock:
+                try:
+                    self._cancel_scope_resources(scope, cancel_scope=False)
+                except BaseException as exc:
+                    cancel_cleanup_errors.append(exc)
+
         try:
+            unregister = scope.register_cancel_wakeup(cleanup_cancelled_scope)
             scope.raise_if_cancelled("UDF subprocess task")
-            return fn(self)
+            result = fn(self)
+            result_ready = True
         finally:
-            unregister()
-            self._cancel_scope_resources(scope, cancel_scope=False)
+            cleanup_errors: list[BaseException] = []
+            if unregister is not None:
+                try:
+                    unregister()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            with cancel_cleanup_lock:
+                cleanup_errors.extend(cancel_cleanup_errors)
+                try:
+                    self._cancel_scope_resources(scope, cancel_scope=False)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
             with self._execution_scope_lock:
                 if self._active_execution_scope is scope:
                     self._active_execution_scope = None
+            if cleanup_errors:
+                if result_ready:
+                    _release_local_ref_bundle_result(result)
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                try:
+                    self._mark_broken(f"UDF subprocess execution-scope cleanup failed: {details}")
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+                    details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"UDF subprocess execution-scope cleanup failed: {details}") from cleanup_errors[0]
+        try:
+            scope.raise_if_cancelled("UDF subprocess task result")
+        except BaseException:
+            _release_local_ref_bundle_result(result)
+            raise
+        return result
 
     def _track_input_lease(
         self,
@@ -509,8 +609,15 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             ]
             for lease_id in lease_ids:
                 self._active_input_leases.pop(lease_id, None)
+        cleanup_errors: list[BaseException] = []
         for lease_id in lease_ids:
-            cancel_local_shm_input_lease(lease_id, name="udf-input-close")
+            try:
+                cancel_local_shm_input_lease(lease_id, name="udf-input-close")
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess input-lease cancellation failed: {details}") from cleanup_errors[0]
 
     def _track_output_grant(
         self,
@@ -551,8 +658,15 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             ]
             for grant_id in grant_ids:
                 self._active_output_grants.pop(grant_id, None)
+        cleanup_errors: list[BaseException] = []
         for grant_id in grant_ids:
-            release_local_shm_output_grant(grant_id, name=name)
+            try:
+                release_local_shm_output_grant(grant_id, name=name)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess output-grant release failed: {details}") from cleanup_errors[0]
 
     def _cancel_scope_resources(
         self,
@@ -560,21 +674,40 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         *,
         cancel_scope: bool = True,
     ) -> None:
+        cleanup_errors: list[BaseException] = []
         if cancel_scope:
-            scope.cancel("subprocess execution cancelled")
+            try:
+                scope.cancel("subprocess execution cancelled")
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         try:
             self._cancel_active_input_leases(scope)
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
             self._release_active_output_grants(name="udf-output-cancel", scope=scope)
-        finally:
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
             wake_local_shm_ref_budget_waiters()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess scope-resource cleanup failed: {details}") from cleanup_errors[0]
 
     def _mark_broken(self, error: str, *, actor_lost: bool = False) -> None:
         self._actor_lost = self._actor_lost or actor_lost
         if self._broken_error is None:
             self._broken_error = error
-        self._cancel_active_input_leases()
-        self._release_active_output_grants(name="udf-output-broken")
         self.close(kill=True)
+
+    def _mark_broken_after_cleanup_failure(self, error: BaseException) -> str:
+        try:
+            self._mark_broken(f"UDF subprocess resource cleanup failed: {error}")
+        except BaseException as cleanup_error:
+            return f"; broken-worker cleanup failed: {type(cleanup_error).__name__}: {cleanup_error}"
+        return ""
 
     def _close_payload_shm(self) -> None:
         shm = self._payload_shm
@@ -635,9 +768,20 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             if worker_payload is None:
                 raise RuntimeError("local_shm descriptor creation failed for subprocess submit")
             return self._submit_ref_bundle_direct(worker_payload)
-        except BaseException:
+        except BaseException as submit_error:
+            cleanup_error: BaseException | None = None
             if lease_id is not None:
-                cancel_local_shm_input_lease(lease_id, name="udf-materialized-input")
+                try:
+                    cancel_local_shm_input_lease(lease_id, name="udf-materialized-input")
+                except BaseException as exc:
+                    cleanup_error = exc
+            if cleanup_error is not None:
+                broken_cleanup_details = self._mark_broken_after_cleanup_failure(cleanup_error)
+                raise RuntimeError(
+                    f"UDF subprocess materialized submit failed: {type(submit_error).__name__}: "
+                    f"{submit_error}; input-lease cleanup failed: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}{broken_cleanup_details}"
+                ) from submit_error
             raise
         finally:
             for ref in refs:
@@ -821,17 +965,36 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             payload_bytes = duckdb_pickle.dumps(payload)
             _send_message(sock, _MSG_SUBMIT_REF_BUNDLE, payload_bytes)
         except Exception as exc:
-            if lease_id is not None:
-                cancel_local_shm_input_lease(lease_id, name="udf-input")
-                self._untrack_input_lease(lease_id)
-            self._mark_broken(f"UDF subprocess ref-bundle submit failed: {exc}", actor_lost=True)
+            broken_error = f"UDF subprocess ref-bundle submit failed: {exc}"
+            try:
+                # Closing the broken worker owns every tracked lease. Mark it
+                # broken before any fallible lease cleanup so a transport
+                # failure can never return this process to an idle pool.
+                self._mark_broken(broken_error, actor_lost=True)
+            except BaseException as broken_worker_cleanup_error:
+                raise RuntimeError(
+                    f"{broken_error}; broken-worker cleanup failed: "
+                    f"{type(broken_worker_cleanup_error).__name__}: {broken_worker_cleanup_error}"
+                ) from exc
             raise RuntimeError(self._broken_error) from exc
         try:
             return self._recv_submit_result()
-        except BaseException:
+        except BaseException as submit_error:
+            cleanup_error: BaseException | None = None
             if lease_id is not None:
-                cancel_local_shm_input_lease(lease_id, name="udf-input")
-                self._untrack_input_lease(lease_id)
+                try:
+                    cancel_local_shm_input_lease(lease_id, name="udf-input")
+                except BaseException as exc:
+                    cleanup_error = exc
+                finally:
+                    self._untrack_input_lease(lease_id)
+            if cleanup_error is not None:
+                broken_cleanup_details = self._mark_broken_after_cleanup_failure(cleanup_error)
+                raise RuntimeError(
+                    f"UDF subprocess result receive failed: {type(submit_error).__name__}: "
+                    f"{submit_error}; input-lease cleanup failed: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}{broken_cleanup_details}"
+                ) from submit_error
             raise
 
     def _submit_ref_bundle(self, block_refs: Any, slices: Any, metadata: Any, names: Any) -> Any | None:
@@ -847,9 +1010,17 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         if worker_payload is not None:
             try:
                 return self._submit_ref_bundle_direct(worker_payload)
-            except BaseException:
+            except BaseException as submit_error:
                 assert lease_id is not None
-                cancel_local_shm_input_lease(lease_id, name="udf-input")
+                try:
+                    cancel_local_shm_input_lease(lease_id, name="udf-input")
+                except BaseException as cleanup_error:
+                    broken_cleanup_details = self._mark_broken_after_cleanup_failure(cleanup_error)
+                    raise RuntimeError(
+                        f"UDF subprocess ref-bundle submit failed: {type(submit_error).__name__}: "
+                        f"{submit_error}; input-lease cleanup failed: "
+                        f"{type(cleanup_error).__name__}: {cleanup_error}{broken_cleanup_details}"
+                    ) from submit_error
                 raise
 
         raise RuntimeError("subprocess UDF ref-bundle input requires local shared-memory descriptors")
@@ -955,6 +1126,34 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         scope = self._current_execution_scope()
         self._cancel_scope_resources(scope)
 
+    def _cancel_startup(self) -> None:
+        """Interrupt startup without waiting for its cleanup thread."""
+        cleanup_errors: list[BaseException] = []
+        cancel_requested = getattr(self, "_startup_cancel_requested", None)
+        if cancel_requested is not None:
+            cancel_requested.set()
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.kill()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        sock = self._sock
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            try:
+                sock.close()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess startup cancellation failed: {details}") from cleanup_errors[0]
+
     def close(self, kill: bool = False) -> None:
         close_lock = getattr(self, "_close_lock", None)
         if close_lock is None:
@@ -967,13 +1166,25 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         if self._closed:
             return
         self._closed = True
-        self.cancel_output_grants()
-        self._cancel_active_input_leases()
+        cleanup_errors: list[BaseException] = []
+        try:
+            self.cancel_output_grants()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
+            self._cancel_active_input_leases()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
+            self._release_active_output_grants(name="udf-output-close")
+        except BaseException as exc:
+            cleanup_errors.append(exc)
 
         proc = self._proc
         sock = self._sock
         shutdown_error: BaseException | None = None
         graceful_error: BaseException | None = None
+        finalizer_cleanup_failed = False
 
         if proc is not None and proc.poll() is None and sock is not None and not kill:
             deadline = time.monotonic() + _subprocess_shutdown_grace_s()
@@ -1024,25 +1235,40 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
 
         self._proc = None
         self._sock = None
-        self._close_payload_shm()
+        try:
+            self._close_payload_shm()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+            finalizer_cleanup_failed = True
         data_shm = self._data_shm
         self._data_shm = None
         if data_shm is not None:
             try:
                 data_shm.close()
-            finally:
-                try:
-                    _unlink_shm(data_shm, track=False)
-                except FileNotFoundError:
-                    pass
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+                finalizer_cleanup_failed = True
+            try:
+                _unlink_shm(data_shm, track=False)
+            except FileNotFoundError:
+                pass
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+                finalizer_cleanup_failed = True
 
         finalizer = getattr(self, "_finalizer", None)
-        if finalizer is not None and finalizer.alive:
-            finalizer.detach()
+        if finalizer is not None and finalizer.alive and shutdown_error is None and not finalizer_cleanup_failed:
+            try:
+                finalizer.detach()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         if shutdown_error is not None:
-            raise RuntimeError(f"UDF subprocess did not terminate cleanly: {shutdown_error}") from shutdown_error
+            cleanup_errors.append(RuntimeError(f"UDF subprocess did not terminate cleanly: {shutdown_error}"))
         if graceful_error is not None:
-            raise RuntimeError(str(graceful_error)) from graceful_error
+            cleanup_errors.append(graceful_error)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess close failed: {details}") from cleanup_errors[0]
 
     def __del__(self) -> None:
         try:
@@ -1162,6 +1388,9 @@ class _TaskWorkerPool:
         self.closing = False
         self.idle: list[_PooledTaskWorker] = []
         self._active_wrappers: set[_PooledTaskWorker] = set()
+        self._spawning_workers: set[int] = set()
+        self._spawning_executors: dict[int, _SingleSubprocessExecutor] = {}
+        self._spawn_cleanup_errors: list[BaseException] = []
         self.active = 0
         self.total = 0
         self.next_worker_idx = 0
@@ -1183,45 +1412,152 @@ class _TaskWorkerPool:
     def release_ref(self, *, kill: bool = False) -> None:
         to_close: list[_SingleSubprocessExecutor] = []
         active_to_kill: list[_SingleSubprocessExecutor] = []
+        close_pool = False
+        close_kill = bool(kill)
         with self.runtime.cond:
             self.ref_count = max(0, self.ref_count - 1)
             if self.ref_count == 0:
+                close_pool = True
                 self.closing = True
-                self.kill_on_release = kill
-                self.admission_slots.close()
+                self.kill_on_release = self.kill_on_release or close_kill
+                close_kill = self.kill_on_release
                 while self.idle:
                     wrapper = self.idle.pop()
                     self.total = max(0, self.total - 1)
                     self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
                     to_close.append(wrapper.worker)
-                if kill:
+                if close_kill:
                     active_to_kill.extend(wrapper.worker for wrapper in self._active_wrappers)
                 self.runtime.pools.pop(self.key, None)
             self.runtime.cond.notify_all()
+        if not close_pool:
+            return
+        cleanup_errors: list[BaseException] = []
+        try:
+            self.admission_slots.close()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
         for worker in to_close:
-            worker.close(kill=kill)
+            try:
+                worker.close(kill=close_kill)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         for worker in active_to_kill:
-            worker.close(kill=True)
+            try:
+                worker.close(kill=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        cleanup_errors.extend(self._close_spawning_workers())
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"subprocess task worker pool close failed: {details}") from cleanup_errors[0]
 
     def cancel_output_grants(self) -> None:
         workers: list[_SingleSubprocessExecutor] = []
         with self.runtime.cond:
             workers.extend(wrapper.worker for wrapper in self.idle)
             workers.extend(wrapper.worker for wrapper in self._active_wrappers)
+        cleanup_errors: list[BaseException] = []
         for worker in workers:
-            worker.cancel_output_grants()
+            try:
+                worker.cancel_output_grants()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"subprocess task output-grant cancellation failed: {details}") from cleanup_errors[0]
 
     def _wake_waiters(self) -> None:
         with self.runtime.cond:
             self.runtime.cond.notify_all()
+
+    def _track_spawning_executor(
+        self,
+        worker_idx: int,
+        worker: _SingleSubprocessExecutor,
+    ) -> None:
+        close_worker = False
+        with self.runtime.cond:
+            spawning_executors = getattr(self, "_spawning_executors", None)
+            if spawning_executors is None:
+                spawning_executors = {}
+                self._spawning_executors = spawning_executors
+            if worker_idx in self._spawning_workers:
+                spawning_executors[worker_idx] = worker
+                close_worker = self.closing or self.runtime.closed
+            self.runtime.cond.notify_all()
+        if close_worker:
+            try:
+                worker._cancel_startup()
+            except BaseException as exc:
+                self._record_spawn_cleanup_error(worker_idx, exc)
+                raise
+
+    def _close_spawning_workers(self, *, deadline: float | None = None) -> list[BaseException]:
+        cleanup_errors: list[BaseException] = []
+        closed_workers: set[int] = set()
+        if deadline is None:
+            deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+        while True:
+            workers_to_close: list[_SingleSubprocessExecutor] = []
+            with self.runtime.cond:
+                spawning_workers = set(getattr(self, "_spawning_workers", ()))
+                if not spawning_workers:
+                    cleanup_errors.extend(getattr(self, "_spawn_cleanup_errors", ()))
+                    self._spawn_cleanup_errors = []
+                    return cleanup_errors
+                spawning_executors = getattr(self, "_spawning_executors", {})
+                for worker_idx in spawning_workers:
+                    worker = spawning_executors.get(worker_idx)
+                    if worker is not None and id(worker) not in closed_workers:
+                        closed_workers.add(id(worker))
+                        workers_to_close.append(worker)
+                if not workers_to_close:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        cleanup_errors.append(
+                            TimeoutError(
+                                "subprocess task worker startup cleanup did not finish before the shutdown deadline"
+                            )
+                        )
+                        cleanup_errors.extend(getattr(self, "_spawn_cleanup_errors", ()))
+                        self._spawn_cleanup_errors = []
+                        return cleanup_errors
+                    self.runtime.cond.wait(timeout=remaining)
+                    continue
+            for worker in workers_to_close:
+                try:
+                    # A provisional worker has never accepted user work, so
+                    # interrupting it is safe even during graceful shutdown.
+                    # The startup thread retains ownership of full cleanup.
+                    cancel_startup = getattr(worker, "_cancel_startup", None)
+                    if callable(cancel_startup):
+                        cancel_startup()
+                    else:
+                        worker.close(kill=True)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
 
     def _spawn_worker(self, worker_idx: int) -> _PooledTaskWorker:
         worker = _SingleSubprocessExecutor(
             self.payload,
             worker_env=_worker_env_for_pool_index(self.payload, worker_idx, self.pool_size),
             session_config=self.session_config,
+            startup_observer=lambda executor: self._track_spawning_executor(worker_idx, executor),
         )
         return _PooledTaskWorker(worker)
+
+    def _record_spawn_cleanup_error(self, worker_idx: int, error: BaseException) -> None:
+        cleanup_error = RuntimeError(
+            f"subprocess task worker {worker_idx} startup cleanup failed: {type(error).__name__}: {error}"
+        )
+        with self.runtime.cond:
+            errors = getattr(self, "_spawn_cleanup_errors", None)
+            if errors is None:
+                errors = []
+                self._spawn_cleanup_errors = errors
+            errors.append(cleanup_error)
+            self.runtime.cond.notify_all()
 
     def acquire_worker(self, scope: ExecutionCancellationScope) -> _PooledTaskWorker:
         wrapper: _PooledTaskWorker | None = None
@@ -1251,6 +1587,7 @@ class _TaskWorkerPool:
                     elif self.total < self.pool_size and self.runtime.total_workers < self.runtime.max_workers:
                         spawn_idx = self.next_worker_idx
                         self.next_worker_idx += 1
+                        self._spawning_workers.add(spawn_idx)
                         self.total += 1
                         self.active += 1
                         self.runtime.total_workers += 1
@@ -1266,11 +1603,13 @@ class _TaskWorkerPool:
             try:
                 assert spawn_idx is not None
                 wrapper = self._spawn_worker(spawn_idx)
-            except Exception:
+            except BaseException:
                 with self.runtime.cond:
                     self.total = max(0, self.total - 1)
                     self.active = max(0, self.active - 1)
                     self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
+                    getattr(self, "_spawning_executors", {}).pop(spawn_idx, None)
+                    self._spawning_workers.discard(spawn_idx)
                     self.runtime.cond.notify_all()
                 raise
             close_kill = False
@@ -1284,8 +1623,20 @@ class _TaskWorkerPool:
                 else:
                     wrapper.active_scope = scope
                     self._active_wrappers.add(wrapper)
+                    getattr(self, "_spawning_executors", {}).pop(spawn_idx, None)
+                    self._spawning_workers.discard(spawn_idx)
+                    self.runtime.cond.notify_all()
                     return wrapper
-            wrapper.worker.close(kill=close_kill)
+            try:
+                wrapper.worker.close(kill=close_kill)
+            except BaseException as exc:
+                self._record_spawn_cleanup_error(spawn_idx, exc)
+                raise
+            finally:
+                with self.runtime.cond:
+                    getattr(self, "_spawning_executors", {}).pop(spawn_idx, None)
+                    self._spawning_workers.discard(spawn_idx)
+                    self.runtime.cond.notify_all()
             raise RuntimeError("subprocess task worker pool is closed")
         finally:
             unregister()
@@ -1317,8 +1668,15 @@ class _TaskWorkerPool:
                     wrapper.abort_requested = True
                     workers.append(wrapper.worker)
             self.runtime.cond.notify_all()
+        cleanup_errors: list[BaseException] = []
         for worker in workers:
-            worker.close(kill=True)
+            try:
+                worker.close(kill=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"subprocess task worker abort failed: {details}") from cleanup_errors[0]
 
 
 class _GlobalSubprocessTaskRuntime:
@@ -1332,6 +1690,7 @@ class _GlobalSubprocessTaskRuntime:
         self.pools: dict[str, _TaskWorkerPool] = {}
         self.total_workers = 0
         self.closed = False
+        self._close_finished = True
 
     def acquire_pool(
         self,
@@ -1374,31 +1733,47 @@ class _GlobalSubprocessTaskRuntime:
         wrapper = pool.acquire_worker(scope)
         acquire_s = time.perf_counter() - acquire_start
         assert wrapper is not None
-        if _should_debug_submit(debug_seq):
-            proc = getattr(wrapper.worker, "_proc", None)
-            _subprocess_debug_log(
-                "task_worker_acquired "
-                f"seq={debug_seq} acquire_s={acquire_s:.6f} "
-                f"worker_pid={getattr(proc, 'pid', None)} pool_size={pool.pool_size} "
-                f"pool_total={pool.total} pool_active={pool.active} pool_idle={len(pool.idle)} "
-                f"runtime_total_workers={self.total_workers} runtime_max_workers={self.max_workers}"
-            )
         reusable = True
         run_start = time.perf_counter()
+        result: Any | None = None
+        result_ready = False
         try:
+            if _should_debug_submit(debug_seq):
+                proc = getattr(wrapper.worker, "_proc", None)
+                _subprocess_debug_log(
+                    "task_worker_acquired "
+                    f"seq={debug_seq} acquire_s={acquire_s:.6f} "
+                    f"worker_pid={getattr(proc, 'pid', None)} pool_size={pool.pool_size} "
+                    f"pool_total={pool.total} pool_active={pool.active} pool_idle={len(pool.idle)} "
+                    f"runtime_total_workers={self.total_workers} runtime_max_workers={self.max_workers}"
+                )
             scope.raise_if_cancelled("subprocess task")
-            return wrapper.worker._run_in_execution_scope(scope, fn)
+            result = wrapper.worker._run_in_execution_scope(scope, fn)
+            result_ready = True
         except BaseException:
             reusable = _worker_is_reusable(wrapper.worker)
             raise
         finally:
             scope.finish()
-            if _should_debug_submit(debug_seq):
-                _subprocess_debug_log(
-                    "task_worker_finished "
-                    f"seq={debug_seq} run_s={time.perf_counter() - run_start:.6f} reusable={reusable}"
-                )
-            pool.release_worker(wrapper, reusable=reusable)
+            try:
+                try:
+                    if _should_debug_submit(debug_seq):
+                        _subprocess_debug_log(
+                            "task_worker_finished "
+                            f"seq={debug_seq} run_s={time.perf_counter() - run_start:.6f} reusable={reusable}"
+                        )
+                finally:
+                    pool.release_worker(wrapper, reusable=reusable)
+            except BaseException:
+                if result_ready:
+                    _release_local_ref_bundle_result(result)
+                raise
+        try:
+            scope.raise_if_cancelled("subprocess task result")
+        except BaseException:
+            _release_local_ref_bundle_result(result)
+            raise
+        return result
 
     def _take_idle_worker_locked(self) -> _SingleSubprocessExecutor | None:
         oldest_pool: _TaskWorkerPool | None = None
@@ -1434,8 +1809,11 @@ class _GlobalSubprocessTaskRuntime:
         active_workers = 0
         with self.cond:
             if self.closed:
+                while not getattr(self, "_close_finished", True):
+                    self.cond.wait()
                 return
             self.closed = True
+            self._close_finished = False
             for pool in list(self.pools.values()):
                 pools_to_cancel.append(pool)
                 pool.closing = True
@@ -1449,13 +1827,42 @@ class _GlobalSubprocessTaskRuntime:
             self.pools.clear()
             self.total_workers = active_workers
             self.cond.notify_all()
-        for pool in pools_to_cancel:
-            pool.cancel_output_grants()
-        self.executor.shutdown(wait=False, cancel_futures=True)
-        for worker in to_close:
-            worker.close(kill=kill)
-        for worker in active_to_kill:
-            worker.close(kill=True)
+        try:
+            cleanup_errors: list[BaseException] = []
+            for pool in pools_to_cancel:
+                try:
+                    pool.admission_slots.close()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            for pool in pools_to_cancel:
+                try:
+                    pool.cancel_output_grants()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            try:
+                self.executor.shutdown(wait=False, cancel_futures=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            for worker in to_close:
+                try:
+                    worker.close(kill=kill)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            for worker in active_to_kill:
+                try:
+                    worker.close(kill=True)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            spawn_cleanup_deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+            for pool in pools_to_cancel:
+                cleanup_errors.extend(pool._close_spawning_workers(deadline=spawn_cleanup_deadline))
+            if cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"global subprocess task runtime close failed: {details}") from cleanup_errors[0]
+        finally:
+            with self.cond:
+                self._close_finished = True
+                self.cond.notify_all()
 
 
 _GLOBAL_TASK_RUNTIME_LOCK = threading.Lock()
@@ -1500,6 +1907,7 @@ class LocalSubprocessActorPool:
         self.pool_size = max(1, int(pool_size))
         self.name = str(name or "")
         self._closed = False
+        self._shutdown_finished = True
         self._lock = threading.RLock()
         self._cond = threading.Condition(self._lock)
         self._active = 0
@@ -1507,6 +1915,9 @@ class LocalSubprocessActorPool:
         self._active_scopes: dict[int, ExecutionCancellationScope] = {}
         self._worker_generations = [0 for _ in range(self.pool_size)]
         self._replacing_workers: set[int] = set()
+        self._replacing_executors: dict[int, _SingleSubprocessExecutor] = {}
+        self._replacement_startup_cancel_requested = False
+        self._replacement_cleanup_errors: list[BaseException] = []
         self._aborting_workers: set[tuple[int, int]] = set()
         pool_identity = self.name or str(id(self))
         self.admission_slots = LocalExecutionSlotPool(
@@ -1585,6 +1996,7 @@ class LocalSubprocessActorPool:
             self.payload,
             worker_env=_worker_env_for_pool_index(self.payload, worker_idx, self.pool_size),
             session_config=self.session_config,
+            startup_observer=lambda executor: self._track_replacing_executor(worker_idx, executor),
         )
 
     def _set_terminal_error(self, error: BaseException) -> None:
@@ -1597,6 +2009,99 @@ class LocalSubprocessActorPool:
         if should_close_admission:
             self.admission_slots.close()
 
+    def _track_replacing_executor(
+        self,
+        worker_idx: int,
+        worker: _SingleSubprocessExecutor,
+    ) -> None:
+        cancel_startup = False
+        with self._cond:
+            replacing_executors = getattr(self, "_replacing_executors", None)
+            if replacing_executors is None:
+                replacing_executors = {}
+                self._replacing_executors = replacing_executors
+            if worker_idx in self._replacing_workers:
+                replacing_executors[worker_idx] = worker
+                cancel_startup = bool(getattr(self, "_replacement_startup_cancel_requested", False))
+            self._cond.notify_all()
+        if cancel_startup:
+            worker._cancel_startup()
+
+    def _interrupt_replacing_workers(self, interrupted_workers: set[int]) -> list[BaseException]:
+        cleanup_errors: list[BaseException] = []
+        workers_to_interrupt: list[_SingleSubprocessExecutor] = []
+        with self._cond:
+            self._replacement_startup_cancel_requested = True
+            replacing_executors = getattr(self, "_replacing_executors", {})
+            for worker_idx in self._replacing_workers:
+                worker = replacing_executors.get(worker_idx)
+                if worker is not None and id(worker) not in interrupted_workers:
+                    interrupted_workers.add(id(worker))
+                    workers_to_interrupt.append(worker)
+            self._cond.notify_all()
+        for worker in workers_to_interrupt:
+            try:
+                # A provisional actor has never accepted user work. Its
+                # startup thread retains ownership of full cleanup.
+                cancel_startup = getattr(worker, "_cancel_startup", None)
+                if callable(cancel_startup):
+                    cancel_startup()
+                else:
+                    worker.close(kill=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        return cleanup_errors
+
+    def _close_replacing_workers(
+        self,
+        *,
+        deadline: float | None = None,
+        interrupted_workers: set[int] | None = None,
+    ) -> list[BaseException]:
+        cleanup_errors: list[BaseException] = []
+        if interrupted_workers is None:
+            interrupted_workers = set()
+        if deadline is None:
+            deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+        while True:
+            cleanup_errors.extend(self._interrupt_replacing_workers(interrupted_workers))
+            with self._cond:
+                if not self._replacing_workers:
+                    cleanup_errors.extend(getattr(self, "_replacement_cleanup_errors", ()))
+                    self._replacement_cleanup_errors = []
+                    return cleanup_errors
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    cleanup_errors.append(
+                        TimeoutError(
+                            "local subprocess actor replacement cleanup did not finish before the shutdown deadline"
+                        )
+                    )
+                    cleanup_errors.extend(getattr(self, "_replacement_cleanup_errors", ()))
+                    self._replacement_cleanup_errors = []
+                    return cleanup_errors
+                self._cond.wait(timeout=remaining)
+
+    def _record_replacement_cleanup_error(
+        self,
+        worker_idx: int,
+        role: str,
+        error: BaseException,
+    ) -> None:
+        cleanup_error = RuntimeError(
+            f"local subprocess actor {worker_idx} {role} cleanup failed: {type(error).__name__}: {error}"
+        )
+        with self._cond:
+            errors = getattr(self, "_replacement_cleanup_errors", None)
+            if errors is None:
+                errors = []
+                self._replacement_cleanup_errors = errors
+            errors.append(cleanup_error)
+            pool_closed = self._closed
+            self._cond.notify_all()
+        if not pool_closed:
+            self._set_terminal_error(cleanup_error)
+
     def _replace_worker(
         self,
         worker_idx: int,
@@ -1604,36 +2109,52 @@ class LocalSubprocessActorPool:
         failed_worker: _SingleSubprocessExecutor,
     ) -> None:
         try:
-            failed_worker.close(kill=True)
-        except Exception:
-            pass
-        try:
-            replacement = self._spawn_worker(worker_idx)
-        except BaseException as exc:
+            try:
+                failed_worker.close(kill=True)
+            except BaseException as exc:
+                self._record_replacement_cleanup_error(worker_idx, "failed worker", exc)
+                return
+            try:
+                replacement = self._spawn_worker(worker_idx)
+            except BaseException as exc:
+                with self._cond:
+                    pool_closed = self._closed
+                if pool_closed and isinstance(exc, _SubprocessStartupCleanupError):
+                    self._record_replacement_cleanup_error(worker_idx, "replacement startup", exc)
+                elif not pool_closed:
+                    self._set_terminal_error(
+                        RuntimeError(f"failed to replace local subprocess actor {worker_idx}: {exc}")
+                    )
+                return
+
+            close_replacement = False
             with self._cond:
+                if (
+                    self._closed
+                    or worker_idx >= len(self._workers)
+                    or self._worker_generations[worker_idx] != worker_generation
+                    or self._workers[worker_idx] is not failed_worker
+                ):
+                    close_replacement = True
+                else:
+                    next_generation = worker_generation + 1
+                    self._workers[worker_idx] = replacement
+                    self._worker_generations[worker_idx] = next_generation
+                    self._idle_workers.append((worker_idx, next_generation))
+            if close_replacement:
+                try:
+                    replacement.close(kill=True)
+                except BaseException as exc:
+                    self._record_replacement_cleanup_error(worker_idx, "replacement", exc)
+        finally:
+            # Keep replacement ownership visible until a rejected replacement
+            # has also finished closing. Shutdown uses this set as its join
+            # condition, so clearing it before close() would let a newly
+            # spawned process and its shared memory outlive the pool.
+            with self._cond:
+                getattr(self, "_replacing_executors", {}).pop(worker_idx, None)
                 self._replacing_workers.discard(worker_idx)
                 self._cond.notify_all()
-            self._set_terminal_error(RuntimeError(f"failed to replace local subprocess actor {worker_idx}: {exc}"))
-            return
-
-        close_replacement = False
-        with self._cond:
-            self._replacing_workers.discard(worker_idx)
-            if (
-                self._closed
-                or worker_idx >= len(self._workers)
-                or self._worker_generations[worker_idx] != worker_generation
-                or self._workers[worker_idx] is not failed_worker
-            ):
-                close_replacement = True
-            else:
-                next_generation = worker_generation + 1
-                self._workers[worker_idx] = replacement
-                self._worker_generations[worker_idx] = next_generation
-                self._idle_workers.append((worker_idx, next_generation))
-            self._cond.notify_all()
-        if close_replacement:
-            replacement.close(kill=True)
 
     def _acquire_worker(
         self,
@@ -1643,6 +2164,7 @@ class LocalSubprocessActorPool:
         try:
             while True:
                 replacement: tuple[int, int, _SingleSubprocessExecutor] | None = None
+                stateful_loss: tuple[int, _SingleSubprocessExecutor] | None = None
                 with self._cond:
                     scope.raise_if_cancelled("local subprocess actor acquisition")
                     self._raise_if_unavailable_locked()
@@ -1657,13 +2179,31 @@ class LocalSubprocessActorPool:
                             self._active += 1
                             self._active_scopes[worker_idx] = scope
                             return worker_idx, worker_generation, worker
-                        if worker_idx not in self._replacing_workers:
+                        if self.payload.get("stateful"):
+                            stateful_loss = (worker_idx, worker)
+                        elif worker_idx not in self._replacing_workers:
                             self._replacing_workers.add(worker_idx)
                             replacement = (worker_idx, worker_generation, worker)
                         break
-                    if replacement is None:
+                    if replacement is None and stateful_loss is None:
                         self._cond.wait()
                         continue
+                if stateful_loss is not None:
+                    worker_idx, worker = stateful_loss
+                    worker_pid = getattr(getattr(worker, "_proc", None), "pid", None)
+                    udf_name = str(self.payload.get("udf_name") or "udf")
+                    actor_id = "unknown" if worker_pid is None else str(worker_pid)
+                    terminal_error = RuntimeError(
+                        f"stateful UDF {udf_name!r} lost local actor pid {actor_id}; "
+                        "state was not recoverable; side effects may already have occurred"
+                    )
+                    self._set_terminal_error(terminal_error)
+                    try:
+                        worker.close(kill=True)
+                    except BaseException as exc:
+                        self._record_replacement_cleanup_error(worker_idx, "lost stateful worker", exc)
+                    raise RuntimeError(f"local subprocess actor pool failed: {terminal_error}") from terminal_error
+                assert replacement is not None
                 self._replace_worker(*replacement)
         finally:
             unregister()
@@ -1694,6 +2234,8 @@ class LocalSubprocessActorPool:
         reusable = False
         replace_worker = False
         terminal_error: BaseException | None = None
+        result: Any | None = None
+        result_ready = False
         try:
             worker_idx, worker_generation, worker = self._acquire_worker(scope)
             with self._lock:
@@ -1706,7 +2248,8 @@ class LocalSubprocessActorPool:
                     f"pool_size={self.pool_size} worker_pid={worker_pid}"
                 )
             scope.raise_if_cancelled("local subprocess actor task")
-            return worker._run_in_execution_scope(scope, fn)
+            result = worker._run_in_execution_scope(scope, fn)
+            result_ready = True
         except BaseException as exc:
             if self.payload.get("stateful") and worker is not None and getattr(worker, "_actor_lost", False):
                 udf_name = str(self.payload.get("udf_name") or "udf")
@@ -1718,39 +2261,50 @@ class LocalSubprocessActorPool:
             raise
         finally:
             scope.finish()
-            active_after = 0
-            if worker_idx is not None and worker is not None:
-                reusable = _worker_is_reusable(worker)
-                with self._cond:
-                    worker_identity = (worker_idx, worker_generation)
-                    abort_requested = worker_identity in self._aborting_workers
-                    self._aborting_workers.discard(worker_identity)
-                    self._active = max(0, self._active - 1)
-                    self._active_scopes.pop(worker_idx, None)
-                    active_after = self._active
-                    if not self._closed and reusable and not abort_requested:
-                        self._idle_workers.append((worker_idx, worker_generation))
-                    elif not self._closed and self.payload.get("stateful"):
-                        udf_name = str(self.payload.get("udf_name") or "udf")
-                        actor_id = "unknown" if worker_pid is None else str(worker_pid)
-                        terminal_error = RuntimeError(
-                            f"stateful UDF {udf_name!r} lost local actor pid {actor_id}; "
-                            "state was not recoverable; side effects may already have occurred"
-                        )
-                    elif not self._closed and worker_idx not in self._replacing_workers:
-                        self._replacing_workers.add(worker_idx)
-                        replace_worker = True
-                    self._cond.notify_all()
-                if terminal_error is not None:
-                    self._set_terminal_error(terminal_error)
-                elif replace_worker:
-                    self._replace_worker(worker_idx, worker_generation, worker)
-            if _should_debug_submit(debug_seq):
-                _subprocess_debug_log(
-                    "local_actor_pool_worker_finished "
-                    f"name={self.name!r} seq={debug_seq} worker_idx={worker_idx} "
-                    f"active={active_after} reusable={reusable}"
-                )
+            try:
+                active_after = 0
+                if worker_idx is not None and worker is not None:
+                    reusable = _worker_is_reusable(worker)
+                    with self._cond:
+                        worker_identity = (worker_idx, worker_generation)
+                        abort_requested = worker_identity in self._aborting_workers
+                        self._aborting_workers.discard(worker_identity)
+                        self._active = max(0, self._active - 1)
+                        self._active_scopes.pop(worker_idx, None)
+                        active_after = self._active
+                        if not self._closed and reusable and not abort_requested:
+                            self._idle_workers.append((worker_idx, worker_generation))
+                        elif not self._closed and self.payload.get("stateful"):
+                            udf_name = str(self.payload.get("udf_name") or "udf")
+                            actor_id = "unknown" if worker_pid is None else str(worker_pid)
+                            terminal_error = RuntimeError(
+                                f"stateful UDF {udf_name!r} lost local actor pid {actor_id}; "
+                                "state was not recoverable; side effects may already have occurred"
+                            )
+                        elif not self._closed and worker_idx not in self._replacing_workers:
+                            self._replacing_workers.add(worker_idx)
+                            replace_worker = True
+                        self._cond.notify_all()
+                    if terminal_error is not None:
+                        self._set_terminal_error(terminal_error)
+                    elif replace_worker:
+                        self._replace_worker(worker_idx, worker_generation, worker)
+                if _should_debug_submit(debug_seq):
+                    _subprocess_debug_log(
+                        "local_actor_pool_worker_finished "
+                        f"name={self.name!r} seq={debug_seq} worker_idx={worker_idx} "
+                        f"active={active_after} reusable={reusable}"
+                    )
+            except BaseException:
+                if result_ready:
+                    _release_local_ref_bundle_result(result)
+                raise
+        try:
+            scope.raise_if_cancelled("local subprocess actor result")
+        except BaseException:
+            _release_local_ref_bundle_result(result)
+            raise
+        return result
 
     def stats(self) -> dict[str, int]:
         with self._lock:
@@ -1765,8 +2319,17 @@ class LocalSubprocessActorPool:
     def cancel_output_grants(self) -> None:
         with self._lock:
             workers = list(self._workers)
+        cleanup_errors: list[BaseException] = []
         for worker in workers:
-            worker.cancel_output_grants()
+            try:
+                worker.cancel_output_grants()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(
+                f"local subprocess actor output-grant cancellation failed: {details}"
+            ) from cleanup_errors[0]
 
     def abort_scopes(self, scopes: set[ExecutionCancellationScope]) -> None:
         workers: list[_SingleSubprocessExecutor] = []
@@ -1778,53 +2341,92 @@ class LocalSubprocessActorPool:
                 self._aborting_workers.add((worker_idx, worker_generation))
                 workers.append(self._workers[worker_idx])
             self._cond.notify_all()
+        cleanup_errors: list[BaseException] = []
         for worker in workers:
-            worker.close(kill=True)
+            try:
+                worker.close(kill=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"local subprocess actor abort failed: {details}") from cleanup_errors[0]
 
     def shutdown(self, *, kill: bool = False) -> None:
         with self._cond:
             if self._closed:
+                while not getattr(self, "_shutdown_finished", True):
+                    self._cond.wait()
                 return
             self._closed = True
+            self._shutdown_finished = False
+            self._replacement_startup_cancel_requested = bool(kill)
             active_scopes = list(self._active_scopes.values())
             self._cond.notify_all()
-        self.admission_slots.close()
-        for scope in active_scopes:
-            scope.cancel("local subprocess actor pool closed")
-
-        close_kill = bool(kill)
-        if not close_kill:
-            deadline = time.monotonic() + _subprocess_shutdown_grace_s()
-            with self._cond:
-                while self._active > 0:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        close_kill = True
-                        break
-                    self._cond.wait(timeout=remaining)
-        if close_kill:
-            self.abort_scopes(set(active_scopes))
-
-        executor = self._executor
-        self._executor = None
-        if executor is not None:
-            executor.shutdown(wait=False, cancel_futures=True)
-        with self._lock:
-            workers = list(self._workers)
-        cleanup_errors: list[BaseException] = []
-        for worker in workers:
+        try:
+            cleanup_errors: list[BaseException] = []
             try:
-                worker.close(kill=close_kill)
+                self.admission_slots.close()
             except BaseException as exc:
                 cleanup_errors.append(exc)
-        with self._cond:
-            self._workers = []
-            self._idle_workers.clear()
-            self._cond.notify_all()
-        _subprocess_debug_log(f"local_actor_pool_shutdown name={self.name!r} kill={close_kill}")
-        if cleanup_errors:
-            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
-            raise RuntimeError(f"local subprocess actor pool shutdown failed: {details}") from cleanup_errors[0]
+            for scope in active_scopes:
+                scope.cancel("local subprocess actor pool closed")
+
+            close_kill = bool(kill)
+            if not close_kill:
+                deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+                with self._cond:
+                    while self._active > 0 or self._replacing_workers:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            close_kill = True
+                            self._replacement_startup_cancel_requested = True
+                            self._cond.notify_all()
+                            break
+                        self._cond.wait(timeout=remaining)
+            interrupted_replacements: set[int] = set()
+            if close_kill:
+                cleanup_errors.extend(self._interrupt_replacing_workers(interrupted_replacements))
+                try:
+                    self.abort_scopes(set(active_scopes))
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+
+            # Once graceful shutdown escalates, interrupt provisional actor
+            # startup instead of waiting for the longer control timeout.
+            replacement_cleanup_deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+            cleanup_errors.extend(
+                self._close_replacing_workers(
+                    deadline=replacement_cleanup_deadline,
+                    interrupted_workers=interrupted_replacements,
+                )
+            )
+
+            executor = self._executor
+            self._executor = None
+            if executor is not None:
+                try:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            with self._lock:
+                workers = list(self._workers)
+            for worker in workers:
+                try:
+                    worker.close(kill=close_kill)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            with self._cond:
+                self._workers = []
+                self._idle_workers.clear()
+                self._cond.notify_all()
+            _subprocess_debug_log(f"local_actor_pool_shutdown name={self.name!r} kill={close_kill}")
+            if cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"local subprocess actor pool shutdown failed: {details}") from cleanup_errors[0]
+        finally:
+            with self._cond:
+                self._shutdown_finished = True
+                self._cond.notify_all()
 
     def __del__(self) -> None:
         try:
@@ -2202,6 +2804,25 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         with self._execution_scopes_lock:
             self._execution_scopes.discard(scope)
 
+    def _cleanup_unscheduled_submit(
+        self,
+        scope: ExecutionCancellationScope,
+        admission: AdmissionLease | None,
+    ) -> None:
+        cleanup_errors: list[BaseException] = []
+        if admission is not None:
+            try:
+                admission.release()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        try:
+            self._retire_execution_scope(scope)
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"unscheduled UDF submit cleanup failed: {details}") from cleanup_errors[0]
+
     def _cancel_execution_scopes(self, reason: str) -> set[ExecutionCancellationScope]:
         lock = getattr(self, "_execution_scopes_lock", None)
         if lock is None:
@@ -2237,8 +2858,15 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         with self._active_input_leases_lock:
             lease_ids = list(self._active_input_leases)
             self._active_input_leases.clear()
+        cleanup_errors: list[BaseException] = []
         for lease_id in lease_ids:
-            cancel_local_shm_input_lease(lease_id, name="udf-input-close")
+            try:
+                cancel_local_shm_input_lease(lease_id, name="udf-input-close")
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF input lease cancellation failed: {details}") from cleanup_errors[0]
 
     def _complete_task_submit(self, submit_id: int | None, future: Future[Any]) -> None:
         item: Any | None = None
@@ -2268,23 +2896,32 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 debug_meta = self._task_future_meta.get(future)
             if debug_meta is not None:
                 debug_submit_id, debug_seq, submit_start, admission, scope = debug_meta
-                if _should_debug_submit(debug_seq):
-                    _subprocess_debug_log(
-                        "task_submit_completed "
-                        f"seq={debug_seq} submit_id={debug_submit_id} "
-                        f"total_s={time.perf_counter() - submit_start:.6f}"
-                    )
+                try:
+                    if _should_debug_submit(debug_seq):
+                        _subprocess_debug_log(
+                            "task_submit_completed "
+                            f"seq={debug_seq} submit_id={debug_submit_id} "
+                            f"total_s={time.perf_counter() - submit_start:.6f}"
+                        )
+                except BaseException as exc:
+                    self._record_wakeup_error(exc)
             if item is not None:
                 with self._queue_lock:
                     if self._closed:
                         _release_local_ref_bundle_result(result)
                         if admission is not None:
-                            admission.release()
+                            try:
+                                admission.release()
+                            except BaseException as exc:
+                                self._record_wakeup_error(exc)
                     else:
                         self._queue.append(item)
                         self._result_admissions.append(admission)
             elif admission is not None:
-                admission.release()
+                try:
+                    admission.release()
+                except BaseException as exc:
+                    self._record_wakeup_error(exc)
             with self._pending_lock:
                 self._pending_batches = max(0, self._pending_batches - 1)
             with self._task_futures_cv:
@@ -2344,12 +2981,16 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                         admission,
                         scope,
                     )
-                except BaseException:
+                except BaseException as submit_error:
                     with self._pending_lock:
                         self._pending_batches = max(0, self._pending_batches - 1)
-                    if admission is not None:
-                        admission.release()
-                    self._retire_execution_scope(scope)
+                    try:
+                        self._cleanup_unscheduled_submit(scope, admission)
+                    except BaseException as cleanup_error:
+                        raise RuntimeError(
+                            f"UDF subprocess actor submit failed: {type(submit_error).__name__}: "
+                            f"{submit_error}; {cleanup_error}"
+                        ) from submit_error
                     raise
                 return
 
@@ -2357,10 +2998,12 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 runtime = self._task_runtime
                 task_pool = self._task_pool
                 if runtime is None:
-                    if admission is not None:
-                        admission.release()
-                    self._retire_execution_scope(scope)
-                    raise RuntimeError("global subprocess task runtime is not available")
+                    missing_runtime_error = RuntimeError("global subprocess task runtime is not available")
+                    try:
+                        self._cleanup_unscheduled_submit(scope, admission)
+                    except BaseException as cleanup_error:
+                        raise RuntimeError(f"{missing_runtime_error}; {cleanup_error}") from missing_runtime_error
+                    raise missing_runtime_error
                 with self._pending_lock:
                     self._pending_batches += 1
                     pending = self._pending_batches
@@ -2385,19 +3028,27 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                         admission,
                         scope,
                     )
-                except BaseException:
+                except BaseException as submit_error:
                     with self._pending_lock:
                         self._pending_batches = max(0, self._pending_batches - 1)
-                    if admission is not None:
-                        admission.release()
-                    self._retire_execution_scope(scope)
+                    try:
+                        self._cleanup_unscheduled_submit(scope, admission)
+                    except BaseException as cleanup_error:
+                        raise RuntimeError(
+                            f"UDF subprocess task submit failed: {type(submit_error).__name__}: "
+                            f"{submit_error}; {cleanup_error}"
+                        ) from submit_error
                     raise
                 return
 
-            if admission is not None:
-                admission.release()
-            self._retire_execution_scope(scope)
-            raise RuntimeError("subprocess executor is not initialized with an actor or task worker owner")
+            missing_owner_error = RuntimeError(
+                "subprocess executor is not initialized with an actor or task worker owner"
+            )
+            try:
+                self._cleanup_unscheduled_submit(scope, admission)
+            except BaseException as cleanup_error:
+                raise RuntimeError(f"{missing_owner_error}; {cleanup_error}") from missing_owner_error
+            raise missing_owner_error
 
     def submit(self, args: pa.Table) -> None:
         table = _ensure_table(args)
@@ -2445,8 +3096,16 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             ) -> Any | None:
                 try:
                     return worker._submit_ref_bundle_direct(payload)
-                except BaseException:
-                    cancel_local_shm_input_lease(lease_id, name=f"udf-input-{int(submit_id)}")
+                except BaseException as submit_error:
+                    try:
+                        cancel_local_shm_input_lease(lease_id, name=f"udf-input-{int(submit_id)}")
+                    except BaseException as cleanup_error:
+                        broken_cleanup_details = worker._mark_broken_after_cleanup_failure(cleanup_error)
+                        raise RuntimeError(
+                            f"UDF ref-bundle worker submit failed: {type(submit_error).__name__}: "
+                            f"{submit_error}; input-lease cleanup failed: "
+                            f"{type(cleanup_error).__name__}: {cleanup_error}{broken_cleanup_details}"
+                        ) from submit_error
                     raise
                 finally:
                     self._untrack_input_lease(lease_id)
@@ -2458,9 +3117,20 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                     submit_worker,
                     admission,
                 )
-            except BaseException:
-                cancel_local_shm_input_lease(lease_id, name=f"udf-input-{int(submit_id)}")
-                self._untrack_input_lease(lease_id)
+            except BaseException as submit_error:
+                cleanup_error: BaseException | None = None
+                try:
+                    cancel_local_shm_input_lease(lease_id, name=f"udf-input-{int(submit_id)}")
+                except BaseException as exc:
+                    cleanup_error = exc
+                finally:
+                    self._untrack_input_lease(lease_id)
+                if cleanup_error is not None:
+                    raise RuntimeError(
+                        f"UDF ref-bundle scheduling failed: {type(submit_error).__name__}: "
+                        f"{submit_error}; input-lease cleanup failed: "
+                        f"{type(cleanup_error).__name__}: {cleanup_error}"
+                    ) from submit_error
                 raise
             return
         raise RuntimeError("subprocess UDF ref-bundle input requires local shared-memory descriptors")
@@ -2521,16 +3191,36 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         self._admission_authority.register_wakeup(callback)
 
     def _cancel_pending_futures(self) -> None:
+        cleanup_errors: list[BaseException] = []
         with self._task_futures_cv:
             for future in list(self._task_futures):
-                future.cancel()
+                try:
+                    future.cancel()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
             self._task_futures_cv.notify_all()
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF pending future cancellation failed: {details}") from cleanup_errors[0]
 
-    def _cancel_local_shm_waits(self) -> set[ExecutionCancellationScope]:
-        scopes = self._cancel_execution_scopes("UDF executor closed")
-        self._cancel_active_input_leases()
-        wake_local_shm_ref_budget_waiters()
-        return scopes
+    def _cancel_local_shm_waits(
+        self,
+    ) -> tuple[set[ExecutionCancellationScope], list[BaseException]]:
+        cleanup_errors: list[BaseException] = []
+        scopes: set[ExecutionCancellationScope] = set()
+        try:
+            scopes = self._cancel_execution_scopes("UDF executor closed")
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
+            self._cancel_active_input_leases()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        try:
+            wake_local_shm_ref_budget_waiters()
+        except BaseException as exc:
+            cleanup_errors.append(exc)
+        return scopes, cleanup_errors
 
     def _wait_for_pending_futures(self, timeout_s: float | None = None) -> bool:
         deadline = None if timeout_s is None else time.monotonic() + max(0.0, float(timeout_s))
@@ -2554,9 +3244,16 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             if self._closed:
                 return
             self._closed = True
+            self._close_after_marked_closed(kill=kill)
+
+    def _close_after_marked_closed(self, *, kill: bool) -> None:
+        cleanup_errors: list[BaseException] = []
         authority = getattr(self, "_admission_authority", None)
         if authority is not None:
-            authority.close()
+            try:
+                authority.close()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         queue_lock = getattr(self, "_queue_lock", None)
         result_queue = getattr(self, "_queue", None)
         result_admissions = getattr(self, "_result_admissions", None)
@@ -2575,48 +3272,91 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             _release_local_ref_bundle_result(result)
         for admission in admissions:
             if admission is not None:
-                admission.release()
+                try:
+                    admission.release()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
         budget_wakeup_unregister = self._budget_wakeup_unregister
         self._budget_wakeup_unregister = None
         if budget_wakeup_unregister is not None:
-            budget_wakeup_unregister()
-        cancelled_scopes = self._cancel_local_shm_waits()
+            try:
+                budget_wakeup_unregister()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        cancelled_scopes, wait_cleanup_errors = self._cancel_local_shm_waits()
+        cleanup_errors.extend(wait_cleanup_errors)
         close_kill = bool(kill)
         if close_kill:
             actor_pool = self._actor_pool
             if actor_pool is not None:
-                actor_pool.abort_scopes(cancelled_scopes)
+                try:
+                    actor_pool.abort_scopes(cancelled_scopes)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
             task_pool = self._task_pool
             if task_pool is not None:
-                task_pool.abort_scopes(cancelled_scopes)
-            self._cancel_pending_futures()
+                try:
+                    task_pool.abort_scopes(cancelled_scopes)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+            try:
+                self._cancel_pending_futures()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         else:
             if not self._wait_for_pending_futures(_subprocess_shutdown_grace_s()):
                 close_kill = True
                 actor_pool = self._actor_pool
                 if actor_pool is not None:
-                    actor_pool.abort_scopes(cancelled_scopes)
+                    try:
+                        actor_pool.abort_scopes(cancelled_scopes)
+                    except BaseException as exc:
+                        cleanup_errors.append(exc)
                 task_pool = self._task_pool
                 if task_pool is not None:
-                    task_pool.abort_scopes(cancelled_scopes)
-                self._cancel_pending_futures()
-                self._cancel_active_input_leases()
-                wake_local_shm_ref_budget_waiters()
+                    try:
+                        task_pool.abort_scopes(cancelled_scopes)
+                    except BaseException as exc:
+                        cleanup_errors.append(exc)
+                try:
+                    self._cancel_pending_futures()
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+                _, escalation_cleanup_errors = self._cancel_local_shm_waits()
+                cleanup_errors.extend(escalation_cleanup_errors)
         actor_pool = self._actor_pool
         if actor_pool is not None:
             self._actor_pool = None
+            if cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"UDF subprocess executor close failed: {details}") from cleanup_errors[0]
             return
         task_pool = self._task_pool
         if task_pool is not None:
             self._task_pool = None
-            task_pool.release_ref(kill=close_kill)
+            try:
+                task_pool.release_ref(kill=close_kill)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            if cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"UDF subprocess executor close failed: {details}") from cleanup_errors[0]
             return
         executor = self._executor
         self._executor = None
         if executor is not None:
-            executor.shutdown(wait=not close_kill, cancel_futures=True)
+            try:
+                executor.shutdown(wait=not close_kill, cancel_futures=True)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         for worker in list(self._workers):
-            worker.close(kill=close_kill)
+            try:
+                worker.close(kill=close_kill)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"UDF subprocess executor close failed: {details}") from cleanup_errors[0]
 
     def __del__(self) -> None:
         try:

--- a/duckdb/execution/udf_subprocess.py
+++ b/duckdb/execution/udf_subprocess.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 import weakref
 from collections import deque
 from collections.abc import Mapping
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
 from duckdb import pickle as duckdb_pickle
 from duckdb.execution._common import ensure_table as _ensure_table
 from duckdb.execution.ref_bundle import (
+    REF_BUNDLE_RESULT_MARKER,
     SUBMIT_RESULT_MARKER,
     _create_shm,
     _open_existing_shm,
@@ -48,6 +50,7 @@ from duckdb.execution.ref_bundle import (
     payload_requests_local_ref_bundle_output,
     register_local_shm_ref_budget_wakeup,
     release_local_shm_output_grant,
+    release_local_shm_ref_bundle_descriptor,
     request_local_shm_output_grant,
     wake_local_shm_ref_budget_waiters,
 )
@@ -56,6 +59,10 @@ from duckdb.execution.udf_admission import (
     AdmissionLease,
     LocalExecutionSlotPool,
     LocalSlotAdmissionAuthority,
+)
+from duckdb.execution.udf_lifecycle import (
+    ExecutionCancellationScope,
+    ExecutionCancelledError,
 )
 from duckdb.execution.udf_threading import (
     worker_thread_env as _worker_thread_env,
@@ -78,6 +85,7 @@ _MSG_OUTPUT_GRANT_REQUEST = 0x0C
 _MSG_OUTPUT_GRANT_GRANTED = 0x0D
 _MSG_OUTPUT_GRANT_CANCELLED = 0x0E
 _MSG_OUTPUT_GRANT_RELEASE = 0x0F
+_MSG_TASK_CANCELLED = 0x10
 
 _HEADER = struct.Struct("=BI")
 _IPC_HEADER = struct.Struct("<Q")
@@ -320,11 +328,14 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._session_config = (
             None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
         )
-        self._active_input_leases: set[int] = set()
+        self._execution_scope_lock = threading.Lock()
+        self._active_execution_scope: ExecutionCancellationScope | None = None
+        self._worker_lifetime_scope = ExecutionCancellationScope(f"subprocess-worker:{id(self)}", 1)
+        self._close_lock = threading.Lock()
+        self._active_input_leases: dict[int, ExecutionCancellationScope] = {}
         self._active_input_leases_lock = threading.Lock()
-        self._active_output_grants: set[int] = set()
+        self._active_output_grants: dict[int, ExecutionCancellationScope] = {}
         self._active_output_grants_lock = threading.Lock()
-        self._output_grant_cancel_event = threading.Event()
 
         self._payload_shm: shared_memory.SharedMemory | None = None
         self._data_shm: shared_memory.SharedMemory | None = None
@@ -441,32 +452,82 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             raise RuntimeError("UDF subprocess data shared memory is not available")
         return self._data_shm
 
-    def _track_input_lease(self, lease_id: int) -> None:
+    def _current_execution_scope(self) -> ExecutionCancellationScope:
+        lock = getattr(self, "_execution_scope_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._execution_scope_lock = lock
+        with lock:
+            scope = getattr(self, "_active_execution_scope", None)
+            if scope is not None:
+                return scope
+            lifetime_scope = getattr(self, "_worker_lifetime_scope", None)
+            if lifetime_scope is None:
+                lifetime_scope = ExecutionCancellationScope(f"subprocess-worker:{id(self)}", 1)
+                self._worker_lifetime_scope = lifetime_scope
+            return lifetime_scope
+
+    def _run_in_execution_scope(
+        self,
+        scope: ExecutionCancellationScope,
+        fn: Callable[[_SingleSubprocessExecutor], Any | None],
+    ) -> Any | None:
+        with self._execution_scope_lock:
+            if self._active_execution_scope is not None:
+                raise RuntimeError("UDF subprocess worker already has an active execution scope")
+            self._active_execution_scope = scope
+        unregister = scope.register_cancel_wakeup(lambda: self._cancel_scope_resources(scope, cancel_scope=False))
+        try:
+            scope.raise_if_cancelled("UDF subprocess task")
+            return fn(self)
+        finally:
+            unregister()
+            self._cancel_scope_resources(scope, cancel_scope=False)
+            with self._execution_scope_lock:
+                if self._active_execution_scope is scope:
+                    self._active_execution_scope = None
+
+    def _track_input_lease(
+        self,
+        lease_id: int,
+        scope: ExecutionCancellationScope | None = None,
+    ) -> None:
+        owner_scope = scope or self._current_execution_scope()
         with self._active_input_leases_lock:
-            self._active_input_leases.add(int(lease_id))
+            self._active_input_leases[int(lease_id)] = owner_scope
 
     def _untrack_input_lease(self, lease_id: int) -> None:
         with self._active_input_leases_lock:
-            self._active_input_leases.discard(int(lease_id))
+            self._active_input_leases.pop(int(lease_id), None)
 
-    def _cancel_active_input_leases(self) -> None:
+    def _cancel_active_input_leases(self, scope: ExecutionCancellationScope | None = None) -> None:
         with self._active_input_leases_lock:
-            lease_ids = list(self._active_input_leases)
-            self._active_input_leases.clear()
+            lease_ids = [
+                lease_id
+                for lease_id, owner_scope in self._active_input_leases.items()
+                if scope is None or owner_scope is scope
+            ]
+            for lease_id in lease_ids:
+                self._active_input_leases.pop(lease_id, None)
         for lease_id in lease_ids:
             cancel_local_shm_input_lease(lease_id, name="udf-input-close")
 
-    def _track_output_grant(self, grant_id: int) -> None:
+    def _track_output_grant(
+        self,
+        grant_id: int,
+        scope: ExecutionCancellationScope | None = None,
+    ) -> None:
         if int(grant_id) <= 0:
             return
+        owner_scope = scope or self._current_execution_scope()
         with self._active_output_grants_lock:
-            self._active_output_grants.add(int(grant_id))
+            self._active_output_grants[int(grant_id)] = owner_scope
 
     def _untrack_output_grant(self, grant_id: int) -> None:
         if int(grant_id) <= 0:
             return
         with self._active_output_grants_lock:
-            self._active_output_grants.discard(int(grant_id))
+            self._active_output_grants.pop(int(grant_id), None)
 
     def _release_output_grant(self, grant_id: int, *, name: str) -> None:
         if int(grant_id) <= 0:
@@ -476,12 +537,36 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         finally:
             self._untrack_output_grant(int(grant_id))
 
-    def _release_active_output_grants(self, *, name: str = "udf-output-close") -> None:
+    def _release_active_output_grants(
+        self,
+        *,
+        name: str = "udf-output-close",
+        scope: ExecutionCancellationScope | None = None,
+    ) -> None:
         with self._active_output_grants_lock:
-            grant_ids = list(self._active_output_grants)
-            self._active_output_grants.clear()
+            grant_ids = [
+                grant_id
+                for grant_id, owner_scope in self._active_output_grants.items()
+                if scope is None or owner_scope is scope
+            ]
+            for grant_id in grant_ids:
+                self._active_output_grants.pop(grant_id, None)
         for grant_id in grant_ids:
             release_local_shm_output_grant(grant_id, name=name)
+
+    def _cancel_scope_resources(
+        self,
+        scope: ExecutionCancellationScope,
+        *,
+        cancel_scope: bool = True,
+    ) -> None:
+        if cancel_scope:
+            scope.cancel("subprocess execution cancelled")
+        try:
+            self._cancel_active_input_leases(scope)
+            self._release_active_output_grants(name="udf-output-cancel", scope=scope)
+        finally:
+            wake_local_shm_ref_budget_waiters()
 
     def _mark_broken(self, error: str, *, actor_lost: bool = False) -> None:
         self._actor_lost = self._actor_lost or actor_lost
@@ -529,9 +614,15 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         if args.num_rows == 0:
             return None
 
-        _marker, refs, metadata, names = make_local_shm_ref_bundle_result(args)
+        scope = self._current_execution_scope()
+        scope.raise_if_cancelled("UDF subprocess input allocation")
+        _marker, refs, metadata, names = make_local_shm_ref_bundle_result(
+            args,
+            cancel_event=scope,
+        )
         lease_id = None
         try:
+            scope.raise_if_cancelled("UDF subprocess input allocation")
             worker_payload, lease_id = _make_local_ref_bundle_worker_payload_with_lease(
                 refs,
                 None,
@@ -577,22 +668,27 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             priority = str(event.get("priority") or "consumer")
             input_lease_id_raw = event.get("input_lease_id")
             input_lease_id = int(input_lease_id_raw) if input_lease_id_raw is not None else None
+            scope = self._current_execution_scope()
+            grant_id = 0
             try:
                 grant_id = request_local_shm_output_grant(
                     size,
                     name=f"udf-output-{request_id}",
                     priority=priority,
                     input_lease_id=input_lease_id,
-                    cancel_event=self._output_grant_cancel_event,
+                    cancel_event=scope,
                 )
+                self._track_output_grant(grant_id, scope)
+                scope.raise_if_cancelled("UDF subprocess output grant")
             except BaseException as exc:
+                if grant_id > 0:
+                    self._release_output_grant(grant_id, name=f"udf-output-{request_id}-cancelled")
                 _send_message(
                     self._require_socket(),
                     _MSG_OUTPUT_GRANT_CANCELLED,
                     str(exc).encode("utf-8", errors="replace"),
                 )
                 return True
-            self._track_output_grant(grant_id)
             response = {"request_id": request_id, "grant_id": int(grant_id)}
             try:
                 _send_message(self._require_socket(), _MSG_OUTPUT_GRANT_GRANTED, duckdb_pickle.dumps(response))
@@ -623,33 +719,72 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                     _MSG_INPUT_CONSUME_FAILED,
                     _MSG_OUTPUT_GRANT_REQUEST,
                     _MSG_OUTPUT_GRANT_RELEASE,
+                    _MSG_TASK_CANCELLED,
                 )
             )
-            if self._handle_submit_control_message(msg_type, payload):
-                msg_type = None
-                continue
+            try:
+                if self._handle_submit_control_message(msg_type, payload):
+                    msg_type = None
+                    continue
+            except BaseException as exc:
+                self._mark_broken(
+                    f"UDF subprocess control-message handling failed: {exc}",
+                    actor_lost=True,
+                )
+                raise RuntimeError(self._broken_error) from exc
             if msg_type == _MSG_ERROR:
                 error = payload.decode("utf-8", errors="replace")
                 self._mark_broken(error)
                 raise RuntimeError(error)
+            if msg_type == _MSG_TASK_CANCELLED:
+                error = payload.decode("utf-8", errors="replace") or "UDF subprocess task cancelled"
+                scope = self._current_execution_scope()
+                if scope.is_set():
+                    raise ExecutionCancelledError(f"UDF subprocess task cancelled: {scope.cancel_reason or error}")
+                self._mark_broken(f"UDF subprocess unexpectedly cancelled a task: {error}")
+                raise RuntimeError(self._broken_error)
             if msg_type == _MSG_REF_BUNDLE_RESULT:
                 descriptor = duckdb_pickle.loads(payload)
                 grant_id_raw = descriptor.get("grant_id") if isinstance(descriptor, dict) else None
                 grant_id = int(grant_id_raw) if grant_id_raw is not None else None
+                scope = self._current_execution_scope()
+                if scope.is_set():
+                    try:
+                        release_local_shm_ref_bundle_descriptor(descriptor)
+                    finally:
+                        if grant_id is not None:
+                            self._release_output_grant(grant_id, name="udf-output-cancelled-result")
+                    raise ExecutionCancelledError(
+                        f"UDF subprocess task cancelled: {scope.cancel_reason or 'cancelled'}"
+                    )
                 try:
-                    result = make_local_shm_ref_bundle_result_from_descriptor(descriptor, block_on_budget=False)
+                    result = make_local_shm_ref_bundle_result_from_descriptor(
+                        descriptor,
+                        block_on_budget=False,
+                        cancel_event=scope,
+                    )
                 except BaseException:
-                    if grant_id is not None:
-                        self._release_output_grant(grant_id, name="udf-output-descriptor-wrap-failed")
+                    try:
+                        release_local_shm_ref_bundle_descriptor(descriptor)
+                    finally:
+                        if grant_id is not None:
+                            self._release_output_grant(grant_id, name="udf-output-descriptor-wrap-failed")
                     raise
                 if grant_id is not None:
                     self._untrack_output_grant(grant_id)
+                try:
+                    scope.raise_if_cancelled("UDF subprocess result")
+                except BaseException:
+                    _release_local_ref_bundle_result(result)
+                    raise
                 return result
             if len(payload) != 8:
                 self._mark_broken("UDF subprocess returned malformed OK response", actor_lost=True)
                 raise RuntimeError(self._broken_error)
 
             result_size = struct.unpack("<Q", payload)[0]
+            scope = self._current_execution_scope()
+            scope.raise_if_cancelled("UDF subprocess task")
             if result_size == 0:
                 return None
             if self._ref_bundle_output:
@@ -674,8 +809,14 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         sock = self._require_socket()
         lease_id_raw = payload.get("input_lease_id")
         lease_id = int(lease_id_raw) if lease_id_raw is not None else None
+        scope = self._current_execution_scope()
+        scope.raise_if_cancelled("UDF subprocess submit")
         if lease_id is not None:
-            self._track_input_lease(lease_id)
+            self._track_input_lease(lease_id, scope)
+            if scope.is_set():
+                cancel_local_shm_input_lease(lease_id, name="udf-input")
+                self._untrack_input_lease(lease_id)
+                scope.raise_if_cancelled("UDF subprocess submit")
         try:
             payload_bytes = duckdb_pickle.dumps(payload)
             _send_message(sock, _MSG_SUBMIT_REF_BUNDLE, payload_bytes)
@@ -804,12 +945,25 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
     def register_wakeup(self, callback: Callable[[], None]) -> None:
         self._wakeup = callback
 
+    def is_reusable(self) -> bool:
+        if self._closed or self._broken_error is not None:
+            return False
+        proc = self._proc
+        return proc is not None and proc.poll() is None
+
     def cancel_output_grants(self) -> None:
-        self._output_grant_cancel_event.set()
-        self._release_active_output_grants(name="udf-output-cancel")
-        wake_local_shm_ref_budget_waiters()
+        scope = self._current_execution_scope()
+        self._cancel_scope_resources(scope)
 
     def close(self, kill: bool = False) -> None:
+        close_lock = getattr(self, "_close_lock", None)
+        if close_lock is None:
+            close_lock = threading.Lock()
+            self._close_lock = close_lock
+        with close_lock:
+            self._close_locked(kill=kill)
+
+    def _close_locked(self, *, kill: bool) -> None:
         if self._closed:
             return
         self._closed = True
@@ -818,20 +972,38 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
 
         proc = self._proc
         sock = self._sock
-        self._proc = None
-        self._sock = None
         shutdown_error: BaseException | None = None
+        graceful_error: BaseException | None = None
 
-        if sock is not None:
+        if proc is not None and proc.poll() is None and sock is not None and not kill:
+            deadline = time.monotonic() + _subprocess_shutdown_grace_s()
             try:
-                if proc is not None and proc.poll() is None and not kill:
-                    _send_message(sock, _MSG_CLOSE)
-            except Exception:
-                pass
-            try:
-                sock.close()
-            except Exception:
-                pass
+                _send_message(sock, _MSG_CLOSE)
+                remaining = max(0.0, deadline - time.monotonic())
+                if hasattr(sock, "settimeout"):
+                    sock.settimeout(remaining)
+                msg_type, payload = _recv_message(sock)
+                if msg_type == _MSG_ERROR:
+                    graceful_error = RuntimeError(
+                        "UDF subprocess graceful shutdown failed: " + payload.decode("utf-8", errors="replace")
+                    )
+                elif msg_type != _MSG_ACK:
+                    graceful_error = RuntimeError(
+                        f"UDF subprocess graceful shutdown returned unexpected message type {msg_type:#x}"
+                    )
+            except (socket.timeout, EOFError, OSError) as exc:
+                _subprocess_debug_log(f"worker graceful shutdown timed out or disconnected: {exc}")
+            except BaseException as exc:
+                graceful_error = exc
+            if proc.poll() is None:
+                remaining = max(0.0, deadline - time.monotonic())
+                try:
+                    proc.wait(timeout=remaining)
+                except (subprocess.TimeoutExpired, TimeoutError) as exc:
+                    _subprocess_debug_log(f"worker graceful shutdown did not exit before deadline: {exc}")
+                except BaseException as exc:
+                    if graceful_error is None:
+                        graceful_error = exc
 
         if proc is not None and proc.poll() is None:
             try:
@@ -844,6 +1016,14 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                 if shutdown_error is None:
                     shutdown_error = exc
 
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+
+        self._proc = None
+        self._sock = None
         self._close_payload_shm()
         data_shm = self._data_shm
         self._data_shm = None
@@ -861,6 +1041,8 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
             finalizer.detach()
         if shutdown_error is not None:
             raise RuntimeError(f"UDF subprocess did not terminate cleanly: {shutdown_error}") from shutdown_error
+        if graceful_error is not None:
+            raise RuntimeError(str(graceful_error)) from graceful_error
 
     def __del__(self) -> None:
         try:
@@ -929,10 +1111,35 @@ def _payload_task_key(
     return hashlib.sha256(duckdb_pickle.dumps(identity)).hexdigest()
 
 
+def _worker_is_reusable(worker: Any) -> bool:
+    check = getattr(worker, "is_reusable", None)
+    if callable(check):
+        return bool(check())
+    if getattr(worker, "_closed", False) or getattr(worker, "_broken_error", None) is not None:
+        return False
+    proc = getattr(worker, "_proc", None)
+    poll = getattr(proc, "poll", None)
+    return proc is None or not callable(poll) or poll() is None
+
+
+def _release_local_ref_bundle_result(value: Any) -> None:
+    if isinstance(value, tuple) and len(value) >= 3 and value[0] == SUBMIT_RESULT_MARKER:
+        value = value[2]
+    if not (isinstance(value, tuple) and len(value) >= 2 and value[0] == REF_BUNDLE_RESULT_MARKER):
+        return
+    for ref in list(value[1] or []):
+        try:
+            ref.release()
+        except Exception:
+            pass
+
+
 class _PooledTaskWorker:
     def __init__(self, worker: _SingleSubprocessExecutor) -> None:
         self.worker = worker
         self.last_used = time.monotonic()
+        self.active_scope: ExecutionCancellationScope | None = None
+        self.abort_requested = False
 
 
 class _TaskWorkerPool:
@@ -1004,6 +1211,10 @@ class _TaskWorkerPool:
         for worker in workers:
             worker.cancel_output_grants()
 
+    def _wake_waiters(self) -> None:
+        with self.runtime.cond:
+            self.runtime.cond.notify_all()
+
     def _spawn_worker(self, worker_idx: int) -> _PooledTaskWorker:
         worker = _SingleSubprocessExecutor(
             self.payload,
@@ -1012,56 +1223,72 @@ class _TaskWorkerPool:
         )
         return _PooledTaskWorker(worker)
 
-    def acquire_worker(self) -> _PooledTaskWorker:
+    def acquire_worker(self, scope: ExecutionCancellationScope) -> _PooledTaskWorker:
         wrapper: _PooledTaskWorker | None = None
         spawn_idx: int | None = None
-        while wrapper is None and spawn_idx is None:
-            evicted: _SingleSubprocessExecutor | None = None
+        unregister = scope.register_cancel_wakeup(self._wake_waiters)
+        try:
+            while wrapper is None and spawn_idx is None:
+                evicted: _SingleSubprocessExecutor | None = None
+                with self.runtime.cond:
+                    scope.raise_if_cancelled("subprocess task worker acquisition")
+                    if self.closing or self.runtime.closed:
+                        raise RuntimeError("subprocess task worker pool is closed")
+                    while self.idle:
+                        candidate = self.idle.pop()
+                        if _worker_is_reusable(candidate.worker):
+                            candidate.active_scope = scope
+                            self.active += 1
+                            self._active_wrappers.add(candidate)
+                            return candidate
+                        self.total = max(0, self.total - 1)
+                        self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
+                        evicted = candidate.worker
+                        self.runtime.cond.notify_all()
+                        break
+                    if evicted is not None:
+                        pass
+                    elif self.total < self.pool_size and self.runtime.total_workers < self.runtime.max_workers:
+                        spawn_idx = self.next_worker_idx
+                        self.next_worker_idx += 1
+                        self.total += 1
+                        self.active += 1
+                        self.runtime.total_workers += 1
+                        break
+                    else:
+                        evicted = self.runtime._take_idle_worker_locked()
+                        if evicted is None:
+                            self.runtime.cond.wait()
+                            continue
+                if evicted is not None:
+                    evicted.close(kill=False)
+
+            try:
+                assert spawn_idx is not None
+                wrapper = self._spawn_worker(spawn_idx)
+            except Exception:
+                with self.runtime.cond:
+                    self.total = max(0, self.total - 1)
+                    self.active = max(0, self.active - 1)
+                    self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
+                    self.runtime.cond.notify_all()
+                raise
+            close_kill = False
             with self.runtime.cond:
-                if self.closing:
-                    raise RuntimeError("subprocess task worker pool is closed")
-                if self.idle:
-                    wrapper = self.idle.pop()
-                    self.active += 1
+                if self.closing or self.runtime.closed:
+                    self.total = max(0, self.total - 1)
+                    self.active = max(0, self.active - 1)
+                    self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
+                    close_kill = self.kill_on_release
+                    self.runtime.cond.notify_all()
+                else:
+                    wrapper.active_scope = scope
                     self._active_wrappers.add(wrapper)
                     return wrapper
-                if self.total < self.pool_size and self.runtime.total_workers < self.runtime.max_workers:
-                    spawn_idx = self.next_worker_idx
-                    self.next_worker_idx += 1
-                    self.total += 1
-                    self.active += 1
-                    self.runtime.total_workers += 1
-                    break
-                evicted = self.runtime._take_idle_worker_locked()
-                if evicted is None:
-                    self.runtime.cond.wait()
-                    continue
-            if evicted is not None:
-                evicted.close(kill=False)
-
-        try:
-            assert spawn_idx is not None
-            wrapper = self._spawn_worker(spawn_idx)
-        except Exception:
-            with self.runtime.cond:
-                self.total = max(0, self.total - 1)
-                self.active = max(0, self.active - 1)
-                self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
-                self.runtime.cond.notify_all()
-            raise
-        close_kill = False
-        with self.runtime.cond:
-            if self.closing or self.runtime.closed:
-                self.total = max(0, self.total - 1)
-                self.active = max(0, self.active - 1)
-                self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
-                close_kill = self.kill_on_release
-                self.runtime.cond.notify_all()
-            else:
-                self._active_wrappers.add(wrapper)
-                return wrapper
-        wrapper.worker.close(kill=close_kill)
-        raise RuntimeError("subprocess task worker pool is closed")
+            wrapper.worker.close(kill=close_kill)
+            raise RuntimeError("subprocess task worker pool is closed")
+        finally:
+            unregister()
 
     def release_worker(self, wrapper: _PooledTaskWorker, *, reusable: bool = True) -> None:
         to_close: _SingleSubprocessExecutor | None = None
@@ -1069,22 +1296,29 @@ class _TaskWorkerPool:
         with self.runtime.cond:
             self._active_wrappers.discard(wrapper)
             self.active = max(0, self.active - 1)
-            if (
-                self.closing
-                or not reusable
-                or getattr(wrapper.worker, "_closed", False)
-                or getattr(wrapper.worker, "_broken_error", None) is not None
-            ):
+            wrapper.active_scope = None
+            if self.closing or wrapper.abort_requested or not reusable or not _worker_is_reusable(wrapper.worker):
                 self.total = max(0, self.total - 1)
                 self.runtime.total_workers = max(0, self.runtime.total_workers - 1)
                 to_close = wrapper.worker
-                kill_close = self.kill_on_release or not reusable
+                kill_close = self.kill_on_release or wrapper.abort_requested or not reusable
             else:
                 wrapper.last_used = time.monotonic()
                 self.idle.append(wrapper)
             self.runtime.cond.notify_all()
         if to_close is not None:
             to_close.close(kill=kill_close)
+
+    def abort_scopes(self, scopes: set[ExecutionCancellationScope]) -> None:
+        workers: list[_SingleSubprocessExecutor] = []
+        with self.runtime.cond:
+            for wrapper in self._active_wrappers:
+                if wrapper.active_scope in scopes:
+                    wrapper.abort_requested = True
+                    workers.append(wrapper.worker)
+            self.runtime.cond.notify_all()
+        for worker in workers:
+            worker.close(kill=True)
 
 
 class _GlobalSubprocessTaskRuntime:
@@ -1121,21 +1355,23 @@ class _GlobalSubprocessTaskRuntime:
         self,
         pool: _TaskWorkerPool,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
+        scope: ExecutionCancellationScope,
         debug_seq: int = 0,
     ) -> Future[Any]:
         if self.closed:
             raise RuntimeError("global subprocess task runtime is closed")
-        return self.executor.submit(self._run_task, pool, fn, debug_seq)
+        return self.executor.submit(self._run_task, pool, fn, scope, debug_seq)
 
     def _run_task(
         self,
         pool: _TaskWorkerPool,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
+        scope: ExecutionCancellationScope,
         debug_seq: int = 0,
     ) -> Any | None:
         acquire_start = time.perf_counter()
         wrapper: _PooledTaskWorker | None = None
-        wrapper = pool.acquire_worker()
+        wrapper = pool.acquire_worker(scope)
         acquire_s = time.perf_counter() - acquire_start
         assert wrapper is not None
         if _should_debug_submit(debug_seq):
@@ -1150,13 +1386,13 @@ class _GlobalSubprocessTaskRuntime:
         reusable = True
         run_start = time.perf_counter()
         try:
-            return fn(wrapper.worker)
+            scope.raise_if_cancelled("subprocess task")
+            return wrapper.worker._run_in_execution_scope(scope, fn)
         except BaseException:
-            reusable = getattr(wrapper.worker, "_broken_error", None) is None and not getattr(
-                wrapper.worker, "_closed", False
-            )
+            reusable = _worker_is_reusable(wrapper.worker)
             raise
         finally:
+            scope.finish()
             if _should_debug_submit(debug_seq):
                 _subprocess_debug_log(
                     "task_worker_finished "
@@ -1264,14 +1500,20 @@ class LocalSubprocessActorPool:
         self.pool_size = max(1, int(pool_size))
         self.name = str(name or "")
         self._closed = False
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._cond = threading.Condition(self._lock)
         self._active = 0
+        self._terminal_error: BaseException | None = None
+        self._active_scopes: dict[int, ExecutionCancellationScope] = {}
+        self._worker_generations = [0 for _ in range(self.pool_size)]
+        self._replacing_workers: set[int] = set()
+        self._aborting_workers: set[tuple[int, int]] = set()
         pool_identity = self.name or str(id(self))
         self.admission_slots = LocalExecutionSlotPool(
             max_slots=self.pool_size,
             execution_slot_prefix=f"subprocess_actor:{pool_identity}",
         )
-        self._idle_workers: queue.Queue[int] = queue.Queue()
+        self._idle_workers: deque[tuple[int, int]] = deque()
         self._workers: list[_SingleSubprocessExecutor] = []
         self._executor: ThreadPoolExecutor | None = None
         try:
@@ -1310,56 +1552,163 @@ class LocalSubprocessActorPool:
                 ) from init_error
             raise
         for worker_idx in range(self.pool_size):
-            self._idle_workers.put(worker_idx)
+            self._idle_workers.append((worker_idx, 0))
         _subprocess_debug_log(
             f"local_actor_pool_created name={self.name!r} pool_size={self.pool_size} worker_pids={self.worker_pids()}"
         )
 
     def worker_pids(self) -> list[int | None]:
-        return [getattr(worker._proc, "pid", None) for worker in self._workers]
+        with self._lock:
+            return [getattr(worker._proc, "pid", None) for worker in self._workers]
 
     def create_admission_authority(self) -> LocalSlotAdmissionAuthority:
         return self.admission_slots.create_authority()
 
     def first_proc(self) -> Any | None:
-        if not self._workers:
-            return None
-        return self._workers[0]._proc
+        with self._lock:
+            if not self._workers:
+                return None
+            return self._workers[0]._proc
+
+    def _wake_waiters(self) -> None:
+        with self._cond:
+            self._cond.notify_all()
+
+    def _raise_if_unavailable_locked(self) -> None:
+        if self._closed:
+            raise RuntimeError("local subprocess actor pool is closed")
+        if self._terminal_error is not None:
+            raise RuntimeError(f"local subprocess actor pool failed: {self._terminal_error}") from self._terminal_error
+
+    def _spawn_worker(self, worker_idx: int) -> _SingleSubprocessExecutor:
+        return _SingleSubprocessExecutor(
+            self.payload,
+            worker_env=_worker_env_for_pool_index(self.payload, worker_idx, self.pool_size),
+            session_config=self.session_config,
+        )
+
+    def _set_terminal_error(self, error: BaseException) -> None:
+        should_close_admission = False
+        with self._cond:
+            if self._terminal_error is None:
+                self._terminal_error = error
+                should_close_admission = True
+            self._cond.notify_all()
+        if should_close_admission:
+            self.admission_slots.close()
+
+    def _replace_worker(
+        self,
+        worker_idx: int,
+        worker_generation: int,
+        failed_worker: _SingleSubprocessExecutor,
+    ) -> None:
+        try:
+            failed_worker.close(kill=True)
+        except Exception:
+            pass
+        try:
+            replacement = self._spawn_worker(worker_idx)
+        except BaseException as exc:
+            with self._cond:
+                self._replacing_workers.discard(worker_idx)
+                self._cond.notify_all()
+            self._set_terminal_error(RuntimeError(f"failed to replace local subprocess actor {worker_idx}: {exc}"))
+            return
+
+        close_replacement = False
+        with self._cond:
+            self._replacing_workers.discard(worker_idx)
+            if (
+                self._closed
+                or worker_idx >= len(self._workers)
+                or self._worker_generations[worker_idx] != worker_generation
+                or self._workers[worker_idx] is not failed_worker
+            ):
+                close_replacement = True
+            else:
+                next_generation = worker_generation + 1
+                self._workers[worker_idx] = replacement
+                self._worker_generations[worker_idx] = next_generation
+                self._idle_workers.append((worker_idx, next_generation))
+            self._cond.notify_all()
+        if close_replacement:
+            replacement.close(kill=True)
+
+    def _acquire_worker(
+        self,
+        scope: ExecutionCancellationScope,
+    ) -> tuple[int, int, _SingleSubprocessExecutor]:
+        unregister = scope.register_cancel_wakeup(self._wake_waiters)
+        try:
+            while True:
+                replacement: tuple[int, int, _SingleSubprocessExecutor] | None = None
+                with self._cond:
+                    scope.raise_if_cancelled("local subprocess actor acquisition")
+                    self._raise_if_unavailable_locked()
+                    while self._idle_workers:
+                        worker_idx, worker_generation = self._idle_workers.popleft()
+                        if worker_idx >= len(self._workers):
+                            continue
+                        if self._worker_generations[worker_idx] != worker_generation:
+                            continue
+                        worker = self._workers[worker_idx]
+                        if _worker_is_reusable(worker):
+                            self._active += 1
+                            self._active_scopes[worker_idx] = scope
+                            return worker_idx, worker_generation, worker
+                        if worker_idx not in self._replacing_workers:
+                            self._replacing_workers.add(worker_idx)
+                            replacement = (worker_idx, worker_generation, worker)
+                        break
+                    if replacement is None:
+                        self._cond.wait()
+                        continue
+                self._replace_worker(*replacement)
+        finally:
+            unregister()
 
     def submit(
         self,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
+        scope: ExecutionCancellationScope,
         debug_seq: int = 0,
     ) -> Future[Any]:
         with self._lock:
-            if self._closed:
-                raise RuntimeError("local subprocess actor pool is closed")
+            self._raise_if_unavailable_locked()
             executor = self._executor
         if executor is None:
             raise RuntimeError("local subprocess actor pool is closed")
-        return executor.submit(self._run, fn, debug_seq)
+        return executor.submit(self._run, fn, scope, debug_seq)
 
     def _run(
         self,
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
+        scope: ExecutionCancellationScope,
         debug_seq: int = 0,
     ) -> Any | None:
-        worker_idx = self._idle_workers.get()
-        with self._lock:
-            self._active += 1
-            active = self._active
-        worker = self._workers[worker_idx]
-        worker_pid = getattr(worker._proc, "pid", None)
+        worker_idx: int | None = None
+        worker_generation = 0
+        worker: _SingleSubprocessExecutor | None = None
+        worker_pid = None
+        reusable = False
+        replace_worker = False
+        terminal_error: BaseException | None = None
         try:
+            worker_idx, worker_generation, worker = self._acquire_worker(scope)
+            with self._lock:
+                active = self._active
+            worker_pid = getattr(worker._proc, "pid", None)
             if _should_debug_submit(debug_seq):
                 _subprocess_debug_log(
                     "local_actor_pool_worker_acquired "
                     f"name={self.name!r} seq={debug_seq} worker_idx={worker_idx} active={active} "
-                    f"pool_size={self.pool_size} worker_pid={getattr(self._workers[worker_idx]._proc, 'pid', None)}"
+                    f"pool_size={self.pool_size} worker_pid={worker_pid}"
                 )
-            return fn(worker)
+            scope.raise_if_cancelled("local subprocess actor task")
+            return worker._run_in_execution_scope(scope, fn)
         except BaseException as exc:
-            if self.payload.get("stateful") and worker._actor_lost:
+            if self.payload.get("stateful") and worker is not None and getattr(worker, "_actor_lost", False):
                 udf_name = str(self.payload.get("udf_name") or "udf")
                 actor_id = "unknown" if worker_pid is None else str(worker_pid)
                 raise RuntimeError(
@@ -1368,44 +1717,114 @@ class LocalSubprocessActorPool:
                 ) from exc
             raise
         finally:
-            with self._lock:
-                self._active = max(0, self._active - 1)
-                active_after = self._active
-            self._idle_workers.put(worker_idx)
+            scope.finish()
+            active_after = 0
+            if worker_idx is not None and worker is not None:
+                reusable = _worker_is_reusable(worker)
+                with self._cond:
+                    worker_identity = (worker_idx, worker_generation)
+                    abort_requested = worker_identity in self._aborting_workers
+                    self._aborting_workers.discard(worker_identity)
+                    self._active = max(0, self._active - 1)
+                    self._active_scopes.pop(worker_idx, None)
+                    active_after = self._active
+                    if not self._closed and reusable and not abort_requested:
+                        self._idle_workers.append((worker_idx, worker_generation))
+                    elif not self._closed and self.payload.get("stateful"):
+                        udf_name = str(self.payload.get("udf_name") or "udf")
+                        actor_id = "unknown" if worker_pid is None else str(worker_pid)
+                        terminal_error = RuntimeError(
+                            f"stateful UDF {udf_name!r} lost local actor pid {actor_id}; "
+                            "state was not recoverable; side effects may already have occurred"
+                        )
+                    elif not self._closed and worker_idx not in self._replacing_workers:
+                        self._replacing_workers.add(worker_idx)
+                        replace_worker = True
+                    self._cond.notify_all()
+                if terminal_error is not None:
+                    self._set_terminal_error(terminal_error)
+                elif replace_worker:
+                    self._replace_worker(worker_idx, worker_generation, worker)
             if _should_debug_submit(debug_seq):
                 _subprocess_debug_log(
                     "local_actor_pool_worker_finished "
-                    f"name={self.name!r} seq={debug_seq} worker_idx={worker_idx} active={active_after}"
+                    f"name={self.name!r} seq={debug_seq} worker_idx={worker_idx} "
+                    f"active={active_after} reusable={reusable}"
                 )
 
     def stats(self) -> dict[str, int]:
         with self._lock:
             active = self._active
+            idle = len(self._idle_workers)
         return {
             "pool_size": self.pool_size,
             "active_workers": active,
-            "idle_workers": max(0, self.pool_size - active),
+            "idle_workers": idle,
         }
 
     def cancel_output_grants(self) -> None:
-        for worker in list(self._workers):
+        with self._lock:
+            workers = list(self._workers)
+        for worker in workers:
             worker.cancel_output_grants()
 
+    def abort_scopes(self, scopes: set[ExecutionCancellationScope]) -> None:
+        workers: list[_SingleSubprocessExecutor] = []
+        with self._cond:
+            for worker_idx, scope in self._active_scopes.items():
+                if scope not in scopes or worker_idx >= len(self._workers):
+                    continue
+                worker_generation = self._worker_generations[worker_idx]
+                self._aborting_workers.add((worker_idx, worker_generation))
+                workers.append(self._workers[worker_idx])
+            self._cond.notify_all()
+        for worker in workers:
+            worker.close(kill=True)
+
     def shutdown(self, *, kill: bool = False) -> None:
-        with self._lock:
+        with self._cond:
             if self._closed:
                 return
             self._closed = True
+            active_scopes = list(self._active_scopes.values())
+            self._cond.notify_all()
         self.admission_slots.close()
-        self.cancel_output_grants()
+        for scope in active_scopes:
+            scope.cancel("local subprocess actor pool closed")
+
+        close_kill = bool(kill)
+        if not close_kill:
+            deadline = time.monotonic() + _subprocess_shutdown_grace_s()
+            with self._cond:
+                while self._active > 0:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        close_kill = True
+                        break
+                    self._cond.wait(timeout=remaining)
+        if close_kill:
+            self.abort_scopes(set(active_scopes))
+
         executor = self._executor
         self._executor = None
         if executor is not None:
             executor.shutdown(wait=False, cancel_futures=True)
-        for worker in list(self._workers):
-            worker.close(kill=kill)
-        self._workers = []
-        _subprocess_debug_log(f"local_actor_pool_shutdown name={self.name!r} kill={kill}")
+        with self._lock:
+            workers = list(self._workers)
+        cleanup_errors: list[BaseException] = []
+        for worker in workers:
+            try:
+                worker.close(kill=close_kill)
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+        with self._cond:
+            self._workers = []
+            self._idle_workers.clear()
+            self._cond.notify_all()
+        _subprocess_debug_log(f"local_actor_pool_shutdown name={self.name!r} kill={close_kill}")
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"local subprocess actor pool shutdown failed: {details}") from cleanup_errors[0]
 
     def __del__(self) -> None:
         try:
@@ -1451,13 +1870,14 @@ def _validate_stateful_local_actor_contract(payload: dict[str, Any], pool_size: 
 
 _LOCAL_ACTOR_POOL_CONTRACT_ERROR = (
     "local_actor_pool must expose submit(), create_admission_authority(), pool_size, stats(), "
-    "cancel_output_grants(), first_proc(), and worker_pids()"
+    "cancel_output_grants(), abort_scopes(), first_proc(), and worker_pids()"
 )
 _LOCAL_ACTOR_POOL_REQUIRED_METHODS = (
     "submit",
     "create_admission_authority",
     "stats",
     "cancel_output_grants",
+    "abort_scopes",
     "first_proc",
     "worker_pids",
 )
@@ -1587,8 +2007,13 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         self._task_futures_lock = self._task_futures_cv
         self._task_future_meta: dict[
             Future[Any],
-            tuple[int | None, int, float, AdmissionLease | None],
+            tuple[int | None, int, float, AdmissionLease | None, ExecutionCancellationScope],
         ] = {}
+        self._execution_owner_id = uuid.uuid4().hex
+        self._execution_scope_generation = 0
+        self._execution_scopes: set[ExecutionCancellationScope] = set()
+        self._execution_scopes_lock = threading.Lock()
+        self._lifecycle_lock = threading.RLock()
         self._debug_submit_count = 0
         self._queue: deque[Any] = deque()
         self._result_admissions: deque[AdmissionLease | None] = deque()
@@ -1743,6 +2168,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         debug_seq: int,
         submit_start: float,
         admission: AdmissionLease | None,
+        scope: ExecutionCancellationScope,
     ) -> None:
         with self._task_futures_lock:
             self._task_futures.add(future)
@@ -1751,12 +2177,40 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 debug_seq,
                 submit_start,
                 admission,
+                scope,
             )
 
         def complete_task(done: Future[Any], submit_id: int | None = submit_id) -> None:
             self._complete_task_submit(submit_id, done)
 
         future.add_done_callback(complete_task)
+
+    def _new_execution_scope(self) -> ExecutionCancellationScope:
+        with self._execution_scopes_lock:
+            if self._closed:
+                raise RuntimeError("UDF subprocess executor is closed")
+            self._execution_scope_generation += 1
+            scope = ExecutionCancellationScope(
+                self._execution_owner_id,
+                self._execution_scope_generation,
+            )
+            self._execution_scopes.add(scope)
+            return scope
+
+    def _retire_execution_scope(self, scope: ExecutionCancellationScope) -> None:
+        scope.finish()
+        with self._execution_scopes_lock:
+            self._execution_scopes.discard(scope)
+
+    def _cancel_execution_scopes(self, reason: str) -> set[ExecutionCancellationScope]:
+        lock = getattr(self, "_execution_scopes_lock", None)
+        if lock is None:
+            return set()
+        with lock:
+            scopes = set(self._execution_scopes)
+        for scope in scopes:
+            scope.cancel(reason)
+        return scopes
 
     def _notify_wakeup(self) -> None:
         callback = self._wakeup
@@ -1788,19 +2242,32 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
 
     def _complete_task_submit(self, submit_id: int | None, future: Future[Any]) -> None:
         item: Any | None = None
-        debug_meta: tuple[int | None, int, float, AdmissionLease | None] | None = None
+        result: Any | None = None
+        debug_meta: (
+            tuple[
+                int | None,
+                int,
+                float,
+                AdmissionLease | None,
+                ExecutionCancellationScope,
+            ]
+            | None
+        ) = None
         admission: AdmissionLease | None = None
+        scope: ExecutionCancellationScope | None = None
         try:
             result = future.result()
             self._record_output_budget_result(result)
             item = self._submit_result_item(submit_id, result)
         except BaseException as exc:
+            _release_local_ref_bundle_result(result)
+            result = None
             item = (SUBMIT_RESULT_MARKER, int(submit_id), exc) if submit_id is not None else exc
         finally:
             with self._task_futures_lock:
                 debug_meta = self._task_future_meta.get(future)
             if debug_meta is not None:
-                debug_submit_id, debug_seq, submit_start, admission = debug_meta
+                debug_submit_id, debug_seq, submit_start, admission, scope = debug_meta
                 if _should_debug_submit(debug_seq):
                     _subprocess_debug_log(
                         "task_submit_completed "
@@ -1810,6 +2277,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             if item is not None:
                 with self._queue_lock:
                     if self._closed:
+                        _release_local_ref_bundle_result(result)
                         if admission is not None:
                             admission.release()
                     else:
@@ -1819,11 +2287,13 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 admission.release()
             with self._pending_lock:
                 self._pending_batches = max(0, self._pending_batches - 1)
-            self._notify_wakeup()
             with self._task_futures_cv:
                 self._task_futures.discard(future)
                 self._task_future_meta.pop(future, None)
                 self._task_futures_cv.notify_all()
+            if scope is not None:
+                self._retire_execution_scope(scope)
+            self._notify_wakeup()
 
     def _submit_async(
         self,
@@ -1831,83 +2301,103 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         fn: Callable[[_SingleSubprocessExecutor], Any | None],
         admission: AdmissionLease | None = None,
     ) -> None:
-        if self._closed:
+        lifecycle_lock = getattr(self, "_lifecycle_lock", None)
+        if lifecycle_lock is None:
+            lifecycle_lock = threading.RLock()
+            self._lifecycle_lock = lifecycle_lock
+        with lifecycle_lock:
+            if self._closed:
+                if admission is not None:
+                    admission.release()
+                raise RuntimeError("UDF subprocess executor is closed")
+            self._debug_submit_count += 1
+            debug_seq = self._debug_submit_count
+            submit_start = time.perf_counter()
+            try:
+                scope = self._new_execution_scope()
+            except BaseException:
+                if admission is not None:
+                    admission.release()
+                raise
+
+            if self._actor_pool is not None:
+                actor_pool = self._actor_pool
+                with self._pending_lock:
+                    self._pending_batches += 1
+                    pending = self._pending_batches
+                try:
+                    if _should_debug_submit(debug_seq):
+                        pool_stats = actor_pool.stats()
+                        _subprocess_debug_log(
+                            "local_actor_pool_submit_scheduled "
+                            f"name={getattr(actor_pool, 'name', '')!r} seq={debug_seq} "
+                            f"submit_id={submit_id} pending={pending} pool_size={actor_pool.pool_size} "
+                            f"pool_active={pool_stats.get('active_workers', 0)} "
+                            f"pool_idle={pool_stats.get('idle_workers', 0)}"
+                        )
+                    future = actor_pool.submit(fn, scope, debug_seq)
+                    self._track_task_future(
+                        future,
+                        submit_id,
+                        debug_seq,
+                        submit_start,
+                        admission,
+                        scope,
+                    )
+                except BaseException:
+                    with self._pending_lock:
+                        self._pending_batches = max(0, self._pending_batches - 1)
+                    if admission is not None:
+                        admission.release()
+                    self._retire_execution_scope(scope)
+                    raise
+                return
+
+            if self._task_pool is not None:
+                runtime = self._task_runtime
+                task_pool = self._task_pool
+                if runtime is None:
+                    if admission is not None:
+                        admission.release()
+                    self._retire_execution_scope(scope)
+                    raise RuntimeError("global subprocess task runtime is not available")
+                with self._pending_lock:
+                    self._pending_batches += 1
+                    pending = self._pending_batches
+                try:
+                    if _should_debug_submit(debug_seq):
+                        with runtime.cond:
+                            _subprocess_debug_log(
+                                "task_submit_scheduled "
+                                f"seq={debug_seq} submit_id={submit_id} pending={pending} "
+                                f"pool_size={task_pool.pool_size} "
+                                f"pool_total={task_pool.total} pool_active={task_pool.active} "
+                                f"pool_idle={len(task_pool.idle)} "
+                                f"runtime_total_workers={runtime.total_workers} "
+                                f"runtime_max_workers={runtime.max_workers}"
+                            )
+                    future = runtime.submit(task_pool, fn, scope, debug_seq)
+                    self._track_task_future(
+                        future,
+                        submit_id,
+                        debug_seq,
+                        submit_start,
+                        admission,
+                        scope,
+                    )
+                except BaseException:
+                    with self._pending_lock:
+                        self._pending_batches = max(0, self._pending_batches - 1)
+                    if admission is not None:
+                        admission.release()
+                    self._retire_execution_scope(scope)
+                    raise
+                return
+
             if admission is not None:
                 admission.release()
-            raise RuntimeError("UDF subprocess executor is closed")
-        self._debug_submit_count += 1
-        debug_seq = self._debug_submit_count
-        submit_start = time.perf_counter()
-
-        if self._actor_pool is not None:
-            actor_pool = self._actor_pool
-            with self._pending_lock:
-                self._pending_batches += 1
-                pending = self._pending_batches
-            if _should_debug_submit(debug_seq):
-                pool_stats = actor_pool.stats()
-                _subprocess_debug_log(
-                    "local_actor_pool_submit_scheduled "
-                    f"name={getattr(actor_pool, 'name', '')!r} seq={debug_seq} submit_id={submit_id} "
-                    f"pending={pending} pool_size={actor_pool.pool_size} "
-                    f"pool_active={pool_stats.get('active_workers', 0)} "
-                    f"pool_idle={pool_stats.get('idle_workers', 0)}"
-                )
-            try:
-                future = actor_pool.submit(fn, debug_seq)
-                self._track_task_future(
-                    future,
-                    submit_id,
-                    debug_seq,
-                    submit_start,
-                    admission,
-                )
-            except Exception:
-                with self._pending_lock:
-                    self._pending_batches = max(0, self._pending_batches - 1)
-                if admission is not None:
-                    admission.release()
-                raise
-            return
-
-        if self._task_pool is not None:
-            runtime = self._task_runtime
-            task_pool = self._task_pool
-            if runtime is None:
-                raise RuntimeError("global subprocess task runtime is not available")
-            with self._pending_lock:
-                self._pending_batches += 1
-                pending = self._pending_batches
-            if _should_debug_submit(debug_seq):
-                with runtime.cond:
-                    _subprocess_debug_log(
-                        "task_submit_scheduled "
-                        f"seq={debug_seq} submit_id={submit_id} pending={pending} "
-                        f"pool_size={task_pool.pool_size} "
-                        f"pool_total={task_pool.total} pool_active={task_pool.active} "
-                        f"pool_idle={len(task_pool.idle)} runtime_total_workers={runtime.total_workers} "
-                        f"runtime_max_workers={runtime.max_workers}"
-                    )
-            try:
-                future = runtime.submit(task_pool, fn, debug_seq)
-                self._track_task_future(
-                    future,
-                    submit_id,
-                    debug_seq,
-                    submit_start,
-                    admission,
-                )
-            except Exception:
-                with self._pending_lock:
-                    self._pending_batches = max(0, self._pending_batches - 1)
-                if admission is not None:
-                    admission.release()
-                raise
-            return
-
-        if admission is not None:
-            admission.release()
-        raise RuntimeError("subprocess executor is not initialized with an actor or task worker owner")
+            self._retire_execution_scope(scope)
+            raise RuntimeError("subprocess executor is not initialized with an actor or task worker owner")
 
     def submit(self, args: pa.Table) -> None:
         table = _ensure_table(args)
@@ -2036,20 +2526,11 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
                 future.cancel()
             self._task_futures_cv.notify_all()
 
-    def _cancel_worker_output_grants(self) -> None:
-        actor_pool = self._actor_pool
-        if actor_pool is not None:
-            actor_pool.cancel_output_grants()
-        task_pool = self._task_pool
-        if task_pool is not None:
-            task_pool.cancel_output_grants()
-        for worker in list(self._workers):
-            worker.cancel_output_grants()
-
-    def _cancel_local_shm_waits(self) -> None:
+    def _cancel_local_shm_waits(self) -> set[ExecutionCancellationScope]:
+        scopes = self._cancel_execution_scopes("UDF executor closed")
         self._cancel_active_input_leases()
-        self._cancel_worker_output_grants()
         wake_local_shm_ref_budget_waiters()
+        return scopes
 
     def _wait_for_pending_futures(self, timeout_s: float | None = None) -> bool:
         deadline = None if timeout_s is None else time.monotonic() + max(0.0, float(timeout_s))
@@ -2065,20 +2546,33 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             return True
 
     def close(self, kill: bool = False) -> None:
-        if self._closed:
-            return
-        self._closed = True
+        lifecycle_lock = getattr(self, "_lifecycle_lock", None)
+        if lifecycle_lock is None:
+            lifecycle_lock = threading.RLock()
+            self._lifecycle_lock = lifecycle_lock
+        with lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
         authority = getattr(self, "_admission_authority", None)
         if authority is not None:
             authority.close()
         queue_lock = getattr(self, "_queue_lock", None)
+        result_queue = getattr(self, "_queue", None)
         result_admissions = getattr(self, "_result_admissions", None)
-        if queue_lock is not None and result_admissions is not None:
+        if queue_lock is not None:
             with queue_lock:
-                admissions = list(result_admissions)
-                result_admissions.clear()
+                queued_results = list(result_queue or ())
+                if result_queue is not None:
+                    result_queue.clear()
+                admissions = list(result_admissions or ())
+                if result_admissions is not None:
+                    result_admissions.clear()
         else:
+            queued_results = []
             admissions = []
+        for result in queued_results:
+            _release_local_ref_bundle_result(result)
         for admission in admissions:
             if admission is not None:
                 admission.release()
@@ -2086,15 +2580,28 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         self._budget_wakeup_unregister = None
         if budget_wakeup_unregister is not None:
             budget_wakeup_unregister()
-        self._cancel_local_shm_waits()
+        cancelled_scopes = self._cancel_local_shm_waits()
         close_kill = bool(kill)
         if close_kill:
+            actor_pool = self._actor_pool
+            if actor_pool is not None:
+                actor_pool.abort_scopes(cancelled_scopes)
+            task_pool = self._task_pool
+            if task_pool is not None:
+                task_pool.abort_scopes(cancelled_scopes)
             self._cancel_pending_futures()
         else:
             if not self._wait_for_pending_futures(_subprocess_shutdown_grace_s()):
                 close_kill = True
+                actor_pool = self._actor_pool
+                if actor_pool is not None:
+                    actor_pool.abort_scopes(cancelled_scopes)
+                task_pool = self._task_pool
+                if task_pool is not None:
+                    task_pool.abort_scopes(cancelled_scopes)
                 self._cancel_pending_futures()
-                self._cancel_local_shm_waits()
+                self._cancel_active_input_leases()
+                wake_local_shm_ref_budget_waiters()
         actor_pool = self._actor_pool
         if actor_pool is not None:
             self._actor_pool = None

--- a/duckdb/execution/udf_subprocess_worker.py
+++ b/duckdb/execution/udf_subprocess_worker.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import gc
 import os
 import socket
 import struct
@@ -48,10 +49,15 @@ _MSG_OUTPUT_GRANT_REQUEST = 0x0C
 _MSG_OUTPUT_GRANT_GRANTED = 0x0D
 _MSG_OUTPUT_GRANT_CANCELLED = 0x0E
 _MSG_OUTPUT_GRANT_RELEASE = 0x0F
+_MSG_TASK_CANCELLED = 0x10
 
 _HEADER = struct.Struct("=BI")
 _IPC_HEADER = struct.Struct("<Q")
 _DEFAULT_SHM_SIZE = 1 << 20
+
+
+class _TaskCancelledError(RuntimeError):
+    """The parent cancelled this task without invalidating the worker."""
 
 
 def _debug_enabled() -> bool:
@@ -269,7 +275,7 @@ def _request_output_grant(
     msg_type, payload_data = _recv_message(sock)
     if msg_type == _MSG_OUTPUT_GRANT_CANCELLED:
         error = payload_data.decode("utf-8", errors="replace") or "local_shm output grant cancelled"
-        raise RuntimeError(error)
+        raise _TaskCancelledError(error)
     if msg_type != _MSG_OUTPUT_GRANT_GRANTED:
         raise RuntimeError(f"unexpected output grant response: {msg_type:#x}")
     response = duckdb_pickle.loads(payload_data)
@@ -468,7 +474,23 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
         while not close_requested:
             msg_type, payload_data = _recv_message(sock)
             if msg_type == _MSG_CLOSE:
-                _send_message(sock, _MSG_ACK)
+                cleanup_error: BaseException | None = None
+                try:
+                    if executor is not None:
+                        executor.close()
+                except BaseException as exc:
+                    cleanup_error = exc
+                finally:
+                    executor = None
+                    gc.collect()
+                if cleanup_error is None:
+                    _send_message(sock, _MSG_ACK)
+                else:
+                    _send_message(
+                        sock,
+                        _MSG_ERROR,
+                        _format_exception(cleanup_error).encode("utf-8", errors="replace"),
+                    )
                 close_requested = True
                 continue
             if msg_type == _MSG_FINISHED:
@@ -553,6 +575,8 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                         result_msg_type=result_msg_type,
                     )
                 _send_message(sock, result_msg_type, result_payload)
+            except _TaskCancelledError as exc:
+                _send_message(sock, _MSG_TASK_CANCELLED, str(exc).encode("utf-8", errors="replace"))
             except Exception as exc:
                 _send_message(sock, _MSG_ERROR, _format_exception(exc).encode("utf-8", errors="replace"))
     except Exception as exc:
@@ -561,6 +585,13 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
         except Exception:
             pass
     finally:
+        if executor is not None:
+            try:
+                executor.close()
+            except Exception:
+                pass
+            executor = None
+            gc.collect()
         try:
             payload_shm.close()
         except Exception:

--- a/duckdb/execution/udf_subprocess_worker.py
+++ b/duckdb/execution/udf_subprocess_worker.py
@@ -23,6 +23,7 @@ from duckdb.execution._common import callable_cache_enabled as _callable_cache_e
 from duckdb.execution._udf_runtime import UDFExecutor as RuntimeUDFExecutor
 from duckdb.execution.ref_bundle import (
     _open_existing_shm,
+    _require_shm_buffer,
     make_local_shm_ref_bundle_descriptor,
     materialize_ref_bundle,
     payload_requests_local_ref_bundle_output,
@@ -166,13 +167,6 @@ def _recv_message(sock: socket.socket) -> tuple[int, bytes]:
     return msg_type, payload
 
 
-def _require_shm_buffer(shm: shared_memory.SharedMemory) -> memoryview[int]:
-    buffer = shm.buf
-    if buffer is None:
-        raise RuntimeError("shared memory mapping is closed")
-    return buffer
-
-
 def _read_ipc_from_shm(shm: shared_memory.SharedMemory, size: int | None = None) -> bytes:
     buffer = _require_shm_buffer(shm)
     ipc_size = _IPC_HEADER.unpack_from(buffer, 0)[0]
@@ -197,10 +191,10 @@ def _write_ipc_to_shm(shm: shared_memory.SharedMemory, ipc_bytes: bytes) -> int:
 
 
 def _resize_shm(shm: shared_memory.SharedMemory, required: int) -> shared_memory.SharedMemory:
-    buffer = _require_shm_buffer(shm)
-    if required <= len(buffer):
+    capacity = len(_require_shm_buffer(shm))
+    if required <= capacity:
         return shm
-    new_size = max(required, len(buffer) * 2, _DEFAULT_SHM_SIZE)
+    new_size = max(required, capacity * 2, _DEFAULT_SHM_SIZE)
     name = shm.name
     path = f"/dev/shm/{name}"
     fd = os.open(path, os.O_RDWR)
@@ -231,7 +225,11 @@ def _format_exception(exc: BaseException) -> str:
         return repr(exc)
 
 
-def _send_input_consumed(sock: socket.socket, ref_bundle: dict[str, Any], input_table: pa.Table) -> None:
+def _send_input_consumed(
+    sock: socket.socket,
+    ref_bundle: dict[str, Any],
+    input_table: pa.Table,
+) -> None:
     lease_id = ref_bundle.get("input_lease_id")
     if lease_id is None:
         return
@@ -244,7 +242,11 @@ def _send_input_consumed(sock: socket.socket, ref_bundle: dict[str, Any], input_
     _send_message(sock, _MSG_INPUT_CONSUMED, duckdb_pickle.dumps(payload))
 
 
-def _send_input_consume_failed(sock: socket.socket, ref_bundle: dict[str, Any], exc: BaseException) -> None:
+def _send_input_consume_failed(
+    sock: socket.socket,
+    ref_bundle: dict[str, Any],
+    exc: BaseException,
+) -> None:
     lease_id = ref_bundle.get("input_lease_id")
     if lease_id is None:
         return
@@ -510,7 +512,7 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                 input_lease_id = None
                 if msg_type == _MSG_SUBMIT:
                     input_size = struct.unpack("<Q", payload_data)[0]
-                    if input_size > len(data_shm.buf):
+                    if input_size > len(_require_shm_buffer(data_shm)):
                         name = data_shm.name
                         data_shm.close()
                         data_shm = _open_existing_shm(name, track=False)

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import threading
 import time
 import uuid
@@ -89,6 +90,16 @@ def _copy_output_info_from_context(context: dict[str, Any] | None) -> dict[str, 
         "run_id": str(run_id or ""),
         "remote_base": str(remote_base or ""),
     }
+
+
+def _shutdown_udf_actor_pools(actor_pools: list[Any], *, kill: bool) -> list[BaseException]:
+    errors: list[BaseException] = []
+    for pool in reversed(actor_pools):
+        try:
+            pool.shutdown(kill=kill)
+        except BaseException as exc:
+            errors.append(exc)
+    return errors
 
 
 def _native_task_maps_from_context(context: dict[str, Any] | None) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -250,8 +261,9 @@ class LocalRunner(Runner):
             num_workers=self.num_workers,
             max_running_tasks=self.max_running_tasks,
         )
-        udf_actor_pools = []
+        udf_actor_pools: list[Any] = []
         renderer = None
+        write_succeeded = False
         try:
             physical_plan = logical_plan.to_physical_plan(conn)
             from duckdb.execution.udf_subprocess import ensure_local_subprocess_actor_pools_for_plan
@@ -267,7 +279,6 @@ class LocalRunner(Runner):
                 return plan_runner.run_copy_plan(physical_plan, conn)
 
             write_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="vane-local-fte-write")
-            write_succeeded = False
             try:
                 future = write_executor.submit(execute_write)
                 if renderer is None:
@@ -292,11 +303,11 @@ class LocalRunner(Runner):
                     renderer.finish(final_state="FINISHED" if write_succeeded else None)
                 write_executor.shutdown(wait=True)
         finally:
-            for pool in reversed(udf_actor_pools):
-                try:
-                    pool.shutdown(kill=True)
-                except Exception:
-                    pass
+            primary_error_active = sys.exc_info()[0] is not None
+            actor_cleanup_errors = _shutdown_udf_actor_pools(
+                udf_actor_pools,
+                kill=not write_succeeded,
+            )
             try:
                 backend.shutdown()
             finally:
@@ -305,3 +316,8 @@ class LocalRunner(Runner):
                     conn.close()
                 except Exception:
                     pass
+            if write_succeeded and not primary_error_active and actor_cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in actor_cleanup_errors)
+                raise RuntimeError(
+                    f"failed to gracefully shut down {len(actor_cleanup_errors)} local UDF actor pool(s): {details}"
+                ) from actor_cleanup_errors[0]

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import asyncio
 import os
-import queue
 import subprocess
 import sys
 import textwrap
 import threading
 import types
 import uuid
+from collections import deque
 from types import SimpleNamespace
 
 import pytest
@@ -1022,23 +1022,45 @@ def test_local_subprocess_actor_pool_rejects_multi_actor_stateful_payload():
 
 
 def test_local_stateful_actor_loss_includes_udf_pid_and_recoverability_context():
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
     from duckdb.execution.udf_subprocess import LocalSubprocessActorPool
+
+    class LostWorker:
+        def __init__(self):
+            self._proc = SimpleNamespace(pid=4242)
+            self._actor_lost = False
+            self.lost = False
+
+        def is_reusable(self):
+            return not self.lost
+
+        def _run_in_execution_scope(self, scope, fn):
+            return fn(self)
 
     pool = LocalSubprocessActorPool.__new__(LocalSubprocessActorPool)
     pool.payload = {"udf_name": "local_counter", "stateful": True}
     pool.pool_size = 1
     pool.name = "local-counter-pool"
-    pool._lock = threading.Lock()
+    pool._closed = False
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
     pool._active = 0
-    pool._idle_workers = queue.Queue()
-    pool._idle_workers.put(0)
-    pool._workers = [SimpleNamespace(_proc=SimpleNamespace(pid=4242), _actor_lost=True)]
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = set()
+    pool._aborting_workers = set()
+    pool._idle_workers = deque([(0, 0)])
+    pool._workers = [LostWorker()]
+    pool.admission_slots = SimpleNamespace(close=lambda: None)
 
-    def fail_after_actor_loss(_worker):
+    def fail_after_actor_loss(worker):
+        worker.lost = True
+        worker._actor_lost = True
         raise RuntimeError("UDF subprocess communication failed")
 
     with pytest.raises(RuntimeError, match="local_counter.*pid 4242.*state was not recoverable"):
-        pool._run(fail_after_actor_loss)
+        pool._run(fail_after_actor_loss, ExecutionCancellationScope("test-executor", 1))
 
 
 def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -132,3 +132,34 @@ rows = conn.sql(f"select count(*), sum(x) from read_parquet('{dst}')").fetchone(
 assert rows == (20, 190)
 """
     subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_local_runner_collects_udf_actor_shutdown_errors_after_attempting_every_pool():
+    from duckdb.runners.local.runner import _shutdown_udf_actor_pools
+
+    calls = []
+
+    class FakePool:
+        def __init__(self, name, *, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def shutdown(self, *, kill):
+            calls.append((self.name, kill))
+            if self.fail:
+                raise RuntimeError(f"{self.name} cleanup failed")
+
+    pools = [FakePool("first"), FakePool("second", fail=True)]
+    graceful_errors = _shutdown_udf_actor_pools(pools, kill=False)
+    forced_errors = _shutdown_udf_actor_pools(pools, kill=True)
+
+    assert calls == [
+        ("second", False),
+        ("first", False),
+        ("second", True),
+        ("first", True),
+    ]
+    assert len(graceful_errors) == 1
+    assert "second cleanup failed" in str(graceful_errors[0])
+    assert len(forced_errors) == 1
+    assert "second cleanup failed" in str(forced_errors[0])

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -1470,6 +1470,9 @@ def test_unified_executor_passes_local_subprocess_actor_pool_option():
         def cancel_output_grants(self):
             return None
 
+        def abort_scopes(self, _scopes):
+            return None
+
     pool = FakeLocalActorPool()
     executor = build_unified_executor(
         _subprocess_map_payload(
@@ -1716,6 +1719,9 @@ def test_ensure_local_subprocess_actor_pools_for_nodes_reuses_injected_pool(monk
         def cancel_output_grants(self):
             pass
 
+        def abort_scopes(self, _scopes):
+            pass
+
         def first_proc(self):
             return None
 
@@ -1774,6 +1780,9 @@ def test_ensure_local_subprocess_actor_pools_rejects_implicit_cross_session_reus
         def cancel_output_grants(self):
             pass
 
+        def abort_scopes(self, _scopes):
+            pass
+
         def first_proc(self):
             return None
 
@@ -1816,6 +1825,9 @@ def test_subprocess_actor_executor_rejects_cross_session_pool_attachment():
             return {}
 
         def cancel_output_grants(self):
+            pass
+
+        def abort_scopes(self, _scopes):
             pass
 
         def first_proc(self):
@@ -2204,6 +2216,38 @@ def test_udf_runtime_map_batches_finished_submitting_flushes_compute_tail():
     assert output.column("x").to_pylist() == list(range(2048))
     assert set(output.column("batch_rows").to_pylist()) == {2048}
     assert executor.take_ready_result() is None
+
+
+def test_udf_runtime_close_flushes_compute_tail_before_releasing_callable():
+    from duckdb.execution._udf_runtime import UDFExecutor
+
+    def report_compute_batch(table):
+        values = table.column("x").to_pylist()
+        return pa.table(
+            {
+                "x": values,
+                "batch_rows": [table.num_rows for _ in values],
+            }
+        )
+
+    executor = UDFExecutor(
+        _subprocess_map_payload(
+            report_compute_batch,
+            batch_size=3000,
+            stream_output=True,
+        )
+    )
+    executor.submit(pa.table({"x": list(range(2048))}))
+    assert executor.take_ready_result() is None
+
+    executor.close()
+    executor.close()
+    output = executor.take_ready_result()
+
+    assert output is not None
+    assert output.column("x").to_pylist() == list(range(2048))
+    assert set(output.column("batch_rows").to_pylist()) == {2048}
+    assert executor._map_fn is None
 
 
 def test_udf_runtime_actor_backend_does_not_buffer_input_across_submits():
@@ -2677,18 +2721,31 @@ def test_subprocess_error_propagates_and_closes_worker():
     import duckdb.execution.udf_subprocess as subprocess_exec
 
     class Fail:
-        def __call__(self, _table):
-            raise ValueError("bad edge udf")
+        def __call__(self, table):
+            values = table.column("x").to_pylist()
+            if values == [1]:
+                raise ValueError("bad edge udf")
+            return pa.table({"y": values})
 
     payload = _subprocess_map_payload(Fail, execution_backend="subprocess_actor", actor_number=1)
     executor, pool = _make_subprocess_actor_executor(subprocess_exec, payload)
     try:
+        original_proc = executor._proc
+        assert original_proc is not None
+        original_pid = original_proc.pid
         _submit_with_admission(executor, pa.table({"x": [1]}))
         result = _wait_for_results(executor, 1, timeout_s=10.0)[0]
         assert isinstance(result, RuntimeError)
         assert "bad edge udf" in str(result)
-        proc = executor._proc
-        assert proc is None or proc.poll() is not None
+        assert original_proc.poll() is not None
+        replacement_proc = executor._proc
+        assert replacement_proc is not None
+        assert replacement_proc.poll() is None
+        assert replacement_proc.pid != original_pid
+
+        _submit_with_admission(executor, pa.table({"x": [2]}))
+        replacement_result = _wait_for_results(executor, 1, timeout_s=10.0)[0]
+        assert replacement_result.to_pydict() == {"y": [2]}
     finally:
         executor.close(kill=True)
         pool.shutdown(kill=True)
@@ -3334,6 +3391,67 @@ def test_subprocess_ref_bundle_mode_rejects_direct_ipc(monkeypatch):
         executor.close(kill=True)
 
 
+def test_subprocess_ref_bundle_wrap_failure_releases_descriptor_and_grant(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    descriptor = {
+        "block_refs": [
+            {
+                "provider": "local_shm",
+                "shm_name": "failed-result-shm",
+                "ipc_size_bytes": 128,
+            }
+        ],
+        "metadata": [{}],
+        "names": ["x"],
+        "grant_id": 77,
+    }
+    scope = ExecutionCancellationScope("test-executor", 1)
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._closed = False
+    executor._broken_error = None
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = scope
+    executor._worker_lifetime_scope = ExecutionCancellationScope("test-worker", 1)
+    executor._active_output_grants = {77: scope}
+    executor._active_output_grants_lock = threading.Lock()
+    executor._recv_expected = lambda _expected: (
+        subprocess_exec._MSG_REF_BUNDLE_RESULT,
+        subprocess_exec.duckdb_pickle.dumps(descriptor),
+    )
+
+    released = []
+
+    def fail_descriptor_wrap(*_args, **_kwargs):
+        raise RuntimeError("descriptor wrap failed")
+
+    monkeypatch.setattr(
+        subprocess_exec,
+        "make_local_shm_ref_bundle_result_from_descriptor",
+        fail_descriptor_wrap,
+    )
+    monkeypatch.setattr(
+        subprocess_exec,
+        "release_local_shm_ref_bundle_descriptor",
+        lambda value: released.append(("descriptor", value)),
+    )
+    monkeypatch.setattr(
+        subprocess_exec,
+        "release_local_shm_output_grant",
+        lambda grant_id, *, name="": released.append(("grant", grant_id, name)),
+    )
+
+    with pytest.raises(RuntimeError, match="descriptor wrap failed"):
+        executor._recv_submit_result()
+
+    assert released == [
+        ("descriptor", descriptor),
+        ("grant", 77, "udf-output-descriptor-wrap-failed"),
+    ]
+    assert not executor._active_output_grants
+
+
 def test_subprocess_ref_bundle_contract_requires_output_mode():
     import duckdb.execution.udf_subprocess as subprocess_exec
 
@@ -3730,8 +3848,9 @@ def test_subprocess_ref_bundle_blob_output_schema_has_initial_budget_estimate():
         executor.close(kill=True)
 
 
-def test_subprocess_output_grant_request_uses_executor_cancel_event(monkeypatch):
+def test_subprocess_output_grant_request_uses_active_execution_scope(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
 
     parent_sock, child_sock = subprocess_exec.socket.socketpair()
     executor = subprocess_exec._SingleSubprocessExecutor.__new__(subprocess_exec._SingleSubprocessExecutor)
@@ -3739,9 +3858,12 @@ def test_subprocess_output_grant_request_uses_executor_cancel_event(monkeypatch)
     executor._broken_error = None
     executor._sock = parent_sock
     executor._wakeup = None
-    executor._active_output_grants = set()
+    executor._active_output_grants = {}
     executor._active_output_grants_lock = threading.Lock()
-    executor._output_grant_cancel_event = threading.Event()
+    executor._execution_scope_lock = threading.Lock()
+    scope = ExecutionCancellationScope("executor-a", 9)
+    executor._active_execution_scope = scope
+    executor._worker_lifetime_scope = ExecutionCancellationScope("worker", 1)
 
     captured: dict[str, object] = {}
 
@@ -3775,7 +3897,7 @@ def test_subprocess_output_grant_request_uses_executor_cancel_event(monkeypatch)
             "name": "udf-output-9",
             "priority": "consumer",
             "input_lease_id": 123,
-            "cancel_event": executor._output_grant_cancel_event,
+            "cancel_event": scope,
         }
     finally:
         parent_sock.close()
@@ -3784,6 +3906,7 @@ def test_subprocess_output_grant_request_uses_executor_cancel_event(monkeypatch)
 
 def test_single_subprocess_close_without_kill_cancels_output_grant_wait(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
 
     events: list[object] = []
     executor = subprocess_exec._SingleSubprocessExecutor.__new__(subprocess_exec._SingleSubprocessExecutor)
@@ -3793,11 +3916,14 @@ def test_single_subprocess_close_without_kill_cancels_output_grant_wait(monkeypa
     executor._payload_shm = None
     executor._data_shm = None
     executor._finalizer = None
-    executor._active_input_leases = {42}
+    scope = ExecutionCancellationScope("worker", 1)
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    executor._worker_lifetime_scope = scope
+    executor._active_input_leases = {42: scope}
     executor._active_input_leases_lock = threading.Lock()
-    executor._active_output_grants = set()
+    executor._active_output_grants = {}
     executor._active_output_grants_lock = threading.Lock()
-    executor._output_grant_cancel_event = threading.Event()
 
     monkeypatch.setattr(
         subprocess_exec,
@@ -3812,14 +3938,14 @@ def test_single_subprocess_close_without_kill_cancels_output_grant_wait(monkeypa
 
     executor.close(kill=False)
 
-    assert executor._output_grant_cancel_event.is_set()
+    assert scope.is_set()
     assert events == [
-        "wake-budget",
         ("cancel-lease", 42, "udf-input-close"),
+        "wake-budget",
     ]
 
 
-def test_local_subprocess_actor_pool_shutdown_cancels_worker_grants_before_executor_wait():
+def test_local_subprocess_actor_pool_shutdown_fences_admission_before_executor_wait():
     import duckdb.execution.udf_subprocess as subprocess_exec
 
     events: list[str] = []
@@ -3828,15 +3954,12 @@ def test_local_subprocess_actor_pool_shutdown_cancels_worker_grants_before_execu
         def __init__(self, name: str):
             self.name = name
 
-        def cancel_output_grants(self) -> None:
-            events.append(f"cancel:{self.name}")
-
         def close(self, *, kill: bool = False) -> None:
             events.append(f"close:{self.name}:{kill}")
 
     class FakeExecutor:
         def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
-            assert events[:3] == ["admission-close", "cancel:w0", "cancel:w1"]
+            assert events == ["admission-close"]
             events.append(f"shutdown:{wait}:{cancel_futures}")
 
     class FakeAdmissionSlots:
@@ -3846,7 +3969,11 @@ def test_local_subprocess_actor_pool_shutdown_cancels_worker_grants_before_execu
     pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
     pool.name = "pool"
     pool._closed = False
-    pool._lock = threading.Lock()
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._active_scopes = {}
+    pool._idle_workers = deque([(0, 0), (1, 0)])
     pool._workers = [FakeWorker("w0"), FakeWorker("w1")]
     pool._executor = FakeExecutor()
     pool.admission_slots = FakeAdmissionSlots()
@@ -3855,13 +3982,146 @@ def test_local_subprocess_actor_pool_shutdown_cancels_worker_grants_before_execu
 
     assert events == [
         "admission-close",
-        "cancel:w0",
-        "cancel:w1",
         "shutdown:False:True",
         "close:w0:False",
         "close:w1:False",
     ]
     assert pool._workers == []
+
+
+def test_local_subprocess_actor_abort_fences_generation_from_idle_reuse():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    task_started = threading.Event()
+    finish_task = threading.Event()
+    close_started = threading.Event()
+    allow_close = threading.Event()
+
+    class FakeWorker:
+        def __init__(self):
+            self._closed = False
+            self._proc = types.SimpleNamespace(pid=4242)
+
+        def is_reusable(self):
+            return not self._closed
+
+        def _run_in_execution_scope(self, _scope, fn):
+            return fn(self)
+
+        def close(self, *, kill=False):
+            assert kill
+            close_started.set()
+            assert allow_close.wait(timeout=5.0)
+            self._closed = True
+
+    class FakeAdmissionSlots:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    worker = FakeWorker()
+    scope = ExecutionCancellationScope("executor-a", 1)
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": True, "udf_name": "stateful_abort_race"}
+    pool.pool_size = 1
+    pool.name = "abort-reuse-race"
+    pool._closed = False
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = set()
+    pool._aborting_workers = set()
+    pool._idle_workers = deque([(0, 0)])
+    pool._workers = [worker]
+    pool.admission_slots = FakeAdmissionSlots()
+
+    def run_task(_worker):
+        task_started.set()
+        assert finish_task.wait(timeout=5.0)
+
+    run_thread = threading.Thread(target=lambda: pool._run(run_task, scope), daemon=True)
+    run_thread.start()
+    assert task_started.wait(timeout=5.0)
+
+    abort_thread = threading.Thread(target=lambda: pool.abort_scopes({scope}), daemon=True)
+    abort_thread.start()
+    assert close_started.wait(timeout=5.0)
+    finish_task.set()
+    with pool._cond:
+        assert pool._cond.wait_for(lambda: pool._active == 0, timeout=5.0)
+        assert not pool._idle_workers
+        assert pool._terminal_error is not None
+
+    allow_close.set()
+    run_thread.join(timeout=5.0)
+    abort_thread.join(timeout=5.0)
+    assert not run_thread.is_alive()
+    assert not abort_thread.is_alive()
+    assert pool.admission_slots.closed
+    pool._closed = True
+
+
+def test_stateful_actor_preserves_structured_udf_error_before_terminal_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    class FailedWorker:
+        def __init__(self):
+            self._actor_lost = False
+            self._proc = types.SimpleNamespace(pid=4242)
+            self.failed = False
+
+        def is_reusable(self):
+            return not self.failed
+
+        def _run_in_execution_scope(self, _scope, fn):
+            return fn(self)
+
+    class FakeAdmissionSlots:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    worker = FailedWorker()
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": True, "udf_name": "stateful_structured_error"}
+    pool.pool_size = 1
+    pool.name = "stateful-structured-error"
+    pool._closed = False
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = set()
+    pool._aborting_workers = set()
+    pool._idle_workers = deque([(0, 0)])
+    pool._workers = [worker]
+    pool.admission_slots = FakeAdmissionSlots()
+
+    def fail_with_structured_udf_error(_worker):
+        worker.failed = True
+        raise ValueError("TIMESTAMP is timezone-naive")
+
+    with pytest.raises(ValueError, match="TIMESTAMP is timezone-naive"):
+        pool._run(
+            fail_with_structured_udf_error,
+            ExecutionCancellationScope("test-executor", 1),
+        )
+
+    assert pool._terminal_error is not None
+    assert "state was not recoverable" in str(pool._terminal_error)
+    assert pool.admission_slots.closed
+    pool._closed = True
 
 
 def test_local_subprocess_actor_pool_rolls_back_created_workers_on_worker_init_failure(monkeypatch):
@@ -4070,6 +4330,10 @@ def test_subprocess_submit_without_worker_owner_fails_fast():
     executor._task_futures_cv = threading.Condition()
     executor._task_futures_lock = executor._task_futures_cv
     executor._task_future_meta = {}
+    executor._execution_owner_id = "unowned-executor"
+    executor._execution_scope_generation = 0
+    executor._execution_scopes = set()
+    executor._execution_scopes_lock = threading.Lock()
 
     with pytest.raises(RuntimeError, match="not initialized with an actor or task worker owner"):
         executor._submit_async(411, lambda _worker: None)
@@ -4185,6 +4449,7 @@ def test_subprocess_task_runtime_keeps_cpu_count_worker_cap(monkeypatch):
 
 def test_subprocess_task_pool_kill_closes_active_worker(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
 
     runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
 
@@ -4207,7 +4472,7 @@ def test_subprocess_task_pool_kill_closes_active_worker(monkeypatch):
     )
     try:
         pool.acquire_ref()
-        wrapper = pool.acquire_worker()
+        wrapper = pool.acquire_worker(ExecutionCancellationScope("test-executor", 1))
 
         pool.release_ref(kill=True)
 
@@ -4217,8 +4482,72 @@ def test_subprocess_task_pool_kill_closes_active_worker(monkeypatch):
         runtime.close(kill=True)
 
 
+def test_subprocess_task_pool_abort_fences_worker_from_idle_reuse(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
+    close_started = threading.Event()
+    allow_close = threading.Event()
+
+    class FakeWorker:
+        def __init__(self):
+            self._closed = False
+            self._broken_error = None
+
+        def is_reusable(self):
+            return not self._closed
+
+        def close(self, kill=False):
+            assert kill
+            close_started.set()
+            assert allow_close.wait(timeout=5.0)
+            self._closed = True
+
+    fake_worker = FakeWorker()
+    pool = subprocess_exec._TaskWorkerPool(
+        runtime,
+        "abort-reuse-race",
+        {"execution_backend": "subprocess_task"},
+        1,
+    )
+    monkeypatch.setattr(
+        pool,
+        "_spawn_worker",
+        lambda _worker_idx: subprocess_exec._PooledTaskWorker(fake_worker),
+    )
+    scope = ExecutionCancellationScope("executor-a", 1)
+    try:
+        pool.acquire_ref()
+        wrapper = pool.acquire_worker(scope)
+        abort_thread = threading.Thread(target=lambda: pool.abort_scopes({scope}), daemon=True)
+        abort_thread.start()
+        assert close_started.wait(timeout=5.0)
+
+        release_thread = threading.Thread(
+            target=lambda: pool.release_worker(wrapper, reusable=True),
+            daemon=True,
+        )
+        release_thread.start()
+        with runtime.cond:
+            assert runtime.cond.wait_for(lambda: pool.active == 0, timeout=5.0)
+            assert wrapper not in pool.idle
+
+        allow_close.set()
+        release_thread.join(timeout=5.0)
+        abort_thread.join(timeout=5.0)
+        assert not release_thread.is_alive()
+        assert not abort_thread.is_alive()
+        assert pool.total == 0
+    finally:
+        allow_close.set()
+        pool.release_ref(kill=True)
+        runtime.close(kill=True)
+
+
 def test_subprocess_task_pool_kill_closes_worker_spawned_during_close(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
 
     runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
     spawn_started = threading.Event()
@@ -4249,7 +4578,7 @@ def test_subprocess_task_pool_kill_closes_worker_spawned_during_close(monkeypatc
 
     def acquire_worker():
         try:
-            acquired.append(pool.acquire_worker())
+            acquired.append(pool.acquire_worker(ExecutionCancellationScope("test-executor", 1)))
         except BaseException as exc:
             errors.append(exc)
 
@@ -5807,6 +6136,48 @@ class _FakeControlSocket:
         self.closed = True
 
 
+class _FakeShutdownProcess:
+    def __init__(self, *, exits_on_wait: bool, honor_wait_timeout: bool = False) -> None:
+        self.exits_on_wait = exits_on_wait
+        self.honor_wait_timeout = honor_wait_timeout
+        self.running = True
+        self.wait_timeouts: list[float | None] = []
+        self.kill_calls = 0
+
+    def poll(self):
+        return None if self.running else 0
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        if self.exits_on_wait or not self.running:
+            self.running = False
+            return 0
+        if self.honor_wait_timeout and timeout is not None:
+            time.sleep(timeout)
+        raise TimeoutError("process did not exit")
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.running = False
+
+
+class _GracefulShutdownSocket(_FakeControlSocket):
+    def __init__(self, recv_payload: bytes = b"", *, time_out_on_recv: bool = False) -> None:
+        super().__init__(recv_payload)
+        self.time_out_on_recv = time_out_on_recv
+        self.timeout: float | None = None
+
+    def settimeout(self, timeout: float | None) -> None:
+        self.timeout = timeout
+
+    def recv(self, size: int) -> bytes:
+        if self.time_out_on_recv:
+            if self.timeout is not None:
+                time.sleep(self.timeout)
+            raise socket.timeout("graceful shutdown timed out")
+        return super().recv(size)
+
+
 def _decode_control_messages(data: bytes, header) -> list[tuple[int, bytes]]:
     messages = []
     offset = 0
@@ -5817,6 +6188,102 @@ def _decode_control_messages(data: bytes, header) -> list[tuple[int, bytes]]:
         offset += payload_len
         messages.append((msg_type, payload))
     return messages
+
+
+def _bare_shutdown_executor(subprocess_exec, sock, proc):
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._closed = False
+    executor._broken_error = None
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    executor._worker_lifetime_scope = subprocess_exec.ExecutionCancellationScope("shutdown-worker", 1)
+    executor._close_lock = threading.Lock()
+    executor._active_input_leases = {}
+    executor._active_input_leases_lock = threading.Lock()
+    executor._active_output_grants = {}
+    executor._active_output_grants_lock = threading.Lock()
+    executor._payload_shm = None
+    executor._data_shm = None
+    executor._sock = sock
+    executor._proc = proc
+    return executor
+
+
+def test_single_subprocess_graceful_close_waits_for_ack_and_exit_without_kill():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    ack = subprocess_exec._HEADER.pack(subprocess_exec._MSG_ACK, 0)
+    sock = _GracefulShutdownSocket(ack)
+    proc = _FakeShutdownProcess(exits_on_wait=True)
+    executor = _bare_shutdown_executor(subprocess_exec, sock, proc)
+
+    executor.close(kill=False)
+
+    messages = _decode_control_messages(bytes(sock.sent), subprocess_exec._HEADER)
+    assert messages == [(subprocess_exec._MSG_CLOSE, b"")]
+    assert proc.kill_calls == 0
+    assert len(proc.wait_timeouts) == 1
+    assert proc.wait_timeouts[0] is not None
+    assert proc.wait_timeouts[0] > 0.0
+    assert sock.closed
+
+
+def test_single_subprocess_graceful_close_reports_cleanup_error_after_exit():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    payload = b"cleanup failed"
+    response = subprocess_exec._HEADER.pack(subprocess_exec._MSG_ERROR, len(payload)) + payload
+    sock = _GracefulShutdownSocket(response)
+    proc = _FakeShutdownProcess(exits_on_wait=True)
+    executor = _bare_shutdown_executor(subprocess_exec, sock, proc)
+
+    with pytest.raises(RuntimeError, match="graceful shutdown failed.*cleanup failed"):
+        executor.close(kill=False)
+
+    assert proc.kill_calls == 0
+    assert len(proc.wait_timeouts) == 1
+    assert sock.closed
+
+
+def test_single_subprocess_graceful_close_honors_timeout_before_kill(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    monkeypatch.setenv("VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S", "0.02")
+    sock = _GracefulShutdownSocket(time_out_on_recv=True)
+    proc = _FakeShutdownProcess(exits_on_wait=False)
+    executor = _bare_shutdown_executor(subprocess_exec, sock, proc)
+
+    started = time.monotonic()
+    executor.close(kill=False)
+    elapsed = time.monotonic() - started
+
+    messages = _decode_control_messages(bytes(sock.sent), subprocess_exec._HEADER)
+    assert messages == [(subprocess_exec._MSG_CLOSE, b"")]
+    assert sock.timeout is not None
+    assert 0.0 < sock.timeout <= 0.02
+    assert elapsed >= sock.timeout
+    assert proc.kill_calls == 1
+    assert sock.closed
+
+
+def test_single_subprocess_graceful_close_waits_after_control_disconnect(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    monkeypatch.setenv("VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S", "0.02")
+    sock = _GracefulShutdownSocket()
+    proc = _FakeShutdownProcess(exits_on_wait=False, honor_wait_timeout=True)
+    executor = _bare_shutdown_executor(subprocess_exec, sock, proc)
+
+    started = time.monotonic()
+    executor.close(kill=False)
+    elapsed = time.monotonic() - started
+
+    assert elapsed >= 0.015
+    assert proc.kill_calls == 1
+    assert proc.wait_timeouts
+    assert proc.wait_timeouts[0] is not None
+    assert 0.0 < proc.wait_timeouts[0] <= 0.02
+    assert sock.closed
 
 
 def test_single_subprocess_close_releases_active_output_grants(monkeypatch):
@@ -5837,11 +6304,14 @@ def test_single_subprocess_close_releases_active_output_grants(monkeypatch):
     executor._wakeup_error = None
     executor._ref_bundle_output = True
     executor._worker_env = {}
-    executor._active_input_leases = set()
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    executor._worker_lifetime_scope = subprocess_exec.ExecutionCancellationScope("test-worker", 1)
+    executor._close_lock = threading.Lock()
+    executor._active_input_leases = {}
     executor._active_input_leases_lock = threading.Lock()
-    executor._active_output_grants = set()
+    executor._active_output_grants = {}
     executor._active_output_grants_lock = threading.Lock()
-    executor._output_grant_cancel_event = threading.Event()
     executor._payload_shm = None
     executor._data_shm = None
     executor._sock = _FakeControlSocket()
@@ -6008,7 +6478,7 @@ def test_subprocess_worker_row_preserving_ref_bundle_requires_scalar_arg_count(p
         worker.split_row_preserving_input(payload, pa.table({"arg": [1], "passthrough": [2]}))
 
 
-def test_subprocess_executor_close_escalates_when_pending_futures_do_not_finish(monkeypatch):
+def test_subprocess_executor_close_escalates_scoped_pending_work(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
 
     class FakeWorker:
@@ -6036,6 +6506,9 @@ def test_subprocess_executor_close_escalates_when_pending_futures_do_not_finish(
     executor._task_futures_cv = threading.Condition()
     executor._task_futures = {Future()}
     executor._task_future_meta = {}
+    executor._execution_scopes_lock = threading.Lock()
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+    executor._execution_scopes = {scope}
     executor._active_input_leases = set()
     executor._active_input_leases_lock = threading.Lock()
     executor._actor_pool = None
@@ -6049,9 +6522,177 @@ def test_subprocess_executor_close_escalates_when_pending_futures_do_not_finish(
     thread.start()
 
     assert done.wait(timeout=1.0)
-    assert executor._workers[0].cancelled
+    assert scope.is_set()
+    assert not executor._workers[0].cancelled
     assert executor._workers[0].closed == [True]
     assert thread_pool.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+
+
+def test_subprocess_executor_close_fences_submit_before_cancelling_scopes(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    submit_started = threading.Event()
+    release_submit = threading.Event()
+    submitted_future = Future()
+
+    class FakeActorPool:
+        name = "submit-close-race"
+        pool_size = 1
+
+        def __init__(self):
+            self.aborted = []
+
+        def stats(self):
+            return {"active_workers": 0, "idle_workers": 1}
+
+        def submit(self, _fn, _scope, _debug_seq):
+            submit_started.set()
+            assert release_submit.wait(timeout=5.0)
+            return submitted_future
+
+        def abort_scopes(self, scopes):
+            self.aborted.append(set(scopes))
+
+    monkeypatch.setenv("VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S", "0.01")
+    actor_pool = FakeActorPool()
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._execution_owner_id = "test-executor"
+    executor._execution_scope_generation = 0
+    executor._execution_scopes = set()
+    executor._execution_scopes_lock = threading.Lock()
+    executor._debug_submit_count = 0
+    executor._actor_pool = actor_pool
+    executor._task_pool = None
+    executor._task_runtime = None
+    executor._executor = None
+    executor._workers = []
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures_lock = executor._task_futures_cv
+    executor._task_futures = set()
+    executor._task_future_meta = {}
+    executor._pending_lock = threading.Lock()
+    executor._pending_batches = 0
+    executor._queue_lock = threading.Lock()
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._active_input_leases = set()
+    executor._active_input_leases_lock = threading.Lock()
+    executor._budget_wakeup_unregister = None
+    executor._admission_authority = None
+    executor._wakeup = None
+    executor._wakeup_error = None
+    executor._ref_bundle_output = False
+
+    submit_errors = []
+
+    def submit():
+        try:
+            executor._submit_async(None, lambda _worker: None)
+        except BaseException as exc:
+            submit_errors.append(exc)
+
+    submit_thread = threading.Thread(target=submit, daemon=True)
+    close_thread = threading.Thread(target=executor.close, daemon=True)
+    submit_thread.start()
+    assert submit_started.wait(timeout=5.0)
+    close_thread.start()
+
+    assert not executor._closed
+    release_submit.set()
+    submit_thread.join(timeout=5.0)
+    close_thread.join(timeout=5.0)
+
+    assert not submit_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert not submit_errors
+    assert submitted_future.cancelled()
+    assert not executor._task_futures
+    assert actor_pool.aborted and len(actor_pool.aborted[0]) == 1
+
+
+def test_subprocess_executor_releases_ref_bundle_result_completed_after_close():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution import ref_bundle
+
+    result = ref_bundle.make_local_shm_ref_bundle_result(pa.table({"x": [1, 2]}))
+    refs = list(result[1])
+    future = Future()
+    future.set_result(result)
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = True
+    executor._ref_bundle_output = False
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._queue_lock = threading.Lock()
+    executor._pending_batches = 1
+    executor._pending_lock = threading.Lock()
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures_lock = executor._task_futures_cv
+    executor._task_futures = {future}
+    executor._task_future_meta = {future: (None, 1, time.perf_counter(), None, scope)}
+    executor._execution_scopes_lock = threading.Lock()
+    executor._execution_scopes = {scope}
+    executor._wakeup = None
+    executor._wakeup_error = None
+
+    executor._complete_task_submit(None, future)
+
+    assert not executor._queue
+    assert executor._pending_batches == 0
+    assert not executor._task_futures
+    assert not executor._execution_scopes
+    assert scope.finished
+    assert all(ref._closed for ref in refs)
+
+
+def test_subprocess_executor_close_releases_queued_ref_bundle_results():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution import ref_bundle
+
+    class FakeAdmission:
+        def __init__(self):
+            self.released = False
+
+        def release(self):
+            self.released = True
+
+    class FakeAuthority:
+        def close(self):
+            return None
+
+    result = ref_bundle.make_local_shm_ref_bundle_result(pa.table({"x": [1, 2]}))
+    refs = list(result[1])
+    admission = FakeAdmission()
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._admission_authority = FakeAuthority()
+    executor._queue = deque([(ref_bundle.SUBMIT_RESULT_MARKER, 41, result)])
+    executor._result_admissions = deque([admission])
+    executor._queue_lock = threading.Lock()
+    executor._budget_wakeup_unregister = None
+    executor._execution_scopes_lock = threading.Lock()
+    executor._execution_scopes = set()
+    executor._active_input_leases = set()
+    executor._active_input_leases_lock = threading.Lock()
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures = set()
+    executor._actor_pool = None
+    executor._task_pool = None
+    executor._executor = None
+    executor._workers = []
+
+    executor.close(kill=True)
+
+    assert not executor._queue
+    assert not executor._result_admissions
+    assert admission.released
+    assert all(ref._closed for ref in refs)
 
 
 def test_ray_actor_init_has_default_timeout(monkeypatch):
@@ -6132,3 +6773,250 @@ def test_subprocess_stats_expose_local_shm_budget_keys():
             assert isinstance(stats[key], int)
     finally:
         executor.close(kill=True)
+
+
+def test_local_shm_allocation_wait_is_cancelled_by_execution_scope(monkeypatch):
+    import duckdb.execution.ref_bundle as ref_bundle
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    manager = ref_bundle.LocalShmBudgetManager(limit_factory=lambda: 100)
+    manager.acquire_allocation(90, name="existing")
+    wait_started = threading.Event()
+    done = threading.Event()
+    errors: list[BaseException] = []
+    original_log = ref_bundle._shm_debug_log
+
+    def record_wait(event, **fields):
+        if event == "budget_wait":
+            wait_started.set()
+        original_log(event, **fields)
+
+    monkeypatch.setattr(ref_bundle, "_shm_debug_log", record_wait)
+    scope = ExecutionCancellationScope("executor-a", 1)
+    unregister = scope.register_cancel_wakeup(manager.wake_waiters)
+
+    def allocate():
+        try:
+            manager.acquire_allocation(
+                20,
+                name="cancelled-allocation",
+                cancel_event=scope,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=allocate, daemon=True)
+    try:
+        thread.start()
+        assert wait_started.wait(timeout=5.0)
+
+        assert scope.cancel("executor closed")
+        assert done.wait(timeout=5.0)
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeError)
+        assert "allocation cancelled" in str(errors[0])
+        assert manager.snapshot()["allocated_bytes"] == 90
+    finally:
+        unregister()
+        manager.release_allocation(90, name="existing")
+        thread.join(timeout=5.0)
+
+
+def test_subprocess_task_shared_pool_close_is_scoped_to_own_executor(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution import ref_bundle
+
+    subprocess_exec._shutdown_global_task_runtime()
+    grant_started = threading.Event()
+    release_grant = threading.Event()
+    captured_cancel_events = []
+    original_request = subprocess_exec.request_local_shm_output_grant
+
+    def gated_request(
+        size,
+        *,
+        name="",
+        priority="producer",
+        input_lease_id=None,
+        cancel_event=None,
+    ):
+        captured_cancel_events.append(cancel_event)
+        if len(captured_cancel_events) == 1:
+            grant_started.set()
+            while not release_grant.wait(timeout=0.01):
+                if cancel_event is not None and cancel_event.is_set():
+                    raise RuntimeError("output grant cancelled")
+        return original_request(
+            size,
+            name=name,
+            priority=priority,
+            input_lease_id=input_lease_id,
+            cancel_event=cancel_event,
+        )
+
+    monkeypatch.setattr(subprocess_exec, "request_local_shm_output_grant", gated_request)
+
+    def add_one(table):
+        return pa.table({"y": [value + 1 for value in table.column("x").to_pylist()]})
+
+    payload = _subprocess_map_payload(
+        add_one,
+        execution_backend="subprocess_task",
+        udf_worker_slots=1,
+        produce_ref_bundle_output=True,
+        streaming_output_mode="local_shm_ref_bundle",
+    )
+    executor_a = subprocess_exec.UDFExecutor(payload)
+    executor_b = subprocess_exec.UDFExecutor(payload)
+    results = []
+    try:
+        assert executor_a._task_pool is executor_b._task_pool
+        _submit_with_admission(executor_b, pa.table({"x": [1]}), submit_id=901)
+        assert grant_started.wait(timeout=10.0)
+        assert captured_cancel_events and not captured_cancel_events[0].is_set()
+
+        executor_a.close(kill=False)
+
+        assert not captured_cancel_events[0].is_set()
+        release_grant.set()
+        results.extend(_wait_for_results(executor_b, 1, timeout_s=10.0))
+        assert len(results) == 1
+        assert results[0][0:2] == (ref_bundle.SUBMIT_RESULT_MARKER, 901)
+        assert results[0][2][0] == ref_bundle.REF_BUNDLE_RESULT_MARKER
+
+        _submit_with_admission(executor_b, pa.table({"x": [2]}), submit_id=902)
+        results.extend(_wait_for_results(executor_b, 1, timeout_s=10.0))
+        assert len(results) == 2
+        assert results[1][0:2] == (ref_bundle.SUBMIT_RESULT_MARKER, 902)
+        assert results[1][2][0] == ref_bundle.REF_BUNDLE_RESULT_MARKER
+    finally:
+        release_grant.set()
+        if not executor_a._closed:
+            executor_a.close(kill=True)
+        executor_b.close(kill=True)
+        subprocess_exec._shutdown_global_task_runtime()
+        for result in results:
+            value = result[2]
+            if isinstance(value, tuple) and value and value[0] == ref_bundle.REF_BUNDLE_RESULT_MARKER:
+                for ref in value[1]:
+                    ref.release()
+
+
+def test_subprocess_actor_shared_pool_close_is_scoped_to_own_executor(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution import ref_bundle
+
+    grant_started = threading.Event()
+    release_grant = threading.Event()
+    captured_cancel_events = []
+    original_request = subprocess_exec.request_local_shm_output_grant
+
+    def gated_request(
+        size,
+        *,
+        name="",
+        priority="producer",
+        input_lease_id=None,
+        cancel_event=None,
+    ):
+        captured_cancel_events.append(cancel_event)
+        if len(captured_cancel_events) == 1:
+            grant_started.set()
+            while not release_grant.wait(timeout=0.01):
+                if cancel_event is not None and cancel_event.is_set():
+                    raise RuntimeError("output grant cancelled")
+        return original_request(
+            size,
+            name=name,
+            priority=priority,
+            input_lease_id=input_lease_id,
+            cancel_event=cancel_event,
+        )
+
+    monkeypatch.setattr(subprocess_exec, "request_local_shm_output_grant", gated_request)
+
+    class AddOne:
+        def __call__(self, table):
+            return pa.table({"y": [value + 1 for value in table.column("x").to_pylist()]})
+
+    payload = _subprocess_map_payload(
+        AddOne,
+        execution_backend="subprocess_actor",
+        actor_number=1,
+        produce_ref_bundle_output=True,
+        streaming_output_mode="local_shm_ref_bundle",
+    )
+    pool = subprocess_exec.LocalSubprocessActorPool(payload, 1, name="shared-scope-test")
+    executor_a = subprocess_exec.UDFExecutor(payload, options={"local_actor_pool": pool})
+    executor_b = subprocess_exec.UDFExecutor(payload, options={"local_actor_pool": pool})
+    results = []
+    try:
+        assert executor_a._actor_pool is pool
+        assert executor_b._actor_pool is pool
+        _submit_with_admission(executor_b, pa.table({"x": [1]}), submit_id=911)
+        assert grant_started.wait(timeout=10.0)
+        assert captured_cancel_events and not captured_cancel_events[0].is_set()
+
+        executor_a.close(kill=False)
+
+        assert not captured_cancel_events[0].is_set()
+        release_grant.set()
+        results.extend(_wait_for_results(executor_b, 1, timeout_s=10.0))
+        assert results[0][0:2] == (ref_bundle.SUBMIT_RESULT_MARKER, 911)
+        assert results[0][2][0] == ref_bundle.REF_BUNDLE_RESULT_MARKER
+
+        _submit_with_admission(executor_b, pa.table({"x": [2]}), submit_id=912)
+        results.extend(_wait_for_results(executor_b, 1, timeout_s=10.0))
+        assert results[1][0:2] == (ref_bundle.SUBMIT_RESULT_MARKER, 912)
+        assert results[1][2][0] == ref_bundle.REF_BUNDLE_RESULT_MARKER
+    finally:
+        release_grant.set()
+        if not executor_a._closed:
+            executor_a.close(kill=True)
+        executor_b.close(kill=True)
+        pool.shutdown(kill=True)
+        for result in results:
+            value = result[2]
+            if isinstance(value, tuple) and value and value[0] == ref_bundle.REF_BUNDLE_RESULT_MARKER:
+                for ref in value[1]:
+                    ref.release()
+
+
+def test_subprocess_stateful_actor_destructor_finishes_before_graceful_close_ack(monkeypatch, tmp_path):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    marker_path = tmp_path / "stateful-cleanup.txt"
+    monkeypatch.setenv("VANE_TEST_STATEFUL_CLEANUP_MARKER", str(marker_path))
+
+    class StatefulCleanup:
+        def __call__(self, table):
+            return table
+
+        def __del__(self):
+            import os
+            import time
+            from pathlib import Path
+
+            time.sleep(0.05)
+            Path(os.environ["VANE_TEST_STATEFUL_CLEANUP_MARKER"]).write_text("cleaned")
+
+    pool = subprocess_exec.LocalSubprocessActorPool(
+        _subprocess_map_payload(
+            StatefulCleanup,
+            execution_backend="subprocess_actor",
+            actor_number=1,
+            stateful=True,
+            udf_name="stateful_cleanup",
+        ),
+        1,
+        name="stateful-cleanup-test",
+    )
+    try:
+        pool.shutdown(kill=False)
+    finally:
+        if not pool._closed:
+            pool.shutdown(kill=True)
+
+    assert marker_path.read_text() == "cleaned"

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -3973,6 +3973,7 @@ def test_local_subprocess_actor_pool_shutdown_fences_admission_before_executor_w
     pool._cond = threading.Condition(pool._lock)
     pool._active = 0
     pool._active_scopes = {}
+    pool._replacing_workers = set()
     pool._idle_workers = deque([(0, 0), (1, 0)])
     pool._workers = [FakeWorker("w0"), FakeWorker("w1")]
     pool._executor = FakeExecutor()
@@ -3987,6 +3988,334 @@ def test_local_subprocess_actor_pool_shutdown_fences_admission_before_executor_w
         "close:w1:False",
     ]
     assert pool._workers == []
+
+
+@pytest.mark.parametrize("cleanup_fails", [False, True])
+@pytest.mark.parametrize("kill", [False, True])
+def test_local_subprocess_actor_pool_shutdown_joins_in_progress_replacement_cleanup(kill, cleanup_fails):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    spawn_entered = threading.Event()
+    allow_spawn_return = threading.Event()
+    replacement_close_entered = threading.Event()
+    allow_replacement_close = threading.Event()
+    events: list[str] = []
+    replacement_errors: list[BaseException] = []
+    shutdown_errors: list[BaseException] = []
+    follower_shutdown_errors: list[BaseException] = []
+
+    class FakeWorker:
+        def __init__(self, name: str):
+            self.name = name
+
+        def close(self, *, kill: bool = False) -> None:
+            events.append(f"close:{self.name}:{kill}")
+            if self.name == "replacement":
+                replacement_close_entered.set()
+                assert allow_replacement_close.wait(timeout=5.0)
+                if cleanup_fails:
+                    raise RuntimeError("planned replacement cleanup failure")
+
+    class FakeExecutor:
+        def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+            assert replacement_close_entered.is_set()
+            assert allow_replacement_close.is_set()
+            events.append(f"shutdown:{wait}:{cancel_futures}")
+
+    class FakeAdmissionSlots:
+        def close(self) -> None:
+            events.append("admission-close")
+
+    failed_worker = FakeWorker("failed")
+    replacement = FakeWorker("replacement")
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": False}
+    pool.pool_size = 1
+    pool.name = "replacement-shutdown-race"
+    pool._closed = False
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = {0}
+    pool._replacement_cleanup_errors = []
+    pool._aborting_workers = set()
+    pool._idle_workers = deque()
+    pool._workers = [failed_worker]
+    pool._executor = FakeExecutor()
+    pool.admission_slots = FakeAdmissionSlots()
+
+    def spawn_worker(worker_idx):
+        assert worker_idx == 0
+        spawn_entered.set()
+        assert allow_spawn_return.wait(timeout=5.0)
+        return replacement
+
+    pool._spawn_worker = spawn_worker
+
+    def replace_worker():
+        try:
+            pool._replace_worker(0, 0, failed_worker)
+        except BaseException as exc:
+            replacement_errors.append(exc)
+
+    replacement_thread = threading.Thread(target=replace_worker, daemon=True)
+    replacement_thread.start()
+    assert spawn_entered.wait(timeout=5.0)
+
+    def shutdown():
+        try:
+            pool.shutdown(kill=kill)
+        except BaseException as exc:
+            shutdown_errors.append(exc)
+
+    shutdown_thread = threading.Thread(target=shutdown, daemon=True)
+    shutdown_thread.start()
+    with pool._cond:
+        assert pool._cond.wait_for(lambda: pool._closed, timeout=5.0)
+    assert shutdown_thread.is_alive()
+
+    def follower_shutdown():
+        try:
+            pool.shutdown(kill=True)
+        except BaseException as exc:
+            follower_shutdown_errors.append(exc)
+
+    follower_shutdown_thread = threading.Thread(target=follower_shutdown, daemon=True)
+    follower_shutdown_thread.start()
+    assert follower_shutdown_thread.is_alive()
+
+    allow_spawn_return.set()
+    assert replacement_close_entered.wait(timeout=5.0)
+    assert shutdown_thread.is_alive()
+    assert follower_shutdown_thread.is_alive()
+
+    allow_replacement_close.set()
+    replacement_thread.join(timeout=5.0)
+    shutdown_thread.join(timeout=5.0)
+    follower_shutdown_thread.join(timeout=5.0)
+
+    assert not replacement_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert not follower_shutdown_thread.is_alive()
+    assert replacement_errors == []
+    if cleanup_fails:
+        assert len(shutdown_errors) == 1
+        assert "planned replacement cleanup failure" in str(shutdown_errors[0])
+    else:
+        assert shutdown_errors == []
+    assert follower_shutdown_errors == []
+    assert pool._replacing_workers == set()
+    assert pool._replacement_cleanup_errors == []
+    assert events == [
+        "close:failed:True",
+        "admission-close",
+        "close:replacement:True",
+        "shutdown:False:True",
+        f"close:failed:{kill}",
+    ]
+
+
+@pytest.mark.parametrize("kill", [False, True])
+def test_local_subprocess_actor_pool_shutdown_interrupts_provisional_replacement(monkeypatch, kill):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    startup_observed = threading.Event()
+    startup_cancelled = threading.Event()
+    replacement_errors: list[BaseException] = []
+
+    class FailedWorker:
+        def close(self, *, kill: bool = False) -> None:
+            assert kill
+
+    class ProvisionalWorker:
+        def _cancel_startup(self) -> None:
+            startup_cancelled.set()
+
+    class FakeExecutor:
+        def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+            assert not wait
+            assert cancel_futures
+
+    class FakeAdmissionSlots:
+        def close(self) -> None:
+            pass
+
+    failed_worker = FailedWorker()
+    provisional_worker = ProvisionalWorker()
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": False}
+    pool.pool_size = 1
+    pool.name = "provisional-replacement-shutdown"
+    pool._closed = False
+    pool._shutdown_finished = True
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = {0}
+    pool._replacing_executors = {}
+    pool._replacement_startup_cancel_requested = False
+    pool._replacement_cleanup_errors = []
+    pool._aborting_workers = set()
+    pool._idle_workers = deque()
+    pool._workers = [failed_worker]
+    pool._executor = FakeExecutor()
+    pool.admission_slots = FakeAdmissionSlots()
+
+    def spawn_worker(worker_idx):
+        assert worker_idx == 0
+        pool._track_replacing_executor(worker_idx, provisional_worker)
+        startup_observed.set()
+        assert startup_cancelled.wait(timeout=5.0)
+        raise RuntimeError("planned replacement startup cancellation")
+
+    pool._spawn_worker = spawn_worker
+    monkeypatch.setattr(subprocess_exec, "_subprocess_shutdown_grace_s", lambda: 0.05)
+
+    def replace_worker():
+        try:
+            pool._replace_worker(0, 0, failed_worker)
+        except BaseException as exc:
+            replacement_errors.append(exc)
+
+    replacement_thread = threading.Thread(target=replace_worker, daemon=True)
+    replacement_thread.start()
+    assert startup_observed.wait(timeout=5.0)
+
+    started = time.monotonic()
+    pool.shutdown(kill=kill)
+    elapsed = time.monotonic() - started
+    replacement_thread.join(timeout=5.0)
+
+    assert elapsed < 1.0
+    assert not replacement_thread.is_alive()
+    assert startup_cancelled.is_set()
+    assert replacement_errors == []
+    assert pool._replacing_workers == set()
+    assert pool._replacing_executors == {}
+    assert pool._shutdown_finished
+
+
+def test_local_subprocess_actor_pool_shutdown_bounds_unpublished_replacement(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    class FailedWorker:
+        def close(self, *, kill: bool = False) -> None:
+            assert kill
+
+    class FakeExecutor:
+        def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+            assert not wait
+            assert cancel_futures
+
+    class FakeAdmissionSlots:
+        def close(self) -> None:
+            pass
+
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": False}
+    pool.pool_size = 1
+    pool.name = "unpublished-replacement-shutdown"
+    pool._closed = False
+    pool._shutdown_finished = True
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = {0}
+    pool._replacing_executors = {}
+    pool._replacement_startup_cancel_requested = False
+    pool._replacement_cleanup_errors = []
+    pool._aborting_workers = set()
+    pool._idle_workers = deque()
+    pool._workers = [FailedWorker()]
+    pool._executor = FakeExecutor()
+    pool.admission_slots = FakeAdmissionSlots()
+    monkeypatch.setattr(subprocess_exec, "_subprocess_shutdown_grace_s", lambda: 0.05)
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="replacement cleanup did not finish before the shutdown deadline"):
+        pool.shutdown(kill=True)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert pool._shutdown_finished
+
+
+def test_local_subprocess_actor_pool_shutdown_continues_after_abort_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+    scopes = [
+        subprocess_exec.ExecutionCancellationScope("executor", 1),
+        subprocess_exec.ExecutionCancellationScope("executor", 2),
+    ]
+
+    class FakeWorker:
+        def __init__(self, name):
+            self.name = name
+            self.close_count = 0
+
+        def close(self, *, kill):
+            self.close_count += 1
+            events.append(f"close:{self.name}:{kill}")
+            if self.name == "w0" and self.close_count == 1:
+                raise RuntimeError("planned active worker cleanup failure")
+
+    class FakeExecutor:
+        def shutdown(self, *, wait, cancel_futures):
+            events.append(f"shutdown:{wait}:{cancel_futures}")
+
+    class FakeAdmissionSlots:
+        def close(self):
+            events.append("admission-close")
+            raise RuntimeError("planned admission close failure")
+
+    workers = [FakeWorker("w0"), FakeWorker("w1")]
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": False}
+    pool.pool_size = 2
+    pool.name = "abort-cleanup-failure"
+    pool._closed = False
+    pool._shutdown_finished = True
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 2
+    pool._terminal_error = None
+    pool._active_scopes = {0: scopes[0], 1: scopes[1]}
+    pool._worker_generations = [0, 0]
+    pool._replacing_workers = set()
+    pool._replacement_cleanup_errors = []
+    pool._aborting_workers = set()
+    pool._idle_workers = deque()
+    pool._workers = workers
+    pool._executor = FakeExecutor()
+    pool.admission_slots = FakeAdmissionSlots()
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned admission close failure.*planned active worker cleanup failure",
+    ):
+        pool.shutdown(kill=True)
+
+    assert events == [
+        "admission-close",
+        "close:w0:True",
+        "close:w1:True",
+        "shutdown:False:True",
+        "close:w0:True",
+        "close:w1:True",
+    ]
+    assert pool._workers == []
+    assert pool._executor is None
+    assert pool._shutdown_finished
 
 
 def test_local_subprocess_actor_abort_fences_generation_from_idle_reuse():
@@ -4124,6 +4453,74 @@ def test_stateful_actor_preserves_structured_udf_error_before_terminal_failure()
     pool._closed = True
 
 
+def test_stateful_actor_idle_loss_fails_pool_without_replacement():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    replacement_attempted = False
+
+    class LostWorker:
+        def __init__(self):
+            self._proc = types.SimpleNamespace(pid=4242)
+            self.close_calls: list[bool] = []
+
+        def is_reusable(self):
+            return False
+
+        def close(self, *, kill=False):
+            self.close_calls.append(bool(kill))
+
+    class FakeAdmissionSlots:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    worker = LostWorker()
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": True, "udf_name": "stateful_idle_loss"}
+    pool.pool_size = 1
+    pool.name = "stateful-idle-loss"
+    pool._closed = False
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 0
+    pool._terminal_error = None
+    pool._active_scopes = {}
+    pool._worker_generations = [0]
+    pool._replacing_workers = set()
+    pool._replacement_cleanup_errors = []
+    pool._aborting_workers = set()
+    pool._idle_workers = deque([(0, 0)])
+    pool._workers = [worker]
+    pool.admission_slots = FakeAdmissionSlots()
+
+    def fail_if_replaced(_worker_idx):
+        nonlocal replacement_attempted
+        replacement_attempted = True
+        raise AssertionError("stateful actor must not be replaced after losing state")
+
+    pool._spawn_worker = fail_if_replaced
+    scope = ExecutionCancellationScope("test-executor", 1)
+
+    with pytest.raises(
+        RuntimeError,
+        match="stateful UDF 'stateful_idle_loss' lost local actor pid 4242",
+    ):
+        pool._run(lambda _worker: None, scope)
+
+    assert not replacement_attempted
+    assert worker.close_calls == [True]
+    assert pool._terminal_error is not None
+    assert "state was not recoverable" in str(pool._terminal_error)
+    assert pool.admission_slots.closed
+    assert pool._replacing_workers == set()
+    assert not pool._idle_workers
+    assert scope.finished
+    pool._closed = True
+
+
 def test_local_subprocess_actor_pool_rolls_back_created_workers_on_worker_init_failure(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
 
@@ -4224,6 +4621,10 @@ def test_global_subprocess_task_runtime_close_without_kill_does_not_wait_for_exe
         def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
             events.append(f"shutdown:{wait}:{cancel_futures}")
 
+    class FakeAdmissionSlots:
+        def close(self) -> None:
+            events.append("admission-close")
+
     idle_wrapper = subprocess_exec._PooledTaskWorker(FakeWorker("idle"))
     active_wrapper = subprocess_exec._PooledTaskWorker(FakeWorker("active"))
     runtime = subprocess_exec._GlobalSubprocessTaskRuntime.__new__(subprocess_exec._GlobalSubprocessTaskRuntime)
@@ -4239,18 +4640,281 @@ def test_global_subprocess_task_runtime_close_without_kill_does_not_wait_for_exe
     pool.kill_on_release = False
     pool.idle = [idle_wrapper]
     pool._active_wrappers = {active_wrapper}
+    pool._spawning_workers = set()
     pool.active = 1
     pool.total = 2
+    pool.admission_slots = FakeAdmissionSlots()
     runtime.pools = {pool.key: pool}
 
     runtime.close(kill=False)
 
     assert events == [
+        "admission-close",
         "cancel:active",
         "shutdown:False:True",
         "close:idle:False",
         "close:active:True",
     ]
+
+
+def test_global_subprocess_task_runtime_close_attempts_all_cleanup_after_failures():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+
+    class FakeWorker:
+        def __init__(self, name, *, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def cancel_output_grants(self):
+            events.append(f"cancel:{self.name}")
+            if self.fail:
+                raise RuntimeError(f"{self.name} cancellation failed")
+
+        def close(self, *, kill):
+            events.append(f"close:{self.name}:{kill}")
+            if self.fail:
+                raise RuntimeError(f"{self.name} close failed")
+
+    class FakeExecutor:
+        def shutdown(self, *, wait, cancel_futures):
+            events.append(f"shutdown:{wait}:{cancel_futures}")
+            raise RuntimeError("executor shutdown failed")
+
+    class FakeAdmissionSlots:
+        def close(self):
+            events.append("admission-close")
+            raise RuntimeError("admission close failed")
+
+    idle_wrapper = subprocess_exec._PooledTaskWorker(FakeWorker("idle", fail=True))
+    active_wrapper = subprocess_exec._PooledTaskWorker(FakeWorker("active"))
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime.__new__(subprocess_exec._GlobalSubprocessTaskRuntime)
+    runtime.executor = FakeExecutor()
+    runtime.cond = threading.Condition()
+    runtime.closed = False
+    runtime.total_workers = 2
+
+    pool = subprocess_exec._TaskWorkerPool.__new__(subprocess_exec._TaskWorkerPool)
+    pool.runtime = runtime
+    pool.key = "pool"
+    pool.closing = False
+    pool.kill_on_release = False
+    pool.idle = [idle_wrapper]
+    pool._active_wrappers = {active_wrapper}
+    pool._spawning_workers = set()
+    pool.active = 1
+    pool.total = 2
+    pool.admission_slots = FakeAdmissionSlots()
+    runtime.pools = {pool.key: pool}
+
+    with pytest.raises(
+        RuntimeError,
+        match="admission close failed.*executor shutdown failed.*idle close failed",
+    ):
+        runtime.close(kill=False)
+
+    assert events == [
+        "admission-close",
+        "cancel:active",
+        "shutdown:False:True",
+        "close:idle:False",
+        "close:active:True",
+    ]
+
+
+def test_global_subprocess_task_runtime_concurrent_close_waits_for_cleanup():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    shutdown_started = threading.Event()
+    allow_shutdown = threading.Event()
+    errors: list[BaseException] = []
+
+    class FakeExecutor:
+        def shutdown(self, *, wait, cancel_futures):
+            assert not wait
+            assert cancel_futures
+            shutdown_started.set()
+            assert allow_shutdown.wait(timeout=5.0)
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime.__new__(subprocess_exec._GlobalSubprocessTaskRuntime)
+    runtime.executor = FakeExecutor()
+    runtime.cond = threading.Condition()
+    runtime.pools = {}
+    runtime.total_workers = 0
+    runtime.closed = False
+    runtime._close_finished = True
+
+    def close_runtime():
+        try:
+            runtime.close(kill=True)
+        except BaseException as exc:
+            errors.append(exc)
+
+    primary = threading.Thread(target=close_runtime)
+    follower = threading.Thread(target=close_runtime)
+    primary.start()
+    assert shutdown_started.wait(timeout=5.0)
+    follower.start()
+    assert follower.is_alive()
+
+    allow_shutdown.set()
+    primary.join(timeout=5.0)
+    follower.join(timeout=5.0)
+
+    assert not primary.is_alive()
+    assert not follower.is_alive()
+    assert errors == []
+    assert runtime._close_finished
+
+
+def test_global_subprocess_task_runtime_releases_worker_when_debug_logging_fails(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+
+    class FakeWorker:
+        _proc = types.SimpleNamespace(pid=4242)
+
+        def is_reusable(self):
+            return True
+
+        def _run_in_execution_scope(self, _scope, _fn):
+            raise AssertionError("worker call must not run after acquired-worker debug failure")
+
+    wrapper = subprocess_exec._PooledTaskWorker(FakeWorker())
+
+    class FakePool:
+        pool_size = 1
+        total = 1
+        active = 1
+        idle = []
+
+        def acquire_worker(self, _scope):
+            events.append("acquire")
+            return wrapper
+
+        def release_worker(self, released, *, reusable):
+            assert released is wrapper
+            events.append(f"release:{reusable}")
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime.__new__(subprocess_exec._GlobalSubprocessTaskRuntime)
+    runtime.total_workers = 1
+    runtime.max_workers = 1
+    monkeypatch.setattr(subprocess_exec, "_should_debug_submit", lambda _seq: True)
+
+    def fail_debug_log(_message):
+        events.append("debug")
+        raise RuntimeError("planned debug logging failure")
+
+    monkeypatch.setattr(subprocess_exec, "_subprocess_debug_log", fail_debug_log)
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    with pytest.raises(RuntimeError, match="planned debug logging failure"):
+        runtime._run_task(FakePool(), lambda _worker: None, scope, debug_seq=1)
+
+    assert events == ["acquire", "debug", "debug", "release:True"]
+    assert scope.finished
+
+
+def test_subprocess_task_completion_cleanup_survives_debug_and_admission_errors(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+
+    class FakeAdmission:
+        def release(self):
+            events.append("release-admission")
+            raise RuntimeError("planned admission release failure")
+
+    future = Future()
+    future.set_result(None)
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+    executor = subprocess_exec.UDFExecutor.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = True
+    executor._ref_bundle_output = False
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures_lock = executor._task_futures_cv
+    executor._task_futures = {future}
+    executor._task_future_meta = {
+        future: (
+            73,
+            1,
+            time.perf_counter(),
+            FakeAdmission(),
+            scope,
+        )
+    }
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._queue_lock = threading.Lock()
+    executor._pending_batches = 1
+    executor._pending_lock = threading.Lock()
+    executor._execution_scopes = {scope}
+    executor._execution_scopes_lock = threading.Lock()
+    executor._wakeup = None
+    executor._wakeup_error = None
+
+    monkeypatch.setattr(subprocess_exec, "_should_debug_submit", lambda _seq: True)
+
+    def fail_debug_log(_message):
+        events.append("debug")
+        raise RuntimeError("planned completion debug failure")
+
+    monkeypatch.setattr(subprocess_exec, "_subprocess_debug_log", fail_debug_log)
+
+    executor._complete_task_submit(73, future)
+
+    assert events == ["debug", "release-admission"]
+    assert executor._pending_batches == 0
+    assert executor._task_futures == set()
+    assert executor._task_future_meta == {}
+    assert executor._execution_scopes == set()
+    assert scope.finished
+    assert isinstance(executor._wakeup_error, RuntimeError)
+    assert "planned completion debug failure" in str(executor._wakeup_error)
+
+
+def test_subprocess_failed_submit_retires_scope_after_admission_cleanup_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+
+    class FakeAdmission:
+        def release(self):
+            events.append("release-admission")
+            raise RuntimeError("planned admission release failure")
+
+    class FakeActorPool:
+        pool_size = 1
+
+        def submit(self, _fn, scope, _debug_seq):
+            events.append(f"submit:{scope.generation}")
+            raise RuntimeError("planned actor submit failure")
+
+    executor = subprocess_exec.UDFExecutor.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._debug_submit_count = 0
+    executor._actor_pool = FakeActorPool()
+    executor._task_pool = None
+    executor._task_runtime = None
+    executor._pending_lock = threading.Lock()
+    executor._pending_batches = 0
+    executor._execution_owner_id = "failed-submit-executor"
+    executor._execution_scope_generation = 0
+    executor._execution_scopes = set()
+    executor._execution_scopes_lock = threading.Lock()
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned actor submit failure.*planned admission release failure",
+    ):
+        executor._submit_async(74, lambda _worker: None, FakeAdmission())
+
+    assert events == ["submit:1", "release-admission"]
+    assert executor._pending_batches == 0
+    assert executor._execution_scopes == set()
 
 
 def test_udf_executor_close_without_kill_cancels_local_shm_waits_before_waiting(monkeypatch):
@@ -4482,6 +5146,48 @@ def test_subprocess_task_pool_kill_closes_active_worker(monkeypatch):
         runtime.close(kill=True)
 
 
+def test_subprocess_task_pool_release_attempts_all_idle_worker_cleanup_after_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
+    calls: list[str] = []
+
+    class FakeWorker:
+        def __init__(self, name, *, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def close(self, *, kill):
+            assert not kill
+            calls.append(self.name)
+            if self.fail:
+                raise RuntimeError(f"{self.name} cleanup failed")
+
+    class FakeAdmissionSlots:
+        def close(self):
+            calls.append("admission")
+            raise RuntimeError("admission cleanup failed")
+
+    pool = subprocess_exec._TaskWorkerPool(runtime, "release-cleanup-failure", {}, 2)
+    pool.admission_slots = FakeAdmissionSlots()
+    runtime.pools[pool.key] = pool
+    runtime.total_workers = 2
+    pool.acquire_ref()
+    pool.total = 2
+    pool.idle = [
+        subprocess_exec._PooledTaskWorker(FakeWorker("first")),
+        subprocess_exec._PooledTaskWorker(FakeWorker("second", fail=True)),
+    ]
+    try:
+        with pytest.raises(RuntimeError, match="admission cleanup failed.*second cleanup failed"):
+            pool.release_ref(kill=False)
+
+        assert calls == ["admission", "second", "first"]
+        assert runtime.total_workers == 0
+    finally:
+        runtime.close(kill=True)
+
+
 def test_subprocess_task_pool_abort_fences_worker_from_idle_reuse(monkeypatch):
     import duckdb.execution.udf_subprocess as subprocess_exec
     from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
@@ -4545,13 +5251,83 @@ def test_subprocess_task_pool_abort_fences_worker_from_idle_reuse(monkeypatch):
         runtime.close(kill=True)
 
 
-def test_subprocess_task_pool_kill_closes_worker_spawned_during_close(monkeypatch):
+def test_subprocess_task_pool_abort_attempts_every_matching_worker_after_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
+
+    calls: list[str] = []
+
+    class FakeWorker:
+        def __init__(self, name, *, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def close(self, *, kill):
+            assert kill
+            calls.append(self.name)
+            if self.fail:
+                raise RuntimeError(f"{self.name} cleanup failed")
+
+    scope_a = ExecutionCancellationScope("executor", 1)
+    scope_b = ExecutionCancellationScope("executor", 2)
+    wrapper_a = subprocess_exec._PooledTaskWorker(FakeWorker("a", fail=True))
+    wrapper_a.active_scope = scope_a
+    wrapper_b = subprocess_exec._PooledTaskWorker(FakeWorker("b"))
+    wrapper_b.active_scope = scope_b
+
+    pool = subprocess_exec._TaskWorkerPool.__new__(subprocess_exec._TaskWorkerPool)
+    pool.runtime = types.SimpleNamespace(cond=threading.Condition())
+    pool._active_wrappers = {wrapper_a, wrapper_b}
+
+    with pytest.raises(RuntimeError, match="a cleanup failed"):
+        pool.abort_scopes({scope_a, scope_b})
+
+    assert set(calls) == {"a", "b"}
+    assert wrapper_a.abort_requested
+    assert wrapper_b.abort_requested
+
+
+def test_subprocess_task_pool_nonfinal_release_does_not_join_shared_worker_spawn():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    runtime = types.SimpleNamespace(
+        cond=threading.Condition(),
+        pools={},
+        total_workers=1,
+    )
+    pool = subprocess_exec._TaskWorkerPool.__new__(subprocess_exec._TaskWorkerPool)
+    pool.runtime = runtime
+    pool.key = "shared-spawn"
+    pool.ref_count = 2
+    pool.closing = False
+    pool.kill_on_release = False
+    pool.idle = []
+    pool._active_wrappers = set()
+    pool._spawning_workers = {0}
+
+    release_thread = threading.Thread(target=pool.release_ref)
+    release_thread.start()
+    release_thread.join(timeout=1.0)
+
+    assert not release_thread.is_alive()
+    assert pool.ref_count == 1
+    assert not pool.closing
+    assert pool._spawning_workers == {0}
+
+
+@pytest.mark.parametrize("close_owner", ["pool", "runtime"])
+@pytest.mark.parametrize("kill", [False, True])
+@pytest.mark.parametrize("cleanup_fails", [False, True])
+def test_subprocess_task_close_joins_worker_spawned_during_close(monkeypatch, kill, close_owner, cleanup_fails):
     import duckdb.execution.udf_subprocess as subprocess_exec
     from duckdb.execution.udf_lifecycle import ExecutionCancellationScope
 
     runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
     spawn_started = threading.Event()
-    release_done = threading.Event()
+    allow_spawn_return = threading.Event()
+    close_started = threading.Event()
+    allow_close = threading.Event()
+    close_finished = threading.Event()
 
     class FakeWorker:
         def __init__(self):
@@ -4561,20 +5337,30 @@ def test_subprocess_task_pool_kill_closes_worker_spawned_during_close(monkeypatc
 
         def close(self, kill=False):
             self.close_calls.append(bool(kill))
+            close_started.set()
+            assert allow_close.wait(timeout=5.0)
             self._closed = True
+            close_finished.set()
+            if cleanup_fails:
+                raise RuntimeError("planned spawned worker cleanup failure")
 
     fake_worker = FakeWorker()
     pool = subprocess_exec._TaskWorkerPool(runtime, "spawn-close-pool", {"execution_backend": "subprocess_task"}, 1)
+    runtime.pools[pool.key] = pool
 
-    def spawn_worker(_worker_idx):
+    def spawn_worker(worker_idx):
+        pool._track_spawning_executor(worker_idx, fake_worker)
         spawn_started.set()
-        assert release_done.wait(timeout=5.0)
+        assert allow_spawn_return.wait(timeout=5.0)
+        if fake_worker._closed:
+            raise RuntimeError("planned worker startup cancellation")
         return subprocess_exec._PooledTaskWorker(fake_worker)
 
     monkeypatch.setattr(pool, "_spawn_worker", spawn_worker)
 
     acquired: list[object] = []
     errors: list[BaseException] = []
+    release_errors: list[BaseException] = []
 
     def acquire_worker():
         try:
@@ -4588,19 +5374,281 @@ def test_subprocess_task_pool_kill_closes_worker_spawned_during_close(monkeypatc
         thread.start()
         assert spawn_started.wait(timeout=5.0)
 
-        pool.release_ref(kill=True)
-        release_done.set()
+        def release_pool():
+            try:
+                if close_owner == "pool":
+                    pool.release_ref(kill=kill)
+                else:
+                    runtime.close(kill=kill)
+            except BaseException as exc:
+                release_errors.append(exc)
+
+        release_thread = threading.Thread(target=release_pool)
+        release_thread.start()
+        assert release_thread.is_alive()
+
+        assert close_started.wait(timeout=5.0)
+        assert release_thread.is_alive()
+
+        allow_close.set()
+        assert close_finished.wait(timeout=5.0)
+        allow_spawn_return.set()
         thread.join(timeout=5.0)
+        release_thread.join(timeout=5.0)
 
         assert not thread.is_alive()
+        assert not release_thread.is_alive()
         assert not acquired
         assert len(errors) == 1
         assert isinstance(errors[0], RuntimeError)
+        if cleanup_fails:
+            assert len(release_errors) == 1
+            assert "planned spawned worker cleanup failure" in str(release_errors[0])
+        else:
+            assert release_errors == []
         assert fake_worker.close_calls == [True]
         assert runtime.stats()["total_workers"] == 0
     finally:
-        release_done.set()
+        allow_spawn_return.set()
+        allow_close.set()
         runtime.close(kill=True)
+
+
+def test_subprocess_task_close_bounds_unpublished_worker_startup(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime()
+    pool = subprocess_exec._TaskWorkerPool(
+        runtime,
+        "unpublished-spawn-close-pool",
+        {"execution_backend": "subprocess_task"},
+        1,
+    )
+    runtime.pools[pool.key] = pool
+    pool.acquire_ref()
+    with runtime.cond:
+        pool._spawning_workers.add(0)
+        pool.total = 1
+        pool.active = 1
+        runtime.total_workers = 1
+    monkeypatch.setattr(subprocess_exec, "_subprocess_shutdown_grace_s", lambda: 0.05)
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(RuntimeError, match="startup cleanup did not finish before the shutdown deadline"):
+            pool.release_ref(kill=True)
+    finally:
+        elapsed = time.monotonic() - started
+        with runtime.cond:
+            pool._spawning_workers.clear()
+            pool.total = 0
+            pool.active = 0
+            runtime.total_workers = 0
+            runtime.cond.notify_all()
+        runtime.close(kill=True)
+
+    assert elapsed < 1.0
+
+
+def test_single_subprocess_startup_can_be_cancelled_before_ready_wait():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    startup_observed = threading.Event()
+    allow_startup_to_continue = threading.Event()
+    observed_workers: list[subprocess_exec._SingleSubprocessExecutor] = []
+    errors: list[BaseException] = []
+
+    def observe_startup(worker):
+        observed_workers.append(worker)
+        startup_observed.set()
+        assert allow_startup_to_continue.wait(timeout=5.0)
+
+    def build_worker():
+        try:
+            subprocess_exec._SingleSubprocessExecutor(
+                _subprocess_map_payload(lambda table: table),
+                startup_observer=observe_startup,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=build_worker)
+    thread.start()
+    assert startup_observed.wait(timeout=5.0)
+    assert len(observed_workers) == 1
+
+    worker = observed_workers[0]
+    worker._cancel_startup()
+    allow_startup_to_continue.set()
+    thread.join(timeout=5.0)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert "startup" in str(errors[0]).lower() or "communication failed" in str(errors[0]).lower()
+    assert worker._closed
+    assert worker._proc is None
+    assert worker._sock is None
+    assert worker._payload_shm is None
+    assert worker._data_shm is None
+
+
+def test_single_subprocess_startup_can_be_cancelled_during_ready_wait(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    ready_wait_started = threading.Event()
+    allow_ready_wait = threading.Event()
+    observed_workers: list[subprocess_exec._SingleSubprocessExecutor] = []
+    errors: list[BaseException] = []
+    original_recv_expected = subprocess_exec._SingleSubprocessExecutor._recv_expected
+
+    def block_ready_wait(self, expected, *, timeout_s=None):
+        if expected == (subprocess_exec._MSG_READY, subprocess_exec._MSG_ERROR):
+            ready_wait_started.set()
+            assert allow_ready_wait.wait(timeout=5.0)
+        return original_recv_expected(self, expected, timeout_s=timeout_s)
+
+    monkeypatch.setattr(
+        subprocess_exec._SingleSubprocessExecutor,
+        "_recv_expected",
+        block_ready_wait,
+    )
+
+    def build_worker():
+        try:
+            subprocess_exec._SingleSubprocessExecutor(
+                _subprocess_map_payload(lambda table: table),
+                startup_observer=observed_workers.append,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=build_worker)
+    thread.start()
+    assert ready_wait_started.wait(timeout=5.0)
+    assert len(observed_workers) == 1
+
+    worker = observed_workers[0]
+    worker._cancel_startup()
+    allow_ready_wait.set()
+    thread.join(timeout=5.0)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert "startup" in str(errors[0]).lower()
+    assert worker._closed
+    assert worker._proc is None
+    assert worker._sock is None
+    assert worker._payload_shm is None
+    assert worker._data_shm is None
+
+
+def test_subprocess_task_releases_result_cancelled_after_worker_call():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.ref_bundle import REF_BUNDLE_RESULT_MARKER
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope, ExecutionCancelledError
+
+    released = 0
+    events: list[str] = []
+
+    class FakeRef:
+        def release(self):
+            nonlocal released
+            released += 1
+
+    result = (REF_BUNDLE_RESULT_MARKER, [FakeRef()])
+    scope = ExecutionCancellationScope("test-executor", 1)
+
+    class FakeWorker:
+        _proc = types.SimpleNamespace(pid=4242)
+
+        def is_reusable(self):
+            return True
+
+        def _run_in_execution_scope(self, active_scope, fn):
+            value = fn(self)
+            assert active_scope.cancel("task pool closed")
+            return value
+
+    wrapper = subprocess_exec._PooledTaskWorker(FakeWorker())
+
+    class FakePool:
+        pool_size = 1
+        total = 1
+        active = 1
+        idle = []
+
+        def acquire_worker(self, _scope):
+            return wrapper
+
+        def release_worker(self, released_wrapper, *, reusable):
+            assert released_wrapper is wrapper
+            events.append(f"release:{reusable}")
+
+    runtime = subprocess_exec._GlobalSubprocessTaskRuntime.__new__(subprocess_exec._GlobalSubprocessTaskRuntime)
+    runtime.total_workers = 1
+    runtime.max_workers = 1
+
+    with pytest.raises(ExecutionCancelledError, match="subprocess task result cancelled"):
+        runtime._run_task(FakePool(), lambda _worker: result, scope)
+
+    assert released == 1
+    assert events == ["release:True"]
+    assert scope.finished
+
+
+def test_subprocess_actor_releases_result_cancelled_after_worker_call():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.ref_bundle import REF_BUNDLE_RESULT_MARKER
+    from duckdb.execution.udf_lifecycle import ExecutionCancellationScope, ExecutionCancelledError
+
+    released = 0
+
+    class FakeRef:
+        def release(self):
+            nonlocal released
+            released += 1
+
+    result = (REF_BUNDLE_RESULT_MARKER, [FakeRef()])
+    scope = ExecutionCancellationScope("test-executor", 1)
+
+    class FakeWorker:
+        _actor_lost = False
+        _proc = types.SimpleNamespace(pid=4242)
+
+        def is_reusable(self):
+            return True
+
+        def _run_in_execution_scope(self, active_scope, fn):
+            value = fn(self)
+            assert active_scope.cancel("actor pool closed")
+            return value
+
+    worker = FakeWorker()
+    pool = subprocess_exec.LocalSubprocessActorPool.__new__(subprocess_exec.LocalSubprocessActorPool)
+    pool.payload = {"stateful": False}
+    pool.pool_size = 1
+    pool.name = "post-call-cancel"
+    pool._closed = True
+    pool._lock = threading.RLock()
+    pool._cond = threading.Condition(pool._lock)
+    pool._active = 1
+    pool._terminal_error = None
+    pool._active_scopes = {0: scope}
+    pool._worker_generations = [0]
+    pool._replacing_workers = set()
+    pool._aborting_workers = set()
+    pool._idle_workers = deque()
+    pool._workers = [worker]
+    pool._acquire_worker = lambda _scope: (0, 0, worker)
+
+    with pytest.raises(ExecutionCancelledError, match="local subprocess actor result cancelled"):
+        pool._run(lambda _worker: result, scope)
+
+    assert released == 1
+    assert pool._active == 0
+    assert pool._active_scopes == {}
+    assert not pool._idle_workers
+    assert scope.finished
 
 
 def test_subprocess_task_shared_payload_pool_keeps_worker_slots_global(monkeypatch):
@@ -6326,6 +7374,228 @@ def test_single_subprocess_close_releases_active_output_grants(monkeypatch):
     assert ref_bundle.local_shm_ref_budget_snapshot()["output_grant_bytes"] == before
 
 
+def test_single_subprocess_close_attempts_all_scope_and_worker_cleanup_after_failures(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+    sock = _FakeControlSocket()
+    executor = _bare_shutdown_executor(subprocess_exec, sock, None)
+    scope = executor._worker_lifetime_scope
+    stale_scope = subprocess_exec.ExecutionCancellationScope("stale-executor", 1)
+    executor._active_input_leases = {
+        1: scope,
+        2: stale_scope,
+    }
+    executor._active_output_grants = {
+        3: scope,
+        4: stale_scope,
+    }
+
+    def cancel_input_lease(lease_id, *, name):
+        events.append(f"lease:{lease_id}:{name}")
+        if lease_id == 1:
+            raise RuntimeError("planned input lease failure")
+        return 0
+
+    def release_output_grant(grant_id, *, name):
+        events.append(f"grant:{grant_id}:{name}")
+        if grant_id == 3:
+            raise RuntimeError("planned output grant failure")
+        return 0
+
+    def wake_budget():
+        events.append("wake")
+        raise RuntimeError("planned budget wakeup failure")
+
+    monkeypatch.setattr(subprocess_exec, "cancel_local_shm_input_lease", cancel_input_lease)
+    monkeypatch.setattr(subprocess_exec, "release_local_shm_output_grant", release_output_grant)
+    monkeypatch.setattr(subprocess_exec, "wake_local_shm_ref_budget_waiters", wake_budget)
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned input lease failure.*planned output grant failure.*planned budget wakeup failure",
+    ):
+        executor.close(kill=True)
+
+    assert events == [
+        "lease:1:udf-input-close",
+        "grant:3:udf-output-cancel",
+        "wake",
+        "lease:2:udf-input-close",
+        "grant:4:udf-output-close",
+    ]
+    assert executor._active_input_leases == {}
+    assert executor._active_output_grants == {}
+    assert sock.closed
+    assert executor._sock is None
+    assert executor._proc is None
+
+
+def test_single_subprocess_execution_scope_is_cleared_after_cleanup_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    def fail_cleanup(_scope, *, cancel_scope):
+        assert not cancel_scope
+        raise RuntimeError("planned scope cleanup failure")
+
+    broken_errors: list[str] = []
+    executor._cancel_scope_resources = fail_cleanup
+    executor._mark_broken = lambda error, **_kwargs: broken_errors.append(error)
+
+    with pytest.raises(RuntimeError, match="planned scope cleanup failure"):
+        executor._run_in_execution_scope(scope, lambda _worker: "result")
+
+    assert executor._active_execution_scope is None
+    assert len(broken_errors) == 1
+    assert "planned scope cleanup failure" in broken_errors[0]
+
+
+def test_single_subprocess_execution_scope_releases_post_call_cancelled_result():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+    from duckdb.execution.ref_bundle import REF_BUNDLE_RESULT_MARKER
+    from duckdb.execution.udf_lifecycle import ExecutionCancelledError
+
+    released = 0
+
+    class FakeRef:
+        def release(self):
+            nonlocal released
+            released += 1
+
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    executor._cancel_scope_resources = lambda _scope, *, cancel_scope: None
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+    result = (REF_BUNDLE_RESULT_MARKER, [FakeRef()])
+
+    def finish_then_cancel(_worker):
+        assert scope.cancel("executor closed")
+        return result
+
+    with pytest.raises(ExecutionCancelledError, match="UDF subprocess task result cancelled"):
+        executor._run_in_execution_scope(scope, finish_then_cancel)
+
+    assert released == 1
+    assert executor._active_execution_scope is None
+
+
+def test_single_subprocess_execution_scope_is_cleared_when_wakeup_registration_fails():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+    cleanup_calls: list[bool] = []
+
+    def fail_registration(_callback):
+        raise RuntimeError("planned wakeup registration failure")
+
+    def cleanup_scope(_scope, *, cancel_scope):
+        cleanup_calls.append(cancel_scope)
+
+    scope.register_cancel_wakeup = fail_registration
+    executor._cancel_scope_resources = cleanup_scope
+
+    with pytest.raises(RuntimeError, match="planned wakeup registration failure"):
+        executor._run_in_execution_scope(scope, lambda _worker: pytest.fail("task must not run"))
+
+    assert executor._active_execution_scope is None
+    assert cleanup_calls == [False]
+
+
+def test_single_subprocess_cancel_wakeup_cleanup_failure_breaks_worker():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    executor = object.__new__(subprocess_exec._SingleSubprocessExecutor)
+    executor._execution_scope_lock = threading.Lock()
+    executor._active_execution_scope = None
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+    cleanup_calls = 0
+    broken_errors: list[str] = []
+
+    def cleanup_scope(_scope, *, cancel_scope):
+        nonlocal cleanup_calls
+        assert not cancel_scope
+        cleanup_calls += 1
+        if cleanup_calls == 1:
+            raise RuntimeError("planned cancel wakeup cleanup failure")
+
+    executor._cancel_scope_resources = cleanup_scope
+    executor._mark_broken = lambda error, **_kwargs: broken_errors.append(error)
+
+    scope.cancel("planned cancellation")
+    with pytest.raises(RuntimeError, match="planned cancel wakeup cleanup failure"):
+        executor._run_in_execution_scope(scope, lambda _worker: pytest.fail("task must not run"))
+
+    assert cleanup_calls == 2
+    assert executor._active_execution_scope is None
+    assert len(broken_errors) == 1
+    assert "planned cancel wakeup cleanup failure" in broken_errors[0]
+
+
+def test_single_subprocess_submit_transport_failure_breaks_worker_before_fallible_lease_cleanup(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    sock = _FakeControlSocket()
+    executor = _bare_shutdown_executor(subprocess_exec, sock, None)
+    executor._actor_lost = False
+
+    def fail_send(_sock, _msg_type, _payload=b""):
+        raise OSError("planned transport failure")
+
+    def fail_lease_cleanup(_lease_id, *, name):
+        assert name == "udf-input-close"
+        raise RuntimeError("planned lease cleanup failure")
+
+    monkeypatch.setattr(subprocess_exec, "_send_message", fail_send)
+    monkeypatch.setattr(subprocess_exec, "cancel_local_shm_input_lease", fail_lease_cleanup)
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned transport failure.*broken-worker cleanup failed.*planned lease cleanup failure",
+    ):
+        executor._submit_ref_bundle_direct({"estimated_num_rows": 1, "input_lease_id": 7})
+
+    assert executor._closed
+    assert executor._actor_lost
+    assert executor._broken_error == "UDF subprocess ref-bundle submit failed: planned transport failure"
+    assert executor._active_input_leases == {}
+    assert sock.closed
+
+
+def test_single_subprocess_result_cleanup_failure_prevents_worker_reuse(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    sock = _FakeControlSocket()
+    executor = _bare_shutdown_executor(subprocess_exec, sock, None)
+    executor._actor_lost = False
+    executor._recv_submit_result = lambda: (_ for _ in ()).throw(RuntimeError("planned receive failure"))
+
+    def fail_lease_cleanup(_lease_id, *, name):
+        assert name == "udf-input"
+        raise RuntimeError("planned lease cleanup failure")
+
+    monkeypatch.setattr(subprocess_exec, "cancel_local_shm_input_lease", fail_lease_cleanup)
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned receive failure.*planned lease cleanup failure",
+    ):
+        executor._submit_ref_bundle_direct({"estimated_num_rows": 1, "input_lease_id": 8})
+
+    assert executor._closed
+    assert not executor.is_reusable()
+    assert executor._active_input_leases == {}
+    assert sock.closed
+
+
 def test_subprocess_worker_releases_output_grant_when_descriptor_creation_fails(monkeypatch):
     import duckdb.execution.udf_subprocess_worker as worker
     from duckdb import pickle as duckdb_pickle
@@ -6526,6 +7796,283 @@ def test_subprocess_executor_close_escalates_scoped_pending_work(monkeypatch):
     assert not executor._workers[0].cancelled
     assert executor._workers[0].closed == [True]
     assert thread_pool.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+
+
+def test_subprocess_executor_close_releases_task_pool_after_abort_failure():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    class FakeTaskPool:
+        def abort_scopes(self, scopes):
+            assert scopes == {scope}
+            events.append("abort")
+            raise RuntimeError("planned abort failure")
+
+        def release_ref(self, *, kill):
+            events.append(f"release:{kill}")
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._admission_authority = None
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._queue_lock = threading.Lock()
+    executor._budget_wakeup_unregister = None
+    executor._execution_scopes_lock = threading.Lock()
+    executor._execution_scopes = {scope}
+    executor._active_input_leases = set()
+    executor._active_input_leases_lock = threading.Lock()
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures = set()
+    executor._actor_pool = None
+    executor._task_pool = FakeTaskPool()
+    executor._executor = None
+    executor._workers = []
+
+    with pytest.raises(RuntimeError, match="planned abort failure"):
+        executor.close(kill=True)
+
+    assert events == ["abort", "release:True"]
+    assert executor._task_pool is None
+
+
+def test_subprocess_executor_close_continues_after_front_half_cleanup_failures():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    class FakeAuthority:
+        def close(self):
+            events.append("authority")
+            raise RuntimeError("planned authority cleanup failure")
+
+    class FakeAdmission:
+        def __init__(self, name, *, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def release(self):
+            events.append(f"admission:{self.name}")
+            if self.fail:
+                raise RuntimeError(f"planned {self.name} admission cleanup failure")
+
+    class FakeTaskPool:
+        def abort_scopes(self, scopes):
+            assert scopes == {scope}
+            events.append("abort")
+            raise RuntimeError("planned abort failure")
+
+        def release_ref(self, *, kill):
+            events.append(f"release:{kill}")
+
+    class FakeFuture:
+        def cancel(self):
+            events.append("cancel-future")
+            raise RuntimeError("planned future cancellation failure")
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._admission_authority = FakeAuthority()
+    executor._queue = deque()
+    executor._result_admissions = deque(
+        [
+            FakeAdmission("first", fail=True),
+            FakeAdmission("second"),
+        ]
+    )
+    executor._queue_lock = threading.Lock()
+    executor._budget_wakeup_unregister = lambda: events.append("unregister")
+    executor._execution_scopes_lock = threading.Lock()
+    executor._execution_scopes = {scope}
+    executor._active_input_leases = {1, 2}
+    executor._active_input_leases_lock = threading.Lock()
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures = {FakeFuture()}
+    executor._actor_pool = None
+    executor._task_pool = FakeTaskPool()
+    executor._executor = None
+    executor._workers = []
+
+    def cancel_waits():
+        events.append("cancel-waits")
+        return {
+            scope,
+        }, [
+            RuntimeError("planned input lease cleanup failure"),
+            RuntimeError("planned budget wakeup failure"),
+        ]
+
+    executor._cancel_local_shm_waits = cancel_waits
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "planned authority cleanup failure"
+            ".*planned first admission cleanup failure"
+            ".*planned input lease cleanup failure"
+            ".*planned budget wakeup failure"
+            ".*planned abort failure"
+            ".*planned future cancellation failure"
+        ),
+    ):
+        executor.close(kill=True)
+
+    assert events == [
+        "authority",
+        "admission:first",
+        "admission:second",
+        "unregister",
+        "cancel-waits",
+        "abort",
+        "cancel-future",
+        "release:True",
+    ]
+    assert executor._task_pool is None
+
+
+def test_subprocess_executor_input_lease_cleanup_attempts_every_lease_after_failure(monkeypatch):
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    calls: list[tuple[int, str]] = []
+
+    def cancel_input_lease(lease_id, *, name):
+        calls.append((lease_id, name))
+        if lease_id == 17:
+            raise RuntimeError("planned input lease cleanup failure")
+        return 0
+
+    monkeypatch.setattr(subprocess_exec, "cancel_local_shm_input_lease", cancel_input_lease)
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._active_input_leases = {17, 23}
+    executor._active_input_leases_lock = threading.Lock()
+
+    with pytest.raises(RuntimeError, match="planned input lease cleanup failure"):
+        executor._cancel_active_input_leases()
+
+    assert set(calls) == {
+        (17, "udf-input-close"),
+        (23, "udf-input-close"),
+    }
+    assert executor._active_input_leases == set()
+
+
+def test_subprocess_executor_timeout_cleanup_errors_do_not_skip_task_pool_release():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    events: list[str] = []
+    scope = subprocess_exec.ExecutionCancellationScope("test-executor", 1)
+
+    class FakeTaskPool:
+        def abort_scopes(self, scopes):
+            assert scopes == {scope}
+            events.append("abort")
+
+        def release_ref(self, *, kill):
+            events.append(f"release:{kill}")
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._admission_authority = None
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._queue_lock = threading.Lock()
+    executor._budget_wakeup_unregister = None
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures = set()
+    executor._actor_pool = None
+    executor._task_pool = FakeTaskPool()
+    executor._executor = None
+    executor._workers = []
+
+    cancel_wait_calls = 0
+
+    def cancel_waits():
+        nonlocal cancel_wait_calls
+        cancel_wait_calls += 1
+        events.append(f"cancel-waits:{cancel_wait_calls}")
+        if cancel_wait_calls == 1:
+            return {scope}, []
+        return set(), [RuntimeError("planned escalation cleanup failure")]
+
+    def cancel_futures():
+        events.append("cancel-futures")
+        raise RuntimeError("planned future cancellation failure")
+
+    executor._cancel_local_shm_waits = cancel_waits
+    executor._wait_for_pending_futures = lambda _timeout_s=None: False
+    executor._cancel_pending_futures = cancel_futures
+
+    with pytest.raises(
+        RuntimeError,
+        match="planned future cancellation failure.*planned escalation cleanup failure",
+    ):
+        executor.close(kill=False)
+
+    assert events == [
+        "cancel-waits:1",
+        "abort",
+        "cancel-futures",
+        "cancel-waits:2",
+        "release:True",
+    ]
+    assert executor._task_pool is None
+
+
+def test_subprocess_executor_concurrent_close_waits_for_task_pool_release():
+    import duckdb.execution.udf_subprocess as subprocess_exec
+
+    release_started = threading.Event()
+    allow_release = threading.Event()
+
+    class FakeTaskPool:
+        def abort_scopes(self, scopes):
+            assert scopes == set()
+
+        def release_ref(self, *, kill):
+            assert kill
+            release_started.set()
+            assert allow_release.wait(timeout=5.0)
+
+    executor = object.__new__(subprocess_exec.UDFExecutor)
+    executor._closed = False
+    executor._lifecycle_lock = threading.RLock()
+    executor._admission_authority = None
+    executor._queue = deque()
+    executor._result_admissions = deque()
+    executor._queue_lock = threading.Lock()
+    executor._budget_wakeup_unregister = None
+    executor._execution_scopes_lock = threading.Lock()
+    executor._execution_scopes = set()
+    executor._active_input_leases = set()
+    executor._active_input_leases_lock = threading.Lock()
+    executor._task_futures_cv = threading.Condition()
+    executor._task_futures = set()
+    executor._actor_pool = None
+    executor._task_pool = FakeTaskPool()
+    executor._executor = None
+    executor._workers = []
+
+    primary = threading.Thread(target=lambda: executor.close(kill=True))
+    follower = threading.Thread(target=lambda: executor.close(kill=True))
+    primary.start()
+    assert release_started.wait(timeout=5.0)
+    follower.start()
+    assert follower.is_alive()
+
+    allow_release.set()
+    primary.join(timeout=5.0)
+    follower.join(timeout=5.0)
+
+    assert not primary.is_alive()
+    assert not follower.is_alive()
+    assert executor._task_pool is None
 
 
 def test_subprocess_executor_close_fences_submit_before_cancelling_scopes(monkeypatch):


### PR DESCRIPTION
## Summary

- scope subprocess cancellation to executor and task generations so closing one executor cannot cancel peers sharing a worker pool
- make worker and local shared-memory waits cancellation-aware, fence worker reuse by health and generation, and replace failed stateless workers
- honor the graceful shutdown deadline before killing workers, flush runtime cleanup before ACK, and close lease/grant/descriptor ownership on error paths
- preserve structured stateful UDF errors while reporting actual actor loss as unrecoverable

## Tests

- python -m pytest tests/fast/test_udf_process.py
- python -m pytest tests/fast/test_udf_executor_lifecycle.py tests/fast/test_driver_udf_precreate.py
- python -m pytest tests/fast/test_udf_process.py tests/fast/test_udf_executor_lifecycle.py tests/fast/test_driver_udf_precreate.py tests/fast/test_ray_fragment_submission.py
- scripts/run_release_tests.sh
- scripts/run_fast_tests.sh
- pre-commit run ruff-check on all changed Python files

Fixes #91