### PR TITLE
[fix](ai) Enforce a strict Anthropic option contract with explicit max_tokens (#146)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
 openai = ["openai"]
-anthropic = ["anthropic"]
+anthropic = ["anthropic>=0.117.0"] # floor matches the Messages.create option surface validated in vane/ai/providers/anthropic.py
 google = ["google-genai"]
 transformers = [
     "sentence-transformers",
@@ -83,7 +83,7 @@ video = [ # video data source; decord is gated to Vane's supported native platfo
     "decord>=0.6; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]
 all = [ # Cloud providers and dataframe/filesystem integrations; local model runtimes stay opt-in.
-    "anthropic",
+    "anthropic>=0.117.0",
     "google-genai",
     "ipython", # used in query_graph
     "fsspec",  # used in filesystem support

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1201,6 +1201,58 @@ class TestAnthropicStrictOptions:
         with pytest.raises(ValueError, match="top_p"):
             self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", top_p=1.0)
 
+    @pytest.mark.parametrize("model", ["claude-fable-5", "claude-mythos-5", "claude-mythos-preview"])
+    def test_fable_mythos_sampling_option_rejected(self, model):
+        """The Fable/Mythos families document the same non-default rejection."""
+        with pytest.raises(ValueError, match="temperature") as excinfo:
+            self._provider(max_tokens=64).get_prompter(model=model, temperature=0.2)
+        assert model in str(excinfo.value)
+
+    def test_fable_default_temperature_passes(self):
+        """The documented default temperature is accepted on Fable too."""
+        desc = self._provider(max_tokens=64).get_prompter(model="claude-fable-5", temperature=1.0)
+        assert desc.prompt_options["temperature"] == 1.0
+
+    def test_fable_top_p_rejected(self):
+        with pytest.raises(ValueError, match="top_p"):
+            self._provider(max_tokens=64).get_prompter(model="claude-fable-5", top_p=1.0)
+
+    # --- per-model thinking.type restrictions -----------------------------
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-sonnet-5", "claude-opus-4-7", "claude-fable-5", "claude-sonnet-5-20260601"],
+    )
+    def test_manual_thinking_rejected_on_adaptive_only_models(self, model):
+        """The removed manual form fails pre-dispatch on adaptive-only families."""
+        with pytest.raises(ValueError, match="thinking.type") as excinfo:
+            self._provider(max_tokens=64).get_prompter(model=model, thinking={"type": "enabled", "budget_tokens": 1024})
+        assert model in str(excinfo.value)
+
+    @pytest.mark.parametrize("model", ["claude-fable-5", "claude-mythos-5", "claude-mythos-preview"])
+    def test_disabled_thinking_rejected_on_always_on_models(self, model):
+        """Thinking cannot be turned off where it is always on."""
+        with pytest.raises(ValueError, match="disabled"):
+            self._provider(max_tokens=64).get_prompter(model=model, thinking={"type": "disabled"})
+
+    @pytest.mark.parametrize("model", ["claude-mythos-preview", "claude-opus-4-6"])
+    def test_manual_thinking_passes_where_still_supported(self, model):
+        """Mythos Preview and the 4.6 models still accept the manual form."""
+        desc = self._provider(max_tokens=64).get_prompter(
+            model=model, thinking={"type": "enabled", "budget_tokens": 1024}
+        )
+        assert desc.prompt_options["thinking"]["type"] == "enabled"
+
+    @pytest.mark.parametrize("model", ["claude-haiku-4-5", "claude-opus-4-5", "claude-sonnet-4-5"])
+    def test_adaptive_thinking_rejected_on_extended_only_models(self, model):
+        """Extended-thinking-only models reject the adaptive form."""
+        with pytest.raises(ValueError, match="adaptive"):
+            self._provider(max_tokens=64).get_prompter(model=model, thinking={"type": "adaptive"})
+
+    def test_adaptive_thinking_passes_on_adaptive_models(self):
+        desc = self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", thinking={"type": "adaptive"})
+        assert desc.prompt_options["thinking"] == {"type": "adaptive"}
+
     # --- extra_body cannot bypass the option contract ---------------------
 
     @pytest.mark.parametrize(
@@ -1396,6 +1448,42 @@ class TestAnthropicStrictOptions:
             prompt_options={"max_tokens": 64, "thinking": {"type": "adaptive"}},
         )
         assert desc.return_format is dict
+
+    # --- forced tool choice needs tool definitions ------------------------
+
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [{"type": "any"}, {"type": "tool", "name": "extract_data"}],
+    )
+    def test_forced_tool_choice_without_return_format_rejected(self, tool_choice):
+        """Vane sends no tools without return_format, so forced tool use cannot be satisfied."""
+        with pytest.raises(ValueError, match="tool_choice"):
+            self._provider(max_tokens=64).get_prompter(tool_choice=tool_choice)
+
+    @pytest.mark.parametrize("tool_choice", [{"type": "auto"}, {"type": "none"}])
+    def test_no_tools_safe_tool_choice_passes(self, tool_choice):
+        """auto/none remain valid without tool definitions."""
+        desc = self._provider(max_tokens=64).get_prompter(tool_choice=tool_choice)
+        assert desc.prompt_options["tool_choice"] == tool_choice
+
+    # --- execution options flow into UDFOptions ---------------------------
+
+    def test_concurrency_and_batch_size_flow_into_udf_options(self):
+        """The raw-dict path carries concurrency/batch_size instead of dropping them."""
+        desc = self._provider(max_tokens=64).get_prompter(concurrency=3, batch_size=7)
+        udf_options = desc.get_udf_options()
+        assert udf_options.actor_number == 3
+        assert udf_options.batch_size == 7
+
+    def test_actor_number_and_matching_concurrency_pass(self):
+        """Equal values for the alias pair are not a conflict."""
+        desc = self._provider(max_tokens=64).get_prompter(actor_number=3, concurrency=3)
+        assert desc.get_udf_options().actor_number == 3
+
+    def test_conflicting_actor_number_and_concurrency_rejected(self):
+        """concurrency aliases actor_number; disagreeing values raise."""
+        with pytest.raises(ValueError, match="alias"):
+            self._provider(max_tokens=64).get_prompter(actor_number=2, concurrency=3)
 
     @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
     def test_structured_output_dispatch_kwargs(self):

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1185,6 +1185,64 @@ class TestAnthropicStrictOptions:
         desc = self._provider(max_tokens=64).get_prompter(model="claude-sonnet-4-6", temperature=0.2)
         assert desc.prompt_options["temperature"] == 0.2
 
+    @pytest.mark.parametrize("default", [1, 1.0])
+    def test_sonnet5_default_temperature_passes(self, default):
+        """The documented default temperature (1.0) is accepted by the API."""
+        desc = self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", temperature=default)
+        assert desc.prompt_options["temperature"] == default
+
+    def test_sonnet5_boolean_temperature_rejected(self):
+        """True == 1 in Python, but a bool is not the documented default."""
+        with pytest.raises(ValueError, match="temperature"):
+            self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", temperature=True)
+
+    def test_sonnet5_default_like_top_p_still_rejected(self):
+        """top_p has no documented default, so any explicit value is non-default."""
+        with pytest.raises(ValueError, match="top_p"):
+            self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", top_p=1.0)
+
+    # --- extra_body cannot bypass the option contract ---------------------
+
+    @pytest.mark.parametrize(
+        "smuggled",
+        [
+            {"thinking": {"type": "enabled", "budget_tokens": 1024}},
+            {"temperature": 0.2},
+            {"max_tokens": 5},
+            {"model": "claude-other-model"},
+            {"stream": True},
+        ],
+    )
+    def test_extra_body_with_validated_field_rejected(self, smuggled):
+        """Vane-owned and known request fields cannot ride in extra_body."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="extra_body") as excinfo:
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                prompt_options={"max_tokens": 64, "extra_body": smuggled},
+            )
+        assert next(iter(smuggled)) in str(excinfo.value)
+
+    def test_extra_body_non_mapping_rejected(self):
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="extra_body"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                prompt_options={"max_tokens": 64, "extra_body": ["thinking"]},
+            )
+
+    def test_extra_body_with_unmodeled_field_passes(self):
+        """extra_body keeps its purpose: fields the SDK does not model."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model",
+            prompt_options={"max_tokens": 64, "extra_body": {"future_api_field": {"enabled": True}}},
+        )
+        assert desc.prompt_options["extra_body"] == {"future_api_field": {"enabled": True}}
+
     # --- explicit max_tokens chain ----------------------------------------
 
     def test_get_prompter_without_max_tokens_raises(self):
@@ -1212,6 +1270,35 @@ class TestAnthropicStrictOptions:
     def test_call_max_tokens_overrides_provider_config(self):
         desc = self._provider(max_tokens=128).get_prompter(max_tokens=512)
         assert desc.prompt_options["max_tokens"] == 512
+
+    def test_none_max_tokens_falls_back_to_provider_config(self):
+        """An explicit max_tokens=None is unconfigured, not a configured value."""
+        desc = self._provider(max_tokens=128).get_prompter(max_tokens=None)
+        assert desc.prompt_options["max_tokens"] == 128
+
+    def test_none_max_tokens_without_config_raises(self):
+        with pytest.raises(ValueError, match="No max_tokens configured"):
+            self._provider().get_prompter(max_tokens=None)
+
+    def test_none_max_tokens_rejected_on_direct_descriptor_construction(self):
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="No max_tokens configured"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                prompt_options={"max_tokens": None},
+            )
+
+    @pytest.mark.parametrize("bad", ["64", 64.0, False, -1])
+    def test_non_integer_max_tokens_rejected(self, bad):
+        """max_tokens must be a non-negative int; False must not satisfy == 0."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="non-negative integer"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                prompt_options={"max_tokens": bad},
+            )
 
     def test_ctor_max_tokens_is_keyword_only(self):
         from vane.ai.providers.anthropic import AnthropicProvider
@@ -1310,6 +1397,7 @@ class TestAnthropicStrictOptions:
         )
         assert desc.return_format is dict
 
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
     def test_structured_output_dispatch_kwargs(self):
         """The dispatched call carries the forced extract_data tool choice."""
         import asyncio
@@ -1345,6 +1433,7 @@ class TestAnthropicStrictOptions:
 
     # --- max_tokens=0 cache prewarming ------------------------------------
 
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
     def test_zero_max_tokens_prewarm_returns_none(self):
         """A max_tokens=0 response with stop_reason=max_tokens is prewarming, not truncation."""
         import asyncio
@@ -1404,6 +1493,7 @@ class TestAnthropicStrictOptions:
                 prompt_options={"max_tokens": 0},
             )
 
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
     def test_positive_max_tokens_truncation_still_raises(self):
         """The prewarming carve-out does not weaken truncation detection."""
         import asyncio

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -726,7 +726,9 @@ class TestUDFExecutionOptions:
         assert OpenAITextEmbedderDescriptor(embed_options={"num_gpus": 1}).get_udf_options().num_gpus == 1
         assert OpenAIPrompterDescriptor(prompt_options={"num_gpus": 2}).get_udf_options().num_gpus == 2
         assert (
-            AnthropicPrompterDescriptor(model_name="claude-test-model", prompt_options={"num_gpus": 3})
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model", prompt_options={"max_tokens": 64, "num_gpus": 3}
+            )
             .get_udf_options()
             .num_gpus
             == 3
@@ -944,6 +946,7 @@ class TestAnthropicProvider:
         desc = AnthropicPrompterDescriptor(
             model_name="claude-sonnet-4-20250514",
             system_message="Be concise.",
+            prompt_options={"max_tokens": 64},
         )
         assert desc.get_provider() == "anthropic"
         assert desc.get_model() == "claude-sonnet-4-20250514"
@@ -956,7 +959,7 @@ class TestAnthropicProvider:
             provider_options={"api_key": "test-key"},
             model_name="claude-sonnet-4-20250514",
             system_message="You are helpful.",
-            prompt_options={"temperature": 0.7},
+            prompt_options={"max_tokens": 64, "temperature": 0.7},
         )
         restored = pickle.loads(pickle.dumps(desc))
         assert restored.model_name == desc.model_name
@@ -967,7 +970,7 @@ class TestAnthropicProvider:
         """Anthropic descriptor produces correct UDFOptions."""
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(model_name="claude-test-model")
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", prompt_options={"max_tokens": 64})
         opts = desc.get_udf_options()
         assert opts.max_api_concurrency == 16
 
@@ -982,6 +985,7 @@ class TestAnthropicProvider:
         desc = provider.get_prompter(
             model="claude-sonnet-4-20250514",
             system_message="Be brief.",
+            max_tokens=64,
             temperature=0.5,
         )
         assert isinstance(desc, AnthropicPrompterDescriptor)
@@ -999,6 +1003,7 @@ class TestAnthropicProvider:
             api_key="call-key",
             base_url="https://call.example",
             timeout=30,
+            max_tokens=64,
             max_api_concurrency=6,
             temperature=0,
         )
@@ -1036,7 +1041,7 @@ class TestAnthropicProvider:
         """Provider-level prompt_model configures the descriptor model."""
         from vane.ai.providers.anthropic import AnthropicProvider
 
-        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model", max_tokens=64)
         desc = provider.get_prompter()
         assert desc.model_name == "claude-config-model"
         # prompt_model is provider-level config, never a request option.
@@ -1047,7 +1052,7 @@ class TestAnthropicProvider:
         """Call-site model beats provider-level prompt_model."""
         from vane.ai.providers.anthropic import AnthropicProvider
 
-        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model", max_tokens=64)
         desc = provider.get_prompter(model="claude-call-model")
         assert desc.model_name == "claude-call-model"
 
@@ -1056,7 +1061,7 @@ class TestAnthropicProvider:
         """A blank call-site model is an error, not a provider-config fallback."""
         from vane.ai.providers.anthropic import AnthropicProvider
 
-        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model")
+        provider = AnthropicProvider(api_key="test-key", prompt_model="claude-config-model", max_tokens=64)
         with pytest.raises(ValueError, match="non-empty string"):
             provider.get_prompter(model=model)
 
@@ -1064,7 +1069,7 @@ class TestAnthropicProvider:
         """A blank provider-level prompt_model fails at expression-build time."""
         from vane.ai.providers.anthropic import AnthropicProvider
 
-        provider = AnthropicProvider(api_key="test-key", prompt_model="")
+        provider = AnthropicProvider(api_key="test-key", prompt_model="", max_tokens=64)
         with pytest.raises(ValueError, match="non-empty string"):
             provider.get_prompter()
 
@@ -1081,6 +1086,194 @@ class TestAnthropicProvider:
 
         with pytest.raises(TypeError):
             AnthropicProvider(api_key="test-key", promt_model="claude-config-model")
+
+
+class TestAnthropicStrictOptions:
+    """Tests for the strict Anthropic option contract (vane#146)."""
+
+    def _provider(self, **kwargs):
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider(api_key="test-key", prompt_model="claude-test-model", **kwargs)
+
+    # --- unknown options are rejected pre-dispatch ------------------------
+
+    def test_unknown_option_rejected(self):
+        """A typo'd request option raises before dispatch, naming the key."""
+        with pytest.raises(ValueError, match="thinkng") as excinfo:
+            self._provider(max_tokens=64).get_prompter(thinkng={"type": "adaptive"})
+        message = str(excinfo.value)
+        assert "claude-test-model" in message
+        assert "thinking" in message  # the supported list points at the fix
+
+    def test_unknown_option_rejected_on_direct_descriptor_construction(self):
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="metdata"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                prompt_options={"max_tokens": 64, "metdata": {"user_id": "u"}},
+            )
+
+    def test_ctor_typo_is_rejected_by_the_named_ctor(self):
+        """The ctor has no **options channel; a misspelled kwarg is a TypeError."""
+        with pytest.raises(TypeError):
+            self._provider(max_tokens=64, promt_model="claude-other-model")
+
+    # --- known options forward to the API ---------------------------------
+
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
+    def test_known_options_forward_to_messages_create(self):
+        """thinking/metadata/tool_choice/service_tier reach the recorded call."""
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model",
+            provider_options={"api_key": "test-key"},
+            prompt_options={
+                "max_tokens": 64,
+                "thinking": {"type": "adaptive"},
+                "metadata": {"user_id": "user-1"},
+                "tool_choice": {"type": "auto"},
+                "service_tier": "auto",
+                "max_api_concurrency": 4,
+                "on_error": "raise",
+            },
+        )
+        prompter = desc.instantiate()
+
+        captured: dict = {}
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "ok"
+        mock_response = MagicMock()
+        mock_response.content = [text_block]
+        mock_response.stop_reason = "end_turn"
+
+        async def mock_create(**kwargs):
+            captured.update(kwargs)
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        assert asyncio.run(prompter.prompt(("Hi",))) == "ok"
+
+        assert captured["max_tokens"] == 64
+        assert captured["thinking"] == {"type": "adaptive"}
+        assert captured["metadata"] == {"user_id": "user-1"}
+        assert captured["tool_choice"] == {"type": "auto"}
+        assert captured["service_tier"] == "auto"
+        # Vane execution options never reach the API.
+        assert "max_api_concurrency" not in captured
+        assert "on_error" not in captured
+
+    # --- per-model unsupported combinations -------------------------------
+
+    def test_sonnet5_sampling_option_rejected(self):
+        """Sonnet 5 documents rejecting non-default sampling parameters."""
+        with pytest.raises(ValueError, match="temperature") as excinfo:
+            self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5", temperature=0.2)
+        assert "claude-sonnet-5" in str(excinfo.value)
+
+    def test_sonnet5_snapshot_id_matches_family_prefix(self):
+        with pytest.raises(ValueError, match="top_p"):
+            self._provider(max_tokens=64).get_prompter(model="claude-sonnet-5-20260601", top_p=0.9)
+
+    def test_sonnet46_sampling_option_passes(self):
+        """The same option is fine on a model without the restriction."""
+        desc = self._provider(max_tokens=64).get_prompter(model="claude-sonnet-4-6", temperature=0.2)
+        assert desc.prompt_options["temperature"] == 0.2
+
+    # --- explicit max_tokens chain ----------------------------------------
+
+    def test_get_prompter_without_max_tokens_raises(self):
+        """Missing max_tokens fails fast, naming both fix paths."""
+        with pytest.raises(ValueError, match="No max_tokens configured") as excinfo:
+            self._provider().get_prompter()
+        message = str(excinfo.value)
+        assert "max_tokens=" in message
+        assert "AnthropicProvider(max_tokens=" in message
+
+    def test_descriptor_requires_max_tokens(self):
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="No max_tokens configured"):
+            AnthropicPrompterDescriptor(model_name="claude-test-model")
+
+    def test_call_max_tokens_flows_through(self):
+        desc = self._provider().get_prompter(max_tokens=256)
+        assert desc.prompt_options["max_tokens"] == 256
+
+    def test_provider_max_tokens_flows_through(self):
+        desc = self._provider(max_tokens=128).get_prompter()
+        assert desc.prompt_options["max_tokens"] == 128
+
+    def test_call_max_tokens_overrides_provider_config(self):
+        desc = self._provider(max_tokens=128).get_prompter(max_tokens=512)
+        assert desc.prompt_options["max_tokens"] == 512
+
+    def test_ctor_max_tokens_is_keyword_only(self):
+        from vane.ai.providers.anthropic import AnthropicProvider
+
+        with pytest.raises(TypeError):
+            AnthropicProvider("anthropic", "claude-config-model", 64)
+
+    # --- truncation surfaces as an error ----------------------------------
+
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
+    def test_truncated_text_response_raises(self):
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompter
+
+        prompter = AnthropicPrompter(
+            provider_options={"api_key": "test-key"},
+            model="claude-test-model",
+            max_tokens=64,
+        )
+
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "partial answ"
+        mock_response = MagicMock()
+        mock_response.content = [text_block]
+        mock_response.stop_reason = "max_tokens"
+
+        async def mock_create(**kwargs):
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        with pytest.raises(ValueError, match="truncated") as excinfo:
+            asyncio.run(prompter.prompt(("Hi",)))
+        message = str(excinfo.value)
+        assert "claude-test-model" in message
+        assert "max_tokens=64" in message
+
+    @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")
+    def test_truncated_structured_response_raises_instead_of_none(self):
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompter
+
+        prompter = AnthropicPrompter(
+            provider_options={"api_key": "test-key"},
+            model="claude-test-model",
+            max_tokens=64,
+            return_format=dict,
+        )
+
+        # Truncation cut the turn before a complete tool_use block emerged.
+        mock_response = MagicMock()
+        mock_response.content = []
+        mock_response.stop_reason = "max_tokens"
+
+        async def mock_create(**kwargs):
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        with pytest.raises(ValueError, match="truncated"):
+            asyncio.run(prompter.prompt(("Extract data",)))
 
 
 # ---------------------------------------------------------------------------
