### PR TITLE
[fix](ray) Backpressure FTE splits and harden native loop lifecycle

### DIFF
--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -6,13 +6,15 @@ from __future__ import annotations
 import asyncio
 import copy
 import inspect
+import math
 import os
 import sys
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -168,55 +170,206 @@ def _native_pending_status_fields(
 
 
 class _BackgroundEventLoop:
-    def __init__(self, thread_name: str) -> None:
+    _NEW = "NEW"
+    _STARTING = "STARTING"
+    _RUNNING = "RUNNING"
+    _STOPPING = "STOPPING"
+    _CLOSED = "CLOSED"
+    _FAILED = "FAILED"
+
+    def __init__(
+        self,
+        thread_name: str,
+        *,
+        start_timeout_s: float = 5.0,
+        operation_timeout_s: float = 30.0,
+    ) -> None:
         self._thread_name = thread_name
+        self._start_timeout_s = float(start_timeout_s)
+        self._operation_timeout_s = float(operation_timeout_s)
+        if not math.isfinite(self._start_timeout_s) or self._start_timeout_s <= 0:
+            raise ValueError("native FTE event-loop start timeout must be finite and positive")
+        if not math.isfinite(self._operation_timeout_s) or self._operation_timeout_s <= 0:
+            raise ValueError("native FTE event-loop operation timeout must be finite and positive")
+        self._condition = threading.Condition(threading.RLock())
+        self._state = self._NEW
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
-        self._ready = threading.Event()
-        self._closed = False
+        self._failure: BaseException | None = None
+        self._pending_futures: set[Future[Any]] = set()
 
-    def start(self) -> None:
-        if self._loop is not None:
-            return
+    @staticmethod
+    def _close_awaitable(awaitable: Awaitable[Any]) -> None:
+        close = getattr(awaitable, "close", None)
+        if callable(close):
+            close()
 
-        def run() -> None:
+    def _raise_unavailable_locked(self) -> None:
+        failure = self._failure
+        if failure is not None:
+            raise RuntimeError("native FTE event loop failed") from failure
+        if self._state == self._STOPPING:
+            raise RuntimeError("native FTE event loop is stopping")
+        raise RuntimeError("native FTE event loop is closed")
+
+    def _thread_main(self) -> None:
+        loop: asyncio.AbstractEventLoop | None = None
+        failure: BaseException | None = None
+        should_run = False
+        try:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            self._loop = loop
-            self._ready.set()
-            loop.run_forever()
-            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
-            for task in pending:
-                task.cancel()
-            if pending:
-                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-            loop.close()
+            with self._condition:
+                if self._state == self._STARTING:
+                    self._loop = loop
+                    self._state = self._RUNNING
+                    should_run = True
+                self._condition.notify_all()
 
-        self._thread = threading.Thread(target=run, name=self._thread_name, daemon=True)
-        self._thread.start()
-        if not self._ready.wait(timeout=5.0):
-            raise RuntimeError("failed to start native FTE event loop")
+            if should_run:
+                loop.run_forever()
+                with self._condition:
+                    if self._state == self._RUNNING:
+                        failure = RuntimeError("native FTE event loop stopped unexpectedly")
+                        self._failure = failure
+                    self._state = self._STOPPING
+                    pending_futures = tuple(self._pending_futures)
+                    self._condition.notify_all()
+                for future in pending_futures:
+                    future.cancel()
+        except BaseException as exc:
+            failure = exc
+            with self._condition:
+                self._failure = exc
+                self._state = self._STOPPING
+                pending_futures = tuple(self._pending_futures)
+                self._condition.notify_all()
+            for future in pending_futures:
+                future.cancel()
+        finally:
+            if loop is not None:
+                try:
+                    pending_tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
+                    for task in pending_tasks:
+                        task.cancel()
+                    if pending_tasks:
+                        loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
+                except BaseException as exc:
+                    if failure is None:
+                        failure = exc
+                try:
+                    loop.close()
+                except BaseException as exc:
+                    if failure is None:
+                        failure = exc
+                asyncio.set_event_loop(None)
+            with self._condition:
+                self._loop = None
+                self._pending_futures.clear()
+                if failure is not None:
+                    self._failure = failure
+                self._state = self._FAILED if self._failure is not None else self._CLOSED
+                self._condition.notify_all()
 
-    def submit(self, coro: Awaitable[Any]) -> Future:
-        if self._closed:
-            raise RuntimeError("native FTE event loop is closed")
-        self.start()
-        assert self._loop is not None
-        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+    def start(self) -> None:
+        deadline = time.monotonic() + self._start_timeout_s
+        with self._condition:
+            if self._state == self._NEW:
+                self._state = self._STARTING
+                thread = threading.Thread(
+                    target=self._thread_main,
+                    name=self._thread_name,
+                    daemon=True,
+                )
+                self._thread = thread
+                try:
+                    thread.start()
+                except BaseException as exc:
+                    self._failure = exc
+                    self._state = self._FAILED
+                    self._condition.notify_all()
+                    raise RuntimeError("failed to start native FTE event loop") from exc
+            while self._state == self._STARTING:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    failure = TimeoutError("native FTE event-loop startup timed out")
+                    self._failure = failure
+                    self._state = self._STOPPING
+                    self._condition.notify_all()
+                    raise RuntimeError("failed to start native FTE event loop") from failure
+                self._condition.wait(remaining)
+            if self._state == self._RUNNING:
+                return
+            self._raise_unavailable_locked()
 
-    def run(self, coro: Awaitable[Any], timeout_s: float | None = None) -> Any:
-        return self.submit(coro).result(timeout=timeout_s)
+    def _discard_future(self, future: Future[Any]) -> None:
+        with self._condition:
+            self._pending_futures.discard(future)
+
+    def submit(self, coro: Coroutine[Any, Any, Any]) -> Future[Any]:
+        try:
+            self.start()
+            with self._condition:
+                if self._state != self._RUNNING or self._loop is None:
+                    self._raise_unavailable_locked()
+                loop = self._loop
+                assert loop is not None
+                future: Future[Any] = asyncio.run_coroutine_threadsafe(coro, loop)
+                self._pending_futures.add(future)
+                future.add_done_callback(self._discard_future)
+                return future
+        except BaseException:
+            self._close_awaitable(coro)
+            raise
+
+    def run(self, coro: Coroutine[Any, Any, Any], timeout_s: float | None = None) -> Any:
+        timeout_s = self._operation_timeout_s if timeout_s is None else float(timeout_s)
+        if not math.isfinite(timeout_s) or timeout_s < 0:
+            self._close_awaitable(coro)
+            raise ValueError("native FTE event-loop operation timeout must be finite and non-negative")
+        future = self.submit(coro)
+        try:
+            return future.result(timeout=timeout_s)
+        except FutureTimeoutError as exc:
+            if future.done():
+                return future.result()
+            future.cancel()
+            raise TimeoutError(f"native FTE event-loop operation timed out after {timeout_s:.3f}s") from exc
 
     def shutdown(self, timeout_s: float = 5.0) -> None:
-        if self._closed:
+        timeout_s = float(timeout_s)
+        if not math.isfinite(timeout_s) or timeout_s < 0:
+            raise ValueError("native FTE event-loop shutdown timeout must be finite and non-negative")
+        with self._condition:
+            if self._state == self._CLOSED:
+                return
+            if self._state == self._NEW:
+                self._state = self._CLOSED
+                self._condition.notify_all()
+                return
+            if self._state == self._FAILED:
+                self._state = self._CLOSED
+                self._condition.notify_all()
+            elif self._state in {self._STARTING, self._RUNNING}:
+                self._state = self._STOPPING
+                loop = self._loop
+                if loop is not None:
+                    try:
+                        loop.call_soon_threadsafe(loop.stop)
+                    except BaseException as exc:
+                        self._failure = exc
+                self._condition.notify_all()
+            thread = self._thread
+        if thread is None or thread is threading.current_thread():
             return
-        self._closed = True
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            loop.call_soon_threadsafe(loop.stop)
-        thread = self._thread
-        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+        if thread.is_alive():
             thread.join(timeout=timeout_s)
+        if thread.is_alive():
+            raise RuntimeError(f"native FTE event loop did not stop within {timeout_s:.3f}s")
+        with self._condition:
+            if self._state in {self._STOPPING, self._FAILED}:
+                self._state = self._CLOSED
+                self._condition.notify_all()
 
 
 def _as_status(method_name: str, value: Any) -> dict[str, Any]:
@@ -381,9 +534,7 @@ def _normalize_result_for_cxx(value: Any) -> Any:
     partition_refs = []
     for index, payload in enumerate(payloads or []):
         if index < len(metadatas or []):
-            num_rows, size_bytes = _metadata_rows_bytes(metadatas[index])
-        else:
-            num_rows, size_bytes = 0, 0
+            _metadata_rows_bytes(metadatas[index])
         if isinstance(payload, RayResultPartitionRef):
             partition_refs.append(payload)
         else:
@@ -654,16 +805,18 @@ class _NativeFteProgressRegistry:
             fragment_executions: dict[str, dict[str, Any]] = {}
             for fragment_id, registered in fragments.items():
                 partitions: dict[str, dict[str, Any]] = {}
-                for partition_id, partition in registered.partitions.items():
+                for partition_id, registered_partition in registered.partitions.items():
                     metrics_key = (query_id, fragment_id, partition_id)
                     metrics = partition_metrics.get(metrics_key)
                     if metrics is not None:
-                        partition.last_metrics = dict(metrics)
-                    metrics = dict(partition.last_metrics or self._placeholder_partition_metrics(partition))
+                        registered_partition.last_metrics = dict(metrics)
+                    metrics = dict(
+                        registered_partition.last_metrics or self._placeholder_partition_metrics(registered_partition)
+                    )
                     self._merge_fragment_progress_topology_locked(registered, metrics)
                     partitions[partition_id] = metrics
                     if str(metrics.get("state") or "").upper() == "FINISHED":
-                        selected_attempt_ids.add(str(partition.task_id))
+                        selected_attempt_ids.add(str(registered_partition.task_id))
 
                 partition_count = len(partitions)
                 running_count = sum(int(partition.get("running_count") or 0) for partition in partitions.values())
@@ -953,7 +1106,7 @@ class NativeWorkerHandle:
         source_node_id: str,
         splits: Sequence[Mapping[str, Any]],
     ) -> dict[str, Any]:
-        split_payloads = [dict(split) for split in splits]
+        split_payloads: list[Mapping[str, Any]] = [dict(split) for split in splits]
         return _as_status(
             "fte_add_splits",
             self._loop.run(self._manager.add_splits(task_id, str(source_node_id), split_payloads)),
@@ -994,9 +1147,13 @@ class NativeWorkerHandle:
         min_version: int | None = None,
         timeout_s: float | None = None,
     ) -> dict[str, Any]:
+        loop_timeout_s = None if timeout_s is None else max(5.0, float(timeout_s) + 5.0)
         return _as_status(
             "fte_wait_task_status",
-            self._loop.run(self._manager.wait_task_status(task_id, min_version, timeout_s)),
+            self._loop.run(
+                self._manager.wait_task_status(task_id, min_version, timeout_s),
+                timeout_s=loop_timeout_s,
+            ),
         )
 
     def fte_wait_split_queue_has_space(
@@ -1006,6 +1163,7 @@ class NativeWorkerHandle:
         max_buffered_splits: int | None = None,
         timeout_s: float | None = None,
     ) -> dict[str, Any]:
+        loop_timeout_s = None if timeout_s is None else max(5.0, float(timeout_s) + 5.0)
         return _as_status(
             "fte_wait_split_queue_has_space",
             self._loop.run(
@@ -1014,7 +1172,8 @@ class NativeWorkerHandle:
                     source_node_id,
                     max_buffered_splits,
                     timeout_s,
-                )
+                ),
+                timeout_s=loop_timeout_s,
             ),
         )
 
@@ -1096,6 +1255,7 @@ class NativeFteWorkerManagerBackend:
         self._dropped_queries: dict[str, dict[str, Any]] = {}
         self._progress_registry = _NativeFteProgressRegistry()
         self._closed = False
+        self._closing = False
         self._debug_sampler_stop = threading.Event()
         self._debug_sampler_thread: threading.Thread | None = None
         if _native_submit_debug_enabled():
@@ -1135,6 +1295,8 @@ class NativeFteWorkerManagerBackend:
     def submit_tasks(self, tasks: Sequence[Any]) -> Sequence[NativeTaskResultHandle]:
         if self._closed:
             raise RuntimeError("native FTE worker manager is shut down")
+        if self._closing:
+            raise RuntimeError("native FTE worker manager is shutting down")
         submit_started_at = time.monotonic()
         batch_size = len(tasks)
         submitted_count = 0
@@ -1435,11 +1597,8 @@ class NativeFteWorkerManagerBackend:
                     **({"task_stats": progress_stats} if progress_stats else {}),
                 }
             )
-        output_stats = (
-            dict(status.get("spooling_output_stats"))
-            if isinstance(status.get("spooling_output_stats"), Mapping)
-            else status.get("spooling_output_stats")
-        )
+        raw_output_stats = status.get("spooling_output_stats")
+        output_stats = dict(raw_output_stats) if isinstance(raw_output_stats, Mapping) else raw_output_stats
         selected_output_stats: Any = None
         if finished:
             selected_output_stats = progress_stats or output_stats
@@ -1595,10 +1754,19 @@ class NativeFteWorkerManagerBackend:
     def shutdown(self) -> None:
         if self._closed:
             return
-        self._closed = True
+        self._closing = True
         self._stop_debug_sampler()
+        worker_errors: list[str] = []
         for worker in self._workers:
-            worker.shutdown()
+            worker_id = str(getattr(worker, "worker_id", "") or "<unknown>")
+            try:
+                worker.shutdown()
+            except BaseException as exc:
+                worker_errors.append(f"{worker_id}: {type(exc).__name__}: {exc}")
+        if worker_errors:
+            raise RuntimeError("native FTE worker manager shutdown failed: " + "; ".join(worker_errors))
+        self._closed = True
+        self._closing = False
 
     def _start_debug_sampler(self) -> None:
         if self._debug_sampler_thread is not None:

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import threading
 import time
 from collections import deque
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,19 @@ if TYPE_CHECKING:
     from duckdb.runners.fte.fte_events import FteEvent, FteWorkerCommand
 
 
+class FteSplitSubmissionCancelled(InterruptedError):
+    """Split backpressure wait stopped because the owning query is closing."""
+
+
+class FteSplitQueueTerminal(RuntimeError):
+    """The target task became terminal while split submission was backpressured."""
+
+    def __init__(self, attempt_id: Any, status: Mapping[str, Any]) -> None:
+        self.attempt_id = attempt_id
+        self.status = dict(status)
+        super().__init__(f"split queue task {attempt_id} became terminal with state {self.status.get('state')}")
+
+
 class FteWorkerCommandExecutor:
     """Execute typed commands through the worker's single ordered control lane."""
 
@@ -62,26 +76,106 @@ class FteWorkerCommandExecutor:
             raise RuntimeError(f"FTE worker handle must provide {method_name}")
         return method
 
-    def wait_split_queue_has_space(self, command: FteAddSplitsCommand) -> None:
-        worker = command.worker
-        space = self._required_worker_method(worker, "fte_wait_split_queue_has_space")(
-            command.attempt_id.to_dict(),
-            command.source_node_id,
-            None,
-            None,
-        )
-        if not bool(space.get("has_space", True)):
-            raise RuntimeError(f"split queue for task {command.attempt_id} source {command.source_node_id} stayed full")
+    @staticmethod
+    def _cancel_requested(cancel_event: Any) -> bool:
+        return cancel_event is not None and bool(cancel_event.is_set())
 
-    def add_splits(self, command: FteAddSplitsCommand) -> Any:
+    @classmethod
+    def _raise_if_split_submission_cancelled(
+        cls,
+        command: FteAddSplitsCommand,
+        cancel_event: Any,
+    ) -> None:
+        if cls._cancel_requested(cancel_event):
+            raise FteSplitSubmissionCancelled(
+                f"split submission canceled for task {command.attempt_id} source {command.source_node_id}"
+            )
+
+    def wait_split_queue_has_space(
+        self,
+        command: FteAddSplitsCommand,
+        *,
+        cancel_event: Any = None,
+    ) -> None:
+        worker = command.worker
+        wait_interruptibly = getattr(worker, "fte_wait_split_queue_has_space_interruptible", None)
+        wait_for_space = self._required_worker_method(worker, "fte_wait_split_queue_has_space")
+        while True:
+            self._raise_if_split_submission_cancelled(command, cancel_event)
+            try:
+                if cancel_event is not None and callable(wait_interruptibly):
+                    space = wait_interruptibly(
+                        command.attempt_id.to_dict(),
+                        command.source_node_id,
+                        None,
+                        None,
+                        cancel_event,
+                    )
+                else:
+                    space = wait_for_space(
+                        command.attempt_id.to_dict(),
+                        command.source_node_id,
+                        None,
+                        None,
+                    )
+            except QueryDeadlineExceeded:
+                raise
+            except Exception as exc:
+                if self._cancel_requested(cancel_event):
+                    raise FteSplitSubmissionCancelled(
+                        f"split submission canceled for task {command.attempt_id} source {command.source_node_id}"
+                    ) from exc
+                raise
+            self._raise_if_split_submission_cancelled(command, cancel_event)
+            if not isinstance(space, Mapping):
+                raise TypeError("fte_wait_split_queue_has_space must return a mapping")
+            has_space = space.get("has_space")
+            if not isinstance(has_space, bool):
+                raise TypeError("fte_wait_split_queue_has_space must return a boolean has_space")
+            status = space.get("status")
+            if not isinstance(status, Mapping):
+                raise TypeError("fte_wait_split_queue_has_space must return a task status mapping")
+            validate_fte_status_identity(status, command.attempt_id)
+            raw_state = status.get("state")
+            try:
+                state = raw_state if isinstance(raw_state, FteTaskState) else FteTaskState(str(raw_state))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"unknown FTE task state while waiting for split queue space: {raw_state!r}") from exc
+            if state in {
+                FteTaskState.FINISHED,
+                FteTaskState.FAILED,
+                FteTaskState.CANCELED,
+                FteTaskState.ABORTED,
+            }:
+                raise FteSplitQueueTerminal(
+                    command.attempt_id,
+                    status,
+                )
+            if has_space:
+                return
+
+    def add_splits(
+        self,
+        command: FteAddSplitsCommand,
+        *,
+        cancel_event: Any = None,
+    ) -> Any:
         self._record(command)
         worker = command.worker
         split_payloads = [dict(split) for split in command.splits]
         task_id = command.attempt_id.to_dict()
