### PR TITLE
[fix](fte) Require structured failure error codes

### DIFF
--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -24,6 +24,7 @@ from duckdb.runners.fte.dynamic_inputs import (
     strip_fte_dynamic_context,
 )
 from duckdb.runners.fte.fte_config import FTE_WORKER_RUNTIME, FteWorkerAdmissionConfig
+from duckdb.runners.fte.fte_failures import _failure_payload, _normalize_failure_payload
 from duckdb.runners.fte.fte_state import FteTaskState
 from duckdb.runners.fte.fte_types import (
     FteTaskAttemptId,
@@ -599,11 +600,14 @@ class NativeTaskResultHandle:
         except Exception:
             pass
 
-    def _failure_status(self) -> dict[str, Any]:
+    def _failure_status(self, error: BaseException) -> dict[str, Any]:
+        failure = _failure_payload("NATIVE_BACKEND_ERROR", error)
+        failure["type"] = type(error).__name__
         return {
             "state": FteTaskState.FAILED.value,
             "task_id": self._task_id.to_dict(),
             "task_id_string": str(self._task_id),
+            "failure": failure,
         }
 
     def _validated_status(self, status: Any, *, operation: str) -> dict[str, Any]:
@@ -611,6 +615,14 @@ class NativeTaskResultHandle:
             raise TypeError(f"{operation} must return a status mapping")
         result = dict(status)
         validate_fte_status_identity(result, self._task_id)
+        raw_state = result.get("state")
+        state = raw_state.value if isinstance(raw_state, FteTaskState) else str(raw_state or "").upper()
+        if state in {
+            FteTaskState.FAILED.value,
+            FteTaskState.CANCELED.value,
+            FteTaskState.ABORTED.value,
+        }:
+            result["failure"] = _normalize_failure_payload(result.get("failure"))
         return result
 
     def status_snapshot(self) -> dict[str, Any]:
@@ -620,7 +632,7 @@ class NativeTaskResultHandle:
                 operation="fte_get_task_status_cached",
             )
         except BaseException as exc:
-            self._record_status(self._failure_status(), exc)
+            self._record_status(self._failure_status(exc), exc)
             raise
         self._record_status(status)
         return status
@@ -637,7 +649,7 @@ class NativeTaskResultHandle:
             )
             info["status"] = status
         except BaseException as exc:
-            self._record_status(self._failure_status(), exc)
+            self._record_status(self._failure_status(exc), exc)
             raise
         self._record_status(status)
         return info
@@ -649,11 +661,12 @@ class NativeTaskResultHandle:
                 operation="fte_get_task_status_cached",
             )
         except BaseException as exc:
-            self._record_status(self._failure_status(), exc)
+            self._record_status(self._failure_status(exc), exc)
             return TaskResultPoll(TaskResultState.ERROR, error=exc)
 
         self._record_status(status)
-        state = str(status.get("state") or "").upper()
+        raw_state = status.get("state")
+        state = raw_state.value if isinstance(raw_state, FteTaskState) else str(raw_state or "").upper()
         if state not in _TERMINAL_STATE_VALUES:
             return TaskResultPoll(TaskResultState.NOT_READY)
         if state == FteTaskState.FINISHED.value:
@@ -661,11 +674,11 @@ class NativeTaskResultHandle:
             if result is None:
                 return TaskResultPoll(TaskResultState.NO_OUTPUT)
             return TaskResultPoll(TaskResultState.MATERIALIZED_OUTPUT, output=result)
-        failure = status.get("failure")
-        message = failure.get("message") if isinstance(failure, Mapping) else None
+        failure = _normalize_failure_payload(status.get("failure"))
+        message = failure.get("message")
         return TaskResultPoll(
             TaskResultState.ERROR,
-            error=RuntimeError(message or f"native FTE task {self._task_id} ended with {state}"),
+            error=RuntimeError(message or f"native FTE task {self._task_id} ended with {failure['error_code']}"),
         )
 
     def done(self) -> bool:
@@ -1586,7 +1599,8 @@ class NativeFteWorkerManagerBackend:
         progress_stats = cls._progress_stats_from_status(status)
         failure = status.get("failure")
         if error is not None:
-            failure = {"type": type(error).__name__, "message": str(error)}
+            failure = _failure_payload("NATIVE_BACKEND_ERROR", error)
+            failure["type"] = type(error).__name__
         running_attempts = []
         if running:
             running_attempts.append(
@@ -1674,7 +1688,12 @@ class NativeFteWorkerManagerBackend:
             try:
                 status = handle.status_snapshot()
             except BaseException as exc:
-                status = {"state": FteTaskState.FAILED.value}
+                failure = _failure_payload("NATIVE_BACKEND_ERROR", exc)
+                failure["type"] = type(exc).__name__
+                status = {
+                    "state": FteTaskState.FAILED.value,
+                    "failure": failure,
+                }
                 status_error = exc
             partition = self._partition_metrics_from_handle(handle, status, error=status_error)
             partition_metrics[(query_id, handle.fragment_id, str(handle.task_id.partition_id))] = partition

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -37,8 +37,11 @@ from duckdb.runners.fte.fte_exchange import (
 )
 from duckdb.runners.fte.fte_failures import (
     _failure_allows_retry,
+    _failure_payload,
     _is_memory_failure,
     _missing_output_stats_failure,
+    _normalize_failure_payload,
+    _safe_failure_message,
 )
 from duckdb.runners.fte.fte_split_assigner import (
     PartitionUpdate,
@@ -82,7 +85,7 @@ class FteWorkerControlFailure(RuntimeError):
         self.cause = cause
         super().__init__(
             f"FTE worker {self.worker_id or '<unknown>'} failed during "
-            f"{self.method_name} for {self.attempt_id}: {cause}"
+            f"{self.method_name} for {self.attempt_id}: {_safe_failure_message(cause)}"
         )
 
 
@@ -154,7 +157,7 @@ class FteTaskPartition:
         self.selected_attempt: int | None = None
         self.finished_attempts: dict[int, FinishedAttempt] = {}
         self.selected_output_stats: Any = None
-        self.failures: list[Any] = []
+        self.failures: list[dict[str, Any]] = []
         self.ready_for_scheduling = bool(self.sealed)
         self.execution_ready_deferred = False
         self.node_wait_started_at: float | None = None
@@ -324,7 +327,7 @@ class FteTaskPartition:
     def mark_attempt_failed(
         self,
         attempt_id: FteTaskAttemptId | str | Mapping[str, Any],
-        error: Any = None,
+        error: dict[str, Any],
         *,
         retryable: bool = True,
     ) -> ReadyTask | None:
@@ -363,7 +366,7 @@ class FteTaskPartition:
     def revoke_attempt(
         self,
         attempt_id: FteTaskAttemptId | str | Mapping[str, Any],
-        error: Any = None,
+        error: dict[str, Any],
     ) -> RevokedAttempt | None:
         attempt = FteTaskAttemptId.coerce(attempt_id)
         self._validate_attempt_task(attempt)
@@ -1256,21 +1259,22 @@ class FteFragmentExecution:
     def task_failed(
         self,
         attempt_id: FteTaskAttemptId | str | Mapping[str, Any],
-        error: Any = None,
+        error: Mapping[str, Any],
         *,
         retryable: bool = True,
         schedule_retry: bool = True,
     ) -> ScheduledAttempt | None:
         attempt = FteTaskAttemptId.coerce(attempt_id)
+        failure = _normalize_failure_payload(error)
         should_schedule = False
         with self._state_lock:
             partition = self.partitions[attempt.partition_id]
             running = partition.running_attempts.get(attempt.attempt_id)
-            failure_retryable = retryable and _failure_allows_retry(error)
+            failure_retryable = retryable and _failure_allows_retry(failure)
             if self.exchange is not None and partition.sink_handle is not None:
                 self.exchange.sink_aborted(partition.sink_handle, attempt.attempt_id)
-            ready = partition.mark_attempt_failed(attempt, error, retryable=failure_retryable)
-            if ready is not None and _is_memory_failure(error):
+            ready = partition.mark_attempt_failed(attempt, failure, retryable=failure_retryable)
+            if ready is not None and _is_memory_failure(failure):
                 partition.failed = True
                 partition.ready_for_scheduling = False
                 partition.execution_ready_deferred = False
@@ -1305,6 +1309,10 @@ class FteFragmentExecution:
         limit = None if max_count is None else max(0, int(max_count))
         if limit == 0:
             return revoked
+        failure = _failure_payload(
+            "SPECULATIVE_ATTEMPT_REVOKED",
+            reason or "speculative task revoked",
+        )
         try:
             with self._state_lock:
                 reached_limit = False
@@ -1330,7 +1338,7 @@ class FteFragmentExecution:
                             self.exchange.sink_aborted(partition.sink_handle, running.attempt_id.attempt_id)
                         revoked_attempt = partition.revoke_attempt(
                             running.attempt_id,
-                            reason or "speculative task revoked",
+                            failure,
                         )
                         if revoked_attempt is None:
                             continue
@@ -1350,7 +1358,7 @@ class FteFragmentExecution:
     def mark_worker_failed(
         self,
         worker_id: str,
-        error: Any = None,
+        error: Mapping[str, Any],
         *,
         retryable: bool = True,
         retryable_by_partition_id: Mapping[int, bool] | None = None,
@@ -1437,6 +1445,9 @@ class FteFragmentExecution:
             return None
         attempt_id = self._attempt_id_from_status(status)
         state = self._task_state_from_status(status)
+        terminal_failure = None
+        if state in (FteTaskState.FAILED, FteTaskState.CANCELED, FteTaskState.ABORTED):
+            terminal_failure = _normalize_failure_payload(status.get("failure"))
         task_stats = _task_status_progress_stats(status)
         raw_task_stats = status.get("task_stats")
         if isinstance(raw_task_stats, Mapping):
@@ -1458,11 +1469,11 @@ class FteFragmentExecution:
                 )
             self.task_finished(attempt_id, output_stats)
             return None
-        if state in (FteTaskState.FAILED, FteTaskState.CANCELED, FteTaskState.ABORTED):
+        if terminal_failure is not None:
             status_retryable = retryable and state == FteTaskState.FAILED
             return self.task_failed(
                 attempt_id,
-                status.get("failure") or dict(status),
+                terminal_failure,
                 retryable=status_retryable,
                 schedule_retry=schedule_retry,
             )

--- a/duckdb/runners/fte/fte_failures.py
+++ b/duckdb/runners/fte/fte_failures.py
@@ -12,24 +12,114 @@ if TYPE_CHECKING:
     from duckdb.runners.fte.fte_types import FteTaskAttemptId
 
 
-def _failure_text(payload: Any) -> str:
-    if payload is None:
-        return ""
-    if isinstance(payload, Mapping):
-        parts: list[str] = []
-        for key in ("error_code", "errorCode", "code", "type", "message", "error", "exception"):
-            value = payload.get(key)
-            if value is not None:
-                parts.append(str(value))
-        failure = payload.get("failure")
-        if failure is not None and failure is not payload:
-            parts.append(_failure_text(failure))
-        return " ".join(part for part in parts if part)
-    return str(payload)
+_MEMORY_FAILURE_CODES = frozenset(
+    {
+        "EXCEEDED_LOCAL_MEMORY_LIMIT",
+        "OUT_OF_MEMORY",
+    }
+)
 
 
 def _normalized_error_token(value: Any) -> str:
     return str(value or "").strip().upper().replace("-", "_").replace(" ", "_")
+
+
+def _safe_failure_message(message: Any) -> str:
+    if message is None:
+        return ""
+    try:
+        return str(message)
+    except BaseException:
+        return f"<unprintable {type(message).__name__}>"
+
+
+def _failure_payload(
+    error_code: str,
+    message: Any,
+    *,
+    error_type: str = "INTERNAL_ERROR",
+) -> dict[str, Any]:
+    if not isinstance(error_code, str):
+        raise TypeError("FTE failure error_code must be a string")
+    code = _normalized_error_token(error_code)
+    if not code:
+        raise ValueError("FTE failure error_code must be non-empty")
+    return {
+        "error_type": _normalized_error_token(error_type),
+        "error_code": code,
+        "message": _safe_failure_message(message),
+    }
+
+
+def _normalize_failure_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise TypeError("FTE failure payload must be a mapping")
+    if "error_code" not in payload:
+        raise ValueError("FTE failure payload requires error_code")
+    raw_code = payload["error_code"]
+    if not isinstance(raw_code, str):
+        raise TypeError("FTE failure payload error_code must be a string")
+    code = _normalized_error_token(raw_code)
+    if not code:
+        raise ValueError("FTE failure payload requires error_code")
+    normalized = dict(payload)
+    normalized["error_code"] = code
+    if "error_type" in normalized:
+        normalized["error_type"] = _normalized_error_token(normalized["error_type"])
+    return normalized
+
+
+_UNREADABLE_EXCEPTION_ATTRIBUTE = object()
+
+
+def _read_exception_attribute(error: BaseException, attribute: str) -> Any:
+    try:
+        return getattr(error, attribute, None)
+    except BaseException:
+        return _UNREADABLE_EXCEPTION_ATTRIBUTE
+
+
+def _failure_exception_matches(
+    error: Any,
+    exception_types: tuple[type[BaseException], ...],
+) -> bool:
+    if not issubclass(type(error), BaseException):
+        return False
+    candidates = [error]
+    candidate_ids = {id(error)}
+    candidate_index = 0
+    while candidate_index < len(candidates) and candidate_index < 16:
+        candidate = candidates[candidate_index]
+        candidate_index += 1
+        if issubclass(type(candidate), exception_types):
+            return True
+        converted = _read_exception_attribute(candidate, "as_instanceof_cause")
+        if callable(converted):
+            try:
+                converted_cause = converted()
+            except BaseException:
+                converted_cause = None
+            if issubclass(type(converted_cause), BaseException) and id(converted_cause) not in candidate_ids:
+                candidate_ids.add(id(converted_cause))
+                candidates.append(converted_cause)
+        chained_causes = [
+            cause
+            for cause in (
+                _read_exception_attribute(candidate, "cause"),
+                _read_exception_attribute(candidate, "__cause__"),
+            )
+            if issubclass(type(cause), BaseException)
+        ]
+        suppress_context = _read_exception_attribute(candidate, "__suppress_context__")
+        if not chained_causes and suppress_context is False:
+            context = _read_exception_attribute(candidate, "__context__")
+            if issubclass(type(context), BaseException):
+                chained_causes.append(context)
+        for cause in chained_causes:
+            if issubclass(type(cause), BaseException) and id(cause) not in candidate_ids:
+                candidate_ids.add(id(cause))
+                candidates.append(cause)
+    return False
 
 
 def _failure_field(payload: Any, *keys: str) -> Any:
@@ -107,15 +197,11 @@ def _failure_allows_retry(payload: Any, *, default: bool = True) -> bool:
 
 
 def _missing_output_stats_failure(attempt_id: FteTaskAttemptId) -> dict[str, Any]:
-    return {
-        "error_type": "INTERNAL_ERROR",
-        "error_code": "MISSING_SPOOLING_OUTPUT_STATS",
-        "message": (f"Treating FINISHED task {attempt_id} as FAILED because spooling output stats are missing"),
-    }
+    return _failure_payload(
+        "MISSING_SPOOLING_OUTPUT_STATS",
+        f"Treating FINISHED task {attempt_id} as FAILED because spooling output stats are missing",
+    )
 
 
 def _is_memory_failure(payload: Any) -> bool:
-    text = _failure_text(payload).lower()
-    return any(
-        token in text for token in ("out_of_memory", "out of memory", "oom", "memory limit", "exceeded_local_memory")
-    )
+    return _normalize_failure_payload(payload)["error_code"] in _MEMORY_FAILURE_CODES

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -27,6 +27,7 @@ from duckdb.runners.fte.fte_events import (
     WorkerFailed,
     WorkerReservationCompleted,
 )
+from duckdb.runners.fte.fte_failures import _safe_failure_message
 from duckdb.runners.fte.fte_state import FteTaskState
 from duckdb.runners.fte.fte_types import validate_fte_status_identity
 
@@ -307,14 +308,14 @@ class FteAttemptStatusWatcher:
 
     @staticmethod
     def _is_soft_status_wait_timeout(exc: BaseException) -> bool:
-        if isinstance(exc, QueryDeadlineExceeded) or "query deadline expired" in str(exc).lower():
+        message = _safe_failure_message(exc)
+        if issubclass(type(exc), QueryDeadlineExceeded) or "query deadline expired" in message.lower():
             return False
-        if isinstance(exc, TimeoutError):
+        if issubclass(type(exc), TimeoutError):
             return True
-        name = exc.__class__.__name__
+        name = type(exc).__name__
         if name in {"TimeoutError", "GetTimeoutError"}:
             return True
-        message = str(exc)
         return "did not complete within" in message or "timed out" in message.lower()
 
     def _run(self) -> None:

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from duckdb import OutOfMemoryException
 from duckdb.runners.fte.debug_memory import (
     debug_flag_enabled,
     describe_result_payload,
@@ -34,8 +35,15 @@ from duckdb.runners.fte.fte_descriptor import (
     normalize_initial_splits,
 )
 from duckdb.runners.fte.fte_exchange import collect_spooling_output_stats
+from duckdb.runners.fte.fte_failures import (
+    _failure_exception_matches,
+    _failure_payload,
+    _normalize_failure_payload,
+    _safe_failure_message,
+)
 from duckdb.runners.fte.fte_state import _TERMINAL_STATES, FteTaskState
 from duckdb.runners.fte.fte_types import FteSplit, FteTaskAttemptId
+from duckdb.runners.fte.memory_config import DuckDBMemoryLimitError
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -139,12 +147,39 @@ def fte_split_queue_space_poll_interval_s() -> float:
     return min(max(0.001, value), 0.1)
 
 
-def _failure_payload(exc: BaseException) -> dict[str, str]:
-    return {
-        "type": type(exc).__name__,
-        "message": str(exc),
-        "traceback": "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
-    }
+def _safe_exception_traceback(exc: BaseException) -> str:
+    try:
+        return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    except BaseException:
+        return f"{type(exc).__name__}: {_safe_failure_message(exc)}\n"
+
+
+def _failure_payload_from_exception(exc: BaseException) -> dict[str, Any]:
+    retryable: bool | None = None
+    if _failure_exception_matches(exc, (DuckDBMemoryLimitError,)):
+        error_code = "MEMORY_LIMIT_CONFIGURATION_FAILED"
+        retryable = False
+    elif _failure_exception_matches(exc, (OutOfMemoryException, MemoryError)):
+        error_code = "OUT_OF_MEMORY"
+    else:
+        error_code = "GENERIC_INTERNAL_ERROR"
+    payload = _failure_payload(error_code, exc)
+    if retryable is not None:
+        payload["retryable"] = retryable
+    payload.update(
+        {
+            "type": type(exc).__name__,
+            "traceback": _safe_exception_traceback(exc),
+        }
+    )
+    return payload
+
+
+def _task_canceled_failure_payload(task_id: FteTaskAttemptId) -> dict[str, Any]:
+    return _failure_payload(
+        "TASK_CANCELED",
+        f"FTE task {task_id} was canceled",
+    )
 
 
 def _fte_admission_debug_enabled() -> bool:
@@ -180,7 +215,7 @@ class TaskStatus:
     task_id: FteTaskAttemptId
     state: FteTaskState
     version: int = 0
-    failure: dict[str, str] | None = None
+    failure: dict[str, Any] | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
     duplicate_split_count: int = 0
@@ -356,13 +391,23 @@ class FteTaskExecution:
         self,
         state: FteTaskState,
         *,
-        failure: dict[str, str] | None = None,
+        failure: Mapping[str, Any] | None = None,
     ) -> None:
         with self._status_lock:
             if self.status.state in _TERMINAL_STATES:
                 return
+            if state in {
+                FteTaskState.FAILED,
+                FteTaskState.CANCELED,
+                FteTaskState.ABORTED,
+            }:
+                normalized_failure = _normalize_failure_payload(failure)
+            elif failure is not None:
+                raise ValueError("FTE failure payload is only valid for FAILED, CANCELED, or ABORTED states")
+            else:
+                normalized_failure = None
             self.status.state = state
-            self.status.failure = failure
+            self.status.failure = normalized_failure
             self.status.version += 1
             self.status.updated_at = time.time()
         self._publish_status_changed()
@@ -628,7 +673,10 @@ class FteTaskExecution:
                 self._record_task_stats({**final_task_stats, **final_split_stats})
             self._transition(FteTaskState.FINISHED)
         except asyncio.CancelledError:
-            self._transition(FteTaskState.CANCELED)
+            self._transition(
+                FteTaskState.CANCELED,
+                failure=_task_canceled_failure_payload(self.task_id),
+            )
             raise
         except Exception as exc:
             if result_stored and not dynamic_source_splits_completed:
@@ -641,7 +689,10 @@ class FteTaskExecution:
                     self.release_result(reason="task_failed")
                 except Exception:
                     pass
-            self._transition(FteTaskState.FAILED, failure=_failure_payload(exc))
+            self._transition(
+                FteTaskState.FAILED,
+                failure=_failure_payload_from_exception(exc),
+            )
 
     def _complete_dynamic_source_splits(self) -> None:
         queues = [
@@ -957,7 +1008,10 @@ class FteTaskExecution:
         if self._future is not None and not self._future.done():
             self._future.cancel()
         self._split_update_event.set()
-        self._transition(FteTaskState.CANCELED)
+        self._transition(
+            FteTaskState.CANCELED,
+            failure=_task_canceled_failure_payload(self.task_id),
+        )
         return self.status
 
     def _log_result_lifecycle(self, event: str, *, result: Any = None, **fields: Any) -> None:

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -38,6 +38,7 @@ from duckdb.runners.fte import (
     fte_status_wait_timeout_s,
     validate_fte_status_identity,
 )
+from duckdb.runners.fte.fte_failures import _normalize_failure_payload, _safe_failure_message
 from duckdb.runners.progress import ProgressRenderer, progress_enabled
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.ray_env import collect_vane_env_overrides, scrub_shared_runtime_session_env
@@ -707,14 +708,14 @@ class FteWorkerTaskHandle:
 
     @staticmethod
     def _is_soft_status_wait_timeout(exc: BaseException) -> bool:
-        if isinstance(exc, QueryDeadlineExceeded) or "query deadline expired" in str(exc).lower():
+        message = _safe_failure_message(exc)
+        if issubclass(type(exc), QueryDeadlineExceeded) or "query deadline expired" in message.lower():
             return False
-        if isinstance(exc, TimeoutError):
+        if issubclass(type(exc), TimeoutError):
             return True
-        name = exc.__class__.__name__
+        name = type(exc).__name__
         if name in {"TimeoutError", "GetTimeoutError"}:
             return True
-        message = str(exc)
         return "did not complete within" in message or "timed out" in message.lower()
 
     async def _watch_status(self) -> Any:
@@ -763,10 +764,12 @@ class FteWorkerTaskHandle:
             if self._worker_failure_publish_started:
                 return
             self._worker_failure_publish_started = True
+        contextual_error = RuntimeError(f"{failure_kind} for {self.task_id}: {_safe_failure_message(exc)}")
+        contextual_error.__cause__ = exc
         await asyncio.to_thread(
             self.worker_handle.mark_fte_worker_failed,
             self.worker_id,
-            f"{failure_kind} for {self.task_id}: {exc}",
+            contextual_error,
         )
 
     async def _finalize_status_watch_failure(
@@ -785,12 +788,12 @@ class FteWorkerTaskHandle:
                 failure_kind=failure_kind,
             )
         except Exception as cleanup_exc:
-            cleanup_errors.append(f"worker failure publication failed: {cleanup_exc}")
+            cleanup_errors.append(f"worker failure publication failed: {_safe_failure_message(cleanup_exc)}")
         try:
             await asyncio.to_thread(self._record_fte_task_terminal)
         except Exception as cleanup_exc:
-            cleanup_errors.append(f"terminal record failed: {cleanup_exc}")
-        message = str(exc)
+            cleanup_errors.append(f"terminal record failed: {_safe_failure_message(cleanup_exc)}")
+        message = _safe_failure_message(exc)
         if cleanup_errors:
             message += "; cleanup also failed: " + "; ".join(cleanup_errors)
         terminal_error = exc if not cleanup_errors and isinstance(exc, Exception) else RuntimeError(message)
@@ -977,11 +980,8 @@ class FteWorkerTaskHandle:
             # FteAttemptStatusWatcher is the sole scheduler/status writer for
             # every terminal state.  The result handle only converts the
             # observed transport terminal into its local consumer result.
-            failure = status.get("failure") or {}
-            if isinstance(failure, dict):
-                message = failure.get("message") or failure.get("type") or state.value
-            else:
-                message = str(failure)
+            failure = _normalize_failure_payload(status.get("failure"))
+            message = failure.get("message") or failure["error_code"]
             self._error = RuntimeError(f"FTE task {self.task_id} {state.value}: {message}")
             self._record_fte_task_terminal()
             self._is_done = True

--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -14,6 +14,7 @@ from duckdb.runners.ray.fragment_registry import (
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _fte_retry_remaining_delay_s,
     _mark_fte_worker_failed,
+    _worker_failure_payload,
 )
 
 
@@ -31,6 +32,7 @@ def quarantine_fte_worker(worker_id: str) -> frozenset[str]:
 
 
 def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[Any], list[Any]]]:
+    failure = _worker_failure_payload(event.worker_id, event.error)
     with _FTE_REGISTRY_LOCK:
         if str(event.query_id) in _FTE_CLOSING_QUERIES:
             return []
@@ -47,7 +49,7 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         return []
     scheduled_by_stage = _mark_fte_worker_failed(
         event.worker_id,
-        event.error,
+        failure,
         query_id_filter=event.query_id,
         failed_worker_ids_override=new_failed_worker_ids,
     )

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -36,6 +36,7 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     _drop_fragment_plan_refs_for_query,
     _drop_fte_registry_for_query,
     _fragment_plan_ref,
+    _worker_failure_payload,
     begin_fte_registry_operation,
     begin_fte_registry_teardown_operation,
     close_fte_registry_for_query,
@@ -326,6 +327,7 @@ class FteWorkerLifecycleMixin:
         failed_worker_id = str(worker_id or self.worker_id or "")
         if not failed_worker_id:
             return []
+        failure = _worker_failure_payload(failed_worker_id, error)
         failed_worker_ids = frozenset({failed_worker_id})
         query_ids = fte_fragment_execution_query_ids()
         query_ids.update(_FTE_SCHEDULERS.query_ids())
@@ -341,7 +343,7 @@ class FteWorkerLifecycleMixin:
                 WorkerFailed(
                     query_id,
                     failed_worker_id,
-                    error,
+                    failure,
                     failed_worker_ids=failed_worker_ids,
                 )
             )