@@ -1892,19 +2085,23 @@ class TestAnthropicStructuredOutput:
     def test_descriptor_has_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", return_format=dict)
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model", return_format=dict, prompt_options={"max_tokens": 64}
+        )
         assert desc.return_format is dict
 
     def test_descriptor_default_no_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(model_name="claude-test-model")
+        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", prompt_options={"max_tokens": 64})
         assert desc.return_format is None
 
     def test_descriptor_pickle_with_return_format(self):
         from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
-        desc = AnthropicPrompterDescriptor(model_name="claude-test-model", return_format=dict)
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model", return_format=dict, prompt_options={"max_tokens": 64}
+        )
         restored = pickle.loads(pickle.dumps(desc))
         assert restored.return_format is dict
 
@@ -1912,7 +2109,7 @@ class TestAnthropicStructuredOutput:
         from vane.ai.providers.anthropic import AnthropicProvider
 
         prov = AnthropicProvider(api_key="test")
-        desc = prov.get_prompter(model="claude-test-model", return_format=dict)
+        desc = prov.get_prompter(model="claude-test-model", max_tokens=64, return_format=dict)
         assert desc.return_format is dict
 
     @pytest.mark.skipif(not _has_module("anthropic"), reason="anthropic not installed")

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1275,6 +1275,158 @@ class TestAnthropicStrictOptions:
         with pytest.raises(ValueError, match="truncated"):
             asyncio.run(prompter.prompt(("Extract data",)))
 
