### PR TITLE
[fix](udf) Drain local COPY fragments before UDF teardown

### DIFF
--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -258,6 +258,16 @@ class _BackgroundEventLoop:
                     if failure is None:
                         failure = exc
                 try:
+                    # asyncio task cancellation does not stop work that has
+                    # already entered a synchronous native call through
+                    # asyncio.to_thread(). Join that owned executor before the
+                    # loop is considered closed so callers have a real native
+                    # execution barrier.
+                    loop.run_until_complete(loop.shutdown_default_executor())
+                except BaseException as exc:
+                    if failure is None:
+                        failure = exc
+                try:
                     loop.close()
                 except BaseException as exc:
                     if failure is None:
@@ -336,10 +346,8 @@ class _BackgroundEventLoop:
             future.cancel()
             raise TimeoutError(f"native FTE event-loop operation timed out after {timeout_s:.3f}s") from exc
 
-    def shutdown(self, timeout_s: float = 5.0) -> None:
-        timeout_s = float(timeout_s)
-        if not math.isfinite(timeout_s) or timeout_s < 0:
-            raise ValueError("native FTE event-loop shutdown timeout must be finite and non-negative")
+    def request_shutdown(self) -> None:
+        """Fence new work and ask the loop thread to begin teardown."""
         with self._condition:
             if self._state == self._CLOSED:
                 return
@@ -359,6 +367,13 @@ class _BackgroundEventLoop:
                     except BaseException as exc:
                         self._failure = exc
                 self._condition.notify_all()
+
+    def shutdown(self, timeout_s: float = 5.0) -> None:
+        timeout_s = float(timeout_s)
+        if not math.isfinite(timeout_s) or timeout_s < 0:
+            raise ValueError("native FTE event-loop shutdown timeout must be finite and non-negative")
+        self.request_shutdown()
+        with self._condition:
             thread = self._thread
         if thread is None or thread is threading.current_thread():
             return
@@ -1213,6 +1228,10 @@ class NativeWorkerHandle:
         if self._owns_loop:
             self._loop.shutdown()
 