-        return self._required_worker_method(worker, "enqueue_fte_add_splits")(
+        enqueue = self._required_worker_method(worker, "enqueue_fte_add_splits")
+        if cancel_event is None:
+            return enqueue(
+                task_id,
+                command.source_node_id,
+                split_payloads,
+            )
+        return enqueue(
             task_id,
             command.source_node_id,
             split_payloads,
+            cancel_event=cancel_event,
         )
 
     def no_more_splits(self, command: FteNoMoreSplitsCommand) -> Any:
@@ -100,12 +194,25 @@ class FteWorkerCommandExecutor:
         update = dict(command.update)
         return self._required_worker_method(worker, "enqueue_fte_update_task")(task_id, update)
 
-    def execute(self, command: Any) -> Any:
+    def execute(self, command: Any, *, cancel_event: Any = None) -> Any:
         if isinstance(command, FteCreateTaskCommand):
             return self.create_task(command)
         if isinstance(command, FteAddSplitsCommand):
-            self.wait_split_queue_has_space(command)
-            return self.add_splits(command)
+            if cancel_event is None:
+                self.wait_split_queue_has_space(command)
+                return self.add_splits(command)
+            self.wait_split_queue_has_space(command, cancel_event=cancel_event)
+            self._raise_if_split_submission_cancelled(command, cancel_event)
+            try:
+                return self.add_splits(command, cancel_event=cancel_event)
+            except Exception as exc:
+                # Query close can win after capacity becomes available, either
+                # before or while the ordered add-splits control is running.
+                if self._cancel_requested(cancel_event):
+                    raise FteSplitSubmissionCancelled(
+                        f"split submission canceled for task {command.attempt_id} source {command.source_node_id}"
+                    ) from exc
+                raise
         if isinstance(command, FteNoMoreSplitsCommand):
             return self.no_more_splits(command)
         if isinstance(command, FteTaskUpdateCommand):

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -559,10 +559,12 @@ class FteTaskExecution:
         while True:
             buffered = self._source_buffered_splits(source_node_id)
             buffered_bytes = self._source_buffered_bytes(source_node_id)
-            has_space = buffered < max_buffered_splits or self.status.state in _TERMINAL_STATES
-            if has_space:
+            has_space = buffered < max_buffered_splits
+            terminal = self.status.state in _TERMINAL_STATES
+            if has_space or terminal:
                 return {
-                    "has_space": True,
+                    "has_space": has_space,
+                    "terminal": terminal,
                     "buffered_splits": buffered,
                     "buffered_bytes": buffered_bytes,
                     "max_buffered_splits": max_buffered_splits,
@@ -572,6 +574,7 @@ class FteTaskExecution:
             if remaining <= 0:
                 return {
                     "has_space": False,
+                    "terminal": False,
                     "buffered_splits": buffered,
                     "buffered_bytes": buffered_bytes,
                     "max_buffered_splits": max_buffered_splits,
@@ -729,8 +732,8 @@ class FteTaskExecution:
         required_sources = {str(source) for source in explicit_sources}
         if not required_sources:
             required_sources = set(self.initial_splits) | set(self.seen_sequences)
-            required_sources.difference_update(self.dynamic_scan_source_ids)
-            required_sources.difference_update(self.dynamic_exchange_source_ids)
+        required_sources.difference_update(self.dynamic_scan_source_ids)
+        required_sources.difference_update(self.dynamic_exchange_source_ids)
         if not required_sources:
             return True
         return required_sources.issubset(self.no_more_split_sources)

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -8,9 +8,14 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.common import QueryDeadlineExceeded
 from duckdb.runners.fte import fte_status_wait_timeout_s
-from duckdb.runners.fte.fte_events import FteCreateTaskCommand
-from duckdb.runners.fte.fte_scheduler import FteAttemptStatusWatcher
+from duckdb.runners.fte.fte_events import FteCreateTaskCommand, TaskStatusChanged
+from duckdb.runners.fte.fte_scheduler import (
+    FteAttemptStatusWatcher,
+    FteSplitQueueTerminal,
+    FteSplitSubmissionCancelled,
+)
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_REGISTRY_LOCK,
@@ -46,6 +51,17 @@ def _fte_command_debug_log(event: str, **fields: Any) -> None:
     print("[vane-fte-command] " + " ".join(parts), file=sys.stderr, flush=True)
 
 
+class _FteQueryClosingEvent:
+    """Event-compatible view of one query's registry close state."""
+
+    def __init__(self, query_id: str) -> None:
+        self._query_id = str(query_id)
+
+    def is_set(self) -> bool:
+        with _FTE_REGISTRY_LOCK:
+            return self._query_id in _FTE_CLOSING_QUERIES
+
+
 class FteWorkerCommandMixin:
     if TYPE_CHECKING:
         # Supplied by the other mixins on the composed Ray worker handle.
@@ -58,16 +74,20 @@ class FteWorkerCommandMixin:
         fragment_execution: FteFragmentExecution,
         worker_commands: list[Any] | tuple[Any, ...],
     ) -> None:
+        terminal_attempts: set[str] = set()
         for command_index, command in enumerate(worker_commands):
             query_id = str(command.query_id)
+            attempt_id = getattr(command, "attempt_id", None)
+            if attempt_id is not None and str(attempt_id) in terminal_attempts:
+                continue
             if not begin_fte_registry_operation(query_id):
                 return
             try:
                 scheduler = _FTE_SCHEDULERS.get_or_create(query_id)
                 self._bind_fte_scheduler_handlers(scheduler)
+                query_closing = _FteQueryClosingEvent(query_id)
                 started_at = time.monotonic()
                 command_type = getattr(command, "command_type", type(command).__name__)
-                attempt_id = getattr(command, "attempt_id", None)
                 _fte_command_debug_log(
                     "execute_command_start",
                     command_index=command_index,
@@ -86,8 +106,32 @@ class FteWorkerCommandMixin:
                             command.partition_id,
                             command.attempt_id,
                         )
-                    scheduler.worker_command_executor.execute(command)
+                    scheduler.worker_command_executor.execute(
+                        command,
+                        cancel_event=query_closing,
+                    )
+                except FteSplitSubmissionCancelled:
+                    if query_closing.is_set():
+                        return
+                    raise
+                except FteSplitQueueTerminal as exc:
+                    if query_closing.is_set():
+                        return
+                    terminal_attempts.add(str(exc.attempt_id))
+                    scheduler.enqueue(
+                        TaskStatusChanged.from_status(
+                            query_id,
+                            exc.attempt_id,
+                            exc.status,
+                        ),
+                        priority=True,
+                    )
+                    continue
+                except QueryDeadlineExceeded:
+                    raise
                 except Exception as exc:
+                    if query_closing.is_set():
+                        return
                     _fte_command_debug_log(
                         "execute_command_error",
                         command_index=command_index,

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from duckdb.runners.fte import FteTaskAttemptId, validate_fte_status_identity
@@ -94,34 +94,59 @@ class FteWorkerTaskControlMixin:
         raise last_error
 
     @staticmethod
+    def _cancel_fte_control_ref(
+        ref: Any,
+        on_cancel: Callable[[], None] | None,
+    ) -> None:
+        if on_cancel is not None:
+            on_cancel()
+        try:
+            import ray
+
+            ray.cancel(ref, force=False)
+        except Exception:
+            pass
+
+    @staticmethod
     def _get_fte_control_ref(
         method_name: str,
         ref: Any,
         timeout_s: float | None = None,
         cancel_event: Any = None,
         honor_query_deadline: bool = True,
+        on_cancel: Callable[[], None] | None = None,
     ) -> Any:
         resolved_timeout_s = _fte_control_rpc_timeout_s() if timeout_s is None else max(0.0, float(timeout_s))
         if cancel_event is not None:
-            resolved_timeout_s = configured_ray_get_timeout_s(resolved_timeout_s)
+            try:
+                resolved_timeout_s = configured_ray_get_timeout_s(resolved_timeout_s)
+            except QueryDeadlineExceeded:
+                FteWorkerTaskControlMixin._cancel_fte_control_ref(ref, on_cancel)
+                raise
             deadline = None if resolved_timeout_s is None else time.monotonic() + resolved_timeout_s
             future = ref.future()
             while True:
                 if cancel_event.is_set():
-                    try:
-                        import ray
-
-                        ray.cancel(ref, force=False)
-                    except Exception:
-                        pass
-                    raise InterruptedError(f"{method_name} interrupted by watcher shutdown")
+                    FteWorkerTaskControlMixin._cancel_fte_control_ref(ref, on_cancel)
+                    raise InterruptedError(f"{method_name} interrupted by cancellation")
+                # Preserve a query-wide deadline as a query failure rather than
+                # misclassifying it as an individual control RPC timeout.
+                try:
+                    configured_ray_get_timeout_s(None)
+                except QueryDeadlineExceeded:
+                    FteWorkerTaskControlMixin._cancel_fte_control_ref(ref, on_cancel)
+                    raise
                 remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
                 if remaining is not None and remaining <= 0.0:
+                    FteWorkerTaskControlMixin._cancel_fte_control_ref(ref, on_cancel)
                     raise TimeoutError(f"{method_name} did not complete within {resolved_timeout_s:.3f}s")
                 wait_slice = 0.05 if remaining is None else min(0.05, remaining)
                 try:
                     return future.result(timeout=wait_slice)
                 except concurrent.futures.TimeoutError:
+                    done = getattr(future, "done", None)
+                    if callable(done) and done():
+                        return future.result()
                     continue
         try:
             if honor_query_deadline:
@@ -137,6 +162,8 @@ class FteWorkerTaskControlMixin:
         except QueryDeadlineExceeded:
             raise
         except TimeoutError as exc:
+            if honor_query_deadline:
+                configured_ray_get_timeout_s(None)
             raise TimeoutError(f"{method_name} did not complete within {resolved_timeout_s:.3f}s") from exc
 
     def _enqueue_ordered_fte_control_rpc(
@@ -145,9 +172,60 @@ class FteWorkerTaskControlMixin:
         task_id: str | dict[str, Any],
         *args: Any,
         timeout_s: float | None = None,
+        cancel_event: Any = None,
     ) -> Any:
-        ref = self._enqueue_ordered_fte_control_ref(method_name, task_id, *args)
-        return self._get_fte_control_ref(method_name, ref, timeout_s=timeout_s)
+        tracked_query_id: str | None = None
+        owns_registry_operation = False
+        if cancel_event is not None:
+            tracked_query_id = FteTaskAttemptId.coerce(task_id).task_id.query_id
+            if not begin_fte_registry_operation(tracked_query_id):
+                raise RuntimeError(f"FTE query registry is closing: {tracked_query_id}")
+            owns_registry_operation = True
+        try:
+            ref = self._enqueue_ordered_fte_control_ref(method_name, task_id, *args)
+            if owns_registry_operation:
+                assert tracked_query_id is not None
+                transfer_fte_registry_operations_to_ref([tracked_query_id], ref)
+                owns_registry_operation = False
+            on_cancel = None
+            if cancel_event is not None:
+
+                def discard_ref() -> None:
+                    self._discard_ordered_fte_control_ref(task_id, ref)
+
+                on_cancel = discard_ref
+            return self._get_fte_control_ref(
+                method_name,
+                ref,
+                timeout_s=timeout_s,
+                cancel_event=cancel_event,
+                on_cancel=on_cancel,
+            )
+        finally:
+            if owns_registry_operation:
+                assert tracked_query_id is not None
+                end_fte_registry_operation(tracked_query_id)
+
+    def _discard_ordered_fte_control_ref(
+        self,
+        task_id: str | dict[str, Any],
+        ref: Any,
+    ) -> None:
+        task_key = str(FteTaskAttemptId.coerce(task_id))
+        with self._fte_control_lock:
+            if self._fte_control_tails_by_task.get(task_key) is not ref:
+                return
+            self._fte_control_tails_by_task.pop(task_key, None)
+            self._fte_control_query_by_task.pop(task_key, None)
+            self._fte_control_operation_by_task.pop(task_key, None)
+
+    def _is_current_ordered_fte_control_ref(
+        self,
+        task_key: str,
+        ref: Any,
+    ) -> bool:
+        with self._fte_control_lock:
+            return self._fte_control_tails_by_task.get(task_key) is ref
 
     def _enqueue_ordered_fte_control_ref(
         self,
@@ -298,8 +376,16 @@ class FteWorkerTaskControlMixin:
         task_id: str | dict[str, Any],
         source_node_id: str,
         splits: list[dict[str, Any]],
+        *,
+        cancel_event: Any = None,
     ) -> dict[str, Any]:
-        raw_status = self._enqueue_ordered_fte_control_rpc("fte_add_splits", task_id, source_node_id, splits)
+        raw_status = self._enqueue_ordered_fte_control_rpc(
+            "fte_add_splits",
+            task_id,
+            source_node_id,
+            splits,
+            cancel_event=cancel_event,
+        )
         if not isinstance(raw_status, dict):
             raise TypeError("worker actor fte_add_splits must return a dict")
         return dict(raw_status)
@@ -427,6 +513,31 @@ class FteWorkerTaskControlMixin:
             raise TypeError("worker actor fte_wait_split_queue_has_space must return a dict")
         return dict(raw_status)
 
+    def fte_wait_split_queue_has_space_interruptible(
+        self,
+        task_id: str | dict[str, Any],
+        source_node_id: str | None,
+        max_buffered_splits: int | None,
+        timeout_s: float | None,
+        stop_event: Any,
+    ) -> dict[str, Any]:
+        server_timeout_s = None if timeout_s is None else max(0.0, float(timeout_s))
+        client_timeout_s = None
+        if server_timeout_s is not None:
+            client_timeout_s = max(30.0, server_timeout_s + 5.0)
+        raw_status = self._fte_control_rpc(
+            "fte_wait_split_queue_has_space",
+            task_id,
+            source_node_id,
+            max_buffered_splits,
+            server_timeout_s,
+            timeout_s=client_timeout_s,
+            cancel_event=stop_event,
+        )
+        if not isinstance(raw_status, dict):
+            raise TypeError("worker actor fte_wait_split_queue_has_space must return a dict")
+        return dict(raw_status)
+
     def fte_get_task_info(self, task_id: str | dict[str, Any]) -> dict[str, Any]:
         raw_info = self._fte_control_rpc("fte_get_task_info", task_id)
         if not isinstance(raw_info, dict):
@@ -471,56 +582,80 @@ class FteWorkerTaskControlMixin:
         except BaseException as exc:
             barrier_resolution_error = exc
 
-        statuses: list[dict[str, Any]] = []
+        status_entries: list[tuple[str, Any, dict[str, Any]]] = []
         terminal_entries: list[tuple[str, Any, str]] = []
         pending_entries: list[tuple[str, Any, str]] = []
-        terminal_errors: list[str] = []
+        terminal_error_entries: list[tuple[str, Any, str]] = []
 
         if raw_statuses is None:
             resolved_entries: list[tuple[tuple[str, Any, str], Any]] = []
             for entry in pending:
                 task_key, ref, _ = entry
+                if not self._is_current_ordered_fte_control_ref(task_key, ref):
+                    continue
                 future_method = getattr(ref, "future", None)
                 if not callable(future_method):
-                    terminal_entries.append(entry)
-                    terminal_errors.append(f"task={task_key}: control ref has no future()")
+                    if self._is_current_ordered_fte_control_ref(task_key, ref):
+                        terminal_entries.append(entry)
+                        terminal_error_entries.append((task_key, ref, f"task={task_key}: control ref has no future()"))
                     continue
                 try:
                     future = future_method()
                 except BaseException as exc:
-                    terminal_entries.append(entry)
-                    terminal_errors.append(f"task={task_key}: {type(exc).__name__}: {exc}")
+                    if self._is_current_ordered_fte_control_ref(task_key, ref):
+                        terminal_entries.append(entry)
+                        terminal_error_entries.append((task_key, ref, f"task={task_key}: {type(exc).__name__}: {exc}"))
                     continue
                 try:
                     raw_status = future.result(timeout=0)
                 except concurrent.futures.TimeoutError:
+                    if not self._is_current_ordered_fte_control_ref(task_key, ref):
+                        continue
                     done_value = getattr(future, "done", None)
                     try:
                         is_done = bool(done_value() if callable(done_value) else done_value)
                     except BaseException:
                         is_done = False
                     if is_done:
-                        terminal_entries.append(entry)
                         try:
                             raw_status = future.result()
                         except BaseException as terminal_exc:
-                            terminal_errors.append(f"task={task_key}: {type(terminal_exc).__name__}: {terminal_exc}")
+                            if self._is_current_ordered_fte_control_ref(task_key, ref):
+                                terminal_entries.append(entry)
+                                terminal_error_entries.append(
+                                    (
+                                        task_key,
+                                        ref,
+                                        f"task={task_key}: {type(terminal_exc).__name__}: {terminal_exc}",
+                                    )
+                                )
                         else:
-                            resolved_entries.append((entry, raw_status))
-                    else:
+                            if self._is_current_ordered_fte_control_ref(task_key, ref):
+                                terminal_entries.append(entry)
+                                resolved_entries.append((entry, raw_status))
+                    elif self._is_current_ordered_fte_control_ref(task_key, ref):
                         pending_entries.append(entry)
                     continue
                 except BaseException as exc:
-                    terminal_entries.append(entry)
-                    terminal_errors.append(f"task={task_key}: {type(exc).__name__}: {exc}")
+                    if self._is_current_ordered_fte_control_ref(task_key, ref):
+                        terminal_entries.append(entry)
+                        terminal_error_entries.append((task_key, ref, f"task={task_key}: {type(exc).__name__}: {exc}"))
                     continue
-                terminal_entries.append(entry)
-                resolved_entries.append((entry, raw_status))
+                if self._is_current_ordered_fte_control_ref(task_key, ref):
+                    terminal_entries.append(entry)
+                    resolved_entries.append((entry, raw_status))
         else:
-            terminal_entries = list(pending)
-            resolved_entries = list(zip(pending, raw_statuses, strict=True))
+            resolved_entries = [
+                (entry, raw_status)
+                for entry, raw_status in zip(pending, raw_statuses, strict=True)
+                if self._is_current_ordered_fte_control_ref(entry[0], entry[1])
+            ]
+            terminal_entries = [entry for entry, _ in resolved_entries]
 
-        for (task_key, _, expected_operation), raw_status in resolved_entries:
+        for entry, raw_status in resolved_entries:
+            task_key, ref, expected_operation = entry
+            if not self._is_current_ordered_fte_control_ref(task_key, ref):
+                continue
             try:
                 if not isinstance(raw_status, Mapping):
                     raise TypeError("FTE result-control barrier status must be a mapping")
@@ -537,26 +672,42 @@ class FteWorkerTaskControlMixin:
                         f"FTE control barrier operation was not applied: task={task_key} operation={expected_operation}"
                     )
             except BaseException as exc:
-                terminal_errors.append(f"task={task_key}: {type(exc).__name__}: {exc}")
+                if self._is_current_ordered_fte_control_ref(task_key, ref):
+                    terminal_error_entries.append((task_key, ref, f"task={task_key}: {type(exc).__name__}: {exc}"))
                 continue
-            statuses.append(status)
+            if self._is_current_ordered_fte_control_ref(task_key, ref):
+                status_entries.append((task_key, ref, status))
 
+        terminal_error: FteControlBarrierTerminalError | None = None
         with self._fte_control_lock:
+            pending_entries = [
+                entry for entry in pending_entries if self._fte_control_tails_by_task.get(entry[0]) is entry[1]
+            ]
+            terminal_entries = [
+                entry for entry in terminal_entries if self._fte_control_tails_by_task.get(entry[0]) is entry[1]
+            ]
+            terminal_errors = [
+                message
+                for task_key, ref, message in terminal_error_entries
+                if self._fte_control_tails_by_task.get(task_key) is ref
+            ]
+            statuses = [
+                status
+                for task_key, ref, status in status_entries
+                if self._fte_control_tails_by_task.get(task_key) is ref
+            ]
             for task_key, ref, _ in terminal_entries:
                 if self._fte_control_tails_by_task.get(task_key) is ref:
                     self._fte_control_tails_by_task.pop(task_key, None)
                     self._fte_control_query_by_task.pop(task_key, None)
                     self._fte_control_operation_by_task.pop(task_key, None)
-
-        terminal_error: FteControlBarrierTerminalError | None = None
-        if terminal_errors:
-            terminal_error = FteControlBarrierTerminalError(
-                f"FTE control barrier reached terminal failures for {query_key}: " + "; ".join(terminal_errors)
-            )
-            # Terminal entries are removed from the control tail above. Keep
-            # their failure visible across a simultaneous pending operation,
-            # fence retry, or remote-drop retry until final storage cleanup.
-            with self._fte_control_lock:
+            if terminal_errors:
+                terminal_error = FteControlBarrierTerminalError(
+                    f"FTE control barrier reached terminal failures for {query_key}: " + "; ".join(terminal_errors)
+                )
+                # Terminal entries are removed from the control tail above. Keep
+                # their failure visible across a simultaneous pending operation,
+                # fence retry, or remote-drop retry until final storage cleanup.
                 self._fte_prepare_terminal_errors.setdefault(query_key, terminal_error)
         if pending_entries:
             details = ["pending=" + ",".join(task_key for task_key, _, _ in pending_entries)]

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -2098,8 +2098,17 @@ struct PyPhysicalPlanWrapperRunner {
 
 		if (fte_scan_source_queue_map && !fte_scan_source_queue_map->empty()) {
 			string error;
-			if (!duckdb::distributed::ApplyFteScanSourceQueuesToPlan(*physical_plan, *fte_scan_source_queue_map,
-			                                                         &error)) {
+			bool applied;
+			{
+				// ExtensionFileListProvider scans materialize the dynamic file list
+				// here and can wait until no_more_splits. The control thread that
+				// seals the queue must be able to acquire the GIL while that wait is
+				// in progress.
+				py::gil_scoped_release release;
+				applied = duckdb::distributed::ApplyFteScanSourceQueuesToPlan(*physical_plan,
+				                                                              *fte_scan_source_queue_map, &error);
+			}
+			if (!applied) {
 				throw py::value_error("Failed to apply FTE scan source queues to plan: " + error);
 			}
 		}

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 import gc
 import os
+import subprocess
+import sys
+import textwrap
 import time
 import uuid
 import weakref
@@ -341,6 +344,114 @@ def test_datasource_worker_plan_uses_resource_query_owner_when_execution_id_diff
         worker_connection.close()
         _duckdb._release_datasource_factories_for_query(resource_query_id)
         duckdb.ray_cxx._cleanup_query_python_replay_state(resource_query_id)
+
+
+def test_datasource_fte_scan_wait_releases_gil_for_queue_seal():
+    # Isolate the expected pre-fix deadlock so the parent pytest process can
+    # enforce a hard timeout and report both thread stacks.
+    code = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import faulthandler
+        import sys
+        import threading
+        import uuid
+        from collections.abc import Iterator
+
+        import pyarrow as pa
+
+        import duckdb
+        import _duckdb
+        from duckdb.datasource import DataSource, DataSourceTask, read_datasource
+
+
+        class SingleTask(DataSourceTask):
+            def execute(self) -> Iterator[pa.RecordBatch]:
+                yield pa.record_batch({"value": pa.array([41], type=pa.int64())})
+
+
+        class SingleSource(DataSource):
+            @property
+            def schema(self) -> dict[str, str]:
+                return {"value": "BIGINT"}
+
+            def get_tasks(self) -> Iterator[DataSourceTask]:
+                yield SingleTask()
+
+
+        faulthandler.dump_traceback_later(5.0, repeat=False)
+        # After the executor thread starts, only an explicit native GIL release
+        # should let this thread resume and seal the queue.
+        sys.setswitchinterval(1000.0)
+
+        query_id = f"query-datasource-fte-gil-{uuid.uuid4().hex[:8]}"
+        source_connection = duckdb.connect()
+        relation = read_datasource(SingleSource(), con=source_connection)
+        source_plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            query_id,
+        ).to_physical_plan(source_connection)
+        scan_task_descriptors = source_plan.scan_task_descriptor_map()
+        assert len(scan_task_descriptors) == 1
+        node_id, descriptors = next(iter(scan_task_descriptors.items()))
+        assert len(descriptors) == 1
+
+        duckdb.ray_cxx._register_query_python_replay_state(query_id, source_plan)
+        worker_connection = duckdb.connect()
+        worker_plan = source_plan.clone(worker_connection)
+        split_queue = duckdb.ray_cxx.FteSplitQueue()
+        split_queue.add_scan_split(bytes(descriptors[0]))
+        started = threading.Event()
+        results = []
+        errors = []
+
+
+        def execute_native() -> None:
+            started.set()
+            try:
+                results.append(
+                    duckdb.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+                        worker_connection,
+                        worker_plan,
+                        fte_scan_source_queues={str(node_id): split_queue},
+                    )
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+
+        thread = threading.Thread(target=execute_native, daemon=True)
+        thread.start()
+        assert started.wait(timeout=2.0)
+        split_queue.no_more_splits()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+        assert errors == []
+        assert len(results) == 1
+        assert results[0].completion_status == "ok"
+        assert results[0].partition_payloads[0].column(0).to_pylist() == [41]
+        assert split_queue.consumed_splits() == 1
+
+        faulthandler.cancel_dump_traceback_later()
+        results.clear()
+        worker_plan = None
+        worker_connection.close()
+        _duckdb._release_datasource_factories_for_query(query_id)
+        duckdb.ray_cxx._cleanup_query_python_replay_state(query_id)
+        source_connection.close()
+        print("ok", flush=True)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=os.getcwd(),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "ok" in proc.stdout
 
 
 def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb_conn):

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -3,23 +3,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import pickle
 import threading
 import time
 import uuid
+from concurrent.futures import CancelledError, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 import duckdb
+import duckdb.runners.fte.backends.native.backend as native_backend_mod
 from duckdb.runners.fte import FteTaskAttemptId, FteTaskId, FteTaskState, TaskResultState
 from duckdb.runners.fte.backends.native import (
     NativeFteWorkerManagerBackend,
     NativeTaskResultHandle,
     NativeWorkerHandle,
 )
-from duckdb.runners.fte.backends.native.backend import _flight_exchange_node_id_from_env
+from duckdb.runners.fte.backends.native.backend import (
+    _BackgroundEventLoop,
+    _flight_exchange_node_id_from_env,
+)
 from duckdb.runners.fte.fte_config import FTE_WORKER_RUNTIME
 from duckdb.runners.progress import build_progress_snapshot
 
@@ -68,6 +74,210 @@ class _FakeNativeWorkerTask:
 
     def exchange_sink_instance(self):
         return self._exchange_sink_instance
+
+
+def test_native_background_event_loop_concurrent_first_submit_starts_once(monkeypatch):
+    background = _BackgroundEventLoop("native-fte-concurrent-start")
+    original_thread_main = background._thread_main
+    thread_main_started = threading.Event()
+    release_thread_main = threading.Event()
+    call_count = 0
+    call_count_lock = threading.Lock()
+
+    def gated_thread_main():
+        nonlocal call_count
+        with call_count_lock:
+            call_count += 1
+        thread_main_started.set()
+        assert release_thread_main.wait(timeout=1.0)
+        original_thread_main()
+
+    monkeypatch.setattr(background, "_thread_main", gated_thread_main)
+    submit_barrier = threading.Barrier(8)
+
+    def submit(index):
+        submit_barrier.wait(timeout=1.0)
+        future = background.submit(asyncio.sleep(0, result=index))
+        return future.result(timeout=1.0)
+
+    try:
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            submitted = [executor.submit(submit, index) for index in range(8)]
+            assert thread_main_started.wait(timeout=1.0)
+            release_thread_main.set()
+            assert sorted(future.result(timeout=2.0) for future in submitted) == list(range(8))
+    finally:
+        release_thread_main.set()
+        background.shutdown(timeout_s=1.0)
+
+    assert call_count == 1
+
+
+def test_native_background_event_loop_submit_during_shutdown_is_rejected(monkeypatch):
+    background = _BackgroundEventLoop("native-fte-submit-during-shutdown")
+    background.start()
+    event_loop = background._loop
+    assert event_loop is not None
+    original_call_soon_threadsafe = event_loop.call_soon_threadsafe
+    stop_scheduling_started = threading.Event()
+    allow_stop_scheduling = threading.Event()
+
+    def gated_call_soon_threadsafe(callback, *args, **kwargs):
+        if callback == event_loop.stop:
+            stop_scheduling_started.set()
+            assert allow_stop_scheduling.wait(timeout=1.0)
+        return original_call_soon_threadsafe(callback, *args, **kwargs)
+
+    monkeypatch.setattr(event_loop, "call_soon_threadsafe", gated_call_soon_threadsafe)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        shutdown = executor.submit(background.shutdown, 1.0)
+        assert stop_scheduling_started.wait(timeout=1.0)
+        submitted = executor.submit(background.submit, asyncio.sleep(0, result="late"))
+        allow_stop_scheduling.set()
+        shutdown.result(timeout=2.0)
+        with pytest.raises(RuntimeError, match="stopping|closed"):
+            submitted.result(timeout=2.0)
+
+
+def test_native_background_event_loop_shutdown_stops_published_loop_before_run(monkeypatch):
+    original_new_event_loop = asyncio.new_event_loop
+    run_forever_entered = threading.Event()
+    allow_run_forever = threading.Event()
+    stop_scheduled = threading.Event()
+
+    def gated_new_event_loop():
+        event_loop = original_new_event_loop()
+        original_run_forever = event_loop.run_forever
+        original_call_soon_threadsafe = event_loop.call_soon_threadsafe
+
+        def gated_run_forever():
+            run_forever_entered.set()
+            assert allow_run_forever.wait(timeout=1.0)
+            original_run_forever()
+
+        def tracked_call_soon_threadsafe(callback, *args, **kwargs):
+            if callback == event_loop.stop:
+                stop_scheduled.set()
+            return original_call_soon_threadsafe(callback, *args, **kwargs)
+
+        monkeypatch.setattr(event_loop, "run_forever", gated_run_forever)
+        monkeypatch.setattr(event_loop, "call_soon_threadsafe", tracked_call_soon_threadsafe)
+        return event_loop
+
+    monkeypatch.setattr(asyncio, "new_event_loop", gated_new_event_loop)
+    background = _BackgroundEventLoop("native-fte-stop-before-run")
+    try:
+        background.start()
+        assert run_forever_entered.wait(timeout=1.0)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            shutdown = executor.submit(background.shutdown, 1.0)
+            assert stop_scheduled.wait(timeout=1.0)
+            allow_run_forever.set()
+            shutdown.result(timeout=2.0)
+    finally:
+        allow_run_forever.set()
+        background.shutdown(timeout_s=1.0)
+
+
+def test_native_background_event_loop_shutdown_completes_pending_future():
+    background = _BackgroundEventLoop("native-fte-cancel-pending")
+
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    future = background.submit(wait_forever())
+    background.shutdown(timeout_s=1.0)
+
+    with pytest.raises(CancelledError):
+        future.result(timeout=1.0)
+
+
+def test_native_background_event_loop_operation_timeout_cancels_coroutine():
+    background = _BackgroundEventLoop(
+        "native-fte-operation-timeout",
+        operation_timeout_s=0.05,
+    )
+    coroutine_finished = threading.Event()
+
+    async def wait_forever():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            coroutine_finished.set()
+
+    try:
+        with pytest.raises(TimeoutError, match="operation timed out"):
+            background.run(wait_forever())
+        assert coroutine_finished.wait(timeout=1.0)
+    finally:
+        background.shutdown(timeout_s=1.0)
+
+
+def test_native_background_event_loop_reloads_result_completed_at_timeout_boundary(monkeypatch):
+    class _RacingFuture:
+        def __init__(self):
+            self.result_calls = []
+
+        def result(self, timeout=None):
+            self.result_calls.append(timeout)
+            if len(self.result_calls) == 1:
+                raise native_backend_mod.FutureTimeoutError
+            return "completed"
+
+        def done(self):
+            return True
+
+    async def unused():
+        return None
+
+    future = _RacingFuture()
+    background = _BackgroundEventLoop("native-fte-timeout-boundary")
+
+    def submit(coroutine):
+        coroutine.close()
+        return future
+
+    monkeypatch.setattr(background, "submit", submit)
+
+    assert background.run(unused(), timeout_s=0.25) == "completed"
+    assert future.result_calls == [0.25, None]
+
+
+def test_native_background_event_loop_catches_pre311_future_timeout(monkeypatch):
+    class _Pre311FutureTimeout(Exception):
+        pass
+
+    class _PendingFuture:
+        def __init__(self):
+            self.cancelled = False
+
+        def result(self, timeout=None):
+            assert timeout == 0.25
+            raise _Pre311FutureTimeout
+
+        def done(self):
+            return False
+
+        def cancel(self):
+            self.cancelled = True
+
+    async def unused():
+        return None
+
+    pending = _PendingFuture()
+    background = _BackgroundEventLoop("native-fte-pre311-future-timeout")
+
+    def submit(coroutine):
+        coroutine.close()
+        return pending
+
+    monkeypatch.setattr(native_backend_mod, "FutureTimeoutError", _Pre311FutureTimeout)
+    monkeypatch.setattr(background, "submit", submit)
+
+    with pytest.raises(TimeoutError, match="operation timed out"):
+        background.run(unused(), timeout_s=0.25)
+    assert pending.cancelled is True
 
 
 def _captured_native_copy_plan(tmp_path, monkeypatch, *, local_staging: bool):
@@ -655,6 +865,41 @@ def test_native_worker_manager_backend_submit_wait_drop_and_shutdown():
         backend.submit_tasks([])
 
 
+def test_native_worker_manager_shutdown_attempts_all_workers_and_is_retryable():
+    shutdown_calls = []
+
+    class _Worker:
+        def __init__(self, worker_id, *, fail_once=False):
+            self.worker_id = worker_id
+            self.fail_once = fail_once
+
+        def shutdown(self):
+            shutdown_calls.append(self.worker_id)
+            if self.fail_once:
+                self.fail_once = False
+                raise RuntimeError(f"{self.worker_id} loop did not stop")
+
+    backend = NativeFteWorkerManagerBackend(
+        workers=[
+            _Worker("first", fail_once=True),
+            _Worker("second"),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="first.*loop did not stop"):
+        backend.shutdown()
+
+    assert shutdown_calls == ["first", "second"]
+    assert backend._closed is False
+    with pytest.raises(RuntimeError, match="shutting down"):
+        backend.submit_tasks([])
+
+    backend.shutdown()
+
+    assert shutdown_calls == ["first", "second", "first", "second"]
+    assert backend._closed is True
+
+
 def test_native_worker_manager_exposes_ray_compatible_query_status_and_handles():
     release = threading.Event()
 
@@ -783,7 +1028,7 @@ def test_native_worker_task_request_converts_inputs_to_dynamic_splits():
     assert [split["data"]["partition_indices"] for split in exchange_splits] == [[0], [1]]
 
 
-def test_native_fte_runtime_removes_dynamic_initial_splits_before_execute():
+def test_native_fte_runtime_starts_dynamic_source_and_removes_initial_splits_before_execute():
     executed = threading.Event()
     captured: list[dict[str, Any]] = []
 
@@ -809,14 +1054,10 @@ def test_native_fte_runtime_removes_dynamic_initial_splits_before_execute():
             ]
         )
 
-        time.sleep(0.02)
-        assert executed.is_set() is False
-
-        backend.task_input_stream_exhausted("query-dynamic-scan", ["7"])
+        assert executed.wait(timeout=1.0)
         outputs = backend.wait_query("query-dynamic-scan", 2.0)
 
         assert outputs == [{"ok": True}]
-        assert executed.is_set() is True
         assert captured[0]["initial_splits"] == {}
         assert captured[0]["dynamic_scan_source_node_ids"] == ["7"]
         assert "fte_scan_source_queues" in captured[0]

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -7,7 +7,8 @@ import subprocess
 import sys
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from types import SimpleNamespace
 
 import pytest
@@ -39,6 +40,7 @@ from duckdb.runners.ray.fte import (
 from duckdb.runners.ray.fte_events import (
     FteAddSplitsCommand,
     FteCreateTaskCommand,
+    FteNoMoreSplitsCommand,
     TaskStatusChanged,
     WorkerReservationCompleted,
 )
@@ -233,7 +235,11 @@ class _FakeActor:
         timeout_s=None,
     ):
         self.fte_calls.append(("wait_split_queue", task_id, source_node_id, max_buffered_splits, timeout_s))
-        return {"has_space": True, "buffered_splits": 0}
+        return {
+            "has_space": True,
+            "buffered_splits": 0,
+            "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+        }
 
     def _fte_get_task_info(self, task_id):
         self.fte_calls.append(("get_info", task_id))
@@ -875,6 +881,348 @@ def test_fte_status_wait_preserves_query_deadline_failure(monkeypatch):
 
     with pytest.raises(QueryDeadlineExceeded, match="query deadline expired"):
         handle.fte_wait_task_status(task_id, 3, 0.01)
+
+
+def test_fte_split_backpressure_remote_error_is_canceled_by_query_close():
+    query_id = "query-split-wait-close"
+    wait_started = threading.Event()
+    add_called = threading.Event()
+
+    class _BackpressuredWorker:
+        def fte_wait_split_queue_has_space(self, *_args):
+            raise AssertionError("query-owned split wait must be interruptible")
+
+        def fte_wait_split_queue_has_space_interruptible(
+            self,
+            _task_id,
+            _source_node_id,
+            _max_buffered_splits,
+            _timeout_s,
+            stop_event,
+        ):
+            wait_started.set()
+            deadline = time.monotonic() + 1.0
+            while not stop_event.is_set():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("query close did not cancel split wait")
+                time.sleep(0.01)
+            raise RuntimeError("remote split wait raced query close")
+
+        def enqueue_fte_add_splits(self, *_args):
+            add_called.set()
+            raise AssertionError("canceled split submission must not reach the worker")
+
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-split-wait-close",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+    attempt_id = FteTaskAttemptId.coerce(
+        {
+            "query_id": query_id,
+            "fragment_execution_id": 0,
+            "partition_id": 0,
+            "attempt_id": 0,
+        }
+    )
+    command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id="worker-split-wait-close",
+        worker=_BackpressuredWorker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            execution = executor.submit(
+                handle._execute_fte_fragment_execution_worker_commands,
+                stage,
+                [command],
+            )
+            assert wait_started.wait(timeout=1.0)
+            worker_handle_mod.close_fte_registry_for_query(query_id)
+            execution.result(timeout=1.0)
+
+        assert add_called.is_set() is False
+        assert query_id not in worker_handle_mod._FTE_ACTIVE_OPERATIONS_BY_QUERY
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_split_backpressure_preserves_query_deadline():
+    query_id = "query-split-wait-deadline"
+
+    class _DeadlineWorker:
+        def fte_wait_split_queue_has_space(self, *_args):
+            raise AssertionError("query-owned split wait must be interruptible")
+
+        def fte_wait_split_queue_has_space_interruptible(self, *_args):
+            raise QueryDeadlineExceeded("query deadline expired while waiting for split capacity")
+
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-split-wait-deadline",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+    attempt_id = FteTaskAttemptId.coerce(
+        {
+            "query_id": query_id,
+            "fragment_execution_id": 0,
+            "partition_id": 0,
+            "attempt_id": 0,
+        }
+    )
+    command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id="worker-split-wait-deadline",
+        worker=_DeadlineWorker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    try:
+        with pytest.raises(QueryDeadlineExceeded, match="query deadline expired"):
+            handle._execute_fte_fragment_execution_worker_commands(stage, [command])
+        assert query_id not in worker_handle_mod._FTE_ACTIVE_OPERATIONS_BY_QUERY
+        assert handle._fte_healthy is True
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_split_backpressure_terminal_status_uses_task_status_path(monkeypatch):
+    query_id = "query-split-wait-terminal"
+    attempt_id = FteTaskAttemptId.coerce(
+        {
+            "query_id": query_id,
+            "fragment_execution_id": 0,
+            "partition_id": 0,
+            "attempt_id": 0,
+        }
+    )
+    terminal_status = {
+        "state": FteTaskState.FAILED.value,
+        "task_id": attempt_id.to_dict(),
+        "failure": {"type": "ValueError", "message": "planned task failure"},
+    }
+
+    class _TerminalWorker:
+        def fte_wait_split_queue_has_space(self, *_args):
+            raise AssertionError("query-owned split wait must be interruptible")
+
+        def fte_wait_split_queue_has_space_interruptible(self, *_args):
+            return {
+                "has_space": False,
+                "terminal": True,
+                "status": terminal_status,
+            }
+
+        def enqueue_fte_add_splits(self, *_args, **_kwargs):
+            raise AssertionError("terminal task must not accept more splits")
+
+        def enqueue_fte_no_more_splits(self, *_args, **_kwargs):
+            raise AssertionError("terminal task must skip trailing controls")
+
+    worker = _TerminalWorker()
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-split-wait-terminal",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+    add_command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id=handle.worker_id,
+        worker=worker,
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+    no_more_command = FteNoMoreSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id=handle.worker_id,
+        worker=worker,
+        attempt_id=attempt_id,
+        source_node_id="7",
+    )
+    captured_events = []
+    monkeypatch.setattr(
+        handle,
+        "_handles_for_task_status_changed_event",
+        lambda event: captured_events.append(event) or [],
+    )
+    worker_handle_mod.open_fte_registry_for_query(query_id)
+
+    try:
+        handle._execute_fte_fragment_execution_worker_commands(
+            stage,
+            [add_command, no_more_command],
+        )
+        scheduler = worker_commands_mod._FTE_SCHEDULERS.get(query_id)
+        assert scheduler is not None
+        scheduler.drain()
+
+        assert len(captured_events) == 1
+        assert captured_events[0].status == terminal_status
+        assert handle._fte_healthy is True
+        stats = scheduler.stats()
+        assert stats.event_counts.get("TaskStatusChanged", 0) == 1
+        assert stats.event_counts.get("WorkerFailed", 0) == 0
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_interruptible_fte_control_ref_preserves_completed_query_deadline():
+    completed = Future()
+    completed.set_exception(QueryDeadlineExceeded("remote query deadline"))
+    ref = SimpleNamespace(future=lambda: completed)
+
+    with pytest.raises(QueryDeadlineExceeded, match="remote query deadline"):
+        task_control_mod.FteWorkerTaskControlMixin._get_fte_control_ref(
+            "fte_wait_split_queue_has_space",
+            ref,
+            timeout_s=0.1,
+            cancel_event=threading.Event(),
+        )
+
+
+def test_interruptible_fte_control_ref_reloads_result_completed_at_timeout_boundary():
+    class _RacingFuture:
+        def __init__(self):
+            self.result_calls = []
+
+        def result(self, timeout=None):
+            self.result_calls.append(timeout)
+            if len(self.result_calls) == 1:
+                raise FutureTimeoutError
+            return "completed"
+
+        def done(self):
+            return True
+
+    future = _RacingFuture()
+    ref = SimpleNamespace(future=lambda: future)
+
+    assert (
+        task_control_mod.FteWorkerTaskControlMixin._get_fte_control_ref(
+            "fte_wait_split_queue_has_space",
+            ref,
+            timeout_s=0.1,
+            cancel_event=threading.Event(),
+        )
+        == "completed"
+    )
+    assert future.result_calls == [0.05, None]
+
+
+def test_fte_control_ref_preserves_query_deadline_when_wait_expires(monkeypatch):
+    pending = Future()
+    ref = SimpleNamespace(future=lambda: pending)
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", str(time.time() + 0.05))
+
+    try:
+        with pytest.raises(QueryDeadlineExceeded, match="query deadline expired"):
+            task_control_mod.FteWorkerTaskControlMixin._get_fte_control_ref(
+                "fte_add_splits",
+                ref,
+                timeout_s=30.0,
+            )
+    finally:
+        pending.cancel()
+
+
+def test_ordered_add_ref_is_canceled_and_unowned_after_query_close(monkeypatch):
+    query_id = "query-cancel-ordered-add"
+    task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    add_started = threading.Event()
+    pending = Future()
+
+    class _DeferredRef:
+        def future(self):
+            return pending
+
+    ref = _DeferredRef()
+
+    class _DeferredAdd:
+        def remote(self, *_args):
+            add_started.set()
+            return ref
+
+    actor = _FakeActor()
+    actor.fte_add_splits = _DeferredAdd()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    canceled_refs = []
+    barrier_snapshot_started = threading.Event()
+    cancellation_applied = threading.Event()
+    resolve_object_refs_blocking = task_control_mod.resolve_object_refs_blocking
+
+    def cancel_ref(object_ref, *, force=False):
+        assert force is False
+        canceled_refs.append(object_ref)
+        pending.cancel()
+        cancellation_applied.set()
+
+    def resolve_after_cancellation(*args, **kwargs):
+        barrier_snapshot_started.set()
+        assert cancellation_applied.wait(timeout=1.0)
+        return resolve_object_refs_blocking(*args, **kwargs)
+
+    monkeypatch.setattr(ray, "cancel", cancel_ref)
+    monkeypatch.setattr(task_control_mod, "resolve_object_refs_blocking", resolve_after_cancellation)
+    query_closing = worker_commands_mod._FteQueryClosingEvent(query_id)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            submitted = executor.submit(
+                handle.enqueue_fte_add_splits,
+                task_id,
+                "7",
+                [{"sequence_id": 1}],
+                cancel_event=query_closing,
+            )
+            assert add_started.wait(timeout=1.0)
+            assert worker_handle_mod._FTE_ACTIVE_OPERATIONS_BY_QUERY[query_id] == 1
+            flushed = executor.submit(handle.close_and_flush_fte_controls, query_id)
+            assert barrier_snapshot_started.wait(timeout=1.0)
+            with pytest.raises(InterruptedError, match="interrupted by cancellation"):
+                submitted.result(timeout=1.0)
+            assert flushed.result(timeout=1.0) == []
+
+        assert canceled_refs == [ref]
+        assert str(FteTaskAttemptId.coerce(task_id)) not in handle._fte_control_tails_by_task
+        assert query_id not in worker_handle_mod._FTE_ACTIVE_OPERATIONS_BY_QUERY
+    finally:
+        if not pending.done():
+            pending.cancel()
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
 
 
 def test_fte_worker_actor_handle_chains_async_control_updates_by_task():