+    # --- documented-invalid option combinations ---------------------------
+
+    def test_return_format_with_caller_tool_choice_rejected(self):
+        """A caller tool_choice would be overridden by extract_data — reject it."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="tool_choice"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                return_format=dict,
+                prompt_options={"max_tokens": 64, "tool_choice": {"type": "none"}},
+            )
+
+    def test_return_format_with_manual_thinking_rejected(self):
+        """Forced tool use plus manual extended thinking is API-rejected."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="manual extended thinking"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                return_format=dict,
+                prompt_options={"max_tokens": 64, "thinking": {"type": "enabled", "budget_tokens": 1024}},
+            )
+
+    def test_return_format_with_adaptive_thinking_passes(self):
+        """Adaptive thinking supports forced tool use and stays allowed."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model",
+            return_format=dict,
+            prompt_options={"max_tokens": 64, "thinking": {"type": "adaptive"}},
+        )
+        assert desc.return_format is dict
+
+    def test_structured_output_dispatch_kwargs(self):
+        """The dispatched call carries the forced extract_data tool choice."""
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model",
+            provider_options={"api_key": "test-key"},
+            return_format=dict,
+            prompt_options={"max_tokens": 64},
+        )
+        prompter = desc.instantiate()
+
+        captured: dict = {}
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.input = {"answer": 42}
+        mock_response = MagicMock()
+        mock_response.content = [tool_block]
+        mock_response.stop_reason = "end_turn"
+
+        async def mock_create(**kwargs):
+            captured.update(kwargs)
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        assert asyncio.run(prompter.prompt(("Extract",))) == {"answer": 42}
+
+        assert captured["tool_choice"] == {"type": "tool", "name": "extract_data"}
+        assert captured["tools"][0]["name"] == "extract_data"
+        assert captured["max_tokens"] == 64
+
+    # --- max_tokens=0 cache prewarming ------------------------------------
+
+    def test_zero_max_tokens_prewarm_returns_none(self):
+        """A max_tokens=0 response with stop_reason=max_tokens is prewarming, not truncation."""
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompter
+
+        prompter = AnthropicPrompter(
+            provider_options={"api_key": "test-key"},
+            model="claude-test-model",
+            max_tokens=0,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        mock_response.stop_reason = "max_tokens"
+
+        async def mock_create(**kwargs):
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        assert asyncio.run(prompter.prompt(("cached prefix",))) is None
+
+    def test_zero_max_tokens_descriptor_constructs(self):
+        """Plain max_tokens=0 (cache prewarming) passes descriptor validation."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        desc = AnthropicPrompterDescriptor(
+            model_name="claude-test-model",
+            prompt_options={"max_tokens": 0, "cache_control": {"type": "ephemeral"}},
+        )
+        assert desc.prompt_options["max_tokens"] == 0
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {"max_tokens": 0, "thinking": {"type": "enabled", "budget_tokens": 1024}},
+            {"max_tokens": 0, "tool_choice": {"type": "any"}},
+            {"max_tokens": 0, "tool_choice": {"type": "tool", "name": "extract_data"}},
+            {"max_tokens": 0, "output_config": {"format": "json"}},
+        ],
+    )
+    def test_zero_max_tokens_rejects_output_implying_options(self, options):
+        """Options that imply output are rejected with max_tokens=0 pre-dispatch."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="cache-prewarming"):
+            AnthropicPrompterDescriptor(model_name="claude-test-model", prompt_options=options)
+
+    def test_zero_max_tokens_rejects_return_format(self):
+        """Structured output implies output and cannot ride a prewarming request."""
+        from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
+
+        with pytest.raises(ValueError, match="cache-prewarming"):
+            AnthropicPrompterDescriptor(
+                model_name="claude-test-model",
+                return_format=dict,
+                prompt_options={"max_tokens": 0},
+            )
+
+    def test_positive_max_tokens_truncation_still_raises(self):
+        """The prewarming carve-out does not weaken truncation detection."""
+        import asyncio
+
+        from vane.ai.providers.anthropic import AnthropicPrompter
+
+        prompter = AnthropicPrompter(
+            provider_options={"api_key": "test-key"},
+            model="claude-test-model",
+            max_tokens=1,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = []
+        mock_response.stop_reason = "max_tokens"
+
+        async def mock_create(**kwargs):
+            return mock_response
+
+        prompter._client.messages.create = mock_create
+        with pytest.raises(ValueError, match="truncated"):
+            asyncio.run(prompter.prompt(("Hi",)))
+
 
 # ---------------------------------------------------------------------------
 # Google Provider tests

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -62,10 +62,13 @@ def _openai_prompter_descriptor():
 def _anthropic_prompter_descriptor():
     from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 
+    # The strict option contract (vane#146) rejects unknown prompt-option
+    # keys and requires max_tokens, so the sensitive value rides in the
+    # known ``extra_headers`` request option.
     return AnthropicPrompterDescriptor(
         provider_options={"api_key": API_KEY, "base_url": "https://api.example"},
         model_name="claude-sonnet-4-20250514",
-        prompt_options={"temperature": 0.2, "auth_token": API_KEY},
+        prompt_options={"temperature": 0.2, "max_tokens": 64, "extra_headers": {"auth_token": API_KEY}},
     )
 
 

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -11,6 +11,22 @@ Vane does not ship a default Anthropic model: the model must be supplied
 per call (``model=...``) or configured on the provider
 (``AnthropicProvider(prompt_model=...)``); the per-call model wins.
 
+Prompt options follow a strict contract enforced at descriptor
+construction, before any request is dispatched:
+
+- Every known Messages API request option is forwarded to the API
+  (``thinking``, ``metadata``, ``tool_choice``, ``service_tier``, ...).
+- Unknown option keys raise :class:`ValueError` instead of being
+  silently dropped.
+- Option/model combinations the API is documented to reject (for
+  example sampling parameters on Claude Sonnet 5) raise
+  :class:`ValueError` before dispatch.
+- ``max_tokens`` has no library default: it must be supplied per call
+  (``max_tokens=...``) or configured on the provider
+  (``AnthropicProvider(max_tokens=...)``); the per-call value wins.
+- A truncated response (``stop_reason == "max_tokens"``) raises instead
+  of silently returning partial text or ``None``.
+
 Requires::
 
     pip install 'vane-ai[anthropic]'
@@ -28,8 +44,93 @@ from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from vane.ai.protocols import Prompter
     from vane.ai.typing import Options
+
+
+# Messages API request options Vane forwards verbatim. Verified against the
+# ``anthropic`` SDK (v0.117.0) ``Messages.create`` signature. Keys Vane owns
+# are deliberately absent: ``model``, ``messages``, ``system``, ``tools``, and
+# ``stream`` are managed by the prompter, and client configuration
+# (``api_key``, ``base_url``, ``timeout``, ``max_retries``) travels through
+# provider options.
+_KNOWN_PROMPT_OPTIONS: frozenset[str] = frozenset(
+    {
+        "cache_control",
+        "container",
+        "extra_body",
+        "extra_headers",
+        "extra_query",
+        "inference_geo",
+        "max_tokens",
+        "metadata",
+        "output_config",
+        "service_tier",
+        "stop_sequences",
+        "temperature",
+        "thinking",
+        "tool_choice",
+        "top_k",
+        "top_p",
+        "user_profile_id",
+    }
+)
+
+# Vane execution options that ride in ``prompt_options`` but are consumed by
+# the UDF machinery and never forwarded to the Messages API.
+_VANE_EXECUTION_OPTIONS: frozenset[str] = frozenset(
+    {
+        "actor_number",
+        "batch_size",
+        "concurrency",
+        "max_api_concurrency",
+        "num_gpus",
+        "on_error",
+    }
+)
+
+# Request options the API is documented to reject per model family. A model
+# matches an entry by family prefix: the exact id or ``<family>-<suffix>``
+# (dated snapshots and successors within the family). Documented sources:
+# https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+# (Claude Sonnet 5 returns a 400 error for non-default ``temperature``,
+# ``top_p``, or ``top_k``) and
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
+# (the same constraint on Claude Opus 4.7 and later Opus models).
+_MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
+    "claude-opus-4-7": frozenset({"temperature", "top_k", "top_p"}),
+    "claude-opus-4-8": frozenset({"temperature", "top_k", "top_p"}),
+    "claude-opus-5": frozenset({"temperature", "top_k", "top_p"}),
+    "claude-sonnet-5": frozenset({"temperature", "top_k", "top_p"}),
+}
+
+
+def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> None:
+    """Reject unknown or model-unsupported prompt options before dispatch.
+
+    Raises:
+        ValueError: If ``options`` contains keys that are neither known
+            Messages API request options nor Vane execution options, or
+            contains request options the selected model is documented to
+            reject.
+    """
+    unknown = sorted(key for key in options if key not in _KNOWN_PROMPT_OPTIONS and key not in _VANE_EXECUTION_OPTIONS)
+    if unknown:
+        raise ValueError(
+            f"Unknown Anthropic prompt option(s) {unknown} for model {model_name!r}. "
+            f"Supported Messages API request options: {sorted(_KNOWN_PROMPT_OPTIONS)}."
+        )
+    for family, unsupported in _MODEL_UNSUPPORTED_OPTIONS.items():
+        if model_name == family or model_name.startswith(f"{family}-"):
+            rejected = sorted(key for key in options if key in unsupported)
+            if rejected:
+                raise ValueError(
+                    f"Anthropic model {model_name!r} does not support option(s) {rejected}: "
+                    "the API rejects non-default sampling parameters for this model "
+                    "family. Remove the option(s) or select a model that supports them."
+                )
 
 
 def _guess_media_type(data: bytes) -> str:
@@ -51,6 +152,8 @@ class AnthropicProvider(Provider):
     Vane does not choose an Anthropic model for you. Configure an
     application-owned model via ``prompt_model=...`` here, or pass
     ``model=...`` on each call; the per-call model takes precedence.
+    The same applies to ``max_tokens``: configure it here or pass it per
+    call; the per-call value wins.
 
     Args:
         name: Optional display-name override (default ``"anthropic"``).
@@ -62,6 +165,8 @@ class AnthropicProvider(Provider):
             client.
         prompt_model: Model used by ``get_prompter`` when the call does not
             pass ``model=...``.
+        max_tokens: Response token cap used by ``get_prompter`` when the
+            call does not pass ``max_tokens``.
 
     All parameters are named; a mistyped keyword raises :class:`TypeError`
     instead of silently leaking into API request options.
@@ -78,9 +183,11 @@ class AnthropicProvider(Provider):
         timeout: Any = None,
         max_retries: int | None = None,
         prompt_model: str | None = None,
+        max_tokens: int | None = None,
     ):
         self._name = name or "anthropic"
         self._prompt_model = prompt_model
+        self._max_tokens = max_tokens
         client_options = {
             "api_key": api_key,
             "base_url": base_url,
@@ -110,11 +217,14 @@ class AnthropicProvider(Provider):
 
         The model resolves as: call-site ``model`` > provider
         ``prompt_model`` configuration; the selected value must be a
-        non-empty string.
+        non-empty string. ``max_tokens`` resolves as: call-site option >
+        provider ``max_tokens`` configuration.
 
         Raises:
-            ValueError: If no model is configured through either path, or
-                the selected model is not a non-empty string.
+            ValueError: If no model or no ``max_tokens`` is configured
+                through either path, if the selected model is not a
+                non-empty string, or if ``options`` contains unknown keys
+                or options the selected model does not support.
         """
         provider_options, prompt_options = self._split_options(options)
         model_name = model if model is not None else self._prompt_model
