### PR TITLE
[fix](ai) Cap Google embedding batches and preserve conversation structure (#145)

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1447,6 +1447,366 @@ class TestGoogleEmbeddingRowPreservation:
             asyncio.run(embedder.embed_text(["first row", "second row"]))
 
 
+class TestGoogleEmbeddingBatching:
+    """Tests for Google embedding request chunking under the API batch cap."""
+
+    def _recording_embedder(self, model, dimensions=None, options=None):
+        """Build a GoogleTextEmbedder around a recording embed_content mock.
+
+        The fake response derives each embedding value from the input text
+        (``"txt-<n>"`` embeds to ``[float(n)]``), so result order can be
+        asserted independently of request order.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vane.ai.providers.google import GoogleTextEmbedder
+
+        calls: list[dict] = []
+
+        async def fake_embed_content(**kwargs):
+            calls.append(kwargs)
+            response = MagicMock()
+            response.embeddings = []
+            for item in kwargs["contents"]:
+                embedding = MagicMock()
+                embedding.values = [float(item.parts[0].text.rsplit("-", 1)[1])]
+                response.embeddings.append(embedding)
+            return response
+
+        embedder = GoogleTextEmbedder.__new__(GoogleTextEmbedder)
+        embedder._client = MagicMock()
+        embedder._client.aio.models.embed_content = AsyncMock(side_effect=fake_embed_content)
+        embedder._model = model
+        embedder._dimensions = dimensions
+        embedder._options = dict(options or {})
+        return embedder, calls
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_oversized_batch_chunked_under_cap(self):
+        """250 inputs become 3 requests of <=100, concatenated in order."""
+        import asyncio
+
+        embedder, calls = self._recording_embedder("gemini-embedding-001")
+        texts = [f"txt-{i}" for i in range(250)]
+
+        result = asyncio.run(embedder.embed_text(texts))
+
+        assert [len(call["contents"]) for call in calls] == [100, 100, 50]
+        assert all(call["model"] == "gemini-embedding-001" for call in calls)
+        # Chunks cover the inputs in order without overlap.
+        sent = [item.parts[0].text for call in calls for item in call["contents"]]
+        assert sent == texts
+        # One embedding per input row, in input order.
+        assert len(result) == len(texts)
+        assert [e[0] for e in result] == [float(i) for i in range(250)]
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    @pytest.mark.parametrize("count", [1, 100])
+    def test_batch_at_or_under_cap_is_single_request(self, count):
+        """Batches within the cap go out as one request."""
+        import asyncio
+
+        embedder, calls = self._recording_embedder("gemini-embedding-001")
+        texts = [f"txt-{i}" for i in range(count)]
+
+        result = asyncio.run(embedder.embed_text(texts))
+
+        assert len(calls) == 1
+        assert len(calls[0]["contents"]) == count
+        assert len(result) == count
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_empty_batch_makes_no_requests(self):
+        import asyncio
+
+        embedder, calls = self._recording_embedder("gemini-embedding-001")
+
+        result = asyncio.run(embedder.embed_text([]))
+
+        assert calls == []
+        assert result == []
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_aggregating_model_batches_via_separate_contents(self):
+        """gemini-embedding-2 aggregates multiple direct string inputs, so
+        each input travels as its own Content and full-size chunks stay
+        row-preserving without falling back to one request per input."""
+        import asyncio
+
+        embedder, calls = self._recording_embedder("gemini-embedding-2")
+        texts = ["txt-0", "txt-1", "txt-2"]
+
+        result = asyncio.run(embedder.embed_text(texts))
+
+        assert len(calls) == 1
+        assert [item.parts[0].text for item in calls[0]["contents"]] == texts
+        assert len(result) == len(texts)
+        assert [e[0] for e in result] == [0.0, 1.0, 2.0]
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_result_count_mismatch_raises(self):
+        """A model that does not embed inputs individually is rejected."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from vane.ai.providers.google import GoogleTextEmbedder
+
+        async def aggregate_embed_content(**kwargs):
+            response = MagicMock()
+            embedding = MagicMock()
+            embedding.values = [1.0]
+            response.embeddings = [embedding]  # one embedding for N inputs
+            return response
+
+        embedder = GoogleTextEmbedder.__new__(GoogleTextEmbedder)
+        embedder._client = MagicMock()
+        embedder._client.aio.models.embed_content = AsyncMock(side_effect=aggregate_embed_content)
+        embedder._model = "custom-aggregating-embedder"
+        embedder._dimensions = None
+        embedder._options = {}
+
+        with pytest.raises(ValueError, match="returned 1 embeddings for 3 inputs"):
+            asyncio.run(embedder.embed_text(["a", "b", "c"]))
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_config_forwarded_to_every_chunk(self):
+        """Dimensions and request options reach each chunked request."""
+        import asyncio
+
+        embedder, calls = self._recording_embedder(
+            "gemini-embedding-001",
+            dimensions=256,
+            options={"task_type": "RETRIEVAL_QUERY"},
+        )
+        texts = [f"txt-{i}" for i in range(150)]
+
+        asyncio.run(embedder.embed_text(texts))
+
+        assert len(calls) == 2
+        for call in calls:
+            assert call["config"]["output_dimensionality"] == 256
+            assert call["config"]["task_type"] == "RETRIEVAL_QUERY"
+
+    def test_udf_batch_size_defaults_to_request_cap(self):
+        """The descriptor's UDF batch size defaults to the per-request cap."""
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        desc = GoogleTextEmbedderDescriptor(model_name="gemini-embedding-001")
+        assert desc.get_udf_options().batch_size == 100
+
+    def test_udf_batch_size_cap_applies_to_aggregating_model(self):
+        """Per-Content encoding keeps gemini-embedding-2 row-preserving at
+        full chunk size, so it gets the same default cap as other models."""
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        desc = GoogleTextEmbedderDescriptor(model_name="gemini-embedding-2")
+        assert desc.get_udf_options().batch_size == 100
+
+    def test_udf_batch_size_explicit_override(self):
+        from vane.ai.providers.google import GoogleTextEmbedderDescriptor
+
+        desc = GoogleTextEmbedderDescriptor(
+            model_name="gemini-embedding-001",
+            embed_options={"batch_size": 25},
+        )
+        assert desc.get_udf_options().batch_size == 25
+
+
+class TestGoogleConversationStructure:
+    """Recording-client structural tests for Google role handling.
+
+    Asserts the exact ``Content`` / ``system_instruction`` structures the
+    prompter sends to ``generate_content``.
+    """
+
+    def _recording_prompter(self, system_message=None):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from vane.ai.providers.google import GooglePrompter
+
+        with patch("google.genai.Client"):
+            prompter = GooglePrompter(
+                provider_options={"api_key": "test"},
+                model="gemini-2.5-pro",
+                system_message=system_message,
+            )
+
+        calls: list[dict] = []
+        response = MagicMock()
+        response.text = "ok"
+        response.usage_metadata = None
+
+        async def fake_generate_content(**kwargs):
+            calls.append(kwargs)
+            return response
+
+        client = MagicMock()
+        client.aio.models.generate_content = AsyncMock(side_effect=fake_generate_content)
+        prompter._client = client
+        return prompter, calls
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_system_plus_user_string(self):
+        """Descriptor system_message routes through system_instruction."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter(system_message="Be helpful.")
+
+        result = asyncio.run(prompter.prompt(("hello",)))
+
+        assert result == "ok"
+        assert len(calls) == 1
+        assert calls[0]["model"] == "gemini-2.5-pro"
+        contents = calls[0]["contents"]
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert [part.text for part in contents[0].parts] == ["hello"]
+        assert calls[0]["config"].system_instruction == "Be helpful."
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_plain_string_prompt_regression(self):
+        """A plain-string prompt stays a single user turn with no config."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        asyncio.run(prompter.prompt(("hello",)))
+
+        contents = calls[0]["contents"]
+        assert [content.role for content in contents] == ["user"]
+        assert [part.text for part in contents[0].parts] == ["hello"]
+        assert calls[0]["config"] is None
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_alternating_turns_preserved_in_order(self):
+        """Role-tagged dicts become ordered user/model Content turns."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        asyncio.run(
+            prompter.prompt(
+                (
+                    {"role": "user", "content": "q1"},
+                    {"role": "assistant", "content": "a1"},
+                    {"role": "user", "content": "q2"},
+                )
+            )
+        )
+
+        contents = calls[0]["contents"]
+        assert [content.role for content in contents] == ["user", "model", "user"]
+        assert [content.parts[0].text for content in contents] == ["q1", "a1", "q2"]
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_system_messages_combined_in_declaration_order(self):
+        """system dicts merge with the descriptor system_message, in order,
+        and never appear as conversation turns."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter(system_message="A.")
+
+        asyncio.run(
+            prompter.prompt(
+                (
+                    {"role": "system", "content": "B."},
+                    {"role": "user", "content": "hi"},
+                )
+            )
+        )
+
+        assert calls[0]["config"].system_instruction == "A.\n\nB."
+        contents = calls[0]["contents"]
+        assert [content.role for content in contents] == ["user"]
+        assert contents[0].parts[0].text == "hi"
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    @pytest.mark.parametrize("role", ["tool", "function", "assistantt"])
+    def test_unsupported_role_raises(self, role):
+        """Unknown roles fail fast instead of degrading into user text."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        with pytest.raises(ValueError, match=f"Unsupported message role '{role}'"):
+            asyncio.run(prompter.prompt(({"role": role, "content": "x"},)))
+        assert calls == []
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_mixed_text_image_parts_preserved_in_order(self):
+        """Structured part lists convert per-part, in order."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 10
+
+        asyncio.run(prompter.prompt(({"role": "user", "content": ["look", png]},)))
+
+        contents = calls[0]["contents"]
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        parts = contents[0].parts
+        assert len(parts) == 2
+        assert parts[0].text == "look"
+        assert parts[1].inline_data.mime_type == "image/png"
+        assert parts[1].inline_data.data == png
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_untagged_parts_group_into_user_turns_between_role_dicts(self):
+        """Loose parts flush into user turns around role-tagged messages."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        asyncio.run(
+            prompter.prompt(
+                (
+                    "intro",
+                    {"role": "assistant", "content": "a"},
+                    "next",
+                )
+            )
+        )
+
+        contents = calls[0]["contents"]
+        assert [content.role for content in contents] == ["user", "model", "user"]
+        assert [content.parts[0].text for content in contents] == ["intro", "a", "next"]
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_dict_text_content_part_converts_without_repr(self):
+        """OpenAI-style text part dicts become real text parts."""
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        asyncio.run(prompter.prompt(({"role": "user", "content": [{"type": "text", "text": "hi"}]},)))
+
+        parts = calls[0]["contents"][0].parts
+        assert [part.text for part in parts] == ["hi"]
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_unsupported_dict_content_part_raises(self):
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        with pytest.raises(ValueError, match="Unsupported dict content part"):
+            asyncio.run(
+                prompter.prompt(({"role": "user", "content": [{"type": "image_url", "image_url": {"url": "u"}}]},))
+            )
+        assert calls == []
+
+    @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+    def test_non_string_system_content_raises(self):
+        import asyncio
+
+        prompter, calls = self._recording_prompter()
+
+        with pytest.raises(ValueError, match="system messages must be plain text"):
+            asyncio.run(prompter.prompt(({"role": "system", "content": ["a", "b"]},)))
+        assert calls == []
+
+
 # ---------------------------------------------------------------------------
 # Anthropic Structured Output + Multimodal tests
 # ---------------------------------------------------------------------------

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -99,6 +99,23 @@ _EMBEDDING_DIM_RANGE: dict[str, tuple[int, int]] = {
     "gemini-embedding-2": (128, 3072),
 }
 
+# Per-request input cap for Gemini embedding requests. The embeddings guide
+# does not publish a batch-size number, but the ``batchEmbedContents``
+# endpoint (which multi-input ``embed_content`` calls use) rejects larger
+# batches with "BatchEmbedContentsRequest.requests: at most 100 requests can
+# be in one batch", so 100 is the server-enforced limit.
+_EMBED_BATCH_LIMIT = 100
+
+# Conversation roles supported by the Gemini API, mapped from the
+# OpenAI/Anthropic-style role names used in Vane message dicts to the wire
+# role names Gemini expects. ``system`` is handled separately via
+# ``GenerateContentConfig.system_instruction``; anything else is rejected.
+_CONVERSATION_ROLES: dict[str, str] = {
+    "user": "user",
+    "assistant": "model",
+}
+
+
 # Request options rejected per model before dispatch. Gemini 3.6 Flash and
 # 3.5 Flash-Lite deprecate the classic sampling parameters: the API ignores
 # them today and returns HTTP 400 in future model generations
@@ -304,6 +321,10 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
     ``model_name`` is required. ``dimensions`` is required unless the model
     has trusted metadata in :data:`_EMBEDDING_DIMS`; both are validated at
     construction time, before anything ships to workers.
+
+    The default UDF ``batch_size`` matches the per-request input cap
+    (:data:`_EMBED_BATCH_LIMIT`); the embedder additionally chunks
+    oversized batches as defense in depth.
     """
 
     model_name: str
@@ -333,6 +354,7 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(
+            batch_size=self.embed_options.get("batch_size", _EMBED_BATCH_LIMIT),
             max_retries=self.embed_options.get("max_retries", 3),
             on_error=self.embed_options.get("on_error", "raise"),
             actor_number=self.embed_options.get("actor_number"),
@@ -389,34 +411,44 @@ class GoogleTextEmbedder:
         }
 
     async def embed_text(self, text: list[str]) -> list[Embedding]:
+        """Embed *text*, chunking into per-request batches under the API cap.
+
+        Each input is sent as its own ``types.Content``, so aggregating
+        models such as ``gemini-embedding-2`` still return one embedding
+        per input. Requests are capped at :data:`_EMBED_BATCH_LIMIT` inputs
+        and results are concatenated in input order, so an oversized arrow
+        batch can never produce a single oversized API call. The result
+        always contains exactly one embedding per input.
+        """
         from google.genai import types
 
-        # Embedding models such as gemini-embedding-2 aggregate multiple
-        # direct string inputs into a single embedding; one Content per input
-        # keeps the call row-preserving.
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            "contents": [types.Content(parts=[types.Part.from_text(text=t)]) for t in text],
-        }
         config = dict(self._options)
         if self._dimensions is not None:
             config["output_dimensionality"] = self._dimensions
