### PR TITLE
[fix](tests) Stabilize Ray snapshot shutdown race

### DIFF
--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2790,7 +2790,8 @@ def test_ray_worker_manager_snapshot_refresh_shutdown_has_no_deadlock(monkeypatc
     assert shutdown_errors == []
     assert start_calls == [()]
     assert len(snapshot_errors) == 2
-    assert all("shut down during worker refresh" in error for error in snapshot_errors)
+    assert all("shut down" in error for error in snapshot_errors)
+    assert any("shut down during worker refresh" in error for error in snapshot_errors)
     assert aborted == ["worker-racing-shutdown"]
 
 


### PR DESCRIPTION
## Summary

- Accept both legal shutdown errors from concurrent `worker_snapshots()` callers: callers already in the shared refresh flight receive the refresh-specific error, while callers that lose the race to shutdown fail before joining.
- Continue requiring at least one refresh-specific shutdown error, along with the existing no-deadlock, single-flight, successful-shutdown, and single-abort assertions.
- Keep production behavior unchanged; this only removes a scheduling-dependent test assumption.

## Related issue

close: #226

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Target shutdown-race pytest: 1 passed
- Target shutdown-race test invoked 100 times under `taskset -c 0`: 100 passed
- `python -m pytest tests/fast/test_ray_cpp_bindings.py -m 'not real_ray' --import-mode=importlib -o pythonpath=tests -q`: 104 passed, 4 skipped
- `scripts/run_release_tests.sh`: 414 passed, 1 skipped (non-Ray); 7 passed (real Ray)
- `VANE_FAST_TEST_NON_RAY_SHARD_COUNT=2 VANE_FAST_TEST_NON_RAY_SHARD_INDEX=0 scripts/run_fast_tests.sh non-ray`: 2,866 passed, 11 skipped, 5 xfailed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