@@ -128,6 +238,8 @@ class AnthropicProvider(Provider):
                 f"Anthropic prompt model must be a non-empty string, got {model_name!r}. "
                 "Pass model=... or configure AnthropicProvider(prompt_model=...)."
             )
+        if "max_tokens" not in prompt_options and self._max_tokens is not None:
+            prompt_options["max_tokens"] = self._max_tokens
         return AnthropicPrompterDescriptor(
             provider_name=self._name,
             provider_options=provider_options,
@@ -143,8 +255,12 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
     """Serializable factory for an Anthropic Messages API prompter.
 
     ``model_name`` is required — Vane does not ship a default Anthropic
-    model. Supports structured output via Anthropic's ``tool_use``
-    mechanism and multimodal input (text + images).
+    model — and ``prompt_options`` must carry ``max_tokens``: there is no
+    library default. Construction validates the option contract: unknown
+    option keys and options the selected model is documented to reject
+    raise :class:`ValueError` before anything is dispatched. Supports
+    structured output via Anthropic's ``tool_use`` mechanism and
+    multimodal input (text + images).
     """
 
     model_name: str
@@ -157,6 +273,12 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
     def __post_init__(self) -> None:
         self.provider_options = wrap_sensitive_options(self.provider_options)
         self.prompt_options = wrap_sensitive_options(self.prompt_options)
+        _validate_prompt_options(self.model_name, self.prompt_options)
+        if "max_tokens" not in self.prompt_options:
+            raise ValueError(
+                "No max_tokens configured for the Anthropic provider. "
+                "Pass max_tokens=... or configure AnthropicProvider(max_tokens=...)."
+            )
 
     def get_provider(self) -> str:
         return self.provider_name
@@ -213,24 +335,10 @@ class AnthropicPrompter:
         self._model = model
         self._system_message = system_message
         self._return_format = return_format
-        self._options = {
-            k: v
-            for k, v in options.items()
-            if k
-            not in {
-                "api_key",
-                "base_url",
-                "timeout",
-                "max_retries",
-                "on_error",
-                "actor_number",
-                "num_gpus",
-                "concurrency",
-                "max_api_concurrency",
-                "model",
-                "batch_size",
-            }
-        }
+        # Forward only known Messages API request options; Vane execution
+        # options (and anything else) never reach the API. The descriptor
+        # rejects unknown keys before the prompter is ever built.
+        self._options = {k: v for k, v in options.items() if k in _KNOWN_PROMPT_OPTIONS}
         client_opts = {
             k: v for k, v in provider_options.items() if k in {"api_key", "base_url", "timeout", "max_retries"}
         }
@@ -331,20 +439,18 @@ class AnthropicPrompter:
 
         _flush_content()
 
+        # Forward every known request option; there is no implicit
+        # max_tokens default (the descriptor enforces its presence).
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": chat_messages,
-            "max_tokens": self._options.get("max_tokens", 1024),
+            **self._options,
         }
         if self._system_message:
             kwargs["system"] = self._system_message
 