@@ -453,7 +455,7 @@ class FteWorkerLifecycleMixin:
             try:
                 self.mark_fte_worker_failed(
                     self.worker_id,
-                    f"FTE worker shutdown: {self.worker_id}",
+                    RuntimeError(f"FTE worker shutdown: {self.worker_id}"),
                 )
             except Exception:
                 pass

--- a/duckdb/runners/ray/fragment_worker_placement.py
+++ b/duckdb/runners/ray/fragment_worker_placement.py
@@ -140,7 +140,7 @@ class FteWorkerPlacementMixin:
         if not current:
             cancel_fte_worker_reservation_future(future)
             return False
-        if not has_matching_node and no_matching_period > _fte_allowed_no_matching_node_period_s():
+        if not has_matching_node and no_matching_period >= _fte_allowed_no_matching_node_period_s():
             raise RuntimeError(
                 f"No nodes available to run query {future.query_id}/{future.fragment_id}/{future.partition_id}"
             )

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -248,7 +248,7 @@ class FteWorkerSubmissionMixin:
                 )
                 if not has_matching_node:
                     no_matching_period = partition.mark_no_matching_node()
-                    if no_matching_period > _fte_allowed_no_matching_node_period_s():
+                    if no_matching_period >= _fte_allowed_no_matching_node_period_s():
                         raise RuntimeError(
                             f"No nodes available to run query {query_id}/{fragment_id}/{partition.task_id.partition_id}"
                         )

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -11,12 +11,18 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from duckdb import OutOfMemoryException
 from duckdb.runners.fte import (
     FteSplit,
     FteTaskAttemptId,
     FteTaskExecutionClass,
     FteWorkerReservationUnavailable,
     validate_fte_status_identity,
+)
+from duckdb.runners.fte.fte_failures import (
+    _failure_exception_matches,
+    _failure_payload,
+    _normalize_failure_payload,
 )
 from duckdb.runners.progress import validate_pipeline_topology
 from duckdb.runners.ray.fragment_submission_window import (
@@ -2250,9 +2256,27 @@ class FteWorkerPlacementManager:
         )
 
 
