### PR TITLE
[fix](ray) Remove inert runner parameters

### DIFF
--- a/benchmarking/tpch/run_tpch_duckdb_native_relapi.py
+++ b/benchmarking/tpch/run_tpch_duckdb_native_relapi.py
@@ -53,7 +53,6 @@ def _run_query_native_in_subprocess(
     parquet_folder: str,
     qnum: int,
     threads: int | None,
-    results_buffer_size: int | None,
     child_verbose: bool,
 ) -> None:
     """Subprocess target: run a single query via NativeRunner and return row count.
@@ -101,7 +100,7 @@ def _run_query_native_in_subprocess(
 
         t0 = time.time()
         row_count = 0
-        for table in runner.run_iter_tables(rel, results_buffer_size):
+        for table in runner.run_iter_tables(rel):
             row_count += table.num_rows
         elapsed = time.time() - t0
 
@@ -115,7 +114,6 @@ def run_query_native_with_timeout(
     parquet_folder: str,
     qnum: int,
     threads: int | None,
-    results_buffer_size: int | None,
     timeout: int,
     child_verbose: bool,
 ) -> tuple[str, float, int | str]:
@@ -123,7 +121,7 @@ def run_query_native_with_timeout(
     queue: multiprocessing.Queue = multiprocessing.Queue()
     proc = multiprocessing.Process(
         target=_run_query_native_in_subprocess,
-        args=(queue, parquet_folder, qnum, threads, results_buffer_size, child_verbose),
+        args=(queue, parquet_folder, qnum, threads, child_verbose),
     )
     proc.start()
     proc.join(timeout=timeout)
@@ -174,12 +172,6 @@ if __name__ == "__main__":
     parser.add_argument("--threads", default=None, type=int, help="Number of DuckDB threads (default: all cores)")
     parser.add_argument(
         "--timeout", default=300, type=int, help="Per-query subprocess timeout in seconds (default: 300)"
-    )
-    parser.add_argument(
-        "--results-buffer-size",
-        default=None,
-        type=int,
-        help="Optional results buffer size passed to runner.run_iter_tables() (default: None)",
     )
     parser.add_argument(
         "--child-verbose",
@@ -235,7 +227,6 @@ if __name__ == "__main__":
                 args.parquet_folder,
                 qnum,
                 args.threads,
-                args.results_buffer_size,
                 args.timeout,
                 args.child_verbose,
             )

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -226,10 +226,10 @@ class LocalRunner(Runner):
         os.environ["VANE_LOCAL_FTE_WORKERS"] = str(self.num_workers)
         os.environ["VANE_LOCAL_FTE_EXECUTION_MODE"] = self.execution_mode
 
-    def run_iter(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[Any]:
+    def run_iter(self, relation: Any) -> Iterator[Any]:
         raise NotImplementedError("local FTE run_iter is not implemented yet")
 
-    def run_iter_tables(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[pa.Table]:
+    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
         raise NotImplementedError("local FTE run_iter_tables is not implemented yet")
 
     @staticmethod

--- a/duckdb/runners/ray/__init__.py
+++ b/duckdb/runners/ray/__init__.py
@@ -32,7 +32,6 @@ def set_runner_ray(
     address: str | None = None,
     noop_if_initialized: bool = False,
     max_task_backlog: int | None = None,
-    force_client_mode: bool = False,
 ) -> Runner:
     """Configure DuckDB to use the Ray distributed computing framework."""
     import duckdb as _duckdb_pkg
@@ -42,5 +41,4 @@ def set_runner_ray(
         address,
         noop_if_initialized,
         max_task_backlog,
-        force_client_mode,
     )

--- a/duckdb/runners/ray/runner.py
+++ b/duckdb/runners/ray/runner.py
@@ -84,11 +84,9 @@ class RayRunner(Runner):
         self,
         address: str | None,
         max_task_backlog: int | None,
-        force_client_mode: bool = False,
     ) -> None:
         self.ray_address = address
         self.max_task_backlog = max_task_backlog
-        self.force_client_mode = force_client_mode
         ensure_vane_session_dir()
         _configure_scan_task_backlog_env(max_task_backlog)
 
@@ -147,9 +145,7 @@ class RayRunner(Runner):
             self._session_ids.add(session_key)
             return client
 
-    def run_iter(
-        self, relation: duckdb.DuckDBPyRelation, results_buffer_size: int | None = None
-    ) -> Iterator[RayMaterializedResult]:
+    def run_iter(self, relation: duckdb.DuckDBPyRelation) -> Iterator[RayMaterializedResult]:
         query_id = str(uuid.uuid4())
 
         PyLogicalPlan = require_ray_cxx_attr(
@@ -184,6 +180,6 @@ class RayRunner(Runner):
         # Send PyLogicalPlan to Driver — Driver will create physical plan
         return client.run_copy_plan(logical_plan)
 
-    def run_iter_tables(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[pa.Table]:
-        for result in self.run_iter(relation, results_buffer_size=results_buffer_size):
+    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
+        for result in self.run_iter(relation):
             yield result.partition()

--- a/duckdb/runners/runner.py
+++ b/duckdb/runners/runner.py
@@ -18,24 +18,20 @@ class Runner:
     name: ClassVar[Literal["ray", "local"]]
 
     @abstractmethod
-    def run_iter(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[MaterializedResult]:
+    def run_iter(self, relation: Any) -> Iterator[MaterializedResult]:
         """Yield individual partitions as they are completed.
 
         Args:
             relation: a DuckDB relation-like object describing the query to execute