-        # Forward extra options
-        for k in ("temperature", "top_p", "top_k", "stop_sequences"):
-            if k in self._options:
-                kwargs[k] = self._options[k]
-
-        # Structured output: use tool_use with forced tool choice
+        # Structured output: use tool_use with forced tool choice. This
+        # overrides any caller-supplied tool_choice for the extraction turn.
         if self._return_format is not None:
             tool_def = self._build_tool_schema()
             kwargs["tools"] = [tool_def]
@@ -363,6 +469,16 @@ class AnthropicPrompter:
                 provider="anthropic",
                 input_tokens=getattr(usage, "input_tokens", None),
                 output_tokens=getattr(usage, "output_tokens", None),
+            )
+
+        # Truncation is an error, never a silent partial answer. The raise
+        # routes through the UDF on_error policy like any other failure.
+        if getattr(response, "stop_reason", None) == "max_tokens":
+            raise ValueError(
+                f"Anthropic response from model {self._model!r} was truncated at "
+                f"max_tokens={self._options.get('max_tokens')} (stop_reason='max_tokens'). "
+                "Raise max_tokens on the call or via AnthropicProvider(max_tokens=...) "
+                "to fit the full response."
             )
 
         if self._return_format is not None:

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -21,7 +21,13 @@ construction, before any request is dispatched:
 - Option/model combinations the API is documented to reject (for
   example non-default sampling parameters on Claude Sonnet 5; the
   documented default ``temperature=1`` still passes) raise
-  :class:`ValueError` before dispatch.
+  :class:`ValueError` before dispatch. The same applies to
+  ``thinking.type`` values the selected model family rejects (manual
+  ``"enabled"`` on adaptive-only families, ``"disabled"`` on always-on
+  families, ``"adaptive"`` on extended-thinking-only families).
+- A forced ``tool_choice`` (``any``/``tool``) without ``return_format``
+  raises :class:`ValueError`: Vane only sends tool definitions for
+  structured output, so the API could not satisfy it.
 - ``extra_body`` is reserved for request fields the SDK does not model:
   Vane-owned fields and known request options inside it raise
   :class:`ValueError` instead of bypassing the validated contract.