+def _worker_failure_payload(worker_id: str, error: Any) -> dict[str, Any]:
+    if error is not None and not issubclass(type(error), BaseException):
+        if isinstance(error, Mapping):
+            return _normalize_failure_payload(error)
+        raise TypeError("FTE worker failure must be an exception or structured failure payload")
+    memory_error_types: tuple[type[BaseException], ...] = (
+        OutOfMemoryException,
+        MemoryError,
+        ray.exceptions.OutOfMemoryError,
+    )
+    error_code = "OUT_OF_MEMORY" if _failure_exception_matches(error, memory_error_types) else "WORKER_LOST"
+    return _failure_payload(
+        error_code,
+        error if error is not None else f"FTE worker lost: {worker_id}",
+        error_type="EXTERNAL",
+    )
+
+
 def _mark_fte_worker_failed(
     worker_id: str,
-    error: Any = None,
+    failure: Mapping[str, Any],
     *,
     query_id_filter: str | None = None,
     failed_worker_ids_override: set[str] | frozenset[str] | None = None,
@@ -2260,6 +2284,7 @@ def _mark_fte_worker_failed(
     worker_id = str(worker_id or "")
     if not worker_id:
         return []
+    failure = _normalize_failure_payload(failure)
     if query_id_filter is not None:
         query_id_filter = str(query_id_filter)
     failed_worker_ids = (
@@ -2367,7 +2392,7 @@ def _mark_fte_worker_failed(
         for failed_worker_id in sorted(failed_worker_ids):
             scheduled = fragment_execution.mark_worker_failed(
                 failed_worker_id,
-                error or f"FTE worker lost: {failed_worker_id}",
+                failure,
                 retryable=True,
                 retryable_by_partition_id=retryable_by_partition_id,
                 schedule_retries=False,

--- a/scripts/sync_duckdb_source_id.py
+++ b/scripts/sync_duckdb_source_id.py
@@ -73,7 +73,9 @@ def _write_tree(environment: dict[str, str], temporary_index: Path) -> str:
     """Write the worktree through a disposable index, with a safe fallback."""
     copied_index = False
     try:
-        shutil.copyfile(_git_path("index"), temporary_index)
+        # Preserve the index timestamp so Git can still detect racily clean
+        # entries after the copy.
+        shutil.copy2(_git_path("index"), temporary_index)
         copied_index = True
     except OSError:
         _git("read-tree", "HEAD", env=environment)

--- a/tests/fast/test_fte_failure_codes.py
+++ b/tests/fast/test_fte_failure_codes.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from duckdb import OutOfMemoryException
+from duckdb.runners.fte.fte_failures import (
+    _failure_allows_retry,
+    _failure_payload,
+    _is_memory_failure,
+    _normalize_failure_payload,
+)
+from duckdb.runners.fte.fte_state import FteTaskState
+from duckdb.runners.fte.fte_worker_runtime import FteTaskExecution, _failure_payload_from_exception
+from duckdb.runners.fte.memory_config import DuckDBMemoryLimitError
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "OUT_OF_MEMORY",
+        "out-of-memory",
+        "EXCEEDED_LOCAL_MEMORY_LIMIT",
+        "exceeded local memory limit",
+    ],
+)
+def test_memory_failure_matches_normalized_error_code(error_code):
+    assert _is_memory_failure({"error_code": error_code}) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "OOM",
+        "out of memory",
+        "bloom filter construction failed",
+        "no room left in the queue",
+        "zoom request failed",
+    ],
+)
+def test_memory_failure_ignores_message(message):
+    failure = _failure_payload("GENERIC_INTERNAL_ERROR", message)
+
+    assert _is_memory_failure(failure) is False
+
+
+def test_memory_failure_uses_code_when_message_is_unrelated():
+    failure = _failure_payload("OUT_OF_MEMORY", "bloom filter construction failed")
+
+    assert _is_memory_failure(failure) is True
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "BLOOM_FILTER_ERROR",
+        "MEMORY_LIMIT_CONFIGURATION_FAILED",
+    ],
+)
+def test_memory_failure_requires_known_error_code(error_code):
+    assert _is_memory_failure({"error_code": error_code}) is False
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        OutOfMemoryException("duckdb exhausted memory"),
+        MemoryError("python exhausted memory"),
+    ],
+)
+def test_exception_failure_payload_maps_memory_exceptions(exception):
+    failure = _failure_payload_from_exception(exception)
+
+    assert failure["error_code"] == "OUT_OF_MEMORY"
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_code", "expected_retryable"),
+    [
+        (RuntimeError("task failed"), "GENERIC_INTERNAL_ERROR", None),
+        (
+            DuckDBMemoryLimitError("failed to configure memory limit"),
+            "MEMORY_LIMIT_CONFIGURATION_FAILED",
+            False,
+        ),
+    ],
+)
+def test_exception_failure_payload_assigns_non_memory_error_code(
+    exception,
+    expected_code,
+    expected_retryable,
+):
+    failure = _failure_payload_from_exception(exception)
+
+    assert failure["error_code"] == expected_code
+    assert failure.get("retryable") is expected_retryable
+    if expected_retryable is False:
+        assert _failure_allows_retry(failure) is False
+
+
+def test_exception_failure_payload_reads_structured_memory_exception_chain():
+    exception = RuntimeError("task execution failed")
+    exception.__cause__ = OutOfMemoryException("duckdb exhausted memory")
+
+    failure = _failure_payload_from_exception(exception)
+
+    assert failure["error_code"] == "OUT_OF_MEMORY"
+
+
+def test_exception_failure_payload_reads_implicit_memory_exception_context():
+    try:
+        raise OutOfMemoryException("duckdb exhausted memory")
+    except OutOfMemoryException:
+        try:
+            raise RuntimeError("task execution failed")
+        except RuntimeError as exception:
+            failure = _failure_payload_from_exception(exception)
+
+    assert failure["error_code"] == "OUT_OF_MEMORY"
+
+
+def test_exception_failure_payload_ignores_suppressed_memory_exception_context():
+    try:
+        raise OutOfMemoryException("duckdb exhausted memory")
+    except OutOfMemoryException:
+        try:
+            raise RuntimeError("replacement task failure") from None
+        except RuntimeError as exception:
+            failure = _failure_payload_from_exception(exception)
+
+    assert failure["error_code"] == "GENERIC_INTERNAL_ERROR"
+
+
+@pytest.mark.parametrize(
+    "unreadable_attribute",
+    [
+        "as_instanceof_cause",
+        "cause",
+        "__cause__",
+        "__suppress_context__",
+        "__context__",
+    ],
+)
+def test_task_execution_reaches_failed_state_when_exception_chain_attributes_raise(
+    unreadable_attribute,
+):
+    class _UnreadableExceptionChain(RuntimeError):
+        def __getattribute__(self, name):
+            if name == unreadable_attribute:
+                raise RuntimeError(f"{name} is unreadable")
+            return super().__getattribute__(name)
+
+    async def run_task():
+        async def execute_fn(_request):
+            raise _UnreadableExceptionChain("task failed")
+
+        execution = FteTaskExecution(
+            {"task_id": "q-unreadable-chain.0.0.0"},
+            execute_fn,
+            default_task_memory_bytes=1,
+        )
+        execution.start()
+        assert execution._future is not None
+        await execution._future
+        return execution.status
+
+    status = asyncio.run(run_task())
+
+    assert status.state == FteTaskState.FAILED
+    assert status.failure is not None
+    assert status.failure["error_code"] == "GENERIC_INTERNAL_ERROR"
+
+
+def test_task_execution_reaches_failed_state_when_exception_message_is_unprintable():
+    class _UnprintableException(RuntimeError):
+        def __str__(self):
+            raise RuntimeError("exception message is unreadable")
+
+    async def run_task():
+        async def execute_fn(_request):
+            raise _UnprintableException()
+
+        execution = FteTaskExecution(
+            {"task_id": "q-unprintable-exception.0.0.0"},
+            execute_fn,
+            default_task_memory_bytes=1,
+        )
+        execution.start()
+        assert execution._future is not None
+        await execution._future
+        return execution.status
+
+    status = asyncio.run(run_task())
+
+    assert status.state == FteTaskState.FAILED
+    assert status.failure is not None
+    assert status.failure["error_code"] == "GENERIC_INTERNAL_ERROR"
+    assert status.failure["message"] == "<unprintable _UnprintableException>"
+
+
+def test_task_execution_publishes_out_of_memory_error_code():
+    async def run_task():
+        async def execute_fn(_request):
+            raise OutOfMemoryException("duckdb exhausted memory")
+
+        execution = FteTaskExecution(
+            {"task_id": "q-out-of-memory.0.0.0"},
+            execute_fn,
+            default_task_memory_bytes=1,
+        )
+        execution.start()
+        assert execution._future is not None
+        await execution._future
+        return execution.status
+
+    status = asyncio.run(run_task())
+
+    assert status.state == FteTaskState.FAILED
+    assert status.failure is not None
+    assert status.failure["error_code"] == "OUT_OF_MEMORY"
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_type", "message"),
+    [
+        ("OOM", TypeError, "must be a mapping"),
+        ({"error_code": 1}, TypeError, "error_code must be a string"),
+        ({"message": "OOM"}, ValueError, "requires error_code"),
+        ({"error_code": "  "}, ValueError, "requires error_code"),
+    ],
+)
+def test_failure_payload_rejects_missing_error_code(payload, error_type, message):
+    with pytest.raises(error_type, match=message):
+        _normalize_failure_payload(payload)
+
+
+def test_task_execution_enforces_failure_code_for_terminal_status():
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {"task_id": "q-failure-code.0.0.0"},
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+
+    with pytest.raises(ValueError, match="requires error_code"):
+        execution._transition(
+            FteTaskState.FAILED,
+            failure={"message": "out of memory"},
+        )
+
+    assert execution.status.state == FteTaskState.PLANNED
+    canceled = execution.cancel()
+    assert canceled.failure is not None
+    assert canceled.failure["error_code"] == "TASK_CANCELED"

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -739,6 +739,7 @@ def test_native_task_result_handle_rejects_mismatched_status_identity():
     assert poll.error is not None
     assert "status identity mismatch" in str(poll.error)
     assert callback_events[-1][0]["state"] == FteTaskState.FAILED.value