-            results_buffer_size: if the plan is executed asynchronously, this is the maximum size of the number of results
-                that can be buffered before execution should pause and wait.
         """
         ...
 
     @abstractmethod
-    def run_iter_tables(self, relation: Any, results_buffer_size: int | None = None) -> Iterator[pa.Table]:
+    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
         """Similar to run_iter(), but always dereference and yield table objects.
 
         Args:
             relation: a DuckDB relation-like object describing the query to execute
-            results_buffer_size: if the plan is executed asynchronously, this is the maximum size of the number of results
-                that can be buffered before execution should pause and wait.
         """
         ...
 

--- a/external/duckdb/examples/driver_demo.py
+++ b/external/duckdb/examples/driver_demo.py
@@ -74,7 +74,7 @@ def run_demo(no_ray_init: bool = False, verbose: bool = False) -> None:
     logger.info("Printing partitions using runner.run_iter_tables for explicit iteration:")
     runner = duckdb.get_or_create_runner()
     builder = df._builder
-    for table in runner.run_iter_tables(builder, results_buffer_size=1):
+    for table in runner.run_iter_tables(builder):
         try:
             print(table.to_pandas())
         except Exception:

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -1190,7 +1190,7 @@ void DuckDBPyRelation::ExecuteOrThrow(bool stream_result) {
 			auto py_relation = DuckDBPyRelation(rel);
 			py_relation.SetConnectionOwner(connection_owner);
 			auto py_relation_obj = py::cast(std::move(py_relation));
-			table_iterator = py::iter(runner_for_db.runner.attr("run_iter_tables")(py_relation_obj, py::int_(1)));
+			table_iterator = py::iter(runner_for_db.runner.attr("run_iter_tables")(py_relation_obj));
 			py::object prefetched_partition;
 			bool has_prefetched_partition = false;
 			bool iterator_exhausted = false;

--- a/src/duckdb_py/vane-runners/vane_runners.cpp
+++ b/src/duckdb_py/vane-runners/vane_runners.cpp
@@ -77,19 +77,13 @@ public:
 
 	// factory: import duckdb.runners.ray_runner and instantiate
 	static std::unique_ptr<RayRunner> try_new(const std::pair<bool, std::string> &address,
-	                                          const std::pair<bool, size_t> &max_task_backlog,
-	                                          const std::pair<bool, bool> &force_client_mode) {
+	                                          const std::pair<bool, size_t> &max_task_backlog) {
 		duckdb::PythonGILWrapper gil;
 		py::module_ mod = py::module_::import("duckdb.runners.ray.runner");
 		py::object RayRunnerClass = mod.attr("RayRunner");
 		py::object py_address = address.first ? py::cast(address.second) : py::none();
 		py::object py_max_task_backlog = max_task_backlog.first ? py::cast(max_task_backlog.second) : py::none();
-		py::object instance;
-		if (force_client_mode.first) {
-			instance = RayRunnerClass(py_address, py_max_task_backlog, force_client_mode.second);
-		} else {
-			instance = RayRunnerClass(py_address, py_max_task_backlog);
-		}
+		py::object instance = RayRunnerClass(py_address, py_max_task_backlog);
 		return std::unique_ptr<RayRunner>(new RayRunner(instance));
 	}
 
@@ -162,11 +156,10 @@ public:
 
 	// call run_iter_tables on the underlying Python runner object
 	// lp_builder is expected to be a Python LogicalPlanBuilder-compatible object
-	py::iterator run_iter_tables(py::object py_builder, const std::pair<bool, size_t> &results_buffer_size) const {
+	py::iterator run_iter_tables(py::object py_builder) const {
 		duckdb::PythonGILWrapper gil;
 		py::object runner_obj = get_pyobj();
-		py::object py_buf_size = results_buffer_size.first ? py::cast(results_buffer_size.second) : py::none();
-		py::object result = runner_obj.attr("run_iter_tables")(py_builder, py_buf_size);
+		py::object result = runner_obj.attr("run_iter_tables")(py_builder);
 		return py::iterator(result);
 	}
 
@@ -190,20 +183,17 @@ struct RunnerConfig {
 	// Ray config
 	std::pair<bool, std::string> address;
 	std::pair<bool, size_t> max_task_backlog;
-	std::pair<bool, bool> force_client_mode;
 
 	RunnerConfig()
 	    : which(Which::Local), address(std::make_pair(false, std::string())),
-	      max_task_backlog(std::make_pair(false, size_t(0))), force_client_mode(std::make_pair(false, false)) {
+	      max_task_backlog(std::make_pair(false, size_t(0))) {
 	}
 
-	static RunnerConfig RayCfg(std::pair<bool, std::string> addr, std::pair<bool, size_t> backlog,
-	                           std::pair<bool, bool> force) {
+	static RunnerConfig RayCfg(std::pair<bool, std::string> addr, std::pair<bool, size_t> backlog) {
 		RunnerConfig rc;
 		rc.which = Which::Ray;
 		rc.address = std::move(addr);
 		rc.max_task_backlog = backlog;
-		rc.force_client_mode = force;
 		return rc;
 	}
 	static RunnerConfig LocalCfg() {
@@ -216,7 +206,7 @@ struct RunnerConfig {
 		if (which == Which::Local) {
 			return std::unique_ptr<Runner>(new Runner(LocalRunner::try_new()));
 		}
-		return std::unique_ptr<Runner>(new Runner(RayRunner::try_new(address, max_task_backlog, force_client_mode)));
+		return std::unique_ptr<Runner>(new Runner(RayRunner::try_new(address, max_task_backlog)));
 	}
 };
 
@@ -243,7 +233,7 @@ static RunnerConfig get_ray_runner_config_from_env() {
 		address = std::make_pair(true, std::string(addr));
 
 	auto max_task_backlog = parse_usize_env_var(VANE_RAY_MAX_TASK_BACKLOG);
-	return RunnerConfig::RayCfg(address, max_task_backlog, std::make_pair(false, false));
+	return RunnerConfig::RayCfg(address, max_task_backlog);
 }
 
 static RunnerConfig get_runner_config_from_env_or_default() {
@@ -340,14 +330,13 @@ static std::shared_ptr<Runner> get_or_create_runner_cpp() {
 
 // Helper to set runner once, following the Rust OnceLock semantics
 static py::object set_runner_ray_py(py::object address_py = py::none(), bool noop_if_initialized = false,
-                                    std::pair<bool, size_t> max_task_backlog = std::make_pair(false, size_t(0)),
-                                    std::pair<bool, bool> force_client_mode = std::make_pair(false, false)) {
+                                    std::pair<bool, size_t> max_task_backlog = std::make_pair(false, size_t(0))) {
 	auto result = initialize_runner([&] {
 		std::pair<bool, std::string> address = std::make_pair(false, std::string());
 		if (!address_py.is_none()) {
 			address = std::make_pair(true, address_py.cast<std::string>());
 		}
-		auto runner = RayRunner::try_new(address, max_task_backlog, force_client_mode);
+		auto runner = RayRunner::try_new(address, max_task_backlog);
 		return std::make_shared<Runner>(std::move(runner));
 	});
 	if (!result.created && (!noop_if_initialized || result.runner->get_type() != Runner::Type::Ray)) {
@@ -474,16 +463,14 @@ void register_vane_runners(py::module_ &m) {
 
 	m.def(
 	    "set_runner_ray",
-	    [](py::object address, bool noop_if_initialized, py::object max_task_backlog_py,
-	       bool force_client_mode) -> py::object {
+	    [](py::object address, bool noop_if_initialized, py::object max_task_backlog_py) -> py::object {
 		    std::pair<bool, size_t> max_task_backlog = std::make_pair(false, size_t(0));
 		    if (!max_task_backlog_py.is_none())
 			    max_task_backlog = std::make_pair(true, max_task_backlog_py.cast<size_t>());
-		    return set_runner_ray_py(address, noop_if_initialized, max_task_backlog,
-		                             std::make_pair(true, force_client_mode));
+		    return set_runner_ray_py(address, noop_if_initialized, max_task_backlog);
 	    },
 	    py::arg("address") = py::none(), py::arg("noop_if_initialized") = false,
-	    py::arg("max_task_backlog") = py::none(), py::arg("force_client_mode") = false);
+	    py::arg("max_task_backlog") = py::none());
 
 	m.def(
 	    "set_runner_local",

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -59,7 +59,7 @@ def ray_runner(_vane_shuffle_env, request):
 
 def _collect_tables(runner, relation, timeout_s: float = 60.0) -> pa.Table:
     start = time.time()
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     elapsed = time.time() - start
     assert elapsed < timeout_s
     assert parts

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -17,13 +17,11 @@ import duckdb
 class _FakeRayRunner:
     def __init__(self, tables: list[pa.Table]) -> None:
         self.tables = tables
-        self.calls: list[tuple[duckdb.DuckDBPyRelation, int | None]] = []
+        self.calls: list[duckdb.DuckDBPyRelation] = []
         self.closed_iterators = 0
 
-    def run_iter_tables(
-        self, relation: duckdb.DuckDBPyRelation, results_buffer_size: int | None = None
-    ) -> Iterator[pa.Table]:
-        self.calls.append((relation, results_buffer_size))
+    def run_iter_tables(self, relation: duckdb.DuckDBPyRelation) -> Iterator[pa.Table]:
+        self.calls.append(relation)
         try:
             yield from self.tables
         finally:
@@ -97,7 +95,6 @@ def test_distributed_row_cursor_is_shared_across_fetch_methods(monkeypatch):
     assert relation.fetchall() == [(3, "three")]
 
     assert len(runner.calls) == 1
-    assert runner.calls[0][1] == 1
     assert runner.closed_iterators == 1
 
 
@@ -137,7 +134,7 @@ def test_distributed_execute_reports_runner_start_error(monkeypatch):
         def __init__(self) -> None:
             self.calls = 0
 
-        def run_iter_tables(self, _relation, results_buffer_size=None):
+        def run_iter_tables(self, _relation):
             self.calls += 1
             raise RuntimeError("runner failed before first partition")
             yield  # pragma: no cover
@@ -157,8 +154,7 @@ def test_distributed_result_reports_midstream_runner_error(monkeypatch):
         def __init__(self) -> None:
             self.closed_iterators = 0
 
-        def run_iter_tables(self, _relation, results_buffer_size=None):
-            del results_buffer_size
+        def run_iter_tables(self, _relation):
             try:
                 yield pa.table({"c0": pa.array([1], pa.int64())})
                 raise RuntimeError("runner failed after first partition")
@@ -681,7 +677,7 @@ def test_distributed_runner_error_does_not_fall_back_to_local(monkeypatch):
         def __init__(self) -> None:
             self.calls = 0
 
-        def run_iter_tables(self, _relation, results_buffer_size=None):
+        def run_iter_tables(self, _relation):
             self.calls += 1
             raise NotImplementedError("unsupported distributed plan")
             yield  # pragma: no cover
@@ -760,4 +756,4 @@ def test_distributed_repr_uses_common_result_source(monkeypatch):
     assert "42" in output
     assert "999" not in output
     assert len(runner.calls) == 1
-    assert "LIMIT 10000" in runner.calls[0][0].sql_query().upper()
+    assert "LIMIT 10000" in runner.calls[0].sql_query().upper()

--- a/tests/fast/test_distributed_show.py
+++ b/tests/fast/test_distributed_show.py
@@ -14,10 +14,10 @@ import duckdb
 class _FakeRayRunner:
     def __init__(self, tables: list[pa.Table]) -> None:
         self.tables = tables
-        self.calls: list[tuple[duckdb.DuckDBPyRelation, int | None]] = []
+        self.calls: list[duckdb.DuckDBPyRelation] = []
 
-    def run_iter_tables(self, relation, results_buffer_size=None):
-        self.calls.append((relation, results_buffer_size))
+    def run_iter_tables(self, relation):
+        self.calls.append(relation)
         yield from self.tables
 
 
@@ -47,9 +47,8 @@ def test_relation_show_materializes_through_ray(monkeypatch, capsys):
     assert "42" in output
     assert "999" not in output
     assert len(runner.calls) == 1
-    limited_relation, results_buffer_size = runner.calls[0]
+    limited_relation = runner.calls[0]
     assert "LIMIT 10000" in limited_relation.sql_query().upper()
-    assert results_buffer_size == 1
 
 
 def test_relation_show_uses_local_execution(monkeypatch, capsys):

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -260,10 +260,10 @@ def _assert_results_match(con, sql, parts, label, *, ordered=False):
         assert sorted(actual_rows) == sorted(expected_rows), f"{label}: result rows do not match expected values"
 
 
-def _run_iter_tables(runner, builder, label, timeout_s=25.0, results_buffer_size=1):
+def _run_iter_tables(runner, builder, label, timeout_s=25.0):
     start = time.time()
     try:
-        parts = list(runner.run_iter_tables(builder, results_buffer_size=results_buffer_size))
+        parts = list(runner.run_iter_tables(builder))
         elapsed = time.time() - start
         _log_partitions(parts)
     except Exception:
@@ -1465,7 +1465,7 @@ def test_ray_task_large_block_stream_reaches_actor_with_bounded_leases(tmp_path,
         )
 
         start = time.time()
-        parts = list(runner.run_iter_tables(rel, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(rel))
         elapsed = time.time() - start
         ids = []
         lengths = []
@@ -1555,7 +1555,7 @@ def test_ray_lazy_tail_block_submits_without_cross_lease_batching(tmp_path, ray_
         )
 
         total = 0
-        for part in runner.run_iter_tables(rel, results_buffer_size=1):
+        for part in runner.run_iter_tables(rel):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
         assert total == row_count
@@ -1658,7 +1658,7 @@ def test_ray_actor_compute_batches_span_upstream_block_boundaries(tmp_path, ray_
         runner = _runners.get_or_create_runner()
         total = 0
         observed_batch_rows = set()
-        for part in runner.run_iter_tables(rel, results_buffer_size=1):
+        for part in runner.run_iter_tables(rel):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
             observed_batch_rows.update(table.column(1).to_pylist())
@@ -1745,7 +1745,7 @@ def test_ray_actor_soft_minimum_task_batch_matches_ray_data_bundling(tmp_path, r
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
         counts = Counter()
-        for part in runner.run_iter_tables(rel, results_buffer_size=1):
+        for part in runner.run_iter_tables(rel):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             counts.update(table.column(0).to_pylist())
 
@@ -1854,7 +1854,7 @@ def test_ray_actor_lazy_row_backpressure_preserves_non_tail_batch_alignment(tmp_
         runner = _runners.get_or_create_runner()
         total = 0
         observed = Counter()
-        for part in runner.run_iter_tables(rel, results_buffer_size=1):
+        for part in runner.run_iter_tables(rel):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
             observed.update(table.column(1).to_pylist())
@@ -1946,7 +1946,7 @@ def test_ray_task_block_stream_does_not_deadlock_when_sink_and_source_blocked(tm
         )
 
         start = time.time()
-        parts = list(runner.run_iter_tables(rel, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(rel))
         elapsed = time.time() - start
         total = 0
         for part in parts:
@@ -2053,7 +2053,7 @@ def test_ray_task_flat_map_ref_stream_preserves_rows_under_actor_backpressure(tm
         ids = set()
         chunk_id_sum = 0
         max_chunk_len = 0
-        for part in runner.run_iter_tables(rel, results_buffer_size=1):
+        for part in runner.run_iter_tables(rel):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             count += table.num_rows
             ids.update(table.column(0).to_pylist())
@@ -2159,7 +2159,7 @@ def test_ray_task_flat_map_projected_ref_stream_preserves_column_projection(tmp_
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(aggregate))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2278,7 +2278,7 @@ def test_ray_task_flat_map_ref_stream_preserves_variable_and_empty_outputs(tmp_p
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(aggregate))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2392,7 +2392,7 @@ def test_ray_task_flat_map_ref_stream_preserves_reordered_alias_projection(tmp_p
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(aggregate))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2484,7 +2484,7 @@ def test_ray_task_flat_map_ref_stream_all_empty_output_finishes(tmp_path, ray_su
         aggregate = rel.aggregate("count(*) AS c")
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate, results_buffer_size=1))
+        parts = list(runner.run_iter_tables(aggregate))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2626,7 +2626,7 @@ def test_ray_python_udf_terminal_failure_propagates(ray_runner, duckdb_conn, par
     )
 
     with pytest.raises(Exception, match="planned scalar failure|FTE query .* failed"):
-        list(ray_runner.run_iter_tables(relation, results_buffer_size=1))
+        list(ray_runner.run_iter_tables(relation))
 
 
 def test_ray_python_udf_map_batches_arrow(ray_runner, duckdb_conn, parquet_path):

--- a/tests/fast/test_ray_e2e_serialization.py
+++ b/tests/fast/test_ray_e2e_serialization.py
@@ -93,7 +93,7 @@ def test_streaming_metadata_and_rows_full_execution(tmp_path):
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     result = pa.concat_tables(tables)
 

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -43,7 +43,7 @@ def test_run_simple_plan_on_ray_local():
     assert getattr(runner, "name", None) == "ray"
 
     relation = duckdb.sql("SELECT a, b, a + b AS sum FROM (VALUES (1, 10), (2, 20), (3, 30)) AS t(a, b)")
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     assert parts
     rows = sorted(_collect_rows_from_parts(parts))
     assert rows == [(1, 10, 11), (2, 20, 22), (3, 30, 33)]
@@ -74,7 +74,7 @@ def test_run_distributed_plan_end_to_end_on_ray_local(tmp_path):
     runner = _runners.get_or_create_runner()
     assert getattr(runner, "name", None) == "ray"
 
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     assert parts
 
     rows = _collect_rows_from_parts(parts)

--- a/tests/fast/test_ray_udf_plan_replay.py
+++ b/tests/fast/test_ray_udf_plan_replay.py
@@ -462,7 +462,7 @@ def test_ray_runner_replays_map_batches_udf_via_task_plan_pickle(tmp_path, monke
     )
     _runners.set_runner_ray(noop_if_initialized=True)
     runner = _runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
 
     result = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
     assert result.column(0).to_pylist() == [0, 2, 4, 6]

--- a/tests/fast/test_vane_config.py
+++ b/tests/fast/test_vane_config.py
@@ -375,6 +375,31 @@ else:
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
+def test_set_runner_ray_rejects_removed_force_client_mode():
+    from duckdb import runners
+
+    with pytest.raises(TypeError, match="force_client_mode"):
+        runners.set_runner_ray(force_client_mode=True)
+
+
+@pytest.mark.parametrize("method_name", ["run_iter", "run_iter_tables"])
+def test_ray_runner_rejects_removed_results_buffer_size(method_name):
+    from duckdb.runners.ray.runner import RayRunner
+
+    runner = object.__new__(RayRunner)
+    method = getattr(runner, method_name)
+
+    with pytest.raises(TypeError, match="results_buffer_size"):
+        method(object(), results_buffer_size=1)
+
+
+def test_native_set_runner_ray_rejects_removed_fourth_argument():
+    import duckdb
+
+    with pytest.raises(TypeError):
+        duckdb.vane_runners_cpp.set_runner_ray(None, False, None, False)
+
+
 def test_ray_noop_reuses_existing_runner_without_validating_address():
     script = """
 import duckdb
