### PR TITLE
[fix](ray) Ignore late FTE no-more-splits signals

### DIFF
--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -930,7 +930,7 @@ class FteTaskExecution:
     def no_more_splits(self, source_node_id: str) -> TaskStatus:
         with self._status_lock:
             if self.status.state in _TERMINAL_STATES:
-                raise RuntimeError(f"cannot update terminal task {self.task_id}")
+                return self.status
             source_node_id = str(source_node_id)
             changed = source_node_id not in self.no_more_split_sources
             if changed:

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -904,6 +904,55 @@ def test_fte_task_execution_terminal_status_refreshes_split_stats_with_fallback(
     assert fallback_status["completed_input_bytes"] == 128
 
 
+@pytest.mark.parametrize(
+    "terminal_state",
+    [
+        FteTaskState.FINISHED,
+        FteTaskState.FAILED,
+        FteTaskState.CANCELED,
+        FteTaskState.ABORTED,
+    ],
+)
+def test_fte_task_execution_late_no_more_splits_is_terminal_noop(terminal_state):
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {
+            "task_id": "q-late-no-more-splits.0.0.0",
+            "no_more_splits": ["already-sealed"],
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+    failure = None
+    if terminal_state == FteTaskState.FAILED:
+        failure = {
+            "type": "RuntimeError",
+            "message": "existing failure",
+            "traceback": "existing traceback",
+        }
+    execution._transition(terminal_state, failure=failure)
+    state_before = execution.status.state
+    version_before = execution.status.version
+    failure_before = None if execution.status.failure is None else dict(execution.status.failure)
+    updated_at_before = execution.status.updated_at
+    sealed_sources_before = set(execution.no_more_split_sources)
+
+    status = execution.no_more_splits("late-source")
+
+    assert status is execution.status
+    assert status.state == state_before
+    assert status.version == version_before
+    assert status.failure == failure_before
+    assert status.updated_at == updated_at_before
+    assert execution.no_more_split_sources == sealed_sources_before
+    with pytest.raises(RuntimeError, match="cannot add splits to terminal task"):
+        execution.add_splits("late-source", [])
+    with pytest.raises(RuntimeError, match="cannot update terminal task"):
+        execution.update_task({})
+
+
 def test_fte_query_status_uses_fragment_execution_snapshot():
     class _SnapshotOnlyFragmentExecution:
         @property
@@ -4332,6 +4381,8 @@ def test_fte_worker_task_manager_unknown_status_is_non_throwing():
         assert status["task_id_string"] == "q.9.3.0"
         with pytest.raises(KeyError, match="unknown FTE task attempt"):
             await manager.add_splits(task_id, "7", [])
+        with pytest.raises(KeyError, match="unknown FTE task attempt"):
+            await manager.no_more_splits(task_id, "7")
 
     asyncio.run(run())
 


### PR DESCRIPTION
<!-- Title format: [type](scope) Subject -->

## Summary

<!-- Describe the user-visible or architectural change and why it is needed. -->

An FTE `no_more_splits` command may be queued before execution finishes but arrive after the task has entered a terminal state. The previous implementation treated it as a mutable task update, raising `RuntimeError` and turning a benign control-plane race into `FteWorkerControlFailure`.

Return the existing terminal status without mutation. Late split additions, task updates, and unknown task attempts remain strict errors. Tests cover every terminal state and the unknown-attempt boundary.

## Related issue

Closes #236.

Related to #90 and follow-up to #231.

## Documentation impact

<!-- Select exactly one option. -->

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

<!-- Link the documentation PR or add follow-up notes here. -->

## Validation

<!-- List the exact checks you ran. Include relevant hardware, dataset, runner, and batch settings for performance changes. -->

  - `scripts/format root --changed`
  - `pre-commit run --files duckdb/runners/fte/fte_worker_runtime.py tests/fast/test_ray_fte.py`
  - FTE regression suite: 398 passed
  - `scripts/run_release_tests.sh`: 414 passed, 1 skipped; real-Ray shard 7 passed

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