+    assert callback_events[-1][0]["failure"]["error_code"] == "NATIVE_BACKEND_ERROR"
     assert callback_events[-1][1] is poll.error
 
     with pytest.raises(RuntimeError, match="status identity mismatch"):
@@ -748,6 +749,25 @@ def test_native_task_result_handle_rejects_mismatched_status_identity():
     with pytest.raises(RuntimeError, match="status identity mismatch"):
         handle.info_snapshot()
     assert callback_events[-1][1] is not None
+
+
+def test_native_task_result_handle_validates_enum_terminal_failure_payload():
+    task = _task_id(0, query_id="query-native-enum-terminal")
+
+    class _EnumTerminalWorker:
+        worker_id = "native-worker-enum-terminal"
+
+        def fte_get_task_status_cached(self, _task_id):
+            return {
+                "state": FteTaskState.FAILED,
+                "task_id": task,
+                "failure": {"message": "out of memory"},
+            }
+
+    handle = NativeTaskResultHandle(_EnumTerminalWorker(), task)
+
+    with pytest.raises(ValueError, match="requires error_code"):
+        handle.status_snapshot()
 
 
 def test_native_backend_rejects_mismatched_create_task_identity():

--- a/tests/fast/test_fte_ray_backend_adapter.py
+++ b/tests/fast/test_fte_ray_backend_adapter.py
@@ -41,7 +41,13 @@ class _FakeWorkerHandle:
 
     def fte_cancel_task(self, task_id):
         self.calls.append(("fte_cancel_task", (task_id,)))
-        return {"state": "CANCELED"}
+        return {
+            "state": "CANCELED",
+            "failure": {
+                "error_code": "TASK_CANCELED",
+                "message": "task canceled",
+            },
+        }
 
     def optional_method(self):
         return "delegated"
@@ -60,7 +66,13 @@ def test_ray_worker_handle_adapter_delegates_worker_protocol_methods():
     assert adapter.fte_no_more_splits("task.0", "source-a") == {"state": "UPDATED"}
     assert adapter.fte_update_task("task.0", {"x": 1})["update"] == {"x": 1}
     assert adapter.fte_wait_task_status("task.0", 3, 0.5) == {"state": "RUNNING", "version": 3}
-    assert adapter.fte_cancel_task("task.0") == {"state": "CANCELED"}
+    assert adapter.fte_cancel_task("task.0") == {
+        "state": "CANCELED",
+        "failure": {
+            "error_code": "TASK_CANCELED",
+            "message": "task canceled",
+        },
+    }
     assert adapter.optional_method() == "delegated"
 
     assert fake.calls == [

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -1019,7 +1019,11 @@ def test_fte_split_backpressure_terminal_status_uses_task_status_path(monkeypatc
     terminal_status = {
         "state": FteTaskState.FAILED.value,
         "task_id": attempt_id.to_dict(),
-        "failure": {"type": "ValueError", "message": "planned task failure"},
+        "failure": {
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "type": "ValueError",
+            "message": "planned task failure",
+        },
     }
 
     class _TerminalWorker:
@@ -3512,7 +3516,17 @@ def test_fte_add_splits_ack_after_task_finish_does_not_revive_pressure():
         remote_handle=handle,
     )
     assert handle.record_fte_task_started(failed_attempt.attempt_id, failed_attempt.request) is True
-    assert stage.task_failed(failed_attempt.attempt_id, "retry", schedule_retry=False) is None
+    assert (
+        stage.task_failed(
+            failed_attempt.attempt_id,
+            {
+                "error_code": "GENERIC_INTERNAL_ERROR",
+                "message": "retry",
+            },
+            schedule_retry=False,
+        )
+        is None
+    )
     retry_attempt = retry_partition.start_attempt(
         worker_id=handle.worker_id,
         remote_handle=handle,
@@ -5506,7 +5520,16 @@ def test_fte_worker_capacity_registers_every_ready_partition_with_credit_authori
     ("terminal_state", "terminal_extra", "next_query_a_attempt"),
     [
         ("FINISHED", {}, "query-a.0.1.0"),
-        ("FAILED", {"failure": {"message": "retry me"}}, "query-a.0.0.1"),
+        (
+            "FAILED",
+            {
+                "failure": {
+                    "error_code": "GENERIC_INTERNAL_ERROR",
+                    "message": "retry me",
+                }
+            },
+            "query-a.0.0.1",
+        ),
     ],
 )
 def test_fte_pending_drain_is_fair_across_queries(
@@ -6461,7 +6484,7 @@ def test_fte_worker_failure_retry_preserves_registered_heap(monkeypatch):
         memory_requirement_bytes=5,
     )
 
-    retries = low_memory.mark_fte_worker_failed("worker-0", "worker lost")
+    retries = low_memory.mark_fte_worker_failed("worker-0", RuntimeError("worker lost"))
 
     assert len(first) == 1
     assert len(retries) == 1
@@ -6543,7 +6566,10 @@ def test_fte_worker_failure_does_not_invert_attempt_start_lock_order(monkeypatch
         failure = executor.submit(
             fte_fragment_scheduler_mod._mark_fte_worker_failed,
             failed.worker_id,
-            "worker lost during attempt start",
+            {
+                "error_code": "WORKER_LOST",
+                "message": "worker lost during attempt start",
+            },
             query_id_filter=query_id,
             failed_worker_ids_override={failed.worker_id},
         )
@@ -6578,7 +6604,7 @@ def test_fte_worker_failure_replays_descriptor_on_new_owner(monkeypatch):
     )
 
     first = handle0.submit_tasks([task])
-    retries = handle1.mark_fte_worker_failed("worker-0", "actor died")
+    retries = handle1.mark_fte_worker_failed("worker-0", RuntimeError("actor died"))
 
     assert len(first) == 1
     assert len(retries) == 1
@@ -6638,7 +6664,7 @@ def test_fte_worker_failure_keeps_retryability_partition_local():
     worker_handle_mod._FTE_PARTITION_OWNERS[(query_id, fragment_id, 0)] = failed
     worker_handle_mod._FTE_PARTITION_OWNERS[(query_id, fragment_id, 1)] = failed
 
-    handles = replacement.mark_fte_worker_failed("failed#0", "actor died")
+    handles = replacement.mark_fte_worker_failed("failed#0", RuntimeError("actor died"))
 
     assert stage.partitions[0].failed is False
     assert stage.partitions[1].failed is True
@@ -6675,7 +6701,7 @@ def test_fte_worker_failure_retry_waits_for_scheduling_delayer(monkeypatch):
         "query-fte-retry-delay.0.0.0"
     ]
 
-    retries = handle1.mark_fte_worker_failed("worker-0", "actor died")
+    retries = handle1.mark_fte_worker_failed("worker-0", RuntimeError("actor died"))
 
     assert retries == []
     assert [call for call in actor1.fte_calls if call[0] == "create"] == []
@@ -6966,7 +6992,7 @@ def test_fte_worker_failure_replays_all_owned_stage_partitions(monkeypatch):
     actor1 = _FakeActor()
     handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-1")
 
-    retries = handle1.mark_fte_worker_failed("worker-0", "host lost")
+    retries = handle1.mark_fte_worker_failed("worker-0", RuntimeError("host lost"))
 
     assert len(first_handles) == 2
     assert len(retries) == 2
@@ -7033,7 +7059,7 @@ def test_fte_worker_failure_without_replacement_fails_stage_without_retry(monkey
     )
 
     first = handle.submit_tasks([task])
-    retries = handle.mark_fte_worker_failed("worker-alone", "host lost")
+    retries = handle.mark_fte_worker_failed("worker-alone", RuntimeError("host lost"))
 
     assert len(first) == 1
     assert retries == []
@@ -8492,7 +8518,10 @@ def test_fte_registry_close_waits_for_terminal_handler_and_suppresses_retry(monk
             return {
                 "state": "FAILED",
                 "task_id": task_id,
-                "failure": {"message": "retryable"},
+                "failure": {
+                    "error_code": "GENERIC_INTERNAL_ERROR",
+                    "message": "retryable",
+                },
                 "version": 1,
             }
 
@@ -8993,7 +9022,10 @@ def test_fte_task_status_event_retries_failed_attempt(monkeypatch):
         {
             "state": "FAILED",
             "task_id": first.task_id.to_dict(),
-            "failure": {"message": "retry me"},
+            "failure": {
+                "error_code": "GENERIC_INTERNAL_ERROR",
+                "message": "retry me",
+            },
             "version": 1,
         }
     )
@@ -9121,7 +9153,11 @@ def test_fte_wait_query_raises_on_failed_partition(monkeypatch):
         {
             "state": "FAILED",
             "task_id": running.task_id.to_dict(),
-            "failure": {"message": "not retryable", "retryable": False},
+            "failure": {
+                "error_code": "GENERIC_INTERNAL_ERROR",
+                "message": "not retryable",
+                "retryable": False,
+            },
             "version": 1,
         }
     )

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -17,6 +17,7 @@ import duckdb
 
 ray = pytest.importorskip("ray")
 
+import duckdb.runners.fte.fte_execution as fte_execution_mod
 import duckdb.runners.ray.fragment_worker_commands as worker_commands_mod
 import duckdb.runners.ray.fragment_worker_placement as worker_placement_mod
 import duckdb.runners.ray.fragment_worker_selection as worker_selection_mod