@@ -395,8 +420,8 @@ ray_runner_module.RayRunner = FakeRayRunner
 vane_runners = duckdb.vane_runners_cpp
 vane_runners.teardown_runner()
 
-first = vane_runners.set_runner_ray(None, False, None, False)
-second = vane_runners.set_runner_ray(object(), True, None, False)
+first = vane_runners.set_runner_ray(None, False, None)
+second = vane_runners.set_runner_ray(object(), True, None)
 
 assert second is first
 """

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -65,7 +65,6 @@ def test_write_failure_releases_cache_and_preserves_configured_native_runner(tmp
     configured_runner = runners_module.set_runner_ray(
         "ray://configured",
         max_task_backlog=17,
-        force_client_mode=True,
     )
     real_set_runner_ray = runners_module.set_runner_ray
 
@@ -87,7 +86,7 @@ def test_write_failure_releases_cache_and_preserves_configured_native_runner(tmp
         assert len(created_runners) == 1
         assert created_runners[0].calls == 2
         assert created_runners[0].close_calls == 0
-        assert created_runners[0].init_args == ("ray://configured", 17, True)
+        assert created_runners[0].init_args == ("ray://configured", 17)
         assert vane_runners.get_runner() is configured_runner
     finally:
         vane_runners.teardown_runner()

--- a/tests/slow/test_expression_udf_ray_chain.py
+++ b/tests/slow/test_expression_udf_ray_chain.py
@@ -45,7 +45,7 @@ try:
         UpperActor()(vane.col("text")).alias("upper_text"),
     )
 
-    parts = list(runner.run_iter_tables(result, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(result))
     table = pa.concat_tables(parts).rename_columns(list(result.columns))
     rows = sorted(table.to_pylist(), key=lambda row: row["id"])
     assert rows == [
@@ -89,7 +89,7 @@ vane.configure(runner="ray")
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 
@@ -269,7 +269,7 @@ class StatefulBatchCounter:
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 
@@ -399,7 +399,7 @@ vane.configure(runner="ray")
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation, results_buffer_size=1))
+    parts = list(runner.run_iter_tables(relation))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 


### PR DESCRIPTION
## Summary

- Remove the unused `results_buffer_size` argument from runner iteration APIs and their callers.
- Remove the unused `force_client_mode` argument from Python and native Ray runner configuration.
- Add regression coverage proving that the removed arguments are rejected instead of being silently accepted.

## Related issue

close: #99

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format workspace --changed`
- Incremental Release native build and install with `uv pip install . --no-build-isolation`
- Focused fast tests: 206 passed, 4 deselected
- Removed-argument regression tests: 4 passed, 24 deselected
- `scripts/run_release_tests.sh`: 418 passed, 1 skipped, 11 deselected; real-Ray shard 7 passed, 423 deselected
- `scripts/run_fast_tests.sh`: non-Ray 5879 passed; shared-Ray 86 passed; isolated Ray-owner shards 6 passed; expected skips/xfails only
- `python -m pytest tests/slow/test_expression_udf_ray_chain.py`: 5 passed
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.