+    def request_shutdown(self) -> None:
+        if self._owns_loop:
+            self._loop.request_shutdown()
+
 
 class NativeFteWorkerManagerBackend:
     def __init__(
@@ -1751,12 +1770,32 @@ class NativeFteWorkerManagerBackend:
         if worker_errors:
             raise RuntimeError(f"native FTE query teardown failed for {query_id}: " + "; ".join(worker_errors))
 
-    def shutdown(self) -> None:
+    def request_shutdown(self) -> None:
         if self._closed:
             return
         self._closing = True
         self._stop_debug_sampler()
         worker_errors: list[str] = []
+        for worker in self._workers:
+            request_shutdown = getattr(worker, "request_shutdown", None)
+            if not callable(request_shutdown):
+                continue
+            worker_id = str(getattr(worker, "worker_id", "") or "<unknown>")
+            try:
+                request_shutdown()
+            except BaseException as exc:
+                worker_errors.append(f"{worker_id}: {type(exc).__name__}: {exc}")
+        if worker_errors:
+            raise RuntimeError("native FTE worker manager shutdown request failed: " + "; ".join(worker_errors))
+
+    def shutdown(self) -> None:
+        if self._closed:
+            return
+        worker_errors: list[str] = []
+        try:
+            self.request_shutdown()
+        except BaseException as exc:
+            worker_errors.append(f"request: {type(exc).__name__}: {exc}")
         for worker in self._workers:
             worker_id = str(getattr(worker, "worker_id", "") or "<unknown>")
             try:

--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -1224,9 +1224,9 @@ class NativeWorkerHandle:
         stats["memory"] = self._total_memory_bytes
         return stats
 
-    def shutdown(self) -> None:
+    def shutdown(self, timeout_s: float = 5.0) -> None:
         if self._owns_loop:
-            self._loop.shutdown()
+            self._loop.shutdown(timeout_s=timeout_s)
 
     def request_shutdown(self) -> None:
         if self._owns_loop:
@@ -1788,9 +1788,15 @@ class NativeFteWorkerManagerBackend:
         if worker_errors:
             raise RuntimeError("native FTE worker manager shutdown request failed: " + "; ".join(worker_errors))
 
-    def shutdown(self) -> None:
+    def shutdown(self, timeout_s: float | None = None) -> None:
         if self._closed:
             return
+        deadline: float | None = None
+        if timeout_s is not None:
+            timeout_s = float(timeout_s)
+            if not math.isfinite(timeout_s) or timeout_s < 0:
+                raise ValueError("native FTE worker manager shutdown timeout must be finite and non-negative")
+            deadline = time.monotonic() + timeout_s
         worker_errors: list[str] = []
         try:
             self.request_shutdown()
@@ -1799,7 +1805,10 @@ class NativeFteWorkerManagerBackend:
         for worker in self._workers:
             worker_id = str(getattr(worker, "worker_id", "") or "<unknown>")
             try:
-                worker.shutdown()
+                if deadline is None:
+                    worker.shutdown()
+                else:
+                    worker.shutdown(timeout_s=max(0.0, deadline - time.monotonic()))
             except BaseException as exc:
                 worker_errors.append(f"{worker_id}: {type(exc).__name__}: {exc}")
         if worker_errors:

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 import threading
@@ -102,6 +103,46 @@ def _shutdown_udf_actor_pools(actor_pools: list[Any], *, kill: bool) -> list[Bas
     return errors
 
 
+def _shutdown_local_write_resources(
+    backend: Any,
+    fragment_executor: Any,
+    conn: Any,
+    actor_pools: list[Any],
+    *,
+    kill_actor_pools: bool,
+) -> list[BaseException]:
+    """Stop execution before releasing any resource a fragment may still use."""
+    errors: list[BaseException] = []
+    try:
+        backend.request_shutdown()
+    except BaseException as exc:
+        errors.append(exc)
+
+    try:
+        fragment_executor.request_shutdown()
+    except BaseException as exc:
+        errors.append(exc)
+
+    try:
+        backend.shutdown()
+    except BaseException as exc:
+        errors.append(exc)
+        return errors
+
+    try:
+        fragment_executor.close()
+    except BaseException as exc:
+        errors.append(exc)
+        return errors
+
+    errors.extend(_shutdown_udf_actor_pools(actor_pools, kill=kill_actor_pools))
+    try:
+        conn.close()
+    except BaseException as exc:
+        errors.append(exc)
+    return errors
+
+
 def _native_task_maps_from_context(context: dict[str, Any] | None) -> tuple[dict[str, Any], dict[str, Any]]:
     scan_task_map: dict[str, Any] = {}
     exchange_source_task_map: dict[str, Any] = {}
@@ -118,23 +159,110 @@ def _native_task_maps_from_context(context: dict[str, Any] | None) -> tuple[dict
 
 
 class _InProcessFragmentExecutor:
-    def __init__(self) -> None:
+    def __init__(self, *, close_timeout_s: float = 30.0) -> None:
+        close_timeout_s = float(close_timeout_s)
+        if not math.isfinite(close_timeout_s) or close_timeout_s <= 0:
+            raise ValueError("local fragment executor close timeout must be finite and positive")
+        self._close_timeout_s = close_timeout_s
         self._local = threading.local()
-        self._resources_lock = threading.Lock()
+        self._resources_lock = threading.RLock()
+        self._resources_condition = threading.Condition(self._resources_lock)
         self._plan_clone_lock = threading.Lock()
         self._connections: list[Any] = []
         self._plan_runners: list[Any] = []
+        self._retained_resources: list[Any] = []
+        self._active_cursors: set[Any] = set()
+        self._in_flight = 0
+        self._closing = False
+        self._closed = False
 
-    def close(self) -> None:
-        with self._resources_lock:
+    def retain_resources(self, *resources: Any) -> None:
+        with self._resources_condition:
+            if self._closing or self._closed:
+                raise RuntimeError("local fragment executor is closing")
+            self._retained_resources.extend(resource for resource in resources if resource is not None)
+
+    def _begin_execution(self) -> None:
+        with self._resources_condition:
+            if self._closing or self._closed:
+                raise RuntimeError("local fragment executor is closing")
+            self._in_flight += 1
+
+    def _end_execution(self) -> None:
+        with self._resources_condition:
+            if self._in_flight <= 0:
+                raise RuntimeError("local fragment executor execution ownership underflow")
+            self._in_flight -= 1
+            self._resources_condition.notify_all()
+
+    def _register_cursor(self, cursor: Any) -> bool:
+        with self._resources_condition:
+            self._active_cursors.add(cursor)
+            return not self._closing
+
+    def _unregister_cursor(self, cursor: Any) -> None:
+        with self._resources_condition:
+            self._active_cursors.discard(cursor)
+            self._resources_condition.notify_all()
+
+    def request_shutdown(self) -> None:
+        """Fence new fragment calls and interrupt cursors currently in native execution."""
+        with self._resources_condition:
+            if self._closed:
+                return
+            self._closing = True
+            active_cursors = list(self._active_cursors)
+
+        interrupt_errors: list[BaseException] = []
+        for cursor in active_cursors:
+            try:
+                cursor.interrupt()
+            except BaseException as exc:
+                interrupt_errors.append(exc)
+        if interrupt_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in interrupt_errors)
+            raise RuntimeError(f"failed to interrupt local fragment execution during close: {details}") from (
+                interrupt_errors[0]
+            )
+
+    def close(self, *, timeout_s: float | None = None) -> None:
+        timeout_s = self._close_timeout_s if timeout_s is None else float(timeout_s)
+        if not math.isfinite(timeout_s) or timeout_s < 0:
+            raise ValueError("local fragment executor close timeout must be finite and non-negative")
+        deadline = time.monotonic() + timeout_s
+        request_error: BaseException | None = None
+        with self._resources_condition:
+            if self._closed:
+                return
+            shutdown_requested = self._closing
+        if not shutdown_requested:
+            try:
+                self.request_shutdown()
+            except BaseException as exc:
+                request_error = exc
+        with self._resources_condition:
+            while self._in_flight > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(
+                        f"local fragment executor did not drain before close: active_executions={self._in_flight}"
+                    )
+                self._resources_condition.wait(timeout=remaining)
             connections = list(self._connections)
             self._connections.clear()
             self._plan_runners.clear()
+            retained_resources = self._retained_resources
+            self._retained_resources = []
+            self._active_cursors.clear()
+            self._closed = True
         for conn in connections:
             try:
                 conn.close()
             except Exception:
                 pass
+        retained_resources.clear()
+        if request_error is not None:
+            raise request_error
 
     @staticmethod
     def _configure_conn(conn: Any) -> None:
@@ -174,22 +302,33 @@ class _InProcessFragmentExecutor:
         return plan_runner
 
     def __call__(self, request: Mapping[str, Any]) -> Any:
-        request_payload = dict(request)
-        context = NativeFteWorkerManagerBackend.materialize_task_context(
-            request_payload,
-            merge_scan_task_descriptors=require_ray_cxx_attr("merge_scan_task_descriptors"),
-        )
-        scan_task_map, exchange_source_task_map = _native_task_maps_from_context(context)
-        plan = request_payload.get("fragment_plan")
-        if plan is None:
-            raise RuntimeError("local fragment execution requires fragment_plan")
-
-        conn = self._get_conn()
-        if hasattr(plan, "clone"):
-            with self._plan_clone_lock:
-                plan = plan.clone(conn)
-        cursor = conn.cursor()
+        self._begin_execution()
+        cursor = None
+        cursor_registered = False
         try:
+            request_payload = dict(request)
+            context = NativeFteWorkerManagerBackend.materialize_task_context(
+                request_payload,
+                merge_scan_task_descriptors=require_ray_cxx_attr("merge_scan_task_descriptors"),
+            )
+            scan_task_map, exchange_source_task_map = _native_task_maps_from_context(context)
+            plan = request_payload.get("fragment_plan")
+            if plan is None:
+                raise RuntimeError("local fragment execution requires fragment_plan")
+
+            conn = self._get_conn()
+            if hasattr(plan, "clone"):
+                with self._plan_clone_lock:
+                    plan = plan.clone(conn)
+            cursor = conn.cursor()
+            accepting_work = self._register_cursor(cursor)
+            cursor_registered = True
+            if not accepting_work:
+                try:
+                    cursor.interrupt()
+                except Exception:
+                    pass
+                raise RuntimeError("local fragment executor is closing")
             return self._get_plan_runner().execute_native(
                 cursor,
                 plan,
@@ -204,9 +343,16 @@ class _InProcessFragmentExecutor:
             )
         finally:
             try:
-                cursor.close()
+                if cursor is not None:
+                    cursor.close()
             except Exception:
                 pass
+            finally:
+                try:
+                    if cursor_registered:
+                        self._unregister_cursor(cursor)
+                finally:
+                    self._end_execution()
 
 
 class LocalRunner(Runner):
@@ -269,6 +415,11 @@ class LocalRunner(Runner):
             from duckdb.execution.udf_subprocess import ensure_local_subprocess_actor_pools_for_plan
 
             udf_actor_pools, _ = ensure_local_subprocess_actor_pools_for_plan(physical_plan, conn=conn)
+            # If a bounded backend shutdown ever times out, an in-flight native
+            # call still owns this executor. Keep its driver and actor
+            # dependencies reachable until the explicit fragment drain
+            # succeeds instead of letting local-variable teardown destroy them.
+            fragment_executor.retain_resources(conn, *udf_actor_pools)
             plan_runner = DistributedPhysicalPlanRunner(backend)
 
             started_at = time.time()
@@ -304,20 +455,13 @@ class LocalRunner(Runner):
                 write_executor.shutdown(wait=True)
         finally:
             primary_error_active = sys.exc_info()[0] is not None
-            actor_cleanup_errors = _shutdown_udf_actor_pools(
+            cleanup_errors = _shutdown_local_write_resources(
+                backend,
+                fragment_executor,
+                conn,
                 udf_actor_pools,
-                kill=not write_succeeded,
+                kill_actor_pools=not write_succeeded,
             )
-            try:
-                backend.shutdown()
-            finally:
-                fragment_executor.close()
-                try:
-                    conn.close()
-                except Exception:
-                    pass
-            if write_succeeded and not primary_error_active and actor_cleanup_errors:
-                details = "; ".join(f"{type(error).__name__}: {error}" for error in actor_cleanup_errors)
-                raise RuntimeError(
-                    f"failed to gracefully shut down {len(actor_cleanup_errors)} local UDF actor pool(s): {details}"
-                ) from actor_cleanup_errors[0]
+            if write_succeeded and not primary_error_active and cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(f"failed to shut down local write resources: {details}") from cleanup_errors[0]

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -216,18 +216,19 @@ class _InProcessFragmentExecutor:
 
     def request_shutdown(self) -> None:
         """Fence new fragment calls and interrupt cursors currently in native execution."""
+        interrupt_errors: list[BaseException] = []
         with self._resources_condition:
             if self._closed:
                 return
             self._closing = True
-            active_cursors = list(self._active_cursors)
-
-        interrupt_errors: list[BaseException] = []
-        for cursor in active_cursors:
-            try:
-                cursor.interrupt()
-            except BaseException as exc:
-                with self._resources_condition:
+            # Keep cursor lifecycle ownership until every interrupt returns.
+            # The fragment finally block must unregister under this condition
+            # before it can close the cursor, so Close() cannot clear the
+            # native connection while Interrupt() is reading it.
+            for cursor in list(self._active_cursors):
+                try:
+                    cursor.interrupt()
+                except BaseException as exc:
                     if cursor in self._active_cursors:
                         interrupt_errors.append(exc)
         if interrupt_errors:

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -110,8 +110,13 @@ def _shutdown_local_write_resources(
     actor_pools: list[Any],
     *,
     kill_actor_pools: bool,
+    timeout_s: float,
 ) -> list[BaseException]:
     """Stop execution before releasing any resource a fragment may still use."""
+    timeout_s = float(timeout_s)
+    if not math.isfinite(timeout_s) or timeout_s < 0:
+        raise ValueError("local write resource shutdown timeout must be finite and non-negative")
+    deadline = time.monotonic() + timeout_s
     errors: list[BaseException] = []
     try:
         backend.request_shutdown()
@@ -124,13 +129,13 @@ def _shutdown_local_write_resources(
         errors.append(exc)
 
     try:
-        backend.shutdown()
+        backend.shutdown(timeout_s=max(0.0, deadline - time.monotonic()))
     except BaseException as exc:
         errors.append(exc)
         return errors
 
     try:
-        fragment_executor.close()
+        fragment_executor.close(timeout_s=max(0.0, deadline - time.monotonic()))
     except BaseException as exc:
         errors.append(exc)
         return errors
@@ -176,6 +181,10 @@ class _InProcessFragmentExecutor:
         self._closing = False
         self._closed = False
 
+    @property
+    def close_timeout_s(self) -> float:
+        return self._close_timeout_s
+
     def retain_resources(self, *resources: Any) -> None:
         with self._resources_condition:
             if self._closing or self._closed:
@@ -218,7 +227,9 @@ class _InProcessFragmentExecutor:
             try:
                 cursor.interrupt()
             except BaseException as exc:
-                interrupt_errors.append(exc)
+                with self._resources_condition:
+                    if cursor in self._active_cursors:
+                        interrupt_errors.append(exc)
         if interrupt_errors:
             details = "; ".join(f"{type(error).__name__}: {error}" for error in interrupt_errors)
             raise RuntimeError(f"failed to interrupt local fragment execution during close: {details}") from (
@@ -343,14 +354,14 @@ class _InProcessFragmentExecutor:
             )
         finally:
             try:
-                if cursor is not None:
-                    cursor.close()
-            except Exception:
-                pass
+                if cursor_registered:
+                    self._unregister_cursor(cursor)
             finally:
                 try:
-                    if cursor_registered:
-                        self._unregister_cursor(cursor)
+                    if cursor is not None:
+                        cursor.close()
+                except Exception:
+                    pass
                 finally:
                     self._end_execution()
 
@@ -461,6 +472,7 @@ class LocalRunner(Runner):
                 conn,
                 udf_actor_pools,
                 kill_actor_pools=not write_succeeded,
+                timeout_s=fragment_executor.close_timeout_s,
             )
             if write_succeeded and not primary_error_active and cleanup_errors:
                 details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import logging
 import os
 import pickle
+import subprocess
+import sys
 import uuid
 from dataclasses import dataclass
 from decimal import Decimal
+from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
@@ -478,6 +481,65 @@ def test_ai_prompt_sql_with_mock_provider():
     """).fetchall()
 
     assert rows == [("topic:alpha",), ("topic:beta",)]
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        pytest.param(
+            """
+            ai_prompt(
+                'describe',
+                struct_pack(provider := 'mock_ai_sql', model := 'text-model', concurrency := 1)
+            )
+            """,
+            "text-model:describe",
+            id="prompt",
+        ),
+        pytest.param(
+            """
+            ai_embed(
+                'abc',
+                struct_pack(provider := 'mock_ai_sql', dimensions := 4, concurrency := 1)
+            )
+            """,
+            [3.0, 3.0, 3.0, 3.0],
+            id="embed",
+        ),
+    ],
+)
+def test_ai_sql_full_local_copy_in_subprocess(tmp_path, expression, expected):
+    repo_root = Path(__file__).resolve().parents[2]
+    output = tmp_path / "ai-local-copy.parquet"
+    script = f"""
+import vane
+from vane.ai import provider as provider_registry
+from duckdb.runners.fte.backends.native.backend import _NativeFteProgressRegistry
+from tests.ai.test_expression_ai_sql import MockProvider
+
+# Keep this teardown regression focused on #214. Live UDF counters currently
+# trigger the independent progress-topology failure tracked by #239.
+_NativeFteProgressRegistry._topology_from_task_stats = staticmethod(lambda _task_stats: None)
+provider_registry.PROVIDERS["mock_ai_sql"] = lambda name=None, **options: MockProvider()
+vane.configure(runner="local")
+conn = vane.connect()
+conn.sql({f"SELECT {expression} AS result"!r}).write_parquet({str(output)!r})
+row = conn.read_parquet({str(output)!r}).fetchone()
+assert row == ({expected!r},), row
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["PYTHONFAULTHANDLER"] = "1"
+    env["VANE_PROGRESS"] = "0"
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        cwd=repo_root,
+        env=env,
+        timeout=60,
+    )
+    assert output.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -511,6 +511,7 @@ def test_ai_prompt_sql_with_mock_provider():
 def test_ai_sql_full_local_copy_in_subprocess(tmp_path, expression, expected):
     repo_root = Path(__file__).resolve().parents[2]
     output = tmp_path / "ai-local-copy.parquet"
+    expected_row = (expected,)
     script = f"""
 import vane
 from vane.ai import provider as provider_registry
@@ -525,10 +526,10 @@ vane.configure(runner="local")
 conn = vane.connect()
 conn.sql({f"SELECT {expression} AS result"!r}).write_parquet({str(output)!r})
 row = conn.read_parquet({str(output)!r}).fetchone()
-assert row == ({expected!r},), row
+assert row == {expected_row!r}, row
 """
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(repo_root)
+    env["PYTHONPATH"] = os.pathsep.join(entry for entry in (str(repo_root), env.get("PYTHONPATH")) if entry)
     env["PYTHONFAULTHANDLER"] = "1"
     env["VANE_PROGRESS"] = "0"
 

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -333,6 +333,16 @@ def test_native_background_event_loop_catches_pre311_future_timeout(monkeypatch)
     assert pending.cancelled is True
 
 
+def test_native_worker_handle_shutdown_forwards_timeout(monkeypatch):
+    worker = NativeWorkerHandle("worker-shutdown-timeout", lambda _request: None)
+    shutdown_timeouts = []
+    monkeypatch.setattr(worker._loop, "shutdown", lambda *, timeout_s: shutdown_timeouts.append(timeout_s))
+
+    worker.shutdown(timeout_s=12.5)
+
+    assert shutdown_timeouts == [12.5]
+
+
 def _captured_native_copy_plan(tmp_path, monkeypatch, *, local_staging: bool):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     if local_staging:
@@ -950,6 +960,29 @@ def test_native_worker_manager_shutdown_attempts_all_workers_and_is_retryable():
     backend.shutdown()
 
     assert shutdown_calls == ["first", "second", "first", "second"]
+    assert backend._closed is True
+
+
+def test_native_worker_manager_shutdown_shares_timeout_across_workers(monkeypatch):
+    shutdown_timeouts = []
+
+    class _Worker:
+        def __init__(self, worker_id):
+            self.worker_id = worker_id
+
+        def shutdown(self, *, timeout_s):
+            shutdown_timeouts.append((self.worker_id, timeout_s))
+
+    monotonic_values = iter([10.0, 10.25, 10.75])
+    monkeypatch.setattr(native_backend_mod.time, "monotonic", lambda: next(monotonic_values))
+    backend = NativeFteWorkerManagerBackend(workers=[_Worker("first"), _Worker("second")])
+
+    backend.shutdown(timeout_s=1.0)
+
+    assert shutdown_timeouts == [
+        ("first", pytest.approx(0.75)),
+        ("second", pytest.approx(0.25)),
+    ]
     assert backend._closed is True
 
 
@@ -2258,6 +2291,151 @@ def test_in_process_fragment_executor_close_does_not_release_live_resources(monk
     executor.close(timeout_s=1.0)
     assert conn.closed is True
     assert conn.cursor_instance.closed is True
+
+
+def test_in_process_fragment_executor_unregisters_cursor_before_close(monkeypatch):
+    from duckdb.runners.local import runner as local_runner
+
+    close_started = threading.Event()
+    release_close = threading.Event()
+    interrupt_calls = []
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def interrupt(self) -> None:
+            interrupt_calls.append("interrupt")
+            if self.closed:
+                raise RuntimeError("cursor already closed")
+
+        def close(self) -> None:
+            self.closed = True
+            close_started.set()
+            assert release_close.wait(timeout=2.0)
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.cursor_instance = FakeCursor()
+            self.closed = False
+
+        def cursor(self) -> FakeCursor:
+            return self.cursor_instance
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakePlanRunner:
+        def execute_native(self, *_args: Any) -> dict[str, bool]:
+            return {"ok": True}
+
+    monkeypatch.setattr(
+        NativeFteWorkerManagerBackend,
+        "materialize_task_context",
+        staticmethod(lambda *_args, **_kwargs: {}),
+    )
+    monkeypatch.setattr(local_runner, "require_ray_cxx_attr", lambda *_args, **_kwargs: lambda values: values)
+
+    executor = local_runner._InProcessFragmentExecutor(close_timeout_s=1.0)
+    conn = FakeConn()
+    executor._connections.append(conn)
+    monkeypatch.setattr(executor, "_get_conn", lambda: conn)
+    monkeypatch.setattr(executor, "_get_plan_runner", lambda: FakePlanRunner())
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        execution = pool.submit(executor, {"fragment_plan": object(), "context": {}})
+        assert close_started.wait(timeout=1.0)
+        try:
+            executor.request_shutdown()
+            assert interrupt_calls == []
+        finally:
+            release_close.set()
+        assert execution.result(timeout=2.0) == {"ok": True}
+
+    executor.close(timeout_s=1.0)
+    assert conn.closed is True
+
+
+def test_in_process_fragment_executor_ignores_stale_cursor_interrupt_failure():
+    from duckdb.runners.local import runner as local_runner
+
+    first_interrupt_started = threading.Event()
+    release_first_interrupt = threading.Event()
+    shutdown_errors = []
+
+    class OrderedCursorRegistry(set[Any]):
+        def __init__(self, *values):
+            super().__init__(values)
+            self._values = list(values)
+
+        def __iter__(self):
+            return iter(list(self._values))
+
+        def discard(self, value):
+            super().discard(value)
+            if value in self._values:
+                self._values.remove(value)
+
+        def clear(self):
+            super().clear()
+            self._values.clear()
+
+    class BlockingCursor:
+        def interrupt(self) -> None:
+            first_interrupt_started.set()
+            assert release_first_interrupt.wait(timeout=2.0)
+
+    class StaleCursor:
+        def __init__(self) -> None:
+            self.closed = False
+            self.interrupt_calls = 0
+
+        def interrupt(self) -> None:
+            self.interrupt_calls += 1
+            if self.closed:
+                raise RuntimeError("cursor already closed")
+
+    blocking_cursor = BlockingCursor()
+    stale_cursor = StaleCursor()
+    executor = local_runner._InProcessFragmentExecutor(close_timeout_s=1.0)
+    executor._active_cursors = OrderedCursorRegistry(blocking_cursor, stale_cursor)
+
+    def request_shutdown():
+        try:
+            executor.request_shutdown()
+        except BaseException as exc:
+            shutdown_errors.append(exc)
+
+    shutdown_thread = threading.Thread(target=request_shutdown)
+    shutdown_thread.start()
+    assert first_interrupt_started.wait(timeout=1.0)
+    executor._unregister_cursor(stale_cursor)
+    stale_cursor.closed = True
+    release_first_interrupt.set()
+    shutdown_thread.join(timeout=2.0)
+
+    assert shutdown_thread.is_alive() is False
+    assert shutdown_errors == []
+    assert stale_cursor.interrupt_calls == 1
+    executor.close(timeout_s=1.0)
+
+
+def test_in_process_fragment_executor_reports_active_cursor_interrupt_failure():
+    from duckdb.runners.local import runner as local_runner
+
+    class ActiveCursor:
+        def interrupt(self) -> None:
+            raise RuntimeError("active cursor interrupt failed")
+
+    cursor = ActiveCursor()
+    executor = local_runner._InProcessFragmentExecutor(close_timeout_s=1.0)
+    executor._active_cursors.add(cursor)
+
+    with pytest.raises(RuntimeError, match="active cursor interrupt failed"):
+        executor.request_shutdown()
+
+    executor._unregister_cursor(cursor)
+    executor.close(timeout_s=1.0)
 
 
 def test_in_process_fragment_executor_registration_failure_releases_execution_ownership(monkeypatch):

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -2356,11 +2356,18 @@ def test_in_process_fragment_executor_unregisters_cursor_before_close(monkeypatc
     assert conn.closed is True
 
 
-def test_in_process_fragment_executor_ignores_stale_cursor_interrupt_failure():
+def test_in_process_fragment_executor_interrupt_ownership_blocks_cursor_close():
     from duckdb.runners.local import runner as local_runner
 
     first_interrupt_started = threading.Event()
     release_first_interrupt = threading.Event()
+    close_progressed = threading.Event()
+    close_blocked_on_lifecycle = threading.Event()
+    close_started = threading.Event()
+    close_finished = threading.Event()
+    release_close = threading.Event()
+    interrupt_during_close = threading.Event()
+    close_thread_id = []
     shutdown_errors = []
 
     class OrderedCursorRegistry(set[Any]):
@@ -2380,25 +2387,50 @@ def test_in_process_fragment_executor_ignores_stale_cursor_interrupt_failure():
             super().clear()
             self._values.clear()
 
+    class ObservedCondition(threading.Condition):
+        def __enter__(self):
+            if close_thread_id and threading.get_ident() == close_thread_id[0]:
+                if self._lock.acquire(blocking=False):
+                    return self
+                close_blocked_on_lifecycle.set()
+                close_progressed.set()
+                self._lock.acquire()
+                return self
+            return super().__enter__()
+
     class BlockingCursor:
         def interrupt(self) -> None:
             first_interrupt_started.set()
             assert release_first_interrupt.wait(timeout=2.0)
 
-    class StaleCursor:
+    class ClosingCursor:
         def __init__(self) -> None:
             self.closed = False
             self.interrupt_calls = 0
 
         def interrupt(self) -> None:
             self.interrupt_calls += 1
+            if close_started.is_set() and not close_finished.is_set():
+                interrupt_during_close.set()
             if self.closed:
                 raise RuntimeError("cursor already closed")
 
+        def close(self) -> None:
+            self.closed = True
+            close_started.set()
+            close_progressed.set()
+            try:
+                assert release_close.wait(timeout=2.0)
+            finally:
+                close_finished.set()
+
     blocking_cursor = BlockingCursor()
-    stale_cursor = StaleCursor()
+    closing_cursor = ClosingCursor()
     executor = local_runner._InProcessFragmentExecutor(close_timeout_s=1.0)
-    executor._active_cursors = OrderedCursorRegistry(blocking_cursor, stale_cursor)
+    lifecycle_lock = threading.RLock()
+    executor._resources_lock = lifecycle_lock
+    executor._resources_condition = ObservedCondition(lifecycle_lock)
+    executor._active_cursors = OrderedCursorRegistry(blocking_cursor, closing_cursor)
 
     def request_shutdown():
         try:
@@ -2406,17 +2438,41 @@ def test_in_process_fragment_executor_ignores_stale_cursor_interrupt_failure():
         except BaseException as exc:
             shutdown_errors.append(exc)
 
+    def unregister_and_close():
+        close_thread_id.append(threading.get_ident())
+        executor._unregister_cursor(closing_cursor)
+        closing_cursor.close()
+
     shutdown_thread = threading.Thread(target=request_shutdown)
     shutdown_thread.start()
-    assert first_interrupt_started.wait(timeout=1.0)
-    executor._unregister_cursor(stale_cursor)
-    stale_cursor.closed = True
-    release_first_interrupt.set()
-    shutdown_thread.join(timeout=2.0)
+    close_thread = threading.Thread(target=unregister_and_close)
+    close_thread_started = False
+    try:
+        assert first_interrupt_started.wait(timeout=1.0)
+        close_thread.start()
+        close_thread_started = True
+        assert close_progressed.wait(timeout=1.0)
+        close_started_before_interrupts_finished = close_started.is_set()
+        close_blocked_before_interrupts_finished = close_blocked_on_lifecycle.is_set()
+        release_first_interrupt.set()
+        shutdown_thread.join(timeout=2.0)
+    finally:
+        release_first_interrupt.set()
+        release_close.set()
+        shutdown_thread.join(timeout=2.0)
+        if close_thread_started:
+            close_thread.join(timeout=2.0)
 
+    assert close_started_before_interrupts_finished is False
+    assert close_blocked_before_interrupts_finished is True
     assert shutdown_thread.is_alive() is False
+    assert close_thread.is_alive() is False
     assert shutdown_errors == []
-    assert stale_cursor.interrupt_calls == 1
+    assert closing_cursor.interrupt_calls == 1
+    assert interrupt_during_close.is_set() is False
+    assert close_started.is_set()
+    assert close_finished.is_set()
+    executor._unregister_cursor(blocking_cursor)
     executor.close(timeout_s=1.0)
 
 

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -193,6 +193,59 @@ def test_native_background_event_loop_shutdown_completes_pending_future():
         future.result(timeout=1.0)
 
 
+def test_native_background_event_loop_request_shutdown_fences_and_shutdown_joins_sync_work():
+    background = _BackgroundEventLoop("native-fte-join-sync-work")
+    work_started = threading.Event()
+    release_work = threading.Event()
+    work_finished = threading.Event()
+    shutdown_finished = threading.Event()
+    shutdown_errors: list[BaseException] = []
+
+    def blocking_work():
+        work_started.set()
+        try:
+            assert release_work.wait(timeout=5.0)
+        finally:
+            work_finished.set()
+
+    async def run_blocking_work():
+        await asyncio.to_thread(blocking_work)
+
+    future = background.submit(run_blocking_work())
+    assert work_started.wait(timeout=1.0)
+    background.request_shutdown()
+    with pytest.raises(RuntimeError, match="stopping|closed"):
+        background.submit(asyncio.sleep(0))
+
+    def shutdown():
+        try:
+            background.shutdown(timeout_s=3.0)
+        except BaseException as exc:
+            shutdown_errors.append(exc)
+        finally:
+            shutdown_finished.set()
+
+    shutdown_thread = threading.Thread(target=shutdown)
+    shutdown_thread.start()
+    try:
+        deadline = time.monotonic() + 1.0
+        while not future.cancelled() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert future.cancelled()
+        assert not shutdown_finished.wait(timeout=0.05)
+        release_work.set()
+        shutdown_thread.join(timeout=5.0)
+    finally:
+        release_work.set()
+        shutdown_thread.join(timeout=5.0)
+
+    assert not shutdown_thread.is_alive()
+    assert shutdown_errors == []
+    assert work_finished.is_set()
+    with pytest.raises(CancelledError):
+        future.result(timeout=1.0)
+
+
 def test_native_background_event_loop_operation_timeout_cancels_coroutine():
     background = _BackgroundEventLoop(
         "native-fte-operation-timeout",
@@ -2141,6 +2194,111 @@ def test_in_process_fragment_executor_uses_thread_local_duckdb_resources(monkeyp
         assert "SET local_exchange_streaming=true" in conn.executed
         assert "SET local_exchange_buffer_bytes = '32MB'" in conn.executed
         assert "SET arrow_large_buffer_size=true" in conn.executed
+
+
+def test_in_process_fragment_executor_close_does_not_release_live_resources(monkeypatch):
+    from duckdb.runners.local import runner as local_runner
+
+    execute_started = threading.Event()
+    release_execute = threading.Event()
+    cursor_interrupted = threading.Event()
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def interrupt(self) -> None:
+            cursor_interrupted.set()
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.cursor_instance = FakeCursor()
+            self.closed = False
+
+        def cursor(self) -> FakeCursor:
+            return self.cursor_instance
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakePlanRunner:
+        def execute_native(self, *_args: Any) -> dict[str, bool]:
+            execute_started.set()
+            assert release_execute.wait(timeout=2.0)
+            return {"ok": True}
+
+    monkeypatch.setattr(
+        NativeFteWorkerManagerBackend,
+        "materialize_task_context",
+        staticmethod(lambda *_args, **_kwargs: {}),
+    )
+    monkeypatch.setattr(local_runner, "require_ray_cxx_attr", lambda *_args, **_kwargs: lambda values: values)
+
+    executor = local_runner._InProcessFragmentExecutor(close_timeout_s=1.0)
+    conn = FakeConn()
+    executor._connections.append(conn)
+    monkeypatch.setattr(executor, "_get_conn", lambda: conn)
+    monkeypatch.setattr(executor, "_get_plan_runner", lambda: FakePlanRunner())
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        execution = pool.submit(executor, {"fragment_plan": object(), "context": {}})
+        assert execute_started.wait(timeout=1.0)
+        try:
+            with pytest.raises(RuntimeError, match="did not drain.*active_executions=1"):
+                executor.close(timeout_s=0.05)
+            assert cursor_interrupted.is_set()
+            assert conn.closed is False
+        finally:
+            release_execute.set()
+        assert execution.result(timeout=2.0) == {"ok": True}
+
+    executor.close(timeout_s=1.0)
+    assert conn.closed is True
+    assert conn.cursor_instance.closed is True
+
+
+def test_in_process_fragment_executor_registration_failure_releases_execution_ownership(monkeypatch):
+    from duckdb.runners.local import runner as local_runner
+
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeConn:
+        def __init__(self) -> None:
+            self.cursor_instance = FakeCursor()
+
+        def cursor(self) -> FakeCursor:
+            return self.cursor_instance
+
+    monkeypatch.setattr(
+        NativeFteWorkerManagerBackend,
+        "materialize_task_context",
+        staticmethod(lambda *_args, **_kwargs: {}),
+    )
+    monkeypatch.setattr(local_runner, "require_ray_cxx_attr", lambda *_args, **_kwargs: lambda values: values)
+
+    executor = local_runner._InProcessFragmentExecutor()
+    conn = FakeConn()
+    monkeypatch.setattr(executor, "_get_conn", lambda: conn)
+
+    def fail_register(_cursor):
+        raise RuntimeError("cursor registration failed")
+
+    monkeypatch.setattr(executor, "_register_cursor", fail_register)
+
+    with pytest.raises(RuntimeError, match="cursor registration failed"):
+        executor({"fragment_plan": object(), "context": {}})
+
+    assert executor._in_flight == 0
+    assert conn.cursor_instance.closed is True
+    executor.close(timeout_s=0)
 
 
 def test_native_cxx_run_copy_plan_selected_attempt_ignores_duplicate_copy_output(tmp_path, monkeypatch):

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -169,19 +169,23 @@ def test_local_runner_teardown_releases_actor_pools_after_execution_resources():
     from duckdb.runners.local.runner import _shutdown_local_write_resources
 
     events = []
+    backend_timeouts = []
+    fragment_timeouts = []
 
     class FakeBackend:
         def request_shutdown(self):
             events.append("backend-request")
 
-        def shutdown(self):
+        def shutdown(self, *, timeout_s):
+            backend_timeouts.append(timeout_s)
             events.append("backend-join")
 
     class FakeFragmentExecutor:
         def request_shutdown(self):
             events.append("fragments-request")
 
-        def close(self):
+        def close(self, *, timeout_s):
+            fragment_timeouts.append(timeout_s)
             events.append("fragments-close")
 
     class FakeConn:
@@ -201,9 +205,11 @@ def test_local_runner_teardown_releases_actor_pools_after_execution_resources():
         FakeConn(),
         [FakePool("first"), FakePool("second")],
         kill_actor_pools=True,
+        timeout_s=7.0,
     )
 
     assert errors == []
+    assert 0 < fragment_timeouts[0] <= backend_timeouts[0] <= 7.0
     assert events == [
         "backend-request",
         "fragments-request",
@@ -224,7 +230,7 @@ def test_local_runner_teardown_keeps_dependencies_when_backend_does_not_stop():
         def request_shutdown(self):
             events.append("backend-request")
 
-        def shutdown(self):
+        def shutdown(self, *, timeout_s):
             events.append("backend-join")
             raise RuntimeError("backend join timed out")
 
@@ -249,6 +255,7 @@ def test_local_runner_teardown_keeps_dependencies_when_backend_does_not_stop():
         UnexpectedConn(),
         [UnexpectedPool()],
         kill_actor_pools=True,
+        timeout_s=7.0,
     )
 
     assert events == ["backend-request", "fragments-request", "backend-join"]
@@ -265,14 +272,14 @@ def test_local_runner_teardown_keeps_dependencies_when_fragment_close_fails():
         def request_shutdown(self):
             events.append("backend-request")
 
-        def shutdown(self):
+        def shutdown(self, *, timeout_s):
             events.append("backend-join")
 
     class FakeFragmentExecutor:
         def request_shutdown(self):
             events.append("fragments-request")
 
-        def close(self):
+        def close(self, *, timeout_s):
             events.append("fragments-close")
             raise RuntimeError("fragment close failed")
 
@@ -290,6 +297,7 @@ def test_local_runner_teardown_keeps_dependencies_when_fragment_close_fails():
         UnexpectedConn(),
         [UnexpectedPool()],
         kill_actor_pools=False,
+        timeout_s=7.0,
     )
 
     assert len(errors) == 1

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -163,3 +163,140 @@ def test_local_runner_collects_udf_actor_shutdown_errors_after_attempting_every_
     assert "second cleanup failed" in str(graceful_errors[0])
     assert len(forced_errors) == 1
     assert "second cleanup failed" in str(forced_errors[0])
+
+
+def test_local_runner_teardown_releases_actor_pools_after_execution_resources():
+    from duckdb.runners.local.runner import _shutdown_local_write_resources
+
+    events = []
+
+    class FakeBackend:
+        def request_shutdown(self):
+            events.append("backend-request")
+
+        def shutdown(self):
+            events.append("backend-join")
+
+    class FakeFragmentExecutor:
+        def request_shutdown(self):
+            events.append("fragments-request")
+
+        def close(self):
+            events.append("fragments-close")
+
+    class FakeConn:
+        def close(self):
+            events.append("connection")
+
+    class FakePool:
+        def __init__(self, name):
+            self.name = name
+
+        def shutdown(self, *, kill):
+            events.append(f"pool:{self.name}:{kill}")
+
+    errors = _shutdown_local_write_resources(
+        FakeBackend(),
+        FakeFragmentExecutor(),
+        FakeConn(),
+        [FakePool("first"), FakePool("second")],
+        kill_actor_pools=True,
+    )
+
+    assert errors == []
+    assert events == [
+        "backend-request",
+        "fragments-request",
+        "backend-join",
+        "fragments-close",
+        "pool:second:True",
+        "pool:first:True",
+        "connection",
+    ]
+
+
+def test_local_runner_teardown_keeps_dependencies_when_backend_does_not_stop():
+    from duckdb.runners.local.runner import _shutdown_local_write_resources
+
+    events = []
+
+    class FakeBackend:
+        def request_shutdown(self):
+            events.append("backend-request")
+
+        def shutdown(self):
+            events.append("backend-join")
+            raise RuntimeError("backend join timed out")
+
+    class FakeFragmentExecutor:
+        def request_shutdown(self):
+            events.append("fragments-request")
+
+        def close(self):
+            raise AssertionError("fragment resources must remain alive")
+
+    class UnexpectedConn:
+        def close(self):
+            raise AssertionError("driver connection must remain alive")
+
+    class UnexpectedPool:
+        def shutdown(self, *, kill):
+            raise AssertionError("actor pool must remain alive")
+
+    errors = _shutdown_local_write_resources(
+        FakeBackend(),
+        FakeFragmentExecutor(),
+        UnexpectedConn(),
+        [UnexpectedPool()],
+        kill_actor_pools=True,
+    )
+
+    assert events == ["backend-request", "fragments-request", "backend-join"]
+    assert len(errors) == 1
+    assert "backend join timed out" in str(errors[0])
+
+
+def test_local_runner_teardown_keeps_dependencies_when_fragment_close_fails():
+    from duckdb.runners.local.runner import _shutdown_local_write_resources
+
+    events = []
+
+    class FakeBackend:
+        def request_shutdown(self):
+            events.append("backend-request")
+
+        def shutdown(self):
+            events.append("backend-join")
+
+    class FakeFragmentExecutor:
+        def request_shutdown(self):
+            events.append("fragments-request")
+
+        def close(self):
+            events.append("fragments-close")
+            raise RuntimeError("fragment close failed")
+
+    class UnexpectedConn:
+        def close(self):
+            raise AssertionError("driver connection must remain alive")
+
+    class UnexpectedPool:
+        def shutdown(self, *, kill):
+            raise AssertionError("actor pool must remain alive")
+
+    errors = _shutdown_local_write_resources(
+        FakeBackend(),
+        FakeFragmentExecutor(),
+        UnexpectedConn(),
+        [UnexpectedPool()],
+        kill_actor_pools=False,
+    )
+
+    assert len(errors) == 1
+    assert "fragment close failed" in str(errors[0])
+    assert events == [
+        "backend-request",
+        "fragments-request",
+        "backend-join",
+        "fragments-close",
+    ]


### PR DESCRIPTION
## Summary

- join synchronous native fragment work owned by local FTE event loops and interrupt/drain in-process fragment cursors before closing DuckDB resources
- release AI SQL subprocess actor pools and the driver connection only after fragment execution stops, retaining dependencies when shutdown cannot prove quiescence
- cover event-loop joins, fragment shutdown barriers, teardown ordering, and full local COPY for mock `ai_prompt` and `ai_embed`

## Related issue

close: #214

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" scripts/format root --changed`
- `.venv/bin/python -m pytest tests/fast/test_fte_native_backend.py tests/fast/test_local_fte_runner_entrypoint.py` (65 passed)
- `.venv/bin/python -m pytest tests/ai/test_expression_ai_sql.py -k full_local_copy_in_subprocess` (2 passed, 58 deselected)
- `PATH="$PWD/.venv/bin:$PATH" scripts/run_release_tests.sh` (non-Ray phase: 414 passed, 1 skipped; real-Ray phase: 7 passed)
- `git diff --cached --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented. The local COPY crash is fixed without changing public APIs.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. This changes shutdown ownership without adding those surfaces.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks. This change is Python-only and passed the checks above.