@@ -4468,6 +4469,7 @@ def test_fte_no_matching_node_waits_before_fail(monkeypatch):
 
 def test_fte_no_matching_node_period_expiry_fails_query(monkeypatch):
     monkeypatch.setenv("VANE_FTE_ALLOWED_NO_MATCHING_NODE_PERIOD_S", "0")
+    monkeypatch.setattr(fte_execution_mod.time, "time", lambda: 42.0)
     actor = _FakeActor()
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60, worker_id="aaa#0")
     stage = handle._get_or_create_fte_fragment_execution(

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -12,7 +12,7 @@ import pytest
 
 from duckdb.runners.common import QueryDeadlineExceeded
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
-from duckdb.runners.fte.fte_failures import _failure_allows_retry
+from duckdb.runners.fte.fte_failures import _failure_allows_retry, _failure_payload
 from duckdb.runners.fte.fte_scheduler import (
     FteSplitQueueTerminal,
     FteSplitSubmissionCancelled,
@@ -882,7 +882,10 @@ def test_fte_task_execution_terminal_status_refreshes_split_stats_with_fallback(
         "completed_split_count": 0,
         "completed_input_bytes": 0,
     }
-    execution.status.state = FteTaskState.FAILED
+    execution._transition(
+        FteTaskState.FAILED,
+        failure=_failure_payload("GENERIC_INTERNAL_ERROR", "task failed"),
+    )
     refreshed_status = {
         "completed_split_count": 1,
         "completed_input_bytes": 128,
@@ -925,13 +928,16 @@ def test_fte_task_execution_late_no_more_splits_is_terminal_noop(terminal_state)
         execute_fn,
         default_task_memory_bytes=1,
     )
-    failure = None
-    if terminal_state == FteTaskState.FAILED:
-        failure = {
-            "type": "RuntimeError",
-            "message": "existing failure",
-            "traceback": "existing traceback",
-        }
+    failure_codes = {
+        FteTaskState.FAILED: "GENERIC_INTERNAL_ERROR",
+        FteTaskState.CANCELED: "TASK_CANCELED",
+        FteTaskState.ABORTED: "TASK_ABORTED",
+    }
+    failure = (
+        None
+        if terminal_state == FteTaskState.FINISHED
+        else _failure_payload(failure_codes[terminal_state], "existing failure")
+    )
     execution._transition(terminal_state, failure=failure)
     state_before = execution.status.state
     version_before = execution.status.version
@@ -1684,7 +1690,13 @@ def test_two_stage_query_dag_worker_loss_uses_selected_attempt_for_final_result(
     lost_path = exchange.record_output_file(scheduled0.sink_instance, 0, "lost", b"999\n")
     exchange.finish_attempt(scheduled0.sink_instance)
 
-    retries = upstream.mark_worker_failed("worker-a", "host lost before status was observed")
+    retries = upstream.mark_worker_failed(
+        "worker-a",
+        {
+            "error_code": "WORKER_LOST",
+            "message": "host lost before status was observed",
+        },
+    )
     assert len(retries) == 1
     retry = retries[0]
     selected_path = exchange.record_output_file(retry.sink_instance, 0, "selected", b"10\n20\n")
@@ -1728,6 +1740,49 @@ def test_two_stage_query_dag_worker_loss_uses_selected_attempt_for_final_result(
     assert exchange.cleanup_unselected_attempts() == 1
     assert not Path(scheduled0.sink_instance.attempt_path).exists()
     assert Path(retry.sink_instance.attempt_path).exists()
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_code"),
+    [
+        (
+            fte_fragment_scheduler.ray.exceptions.OutOfMemoryError("ray node exhausted memory"),
+            "OUT_OF_MEMORY",
+        ),
+        (RuntimeError("bloom filter construction failed"), "WORKER_LOST"),
+        (RuntimeError("out of memory"), "WORKER_LOST"),
+    ],
+)
+def test_fte_worker_failure_payload_uses_structured_exception_type(error, expected_code):
+    failure = fte_fragment_scheduler._worker_failure_payload("worker-a", error)
+
+    assert failure["error_code"] == expected_code
+
+
+def test_fte_worker_failure_payload_reads_structured_exception_chain():
+    error = RuntimeError("worker RPC failed")
+    error.__cause__ = fte_fragment_scheduler.ray.exceptions.OutOfMemoryError("ray node exhausted memory")
+
+    failure = fte_fragment_scheduler._worker_failure_payload("worker-a", error)
+
+    assert failure["error_code"] == "OUT_OF_MEMORY"
+
+
+def test_fte_worker_failure_payload_preserves_normalized_structured_code():
+    failure = fte_fragment_scheduler._worker_failure_payload(
+        "worker-a",
+        {
+            "error_code": "out-of-memory",
+            "message": "Ray node exhausted memory",
+        },
+    )
+
+    assert failure["error_code"] == "OUT_OF_MEMORY"
+
+
+def test_fte_worker_failure_payload_rejects_unstructured_text():
+    with pytest.raises(TypeError, match="exception or structured failure payload"):
+        fte_fragment_scheduler._worker_failure_payload("worker-a", "out of memory")
 
 
 class _FakeLiveWorker:
@@ -1784,7 +1839,14 @@ class _FakeLiveWorker:
 
     def fte_cancel_task(self, task_id):
         self.calls.append(("cancel", task_id))
-        return {"state": "CANCELED", "task_id": task_id}
+        return {
+            "state": "CANCELED",
+            "task_id": task_id,
+            "failure": {
+                "error_code": "TASK_CANCELED",
+                "message": "task canceled",
+            },
+        }
 
     def set_fte_task_execution_class(self, task_id, execution_class):
         self.calls.append(
@@ -2271,7 +2333,14 @@ def test_fte_worker_command_executor_reports_terminal_task_during_split_wait():
             return {
                 "has_space": False,
                 "terminal": True,
-                "status": {"state": FteTaskState.FAILED.value, "task_id": task_id},
+                "status": {
+                    "state": FteTaskState.FAILED.value,
+                    "task_id": task_id,
+                    "failure": {
+                        "error_code": "GENERIC_INTERNAL_ERROR",
+                        "message": "task failed",
+                    },
+                },
             }
 
     attempt_id = FteTaskAttemptId(FteTaskId("q-terminal-splits", 0, 1), 0)
@@ -2746,6 +2815,32 @@ def test_fte_fragment_execution_appends_descriptor_before_add_splits_command_fai
     assert [split.data for split in descriptor.initial_splits["7"]] == [b"a", b"b"]
 
 
+def test_fte_worker_control_failure_preserves_unprintable_cause():
+    class _UnprintableError(RuntimeError):
+        def __str__(self):
+            raise RuntimeError("exception message is unreadable")
+
+    cause = _UnprintableError()
+    attempt_id = FteTaskAttemptId(FteTaskId("q-unprintable-control", 0, 0), 0)
+
+    failure = FteWorkerControlFailure(
+        worker_id="worker-unprintable-control",
+        attempt_id=attempt_id,
+        method_name="fte_add_splits",
+        cause=cause,
+    )
+
+    assert failure.cause is cause
+    assert str(failure).endswith("<unprintable _UnprintableError>")
+    assert (
+        fte_fragment_scheduler._worker_failure_payload(
+            failure.worker_id,
+            failure,
+        )["error_code"]
+        == "WORKER_LOST"
+    )
+
+
 def test_fte_fragment_execution_backpressures_until_split_queue_recovers():
     class _RecoveringSplitQueueWorker(_FakeLiveWorker):
         def __init__(self):
@@ -2860,6 +2955,13 @@ def test_fte_fragment_execution_revoke_unsealed_speculative_waits_for_seal():
     assert worker.calls[-1] == ("cancel", scheduled[0].attempt_id.to_dict())
     assert stage.schedule_next_pending_partition() is None
     assert stage.partitions[0].ready_for_scheduling is False
+    assert stage.partitions[0].failures == [
+        {
+            "error_type": "INTERNAL_ERROR",
+            "error_code": "SPECULATIVE_ATTEMPT_REVOKED",
+            "message": "memory pressure",
+        }
+    ]
 
     scheduled_after_seal = stage.seal_partition(0)
 
@@ -3249,7 +3351,13 @@ def test_fte_fragment_execution_retry_replays_accumulated_descriptor():
         )
     )
     _execute_stage_commands(stage, initial)
-    retry = stage.task_failed(FteTaskAttemptId(FteTaskId("q", 4, 0), 0), "lost")
+    retry = stage.task_failed(
+        FteTaskAttemptId(FteTaskId("q", 4, 0), 0),
+        {
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "message": "bloom filter construction failed",
+        },
+    )
     _execute_stage_commands(stage)
 
     assert retry is not None
@@ -3261,6 +3369,36 @@ def test_fte_fragment_execution_retry_replays_accumulated_descriptor():
     assert retry_request["initial_splits"]["7"][0]["data"] == b"a"
     assert retry_request["no_more_splits"] == ["7"]
     assert stage.partitions[0].remaining_attempts == 1
+
+
+def test_fte_fragment_execution_rejects_terminal_status_without_error_code():
+    worker = _FakeLiveWorker()
+    stage = _fte_fragment_execution(
+        "q-failure-code",
+        4,
+        fragment_id="q-failure-code:node:scan",
+        worker=worker,
+        max_attempts=2,
+    )
+    scheduled = stage.seal_partition(0)
+
+    assert scheduled is not None
+    with pytest.raises(ValueError, match="requires error_code"):
+        stage.handle_task_status(
+            {
+                "state": FteTaskState.FAILED.value,
+                "task_id": scheduled.attempt_id.to_dict(),
+                "failure": {"message": "out of memory"},
+                "task_stats": {"completed_split_count": 1},
+            }
+        )
+
+    partition = stage.partitions[0]
+    assert partition.failed is False
+    assert partition.failures == []
+    assert partition.running_task_stats == {}
+    assert partition.running_attempt is not None
+    assert partition.running_attempt.attempt_id == scheduled.attempt_id
 
 
 def test_fte_fragment_execution_oom_is_terminal_for_fixed_heap():
@@ -3501,7 +3639,14 @@ def test_fte_fragment_execution_handle_failed_status_retries_with_replayed_descr
     )
     scheduled0 = scheduled_result[0]
     _execute_stage_commands(stage, scheduled_result)
-    worker.set_status(scheduled0.attempt_id.to_dict(), "FAILED", failure={"message": "lost"})
+    worker.set_status(
+        scheduled0.attempt_id.to_dict(),
+        "FAILED",
+        failure={
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "message": "lost",
+        },
+    )
 
     retries = _handle_live_worker_statuses(stage)
     _execute_stage_commands(stage)
@@ -3565,6 +3710,7 @@ def test_fte_fragment_execution_handle_fatal_status_fails_without_retry():
         "FAILED",
         failure={
             "error_type": "INTERNAL_ERROR",
+            "error_code": "COORDINATOR_FAILURE",
             "fatal": True,
             "message": "coordinator cannot recover",
         },
@@ -3595,7 +3741,10 @@ def test_fte_fragment_execution_handle_canceled_status_fails_without_retry_by_de
     worker.set_status(
         scheduled.attempt_id.to_dict(),
         "CANCELED",
-        failure={"message": "query canceled"},
+        failure={
+            "error_code": "TASK_CANCELED",
+            "message": "query canceled",
+        },
     )
 
     retries = _handle_live_worker_statuses(stage)
@@ -3650,7 +3799,14 @@ def test_fte_fragment_execution_handle_failed_status_marks_stage_failed_when_att
     scheduled = stage.apply_assignment_result(
         AssignmentResult(partitions_added=[PartitionInfo(0)], sealed_partitions=[0])
     )[0]
-    worker.set_status(scheduled.attempt_id.to_dict(), "FAILED", failure={"message": "fatal"})
+    worker.set_status(
+        scheduled.attempt_id.to_dict(),
+        "FAILED",
+        failure={
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "message": "fatal",
+        },
+    )
 
     retries = _handle_live_worker_statuses(stage)
 
@@ -3698,7 +3854,13 @@ def test_fte_fragment_execution_worker_lost_uses_retry_attempt_as_durable_output
     lost_path = exchange.record_output_file(scheduled0.sink_instance, 0, "lost", b"lost")
     exchange.finish_attempt(scheduled0.sink_instance)
 
-    retries = stage.mark_worker_failed("worker-a", "actor died before status was observed")
+    retries = stage.mark_worker_failed(
+        "worker-a",
+        {
+            "error_code": "WORKER_LOST",
+            "message": "actor died before status was observed",
+        },
+    )
     _execute_stage_commands(stage)
 
     assert len(retries) == 1
@@ -3762,7 +3924,13 @@ def test_fte_fragment_execution_retries_base_remote_exchange_sink_instance():
     )
     scheduled0 = scheduled_result[0]
     _execute_stage_commands(stage, scheduled_result)
