### PR TITLE
[fix](ray) Preserve committed COPY outcomes

### DIFF
--- a/duckdb/runners/ray/__init__.py
+++ b/duckdb/runners/ray/__init__.py
@@ -9,6 +9,7 @@ import os
 from typing import TYPE_CHECKING
 
 from duckdb.runners.ray.committed_copy import read_committed_copy_direct_write_parquet
+from duckdb.runners.ray.driver import CopyOutcomeUnknownError
 from duckdb.runners.ray.lifecycle import (
     cleanup_copy_direct_write_lifecycle_once,
     run_copy_direct_write_lifecycle_cleanup_loop,
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "CopyOutcomeUnknownError",
     "RayRunner",
     "cleanup_copy_direct_write_lifecycle_once",
     "read_committed_copy_direct_write_parquet",

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -13,10 +13,11 @@ import uuid
 import weakref
 from collections.abc import Callable, Mapping
 from concurrent.futures import TimeoutError as FutureTimeoutError
-from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any
+from dataclasses import asdict, dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Literal
 
 from duckdb._ray_cxx import require_ray_cxx_attr
+from duckdb._ray_errors import restore_remote_ray_exception
 from duckdb._ray_progress_env import configure_ray_progress_logging_defaults
 
 RayResultPartitionRef = require_ray_cxx_attr(
@@ -46,6 +47,7 @@ from duckdb.runners.ray.worker import WorkerTaskMetadata
 _LEASE_REQUEST_REPLAY_CAPACITY = 65_536
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 _CLIENT_DETACH_REPLAY_CAPACITY = 65_536
+_COPY_OPERATION_REPLAY_CAPACITY = 1_024
 _DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S = 60.0
 _RUNTIME_ATTACH_TIMEOUT_S = 300.0
 _RUNTIME_ATTACH_RETRY_INTERVAL_S = 0.05
@@ -113,6 +115,20 @@ class QueryExecutionCleanupError(RuntimeError):
             primary_error=primary_error,
             cleanup_errors=cleanup,
         )
+
+
+class CopyOutcomeUnknownError(RuntimeError):
+    """The actor cannot prove whether a COPY operation committed."""
+
+    def __init__(self, operation_id: str) -> None:
+        self.operation_id = str(operation_id)
+        super().__init__(
+            f"COPY outcome is unknown for operation {self.operation_id}; "
+            "refusing to resubmit a potentially committed write"
+        )
+
+    def __reduce__(self) -> tuple[type[CopyOutcomeUnknownError], tuple[str]]:
+        return CopyOutcomeUnknownError, (self.operation_id,)
 
 
 def _client_owner_lease_settings() -> tuple[float, float]:
@@ -208,7 +224,35 @@ class CopyPlanOutcome:
     """Internal actor-to-client COPY result captured before query teardown."""
 
     result: dict[str, Any]
-    final_progress_snapshot: dict[str, Any]
+    final_progress_snapshot: dict[str, Any] | None
+    operation_id: str = ""
+    write_state: Literal["committed"] = "committed"
+    cleanup_state: Literal["complete", "pending"] = "complete"
+    cleanup_warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CopyPlanRecovery:
+    """Read-only reconciliation response for one submitted COPY operation."""
+
+    operation_id: str
+    outcome: CopyPlanOutcome | None = None
+    error: BaseException | None = None
+
+
+@dataclass(frozen=True)
+class _CopyOperationInFlight:
+    owner_id: str
+    session_id: str
+    task: asyncio.Task[CopyPlanOutcome]
+
+
+@dataclass(frozen=True)
+class _CopyOperationTerminal:
+    owner_id: str
+    session_id: str
+    outcome: CopyPlanOutcome | None = None
+    error: BaseException | None = None
 
 
 @dataclass(frozen=True)
@@ -1172,6 +1216,15 @@ class RayQueryDriverActor:
         self._plan_connections: dict[str, Any] = {}
         self._plan_teardown_condition = threading.Condition(self._session_lock)
         self._plan_teardowns_in_progress: set[str] = set()
+        self._copy_operations_inflight: dict[str, _CopyOperationInFlight] = {}
+        self._copy_operation_terminal = BoundedReplayMap[str, _CopyOperationTerminal](
+            capacity=_COPY_OPERATION_REPLAY_CAPACITY
+        )
+        # Outcome payloads are bounded, but an admitted identity must remain
+        # known for the owner's lifetime. Evicting a payload may make recovery
+        # impossible; it must never authorize the same write to run again.
+        self._copy_operation_identities: dict[str, tuple[str, str]] = {}
+        self._copy_cleanup_tasks: dict[str, asyncio.Task[CopyPlanOutcome]] = {}
         self._driver_handle = ray.get_runtime_context().current_actor
         # Avoid referencing C++ types at import time; store opaque plan objects and
         # lazily instantiate the plan runner when first required.
@@ -1945,6 +1998,7 @@ class RayQueryDriverActor:
                     await self._shutdown_runtime()
                     with self._session_lock:
                         self._client_ids.remove(owner_key)
+                self._discard_copy_operation_state_for_owner(owner_key)
             except BaseException as error:
                 with self._session_lock:
                     lease = self._client_leases[owner_key]
@@ -4524,20 +4578,418 @@ class RayQueryDriverActor:
             session_config,
         )
 
+    def _ensure_copy_operation_state(self) -> None:
+        if not isinstance(getattr(self, "_copy_operations_inflight", None), dict):
+            self._copy_operations_inflight = {}
+        if not isinstance(getattr(self, "_copy_operation_terminal", None), BoundedReplayMap):
+            self._copy_operation_terminal = BoundedReplayMap(capacity=_COPY_OPERATION_REPLAY_CAPACITY)
+        if not isinstance(getattr(self, "_copy_operation_identities", None), dict):
+            self._copy_operation_identities = {}
+        if not isinstance(getattr(self, "_copy_cleanup_tasks", None), dict):
+            self._copy_cleanup_tasks = {}
+
+    def _discard_copy_operation_state_for_owner(self, owner_id: str) -> None:
+        self._ensure_copy_operation_state()
+        operation_ids = {
+            operation_id
+            for operation_id, (record_owner_id, _) in self._copy_operation_identities.items()
+            if record_owner_id == owner_id
+        }
+        for operation_id in operation_ids:
+            self._copy_operation_identities.pop(operation_id, None)
+        self._copy_operation_terminal.discard_where(
+            lambda operation_id, record: operation_id in operation_ids and record.owner_id == owner_id
+        )
+
+    @staticmethod
+    def _copy_operation_id(plan: Any) -> str:
+        operation_id = str(plan.idx()).strip()
+        if not operation_id:
+            raise ValueError("COPY operation identity must not be empty")
+        return operation_id
+
+    @staticmethod
+    def _validate_copy_operation_identity(
+        record: _CopyOperationInFlight | _CopyOperationTerminal,
+        *,
+        owner_id: str,
+        session_id: str | None,
+        operation_id: str,
+    ) -> None:
+        if record.owner_id != owner_id or (session_id is not None and record.session_id != session_id):
+            raise PermissionError(
+                f"COPY operation {operation_id} does not belong to the requested runtime owner and session"
+            )
+
+    @staticmethod
+    def _validate_copy_identity_tombstone(
+        identity: tuple[str, str],
+        *,
+        owner_id: str,
+        session_id: str | None,
+        operation_id: str,
+    ) -> None:
+        record_owner_id, record_session_id = identity
+        if record_owner_id != owner_id or (session_id is not None and record_session_id != session_id):
+            raise PermissionError(
+                f"COPY operation {operation_id} does not belong to the requested runtime owner and session"
+            )
+
+    @staticmethod
+    def _copy_terminal_result(record: _CopyOperationTerminal) -> CopyPlanOutcome:
+        if record.error is not None:
+            raise record.error
+        if record.outcome is None:
+            raise RuntimeError("COPY terminal replay record has no result")
+        return record.outcome
+
+    @staticmethod
+    def _copy_terminal_recovery(
+        operation_id: str,
+        record: _CopyOperationTerminal,
+    ) -> CopyPlanRecovery:
+        if (record.outcome is None) == (record.error is None):
+            raise RuntimeError("COPY terminal replay record must contain exactly one result")
+        return CopyPlanRecovery(
+            operation_id=operation_id,
+            outcome=record.outcome,
+            error=record.error,
+        )
+
+    @staticmethod
+    async def _await_copy_operation(task: asyncio.Task[CopyPlanOutcome]) -> CopyPlanOutcome:
+        cancellation: asyncio.CancelledError | None = None
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as error:
+                # The write owns its operation identity until a terminal
+                # outcome is recorded. Do not let cancellation of one waiter
+                # cancel the write or interrupt observation of its outcome.
+                cancellation = error
+            except BaseException:
+                break
+        if cancellation is not None:
+            try:
+                task.result()
+            except BaseException:
+                pass
+            raise cancellation
+        return task.result()
+
+    @staticmethod
+    async def _drain_copy_startup_tasks(tasks: list[asyncio.Task[Any]]) -> None:
+        if not tasks:
+            return
+        drain = asyncio.gather(*tasks, return_exceptions=True)
+        while not drain.done():
+            try:
+                await asyncio.shield(drain)
+            except asyncio.CancelledError:
+                # Once native COPY may have committed, cancellation cannot
+                # interrupt observation of the remaining startup tasks.
+                continue
+        drain.result()
+
+    @staticmethod
+    def _copy_cleanup_warning(stage: str, error: BaseException) -> str:
+        try:
+            message = str(error)
+        except BaseException:
+            message = "<error message unavailable>"
+        return f"{stage} failed: {type(error).__name__}: {message}"
+
+    @staticmethod
+    def _copy_native_cleanup_warnings(result: Mapping[str, Any]) -> tuple[str, ...]:
+        raw_warnings = result.get("copy_runner_cleanup_warnings", ())
+        if isinstance(raw_warnings, str):
+            return (raw_warnings,) if raw_warnings else ()
+        if not isinstance(raw_warnings, (list, tuple)):
+            return ()
+        return tuple(str(warning) for warning in raw_warnings if str(warning))
+
+    @staticmethod
+    def _committed_copy_outcome(
+        operation_id: str,
+        result: Mapping[str, Any],
+        final_progress_snapshot: dict[str, Any] | None,
+        *,
+        cleanup_state: Literal["complete", "pending"],
+        cleanup_warnings: tuple[str, ...],
+    ) -> CopyPlanOutcome:
+        public_result = dict(result)
+        public_result["copy_operation_id"] = operation_id
+        public_result["copy_write_state"] = "committed"
+        public_result["copy_cleanup_state"] = cleanup_state
+        public_result["copy_cleanup_warnings"] = list(cleanup_warnings)
+        return CopyPlanOutcome(
+            result=public_result,
+            final_progress_snapshot=final_progress_snapshot,
+            operation_id=operation_id,
+            write_state="committed",
+            cleanup_state=cleanup_state,
+            cleanup_warnings=cleanup_warnings,
+        )
+
+    async def _execute_copy_operation(
+        self,
+        owner_id: str,
+        session_id: str,
+        session: _DriverSession,
+        plan: Any,
+        operation_id: str,
+    ) -> CopyPlanOutcome:
+        try:
+            self._begin_session_operation(session, session_id)
+            try:
+                outcome = await self._run_copy_plan_for_session(
+                    session_id,
+                    session,
+                    plan,
+                )
+            finally:
+                self._end_session_operation(session)
+        except BaseException as error:
+            self._copy_operation_terminal[operation_id] = _CopyOperationTerminal(
+                owner_id=owner_id,
+                session_id=session_id,
+                error=error,
+            )
+            raise
+        else:
+            self._copy_operation_terminal[operation_id] = _CopyOperationTerminal(
+                owner_id=owner_id,
+                session_id=session_id,
+                outcome=outcome,
+            )
+            return outcome
+        finally:
+            current = self._copy_operations_inflight.get(operation_id)
+            if current is not None and current.task is asyncio.current_task():
+                self._copy_operations_inflight.pop(operation_id, None)
+
     async def run_copy_plan(
         self,
         owner_id: str,
         session_id: str,
         plan: Any,
     ) -> CopyPlanOutcome:
-        """Run COPY and capture its final progress state before teardown."""
+        """Run one idempotently identified COPY and replay its terminal outcome."""
+        self._ensure_copy_operation_state()
+        owner_key = str(owner_id).strip()
+        session_key = str(session_id).strip()
+        operation_id = self._copy_operation_id(plan)
         session = self._require_session(owner_id, session_id)
         self._validate_plan_session(session_id, plan, session)
-        self._begin_session_operation(session, session_id)
+        terminal = self._copy_operation_terminal.get(operation_id)
+        if terminal is not None:
+            self._validate_copy_operation_identity(
+                terminal,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_id,
+            )
+            self._copy_operation_identities.setdefault(
+                operation_id,
+                (terminal.owner_id, terminal.session_id),
+            )
+            return self._copy_terminal_result(terminal)
+        in_flight = self._copy_operations_inflight.get(operation_id)
+        if in_flight is not None:
+            self._validate_copy_operation_identity(
+                in_flight,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_id,
+            )
+            self._copy_operation_identities.setdefault(
+                operation_id,
+                (in_flight.owner_id, in_flight.session_id),
+            )
+            return await self._await_copy_operation(in_flight.task)
+        identity = self._copy_operation_identities.get(operation_id)
+        if identity is not None:
+            self._validate_copy_identity_tombstone(
+                identity,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_id,
+            )
+            raise CopyOutcomeUnknownError(operation_id)
+        self._copy_operation_identities[operation_id] = (
+            owner_key,
+            session_key,
+        )
+        task = asyncio.create_task(
+            self._execute_copy_operation(
+                owner_key,
+                session_key,
+                session,
+                plan,
+                operation_id,
+            ),
+            name=f"vane-copy-operation:{operation_id}",
+        )
+        self._copy_operations_inflight[operation_id] = _CopyOperationInFlight(
+            owner_id=owner_key,
+            session_id=session_key,
+            task=task,
+        )
+        return await self._await_copy_operation(task)
+
+    async def _recover_copy_operation(
+        self,
+        owner_id: str,
+        operation_id: str,
+        *,
+        session_id: str | None,
+    ) -> CopyPlanRecovery:
+        self._ensure_copy_operation_state()
+        owner_key = str(owner_id).strip()
+        session_key = None if session_id is None else str(session_id).strip()
+        operation_key = str(operation_id).strip()
+        self._require_owner(owner_key)
+        if session_id is not None and not session_key:
+            raise ValueError("Vane session_id must not be empty")
+        if not operation_key:
+            raise ValueError("COPY operation identity must not be empty")
+        terminal = self._copy_operation_terminal.get(operation_key)
+        if terminal is not None:
+            self._validate_copy_operation_identity(
+                terminal,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_key,
+            )
+            return self._copy_terminal_recovery(operation_key, terminal)
+        in_flight = self._copy_operations_inflight.get(operation_key)
+        if in_flight is not None:
+            self._validate_copy_operation_identity(
+                in_flight,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_key,
+            )
+            try:
+                outcome = await self._await_copy_operation(in_flight.task)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as operation_error:
+                terminal = self._copy_operation_terminal.get(operation_key)
+                if terminal is not None:
+                    self._validate_copy_operation_identity(
+                        terminal,
+                        owner_id=owner_key,
+                        session_id=session_key,
+                        operation_id=operation_key,
+                    )
+                    return self._copy_terminal_recovery(operation_key, terminal)
+                return CopyPlanRecovery(
+                    operation_id=operation_key,
+                    error=operation_error,
+                )
+            return CopyPlanRecovery(
+                operation_id=operation_key,
+                outcome=outcome,
+            )
+        identity = self._copy_operation_identities.get(operation_key)
+        if identity is not None:
+            self._validate_copy_identity_tombstone(
+                identity,
+                owner_id=owner_key,
+                session_id=session_key,
+                operation_id=operation_key,
+            )
+        raise CopyOutcomeUnknownError(operation_key)
+
+    async def recover_copy_plan(
+        self,
+        owner_id: str,
+        session_id: str,
+        operation_id: str,
+    ) -> CopyPlanRecovery:
+        """Read or await an existing COPY outcome without submitting a write."""
+        return await self._recover_copy_operation(
+            owner_id,
+            operation_id,
+            session_id=session_id,
+        )
+
+    async def _retry_copy_cleanup_for_operation(
+        self,
+        operation_id: str,
+        terminal: _CopyOperationTerminal,
+        outcome: CopyPlanOutcome,
+    ) -> CopyPlanOutcome:
+        cleanup_warnings = outcome.cleanup_warnings
+        cleanup_state: Literal["complete", "pending"] = "complete"
         try:
-            return await self._run_copy_plan_for_session(session_id, session, plan)
-        finally:
-            self._end_session_operation(session)
+            await _to_thread_with_owned_side_effects(
+                self._cleanup_finished_plan,
+                operation_id,
+            )
+        except asyncio.CancelledError:
+            # The owned cleanup call completed before waiter cancellation was
+            # exposed, so there is no cleanup work left to retry.
+            pass
+        except BaseException as cleanup_error:
+            cleanup_state = "pending"
+            cleanup_warnings += (self._copy_cleanup_warning("COPY cleanup retry", cleanup_error),)
+        updated = self._committed_copy_outcome(
+            operation_id,
+            outcome.result,
+            outcome.final_progress_snapshot,
+            cleanup_state=cleanup_state,
+            cleanup_warnings=cleanup_warnings,
+        )
+        current = self._copy_operation_terminal.get(operation_id)
+        if current is terminal:
+            self._copy_operation_terminal[operation_id] = replace(
+                terminal,
+                outcome=updated,
+            )
+        return updated
+
+    async def retry_copy_cleanup(
+        self,
+        owner_id: str,
+        operation_id: str,
+    ) -> CopyPlanOutcome:
+        """Retry only post-commit cleanup for an existing COPY operation."""
+        recovery = await self._recover_copy_operation(
+            owner_id,
+            operation_id,
+            session_id=None,
+        )
+        if recovery.error is not None:
+            raise recovery.error
+        outcome = recovery.outcome
+        if outcome is None:
+            raise CopyOutcomeUnknownError(str(operation_id).strip())
+        if outcome.cleanup_state == "complete":
+            return outcome
+        operation_key = str(operation_id).strip()
+        terminal = self._copy_operation_terminal.get(operation_key)
+        if terminal is None or terminal.outcome is None:
+            raise CopyOutcomeUnknownError(operation_key)
+        cleanup_task = self._copy_cleanup_tasks.get(operation_key)
+        if cleanup_task is None:
+            cleanup_task = asyncio.create_task(
+                self._retry_copy_cleanup_for_operation(
+                    operation_key,
+                    terminal,
+                    outcome,
+                ),
+                name=f"vane-copy-cleanup:{operation_key}",
+            )
+            self._copy_cleanup_tasks[operation_key] = cleanup_task
+
+            def discard_completed_cleanup(completed: asyncio.Task[CopyPlanOutcome]) -> None:
+                if self._copy_cleanup_tasks.get(operation_key) is completed:
+                    self._copy_cleanup_tasks.pop(operation_key, None)
+
+            cleanup_task.add_done_callback(discard_completed_cleanup)
+        return await self._await_copy_operation(cleanup_task)
 
     async def _run_copy_plan_for_session(
         self,
@@ -4624,7 +5076,7 @@ class RayQueryDriverActor:
                         # before a slow actor has initialized, so keep waiting
                         # for the startup barriers instead of rewriting that
                         # success as an execution error.
-                        await plan_execution
+                        await self._await_copy_operation(plan_execution)
                         plan_execution_observed = True
                     for task in done:
                         if task is plan_execution:
@@ -4632,7 +5084,16 @@ class RayQueryDriverActor:
                         await task
                         pending_startup.discard(task)
             self._mark_query_actor_stages_ready(graph)
-            result = await plan_execution
+            # Cancellation must reach the exception path promptly so teardown
+            # can interrupt a still-running native write, but it must not
+            # cancel the asyncio wrapper around that thread. The exception path
+            # waits for the wrapper's terminal result and checks the commit
+            # marker before classifying the operation.
+            result = await asyncio.shield(plan_execution)
+            if not isinstance(result, Mapping):
+                raise TypeError(f"native COPY returned {type(result).__name__}, expected a mapping")
+            if result.get("copy_output_committed") is not True:
+                raise RuntimeError(f"native COPY plan {plan_id} returned without a committed output marker")
         except BaseException as execution_error:
             query_id = self._plan_query_ids.get(plan_id, "")
             teardown_error: BaseException | None = None
@@ -4651,13 +5112,52 @@ class RayQueryDriverActor:
             # Teardown interrupts the native runner. Always retrieve its
             # terminal result so a concurrent failure cannot escape as an
             # unobserved asyncio task exception.
+            committed_result: Mapping[str, Any] | None = None
             if plan_execution is not None:
                 try:
-                    await plan_execution
+                    await self._await_copy_operation(plan_execution)
                 except BaseException:
                     pass
-            if startup_tasks:
-                await asyncio.gather(*startup_tasks, return_exceptions=True)
+                try:
+                    observed_result = plan_execution.result()
+                except BaseException:
+                    pass
+                else:
+                    if isinstance(observed_result, Mapping) and observed_result.get("copy_output_committed") is True:
+                        committed_result = observed_result
+            await self._drain_copy_startup_tasks(startup_tasks)
+            if committed_result is not None:
+                cleanup_warnings = self._copy_native_cleanup_warnings(committed_result) + (
+                    self._copy_cleanup_warning(
+                        "COPY post-commit execution finalization",
+                        execution_error,
+                    ),
+                )
+                cleanup_state: Literal["complete", "pending"] = "complete"
+                if teardown_error is not None:
+                    cleanup_state = "pending"
+                    cleanup_warnings += (
+                        self._copy_cleanup_warning(
+                            "COPY post-commit teardown",
+                            teardown_error,
+                        ),
+                    )
+                try:
+                    _log_copy_result_debug(str(query_id or plan_id), committed_result)
+                except BaseException as logging_error:
+                    cleanup_warnings += (
+                        self._copy_cleanup_warning(
+                            "COPY result logging",
+                            logging_error,
+                        ),
+                    )
+                return self._committed_copy_outcome(
+                    plan_id,
+                    committed_result,
+                    None,
+                    cleanup_state=cleanup_state,
+                    cleanup_warnings=cleanup_warnings,
+                )
             if teardown_error is not None:
                 aggregate_error = QueryExecutionCleanupError.from_errors(
                     f"COPY query plan {plan_id} failed and teardown also failed",
@@ -4667,13 +5167,19 @@ class RayQueryDriverActor:
                 raise aggregate_error from execution_error
             raise
         query_id = str(graph.query_id)
-        _log_copy_result_debug(query_id, result)
-        if query_id in getattr(self, "_query_terminal_errors", {}):
-            await _to_thread_with_owned_side_effects(
-                self._finish_terminal_query,
-                plan_id,
-                query_id,
+        cleanup_warnings = self._copy_native_cleanup_warnings(result)
+        try:
+            _log_copy_result_debug(query_id, result)
+        except BaseException as logging_error:
+            cleanup_warnings += (
+                self._copy_cleanup_warning(
+                    "COPY result logging",
+                    logging_error,
+                ),
             )
+        terminal_reason = str(getattr(self, "_query_terminal_errors", {}).get(query_id, ""))
+        if terminal_reason:
+            cleanup_warnings += (f"COPY post-commit terminal query state: {terminal_reason}",)
         try:
             final_progress_snapshot = await _to_thread_with_owned_side_effects(
                 self._build_local_progress_snapshot,
@@ -4681,32 +5187,38 @@ class RayQueryDriverActor:
                 None,
             )
         except BaseException as progress_error:
-            try:
-                await _to_thread_with_owned_side_effects(
-                    self._teardown_plan_resources,
-                    plan_id,
-                    query_id,
-                    drop_fragments=True,
-                )
-            except asyncio.CancelledError:
-                raise progress_error
-            except BaseException as teardown_error:
-                aggregate_error = QueryExecutionCleanupError.from_errors(
-                    f"COPY query plan {plan_id} progress finalization failed and teardown also failed",
+            final_progress_snapshot = None
+            cleanup_warnings += (
+                self._copy_cleanup_warning(
+                    "COPY progress finalization",
                     progress_error,
-                    [teardown_error],
-                )
-                raise aggregate_error from progress_error
-            raise
-        await _to_thread_with_owned_side_effects(
-            self._teardown_plan_resources,
+                ),
+            )
+        final_cleanup_state: Literal["complete", "pending"] = "complete"
+        try:
+            await _to_thread_with_owned_side_effects(
+                self._teardown_plan_resources,
+                plan_id,
+                query_id,
+                drop_fragments=True,
+            )
+        except asyncio.CancelledError:
+            # The owned teardown completed before cancellation was exposed.
+            pass
+        except BaseException as teardown_error:
+            final_cleanup_state = "pending"
+            cleanup_warnings += (
+                self._copy_cleanup_warning(
+                    "COPY post-commit teardown",
+                    teardown_error,
+                ),
+            )
+        return self._committed_copy_outcome(
             plan_id,
-            query_id,
-            drop_fragments=True,
-        )
-        return CopyPlanOutcome(
-            result=result,
-            final_progress_snapshot=final_progress_snapshot,
+            result,
+            final_progress_snapshot,
+            cleanup_state=final_cleanup_state,
+            cleanup_warnings=cleanup_warnings,
         )
 
     def _prepare_copy_plan_sync(
@@ -5148,14 +5660,18 @@ class RayQueryDriverClient:
             current_gcs_address = runtime_context.gcs_address
         except Exception:
             return False
+        expected_gcs_address = getattr(self, "_ray_gcs_address", None)
         if (
-            self._ray_gcs_address is not None
+            expected_gcs_address is not None
             and current_gcs_address is not None
-            and current_gcs_address != self._ray_gcs_address
+            and current_gcs_address != expected_gcs_address
         ):
             return True
+        expected_job_id = getattr(self, "_ray_job_id", None)
+        if expected_job_id is None:
+            return False
         try:
-            return _ray_runtime_job_id(runtime_context) != self._ray_job_id
+            return _ray_runtime_job_id(runtime_context) != expected_job_id
         except Exception:
             # A context lookup failure is not proof that the old runtime was
             # replaced; let the actor RPC produce the actionable error.
@@ -5475,6 +5991,110 @@ class RayQueryDriverClient:
             )
             raise aggregate_error from operation_error
 
+    def _recover_copy_plan(
+        self,
+        runner: Any,
+        *,
+        session_id: str,
+        operation_id: str,
+        operation_error: BaseException,
+    ) -> CopyPlanOutcome:
+        """Resolve an ambiguous COPY response without ever resubmitting it."""
+        try:
+            recovery_future = runner.recover_copy_plan.remote(
+                self._owner_id,
+                session_id,
+                operation_id,
+            )
+        except BaseException:
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
+        while True:
+            try:
+                recovery = resolve_object_refs_blocking(
+                    recovery_future,
+                    honor_query_deadline=False,
+                )
+            except BaseException as recovery_error:
+                if _runtime_error_is_wait_timeout(recovery_error):
+                    # Rewait on the same read-only ObjectRef. A new RPC is not
+                    # needed and the write operation must never be resubmitted.
+                    continue
+                unknown_error = next(
+                    (
+                        candidate
+                        for candidate in _runtime_error_candidates(recovery_error)
+                        if isinstance(candidate, CopyOutcomeUnknownError)
+                    ),
+                    None,
+                )
+                if unknown_error is not None:
+                    raise unknown_error
+                raise CopyOutcomeUnknownError(operation_id) from operation_error
+            break
+        if not isinstance(recovery, CopyPlanRecovery):
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
+        if recovery.operation_id != operation_id:
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
+        if (recovery.outcome is None) == (recovery.error is None):
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
+        if recovery.error is not None:
+            if not isinstance(recovery.error, BaseException):
+                raise CopyOutcomeUnknownError(operation_id) from operation_error
+            restored_error = restore_remote_ray_exception(recovery.error)
+            raise recovery.error if restored_error is None else restored_error
+        try:
+            return self._validate_copy_outcome(
+                recovery.outcome,
+                operation_id,
+            )
+        except BaseException:
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
+
+    @staticmethod
+    def _validate_copy_outcome(
+        outcome: Any,
+        operation_id: str,
+    ) -> CopyPlanOutcome:
+        if not isinstance(outcome, CopyPlanOutcome):
+            raise TypeError(f"Ray COPY returned {type(outcome).__name__}, expected CopyPlanOutcome")
+        if outcome.operation_id != operation_id:
+            raise RuntimeError(
+                f"Ray COPY outcome identity mismatch: expected={operation_id} actual={outcome.operation_id}"
+            )
+        if outcome.write_state != "committed":
+            raise RuntimeError(
+                f"Ray COPY operation {operation_id} returned non-committed write state: {outcome.write_state}"
+            )
+        if outcome.cleanup_state not in {"complete", "pending"}:
+            raise RuntimeError(
+                f"Ray COPY operation {operation_id} returned invalid cleanup state: {outcome.cleanup_state}"
+            )
+        if not isinstance(outcome.result, dict):
+            raise TypeError(f"Ray COPY operation {operation_id} returned a non-dict result")
+        return outcome
+
+    def retry_copy_cleanup(self, operation_id: str) -> dict[str, Any]:
+        """Retry post-commit cleanup using the operation id returned by run_copy_plan()."""
+        operation_key = str(operation_id).strip()
+        if not operation_key:
+            raise ValueError("COPY operation identity must not be empty")
+        with self._session_condition:
+            runner = getattr(self, "runner", None)
+            if runner is None or self._client_closing:
+                raise RuntimeError("Ray query runtime client is closed")
+        outcome = resolve_object_refs_blocking(
+            runner.retry_copy_cleanup.remote(
+                self._owner_id,
+                operation_key,
+            ),
+            honor_query_deadline=False,
+        )
+        validated = self._validate_copy_outcome(
+            outcome,
+            operation_key,
+        )
+        return validated.result
+
     def stream_plan(
         self,
         plan: Any,
@@ -5581,16 +6201,25 @@ class RayQueryDriverClient:
                 try:
                     outcome = progress.resolve(future)
                 except BaseException as operation_error:
-                    self._teardown_failed_plan(
+                    outcome = self._recover_copy_plan(
                         runner,
-                        future,
                         session_id=session_id,
-                        plan_id=plan_id,
+                        operation_id=plan_id,
                         operation_error=operation_error,
                     )
-                    raise
-                if not isinstance(outcome, CopyPlanOutcome):
-                    raise TypeError(f"Ray COPY returned {type(outcome).__name__}, expected CopyPlanOutcome")
+                else:
+                    try:
+                        outcome = self._validate_copy_outcome(
+                            outcome,
+                            plan_id,
+                        )
+                    except BaseException as response_error:
+                        outcome = self._recover_copy_plan(
+                            runner,
+                            session_id=session_id,
+                            operation_id=plan_id,
+                            operation_error=response_error,
+                        )
                 final_progress_snapshot = outcome.final_progress_snapshot
                 completed = True
             finally:
@@ -5600,6 +6229,16 @@ class RayQueryDriverClient:
                 )
             return outcome.result
         except Exception as e:
+            unknown_outcome = next(
+                (
+                    candidate
+                    for candidate in _runtime_error_candidates(e)
+                    if isinstance(candidate, CopyOutcomeUnknownError)
+                ),
+                None,
+            )
+            if unknown_outcome is not None:
+                raise unknown_outcome
             cleanup_failure = next(
                 (
                     candidate

--- a/duckdb/runners/ray/runner.py
+++ b/duckdb/runners/ray/runner.py
@@ -180,6 +180,16 @@ class RayRunner(Runner):
         # Send PyLogicalPlan to Driver — Driver will create physical plan
         return client.run_copy_plan(logical_plan)
 
+    def retry_copy_cleanup(self, operation_id: str) -> dict[str, Any]:
+        """Retry cleanup for a committed write without executing the write again."""
+        with self._session_lock:
+            if self._closed:
+                raise RuntimeError("RayRunner is closed")
+            client = self.query_driver_client
+            if client is None:
+                raise RuntimeError("RayRunner has no active query runtime client")
+        return client.retry_copy_cleanup(operation_id)
+
     def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
         for result in self.run_iter(relation):
             yield result.partition()

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1917,12 +1917,23 @@ struct PyPhysicalPlanWrapperRunner {
 				run_plan_ms = elapsed_ms(run_plan_started);
 			}
 
-			rethrow_submission_error(plan.idx());
 			if (!res.is_ok()) {
+				rethrow_submission_error(plan.idx());
 				throw py::value_error(res.error().what());
 			}
 
 			auto result = std::move(res).value();
+			if (!result.output_committed) {
+				rethrow_submission_error(plan.idx());
+				throw py::value_error("distributed COPY completed without a committed output marker");
+			}
+			std::vector<string> post_commit_warnings;
+			try {
+				rethrow_submission_error(plan.idx());
+			} catch (...) {
+				post_commit_warnings.push_back("native COPY post-commit submission state failed: " +
+				                               exception_message(std::current_exception()));
+			}
 			py::list files;
 			for (auto &info : result.files) {
 				py::dict entry;
@@ -1948,12 +1959,18 @@ struct PyPhysicalPlanWrapperRunner {
 			AppendDistributedCopyResultMetadata(out, result);
 			body_succeeded = true;
 			cleanup();
-			if (cleanup_error) {
-				std::rethrow_exception(cleanup_error);
-			}
 			out["copy_total_ms"] = py::int_(elapsed_ms(copy_started));
 			out["copy_run_plan_ms"] = py::int_(run_plan_ms);
 			out["copy_runner_cleanup_ms"] = py::int_(cleanup_ms);
+			out["copy_runner_cleanup_pending"] = py::bool_(cleanup_error != nullptr);
+			py::list cleanup_warnings;
+			for (const auto &warning : post_commit_warnings) {
+				cleanup_warnings.append(warning);
+			}
+			if (cleanup_error) {
+				cleanup_warnings.append("native COPY runner cleanup failed: " + exception_message(cleanup_error));
+			}
+			out["copy_runner_cleanup_warnings"] = cleanup_warnings;
 			out["copy_selected_file_count"] = py::int_(result.files.size());
 			out["copy_duplicate_file_count"] = py::int_(0);
 			return out;

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -553,7 +553,10 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
     runner._precreate_vllm_actors = lambda *_args, **_kwargs: []
     runner._get_plan_runner = lambda: SimpleNamespace(
-        run_copy_plan=lambda _plan, _conn: {"rows_copied": 1},
+        run_copy_plan=lambda _plan, _conn: {
+            "rows_copied": 1,
+            "copy_output_committed": True,
+        },
     )
     runner._mark_query_actor_stages_ready = lambda _graph: None
     runner._build_local_progress_snapshot = lambda query_id, _started_at: {
@@ -693,7 +696,14 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
 
     outcome = asyncio.run(_run_concurrently())
 
-    assert outcome.result == {"rows_copied": 1}
+    assert outcome.result == {
+        "rows_copied": 1,
+        "copy_output_committed": True,
+        "copy_operation_id": copy_query_id,
+        "copy_write_state": "committed",
+        "copy_cleanup_state": "complete",
+        "copy_cleanup_warnings": [],
+    }
     assert outcome.final_progress_snapshot == {
         "query_id": copy_query_id,
         "state": "FINISHED",

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -1952,7 +1952,7 @@ def test_native_cxx_run_copy_plan_preserves_worker_plan_exception_cause(tmp_path
     assert not dst.exists()
 
 
-def test_native_cxx_run_copy_plan_surfaces_backend_cleanup_failure(tmp_path, monkeypatch):
+def test_native_cxx_committed_copy_returns_backend_cleanup_warning(tmp_path, monkeypatch):
     con, _dst, relation = _capture_native_copy_relation(tmp_path, monkeypatch, local_staging=True)
 
     from duckdb.runners.local.runner import _InProcessFragmentExecutor
@@ -1977,10 +1977,14 @@ def test_native_cxx_run_copy_plan_surfaces_backend_cleanup_failure(tmp_path, mon
     backend.drop_query = failing_drop_query
     try:
         runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner(backend)
-        with pytest.raises(RuntimeError, match="planned copy backend cleanup failure"):
-            runner.run_copy_plan(plan, con)
+        result = runner.run_copy_plan(plan, con)
 
         assert drop_calls == [query_id]
+        assert result["copy_output_committed"] is True
+        assert result["copy_runner_cleanup_pending"] is True
+        assert any(
+            "planned copy backend cleanup failure" in warning for warning in result["copy_runner_cleanup_warnings"]
+        )
     finally:
         backend.shutdown()
         con.close()
@@ -2016,6 +2020,8 @@ def test_native_cxx_run_copy_plan_successive_local_staging_runs_use_distinct_pat
             assert result["copy_finalize_ms"] >= 0
             assert result["copy_cleanup_ms"] >= 0
             assert result["copy_runner_cleanup_ms"] >= 0
+            assert result["copy_runner_cleanup_pending"] is False
+            assert result["copy_runner_cleanup_warnings"] == []
             assert result["copy_selected_file_count"] == len(result["files"])
             assert result["copy_duplicate_file_count"] == 0
         assert first_path != second_path

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -279,6 +279,20 @@ def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, 
     def succeed(value: Any = None) -> Any:
         return value
 
+    @ray.remote
+    def recover_failure_with_chain(label: str, operation_id: str) -> Any:
+        import duckdb as remote_duckdb
+        from duckdb._ray_errors import remote_ray_exception as build_remote_ray_exception
+        from duckdb.runners.ray.driver import CopyPlanRecovery
+
+        try:
+            raise remote_duckdb.NotImplementedException(f"{label} original")
+        except remote_duckdb.NotImplementedException as cause:
+            return CopyPlanRecovery(
+                operation_id=operation_id,
+                error=build_remote_ray_exception(f"{label} outer", cause),
+            )
+
     class SuccessMethod:
         def __init__(self, value: Any = None) -> None:
             self.value = value
@@ -292,6 +306,13 @@ def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, 
 
         def remote(self, *_args, **_kwargs):
             return fail_with_chain.remote(self.label)
+
+    class RecoveryFailureMethod:
+        def __init__(self, label: str) -> None:
+            self.label = label
+
+        def remote(self, *_args):
+            return recover_failure_with_chain.remote(self.label, str(_args[-1]))
 
     class Plan:
         def idx(self) -> str:
@@ -311,6 +332,7 @@ def test_ray_driver_client_restores_preflight_stream_and_copy_causes(ray_local, 
             self.run_plan = FailureMethod("preflight") if failure_path == "preflight" else SuccessMethod()
             self.get_next_partition = FailureMethod("stream") if failure_path == "stream" else SuccessMethod(None)
             self.run_copy_plan = FailureMethod("copy") if failure_path == "copy" else SuccessMethod()
+            self.recover_copy_plan = RecoveryFailureMethod("copy") if failure_path == "copy" else SuccessMethod()
 
     monkeypatch.setattr(driver, "_collect_vane_env_overrides", dict)
     monkeypatch.setattr(driver, "progress_enabled", lambda: False)

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import pickle
 import threading
 import time
 import uuid
@@ -294,6 +295,15 @@ def _run_actor_stream_plan(runner, plan):
         _TEST_SESSION_ID,
         plan,
     )
+
+
+def _committed_copy_result(**values):
+    result = {
+        "rows_copied": 1,
+        "copy_output_committed": True,
+    }
+    result.update(values)
+    return result
 
 
 def test_driver_connection_applies_duckdb_execution_width(monkeypatch):
@@ -630,7 +640,7 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
         def run_copy_plan(self, plan, conn):
             captured["plan"] = plan
             captured["conn"] = conn
-            return {"ok": True}
+            return _committed_copy_result(ok=True)
 
     def _precreate_udf_actors(
         _self,
@@ -673,7 +683,10 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
     outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert isinstance(outcome, driver.CopyPlanOutcome)
-    assert outcome.result == {"ok": True}
+    assert outcome.result["ok"] is True
+    assert outcome.result["copy_operation_id"] == "copy-plan"
+    assert outcome.result["copy_write_state"] == "committed"
+    assert outcome.result["copy_cleanup_state"] == "complete"
     assert outcome.final_progress_snapshot == {"query_id": "copy-plan", "state": "FINISHED"}
     assert captured["plan"] is physical_plan
     assert captured["conn"] is runner._test_session_connection.cursors[-1]
@@ -681,7 +694,7 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
     assert captured["lifecycle"] == ["snapshot", "teardown"]
 
 
-def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monkeypatch):
+def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-plan-terminal")
     logical_plan = _FakeLogicalPlan(physical_plan)
@@ -690,7 +703,7 @@ def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monke
     class _PlanRunner:
         def run_copy_plan(self, _plan, _conn):
             runner._query_terminal_errors["copy-query-terminal"] = "fixed Ray actor placement was lost"
-            return {"ok": True}
+            return _committed_copy_result(ok=True)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -708,22 +721,24 @@ def test_query_driver_run_copy_plan_surfaces_terminal_actor_placement_loss(monke
 
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
-    with pytest.raises(RuntimeError, match="fixed Ray actor placement was lost"):
-        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_calls == [
         ("copy-plan-terminal", "copy-query-terminal", True),
     ]
+    assert outcome.write_state == "committed"
+    assert outcome.cleanup_state == "complete"
+    assert any("fixed Ray actor placement was lost" in warning for warning in outcome.cleanup_warnings)
 
 
-def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatch):
+def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr("copy-progress-contract-failure"))
     teardown_calls = []
 
     class _PlanRunner:
         def run_copy_plan(self, _plan, _conn):
-            return {"ok": True}
+            return _committed_copy_result()
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -745,8 +760,7 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
         lambda _self, plan_id, query_id, *, drop_fragments: teardown_calls.append((plan_id, query_id, drop_fragments)),
     )
 
-    with pytest.raises(RuntimeError, match="invalid progress topology"):
-        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
     assert teardown_calls == [
         (
@@ -755,6 +769,434 @@ def test_query_driver_copy_progress_contract_failure_still_tears_down(monkeypatc
             True,
         )
     ]
+    assert outcome.operation_id == "copy-progress-contract-failure"
+    assert outcome.write_state == "committed"
+    assert outcome.cleanup_state == "complete"
+    assert outcome.final_progress_snapshot is None
+    assert len(outcome.cleanup_warnings) == 1
+    assert "progress finalization failed: RuntimeError: invalid progress topology" in outcome.cleanup_warnings[0]
+
+
+def test_query_driver_failure_immediately_after_commit_replays_success(monkeypatch):
+    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
+
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-failure-immediately-after-commit"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_finished = threading.Event()
+    plan_calls = 0
+    teardown_calls = []
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            plan_finished.set()
+            return _committed_copy_result(rows_copied=5)
+
+    def _fail_after_commit(_self, _actors):
+        assert plan_finished.wait(timeout=2.0)
+        raise RuntimeError("injected immediately-after-commit failure")
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
+    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_after_commit)
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "wait_for_fte_query_progress_topology",
+        lambda *_args, **_kwargs: plan_finished.wait(timeout=2.0),
+    )
+
+    first = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+    replayed = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+
+    assert first == replayed
+    assert first.write_state == "committed"
+    assert first.cleanup_state == "complete"
+    assert first.final_progress_snapshot is None
+    assert any("injected immediately-after-commit failure" in warning for warning in first.cleanup_warnings), (
+        first.cleanup_warnings
+    )
+    assert plan_calls == 1
+    assert teardown_calls == [(plan_id, plan_id, True)]
+
+
+def test_query_driver_postcommit_startup_drain_cancellation_replays_success(monkeypatch):
+    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
+
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-postcommit-startup-drain-cancellation"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_finished = threading.Event()
+    topology_started = threading.Event()
+    topology_release = threading.Event()
+    teardown_finished = threading.Event()
+    startup_drain_started = threading.Event()
+    plan_calls = 0
+    original_gather = asyncio.gather
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            plan_finished.set()
+            return _committed_copy_result(rows_copied=19)
+
+    def _fail_actor_barrier(_self, _actors):
+        assert plan_finished.wait(timeout=2.0)
+        raise RuntimeError("actor barrier failed after commit")
+
+    def _wait_for_topology(*_args, **_kwargs):
+        topology_started.set()
+        assert topology_release.wait(timeout=2.0)
+
+    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+        assert actual_plan_id == plan_id
+        assert drop_fragments is True
+        cls._release_plan_session_state(runner, actual_plan_id)
+        teardown_finished.set()
+
+    def _tracked_gather(*args, **kwargs):
+        startup_drain_started.set()
+        return original_gather(*args, **kwargs)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
+    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_actor_barrier)
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+    monkeypatch.setattr(driver.asyncio, "gather", _tracked_gather)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "wait_for_fte_query_progress_topology",
+        _wait_for_topology,
+    )
+
+    async def _cancel_during_startup_drain():
+        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        assert await asyncio.to_thread(topology_started.wait, 1.0)
+        assert await asyncio.to_thread(teardown_finished.wait, 1.0)
+        assert await asyncio.to_thread(startup_drain_started.wait, 1.0)
+        operation_task = runner._copy_operations_inflight[plan_id].task
+        operation_task.cancel()
+        await asyncio.sleep(0)
+        topology_release.set()
+        outcome = await asyncio.wait_for(copy_task, timeout=1.0)
+        replayed = await _run_actor_copy_plan(runner, logical_plan)
+        return outcome, replayed
+
+    outcome, replayed = asyncio.run(_cancel_during_startup_drain())
+
+    assert outcome == replayed
+    assert outcome.write_state == "committed"
+    assert outcome.result["rows_copied"] == 19
+    assert any("actor barrier failed after commit" in warning for warning in outcome.cleanup_warnings)
+    assert plan_calls == 1
+
+
+def test_query_driver_concurrent_copy_retries_share_one_write(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-concurrent-singleflight"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_started = threading.Event()
+    plan_release = threading.Event()
+    plan_calls = 0
+    teardown_calls = 0
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            plan_started.set()
+            assert plan_release.wait(timeout=2.0)
+            return _committed_copy_result(rows_copied=17)
+
+    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+        nonlocal teardown_calls
+        teardown_calls += 1
+        assert actual_plan_id == plan_id
+        assert drop_fragments is True
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    async def _run_concurrent_retries():
+        first_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        assert await asyncio.to_thread(plan_started.wait, 1.0)
+        second_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        await asyncio.sleep(0.01)
+        assert plan_calls == 1
+        plan_release.set()
+        return await asyncio.gather(first_task, second_task)
+
+    first, second = asyncio.run(_run_concurrent_retries())
+
+    assert first == second
+    assert first.result["rows_copied"] == 17
+    assert first.write_state == "committed"
+    assert plan_calls == 1
+    assert teardown_calls == 1
+
+
+def test_query_driver_copy_result_logging_failure_replays_committed_success(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-committed-result-logging-failure"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_calls = 0
+    teardown_calls = []
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            return _committed_copy_result(rows_copied=5)
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+    monkeypatch.setattr(
+        driver,
+        "_log_copy_result_debug",
+        lambda *_args: (_ for _ in ()).throw(OSError("stderr unavailable")),
+    )
+
+    first = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+    replayed = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+
+    assert first == replayed
+    assert first.write_state == "committed"
+    assert first.cleanup_state == "complete"
+    assert any("stderr unavailable" in warning for warning in first.cleanup_warnings)
+    assert plan_calls == 1
+    assert teardown_calls == [(plan_id, plan_id, True)]
+
+
+def test_query_driver_committed_copy_teardown_is_retryable_without_reexecution(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-committed-cleanup-retry"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_calls = 0
+    teardown_calls = 0
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            return _committed_copy_result(rows_copied=7)
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        nonlocal teardown_calls
+        teardown_calls += 1
+        assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
+        if teardown_calls == 1:
+            raise RuntimeError("planned post-commit teardown failure")
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    first = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+    recovered = asyncio.run(
+        cls.recover_copy_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+        )
+    )
+    cleaned = asyncio.run(
+        cls.retry_copy_cleanup(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            plan_id,
+        )
+    )
+    replayed = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+
+    assert first.cleanup_state == "pending"
+    assert "planned post-commit teardown failure" in first.cleanup_warnings[0]
+    assert recovered.outcome == first
+    assert recovered.error is None
+    assert cleaned.cleanup_state == "complete"
+    assert replayed == cleaned
+    assert plan_calls == 1
+    assert teardown_calls == 2
+
+
+def test_query_driver_copy_failure_is_replayed_without_reexecution(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-failed-before-commit"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_calls = 0
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            raise ValueError("planned failure before commit")
+
+    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+        assert actual_plan_id == plan_id
+        assert drop_fragments is True
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    for operation in (
+        lambda: _run_actor_copy_plan(runner, logical_plan),
+        lambda: _run_actor_copy_plan(runner, logical_plan),
+    ):
+        with pytest.raises(ValueError, match="planned failure before commit"):
+            asyncio.run(operation())
+
+    recovered = asyncio.run(
+        cls.recover_copy_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+        )
+    )
+
+    assert recovered.outcome is None
+    assert isinstance(recovered.error, ValueError)
+    assert str(recovered.error) == "planned failure before commit"
+    assert plan_calls == 1
+
+
+def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    first_plan_id = "copy-evicted-terminal-first"
+    second_plan_id = "copy-evicted-terminal-second"
+    logical_plans = {
+        plan_id: _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+        for plan_id in (first_plan_id, second_plan_id)
+    }
+    plan_calls = {first_plan_id: 0, second_plan_id: 0}
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(plan, _conn):
+            plan_id = str(plan.idx())
+            plan_calls[plan_id] += 1
+            return _committed_copy_result(rows_copied=plan_calls[plan_id])
+
+    async def _register(
+        _self,
+        plan,
+        *,
+        query_connection,
+        expected_plan_id=None,
+    ):
+        del query_connection
+        plan_id = str(plan.idx())
+        assert expected_plan_id == plan_id
+        return SimpleNamespace(query_id=plan_id, stages=()), object()
+
+    def _teardown(_self, plan_id, query_id, *, drop_fragments):
+        assert query_id == plan_id
+        assert drop_fragments is True
+        cls._release_plan_session_state(runner, plan_id)
+
+    runner._copy_operation_terminal = driver.BoundedReplayMap(capacity=1)
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _register)
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    first = asyncio.run(_run_actor_copy_plan(runner, logical_plans[first_plan_id]))
+    second = asyncio.run(_run_actor_copy_plan(runner, logical_plans[second_plan_id]))
+
+    assert first.operation_id == first_plan_id
+    assert second.operation_id == second_plan_id
+    assert runner._copy_operation_terminal.get(first_plan_id) is None
+    with pytest.raises(driver.CopyOutcomeUnknownError, match=first_plan_id):
+        asyncio.run(_run_actor_copy_plan(runner, logical_plans[first_plan_id]))
+    with pytest.raises(driver.CopyOutcomeUnknownError, match=first_plan_id):
+        asyncio.run(
+            cls.recover_copy_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                first_plan_id,
+            )
+        )
+    assert asyncio.run(_run_actor_copy_plan(runner, logical_plans[second_plan_id])) == second
+    assert plan_calls == {
+        first_plan_id: 1,
+        second_plan_id: 1,
+    }
+
+
+def test_query_driver_unknown_copy_recovery_never_submits_a_write():
+    cls, runner = _make_local_query_driver_actor()
+
+    with pytest.raises(driver.CopyOutcomeUnknownError, match="unknown-copy-operation") as error:
+        asyncio.run(
+            cls.recover_copy_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                "unknown-copy-operation",
+            )
+        )
+
+    assert error.value.operation_id == "unknown-copy-operation"
+
+
+def test_copy_outcome_unknown_error_preserves_operation_id_across_serialization():
+    error = driver.CopyOutcomeUnknownError("unknown-copy-operation")
+
+    restored = pickle.loads(pickle.dumps(error))
+
+    assert type(restored) is driver.CopyOutcomeUnknownError
+    assert restored.operation_id == error.operation_id
+    assert str(restored) == str(error)
+
+
+def test_copy_outcome_unknown_error_is_exported_from_ray_runner_package():
+    from duckdb.runners.ray import CopyOutcomeUnknownError
+
+    assert CopyOutcomeUnknownError is driver.CopyOutcomeUnknownError
 
 
 def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypatch):
@@ -769,7 +1211,7 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
     class _PlanRunner:
         @staticmethod
         def run_copy_plan(_plan, _conn):
-            return {"ok": True}
+            return _committed_copy_result(ok=True)
 
     def _build_snapshot(_self, query_id, _started_at):
         assert query_id == plan_id
@@ -813,6 +1255,114 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
     assert plan_id not in runner._plan_session_ids
 
 
+def test_query_driver_copy_operation_cancellation_waits_for_native_commit(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-native-commit-during-cancellation"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    native_started = threading.Event()
+    native_release = threading.Event()
+    native_finished = threading.Event()
+    teardown_started = threading.Event()
+    plan_calls = 0
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            native_started.set()
+            assert native_release.wait(timeout=2.0)
+            native_finished.set()
+            return _committed_copy_result(rows_copied=11)
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
+        teardown_started.set()
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    async def _cancel_while_native_write_is_running():
+        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        assert await asyncio.to_thread(native_started.wait, 1.0)
+        operation_task = runner._copy_operations_inflight[plan_id].task
+        operation_task.cancel()
+        assert await asyncio.to_thread(teardown_started.wait, 1.0)
+        assert native_finished.is_set() is False
+        native_release.set()
+        outcome = await asyncio.wait_for(copy_task, timeout=1.0)
+        recovered = await cls.recover_copy_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+        )
+        return outcome, recovered
+
+    outcome, recovered = asyncio.run(_cancel_while_native_write_is_running())
+
+    assert outcome.write_state == "committed"
+    assert outcome.result["rows_copied"] == 11
+    assert recovered.outcome == outcome
+    assert plan_calls == 1
+    assert teardown_started.is_set()
+
+
+def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-teardown-cancellation"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    teardown_started = threading.Event()
+    teardown_release = threading.Event()
+    teardown_finished = threading.Event()
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            return _committed_copy_result(rows_copied=13)
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
+        teardown_started.set()
+        assert teardown_release.wait(timeout=2.0)
+        cls._release_plan_session_state(runner, actual_plan_id)
+        teardown_finished.set()
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    async def _cancel_during_teardown():
+        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        assert await asyncio.to_thread(teardown_started.wait, 1.0)
+        operation_task = runner._copy_operations_inflight[plan_id].task
+        operation_task.cancel()
+        await asyncio.sleep(0.01)
+        assert copy_task.done() is False
+        teardown_release.set()
+        outcome = await asyncio.wait_for(copy_task, timeout=1.0)
+        replayed = await _run_actor_copy_plan(runner, logical_plan)
+        return outcome, replayed
+
+    outcome, replayed = asyncio.run(_cancel_during_teardown())
+
+    assert teardown_finished.is_set()
+    assert outcome == replayed
+    assert outcome.write_state == "committed"
+    assert outcome.cleanup_state == "complete"
+    assert not any("CancelledError" in warning for warning in outcome.cleanup_warnings)
+
+
 def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(monkeypatch):
     import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
 
@@ -829,7 +1379,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
             plan_started.set()
             assert actor_stage_open.wait(timeout=2.0)
             events.append("plan-finished")
-            return {"ok": True}
+            return _committed_copy_result(ok=True)
 
     def wait_for_topology(query_id, *, timeout_s):
         assert query_id == "copy-startup-order"
@@ -865,7 +1415,8 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
 
     outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
-    assert outcome.result == {"ok": True}
+    assert outcome.result["ok"] is True
+    assert outcome.write_state == "committed"
     open_index = events.index("actor-stage-open")
     assert events.index("topology-ready") < open_index
     assert events.index("actors-ready") < open_index
@@ -885,7 +1436,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
         def run_copy_plan(self, _plan, _conn):
             events.append("plan-finished")
             plan_finished.set()
-            return {"rows_copied": 0}
+            return _committed_copy_result(rows_copied=0)
 
     def wait_for_topology(query_id, *, timeout_s):
         assert query_id == "copy-plan-before-startup-barriers"
@@ -929,7 +1480,8 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
     outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
     release_thread.join(timeout=2.0)
 
-    assert outcome.result == {"rows_copied": 0}
+    assert outcome.result["rows_copied"] == 0
+    assert outcome.write_state == "committed"
     open_index = events.index("actor-stage-open")
     assert events.index("plan-finished") < events.index("topology-ready") < open_index
     assert events.index("plan-finished") < events.index("actors-ready") < open_index
@@ -1089,6 +1641,7 @@ def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot
     outcome = driver.CopyPlanOutcome(
         result={"rows_copied": 7},
         final_progress_snapshot=final_snapshot,
+        operation_id="copy-plan",
     )
 
     class _Runner:
@@ -1131,6 +1684,191 @@ def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot
             "final_snapshot": final_snapshot,
         }
     ]
+
+
+def test_ray_query_driver_client_recovers_ambiguous_copy_without_resubmission(monkeypatch):
+    submit_ref = object()
+    recovery_ref = object()
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    outcome = driver.CopyPlanOutcome(
+        operation_id="copy-ambiguous-response",
+        write_state="committed",
+        cleanup_state="complete",
+        result=_committed_copy_result(rows_copied=11),
+        final_progress_snapshot={"state": "FINISHED"},
+    )
+    runner = SimpleNamespace(
+        run_copy_plan=_RemoteMethod(submit_ref),
+        recover_copy_plan=_RemoteMethod(recovery_ref),
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = runner
+    resolutions = []
+
+    def _resolve(ref, **kwargs):
+        resolutions.append((ref, kwargs))
+        if ref is submit_ref:
+            raise FutureTimeoutError("COPY response wait timed out")
+        assert ref is recovery_ref
+        return driver.CopyPlanRecovery(
+            operation_id=outcome.operation_id,
+            outcome=outcome,
+        )
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(
+        driver.ray,
+        "cancel",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("ambiguous COPY recovery must not cancel the committed operation")
+        ),
+    )
+
+    plan = _FakePhysicalPlanWithoutPlanAttr("copy-ambiguous-response")
+    result = client.run_copy_plan(plan)
+
+    assert result["rows_copied"] == 11
+    assert runner.run_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan,
+        )
+    ]
+    assert runner.recover_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            outcome.operation_id,
+        )
+    ]
+    assert resolutions == [
+        (submit_ref, {}),
+        (
+            recovery_ref,
+            {
+                "honor_query_deadline": False,
+            },
+        ),
+    ]
+
+
+def test_ray_query_driver_client_recovers_invalid_copy_response_without_resubmission(monkeypatch):
+    submit_ref = object()
+    recovery_ref = object()
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    invalid_outcome = driver.CopyPlanOutcome(
+        operation_id="wrong-operation",
+        result=_committed_copy_result(rows_copied=11),
+        final_progress_snapshot={"state": "FINISHED"},
+    )
+    recovered_outcome = driver.CopyPlanOutcome(
+        operation_id="copy-invalid-response",
+        result=_committed_copy_result(rows_copied=11),
+        final_progress_snapshot={"state": "FINISHED"},
+    )
+    runner = SimpleNamespace(
+        run_copy_plan=_RemoteMethod(submit_ref),
+        recover_copy_plan=_RemoteMethod(recovery_ref),
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = runner
+
+    def _resolve(ref, **_kwargs):
+        if ref is submit_ref:
+            return invalid_outcome
+        assert ref is recovery_ref
+        return driver.CopyPlanRecovery(
+            operation_id=recovered_outcome.operation_id,
+            outcome=recovered_outcome,
+        )
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    plan = _FakePhysicalPlanWithoutPlanAttr("copy-invalid-response")
+    result = client.run_copy_plan(plan)
+
+    assert result["rows_copied"] == 11
+    assert runner.run_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan,
+        )
+    ]
+    assert runner.recover_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "copy-invalid-response",
+        )
+    ]
+
+
+def test_ray_query_driver_client_maps_invalid_recovery_outcome_to_unknown(monkeypatch):
+    submit_ref = object()
+    recovery_ref = object()
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+
+        def remote(self, *_args):
+            return self.result
+
+    mismatched_outcome = driver.CopyPlanOutcome(
+        operation_id="wrong-operation",
+        result=_committed_copy_result(),
+        final_progress_snapshot=None,
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_copy_plan=_RemoteMethod(submit_ref),
+        recover_copy_plan=_RemoteMethod(recovery_ref),
+    )
+
+    def _resolve(ref, **_kwargs):
+        if ref is submit_ref:
+            raise FutureTimeoutError("COPY response wait timed out")
+        assert ref is recovery_ref
+        return driver.CopyPlanRecovery(
+            operation_id="copy-invalid-recovery",
+            outcome=mismatched_outcome,
+        )
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-invalid-recovery"))
+
+    assert error.value.operation_id == "copy-invalid-recovery"
 
 
 def test_ray_query_driver_client_stream_waits_through_progress_session(monkeypatch):
