### PR TITLE
[fix](udf) Fence Ray output lease cancellation

### DIFF
--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -512,12 +512,12 @@ def _create_actor_pools_for_nodes(
                 },
             }
 
-            stateful_options: dict[str, int] = {}
+            fault_tolerance_options: dict[str, int] = {}
+            if payload.get("side_effects"):
+                fault_tolerance_options["max_task_retries"] = 0
             if payload.get("stateful"):
-                stateful_options = {
-                    "max_restarts": 0,
-                    "max_task_retries": 0,
-                }
+                fault_tolerance_options["max_restarts"] = 0
+                fault_tolerance_options["max_task_retries"] = 0
 
             actors_obj = actor_pool_cls(
                 payload=payload,
@@ -525,7 +525,7 @@ def _create_actor_pools_for_nodes(
                 gpus_per_actor=gpus,
                 actor_node_ids=list(assigned_node_ids),
                 ray_options=ray_options,
-                **stateful_options,
+                **fault_tolerance_options,
             )
             created.append(actors_obj)
             if wait_for_ready:

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -97,7 +97,9 @@ class _StreamRecord:
     metadata: dict[str, Any] | None = None
     block_item_capacity_bytes: int | None = None
     output_request_id: str = ""
+    output_request: dict[str, Any] | None = None
     output_lease_ref: Any | None = None
+    output_cancel_sent: bool = False
     producer_completed: bool = False
     terminal: bool = False
     error_context: dict[str, Any] | None = None
@@ -659,23 +661,36 @@ class AsyncResultCollector:
         if driver is None:
             raise RuntimeError("Ray UDF stream has no query resource driver")
         request_id = f"output-request:{validated['block_id']}"
-        record.metadata = validated
-        record.output_request_id = request_id
-        record.output_lease_ref = driver.acquire_query_output_block_lease.remote(
-            {
-                "request_id": request_id,
-                "query_id": validated["query_id"],
-                "producer_stage_id": validated["producer_stage_id"],
-                "task_lease_id": validated["task_lease_id"],
-                "attempt_id": validated["attempt_id"],
-                "block_id": validated["block_id"],
-                "size_bytes": validated["size_bytes"],
-            }
-        )
+        request = {
+            "request_id": request_id,
+            "query_id": validated["query_id"],
+            "producer_stage_id": validated["producer_stage_id"],
+            "task_lease_id": validated["task_lease_id"],
+            "attempt_id": validated["attempt_id"],
+            "block_id": validated["block_id"],
+            "size_bytes": validated["size_bytes"],
+        }
         # Metadata is already consumed at this point.  Keep output admission as
         # its own state so producer completion cannot mistake a drained stream
         # for a block whose metadata never arrived.
-        record.phase = "output_lease"
+        key = (record.slot_id, record.submit_id)
+        with self._cv:
+            if self._shutdown or self._records.get(key) is not record or record.terminal:
+                return
+            record.metadata = validated
+            record.output_request_id = request_id
+            record.output_request = request
+            record.output_cancel_sent = False
+            record.phase = "output_lease"
+
+        output_lease_ref = driver.acquire_query_output_block_lease.remote(request)
+        with self._cv:
+            stale = self._shutdown or self._records.get(key) is not record or record.terminal
+            if not stale:
+                record.output_lease_ref = output_lease_ref
+        if stale:
+            self._cancel_record_control(record)
+            return
         _collector_debug_log("output_lease_requested", record)
 
     @staticmethod
@@ -750,7 +765,9 @@ class AsyncResultCollector:
                 record.metadata = None
                 record.block_item_capacity_bytes = None
                 record.output_request_id = ""
+                record.output_request = None
                 record.output_lease_ref = None
+                record.output_cancel_sent = False
                 self._cv.notify_all()
         if stale:
             driver.release_query_output_block_lease.remote(
@@ -781,11 +798,13 @@ class AsyncResultCollector:
         self._notify_wakeup()
 
     def _cancel_record_control(self, record: _StreamRecord) -> None:
-        if record.output_lease_ref is None or not record.output_request_id:
-            return
-        driver = record.adapter.driver
-        if driver is not None:
-            driver.cancel_query_output_block_lease_request.remote(record.output_request_id)
+        with self._cv:
+            request = record.output_request
+            driver = record.adapter.driver
+            if request is None or driver is None or record.output_cancel_sent:
+                return
+            record.output_cancel_sent = True
+        driver.cancel_query_output_block_lease_request.remote(request)
 
     def _fail_record(self, record: _StreamRecord, exc: BaseException) -> None:
         exc = format_stateful_actor_loss(record.error_context, exc)

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -3470,6 +3470,8 @@ class RayQueryDriverActor:
 
         request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
+        if str(request.query_id) in self._query_resource_closing_queries:
+            return {"cancelled": True, "released": False}
         request_key = request_id
         tombstone = self._query_output_lease_request_tombstones.get(request_key)
         if tombstone is not None and tombstone["identity"] != identity:

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -3047,6 +3047,29 @@ class RayQueryDriverActor:
         values["request_id"] = request_id
         return values
 
+    def _parse_output_block_lease_request(
+        self,
+        payload: dict[str, Any],
+    ) -> tuple[str, Any, dict[str, Any]]:
+        from duckdb.runners.ray.query_resource_manager import OutputBlockRequest
+
+        values = self._strict_lease_request(
+            payload,
+            fields={
+                "request_id",
+                "query_id",
+                "producer_stage_id",
+                "task_lease_id",
+                "attempt_id",
+                "block_id",
+                "size_bytes",
+            },
+            kind="output block",
+        )
+        request_id = values.pop("request_id")
+        request = OutputBlockRequest(**values)
+        return request_id, request, asdict(request)
+
     async def acquire_query_task_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Resolve one task lease through the query's serialized admission pump."""
         from duckdb.runners.ray.query_resource_manager import TaskGrant, TaskRequest
@@ -3286,25 +3309,10 @@ class RayQueryDriverActor:
 
     async def acquire_query_output_block_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Resolve one produced block through the query's admission pump."""
-        from duckdb.runners.ray.query_resource_manager import OutputBlockGrant, OutputBlockRequest
+        from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        values = self._strict_lease_request(
-            payload,
-            fields={
-                "request_id",
-                "query_id",
-                "producer_stage_id",
-                "task_lease_id",
-                "attempt_id",
-                "block_id",
-                "size_bytes",
-            },
-            kind="output block",
-        )
-        request_id = values.pop("request_id")
-        request = OutputBlockRequest(**values)
-        identity = asdict(request)
+        request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
         if str(request.query_id) in self._query_resource_closing_queries:
             return self._grant_payload(
@@ -3456,17 +3464,21 @@ class RayQueryDriverActor:
         self._run_query_resource_admission_pumps(lease["query_id"])
         return {"released": bool(released)}
 
-    async def cancel_query_output_block_lease_request(self, request_id: str) -> dict[str, Any]:
+    async def cancel_query_output_block_lease_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
+        request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
-        request_key = str(request_id)
+        request_key = request_id
+        tombstone = self._query_output_lease_request_tombstones.get(request_key)
+        if tombstone is not None and tombstone["identity"] != identity:
+            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
+        if tombstone is not None:
+            return {"cancelled": True, "released": False}
         state = self._query_output_lease_requests.get(request_key)
-        if state is None:
-            if request_key in self._query_output_lease_request_tombstones:
-                return {"cancelled": True, "released": False}
-            return {"cancelled": False, "released": False}
+        if state is not None and state["identity"] != identity:
+            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
         denial = self._grant_payload(
             OutputBlockGrant(
                 False,
@@ -3474,6 +3486,29 @@ class RayQueryDriverActor:
                 fatal=True,
             )
         )
+        if state is None:
+            resource_identity = (
+                str(identity["query_id"]),
+                str(identity["block_id"]),
+            )
+            conflicting_owner = self._query_output_request_owner_by_identity.get(resource_identity)
+            if conflicting_owner is not None:
+                raise ValueError(
+                    "output block is already owned by request_id "
+                    f"{conflicting_owner}: query_id={request.query_id} "
+                    f"block_id={request.block_id}"
+                )
+            try:
+                get_query_resource_manager(request.query_id).mark_output_block_terminal(request.block_id)
+            except KeyError:
+                pass
+            self._query_output_lease_request_tombstones[request_key] = {
+                "identity": identity,
+                "status": "cancelled",
+                "result": denial,
+            }
+            self._run_query_resource_admission_pumps(request.query_id)
+            return {"cancelled": True, "released": False}
         lease = state.get("lease")
         released = False
         if lease is not None:

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -1822,6 +1822,20 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
 
         runner_cls._close_query_resource_admission(runner, query_id)
         assert query_id in runner._query_resource_closing_queries
+        late_cancel = await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            {
+                "request_id": "request:late-old-generation-output",
+                "query_id": query_id,
+                "producer_stage_id": graph.stages[0].stage_id,
+                "task_lease_id": "lease:retired-old-generation-task",
+                "attempt_id": "attempt:retired-old-generation-task",
+                "block_id": "block:late-old-generation-output",
+                "size_bytes": 10,
+            },
+        )
+        assert late_cancel == {"cancelled": True, "released": False}
+        assert len(runner._query_output_lease_request_tombstones) == 0
         clear_query_resource_managers()
 
         manager = register_query_graph(graph, _allocation())

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -441,7 +441,7 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
 
         assert await runner_cls.cancel_query_output_block_lease_request(
             runner,
-            output_request["request_id"],
+            output_request,
         ) == {"cancelled": True, "released": False}
         denial = await asyncio.wait_for(pending, timeout=1)
         assert denial["blocked_reason"] == "output_lease_request_cancelled"
@@ -458,6 +458,124 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
             task["lease"]["lease_id"],
             task["lease"]["attempt_id"],
         )
+
+    asyncio.run(scenario())
+
+
+def test_driver_output_cancel_before_acquire_is_durable_and_restores_budget():
+    async def scenario():
+        query_id = "query-output-pre-cancel"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(
+            graph,
+            _allocation(),
+            on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
+        )
+        stage_id = graph.stages[0].stage_id
+        manager.update_stage_state(stage_id, runnable=True)
+        task_request = _task_request(query_id, "request:task", "task:pre-cancel-output")
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+        output_request = {
+            "request_id": "request:pre-cancel-output",
+            "query_id": query_id,
+            "producer_stage_id": stage_id,
+            "task_lease_id": task["lease"]["lease_id"],
+            "attempt_id": task["lease"]["attempt_id"],
+            "block_id": "block:pre-cancel-output",
+            "size_bytes": 10,
+        }
+        baseline = manager.snapshot()
+
+        assert await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            output_request,
+        ) == {"cancelled": True, "released": False}
+        denial = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+
+        assert denial["granted"] is False
+        assert denial["fatal"] is True
+        assert denial["blocked_reason"] == "output_lease_request_cancelled"
+        snapshot = manager.snapshot()
+        assert snapshot["output_leases"] == baseline["output_leases"]
+        assert (
+            snapshot["stages"][stage_id]["pending_output_count"] == baseline["stages"][stage_id]["pending_output_count"]
+        )
+        assert (
+            snapshot["stages"][stage_id]["queued_output_bytes"] == baseline["stages"][stage_id]["queued_output_bytes"]
+        )
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+
+    asyncio.run(scenario())
+
+
+def test_driver_output_cancel_after_grant_releases_late_lease_and_restores_budget():
+    async def scenario():
+        query_id = "query-output-late-grant-cancel"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(
+            graph,
+            _allocation(),
+            on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
+        )
+        stage_id = graph.stages[0].stage_id
+        manager.update_stage_state(stage_id, runnable=True)
+        task_request = _task_request(query_id, "request:task", "task:late-grant-output")
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+        output_request = {
+            "request_id": "request:late-grant-output",
+            "query_id": query_id,
+            "producer_stage_id": stage_id,
+            "task_lease_id": task["lease"]["lease_id"],
+            "attempt_id": task["lease"]["attempt_id"],
+            "block_id": "block:late-grant-output",
+            "size_bytes": 10,
+        }
+        baseline = manager.snapshot()
+
+        grant = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+        assert grant["granted"] is True
+        assert manager.snapshot()["output_leases"]
+
+        assert await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            output_request,
+        ) == {"cancelled": True, "released": True}
+
+        snapshot = manager.snapshot()
+        assert snapshot["output_leases"] == baseline["output_leases"]
+        assert (
+            snapshot["stages"][stage_id]["pending_output_count"] == baseline["stages"][stage_id]["pending_output_count"]
+        )
+        assert (
+            snapshot["stages"][stage_id]["queued_output_bytes"] == baseline["stages"][stage_id]["queued_output_bytes"]
+        )
+        replay = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+        assert replay["granted"] is False
+        assert replay["blocked_reason"] == "output_lease_request_cancelled"
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
 
     asyncio.run(scenario())
 