-    retry = stage.task_failed(scheduled0.attempt_id, "lost worker")
+    retry = stage.task_failed(
+        scheduled0.attempt_id,
+        {
+            "error_code": "WORKER_LOST",
+            "message": "lost worker",
+        },
+    )
     _execute_stage_commands(stage)
 
     assert retry is not None
@@ -3836,7 +4004,10 @@ def test_fte_fragment_execution_handle_task_status_accepts_task_id_string():
         {
             "task_id_string": str(scheduled.attempt_id),
             "state": FteTaskState.CANCELED,
-            "failure": {"message": "canceled"},
+            "failure": {
+                "error_code": "TASK_CANCELED",
+                "message": "canceled",
+            },
         },
         retryable=False,
     )
@@ -4488,6 +4659,7 @@ def test_fte_worker_task_manager_finalization_failure_is_terminal_and_releases_s
             timeout=2.0,
         )
         assert first_terminal["state"] == FteTaskState.FAILED.value
+        assert first_terminal["failure"]["error_code"] == "GENERIC_INTERNAL_ERROR"
         assert first_terminal["failure"]["message"].startswith(failure_message)
         assert complete_dynamic_source_splits_calls == 1
         assert first_execution.result is None

--- a/tests/fast/test_ray_fte_event_scheduler.py
+++ b/tests/fast/test_ray_fte_event_scheduler.py
@@ -848,6 +848,47 @@ def test_attempt_status_watcher_treats_query_deadline_as_hard_failure():
     assert calls == [("worker-query-deadline", "query deadline expired before Ray ObjectRef get")]
 
 