@@ -1423,9 +2161,9 @@ def test_ray_query_driver_client_stream_failure_accepts_concurrent_detach_cleanu
         list(client.stream_plan(_FakePhysicalPlanWithoutPlanAttr("detached-stream-cleanup")))
 
 
-def test_ray_query_driver_client_copy_failure_cancels_and_settles(monkeypatch):
+def test_ray_query_driver_client_copy_failure_recovers_without_cancel_or_close(monkeypatch):
     copy_future = object()
-    close_future = object()
+    recovery_future = object()
     resolved = []
     cancelled = []
 
@@ -1443,46 +2181,186 @@ def test_ray_query_driver_client_copy_failure_cancels_and_settles(monkeypatch):
     _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
     client.runner = SimpleNamespace(
         run_copy_plan=_RemoteMethod(copy_future),
-        close_plan=_RemoteMethod(close_future),
+        recover_copy_plan=_RemoteMethod(recovery_future),
     )
 
     def _resolve(ref, **kwargs):
         resolved.append((ref, kwargs))
         if ref is copy_future:
             raise RuntimeError("planned COPY failure")
-        assert ref is close_future
-        return None
+        assert ref is recovery_future
+        return driver.CopyPlanRecovery(
+            operation_id="failed-copy",
+            error=RuntimeError("planned COPY failure"),
+        )
 
     monkeypatch.setattr(driver, "progress_enabled", lambda: False)
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
     monkeypatch.setattr(driver.ray, "cancel", lambda ref, *, force: cancelled.append((ref, force)))