@@ -96,7 +102,10 @@ _KNOWN_PROMPT_OPTIONS: frozenset[str] = frozenset(
 _VANE_OWNED_REQUEST_FIELDS: frozenset[str] = frozenset({"messages", "model", "stream", "system", "tools"})
 
 # Vane execution options that ride in ``prompt_options`` but are consumed by
-# the UDF machinery and never forwarded to the Messages API.
+# the UDF machinery (``get_udf_options``) and never forwarded to the Messages
+# API. ``concurrency`` is an alias for ``actor_number`` — the same mapping the
+# typed ``AnthropicProviderOptions.concurrency`` field uses — and conflicting
+# values for the pair are rejected at validation.
 _VANE_EXECUTION_OPTIONS: frozenset[str] = frozenset(
     {
         "actor_number",
@@ -114,18 +123,44 @@ _VANE_EXECUTION_OPTIONS: frozenset[str] = frozenset(
 # ``temperature`` has a documented default of 1.0 (Messages API reference,
 # https://platform.claude.com/docs/en/api/messages), so passing exactly that
 # value is accepted; ``top_p`` and ``top_k`` have no documented default, so
-# any explicit value is non-default and rejected. Documented sources:
-# https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
-# (Claude Sonnet 5 returns a 400 error for non-default ``temperature``,
-# ``top_p``, or ``top_k``) and
-# https://platform.claude.com/docs/en/about-claude/models/migration-guide
-# ("Setting temperature, top_p, or top_k to a non-default value returns a
-# 400 error" on Claude Opus 4.7 and later Opus models).
+# any explicit value is non-default and rejected. Documented source
+# (https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models#limits-and-feature-compatibility):
+# "On Claude Fable 5, Claude Mythos 5, Claude Mythos Preview, Claude Opus 5,
+# Claude Opus 4.8, Claude Opus 4.7, and Claude Sonnet 5, non-default
+# temperature, top_p, or top_k values return a 400 error on every request."
+_RESTRICTED_SAMPLING_OPTIONS: frozenset[str] = frozenset({"temperature", "top_k", "top_p"})
+
 _MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
-    "claude-opus-4-7": frozenset({"temperature", "top_k", "top_p"}),
-    "claude-opus-4-8": frozenset({"temperature", "top_k", "top_p"}),
-    "claude-opus-5": frozenset({"temperature", "top_k", "top_p"}),
-    "claude-sonnet-5": frozenset({"temperature", "top_k", "top_p"}),
+    "claude-fable-5": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-mythos-5": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-mythos-preview": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-opus-4-7": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-opus-4-8": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-opus-5": _RESTRICTED_SAMPLING_OPTIONS,
+    "claude-sonnet-5": _RESTRICTED_SAMPLING_OPTIONS,
+}
+
+# ``thinking.type`` values the API rejects with a 400 per model family, from
+# the per-model table at
+# https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#configurations-each-model-rejects:
+# adaptive-only families reject the legacy manual form (``"enabled"``),
+# always-on families additionally reject ``"disabled"``, and
+# extended-thinking-only families reject ``"adaptive"``. Claude Opus 5
+# rejects ``"disabled"`` only combined with effort xhigh/max; that
+# conditional case is not modeled here. Claude Mythos Preview still supports
+# the manual form, so it only rejects ``"disabled"``.
+_MODEL_REJECTED_THINKING_TYPES: dict[str, frozenset[str]] = {
+    "claude-fable-5": frozenset({"disabled", "enabled"}),
+    "claude-haiku-4-5": frozenset({"adaptive"}),
+    "claude-mythos-5": frozenset({"disabled", "enabled"}),
+    "claude-mythos-preview": frozenset({"disabled"}),
+    "claude-opus-4-1": frozenset({"adaptive"}),
+    "claude-opus-4-5": frozenset({"adaptive"}),
+    "claude-opus-4-7": frozenset({"enabled"}),
+    "claude-opus-4-8": frozenset({"enabled"}),
+    "claude-opus-5": frozenset({"enabled"}),
+    "claude-sonnet-4-5": frozenset({"adaptive"}),
+    "claude-sonnet-5": frozenset({"enabled"}),
 }
 
 
@@ -140,16 +175,26 @@ def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> Non
     Raises:
         ValueError: If ``options`` contains keys that are neither known
             Messages API request options nor Vane execution options; if
+            ``actor_number`` and its alias ``concurrency`` disagree; if
             ``extra_body`` is not a mapping or carries Vane-owned or
-            otherwise-validated request fields; or if a sampling option
+            otherwise-validated request fields; if a sampling option
             carries a non-default value on a model family the API is
-            documented to reject it for.
+            documented to reject it for; or if ``thinking.type`` is a
+            value the selected model family is documented to reject.
     """
     unknown = sorted(key for key in options if key not in _KNOWN_PROMPT_OPTIONS and key not in _VANE_EXECUTION_OPTIONS)
     if unknown:
         raise ValueError(
             f"Unknown Anthropic prompt option(s) {unknown} for model {model_name!r}. "
             f"Supported Messages API request options: {sorted(_KNOWN_PROMPT_OPTIONS)}."
+        )
+    actor_number = options.get("actor_number")
+    concurrency = options.get("concurrency")
+    if actor_number is not None and concurrency is not None and actor_number != concurrency:
+        raise ValueError(
+            f"Conflicting Anthropic execution options actor_number={actor_number!r} "
+            f"and concurrency={concurrency!r}: concurrency is an alias for "
+            "actor_number. Pass only one of them."
         )
     extra_body = options.get("extra_body")
     if extra_body is not None:
@@ -184,6 +229,18 @@ def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> Non
                     "explicit value is non-default). Omit the option(s) or select a "
                     "model that supports them."
                 )
+    thinking = options.get("thinking")
+    if isinstance(thinking, Mapping):
+        thinking_type = thinking.get("type")
+        for family, rejected_types in _MODEL_REJECTED_THINKING_TYPES.items():
+            if (model_name == family or model_name.startswith(f"{family}-")) and thinking_type in rejected_types:
+                raise ValueError(
+                    f"Anthropic model {model_name!r} does not support thinking.type "
+                    f"{thinking_type!r}: the API rejects this configuration with a 400 "
+                    "error on this model family (see the per-model table at "
+                    "https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting#configurations-each-model-rejects). "
+                    "Omit the thinking option or use a supported type."
+                )
 
 
 def _is_manual_thinking(thinking: Any) -> bool:
@@ -199,26 +256,16 @@ def _validate_option_combinations(return_format: Any | None, options: Mapping[st
     extended thinking (``thinking.type == "enabled"``) only supports
     auto/none tool choices
     (https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models#thinking-with-tool-use).
-    ``max_tokens=0`` is a cache-prewarming request whose response has no
-    content, so options that imply output are rejected up front
+    Without ``return_format`` the request carries no tool definitions at
+    all, so a forced ``tool_choice`` (``any``/``tool``) cannot be
+    satisfied and the API rejects it. ``max_tokens=0`` is a
+    cache-prewarming request whose response has no content, so options
+    that imply output are rejected up front
     (https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pre-warming-the-cache).
 
     Raises:
         ValueError: On any of the documented-invalid combinations above.
     """
-    if return_format is not None:
-        if "tool_choice" in options:
-            raise ValueError(
-                "return_format dispatches a forced extract_data tool choice, which "
-                f"would override the caller-supplied tool_choice {options['tool_choice']!r}. "
-                "Remove tool_choice from the options or drop return_format."
-            )
-        if _is_manual_thinking(options.get("thinking")):
-            raise ValueError(
-                "return_format dispatches a forced tool choice, which the Anthropic "
-                'API rejects together with manual extended thinking (thinking={"type": '
-                '"enabled", ...}). Use adaptive thinking or drop return_format.'
-            )
     if options.get("max_tokens") == 0:
         offending = []
         if return_format is not None:
@@ -236,6 +283,28 @@ def _validate_option_combinations(return_format: Any | None, options: Mapping[st
                 "max_tokens=0 is a cache-prewarming request whose successful response "
                 f"has no content; the API rejects it combined with {', '.join(offending)}. "
                 "Remove those options or use a positive max_tokens."
+            )
+    if return_format is not None:
+        if "tool_choice" in options:
+            raise ValueError(
+                "return_format dispatches a forced extract_data tool choice, which "
+                f"would override the caller-supplied tool_choice {options['tool_choice']!r}. "
+                "Remove tool_choice from the options or drop return_format."
+            )
+        if _is_manual_thinking(options.get("thinking")):
+            raise ValueError(
+                "return_format dispatches a forced tool choice, which the Anthropic "
+                'API rejects together with manual extended thinking (thinking={"type": '
+                '"enabled", ...}). Use adaptive thinking or drop return_format.'
+            )
+    else:
+        tool_choice = options.get("tool_choice")
+        if isinstance(tool_choice, Mapping) and tool_choice.get("type") in ("any", "tool"):
+            raise ValueError(
+                f"tool_choice {tool_choice!r} forces tool use, but without "
+                "return_format the request carries no tool definitions, which the "
+                "API cannot satisfy. Use return_format for structured output, or a "
+                'tool_choice of type "auto"/"none".'
             )
 
 
@@ -404,11 +473,15 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
         return dict(self.prompt_options)
 
     def get_udf_options(self) -> UDFOptions:
+        actor_number = self.prompt_options.get("actor_number")
+        if actor_number is None:
+            actor_number = self.prompt_options.get("concurrency")
         return UDFOptions(
             max_retries=0,  # anthropic client handles retries internally
             on_error=self.prompt_options.get("on_error", "raise"),
-            actor_number=self.prompt_options.get("actor_number"),
+            actor_number=actor_number,
             num_gpus=self.prompt_options.get("num_gpus"),
+            batch_size=self.prompt_options.get("batch_size"),
             max_api_concurrency=self.prompt_options.get("max_api_concurrency", 16),
         )
 

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -25,7 +25,15 @@ construction, before any request is dispatched:
   (``max_tokens=...``) or configured on the provider
   (``AnthropicProvider(max_tokens=...)``); the per-call value wins.
 - A truncated response (``stop_reason == "max_tokens"``) raises instead
-  of silently returning partial text or ``None``.
+  of silently returning partial text or ``None``. The one documented
+  exception is ``max_tokens=0`` cache prewarming, whose successful
+  response intentionally has empty content and that stop reason; it
+  returns ``None``.
+- Option combinations the API is documented to reject — structured
+  output with a caller-supplied ``tool_choice`` or manual extended
+  thinking, and ``max_tokens=0`` with anything that implies output —
+  raise :class:`ValueError` at construction instead of being silently
+  overridden.
 
 Requires::
 
@@ -35,6 +43,7 @@ Requires::
 from __future__ import annotations
 
 import base64
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -44,8 +53,6 @@ from vane.ai.provider import Provider, ProviderImportError
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from vane.ai.protocols import Prompter
     from vane.ai.typing import Options
 
@@ -131,6 +138,59 @@ def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> Non
                     "the API rejects non-default sampling parameters for this model "
                     "family. Remove the option(s) or select a model that supports them."
                 )
+
+
+def _is_manual_thinking(thinking: Any) -> bool:
+    """True for manual extended thinking (``thinking.type == "enabled"``)."""
+    return isinstance(thinking, Mapping) and thinking.get("type") == "enabled"
+
+
+def _validate_option_combinations(return_format: Any | None, options: Mapping[str, Any]) -> None:
+    """Reject option combinations the API is documented to refuse.
+
+    Structured output dispatches a forced ``extract_data`` tool choice, so a
+    caller-supplied ``tool_choice`` would be silently replaced, and manual
+    extended thinking (``thinking.type == "enabled"``) only supports
+    auto/none tool choices
+    (https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models#thinking-with-tool-use).
+    ``max_tokens=0`` is a cache-prewarming request whose response has no
+    content, so options that imply output are rejected up front
+    (https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pre-warming-the-cache).
+
+    Raises:
+        ValueError: On any of the documented-invalid combinations above.
+    """
+    if return_format is not None:
+        if "tool_choice" in options:
+            raise ValueError(
+                "return_format dispatches a forced extract_data tool choice, which "
+                f"would override the caller-supplied tool_choice {options['tool_choice']!r}. "
+                "Remove tool_choice from the options or drop return_format."
+            )
+        if _is_manual_thinking(options.get("thinking")):
+            raise ValueError(
+                "return_format dispatches a forced tool choice, which the Anthropic "
+                'API rejects together with manual extended thinking (thinking={"type": '
+                '"enabled", ...}). Use adaptive thinking or drop return_format.'
+            )
+    if options.get("max_tokens") == 0:
+        offending = []
+        if return_format is not None:
+            offending.append("return_format")
+        if _is_manual_thinking(options.get("thinking")):
+            offending.append('thinking={"type": "enabled"}')
+        tool_choice = options.get("tool_choice")
+        if isinstance(tool_choice, Mapping) and tool_choice.get("type") in ("tool", "any"):
+            offending.append(f"tool_choice={tool_choice!r}")
+        output_config = options.get("output_config")
+        if isinstance(output_config, Mapping) and "format" in output_config:
+            offending.append("output_config.format")
+        if offending:
+            raise ValueError(
+                "max_tokens=0 is a cache-prewarming request whose successful response "
+                f"has no content; the API rejects it combined with {', '.join(offending)}. "
+                "Remove those options or use a positive max_tokens."
+            )
 
 
 def _guess_media_type(data: bytes) -> str:
@@ -279,6 +339,7 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
                 "No max_tokens configured for the Anthropic provider. "
                 "Pass max_tokens=... or configure AnthropicProvider(max_tokens=...)."
             )
+        _validate_option_combinations(self.return_format, self.prompt_options)
 
     def get_provider(self) -> str:
         return self.provider_name
@@ -449,8 +510,9 @@ class AnthropicPrompter:
         if self._system_message:
             kwargs["system"] = self._system_message
 
-        # Structured output: use tool_use with forced tool choice. This
-        # overrides any caller-supplied tool_choice for the extraction turn.
+        # Structured output: use tool_use with forced tool choice. The
+        # descriptor rejects caller-supplied tool_choice and manual thinking
+        # alongside return_format, so nothing is silently replaced here.
         if self._return_format is not None:
             tool_def = self._build_tool_schema()
             kwargs["tools"] = [tool_def]
@@ -472,8 +534,12 @@ class AnthropicPrompter:
             )
 
         # Truncation is an error, never a silent partial answer. The raise
-        # routes through the UDF on_error policy like any other failure.
+        # routes through the UDF on_error policy like any other failure. The
+        # exception is max_tokens=0: a documented cache-prewarming request
+        # whose successful response has empty content and this stop reason.
         if getattr(response, "stop_reason", None) == "max_tokens":
+            if self._options.get("max_tokens") == 0:
+                return None
             raise ValueError(
                 f"Anthropic response from model {self._model!r} was truncated at "
                 f"max_tokens={self._options.get('max_tokens')} (stop_reason='max_tokens'). "

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -19,11 +19,17 @@ construction, before any request is dispatched:
 - Unknown option keys raise :class:`ValueError` instead of being
   silently dropped.
 - Option/model combinations the API is documented to reject (for
-  example sampling parameters on Claude Sonnet 5) raise
+  example non-default sampling parameters on Claude Sonnet 5; the
+  documented default ``temperature=1`` still passes) raise
   :class:`ValueError` before dispatch.
+- ``extra_body`` is reserved for request fields the SDK does not model:
+  Vane-owned fields and known request options inside it raise
+  :class:`ValueError` instead of bypassing the validated contract.
 - ``max_tokens`` has no library default: it must be supplied per call
   (``max_tokens=...``) or configured on the provider
-  (``AnthropicProvider(max_tokens=...)``); the per-call value wins.
+  (``AnthropicProvider(max_tokens=...)``); the per-call value wins. An
+  explicit ``None`` is treated as unconfigured, and the resolved value
+  must be a non-negative integer.
 - A truncated response (``stop_reason == "max_tokens"``) raises instead
   of silently returning partial text or ``None``. The one documented
   exception is ``max_tokens=0`` cache prewarming, whose successful
@@ -85,6 +91,10 @@ _KNOWN_PROMPT_OPTIONS: frozenset[str] = frozenset(
     }
 )
 