-        if config:
-            kwargs["config"] = config
 
-        try:
-            result = await self._client.aio.models.embed_content(**kwargs)
-        except Exception as exc:
-            _raise_retry_after_on_google_error(exc)
-            raise
-        embeddings = result.embeddings or []
-        if len(embeddings) != len(text):
-            raise ValueError(
-                f"Google embed_content returned {len(embeddings)} embeddings for "
-                f"{len(text)} inputs with model {self._model!r}; embedding calls "
-                "must return exactly one embedding per input row."
-            )
-        return [np.array(e.values, dtype=np.float32) for e in embeddings]
+        embeddings: list[Embedding] = []
+        for start in range(0, len(text), _EMBED_BATCH_LIMIT):
+            chunk = text[start : start + _EMBED_BATCH_LIMIT]
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "contents": [types.Content(parts=[types.Part.from_text(text=t)]) for t in chunk],
+            }
+            if config:
+                kwargs["config"] = config
+            try:
+                result = await self._client.aio.models.embed_content(**kwargs)
+            except Exception as exc:
+                _raise_retry_after_on_google_error(exc)
+                raise
+            chunk_embeddings = result.embeddings or []
+            if len(chunk_embeddings) != len(chunk):
+                raise ValueError(
+                    f"Google embed_content returned {len(chunk_embeddings)} embeddings for "
+                    f"{len(chunk)} inputs with model {self._model!r}; embedding calls "
+                    "must return exactly one embedding per input row."
+                )
+            embeddings.extend(np.array(e.values, dtype=np.float32) for e in chunk_embeddings)
+        return embeddings
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +512,9 @@ class GooglePrompter:
 
     Features:
     - Multimodal: str, bytes (images), numpy arrays → Gemini content parts