+    monkeypatch.setattr(driver.ray, "is_initialized", lambda: True)
 
     with pytest.raises(RuntimeError, match="planned COPY failure"):
         client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("failed-copy"))
 
-    assert cancelled == [(copy_future, False)]
+    assert cancelled == []
     assert resolved == [
         (copy_future, {}),
         (
-            copy_future,
+            recovery_future,
             {
-                "timeout": 300,
-                "honor_query_deadline": False,
-            },
-        ),
-        (
-            close_future,
-            {
-                "timeout": 300,
                 "honor_query_deadline": False,
             },
         ),
     ]
-    assert client.runner.close_plan.calls == [
+    assert client.runner.recover_copy_plan.calls == [
         (
             _TEST_RUNTIME_OWNER_ID,
             _TEST_SESSION_ID,
             "failed-copy",
+        )
+    ]
+
+
+def test_ray_query_driver_client_maps_recovery_rpc_creation_failure_to_unknown(monkeypatch):
+    copy_future = object()
+
+    class _RemoteMethod:
+        def __init__(self, result=None, *, error=None):
+            self.result = result
+            self.error = error
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            if self.error is not None:
+                raise self.error
+            return self.result
+
+    run_copy_plan = _RemoteMethod(copy_future)
+    recover_copy_plan = _RemoteMethod(error=RuntimeError("recovery RPC could not be created"))
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_copy_plan=run_copy_plan,
+        recover_copy_plan=recover_copy_plan,
+    )
+    monkeypatch.setattr(client, "_runtime_is_unavailable_or_replaced", lambda: False)
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda ref, **_kwargs: (_ for _ in ()).throw(FutureTimeoutError("COPY response wait timed out")),
+    )
+
+    with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-recovery-creation-failed"))
+
+    assert error.value.operation_id == "copy-recovery-creation-failed"
+    assert len(run_copy_plan.calls) == 1
+    assert recover_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "copy-recovery-creation-failed",
+        )
+    ]
+
+
+def test_ray_query_driver_client_maps_recovery_resolution_failure_to_unknown(monkeypatch):
+    copy_future = object()
+    recovery_future = object()
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    run_copy_plan = _RemoteMethod(copy_future)
+    recover_copy_plan = _RemoteMethod(recovery_future)
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_copy_plan=run_copy_plan,
+        recover_copy_plan=recover_copy_plan,
+    )
+    monkeypatch.setattr(client, "_runtime_is_unavailable_or_replaced", lambda: False)
+
+    def _resolve(ref, **_kwargs):
+        if ref is copy_future:
+            raise FutureTimeoutError("COPY response wait timed out")
+        assert ref is recovery_future
+        raise PermissionError("runtime owner expired during COPY recovery")
+
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+
+    with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-recovery-resolution-failed"))
+
+    assert error.value.operation_id == "copy-recovery-resolution-failed"
+    assert len(run_copy_plan.calls) == 1
+    assert recover_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "copy-recovery-resolution-failed",
+        )
+    ]
+
+
+def test_ray_query_driver_client_retries_pending_copy_cleanup_by_operation_id(monkeypatch):
+    cleanup_ref = object()
+    operation_id = "copy-cleanup-client-retry"
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    retry_copy_cleanup = _RemoteMethod(cleanup_ref)
+    outcome = driver.CopyPlanOutcome(
+        operation_id=operation_id,
+        result=_committed_copy_result(
+            copy_operation_id=operation_id,
+            copy_write_state="committed",
+            copy_cleanup_state="complete",
+            copy_cleanup_warnings=[],
+        ),
+        final_progress_snapshot={"state": "FINISHED"},
+    )
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(retry_copy_cleanup=retry_copy_cleanup)
+
+    monkeypatch.setattr(
+        driver,
+        "resolve_object_refs_blocking",
+        lambda ref, **kwargs: (
+            outcome
+            if ref is cleanup_ref and kwargs == {"honor_query_deadline": False}
+            else (_ for _ in ()).throw(AssertionError("unexpected cleanup resolution"))
+        ),
+    )
+
+    result = client.retry_copy_cleanup(operation_id)
+
+    assert result["copy_cleanup_state"] == "complete"
+    assert retry_copy_cleanup.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            operation_id,
         )
     ]
 
