### PR TITLE
[fix](ray) Publish completion after stream retirement

### DIFF
--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -791,13 +791,16 @@ class AsyncResultCollector:
         record.adapter.mark_drained()
         key = (record.slot_id, record.submit_id)
         with self._cv:
-            if self._records.pop(key, None) is not record:
+            if self._records.get(key) is not record:
                 return
             record.terminal = True
+        record.adapter.retire()
+        with self._cv:
+            if self._records.pop(key, None) is not record:
+                return
             self._ready_by_slot[record.slot_id].append(_ReadyEvent(record.slot_id, record.submit_id, "complete", None))
             self._cv.notify_all()
         _collector_debug_log("retired", record)
-        record.adapter.retire()
         self._notify_wakeup()
 
     def _cancel_record_control(self, record: _StreamRecord) -> None:

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-import gc
 import threading
 import time
 import weakref
@@ -641,10 +640,20 @@ def test_inflight_block_keeps_item_capacity_from_read_admission():
         collector.shutdown()
 
 
-def test_terminal_stream_is_retired_without_waiting_for_collector_shutdown():
+def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     generator_holder = {}
+    retire_started = threading.Event()
+    allow_retire = threading.Event()
+    original_retire = RayStreamAdapter.retire
+
+    def blocking_retire(adapter):
+        retire_started.set()
+        allow_retire.wait()
+        original_retire(adapter)
+
+    monkeypatch.setattr(RayStreamAdapter, "retire", blocking_retire)
 
     def make_source():
         def submitter(lease):
@@ -669,27 +678,43 @@ def test_terminal_stream_is_retired_without_waiting_for_collector_shutdown():
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(2, 22, source)
     del source
+    capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
     try:
-        events = _drain_until(
-            collector,
-            {2: {"rows": 1, "bytes": 128, "item_bytes": 128}},
-            predicate=lambda values: any(item[2] == "complete" for item in values),
-        )
+        events = []
+        deadline = time.monotonic() + 2.0
+        while not retire_started.is_set() and time.monotonic() < deadline:
+            events.extend(collector.drain_results(capacity))
+            time.sleep(0.005)
+        assert retire_started.is_set()
+        events.extend(collector.drain_results(capacity))
+
+        # Completion is the observable retirement boundary. Keep the record
+        # pending, and do not publish completion, until local stream cleanup
+        # has dropped the source and deleted the Ray ObjectRef stream.
+        assert [item[2] for item in events] == ["data"]
+        assert collector._records
+        assert source_ref() is not None
+        generator = generator_holder["generator"]
+        assert generator.deleted_streams == []
+
         data = next(item for item in events if item[2] == "data")
         assert collector.release_output_block_lease(data[4], data[5]) is True
         del data
         del events
 
-        deadline = time.monotonic() + 1.0
-        while source_ref() is not None and time.monotonic() < deadline:
-            gc.collect()
-            time.sleep(0.005)
+        allow_retire.set()
+        events = _drain_until(
+            collector,
+            capacity,
+            predicate=lambda values: any(item[2] == "complete" for item in values),
+        )
 
+        assert [item[2] for item in events] == ["complete"]
         assert collector._records == {}
         assert source_ref() is None
-        generator = generator_holder["generator"]
         assert generator.deleted_streams == [generator.completion_ref]
     finally:
+        allow_retire.set()
         collector.shutdown()
 
 


### PR DESCRIPTION
## Summary

- keep a terminal stream record pending while `RayStreamAdapter.retire()` releases task/source ownership and deletes the ObjectRef stream
- publish the collector `complete` event only after that local retirement finishes
- replace the GC-timing assertion with a deterministic retirement gate that proves completion cannot overtake cleanup

## Root cause

`AsyncResultCollector._maybe_complete_record()` removed the record and published `complete` before calling `record.adapter.retire()`. Consumers could therefore observe an empty collector while the adapter still held strong references to `TaskLeaseObjectRefGenerator`, making the weakref assertion scheduler-dependent in the full fast suite.

## Testing

- `python -m pytest tests/fast/test_udf_stream_result_collector.py` (21 passed)
- related stream adapter and collector tests (33 passed)
- `python -m pytest tests/fast/test_udf_process.py` (6 passed)
- `scripts/run_release_tests.sh` (418 passed, 1 skipped; 7 real-Ray tests passed)
- `scripts/run_fast_tests.sh non-ray` (5895 passed, 28 skipped, 8 xfailed, 1 xpassed)
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

Closes #217