@@ -541,7 +659,7 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
                 continue
             assert await runner_cls.cancel_query_output_block_lease_request(
                 runner,
-                request["request_id"],
+                request,
             ) == {"cancelled": True, "released": False}
         results = await asyncio.gather(*output_tasks)
         for request, result in zip(output_requests, results):
@@ -675,7 +793,7 @@ def test_output_block_rejects_a_second_request_id_instead_of_orphaning_future():
 
         assert await runner_cls.cancel_query_output_block_lease_request(
             runner,
-            first_request["request_id"],
+            first_request,
         ) == {"cancelled": True, "released": False}
         denial = await first_waiter
         assert denial["blocked_reason"] == "output_lease_request_cancelled"

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -872,6 +872,64 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
     ]
 
 
+def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+    from duckdb.execution.udf_ray_config import MAX_ACTOR_RESTARTS
+
+    calls = []
+
+    class _FakeUDFActorPool:
+        def __init__(
+            self,
+            *,
+            payload,
+            concurrency,
+            gpus_per_actor,
+            actor_node_ids,
+            ray_options=None,
+            max_restarts=MAX_ACTOR_RESTARTS,
+            max_task_retries=None,
+        ):
+            calls.append((max_restarts, max_task_retries))
+            self.actors = ["side-effecting-actor"]
+            self._init_refs = []
+            self._confirmed_ready = set()
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.is_initialized = lambda: True
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
+    monkeypatch.setattr(udf_ray, "UDFActorPool", _FakeUDFActorPool)
+
+    plan = _FakePlan(
+        [
+            {
+                "node_id": 8,
+                "actor_pool_size": 1,
+                "gpus": 0.0,
+                "payload": {
+                    "udf_name": "external_counter",
+                    "execution_backend": "ray_actor",
+                    "stateful": False,
+                    "side_effects": True,
+                    "stage_id": "stage:test:side-effects",
+                },
+            }
+        ]
+    )
+
+    created, _ = udf_ray.ensure_actor_pools_for_plan(
+        plan,
+        actor_node_ids_by_stage={"stage:test:side-effects": ("node-a",)},
+        query_driver_handle=object(),
+        session_config={},
+        conn=object(),
+    )
+
+    assert len(created) == 1
+    assert calls == [(MAX_ACTOR_RESTARTS, 0)]
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -191,6 +191,20 @@ class _RemoteMethod:
         return _Ref(self.fn(*args, **kwargs))
 
 