@@ -4986,6 +5864,8 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
     assert result["copy_output_run_id"]
     assert result["copy_output_direct_write"] is True
     assert result["copy_output_committed"] is True
+    assert result["copy_runner_cleanup_pending"] is False
+    assert result["copy_runner_cleanup_warnings"] == []
     assert Path(result["copy_output_commit_dir"]).is_dir()
     assert Path(result["copy_output_lifecycle_path"]).is_file()
     assert Path(result["copy_output_manifest_path"]).is_file()
@@ -6975,6 +7855,33 @@ def test_ray_runner_close_is_terminal_and_idempotent(monkeypatch):
     assert closed_clients == [original_client]
     assert ray_runner._session_ids == set()
     assert ray_runner._closed is True
+
+
+def test_ray_runner_retries_pending_copy_cleanup_by_operation_id():
+    from duckdb.runners.ray import runner as runner_module
+
+    calls = []
+    expected = {
+        "copy_operation_id": "copy-cleanup-runner-retry",
+        "copy_cleanup_state": "complete",
+    }
+
+    class _FakeClient:
+        def retry_copy_cleanup(self, operation_id):
+            calls.append(operation_id)
+            return expected
+
+    ray_runner = object.__new__(runner_module.RayRunner)
+    ray_runner.query_driver_client = _FakeClient()
+    ray_runner._session_ids = set()
+    ray_runner._closed_session_ids = runner_module.BoundedReplayMap(capacity=65_536)
+    ray_runner._session_lock = threading.RLock()
+    ray_runner._closed = False
+
+    result = ray_runner.retry_copy_cleanup("copy-cleanup-runner-retry")
+
+    assert result is expected
+    assert calls == ["copy-cleanup-runner-retry"]
 
 
 def test_connection_close_notification_reenters_runner_registry_lock(monkeypatch):