@@ -1784,6 +2132,62 @@ def test_control_future_completed_during_zero_timeout_probe_is_reloaded(monkeypa
     assert future.calls == 2
     assert handle._has_fte_control_state_for_query(query_id) is False
     worker_handle_mod.open_fte_registry_for_query(query_id)
+
+
+def test_control_barrier_ignores_terminal_error_from_detached_ref(monkeypatch):
+    query_id = "query-control-detached-terminal-error"
+    task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+    raw_status = {
+        "state": "FINISHED",
+        "task_id": task_id,
+        "_fte_control_operation": "fte_ack_task_result",
+        "_fte_control_applied": True,
+    }
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    ref = handle.enqueue_fte_ack_task_result(task_id)
+    validation_failed = threading.Event()
+    current_ref_confirmed = threading.Event()
+    allow_error_recording = threading.Event()
+    original_is_current = handle._is_current_ordered_fte_control_ref
+
+    def resolve(refs, **_kwargs):
+        assert refs == [ref]
+        return [raw_status]
+
+    def fail_validation(_status, _expected_task):
+        validation_failed.set()
+        raise RuntimeError("canceled detached ref")
+
+    def gate_after_current_ref_check(task_key, candidate_ref):
+        is_current = original_is_current(task_key, candidate_ref)
+        if validation_failed.is_set() and is_current and not current_ref_confirmed.is_set():
+            current_ref_confirmed.set()
+            assert allow_error_recording.wait(timeout=1.0)
+        return is_current
+
+    monkeypatch.setattr(task_control_mod, "resolve_object_refs_blocking", resolve)
+    monkeypatch.setattr(task_control_mod, "validate_fte_status_identity", fail_validation)
+    monkeypatch.setattr(handle, "_is_current_ordered_fte_control_ref", gate_after_current_ref_check)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            closed = executor.submit(handle.close_and_flush_fte_controls, query_id)
+            assert current_ref_confirmed.wait(timeout=1.0)
+            handle._discard_ordered_fte_control_ref(task_id, ref)
+            allow_error_recording.set()
+            assert closed.result(timeout=1.0) == []
+
+        assert handle._has_fte_control_state_for_query(query_id) is False
+        assert query_id not in handle._fte_prepare_terminal_errors
+    finally:
+        allow_error_recording.set()
+        worker_handle_mod.open_fte_registry_for_query(query_id)
 
 
 def test_fte_control_close_fences_concurrent_late_admission(monkeypatch):
@@ -2859,7 +3263,7 @@ def test_fte_split_ack_before_create_ack_is_merged_into_running_pressure(monkeyp
     release_create_ack = threading.Event()
     scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create(query_id)
 
-    def execute(command):
+    def execute(command, **_kwargs):
         if isinstance(command, FteCreateTaskCommand):
             create_rpc_completed.set()
             assert release_create_ack.wait(2.0)
@@ -3027,10 +3431,39 @@ def test_fte_add_splits_ack_after_task_finish_does_not_revive_pressure():
     class _BlockingFuture:
         def __init__(self, value):
             self.value = value
+            self._lock = threading.Lock()
+            self._callbacks = []
+            self._done = False
 
         def result(self, timeout=None):
-            assert release_rpc.wait(timeout)
+            with self._lock:
+                if self._done:
+                    return self.value
+            if not release_rpc.wait(timeout):
+                raise FutureTimeoutError
+            with self._lock:
+                if self._done:
+                    return self.value
+                self._done = True
+                callbacks = list(self._callbacks)
+                self._callbacks.clear()
+            for callback in callbacks:
+                callback(self)
             return self.value
+
+        def add_done_callback(self, callback):
+            with self._lock:
+                if self._done:
+                    invoke_now = True
+                else:
+                    self._callbacks.append(callback)
+                    invoke_now = False
+            if invoke_now:
+                callback(self)
+
+        def done(self):
+            with self._lock:
+                return self._done
 
     class _BlockingObjectRef:
         def __init__(self, value):
@@ -6410,14 +6843,18 @@ def test_fte_control_failure_preempts_queued_work_across_queries(monkeypatch):
     assert all(owner is replacement for owner in query_owners.values())
 
 
-def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):
+def test_fte_split_queue_full_recovers_without_replacing_worker(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,
         "_fte_task_handle_cls",
         staticmethod(lambda: _FakeFteTaskHandle),
     )
 
-    class _FullSplitQueueActor(_FakeActor):
+    class _RecoveringSplitQueueActor(_FakeActor):
+        def __init__(self):
+            super().__init__()
+            self.space_checks = 0
+
         def _fte_wait_split_queue_has_space(
             self,
             task_id,
@@ -6434,12 +6871,17 @@ def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):
                     timeout_s,
                 )
             )