+    - Conversations: role-tagged dicts become ordered ``Content`` turns
+      (``user`` → ``user``, ``assistant`` → ``model``); ``system`` messages
+      route through ``system_instruction``; other roles are rejected.
     - Structured Output: ``return_format`` (Pydantic BaseModel) uses
       ``response_mime_type="application/json"`` + ``response_schema``.
     """
@@ -532,8 +567,13 @@ class GooglePrompter:
             media_type = _guess_media_type(msg)
             return types.Part.from_bytes(data=msg, mime_type=media_type)
         if isinstance(msg, dict):
-            # Dict content part — convert to text representation
-            return types.Part.from_text(text=str(msg.get("content", msg)))
+            # Structured content part. Only explicit text parts convert;
+            # anything else raises instead of degrading into a ``str()`` repr.
+            if isinstance(msg.get("text"), str):
+                return types.Part.from_text(text=msg["text"])
+            if isinstance(msg.get("content"), str):
+                return types.Part.from_text(text=msg["content"])
+            raise ValueError(f"Unsupported dict content part for the Google provider: {msg!r}")
         # numpy array
         type_name = type(msg).__name__
         mod = getattr(type(msg), "__module__", "")
@@ -556,6 +596,12 @@ class GooglePrompter:
         img.save(buf, "PNG")
         return types.Part.from_bytes(data=buf.getvalue(), mime_type="image/png")
 
+    def _content_parts(self, content: Any) -> list[Any]:
+        """Convert a role-tagged message's ``content`` into ordered Gemini parts."""
+        if isinstance(content, (list, tuple)):
+            return [self._process_message(part) for part in content]
+        return [self._process_message(content)]
+
     # --- API call --------------------------------------------------------
 
     async def prompt(self, messages: tuple[Any, ...]) -> Any:
@@ -563,24 +609,60 @@ class GooglePrompter:
 
         Supports multimodal content (str, bytes, numpy arrays) and
         structured output via ``response_schema``.
+
+        Role-tagged dicts (``{"role": ..., "content": ...}``) become genuine
+        ordered conversation turns: ``user`` maps to a ``user`` turn,
+        ``assistant`` to a ``model`` turn, and ``system`` messages are routed
+        through ``GenerateContentConfig.system_instruction`` (combined with
+        the descriptor's ``system_message`` in declaration order). Any other
+        role raises :class:`ValueError`. Untagged parts between role-tagged
+        messages are grouped into user turns, preserving order.
         """
         from google.genai import types
 
-        # Build content parts
-        parts: list[Any] = []
+        contents: list[Any] = []
+        system_texts: list[str] = []
+        if self._system_message:
+            system_texts.append(self._system_message)
+
+        # Untagged parts accumulate into a single user turn until a
+        # role-tagged message closes it.
+        pending_parts: list[Any] = []
+
+        def _flush_pending() -> None:
+            if pending_parts:
+                contents.append(types.Content(role="user", parts=list(pending_parts)))
+                pending_parts.clear()
+
         for msg in messages:
             if isinstance(msg, dict) and "role" in msg:
-                # Complete message — extract text content
-                parts.append(types.Part.from_text(text=str(msg.get("content", ""))))
+                role = msg["role"]
+                content = msg.get("content", "")
+                if role == "system":
+                    if not isinstance(content, str):
+                        raise ValueError(
+                            f"Google system messages must be plain text, got content of type {type(content).__name__}."
+                        )
+                    system_texts.append(content)
+                    continue
+                mapped_role = _CONVERSATION_ROLES.get(role)
+                if mapped_role is None:
+                    supported = sorted((*_CONVERSATION_ROLES, "system"))
+                    raise ValueError(
+                        f"Unsupported message role {role!r} for the Google provider. Supported roles: {supported}."
+                    )
+                _flush_pending()
+                contents.append(types.Content(role=mapped_role, parts=self._content_parts(content)))
             else:
-                parts.append(self._process_message(msg))
+                pending_parts.append(self._process_message(msg))
 
-        contents = [types.Content(role="user", parts=parts)]
+        _flush_pending()
 
         # Build config
         config_kwargs: dict[str, Any] = {}
-        if self._system_message:
-            config_kwargs["system_instruction"] = self._system_message
+        system_instruction = "\n\n".join(text for text in system_texts if text)
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
         for k in ("temperature", "top_p", "top_k", "max_output_tokens"):
             if k in self._options:
                 config_kwargs[k] = self._options[k]


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #161; now rebased onto `main` (single commit `e3aec094`) after #161 merged, and marked ready for review.

## Summary

Fixes the two remaining correctness hazards from #145 in the Google provider (item 1, the silent 768-dimension fallback, landed in #161 per maintainer direction).

**Embedding batch cap (#145 item 2).** `embed_text` previously forwarded the entire arrow batch as a single `embed_content` call; the `batchEmbedContents` endpoint rejects anything above 100 inputs ("at most 100 requests can be in one batch"). Now:

- Requests are chunked at the server-enforced 100-input cap and results are concatenated in input order, so an oversized arrow batch can never produce an oversized API call.
- Aggregation safety is handled by the parent #161: each input is sent as its own `types.Content`, which keeps `gemini-embedding-2` row-preserving at full chunk size — no one-input-per-request fallback is needed, so full-size chunks apply to every model.
- `GoogleTextEmbedderDescriptor.get_udf_options()` now defaults `batch_size` to the per-request cap (100), following the OpenAI embedder's precedent; an explicit `batch_size` in the options still wins. The in-embedder chunking remains as defense in depth.
- If the number of returned embeddings in any chunk diverges from the chunk's input count, `embed_text` raises `ValueError` naming the model instead of letting misaligned rows flow downstream.

*Note on the cap's source:* the embeddings guide and API reference do not publish a per-request input number; 100 is the limit the live API enforces (`BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch`). This is recorded in a code comment next to `_EMBED_BATCH_LIMIT`.

**Role-structured conversations (#145 item 3, absorbing the #102 acceptance scope).** Role-tagged dict messages were flattened into one `Content(role="user")` turn with `str()` reprs of structured parts. Now:

- Each role-tagged dict becomes its own ordered `types.Content` turn: `user` → `"user"`, `assistant` → `"model"`. Untagged parts between role dicts group into user turns, preserving order.
- `system` messages route through `GenerateContentConfig.system_instruction`, combined with the descriptor's `system_message` in declaration order — never dropped, never sent as a user turn. Non-string system content raises.
- Unsupported roles (`tool`, `function`, typos) raise `ValueError` naming the role and listing the supported ones, instead of degrading into user-turn text.
- Structured part lists (text + images) convert per-part in order via the existing part-conversion helpers; dict parts no longer stringify — explicit text parts convert, unknown dict shapes raise.
- Plain-string prompts keep producing a single user turn (regression-tested).

## Related issue

close: #145

Item 1 of #145 (stale dims table / silent 768 fallback / `0`-is-falsy) landed via #161 per the maintainer direction on the issue; this PR completes items 2 and 3.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Behavior contracts are documented in the provider docstrings (`GoogleTextEmbedderDescriptor`, `GoogleTextEmbedder.embed_text`, `GooglePrompter.prompt`).

## Validation

- Local stub-harness run of the touched test files (`pytest -p vane_pkg_stub_plugin --noconftest tests/ai/test_ai_functions.py tests/ai/test_descriptor_secret_redaction.py`): 330 passed, 16 failed — the identical 16 failures reproduce on the base commit and stem from optional deps missing locally (Pillow/duckdb/vllm); zero new failures.
- New recording-client structural tests assert the exact `Content` / `system_instruction` structures sent to `generate_content` (system+user, alternating user/model turns, combined system messages, unsupported roles, mixed image+text parts, untagged-part grouping, plain-string regression) and the embedding chunking behavior (250 inputs → 3 requests of ≤100 preserving order; ≤100 → 1 request; empty → 0 requests; aggregating model batched via separate `Content`s in one request; per-chunk result-length invariant; config forwarded to every chunk; UDF batch-size defaults and override).
- `ruff check` / `ruff format` clean (repo pre-commit hooks).
- Full suite: CI.

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

Compatibility note: prompts that previously relied on unsupported roles or non-text dict parts being silently flattened into user text now raise `ValueError`; per the no-compat direction on #141/#145 this is intentional fail-fast behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXGCZZzpBqP7D1kivLJABc