### PR DESCRIPTION
## Summary

- Treat `DistributedCopyResult.output_committed` as the native COPY commit boundary and convert post-commit submission/cleanup failures into committed outcomes with cleanup warnings.
- Give every distributed COPY an operation identity with actor-side single-flight execution, bounded terminal replay, owner-lifetime identity tombstones, and read-only client recovery. Ambiguous responses are never canceled or resubmitted.
- Return explicit write/cleanup state, expose operation-id-only cleanup retry through the Ray client/runner, and make cancellation-safe finalization observe the native commit result before classifying failure.
- Add fault-injection coverage before commit, immediately after commit, during progress finalization and teardown, plus concurrent retry, cancellation, terminal-cache eviction, invalid recovery, and real-Ray exception transport cases.

Durable actor-restart recovery, bounded recovery timeouts, and explicit outcome-payload acknowledgement remain scoped to #179, #180, and #181.

## Related issue

close: #86

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change hardens the existing distributed COPY contract; returned operation and cleanup fields are self-describing and covered by API tests.

## Validation

- `scripts/format root --changed`
- Incremental Release native build and install with `uv pip install . --no-build-isolation`
- Affected fast tests: 284 passed
- `scripts/run_release_tests.sh`: 437 passed, 1 skipped, 11 deselected; real-Ray shard 7 passed, 442 deselected
- `scripts/run_fast_tests.sh`: non-Ray 5706 passed, 44 skipped, 102 deselected, 8 xfailed, 1 xpassed; shared-Ray 86 passed, 17 skipped; six isolated Ray-owner tests passed; vLLM test skipped because vLLM is unavailable
- `pre-commit run --files ...`: ruff, formatting, clang-format, mypy, conflict and credential checks passed
- Cancellation/state-machine matrix with `PYTHONASYNCIODEBUG=1`: 11 passed
- Native commit/cleanup and real-Ray exception follow-up matrix: 3 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.