-            return {"has_space": False, "buffered_splits": 1024}
+            self.space_checks += 1
+            return {
+                "has_space": self.space_checks >= 2,
+                "buffered_splits": 0 if self.space_checks >= 2 else 1024,
+                "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            }
 
-    actor0 = _FullSplitQueueActor()
+    actor0 = _RecoveringSplitQueueActor()
     actor1 = _FakeActor()
     handle0 = RayWorkerActorHandle(actor0, memory_capacity_bytes=1 << 60, worker_id="worker-0")
-    handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-1")
+    _handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-1")
     first_task = _FakeTask(
         name="scan-task-0",
         context={"query_id": "query-fte-queue-full", "node_id": "7"},
@@ -6458,27 +6900,21 @@ def test_fte_split_queue_full_replays_descriptor_on_replacement(monkeypatch):
 
     assert len(first) == 1
     assert first[0].worker_handle is handle0
-    assert len(retries) == 1
-    assert retries[0].worker_handle is handle1
+    assert retries == []
     assert [call[0] for call in actor0.fte_calls] == [
         "create",
         "wait_split_queue",
+        "wait_split_queue",
+        "add_splits",
     ]
-    retry_creates = [call for call in actor1.fte_calls if call[0] == "create"]
-    assert len(retry_creates) == 1
-    retry_request = retry_creates[0][1]
-    assert retry_request["task_id"]["attempt_id"] == 1
-    assert [split["data"] for split in retry_request["initial_splits"]["7"]] == [b"a", b"b"]
-    assert "worker-0" not in worker_handle_mod._FTE_WORKER_HANDLES
+    assert [call for call in actor1.fte_calls if call[0] == "create"] == []
+    assert handle0._fte_healthy is True
+    assert "worker-0" in worker_handle_mod._FTE_WORKER_HANDLES
     assert (
-        worker_handle_mod._FTE_PARTITION_OWNERS[("query-fte-queue-full", "query-fte-queue-full:node:7", 0)] is handle1
+        worker_handle_mod._FTE_PARTITION_OWNERS[("query-fte-queue-full", "query-fte-queue-full:node:7", 0)] is handle0
     )
     stats = handle0.fte_registry_stats()["event_schedulers"]["query-fte-queue-full"]
-    assert stats["event_counts"] == {
-        "SplitEventsSubmitted": 2,
-        "WorkerReservationCompleted": 2,
-        "WorkerFailed": 1,
-    }
+    assert stats["event_counts"].get("WorkerFailed", 0) == 0
 
 
 def test_fte_worker_failure_replays_all_owned_stage_partitions(monkeypatch):

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -10,8 +10,13 @@ from pathlib import Path
 
 import pytest
 
+from duckdb.runners.common import QueryDeadlineExceeded
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
 from duckdb.runners.fte.fte_failures import _failure_allows_retry
+from duckdb.runners.fte.fte_scheduler import (
+    FteSplitQueueTerminal,
+    FteSplitSubmissionCancelled,
+)
 from duckdb.runners.ray import fte_fragment_scheduler
 from duckdb.runners.ray.fragment_registry import (
     _FTE_FRAGMENT_EXECUTIONS,
@@ -1714,12 +1719,19 @@ class _FakeLiveWorker:
 
     def fte_wait_split_queue_has_space(
         self,
-        _task_id,
+        task_id,
         _source_node_id=None,
         _max_buffered_splits=None,
         _timeout_s=None,
     ):
-        return {"has_space": True, "buffered_splits": 0}
+        return {
+            "has_space": True,
+            "buffered_splits": 0,
+            "status": self.statuses.get(
+                self._key(task_id),
+                {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            ),
+        }
 
     def fte_cancel_task(self, task_id):
         self.calls.append(("cancel", task_id))
@@ -2006,8 +2018,11 @@ def test_fte_worker_command_executor_requires_split_queue_wait_protocol():
 
 def test_fte_worker_command_executor_requires_single_ordered_enqueue_protocol():
     class _Worker:
-        def fte_wait_split_queue_has_space(self, *_args):
-            return {"has_space": True}
+        def fte_wait_split_queue_has_space(self, task_id, *_args):
+            return {
+                "has_space": True,
+                "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            }
 
         def fte_add_splits(self, _task_id, _source_node_id, _splits):
             raise AssertionError("ordered control must use enqueue_fte_add_splits")
@@ -2024,6 +2039,204 @@ def test_fte_worker_command_executor_requires_single_ordered_enqueue_protocol():
     )
 
     with pytest.raises(RuntimeError, match="enqueue_fte_add_splits"):
+        FteWorkerCommandExecutor().execute(command)
+
+
+def test_fte_worker_command_executor_waits_for_slow_split_consumer():
+    wait_started = threading.Event()
+    queue_recovered = threading.Event()
+
+    class _Worker:
+        def __init__(self):
+            self.added = []
+
+        def fte_wait_split_queue_has_space(self, task_id, *_args):
+            wait_started.set()
+            assert queue_recovered.wait(timeout=1.0)
+            return {
+                "has_space": True,
+                "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            }
+
+        def enqueue_fte_add_splits(self, task_id, source_node_id, splits):
+            self.added.append((task_id, source_node_id, splits))
+            return {"state": FteTaskState.RUNNING.value, "task_id": task_id}
+
+    worker = _Worker()
+    attempt_id = FteTaskAttemptId(FteTaskId("q-slow-consumer", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-slow-consumer:node:scan",
+        worker_id="worker-a",
+        worker=worker,
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        submitted = executor.submit(FteWorkerCommandExecutor().execute, command)
+        assert wait_started.wait(timeout=1.0)
+        assert submitted.done() is False
+        queue_recovered.set()
+        submitted.result(timeout=1.0)
+
+    assert len(worker.added) == 1
+
+
+def test_fte_worker_command_executor_split_wait_is_cancellable():
+    cancel_event = threading.Event()
+
+    class _Worker:
+        def fte_wait_split_queue_has_space(self, *_args):
+            raise AssertionError("interruptible split wait must be used")
+
+        def fte_wait_split_queue_has_space_interruptible(
+            self,
+            _task_id,
+            _source_node_id,
+            _max_buffered_splits,
+            _timeout_s,
+            stop_event,
+        ):
+            stop_event.set()
+            raise InterruptedError("query closed")
+
+    attempt_id = FteTaskAttemptId(FteTaskId("q-cancel-splits", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-cancel-splits:node:scan",
+        worker_id="worker-a",
+        worker=_Worker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with pytest.raises(FteSplitSubmissionCancelled, match="split submission canceled"):
+        FteWorkerCommandExecutor().execute(command, cancel_event=cancel_event)
+
+
+def test_fte_worker_command_executor_close_wins_capacity_to_enqueue_race():
+    cancel_event = threading.Event()
+
+    class _Worker:
+        def fte_wait_split_queue_has_space(self, task_id, *_args):
+            return {
+                "has_space": True,
+                "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            }
+
+        def enqueue_fte_add_splits(self, *_args, cancel_event=None):
+            assert cancel_event is not None
+            cancel_event.set()
+            raise RuntimeError("query control admission closed")
+
+    attempt_id = FteTaskAttemptId(FteTaskId("q-close-enqueue-race", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-close-enqueue-race:node:scan",
+        worker_id="worker-a",
+        worker=_Worker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with pytest.raises(FteSplitSubmissionCancelled, match="split submission canceled"):
+        FteWorkerCommandExecutor().execute(command, cancel_event=cancel_event)
+
+
+def test_fte_worker_command_executor_cancels_ordered_add_after_capacity():
+    cancel_event = threading.Event()
+    add_started = threading.Event()
+
+    class _Worker:
+        def fte_wait_split_queue_has_space(self, task_id, *_args):
+            return {
+                "has_space": True,
+                "status": {"state": FteTaskState.RUNNING.value, "task_id": task_id},
+            }
+
+        def enqueue_fte_add_splits(
+            self,
+            _task_id,
+            _source_node_id,
+            _splits,
+            *,
+            cancel_event,
+        ):
+            add_started.set()
+            assert cancel_event.wait(timeout=1.0)
+            raise InterruptedError("query closed during ordered add")
+
+    attempt_id = FteTaskAttemptId(FteTaskId("q-close-blocked-add", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-close-blocked-add:node:scan",
+        worker_id="worker-a",
+        worker=_Worker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        submitted = executor.submit(
+            FteWorkerCommandExecutor().execute,
+            command,
+            cancel_event=cancel_event,
+        )
+        assert add_started.wait(timeout=1.0)
+        cancel_event.set()
+        with pytest.raises(FteSplitSubmissionCancelled, match="split submission canceled"):
+            submitted.result(timeout=1.0)
+
+
+def test_fte_worker_command_executor_preserves_query_deadline():
+    class _Worker:
+        def fte_wait_split_queue_has_space(self, *_args):
+            raise AssertionError("interruptible split wait must be used")
+
+        def fte_wait_split_queue_has_space_interruptible(self, *_args):
+            raise QueryDeadlineExceeded("query deadline expired while waiting for split capacity")
+
+    attempt_id = FteTaskAttemptId(FteTaskId("q-deadline-splits", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-deadline-splits:node:scan",
+        worker_id="worker-a",
+        worker=_Worker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with pytest.raises(QueryDeadlineExceeded, match="query deadline expired"):
+        FteWorkerCommandExecutor().execute(command, cancel_event=threading.Event())
+
+
+def test_fte_worker_command_executor_reports_terminal_task_during_split_wait():
+    class _Worker:
+        def fte_wait_split_queue_has_space(self, task_id, *_args):
+            return {
+                "has_space": False,
+                "terminal": True,
+                "status": {"state": FteTaskState.FAILED.value, "task_id": task_id},
+            }
+
+    attempt_id = FteTaskAttemptId(FteTaskId("q-terminal-splits", 0, 1), 0)
+    command = FteAddSplitsCommand(
+        query_id=attempt_id.query_id,
+        fragment_id="q-terminal-splits:node:scan",
+        worker_id="worker-a",
+        worker=_Worker(),
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+
+    with pytest.raises(FteSplitQueueTerminal, match="became terminal with state FAILED"):
         FteWorkerCommandExecutor().execute(command)
 
 
@@ -2484,8 +2697,12 @@ def test_fte_fragment_execution_appends_descriptor_before_add_splits_command_fai
     assert [split.data for split in descriptor.initial_splits["7"]] == [b"a", b"b"]
 
 
-def test_fte_fragment_execution_appends_descriptor_before_split_queue_full_failure():
-    class _FullSplitQueueWorker(_FakeLiveWorker):
+def test_fte_fragment_execution_backpressures_until_split_queue_recovers():
+    class _RecoveringSplitQueueWorker(_FakeLiveWorker):
+        def __init__(self):
+            super().__init__()
+            self.wait_count = 0
+
         def fte_wait_split_queue_has_space(
             self,
             task_id,
@@ -2502,9 +2719,14 @@ def test_fte_fragment_execution_appends_descriptor_before_split_queue_full_failu
                     timeout_s,
                 )
             )
-            return {"has_space": False, "buffered_splits": 1024}
+            self.wait_count += 1
+            return {
+                "has_space": self.wait_count >= 2,
+                "buffered_splits": 0 if self.wait_count >= 2 else 1024,
+                "status": self.statuses[self._key(task_id)],
+            }
 
-    worker = _FullSplitQueueWorker()
+    worker = _RecoveringSplitQueueWorker()
     stage = _fte_fragment_execution(
         "q",
         37,
@@ -2541,10 +2763,14 @@ def test_fte_fragment_execution_appends_descriptor_before_split_queue_full_failu
         )
     )
 
-    with pytest.raises(FteWorkerControlFailure, match="fte_add_splits"):
-        _execute_stage_commands(stage, update_result)
+    _execute_stage_commands(stage, update_result)
 
-    assert [call[0] for call in worker.calls] == ["create", "wait_space"]
+    assert [call[0] for call in worker.calls] == [
+        "create",
+        "wait_space",
+        "wait_space",
+        "add",
+    ]
     descriptor = stage.descriptor_storage.require(FteTaskId("q", 37, 0))
     assert [split.data for split in descriptor.initial_splits["7"]] == [b"a", b"b"]
 
@@ -4752,16 +4978,29 @@ def test_fte_worker_task_manager_fte_runtime_uses_dynamic_scan_source_queue():
     asyncio.run(run())
 
 
-def test_fte_worker_task_manager_fte_dynamic_scan_with_explicit_source_waits_until_sealed():
-    executed = asyncio.Event()
-    captured = {}
-
-    async def execute_fn(request):
-        captured["request"] = request
-        executed.set()
-        return {"ok": True}
-
+def test_fte_worker_task_manager_dynamic_source_consumes_before_no_more_splits():
     async def run():
+        execution_started = asyncio.Event()
+        allow_consumer = asyncio.Event()
+        captured = {}
+        consumed = []
+
+        async def execute_fn(request):
+            captured["request"] = request
+            execution_started.set()
+            await allow_consumer.wait()
+            queue = request["fte_scan_source_queues"]["7"]
+            while True:
+                item = queue.try_get_next()
+                if item["state"] == "BLOCKED":
+                    await asyncio.sleep(0.001)
+                    continue
+                if item["state"] == "SPLIT":
+                    consumed.append(item["data"])
+                    continue
+                assert item == {"state": "FINISHED"}
+                return {"ok": True}
+
         manager = _fte_worker_task_manager(execute_fn)
         task_id = {"query_id": "q", "fragment_execution_id": 0, "partition_id": 12, "attempt_id": 0}
         await manager.create_task(
@@ -4771,47 +5010,49 @@ def test_fte_worker_task_manager_fte_dynamic_scan_with_explicit_source_waits_unt
                 "worker_runtime": "fte",
                 "source_node_ids": ["7"],
                 "dynamic_scan_source_node_ids": ["7"],
-                "initial_splits": {
-                    "7": [
-                        {
-                            "sequence_id": 0,
-                            "kind": "scan_task",
-                            "data": b"initial-scan",
-                        }
-                    ],
-                },
+                "split_queue_max_buffered_splits": 1,
             }
         )
-        await asyncio.sleep(0)
-        assert executed.is_set() is False
+        await asyncio.wait_for(execution_started.wait(), timeout=1.0)
 
         await manager.add_splits(
             task_id,
             "7",
-            [{"sequence_id": 1, "kind": "scan_task", "data": b"late-scan"}],
+            [{"sequence_id": 0, "kind": "scan_task", "data": b"first"}],
         )
-        await asyncio.sleep(0)
-        assert executed.is_set() is False
+        full = await manager.wait_split_queue_has_space(
+            task_id,
+            source_node_id="7",
+            max_buffered_splits=1,
+            timeout_s=0.01,
+        )
+        assert full["has_space"] is False
+        assert full["buffered_splits"] == 1
 
-        await manager.no_more_splits(task_id, "7")
-        await asyncio.wait_for(executed.wait(), timeout=1)
-        status = await manager.wait_task_status(task_id, 0, timeout_s=1.0)
+        wait_for_space = asyncio.create_task(
+            manager.wait_split_queue_has_space(
+                task_id,
+                source_node_id="7",
+                max_buffered_splits=1,
+                timeout_s=1.0,
+            )
+        )
+        await asyncio.sleep(0.02)
+        assert wait_for_space.done() is False
+
+        allow_consumer.set()
+        space = await asyncio.wait_for(wait_for_space, timeout=1.0)
+        assert space["has_space"] is True
+        await manager.add_splits(
+            task_id,
+            "7",
+            [{"sequence_id": 1, "kind": "scan_task", "data": b"second"}],
+        )
+        sealed = await manager.no_more_splits(task_id, "7")
+        status = await manager.wait_task_status(task_id, sealed["version"], timeout_s=1.0)
         assert status["state"] == FteTaskState.FINISHED.value
-
-        request = captured["request"]
-        assert request["initial_splits"] == {}
-        queue = request["fte_scan_source_queues"]["7"]
-        assert queue.try_get_next() == {
-            "state": "SPLIT",
-            "kind": "scan_task",
-            "data": b"initial-scan",
-        }
-        assert queue.try_get_next() == {
-            "state": "SPLIT",
-            "kind": "scan_task",
-            "data": b"late-scan",
-        }
-        assert queue.try_get_next() == {"state": "FINISHED"}
+        assert consumed == [b"first", b"second"]
+        assert captured["request"]["initial_splits"] == {}
 
     asyncio.run(run())
 
@@ -4859,14 +5100,20 @@ def test_fte_worker_task_manager_wait_split_queue_has_space_tracks_buffered_spli
         assert full["status"]["queued_split_weight"] == 1
         assert full["status"]["split_queue_has_space"] is False
 
-        assert queue.try_get_next()["state"] == "SPLIT"
+        async def consume_after_delay():
+            await asyncio.sleep(0.02)
+            assert queue.try_get_next()["state"] == "SPLIT"
+
+        consumer = asyncio.create_task(consume_after_delay())
         space = await manager.wait_split_queue_has_space(
             task_id,
             source_node_id="7",
             max_buffered_splits=1,
-            timeout_s=0.1,
+            timeout_s=0.5,
         )
+        await asyncio.wait_for(consumer, timeout=1.0)
         assert space["has_space"] is True
+        assert space["terminal"] is False
         assert space["buffered_splits"] == 0
         assert space["buffered_bytes"] == 0
 


### PR DESCRIPTION
## Summary

Keep FTE split submission backpressured until capacity returns, the query closes or reaches its deadline, or the target task or worker becomes terminal. Route terminal task state through scheduler recovery instead of misclassifying temporary queue pressure as worker corruption.

Make Ray control waits cancellable during teardown, start dynamic split consumers early enough to drain their queues, and replace the native background event-loop lifecycle flags with an atomic bounded state machine for concurrent startup, submission, and shutdown.

## Related issue

close: #90

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in AstroVela/vane-website.

## Validation

- .venv/bin/python -m pytest -q tests/fast/test_fte_native_backend.py tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_fte.py (421 passed)
- scripts/run_release_tests.sh with .venv/bin on PATH (414 passed, 1 skipped; real-Ray shard 7 passed)
- .venv/bin/python -m pytest -q tests/fast/test_ray_fte_fault_injection.py (5 passed)
- .venv/bin/python -m pytest -q tests/fast/test_ray_fte_event_scheduler.py (24 passed)
- Ruff 0.15.22 lint and format checks on all 8 changed files
- git diff --check

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered; this change does not add those surfaces.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks. This change is Python-only and passed the relevant checks above.