+# Request fields Vane owns end-to-end. They are set by the prompter and may
+# not be smuggled past pre-dispatch validation through ``extra_body``.
+_VANE_OWNED_REQUEST_FIELDS: frozenset[str] = frozenset({"messages", "model", "stream", "system", "tools"})
+
 # Vane execution options that ride in ``prompt_options`` but are consumed by
 # the UDF machinery and never forwarded to the Messages API.
 _VANE_EXECUTION_OPTIONS: frozenset[str] = frozenset(
@@ -98,14 +108,19 @@ _VANE_EXECUTION_OPTIONS: frozenset[str] = frozenset(
     }
 )
 
-# Request options the API is documented to reject per model family. A model
-# matches an entry by family prefix: the exact id or ``<family>-<suffix>``
-# (dated snapshots and successors within the family). Documented sources:
+# Request options the API rejects per model family when set to a non-default
+# value. A model matches an entry by family prefix: the exact id or
+# ``<family>-<suffix>`` (dated snapshots and successors within the family).
+# ``temperature`` has a documented default of 1.0 (Messages API reference,
+# https://platform.claude.com/docs/en/api/messages), so passing exactly that
+# value is accepted; ``top_p`` and ``top_k`` have no documented default, so
+# any explicit value is non-default and rejected. Documented sources:
 # https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
 # (Claude Sonnet 5 returns a 400 error for non-default ``temperature``,
 # ``top_p``, or ``top_k``) and
 # https://platform.claude.com/docs/en/about-claude/models/migration-guide
-# (the same constraint on Claude Opus 4.7 and later Opus models).
+# ("Setting temperature, top_p, or top_k to a non-default value returns a
+# 400 error" on Claude Opus 4.7 and later Opus models).
 _MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
     "claude-opus-4-7": frozenset({"temperature", "top_k", "top_p"}),
     "claude-opus-4-8": frozenset({"temperature", "top_k", "top_p"}),
@@ -114,14 +129,21 @@ _MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]] = {
 }
 
 
+def _is_default_temperature(value: Any) -> bool:
+    """True when ``value`` is the documented API default ``temperature`` (1.0)."""
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and value == 1
+
+
 def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> None:
-    """Reject unknown or model-unsupported prompt options before dispatch.
+    """Reject unknown, contract-bypassing, or model-unsupported prompt options.
 
     Raises:
         ValueError: If ``options`` contains keys that are neither known