+class _BlockingRemoteMethod(_RemoteMethod):
+    def __init__(self, fn):
+        super().__init__(fn)
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def remote(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        self.started.set()
+        if not self.release.wait(timeout=2.0):
+            raise TimeoutError("timed out waiting to release blocked remote call")
+        return _Ref(self.fn(*args, **kwargs))
+
+
 class _Driver:
     def __init__(self):
         self.next_task = 0
@@ -438,6 +452,48 @@ def test_metadata_transition_is_atomic_with_concurrent_capacity_refresh(
         assert [item[2] for item in events] == ["data", "complete"]
     finally:
         allow_transition.set()
+        collector.shutdown()
+
+
+def test_slot_cancel_fences_output_lease_acquire_before_ref_publication():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    acquire = _BlockingRemoteMethod(driver._acquire_output)
+    driver.acquire_query_output_block_lease = acquire
+
+    def submitter(lease):
+        return _Generator(
+            [_Ref("block", is_block=True), _Ref(_metadata(lease))],
+            completed=False,
+        )
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        24,
+        _source(
+            fake_ray,
+            driver,
+            request_id="cancel-during-output-acquire",
+            submitter=submitter,
+        ),
+    )
+    try:
+        collector.drain_results({2: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+        assert acquire.started.wait(timeout=2.0)
+
+        collector.cancel_slot(2)
+        acquire.release.set()
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not driver.cancel_query_output_block_lease_request.calls:
+            time.sleep(0.005)
+
+        assert len(driver.cancel_query_output_block_lease_request.calls) == 1
+        assert driver.cancel_query_output_block_lease_request.calls[0] == acquire.calls[0]
+        assert collector.slot_has_pending(2) is False
+    finally:
+        acquire.release.set()
         collector.shutdown()
 
 

--- a/tests/slow/test_expression_udf_side_effect_fault.py
+++ b/tests/slow/test_expression_udf_side_effect_fault.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fault-injection coverage for side-effecting Ray actor UDF retries."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("ray")
+
+
+@pytest.mark.real_ray
+@pytest.mark.ray_cluster_owner
+def test_side_effecting_ray_actor_crash_fails_without_replaying_call():
+    script = r"""
+import os
+import time
+import uuid
+
+import ray
+
+import duckdb.execution.udf_ray as udf_ray
+from duckdb.execution.udf_ray_config import MAX_ACTOR_RESTARTS, MAX_ACTOR_TASK_RETRIES
+
+
+CONTROL_NAMESPACE = f"vane-side-effect-fault-{uuid.uuid4().hex}"
+CONTROL_NAME = f"side-effect-fault-control-{uuid.uuid4().hex}"
+
+
+@ray.remote
+class FaultControl:
+    def __init__(self):
+        self.call_count = 0
+
+    def record_call(self):
+        self.call_count += 1
+
+    def snapshot(self):
+        return self.call_count
+
+
+class FakePlan:
+    def __init__(self):
+        self.handles = None
+
+    def collect_udf_nodes(self, conn=None):
+        return [
+            {
+                "node_id": 1,
+                "actor_pool_size": 1,
+                "gpus": 0.0,
+                "payload": {
+                    "execution_backend": "ray_actor",
+                    "side_effects": True,
+                    "stage_id": "stage:side-effect-fault",
+                },
+            }
+        ]
+
+    def set_udf_actor_handles(self, handles, conn=None):
+        self.handles = handles
+
+
+class FaultPool:
+    def __init__(
+        self,
+        *,
+        payload,
+        concurrency,
+        gpus_per_actor,
+        actor_node_ids,
+        ray_options=None,
+        max_restarts=MAX_ACTOR_RESTARTS,
+        max_task_retries=MAX_ACTOR_TASK_RETRIES,
+    ):
+        assert concurrency == 1
+        self.policy = (max_restarts, max_task_retries)
+
+        @ray.remote(
+            max_restarts=max_restarts,
+            max_task_retries=max_task_retries,
+            num_cpus=0,
+        )
+        class CrashAfterSideEffect:
+            def pid(self):
+                return os.getpid()
+
+            def crash(self, control):
+                ray.get(control.record_call.remote())
+                os._exit(23)
+
+        self.actors = [CrashAfterSideEffect.remote()]
+        self._init_refs = []
+        self._confirmed_ready = set()
+
+    def shutdown(self):
+        for actor in self.actors:
+            ray.kill(actor, no_restart=True)
+
+
+os.environ["RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO"] = "0"
+ray.init(
+    address="local",
+    namespace=CONTROL_NAMESPACE,
+    num_cpus=4,
+    ignore_reinit_error=True,
+    include_dashboard=False,
+)
+control = FaultControl.options(name=CONTROL_NAME, namespace=CONTROL_NAMESPACE).remote()
+udf_ray.UDFActorPool = FaultPool
+created = []
+try:
+    node_id = ray.get_runtime_context().get_node_id()
+    created, _ = udf_ray.ensure_actor_pools_for_plan(
+        FakePlan(),
+        actor_node_ids_by_stage={"stage:side-effect-fault": (node_id,)},
+        query_driver_handle=object(),
+        session_config={},
+    )
+    assert len(created) == 1
+    assert created[0].policy == (MAX_ACTOR_RESTARTS, 0)
+    actor = created[0].actors[0]
+    original_pid = ray.get(actor.pid.remote())
+
+    try:
+        ray.get(actor.crash.remote(control))
+    except Exception as exc:
+        print("FAULT_ERROR", type(exc).__name__, str(exc), flush=True)
+    else:
+        raise AssertionError("side-effecting actor call returned after its process exited")
+
+    replacement_pid = ray.get(actor.pid.remote(), timeout=15)
+    assert replacement_pid != original_pid
+    deadline = time.monotonic() + 5.0
+    call_count = 0
+    while time.monotonic() < deadline:
+        call_count = ray.get(control.snapshot.remote())
+        if call_count:
+            break
+        time.sleep(0.02)
+    assert call_count == 1
+    time.sleep(1.0)
+    assert ray.get(control.snapshot.remote()) == 1
+    print("FAULT_COUNT", call_count, flush=True)
+finally:
+    for pool in created:
+        pool.shutdown()
+    ray.shutdown()
+"""
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "FAULT_ERROR" in result.stdout
+    assert "FAULT_COUNT 1" in result.stdout


### PR DESCRIPTION
## Summary

- fence the collector metadata-to-output-lease transition by publishing the full request under the terminal-state lock
- make output cancellation durable when it reaches the driver before acquire, and release grants that win the opposite ordering
- disable Ray actor task replay for side-effecting UDFs while preserving actor restart for future calls
- add deterministic cancel/acquire barriers, output-budget checks, and a real-Ray crash/restart side-effect counter regression

## Root cause

The collector could pass its stale check, be cancelled before storing the output lease ref, and then submit an acquisition whose grant had no remaining owner. The driver cancellation API only accepted a request ID, so a cancel that arrived before acquire could not leave an identity-validated tombstone. Separately, Ray task UDFs disabled retries for `side_effects`, but non-stateful actor UDFs retained the default task retry policy.

## Validation

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- targeted lease/collector/actor regressions: 87 passed
- `scripts/run_release_tests.sh`: 414 passed, 1 skipped; real-Ray shard 7 passed
- `scripts/run_fast_tests.sh`: 5734 passed, 30 skipped, 9 xfailed; shared-Ray shard 86 passed, 9 skipped; test-owned Ray shards passed

Fixes #92