+def test_attempt_status_watcher_reports_failure_with_unprintable_message():
+    class _UnprintableError(RuntimeError):
+        def __getattribute__(self, name):
+            if name == "__class__":
+                raise RuntimeError("exception class is unreadable")
+            return super().__getattribute__(name)
+
+        def __str__(self):
+            raise RuntimeError("exception message is unreadable")
+
+    error = _UnprintableError()
+
+    class _Worker:
+        worker_id = "worker-unprintable-failure"
+
+        def fte_wait_task_status(self, task_id, min_version, timeout_s):
+            raise error
+
+    scheduler = FteSchedulerRegistry().get_or_create("query-watch-unprintable-failure")
+    calls = []
+    scheduler.set_handlers(
+        FteEventHandlers(
+            on_worker_failed=lambda event: calls.append((event.worker_id, event.error)) or [],
+        )
+    )
+    attempt_id = FteTaskAttemptId(FteTaskId("query-watch-unprintable-failure", 0, 1), 0)
+    watcher = FteAttemptStatusWatcher(
+        scheduler=scheduler,
+        attempt_id=attempt_id,
+        worker=_Worker(),
+        wait_timeout_s=0,
+        poll_interval_s=0.001,
+    )
+
+    assert watcher.start() is True
+    watcher.join(1.0)
+
+    assert watcher.is_alive() is False
+    assert calls == [("worker-unprintable-failure", error)]
+
+
 def test_attempt_status_watcher_join_observes_real_thread_lifecycle():
     entered = threading.Event()
 

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -25,6 +25,7 @@ pytestmark = [
 _FAULT_RAY_CLUSTER = None
 
 import duckdb.runners.ray.worker_handle as worker_handle_mod
+from duckdb.runners.ray import driver as ray_driver
 from duckdb.runners.ray import worker as worker_mod
 from duckdb.runners.ray.fte_fragment_scheduler import ensure_fte_fragment_progress_topology
 from duckdb.runners.ray.query_execution_graph import (
@@ -395,7 +396,12 @@ def _shutdown_ray_for_fault_test() -> None:
 
     cluster = _FAULT_RAY_CLUSTER
     try:
-        ray.shutdown()
+        try:
+            # Result-handle watchers await Ray ObjectRefs on this loop. Stop
+            # them before ray.shutdown() destroys the driver's core worker.
+            ray_driver.shutdown_background_event_loop()
+        finally:
+            ray.shutdown()
     finally:
         _FAULT_RAY_CLUSTER = None
         if cluster is not None and os.environ.get("VANE_TEST_EXTERNAL_RAY_CLUSTER_CLEANUP") != "1":

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -27,7 +27,10 @@ _FAULT_RAY_CLUSTER = None
 import duckdb.runners.ray.worker_handle as worker_handle_mod
 from duckdb.runners.ray import driver as ray_driver
 from duckdb.runners.ray import worker as worker_mod
-from duckdb.runners.ray.fte_fragment_scheduler import ensure_fte_fragment_progress_topology
+from duckdb.runners.ray.fte_fragment_scheduler import (
+    _stop_fte_status_watchers,
+    ensure_fte_fragment_progress_topology,
+)
 from duckdb.runners.ray.query_execution_graph import (
     NodeResourceAllocation,
     QueryAllocation,
@@ -261,6 +264,7 @@ class _NativeDynamicScanTask:
 
 
 def _clear_fte_state() -> None:
+    _stop_fte_status_watchers()
     clear_query_resource_managers()
     worker_handle_mod._FTE_FRAGMENT_EXECUTION_IDS.clear()
     worker_handle_mod._FTE_QUERY_NEXT_FRAGMENT_EXECUTION_ID.clear()

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -3901,7 +3901,13 @@ def test_fte_output_publication_is_bounded_by_block_target_and_task_window():
 
 class _RequiredFteWorkerCallbacks:
     def fte_cancel_task(self, _task_id):
-        return {"state": "CANCELED"}
+        return {
+            "state": "CANCELED",
+            "failure": {
+                "error_code": "TASK_CANCELED",
+                "message": "task canceled",
+            },
+        }
 
     def mark_fte_worker_failed(self, _worker_id, _error):
         return []
@@ -3953,7 +3959,14 @@ class _FakeFteStatusWorker(_RequiredFteWorkerCallbacks):
 
     def fte_cancel_task(self, task_id):
         self.calls.append(("cancel", task_id))
-        self.status = {"state": "CANCELED", "task_id": task_id}
+        self.status = {
+            "state": "CANCELED",
+            "task_id": task_id,
+            "failure": {
+                "error_code": "TASK_CANCELED",
+                "message": "task canceled",
+            },
+        }
         return dict(self.status)
 
     def fte_ack_task_result(self, task_id):
@@ -4482,7 +4495,10 @@ def test_fte_worker_task_handle_does_not_publish_failed_status_event():
     task_id = {"query_id": "q", "fragment_execution_id": 1, "partition_id": 2, "attempt_id": 0}
     worker.status = {
         "state": "FAILED",
-        "failure": {"message": "remote failed"},
+        "failure": {
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "message": "remote failed",
+        },
     }
     handle = driver.FteWorkerTaskHandle(task_id, worker)
 
@@ -4501,7 +4517,10 @@ def test_fte_worker_task_handle_does_not_adopt_retry_from_data_plane():
             return {
                 "state": "FAILED",
                 "task_id": task_id,
-                "failure": {"message": "retryable"},
+                "failure": {
+                    "error_code": "GENERIC_INTERNAL_ERROR",
+                    "message": "retryable",
+                },
                 "version": 1,
             }
 
@@ -4552,7 +4571,88 @@ def test_fte_worker_task_handle_malformed_status_fails_worker_and_records_termin
     assert handle.done() is True
     assert len(worker.worker_failures) == 1
     assert worker.worker_failures[0][0] == "worker-malformed-status"
-    assert "status protocol failed" in worker.worker_failures[0][1]
+    assert "status protocol failed" in str(worker.worker_failures[0][1])
+    assert worker.terminal_attempts == ["q.1.2.0"]
+
+
+def test_fte_worker_task_handle_preserves_ray_oom_type_when_publishing_worker_failure():
+    class _OomStatusWorker(_RequiredFteWorkerCallbacks):
+        worker_id = "worker-oom-status"
+
+        def __init__(self, error):
+            self.error = error
+            self.worker_failures = []
+            self.terminal_attempts = []
+
+        def fte_wait_task_status(self, _task_id, _min_version, _timeout_s):
+            raise self.error
+
+        def mark_fte_worker_failed(self, worker_id, error):
+            self.worker_failures.append((worker_id, error))
+            return []
+
+        def record_fte_task_terminal(self, task_id):
+            self.terminal_attempts.append(str(driver.FteTaskAttemptId.coerce(task_id)))
+
+    oom_error = driver.ray.exceptions.OutOfMemoryError("Ray killed the worker for memory pressure")
+    worker = _OomStatusWorker(oom_error)
+    handle = driver.FteWorkerTaskHandle(
+        {"query_id": "q", "fragment_execution_id": 1, "partition_id": 2, "attempt_id": 0},
+        worker,
+    )
+
+    with pytest.raises(driver.ray.exceptions.OutOfMemoryError, match="memory pressure"):
+        asyncio.run(handle.get_result())
+
+    assert len(worker.worker_failures) == 1
+    worker_id, published_error = worker.worker_failures[0]
+    assert worker_id == "worker-oom-status"
+    assert "status wait failed" in str(published_error)
+    assert published_error.__cause__ is oom_error
+    from duckdb.runners.ray.fte_fragment_scheduler import _worker_failure_payload
+
+    assert _worker_failure_payload(worker_id, published_error)["error_code"] == "OUT_OF_MEMORY"
+    assert worker.terminal_attempts == ["q.1.2.0"]
+
+
+def test_fte_worker_task_handle_publishes_failure_with_unprintable_message():
+    class _UnprintableError(RuntimeError):
+        def __str__(self):
+            raise RuntimeError("exception message is unreadable")
+
+    class _StatusWorker(_RequiredFteWorkerCallbacks):
+        worker_id = "worker-unprintable-status"
+
+        def __init__(self, error):
+            self.error = error
+            self.worker_failures = []
+            self.terminal_attempts = []
+
+        def fte_wait_task_status(self, _task_id, _min_version, _timeout_s):
+            raise self.error
+
+        def mark_fte_worker_failed(self, worker_id, error):
+            self.worker_failures.append((worker_id, error))
+            return []
+
+        def record_fte_task_terminal(self, task_id):
+            self.terminal_attempts.append(str(driver.FteTaskAttemptId.coerce(task_id)))
+
+    failure = _UnprintableError()
+    worker = _StatusWorker(failure)
+    handle = driver.FteWorkerTaskHandle(
+        {"query_id": "q", "fragment_execution_id": 1, "partition_id": 2, "attempt_id": 0},
+        worker,
+    )
+
+    with pytest.raises(_UnprintableError):
+        asyncio.run(handle.get_result())
+
+    assert len(worker.worker_failures) == 1
+    worker_id, published_error = worker.worker_failures[0]
+    assert worker_id == "worker-unprintable-status"
+    assert str(published_error).endswith("<unprintable _UnprintableError>")
+    assert published_error.__cause__ is failure
     assert worker.terminal_attempts == ["q.1.2.0"]
 
 
@@ -4820,7 +4920,13 @@ def test_fte_worker_task_handle_failed_status_raises_result_error():
     worker = _FakeFteStatusWorker()
     task_id = {"query_id": "q", "fragment_execution_id": 1, "partition_id": 2, "attempt_id": 0}
     handle = driver.FteWorkerTaskHandle(task_id, worker)
-    worker.status = {"state": "FAILED", "failure": {"message": "boom"}}
+    worker.status = {
+        "state": "FAILED",
+        "failure": {
+            "error_code": "GENERIC_INTERNAL_ERROR",
+            "message": "boom",
+        },
+    }
 
     assert _wait_batch_ready(handle) == [0]
     with pytest.raises(RuntimeError, match="boom"):

--- a/tests/fast/test_sync_duckdb_source_id.py
+++ b/tests/fast/test_sync_duckdb_source_id.py
@@ -96,10 +96,22 @@ def test_source_tree_id_clears_suppression_in_temporary_index(tmp_path, monkeypa
     source.mkdir(parents=True)
     tracked_file = source / "source.cpp"
     tracked_file.write_text("original\n", encoding="ascii")
+    fixed_timestamp_ns = tracked_file.stat().st_mtime_ns - 5_000_000_000
+    os.utime(tracked_file, ns=(fixed_timestamp_ns, fixed_timestamp_ns))
     _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "core.trustctime", "false")
     _git(tmp_path, "add", "external/duckdb/source.cpp")
+    original_timestamps = tracked_file.stat()
     _git(tmp_path, "update-index", suppression_flag, "external/duckdb/source.cpp")
+    os.utime(
+        tmp_path / ".git" / "index",
+        ns=(original_timestamps.st_mtime_ns, original_timestamps.st_mtime_ns),
+    )
     tracked_file.write_text("modified\n", encoding="ascii")
+    os.utime(
+        tracked_file,
+        ns=(original_timestamps.st_atime_ns, original_timestamps.st_mtime_ns),
+    )
     monkeypatch.setattr(sync_duckdb_source_id, "REPOSITORY_ROOT", tmp_path)
 
     expected = sync_duckdb_source_id.filesystem_tree_id(source, object_format="sha1")


### PR DESCRIPTION
## Problem

`_is_memory_failure` flattened arbitrary failure payloads into text and used a raw `"oom" in text` check. Messages such as `bloom`, `room`, and `zoom` could therefore enter the memory-specific terminal path even when the failure was unrelated and retryable.

## Design

This intentionally uses a strict structured protocol:

- every internal FTE `FAILED`, `CANCELED`, or `ABORTED` task status must carry a top-level, non-empty string `error_code`;
- producers assign canonical codes for DuckDB/Python/Ray OOM, generic execution failure, cancellation, worker loss, speculative revocation, missing output statistics, and native-backend failures;
- consumers normalize case plus hyphen/space separators, then classify memory failures by exact membership in `OUT_OF_MEMORY` or `EXCEEDED_LOCAL_MEMORY_LIMIT`;
- messages and tracebacks remain diagnostics only and never influence memory classification;
- malformed terminal payloads are rejected before task state or task statistics mutate;
- typed causes are preserved through Ray worker-control publication, while diagnostic rendering and exception-chain traversal are bounded and guarded against hostile exception objects;
- the real-Ray fault-injection fixture stops and joins FTE status-watcher threads, then stops the background driver loop before `ray.shutdown()`, allowing pytest and JUnit finalization to complete reliably.

There is no compatibility or text fallback by design. A terminal internal FTE status without `error_code` now fails protocol validation instead of being inferred from text. This is an internal protocol change and does not add a public API.

## CI stability fixes

Two failures exposed by the full PR matrix are fixed at their boundaries:

- a configured zero-second no-matching-node allowance now expires at `elapsed >= limit`, including when two clock reads return the same value;
- the disposable Git index used for DuckDB SourceID computation preserves the real index timestamp, so Git's racy-clean detection still rehashes a same-size, same-mtime worktree change without forcing a full subtree rehash.

Both cases have deterministic regression coverage.

## Verification

- `scripts/format root --changed`
- pre-commit on all 21 changed files, including Ruff and mypy
- directly affected CI-regression modules: `224 passed`
- `scripts/run_release_tests.sh`:
  - non-Ray release shard: `439 passed, 1 skipped, 11 deselected`
  - real-Ray release shard: `7 passed, 444 deselected`
- `scripts/run_fast_tests.sh` on the final pushed code:
  - non-Ray: `5749 passed, 44 skipped, 102 deselected, 8 xfailed, 1 xpassed`
  - shared-Ray: `86 passed, 17 skipped, 5801 deselected`
  - test-owned Ray clusters: all 6 isolated real-Ray tests passed
  - vLLM isolated test skipped because vLLM is not installed

GPU/vLLM and other optional-dependency cases skipped by the project launchers were not independently exercised. The repository-wide license-header helper cannot complete in this checkout because the DuckDB subtree lacks its historical baseline object and it reports six pre-existing root files outside this PR; all changed files have the applicable existing or new SPDX headers.

The final diff completed two clean local review passes after the last finding was fixed. Runtime classification work is limited to constant-size code matching, shallow payload normalization, and a bounded exception-chain walk on failure paths. The SourceID fix only preserves copied index metadata. No dependencies, generated assets, imported code, security-sensitive behavior, or license provenance are added.

## AI assistance

Codex assisted with implementation, test updates, CI diagnosis, and iterative review. The resulting diff was reviewed through repeated clean-review passes and the verification above; no AI-generated assets or externally sourced code are included.

Closes #66.