-            Messages API request options nor Vane execution options, or
-            contains request options the selected model is documented to
-            reject.
+            Messages API request options nor Vane execution options; if
+            ``extra_body`` is not a mapping or carries Vane-owned or
+            otherwise-validated request fields; or if a sampling option
+            carries a non-default value on a model family the API is
+            documented to reject it for.
     """
     unknown = sorted(key for key in options if key not in _KNOWN_PROMPT_OPTIONS and key not in _VANE_EXECUTION_OPTIONS)
     if unknown:
@@ -129,14 +151,38 @@ def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> Non
             f"Unknown Anthropic prompt option(s) {unknown} for model {model_name!r}. "
             f"Supported Messages API request options: {sorted(_KNOWN_PROMPT_OPTIONS)}."
         )
+    extra_body = options.get("extra_body")
+    if extra_body is not None:
+        if not isinstance(extra_body, Mapping):
+            raise ValueError(
+                f"Anthropic option extra_body must be a mapping of additional JSON "
+                f"request body fields, got {type(extra_body).__name__}."
+            )
+        bypassing = sorted(
+            key for key in extra_body if key in _VANE_OWNED_REQUEST_FIELDS or key in _KNOWN_PROMPT_OPTIONS
+        )
+        if bypassing:
+            raise ValueError(
+                f"extra_body must not carry field(s) {bypassing} for model {model_name!r}: "
+                "Vane-owned request fields and known Messages API request options are "
+                "validated before dispatch and cannot bypass that contract through "
+                "extra_body. Pass request options at the top level instead."
+            )
     for family, unsupported in _MODEL_UNSUPPORTED_OPTIONS.items():
         if model_name == family or model_name.startswith(f"{family}-"):
-            rejected = sorted(key for key in options if key in unsupported)
+            rejected = sorted(
+                key
+                for key, value in options.items()
+                if key in unsupported and not (key == "temperature" and _is_default_temperature(value))
+            )
             if rejected:
                 raise ValueError(
                     f"Anthropic model {model_name!r} does not support option(s) {rejected}: "
-                    "the API rejects non-default sampling parameters for this model "
-                    "family. Remove the option(s) or select a model that supports them."
+                    "the API returns a 400 error for non-default sampling parameters on "
+                    "this model family (temperature is accepted only at its documented "
+                    "default of 1; top_p and top_k have no documented default, so any "
+                    "explicit value is non-default). Omit the option(s) or select a "
+                    "model that supports them."
                 )
 
 
@@ -278,7 +324,8 @@ class AnthropicProvider(Provider):
         The model resolves as: call-site ``model`` > provider
         ``prompt_model`` configuration; the selected value must be a
         non-empty string. ``max_tokens`` resolves as: call-site option >
-        provider ``max_tokens`` configuration.
+        provider ``max_tokens`` configuration; an explicit
+        ``max_tokens=None`` is treated as unconfigured.
 
         Raises:
             ValueError: If no model or no ``max_tokens`` is configured
@@ -298,7 +345,7 @@ class AnthropicProvider(Provider):
                 f"Anthropic prompt model must be a non-empty string, got {model_name!r}. "
                 "Pass model=... or configure AnthropicProvider(prompt_model=...)."
             )
-        if "max_tokens" not in prompt_options and self._max_tokens is not None:
+        if prompt_options.get("max_tokens") is None and self._max_tokens is not None:
             prompt_options["max_tokens"] = self._max_tokens
         return AnthropicPrompterDescriptor(
             provider_name=self._name,
@@ -334,9 +381,15 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
         self.provider_options = wrap_sensitive_options(self.provider_options)
         self.prompt_options = wrap_sensitive_options(self.prompt_options)
         _validate_prompt_options(self.model_name, self.prompt_options)
-        if "max_tokens" not in self.prompt_options:
+        max_tokens = self.prompt_options.get("max_tokens")
+        if max_tokens is None:
             raise ValueError(
                 "No max_tokens configured for the Anthropic provider. "
+                "Pass max_tokens=... or configure AnthropicProvider(max_tokens=...)."
+            )
+        if isinstance(max_tokens, bool) or not isinstance(max_tokens, int) or max_tokens < 0:
+            raise ValueError(
+                f"Anthropic max_tokens must be a non-negative integer, got {max_tokens!r}. "
                 "Pass max_tokens=... or configure AnthropicProvider(max_tokens=...)."
             )
         _validate_option_combinations(self.return_format, self.prompt_options)


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #168; now rebased onto `main` (single commit `d744dfd7`, on top of the merged #168 and #160) and marked ready for review.

## Summary

Per maintainer direction on #146, the Anthropic prompter's silent 5-key forwarding whitelist and the invisible `max_tokens=1024` default are replaced by a strict, validated contract enforced at descriptor construction — before anything ships to workers:

- **Forward the full known surface.** Every Messages API request option accepted by the installed `anthropic` SDK (0.117.0 `Messages.create`) forwards verbatim: `max_tokens`, `temperature`, `top_p`, `top_k`, `stop_sequences`, `thinking`, `metadata`, `tool_choice`, `service_tier`, `output_config`, `cache_control`, `container`, `inference_geo`, `user_profile_id`, plus the SDK per-request extras `extra_headers`/`extra_query`/`extra_body`. Keys Vane owns (`model`, `messages`, `system`, `tools`, `stream`) and client configuration (`api_key`, `base_url`, `timeout`, `max_retries`) stay out of the set by design. Beta features remain reachable via `extra_headers={"anthropic-beta": ...}` (the non-beta `messages.create` has no `betas` parameter).
- **Reject unknown options.** A key that is neither a known request option nor a Vane execution option (`on_error`, `max_api_concurrency`, ...) raises `ValueError` at expression-build time, listing the offending keys, the model, and the supported set. Together with #168's fully-named constructor (ctor typos are a `TypeError`), a misspelled option can no longer ride silently into (or vanish before) the request on any path.
- **Reject documented-unsupported combinations.** A per-model capability table `_MODEL_UNSUPPORTED_OPTIONS: dict[str, frozenset[str]]` plus `_validate_prompt_options(model_name, options)` (invoked from `AnthropicPrompterDescriptor.__post_init__`) rejects non-default sampling parameters (`temperature`/`top_p`/`top_k`) on the model families Anthropic documents as returning a 400 for them: `claude-sonnet-5` ([What's new in Claude Sonnet 5](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5)) and `claude-opus-4-7`/`claude-opus-4-8`/`claude-opus-5` ([migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide): "Setting `temperature`, `top_p`, or `top_k` to a non-default value returns a 400 error on Claude Opus 4.7 or later models"). Matching is by family prefix (exact id or `<family>-<suffix>`, so dated snapshots are covered). The table shape is intentionally identical to the Google one in #161 so both can be lifted into a core capability framework under #152.
- **Explicit `max_tokens`.** The implicit `1024` is deleted. `max_tokens` resolves as **call-site option > `AnthropicProvider(max_tokens=...)` (new keyword-only constructor parameter) > `ValueError`** naming both fix paths: `"No max_tokens configured for the Anthropic provider. Pass max_tokens=... or configure AnthropicProvider(max_tokens=...)."` Enforced in the descriptor `__post_init__`, so direct descriptor construction is covered too.
- **Truncation raises.** A response with `stop_reason == "max_tokens"` raises `ValueError` (naming the model and the configured `max_tokens`) instead of returning partial text — or, on the `return_format` path, a silent `None`. The raise flows through the existing UDF `on_error` policy (`raise`/`log`/`ignore`) like any other request failure.

No backward compatibility or deprecation window, per maintainer direction (early-stage project).

## Related issue

close: #146

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The option contract, `max_tokens` chain, and truncation behavior are documented in the provider module/class docstrings updated in this PR.

## Validation

- Stub-harness runs (local venv, `anthropic` 0.117.0 installed; duckdb-engine-dependent tests and Pillow-dependent tests are environment-blocked and fail identically on the base branch):
  - `pytest -p vane_pkg_stub_plugin --noconftest tests/ai/test_ai_functions.py -k Anthropic`: 49 passed, 1 environment-blocked (Pillow).
  - Full `tests/ai/test_ai_functions.py` + `tests/ai/test_descriptor_secret_redaction.py`: 294 passed, 16 environment-blocked failures — the identical 16 fail on the base commit; no new failures.
  - `tests/ai/test_expression_ai_functions.py` + `tests/fast/test_ai_options_repr.py`: 47 passed / 15 failed, failure set identical to the base commit (duckdb-engine stubs).
- New tests pin: unknown option (`thinkng=...`) rejected pre-dispatch on both the provider and direct-descriptor paths (a ctor typo like `promt_model=` is a `TypeError` from #168's named constructor); `thinking`/`metadata`/`tool_choice`/`service_tier` reaching the recorded `messages.create` kwargs while Vane execution options stay out; `claude-sonnet-5` (and a dated snapshot id) + `temperature`/`top_p` rejected while `claude-sonnet-4-6` passes; missing `max_tokens` error with both fix paths on both construction paths; per-call and provider-config `max_tokens` flow-through with call beating config; `stop_reason="max_tokens"` raising on both the plain-text and structured paths (mocks carry `.type`/`.text`/`.stop_reason`).
- Option-surface verification: `_KNOWN_PROMPT_OPTIONS` was generated from the installed SDK's `Messages.create` signature (`anthropic` 0.117.0), not from memory; the capability-table entries carry their documentation URLs in a source comment.
- `ruff check` / `ruff format --check` clean; pre-commit hooks passed on commit.

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (None added.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (No new surface; the change adds
      pre-dispatch validation and removes an implicit request parameter. Secret
      redaction behavior is unchanged and still covered by
      `test_descriptor_secret_redaction.py`.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. (Python-only; ruff + pre-commit clean,
      stub-harness tests pass locally, full suite delegated to CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXGCZZzpBqP7D1kivLJABc

