### PR TITLE
[fix](ray) Treat pipeline object bytes as a soft budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,10 +203,6 @@ jobs:
             "$GITHUB_WORKSPACE/tests/typing/ai_embed.py"
 
       - name: Verify the base installation Quickstart outside the checkout
-        env:
-          # Keep this distributed smoke test within a standard 16 GB runner.
-          VANE_FTE_TASK_HEAP_BYTES: "1073741824"
-          VANE_UDF_TASK_HEAP_BYTES: "1073741824"
         run: |
           cd "$RUNNER_TEMP"
           env -u VANE_RUNNER python "$GITHUB_WORKSPACE/scripts/verify_base_install.py"
@@ -329,17 +325,6 @@ jobs:
         env:
           FAST_TEST_PHASE: ${{ matrix.phase }}
         run: |
-          if [[ "$FAST_TEST_PHASE" != "non-ray" ]]; then
-            # A public ubuntu-24.04 runner has 16 GiB RAM and no GPU. Keep the
-            # Ray test topology below that physical limit while retaining the
-            # 2 GiB object store required by representative FTE plans. The
-            # tiny UDF fixtures keep multiple actor pools resident, so they do
-            # not need the production profile's 4 GiB heap per actor.
-            export VANE_TEST_RAY_OBJECT_STORE_BYTES=2147483648
-            export VANE_FTE_TASK_HEAP_BYTES=1073741824
-            export VANE_UDF_TASK_HEAP_BYTES=1073741824
-            export VANE_UDF_ACTOR_HEAP_BYTES=536870912
-          fi
           if [[ "$FAST_TEST_PHASE" == "owner-ray" ]]; then
             # This runner is dedicated to one shard, so Ray daemon cleanup can
             # happen outside pytest without risking an unrelated local cluster.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ The launcher runs non-Ray tests, shared-cluster Ray tests, and test-owned Ray
 clusters in separate pytest processes. Do not replace it with one long-lived
 `pytest tests/fast` process.
 
-The fast/release Ray shards use a 2 GiB object store by default. Override the
-test-only profile with `VANE_TEST_RAY_OBJECT_STORE_BYTES`; it does not configure
-production clusters. Tests that call `ray.init()` directly must be marked
-`real_ray` and `ray_cluster_owner`. Tests that require CUDA hardware must also
-be marked `gpu`; the standard CPU-only CI fast-test shards exclude that marker.
+The fast/release Ray shards let Ray size the object store from the node's
+available memory by default. Use `VANE_TEST_RAY_OBJECT_STORE_BYTES` only to pin
+the capacity for a specialized test; it does not configure production clusters.
+Tests that call `ray.init()` directly must be marked `real_ray` and
+`ray_cluster_owner`. Tests that require CUDA hardware must also be marked `gpu`;
+the standard CPU-only CI fast-test shards exclude that marker.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,17 +85,16 @@ python -m pytest tests/ai
 The fast-test launcher runs non-Ray tests, shared-cluster Ray tests, and
 test-owned Ray clusters in separate pytest processes. This keeps the real Ray
 runtime out of the long-lived non-Ray pytest process. Fast and release Ray test
-clusters use a 2 GiB object store by default;
-`VANE_TEST_RAY_OBJECT_STORE_BYTES` overrides this test-only profile and does
-not configure production clusters. Tests that call `ray.init()` directly must
-be marked `real_ray` and `ray_cluster_owner`.
+clusters let Ray size the object store from the node's available memory by
+default. `VANE_TEST_RAY_OBJECT_STORE_BYTES` pins the capacity for a specialized
+test; it does not configure production clusters. Tests that call `ray.init()`
+directly must be marked `real_ray` and `ray_cluster_owner`.
 
 CI further splits the non-Ray phase across CPU-only jobs. The jobs install the
-built wheel, use CPU-only PyTorch, cap Ray task heap requests at 1 GiB, and set
-hard pytest-process and job deadlines so the suite fits a standard 4-vCPU,
-16-GiB GitHub-hosted runner. Tests marked `gpu` are excluded there because
-standard runners do not provide CUDA hardware; run the default launcher on a
-GPU host to include them.
+built wheel, use CPU-only PyTorch, and set hard pytest-process and job deadlines
+so the suite fits a standard 4-vCPU, 16-GiB GitHub-hosted runner. Tests marked
+`gpu` are excluded there because standard runners do not provide CUDA hardware;
+run the default launcher on a GPU host to include them.
 
 Tests that require an externally provisioned service are excluded by default.
 Run them explicitly when the required service and credentials are available:

--- a/duckdb/execution/udf.py
+++ b/duckdb/execution/udf.py
@@ -20,8 +20,10 @@ _ALLOWED_OPTIONS = frozenset(
     {
         *_DEFAULTS,
         "actor_handles",
+        "actor_init_refs",
         "actor_node_ids",
         "actor_dispatch_indices",
+        "actor_pool_locator",
         "local_actor_pool",
         "query_driver_handle",
         "query_generation_capability",

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -150,8 +150,8 @@ def _ray_payload_requires_block_stream(payload: dict[str, Any]) -> bool:
         raise RuntimeError("distributed Ray UDF output requires produce_ray_block_stream=True")
     if not str(payload.get("query_id") or "").strip():
         raise RuntimeError("distributed Ray UDF payload requires query_id")
-    if not str(payload.get("stage_id") or "").strip():
-        raise RuntimeError("distributed Ray UDF payload requires pre-registered stage_id")
+    if not str(payload.get("resource_unit_id") or "").strip():
+        raise RuntimeError("distributed Ray UDF payload requires pre-registered resource_unit_id")
     return True
 
 
@@ -329,7 +329,7 @@ def _apply_actor_node_options(
 def ensure_actor_pools_for_plan(
     plan: Any,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -338,7 +338,7 @@ def ensure_actor_pools_for_plan(
     return _ensure_actor_pools_for_plan_impl(
         plan,
         conn=conn,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -356,7 +356,7 @@ def ensure_actor_pools_for_plan(
 def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -364,7 +364,7 @@ def ensure_actor_pools_for_nodes(
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _ensure_actor_pools_for_nodes_impl(
         udf_nodes,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -383,7 +383,7 @@ def ensure_actor_pools_for_nodes(
 def prepare_actor_pools_for_plan(
     plan: Any,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -392,7 +392,7 @@ def prepare_actor_pools_for_plan(
     return _prepare_actor_pools_for_plan_impl(
         plan,
         conn=conn,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -31,6 +31,9 @@ from duckdb.execution.udf_ray_actor_pool import (
     ensure_actor_pools_for_plan as _ensure_actor_pools_for_plan_impl,
 )
 from duckdb.execution.udf_ray_actor_pool import (
+    prepare_actor_pools_for_nodes as _prepare_actor_pools_for_nodes_impl,
+)
+from duckdb.execution.udf_ray_actor_pool import (
     prepare_actor_pools_for_plan as _prepare_actor_pools_for_plan_impl,
 )
 from duckdb.execution.udf_ray_actor_pool import (
@@ -38,6 +41,9 @@ from duckdb.execution.udf_ray_actor_pool import (
 )
 from duckdb.execution.udf_ray_actor_pool import (
     wait_for_actor_pools_ready as _wait_for_actor_pools_ready_impl,
+)
+from duckdb.execution.udf_ray_actor_pool import (
+    wait_for_first_actor_pool_ready as _wait_for_first_actor_pool_ready_impl,
 )
 from duckdb.execution.udf_ray_actor_runtime import (
     _actor_class as _actor_runtime_class,
@@ -110,6 +116,7 @@ from duckdb.runners.ray.ray_env import (
     install_explicit_session_runtime_env,
     scrub_shared_runtime_session_env,
 )
+from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
 DEFAULT_UDF_OUTPUT_TARGET_MAX_BYTES = 128 * 1024 * 1024
 DEFAULT_GENERATOR_BACKPRESSURE_NUM_OBJECTS = RAY_UDF_GENERATOR_BACKPRESSURE_OBJECTS
@@ -251,13 +258,15 @@ def _build_udf_executor_options(
     actor_handles: list[Any],
     actor_node_ids: list[str] | None,
     actor_dispatch_indices: set[int] | list[int] | tuple[int, ...] | None,
+    actor_init_refs: list[Any] | tuple[Any, ...] | None = None,
 ) -> dict[str, Any]:
-    normalized_node_ids = _normalize_actor_node_ids(
-        actor_node_ids,
-        expected_count=len(actor_handles),
+    normalized_node_ids = (
+        [""] * len(actor_handles)
+        if actor_node_ids is None
+        else [str(node_id or "").strip() for node_id in actor_node_ids]
     )
-    if normalized_node_ids is None:
-        raise ValueError("actor node IDs are required for pre-created Ray UDF actors")
+    if len(normalized_node_ids) != len(actor_handles):
+        raise ValueError("actor node IDs count must match actor handle count")
     if actor_dispatch_indices is None:
         raise ValueError("actor_dispatch_indices are required for pre-created Ray UDF actors")
     raw_dispatch_indices = list(actor_dispatch_indices)
@@ -268,10 +277,19 @@ def _build_udf_executor_options(
     invalid = [idx for idx in raw_dispatch_indices if idx < 0 or idx >= len(actor_handles)]
     if invalid:
         raise ValueError(f"actor_dispatch_indices contains out-of-range indices: {invalid}")
+    missing_ready_node_ids = [idx for idx in raw_dispatch_indices if not normalized_node_ids[idx]]
+    if missing_ready_node_ids:
+        raise ValueError(
+            "dispatch-ready actors require runtime node IDs: " + ", ".join(str(idx) for idx in missing_ready_node_ids)
+        )
+    init_refs = [] if actor_init_refs is None else list(actor_init_refs)
+    if init_refs and len(init_refs) != len(actor_handles):
+        raise ValueError("actor init refs count must match actor handle count")
     return {
         "actor_handles": list(actor_handles),
         "actor_node_ids": normalized_node_ids,
         "actor_dispatch_indices": sorted(raw_dispatch_indices),
+        "actor_init_refs": init_refs,
     }
 
 
@@ -322,7 +340,6 @@ def _apply_actor_node_options(
     return _apply_actor_node_options_impl(
         actors,
         options=options,
-        normalize_actor_node_ids=_normalize_actor_node_ids,
     )
 
 
@@ -380,6 +397,33 @@ def ensure_actor_pools_for_nodes(
     )
 
 
+def prepare_actor_pools_for_nodes(
+    udf_nodes: Any,
+    *,
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    query_generation_capability: str,
+    session_config: dict[str, str],
+    set_handles: Any = None,
+) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
+    return _prepare_actor_pools_for_nodes_impl(
+        udf_nodes,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
+        query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
+        session_config=session_config,
+        set_handles=set_handles,
+        actor_pool_cls=UDFActorPool,
+        is_vane_worker_process=_is_vane_worker_process,
+        requires_actor_pool_fn=_requires_actor_pool_impl,
+        normalize_actor_pool_payload=_normalize_actor_pool_payload,
+        payload_num_gpus=_payload_num_gpus,
+        required_positive_int=_required_positive_int,
+        resolve_actor_num_cpus=_resolve_actor_num_cpus,
+        build_udf_executor_options=_build_udf_executor_options,
+    )
+
+
 def prepare_actor_pools_for_plan(
     plan: Any,
     *,
@@ -409,6 +453,82 @@ def prepare_actor_pools_for_plan(
 
 def wait_for_actor_pools_ready(actor_pools: list[_UDFActorPoolBase]) -> None:
     _wait_for_actor_pools_ready_impl(actor_pools)
+
+
+def wait_for_first_actor_pool_ready(actor_pool: _UDFActorPoolBase) -> dict[int, str]:
+    return _wait_for_first_actor_pool_ready_impl(actor_pool)
+
+
+def configure_query_udf_execution_for_plan(
+    plan: Any,
+    *,
+    query_id: str,
+    query_driver_handle: Any,
+    query_generation_capability: str,
+    session_config: dict[str, str],
+    conn: Any = None,
+) -> dict[str, dict[str, Any]]:
+    """Inject query-scoped UDF options without eagerly creating actor pools.
+
+    Ray actor nodes receive a stable locator.  The executor resolves that
+    locator only when DuckDB reaches the node, so actor processes belong to the
+    current execution phase instead of the whole query lifetime.
+    """
+
+    if _is_vane_worker_process():
+        return {}
+    query_key = str(query_id or "").strip()
+    capability = str(query_generation_capability or "").strip()
+    if not query_key:
+        raise ValueError("query UDF execution requires query_id")
+    if query_driver_handle is None:
+        raise ValueError("query UDF execution requires an explicit query driver handle")
+    if not capability:
+        raise ValueError("query UDF execution requires a query generation capability")
+
+    normalized_session_config = {str(key): str(value) for key, value in session_config.items()}
+    actor_nodes_by_unit: dict[str, dict[str, Any]] = {}
+    executor_options_by_node: dict[str, dict[str, Any]] = {}
+    for raw_node in plan.collect_udf_nodes(conn=conn):
+        node = dict(raw_node)
+        payload = dict(node.get("payload") or {})
+        backend = str(payload.get("execution_backend") or "").strip().lower()
+        if backend not in {"ray_task", "ray_actor", "subprocess_task", "subprocess_actor"}:
+            continue
+        raw_node_id = node.get("node_id")
+        node_id = "" if raw_node_id is None else str(raw_node_id).strip()
+        if not node_id:
+            raise ValueError("query UDF node is missing node_id")
+        options: dict[str, Any] = {"session_config": normalized_session_config}
+        executor_options_by_node[node_id] = options
+        if backend not in {"ray_task", "ray_actor"}:
+            continue
+        options["query_driver_handle"] = query_driver_handle
+        options["query_generation_capability"] = capability
+        if backend != "ray_actor":
+            continue
+        normalized_payload = _normalize_actor_pool_payload(payload)
+        payload_query_id = str(normalized_payload.get("query_id") or "").strip()
+        if payload_query_id != query_key:
+            raise ValueError(
+                f"Ray actor UDF node {node_id} query_id mismatch: got {payload_query_id!r}, expected {query_key!r}"
+            )
+        resource_unit_id = str(normalized_payload.get("resource_unit_id") or "").strip()
+        if not resource_unit_id:
+            raise ValueError(f"Ray actor UDF node {node_id} is missing resource_unit_id")
+        if resource_unit_id in actor_nodes_by_unit:
+            raise ValueError(f"duplicate Ray actor UDF resource_unit_id: {resource_unit_id}")
+        node["payload"] = normalized_payload
+        actor_nodes_by_unit[resource_unit_id] = node
+        options["actor_pool_locator"] = {
+            "query_id": query_key,
+            "resource_unit_id": resource_unit_id,
+            "physical_node_id": node_id,
+        }
+
+    if executor_options_by_node:
+        plan.set_udf_actor_handles(executor_options_by_node, conn=conn)
+    return actor_nodes_by_unit
 
 
 class RemoteUDFExecutor(
@@ -457,12 +577,11 @@ class RemoteUDFExecutor(
         raw_input_names = payload.get("input_names")
         self._input_names: list[str] | None = list(raw_input_names) if raw_input_names else None
 
-        self._actor_node_ids = _normalize_actor_node_ids(
-            self._actors_obj.actor_node_ids,
-            expected_count=len(self.actors),
-        )
-        if not self._actor_node_ids or any(not node_id for node_id in self._actor_node_ids):
-            raise RuntimeError("every Ray actor handle requires a coordinator-confirmed node identity")
+        self._actor_node_ids = [str(node_id or "").strip() for node_id in self._actors_obj.actor_node_ids]
+        if len(self._actor_node_ids) != len(self.actors):
+            raise RuntimeError("Ray actor node identity count does not match its handle count")
+        if any(not self._actor_node_ids[actor_index] for actor_index in self._actors_obj._confirmed_ready):
+            raise RuntimeError("a confirmed-ready Ray actor is missing its runtime node identity")
 
         self._prime_actor_readiness()
         self._refresh_actor_readiness()
@@ -482,35 +601,66 @@ class RemoteUDFExecutor(
 
 
 def _build_ray_actor_executor(payload: dict[str, Any], options: dict[str, Any]) -> UDFExecutor:
-    """Build a Ray-backed UDF executor using pre-created actor handles.
-
-    Actor handles MUST be provided via ``options["actor_handles"]``.
-
-    This function NEVER creates actors.  All actor creation must happen
-    at the driver level.
-    """
+    """Resolve the phase-local pool on the driver and attach its handles."""
     if options.get("ray_actor_pool_name") is not None or payload.get("ray_actor_pool_name") is not None:
         raise RuntimeError("Ray UDF named actor pools have been removed; use driver pre-created actor_handles instead")
 
     payload = _normalize_actor_pool_payload(payload)
     _ray_payload_requires_block_stream(payload)
 
-    pre_created_handles = options.get("actor_handles")
-    if pre_created_handles is not None:
-        query_driver_handle = options.get("query_driver_handle")
+    resolved_options = dict(options)
+    locator = resolved_options.pop("actor_pool_locator", None)
+    if locator is not None:
+        if resolved_options.get("actor_handles") is not None:
+            raise RuntimeError("Ray actor UDF options cannot contain both actor_pool_locator and actor_handles")
+        if not isinstance(locator, dict):
+            raise TypeError("Ray actor UDF actor_pool_locator must be a dict")
+        expected_locator_fields = {"query_id", "resource_unit_id", "physical_node_id"}
+        if set(locator) != expected_locator_fields:
+            raise ValueError("Ray actor UDF actor_pool_locator fields do not match the query protocol")
+        query_driver_handle = resolved_options.get("query_driver_handle")
         if query_driver_handle is None:
             raise RuntimeError("Ray actor UDF executor requires an explicit query driver handle")
-        query_generation_capability = str(options.get("query_generation_capability") or "").strip()
+        query_generation_capability = str(resolved_options.get("query_generation_capability") or "").strip()
         if not query_generation_capability:
             raise RuntimeError("Ray actor UDF executor requires a query generation capability")
-        if "session_config" not in options:
+        activated_options = resolve_object_refs_blocking(
+            query_driver_handle.activate_query_udf_actor_pool.remote(
+                dict(locator),
+                query_generation_capability,
+            )
+        )
+        if not isinstance(activated_options, dict):
+            raise TypeError("query driver actor-pool activation must return a dict")
+        forbidden = set(activated_options) - {
+            "actor_handles",
+            "actor_node_ids",
+            "actor_dispatch_indices",
+            "actor_init_refs",
+        }
+        if forbidden:
+            raise ValueError(
+                "query driver actor-pool activation returned unknown fields: " + ", ".join(sorted(forbidden))
+            )
+        resolved_options.update(activated_options)
+
+    pre_created_handles = resolved_options.get("actor_handles")
+    if pre_created_handles is not None:
+        query_driver_handle = resolved_options.get("query_driver_handle")
+        if query_driver_handle is None:
+            raise RuntimeError("Ray actor UDF executor requires an explicit query driver handle")
+        query_generation_capability = str(resolved_options.get("query_generation_capability") or "").strip()
+        if not query_generation_capability:
+            raise RuntimeError("Ray actor UDF executor requires a query generation capability")
+        if "session_config" not in resolved_options:
             raise RuntimeError("Ray actor UDF executor requires explicit Vane session config")
         actors = UDFActorPool._from_handles(
             pre_created_handles,
             payload=payload,
-            actor_dispatch_indices=options.get("actor_dispatch_indices"),
+            actor_dispatch_indices=resolved_options.get("actor_dispatch_indices"),
+            actor_init_refs=resolved_options.get("actor_init_refs"),
         )
-        actors = _apply_actor_node_options(actors, options=options)
+        actors = _apply_actor_node_options(actors, options=resolved_options)
         return RemoteUDFExecutor(
             actors,
             payload,
@@ -518,9 +668,7 @@ def _build_ray_actor_executor(payload: dict[str, Any], options: dict[str, Any]) 
             query_generation_capability=query_generation_capability,
         )
 
-    raise RuntimeError(
-        "build_ray_executor requires pre-created actor handles. Ray UDF named actor pools have been removed."
-    )
+    raise RuntimeError("build_ray_executor requires an actor_pool_locator resolved by the query driver")
 
 
 class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -649,7 +649,12 @@ def _task_remote_options(
     options = dict(ray_options or {})
     options["num_cpus"] = num_cpus
     options["num_gpus"] = num_gpus
-    options["memory"] = int(memory_bytes)
+    options.pop("memory", None)
+    declared_memory_bytes = int(memory_bytes)
+    if declared_memory_bytes < 0:
+        raise ValueError("memory_bytes must be non-negative")
+    if declared_memory_bytes > 0:
+        options["memory"] = declared_memory_bytes
     options["max_retries"] = max_retries
     options["_generator_backpressure_num_objects"] = RAY_UDF_GENERATOR_BACKPRESSURE_OBJECTS
     return options

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -70,9 +70,6 @@ from duckdb.execution.udf_ray_env import (
     is_vane_worker_process as _is_vane_worker_process,
 )
 from duckdb.execution.udf_ray_env import (
-    normalize_actor_node_ids as _normalize_actor_node_ids,
-)
-from duckdb.execution.udf_ray_env import (
     normalize_actor_pool_payload as _normalize_actor_pool_payload,
 )
 from duckdb.execution.udf_ray_env import (
@@ -162,18 +159,10 @@ def _ray_payload_requires_block_stream(payload: dict[str, Any]) -> bool:
     return True
 
 
-def _submit_ray_remote(remote_fn: Any, node_id: str, *args: Any, **kwargs: Any) -> Any:
-    node_key = str(node_id).strip()
-    if not node_key:
-        raise RuntimeError("Ray task submission requires its leased node_id")
-    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+def _submit_ray_remote(remote_fn: Any, *args: Any, **kwargs: Any) -> Any:
+    """Submit the real request without preselecting a physical Ray node."""
 
-    return remote_fn.options(
-        scheduling_strategy=NodeAffinitySchedulingStrategy(
-            node_id=node_key,
-            soft=False,
-        )
-    ).remote(*args, **kwargs)
+    return remote_fn.remote(*args, **kwargs)
 
 
 def _ray_task_debug_enabled() -> bool:
@@ -323,14 +312,6 @@ class UDFActorPool(_UDFActorPoolBase):
     def _build_actor_runtime_env(ray_options: dict[str, Any] | None) -> dict[str, Any]:
         return _build_actor_runtime_env(ray_options)
 
-    @staticmethod
-    def _normalize_actor_node_ids(
-        node_ids: list[str] | None,
-        *,
-        expected_count: int,
-    ) -> list[str] | None:
-        return _normalize_actor_node_ids(node_ids, expected_count=expected_count)
-
 
 def _apply_actor_node_options(
     actors: _UDFActorPoolBase,
@@ -346,7 +327,6 @@ def _apply_actor_node_options(
 def ensure_actor_pools_for_plan(
     plan: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -355,7 +335,6 @@ def ensure_actor_pools_for_plan(
     return _ensure_actor_pools_for_plan_impl(
         plan,
         conn=conn,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -373,7 +352,6 @@ def ensure_actor_pools_for_plan(
 def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -381,7 +359,6 @@ def ensure_actor_pools_for_nodes(
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _ensure_actor_pools_for_nodes_impl(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -400,7 +377,6 @@ def ensure_actor_pools_for_nodes(
 def prepare_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -408,7 +384,6 @@ def prepare_actor_pools_for_nodes(
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
     return _prepare_actor_pools_for_nodes_impl(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -427,7 +402,6 @@ def prepare_actor_pools_for_nodes(
 def prepare_actor_pools_for_plan(
     plan: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -436,7 +410,6 @@ def prepare_actor_pools_for_plan(
     return _prepare_actor_pools_for_plan_impl(
         plan,
         conn=conn,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -724,7 +697,6 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
             admission=admission,
             submitter=lambda granted_lease: _submit_ray_remote(
                 self.run_bundle_stream,
-                granted_lease["node_id"],
                 task_payload_with_lease(self.payload, granted_lease),
                 [table],
             ),
@@ -756,7 +728,6 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
             admission=admission,
             submitter=lambda granted_lease: _submit_ray_remote(
                 self.run_ref_bundle_stream,
-                granted_lease["node_id"],
                 *task_block_refs,
                 payload=task_payload_with_lease(self.payload, granted_lease),
                 slices=list(slices or []),

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -330,7 +330,7 @@ def ensure_actor_pools_for_plan(
     plan: Any,
     conn: Any = None,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -346,7 +346,7 @@ def ensure_actor_pools_for_plan(
     udf_nodes = plan.collect_udf_nodes(conn=conn)
     return ensure_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -366,7 +366,7 @@ def prepare_actor_pools_for_plan(
     plan: Any,
     conn: Any = None,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -381,7 +381,7 @@ def prepare_actor_pools_for_plan(
 ) -> tuple[list[UDFActorPoolBase], dict[str, Any]]:
     """Create actors and publish immutable handles without waiting for init.
 
-    The query coordinator keeps every Ray-actor QRM stage closed until
+    The query coordinator keeps every Ray-actor resource unit closed until
     :func:`wait_for_actor_pools_ready` succeeds.  Publishing the handles first
     lets native fragment executors initialize and expose their real pipeline
     topology while expensive user-model initialization is still running.
@@ -389,7 +389,7 @@ def prepare_actor_pools_for_plan(
     udf_nodes = plan.collect_udf_nodes(conn=conn)
     return _create_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -409,7 +409,7 @@ def prepare_actor_pools_for_plan(
 def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -425,7 +425,7 @@ def ensure_actor_pools_for_nodes(
 ) -> tuple[list[UDFActorPoolBase], dict[str, Any]]:
     return _create_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_stage=actor_node_ids_by_stage,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -445,7 +445,7 @@ def ensure_actor_pools_for_nodes(
 def _create_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_stage: dict[str, tuple[str, ...]],
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -504,15 +504,15 @@ def _create_actor_pools_for_nodes(
             if not requires_actor_pool_fn(payload):
                 continue
 
-            stage_id = str(payload.get("stage_id") or "").strip()
-            if not stage_id:
-                raise RuntimeError(f"Ray actor UDF node {node_id} is missing stage_id")
+            resource_unit_id = str(payload.get("resource_unit_id") or "").strip()
+            if not resource_unit_id:
+                raise RuntimeError(f"Ray actor UDF node {node_id} is missing resource_unit_id")
             concurrency = required_positive_int(node, "actor_pool_size")
             _validate_stateful_actor_pool_contract(payload, concurrency)
-            assigned_node_ids = tuple(actor_node_ids_by_stage.get(stage_id, ()))
+            assigned_node_ids = tuple(actor_node_ids_by_unit.get(resource_unit_id, ()))
             if len(assigned_node_ids) != concurrency:
                 raise RuntimeError(
-                    f"Ray actor UDF stage {stage_id} requires {concurrency} coordinator placements, "
+                    f"Ray actor UDF resource unit {resource_unit_id} requires {concurrency} coordinator placements, "
                     f"got {len(assigned_node_ids)}"
                 )
             cpus = resolve_actor_num_cpus(payload)

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -5,18 +5,11 @@ from __future__ import annotations
 
 import math
 import os
+import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
-from duckdb.runners.ray.safe_get import (
-    configured_ray_get_timeout_s,
-    resolve_object_refs_blocking,
-)
-
-_DEFAULT_RAY_ACTOR_INIT_TIMEOUT_S = 60.0
 
 from duckdb.execution.udf_ray_config import (
     MAX_ACTOR_RESTARTS,
@@ -26,6 +19,11 @@ from duckdb.execution.udf_threading import (
     RAY_ACTOR_THREAD_POLICY_ENV,
     ray_actor_thread_env,
     ray_actor_thread_policy,
+)
+from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
+from duckdb.runners.ray.safe_get import (
+    configured_ray_get_timeout_s,
+    resolve_object_refs_blocking,
 )
 
 
@@ -85,7 +83,7 @@ class UDFActorPoolBase:
         payload: dict[str, Any],
         concurrency: int,
         gpus_per_actor: float,
-        actor_node_ids: list[str],
+        actor_node_ids: list[str] | None,
         ray_options: dict[str, Any] | None = None,
         max_restarts: int = MAX_ACTOR_RESTARTS,
         max_task_retries: int = MAX_ACTOR_TASK_RETRIES,
@@ -99,7 +97,7 @@ class UDFActorPoolBase:
         Actor = self._actor_class(max_restarts, max_task_retries)
         options = dict(ray_options or {})
         if "scheduling_strategy" in options:
-            raise ValueError("UDF actor scheduling_strategy is owned by the query coordinator")
+            raise ValueError("UDF actor scheduling_strategy is owned by Vane")
         options["num_cpus"] = self._resolve_actor_num_cpus(payload)
         options["num_gpus"] = gpus_per_actor
         options.pop("memory", None)
@@ -117,13 +115,16 @@ class UDFActorPoolBase:
             actor_node_ids,
             expected_count=concurrency,
         )
-        if normalized_node_ids is None or any(not str(node_id).strip() for node_id in normalized_node_ids):
-            raise ValueError("every UDF actor requires a coordinator-selected Ray node_id")
-        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+        actor_options: list[dict[str, Any]] = []
+        if normalized_node_ids is None:
+            # Ray Core owns actual actor placement. If a fixed pool does not
+            # fit immediately, handles remain PENDING instead of making the
+            # query-wide reservation a hard admission gate.
+            actor_options = [dict(options) for _ in range(concurrency)]
+        else:
+            from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
-        actor_options = []
-        for node_id in normalized_node_ids:
-            actor_options.append(
+            actor_options = [
                 {
                     **options,
                     "scheduling_strategy": NodeAffinitySchedulingStrategy(
@@ -131,9 +132,10 @@ class UDFActorPoolBase:
                         soft=False,
                     ),
                 }
-            )
+                for node_id in normalized_node_ids
+            ]
         self._owns_actors = True
-        self.actor_node_ids: list[str] | None = normalized_node_ids
+        self.actor_node_ids: list[str] = [""] * concurrency if normalized_node_ids is None else normalized_node_ids
         self._payload = payload
 
         import ray
@@ -161,6 +163,9 @@ class UDFActorPoolBase:
                 ) from creation_error
             raise
         self._confirmed_ready: set[int] = set()
+        self._vane_retired = False
+        self._vane_readiness_futures: list[Any] = []
+        self._vane_init_errors: dict[int, BaseException] = {}
 
     @staticmethod
     def _actor_class(max_restarts: int, max_task_retries: int) -> Any:
@@ -194,6 +199,7 @@ class UDFActorPoolBase:
         payload: dict[str, Any] | None = None,
         actor_node_ids: list[str] | None = None,
         actor_dispatch_indices: list[int] | tuple[int, ...] | set[int] | None = None,
+        actor_init_refs: list[Any] | tuple[Any, ...] | None = None,
     ) -> UDFActorPoolBase:
         _validate_stateful_actor_pool_contract(payload, len(actors))
         if actor_dispatch_indices is None:
@@ -210,10 +216,22 @@ class UDFActorPoolBase:
         if invalid:
             raise ValueError(f"actor_dispatch_indices contains out-of-range indices: {invalid}")
         instance._confirmed_ready = set(parsed_dispatch_indices)
+        instance._vane_retired = False
+        instance._vane_readiness_futures = []
+        instance._vane_init_errors = {}
         instance._payload = payload or {}
         instance._payload_ref = None
-        instance._init_refs = []
-        instance.actor_node_ids = cls._normalize_actor_node_ids(actor_node_ids, expected_count=len(actors))
+        init_refs = [] if actor_init_refs is None else list(actor_init_refs)
+        if init_refs and len(init_refs) != len(actors):
+            raise ValueError("actor_init_refs count must match actor handle count")
+        instance._init_refs = init_refs
+        if actor_node_ids is None:
+            instance.actor_node_ids = [""] * len(actors)
+        else:
+            parsed_node_ids = [str(node_id or "").strip() for node_id in actor_node_ids]
+            if len(parsed_node_ids) != len(actors):
+                raise ValueError("actor node IDs count must match actor handle count")
+            instance.actor_node_ids = parsed_node_ids
         return instance
 
     def shutdown(self, *, kill: bool = False) -> None:
@@ -239,12 +257,13 @@ def apply_actor_node_options(
     actors: UDFActorPoolBase,
     *,
     options: dict[str, Any],
-    normalize_actor_node_ids: Callable[..., list[str] | None],
 ) -> UDFActorPoolBase:
-    normalized_node_ids = normalize_actor_node_ids(
-        options.get("actor_node_ids"),
-        expected_count=len(actors.actors),
-    )
+    raw_node_ids = options.get("actor_node_ids")
+    if not isinstance(raw_node_ids, list | tuple):
+        raise TypeError("actor_node_ids must be a list or tuple")
+    normalized_node_ids = [str(node_id or "").strip() for node_id in raw_node_ids]
+    if len(normalized_node_ids) != len(actors.actors):
+        raise ValueError("actor node IDs count must match actor handle count")
     actors.actor_node_ids = normalized_node_ids
     return actors
 
@@ -264,9 +283,7 @@ def _positive_float_env(name: str, default: float | None = None) -> float | None
 
 
 def _actor_init_timeout_s() -> float | None:
-    return configured_ray_get_timeout_s(
-        _positive_float_env("VANE_RAY_ACTOR_INIT_TIMEOUT_S", _DEFAULT_RAY_ACTOR_INIT_TIMEOUT_S)
-    )
+    return configured_ray_get_timeout_s(_positive_float_env("VANE_RAY_ACTOR_INIT_TIMEOUT_S"))
 
 
 def _is_timeout_error(exc: BaseException) -> bool:
@@ -306,9 +323,12 @@ def _resolve_actor_pool_init_refs(ray: Any, actors_obj: Any) -> None:
     try:
         timeout_s = _actor_init_timeout_s()
         if timeout_s is None:
-            resolve_object_refs_blocking(refs)
+            resolved_node_ids = resolve_object_refs_blocking(refs)
         else:
-            resolve_object_refs_blocking(refs, timeout=timeout_s)
+            resolved_node_ids = resolve_object_refs_blocking(refs, timeout=timeout_s)
+        node_ids = [str(node_id or "").strip() for node_id in resolved_node_ids]
+        if len(node_ids) != len(actors) or any(not node_id for node_id in node_ids):
+            raise RuntimeError("UDF actor initialization did not return one Ray node_id per actor")
     except Exception as exc:
         if _is_timeout_error(exc):
             timeout_desc = "query deadline" if timeout_s is None else f"{timeout_s:.3f}s"
@@ -328,7 +348,85 @@ def _resolve_actor_pool_init_refs(ray: Any, actors_obj: Any) -> None:
                 creation_error=readiness_error,
             ) from exc
         raise readiness_error from exc
+    actors_obj.actor_node_ids = node_ids
     actors_obj._confirmed_ready.update(range(len(actors)))
+
+
+def wait_for_first_actor_pool_ready(actors_obj: UDFActorPoolBase) -> dict[int, str]:
+    """Wait until at least one actor is usable, leaving the rest pending.
+
+    Actor CPU/GPU/declared heap are Ray Core resources.  A pool larger than
+    the currently free cluster capacity therefore starts incrementally: the
+    first successfully initialized actor opens execution while remaining
+    handles stay pending and may join later.
+    """
+
+    refs = list(getattr(actors_obj, "_init_refs", ()))
+    actors = list(getattr(actors_obj, "actors", ()))
+    if len(refs) != len(actors) or not refs or any(ref is None for ref in refs):
+        raise RuntimeError("UDF actor pool has incomplete init readiness refs")
+
+    import ray
+
+    pending = list(refs)
+    actor_index_by_ref = {ref: actor_index for actor_index, ref in enumerate(refs)}
+    timeout_s = _actor_init_timeout_s()
+    deadline = None if timeout_s is None else time.monotonic() + timeout_s
+    failures: list[BaseException] = []
+    try:
+        while pending:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            ready, pending = ray.wait(
+                pending,
+                num_returns=1,
+                timeout=remaining,
+            )
+            if not ready:
+                timeout_desc = "query deadline" if timeout_s is None else f"{timeout_s:.3f}s"
+                raise RuntimeError(
+                    "UDF actor pool initialization timed out "
+                    f"after {timeout_desc} while waiting for its first ready actor"
+                )
+            ready_refs = list(ready)
+            if pending:
+                immediately_ready, pending = ray.wait(
+                    pending,
+                    num_returns=len(pending),
+                    timeout=0,
+                )
+                ready_refs.extend(immediately_ready)
+            ready_nodes: dict[int, str] = {}
+            for ref in ready_refs:
+                actor_index = actor_index_by_ref[ref]
+                try:
+                    node_id = str(resolve_object_refs_blocking(ref) or "").strip()
+                    if not node_id:
+                        raise RuntimeError("UDF actor initialization returned an empty Ray node_id")
+                except BaseException as exc:
+                    failures.append(exc)
+                    continue
+                actors_obj.actor_node_ids[actor_index] = node_id
+                actors_obj._confirmed_ready.add(actor_index)
+                ready_nodes[actor_index] = node_id
+            if ready_nodes:
+                return ready_nodes
+        if failures:
+            raise RuntimeError(
+                "all UDF actors failed during initialization: "
+                + "; ".join(f"{type(exc).__name__}: {exc}" for exc in failures[:3])
+            ) from failures[0]
+        raise RuntimeError("all UDF actors finished initialization without becoming ready")
+    except BaseException as readiness_error:
+        try:
+            _shutdown_owned_actors(ray, actors_obj)
+        except BaseException as cleanup_error:
+            raise _OwnedUDFActorPoolsError(
+                "UDF actor pool initialization failed and actor cleanup also failed: "
+                f"initialization={readiness_error}; cleanup={type(cleanup_error).__name__}: {cleanup_error}",
+                owned_actor_pools=[actors_obj],
+                creation_error=readiness_error,
+            ) from readiness_error
+        raise
 
 
 def ensure_actor_pools_for_plan(
@@ -447,6 +545,42 @@ def ensure_actor_pools_for_nodes(
     )
 
 
+def prepare_actor_pools_for_nodes(
+    udf_nodes: Any,
+    *,
+    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
+    query_driver_handle: Any,
+    query_generation_capability: str,
+    session_config: dict[str, str],
+    set_handles: Callable[[dict[str, Any]], None] | None = None,
+    actor_pool_cls: type[UDFActorPoolBase],
+    is_vane_worker_process: Callable[[], bool],
+    requires_actor_pool_fn: Callable[[dict[str, Any]], bool],
+    normalize_actor_pool_payload: Callable[..., dict[str, Any]],
+    payload_num_gpus: Callable[[dict[str, Any]], float],
+    required_positive_int: Callable[[dict[str, Any], str], int],
+    resolve_actor_num_cpus: Callable[[dict[str, Any]], float],
+    build_udf_executor_options: Callable[..., dict[str, Any]],
+) -> tuple[list[UDFActorPoolBase], dict[str, Any]]:
+    return _create_actor_pools_for_nodes(
+        udf_nodes,
+        actor_node_ids_by_unit=actor_node_ids_by_unit,
+        query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
+        session_config=session_config,
+        set_handles=set_handles,
+        actor_pool_cls=actor_pool_cls,
+        is_vane_worker_process=is_vane_worker_process,
+        requires_actor_pool_fn=requires_actor_pool_fn,
+        normalize_actor_pool_payload=normalize_actor_pool_payload,
+        payload_num_gpus=payload_num_gpus,
+        required_positive_int=required_positive_int,
+        resolve_actor_num_cpus=resolve_actor_num_cpus,
+        build_udf_executor_options=build_udf_executor_options,
+        wait_for_ready=False,
+    )
+
+
 def _create_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
@@ -515,9 +649,10 @@ def _create_actor_pools_for_nodes(
             concurrency = required_positive_int(node, "actor_pool_size")
             _validate_stateful_actor_pool_contract(payload, concurrency)
             assigned_node_ids = tuple(actor_node_ids_by_unit.get(resource_unit_id, ()))
-            if len(assigned_node_ids) != concurrency:
+            if assigned_node_ids and len(assigned_node_ids) != concurrency:
                 raise RuntimeError(
-                    f"Ray actor UDF resource unit {resource_unit_id} requires {concurrency} coordinator placements, "
+                    f"Ray actor UDF resource unit {resource_unit_id} requires either no fixed placement or "
+                    f"{concurrency} explicit placements, "
                     f"got {len(assigned_node_ids)}"
                 )
             cpus = resolve_actor_num_cpus(payload)
@@ -539,20 +674,21 @@ def _create_actor_pools_for_nodes(
                 payload=payload,
                 concurrency=concurrency,
                 gpus_per_actor=gpus,
-                actor_node_ids=list(assigned_node_ids),
+                actor_node_ids=(list(assigned_node_ids) if assigned_node_ids else None),
                 ray_options=ray_options,
                 **fault_tolerance_options,
             )
             created.append(actors_obj)
             if wait_for_ready:
                 _resolve_actor_pool_init_refs(ray, actors_obj)
-            actor_node_ids = list(assigned_node_ids)
-            actor_dispatch_indices = set(range(len(actors_obj.actors)))
+            actor_node_ids = list(actors_obj.actor_node_ids)
+            actor_dispatch_indices = set(actors_obj._confirmed_ready)
             executor_options.update(
                 build_udf_executor_options(
                     actor_handles=list(actors_obj.actors),
                     actor_node_ids=actor_node_ids,
                     actor_dispatch_indices=actor_dispatch_indices,
+                    actor_init_refs=list(actors_obj._init_refs),
                 )
             )
 

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -125,9 +125,10 @@ class UDFActorPoolBase:
         )
         actor_options: list[dict[str, Any]] = []
         if normalized_node_ids is None:
-            # Ray Core owns actual actor placement. If a fixed pool does not
-            # fit immediately, handles remain PENDING instead of making the
-            # query-wide reservation a hard admission gate.
+            # Ray Core owns actual actor placement. Query admission proves that
+            # at least one actor of this shape can run on a concrete node; the
+            # remaining fixed-pool handles may stay PENDING instead of turning
+            # full pool multiplicity into a hard admission gate.
             actor_options = [dict(options) for _ in range(concurrency)]
         else:
             from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import os
+import secrets
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +22,13 @@ from duckdb.execution.udf_threading import (
     ray_actor_thread_policy,
 )
 from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
+from duckdb.runners.ray.query_runtime_protocol import (
+    RAY_ACTOR_GENERATION_CAPABILITY_ENV,
+    RAY_ACTOR_INDEX_ENV,
+    RAY_ACTOR_POOL_NONCE_ENV,
+    RAY_ACTOR_QUERY_ID_ENV,
+    RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
+)
 from duckdb.runners.ray.safe_get import (
     configured_ray_get_timeout_s,
     resolve_object_refs_blocking,
@@ -134,6 +142,12 @@ class UDFActorPoolBase:
                 }
                 for node_id in normalized_node_ids
             ]
+        for actor_index, actor_option in enumerate(actor_options):
+            runtime_env = dict(actor_option.get("runtime_env") or {})
+            env_vars = dict(runtime_env.get("env_vars") or {})
+            env_vars[RAY_ACTOR_INDEX_ENV] = str(actor_index)
+            runtime_env["env_vars"] = env_vars
+            actor_option["runtime_env"] = runtime_env
         self._owns_actors = True
         self.actor_node_ids: list[str] = [""] * concurrency if normalized_node_ids is None else normalized_node_ids
         self._payload = payload
@@ -646,6 +660,9 @@ def _create_actor_pools_for_nodes(
             resource_unit_id = str(payload.get("resource_unit_id") or "").strip()
             if not resource_unit_id:
                 raise RuntimeError(f"Ray actor UDF node {node_id} is missing resource_unit_id")
+            query_id = str(payload.get("query_id") or "").strip()
+            if not query_id:
+                raise RuntimeError(f"Ray actor UDF node {node_id} is missing query_id")
             concurrency = required_positive_int(node, "actor_pool_size")
             _validate_stateful_actor_pool_contract(payload, concurrency)
             assigned_node_ids = tuple(actor_node_ids_by_unit.get(resource_unit_id, ()))
@@ -656,10 +673,17 @@ def _create_actor_pools_for_nodes(
                     f"got {len(assigned_node_ids)}"
                 )
             cpus = resolve_actor_num_cpus(payload)
+            actor_location_nonce = secrets.token_urlsafe(32)
             ray_options = {
                 "num_cpus": cpus,
                 "runtime_env": {
-                    "env_vars": session_runtime_env_vars,
+                    "env_vars": {
+                        **session_runtime_env_vars,
+                        RAY_ACTOR_QUERY_ID_ENV: query_id,
+                        RAY_ACTOR_RESOURCE_UNIT_ID_ENV: resource_unit_id,
+                        RAY_ACTOR_POOL_NONCE_ENV: actor_location_nonce,
+                        RAY_ACTOR_GENERATION_CAPABILITY_ENV: generation_capability,
+                    },
                 },
             }
 
@@ -678,6 +702,7 @@ def _create_actor_pools_for_nodes(
                 ray_options=ray_options,
                 **fault_tolerance_options,
             )
+            actors_obj._vane_location_nonce = actor_location_nonce
             created.append(actors_obj)
             if wait_for_ready:
                 _resolve_actor_pool_init_refs(ray, actors_obj)

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -91,7 +91,6 @@ class UDFActorPoolBase:
         payload: dict[str, Any],
         concurrency: int,
         gpus_per_actor: float,
-        actor_node_ids: list[str] | None,
         ray_options: dict[str, Any] | None = None,
         max_restarts: int = MAX_ACTOR_RESTARTS,
         max_task_retries: int = MAX_ACTOR_TASK_RETRIES,
@@ -105,7 +104,7 @@ class UDFActorPoolBase:
         Actor = self._actor_class(max_restarts, max_task_retries)
         options = dict(ray_options or {})
         if "scheduling_strategy" in options:
-            raise ValueError("UDF actor scheduling_strategy is owned by Vane")
+            raise ValueError("UDF actor scheduling_strategy must leave placement to Ray Core")
         options["num_cpus"] = self._resolve_actor_num_cpus(payload)
         options["num_gpus"] = gpus_per_actor
         options.pop("memory", None)
@@ -119,30 +118,9 @@ class UDFActorPoolBase:
             payload,
         )
         options["runtime_env"] = runtime_env
-        normalized_node_ids = self._normalize_actor_node_ids(
-            actor_node_ids,
-            expected_count=concurrency,
-        )
-        actor_options: list[dict[str, Any]] = []
-        if normalized_node_ids is None:
-            # Ray Core owns actual actor placement. Query admission proves that
-            # at least one actor of this shape can run on a concrete node; the
-            # remaining fixed-pool handles may stay PENDING instead of turning
-            # full pool multiplicity into a hard admission gate.
-            actor_options = [dict(options) for _ in range(concurrency)]
-        else:
-            from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-
-            actor_options = [
-                {
-                    **options,
-                    "scheduling_strategy": NodeAffinitySchedulingStrategy(
-                        node_id=str(node_id),
-                        soft=False,
-                    ),
-                }
-                for node_id in normalized_node_ids
-            ]
+        # Submit the real actor requests without a Vane-selected node. Ray Core
+        # owns placement, pending demand, autoscaling, and reconstruction.
+        actor_options = [dict(options) for _ in range(concurrency)]
         for actor_index, actor_option in enumerate(actor_options):
             runtime_env = dict(actor_option.get("runtime_env") or {})
             env_vars = dict(runtime_env.get("env_vars") or {})
@@ -150,7 +128,7 @@ class UDFActorPoolBase:
             runtime_env["env_vars"] = env_vars
             actor_option["runtime_env"] = runtime_env
         self._owns_actors = True
-        self.actor_node_ids: list[str] = [""] * concurrency if normalized_node_ids is None else normalized_node_ids
+        self.actor_node_ids: list[str] = [""] * concurrency
         self._payload = payload
 
         import ray
@@ -197,14 +175,6 @@ class UDFActorPoolBase:
 
     @staticmethod
     def _build_actor_runtime_env(ray_options: dict[str, Any] | None) -> dict[str, Any]:
-        raise NotImplementedError
-
-    @staticmethod
-    def _normalize_actor_node_ids(
-        node_ids: list[str] | None,
-        *,
-        expected_count: int,
-    ) -> list[str] | None:
         raise NotImplementedError
 
     @classmethod
@@ -450,7 +420,6 @@ def ensure_actor_pools_for_plan(
     plan: Any,
     conn: Any = None,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -466,7 +435,6 @@ def ensure_actor_pools_for_plan(
     udf_nodes = plan.collect_udf_nodes(conn=conn)
     return ensure_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -486,7 +454,6 @@ def prepare_actor_pools_for_plan(
     plan: Any,
     conn: Any = None,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -509,7 +476,6 @@ def prepare_actor_pools_for_plan(
     udf_nodes = plan.collect_udf_nodes(conn=conn)
     return _create_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -529,7 +495,6 @@ def prepare_actor_pools_for_plan(
 def ensure_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -545,7 +510,6 @@ def ensure_actor_pools_for_nodes(
 ) -> tuple[list[UDFActorPoolBase], dict[str, Any]]:
     return _create_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -565,7 +529,6 @@ def ensure_actor_pools_for_nodes(
 def prepare_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -581,7 +544,6 @@ def prepare_actor_pools_for_nodes(
 ) -> tuple[list[UDFActorPoolBase], dict[str, Any]]:
     return _create_actor_pools_for_nodes(
         udf_nodes,
-        actor_node_ids_by_unit=actor_node_ids_by_unit,
         query_driver_handle=query_driver_handle,
         query_generation_capability=query_generation_capability,
         session_config=session_config,
@@ -601,7 +563,6 @@ def prepare_actor_pools_for_nodes(
 def _create_actor_pools_for_nodes(
     udf_nodes: Any,
     *,
-    actor_node_ids_by_unit: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
     query_generation_capability: str,
     session_config: dict[str, str],
@@ -668,13 +629,6 @@ def _create_actor_pools_for_nodes(
                 raise RuntimeError(f"Ray actor UDF node {node_id} is missing query_id")
             concurrency = required_positive_int(node, "actor_pool_size")
             _validate_stateful_actor_pool_contract(payload, concurrency)
-            assigned_node_ids = tuple(actor_node_ids_by_unit.get(resource_unit_id, ()))
-            if assigned_node_ids and len(assigned_node_ids) != concurrency:
-                raise RuntimeError(
-                    f"Ray actor UDF resource unit {resource_unit_id} requires either no fixed placement or "
-                    f"{concurrency} explicit placements, "
-                    f"got {len(assigned_node_ids)}"
-                )
             cpus = resolve_actor_num_cpus(payload)
             actor_location_nonce = secrets.token_urlsafe(32)
             ray_options = {
@@ -701,7 +655,6 @@ def _create_actor_pools_for_nodes(
                 payload=payload,
                 concurrency=concurrency,
                 gpus_per_actor=gpus,
-                actor_node_ids=(list(assigned_node_ids) if assigned_node_ids else None),
                 ray_options=ray_options,
                 **fault_tolerance_options,
             )

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -21,7 +21,6 @@ from duckdb.execution.udf_threading import (
     ray_actor_thread_env,
     ray_actor_thread_policy,
 )
-from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 from duckdb.runners.ray.query_runtime_protocol import (
     RAY_ACTOR_GENERATION_CAPABILITY_ENV,
     RAY_ACTOR_INDEX_ENV,
@@ -29,6 +28,7 @@ from duckdb.runners.ray.query_runtime_protocol import (
     RAY_ACTOR_QUERY_ID_ENV,
     RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
 )
+from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 from duckdb.runners.ray.safe_get import (
     configured_ray_get_timeout_s,
     resolve_object_refs_blocking,
@@ -178,6 +178,7 @@ class UDFActorPoolBase:
             raise
         self._confirmed_ready: set[int] = set()
         self._vane_retired = False
+        self._vane_location_nonce = ""
         self._vane_readiness_futures: list[Any] = []
         self._vane_init_errors: dict[int, BaseException] = {}
 
@@ -231,6 +232,7 @@ class UDFActorPoolBase:
             raise ValueError(f"actor_dispatch_indices contains out-of-range indices: {invalid}")
         instance._confirmed_ready = set(parsed_dispatch_indices)
         instance._vane_retired = False
+        instance._vane_location_nonce = ""
         instance._vane_readiness_futures = []
         instance._vane_init_errors = {}
         instance._payload = payload or {}

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -102,7 +102,12 @@ class UDFActorPoolBase:
             raise ValueError("UDF actor scheduling_strategy is owned by the query coordinator")
         options["num_cpus"] = self._resolve_actor_num_cpus(payload)
         options["num_gpus"] = gpus_per_actor
-        options["memory"] = self._resolve_actor_memory_bytes(payload)
+        options.pop("memory", None)
+        memory_bytes = int(self._resolve_actor_memory_bytes(payload))
+        if memory_bytes < 0:
+            raise ValueError("memory_bytes must be non-negative")
+        if memory_bytes > 0:
+            options["memory"] = memory_bytes
         runtime_env = _with_actor_thread_env(
             self._build_actor_runtime_env(options),
             payload,

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -54,9 +54,9 @@ def _actor_debug_log(event: str, payload: dict[str, Any] | None = None, **fields
     query_id = payload.get("query_id")
     if query_id:
         parts.append(f"query_id={query_id}")
-    stage_id = payload.get("stage_id")
-    if stage_id:
-        parts.append(f"stage_id={stage_id}")
+    resource_unit_id = payload.get("resource_unit_id")
+    if resource_unit_id:
+        parts.append(f"resource_unit_id={resource_unit_id}")
     backend = payload.get("backend")
     if backend:
         parts.append(f"backend={backend}")

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -27,10 +27,19 @@ from duckdb.execution.udf_ray_stream_protocol import (
     iter_bounded_stream_blocks,
     make_stream_block_metadata,
     make_stream_error_pair,
-    validate_task_runtime_node,
 )
 from duckdb.execution.udf_threading import configure_ray_actor_loaded_torch_threads
 from duckdb.runners.ray.ray_env import install_explicit_session_runtime_env
+from duckdb.runners.ray.query_runtime_protocol import (
+    RAY_ACTOR_GENERATION_CAPABILITY_ENV,
+    RAY_ACTOR_INDEX_ENV,
+    RAY_ACTOR_POOL_NONCE_ENV,
+    RAY_ACTOR_QUERY_ID_ENV,
+    RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
+    RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
+    query_runtime_actor_name,
+    ray_runtime_job_id,
+)
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
 
@@ -88,6 +97,98 @@ def _materialize_ref_bundle(
     return _apply_ref_bundle_slices(blocks, slices, metadata=metadata, names=names)
 
 
+def _reconstructed_actor_location_report(
+    runtime_context: Any,
+    *,
+    expected_payload: dict[str, Any] | None = None,
+    wait: bool,
+) -> Any | None:
+    if not bool(runtime_context.was_current_actor_reconstructed):
+        return None
+
+    values = {
+        "query_id": os.environ.get(RAY_ACTOR_QUERY_ID_ENV, "").strip(),
+        "resource_unit_id": os.environ.get(RAY_ACTOR_RESOURCE_UNIT_ID_ENV, "").strip(),
+        "pool_nonce": os.environ.get(RAY_ACTOR_POOL_NONCE_ENV, "").strip(),
+        "generation_capability": os.environ.get(RAY_ACTOR_GENERATION_CAPABILITY_ENV, "").strip(),
+        "actor_index": os.environ.get(RAY_ACTOR_INDEX_ENV, "").strip(),
+    }
+    missing = sorted(key for key, value in values.items() if not value)
+    if missing:
+        raise RuntimeError("reconstructed Ray actor is missing location protocol environment: " + ", ".join(missing))
+    try:
+        actor_index = int(values["actor_index"])
+    except ValueError as exc:
+        raise RuntimeError("reconstructed Ray actor has an invalid actor index") from exc
+    if actor_index < 0:
+        raise RuntimeError("reconstructed Ray actor has a negative actor index")
+    if expected_payload is not None:
+        expected_query_id = str(expected_payload.get("query_id") or "").strip()
+        expected_resource_unit_id = str(expected_payload.get("resource_unit_id") or "").strip()
+        expected_actor_index = expected_payload.get("actor_index")
+        if (
+            values["query_id"] != expected_query_id
+            or values["resource_unit_id"] != expected_resource_unit_id
+            or isinstance(expected_actor_index, bool)
+            or not isinstance(expected_actor_index, int)
+            or actor_index != expected_actor_index
+        ):
+            raise RuntimeError("reconstructed Ray actor location does not match its task lease")
+
+    node_id = str(runtime_context.get_node_id() or "").strip()
+    if not node_id:
+        raise RuntimeError("reconstructed Ray actor runtime did not expose node_id")
+    import ray
+
+    driver = ray.get_actor(
+        query_runtime_actor_name(ray_runtime_job_id(runtime_context)),
+        namespace=RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
+    )
+    report_ref = driver.report_query_udf_actor_location.remote(
+        {
+            "query_id": values["query_id"],
+            "resource_unit_id": values["resource_unit_id"],
+            "actor_index": actor_index,
+            "pool_nonce": values["pool_nonce"],
+            "node_id": node_id,
+        },
+        values["generation_capability"],
+    )
+    if not wait:
+        return report_ref
+    result = resolve_object_refs_blocking(report_ref)
+    if not isinstance(result, dict):
+        raise RuntimeError("Ray actor location reconciliation returned an invalid result")
+    if not bool(result.get("accepted")) or str(result.get("node_id") or "").strip() != node_id:
+        raise RuntimeError("Ray query no longer accepts this reconstructed actor location")
+    return report_ref
+
+
+def _validate_actor_task_runtime_node(payload: dict[str, Any]) -> str:
+    expected_node_id = str(payload.get("node_id") or "").strip()
+    if not expected_node_id:
+        raise RuntimeError("distributed Ray UDF task payload is missing leased node_id")
+    import ray
+
+    runtime_context = ray.get_runtime_context()
+    actual_node_id = str(runtime_context.get_node_id() or "").strip()
+    if not actual_node_id:
+        raise RuntimeError("Ray runtime context did not expose the executing node_id")
+    if actual_node_id == expected_node_id:
+        return actual_node_id
+    report_ref = _reconstructed_actor_location_report(
+        runtime_context,
+        expected_payload=payload,
+        wait=True,
+    )
+    if report_ref is None:
+        raise RuntimeError(
+            "distributed Ray UDF executed outside its query lease: "
+            f"expected_node_id={expected_node_id} actual_node_id={actual_node_id}"
+        )
+    return actual_node_id
+
+
 def _payload_requires_ray_block_stream(payload: dict[str, Any] | None) -> bool:
     payload = payload or {}
     if not bool(payload.get("produce_ray_block_stream", False)):
@@ -112,6 +213,20 @@ def _actor_class(
             # Payload is injected via init_payload() immediately after creation.
             self._payload: dict[str, Any] | None = None
             self.executor: RuntimeUDFExecutor | None = None  # lazy init on first streaming submission
+            self._vane_location_report_ref: Any | None = None
+            self._vane_location_report_error: BaseException | None = None
+            try:
+                import ray
+
+                self._vane_location_report_ref = _reconstructed_actor_location_report(
+                    ray.get_runtime_context(),
+                    wait=False,
+                )
+            except BaseException as exc:
+                # Do not turn a transient driver lookup race into another Ray
+                # actor reconstruction. The first retried invocation performs
+                # the same report synchronously before executing user code.
+                self._vane_location_report_error = exc
 
         def init_payload(self, payload: dict[str, Any]) -> str:
             """Inject payload after construction to avoid Ray object-store GC issues."""
@@ -180,7 +295,7 @@ def _actor_class(
             effective_payload: dict[str, Any],
         ) -> Iterator[Any]:
             _payload_requires_ray_block_stream(effective_payload)
-            validate_task_runtime_node(effective_payload)
+            _validate_actor_task_runtime_node(effective_payload)
             executor = self.executor
             if executor is None:
                 _actor_debug_log("executor_init_start", effective_payload, path="run_block_stream")
@@ -268,11 +383,17 @@ def _actor_class(
             metadata: Any = None,
             names: Any = None,
         ) -> Iterator[Any]:
-            base_payload = payload or self._payload or {}
+            effective_payload = dict(payload or self._payload or {})
             try:
+                # A reconstructed actor may have moved to another Ray node. Move
+                # the resident slot and any prefetched task lease in QRM before
+                # resolving input ObjectRefs on that node, not merely before the
+                # user callable starts. Carry the reconciled node into the nested
+                # block-stream call so it does not report the same move twice.
+                effective_payload["node_id"] = _validate_actor_task_runtime_node(effective_payload)
                 _actor_debug_log(
                     "run_ref_bundle_stream_start",
-                    base_payload,
+                    effective_payload,
                     blocks=len(blocks or []),
                     slices=len(slices or []),
                     metadata=len(metadata or []),
@@ -283,18 +404,18 @@ def _actor_class(
                 args = _apply_ref_bundle_slices(blocks, slices, metadata=metadata, names=names)
                 _actor_debug_log(
                     "run_ref_bundle_stream_materialized",
-                    base_payload,
+                    effective_payload,
                     rows=args.num_rows,
                     columns=args.num_columns,
                     materialize_s=f"{time.perf_counter() - materialize_start:.6f}",
                 )
                 for result in self.run_block_stream(
                     args,
-                    payload=payload,
+                    payload=effective_payload,
                 ):
                     yield result
             except Exception as exc:
-                error_block, error_metadata = make_stream_error_pair(base_payload, exc)
+                error_block, error_metadata = make_stream_error_pair(effective_payload, exc)
                 yield error_block
                 yield error_metadata
 

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -113,7 +113,7 @@ def _actor_class(
             self._payload: dict[str, Any] | None = None
             self.executor: RuntimeUDFExecutor | None = None  # lazy init on first streaming submission
 
-        def init_payload(self, payload: dict[str, Any]) -> None:
+        def init_payload(self, payload: dict[str, Any]) -> str:
             """Inject payload after construction to avoid Ray object-store GC issues."""
             self._payload = payload
             _actor_debug_log("init_payload", self._payload)
@@ -128,6 +128,12 @@ def _actor_class(
                 if _eager_actor_warm_up_enabled(self._payload):
                     executor.warm_up()
                 _actor_debug_log("executor_init_done", self._payload, path="init_payload")
+            import ray
+
+            node_id = str(ray.get_runtime_context().get_node_id() or "").strip()
+            if not node_id:
+                raise RuntimeError("Ray actor runtime did not expose node_id after initialization")
+            return node_id
 
         def _ensure_executor(self, effective_payload: dict[str, Any]) -> RuntimeUDFExecutor:
             executor = self.executor

--- a/duckdb/execution/udf_ray_actor_runtime.py
+++ b/duckdb/execution/udf_ray_actor_runtime.py
@@ -29,7 +29,6 @@ from duckdb.execution.udf_ray_stream_protocol import (
     make_stream_error_pair,
 )
 from duckdb.execution.udf_threading import configure_ray_actor_loaded_torch_threads
-from duckdb.runners.ray.ray_env import install_explicit_session_runtime_env
 from duckdb.runners.ray.query_runtime_protocol import (
     RAY_ACTOR_GENERATION_CAPABILITY_ENV,
     RAY_ACTOR_INDEX_ENV,
@@ -40,6 +39,7 @@ from duckdb.runners.ray.query_runtime_protocol import (
     query_runtime_actor_name,
     ray_runtime_job_id,
 )
+from duckdb.runners.ray.ray_env import install_explicit_session_runtime_env
 from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
 
 

--- a/duckdb/execution/udf_ray_env.py
+++ b/duckdb/execution/udf_ray_env.py
@@ -49,26 +49,5 @@ def normalize_actor_pool_payload(
     return normalized
 
 
-def normalize_actor_node_ids(
-    value: Any | None,
-    *,
-    expected_count: int | None = None,
-) -> list[str] | None:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        node_ids = [value]
-    else:
-        try:
-            node_ids = [str(item) if item is not None else "" for item in value]
-        except TypeError as exc:
-            raise ValueError("actor node IDs must be a string or iterable of strings") from exc
-    if expected_count is not None and expected_count >= 0 and len(node_ids) != expected_count:
-        raise ValueError(f"actor node IDs count {len(node_ids)} does not match expected actor count {expected_count}")
-    if any(not node_id.strip() for node_id in node_ids):
-        raise ValueError("actor node IDs must be non-empty strings")
-    return node_ids
-
-
 def resolve_actor_num_cpus(payload: dict[str, Any]) -> float:
     return payload_num_cpus(payload)

--- a/duckdb/execution/udf_ray_remote_readiness.py
+++ b/duckdb/execution/udf_ray_remote_readiness.py
@@ -192,19 +192,16 @@ class RemoteUDFActorReadinessMixin:
             future = future_method() if callable(future_method) else None
             if future is not None and future.done():
                 resolved_node_id = str(self._resolve_object_ref(init_ref) or "").strip()
-                if resolved_node_id != node_key:
-                    raise RuntimeError(
-                        "UDF actor lease slot/node mismatch after readiness resolution: "
-                        f"actor_index={actor_idx} runtime_node={resolved_node_id} leased_node={node_key}"
-                    )
                 self._actor_node_ids[actor_idx] = resolved_node_id
                 self._actors_obj.actor_node_ids[actor_idx] = resolved_node_id
                 self._mark_actor_ready(actor_idx)
         if self._actor_node_ids[actor_idx] != node_key:
-            raise RuntimeError(
-                "UDF actor lease slot/node mismatch: "
-                f"actor_index={actor_idx} expected_node={self._actor_node_ids[actor_idx]} leased_node={node_key}"
-            )
+            # The signed query lease is newer than this executor's immutable
+            # activation snapshot when Ray has reconstructed the actor on
+            # another node. The actor itself synchronously reconciles a stale
+            # prefetch lease before running user code.
+            self._actor_node_ids[actor_idx] = node_key
+            self._actors_obj.actor_node_ids[actor_idx] = node_key
         if actor_idx not in self._ready_actor_set:
             raise RuntimeError(f"UDF actor lease targets actor_index={actor_idx}, but that actor is not ready")
         return actor_idx, self.actors[actor_idx]

--- a/duckdb/execution/udf_ray_remote_readiness.py
+++ b/duckdb/execution/udf_ray_remote_readiness.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import threading
+    from collections import deque
+    from collections.abc import Callable
 
 from duckdb.execution.udf_ray_actor_state import (
     format_stateful_actor_loss as _format_stateful_actor_loss,
@@ -11,9 +16,25 @@ from duckdb.execution.udf_ray_actor_state import (
 
 
 class RemoteUDFActorReadinessMixin:
+    if TYPE_CHECKING:
+        _actor_init_errors: dict[int, BaseException | str]
+        _actor_node_ids: list[str]
+        _actors_obj: Any
+        _pending_ready_refs: dict[Any, int]
+        _ready_actor_indices: list[int]
+        _ready_actor_set: set[int]
+        _ready_probe_refs: deque[Any]
+        _ready_probe_ref_set: set[Any]
+        _ready_refs_cv: threading.Condition
+        _resolve_object_ref: Callable[[Any], Any]
+        actors: list[Any]
+        error_context: Callable[[], dict[str, Any] | None]
+
     def _mark_actor_ready(self, actor_idx: int) -> None:
         if actor_idx in self._ready_actor_set:
             return
+        if actor_idx >= len(self._actor_node_ids) or not self._actor_node_ids[actor_idx]:
+            raise RuntimeError(f"Ray actor {actor_idx} became ready without a runtime node identity")
         self._ready_actor_set.add(actor_idx)
         self._ready_actor_indices.append(actor_idx)
         self._actor_init_errors.pop(actor_idx, None)
@@ -118,10 +139,15 @@ class RemoteUDFActorReadinessMixin:
                 if actor_idx is not None:
                     ready_items.append((ready_ref, actor_idx))
         for ready_ref, actor_idx in ready_items:
-            if actor_idx is None:
-                continue
             try:
-                self._resolve_object_ref(ready_ref)
+                result = self._resolve_object_ref(ready_ref)
+                init_refs = self._actors_obj._init_refs
+                if actor_idx < len(init_refs) and ready_ref == init_refs[actor_idx]:
+                    node_id = str(result or "").strip()
+                    if not node_id:
+                        raise RuntimeError(f"Ray actor {actor_idx} initialization returned an empty node_id")
+                    self._actor_node_ids[actor_idx] = node_id
+                    self._actors_obj.actor_node_ids[actor_idx] = node_id
             except Exception as exc:
                 self._actor_init_errors[actor_idx] = exc
                 continue
@@ -148,14 +174,32 @@ class RemoteUDFActorReadinessMixin:
         )
 
     def _pick_ready_actor_on_node(self, node_id: str, actor_index: int) -> tuple[int, Any]:
+        self._refresh_actor_readiness()
         node_key = str(node_id).strip()
         if not node_key:
             raise RuntimeError("UDF actor invocation requires its leased Ray node_id")
         if not self._actor_node_ids:
-            raise RuntimeError("UDF actor pool is missing coordinator-confirmed node identities")
+            raise RuntimeError("UDF actor pool is missing runtime node identities")
         actor_idx = int(actor_index)
         if actor_idx < 0 or actor_idx >= len(self.actors):
             raise RuntimeError(f"UDF actor lease has invalid actor_index={actor_idx}")
+        if actor_idx not in self._ready_actor_set and actor_idx < len(self._actors_obj._init_refs):
+            # The driver only publishes a slot after this init ref resolves.
+            # Its callback and this executor's callback run independently, so
+            # close the small notification race before consuming the lease.
+            init_ref = self._actors_obj._init_refs[actor_idx]
+            future_method = getattr(init_ref, "future", None)
+            future = future_method() if callable(future_method) else None
+            if future is not None and future.done():
+                resolved_node_id = str(self._resolve_object_ref(init_ref) or "").strip()
+                if resolved_node_id != node_key:
+                    raise RuntimeError(
+                        "UDF actor lease slot/node mismatch after readiness resolution: "
+                        f"actor_index={actor_idx} runtime_node={resolved_node_id} leased_node={node_key}"
+                    )
+                self._actor_node_ids[actor_idx] = resolved_node_id
+                self._actors_obj.actor_node_ids[actor_idx] = resolved_node_id
+                self._mark_actor_ready(actor_idx)
         if self._actor_node_ids[actor_idx] != node_key:
             raise RuntimeError(
                 "UDF actor lease slot/node mismatch: "

--- a/duckdb/execution/udf_ray_stream_protocol.py
+++ b/duckdb/execution/udf_ray_stream_protocol.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import pyarrow as pa
-from _duckdb import __standard_vector_size__ as DUCKDB_STANDARD_VECTOR_SIZE
+from _duckdb import __standard_vector_size__ as DUCKDB_STANDARD_VECTOR_SIZE  # type: ignore[import-not-found]
 
 from duckdb.execution._common import ensure_table, estimate_table_bytes
 
@@ -37,7 +37,7 @@ def validate_task_runtime_node(payload: dict[str, Any]) -> str:
 _RAW_METADATA_FIELDS = {
     "protocol_version",
     "query_id",
-    "producer_stage_id",
+    "producer_unit_id",
     "task_lease_id",
     "attempt_id",
     "block_id",
@@ -49,7 +49,7 @@ _ERROR_METADATA_FIELDS = {
     "protocol_version",
     "event_kind",
     "query_id",
-    "producer_stage_id",
+    "producer_unit_id",
     "task_lease_id",
     "attempt_id",
     "exception_type",
@@ -68,36 +68,38 @@ _PROVIDER_CAPABILITY_DETAIL_FIELDS = {
 
 def _stream_identity(payload: dict[str, Any]) -> tuple[str, str, str, str]:
     query_id = str(payload.get("query_id") or "").strip()
-    stage_id = str(payload.get("stage_id") or "").strip()
+    resource_unit_id = str(payload.get("resource_unit_id") or "").strip()
     task_lease_id = str(payload.get("task_lease_id") or "").strip()
     attempt_id = str(payload.get("attempt_id") or "").strip()
-    if not query_id or not stage_id or not task_lease_id or not attempt_id:
-        raise RuntimeError("Ray UDF stream output requires query_id, stage_id, task_lease_id, and attempt_id")
-    return query_id, stage_id, task_lease_id, attempt_id
+    if not query_id or not resource_unit_id or not task_lease_id or not attempt_id:
+        raise RuntimeError("Ray UDF stream output requires query_id, resource_unit_id, task_lease_id, and attempt_id")
+    return query_id, resource_unit_id, task_lease_id, attempt_id
 
 
 def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> dict[str, Any]:
     """Bind a remote UDF invocation to its pre-admitted task lease."""
     merged = dict(payload)
     query_id = str(lease.get("query_id") or "").strip()
-    stage_id = str(lease.get("stage_id") or "").strip()
+    resource_unit_id = str(lease.get("resource_unit_id") or "").strip()
     lease_id = str(lease.get("lease_id") or "").strip()
     attempt_id = str(lease.get("attempt_id") or "").strip()
     node_id = str(lease.get("node_id") or "").strip()
     execution_slot_id = str(lease.get("execution_slot_id") or "").strip()
     output_window_bytes = int(lease.get("output_window_bytes") or 0)
-    if not query_id or not stage_id or not lease_id or not attempt_id or not node_id or not execution_slot_id:
-        raise ValueError("task lease is missing query, stage, lease, attempt, Ray node, or execution slot identity")
+    if not query_id or not resource_unit_id or not lease_id or not attempt_id or not node_id or not execution_slot_id:
+        raise ValueError(
+            "task lease is missing query, resource unit, lease, attempt, Ray node, or execution slot identity"
+        )
     if str(merged.get("query_id") or "").strip() != query_id:
         raise ValueError("UDF payload query_id does not match task lease")
-    if str(merged.get("stage_id") or "").strip() != stage_id:
-        raise ValueError("UDF payload stage_id does not match task lease")
+    if str(merged.get("resource_unit_id") or "").strip() != resource_unit_id:
+        raise ValueError("UDF payload resource_unit_id does not match task lease")
     backend = str(merged.get("execution_backend") or "").strip()
     raw_actor_index = lease.get("actor_index")
     if backend == "ray_actor":
         if isinstance(raw_actor_index, bool) or not isinstance(raw_actor_index, int) or raw_actor_index < 0:
             raise ValueError("Ray actor task lease is missing a valid actor_index")
-        expected_slot_id = f"ray_actor:{stage_id}:{raw_actor_index}"
+        expected_slot_id = f"ray_actor:{resource_unit_id}:{raw_actor_index}"
         if execution_slot_id != expected_slot_id:
             raise ValueError(
                 "Ray actor task lease execution slot does not match actor_index: "
@@ -106,7 +108,7 @@ def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> d
     elif backend == "ray_task":
         if raw_actor_index is not None:
             raise ValueError("Ray task lease must not contain actor_index")
-        expected_slot_id = f"ray_task:{stage_id}:{lease_id}"
+        expected_slot_id = f"ray_task:{resource_unit_id}:{lease_id}"
         if execution_slot_id != expected_slot_id:
             raise ValueError(
                 "Ray task lease execution slot does not match lease_id: "
@@ -158,10 +160,10 @@ def iter_bounded_stream_blocks(
         yield block
         return
     if block.num_rows <= 1:
-        query_id, stage_id, task_lease_id, attempt_id = _stream_identity(payload)
+        query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
         raise RuntimeError(
             "Ray UDF single output row exceeds the pre-publication block target: "
-            f"query={query_id} stage={stage_id} task_lease={task_lease_id} "
+            f"query={query_id} resource_unit={resource_unit_id} task_lease={task_lease_id} "
             f"attempt={attempt_id} size_bytes={size_bytes} target_bytes={target_bytes}"
         )
 
@@ -186,10 +188,10 @@ def iter_bounded_stream_blocks(
         if best_block is None:
             single_row = block.slice(offset, 1)
             single_row_bytes = max(1, int(estimate_table_bytes(single_row)))
-            query_id, stage_id, task_lease_id, attempt_id = _stream_identity(payload)
+            query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
             raise RuntimeError(
                 "Ray UDF single output row exceeds the pre-publication block target: "
-                f"query={query_id} stage={stage_id} task_lease={task_lease_id} "
+                f"query={query_id} resource_unit={resource_unit_id} task_lease={task_lease_id} "
                 f"attempt={attempt_id} row={offset} size_bytes={single_row_bytes} "
                 f"target_bytes={target_bytes}"
             )
@@ -205,14 +207,14 @@ def make_stream_block_metadata(
 ) -> dict[str, Any]:
     """Build the bounded control object paired with one direct Ray block."""
     block = ensure_table(table)
-    query_id, stage_id, task_lease_id, attempt_id = _stream_identity(payload)
+    query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
     index = int(output_index)
     if index < 0:
         raise ValueError("output_index must be >= 0")
     return {
         "protocol_version": RAY_UDF_STREAM_PROTOCOL_VERSION,
         "query_id": query_id,
-        "producer_stage_id": stage_id,
+        "producer_unit_id": resource_unit_id,
         "task_lease_id": task_lease_id,
         "attempt_id": attempt_id,
         "block_id": f"block:{task_lease_id}:{index}",
@@ -229,7 +231,7 @@ def make_stream_error_pair(
     exc: BaseException,
 ) -> tuple[pa.Table, dict[str, Any]]:
     """Encode an application failure as one bounded block/control pair."""
-    query_id, stage_id, task_lease_id, attempt_id = _stream_identity(payload)
+    query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
     exception_type = type(exc).__name__[:256] or "Exception"
     exception_message = str(exc)
     if len(exception_message) > _MAX_ERROR_TEXT_CHARS:
@@ -250,7 +252,7 @@ def make_stream_error_pair(
         "protocol_version": RAY_UDF_STREAM_PROTOCOL_VERSION,
         "event_kind": "error",
         "query_id": query_id,
-        "producer_stage_id": stage_id,
+        "producer_unit_id": resource_unit_id,
         "task_lease_id": task_lease_id,
         "attempt_id": attempt_id,
         "exception_type": exception_type,
@@ -276,7 +278,7 @@ def validate_stream_block_metadata(metadata: Any) -> dict[str, Any]:
         raise ValueError(f"unsupported Ray UDF stream protocol version: {result['protocol_version']}")
     for name in (
         "query_id",
-        "producer_stage_id",
+        "producer_unit_id",
         "task_lease_id",
         "attempt_id",
         "block_id",
@@ -315,7 +317,7 @@ def validate_stream_error_metadata(metadata: Any) -> dict[str, Any]:
         raise ValueError("Ray UDF stream error metadata event_kind must be 'error'")
     for name in (
         "query_id",
-        "producer_stage_id",
+        "producer_unit_id",
         "task_lease_id",
         "attempt_id",
         "exception_type",

--- a/duckdb/execution/udf_ray_stream_protocol.py
+++ b/duckdb/execution/udf_ray_stream_protocol.py
@@ -18,19 +18,15 @@ RAY_UDF_GENERATOR_BACKPRESSURE_OBJECTS = RAY_UDF_STREAM_OBJECTS_PER_BLOCK * RAY_
 
 
 def validate_task_runtime_node(payload: dict[str, Any]) -> str:
-    expected_node_id = str(payload.get("node_id") or "").strip()
-    if not expected_node_id:
-        raise RuntimeError("distributed Ray UDF task payload is missing leased node_id")
+    if str(payload.get("execution_backend") or "").strip() != "ray_task":
+        raise RuntimeError("task runtime node discovery requires the ray_task backend")
+    if str(payload.get("node_id") or "").strip():
+        raise RuntimeError("Ray task payload must leave physical placement to Ray Core")
     import ray
 
     actual_node_id = str(ray.get_runtime_context().get_node_id() or "").strip()
     if not actual_node_id:
         raise RuntimeError("Ray runtime context did not expose the executing node_id")
-    if actual_node_id != expected_node_id:
-        raise RuntimeError(
-            "distributed Ray UDF executed outside its query lease: "
-            f"expected_node_id={expected_node_id} actual_node_id={actual_node_id}"
-        )
     return actual_node_id
 
 
@@ -83,13 +79,10 @@ def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> d
     resource_unit_id = str(lease.get("resource_unit_id") or "").strip()
     lease_id = str(lease.get("lease_id") or "").strip()
     attempt_id = str(lease.get("attempt_id") or "").strip()
-    node_id = str(lease.get("node_id") or "").strip()
     execution_slot_id = str(lease.get("execution_slot_id") or "").strip()
     output_window_bytes = int(lease.get("output_window_bytes") or 0)
-    if not query_id or not resource_unit_id or not lease_id or not attempt_id or not node_id or not execution_slot_id:
-        raise ValueError(
-            "task lease is missing query, resource unit, lease, attempt, Ray node, or execution slot identity"
-        )
+    if not query_id or not resource_unit_id or not lease_id or not attempt_id or not execution_slot_id:
+        raise ValueError("task lease is missing query, resource unit, lease, attempt, or execution slot identity")
     if str(merged.get("query_id") or "").strip() != query_id:
         raise ValueError("UDF payload query_id does not match task lease")
     if str(merged.get("resource_unit_id") or "").strip() != resource_unit_id:
@@ -97,6 +90,9 @@ def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> d
     backend = str(merged.get("execution_backend") or "").strip()
     raw_actor_index = lease.get("actor_index")
     if backend == "ray_actor":
+        node_id = str(lease.get("node_id") or "").strip()
+        if not node_id:
+            raise ValueError("Ray actor task lease is missing its runtime node")
         if isinstance(raw_actor_index, bool) or not isinstance(raw_actor_index, int) or raw_actor_index < 0:
             raise ValueError("Ray actor task lease is missing a valid actor_index")
         expected_slot_id = f"ray_actor:{resource_unit_id}:{raw_actor_index}"
@@ -106,6 +102,8 @@ def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> d
                 f"slot={execution_slot_id} expected={expected_slot_id}"
             )
     elif backend == "ray_task":
+        if lease.get("node_id") is not None:
+            raise ValueError("Ray task lease must leave physical placement to Ray Core")
         if raw_actor_index is not None:
             raise ValueError("Ray task lease must not contain actor_index")
         expected_slot_id = f"ray_task:{resource_unit_id}:{lease_id}"
@@ -127,7 +125,10 @@ def task_payload_with_lease(payload: dict[str, Any], lease: dict[str, Any]) -> d
         )
     merged["task_lease_id"] = lease_id
     merged["attempt_id"] = attempt_id
-    merged["node_id"] = node_id
+    if backend == "ray_actor":
+        merged["node_id"] = node_id
+    else:
+        merged.pop("node_id", None)
     merged["execution_slot_id"] = execution_slot_id
     merged["actor_index"] = raw_actor_index
     merged["output_window_bytes"] = output_window_bytes

--- a/duckdb/execution/udf_ray_stream_protocol.py
+++ b/duckdb/execution/udf_ray_stream_protocol.py
@@ -152,7 +152,7 @@ def iter_bounded_stream_blocks(
     table: pa.Table,
     payload: dict[str, Any],
 ) -> Iterator[pa.Table]:
-    """Split one producer result under its hard byte and row targets."""
+    """Split one producer result around its soft byte and hard row targets."""
     block = ensure_table(table)
     target_bytes = _output_block_target_bytes(payload)
     size_bytes = max(1, int(estimate_table_bytes(block)))
@@ -160,12 +160,11 @@ def iter_bounded_stream_blocks(
         yield block
         return
     if block.num_rows <= 1:
-        query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
-        raise RuntimeError(
-            "Ray UDF single output row exceeds the pre-publication block target: "
-            f"query={query_id} resource_unit={resource_unit_id} task_lease={task_lease_id} "
-            f"attempt={attempt_id} size_bytes={size_bytes} target_bytes={target_bytes}"
-        )
+        # One row is the smallest publishable Arrow block. Let the query
+        # resource manager account its exact size and use the bounded
+        # full-block liveness escape when it exceeds the soft target.
+        yield block
+        return
 
     offset = 0
     while offset < block.num_rows:
@@ -187,14 +186,9 @@ def iter_bounded_stream_blocks(
 
         if best_block is None:
             single_row = block.slice(offset, 1)
-            single_row_bytes = max(1, int(estimate_table_bytes(single_row)))
-            query_id, resource_unit_id, task_lease_id, attempt_id = _stream_identity(payload)
-            raise RuntimeError(
-                "Ray UDF single output row exceeds the pre-publication block target: "
-                f"query={query_id} resource_unit={resource_unit_id} task_lease={task_lease_id} "
-                f"attempt={attempt_id} row={offset} size_bytes={single_row_bytes} "
-                f"target_bytes={target_bytes}"
-            )
+            yield single_row
+            offset += 1
+            continue
         yield best_block
         offset += best_rows
 

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -122,7 +122,6 @@ class _StreamRecord:
     metadata_ref: Any | None = None
     terminal_ref: Any | None = None
     metadata: dict[str, Any] | None = None
-    block_item_capacity_bytes: int | None = None
     output_request_id: str = ""
     output_request: dict[str, Any] | None = None
     output_submit_future: Any | None = None
@@ -414,12 +413,22 @@ class UDFStreamResultCollector:
                         if capacity.bytes is not None:
                             if capacity.bytes <= delivered_bytes:
                                 break
-                            if delivered_bytes + event.size_bytes > capacity.bytes:
+                            if delivered_rows > 0 and delivered_bytes + event.size_bytes > capacity.bytes:
                                 break
                         if capacity.item_bytes is not None and capacity.item_bytes <= 0:
                             break
-                        if capacity.item_bytes is not None and event.size_bytes > capacity.item_bytes:
+                        if (
+                            capacity.item_bytes is not None
+                            and delivered_rows > 0
+                            and event.size_bytes > capacity.item_bytes
+                        ):
                             break
+                        # The byte windows are soft backpressure targets. Let
+                        # one complete block cross either target when the slot
+                        # is otherwise empty, then report zero residual
+                        # capacity until C++ hands that block downstream. This
+                        # is the same bounded full-block liveness escape used
+                        # by Ray Data and by Vane's local subprocess budget.
                         delivered_rows += 1
                         delivered_bytes += event.size_bytes
                     results.append(ready.popleft().as_tuple())
@@ -1739,11 +1748,6 @@ class UDFStreamResultCollector:
                 capacity = self._capacity_by_slot.get(record.slot_id)
                 if capacity is None:
                     raise RuntimeError("Ray UDF block read was scheduled without downstream capacity")
-                # Consuming the block ObjectRef is the admission point for the
-                # whole block/metadata pair. Keep its per-item limit stable;
-                # downstream capacity may legitimately fall to zero before the
-                # metadata ObjectRef becomes ready.
-                record.block_item_capacity_bytes = capacity.item_bytes
                 record.next_ref_ready = False
                 record.ready_sequence = None
                 block_admitted = True
@@ -1981,17 +1985,6 @@ class UDFStreamResultCollector:
             )
         validated = validate_stream_block_metadata(metadata)
         self._validate_task_identity(record, validated)
-        item_capacity_bytes = record.block_item_capacity_bytes
-        if item_capacity_bytes is not None and int(validated["size_bytes"]) > item_capacity_bytes:
-            raise RuntimeError(
-                "Ray UDF block exceeds downstream item capacity: "
-                f"query={validated['query_id']} "
-                f"resource_unit={validated['producer_unit_id']} "
-                f"task_lease={validated['task_lease_id']} "
-                f"block={validated['block_id']} "
-                f"size_bytes={validated['size_bytes']} "
-                f"item_capacity_bytes={item_capacity_bytes}"
-            )
         driver = record.adapter.driver
         if driver is None:
             raise RuntimeError("Ray UDF stream has no query resource driver")
@@ -2185,7 +2178,6 @@ class UDFStreamResultCollector:
                     record.phase = "block"
                     record.block_ref = None
                     record.metadata = None
-                    record.block_item_capacity_bytes = None
                     record.output_request_id = ""
                     record.output_request = None
                     record.output_lease_ref = None

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -1986,7 +1986,7 @@ class UDFStreamResultCollector:
             raise RuntimeError(
                 "Ray UDF block exceeds downstream item capacity: "
                 f"query={validated['query_id']} "
-                f"stage={validated['producer_stage_id']} "
+                f"resource_unit={validated['producer_unit_id']} "
                 f"task_lease={validated['task_lease_id']} "
                 f"block={validated['block_id']} "
                 f"size_bytes={validated['size_bytes']} "
@@ -1999,7 +1999,7 @@ class UDFStreamResultCollector:
         request = {
             "request_id": request_id,
             "query_id": validated["query_id"],
-            "producer_stage_id": validated["producer_stage_id"],
+            "producer_unit_id": validated["producer_unit_id"],
             "task_lease_id": validated["task_lease_id"],
             "attempt_id": validated["attempt_id"],
             "block_id": validated["block_id"],
@@ -2115,7 +2115,7 @@ class UDFStreamResultCollector:
             raise RuntimeError("Ray UDF stream metadata arrived before task lease admission")
         expected = {
             "query_id": str(lease["query_id"]),
-            "producer_stage_id": str(lease["stage_id"]),
+            "producer_unit_id": str(lease["resource_unit_id"]),
             "task_lease_id": str(lease["lease_id"]),
             "attempt_id": str(lease["attempt_id"]),
         }
@@ -2150,7 +2150,7 @@ class UDFStreamResultCollector:
         )
         descriptor = {
             "query_id": metadata["query_id"],
-            "producer_stage_id": metadata["producer_stage_id"],
+            "producer_unit_id": metadata["producer_unit_id"],
             "task_lease_id": metadata["task_lease_id"],
             "attempt_id": metadata["attempt_id"],
             "block_id": metadata["block_id"],

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -310,9 +310,9 @@ class TaskAdmissionController:
     ) -> None:
         self._payload = dict(payload)
         self._query_id = str(self._payload.get("query_id") or "").strip()
-        self._stage_id = str(self._payload.get("stage_id") or "").strip()
-        if not self._query_id or not self._stage_id:
-            raise ValueError("distributed Ray UDF task admission requires query_id and stage_id")
+        self._resource_unit_id = str(self._payload.get("resource_unit_id") or "").strip()
+        if not self._query_id or not self._resource_unit_id:
+            raise ValueError("distributed Ray UDF task admission requires query_id and resource_unit_id")
         if driver is None:
             raise ValueError("distributed Ray UDF task admission requires an explicit query driver handle")
         self._query_generation_capability = str(query_generation_capability or "").strip()
@@ -348,10 +348,10 @@ class TaskAdmissionController:
         self._sequence += 1
         identity = f"executor:{self._executor_id}:admission:{self._sequence}"
         return {
-            "request_id": f"request:task:{self._stage_id}:{identity}",
+            "request_id": f"request:task:{self._resource_unit_id}:{identity}",
             "query_id": self._query_id,
-            "stage_id": self._stage_id,
-            "task_id": f"task:{self._stage_id}:{identity}",
+            "resource_unit_id": self._resource_unit_id,
+            "task_id": f"task:{self._resource_unit_id}:{identity}",
             "attempt_id": f"attempt:{self._executor_id}:{self._sequence}",
             "node_id": None,
             "retained_input_bytes": retained_input_bytes,

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import threading
 import uuid
 import weakref
@@ -28,8 +27,6 @@ from duckdb.execution.udf_admission import (
     AdmissionLease,
 )
 
-_DEFAULT_RAY_TASK_HEAP_BYTES = 2 * 1024**3
-_DEFAULT_RAY_ACTOR_HEAP_BYTES = 4 * 1024**3
 _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
@@ -45,17 +42,11 @@ def _positive_int(value: Any, name: str) -> int:
 
 def ray_udf_task_memory_bytes(payload: dict[str, Any]) -> int:
     backend = str(payload.get("execution_backend") or "").strip()
-    if backend == "ray_task":
-        env_name = "VANE_UDF_TASK_HEAP_BYTES"
-        default = _DEFAULT_RAY_TASK_HEAP_BYTES
-    elif backend == "ray_actor":
-        env_name = "VANE_UDF_ACTOR_HEAP_BYTES"
-        default = _DEFAULT_RAY_ACTOR_HEAP_BYTES
-    else:
+    if backend not in {"ray_task", "ray_actor"}:
         raise ValueError(f"task admission requires a Ray UDF backend, got {backend!r}")
     raw = payload.get("memory_bytes")
     if raw is None:
-        raw = os.environ.get(env_name, str(default))
+        return 0
     return _positive_int(raw, "memory_bytes")
 
 

--- a/duckdb/runners/fte/backend.py
+++ b/duckdb/runners/fte/backend.py
@@ -95,6 +95,8 @@ class WorkerManagerBackend(Protocol):
         source_node_ids: Sequence[str],
     ) -> None: ...
 
+    def materialization_barrier_completed(self, query_id: str, node_id: str) -> None: ...
+
     def wait_query(
         self,
         query_id: str,

--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -1214,7 +1214,6 @@ class _NativeFteProgressRegistry:
                     "pipeline_id": raw_pipeline["pipeline_id"],
                     "operators": raw_pipeline["operators"],
                     "operator_details": operator_details,
-                    "stage_ids": raw_pipeline["stage_ids"],
                 }
             )
         return validate_pipeline_topology({"schema": "pipeline_topology", "pipelines": pipelines})
@@ -1235,10 +1234,7 @@ class _NativeFteProgressRegistry:
                 pipelines.append(copied)
                 pipelines_by_id[pipeline_id] = copied
                 continue
-            if (
-                current_pipeline["operators"] != incoming_pipeline["operators"]
-                or current_pipeline["stage_ids"] != incoming_pipeline["stage_ids"]
-            ):
+            if current_pipeline["operators"] != incoming_pipeline["operators"]:
                 return None
             for current_details, incoming_details in zip(
                 current_pipeline["operator_details"],

--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -1540,6 +1540,13 @@ class NativeFteWorkerManagerBackend:
     def worker_snapshots(self) -> Sequence[Mapping[str, Any]]:
         return [worker.snapshot() for worker in self._workers]
 
+    def materialization_barrier_completed(self, query_id: str, node_id: str) -> None:
+        """Acknowledge the runner protocol; native resources stay DuckDB-owned."""
+        if not str(query_id or "").strip():
+            raise ValueError("materialization barrier completion requires non-empty query_id")
+        if not str(node_id or "").strip():
+            raise ValueError("materialization barrier completion requires non-empty node_id")
+
     def fragment_stats_by_worker(self) -> dict[str, dict[str, int]]:
         stats_by_worker: dict[str, dict[str, int]] = {}
         for worker in self._workers:

--- a/duckdb/runners/fte/backends/ray/backend.py
+++ b/duckdb/runners/fte/backends/ray/backend.py
@@ -247,6 +247,12 @@ class RayWorkerManagerBackend:
         for handle in self._adapt_handles(raw_handles or []):
             self._handles_by_query[str(query_id)].append(handle)
 
+    def materialization_barrier_completed(self, query_id: str, node_id: str) -> None:
+        _required_method(self._coordinator, "materialization_barrier_completed")(
+            str(query_id),
+            str(node_id),
+        )
+
     def fte_query_status(
         self,
         query_id: str,

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -481,7 +481,7 @@ class FteFragmentExecution:
         source_node_ids: set[str] | list[str] | tuple[str, ...] | None = None,
         dynamic_scan_source_node_ids: set[str] | list[str] | tuple[str, ...] | None = None,
         dynamic_exchange_source_node_ids: set[str] | list[str] | tuple[str, ...] | None = None,
-        task_memory_bytes: int,
+        task_memory_bytes: int | None,
     ) -> None:
         self.query_id = str(query_id).strip()
         if not self.query_id:
@@ -537,8 +537,8 @@ class FteFragmentExecution:
         self._attempt_scheduling_lock = threading.RLock()
         self._current_worker_commands: list[Any] | None = None
         self._worker_command_outbox: list[Any] = []
-        self.task_memory_bytes = int(task_memory_bytes)
-        if self.task_memory_bytes <= 0:
+        self.task_memory_bytes = None if task_memory_bytes is None else int(task_memory_bytes)
+        if self.task_memory_bytes is not None and self.task_memory_bytes <= 0:
             raise ValueError("FTE task_memory_bytes must be positive")
 
     def add_partition(

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -115,12 +115,14 @@ class FteWorkerReservationUnavailable(RuntimeError):
         partition_id: int,
         memory_requirement_bytes: int | None,
         blocked_reason: str = "",
+        admission_epoch: int | None = None,
     ) -> None:
         self.query_id = str(query_id)
         self.fragment_id = str(fragment_id)
         self.partition_id = int(partition_id)
         self.memory_requirement_bytes = memory_requirement_bytes
         self.blocked_reason = str(blocked_reason)
+        self.admission_epoch = None if admission_epoch is None else int(admission_epoch)
         super().__init__(
             "no FTE worker reservation available for "
             f"{self.query_id}/{self.fragment_id}/{self.partition_id} "

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -120,8 +120,8 @@ def _query_task_lease_heap_bytes(
     if not isinstance(resources, Mapping):
         raise RuntimeError("Ray FTE query_task_lease resources must be a mapping")
     heap_bytes = int(resources.get("heap_bytes") or 0)
-    if heap_bytes <= 0:
-        raise RuntimeError("Ray FTE query_task_lease heap_bytes must be positive")
+    if heap_bytes < 0:
+        raise RuntimeError("Ray FTE query_task_lease heap_bytes must be non-negative")
     explicit = _memory_requirement_from_request(request, None) if _has_explicit_memory_requirement(request) else None
     if explicit is not None and int(explicit) != heap_bytes:
         raise RuntimeError(

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -106,7 +106,7 @@ def _query_task_lease_heap_bytes(
         "lease_id": str(lease.get("lease_id") or "").strip(),
         "query_id": str(lease.get("query_id") or "").strip(),
         "execution_query_id": str(lease.get("execution_query_id") or "").strip(),
-        "stage_id": str(lease.get("stage_id") or "").strip(),
+        "resource_unit_id": str(lease.get("resource_unit_id") or "").strip(),
         "attempt_id": str(lease.get("attempt_id") or "").strip(),
     }
     missing = [name for name, value in required_identity.items() if not value]

--- a/duckdb/runners/progress.py
+++ b/duckdb/runners/progress.py
@@ -71,11 +71,11 @@ def validate_pipeline_topology(
 
     pipeline_ids: set[int] = set()
     pipelines: list[dict[str, Any]] = []
-    required_fields = {"pipeline_id", "operators", "operator_details", "stage_ids"}
+    required_fields = {"pipeline_id", "operators", "operator_details"}
     for raw_pipeline in raw_pipelines:
         if type(raw_pipeline) is not dict or set(raw_pipeline) != required_fields:
             raise ValueError(
-                "pipeline topology entries must contain exactly pipeline_id, operators, operator_details, and stage_ids"
+                "pipeline topology entries must contain exactly pipeline_id, operators, and operator_details"
             )
         pipeline_id = raw_pipeline["pipeline_id"]
         if type(pipeline_id) is not int or pipeline_id <= 0 or pipeline_id in pipeline_ids:
@@ -90,15 +90,11 @@ def validate_pipeline_topology(
             raise ValueError("pipeline topology operator_details must align with operators")
         if any(type(details) is not dict for details in operator_details):
             raise TypeError("pipeline topology operator_details entries must be dicts")
-        stage_ids = raw_pipeline["stage_ids"]
-        if type(stage_ids) is not list or any(type(stage_id) is not int or stage_id < 0 for stage_id in stage_ids):
-            raise ValueError("pipeline topology stage_ids must be non-negative integers")
         pipelines.append(
             {
                 "pipeline_id": pipeline_id,
                 "operators": list(operators),
                 "operator_details": copy.deepcopy(operator_details),
-                "stage_ids": list(stage_ids),
             }
         )
     return {"schema": _PIPELINE_TOPOLOGY_SCHEMA, "pipelines": pipelines}

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from duckdb.runners.ray.query_resource_graph import (
-    ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
     ResourceVector,
@@ -20,36 +19,6 @@ from duckdb.runners.ray.query_resource_graph import (
 from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 
 _EPSILON = 1e-9
-
-
-class ElasticGpuDemandError(ValueError):
-    code = "ELASTIC_GPU_UNSUPPORTED"
-
-    def __init__(
-        self,
-        query_id: str,
-        minimum_gpu: float,
-        desired_gpu: float,
-    ) -> None:
-        self.query_id = str(query_id)
-        self.minimum_gpu = float(minimum_gpu)
-        self.desired_gpu = float(desired_gpu)
-        super().__init__(self.query_id, self.minimum_gpu, self.desired_gpu)
-
-    def __str__(self) -> str:
-        return (
-            f"query {self.query_id} GPU resources cannot be elastic: "
-            f"minimum={self.minimum_gpu:g}, desired={self.desired_gpu:g}"
-        )
-
-    def to_dict(self) -> dict[str, str | float]:
-        return {
-            "code": self.code,
-            "query_id": self.query_id,
-            "resource": "gpu",
-            "minimum": self.minimum_gpu,
-            "desired": self.desired_gpu,
-        }
 
 
 def _sum_resources(resources: Sequence[ResourceVector]) -> ResourceVector:
@@ -104,27 +73,6 @@ class NodeCapacity:
 
 
 @dataclass(frozen=True)
-class ActorResourceBundle:
-    resource_unit_id: str
-    actor_index: int
-    resources: ResourceVector
-
-    def __post_init__(self) -> None:
-        resource_unit_id = str(self.resource_unit_id).strip()
-        actor_index = int(self.actor_index)
-        if not resource_unit_id:
-            raise ValueError("actor resource bundle resource_unit_id must be non-empty")
-        if actor_index < 0:
-            raise ValueError("actor resource bundle actor_index must be >= 0")
-        if self.resources.is_zero():
-            raise ValueError("actor resource bundle must own non-zero resources")
-        if self.resources.object_store_bytes != 0:
-            raise ValueError("actor resource bundles may not hard-reserve object-store bytes")
-        object.__setattr__(self, "resource_unit_id", resource_unit_id)
-        object.__setattr__(self, "actor_index", actor_index)
-
-
-@dataclass(frozen=True)
 class QueryDemand:
     """Hard placement minimum plus elastic resource targets.
 
@@ -139,7 +87,6 @@ class QueryDemand:
     desired: ResourceVector
     weight: float = 1.0
     priority: int = 0
-    actor_bundles: tuple[ActorResourceBundle, ...] = ()
     task_bundles: tuple[ResourceVector, ...] = ()
 
     def __post_init__(self) -> None:
@@ -149,37 +96,22 @@ class QueryDemand:
         if not self.minimum.fits_within(self.desired):
             exceeded = self.minimum.exceeded_dimensions(self.desired)
             raise ValueError(f"minimum query demand exceeds desired demand for {', '.join(exceeded)}")
-        if not math.isclose(self.minimum.gpu, self.desired.gpu, rel_tol=0.0, abs_tol=_EPSILON):
-            raise ElasticGpuDemandError(
-                query_id=query_id,
-                minimum_gpu=self.minimum.gpu,
-                desired_gpu=self.desired.gpu,
-            )
         weight = float(self.weight)
         if not math.isfinite(weight) or weight <= 0:
             raise ValueError("weight must be finite and > 0")
-        actor_bundles = tuple(self.actor_bundles)
         task_bundles = tuple(self.task_bundles)
         if self.minimum.object_store_bytes != 0:
             raise ValueError("minimum query resources may not hard-reserve object-store bytes")
         if any(bundle.object_store_bytes != 0 for bundle in task_bundles):
             raise ValueError("task resource bundles may not hard-reserve object-store bytes")
-        actor_keys = [(bundle.resource_unit_id, bundle.actor_index) for bundle in actor_bundles]
-        if len(set(actor_keys)) != len(actor_keys):
-            raise ValueError("actor resource bundles contain duplicate resource-unit/index identities")
-        actor_total = _sum_resources([bundle.resources for bundle in actor_bundles])
         task_total = _sum_resources(task_bundles)
-        bundle_total = actor_total + task_total
-        if bundle_total != self.minimum:
-            raise ValueError("actor_bundles plus task_bundles must exactly equal minimum query resources")
-        if not bundle_total.fits_within(self.desired):
+        if task_total != self.minimum:
+            raise ValueError("task_bundles must exactly equal minimum query resources")
+        if not task_total.fits_within(self.desired):
             raise ValueError("minimum placement bundles exceed desired query resources")
-        if actor_total.gpu > self.desired.gpu + _EPSILON:
-            raise ValueError("actor bundles exceed desired GPU resources")
         object.__setattr__(self, "query_id", query_id)
         object.__setattr__(self, "weight", weight)
         object.__setattr__(self, "priority", int(self.priority))
-        object.__setattr__(self, "actor_bundles", actor_bundles)
         object.__setattr__(self, "task_bundles", task_bundles)
 
 
@@ -192,16 +124,13 @@ class _QueryState:
         default_factory=lambda: QueryAllocation(
             resources=ResourceVector(),
             node_allocations=(),
-            actor_placements=(),
             generation=1,
         )
     )
     node_allocations: dict[str, ResourceVector] = field(default_factory=dict)
-    actor_placements: tuple[ActorPlacement, ...] = ()
     allocation_debt: ResourceVector = field(default_factory=ResourceVector)
     state: str = "PENDING_RESOURCES"
     rejection_reason: str = ""
-    actor_placement_lost: bool = False
     expires_at: float = 0.0
 
 
@@ -354,6 +283,7 @@ class ClusterQueryResourceCoordinator:
         *,
         observed_usage_by_query: Mapping[str, ResourceVector],
         generations: Mapping[str, int],
+        demands_by_query: Mapping[str, QueryDemand] | None = None,
         now: float | None = None,
     ) -> dict[str, QueryAllocation]:
         """Atomically refresh every live query from one coordinator snapshot.
@@ -367,8 +297,15 @@ class ClusterQueryResourceCoordinator:
         timestamp = time.monotonic() if now is None else float(now)
         usage = {str(query_id): value for query_id, value in observed_usage_by_query.items()}
         generation_by_query = {str(query_id): int(generation) for query_id, generation in generations.items()}
+        demands = (
+            None
+            if demands_by_query is None
+            else {str(query_id): demand for query_id, demand in demands_by_query.items()}
+        )
         if set(usage) != set(generation_by_query):
             raise ValueError("refresh query usage and generation sets must match")
+        if demands is not None and set(demands) != set(usage):
+            raise ValueError("refresh query demand and usage sets must match")
         with self._lock:
             expected = set(self._queries)
             if set(usage) != expected:
@@ -385,8 +322,16 @@ class ClusterQueryResourceCoordinator:
                 self._require_generation(state, generation_by_query[query_id])
                 if not isinstance(usage[query_id], ResourceVector):
                     raise TypeError(f"observed usage for query {query_id} must be ResourceVector")
+                if demands is not None:
+                    demand = demands[query_id]
+                    if not isinstance(demand, QueryDemand):
+                        raise TypeError(f"demand for query {query_id} must be QueryDemand")
+                    if demand.query_id != query_id:
+                        raise ValueError(f"refresh demand query_id mismatch for query {query_id}")
             for query_id in sorted(expected):
                 state = self._queries[query_id]
+                if demands is not None:
+                    state.demand = demands[query_id]
                 state.observed_usage = usage[query_id]
                 state.expires_at = timestamp + self._heartbeat_timeout_s
             if expected:
@@ -403,6 +348,22 @@ class ClusterQueryResourceCoordinator:
             self._require_generation(state, generation)
             state.expires_at = timestamp + self._heartbeat_timeout_s
             return state.allocation
+
+    def query_state(self, query_id: str, generation: int) -> str:
+        """Return one generation-fenced query scheduling state.
+
+        Registration needs this small control-plane value before the query-local
+        manager exists. Exposing it directly avoids constructing and traversing
+        the coordinator's full diagnostic snapshot on every query start.
+        """
+
+        query_key = str(query_id)
+        with self._lock:
+            state = self._queries.get(query_key)
+            if state is None:
+                raise KeyError(f"query is not registered: {query_key}")
+            self._require_generation(state, generation)
+            return str(state.state)
 
     def release_query(self, query_id: str, generation: int) -> bool:
         query_key = str(query_id)
@@ -450,46 +411,7 @@ class ClusterQueryResourceCoordinator:
         generation = self._generation
         remaining = {node_id: node.resources for node_id, node in self._nodes.items()}
         node_allocations_by_query: dict[str, dict[str, ResourceVector]] = {query_id: {} for query_id in self._queries}
-        actor_placements_by_query: dict[str, tuple[ActorPlacement, ...]] = {query_id: () for query_id in self._queries}
         admitted: list[_QueryState] = []
-
-        # Eager actor placements become non-preemptible as soon as admission
-        # publishes them.  The driver creates actors immediately after this
-        # allocation, so moving the placement during the startup gap would make
-        # the virtual lease disagree with Ray's hard NodeAffinity placement.
-        pinned_query_ids: set[str] = set()
-        lost_actor_placement_query_ids: set[str] = set()
-        for state in sorted(self._queries.values(), key=lambda item: (item.sequence, item.demand.query_id)):
-            if state.actor_placement_lost:
-                lost_actor_placement_query_ids.add(state.demand.query_id)
-                continue
-            if not state.actor_placements:
-                continue
-            trial_remaining = dict(remaining)
-            placement_valid = True
-            actor_bundles = {
-                (bundle.resource_unit_id, bundle.actor_index): bundle.resources for bundle in state.demand.actor_bundles
-            }
-            pinned_allocations: dict[str, ResourceVector] = {}
-            for placement in state.actor_placements:
-                vector = actor_bundles.get((placement.resource_unit_id, placement.actor_index))
-                capacity = trial_remaining.get(placement.node_id)
-                if vector is None or capacity is None or not vector.fits_within(capacity):
-                    placement_valid = False
-                    break
-                trial_remaining[placement.node_id] = capacity - vector
-                pinned_allocations[placement.node_id] = (
-                    pinned_allocations.get(placement.node_id, ResourceVector()) + vector
-                )
-            if not placement_valid:
-                state.actor_placement_lost = True
-                lost_actor_placement_query_ids.add(state.demand.query_id)
-                continue
-            query_id = state.demand.query_id
-            remaining = trial_remaining
-            pinned_query_ids.add(query_id)
-            actor_placements_by_query[query_id] = state.actor_placements
-            node_allocations_by_query[query_id] = pinned_allocations
 
         ordered = sorted(
             self._queries.values(),
@@ -497,41 +419,10 @@ class ClusterQueryResourceCoordinator:
         )
         for state in ordered:
             query_id = state.demand.query_id
-            if query_id in lost_actor_placement_query_ids:
+            placement = self._place_task_bundles(state.demand.task_bundles, remaining)
+            if placement is None:
                 continue
-            trial_remaining = dict(remaining)
-            trial_allocations: dict[str, ResourceVector] = dict(node_allocations_by_query[query_id])
-            if query_id not in pinned_query_ids:
-                actor_ok = True
-                new_actor_placements: list[ActorPlacement] = []
-                for actor_bundle in state.demand.actor_bundles:
-                    node_id = self._place_bundle(actor_bundle.resources, trial_remaining)
-                    if node_id is None:
-                        actor_ok = False
-                        break
-                    new_actor_placements.append(
-                        ActorPlacement(
-                            resource_unit_id=actor_bundle.resource_unit_id,
-                            actor_index=actor_bundle.actor_index,
-                            node_id=node_id,
-                        )
-                    )
-                    trial_allocations[node_id] = (
-                        trial_allocations.get(node_id, ResourceVector()) + actor_bundle.resources
-                    )
-                if not actor_ok:
-                    continue
-                actor_placements_by_query[query_id] = tuple(new_actor_placements)
-
-            task_ok = True
-            for task_bundle in state.demand.task_bundles:
-                node_id = self._place_bundle(task_bundle, trial_remaining)
-                if node_id is None:
-                    task_ok = False
-                    break
-                trial_allocations[node_id] = trial_allocations.get(node_id, ResourceVector()) + task_bundle
-            if not task_ok:
-                continue
+            trial_remaining, trial_allocations = placement
 
             remaining = trial_remaining
             node_allocations_by_query[query_id] = trial_allocations
@@ -541,8 +432,9 @@ class ClusterQueryResourceCoordinator:
         extra_capacity = _sum_resources(list(remaining.values()))
         extras = self._weighted_drf_extras(admitted, extra_capacity, total_capacity)
 
-        # Place the aggregate DRF result onto concrete nodes. GPU demand is
-        # fixed in the bundles above; only CPU and memory extras are divisible.
+        # Place the aggregate DRF result onto concrete nodes. Extra allocations
+        # are soft scheduling attribution; Ray Core still places concrete work
+        # and enforces its real CPU/GPU/memory request.
         for state in admitted:
             query_id = state.demand.query_id
             extra = extras.get(query_id, ResourceVector())
@@ -560,9 +452,6 @@ class ClusterQueryResourceCoordinator:
             if query_id in admitted_ids:
                 state.state = "RUNNING"
                 state.rejection_reason = ""
-            elif query_id in lost_actor_placement_query_ids:
-                state.state = "ACTOR_PLACEMENT_LOST"
-                state.rejection_reason = "allocated Ray actor node is no longer available"
             else:
                 state.state = "PENDING_RESOURCES"
                 state.rejection_reason = "minimum query resource bundles are not currently feasible"
@@ -574,15 +463,93 @@ class ClusterQueryResourceCoordinator:
                     for node_id, vector in sorted(node_allocations_by_query[query_id].items())
                     if not vector.is_zero()
                 ),
-                actor_placements=actor_placements_by_query[query_id],
                 generation=generation,
             )
             state.node_allocations = node_allocations_by_query[query_id]
-            state.actor_placements = actor_placements_by_query[query_id]
             state.allocation_debt = _hard_positive_difference(state.observed_usage, resources)
-            if not state.allocation_debt.is_zero() and state.state != "ACTOR_PLACEMENT_LOST":
+            if not state.allocation_debt.is_zero():
                 state.state = "ALLOCATION_DEBT"
                 state.rejection_reason = "live query hard-resource leases exceed the current allocation"
+
+    def _place_task_bundles(
+        self,
+        bundles: Sequence[ResourceVector],
+        remaining: Mapping[str, ResourceVector],
+    ) -> tuple[dict[str, ResourceVector], dict[str, ResourceVector]] | None:
+        """Place indivisible minima without depending on greedy node order.
+
+        A heterogeneous execution phase can require more than one capability
+        envelope.  Best-fit placement is a useful ordering heuristic, but a
+        locally valid first node can hide the only node available to a later
+        bundle.  The bounded backtracking below finds the deterministic
+        feasible assignment that the graph builder established from concrete
+        node capacities.
+        """
+
+        original = dict(remaining)
+        if not bundles:
+            return original, {}
+        ordered = tuple(
+            bundle
+            for _index, bundle in sorted(
+                enumerate(bundles),
+                key=lambda item: (
+                    sum(item[1].fits_within(capacity) for capacity in original.values()),
+                    -item[1].gpu,
+                    -item[1].cpu,
+                    -item[1].heap_bytes,
+                    item[0],
+                ),
+            )
+        )
+        node_ids = tuple(sorted(original))
+        failed: set[tuple[int, tuple[tuple[str, ResourceVector], ...]]] = set()
+
+        def search(
+            bundle_index: int,
+            current: dict[str, ResourceVector],
+        ) -> dict[str, ResourceVector] | None:
+            if bundle_index == len(ordered):
+                return current
+            state_key = (
+                bundle_index,
+                tuple((node_id, current[node_id]) for node_id in node_ids),
+            )
+            if state_key in failed:
+                return None
+            bundle = ordered[bundle_index]
+            candidates = sorted(
+                (node_id for node_id in node_ids if bundle.fits_within(current[node_id])),
+                key=lambda node_id: (
+                    current[node_id].gpu - bundle.gpu,
+                    current[node_id].cpu - bundle.cpu,
+                    current[node_id].heap_bytes - bundle.heap_bytes,
+                    node_id,
+                ),
+            )
+            for node_id in candidates:
+                # Keep the single-bundle primitive as the mutation authority;
+                # tests also fault-inject it to verify registration rollback.
+                selected_remaining = {node_id: current[node_id]}
+                if self._place_bundle(bundle, selected_remaining) is None:
+                    raise RuntimeError("selected task bundle unexpectedly became unplaceable")
+                trial = dict(current)
+                trial[node_id] = selected_remaining[node_id]
+                placed = search(bundle_index + 1, trial)
+                if placed is not None:
+                    return placed
+            failed.add(state_key)
+            return None
+
+        placed_remaining = search(0, original)
+        if placed_remaining is None:
+            return None
+        allocations = {
+            node_id: original[node_id] - placed_remaining[node_id]
+            for node_id in node_ids
+            if original[node_id] != placed_remaining[node_id]
+        }
+        return placed_remaining, allocations
 
     @staticmethod
     def _place_bundle(bundle: ResourceVector, remaining: dict[str, ResourceVector]) -> str | None:
@@ -606,11 +573,9 @@ class ClusterQueryResourceCoordinator:
         request: ResourceVector,
         remaining: dict[str, ResourceVector],
     ) -> dict[str, ResourceVector] | None:
-        if request.gpu > _EPSILON:
-            raise AssertionError("divisible placement received fixed GPU resources")
         trial_remaining = dict(remaining)
         allocations = {node_id: ResourceVector() for node_id in remaining}
-        for field_name in ("cpu", "heap_bytes", "object_store_bytes"):
+        for field_name in ("cpu", "gpu", "heap_bytes", "object_store_bytes"):
             needed = float(getattr(request, field_name))
             if needed <= _EPSILON:
                 continue
@@ -623,7 +588,7 @@ class ClusterQueryResourceCoordinator:
                 if available <= _EPSILON:
                     continue
                 amount = min(needed, available)
-                if field_name != "cpu":
+                if field_name not in {"cpu", "gpu"}:
                     amount = int(amount)
                 if amount <= 0:
                     continue
@@ -957,9 +922,7 @@ class ClusterQueryResourceCoordinator:
 
 
 __all__ = [
-    "ActorResourceBundle",
     "ClusterQueryResourceCoordinator",
-    "ElasticGpuDemandError",
     "NodeCapacity",
     "QueryDemand",
     "read_ray_node_capacities",

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -646,14 +646,33 @@ class ClusterQueryResourceCoordinator:
         extra_capacity: ResourceVector,
         total_capacity: ResourceVector,
     ) -> dict[str, ResourceVector]:
-        if not admitted or extra_capacity.is_zero():
+        if not admitted:
             return {}
 
+        # Object-store bytes are a soft flow-control budget. Allocate them
+        # independently so saturation in a hard DRF dimension (for example,
+        # all CPU consumed by query minima) cannot give one admitted query the
+        # entire store tail while another receives zero.
+        hard_extra_capacity = ResourceVector(
+            cpu=extra_capacity.cpu,
+            gpu=extra_capacity.gpu,
+            heap_bytes=extra_capacity.heap_bytes,
+        )
+        hard_total_capacity = ResourceVector(
+            cpu=total_capacity.cpu,
+            gpu=total_capacity.gpu,
+            heap_bytes=total_capacity.heap_bytes,
+        )
         headroom: dict[str, ResourceVector] = {
-            state.demand.query_id: state.demand.desired - state.demand.minimum for state in admitted
+            state.demand.query_id: ResourceVector(
+                cpu=(state.demand.desired - state.demand.minimum).cpu,
+                gpu=(state.demand.desired - state.demand.minimum).gpu,
+                heap_bytes=(state.demand.desired - state.demand.minimum).heap_bytes,
+            )
+            for state in admitted
         }
         dominant: dict[str, float] = {
-            query_id: vector.dominant_share(total_capacity) for query_id, vector in headroom.items()
+            query_id: vector.dominant_share(hard_total_capacity) for query_id, vector in headroom.items()
         }
         states_by_id = {state.demand.query_id: state for state in admitted}
         finite_limits = [
@@ -661,8 +680,6 @@ class ClusterQueryResourceCoordinator:
             for query_id in headroom
             if dominant[query_id] > 0 and math.isfinite(dominant[query_id])
         ]
-        if not finite_limits:
-            return {}
 
         def allocation_at(level: float) -> dict[str, ResourceVector]:
             result: dict[str, ResourceVector] = {}
@@ -678,34 +695,48 @@ class ClusterQueryResourceCoordinator:
 
         def feasible(level: float) -> bool:
             total = _sum_resources(list(allocation_at(level).values()))
-            return total.fits_within(extra_capacity)
+            return total.fits_within(hard_extra_capacity)
 
-        low = 0.0
-        high = max(finite_limits)
-        if feasible(high):
-            low = high
+        if finite_limits:
+            low = 0.0
+            high = max(finite_limits)
+            if feasible(high):
+                low = high
+            else:
+                for _ in range(80):
+                    middle = (low + high) / 2.0
+                    if feasible(middle):
+                        low = middle
+                    else:
+                        high = middle
+            allocated = allocation_at(low)
         else:
-            for _ in range(80):
-                middle = (low + high) / 2.0
-                if feasible(middle):
-                    low = middle
-                else:
-                    high = middle
-        allocated = allocation_at(low)
+            allocated = {state.demand.query_id: ResourceVector() for state in admitted}
 
         # Byte flooring can leave a small tail. Assign it deterministically to
         # the currently lowest weighted dominant share without exceeding demand.
         used = _sum_resources(list(allocated.values()))
-        remaining = _positive_difference(extra_capacity, used)
-        for field_name in ("heap_bytes", "object_store_bytes"):
+        remaining = _positive_difference(hard_extra_capacity, used)
+        for field_name in ("heap_bytes",):
             tail = int(getattr(remaining, field_name))
             if tail <= 0:
                 continue
+
+            def weighted_hard_share(state: _QueryState) -> float:
+                query_id = state.demand.query_id
+                minimum = state.demand.minimum
+                extra = allocated[query_id]
+                current = ResourceVector(
+                    cpu=minimum.cpu + extra.cpu,
+                    gpu=minimum.gpu + extra.gpu,
+                    heap_bytes=minimum.heap_bytes + extra.heap_bytes,
+                )
+                return current.dominant_share(hard_total_capacity) / state.demand.weight
+
             candidates = sorted(
                 admitted,
                 key=lambda state: (
-                    (state.demand.minimum + allocated[state.demand.query_id]).dominant_share(total_capacity)
-                    / state.demand.weight,
+                    weighted_hard_share(state),
                     -state.demand.priority,
                     state.sequence,
                 ),
@@ -724,6 +755,96 @@ class ClusterQueryResourceCoordinator:
                 tail -= amount
                 if tail == 0:
                     break
+
+        object_store_extras = ClusterQueryResourceCoordinator._weighted_object_store_extras(
+            admitted,
+            int(extra_capacity.object_store_bytes),
+        )
+        for state in admitted:
+            query_id = state.demand.query_id
+            allocated[query_id] = _replace_resource(
+                allocated[query_id],
+                "object_store_bytes",
+                object_store_extras.get(query_id, 0),
+            )
+        return allocated
+
+    @staticmethod
+    def _weighted_object_store_extras(
+        admitted: Sequence[_QueryState],
+        extra_capacity_bytes: int,
+    ) -> dict[str, int]:
+        """Weighted max-min allocation for the spillable query budget."""
+        capacity = max(0, int(extra_capacity_bytes))
+        if not admitted or capacity <= 0:
+            return {}
+
+        minimum = {state.demand.query_id: int(state.demand.minimum.object_store_bytes) for state in admitted}
+        desired = {state.demand.query_id: int(state.demand.desired.object_store_bytes) for state in admitted}
+        limits = [
+            desired[state.demand.query_id] / state.demand.weight
+            for state in admitted
+            if desired[state.demand.query_id] > minimum[state.demand.query_id]
+        ]
+        if not limits:
+            return {}
+
+        def allocation_at(level: float) -> dict[str, int]:
+            result: dict[str, int] = {}
+            for state in admitted:
+                query_id = state.demand.query_id
+                target = min(
+                    desired[query_id],
+                    max(
+                        minimum[query_id],
+                        level * state.demand.weight,
+                    ),
+                )
+                result[query_id] = min(
+                    desired[query_id] - minimum[query_id],
+                    max(0, math.floor(target - minimum[query_id])),
+                )
+            return result
+
+        def feasible(level: float) -> bool:
+            return sum(allocation_at(level).values()) <= capacity
+
+        low = 0.0
+        high = max(limits)
+        if feasible(high):
+            low = high
+        else:
+            for _ in range(80):
+                middle = (low + high) / 2.0
+                if feasible(middle):
+                    low = middle
+                else:
+                    high = middle
+        allocated = allocation_at(low)
+
+        # Flooring leaves at most a small integer tail. Hand out individual
+        # bytes at the lowest weighted final budget to preserve fairness and a
+        # deterministic priority/arrival-order tie break.
+        tail = capacity - sum(allocated.values())
+        while tail > 0:
+            candidates = [
+                state
+                for state in admitted
+                if allocated[state.demand.query_id] < desired[state.demand.query_id] - minimum[state.demand.query_id]
+            ]
+            if not candidates:
+                break
+            selected = min(
+                candidates,
+                key=lambda state: (
+                    (minimum[state.demand.query_id] + allocated[state.demand.query_id]) / state.demand.weight,
+                    -state.demand.priority,
+                    state.sequence,
+                    state.demand.query_id,
+                ),
+            )
+            allocated[selected.demand.query_id] += 1
+            tail -= 1
         return allocated
 
     def snapshot(self) -> dict[str, Any]:

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -7,6 +7,7 @@ import copy
 import math
 import threading
 import time
+from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -476,25 +477,40 @@ class ClusterQueryResourceCoordinator:
         bundles: Sequence[ResourceVector],
         remaining: Mapping[str, ResourceVector],
     ) -> tuple[dict[str, ResourceVector], dict[str, ResourceVector]] | None:
-        """Place indivisible minima without depending on greedy node order.
+        """Match indivisible capability envelopes to distinct Ray nodes.
 
-        A heterogeneous execution phase can require more than one capability
-        envelope.  Best-fit placement is a useful ordering heuristic, but a
-        locally valid first node can hide the only node available to a later
-        bundle.  The bounded backtracking below finds the deterministic
-        feasible assignment that the graph builder established from concrete
-        node capacities.
+        The graph builder emits at most one envelope for each concrete source
+        node: if one node could run two task-shape groups, it would have merged
+        them into one component-wise envelope.  Placement is therefore a
+        bipartite matching problem, not multidimensional bin packing.  An
+        augmenting-path matcher avoids both greedy false negatives and
+        exponential backtracking when a large query is currently infeasible.
         """
 
         original = dict(remaining)
         if not bundles:
             return original, {}
-        ordered = tuple(
-            bundle
-            for _index, bundle in sorted(
+        node_ids = tuple(sorted(original))
+        candidates_by_bundle = {
+            bundle_index: tuple(
+                sorted(
+                    (node_id for node_id in node_ids if bundle.fits_within(original[node_id])),
+                    key=lambda node_id: (
+                        original[node_id].gpu - bundle.gpu,
+                        original[node_id].cpu - bundle.cpu,
+                        original[node_id].heap_bytes - bundle.heap_bytes,
+                        node_id,
+                    ),
+                )
+            )
+            for bundle_index, bundle in enumerate(bundles)
+        }
+        ordered_bundle_indices = tuple(
+            bundle_index
+            for bundle_index, bundle in sorted(
                 enumerate(bundles),
                 key=lambda item: (
-                    sum(item[1].fits_within(capacity) for capacity in original.values()),
+                    len(candidates_by_bundle[item[0]]),
                     -item[1].gpu,
                     -item[1].cpu,
                     -item[1].heap_bytes,
@@ -502,53 +518,57 @@ class ClusterQueryResourceCoordinator:
                 ),
             )
         )
-        node_ids = tuple(sorted(original))
-        failed: set[tuple[int, tuple[tuple[str, ResourceVector], ...]]] = set()
+        bundle_by_node: dict[str, int] = {}
+        node_by_bundle: dict[int, str] = {}
 
-        def search(
-            bundle_index: int,
-            current: dict[str, ResourceVector],
-        ) -> dict[str, ResourceVector] | None:
-            if bundle_index == len(ordered):
-                return current
-            state_key = (
-                bundle_index,
-                tuple((node_id, current[node_id]) for node_id in node_ids),
-            )
-            if state_key in failed:
+        def augment(root_bundle_index: int) -> bool:
+            pending = deque((root_bundle_index,))
+            visited_bundle_indices = {root_bundle_index}
+            parent_bundle_by_node: dict[str, int] = {}
+            terminal_node_id: str | None = None
+            while pending and terminal_node_id is None:
+                bundle_index = pending.popleft()
+                for node_id in candidates_by_bundle[bundle_index]:
+                    if node_id in parent_bundle_by_node:
+                        continue
+                    parent_bundle_by_node[node_id] = bundle_index
+                    incumbent = bundle_by_node.get(node_id)
+                    if incumbent is None:
+                        terminal_node_id = node_id
+                        break
+                    if incumbent not in visited_bundle_indices:
+                        visited_bundle_indices.add(incumbent)
+                        pending.append(incumbent)
+            if terminal_node_id is None:
+                return False
+
+            # Reverse the alternating path. Iteration keeps this safe for
+            # clusters larger than Python's recursion limit.
+            node_id = terminal_node_id
+            while True:
+                bundle_index = parent_bundle_by_node[node_id]
+                previous_node_id = node_by_bundle.get(bundle_index)
+                bundle_by_node[node_id] = bundle_index
+                node_by_bundle[bundle_index] = node_id
+                if previous_node_id is None:
+                    return True
+                node_id = previous_node_id
+
+        for bundle_index in ordered_bundle_indices:
+            if not augment(bundle_index):
                 return None
-            bundle = ordered[bundle_index]
-            candidates = sorted(
-                (node_id for node_id in node_ids if bundle.fits_within(current[node_id])),
-                key=lambda node_id: (
-                    current[node_id].gpu - bundle.gpu,
-                    current[node_id].cpu - bundle.cpu,
-                    current[node_id].heap_bytes - bundle.heap_bytes,
-                    node_id,
-                ),
-            )
-            for node_id in candidates:
-                # Keep the single-bundle primitive as the mutation authority;
-                # tests also fault-inject it to verify registration rollback.
-                selected_remaining = {node_id: current[node_id]}
-                if self._place_bundle(bundle, selected_remaining) is None:
-                    raise RuntimeError("selected task bundle unexpectedly became unplaceable")
-                trial = dict(current)
-                trial[node_id] = selected_remaining[node_id]
-                placed = search(bundle_index + 1, trial)
-                if placed is not None:
-                    return placed
-            failed.add(state_key)
-            return None
 
-        placed_remaining = search(0, original)
-        if placed_remaining is None:
-            return None
-        allocations = {
-            node_id: original[node_id] - placed_remaining[node_id]
-            for node_id in node_ids
-            if original[node_id] != placed_remaining[node_id]
-        }
+        placed_remaining = dict(original)
+        allocations: dict[str, ResourceVector] = {}
+        for node_id, bundle_index in sorted(bundle_by_node.items()):
+            bundle = bundles[bundle_index]
+            # Keep the single-bundle primitive as the mutation authority;
+            # tests also fault-inject it to verify registration rollback.
+            selected_remaining = {node_id: placed_remaining[node_id]}
+            if self._place_bundle(bundle, selected_remaining) is None:
+                raise RuntimeError("matched task bundle unexpectedly became unplaceable")
+            placed_remaining[node_id] = selected_remaining[node_id]
+            allocations[node_id] = bundle
         return placed_remaining, allocations
 
     @staticmethod

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -118,6 +118,8 @@ class ActorResourceBundle:
             raise ValueError("actor resource bundle actor_index must be >= 0")
         if self.resources.is_zero():
             raise ValueError("actor resource bundle must own non-zero resources")
+        if self.resources.object_store_bytes != 0:
+            raise ValueError("actor resource bundles may not hard-reserve object-store bytes")
         object.__setattr__(self, "resource_unit_id", resource_unit_id)
         object.__setattr__(self, "actor_index", actor_index)
 
@@ -158,6 +160,10 @@ class QueryDemand:
             raise ValueError("weight must be finite and > 0")
         actor_bundles = tuple(self.actor_bundles)
         task_bundles = tuple(self.task_bundles)
+        if self.minimum.object_store_bytes != 0:
+            raise ValueError("minimum query resources may not hard-reserve object-store bytes")
+        if any(bundle.object_store_bytes != 0 for bundle in task_bundles):
+            raise ValueError("task resource bundles may not hard-reserve object-store bytes")
         actor_keys = [(bundle.resource_unit_id, bundle.actor_index) for bundle in actor_bundles]
         if len(set(actor_keys)) != len(actor_keys):
             raise ValueError("actor resource bundles contain duplicate resource-unit/index identities")

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -88,7 +88,7 @@ class QueryDemand:
     desired: ResourceVector
     weight: float = 1.0
     priority: int = 0
-    task_bundles: tuple[ResourceVector, ...] = ()
+    placement_bundles: tuple[ResourceVector, ...] = ()
 
     def __post_init__(self) -> None:
         query_id = str(self.query_id).strip()
@@ -100,20 +100,20 @@ class QueryDemand:
         weight = float(self.weight)
         if not math.isfinite(weight) or weight <= 0:
             raise ValueError("weight must be finite and > 0")
-        task_bundles = tuple(self.task_bundles)
+        placement_bundles = tuple(self.placement_bundles)
         if self.minimum.object_store_bytes != 0:
             raise ValueError("minimum query resources may not hard-reserve object-store bytes")
-        if any(bundle.object_store_bytes != 0 for bundle in task_bundles):
-            raise ValueError("task resource bundles may not hard-reserve object-store bytes")
-        task_total = _sum_resources(task_bundles)
-        if task_total != self.minimum:
-            raise ValueError("task_bundles must exactly equal minimum query resources")
-        if not task_total.fits_within(self.desired):
+        if any(bundle.object_store_bytes != 0 for bundle in placement_bundles):
+            raise ValueError("placement bundles may not hard-reserve object-store bytes")
+        placement_total = _sum_resources(placement_bundles)
+        if placement_total != self.minimum:
+            raise ValueError("placement_bundles must exactly equal minimum query resources")
+        if not placement_total.fits_within(self.desired):
             raise ValueError("minimum placement bundles exceed desired query resources")
         object.__setattr__(self, "query_id", query_id)
         object.__setattr__(self, "weight", weight)
         object.__setattr__(self, "priority", int(self.priority))
-        object.__setattr__(self, "task_bundles", task_bundles)
+        object.__setattr__(self, "placement_bundles", placement_bundles)
 
 
 @dataclass
@@ -420,7 +420,7 @@ class ClusterQueryResourceCoordinator:
         )
         for state in ordered:
             query_id = state.demand.query_id
-            placement = self._place_task_bundles(state.demand.task_bundles, remaining)
+            placement = self._place_bundles(state.demand.placement_bundles, remaining)
             if placement is None:
                 continue
             trial_remaining, trial_allocations = placement
@@ -472,12 +472,12 @@ class ClusterQueryResourceCoordinator:
                 state.state = "ALLOCATION_DEBT"
                 state.rejection_reason = "live query hard-resource leases exceed the current allocation"
 
-    def _place_task_bundles(
+    def _place_bundles(
         self,
         bundles: Sequence[ResourceVector],
         remaining: Mapping[str, ResourceVector],
     ) -> tuple[dict[str, ResourceVector], dict[str, ResourceVector]] | None:
-        """Match indivisible capability envelopes to distinct Ray nodes.
+        """Match indivisible task/actor capability envelopes to distinct Ray nodes.
 
         The graph builder emits at most one envelope for each concrete source
         node: if one node could run two task-shape groups, it would have merged
@@ -566,7 +566,7 @@ class ClusterQueryResourceCoordinator:
             # tests also fault-inject it to verify registration rollback.
             selected_remaining = {node_id: placed_remaining[node_id]}
             if self._place_bundle(bundle, selected_remaining) is None:
-                raise RuntimeError("matched task bundle unexpectedly became unplaceable")
+                raise RuntimeError("matched placement bundle unexpectedly became unplaceable")
             placed_remaining[node_id] = selected_remaining[node_id]
             allocations[node_id] = bundle
         return placed_remaining, allocations

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -74,6 +74,15 @@ def _positive_difference(left: ResourceVector, right: ResourceVector) -> Resourc
     )
 
 
+def _hard_positive_difference(left: ResourceVector, right: ResourceVector) -> ResourceVector:
+    """Return allocation debt for resources that cannot be relieved by spill."""
+    return ResourceVector(
+        cpu=max(0.0, left.cpu - right.cpu),
+        gpu=max(0.0, left.gpu - right.gpu),
+        heap_bytes=max(0, left.heap_bytes - right.heap_bytes),
+    )
+
+
 @dataclass(frozen=True)
 class NodeCapacity:
     node_id: str
@@ -115,6 +124,14 @@ class ActorResourceBundle:
 
 @dataclass(frozen=True)
 class QueryDemand:
+    """Hard placement minimum plus elastic resource targets.
+
+    CPU, GPU, and heap in ``minimum`` are placement requirements. The
+    object-store components are soft flow-control budgets; spillable task
+    input/output windows must not be copied into ``minimum`` or the placement
+    bundles.
+    """
+
     query_id: str
     minimum: ResourceVector
     desired: ResourceVector
@@ -556,10 +573,10 @@ class ClusterQueryResourceCoordinator:
             )
             state.node_allocations = node_allocations_by_query[query_id]
             state.actor_placements = actor_placements_by_query[query_id]
-            state.allocation_debt = _positive_difference(state.observed_usage, resources)
+            state.allocation_debt = _hard_positive_difference(state.observed_usage, resources)
             if not state.allocation_debt.is_zero() and state.state != "ACTOR_PLACEMENT_LOST":
                 state.state = "ALLOCATION_DEBT"
-                state.rejection_reason = "live query leases exceed the current allocation"
+                state.rejection_reason = "live query hard-resource leases exceed the current allocation"
 
     @staticmethod
     def _place_bundle(bundle: ResourceVector, remaining: dict[str, ResourceVector]) -> str | None:
@@ -723,6 +740,10 @@ class ClusterQueryResourceCoordinator:
                         "allocation": state.allocation.to_dict(),
                         "observed_usage": state.observed_usage.to_dict(),
                         "allocation_debt": state.allocation_debt.to_dict(),
+                        "soft_object_store_debt_bytes": max(
+                            0,
+                            state.observed_usage.object_store_bytes - state.allocation.resources.object_store_bytes,
+                        ),
                         "can_admit_new_tasks": state.state == "RUNNING" and state.allocation_debt.is_zero(),
                         "rejection_reason": state.rejection_reason,
                         "node_allocations": {

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -7,19 +7,16 @@ import copy
 import math
 import threading
 import time
-from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
-    QueryAllocation,
-    ResourceVector,
-)
+from duckdb.runners.ray.query_resource_graph import QueryAllocation, ResourceVector
 from duckdb.runners.ray.worker_memory import build_ray_node_memory_layout
 
 _EPSILON = 1e-9
+_RESOURCE_FIELDS = ("cpu", "gpu", "heap_bytes", "object_store_bytes")
+_INTEGER_RESOURCE_FIELDS = {"heap_bytes", "object_store_bytes"}
 
 
 def _sum_resources(resources: Sequence[ResourceVector]) -> ResourceVector:
@@ -27,12 +24,6 @@ def _sum_resources(resources: Sequence[ResourceVector]) -> ResourceVector:
     for item in resources:
         total = total + item
     return total
-
-
-def _replace_resource(vector: ResourceVector, field_name: str, value: float) -> ResourceVector:
-    payload = vector.to_dict()
-    payload[field_name] = value
-    return ResourceVector.from_dict(payload)
 
 
 def _positive_difference(left: ResourceVector, right: ResourceVector) -> ResourceVector:
@@ -44,17 +35,10 @@ def _positive_difference(left: ResourceVector, right: ResourceVector) -> Resourc
     )
 
 
-def _hard_positive_difference(left: ResourceVector, right: ResourceVector) -> ResourceVector:
-    """Return allocation debt for resources that cannot be relieved by spill."""
-    return ResourceVector(
-        cpu=max(0.0, left.cpu - right.cpu),
-        gpu=max(0.0, left.gpu - right.gpu),
-        heap_bytes=max(0, left.heap_bytes - right.heap_bytes),
-    )
-
-
 @dataclass(frozen=True)
 class NodeCapacity:
+    """One live Ray node used only to derive the cluster-wide soft budget."""
+
     node_id: str
     resources: ResourceVector
     labels: tuple[str, ...] = ()
@@ -75,45 +59,30 @@ class NodeCapacity:
 
 @dataclass(frozen=True)
 class QueryDemand:
-    """Hard placement minimum plus elastic resource targets.
+    """A query's current-phase soft resource target.
 
-    CPU, GPU, and heap in ``minimum`` are placement requirements. The
-    object-store components are soft flow-control budgets; spillable task
-    input/output windows must not be copied into ``minimum`` or the placement
-    bundles.
+    Demand is intentionally aggregate and divisible. It is not a placement
+    bundle and never prevents concrete Ray tasks or actors from being
+    submitted. Ray Core owns physical feasibility, pending demand, and
+    autoscaling; the coordinator only divides the observed cluster capacity
+    into weighted soft backpressure budgets.
     """
 
     query_id: str
-    minimum: ResourceVector
     desired: ResourceVector
     weight: float = 1.0
     priority: int = 0
-    placement_bundles: tuple[ResourceVector, ...] = ()
 
     def __post_init__(self) -> None:
         query_id = str(self.query_id).strip()
         if not query_id:
             raise ValueError("query_id must be non-empty")
-        if not self.minimum.fits_within(self.desired):
-            exceeded = self.minimum.exceeded_dimensions(self.desired)
-            raise ValueError(f"minimum query demand exceeds desired demand for {', '.join(exceeded)}")
         weight = float(self.weight)
         if not math.isfinite(weight) or weight <= 0:
             raise ValueError("weight must be finite and > 0")
-        placement_bundles = tuple(self.placement_bundles)
-        if self.minimum.object_store_bytes != 0:
-            raise ValueError("minimum query resources may not hard-reserve object-store bytes")
-        if any(bundle.object_store_bytes != 0 for bundle in placement_bundles):
-            raise ValueError("placement bundles may not hard-reserve object-store bytes")
-        placement_total = _sum_resources(placement_bundles)
-        if placement_total != self.minimum:
-            raise ValueError("placement_bundles must exactly equal minimum query resources")
-        if not placement_total.fits_within(self.desired):
-            raise ValueError("minimum placement bundles exceed desired query resources")
         object.__setattr__(self, "query_id", query_id)
         object.__setattr__(self, "weight", weight)
         object.__setattr__(self, "priority", int(self.priority))
-        object.__setattr__(self, "placement_bundles", placement_bundles)
 
 
 @dataclass
@@ -124,14 +93,10 @@ class _QueryState:
     allocation: QueryAllocation = field(
         default_factory=lambda: QueryAllocation(
             resources=ResourceVector(),
-            node_allocations=(),
             generation=1,
         )
     )
-    node_allocations: dict[str, ResourceVector] = field(default_factory=dict)
-    allocation_debt: ResourceVector = field(default_factory=ResourceVector)
-    state: str = "PENDING_RESOURCES"
-    rejection_reason: str = ""
+    soft_allocation_debt: ResourceVector = field(default_factory=ResourceVector)
     expires_at: float = 0.0
 
 
@@ -141,12 +106,8 @@ def read_ray_node_capacities(
     object_store_fraction: float = 0.5,
     heap_reserve_bytes_per_node: int = 0,
 ) -> tuple[NodeCapacity, ...]:
-    """Read the only supported capacity source: live resources reported by Ray.
+    """Read live Ray capacity without inventing host-resource fallbacks."""
 
-    This function is deliberately separate from coordinator locks. A slow GCS
-    request can delay a refresh, but it cannot block query admission already
-    operating on the last complete capacity snapshot.
-    """
     fraction = float(object_store_fraction)
     if not math.isfinite(fraction) or fraction <= 0 or fraction > 1:
         raise ValueError("object_store_fraction must be in (0, 1]")
@@ -192,11 +153,11 @@ def read_ray_node_capacities(
 
 
 class ClusterQueryResourceCoordinator:
-    """Deterministic cluster-to-query allocation authority.
+    """Divide cluster capacity into query-level soft budgets.
 
-    Ray I/O is intentionally absent from this class. Callers refresh a complete
-    immutable node-capacity snapshot, then all allocation and lease bookkeeping
-    happens under one local lock.
+    The coordinator deliberately performs no bin packing and has no pending
+    admission state. Even a zero-budget query remains runnable so one bounded
+    QRM liveness grant can submit real demand to Ray Core and its autoscaler.
     """
 
     def __init__(
@@ -244,10 +205,6 @@ class ClusterQueryResourceCoordinator:
                 self._next_sequence = previous_next_sequence + 1
                 self._rebalance_locked()
             except BaseException:
-                # Rebalancing updates every query allocation in place. Restore
-                # the exact pre-registration objects and counters after any
-                # failure so no partial allocation, heartbeat, or lease state
-                # can escape.
                 self._queries = previous_queries
                 self._next_sequence = previous_next_sequence
                 self._generation = previous_generation
@@ -287,13 +244,7 @@ class ClusterQueryResourceCoordinator:
         demands_by_query: Mapping[str, QueryDemand] | None = None,
         now: float | None = None,
     ) -> dict[str, QueryAllocation]:
-        """Atomically refresh every live query from one coordinator snapshot.
-
-        A multi-query driver must not refresh queries one by one because each
-        rebalance advances every allocation generation.  Validating the full
-        batch before mutation also prevents a stale query from partially
-        extending other heartbeat deadlines.
-        """
+        """Atomically refresh every live query from one driver snapshot."""
 
         timestamp = time.monotonic() if now is None else float(now)
         usage = {str(query_id): value for query_id, value in observed_usage_by_query.items()}
@@ -351,12 +302,7 @@ class ClusterQueryResourceCoordinator:
             return state.allocation
 
     def query_state(self, query_id: str, generation: int) -> str:
-        """Return one generation-fenced query scheduling state.
-
-        Registration needs this small control-plane value before the query-local
-        manager exists. Exposing it directly avoids constructing and traversing
-        the coordinator's full diagnostic snapshot on every query start.
-        """
+        """Return the generation-fenced state; registered queries always run."""
 
         query_key = str(query_id)
         with self._lock:
@@ -364,7 +310,7 @@ class ClusterQueryResourceCoordinator:
             if state is None:
                 raise KeyError(f"query is not registered: {query_key}")
             self._require_generation(state, generation)
-            return str(state.state)
+            return "RUNNING"
 
     def release_query(self, query_id: str, generation: int) -> bool:
         query_key = str(query_id)
@@ -394,7 +340,7 @@ class ClusterQueryResourceCoordinator:
         *,
         now: float | None = None,
     ) -> None:
-        del now  # Capacity generations, not wall clock, order this update.
+        del now
         normalized = self._normalize_nodes(node_capacities)
         with self._lock:
             self._nodes = normalized
@@ -410,506 +356,106 @@ class ClusterQueryResourceCoordinator:
     def _rebalance_locked(self) -> None:
         self._generation += 1
         generation = self._generation
-        remaining = {node_id: node.resources for node_id, node in self._nodes.items()}
-        node_allocations_by_query: dict[str, dict[str, ResourceVector]] = {query_id: {} for query_id in self._queries}
-        admitted: list[_QueryState] = []
-
-        ordered = sorted(
-            self._queries.values(),
-            key=lambda state: (-state.demand.priority, state.sequence, state.demand.query_id),
+        total_capacity = _sum_resources(tuple(node.resources for node in self._nodes.values()))
+        ordered = tuple(
+            sorted(
+                self._queries.values(),
+                key=lambda state: (-state.demand.priority, state.sequence, state.demand.query_id),
+            )
         )
+        allocations = self._weighted_soft_allocations(ordered, total_capacity)
         for state in ordered:
-            query_id = state.demand.query_id
-            placement = self._place_bundles(state.demand.placement_bundles, remaining)
-            if placement is None:
-                continue
-            trial_remaining, trial_allocations = placement
-
-            remaining = trial_remaining
-            node_allocations_by_query[query_id] = trial_allocations
-            admitted.append(state)
-
-        total_capacity = _sum_resources([node.resources for node in self._nodes.values()])
-        extra_capacity = _sum_resources(list(remaining.values()))
-        extras = self._weighted_drf_extras(admitted, extra_capacity, total_capacity)
-
-        # Place the aggregate DRF result onto concrete nodes. Extra allocations
-        # are soft scheduling attribution; Ray Core still places concrete work
-        # and enforces its real CPU/GPU/memory request.
-        for state in admitted:
-            query_id = state.demand.query_id
-            extra = extras.get(query_id, ResourceVector())
-            placed = self._place_divisible(extra, remaining)
-            if placed is None:
-                # Aggregate feasibility should make this impossible because the
-                # divisible dimensions may be split independently across nodes.
-                raise RuntimeError(f"failed to place feasible DRF allocation for query {query_id}")
-            for node_id, vector in placed.items():
-                allocations = node_allocations_by_query[query_id]
-                allocations[node_id] = allocations.get(node_id, ResourceVector()) + vector
-
-        admitted_ids = {state.demand.query_id for state in admitted}
-        for query_id, state in self._queries.items():
-            if query_id in admitted_ids:
-                state.state = "RUNNING"
-                state.rejection_reason = ""
-            else:
-                state.state = "PENDING_RESOURCES"
-                state.rejection_reason = "minimum query resource bundles are not currently feasible"
-            resources = _sum_resources(list(node_allocations_by_query[query_id].values()))
-            state.allocation = QueryAllocation(
-                resources=resources,
-                node_allocations=tuple(
-                    NodeResourceAllocation(node_id=node_id, resources=vector)
-                    for node_id, vector in sorted(node_allocations_by_query[query_id].items())
-                    if not vector.is_zero()
-                ),
-                generation=generation,
-            )
-            state.node_allocations = node_allocations_by_query[query_id]
-            state.allocation_debt = _hard_positive_difference(state.observed_usage, resources)
-            if not state.allocation_debt.is_zero():
-                state.state = "ALLOCATION_DEBT"
-                state.rejection_reason = "live query hard-resource leases exceed the current allocation"
-
-    def _place_bundles(
-        self,
-        bundles: Sequence[ResourceVector],
-        remaining: Mapping[str, ResourceVector],
-    ) -> tuple[dict[str, ResourceVector], dict[str, ResourceVector]] | None:
-        """Match indivisible task/actor capability envelopes to distinct Ray nodes.
-
-        The graph builder emits at most one envelope for each concrete source
-        node: if one node could run two task-shape groups, it would have merged
-        them into one component-wise envelope.  Placement is therefore a
-        bipartite matching problem, not multidimensional bin packing.  An
-        augmenting-path matcher avoids both greedy false negatives and
-        exponential backtracking when a large query is currently infeasible.
-        """
-
-        original = dict(remaining)
-        if not bundles:
-            return original, {}
-        node_ids = tuple(sorted(original))
-        candidates_by_bundle = {
-            bundle_index: tuple(
-                sorted(
-                    (node_id for node_id in node_ids if bundle.fits_within(original[node_id])),
-                    key=lambda node_id: (
-                        original[node_id].gpu - bundle.gpu,
-                        original[node_id].cpu - bundle.cpu,
-                        original[node_id].heap_bytes - bundle.heap_bytes,
-                        node_id,
-                    ),
-                )
-            )
-            for bundle_index, bundle in enumerate(bundles)
-        }
-        ordered_bundle_indices = tuple(
-            bundle_index
-            for bundle_index, bundle in sorted(
-                enumerate(bundles),
-                key=lambda item: (
-                    len(candidates_by_bundle[item[0]]),
-                    -item[1].gpu,
-                    -item[1].cpu,
-                    -item[1].heap_bytes,
-                    item[0],
-                ),
-            )
-        )
-        bundle_by_node: dict[str, int] = {}
-        node_by_bundle: dict[int, str] = {}
-
-        def augment(root_bundle_index: int) -> bool:
-            pending = deque((root_bundle_index,))
-            visited_bundle_indices = {root_bundle_index}
-            parent_bundle_by_node: dict[str, int] = {}
-            terminal_node_id: str | None = None
-            while pending and terminal_node_id is None:
-                bundle_index = pending.popleft()
-                for node_id in candidates_by_bundle[bundle_index]:
-                    if node_id in parent_bundle_by_node:
-                        continue
-                    parent_bundle_by_node[node_id] = bundle_index
-                    incumbent = bundle_by_node.get(node_id)
-                    if incumbent is None:
-                        terminal_node_id = node_id
-                        break
-                    if incumbent not in visited_bundle_indices:
-                        visited_bundle_indices.add(incumbent)
-                        pending.append(incumbent)
-            if terminal_node_id is None:
-                return False
-
-            # Reverse the alternating path. Iteration keeps this safe for
-            # clusters larger than Python's recursion limit.
-            node_id = terminal_node_id
-            while True:
-                bundle_index = parent_bundle_by_node[node_id]
-                previous_node_id = node_by_bundle.get(bundle_index)
-                bundle_by_node[node_id] = bundle_index
-                node_by_bundle[bundle_index] = node_id
-                if previous_node_id is None:
-                    return True
-                node_id = previous_node_id
-
-        for bundle_index in ordered_bundle_indices:
-            if not augment(bundle_index):
-                return None
-
-        placed_remaining = dict(original)
-        allocations: dict[str, ResourceVector] = {}
-        for node_id, bundle_index in sorted(bundle_by_node.items()):
-            bundle = bundles[bundle_index]
-            # Keep the single-bundle primitive as the mutation authority;
-            # tests also fault-inject it to verify registration rollback.
-            selected_remaining = {node_id: placed_remaining[node_id]}
-            if self._place_bundle(bundle, selected_remaining) is None:
-                raise RuntimeError("matched placement bundle unexpectedly became unplaceable")
-            placed_remaining[node_id] = selected_remaining[node_id]
-            allocations[node_id] = bundle
-        return placed_remaining, allocations
+            resources = allocations.get(state.demand.query_id, ResourceVector())
+            state.allocation = QueryAllocation(resources=resources, generation=generation)
+            state.soft_allocation_debt = _positive_difference(state.observed_usage, resources)
 
     @staticmethod
-    def _place_bundle(bundle: ResourceVector, remaining: dict[str, ResourceVector]) -> str | None:
-        candidates = [node_id for node_id, capacity in remaining.items() if bundle.fits_within(capacity)]
-        if not candidates:
-            return None
-        node_id = min(
-            candidates,
-            key=lambda candidate: (
-                remaining[candidate].gpu - bundle.gpu,
-                remaining[candidate].cpu - bundle.cpu,
-                remaining[candidate].heap_bytes - bundle.heap_bytes,
-                candidate,
-            ),
-        )
-        remaining[node_id] = remaining[node_id] - bundle
-        return node_id
-
-    @staticmethod
-    def _place_divisible(
-        request: ResourceVector,
-        remaining: dict[str, ResourceVector],
-    ) -> dict[str, ResourceVector] | None:
-        trial_remaining = dict(remaining)
-        allocations = {node_id: ResourceVector() for node_id in remaining}
-        for field_name in ("cpu", "gpu", "heap_bytes", "object_store_bytes"):
-            needed = float(getattr(request, field_name))
-            if needed <= _EPSILON:
-                continue
-            candidates = sorted(
-                trial_remaining,
-                key=lambda node_id: (-float(getattr(trial_remaining[node_id], field_name)), node_id),
-            )
-            for node_id in candidates:
-                available = float(getattr(trial_remaining[node_id], field_name))
-                if available <= _EPSILON:
-                    continue
-                amount = min(needed, available)
-                if field_name not in {"cpu", "gpu"}:
-                    amount = int(amount)
-                if amount <= 0:
-                    continue
-                allocations[node_id] = _replace_resource(
-                    allocations[node_id],
-                    field_name,
-                    getattr(allocations[node_id], field_name) + amount,
-                )
-                trial_remaining[node_id] = _replace_resource(
-                    trial_remaining[node_id],
-                    field_name,
-                    getattr(trial_remaining[node_id], field_name) - amount,
-                )
-                needed -= amount
-                if needed <= _EPSILON:
-                    break
-            if needed > _EPSILON:
-                return None
-        remaining.clear()
-        remaining.update(trial_remaining)
-        return {node_id: vector for node_id, vector in allocations.items() if not vector.is_zero()}
-
-    @staticmethod
-    def _weighted_drf_extras(
-        admitted: Sequence[_QueryState],
-        extra_capacity: ResourceVector,
-        total_capacity: ResourceVector,
-    ) -> dict[str, ResourceVector]:
-        if not admitted:
-            return {}
-
-        # Object-store bytes are a soft flow-control budget. Allocate them
-        # independently so saturation in a hard DRF dimension (for example,
-        # all CPU consumed by query minima) cannot give one admitted query the
-        # entire store tail while another receives zero.
-        hard_extra_capacity = ResourceVector(
-            cpu=extra_capacity.cpu,
-            gpu=extra_capacity.gpu,
-            heap_bytes=extra_capacity.heap_bytes,
-        )
-        hard_total_capacity = ResourceVector(
-            cpu=total_capacity.cpu,
-            gpu=total_capacity.gpu,
-            heap_bytes=total_capacity.heap_bytes,
-        )
-        # Water-fill each query's final weighted dominant share. Hard minima
-        # are already allocated, so fairness must start from those shares
-        # instead of treating every query's remaining headroom as a fresh zero.
-        states_by_id = {state.demand.query_id: state for state in admitted}
-        minimum: dict[str, ResourceVector] = {
-            state.demand.query_id: ResourceVector(
-                cpu=state.demand.minimum.cpu,
-                gpu=state.demand.minimum.gpu,
-                heap_bytes=state.demand.minimum.heap_bytes,
-            )
-            for state in admitted
-        }
-        desired: dict[str, ResourceVector] = {
-            state.demand.query_id: ResourceVector(
-                cpu=state.demand.desired.cpu,
-                gpu=state.demand.desired.gpu,
-                heap_bytes=state.demand.desired.heap_bytes,
-            )
-            for state in admitted
-        }
-        headroom = {query_id: desired[query_id] - minimum[query_id] for query_id in states_by_id}
-        minimum_share = {query_id: minimum[query_id].dominant_share(hard_total_capacity) for query_id in states_by_id}
-        desired_share = {query_id: desired[query_id].dominant_share(hard_total_capacity) for query_id in states_by_id}
-        finite_limits = [
-            desired_share[query_id] / states_by_id[query_id].demand.weight
-            for query_id in headroom
-            if not headroom[query_id].is_zero() and math.isfinite(desired_share[query_id])
-        ]
-
-        def minimum_factor_at(query_id: str, level: float) -> float:
-            """Return the least headroom fraction that reaches a weighted share."""
-            room = headroom[query_id]
-            if room.is_zero():
-                return 0.0
-            weight = states_by_id[query_id].demand.weight
-            target_share = level * weight
-            if minimum_share[query_id] >= target_share - _EPSILON:
-                return 0.0
-            factors: list[float] = []
-            for field_name in ("cpu", "gpu", "heap_bytes"):
-                room_amount = float(getattr(room, field_name))
-                if room_amount <= 0:
-                    continue
-                capacity = float(getattr(hard_total_capacity, field_name))
-                if capacity <= 0:
-                    return 0.0
-                base_amount = float(getattr(minimum[query_id], field_name))
-                factors.append((target_share * capacity - base_amount) / room_amount)
-            return min(1.0, max(0.0, min(factors, default=0.0)))
-
-        def allocation_at(level: float) -> dict[str, ResourceVector]:
-            return {query_id: room.scale(minimum_factor_at(query_id, level)) for query_id, room in headroom.items()}
-
-        def feasible(level: float) -> bool:
-            total = _sum_resources(list(allocation_at(level).values()))
-            return total.fits_within(hard_extra_capacity)
-
-        if finite_limits:
-            low = 0.0
-            high = max(finite_limits)
-            if feasible(high):
-                low = high
-            else:
-                for _ in range(80):
-                    middle = (low + high) / 2.0
-                    if feasible(middle):
-                        low = middle
-                    else:
-                        high = middle
-            allocated = allocation_at(low)
-
-            # A query can have headroom in a non-dominant dimension. Fill as
-            # much of that plateau as capacity permits without raising its
-            # weighted dominant share above the water level. This preserves
-            # max-min fairness while avoiding stranded divisible capacity.
-            remaining = _positive_difference(
-                hard_extra_capacity,
-                _sum_resources(list(allocated.values())),
-            )
-            for state in sorted(
-                admitted,
-                key=lambda item: (-item.demand.priority, item.sequence, item.demand.query_id),
-            ):
-                query_id = state.demand.query_id
-                unit_headroom = headroom[query_id]
-                if unit_headroom.is_zero():
-                    continue
-                current_factor = minimum_factor_at(query_id, low)
-                share_ceiling = max(minimum_share[query_id], low * state.demand.weight)
-                upper_factors: list[float] = []
-                for field_name in ("cpu", "gpu", "heap_bytes"):
-                    room_amount = float(getattr(unit_headroom, field_name))
-                    if room_amount <= 0:
-                        continue
-                    capacity = float(getattr(hard_total_capacity, field_name))
-                    if capacity <= 0:
-                        upper_factors.append(0.0)
-                        continue
-                    base_amount = float(getattr(minimum[query_id], field_name))
-                    upper_factors.append((share_ceiling * capacity - base_amount) / room_amount)
-                maximum_factor = min(1.0, max(0.0, min(upper_factors, default=0.0)))
-                if maximum_factor <= current_factor + _EPSILON:
-                    continue
-
-                candidate = unit_headroom.scale(maximum_factor)
-                delta = candidate - allocated[query_id]
-                if not delta.fits_within(remaining):
-                    lower = current_factor
-                    upper = maximum_factor
-                    for _ in range(80):
-                        middle = (lower + upper) / 2.0
-                        middle_delta = unit_headroom.scale(middle) - allocated[query_id]
-                        if middle_delta.fits_within(remaining):
-                            lower = middle
-                        else:
-                            upper = middle
-                    candidate = unit_headroom.scale(lower)
-                    delta = candidate - allocated[query_id]
-                allocated[query_id] = candidate
-                remaining = remaining - delta
-        else:
-            allocated = {state.demand.query_id: ResourceVector() for state in admitted}
-
-        # Byte flooring can leave a small tail. Assign it deterministically to
-        # the currently lowest weighted dominant share without exceeding demand.
-        used = _sum_resources(list(allocated.values()))
-        remaining = _positive_difference(hard_extra_capacity, used)
-        for field_name in ("heap_bytes",):
-            tail = int(getattr(remaining, field_name))
-            if tail <= 0:
-                continue
-
-            def weighted_hard_share(state: _QueryState) -> float:
-                query_id = state.demand.query_id
-                minimum = state.demand.minimum
-                extra = allocated[query_id]
-                current = ResourceVector(
-                    cpu=minimum.cpu + extra.cpu,
-                    gpu=minimum.gpu + extra.gpu,
-                    heap_bytes=minimum.heap_bytes + extra.heap_bytes,
-                )
-                return current.dominant_share(hard_total_capacity) / state.demand.weight
-
-            candidates = sorted(
-                admitted,
-                key=lambda state: (
-                    weighted_hard_share(state),
-                    -state.demand.priority,
-                    state.sequence,
-                ),
-            )
-            for state in candidates:
-                query_id = state.demand.query_id
-                field_headroom = int(getattr(headroom[query_id], field_name) - getattr(allocated[query_id], field_name))
-                amount = min(tail, max(0, field_headroom))
-                if amount <= 0:
-                    continue
-                allocated[query_id] = _replace_resource(
-                    allocated[query_id],
-                    field_name,
-                    getattr(allocated[query_id], field_name) + amount,
-                )
-                tail -= amount
-                if tail == 0:
-                    break
-
-        object_store_extras = ClusterQueryResourceCoordinator._weighted_object_store_extras(
-            admitted,
-            int(extra_capacity.object_store_bytes),
-        )
-        for state in admitted:
-            query_id = state.demand.query_id
-            allocated[query_id] = _replace_resource(
-                allocated[query_id],
-                "object_store_bytes",
-                object_store_extras.get(query_id, 0),
-            )
-        return allocated
-
-    @staticmethod
-    def _weighted_object_store_extras(
-        admitted: Sequence[_QueryState],
-        extra_capacity_bytes: int,
-    ) -> dict[str, int]:
-        """Weighted max-min allocation for the spillable query budget."""
-        capacity = max(0, int(extra_capacity_bytes))
-        if not admitted or capacity <= 0:
-            return {}
-
-        minimum = {state.demand.query_id: int(state.demand.minimum.object_store_bytes) for state in admitted}
-        desired = {state.demand.query_id: int(state.demand.desired.object_store_bytes) for state in admitted}
-        limits = [
-            desired[state.demand.query_id] / state.demand.weight
-            for state in admitted
-            if desired[state.demand.query_id] > minimum[state.demand.query_id]
-        ]
-        if not limits:
-            return {}
-
-        def allocation_at(level: float) -> dict[str, int]:
-            result: dict[str, int] = {}
-            for state in admitted:
-                query_id = state.demand.query_id
-                target = min(
-                    desired[query_id],
-                    max(
-                        minimum[query_id],
-                        level * state.demand.weight,
-                    ),
-                )
-                result[query_id] = min(
-                    desired[query_id] - minimum[query_id],
-                    max(0, math.floor(target - minimum[query_id])),
-                )
+    def _weighted_field_allocations(
+        states: Sequence[_QueryState],
+        capacity: int | float,
+        field_name: str,
+    ) -> dict[str, int | float]:
+        available = max(0.0, float(capacity))
+        result: dict[str, int | float] = {state.demand.query_id: 0 for state in states}
+        candidates = [state for state in states if float(getattr(state.demand.desired, field_name)) > 0]
+        if not candidates or available <= 0:
             return result
 
-        def feasible(level: float) -> bool:
-            return sum(allocation_at(level).values()) <= capacity
+        total_desired = sum(float(getattr(state.demand.desired, field_name)) for state in candidates)
+        if total_desired <= available + _EPSILON:
+            for state in candidates:
+                result[state.demand.query_id] = getattr(state.demand.desired, field_name)
+            return result
+
+        high = max(float(getattr(state.demand.desired, field_name)) / state.demand.weight for state in candidates)
+
+        def allocation_at(level: float) -> dict[str, float]:
+            return {
+                state.demand.query_id: min(
+                    float(getattr(state.demand.desired, field_name)),
+                    level * state.demand.weight,
+                )
+                for state in candidates
+            }
 
         low = 0.0
-        high = max(limits)
-        if feasible(high):
-            low = high
-        else:
-            for _ in range(80):
-                middle = (low + high) / 2.0
-                if feasible(middle):
-                    low = middle
-                else:
-                    high = middle
-        allocated = allocation_at(low)
+        for _ in range(80):
+            middle = (low + high) / 2.0
+            if sum(allocation_at(middle).values()) <= available:
+                low = middle
+            else:
+                high = middle
+        raw = allocation_at(low)
 
-        # Flooring leaves at most a small integer tail. Hand out individual
-        # bytes at the lowest weighted final budget to preserve fairness and a
-        # deterministic priority/arrival-order tie break.
-        tail = capacity - sum(allocated.values())
-        while tail > 0:
-            candidates = [
+        if field_name not in _INTEGER_RESOURCE_FIELDS:
+            for query_id, amount in raw.items():
+                result[query_id] = amount
+            return result
+
+        integer_capacity = int(capacity)
+        for query_id, amount in raw.items():
+            result[query_id] = math.floor(amount)
+        remaining = integer_capacity - sum(int(value) for value in result.values())
+        while remaining > 0:
+            eligible = [
                 state
-                for state in admitted
-                if allocated[state.demand.query_id] < desired[state.demand.query_id] - minimum[state.demand.query_id]
+                for state in candidates
+                if int(result[state.demand.query_id]) < int(getattr(state.demand.desired, field_name))
             ]
-            if not candidates:
+            if not eligible:
                 break
             selected = min(
-                candidates,
+                eligible,
                 key=lambda state: (
-                    (minimum[state.demand.query_id] + allocated[state.demand.query_id]) / state.demand.weight,
+                    float(result[state.demand.query_id]) / state.demand.weight,
                     -state.demand.priority,
                     state.sequence,
                     state.demand.query_id,
                 ),
             )
-            allocated[selected.demand.query_id] += 1
-            tail -= 1
-        return allocated
+            result[selected.demand.query_id] = int(result[selected.demand.query_id]) + 1
+            remaining -= 1
+        return result
+
+    @classmethod
+    def _weighted_soft_allocations(
+        cls,
+        states: Sequence[_QueryState],
+        capacity: ResourceVector,
+    ) -> dict[str, ResourceVector]:
+        by_field = {
+            field_name: cls._weighted_field_allocations(states, getattr(capacity, field_name), field_name)
+            for field_name in _RESOURCE_FIELDS
+        }
+        return {
+            state.demand.query_id: ResourceVector(
+                cpu=float(by_field["cpu"][state.demand.query_id]),
+                gpu=float(by_field["gpu"][state.demand.query_id]),
+                heap_bytes=int(by_field["heap_bytes"][state.demand.query_id]),
+                object_store_bytes=int(by_field["object_store_bytes"][state.demand.query_id]),
+            )
+            for state in states
+        }
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
@@ -919,21 +465,12 @@ class ClusterQueryResourceCoordinator:
                 "nodes": {node_id: node.to_dict() for node_id, node in self._nodes.items()},
                 "queries": {
                     query_id: {
-                        "state": state.state,
+                        "state": "RUNNING",
                         "priority": state.demand.priority,
                         "weight": state.demand.weight,
                         "allocation": state.allocation.to_dict(),
                         "observed_usage": state.observed_usage.to_dict(),
-                        "allocation_debt": state.allocation_debt.to_dict(),
-                        "soft_object_store_debt_bytes": max(
-                            0,
-                            state.observed_usage.object_store_bytes - state.allocation.resources.object_store_bytes,
-                        ),
-                        "can_admit_new_tasks": state.state == "RUNNING" and state.allocation_debt.is_zero(),
-                        "rejection_reason": state.rejection_reason,
-                        "node_allocations": {
-                            node_id: vector.to_dict() for node_id, vector in sorted(state.node_allocations.items())
-                        },
+                        "soft_allocation_debt": state.soft_allocation_debt.to_dict(),
                         "expires_at": state.expires_at,
                     }
                     for query_id, state in sorted(self._queries.items())

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -663,35 +663,58 @@ class ClusterQueryResourceCoordinator:
             gpu=total_capacity.gpu,
             heap_bytes=total_capacity.heap_bytes,
         )
-        headroom: dict[str, ResourceVector] = {
+        # Water-fill each query's final weighted dominant share. Hard minima
+        # are already allocated, so fairness must start from those shares
+        # instead of treating every query's remaining headroom as a fresh zero.
+        states_by_id = {state.demand.query_id: state for state in admitted}
+        minimum: dict[str, ResourceVector] = {
             state.demand.query_id: ResourceVector(
-                cpu=(state.demand.desired - state.demand.minimum).cpu,
-                gpu=(state.demand.desired - state.demand.minimum).gpu,
-                heap_bytes=(state.demand.desired - state.demand.minimum).heap_bytes,
+                cpu=state.demand.minimum.cpu,
+                gpu=state.demand.minimum.gpu,
+                heap_bytes=state.demand.minimum.heap_bytes,
             )
             for state in admitted
         }
-        dominant: dict[str, float] = {
-            query_id: vector.dominant_share(hard_total_capacity) for query_id, vector in headroom.items()
+        desired: dict[str, ResourceVector] = {
+            state.demand.query_id: ResourceVector(
+                cpu=state.demand.desired.cpu,
+                gpu=state.demand.desired.gpu,
+                heap_bytes=state.demand.desired.heap_bytes,
+            )
+            for state in admitted
         }
-        states_by_id = {state.demand.query_id: state for state in admitted}
+        headroom = {query_id: desired[query_id] - minimum[query_id] for query_id in states_by_id}
+        minimum_share = {query_id: minimum[query_id].dominant_share(hard_total_capacity) for query_id in states_by_id}
+        desired_share = {query_id: desired[query_id].dominant_share(hard_total_capacity) for query_id in states_by_id}
         finite_limits = [
-            dominant[query_id] / states_by_id[query_id].demand.weight
+            desired_share[query_id] / states_by_id[query_id].demand.weight
             for query_id in headroom
-            if dominant[query_id] > 0 and math.isfinite(dominant[query_id])
+            if not headroom[query_id].is_zero() and math.isfinite(desired_share[query_id])
         ]
 
-        def allocation_at(level: float) -> dict[str, ResourceVector]:
-            result: dict[str, ResourceVector] = {}
-            for query_id, room in headroom.items():
-                room_dominant = dominant[query_id]
-                if room_dominant <= 0 or not math.isfinite(room_dominant):
-                    result[query_id] = ResourceVector()
+        def minimum_factor_at(query_id: str, level: float) -> float:
+            """Return the least headroom fraction that reaches a weighted share."""
+            room = headroom[query_id]
+            if room.is_zero():
+                return 0.0
+            weight = states_by_id[query_id].demand.weight
+            target_share = level * weight
+            if minimum_share[query_id] >= target_share - _EPSILON:
+                return 0.0
+            factors: list[float] = []
+            for field_name in ("cpu", "gpu", "heap_bytes"):
+                room_amount = float(getattr(room, field_name))
+                if room_amount <= 0:
                     continue
-                weight = states_by_id[query_id].demand.weight
-                factor = min(1.0, level * weight / room_dominant)
-                result[query_id] = room.scale(factor)
-            return result
+                capacity = float(getattr(hard_total_capacity, field_name))
+                if capacity <= 0:
+                    return 0.0
+                base_amount = float(getattr(minimum[query_id], field_name))
+                factors.append((target_share * capacity - base_amount) / room_amount)
+            return min(1.0, max(0.0, min(factors, default=0.0)))
+
+        def allocation_at(level: float) -> dict[str, ResourceVector]:
+            return {query_id: room.scale(minimum_factor_at(query_id, level)) for query_id, room in headroom.items()}
 
         def feasible(level: float) -> bool:
             total = _sum_resources(list(allocation_at(level).values()))
@@ -710,6 +733,56 @@ class ClusterQueryResourceCoordinator:
                     else:
                         high = middle
             allocated = allocation_at(low)
+
+            # A query can have headroom in a non-dominant dimension. Fill as
+            # much of that plateau as capacity permits without raising its
+            # weighted dominant share above the water level. This preserves
+            # max-min fairness while avoiding stranded divisible capacity.
+            remaining = _positive_difference(
+                hard_extra_capacity,
+                _sum_resources(list(allocated.values())),
+            )
+            for state in sorted(
+                admitted,
+                key=lambda item: (-item.demand.priority, item.sequence, item.demand.query_id),
+            ):
+                query_id = state.demand.query_id
+                unit_headroom = headroom[query_id]
+                if unit_headroom.is_zero():
+                    continue
+                current_factor = minimum_factor_at(query_id, low)
+                share_ceiling = max(minimum_share[query_id], low * state.demand.weight)
+                upper_factors: list[float] = []
+                for field_name in ("cpu", "gpu", "heap_bytes"):
+                    room_amount = float(getattr(unit_headroom, field_name))
+                    if room_amount <= 0:
+                        continue
+                    capacity = float(getattr(hard_total_capacity, field_name))
+                    if capacity <= 0:
+                        upper_factors.append(0.0)
+                        continue
+                    base_amount = float(getattr(minimum[query_id], field_name))
+                    upper_factors.append((share_ceiling * capacity - base_amount) / room_amount)
+                maximum_factor = min(1.0, max(0.0, min(upper_factors, default=0.0)))
+                if maximum_factor <= current_factor + _EPSILON:
+                    continue
+
+                candidate = unit_headroom.scale(maximum_factor)
+                delta = candidate - allocated[query_id]
+                if not delta.fits_within(remaining):
+                    lower = current_factor
+                    upper = maximum_factor
+                    for _ in range(80):
+                        middle = (lower + upper) / 2.0
+                        middle_delta = unit_headroom.scale(middle) - allocated[query_id]
+                        if middle_delta.fits_within(remaining):
+                            lower = middle
+                        else:
+                            upper = middle
+                    candidate = unit_headroom.scale(lower)
+                    delta = candidate - allocated[query_id]
+                allocated[query_id] = candidate
+                remaining = remaining - delta
         else:
             allocated = {state.demand.query_id: ResourceVector() for state in admitted}
 
@@ -743,8 +816,8 @@ class ClusterQueryResourceCoordinator:
             )
             for state in candidates:
                 query_id = state.demand.query_id
-                room = int(getattr(headroom[query_id], field_name) - getattr(allocated[query_id], field_name))
-                amount = min(tail, max(0, room))
+                field_headroom = int(getattr(headroom[query_id], field_name) - getattr(allocated[query_id], field_name))
+                amount = min(tail, max(0, field_headroom))
                 if amount <= 0:
                     continue
                 allocated[query_id] = _replace_resource(

--- a/duckdb/runners/ray/cluster_resource_coordinator.py
+++ b/duckdb/runners/ray/cluster_resource_coordinator.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
@@ -105,20 +105,20 @@ class NodeCapacity:
 
 @dataclass(frozen=True)
 class ActorResourceBundle:
-    stage_id: str
+    resource_unit_id: str
     actor_index: int
     resources: ResourceVector
 
     def __post_init__(self) -> None:
-        stage_id = str(self.stage_id).strip()
+        resource_unit_id = str(self.resource_unit_id).strip()
         actor_index = int(self.actor_index)
-        if not stage_id:
-            raise ValueError("actor resource bundle stage_id must be non-empty")
+        if not resource_unit_id:
+            raise ValueError("actor resource bundle resource_unit_id must be non-empty")
         if actor_index < 0:
             raise ValueError("actor resource bundle actor_index must be >= 0")
         if self.resources.is_zero():
             raise ValueError("actor resource bundle must own non-zero resources")
-        object.__setattr__(self, "stage_id", stage_id)
+        object.__setattr__(self, "resource_unit_id", resource_unit_id)
         object.__setattr__(self, "actor_index", actor_index)
 
 
@@ -158,9 +158,9 @@ class QueryDemand:
             raise ValueError("weight must be finite and > 0")
         actor_bundles = tuple(self.actor_bundles)
         task_bundles = tuple(self.task_bundles)
-        actor_keys = [(bundle.stage_id, bundle.actor_index) for bundle in actor_bundles]
+        actor_keys = [(bundle.resource_unit_id, bundle.actor_index) for bundle in actor_bundles]
         if len(set(actor_keys)) != len(actor_keys):
-            raise ValueError("actor resource bundles contain duplicate stage/index identities")
+            raise ValueError("actor resource bundles contain duplicate resource-unit/index identities")
         actor_total = _sum_resources([bundle.resources for bundle in actor_bundles])
         task_total = _sum_resources(task_bundles)
         bundle_total = actor_total + task_total
@@ -462,11 +462,11 @@ class ClusterQueryResourceCoordinator:
             trial_remaining = dict(remaining)
             placement_valid = True
             actor_bundles = {
-                (bundle.stage_id, bundle.actor_index): bundle.resources for bundle in state.demand.actor_bundles
+                (bundle.resource_unit_id, bundle.actor_index): bundle.resources for bundle in state.demand.actor_bundles
             }
             pinned_allocations: dict[str, ResourceVector] = {}
             for placement in state.actor_placements:
-                vector = actor_bundles.get((placement.stage_id, placement.actor_index))
+                vector = actor_bundles.get((placement.resource_unit_id, placement.actor_index))
                 capacity = trial_remaining.get(placement.node_id)
                 if vector is None or capacity is None or not vector.fits_within(capacity):
                     placement_valid = False
@@ -505,7 +505,7 @@ class ClusterQueryResourceCoordinator:
                         break
                     new_actor_placements.append(
                         ActorPlacement(
-                            stage_id=actor_bundle.stage_id,
+                            resource_unit_id=actor_bundle.resource_unit_id,
                             actor_index=actor_bundle.actor_index,
                             node_id=node_id,
                         )

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -2249,8 +2249,6 @@ class RayQueryDriverActor:
             object_store_fraction=object_store_fraction,
             heap_reserve_bytes_per_node=heap_reserve,
         )
-        if not capacities:
-            raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
         self._query_node_capacities = capacities
         return ClusterQueryResourceCoordinator(
             capacities,
@@ -2264,25 +2262,17 @@ class RayQueryDriverActor:
 
         snapshot = self._query_resource_coordinator.snapshot()
         coordinator_queries = snapshot["queries"]
-        for query_id, graph in self._query_resource_graphs.items():
+        for query_id in self._query_resource_graphs:
             query_snapshot = coordinator_queries.get(query_id)
             if query_snapshot is None:
                 raise RuntimeError(f"coordinator lost registered query {query_id}")
             allocation = QueryAllocation.from_dict(query_snapshot["allocation"])
             manager = get_query_resource_manager(query_id)
-            state = str(query_snapshot.get("state") or "")
-            if state not in {"RUNNING", "PENDING_RESOURCES", "ALLOCATION_DEBT"}:
-                raise RuntimeError(f"coordinator returned invalid query state for {query_id}: {state!r}")
-            graph.validate_allocation(
-                allocation,
-                eligible_unit_ids=(manager.current_eligible_resource_unit_ids() if state == "RUNNING" else ()),
-            )
             current = self._query_allocations[query_id]
             if allocation.generation > current.generation:
                 manager.update_allocation(
                     allocation,
-                    admission_open=state in {"RUNNING", "ALLOCATION_DEBT"},
-                    debt_neutral_only=state == "ALLOCATION_DEBT",
+                    admission_open=True,
                 )
                 self._query_allocations[query_id] = allocation
 
@@ -2297,11 +2287,9 @@ class RayQueryDriverActor:
         Request start time orders overlapping reads so a slow older request
         cannot overwrite a later request that already committed.
         """
-        if not capacities:
-            raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
         last_snapshot_started_at = float(getattr(self, "_query_resource_last_capacity_refresh_at", 0.0))
         cached_capacities = tuple(getattr(self, "_query_node_capacities", ()))
-        if cached_capacities and float(snapshot_started_at) < last_snapshot_started_at:
+        if float(snapshot_started_at) < last_snapshot_started_at:
             return self._sum_node_capacity(cached_capacities)
         self._query_resource_coordinator.update_node_capacities(capacities)
         self._query_node_capacities = capacities
@@ -2343,8 +2331,6 @@ class RayQueryDriverActor:
                 capacity_error = exc
                 capacities = ()
         capacities = tuple(capacities)
-        if capacity_error is None and not capacities:
-            raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
 
         with self._query_resource_lock:
             if capacity_error is None:
@@ -2354,10 +2340,6 @@ class RayQueryDriverActor:
                 )
             else:
                 cached_capacities = tuple(self._query_node_capacities)
-                if not cached_capacities:
-                    raise RuntimeError(
-                        f"failed to refresh Ray capacity and no cached snapshot exists: {capacity_error}"
-                    ) from capacity_error
                 self._query_resource_coordinator.update_node_capacities(
                     cached_capacities,
                     now=timestamp,
@@ -4697,8 +4679,6 @@ class RayQueryDriverActor:
             raise ValueError(f"resource graph query_id mismatch: graph={graph.query_id!r} plan={plan_id!r}")
         capacity_snapshot_started_at = time.monotonic()
         capacities = self._read_query_node_capacities()
-        if not capacities:
-            raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
         return _PreparedQueryResourceRegistration(
             graph=graph,
             node_capacities=tuple(capacities),
@@ -4755,20 +4735,11 @@ class RayQueryDriverActor:
             allocation = self._query_resource_coordinator.register_query(demand)
             manager_registered = False
             try:
-                coordinator_state = self._query_resource_coordinator.query_state(
-                    graph.query_id,
-                    allocation.generation,
-                )
-                if coordinator_state not in {"RUNNING", "PENDING_RESOURCES", "ALLOCATION_DEBT"}:
-                    raise RuntimeError(
-                        f"coordinator returned invalid query state for {graph.query_id}: {coordinator_state!r}"
-                    )
                 self._synchronize_query_allocations()
                 manager = register_query_resource_graph(
                     graph,
                     allocation,
-                    admission_open=coordinator_state in {"RUNNING", "ALLOCATION_DEBT"},
-                    debt_neutral_only=coordinator_state == "ALLOCATION_DEBT",
+                    admission_open=True,
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
                     on_change=lambda: self._signal_query_resource_change(graph.query_id),
                     on_eligible_units_change=lambda eligible: self._transition_query_execution_phase(
@@ -5212,9 +5183,6 @@ class RayQueryDriverActor:
             try:
                 pools, options_by_node = prepare_actor_pools_for_nodes(
                     [node],
-                    # Actor CPU/GPU/declared heap are real Ray Core requests. They
-                    # are intentionally not pinned to soft-reservation nodes.
-                    actor_node_ids_by_unit={},
                     query_driver_handle=self._driver_handle,
                     query_generation_capability=query_generation_capability,
                     session_config=session_config,

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -1293,7 +1293,7 @@ class RayQueryDriverActor:
         self._active_vllm_actors: list[Any] = []
         self._active_vllm_actors_by_plan: dict[str, list[Any]] = {}
         self._query_resource_lock = threading.RLock()
-        self._query_graphs: dict[str, Any] = {}
+        self._query_resource_graphs: dict[str, Any] = {}
         self._query_allocations: dict[str, Any] = {}
         self._query_node_capacities: tuple[Any, ...] = ()
         self._query_allocation_teardowns_pending: dict[
@@ -2180,7 +2180,7 @@ class RayQueryDriverActor:
 
     @staticmethod
     def _sum_node_capacity(node_capacities: tuple[Any, ...]) -> Any:
-        from duckdb.runners.ray.query_execution_graph import ResourceVector
+        from duckdb.runners.ray.query_resource_graph import ResourceVector
 
         total = ResourceVector()
         for node in node_capacities:
@@ -2235,7 +2235,7 @@ class RayQueryDriverActor:
         The caller owns ``_query_resource_lock``. Returned work may perform
         remote calls and must run only after that lock is released.
         """
-        from duckdb.runners.ray.query_execution_graph import QueryAllocation
+        from duckdb.runners.ray.query_resource_graph import QueryAllocation
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         self._ensure_query_allocation_teardown_state()
@@ -2246,7 +2246,7 @@ class RayQueryDriverActor:
         if terminal_errors is None:
             terminal_errors = {}
             self._query_terminal_errors = terminal_errors
-        for query_id, graph in self._query_graphs.items():
+        for query_id, graph in self._query_resource_graphs.items():
             query_snapshot = coordinator_queries.get(query_id)
             if query_snapshot is None:
                 raise RuntimeError(f"coordinator lost registered query {query_id}")
@@ -2309,7 +2309,7 @@ class RayQueryDriverActor:
                 with self._query_resource_lock:
                     if (
                         self._query_allocation_teardowns_pending.get(query_id) == teardown
-                        and query_id in self._query_graphs
+                        and query_id in self._query_resource_graphs
                     ):
                         self._query_terminal_errors[query_id] = (
                             f"{teardown.reason}; fragment cancellation failed: {type(exc).__name__}: {exc}"
@@ -2386,7 +2386,7 @@ class RayQueryDriverActor:
         transiently unavailable, the last complete Ray snapshot remains valid
         for this cycle while active query heartbeats and usage still advance.
         """
-        from duckdb.runners.ray.query_execution_graph import ResourceVector
+        from duckdb.runners.ray.query_resource_graph import ResourceVector
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         timestamp = time.monotonic() if now is None else float(now)
@@ -2423,7 +2423,7 @@ class RayQueryDriverActor:
 
                 observed_usage: dict[str, ResourceVector] = {}
                 generations: dict[str, int] = {}
-                for query_id in sorted(self._query_graphs):
+                for query_id in sorted(self._query_resource_graphs):
                     manager = get_query_resource_manager(query_id)
                     observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
                     generations[query_id] = self._query_allocations[query_id].generation
@@ -3360,14 +3360,17 @@ class RayQueryDriverActor:
                 _log_resource_debug(
                     "task_admission_yield",
                     query_id=query_key,
-                    stage_id=request.stage_id,
+                    resource_unit_id=request.resource_unit_id,
                     task_id=request.task_id,
                     reason=grant.blocked_reason,
                 )
                 return
             request_id, state = owned_request
             if grant.granted:
-                lease_payload = asdict(grant.lease)
+                lease = grant.lease
+                if lease is None:
+                    raise RuntimeError("QRM granted a queued task without returning its lease")
+                lease_payload = asdict(lease)
                 manager_lease_id = str(lease_payload["lease_id"])
                 public_lease_id = self._issue_task_lease_capability(
                     request_id=request_id,
@@ -3381,7 +3384,9 @@ class RayQueryDriverActor:
                     # Keep the QRM's raw lease ID from being used as an
                     # authoritative external control token and bind the
                     # worker-visible slot to the signed capability.
-                    lease_payload["execution_slot_id"] = f"ray_task:{lease_payload['stage_id']}:{public_lease_id}"
+                    lease_payload["execution_slot_id"] = (
+                        f"ray_task:{lease_payload['resource_unit_id']}:{public_lease_id}"
+                    )
                 # This request record is both the admission result and the
                 # durable execution owner. Publish it before completing the
                 # caller's Future so teardown can never miss a visible grant.
@@ -3393,7 +3398,7 @@ class RayQueryDriverActor:
                 _log_resource_debug(
                     "task_granted",
                     query_id=request.query_id,
-                    stage_id=request.stage_id,
+                    resource_unit_id=request.resource_unit_id,
                     request_id=request_id,
                     lease_id=lease_payload["lease_id"],
                 )
@@ -3418,7 +3423,7 @@ class RayQueryDriverActor:
             _log_resource_debug(
                 "task_blocked",
                 query_id=request.query_id,
-                stage_id=request.stage_id,
+                resource_unit_id=request.resource_unit_id,
                 request_id=request_id,
                 reason=grant.blocked_reason,
             )
@@ -3486,8 +3491,8 @@ class RayQueryDriverActor:
             if grant.granted:
                 lease = grant.lease
                 assert lease is not None
-                if lease.state != "stage_queue":
-                    raise RuntimeError("queued output admission must atomically grant stage_queue ownership")
+                if lease.state != "unit_queue":
+                    raise RuntimeError("queued output admission must atomically grant unit_queue ownership")
                 lease_payload = asdict(lease)
                 manager_lease_id = str(lease_payload["lease_id"])
                 lease_payload["lease_id"] = self._issue_output_lease_capability(
@@ -3501,7 +3506,7 @@ class RayQueryDriverActor:
                 _log_resource_debug(
                     "output_granted",
                     query_id=request.query_id,
-                    stage_id=request.producer_stage_id,
+                    resource_unit_id=request.producer_unit_id,
                     request_id=request_id,
                     lease_id=lease_payload["lease_id"],
                 )
@@ -3530,7 +3535,7 @@ class RayQueryDriverActor:
             _log_resource_debug(
                 "output_blocked",
                 query_id=request.query_id,
-                stage_id=request.producer_stage_id,
+                resource_unit_id=request.producer_unit_id,
                 request_id=request_id,
                 reason=grant.blocked_reason,
             )
@@ -3583,7 +3588,7 @@ class RayQueryDriverActor:
             fields={
                 "request_id",
                 "query_id",
-                "producer_stage_id",
+                "producer_unit_id",
                 "task_lease_id",
                 "attempt_id",
                 "block_id",
@@ -3632,7 +3637,7 @@ class RayQueryDriverActor:
             fields={
                 "request_id",
                 "query_id",
-                "stage_id",
+                "resource_unit_id",
                 "task_id",
                 "attempt_id",
                 "node_id",
@@ -3741,7 +3746,7 @@ class RayQueryDriverActor:
             manager = get_query_resource_manager(request.query_id)
         except KeyError:
             return self._grant_payload(TaskGrant(False, blocked_reason="query_not_registered", fatal=True))
-        expected_resources = manager.graph.stage_by_id(request.stage_id).per_task.to_dict()
+        expected_resources = manager.graph.unit_by_id(request.resource_unit_id).per_task.to_dict()
         if dict(raw_resources) != expected_resources:
             denial = self._grant_payload(TaskGrant(False, blocked_reason="task_resource_spec_mismatch", fatal=True))
             self._query_task_lease_request_tombstones[request_id] = {
@@ -3770,7 +3775,7 @@ class RayQueryDriverActor:
         _log_resource_debug(
             "task_request",
             query_id=request.query_id,
-            stage_id=request.stage_id,
+            resource_unit_id=request.resource_unit_id,
             request_id=request_id,
         )
         try:
@@ -4319,7 +4324,7 @@ class RayQueryDriverActor:
             _log_resource_debug(
                 "task_release_start",
                 query_id=query_id,
-                stage_id=identity.get("stage_id", ""),
+                resource_unit_id=identity.get("resource_unit_id", ""),
                 request_id=request_key,
                 lease_id=lease_id,
             )
@@ -4353,7 +4358,7 @@ class RayQueryDriverActor:
         _log_resource_debug(
             "task_release_done",
             query_id=query_id,
-            stage_id=identity.get("stage_id", ""),
+            resource_unit_id=identity.get("resource_unit_id", ""),
             request_id=request_key,
             lease_id=lease_id,
             released=bool(released),
@@ -4465,7 +4470,7 @@ class RayQueryDriverActor:
 
         This returns producer-side liveness credit. The output lease itself
         remains active, so its bytes continue to count against the query and
-        stage soft object-store budgets until the final descriptor owner
+        resource-unit soft object-store budgets until the final descriptor owner
         releases it.
         """
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
@@ -4496,8 +4501,8 @@ class RayQueryDriverActor:
         current_state = str(lease.get("state") or "")
         if current_state == "downstream_input":
             return {"handed_off": True}
-        if current_state != "stage_queue":
-            raise RuntimeError(f"output lease handoff requires stage_queue state, got {current_state!r}")
+        if current_state != "unit_queue":
+            raise RuntimeError(f"output lease handoff requires unit_queue state, got {current_state!r}")
         try:
             handed_off = get_query_resource_manager(capability_query_id).transition_output_block(
                 manager_lease_id,
@@ -4692,18 +4697,18 @@ class RayQueryDriverActor:
         query_connection: Any,
         expected_plan_id: str | None = None,
     ) -> _PreparedQueryResourceRegistration:
-        from duckdb.runners.ray.query_graph_builder import (
-            build_query_execution_graph,
+        from duckdb.runners.ray.query_resource_graph_builder import (
+            build_query_resource_graph,
         )
 
-        metadata = plan.collect_execution_stages(conn=query_connection)
-        graph = build_query_execution_graph(metadata)
+        metadata = plan.collect_query_resource_graph_metadata(conn=query_connection)
+        graph = build_query_resource_graph(metadata)
         # The session preparation step already compared the logical and
         # physical IDs. Reuse that immutable identity after handing the plan to
         # the registration thread instead of re-entering the physical wrapper.
         plan_id = str(plan.idx()) if expected_plan_id is None else str(expected_plan_id)
         if graph.query_id != plan_id:
-            raise ValueError(f"execution graph query_id mismatch: graph={graph.query_id!r} plan={plan_id!r}")
+            raise ValueError(f"resource graph query_id mismatch: graph={graph.query_id!r} plan={plan_id!r}")
         capacity_snapshot_started_at = time.monotonic()
         capacities = self._read_query_node_capacities()
         if not capacities:
@@ -4754,16 +4759,16 @@ class RayQueryDriverActor:
         *,
         deferred_teardowns: list[_DeferredQueryAllocationTeardown],
     ) -> tuple[Any, Any]:
-        from duckdb.runners.ray.query_graph_builder import build_query_demand
+        from duckdb.runners.ray.query_resource_graph_builder import build_query_demand
         from duckdb.runners.ray.query_resource_runtime import (
-            register_query_graph,
+            register_query_resource_graph,
             release_query_resource_manager,
         )
 
         graph = prepared.graph
         with self._query_resource_lock:
-            if graph.query_id in self._query_graphs:
-                raise ValueError(f"query graph is already registered: {graph.query_id}")
+            if graph.query_id in self._query_resource_graphs:
+                raise ValueError(f"query resource graph is already registered: {graph.query_id}")
             self._ensure_query_allocation_teardown_state()
             if graph.query_id in self._query_allocation_teardowns_pending:
                 raise RuntimeError(f"query {graph.query_id} still has a pending allocation-loss teardown")
@@ -4780,20 +4785,20 @@ class RayQueryDriverActor:
             manager_registered = False
             try:
                 deferred_teardowns.extend(self._synchronize_query_allocations())
-                manager = register_query_graph(
+                manager = register_query_resource_graph(
                     graph,
                     allocation,
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
                     on_change=lambda: self._signal_query_resource_change(graph.query_id),
                 )
                 manager_registered = True
-                for stage in graph.stages:
-                    manager.update_stage_state(
-                        stage.stage_id,
-                        runnable=not stage.input_stage_ids,
-                        actor_ready=stage.backend != "ray_actor",
+                for unit in graph.units:
+                    manager.update_unit_state(
+                        unit.resource_unit_id,
+                        runnable=not unit.input_unit_ids,
+                        actor_ready=unit.backend != "ray_actor",
                     )
-                self._query_graphs[graph.query_id] = graph
+                self._query_resource_graphs[graph.query_id] = graph
                 self._query_allocations[graph.query_id] = allocation
                 self._open_query_resource_admission(graph.query_id)
                 return graph, allocation
@@ -4821,10 +4826,10 @@ class RayQueryDriverActor:
                     except BaseException as exc:
                         cleanup_errors.append(exc)
                 if coordinator_released:
-                    self._query_graphs.pop(graph.query_id, None)
+                    self._query_resource_graphs.pop(graph.query_id, None)
                     self._query_allocations.pop(graph.query_id, None)
                 else:
-                    self._query_graphs[graph.query_id] = graph
+                    self._query_resource_graphs[graph.query_id] = graph
                     self._query_allocations[graph.query_id] = allocation
                 try:
                     deferred_teardowns.extend(self._synchronize_query_allocations())
@@ -4838,13 +4843,13 @@ class RayQueryDriverActor:
                     ) from registration_error
                 raise
 
-    def _mark_query_actor_stages_ready(self, graph: Any) -> None:
+    def _mark_query_actor_units_ready(self, graph: Any) -> None:
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         manager = get_query_resource_manager(graph.query_id)
-        for stage in graph.stages:
-            if stage.backend == "ray_actor":
-                manager.set_stage_actor_ready(stage.stage_id, True)
+        for unit in graph.units:
+            if unit.backend == "ray_actor":
+                manager.set_unit_actor_ready(unit.resource_unit_id, True)
 
     def _fence_query_resource_admission_for_teardown(self, query_id: str) -> None:
         from duckdb.runners.ray.fte_fragment_scheduler import quiesce_fte_registry_for_query
@@ -4935,7 +4940,7 @@ class RayQueryDriverActor:
                         release_query_resource_manager(query_key, reason=reason)
                     except BaseException as exc:
                         cleanup_errors.append(exc)
-                    self._query_graphs.pop(query_key, None)
+                    self._query_resource_graphs.pop(query_key, None)
                     self._query_allocations.pop(query_key, None)
                 try:
                     deferred_teardowns = self._synchronize_query_allocations()
@@ -5049,15 +5054,15 @@ class RayQueryDriverActor:
         from duckdb.execution.udf_ray import prepare_actor_pools_for_plan
 
         plan_id = str(plan.idx())
-        actor_node_ids_by_stage = {
-            stage.stage_id: allocation.actor_node_ids_for_stage(stage.stage_id)
-            for stage in graph.stages
-            if stage.backend == "ray_actor"
+        actor_node_ids_by_unit = {
+            unit.resource_unit_id: allocation.actor_node_ids_for_unit(unit.resource_unit_id)
+            for unit in graph.units
+            if unit.backend == "ray_actor"
         }
         try:
             created, _ = prepare_actor_pools_for_plan(
                 plan,
-                actor_node_ids_by_stage=actor_node_ids_by_stage,
+                actor_node_ids_by_unit=actor_node_ids_by_unit,
                 query_driver_handle=self._driver_handle,
                 query_generation_capability=self._issue_query_task_admission_capability(
                     graph.query_id,
@@ -5655,7 +5660,7 @@ class RayQueryDriverActor:
             # Fragment/Pipeline topology, but its Ray-actor UDF dispatcher
             # cannot obtain a QRM lease until model initialization succeeds.
             self._wait_for_udf_actors_ready(udf_actors)
-            self._mark_query_actor_stages_ready(graph)
+            self._mark_query_actor_units_ready(graph)
         except BaseException as start_error:
             query_id = self._plan_query_ids.get(plan_id, "")
             try:
@@ -6223,7 +6228,7 @@ class RayQueryDriverActor:
                             continue
                         await task
                         pending_startup.discard(task)
-            self._mark_query_actor_stages_ready(graph)
+            self._mark_query_actor_units_ready(graph)
             # Cancellation must reach the exception path promptly so teardown
             # can interrupt a still-running native write, but it must not
             # cancel the asyncio wrapper around that thread. The exception path

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -48,15 +48,15 @@ from duckdb.runners.fte import (
 from duckdb.runners.fte.fte_failures import _normalize_failure_payload, _safe_failure_message
 from duckdb.runners.progress import ProgressRenderer, progress_enabled
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
-from duckdb.runners.ray.ray_env import (
-    collect_vane_env_overrides,
-    reject_node_local_ray_runtime_env,
-    scrub_shared_runtime_session_env,
-)
 from duckdb.runners.ray.query_runtime_protocol import (
     RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
     query_runtime_actor_name,
     ray_runtime_job_id,
+)
+from duckdb.runners.ray.ray_env import (
+    collect_vane_env_overrides,
+    reject_node_local_ray_runtime_env,
+    scrub_shared_runtime_session_env,
 )
 from duckdb.runners.ray.safe_get import QueryDeadlineExceeded, resolve_object_refs_blocking
 from duckdb.runners.ray.worker import WorkerTaskMetadata

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -2773,13 +2773,13 @@ class RayQueryDriverActor:
     def _schedule_query_fte_admission_pump(self, query_id: str) -> None:
         """Wake the FTE ownership domain without blocking the actor loop."""
         from duckdb.runners.ray.fte_fragment_scheduler import (
-            has_fte_resource_admission_waiter,
+            has_fte_resource_admission_demand,
         )
 
         query_key = str(query_id)
         if query_key in self._query_resource_closing_queries:
             return
-        if not has_fte_resource_admission_waiter(query_key):
+        if not has_fte_resource_admission_demand(query_key):
             return
         self._query_fte_admission_dirty_queries.add(query_key)
         existing = self._query_fte_admission_pumps.get(query_key)

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -4463,9 +4463,9 @@ class RayQueryDriverActor:
     ) -> dict[str, Any]:
         """Transfer a live output from the producer queue to downstream input.
 
-        This returns only the producer-side liveness credit.  The output lease
-        itself remains active, so its bytes continue to count against query,
-        stage, and node object-store limits until the final descriptor owner
+        This returns producer-side liveness credit. The output lease itself
+        remains active, so its bytes continue to count against the query and
+        stage soft object-store budgets until the final descriptor owner
         releases it.
         """
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -53,6 +53,11 @@ from duckdb.runners.ray.ray_env import (
     reject_node_local_ray_runtime_env,
     scrub_shared_runtime_session_env,
 )
+from duckdb.runners.ray.query_runtime_protocol import (
+    RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
+    query_runtime_actor_name,
+    ray_runtime_job_id,
+)
 from duckdb.runners.ray.safe_get import QueryDeadlineExceeded, resolve_object_refs_blocking
 from duckdb.runners.ray.worker import WorkerTaskMetadata
 
@@ -70,8 +75,6 @@ _DEFAULT_CLIENT_HEARTBEAT_INTERVAL_S = 10.0
 _TASK_COMPLETION_CLEANUP_RETRY_MIN_S = 0.01
 _TASK_COMPLETION_CLEANUP_RETRY_MAX_S = 1.0
 _QUERY_ADMISSION_BATCH_SIZE = 64
-RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
-RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
 
 
 def _query_udf_actor_lifecycle_lock(owner: Any, query_id: str) -> threading.RLock:
@@ -450,12 +453,7 @@ def _normalize_session_config(config: Mapping[str, Any]) -> dict[str, str]:
 
 
 def _ray_runtime_job_id(runtime_context: Any) -> str:
-    job_id_obj = runtime_context.get_job_id()
-    job_id_hex = getattr(job_id_obj, "hex", None)
-    job_id = str(job_id_hex() if callable(job_id_hex) else job_id_obj).strip()
-    if not job_id:
-        raise RuntimeError("Ray runtime context returned an empty job identity")
-    return job_id
+    return ray_runtime_job_id(runtime_context)
 
 
 async def _to_thread_with_owned_side_effects(callback: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
@@ -2272,20 +2270,19 @@ class RayQueryDriverActor:
                 raise RuntimeError(f"coordinator lost registered query {query_id}")
             allocation = QueryAllocation.from_dict(query_snapshot["allocation"])
             manager = get_query_resource_manager(query_id)
+            state = str(query_snapshot.get("state") or "")
+            if state not in {"RUNNING", "PENDING_RESOURCES", "ALLOCATION_DEBT"}:
+                raise RuntimeError(f"coordinator returned invalid query state for {query_id}: {state!r}")
             graph.validate_allocation(
                 allocation,
-                eligible_unit_ids=(
-                    manager.current_eligible_resource_unit_ids()
-                    if str(query_snapshot.get("state") or "") == "RUNNING"
-                    else ()
-                ),
+                eligible_unit_ids=(manager.current_eligible_resource_unit_ids() if state == "RUNNING" else ()),
             )
             current = self._query_allocations[query_id]
             if allocation.generation > current.generation:
-                state = str(query_snapshot.get("state") or "")
                 manager.update_allocation(
                     allocation,
-                    admission_open=(state == "RUNNING"),
+                    admission_open=state in {"RUNNING", "ALLOCATION_DEBT"},
+                    debt_neutral_only=state == "ALLOCATION_DEBT",
                 )
                 self._query_allocations[query_id] = allocation
 
@@ -2373,7 +2370,7 @@ class RayQueryDriverActor:
             node_capacities = tuple(self._query_node_capacities)
             for query_id in sorted(self._query_resource_graphs):
                 manager = get_query_resource_manager(query_id)
-                observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
+                observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["soft_allocation_usage"])
                 generations[query_id] = self._query_allocations[query_id].generation
                 demands[query_id] = build_query_demand(
                     self._query_resource_graphs[query_id],
@@ -2780,7 +2777,11 @@ class RayQueryDriverActor:
                     get_query_resource_manager,
                 )
 
-                get_query_resource_manager(query_key).cancel(message)
+                # The failed admission pump is terminal for the query, but it
+                # is not proof that already submitted Ray work has stopped.
+                # Fence new work while retaining every live lease until the
+                # normal teardown path quiesces its physical owner.
+                get_query_resource_manager(query_key).fail(message)
             except KeyError:
                 pass
             self._fail_query_admission_requests(query_key)
@@ -4752,17 +4753,22 @@ class RayQueryDriverActor:
                 tuple(self._query_node_capacities),
             )
             allocation = self._query_resource_coordinator.register_query(demand)
-            coordinator_state = self._query_resource_coordinator.query_state(
-                graph.query_id,
-                allocation.generation,
-            )
             manager_registered = False
             try:
+                coordinator_state = self._query_resource_coordinator.query_state(
+                    graph.query_id,
+                    allocation.generation,
+                )
+                if coordinator_state not in {"RUNNING", "PENDING_RESOURCES", "ALLOCATION_DEBT"}:
+                    raise RuntimeError(
+                        f"coordinator returned invalid query state for {graph.query_id}: {coordinator_state!r}"
+                    )
                 self._synchronize_query_allocations()
                 manager = register_query_resource_graph(
                     graph,
                     allocation,
-                    admission_open=(coordinator_state == "RUNNING"),
+                    admission_open=coordinator_state in {"RUNNING", "ALLOCATION_DEBT"},
+                    debt_neutral_only=coordinator_state == "ALLOCATION_DEBT",
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
                     on_change=lambda: self._signal_query_resource_change(graph.query_id),
                     on_eligible_units_change=lambda eligible: self._transition_query_execution_phase(
@@ -4920,7 +4926,7 @@ class RayQueryDriverActor:
                     tuple(self._query_node_capacities),
                     eligible_unit_ids=eligible,
                 )
-                observed_usage = manager.snapshot()["usage"]
+                observed_usage = manager.snapshot()["soft_allocation_usage"]
                 from duckdb.runners.ray.query_resource_graph import ResourceVector
 
                 self._query_resource_coordinator.refresh_query(
@@ -5246,7 +5252,7 @@ class RayQueryDriverActor:
             pool._vane_readiness_futures = []
             pool._vane_init_errors = {}
 
-            phase_activation_error: RuntimeError | None = None
+            phase_activation_error: BaseException | None = None
             with self._session_lock:
                 if (
                     query_id not in self._query_udf_actor_nodes
@@ -5264,16 +5270,20 @@ class RayQueryDriverActor:
                             f"Ray actor UDF pool was activated concurrently: {resource_unit_id}"
                         )
                     else:
-                        active_by_unit[resource_unit_id] = pool
-                        self._active_udf_actors.append(pool)
-                        self._active_udf_actors_by_plan.setdefault(plan_id, []).append(pool)
                         # Publish submission in the same ownership critical section.
                         # A phase transition can now see either no pool or a fully
                         # registered pool, never the half-registered state.
-                        manager.set_submitted_actor_slots(
-                            resource_unit_id,
-                            set(range(len(pool.actors))),
-                        )
+                        try:
+                            manager.set_submitted_actor_slots(
+                                resource_unit_id,
+                                set(range(len(pool.actors))),
+                            )
+                        except BaseException as exc:
+                            phase_activation_error = exc
+                        else:
+                            active_by_unit[resource_unit_id] = pool
+                            self._active_udf_actors.append(pool)
+                            self._active_udf_actors_by_plan.setdefault(plan_id, []).append(pool)
             if phase_activation_error is not None:
                 _shutdown_unregistered_udf_actor_pools(
                     self,
@@ -5381,7 +5391,11 @@ class RayQueryDriverActor:
                 )
                 with self._query_resource_lock:
                     self._query_terminal_errors.setdefault(query_id, message)
-                manager.cancel(message)
+                # A failed pending actor makes the fixed pool unusable, but
+                # other actors/tasks may still be live.  Preserve their QRM
+                # charges until ordered plan teardown kills the pool and
+                # observes task termination.
+                manager.fail(message)
                 return
 
             with self._session_lock:
@@ -5410,6 +5424,87 @@ class RayQueryDriverActor:
             future.add_done_callback(lambda done, _actor_index=actor_index: actor_ready(_actor_index, done))
             readiness_futures.append(future)
         pool._vane_readiness_futures = readiness_futures
+
+    async def report_query_udf_actor_location(
+        self,
+        payload: dict[str, Any],
+        query_generation_capability: str,
+    ) -> dict[str, Any]:
+        """Rebind a transparently reconstructed actor to its current Ray node."""
+
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        if not isinstance(payload, dict):
+            raise TypeError("Ray actor location report must be a dict")
+        expected_fields = {
+            "query_id",
+            "resource_unit_id",
+            "actor_index",
+            "pool_nonce",
+            "node_id",
+        }
+        if set(payload) != expected_fields:
+            raise ValueError("Ray actor location report fields do not match the query protocol")
+        query_id = str(payload["query_id"] or "").strip()
+        resource_unit_id = str(payload["resource_unit_id"] or "").strip()
+        pool_nonce = str(payload["pool_nonce"] or "").strip()
+        node_id = str(payload["node_id"] or "").strip()
+        raw_actor_index = payload["actor_index"]
+        if any(not value for value in (query_id, resource_unit_id, pool_nonce, node_id)):
+            raise ValueError("Ray actor location report string fields must be non-empty")
+        if isinstance(raw_actor_index, bool) or not isinstance(raw_actor_index, int) or raw_actor_index < 0:
+            raise ValueError("Ray actor location report actor_index must be a non-negative integer")
+        actor_index = int(raw_actor_index)
+        generation_id = self._verify_query_task_admission_capability(
+            capability=str(query_generation_capability or ""),
+            query_id=query_id,
+        )
+        if generation_id is None or self._capability_targets_inactive_query_generation(query_id, generation_id):
+            return {"accepted": False, "node_id": node_id, "moved_task_lease_count": 0}
+
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, query_id)
+        with lifecycle_lock:
+            with self._session_lock:
+                pool = self._active_udf_actor_by_unit.get(query_id, {}).get(resource_unit_id)
+                if pool is None or bool(getattr(pool, "_vane_retired", False)):
+                    return {"accepted": False, "node_id": node_id, "moved_task_lease_count": 0}
+                if str(getattr(pool, "_vane_location_nonce", "")) != pool_nonce:
+                    return {"accepted": False, "node_id": node_id, "moved_task_lease_count": 0}
+                if actor_index >= len(pool.actors):
+                    raise ValueError(
+                        f"Ray actor location report index is outside pool {resource_unit_id}: {actor_index}"
+                    )
+            try:
+                manager = get_query_resource_manager(query_id)
+            except KeyError:
+                return {"accepted": False, "node_id": node_id, "moved_task_lease_count": 0}
+            moved_manager_lease_ids = manager.reconcile_actor_runtime_node(
+                resource_unit_id,
+                actor_index,
+                node_id,
+            )
+            with self._session_lock:
+                active_pool = self._active_udf_actor_by_unit.get(query_id, {}).get(resource_unit_id)
+                if active_pool is not pool or bool(getattr(pool, "_vane_retired", False)):
+                    raise RuntimeError("Ray actor pool changed during location reconciliation")
+                pool.actor_node_ids[actor_index] = node_id
+                pool._confirmed_ready.add(actor_index)
+
+            moved_set = set(moved_manager_lease_ids)
+            if moved_set:
+                with self._query_task_lease_condition:
+                    for state in self._query_task_lease_requests.values():
+                        if state.get("manager_lease_id") not in moved_set:
+                            continue
+                        public_lease = state.get("lease")
+                        if isinstance(public_lease, dict):
+                            public_lease["node_id"] = node_id
+                    self._query_task_lease_condition.notify_all()
+            return {
+                "accepted": True,
+                "node_id": node_id,
+                "moved_task_lease_count": len(moved_manager_lease_ids),
+            }
 
     async def activate_query_udf_actor_pool(
         self,
@@ -5444,23 +5539,51 @@ class RayQueryDriverActor:
             )
 
         key = (query_id, normalized["resource_unit_id"])
-        task = self._query_udf_actor_activation_tasks.get(key)
-        if task is None:
-            task = asyncio.create_task(
-                _to_thread_with_owned_side_effects(
-                    self._activate_query_udf_actor_pool_sync,
-                    normalized,
-                    str(query_generation_capability),
-                ),
-                name=f"vane-activate-udf-actor:{query_id}:{normalized['resource_unit_id']}",
-            )
-            self._query_udf_actor_activation_tasks[key] = task
-        try:
-            return dict(await asyncio.shield(task))
-        except BaseException:
-            if self._query_udf_actor_activation_tasks.get(key) is task:
-                self._query_udf_actor_activation_tasks.pop(key, None)
-            raise
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, query_id)
+        while True:
+            task = self._query_udf_actor_activation_tasks.get(key)
+            if task is None:
+                task = asyncio.create_task(
+                    _to_thread_with_owned_side_effects(
+                        self._activate_query_udf_actor_pool_sync,
+                        normalized,
+                        str(query_generation_capability),
+                    ),
+                    name=f"vane-activate-udf-actor:{query_id}:{normalized['resource_unit_id']}",
+                )
+                self._query_udf_actor_activation_tasks[key] = task
+            try:
+                result = dict(await asyncio.shield(task))
+            except asyncio.CancelledError:
+                # shield() deliberately leaves the shared, side-effecting
+                # activation alive. Keep it discoverable so a retried worker
+                # cannot create a second actor pool concurrently.
+                raise
+            except BaseException:
+                if task.done() and self._query_udf_actor_activation_tasks.get(key) is task:
+                    self._query_udf_actor_activation_tasks.pop(key, None)
+                raise
+
+            with lifecycle_lock:
+                current_manager = get_query_resource_manager(query_id)
+                eligible = normalized["resource_unit_id"] in current_manager.current_eligible_resource_unit_ids()
+                with self._session_lock:
+                    pool = self._active_udf_actor_by_unit.get(query_id, {}).get(normalized["resource_unit_id"])
+                    pool_active = pool is not None and not bool(getattr(pool, "_vane_retired", False))
+                if eligible and pool_active:
+                    return result
+                if self._query_udf_actor_activation_tasks.get(key) is task:
+                    self._query_udf_actor_activation_tasks.pop(key, None)
+                if not eligible:
+                    raise RuntimeError(
+                        "query phase ended while resolving Ray actor UDF pool: "
+                        f"{query_id}/{normalized['resource_unit_id']}"
+                    )
+                # A resource unit can leave the frontier behind one barrier and
+                # later re-enter through another DAG branch. Its completed
+                # activation task then refers to a pool that phase retirement
+                # has already killed. Drop that stale result and create a new
+                # query-owned pool for the current frontier.
 
     def _precreate_vllm_actors(
         self,
@@ -7025,7 +7148,7 @@ class RayQueryDriverClient:
             soft=False,
         )
         runner_options = {
-            "name": f"{RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX}{self._ray_job_id}",
+            "name": query_runtime_actor_name(self._ray_job_id),
             "namespace": RAY_QUERY_RUNTIME_ACTOR_NAMESPACE,
             "get_if_exists": True,
             "scheduling_strategy": scheduling,

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -16,7 +16,7 @@ import threading
 import time
 import uuid
 import weakref
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from concurrent.futures import Future as ConcurrentFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import asdict, dataclass, field, replace
@@ -60,7 +60,6 @@ _LEASE_REQUEST_REPLAY_CAPACITY = 65_536
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 _CLIENT_DETACH_REPLAY_CAPACITY = 65_536
 _COPY_OPERATION_REPLAY_CAPACITY = 1_024
-_DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S = 60.0
 _DEFAULT_COPY_RECONCILIATION_TIMEOUT_S = 30.0
 _RUNTIME_ATTACH_TIMEOUT_S = 300.0
 _RUNTIME_ATTACH_RETRY_INTERVAL_S = 0.05
@@ -70,13 +69,77 @@ _DEFAULT_CLIENT_LEASE_TIMEOUT_S = 60.0
 _DEFAULT_CLIENT_HEARTBEAT_INTERVAL_S = 10.0
 _TASK_COMPLETION_CLEANUP_RETRY_MIN_S = 0.01
 _TASK_COMPLETION_CLEANUP_RETRY_MAX_S = 1.0
+_QUERY_ADMISSION_BATCH_SIZE = 64
 RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
 RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
 
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
+def _query_udf_actor_lifecycle_lock(owner: Any, query_id: str) -> threading.RLock:
+    """Return the single-owner lock for one query's physical UDF actors."""
+
+    query_key = str(query_id)
+    with owner._session_lock:
+        locks = getattr(owner, "_query_udf_actor_lifecycle_locks", None)
+        if locks is None:
+            locks = {}
+            owner._query_udf_actor_lifecycle_locks = locks
+        lifecycle_lock = locks.get(query_key)
+        if lifecycle_lock is None:
+            lifecycle_lock = threading.RLock()
+            locks[query_key] = lifecycle_lock
+        return lifecycle_lock
+
+
+def _retain_udf_actor_pools_for_cleanup(
+    owner: Any,
+    plan_id: str,
+    pools: list[Any],
+) -> None:
+    """Keep partially killed pools reachable by the normal plan teardown."""
+
+    with owner._session_lock:
+        plan_pools = owner._active_udf_actors_by_plan.setdefault(str(plan_id), [])
+        for pool in pools:
+            pool._vane_retired = True
+            if all(existing is not pool for existing in owner._active_udf_actors):
+                owner._active_udf_actors.append(pool)
+            if all(existing is not pool for existing in plan_pools):
+                plan_pools.append(pool)
+
+
+def _shutdown_unregistered_udf_actor_pools(
+    owner: Any,
+    plan_id: str,
+    pools: list[Any],
+    activation_error: BaseException,
+) -> None:
+    """Kill unpublished actors or retain every failed kill for a retry."""
+
+    cleanup_errors: list[BaseException] = []
+    remaining: list[Any] = []
+    for pool in reversed(pools):
+        try:
+            pool.shutdown()
+        except BaseException as cleanup_error:
+            cleanup_errors.append(cleanup_error)
+            remaining.append(pool)
+    if not cleanup_errors:
+        return
+    _retain_udf_actor_pools_for_cleanup(
+        owner,
+        plan_id,
+        list(reversed(remaining)),
+    )
+    raise RuntimeError(
+        "Ray actor UDF activation failed and actor cleanup also failed: "
+        f"activation={type(activation_error).__name__}: {activation_error}; "
+        f"cleanup={type(cleanup_errors[0]).__name__}: {cleanup_errors[0]}"
+    ) from activation_error
+
+
+if TYPE_CHECKING:
     import duckdb
+    from duckdb.execution.udf_ray_actor_pool import UDFActorPoolBase
     from duckdb.runners.ray.partition_metadata import RayMaterializedResult
 
 import ray
@@ -314,15 +377,6 @@ class _PreparedQueryResourceRegistration:
     capacity_snapshot_started_at: float
 
 
-@dataclass(frozen=True)
-class _DeferredQueryAllocationTeardown:
-    """Generation-fenced fragment teardown discovered during a local commit."""
-
-    query_id: str
-    generation: int
-    reason: str
-
-
 class _PlanStartupOwnership:
     """Hand registered resources to exactly one startup or cancellation path."""
 
@@ -417,18 +471,6 @@ async def _to_thread_with_owned_side_effects(callback: Callable[..., Any], /, *a
     if cancellation is not None:
         raise cancellation
     return result
-
-
-def _progress_topology_init_timeout_s() -> float:
-    value = float(
-        os.environ.get(
-            "VANE_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S",
-            str(_DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S),
-        )
-    )
-    if not math.isfinite(value) or value <= 0:
-        raise ValueError("VANE_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S must be finite and > 0")
-    return value
 
 
 def _log_resource_debug(event: str, **fields: Any) -> None:
@@ -1288,20 +1330,22 @@ class RayQueryDriverActor:
         self._leased_result_partition_refs: dict[str, dict[str, Any]] = {}
         self._result_partition_ref_counters: dict[str, int] = {}
         self.plan_runner: Any | None = None
-        self._active_udf_actors: list[Any] = []
-        self._active_udf_actors_by_plan: dict[str, list[Any]] = {}
+        self._active_udf_actors: list[UDFActorPoolBase] = []
+        self._active_udf_actors_by_plan: dict[str, list[UDFActorPoolBase]] = {}
+        self._active_udf_actor_by_unit: dict[str, dict[str, UDFActorPoolBase]] = {}
+        self._query_udf_actor_lifecycle_locks: dict[str, threading.RLock] = {}
+        self._query_udf_actor_nodes: dict[str, dict[str, dict[str, Any]]] = {}
+        self._query_udf_session_configs: dict[str, dict[str, str]] = {}
+        self._query_udf_actor_activation_tasks: dict[
+            tuple[str, str],
+            asyncio.Task[dict[str, Any]],
+        ] = {}
         self._active_vllm_actors: list[Any] = []
         self._active_vllm_actors_by_plan: dict[str, list[Any]] = {}
         self._query_resource_lock = threading.RLock()
         self._query_resource_graphs: dict[str, Any] = {}
         self._query_allocations: dict[str, Any] = {}
         self._query_node_capacities: tuple[Any, ...] = ()
-        self._query_allocation_teardowns_pending: dict[
-            str,
-            _DeferredQueryAllocationTeardown,
-        ] = {}
-        self._query_allocation_teardowns_claimed: set[str] = set()
-        self._query_allocation_teardown_futures: set[asyncio.Future[Any]] = set()
         self._query_task_lease_requests: dict[str, dict[str, Any]] = {}
         self._query_output_lease_requests: dict[str, dict[str, Any]] = {}
         self._query_task_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
@@ -1905,10 +1949,6 @@ class RayQueryDriverActor:
                 plan_runner = self.plan_runner
             await self.stop_client_lease_maintenance()
             await self.stop_query_resource_maintenance()
-            self._ensure_query_allocation_teardown_state()
-            teardown_futures = tuple(self._query_allocation_teardown_futures)
-            if teardown_futures:
-                await asyncio.gather(*teardown_futures, return_exceptions=True)
             if plan_runner is not None:
                 await _to_thread_with_owned_side_effects(plan_runner.shutdown)
             self._driver_shutdown_complete = True
@@ -2219,128 +2259,35 @@ class RayQueryDriverActor:
             heartbeat_timeout_s=heartbeat_timeout,
         )
 
-    def _ensure_query_allocation_teardown_state(self) -> None:
-        if not hasattr(self, "_query_allocation_teardowns_pending"):
-            self._query_allocation_teardowns_pending = {}
-        if not hasattr(self, "_query_allocation_teardowns_claimed"):
-            self._query_allocation_teardowns_claimed = set()
-        if not hasattr(self, "_query_allocation_teardown_futures"):
-            self._query_allocation_teardown_futures = set()
-
-    def _synchronize_query_allocations(
-        self,
-    ) -> tuple[_DeferredQueryAllocationTeardown, ...]:
-        """Commit local allocation state and return teardown work.
-
-        The caller owns ``_query_resource_lock``. Returned work may perform
-        remote calls and must run only after that lock is released.
-        """
+    def _synchronize_query_allocations(self) -> None:
+        """Commit coordinator allocations into every local query manager."""
         from duckdb.runners.ray.query_resource_graph import QueryAllocation
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        self._ensure_query_allocation_teardown_state()
         snapshot = self._query_resource_coordinator.snapshot()
         coordinator_queries = snapshot["queries"]
-        deferred_teardowns = dict(self._query_allocation_teardowns_pending)
-        terminal_errors = getattr(self, "_query_terminal_errors", None)
-        if terminal_errors is None:
-            terminal_errors = {}
-            self._query_terminal_errors = terminal_errors
         for query_id, graph in self._query_resource_graphs.items():
             query_snapshot = coordinator_queries.get(query_id)
             if query_snapshot is None:
                 raise RuntimeError(f"coordinator lost registered query {query_id}")
             allocation = QueryAllocation.from_dict(query_snapshot["allocation"])
+            manager = get_query_resource_manager(query_id)
             graph.validate_allocation(
                 allocation,
-                require_full_minimum=False,
+                eligible_unit_ids=(
+                    manager.current_eligible_resource_unit_ids()
+                    if str(query_snapshot.get("state") or "") == "RUNNING"
+                    else ()
+                ),
             )
             current = self._query_allocations[query_id]
             if allocation.generation > current.generation:
                 state = str(query_snapshot.get("state") or "")
-                placement_changed = (
-                    bool(current.actor_placements) and current.actor_placements != allocation.actor_placements
-                )
-                placement_lost = state == "ACTOR_PLACEMENT_LOST" or placement_changed
-                manager = get_query_resource_manager(query_id)
                 manager.update_allocation(
                     allocation,
-                    admission_open=(state == "RUNNING" and not placement_lost),
+                    admission_open=(state == "RUNNING"),
                 )
                 self._query_allocations[query_id] = allocation
-                if placement_lost and query_id not in terminal_errors:
-                    reason = (
-                        f"query {query_id} lost its fixed Ray actor placement; "
-                        "the running actor-backed execution cannot migrate in place"
-                    )
-                    terminal_errors[query_id] = reason
-                    manager.cancel("ray_actor_placement_lost")
-                    teardown = _DeferredQueryAllocationTeardown(
-                        query_id=query_id,
-                        generation=allocation.generation,
-                        reason=reason,
-                    )
-                    self._query_allocation_teardowns_pending[query_id] = teardown
-                    deferred_teardowns[query_id] = teardown
-        return tuple(deferred_teardowns[query_id] for query_id in sorted(deferred_teardowns))
-
-    def _run_query_allocation_teardowns(
-        self,
-        teardowns: tuple[_DeferredQueryAllocationTeardown, ...],
-    ) -> None:
-        """Run remote fragment teardown after releasing resource-state locks."""
-        self._ensure_query_allocation_teardown_state()
-        for teardown in teardowns:
-            query_id = teardown.query_id
-            with self._query_resource_lock:
-                if self._query_allocation_teardowns_pending.get(query_id) != teardown:
-                    continue
-                if query_id in self._query_allocation_teardowns_claimed:
-                    continue
-                self._query_allocation_teardowns_claimed.add(query_id)
-            succeeded = False
-            try:
-                self._drop_query_fragments_after_admission_fence_sync(
-                    query_id,
-                    release_resources=False,
-                )
-                succeeded = True
-            except BaseException as exc:
-                with self._query_resource_lock:
-                    if (
-                        self._query_allocation_teardowns_pending.get(query_id) == teardown
-                        and query_id in self._query_resource_graphs
-                    ):
-                        self._query_terminal_errors[query_id] = (
-                            f"{teardown.reason}; fragment cancellation failed: {type(exc).__name__}: {exc}"
-                        )
-            finally:
-                with self._query_resource_lock:
-                    self._query_allocation_teardowns_claimed.discard(query_id)
-                    if succeeded and self._query_allocation_teardowns_pending.get(query_id) == teardown:
-                        self._query_allocation_teardowns_pending.pop(query_id, None)
-
-    def _schedule_query_allocation_teardowns(
-        self,
-        teardowns: tuple[_DeferredQueryAllocationTeardown, ...],
-    ) -> None:
-        """Submit teardown work without adding a post-commit cancellation point."""
-        if not teardowns:
-            return
-        self._ensure_query_allocation_teardown_state()
-        future = asyncio.get_running_loop().run_in_executor(
-            None,
-            self._run_query_allocation_teardowns,
-            teardowns,
-        )
-        self._query_allocation_teardown_futures.add(future)
-
-        def _retire(done: asyncio.Future[Any]) -> None:
-            self._query_allocation_teardown_futures.discard(done)
-            if not done.cancelled():
-                done.exception()
-
-        future.add_done_callback(_retire)
 
     def _apply_query_capacity_snapshot(
         self,
@@ -2387,6 +2334,7 @@ class RayQueryDriverActor:
         for this cycle while active query heartbeats and usage still advance.
         """
         from duckdb.runners.ray.query_resource_graph import ResourceVector
+        from duckdb.runners.ray.query_resource_graph_builder import build_query_demand
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         timestamp = time.monotonic() if now is None else float(now)
@@ -2401,49 +2349,53 @@ class RayQueryDriverActor:
         if capacity_error is None and not capacities:
             raise RuntimeError("Ray reports no alive nodes with schedulable query resources")
 
-        deferred_teardowns: list[_DeferredQueryAllocationTeardown] = []
-        try:
-            with self._query_resource_lock:
-                if capacity_error is None:
-                    self._apply_query_capacity_snapshot(
-                        capacities,
-                        snapshot_started_at=timestamp,
-                    )
-                else:
-                    cached_capacities = tuple(self._query_node_capacities)
-                    if not cached_capacities:
-                        raise RuntimeError(
-                            f"failed to refresh Ray capacity and no cached snapshot exists: {capacity_error}"
-                        ) from capacity_error
-                    self._query_resource_coordinator.update_node_capacities(
-                        cached_capacities,
-                        now=timestamp,
-                    )
-                deferred_teardowns.extend(self._synchronize_query_allocations())
-
-                observed_usage: dict[str, ResourceVector] = {}
-                generations: dict[str, int] = {}
-                for query_id in sorted(self._query_resource_graphs):
-                    manager = get_query_resource_manager(query_id)
-                    observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
-                    generations[query_id] = self._query_allocations[query_id].generation
-                self._query_resource_coordinator.refresh_queries(
-                    observed_usage_by_query=observed_usage,
-                    generations=generations,
+        with self._query_resource_lock:
+            if capacity_error is None:
+                self._apply_query_capacity_snapshot(
+                    capacities,
+                    snapshot_started_at=timestamp,
+                )
+            else:
+                cached_capacities = tuple(self._query_node_capacities)
+                if not cached_capacities:
+                    raise RuntimeError(
+                        f"failed to refresh Ray capacity and no cached snapshot exists: {capacity_error}"
+                    ) from capacity_error
+                self._query_resource_coordinator.update_node_capacities(
+                    cached_capacities,
                     now=timestamp,
                 )
-                expired = self._query_resource_coordinator.expire_queries(now=timestamp)
-                if expired:
-                    raise RuntimeError("active query resource heartbeats expired unexpectedly: " + ", ".join(expired))
-                deferred_teardowns.extend(self._synchronize_query_allocations())
-                self._query_resource_last_maintenance_at = timestamp
-                result = {
-                    "query_count": len(observed_usage),
-                    "capacity_cached": capacity_error is not None,
-                    "capacity_error": "" if capacity_error is None else str(capacity_error),
-                }
-        finally:
-            self._run_query_allocation_teardowns(tuple(deferred_teardowns))
+            self._synchronize_query_allocations()
+
+            observed_usage: dict[str, ResourceVector] = {}
+            generations: dict[str, int] = {}
+            demands = {}
+            node_capacities = tuple(self._query_node_capacities)
+            for query_id in sorted(self._query_resource_graphs):
+                manager = get_query_resource_manager(query_id)
+                observed_usage[query_id] = ResourceVector.from_dict(manager.snapshot()["usage"])
+                generations[query_id] = self._query_allocations[query_id].generation
+                demands[query_id] = build_query_demand(
+                    self._query_resource_graphs[query_id],
+                    node_capacities,
+                    eligible_unit_ids=manager.current_eligible_resource_unit_ids(),
+                )
+            self._query_resource_coordinator.refresh_queries(
+                observed_usage_by_query=observed_usage,
+                generations=generations,
+                demands_by_query=demands,
+                now=timestamp,
+            )
+            expired = self._query_resource_coordinator.expire_queries(now=timestamp)
+            if expired:
+                raise RuntimeError("active query resource heartbeats expired unexpectedly: " + ", ".join(expired))
+            self._synchronize_query_allocations()
+            self._query_resource_last_maintenance_at = timestamp
+            result = {
+                "query_count": len(observed_usage),
+                "capacity_cached": capacity_error is not None,
+                "capacity_error": "" if capacity_error is None else str(capacity_error),
+            }
         return result
 
     def _start_query_resource_maintenance(self) -> None:
@@ -3349,86 +3301,95 @@ class RayQueryDriverActor:
                     continue
                 key = (str(request.task_id), str(request.attempt_id))
                 pending_by_key.setdefault(key, (request_id, state))
-            if not pending_by_key:
-                return
-            request, grant = manager.try_acquire_next_queued_task(set(pending_by_key))
-            if request is None or grant is None:
-                return
-            selected_key = (str(request.task_id), str(request.attempt_id))
-            owned_request = pending_by_key.get(selected_key)
-            if owned_request is None:
-                _log_resource_debug(
-                    "task_admission_yield",
-                    query_id=query_key,
-                    resource_unit_id=request.resource_unit_id,
-                    task_id=request.task_id,
-                    reason=grant.blocked_reason,
-                )
-                return
-            request_id, state = owned_request
-            if grant.granted:
-                lease = grant.lease
-                if lease is None:
-                    raise RuntimeError("QRM granted a queued task without returning its lease")
-                lease_payload = asdict(lease)
-                manager_lease_id = str(lease_payload["lease_id"])
-                public_lease_id = self._issue_task_lease_capability(
-                    request_id=request_id,
-                    manager_lease_id=manager_lease_id,
-                    attempt_id=lease_payload["attempt_id"],
-                    query_id=lease_payload["query_id"],
-                )
-                lease_payload["lease_id"] = public_lease_id
-                if lease_payload.get("actor_index") is None:
-                    # A task execution slot is a public per-lease identity.
-                    # Keep the QRM's raw lease ID from being used as an
-                    # authoritative external control token and bind the
-                    # worker-visible slot to the signed capability.
-                    lease_payload["execution_slot_id"] = (
-                        f"ray_task:{lease_payload['resource_unit_id']}:{public_lease_id}"
+            for _ in range(_QUERY_ADMISSION_BATCH_SIZE):
+                if not pending_by_key:
+                    return
+                request, grant = manager.try_acquire_next_queued_task(set(pending_by_key))
+                if request is None or grant is None:
+                    return
+                selected_key = (str(request.task_id), str(request.attempt_id))
+                owned_request = pending_by_key.get(selected_key)
+                if owned_request is None:
+                    _log_resource_debug(
+                        "task_admission_yield",
+                        query_id=query_key,
+                        resource_unit_id=request.resource_unit_id,
+                        task_id=request.task_id,
+                        reason=grant.blocked_reason,
                     )
-                # This request record is both the admission result and the
-                # durable execution owner. Publish it before completing the
-                # caller's Future so teardown can never miss a visible grant.
-                with self._query_task_lease_condition:
-                    state["manager_lease_id"] = manager_lease_id
-                    state["lease"] = lease_payload
-                    state["status"] = "granted"
-                    self._query_task_lease_condition.notify_all()
+                    return
+                request_id, state = owned_request
+                if grant.granted:
+                    lease = grant.lease
+                    if lease is None:
+                        raise RuntimeError("QRM granted a queued task without returning its lease")
+                    lease_payload = asdict(lease)
+                    manager_lease_id = str(lease_payload["lease_id"])
+                    public_lease_id = self._issue_task_lease_capability(
+                        request_id=request_id,
+                        manager_lease_id=manager_lease_id,
+                        attempt_id=lease_payload["attempt_id"],
+                        query_id=lease_payload["query_id"],
+                    )
+                    lease_payload["lease_id"] = public_lease_id
+                    if lease_payload.get("actor_index") is None:
+                        # A task execution slot is a public per-lease identity.
+                        # Keep the QRM's raw lease ID from being used as an
+                        # authoritative external control token and bind the
+                        # worker-visible slot to the signed capability.
+                        lease_payload["execution_slot_id"] = (
+                            f"ray_task:{lease_payload['resource_unit_id']}:{public_lease_id}"
+                        )
+                    # This request record is both the admission result and the
+                    # durable execution owner. Publish it before completing the
+                    # caller's Future so teardown can never miss a visible grant.
+                    with self._query_task_lease_condition:
+                        state["manager_lease_id"] = manager_lease_id
+                        state["lease"] = lease_payload
+                        state["status"] = "granted"
+                        self._query_task_lease_condition.notify_all()
+                    _log_resource_debug(
+                        "task_granted",
+                        query_id=request.query_id,
+                        resource_unit_id=request.resource_unit_id,
+                        request_id=request_id,
+                        lease_id=lease_payload["lease_id"],
+                    )
+                    result = self._grant_payload(grant)
+                    result["lease"] = lease_payload
+                    self._complete_lease_request(
+                        state,
+                        result,
+                    )
+                    pending_by_key.pop(selected_key, None)
+                    continue
+                if grant.fatal:
+                    manager.remove_task_waiter(
+                        request.task_id,
+                        request.attempt_id,
+                    )
+                    self._retire_query_lease_request(
+                        request_id=request_id,
+                        state=state,
+                        result=self._grant_payload(grant),
+                        status="failed",
+                        active=self._query_task_lease_requests,
+                        tombstones=self._query_task_lease_request_tombstones,
+                    )
+                    pending_by_key.pop(selected_key, None)
+                    continue
                 _log_resource_debug(
-                    "task_granted",
+                    "task_blocked",
                     query_id=request.query_id,
                     resource_unit_id=request.resource_unit_id,
                     request_id=request_id,
-                    lease_id=lease_payload["lease_id"],
-                )
-                result = self._grant_payload(grant)
-                result["lease"] = lease_payload
-                self._complete_lease_request(
-                    state,
-                    result,
+                    reason=grant.blocked_reason,
                 )
                 return
-            if grant.fatal:
-                manager.remove_task_waiter(request.task_id, request.attempt_id)
-                self._retire_query_lease_request(
-                    request_id=request_id,
-                    state=state,
-                    result=self._grant_payload(grant),
-                    status="failed",
-                    active=self._query_task_lease_requests,
-                    tombstones=self._query_task_lease_request_tombstones,
-                )
-                return
-            _log_resource_debug(
-                "task_blocked",
-                query_id=request.query_id,
-                resource_unit_id=request.resource_unit_id,
-                request_id=request_id,
-                reason=grant.blocked_reason,
-            )
         finally:
             self._query_task_admission_pumps.discard(query_key)
+        if pending_by_key:
+            self._schedule_query_task_admission_pump(query_key)
 
     def _schedule_query_output_admission_pump(self, query_id: str) -> None:
         self._ensure_query_resource_admission_state()
@@ -3482,65 +3443,72 @@ class RayQueryDriverActor:
                     str(request.block_id),
                     (request_id, state),
                 )
-            if not pending_by_block:
-                return
-            request, grant = manager.try_acquire_next_queued_output_block(set(pending_by_block))
-            if request is None or grant is None:
-                return
-            request_id, state = pending_by_block[str(request.block_id)]
-            if grant.granted:
-                lease = grant.lease
-                assert lease is not None
-                if lease.state != "unit_queue":
-                    raise RuntimeError("queued output admission must atomically grant unit_queue ownership")
-                lease_payload = asdict(lease)
-                manager_lease_id = str(lease_payload["lease_id"])
-                lease_payload["lease_id"] = self._issue_output_lease_capability(
-                    request_id=request_id,
-                    manager_lease_id=manager_lease_id,
-                    query_id=lease_payload["query_id"],
-                )
-                state["manager_lease_id"] = manager_lease_id
-                state["status"] = "granted"
-                state["lease"] = lease_payload
+            for _ in range(_QUERY_ADMISSION_BATCH_SIZE):
+                if not pending_by_block:
+                    return
+                request, grant = manager.try_acquire_next_queued_output_block(set(pending_by_block))
+                if request is None or grant is None:
+                    return
+                block_id = str(request.block_id)
+                request_id, state = pending_by_block[block_id]
+                if grant.granted:
+                    lease = grant.lease
+                    assert lease is not None
+                    if lease.state != "unit_queue":
+                        raise RuntimeError("queued output admission must atomically grant unit_queue ownership")
+                    lease_payload = asdict(lease)
+                    manager_lease_id = str(lease_payload["lease_id"])
+                    lease_payload["lease_id"] = self._issue_output_lease_capability(
+                        request_id=request_id,
+                        manager_lease_id=manager_lease_id,
+                        query_id=lease_payload["query_id"],
+                    )
+                    state["manager_lease_id"] = manager_lease_id
+                    state["status"] = "granted"
+                    state["lease"] = lease_payload
+                    _log_resource_debug(
+                        "output_granted",
+                        query_id=request.query_id,
+                        resource_unit_id=request.producer_unit_id,
+                        request_id=request_id,
+                        lease_id=lease_payload["lease_id"],
+                    )
+                    self._complete_lease_request(
+                        state,
+                        {
+                            "granted": True,
+                            "lease": lease_payload,
+                            "blocked_reason": "",
+                            "fatal": False,
+                            "liveness": bool(lease_payload["liveness"]),
+                        },
+                    )
+                    pending_by_block.pop(block_id, None)
+                    continue
+                if grant.fatal:
+                    manager.remove_output_waiter(request.block_id)
+                    self._retire_query_lease_request(
+                        request_id=request_id,
+                        state=state,
+                        result=self._grant_payload(grant),
+                        status="failed",
+                        active=self._query_output_lease_requests,
+                        tombstones=self._query_output_lease_request_tombstones,
+                    )
+                    pending_by_block.pop(block_id, None)
+                    continue
                 _log_resource_debug(
-                    "output_granted",
+                    "output_blocked",
                     query_id=request.query_id,
                     resource_unit_id=request.producer_unit_id,
                     request_id=request_id,
-                    lease_id=lease_payload["lease_id"],
-                )
-                self._complete_lease_request(
-                    state,
-                    {
-                        "granted": True,
-                        "lease": lease_payload,
-                        "blocked_reason": "",
-                        "fatal": False,
-                        "liveness": bool(lease_payload["liveness"]),
-                    },
+                    reason=grant.blocked_reason,
                 )
                 return
-            if grant.fatal:
-                manager.remove_output_waiter(request.block_id)
-                self._retire_query_lease_request(
-                    request_id=request_id,
-                    state=state,
-                    result=self._grant_payload(grant),
-                    status="failed",
-                    active=self._query_output_lease_requests,
-                    tombstones=self._query_output_lease_request_tombstones,
-                )
-                return
-            _log_resource_debug(
-                "output_blocked",
-                query_id=request.query_id,
-                resource_unit_id=request.producer_unit_id,
-                request_id=request_id,
-                reason=grant.blocked_reason,
-            )
         finally:
             self._query_output_admission_pumps.discard(query_key)
+        if pending_by_block:
+            self._schedule_query_output_admission_pump(query_key)
 
     def _run_query_resource_admission_pumps(self, query_id: str) -> None:
         """Drain admission immediately when already executing on the owner loop."""
@@ -4447,7 +4415,24 @@ class RayQueryDriverActor:
         self._query_output_request_owner_by_identity[resource_identity] = request_id
         self._query_output_lease_requests[request_id] = existing
         try:
-            manager.note_output_waiting(request)
+            fatal_reason = manager.note_output_waiting(request)
+            if fatal_reason is not None:
+                denial = self._grant_payload(
+                    OutputBlockGrant(
+                        False,
+                        blocked_reason=fatal_reason,
+                        fatal=True,
+                    )
+                )
+                self._retire_query_lease_request(
+                    request_id=request_id,
+                    state=existing,
+                    result=denial,
+                    status="failed",
+                    active=self._query_output_lease_requests,
+                    tombstones=self._query_output_lease_request_tombstones,
+                )
+                return denial
             self._run_query_output_admission_pump(request.query_id)
         except BaseException:
             manager.remove_output_waiter(request.block_id)
@@ -4741,23 +4726,11 @@ class RayQueryDriverActor:
             query_connection,
             expected_plan_id,
         )
-        deferred_teardowns: list[_DeferredQueryAllocationTeardown] = []
-        try:
-            result = self._commit_query_resource_registration(
-                prepared,
-                deferred_teardowns=deferred_teardowns,
-            )
-        finally:
-            self._schedule_query_allocation_teardowns(
-                tuple(deferred_teardowns),
-            )
-        return result
+        return self._commit_query_resource_registration(prepared)
 
     def _commit_query_resource_registration(
         self,
         prepared: _PreparedQueryResourceRegistration,
-        *,
-        deferred_teardowns: list[_DeferredQueryAllocationTeardown],
     ) -> tuple[Any, Any]:
         from duckdb.runners.ray.query_resource_graph_builder import build_query_demand
         from duckdb.runners.ray.query_resource_runtime import (
@@ -4769,34 +4742,39 @@ class RayQueryDriverActor:
         with self._query_resource_lock:
             if graph.query_id in self._query_resource_graphs:
                 raise ValueError(f"query resource graph is already registered: {graph.query_id}")
-            self._ensure_query_allocation_teardown_state()
-            if graph.query_id in self._query_allocation_teardowns_pending:
-                raise RuntimeError(f"query {graph.query_id} still has a pending allocation-loss teardown")
-            cluster_capacity = self._apply_query_capacity_snapshot(
+            self._apply_query_capacity_snapshot(
                 prepared.node_capacities,
                 snapshot_started_at=prepared.capacity_snapshot_started_at,
             )
-            deferred_teardowns.extend(self._synchronize_query_allocations())
+            self._synchronize_query_allocations()
             demand = build_query_demand(
                 graph,
-                cluster_capacity,
+                tuple(self._query_node_capacities),
             )
             allocation = self._query_resource_coordinator.register_query(demand)
+            coordinator_state = self._query_resource_coordinator.query_state(
+                graph.query_id,
+                allocation.generation,
+            )
             manager_registered = False
             try:
-                deferred_teardowns.extend(self._synchronize_query_allocations())
+                self._synchronize_query_allocations()
                 manager = register_query_resource_graph(
                     graph,
                     allocation,
+                    admission_open=(coordinator_state == "RUNNING"),
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
                     on_change=lambda: self._signal_query_resource_change(graph.query_id),
+                    on_eligible_units_change=lambda eligible: self._transition_query_execution_phase(
+                        graph.query_id,
+                        eligible,
+                    ),
                 )
                 manager_registered = True
                 for unit in graph.units:
                     manager.update_unit_state(
                         unit.resource_unit_id,
                         runnable=not unit.input_unit_ids,
-                        actor_ready=unit.backend != "ray_actor",
                     )
                 self._query_resource_graphs[graph.query_id] = graph
                 self._query_allocations[graph.query_id] = allocation
@@ -4832,7 +4810,7 @@ class RayQueryDriverActor:
                     self._query_resource_graphs[graph.query_id] = graph
                     self._query_allocations[graph.query_id] = allocation
                 try:
-                    deferred_teardowns.extend(self._synchronize_query_allocations())
+                    self._synchronize_query_allocations()
                 except BaseException as exc:
                     cleanup_errors.append(exc)
                 if cleanup_errors:
@@ -4843,13 +4821,116 @@ class RayQueryDriverActor:
                     ) from registration_error
                 raise
 
-    def _mark_query_actor_units_ready(self, graph: Any) -> None:
+    def _retire_udf_actor_pools_outside_phase(
+        self,
+        query_id: str,
+        eligible_unit_ids: tuple[str, ...],
+    ) -> None:
+        """Stop completed-phase actor pools before releasing their reservation."""
+
+        query_key = str(query_id)
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, query_key)
+        with lifecycle_lock:
+            eligible = set(eligible_unit_ids)
+            with self._session_lock:
+                active_by_unit = dict(self._active_udf_actor_by_unit.get(query_key, {}))
+            retiring = [
+                (resource_unit_id, pool)
+                for resource_unit_id, pool in active_by_unit.items()
+                if resource_unit_id not in eligible
+            ]
+            if not retiring:
+                return
+
+            from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+            manager = get_query_resource_manager(query_key)
+            for resource_unit_id, pool in retiring:
+                if pool is None:
+                    raise RuntimeError(f"Ray actor UDF pool is missing while retiring {resource_unit_id}")
+                with self._session_lock:
+                    current = self._active_udf_actor_by_unit.get(query_key, {}).get(resource_unit_id)
+                    if current is not pool:
+                        if bool(getattr(pool, "_vane_retired", False)):
+                            continue
+                        raise RuntimeError(f"Ray actor UDF pool ownership changed while retiring {resource_unit_id}")
+                    if not manager.begin_actor_pool_retirement(resource_unit_id):
+                        # The callback was overtaken by a newer frontier snapshot.
+                        continue
+                    pool._vane_retired = True
+                pool.shutdown()
+                if not manager.complete_actor_pool_retirement(resource_unit_id):
+                    raise RuntimeError(f"Ray actor UDF pool retirement state disappeared for {resource_unit_id}")
+                with self._session_lock:
+                    current = self._active_udf_actor_by_unit.get(query_key, {}).get(resource_unit_id)
+                    if current is not pool:
+                        raise RuntimeError(f"Ray actor UDF pool ownership changed while retiring {resource_unit_id}")
+                    self._active_udf_actor_by_unit[query_key].pop(resource_unit_id, None)
+                    try:
+                        self._active_udf_actors.remove(pool)
+                    except ValueError:
+                        pass
+                    plan_pools = self._active_udf_actors_by_plan.get(query_key)
+                    if plan_pools is not None:
+                        try:
+                            plan_pools.remove(pool)
+                        except ValueError:
+                            pass
+                        if not plan_pools:
+                            self._active_udf_actors_by_plan.pop(query_key, None)
+
+    def _transition_query_execution_phase(
+        self,
+        query_id: str,
+        eligible_unit_ids: tuple[str, ...],
+    ) -> None:
+        """Retire the old phase and recompute reservation for the new frontier."""
+
+        from duckdb.runners.ray.query_resource_graph_builder import build_query_demand
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        manager = get_query_resource_manager(graph.query_id)
-        for unit in graph.units:
-            if unit.backend == "ray_actor":
-                manager.set_unit_actor_ready(unit.resource_unit_id, True)
+        query_key = str(query_id)
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, query_key)
+        with lifecycle_lock:
+            with self._plan_teardown_condition:
+                if query_key in self._plan_teardowns_in_progress:
+                    return
+                if query_key not in self._plan_session_ids:
+                    return
+            eligible = tuple(str(resource_unit_id) for resource_unit_id in eligible_unit_ids)
+            manager = get_query_resource_manager(query_key)
+            # Validate before touching physical actors. The manager repeats this
+            # check atomically in begin_actor_pool_retirement() to close the race
+            # with a still newer barrier completion.
+            if eligible != manager.current_eligible_resource_unit_ids():
+                return
+            self._retire_udf_actor_pools_outside_phase(query_key, eligible)
+
+            with self._query_resource_lock:
+                graph = self._query_resource_graphs.get(query_key)
+                allocation = self._query_allocations.get(query_key)
+                if graph is None or allocation is None:
+                    return
+                # Ignore a stale callback overtaken by another completion.
+                current_eligible = manager.current_eligible_resource_unit_ids()
+                if eligible != current_eligible:
+                    return
+                demand = build_query_demand(
+                    graph,
+                    tuple(self._query_node_capacities),
+                    eligible_unit_ids=eligible,
+                )
+                observed_usage = manager.snapshot()["usage"]
+                from duckdb.runners.ray.query_resource_graph import ResourceVector
+
+                self._query_resource_coordinator.refresh_query(
+                    query_key,
+                    observed_usage=ResourceVector.from_dict(observed_usage),
+                    generation=allocation.generation,
+                    demand=demand,
+                )
+                self._synchronize_query_allocations()
+            self._signal_query_resource_change(query_key)
 
     def _fence_query_resource_admission_for_teardown(self, query_id: str) -> None:
         from duckdb.runners.ray.fte_fragment_scheduler import quiesce_fte_registry_for_query
@@ -4914,40 +4995,36 @@ class RayQueryDriverActor:
         # arrive after query teardown is already fenced.
         self._wait_for_query_task_leases(query_key)
         cleanup_errors: list[BaseException] = []
-        deferred_teardowns: tuple[_DeferredQueryAllocationTeardown, ...] = ()
-        try:
-            with self._query_resource_lock:
-                allocation = self._query_allocations.get(query_key)
-                coordinator_released = allocation is None
-                if allocation is not None:
-                    try:
-                        released = self._query_resource_coordinator.release_query(
-                            query_key,
-                            allocation.generation,
-                        )
-                        coordinator_released = True
-                        if not released:
-                            cleanup_errors.append(
-                                RuntimeError(
-                                    f"coordinator allocation was already absent for query {query_key} "
-                                    f"at generation {allocation.generation}"
-                                )
-                            )
-                    except BaseException as exc:
-                        cleanup_errors.append(exc)
-                if coordinator_released:
-                    try:
-                        release_query_resource_manager(query_key, reason=reason)
-                    except BaseException as exc:
-                        cleanup_errors.append(exc)
-                    self._query_resource_graphs.pop(query_key, None)
-                    self._query_allocations.pop(query_key, None)
+        with self._query_resource_lock:
+            allocation = self._query_allocations.get(query_key)
+            coordinator_released = allocation is None
+            if allocation is not None:
                 try:
-                    deferred_teardowns = self._synchronize_query_allocations()
+                    released = self._query_resource_coordinator.release_query(
+                        query_key,
+                        allocation.generation,
+                    )
+                    coordinator_released = True
+                    if not released:
+                        cleanup_errors.append(
+                            RuntimeError(
+                                f"coordinator allocation was already absent for query {query_key} "
+                                f"at generation {allocation.generation}"
+                            )
+                        )
                 except BaseException as exc:
                     cleanup_errors.append(exc)
-        finally:
-            self._run_query_allocation_teardowns(deferred_teardowns)
+            if coordinator_released:
+                try:
+                    release_query_resource_manager(query_key, reason=reason)
+                except BaseException as exc:
+                    cleanup_errors.append(exc)
+                self._query_resource_graphs.pop(query_key, None)
+                self._query_allocations.pop(query_key, None)
+            try:
+                self._synchronize_query_allocations()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
         if cleanup_errors:
             raise RuntimeError(
                 f"query resource cleanup for {query_key} had "
@@ -5045,49 +5122,345 @@ class RayQueryDriverActor:
         self,
         plan: Any,
         graph: Any,
-        allocation: Any,
         *,
         query_connection: Any,
         session_config: dict[str, str],
     ) -> list[Any]:
-        """Create Ray actors and inject handles without waiting for model init."""
-        from duckdb.execution.udf_ray import prepare_actor_pools_for_plan
+        """Inject phase-local actor locators; actor creation remains lazy."""
+        from duckdb.execution.udf_ray import configure_query_udf_execution_for_plan
 
         plan_id = str(plan.idx())
-        actor_node_ids_by_unit = {
-            unit.resource_unit_id: allocation.actor_node_ids_for_unit(unit.resource_unit_id)
-            for unit in graph.units
-            if unit.backend == "ray_actor"
-        }
+        actor_nodes = configure_query_udf_execution_for_plan(
+            plan,
+            query_id=str(graph.query_id),
+            query_driver_handle=self._driver_handle,
+            query_generation_capability=self._issue_query_task_admission_capability(
+                graph.query_id,
+            ),
+            session_config=session_config,
+            conn=query_connection,
+        )
+        with self._session_lock:
+            if plan_id not in self._plan_session_ids:
+                raise RuntimeError(f"query plan is no longer active: {plan_id}")
+            self._query_udf_actor_nodes[str(graph.query_id)] = actor_nodes
+            self._query_udf_session_configs[str(graph.query_id)] = {
+                str(key): str(value) for key, value in session_config.items()
+            }
+            self._active_udf_actor_by_unit.setdefault(plan_id, {})
+        return []
+
+    def _activate_query_udf_actor_pool_sync(
+        self,
+        locator: dict[str, str],
+        query_generation_capability: str,
+    ) -> dict[str, Any]:
+        from duckdb.execution.udf_ray import (
+            prepare_actor_pools_for_nodes,
+            wait_for_first_actor_pool_ready,
+        )
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        query_id = str(locator["query_id"])
+        resource_unit_id = str(locator["resource_unit_id"])
+        physical_node_id = str(locator["physical_node_id"])
+        plan_id = query_id
+        with self._query_resource_lock:
+            graph = self._query_resource_graphs.get(query_id)
+            if graph is None or self._query_allocations.get(query_id) is None:
+                raise RuntimeError(f"query resources are no longer active: {query_id}")
+            unit = graph.unit_by_id(resource_unit_id)
+            if unit.backend != "ray_actor":
+                raise ValueError(f"resource unit is not a Ray actor pool: {resource_unit_id}")
+            manager = get_query_resource_manager(query_id)
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, query_id)
+        with lifecycle_lock:
+            with self._session_lock:
+                if (
+                    query_id not in self._query_udf_actor_nodes
+                    or plan_id not in self._plan_session_ids
+                    or plan_id in getattr(self, "_plan_teardowns_in_progress", ())
+                ):
+                    raise RuntimeError(f"query UDF actor locators are no longer active: {query_id}")
+                if resource_unit_id not in manager.current_eligible_resource_unit_ids():
+                    raise RuntimeError(
+                        f"Ray actor UDF resource unit is outside the current execution phase: {resource_unit_id}"
+                    )
+                active_by_unit = self._active_udf_actor_by_unit.setdefault(plan_id, {})
+                if resource_unit_id in active_by_unit:
+                    raise RuntimeError(f"Ray actor UDF pool was activated concurrently: {resource_unit_id}")
+                nodes_by_unit = self._query_udf_actor_nodes[query_id]
+                session_config = self._query_udf_session_configs.get(query_id)
+                if session_config is None:
+                    raise RuntimeError(f"query UDF actor session config is no longer active: {query_id}")
+                node = nodes_by_unit.get(resource_unit_id)
+                if node is None:
+                    raise KeyError(f"query has no Ray actor UDF node for {resource_unit_id}")
+                raw_node_id = node.get("node_id")
+                if ("" if raw_node_id is None else str(raw_node_id)) != physical_node_id:
+                    raise ValueError(f"Ray actor UDF locator physical_node_id mismatch for {resource_unit_id}")
+
+            # Hold the lifecycle lock from the first actor submission until the
+            # pool is either registered or fully killed. Plan teardown and phase
+            # retirement can therefore never pass an unowned, query-scoped pool.
+            try:
+                pools, options_by_node = prepare_actor_pools_for_nodes(
+                    [node],
+                    # Actor CPU/GPU/declared heap are real Ray Core requests. They
+                    # are intentionally not pinned to soft-reservation nodes.
+                    actor_node_ids_by_unit={},
+                    query_driver_handle=self._driver_handle,
+                    query_generation_capability=query_generation_capability,
+                    session_config=session_config,
+                )
+            except BaseException as creation_error:
+                owned_pools = list(getattr(creation_error, "owned_actor_pools", ()))
+                if owned_pools:
+                    _retain_udf_actor_pools_for_cleanup(self, plan_id, owned_pools)
+                raise
+            if len(pools) != 1:
+                pool_count_error = RuntimeError(
+                    f"Ray actor UDF activation for {resource_unit_id} created {len(pools)} pools, expected 1"
+                )
+                _shutdown_unregistered_udf_actor_pools(
+                    self,
+                    plan_id,
+                    list(pools),
+                    pool_count_error,
+                )
+                raise pool_count_error
+            pool = pools[0]
+            options = options_by_node.get(physical_node_id) if isinstance(options_by_node, dict) else None
+            if not isinstance(options, dict):
+                missing_options_error = RuntimeError(
+                    f"Ray actor UDF activation did not return executor options for node {physical_node_id}"
+                )
+                _shutdown_unregistered_udf_actor_pools(
+                    self,
+                    plan_id,
+                    [pool],
+                    missing_options_error,
+                )
+                raise missing_options_error
+            pool._vane_retired = False
+            pool._vane_readiness_futures = []
+            pool._vane_init_errors = {}
+
+            phase_activation_error: RuntimeError | None = None
+            with self._session_lock:
+                if (
+                    query_id not in self._query_udf_actor_nodes
+                    or plan_id not in self._plan_session_ids
+                    or plan_id in getattr(self, "_plan_teardowns_in_progress", ())
+                    or resource_unit_id not in manager.current_eligible_resource_unit_ids()
+                ):
+                    phase_activation_error = RuntimeError(
+                        f"query phase ended while activating Ray actor UDF pool: {query_id}/{resource_unit_id}"
+                    )
+                else:
+                    active_by_unit = self._active_udf_actor_by_unit.setdefault(plan_id, {})
+                    if resource_unit_id in active_by_unit:
+                        phase_activation_error = RuntimeError(
+                            f"Ray actor UDF pool was activated concurrently: {resource_unit_id}"
+                        )
+                    else:
+                        active_by_unit[resource_unit_id] = pool
+                        self._active_udf_actors.append(pool)
+                        self._active_udf_actors_by_plan.setdefault(plan_id, []).append(pool)
+                        # Publish submission in the same ownership critical section.
+                        # A phase transition can now see either no pool or a fully
+                        # registered pool, never the half-registered state.
+                        manager.set_submitted_actor_slots(
+                            resource_unit_id,
+                            set(range(len(pool.actors))),
+                        )
+            if phase_activation_error is not None:
+                _shutdown_unregistered_udf_actor_pools(
+                    self,
+                    plan_id,
+                    [pool],
+                    phase_activation_error,
+                )
+                raise phase_activation_error
         try:
-            created, _ = prepare_actor_pools_for_plan(
-                plan,
-                actor_node_ids_by_unit=actor_node_ids_by_unit,
-                query_driver_handle=self._driver_handle,
-                query_generation_capability=self._issue_query_task_admission_capability(
-                    graph.query_id,
-                ),
-                session_config=session_config,
-                conn=query_connection,
+            ready_nodes = wait_for_first_actor_pool_ready(pool)
+            with self._session_lock:
+                if (
+                    bool(getattr(pool, "_vane_retired", False))
+                    or self._active_udf_actor_by_unit.get(plan_id, {}).get(resource_unit_id) is not pool
+                ):
+                    raise RuntimeError(f"query ended while activating Ray actor UDF pool: {query_id}")
+                if resource_unit_id not in manager.current_eligible_resource_unit_ids():
+                    raise RuntimeError(
+                        f"query phase ended while activating Ray actor UDF pool: {query_id}/{resource_unit_id}"
+                    )
+                manager.set_ready_actor_slots(resource_unit_id, ready_nodes)
+            self._watch_query_udf_actor_pool_readiness(
+                query_id,
+                resource_unit_id,
+                pool,
+                manager,
             )
-        except BaseException as creation_error:
-            owned_pools = list(getattr(creation_error, "owned_actor_pools", ()))
-            for pool in owned_pools:
-                if all(existing is not pool for existing in self._active_udf_actors):
-                    self._active_udf_actors.append(pool)
-            if owned_pools:
-                self._active_udf_actors_by_plan[plan_id] = owned_pools
+            options["actor_node_ids"] = list(pool.actor_node_ids)
+            options["actor_dispatch_indices"] = sorted(ready_nodes)
+            options["actor_init_refs"] = list(pool._init_refs)
+            return {
+                key: options[key]
+                for key in (
+                    "actor_handles",
+                    "actor_node_ids",
+                    "actor_dispatch_indices",
+                    "actor_init_refs",
+                )
+            }
+        except BaseException as activation_error:
+            cleanup_owned = False
+            with lifecycle_lock:
+                with self._session_lock:
+                    if not bool(getattr(pool, "_vane_retired", False)):
+                        cleanup_owned = True
+                        pool._vane_retired = True
+                        cleanup_active_by_unit = self._active_udf_actor_by_unit.get(plan_id)
+                        if cleanup_active_by_unit is not None and cleanup_active_by_unit.get(resource_unit_id) is pool:
+                            cleanup_active_by_unit.pop(resource_unit_id, None)
+                            if not cleanup_active_by_unit:
+                                self._active_udf_actor_by_unit.pop(plan_id, None)
+                if cleanup_owned:
+                    try:
+                        if pool.actors:
+                            pool.shutdown()
+                    except BaseException as cleanup_error:
+                        raise RuntimeError(
+                            "Ray actor UDF activation failed and actor cleanup also failed: "
+                            f"activation={type(activation_error).__name__}: {activation_error}; "
+                            f"cleanup={type(cleanup_error).__name__}: {cleanup_error}"
+                        ) from activation_error
+                    if not manager.complete_actor_pool_retirement(resource_unit_id):
+                        manager.set_ready_actor_slots(resource_unit_id, {})
+                        manager.set_submitted_actor_slots(resource_unit_id, set())
+                    with self._session_lock:
+                        try:
+                            self._active_udf_actors.remove(pool)
+                        except ValueError:
+                            pass
+                        plan_pools = self._active_udf_actors_by_plan.get(plan_id)
+                        if plan_pools is not None:
+                            try:
+                                plan_pools.remove(pool)
+                            except ValueError:
+                                pass
+                            if not plan_pools:
+                                self._active_udf_actors_by_plan.pop(plan_id, None)
             raise
-        self._active_udf_actors.extend(created)
-        if created:
-            self._active_udf_actors_by_plan[plan_id] = list(created)
-        return created
 
-    @staticmethod
-    def _wait_for_udf_actors_ready(actor_pools: list[Any]) -> None:
-        from duckdb.execution.udf_ray import wait_for_actor_pools_ready
+    def _watch_query_udf_actor_pool_readiness(
+        self,
+        query_id: str,
+        resource_unit_id: str,
+        pool: UDFActorPoolBase,
+        manager: Any,
+    ) -> None:
+        """Publish actors that Ray Core schedules after the first pool slot."""
 
-        wait_for_actor_pools_ready(actor_pools)
+        def actor_ready(actor_index: int, future: Any) -> None:
+            try:
+                node_id = str(future.result() or "").strip()
+                if not node_id:
+                    raise RuntimeError("actor initialization returned an empty Ray node_id")
+            except BaseException as exc:
+                with self._session_lock:
+                    if (
+                        bool(getattr(pool, "_vane_retired", False))
+                        or self._active_udf_actor_by_unit.get(query_id, {}).get(resource_unit_id) is not pool
+                    ):
+                        return
+                    pool._vane_init_errors[actor_index] = exc
+                message = (
+                    f"Ray actor UDF pool initialization failed for "
+                    f"{resource_unit_id}/actor-{actor_index}: {type(exc).__name__}: {exc}"
+                )
+                with self._query_resource_lock:
+                    self._query_terminal_errors.setdefault(query_id, message)
+                manager.cancel(message)
+                return
+
+            with self._session_lock:
+                if (
+                    bool(getattr(pool, "_vane_retired", False))
+                    or self._active_udf_actor_by_unit.get(query_id, {}).get(resource_unit_id) is not pool
+                ):
+                    return
+                pool.actor_node_ids[actor_index] = node_id
+                pool._confirmed_ready.add(actor_index)
+                ready_nodes = {
+                    ready_index: str(pool.actor_node_ids[ready_index])
+                    for ready_index in sorted(pool._confirmed_ready)
+                    if str(pool.actor_node_ids[ready_index]).strip()
+                }
+                manager.set_ready_actor_slots(resource_unit_id, ready_nodes)
+
+        readiness_futures: list[Any] = []
+        for actor_index, init_ref in enumerate(pool._init_refs):
+            if actor_index in pool._confirmed_ready:
+                continue
+            future_method = getattr(init_ref, "future", None)
+            if not callable(future_method):
+                raise TypeError("Ray actor init ObjectRef does not expose future()")
+            future = future_method()
+            future.add_done_callback(lambda done, _actor_index=actor_index: actor_ready(_actor_index, done))
+            readiness_futures.append(future)
+        pool._vane_readiness_futures = readiness_futures
+
+    async def activate_query_udf_actor_pool(
+        self,
+        locator: dict[str, Any],
+        query_generation_capability: str,
+    ) -> dict[str, Any]:
+        if not isinstance(locator, dict):
+            raise TypeError("Ray actor UDF locator must be a dict")
+        expected_fields = {"query_id", "resource_unit_id", "physical_node_id"}
+        if set(locator) != expected_fields:
+            raise ValueError("Ray actor UDF locator fields do not match the query protocol")
+        normalized = {key: str(locator[key] or "").strip() for key in expected_fields}
+        if any(not value for value in normalized.values()):
+            raise ValueError("Ray actor UDF locator fields must be non-empty")
+        query_id = normalized["query_id"]
+        generation_id = self._verify_query_task_admission_capability(
+            capability=str(query_generation_capability or ""),
+            query_id=query_id,
+        )
+        if generation_id is None or self._capability_targets_inactive_query_generation(
+            query_id,
+            generation_id,
+        ):
+            raise PermissionError("Ray actor UDF locator does not own the active query generation")
+
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        manager = get_query_resource_manager(query_id)
+        if normalized["resource_unit_id"] not in manager.current_eligible_resource_unit_ids():
+            raise RuntimeError(
+                f"Ray actor UDF resource unit is outside the current execution phase: {normalized['resource_unit_id']}"
+            )
+
+        key = (query_id, normalized["resource_unit_id"])
+        task = self._query_udf_actor_activation_tasks.get(key)
+        if task is None:
+            task = asyncio.create_task(
+                _to_thread_with_owned_side_effects(
+                    self._activate_query_udf_actor_pool_sync,
+                    normalized,
+                    str(query_generation_capability),
+                ),
+                name=f"vane-activate-udf-actor:{query_id}:{normalized['resource_unit_id']}",
+            )
+            self._query_udf_actor_activation_tasks[key] = task
+        try:
+            return dict(await asyncio.shield(task))
+        except BaseException:
+            if self._query_udf_actor_activation_tasks.get(key) is task:
+                self._query_udf_actor_activation_tasks.pop(key, None)
+            raise
 
     def _precreate_vllm_actors(
         self,
@@ -5121,28 +5494,41 @@ class RayQueryDriverActor:
 
     def _cleanup_udf_actor_pools(self, plan_id: str) -> None:
         plan_key = str(plan_id)
-        pools = list(self._active_udf_actors_by_plan.get(plan_key, ()))
-        if not pools:
-            return
-        errors: list[str] = []
-        remaining_pools: list[Any] = []
-        for pool in pools:
-            try:
-                pool.shutdown()
-            except BaseException as exc:
-                errors.append(f"{type(exc).__name__}: {exc}")
-                remaining_pools.append(pool)
-            else:
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, plan_key)
+        with lifecycle_lock:
+            pools = list(self._active_udf_actors_by_plan.get(plan_key, ()))
+            if not pools:
+                return
+            errors: list[str] = []
+            remaining_pools: list[Any] = []
+            for pool in pools:
+                with self._session_lock:
+                    pool._vane_retired = True
                 try:
-                    self._active_udf_actors.remove(pool)
-                except ValueError:
-                    pass
-        if remaining_pools:
-            self._active_udf_actors_by_plan[plan_key] = remaining_pools
-        else:
-            self._active_udf_actors_by_plan.pop(plan_key, None)
-        if errors:
-            raise RuntimeError(f"failed to shut down {len(errors)} query-owned UDF actor pool(s): " + "; ".join(errors))
+                    pool.shutdown()
+                except BaseException as exc:
+                    errors.append(f"{type(exc).__name__}: {exc}")
+                    remaining_pools.append(pool)
+                else:
+                    try:
+                        self._active_udf_actors.remove(pool)
+                    except ValueError:
+                        pass
+                    active_by_unit = self._active_udf_actor_by_unit.get(plan_key)
+                    if active_by_unit is not None:
+                        for resource_unit_id, active_pool in tuple(active_by_unit.items()):
+                            if active_pool is pool:
+                                active_by_unit.pop(resource_unit_id, None)
+                        if not active_by_unit:
+                            self._active_udf_actor_by_unit.pop(plan_key, None)
+            if remaining_pools:
+                self._active_udf_actors_by_plan[plan_key] = remaining_pools
+            else:
+                self._active_udf_actors_by_plan.pop(plan_key, None)
+            if errors:
+                raise RuntimeError(
+                    f"failed to shut down {len(errors)} query-owned UDF actor pool(s): " + "; ".join(errors)
+                )
 
     def _cleanup_vllm_actor_pools(self, plan_id: str) -> None:
         plan_key = str(plan_id)
@@ -5173,6 +5559,23 @@ class RayQueryDriverActor:
 
     def _release_plan_session_state(self, plan_id: str) -> None:
         plan_key = str(plan_id)
+        activation_tasks = [
+            task
+            for (query_id, _resource_unit_id), task in tuple(self._query_udf_actor_activation_tasks.items())
+            if query_id == plan_key
+        ]
+        for key in tuple(self._query_udf_actor_activation_tasks):
+            if key[0] == plan_key:
+                self._query_udf_actor_activation_tasks.pop(key, None)
+        self._query_udf_actor_nodes.pop(plan_key, None)
+        self._query_udf_session_configs.pop(plan_key, None)
+        self._active_udf_actor_by_unit.pop(plan_key, None)
+        loop = self._query_resource_admission_loop
+        for task in activation_tasks:
+            if task.done():
+                continue
+            if loop is not None and loop.is_running() and not loop.is_closed():
+                loop.call_soon_threadsafe(task.cancel)
         with self._session_lock:
             session_id = self._plan_session_ids.get(plan_key)
             query_connection = self._plan_connections.get(plan_key)
@@ -5184,6 +5587,9 @@ class RayQueryDriverActor:
                 self._plan_session_ids.pop(plan_key, None)
             if self._plan_connections.get(plan_key) is query_connection:
                 self._plan_connections.pop(plan_key, None)
+            lifecycle_locks = getattr(self, "_query_udf_actor_lifecycle_locks", None)
+            if lifecycle_locks is not None:
+                lifecycle_locks.pop(plan_key, None)
         if session is not None:
             with session.condition:
                 session.plan_ids.discard(plan_key)
@@ -5202,12 +5608,14 @@ class RayQueryDriverActor:
             if plan_key not in self._plan_session_ids:
                 return
             self._plan_teardowns_in_progress.add(plan_key)
+        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, plan_key)
         try:
-            self._teardown_plan_resources_once(
-                plan_key,
-                query_id,
-                drop_fragments=drop_fragments,
-            )
+            with lifecycle_lock:
+                self._teardown_plan_resources_once(
+                    plan_key,
+                    query_id,
+                    drop_fragments=drop_fragments,
+                )
         finally:
             with self._plan_teardown_condition:
                 self._plan_teardowns_in_progress.discard(plan_key)
@@ -5477,7 +5885,7 @@ class RayQueryDriverActor:
 
             self._plan_query_ids[plan_id] = plan_id
             try:
-                graph, allocation = await self._register_query_resources(
+                graph, _ = await self._register_query_resources(
                     plan,
                     query_connection=query_connection,
                     expected_plan_id=plan_id,
@@ -5509,7 +5917,6 @@ class RayQueryDriverActor:
                     plan,
                     plan_id,
                     graph,
-                    allocation,
                     query_connection,
                     session.config,
                     startup_ownership,
@@ -5628,22 +6035,18 @@ class RayQueryDriverActor:
         plan: Any,
         plan_id: str,
         graph: Any,
-        allocation: Any,
         query_connection: Any,
         session_config: dict[str, str],
     ) -> None:
         """Start an already registered streaming plan on a worker thread."""
         plan_runner_started = False
         try:
-            udf_actors = self._precreate_udf_actors(
+            self._precreate_udf_actors(
                 plan,
                 graph,
-                allocation,
                 query_connection=query_connection,
                 session_config=session_config,
             )
-            if udf_actors:
-                self._active_udf_actors_by_plan[plan_id] = list(udf_actors)
             self._precreate_vllm_actors(
                 plan,
                 query_connection=query_connection,
@@ -5655,12 +6058,6 @@ class RayQueryDriverActor:
             plan_runner = self._get_plan_runner()
             plan_runner_started = True
             self.curr_streams[plan_id] = plan_runner.run_plan(plan, query_connection)
-            # Native FTE execution is intentionally started before the actor
-            # readiness fence opens.  It can initialize DuckDB's real
-            # Fragment/Pipeline topology, but its Ray-actor UDF dispatcher
-            # cannot obtain a QRM lease until model initialization succeeds.
-            self._wait_for_udf_actors_ready(udf_actors)
-            self._mark_query_actor_units_ready(graph)
         except BaseException as start_error:
             query_id = self._plan_query_ids.get(plan_id, "")
             try:
@@ -5683,7 +6080,6 @@ class RayQueryDriverActor:
         plan: Any,
         plan_id: str,
         graph: Any,
-        allocation: Any,
         query_connection: Any,
         session_config: dict[str, str],
         startup_ownership: _PlanStartupOwnership,
@@ -5695,7 +6091,6 @@ class RayQueryDriverActor:
             plan,
             plan_id,
             graph,
-            allocation,
             query_connection,
             session_config,
         )
@@ -5798,20 +6193,6 @@ class RayQueryDriverActor:
                 pass
             raise cancellation
         return task.result()
-
-    @staticmethod
-    async def _drain_copy_startup_tasks(tasks: list[asyncio.Task[Any]]) -> None:
-        if not tasks:
-            return
-        drain = asyncio.gather(*tasks, return_exceptions=True)
-        while not drain.done():
-            try:
-                await asyncio.shield(drain)
-            except asyncio.CancelledError:
-                # Once native COPY may have committed, cancellation cannot
-                # interrupt observation of the remaining startup tasks.
-                continue
-        drain.result()
 
     @staticmethod
     def _copy_cleanup_warning(stage: str, error: BaseException) -> str:
@@ -6147,7 +6528,6 @@ class RayQueryDriverActor:
         graph = None
         plan_runner_started = False
         plan_execution: asyncio.Task[Any] | None = None
-        startup_tasks: list[asyncio.Task[Any]] = []
         try:
             plan, query_connection = await _to_thread_with_owned_side_effects(
                 self._prepare_copy_plan_sync,
@@ -6157,17 +6537,16 @@ class RayQueryDriverActor:
                 plan_id,
             )
             self._plan_query_ids[plan_id] = plan_id
-            graph, allocation = await self._register_query_resources(
+            graph, _ = await self._register_query_resources(
                 plan,
                 query_connection=query_connection,
                 expected_plan_id=plan_id,
             )
             self._plan_query_ids[plan_id] = str(graph.query_id)
-            udf_actors = await _to_thread_with_owned_side_effects(
+            await _to_thread_with_owned_side_effects(
                 self._precreate_udf_actors,
                 plan,
                 graph,
-                allocation,
                 query_connection=query_connection,
                 session_config=session.config,
             )
@@ -6187,48 +6566,6 @@ class RayQueryDriverActor:
                 ),
                 name=f"vane-copy-plan:{plan_id}",
             )
-            if udf_actors:
-                from duckdb.runners.ray.fte_fragment_scheduler import (
-                    wait_for_fte_query_progress_topology,
-                )
-
-                topology_ready = asyncio.create_task(
-                    asyncio.to_thread(
-                        wait_for_fte_query_progress_topology,
-                        graph.query_id,
-                        timeout_s=_progress_topology_init_timeout_s(),
-                    ),
-                    name=f"vane-copy-topology-ready:{plan_id}",
-                )
-                actors_ready = asyncio.create_task(
-                    asyncio.to_thread(self._wait_for_udf_actors_ready, udf_actors),
-                    name=f"vane-copy-actors-ready:{plan_id}",
-                )
-                startup_tasks.extend((topology_ready, actors_ready))
-                pending_startup = set(startup_tasks)
-                plan_execution_observed = False
-                while pending_startup:
-                    wait_tasks = set(pending_startup)
-                    if not plan_execution_observed:
-                        wait_tasks.add(plan_execution)
-                    done, _ = await asyncio.wait(
-                        wait_tasks,
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    if plan_execution in done:
-                        # Propagate a native-plan failure immediately. A
-                        # successful zero-row COPY may legitimately finish
-                        # before a slow actor has initialized, so keep waiting
-                        # for the startup barriers instead of rewriting that
-                        # success as an execution error.
-                        await self._await_copy_operation(plan_execution)
-                        plan_execution_observed = True
-                    for task in done:
-                        if task is plan_execution:
-                            continue
-                        await task
-                        pending_startup.discard(task)
-            self._mark_query_actor_units_ready(graph)
             # Cancellation must reach the exception path promptly so teardown
             # can interrupt a still-running native write, but it must not
             # cancel the asyncio wrapper around that thread. The exception path
@@ -6280,7 +6617,6 @@ class RayQueryDriverActor:
                                 )
                         elif observed_result.get("copy_output_committed") is True:
                             committed_result = observed_result
-            await self._drain_copy_startup_tasks(startup_tasks)
             if committed_result is not None:
                 cleanup_warnings = self._copy_native_cleanup_warnings(committed_result) + (
                     self._copy_cleanup_warning(

--- a/duckdb/runners/ray/fragment_registry.py
+++ b/duckdb/runners/ray/fragment_registry.py
@@ -309,14 +309,14 @@ class FteRegistryState:
     ] = field(default_factory=dict)
     # FTE keeps logical task descriptors outside QRM until one descriptor can
     # actually enter the execution window.  At most one partition per
-    # resource stage may probe admission at a time.  A denial is memoized at
+    # resource unit may probe admission at a time.  A denial is memoized at
     # the QRM admission epoch so the remaining descriptors stay passive until
     # a real resource/accounting change occurs.
-    stage_submission_probes: dict[
+    resource_unit_submission_probes: dict[
         tuple[str, str],
         tuple[str, str, int],
     ] = field(default_factory=dict)
-    stage_submission_blocks: dict[
+    resource_unit_submission_blocks: dict[
         tuple[str, str],
         tuple[int, str, tuple[str, str, int]],
     ] = field(default_factory=dict)
@@ -352,8 +352,8 @@ _FTE_ACTIVE_TEARDOWN_OPERATIONS_BY_QUERY = _FTE_REGISTRY_STATE.active_teardown_o
 _FTE_WORKER_RESERVATION_GENERATIONS = _FTE_REGISTRY_STATE.worker_reservation_generations
 _FTE_PENDING_WORKER_RESERVATIONS = _FTE_REGISTRY_STATE.pending_worker_reservations
 _FTE_PARTITION_TASK_WAITERS = _FTE_REGISTRY_STATE.partition_task_waiters
-_FTE_STAGE_SUBMISSION_PROBES = _FTE_REGISTRY_STATE.stage_submission_probes
-_FTE_STAGE_SUBMISSION_BLOCKS = _FTE_REGISTRY_STATE.stage_submission_blocks
+_FTE_RESOURCE_UNIT_SUBMISSION_PROBES = _FTE_REGISTRY_STATE.resource_unit_submission_probes
+_FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS = _FTE_REGISTRY_STATE.resource_unit_submission_blocks
 _FTE_PARTITION_TASK_LEASES = _FTE_REGISTRY_STATE.partition_task_leases
 _FTE_RESULT_HANDLES_BY_QUERY = _FTE_REGISTRY_STATE.result_handles_by_query
 _FTE_FRAGMENT_STATES = _FTE_REGISTRY_STATE.fragment_states
@@ -383,8 +383,8 @@ __all__ = [
     "_FTE_RETRY_DELAYS",
     "_FTE_SCHEDULERS",
     "_FTE_SEQUENCES",
-    "_FTE_STAGE_SUBMISSION_BLOCKS",
-    "_FTE_STAGE_SUBMISSION_PROBES",
+    "_FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS",
+    "_FTE_RESOURCE_UNIT_SUBMISSION_PROBES",
     "_FTE_STABLE_TASK_IDENTITY_KEYS_BY_RESOURCE_QUERY",
     "_FTE_STATUS_WATCHERS",
     "_FTE_WORKER_HANDLES",

--- a/duckdb/runners/ray/fragment_submission_window.py
+++ b/duckdb/runners/ray/fragment_submission_window.py
@@ -10,13 +10,13 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_FRAGMENT_EXECUTIONS,
     _FTE_PARTITION_TASK_LEASES,
     _FTE_REGISTRY_LOCK,
-    _FTE_STAGE_SUBMISSION_BLOCKS,
-    _FTE_STAGE_SUBMISSION_PROBES,
+    _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS,
+    _FTE_RESOURCE_UNIT_SUBMISSION_PROBES,
 )
 from duckdb.runners.ray.fragment_worker_context import resource_identity_from_context
 
 PartitionKey = tuple[str, str, int]
-StageKey = tuple[str, str]
+ResourceUnitKey = tuple[str, str]
 
 
 def _partition_key(
@@ -27,7 +27,7 @@ def _partition_key(
     return (str(query_id), str(fragment_id), int(partition_id))
 
 
-def _stage_key_for_partition(key: PartitionKey) -> StageKey:
+def _resource_unit_key_for_partition(key: PartitionKey) -> ResourceUnitKey:
     with _FTE_REGISTRY_LOCK:
         fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((key[0], key[1]))
     if fragment_execution is None:
@@ -40,7 +40,7 @@ def admit_fte_partition_submission(
     fragment_id: str,
     partition_id: int,
 ) -> bool:
-    """Claim the single edge-triggered admission probe for a resource stage.
+    """Claim the single edge-triggered admission probe for a resource unit.
 
     Active leases bypass the probe.  Unleased descriptors are promoted one at
     a time.  After QRM denies one probe, all other descriptors remain passive
@@ -49,24 +49,24 @@ def admit_fte_partition_submission(
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     key = _partition_key(query_id, fragment_id, partition_id)
-    stage_key = _stage_key_for_partition(key)
-    manager = get_query_resource_manager(stage_key[0])
+    resource_unit_key = _resource_unit_key_for_partition(key)
+    manager = get_query_resource_manager(resource_unit_key[0])
     admission_epoch = manager.admission_epoch()
     with _FTE_REGISTRY_LOCK:
         if key[0] in _FTE_CLOSING_QUERIES:
             return False
         if key in _FTE_PARTITION_TASK_LEASES:
             return True
-        owner = _FTE_STAGE_SUBMISSION_PROBES.get(stage_key)
+        owner = _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.get(resource_unit_key)
         if owner is not None:
             return owner == key
-        blocked = _FTE_STAGE_SUBMISSION_BLOCKS.get(stage_key)
+        blocked = _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.get(resource_unit_key)
         if blocked is not None and int(blocked[0]) == admission_epoch:
             return False
         # The epoch advanced because capacity, allocation, downstream demand,
         # or arbitration state changed.  The old denial is no longer valid.
-        _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
-        _FTE_STAGE_SUBMISSION_PROBES[stage_key] = key
+        _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
+        _FTE_RESOURCE_UNIT_SUBMISSION_PROBES[resource_unit_key] = key
         return True
 
 
@@ -80,28 +80,28 @@ def resolve_fte_partition_submission(
     fatal: bool = False,
     admission_epoch: int | None = None,
 ) -> None:
-    """Resolve a stage probe after its atomic QRM admission attempt."""
+    """Resolve a resource-unit probe after its atomic QRM admission attempt."""
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     key = _partition_key(query_id, fragment_id, partition_id)
     try:
-        stage_key = _stage_key_for_partition(key)
+        resource_unit_key = _resource_unit_key_for_partition(key)
     except KeyError:
         return
     if admission_epoch is None:
         try:
-            resolved_epoch = get_query_resource_manager(stage_key[0]).admission_epoch()
+            resolved_epoch = get_query_resource_manager(resource_unit_key[0]).admission_epoch()
         except KeyError:
             resolved_epoch = -1
     else:
         resolved_epoch = int(admission_epoch)
     with _FTE_REGISTRY_LOCK:
-        if _FTE_STAGE_SUBMISSION_PROBES.get(stage_key) == key:
-            _FTE_STAGE_SUBMISSION_PROBES.pop(stage_key, None)
+        if _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.get(resource_unit_key) == key:
+            _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.pop(resource_unit_key, None)
         if granted or fatal or resolved_epoch < 0:
-            _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
+            _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
         else:
-            _FTE_STAGE_SUBMISSION_BLOCKS[stage_key] = (
+            _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS[resource_unit_key] = (
                 resolved_epoch,
                 str(blocked_reason or "task_not_admissible"),
                 key,
@@ -115,20 +115,20 @@ def release_fte_partition_submission(
     *,
     allow_next: bool = True,
 ) -> bool:
-    """Release an abandoned probe without leaving the stage permanently shut."""
+    """Release an abandoned probe without leaving the resource unit permanently shut."""
     key = _partition_key(query_id, fragment_id, partition_id)
     try:
-        stage_key = _stage_key_for_partition(key)
+        resource_unit_key = _resource_unit_key_for_partition(key)
     except KeyError:
         return False
     with _FTE_REGISTRY_LOCK:
         released = False
-        if _FTE_STAGE_SUBMISSION_PROBES.get(stage_key) == key:
-            _FTE_STAGE_SUBMISSION_PROBES.pop(stage_key, None)
+        if _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.get(resource_unit_key) == key:
+            _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.pop(resource_unit_key, None)
             released = True
-        blocked = _FTE_STAGE_SUBMISSION_BLOCKS.get(stage_key)
+        blocked = _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.get(resource_unit_key)
         if allow_next and blocked is not None and blocked[2] == key:
-            _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
+            _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
             released = True
         return released
 
@@ -136,45 +136,49 @@ def release_fte_partition_submission(
 def release_fte_query_submissions(query_id: str) -> int:
     query_key = str(query_id)
     with _FTE_REGISTRY_LOCK:
-        resource_stage_keys = {
+        resource_unit_keys = {
             resource_identity_from_context(fragment_execution.context)
             for (execution_query_id, _fragment_id), fragment_execution in _FTE_FRAGMENT_EXECUTIONS.items()
             if execution_query_id == query_key
         }
-        owned_stage_keys = [
-            stage_key
-            for stage_key, partition_key in _FTE_STAGE_SUBMISSION_PROBES.items()
+        owned_resource_unit_keys = [
+            resource_unit_key
+            for resource_unit_key, partition_key in _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.items()
             if partition_key[0] == query_key
         ]
-        for stage_key in owned_stage_keys:
-            _FTE_STAGE_SUBMISSION_PROBES.pop(stage_key, None)
-            _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
-        # A blocked stage normally has a probe owner from this execution query
+        for resource_unit_key in owned_resource_unit_keys:
+            _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.pop(resource_unit_key, None)
+            _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
+        # A blocked resource unit normally has a probe owner from this execution query
         # at the time it is recorded.  Drop orphaned blocks for resource-owned
         # queries too, which covers teardown after partial registration.
-        for stage_key in list(_FTE_STAGE_SUBMISSION_BLOCKS):
-            if stage_key[0] == query_key or stage_key in resource_stage_keys:
-                _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
-        return len(owned_stage_keys)
+        for resource_unit_key in list(_FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS):
+            if resource_unit_key[0] == query_key or resource_unit_key in resource_unit_keys:
+                _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
+        return len(owned_resource_unit_keys)
 
 
 def fte_submission_window_snapshot() -> dict[str, Any]:
     with _FTE_REGISTRY_LOCK:
         return {
             "probes": {
-                f"{resource_query_id}/{stage_id}": {
+                f"{resource_query_id}/{resource_unit_id}": {
                     "query_id": partition_key[0],
                     "fragment_id": partition_key[1],
                     "partition_id": partition_key[2],
                 }
-                for (resource_query_id, stage_id), partition_key in sorted(_FTE_STAGE_SUBMISSION_PROBES.items())
+                for (resource_query_id, resource_unit_id), partition_key in sorted(
+                    _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.items()
+                )
             },
             "blocks": {
-                f"{resource_query_id}/{stage_id}": {
+                f"{resource_query_id}/{resource_unit_id}": {
                     "admission_epoch": int(blocked[0]),
                     "blocked_reason": str(blocked[1]),
                 }
-                for (resource_query_id, stage_id), blocked in sorted(_FTE_STAGE_SUBMISSION_BLOCKS.items())
+                for (resource_query_id, resource_unit_id), blocked in sorted(
+                    _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.items()
+                )
             },
         }
 

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -25,6 +25,7 @@ from duckdb.runners.ray.fragment_registry import (
 )
 from duckdb.runners.ray.fragment_worker_failures import quarantine_fte_worker
 from duckdb.runners.ray.fte_fragment_scheduler import (
+    _sync_write_sink_unit_for_fragment,
     _store_fte_result_handles,
     begin_fte_registry_operation,
     end_fte_registry_operation,
@@ -287,6 +288,10 @@ class FteWorkerCommandMixin:
         self,
         fragment_execution: FteFragmentExecution,
     ) -> FteWorkerCommandDispatchResult:
+        # Worker failure reconciliation mutates fragment state before commands
+        # are placed in the outbox.  Publish that state even when the mutation
+        # produced no retry command (for example, the final failed sink input).
+        _sync_write_sink_unit_for_fragment(fragment_execution)
         return self._execute_fte_fragment_execution_worker_commands(
             fragment_execution,
             fragment_execution.pop_worker_commands(),
@@ -297,6 +302,10 @@ class FteWorkerCommandMixin:
         fragment_execution: FteFragmentExecution,
         result: Any,
     ) -> FteWorkerCommandDispatchResult:
+        # Assignment can seal the dynamic partition set without scheduling a
+        # task.  Synchronize before dispatch so a terminal write-sink unit still
+        # advances query-resource allocation in that zero-command case.
+        _sync_write_sink_unit_for_fragment(fragment_execution)
         return self._execute_fte_fragment_execution_worker_commands(
             fragment_execution,
             list(result.worker_commands),

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -25,8 +25,8 @@ from duckdb.runners.ray.fragment_registry import (
 )
 from duckdb.runners.ray.fragment_worker_failures import quarantine_fte_worker
 from duckdb.runners.ray.fte_fragment_scheduler import (
-    _sync_write_sink_unit_for_fragment,
     _store_fte_result_handles,
+    _sync_write_sink_unit_for_fragment,
     begin_fte_registry_operation,
     end_fte_registry_operation,
     fte_partition_task_lease_payload,

--- a/duckdb/runners/ray/fragment_worker_context.py
+++ b/duckdb/runners/ray/fragment_worker_context.py
@@ -22,20 +22,17 @@ def resource_identity_from_context(
     if not context:
         raise ValueError("FTE task context is missing resource identity")
     resource_query_id = str(context.get("resource_query_id") or "").strip()
-    resource_stage_id = str(context.get("resource_stage_id") or "").strip()
-    if not resource_query_id or not resource_stage_id:
-        raise ValueError("FTE task context requires resource_query_id and resource_stage_id")
-    expected_prefix = f"stage:{resource_query_id}:node:"
-    if (
-        not resource_stage_id.startswith(expected_prefix)
-        or not resource_stage_id.endswith(":fte")
-        or not resource_stage_id[len(expected_prefix) : -len(":fte")]
-    ):
+    resource_unit_id = str(context.get("resource_unit_id") or "").strip()
+    if not resource_query_id or not resource_unit_id:
+        raise ValueError("FTE task context requires resource_query_id and resource_unit_id")
+    expected_prefix = f"resource:{resource_query_id}:fragment:node:"
+    node_id = resource_unit_id[len(expected_prefix) :] if resource_unit_id.startswith(expected_prefix) else ""
+    if not node_id or ":" in node_id:
         raise ValueError(
-            "FTE task resource_stage_id does not belong to resource_query_id: "
-            f"query={resource_query_id!r} stage={resource_stage_id!r}"
+            "FTE task resource_unit_id does not belong to resource_query_id: "
+            f"query={resource_query_id!r} resource_unit={resource_unit_id!r}"
         )
-    return resource_query_id, resource_stage_id
+    return resource_query_id, resource_unit_id
 
 
 def node_id_from_context(context: dict[str, str] | None) -> str | None:

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -30,7 +30,11 @@ from duckdb.runners.ray.fragment_worker_reservations import (
     fte_worker_reservation_event_state,
     remove_pending_fte_worker_reservation_if_current,
 )
-from duckdb.runners.ray.fte_fragment_scheduler import FteWorkerPlacementManager, request_fte_pending_task_drain
+from duckdb.runners.ray.fte_fragment_scheduler import (
+    FteWorkerPlacementManager,
+    _sync_write_sink_unit_for_fragment,
+    request_fte_pending_task_drain,
+)
 
 if TYPE_CHECKING:
     from duckdb.runners.fte.fte_events import ExchangeSelectorUpdated, TaskStatusChanged, WorkerReservationCompleted
@@ -263,7 +267,13 @@ class FteWorkerEventHandlingMixin:
                     raise
         finally:
             if terminal:
-                handles.extend(request_fte_pending_task_drain())
+                try:
+                    # A terminal status can leave no pending descriptor for the
+                    # admission scanner to revisit.  Publish the sink lifecycle
+                    # directly before waking work made eligible by completion.
+                    _sync_write_sink_unit_for_fragment(fragment_execution)
+                finally:
+                    handles.extend(request_fte_pending_task_drain())
         return handles
 
     def _handles_for_exchange_selector_updated_event(self, event: ExchangeSelectorUpdated) -> list[Any]:

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -74,10 +74,10 @@ class FteWorkerEventHandlingMixin:
 
     def _handles_for_marked_fte_worker_failed(
         self,
-        scheduled_by_stage: list[tuple[str, str, list[Any], list[Any]]],
+        scheduled_by_fragment: list[tuple[str, str, list[Any], list[Any]]],
     ) -> list[Any]:
         handles: list[Any] = []
-        for query_id, fragment_id, scheduled_attempts, _ in scheduled_by_stage:
+        for query_id, fragment_id, scheduled_attempts, _ in scheduled_by_fragment:
             with _FTE_REGISTRY_LOCK:
                 if query_id in _FTE_CLOSING_QUERIES:
                     continue
@@ -98,9 +98,9 @@ class FteWorkerEventHandlingMixin:
     def _handles_for_worker_failed_event(self, event: WorkerFailed) -> list[Any]:
         handles: list[Any] = []
         try:
-            scheduled_by_stage = mark_fte_worker_failed_for_event(event)
-            if scheduled_by_stage:
-                handles.extend(self._handles_for_marked_fte_worker_failed(scheduled_by_stage))
+            scheduled_by_fragment = mark_fte_worker_failed_for_event(event)
+            if scheduled_by_fragment:
+                handles.extend(self._handles_for_marked_fte_worker_failed(scheduled_by_fragment))
         finally:
             handles.extend(request_fte_pending_task_drain())
         return handles

--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -106,7 +106,7 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
             reconciliation_schedulers[query_id] = scheduler
     reconciliation_query_ids = set(reconciliation_schedulers)
     try:
-        scheduled_by_stage = _mark_fte_worker_failed(
+        scheduled_by_fragment = _mark_fte_worker_failed(
             event.worker_id,
             failure,
             query_id_filters=reconciliation_query_ids,
@@ -123,4 +123,4 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         delay_s = _fte_retry_remaining_delay_s(query_id)
         if delay_s > 0:
             scheduler.arm_retry_delay(delay_s)
-    return scheduled_by_stage
+    return scheduled_by_fragment

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -327,7 +327,7 @@ class FteWorkerLifecycleMixin:
         return scheduler.drain()
 
     def blocking_materialization_completed(self, query_id: str, node_id: str) -> bool:
-        from duckdb.runners.ray.query_graph_builder import fte_stage_id_for_node
+        from duckdb.runners.ray.query_resource_graph_builder import native_fragment_unit_id_for_node
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         query_key = str(query_id or "").strip()
@@ -335,8 +335,8 @@ class FteWorkerLifecycleMixin:
         if not query_key or not node_key:
             raise ValueError("blocking materialization completion requires query_id and node_id")
         manager = get_query_resource_manager(query_key)
-        return manager.mark_materializing_stage_completed(
-            fte_stage_id_for_node(query_key, node_key),
+        return manager.mark_barrier_unit_completed(
+            native_fragment_unit_id_for_node(query_key, node_key),
         )
 
     def mark_fte_worker_failed(

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -326,6 +326,19 @@ class FteWorkerLifecycleMixin:
         scheduler.enqueue(SourceInputExhausted.from_source_node_ids(query_id, exhausted_sources))
         return scheduler.drain()
 
+    def blocking_materialization_completed(self, query_id: str, node_id: str) -> bool:
+        from duckdb.runners.ray.query_graph_builder import fte_stage_id_for_node
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        query_key = str(query_id or "").strip()
+        node_key = str(node_id or "").strip()
+        if not query_key or not node_key:
+            raise ValueError("blocking materialization completion requires query_id and node_id")
+        manager = get_query_resource_manager(query_key)
+        return manager.mark_materializing_stage_completed(
+            fte_stage_id_for_node(query_key, node_key),
+        )
+
     def mark_fte_worker_failed(
         self,
         worker_id: str,

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -326,19 +326,6 @@ class FteWorkerLifecycleMixin:
         scheduler.enqueue(SourceInputExhausted.from_source_node_ids(query_id, exhausted_sources))
         return scheduler.drain()
 
-    def blocking_materialization_completed(self, query_id: str, node_id: str) -> bool:
-        from duckdb.runners.ray.query_resource_graph_builder import native_fragment_unit_id_for_node
-        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
-
-        query_key = str(query_id or "").strip()
-        node_key = str(node_id or "").strip()
-        if not query_key or not node_key:
-            raise ValueError("blocking materialization completion requires query_id and node_id")
-        manager = get_query_resource_manager(query_key)
-        return manager.mark_barrier_unit_completed(
-            native_fragment_unit_id_for_node(query_key, node_key),
-        )
-
     def mark_fte_worker_failed(
         self,
         worker_id: str,

--- a/duckdb/runners/ray/fragment_worker_pressure_accounting.py
+++ b/duckdb/runners/ray/fragment_worker_pressure_accounting.py
@@ -45,19 +45,19 @@ class FteWorkerPressureAccountingMixin:
         lease = dict(query_task_lease or {})
         query_id = str(lease.get("query_id") or "").strip()
         execution_query_id = str(lease.get("execution_query_id") or "").strip()
-        stage_id = str(lease.get("stage_id") or "").strip()
+        resource_unit_id = str(lease.get("resource_unit_id") or "").strip()
         task_lease_id = str(lease.get("lease_id") or "").strip()
         lease_attempt_id = str(lease.get("attempt_id") or "").strip()
         if execution_query_id != attempt.task_id.query_id or lease_attempt_id != str(attempt):
             raise RuntimeError("FTE result task lease identity does not match its attempt")
-        if not stage_id or not task_lease_id:
-            raise RuntimeError("FTE result task lease is missing stage_id or lease_id")
+        if not resource_unit_id or not task_lease_id:
+            raise RuntimeError("FTE result task lease is missing resource_unit_id or lease_id")
 
         manager = get_query_resource_manager(query_id)
         requests = tuple(
             OutputBlockRequest(
                 query_id=query_id,
-                producer_stage_id=stage_id,
+                producer_unit_id=resource_unit_id,
                 task_lease_id=task_lease_id,
                 attempt_id=lease_attempt_id,
                 block_id=str(output["block_id"]),

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -79,23 +79,23 @@ RayWorkerTask = require_ray_cxx_attr(
 
 def _registered_fte_task_memory_bytes(
     resource_query_id: str,
-    resource_stage_id: str,
+    resource_unit_id: str,
 ) -> int:
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     manager = get_query_resource_manager(resource_query_id)
-    stage = manager.graph.stage_by_id(resource_stage_id)
-    if stage.backend != "ray_worker":
-        raise RuntimeError(f"FTE stage {resource_stage_id} has invalid registered backend {stage.backend!r}")
-    task_memory_bytes = int(stage.per_task.heap_bytes)
+    unit = manager.graph.unit_by_id(resource_unit_id)
+    if unit.backend != "ray_worker":
+        raise RuntimeError(f"FTE resource unit {resource_unit_id} has invalid registered backend {unit.backend!r}")
+    task_memory_bytes = int(unit.per_task.heap_bytes)
     if task_memory_bytes <= 0:
-        raise RuntimeError(f"FTE stage {resource_stage_id} has invalid per-task heap lease {task_memory_bytes}")
+        raise RuntimeError(f"FTE resource unit {resource_unit_id} has invalid per-task heap lease {task_memory_bytes}")
     return task_memory_bytes
 
 
 def _registered_fte_logical_fragment_identity(
     resource_query_id: str,
-    resource_stage_id: str,
+    resource_unit_id: str,
     query_id: str,
     fragment_id: str,
 ) -> str:
@@ -103,9 +103,9 @@ def _registered_fte_logical_fragment_identity(
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     manager = get_query_resource_manager(resource_query_id)
-    stage = manager.graph.stage_by_id(resource_stage_id)
-    if stage.backend != "ray_worker":
-        raise RuntimeError(f"FTE stage {resource_stage_id} has invalid registered backend {stage.backend!r}")
+    unit = manager.graph.unit_by_id(resource_unit_id)
+    if unit.backend != "ray_worker":
+        raise RuntimeError(f"FTE resource unit {resource_unit_id} has invalid registered backend {unit.backend!r}")
     if query_id == resource_query_id:
         execution_scope = "root"
     elif query_id.startswith(resource_query_id):
@@ -118,7 +118,7 @@ def _registered_fte_logical_fragment_identity(
     return json.dumps(
         [
             "ray-fte-logical-fragment-v1",
-            stage.physical_node_id,
+            unit.physical_node_id,
             execution_scope,
             fragment_id[len(query_prefix) :],
         ],
@@ -276,10 +276,10 @@ class FteWorkerSubmissionMixin:
             dynamic_exchange_sources,
         )
         resource_query_id = str(item["resource_query_id"])
-        resource_stage_id = str(item["resource_stage_id"])
+        resource_unit_id = str(item["resource_unit_id"])
         logical_fragment_identity = _registered_fte_logical_fragment_identity(
             resource_query_id,
-            resource_stage_id,
+            resource_unit_id,
             query_id,
             fragment_id,
         )
@@ -394,7 +394,7 @@ class FteWorkerSubmissionMixin:
             dynamic_exchange_source_node_ids=dynamic_exchange_sources,
             task_memory_bytes=_registered_fte_task_memory_bytes(
                 resource_query_id,
-                resource_stage_id,
+                resource_unit_id,
             ),
         )
         with _FTE_REGISTRY_LOCK:
@@ -925,7 +925,7 @@ class FteWorkerSubmissionMixin:
             task_context_info = dict(task.task_context() or {})
             context = extract_task_inputs(task, context)
             exchange_sink_instance = task.exchange_sink_instance()
-            resource_query_id, resource_stage_id = resource_identity_from_context(context)
+            resource_query_id, resource_unit_id = resource_identity_from_context(context)
 
             query_id, fragment_id = fragment_id_for_task(context, task_name)
             if (
@@ -970,7 +970,7 @@ class FteWorkerSubmissionMixin:
                     "fragment_plan": fragment_plan,
                     "query_id": query_id,
                     "resource_query_id": resource_query_id,
-                    "resource_stage_id": resource_stage_id,
+                    "resource_unit_id": resource_unit_id,
                     "task_context_info": task_context_info,
                     "exchange_sink_instance": exchange_sink_instance,
                 }

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -77,22 +77,6 @@ RayWorkerTask = require_ray_cxx_attr(
 )
 
 
-def _registered_fte_task_memory_bytes(
-    resource_query_id: str,
-    resource_unit_id: str,
-) -> int:
-    from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
-
-    manager = get_query_resource_manager(resource_query_id)
-    unit = manager.graph.unit_by_id(resource_unit_id)
-    if unit.backend != "ray_worker":
-        raise RuntimeError(f"FTE resource unit {resource_unit_id} has invalid registered backend {unit.backend!r}")
-    task_memory_bytes = int(unit.per_task.heap_bytes)
-    if task_memory_bytes <= 0:
-        raise RuntimeError(f"FTE resource unit {resource_unit_id} has invalid per-task heap lease {task_memory_bytes}")
-    return task_memory_bytes
-
-
 def _registered_fte_logical_fragment_identity(
     resource_query_id: str,
     resource_unit_id: str,
@@ -392,10 +376,11 @@ class FteWorkerSubmissionMixin:
             source_node_ids=dynamic_scan_sources | dynamic_exchange_sources,
             dynamic_scan_source_node_ids=dynamic_scan_sources,
             dynamic_exchange_source_node_ids=dynamic_exchange_sources,
-            task_memory_bytes=_registered_fte_task_memory_bytes(
-                resource_query_id,
-                resource_unit_id,
-            ),
+            # Native fragments share the node-local DuckDB instance. DuckDB's
+            # memory_limit and buffer manager own their working-memory
+            # admission; the query resource graph does not synthesize a
+            # per-fragment heap requirement.
+            task_memory_bytes=None,
         )
         with _FTE_REGISTRY_LOCK:
             if fte_registry_query_is_closing(query_id):

--- a/duckdb/runners/ray/fragment_worker_transitions.py
+++ b/duckdb/runners/ray/fragment_worker_transitions.py
@@ -24,6 +24,7 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     _fte_pressure_total_memory_bytes,
     _ordered_fte_fragment_execution_items_for_pending_drain,
     _required_fte_pressure_stats,
+    _sync_write_sink_unit_for_fragment,
     fte_registry_query_is_closing,
 )
 
@@ -131,6 +132,7 @@ class FteWorkerTransitionMixin:
             except FteWorkerControlFailure as exc:
                 self._handles_for_fte_worker_control_failure(exc)
                 fragment_execution_revoked = []
+            _sync_write_sink_unit_for_fragment(fragment_execution)
             revoked.extend(fragment_execution_revoked)
             if remaining is not None:
                 remaining -= len(fragment_execution_revoked)

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -976,10 +976,9 @@ def drain_fte_resource_admission_change(query_id: str) -> list[Any]:
     return request_fte_pending_task_drain()
 
 
-def has_fte_resource_admission_waiter(query_id: str) -> bool:
-    # Kept as a compatibility name for the driver bridge.  Demand now includes
-    # passive FTE descriptors; FTE task waiters are intentionally absent from
-    # QRM when the execution window is full.
+def has_fte_resource_admission_demand(query_id: str) -> bool:
+    # Demand includes passive FTE descriptors; FTE task waiters are
+    # intentionally absent from QRM when the execution window is full.
     return bool(_fte_execution_queries_waiting_for_resource(query_id))
 
 
@@ -2006,21 +2005,12 @@ class FteWorkerPlacementManager:
         partition_id = int(partition_id)
         owner_key = (query_id, fragment_id, partition_id)
         fragment_execution_id = _fte_partition_fragment_execution_id(query_id, fragment_id, partition_id)
-        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
-
-        resource_query_id, resource_unit_id = _fte_fragment_resource_identity(
-            query_id,
-            fragment_id,
-        )
-        eligible_node_ids = set(get_query_resource_manager(resource_query_id).task_eligible_node_ids(resource_unit_id))
-        if not eligible_node_ids:
-            raise RuntimeError(f"FTE resource unit {resource_unit_id} has no feasible node in its query allocation")
         with _FTE_REGISTRY_LOCK:
             if query_id in _FTE_CLOSING_QUERIES:
                 raise RuntimeError(f"FTE query registry is closing: {query_id}")
             lease_record = _FTE_PARTITION_TASK_LEASES.get(owner_key)
             owner = _FTE_PARTITION_OWNERS.get(owner_key)
-            if owner is not None and (not owner._fte_healthy or str(owner.node_id) not in eligible_node_ids):
+            if owner is not None and not owner._fte_healthy:
                 _FTE_PARTITION_OWNERS.pop(owner_key, None)
                 _release_fte_partition_task_lease_for_key(
                     query_id,
@@ -2063,7 +2053,6 @@ class FteWorkerPlacementManager:
                 try:
                     owner = self.coordinator._select_fte_worker(
                         exclude=excluded_worker_ids,
-                        allowed_node_ids=eligible_node_ids,
                         memory_requirement_bytes=memory_requirement_bytes,
                         execution_class=execution_class,
                         node_requirements=node_requirements,
@@ -2084,21 +2073,6 @@ class FteWorkerPlacementManager:
                         fragment_id,
                         partition_id,
                     )
-                    from duckdb.runners.ray.fragment_worker_selection import (
-                        available_fte_workers,
-                    )
-
-                    available_workers = available_fte_workers(
-                        self.coordinator,
-                        getattr(self.coordinator, "worker_id", None),
-                    )
-                    live_worker_node_ids = {str(worker.node_id) for worker in available_workers}
-                    if eligible_node_ids.isdisjoint(live_worker_node_ids):
-                        raise RuntimeError(
-                            f"FTE resource unit {resource_unit_id} allocation has no live Ray worker: "
-                            f"allocated_nodes={sorted(eligible_node_ids)} "
-                            f"worker_nodes={sorted(live_worker_node_ids)}"
-                        )
                     raise FteWorkerReservationUnavailable(
                         query_id=query_id,
                         fragment_id=fragment_id,

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -72,13 +72,13 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_QUERY_NEXT_FRAGMENT_EXECUTION_ID,
     _FTE_REGISTRY_CONDITION,
     _FTE_REGISTRY_LOCK,
+    _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS,
+    _FTE_RESOURCE_UNIT_SUBMISSION_PROBES,
     _FTE_RESULT_HANDLES_BY_QUERY,
     _FTE_RETRY_DELAYS,
     _FTE_SCHEDULERS,
     _FTE_SEQUENCES,
     _FTE_STABLE_TASK_IDENTITY_KEYS_BY_RESOURCE_QUERY,
-    _FTE_STAGE_SUBMISSION_BLOCKS,
-    _FTE_STAGE_SUBMISSION_PROBES,
     _FTE_STATUS_WATCHERS,
     _FTE_WORKER_HANDLES,
     _FTE_WORKER_RESERVATION_GENERATIONS,
@@ -661,12 +661,16 @@ def open_fte_registry_for_query(query_id: str) -> None:
                 ("partition_task_leases", any(key[0] == query_key for key in _FTE_PARTITION_TASK_LEASES)),
                 ("partition_task_waiters", any(key[0] == query_key for key in _FTE_PARTITION_TASK_WAITERS)),
                 (
-                    "stage_submission_probes",
-                    any(partition_key[0] == query_key for partition_key in _FTE_STAGE_SUBMISSION_PROBES.values()),
+                    "resource_unit_submission_probes",
+                    any(
+                        partition_key[0] == query_key for partition_key in _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.values()
+                    ),
                 ),
                 (
-                    "stage_submission_blocks",
-                    any(stage_key[0] == query_key for stage_key in _FTE_STAGE_SUBMISSION_BLOCKS),
+                    "resource_unit_submission_blocks",
+                    any(
+                        resource_unit_key[0] == query_key for resource_unit_key in _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS
+                    ),
                 ),
                 ("pending_worker_reservations", any(key[0] == query_key for key in _FTE_PENDING_WORKER_RESERVATIONS)),
                 (
@@ -943,7 +947,7 @@ def _fte_execution_queries_waiting_for_resource(
         if scheduler is None or scheduler.stats().state != "RUNNING":
             continue
         try:
-            owner_query_id, _stage_id = resource_identity_from_context(fragment_execution.context)
+            owner_query_id, _resource_unit_id = resource_identity_from_context(fragment_execution.context)
             if owner_query_id != resource_query_key:
                 continue
             has_pending_partitions = fragment_execution.has_pending_partitions()
@@ -1154,20 +1158,20 @@ def _write_sink_has_input(fragment_execution: Any) -> tuple[bool, bool]:
     return False, all_terminal
 
 
-def _sync_write_sink_stage_for_fragment(fragment_execution: Any) -> str | None:
+def _sync_write_sink_unit_for_fragment(fragment_execution: Any) -> str | None:
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     with fragment_execution._state_lock:
         if not _is_write_sink_fragment(fragment_execution):
             return None
-        resource_query_id, stage_id = resource_identity_from_context(fragment_execution.context)
+        resource_query_id, resource_unit_id = resource_identity_from_context(fragment_execution.context)
         has_input, all_terminal = _write_sink_has_input(fragment_execution)
-    get_query_resource_manager(resource_query_id).update_stage_state(
-        stage_id,
+    get_query_resource_manager(resource_query_id).update_unit_state(
+        resource_unit_id,
         runnable=has_input,
         completed=all_terminal,
     )
-    return stage_id
+    return resource_unit_id
 
 
 def _fte_partition_resource_key(query_id: str, fragment_id: str, partition_id: int) -> tuple[str, str, int]:
@@ -1247,7 +1251,7 @@ def _acquire_fte_partition_task_lease(
     with _FTE_REGISTRY_LOCK:
         if str(query_id) in _FTE_CLOSING_QUERIES:
             raise RuntimeError(f"FTE query registry is closing: {query_id}")
-    resource_query_id, stage_id = _fte_fragment_resource_identity(
+    resource_query_id, resource_unit_id = _fte_fragment_resource_identity(
         query_id,
         fragment_id,
     )
@@ -1279,7 +1283,7 @@ def _acquire_fte_partition_task_lease(
     manager = get_query_resource_manager(resource_query_id)
     request = TaskRequest(
         query_id=resource_query_id,
-        stage_id=stage_id,
+        resource_unit_id=resource_unit_id,
         task_id=task_id,
         attempt_id=attempt_id,
         node_id=str(node_id),
@@ -1298,6 +1302,9 @@ def _acquire_fte_partition_task_lease(
         )
         raise
     if grant.granted:
+        lease = grant.lease
+        if lease is None:
+            raise RuntimeError("QRM granted an FTE task without returning its lease")
         resolve_fte_partition_submission(
             query_id,
             fragment_id,
@@ -1308,11 +1315,11 @@ def _acquire_fte_partition_task_lease(
             query_closing = str(query_id) in _FTE_CLOSING_QUERIES
         if query_closing:
             manager.abandon_task_lease(
-                grant.lease.lease_id,
-                attempt_id=grant.lease.attempt_id,
+                lease.lease_id,
+                attempt_id=lease.attempt_id,
             )
             raise RuntimeError(f"FTE query registry is closing: {query_id}")
-        return grant.lease
+        return lease
     _set_fte_pending_reservation_blocked_reason(
         query_id,
         fragment_id,
@@ -1429,18 +1436,18 @@ def fte_partition_task_lease_payload(
         raise RuntimeError(f"FTE task lease attempt mismatch: lease={lease.attempt_id} command={actual_attempt_id}")
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-    stage = get_query_resource_manager(lease.query_id).graph.stage_by_id(lease.stage_id)
+    unit = get_query_resource_manager(lease.query_id).graph.unit_by_id(lease.resource_unit_id)
     return {
         "lease_id": lease.lease_id,
         "query_id": lease.query_id,
         "execution_query_id": str(query_id),
-        "stage_id": lease.stage_id,
+        "resource_unit_id": lease.resource_unit_id,
         "task_id": lease.task_id,
         "attempt_id": lease.attempt_id,
         "node_id": lease.node_id,
         "resources": lease.resources.to_dict(),
         "output_window_bytes": lease.output_window_bytes,
-        "target_output_block_bytes": stage.target_output_block_bytes,
+        "target_output_block_bytes": unit.target_output_block_bytes,
         "liveness": lease.liveness,
         "allocation_generation": lease.allocation_generation,
     }
@@ -1731,7 +1738,7 @@ def _admit_fte_partition_execution_ready(
     partition: Any,
 ) -> bool:
     if fragment_execution is not None:
-        _sync_write_sink_stage_for_fragment(fragment_execution)
+        _sync_write_sink_unit_for_fragment(fragment_execution)
     if fragment_execution is None:
         return False
     return admit_fte_partition_submission(
@@ -1747,7 +1754,7 @@ def _admit_fte_partition_node_wait(
     fragment_execution: FteFragmentExecution | None = None,
 ) -> bool:
     if fragment_execution is not None:
-        _sync_write_sink_stage_for_fragment(fragment_execution)
+        _sync_write_sink_unit_for_fragment(fragment_execution)
     with _FTE_REGISTRY_LOCK:
         fragment_execution_items = [
             item for item in _FTE_FRAGMENT_EXECUTIONS.items() if item[0][0] not in _FTE_CLOSING_QUERIES
@@ -1777,7 +1784,7 @@ class FteWorkerReservation:
         fragment_id: str,
         partition_id: int,
         worker: RayWorkerActorHandle,
-        stage_id: str,
+        resource_unit_id: str,
         task_lease_id: str,
         attempt_id: str,
     ) -> None:
@@ -1787,7 +1794,7 @@ class FteWorkerReservation:
         self.partition_id = int(partition_id)
         self.worker = worker
         self.worker_id = str(worker.worker_id)
-        self.stage_id = str(stage_id)
+        self.resource_unit_id = str(resource_unit_id)
         self.task_lease_id = str(task_lease_id)
         self.attempt_id = str(attempt_id)
 
@@ -2001,13 +2008,13 @@ class FteWorkerPlacementManager:
         fragment_execution_id = _fte_partition_fragment_execution_id(query_id, fragment_id, partition_id)
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        resource_query_id, stage_id = _fte_fragment_resource_identity(
+        resource_query_id, resource_unit_id = _fte_fragment_resource_identity(
             query_id,
             fragment_id,
         )
-        eligible_node_ids = set(get_query_resource_manager(resource_query_id).task_eligible_node_ids(stage_id))
+        eligible_node_ids = set(get_query_resource_manager(resource_query_id).task_eligible_node_ids(resource_unit_id))
         if not eligible_node_ids:
-            raise RuntimeError(f"FTE stage {stage_id} has no feasible node in its query allocation")
+            raise RuntimeError(f"FTE resource unit {resource_unit_id} has no feasible node in its query allocation")
         with _FTE_REGISTRY_LOCK:
             if query_id in _FTE_CLOSING_QUERIES:
                 raise RuntimeError(f"FTE query registry is closing: {query_id}")
@@ -2088,7 +2095,7 @@ class FteWorkerPlacementManager:
                     live_worker_node_ids = {str(worker.node_id) for worker in available_workers}
                     if eligible_node_ids.isdisjoint(live_worker_node_ids):
                         raise RuntimeError(
-                            f"FTE stage {stage_id} allocation has no live Ray worker: "
+                            f"FTE resource unit {resource_unit_id} allocation has no live Ray worker: "
                             f"allocated_nodes={sorted(eligible_node_ids)} "
                             f"worker_nodes={sorted(live_worker_node_ids)}"
                         )
@@ -2151,7 +2158,7 @@ class FteWorkerPlacementManager:
             fragment_id=fragment_id,
             partition_id=partition_id,
             worker=owner,
-            stage_id=task_lease.stage_id,
+            resource_unit_id=task_lease.resource_unit_id,
             task_lease_id=task_lease.lease_id,
             attempt_id=task_lease.attempt_id,
         )
@@ -2181,12 +2188,12 @@ class FteWorkerPlacementManager:
             owner = _FTE_PARTITION_OWNERS.pop(owner_key, None)
             lease_record = _FTE_PARTITION_TASK_LEASES.pop(owner_key, None)
             waiter_identity = _FTE_PARTITION_TASK_WAITERS.pop(owner_key, None)
-            for stage_key, partition_key in list(_FTE_STAGE_SUBMISSION_PROBES.items()):
+            for resource_unit_key, partition_key in list(_FTE_RESOURCE_UNIT_SUBMISSION_PROBES.items()):
                 if partition_key == owner_key:
-                    _FTE_STAGE_SUBMISSION_PROBES.pop(stage_key, None)
-            for stage_key, blocked in list(_FTE_STAGE_SUBMISSION_BLOCKS.items()):
+                    _FTE_RESOURCE_UNIT_SUBMISSION_PROBES.pop(resource_unit_key, None)
+            for resource_unit_key, blocked in list(_FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.items()):
                 if blocked[2] == owner_key:
-                    _FTE_STAGE_SUBMISSION_BLOCKS.pop(stage_key, None)
+                    _FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.pop(resource_unit_key, None)
             if terminal is None and lease_record is not None:
                 fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
         if terminal is None and lease_record is not None:
@@ -2650,7 +2657,7 @@ def _mark_fte_worker_failed(
     for future in pending_worker_reservation_futures_to_cancel:
         future.cancel()
 
-    scheduled_by_stage: list[tuple[str, str, list[Any], list[Any]]] = []
+    scheduled_fragment_batches: list[tuple[str, str, list[Any], list[Any]]] = []
     delayed_query_ids: set[str] = set()
     for (query_id, fragment_id), fragment_execution in fragment_execution_items:
         retryable_by_partition_id = {
@@ -2679,8 +2686,8 @@ def _mark_fte_worker_failed(
                 schedule_retries=False,
             )
             if scheduled:
-                scheduled_by_stage.append((query_id, fragment_id, scheduled, []))
-    return scheduled_by_stage
+                scheduled_fragment_batches.append((query_id, fragment_id, scheduled, []))
+    return scheduled_fragment_batches
 
 
 def _collect_vane_env_overrides() -> dict[str, str]:
@@ -2753,7 +2760,7 @@ def _fte_partition_metrics(
         "pending_worker_reservation_blocked_reason": (
             "" if pending_reservation is None else str(pending_reservation.blocked_reason)
         ),
-        "resource_stage_id": None if task_lease is None else task_lease.stage_id,
+        "resource_unit_id": None if task_lease is None else task_lease.resource_unit_id,
         "task_lease_id": None if task_lease is None else task_lease.lease_id,
         "task_lease_active": task_lease is not None,
         "running_attempts": [
@@ -3153,8 +3160,8 @@ def fte_registry_stats() -> dict[str, Any]:
             "pending_worker_reservation_count": len(_FTE_PENDING_WORKER_RESERVATIONS),
             "partition_task_lease_count": len(_FTE_PARTITION_TASK_LEASES),
             "partition_task_waiter_count": len(_FTE_PARTITION_TASK_WAITERS),
-            "stage_submission_probe_count": len(_FTE_STAGE_SUBMISSION_PROBES),
-            "stage_submission_block_count": len(_FTE_STAGE_SUBMISSION_BLOCKS),
+            "resource_unit_submission_probe_count": len(_FTE_RESOURCE_UNIT_SUBMISSION_PROBES),
+            "resource_unit_submission_block_count": len(_FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS),
             "pending_worker_reservation_done_count": sum(
                 1 for future in _FTE_PENDING_WORKER_RESERVATIONS.values() if future.done()
             ),

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -1251,7 +1251,6 @@ def _acquire_fte_partition_task_lease(
     fragment_id: str,
     partition_id: int,
     node_id: str,
-    retain_probe_on_node_local_denial: bool = False,
 ) -> Any:
     from duckdb.runners.ray.query_resource_manager import TaskRequest
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
@@ -1339,21 +1338,15 @@ def _acquire_fte_partition_task_lease(
         partition_id,
         grant.blocked_reason,
     )
-    node_local_denial = grant.blocked_reason in {
-        "node_allocation_debt",
-        "node_capacity",
-        "continuation_node_capacity",
-    }
-    if not (retain_probe_on_node_local_denial and node_local_denial and not grant.fatal):
-        resolve_fte_partition_submission(
-            query_id,
-            fragment_id,
-            partition_id,
-            granted=False,
-            blocked_reason=grant.blocked_reason,
-            fatal=grant.fatal,
-            admission_epoch=getattr(grant, "admission_epoch", None),
-        )
+    resolve_fte_partition_submission(
+        query_id,
+        fragment_id,
+        partition_id,
+        granted=False,
+        blocked_reason=grant.blocked_reason,
+        fatal=grant.fatal,
+        admission_epoch=getattr(grant, "admission_epoch", None),
+    )
     if grant.fatal:
         raise RuntimeError(
             f"fatal FTE task lease rejection for {query_id}/{fragment_id}/{partition_id}: {grant.blocked_reason}"
@@ -2069,31 +2062,21 @@ class FteWorkerPlacementManager:
                     lease_record = None
                     owner = None
 
-            excluded_worker_ids: set[str] = set()
-            deferred_node_denial: FteWorkerReservationUnavailable | None = None
-            while owner is None:
+            if owner is None:
                 try:
                     owner = self.coordinator._select_fte_worker(
-                        exclude=excluded_worker_ids,
+                        exclude=set(),
                         memory_requirement_bytes=memory_requirement_bytes,
                         execution_class=execution_class,
                         node_requirements=node_requirements,
                         node_requirements_wait_started_at=node_requirements_wait_started_at,
                     )
-                    if owner is not None and str(owner.worker_id) in excluded_worker_ids:
-                        owner = None
                 except Exception:
                     _release_fte_partition_task_lease_for_key(
                         query_id,
                         fragment_id,
                         partition_id,
                     )
-                    # A preceding node-local QRM denial deliberately keeps the
-                    # resource-unit probe while alternate workers are tried.
-                    # Worker selection can still fail independently (for
-                    # example while inspecting a stale worker handle); that
-                    # terminal path must not strand the retained probe and
-                    # block every later descriptor for the resource unit.
                     release_fte_partition_submission(
                         query_id,
                         fragment_id,
@@ -2106,45 +2089,20 @@ class FteWorkerPlacementManager:
                         fragment_id,
                         partition_id,
                     )
-                    if deferred_node_denial is not None:
-                        resolve_fte_partition_submission(
-                            query_id,
-                            fragment_id,
-                            partition_id,
-                            granted=False,
-                            blocked_reason=deferred_node_denial.blocked_reason,
-                            admission_epoch=deferred_node_denial.admission_epoch,
-                        )
                     raise FteWorkerReservationUnavailable(
                         query_id=query_id,
                         fragment_id=fragment_id,
                         partition_id=partition_id,
                         memory_requirement_bytes=_memory_requirement_bytes(memory_requirement_bytes),
-                        blocked_reason=("" if deferred_node_denial is None else deferred_node_denial.blocked_reason),
-                        admission_epoch=(
-                            None if deferred_node_denial is None else deferred_node_denial.admission_epoch
-                        ),
+                        blocked_reason="",
                     )
-                try:
-                    task_lease = _acquire_fte_partition_task_lease(
-                        query_id=query_id,
-                        fragment_execution_id=fragment_execution_id,
-                        fragment_id=fragment_id,
-                        partition_id=partition_id,
-                        node_id=owner.node_id,
-                        retain_probe_on_node_local_denial=True,
-                    )
-                except FteWorkerReservationUnavailable as exc:
-                    if exc.blocked_reason not in {
-                        "node_allocation_debt",
-                        "node_capacity",
-                        "continuation_node_capacity",
-                    }:
-                        raise
-                    deferred_node_denial = exc
-                    excluded_worker_ids.add(str(owner.worker_id))
-                    owner = None
-                    continue
+                task_lease = _acquire_fte_partition_task_lease(
+                    query_id=query_id,
+                    fragment_execution_id=fragment_execution_id,
+                    fragment_id=fragment_id,
+                    partition_id=partition_id,
+                    node_id=owner.node_id,
+                )
                 lease_record = (fragment_execution_id, task_lease)
                 _FTE_PARTITION_TASK_LEASES[owner_key] = lease_record
 

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -2493,6 +2493,7 @@ def _mark_fte_worker_failed(
     ) -> bool:
         if _FTE_WORKER_HANDLES.get(failed_worker_id) is not failed_handle:
             return False
+        assert failed_handle is not None
         if not _worker_matches_failure_incarnation(
             failed_handle,
             failed_worker_ids,

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -1137,8 +1137,9 @@ def _is_write_sink_fragment(fragment_execution: Any) -> bool:
 
 def _write_sink_has_input(fragment_execution: Any) -> tuple[bool, bool]:
     partitions = getattr(fragment_execution, "partitions", {}) or {}
+    no_more_partitions = bool(getattr(fragment_execution, "no_more_partitions", False))
     if not partitions:
-        return False, False
+        return False, no_more_partitions
     all_terminal = True
     for partition in partitions.values():
         finished = bool(getattr(partition, "finished", False))
@@ -1154,15 +1155,22 @@ def _write_sink_has_input(fragment_execution: Any) -> tuple[bool, bool]:
             or getattr(partition, "node_wait_started_at", None) is not None
         ):
             return True, False
-    return False, all_terminal
+    # Dynamic exchange/scan inputs can append partitions after every currently
+    # known partition has finished.  ``completed`` is a permanent resource-unit
+    # transition, so publish it only after the fragment's partition set is
+    # sealed as well as terminal.
+    return False, no_more_partitions and all_terminal
 
 
 def _sync_write_sink_unit_for_fragment(fragment_execution: Any) -> str | None:
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
+    # Most FTE fragments are not terminal write sinks.  Check that immutable
+    # identity before touching the concrete execution's state lock so generic
+    # event-path test doubles (and non-sink fragments) need no sink lifecycle.
+    if not _is_write_sink_fragment(fragment_execution):
+        return None
     with fragment_execution._state_lock:
-        if not _is_write_sink_fragment(fragment_execution):
-            return None
         resource_query_id, resource_unit_id = resource_identity_from_context(fragment_execution.context)
         has_input, all_terminal = _write_sink_has_input(fragment_execution)
     get_query_resource_manager(resource_query_id).update_unit_state(
@@ -1243,6 +1251,7 @@ def _acquire_fte_partition_task_lease(
     fragment_id: str,
     partition_id: int,
     node_id: str,
+    retain_probe_on_node_local_denial: bool = False,
 ) -> Any:
     from duckdb.runners.ray.query_resource_manager import TaskRequest
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
@@ -1303,6 +1312,11 @@ def _acquire_fte_partition_task_lease(
     if grant.granted:
         lease = grant.lease
         if lease is None:
+            release_fte_partition_submission(
+                query_id,
+                fragment_id,
+                partition_id,
+            )
             raise RuntimeError("QRM granted an FTE task without returning its lease")
         resolve_fte_partition_submission(
             query_id,
@@ -1325,15 +1339,21 @@ def _acquire_fte_partition_task_lease(
         partition_id,
         grant.blocked_reason,
     )
-    resolve_fte_partition_submission(
-        query_id,
-        fragment_id,
-        partition_id,
-        granted=False,
-        blocked_reason=grant.blocked_reason,
-        fatal=grant.fatal,
-        admission_epoch=getattr(grant, "admission_epoch", None),
-    )
+    node_local_denial = grant.blocked_reason in {
+        "node_allocation_debt",
+        "node_capacity",
+        "continuation_node_capacity",
+    }
+    if not (retain_probe_on_node_local_denial and node_local_denial and not grant.fatal):
+        resolve_fte_partition_submission(
+            query_id,
+            fragment_id,
+            partition_id,
+            granted=False,
+            blocked_reason=grant.blocked_reason,
+            fatal=grant.fatal,
+            admission_epoch=getattr(grant, "admission_epoch", None),
+        )
     if grant.fatal:
         raise RuntimeError(
             f"fatal FTE task lease rejection for {query_id}/{fragment_id}/{partition_id}: {grant.blocked_reason}"
@@ -1344,6 +1364,7 @@ def _acquire_fte_partition_task_lease(
         partition_id=int(partition_id),
         memory_requirement_bytes=0,
         blocked_reason=grant.blocked_reason,
+        admission_epoch=getattr(grant, "admission_epoch", None),
     )
 
 
@@ -2049,6 +2070,7 @@ class FteWorkerPlacementManager:
                     owner = None
 
             excluded_worker_ids: set[str] = set()
+            deferred_node_denial: FteWorkerReservationUnavailable | None = None
             while owner is None:
                 try:
                     owner = self.coordinator._select_fte_worker(
@@ -2066,6 +2088,17 @@ class FteWorkerPlacementManager:
                         fragment_id,
                         partition_id,
                     )
+                    # A preceding node-local QRM denial deliberately keeps the
+                    # resource-unit probe while alternate workers are tried.
+                    # Worker selection can still fail independently (for
+                    # example while inspecting a stale worker handle); that
+                    # terminal path must not strand the retained probe and
+                    # block every later descriptor for the resource unit.
+                    release_fte_partition_submission(
+                        query_id,
+                        fragment_id,
+                        partition_id,
+                    )
                     raise
                 if owner is None:
                     _release_fte_partition_task_lease_for_key(
@@ -2073,11 +2106,24 @@ class FteWorkerPlacementManager:
                         fragment_id,
                         partition_id,
                     )
+                    if deferred_node_denial is not None:
+                        resolve_fte_partition_submission(
+                            query_id,
+                            fragment_id,
+                            partition_id,
+                            granted=False,
+                            blocked_reason=deferred_node_denial.blocked_reason,
+                            admission_epoch=deferred_node_denial.admission_epoch,
+                        )
                     raise FteWorkerReservationUnavailable(
                         query_id=query_id,
                         fragment_id=fragment_id,
                         partition_id=partition_id,
                         memory_requirement_bytes=_memory_requirement_bytes(memory_requirement_bytes),
+                        blocked_reason=("" if deferred_node_denial is None else deferred_node_denial.blocked_reason),
+                        admission_epoch=(
+                            None if deferred_node_denial is None else deferred_node_denial.admission_epoch
+                        ),
                     )
                 try:
                     task_lease = _acquire_fte_partition_task_lease(
@@ -2086,10 +2132,16 @@ class FteWorkerPlacementManager:
                         fragment_id=fragment_id,
                         partition_id=partition_id,
                         node_id=owner.node_id,
+                        retain_probe_on_node_local_denial=True,
                     )
                 except FteWorkerReservationUnavailable as exc:
-                    if exc.blocked_reason != "node_capacity":
+                    if exc.blocked_reason not in {
+                        "node_allocation_debt",
+                        "node_capacity",
+                        "continuation_node_capacity",
+                    }:
                         raise
+                    deferred_node_denial = exc
                     excluded_worker_ids.add(str(owner.worker_id))
                     owner = None
                     continue

--- a/duckdb/runners/ray/query_execution_graph.py
+++ b/duckdb/runners/ray/query_execution_graph.py
@@ -28,8 +28,11 @@ class ResourceVector:
     """Resources owned by a query, stage, task, or output window.
 
     CPU and GPU are Ray logical resources and may be fractional. Byte resources
-    are exact integer ownership quantities. A vector is never allowed to carry
-    negative capacity; subtraction that would underflow is a control-plane bug.
+    use integer accounting units. Query allocations treat CPU, GPU, and heap as
+    hard ownership while object-store bytes are a flow-control budget: live
+    ObjectRefs may temporarily exceed it under the bounded liveness policy and
+    Ray Core may spill them. A vector is never allowed to carry negative
+    capacity; subtraction that would underflow is a control-plane bug.
     """
 
     cpu: float = 0.0
@@ -140,7 +143,7 @@ class ResourceVector:
 
 @dataclass(frozen=True)
 class NodeResourceAllocation:
-    """One query's hard resource ownership on one concrete Ray node."""
+    """One query's hard process ownership and soft object budget on one node."""
 
     node_id: str
     resources: ResourceVector
@@ -216,6 +219,15 @@ def _resource_vectors_equivalent(left: ResourceVector, right: ResourceVector) ->
         and math.isclose(left.gpu, right.gpu, rel_tol=0.0, abs_tol=1e-9)
         and left.heap_bytes == right.heap_bytes
         and left.object_store_bytes == right.object_store_bytes
+    )
+
+
+def _hard_resources(resources: ResourceVector) -> ResourceVector:
+    """Return the non-spillable portion of a query resource vector."""
+    return ResourceVector(
+        cpu=resources.cpu,
+        gpu=resources.gpu,
+        heap_bytes=resources.heap_bytes,
     )
 
 
@@ -620,33 +632,12 @@ class QueryExecutionGraph:
         *,
         require_full_minimum: bool = True,
     ) -> None:
-        capacity = allocation.resources
+        hard_capacity = _hard_resources(allocation.resources)
         for stage in self.stages:
-            task_commitment = ResourceVector(
-                cpu=stage.per_task.cpu,
-                gpu=stage.per_task.gpu,
-                heap_bytes=stage.per_task.heap_bytes,
-                object_store_bytes=(stage.per_task.object_store_bytes + stage.output_window_bytes),
-            )
+            task_commitment = _hard_resources(stage.per_task)
             actor_resident = stage.resident_per_actor if stage.backend == "ray_actor" else ResourceVector()
             placement_commitment = actor_resident + task_commitment
-            output_window = stage.output_window_bytes
-            if require_full_minimum and capacity.object_store_bytes > 0 and output_window > capacity.object_store_bytes:
-                raise ValueError(
-                    f"stage {stage.stage_id} output window {output_window} exceeds query object-store allocation "
-                    f"{capacity.object_store_bytes}"
-                )
-            total_object_store = stage.per_task.object_store_bytes + output_window
-            if (
-                require_full_minimum
-                and capacity.object_store_bytes > 0
-                and total_object_store > capacity.object_store_bytes
-            ):
-                raise ValueError(
-                    f"stage {stage.stage_id} retained input plus output window {total_object_store} exceeds "
-                    f"query object-store allocation {capacity.object_store_bytes}"
-                )
-            exceeded = placement_commitment.exceeded_dimensions(capacity)
+            exceeded = placement_commitment.exceeded_dimensions(hard_capacity)
             if require_full_minimum and exceeded:
                 raise ValueError(
                     f"stage {stage.stage_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
@@ -655,14 +646,14 @@ class QueryExecutionGraph:
                 require_full_minimum
                 and not task_commitment.is_zero()
                 and not any(
-                    placement_commitment.fits_within(node_allocation.resources)
+                    placement_commitment.fits_within(_hard_resources(node_allocation.resources))
                     for node_allocation in allocation.node_allocations
                 )
             ):
                 raise ValueError(f"stage {stage.stage_id} maximum task does not fit any allocated Ray node")
             if stage.backend == "ray_actor":
-                actor_pool = placement_commitment.scale(stage.actor_pool_size)
-                exceeded_actor = actor_pool.exceeded_dimensions(capacity)
+                actor_pool = actor_resident.scale(stage.actor_pool_size)
+                exceeded_actor = actor_pool.exceeded_dimensions(hard_capacity)
                 if require_full_minimum and exceeded_actor:
                     raise ValueError(
                         f"stage {stage.stage_id} actor pool exceeds query allocation for {', '.join(exceeded_actor)}"
@@ -679,7 +670,9 @@ class QueryExecutionGraph:
                 if placements and placement_indices != expected_indices:
                     raise ValueError(f"stage {stage.stage_id} actor placement indices must be contiguous from zero")
                 for placement in placements:
-                    if not placement_commitment.fits_within(allocation.resources_for_node(placement.node_id)):
+                    if not placement_commitment.fits_within(
+                        _hard_resources(allocation.resources_for_node(placement.node_id))
+                    ):
                         raise ValueError(
                             f"stage {stage.stage_id} actor {placement.actor_index} does not fit "
                             f"allocated Ray node {placement.node_id}"
@@ -695,19 +688,15 @@ class QueryExecutionGraph:
             actor_commitment_by_node: dict[str, ResourceVector] = {}
             for placement in allocation.actor_placements:
                 stage = self.stage_by_id(placement.stage_id)
-                invocation = ResourceVector(
-                    object_store_bytes=(stage.per_task.object_store_bytes + stage.output_window_bytes)
-                )
                 actor_commitment_by_node[placement.node_id] = (
                     actor_commitment_by_node.get(
                         placement.node_id,
                         ResourceVector(),
                     )
                     + stage.resident_per_actor
-                    + invocation
                 )
             for node_id, commitment in actor_commitment_by_node.items():
-                if not commitment.fits_within(allocation.resources_for_node(node_id)):
+                if not commitment.fits_within(_hard_resources(allocation.resources_for_node(node_id))):
                     raise ValueError(f"cumulative actor placements do not fit allocated Ray node {node_id}")
 
     def normalized_digest(self) -> str:

--- a/duckdb/runners/ray/query_graph_builder.py
+++ b/duckdb/runners/ray/query_graph_builder.py
@@ -404,12 +404,17 @@ def build_query_execution_graph(
     )
 
 
-def _task_commitment(stage: StageResourceSpec) -> ResourceVector:
+def _hard_task_commitment(stage: StageResourceSpec) -> ResourceVector:
+    """Return resources that must be placed before a task can run.
+
+    Retained inputs and generator output windows are spillable pipeline data.
+    They are controlled dynamically by QRM against the query's object-store
+    budget instead of being reserved for every possible task at registration.
+    """
     return ResourceVector(
         cpu=stage.per_task.cpu,
         gpu=stage.per_task.gpu,
         heap_bytes=stage.per_task.heap_bytes,
-        object_store_bytes=stage.per_task.object_store_bytes + stage.output_window_bytes,
     )
 
 
@@ -437,14 +442,13 @@ def build_query_demand(
     downstream_fte_tasks: list[ResourceVector] = []
     stage_by_id = {stage.stage_id: stage for stage in graph.stages}
     for stage in graph.stages:
-        commitment = _task_commitment(stage)
+        commitment = _hard_task_commitment(stage)
         if stage.backend == "ray_actor":
-            actor_commitment = stage.resident_per_actor + commitment
             actor_bundles.extend(
                 ActorResourceBundle(
                     stage_id=stage.stage_id,
                     actor_index=actor_index,
-                    resources=actor_commitment,
+                    resources=stage.resident_per_actor,
                 )
                 for actor_index in range(stage.actor_pool_size)
             )
@@ -459,7 +463,7 @@ def build_query_demand(
         for downstream_stage_id in (graph.downstream_fte_stage_ids_requiring_separate_slot(stage.stage_id))
     }
     downstream_fte_tasks.extend(
-        _task_commitment(stage_by_id[stage_id])
+        _hard_task_commitment(stage_by_id[stage_id])
         for stage_id in graph.topological_stage_ids()
         if stage_id in downstream_fte_stage_ids
     )

--- a/duckdb/runners/ray/query_graph_builder.py
+++ b/duckdb/runners/ray/query_graph_builder.py
@@ -33,6 +33,7 @@ _NODE_FIELDS = (
     "node_name",
     "input_node_ids",
     "is_sink",
+    "is_blocking_materializing",
     "num_partitions",
     "udf_payload",
 )
@@ -144,6 +145,7 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> tuple[str, dict[str, dic
         node["input_node_ids"] = tuple(str(item).strip() for item in node["input_node_ids"])
         node["num_partitions"] = _positive_int(node["num_partitions"], "num_partitions")
         node["is_sink"] = bool(node["is_sink"])
+        node["is_blocking_materializing"] = bool(node["is_blocking_materializing"])
         if node["udf_payload"] is not None and not isinstance(node["udf_payload"], Mapping):
             raise TypeError(f"execution stage node {node_id} udf_payload must be a mapping or None")
         node["udf_payload"] = None if node["udf_payload"] is None else dict(node["udf_payload"])
@@ -353,6 +355,7 @@ def build_query_execution_graph(
         fte_stage_id = fte_stage_id_for_node(query_id, node_id)
         input_stage_ids = tuple(output_stage_by_node[parent] for parent in node["input_node_ids"])
         is_sink = bool(node["is_sink"])
+        is_blocking_materializing = bool(node["is_blocking_materializing"])
         remote_udf_driver = node_id in remote_udf_driver_node_ids
         stages.append(
             StageResourceSpec(
@@ -376,7 +379,7 @@ def build_query_execution_graph(
                 target_output_block_bytes=0 if is_sink else fte_target,
                 generator_buffer_blocks=0 if is_sink else _GENERATOR_BUFFER_BLOCKS,
                 max_concurrency=int(node["num_partitions"]),
-                spill_mode="barrier" if is_sink else "streaming",
+                spill_mode="barrier" if is_blocking_materializing else "streaming",
             )
         )
         udf_stage = _udf_stage(

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -179,54 +179,7 @@ class ResourceVector:
         )
 
 
-@dataclass(frozen=True)
-class NodeResourceAllocation:
-    """One query's allocation attribution on one Ray node.
-
-    QRM uses CPU, GPU, and heap attribution to choose a feasible logical slot
-    before submission; Ray Core remains the physical placement authority and
-    actors are not pinned to these nodes. The object-store component contributes
-    only to the query-wide soft flow-control budget. Per-node debt is
-    observable, while Ray Core remains responsible for node-local spill and OOM
-    protection.
-    """
-
-    node_id: str
-    resources: ResourceVector
-
-    _FIELDS: ClassVar[tuple[str, ...]] = ("node_id", "resources")
-
-    def __post_init__(self) -> None:
-        node_id = str(self.node_id).strip()
-        if not node_id:
-            raise ValueError("node allocation node_id must be non-empty")
-        if self.resources.is_zero():
-            raise ValueError(f"node allocation {node_id} must own non-zero resources")
-        object.__setattr__(self, "node_id", node_id)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"node_id": self.node_id, "resources": self.resources.to_dict()}
-
-    @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> NodeResourceAllocation:
-        values = dict(payload)
-        _strict_fields(values, cls._FIELDS, cls.__name__)
-        return cls(
-            node_id=str(values["node_id"]),
-            resources=ResourceVector.from_dict(values["resources"]),
-        )
-
-
-def _resource_vectors_equivalent(left: ResourceVector, right: ResourceVector) -> bool:
-    return (
-        math.isclose(left.cpu, right.cpu, rel_tol=0.0, abs_tol=1e-9)
-        and math.isclose(left.gpu, right.gpu, rel_tol=0.0, abs_tol=1e-9)
-        and left.heap_bytes == right.heap_bytes
-        and left.object_store_bytes == right.object_store_bytes
-    )
-
-
-def _hard_resources(resources: ResourceVector) -> ResourceVector:
+def _process_resources(resources: ResourceVector) -> ResourceVector:
     """Return the non-spillable portion of a query resource vector."""
     return ResourceVector(
         cpu=resources.cpu,
@@ -237,13 +190,19 @@ def _hard_resources(resources: ResourceVector) -> ResourceVector:
 
 @dataclass(frozen=True)
 class QueryAllocation:
+    """One driver's aggregate soft budget for a query.
+
+    This is deliberately not a Ray placement claim. Concrete tasks and actors
+    carry their real resource requests to Ray Core, which owns node selection,
+    pending demand, and autoscaling. Vane uses this vector only to decide when
+    to apply query/operator backpressure.
+    """
+
     resources: ResourceVector
-    node_allocations: tuple[NodeResourceAllocation, ...]
     generation: int
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "resources",
-        "node_allocations",
         "generation",
     )
 
@@ -251,22 +210,11 @@ class QueryAllocation:
         generation = int(self.generation)
         if generation <= 0:
             raise ValueError("generation must be > 0")
-        node_allocations = tuple(self.node_allocations)
-        node_ids = [allocation.node_id for allocation in node_allocations]
-        if len(set(node_ids)) != len(node_ids):
-            raise ValueError("query allocation contains duplicate node_id entries")
-        aggregate = ResourceVector()
-        for node_allocation in node_allocations:
-            aggregate = aggregate + node_allocation.resources
-        if not _resource_vectors_equivalent(aggregate, self.resources):
-            raise ValueError("query allocation resources must equal the sum of node_allocations")
         object.__setattr__(self, "generation", generation)
-        object.__setattr__(self, "node_allocations", node_allocations)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "resources": self.resources.to_dict(),
-            "node_allocations": [allocation.to_dict() for allocation in self.node_allocations],
             "generation": self.generation,
         }
 
@@ -276,7 +224,6 @@ class QueryAllocation:
         _strict_fields(values, cls._FIELDS, cls.__name__)
         return cls(
             resources=ResourceVector.from_dict(values["resources"]),
-            node_allocations=tuple(NodeResourceAllocation.from_dict(item) for item in values["node_allocations"]),
             generation=int(values["generation"]),
         )
 
@@ -617,7 +564,9 @@ class QueryResourceGraph:
             )
         if unit.max_concurrency is not None and int(unit.max_concurrency) <= 0:
             raise ValueError(f"unit {unit.resource_unit_id} max_concurrency must be > 0")
-        process_resources = unit.resident_per_actor if unit.backend == "ray_actor" else _hard_resources(unit.per_task)
+        process_resources = (
+            unit.resident_per_actor if unit.backend == "ray_actor" else _process_resources(unit.per_task)
+        )
         if unit.backend == "ray_worker":
             if not process_resources.is_zero():
                 raise ValueError(f"native fragment unit {unit.resource_unit_id} process resources are owned by DuckDB")
@@ -826,43 +775,6 @@ class QueryResourceGraph:
             raise ValueError("attempt_id must be non-empty")
         return f"task:{unit.resource_unit_id}:partition:{partition}:attempt:{attempt}"
 
-    def validate_allocation(
-        self,
-        allocation: QueryAllocation,
-        *,
-        eligible_unit_ids: tuple[str, ...] | None = None,
-    ) -> None:
-        eligible = (
-            {unit.resource_unit_id for unit in self.units}
-            if eligible_unit_ids is None
-            else {str(resource_unit_id) for resource_unit_id in eligible_unit_ids}
-        )
-        unknown = sorted(eligible - {unit.resource_unit_id for unit in self.units})
-        if unknown:
-            raise ValueError(f"allocation validation references unknown eligible unit: {unknown[0]}")
-        hard_capacity = _hard_resources(allocation.resources)
-        for unit in self.units:
-            if unit.resource_unit_id not in eligible:
-                continue
-            if unit.backend == "ray_task":
-                process_commitment = _hard_resources(unit.per_task)
-                commitment_name = "maximum task"
-            elif unit.backend == "ray_actor":
-                process_commitment = _hard_resources(unit.resident_per_actor)
-                commitment_name = "actor process"
-            else:
-                continue
-            exceeded = process_commitment.exceeded_dimensions(hard_capacity)
-            if exceeded:
-                raise ValueError(
-                    f"unit {unit.resource_unit_id} {commitment_name} exceeds query allocation for {', '.join(exceeded)}"
-                )
-            if not process_commitment.is_zero() and not any(
-                process_commitment.fits_within(_hard_resources(node_allocation.resources))
-                for node_allocation in allocation.node_allocations
-            ):
-                raise ValueError(f"unit {unit.resource_unit_id} {commitment_name} does not fit any allocated Ray node")
-
     def normalized_digest(self) -> str:
         payload = self.to_dict()
         payload["plan_digest"] = ""
@@ -895,7 +807,6 @@ class QueryResourceGraph:
 
 __all__ = [
     "MaterializationBarrierSpec",
-    "NodeResourceAllocation",
     "QueryAllocation",
     "QueryResourceGraph",
     "ResourceVector",

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -842,18 +842,26 @@ class QueryResourceGraph:
             raise ValueError(f"allocation validation references unknown eligible unit: {unknown[0]}")
         hard_capacity = _hard_resources(allocation.resources)
         for unit in self.units:
-            task_commitment = _hard_resources(unit.per_task)
-            if unit.backend == "ray_task" and unit.resource_unit_id in eligible:
-                exceeded = task_commitment.exceeded_dimensions(hard_capacity)
-                if exceeded:
-                    raise ValueError(
-                        f"unit {unit.resource_unit_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
-                    )
-                if not task_commitment.is_zero() and not any(
-                    task_commitment.fits_within(_hard_resources(node_allocation.resources))
-                    for node_allocation in allocation.node_allocations
-                ):
-                    raise ValueError(f"unit {unit.resource_unit_id} maximum task does not fit any allocated Ray node")
+            if unit.resource_unit_id not in eligible:
+                continue
+            if unit.backend == "ray_task":
+                process_commitment = _hard_resources(unit.per_task)
+                commitment_name = "maximum task"
+            elif unit.backend == "ray_actor":
+                process_commitment = _hard_resources(unit.resident_per_actor)
+                commitment_name = "actor process"
+            else:
+                continue
+            exceeded = process_commitment.exceeded_dimensions(hard_capacity)
+            if exceeded:
+                raise ValueError(
+                    f"unit {unit.resource_unit_id} {commitment_name} exceeds query allocation for {', '.join(exceeded)}"
+                )
+            if not process_commitment.is_zero() and not any(
+                process_commitment.fits_within(_hard_resources(node_allocation.resources))
+                for node_allocation in allocation.node_allocations
+            ):
+                raise ValueError(f"unit {unit.resource_unit_id} {commitment_name} does not fit any allocated Ray node")
 
     def normalized_digest(self) -> str:
         payload = self.to_dict()

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -11,6 +11,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
+_RESOURCE_UNIT_KIND_BY_BACKEND = {
+    "ray_worker": "native_fragment",
+    "ray_task": "ray_task_udf",
+    "ray_actor": "ray_actor_pool",
+}
+
 
 def _strict_fields(payload: Mapping[str, Any], expected: tuple[str, ...], type_name: str) -> None:
     actual = set(payload)
@@ -25,7 +31,7 @@ def _strict_fields(payload: Mapping[str, Any], expected: tuple[str, ...], type_n
 
 @dataclass(frozen=True)
 class ResourceVector:
-    """Resources owned by a query, stage, task, or output window.
+    """Resources owned by a query, resource unit, task, or output window.
 
     CPU and GPU are Ray logical resources and may be fractional. Byte resources
     use integer accounting units. Query allocations treat CPU, GPU, and heap as
@@ -143,7 +149,14 @@ class ResourceVector:
 
 @dataclass(frozen=True)
 class NodeResourceAllocation:
-    """One query's hard process ownership and soft object budget on one node."""
+    """One query's allocation attribution on one Ray node.
+
+    CPU, GPU, and heap are enforced when a task or actor is placed on this
+    node. The object-store component contributes to the query-wide soft
+    flow-control budget; per-node object-store debt is observable but is not a
+    separate QRM admission limit. Ray Core remains responsible for node-local
+    spill and OOM protection.
+    """
 
     node_id: str
     resources: ResourceVector
@@ -175,29 +188,29 @@ class NodeResourceAllocation:
 class ActorPlacement:
     """Coordinator-selected placement for one query-owned Ray actor."""
 
-    stage_id: str
+    resource_unit_id: str
     actor_index: int
     node_id: str
 
-    _FIELDS: ClassVar[tuple[str, ...]] = ("stage_id", "actor_index", "node_id")
+    _FIELDS: ClassVar[tuple[str, ...]] = ("resource_unit_id", "actor_index", "node_id")
 
     def __post_init__(self) -> None:
-        stage_id = str(self.stage_id).strip()
+        resource_unit_id = str(self.resource_unit_id).strip()
         node_id = str(self.node_id).strip()
         actor_index = int(self.actor_index)
-        if not stage_id:
-            raise ValueError("actor placement stage_id must be non-empty")
+        if not resource_unit_id:
+            raise ValueError("actor placement resource_unit_id must be non-empty")
         if actor_index < 0:
             raise ValueError("actor placement actor_index must be >= 0")
         if not node_id:
             raise ValueError("actor placement node_id must be non-empty")
-        object.__setattr__(self, "stage_id", stage_id)
+        object.__setattr__(self, "resource_unit_id", resource_unit_id)
         object.__setattr__(self, "actor_index", actor_index)
         object.__setattr__(self, "node_id", node_id)
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "stage_id": self.stage_id,
+            "resource_unit_id": self.resource_unit_id,
             "actor_index": self.actor_index,
             "node_id": self.node_id,
         }
@@ -207,7 +220,7 @@ class ActorPlacement:
         values = dict(payload)
         _strict_fields(values, cls._FIELDS, cls.__name__)
         return cls(
-            stage_id=str(values["stage_id"]),
+            resource_unit_id=str(values["resource_unit_id"]),
             actor_index=int(values["actor_index"]),
             node_id=str(values["node_id"]),
         )
@@ -259,7 +272,7 @@ class QueryAllocation:
             aggregate = aggregate + node_allocation.resources
         if not _resource_vectors_equivalent(aggregate, self.resources):
             raise ValueError("query allocation resources must equal the sum of node_allocations")
-        placement_keys = [(placement.stage_id, placement.actor_index) for placement in actor_placements]
+        placement_keys = [(placement.resource_unit_id, placement.actor_index) for placement in actor_placements]
         if len(set(placement_keys)) != len(placement_keys):
             raise ValueError("query allocation contains duplicate actor placements")
         unknown_nodes = sorted({placement.node_id for placement in actor_placements} - set(node_ids))
@@ -276,10 +289,10 @@ class QueryAllocation:
                 return allocation.resources
         raise KeyError(f"query has no allocation on Ray node {node_key!r}")
 
-    def actor_node_ids_for_stage(self, stage_id: str) -> tuple[str, ...]:
-        stage_key = str(stage_id)
+    def actor_node_ids_for_unit(self, resource_unit_id: str) -> tuple[str, ...]:
+        unit_key = str(resource_unit_id)
         placements = sorted(
-            (placement for placement in self.actor_placements if placement.stage_id == stage_key),
+            (placement for placement in self.actor_placements if placement.resource_unit_id == unit_key),
             key=lambda placement: placement.actor_index,
         )
         return tuple(placement.node_id for placement in placements)
@@ -305,13 +318,20 @@ class QueryAllocation:
 
 
 @dataclass(frozen=True)
-class StageResourceSpec:
+class ResourceUnitSpec:
+    """Resource accounting for one independently scheduled execution family.
+
+    A unit represents native fragment tasks, Ray task UDFs, or a Ray actor
+    pool. It does not gate pipeline execution; ``is_barrier`` only marks the
+    materialization boundary used to calculate the current reservation scope.
+    """
+
     query_id: str
-    stage_id: str
+    resource_unit_id: str
     physical_node_id: str
-    stage_kind: str
+    unit_kind: str
     backend: str
-    input_stage_ids: tuple[str, ...]
+    input_unit_ids: tuple[str, ...]
     per_task: ResourceVector
     target_output_block_bytes: int
     generator_buffer_blocks: int
@@ -319,15 +339,15 @@ class StageResourceSpec:
     resident_per_actor: ResourceVector = field(default_factory=ResourceVector)
     actor_pool_size: int = 0
     actor_prefetch_depth: int = 1
-    spill_mode: str = "streaming"
+    is_barrier: bool = False
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "query_id",
-        "stage_id",
+        "resource_unit_id",
         "physical_node_id",
-        "stage_kind",
+        "unit_kind",
         "backend",
-        "input_stage_ids",
+        "input_unit_ids",
         "per_task",
         "target_output_block_bytes",
         "generator_buffer_blocks",
@@ -335,25 +355,21 @@ class StageResourceSpec:
         "resident_per_actor",
         "actor_pool_size",
         "actor_prefetch_depth",
-        "spill_mode",
+        "is_barrier",
     )
 
     @property
     def output_window_bytes(self) -> int:
         return int(self.target_output_block_bytes) * int(self.generator_buffer_blocks)
 
-    @property
-    def is_ray_process(self) -> bool:
-        return self.backend in {"ray_task", "ray_actor", "ray_worker"}
-
     def to_dict(self) -> dict[str, Any]:
         return {
             "query_id": self.query_id,
-            "stage_id": self.stage_id,
+            "resource_unit_id": self.resource_unit_id,
             "physical_node_id": self.physical_node_id,
-            "stage_kind": self.stage_kind,
+            "unit_kind": self.unit_kind,
             "backend": self.backend,
-            "input_stage_ids": list(self.input_stage_ids),
+            "input_unit_ids": list(self.input_unit_ids),
             "per_task": self.per_task.to_dict(),
             "target_output_block_bytes": int(self.target_output_block_bytes),
             "generator_buffer_blocks": int(self.generator_buffer_blocks),
@@ -361,21 +377,21 @@ class StageResourceSpec:
             "resident_per_actor": self.resident_per_actor.to_dict(),
             "actor_pool_size": int(self.actor_pool_size),
             "actor_prefetch_depth": int(self.actor_prefetch_depth),
-            "spill_mode": self.spill_mode,
+            "is_barrier": self.is_barrier,
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> StageResourceSpec:
+    def from_dict(cls, payload: Mapping[str, Any]) -> ResourceUnitSpec:
         values = dict(payload)
         _strict_fields(values, cls._FIELDS, cls.__name__)
         max_concurrency = values["max_concurrency"]
         return cls(
             query_id=str(values["query_id"]),
-            stage_id=str(values["stage_id"]),
+            resource_unit_id=str(values["resource_unit_id"]),
             physical_node_id=str(values["physical_node_id"]),
-            stage_kind=str(values["stage_kind"]),
+            unit_kind=str(values["unit_kind"]),
             backend=str(values["backend"]),
-            input_stage_ids=tuple(str(item) for item in values["input_stage_ids"]),
+            input_unit_ids=tuple(str(item) for item in values["input_unit_ids"]),
             per_task=ResourceVector.from_dict(values["per_task"]),
             target_output_block_bytes=int(values["target_output_block_bytes"]),
             generator_buffer_blocks=int(values["generator_buffer_blocks"]),
@@ -383,29 +399,31 @@ class StageResourceSpec:
             resident_per_actor=ResourceVector.from_dict(values["resident_per_actor"]),
             actor_pool_size=int(values["actor_pool_size"]),
             actor_prefetch_depth=int(values["actor_prefetch_depth"]),
-            spill_mode=str(values["spill_mode"]),
+            is_barrier=values["is_barrier"],
         )
 
 
 @dataclass(frozen=True)
-class QueryExecutionGraph:
+class QueryResourceGraph:
+    """Dependency graph for query resource accounting and admission."""
+
     query_id: str
     plan_digest: str
-    stages: tuple[StageResourceSpec, ...]
-    terminal_stage_ids: tuple[str, ...]
+    units: tuple[ResourceUnitSpec, ...]
+    terminal_unit_ids: tuple[str, ...]
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "query_id",
         "plan_digest",
-        "stages",
-        "terminal_stage_ids",
+        "units",
+        "terminal_unit_ids",
     )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "query_id", str(self.query_id).strip())
         object.__setattr__(self, "plan_digest", str(self.plan_digest).strip())
-        object.__setattr__(self, "stages", tuple(self.stages))
-        object.__setattr__(self, "terminal_stage_ids", tuple(str(item) for item in self.terminal_stage_ids))
+        object.__setattr__(self, "units", tuple(self.units))
+        object.__setattr__(self, "terminal_unit_ids", tuple(str(item) for item in self.terminal_unit_ids))
         self._validate()
 
     def _validate(self) -> None:
@@ -413,218 +431,228 @@ class QueryExecutionGraph:
             raise ValueError("query_id must be non-empty")
         if not self.plan_digest:
             raise ValueError("plan_digest must be non-empty")
-        if not self.stages:
-            raise ValueError("query graph must contain at least one stage")
-        if not self.terminal_stage_ids:
-            raise ValueError("query graph must contain at least one terminal stage")
+        if not self.units:
+            raise ValueError("query resource graph must contain at least one unit")
+        if not self.terminal_unit_ids:
+            raise ValueError("query resource graph must contain at least one terminal unit")
 
-        by_id: dict[str, StageResourceSpec] = {}
+        by_id: dict[str, ResourceUnitSpec] = {}
         physical_nodes: dict[str, str] = {}
-        for stage in self.stages:
-            self._validate_stage(stage)
-            if stage.stage_id in by_id:
-                raise ValueError(f"duplicate stage_id: {stage.stage_id}")
-            if stage.physical_node_id in physical_nodes:
+        for unit in self.units:
+            self._validate_unit(unit)
+            if unit.resource_unit_id in by_id:
+                raise ValueError(f"duplicate resource_unit_id: {unit.resource_unit_id}")
+            if unit.physical_node_id in physical_nodes:
                 raise ValueError(
                     "duplicate physical_node_id: "
-                    f"{stage.physical_node_id} used by {physical_nodes[stage.physical_node_id]} and {stage.stage_id}"
+                    f"{unit.physical_node_id} used by {physical_nodes[unit.physical_node_id]} and {unit.resource_unit_id}"
                 )
-            by_id[stage.stage_id] = stage
-            physical_nodes[stage.physical_node_id] = stage.stage_id
+            by_id[unit.resource_unit_id] = unit
+            physical_nodes[unit.physical_node_id] = unit.resource_unit_id
 
-        if len(set(self.terminal_stage_ids)) != len(self.terminal_stage_ids):
-            raise ValueError("terminal_stage_ids must be unique")
-        for terminal in self.terminal_stage_ids:
+        if len(set(self.terminal_unit_ids)) != len(self.terminal_unit_ids):
+            raise ValueError("terminal_unit_ids must be unique")
+        for terminal in self.terminal_unit_ids:
             if terminal not in by_id:
-                raise ValueError(f"terminal stage is not registered: {terminal}")
+                raise ValueError(f"terminal unit is not registered: {terminal}")
 
-        downstream: dict[str, set[str]] = {stage_id: set() for stage_id in by_id}
-        for stage in self.stages:
-            if len(set(stage.input_stage_ids)) != len(stage.input_stage_ids):
-                raise ValueError(f"stage {stage.stage_id} has duplicate input_stage_ids")
-            for input_stage_id in stage.input_stage_ids:
-                if input_stage_id not in by_id:
-                    raise ValueError(f"stage {stage.stage_id} references missing input stage {input_stage_id}")
-                if input_stage_id == stage.stage_id:
-                    raise ValueError(f"query graph contains a cycle at stage {stage.stage_id}")
-                downstream[input_stage_id].add(stage.stage_id)
+        downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in by_id}
+        for unit in self.units:
+            if len(set(unit.input_unit_ids)) != len(unit.input_unit_ids):
+                raise ValueError(f"unit {unit.resource_unit_id} has duplicate input_unit_ids")
+            for input_unit_id in unit.input_unit_ids:
+                if input_unit_id not in by_id:
+                    raise ValueError(f"unit {unit.resource_unit_id} references missing input unit {input_unit_id}")
+                if input_unit_id == unit.resource_unit_id:
+                    raise ValueError(f"query resource graph contains a cycle at unit {unit.resource_unit_id}")
+                downstream[input_unit_id].add(unit.resource_unit_id)
 
         ordered = self._topological_order(by_id, downstream)
         if len(ordered) != len(by_id):
-            raise ValueError("query graph contains a cycle")
+            raise ValueError("query resource graph contains a cycle")
 
-        for terminal in self.terminal_stage_ids:
+        for terminal in self.terminal_unit_ids:
             if downstream[terminal]:
                 raise ValueError(
-                    f"terminal stage {terminal} has downstream stages: {', '.join(sorted(downstream[terminal]))}"
+                    f"terminal unit {terminal} has downstream units: {', '.join(sorted(downstream[terminal]))}"
                 )
 
-        reaches_terminal = set(self.terminal_stage_ids)
-        for stage_id in reversed(ordered):
-            if any(child in reaches_terminal for child in downstream[stage_id]):
-                reaches_terminal.add(stage_id)
+        reaches_terminal = set(self.terminal_unit_ids)
+        for resource_unit_id in reversed(ordered):
+            if any(child in reaches_terminal for child in downstream[resource_unit_id]):
+                reaches_terminal.add(resource_unit_id)
         missing_terminal_path = sorted(set(by_id) - reaches_terminal)
         if missing_terminal_path:
-            raise ValueError(f"stage {missing_terminal_path[0]} does not reach a terminal stage")
+            raise ValueError(f"unit {missing_terminal_path[0]} does not reach a terminal unit")
 
-    def _validate_stage(self, stage: StageResourceSpec) -> None:
-        if str(stage.query_id).strip() != self.query_id:
+    def _validate_unit(self, unit: ResourceUnitSpec) -> None:
+        if str(unit.query_id).strip() != self.query_id:
             raise ValueError(
-                f"stage {stage.stage_id or '<empty>'} query_id {stage.query_id!r} does not match {self.query_id!r}"
+                f"unit {unit.resource_unit_id or '<empty>'} query_id {unit.query_id!r} does not match {self.query_id!r}"
             )
-        if not str(stage.stage_id).strip():
-            raise ValueError("stage_id must be non-empty")
-        if not str(stage.stage_id).startswith("stage:"):
-            raise ValueError(f"stage_id must use stable 'stage:' identity: {stage.stage_id}")
-        if not str(stage.physical_node_id).strip():
-            raise ValueError(f"stage {stage.stage_id} physical_node_id must be non-empty")
-        if not str(stage.stage_kind).strip():
-            raise ValueError(f"stage {stage.stage_id} stage_kind must be non-empty")
-        if not str(stage.backend).strip():
-            raise ValueError(f"stage {stage.stage_id} backend must be non-empty")
-        if int(stage.target_output_block_bytes) < 0:
-            raise ValueError(f"stage {stage.stage_id} target_output_block_bytes must be >= 0")
-        if int(stage.generator_buffer_blocks) < 0:
-            raise ValueError(f"stage {stage.stage_id} generator_buffer_blocks must be >= 0")
-        target = int(stage.target_output_block_bytes)
-        blocks = int(stage.generator_buffer_blocks)
+        if not str(unit.resource_unit_id).strip():
+            raise ValueError("resource_unit_id must be non-empty")
+        if not str(unit.resource_unit_id).startswith("resource:"):
+            raise ValueError(f"resource_unit_id must use stable 'resource:' identity: {unit.resource_unit_id}")
+        if not str(unit.physical_node_id).strip():
+            raise ValueError(f"unit {unit.resource_unit_id} physical_node_id must be non-empty")
+        unit_kind = str(unit.unit_kind).strip()
+        if not unit_kind:
+            raise ValueError(f"unit {unit.resource_unit_id} unit_kind must be non-empty")
+        backend = str(unit.backend).strip()
+        if not backend:
+            raise ValueError(f"unit {unit.resource_unit_id} backend must be non-empty")
+        expected_unit_kind = _RESOURCE_UNIT_KIND_BY_BACKEND.get(backend)
+        if expected_unit_kind is None:
+            raise ValueError(f"unit {unit.resource_unit_id} has unsupported backend {backend!r}")
+        if unit_kind != expected_unit_kind:
+            raise ValueError(
+                f"unit {unit.resource_unit_id} kind {unit_kind!r} does not match "
+                f"backend {backend!r}; expected {expected_unit_kind!r}"
+            )
+        if int(unit.target_output_block_bytes) < 0:
+            raise ValueError(f"unit {unit.resource_unit_id} target_output_block_bytes must be >= 0")
+        if int(unit.generator_buffer_blocks) < 0:
+            raise ValueError(f"unit {unit.resource_unit_id} generator_buffer_blocks must be >= 0")
+        target = int(unit.target_output_block_bytes)
+        blocks = int(unit.generator_buffer_blocks)
         if target == 0 and blocks != 0:
             raise ValueError(
-                f"stage {stage.stage_id} target_output_block_bytes and generator_buffer_blocks must both be zero"
+                f"unit {unit.resource_unit_id} target_output_block_bytes and generator_buffer_blocks must both be zero"
             )
         if target > 0 and blocks <= 0:
             raise ValueError(
-                f"stage {stage.stage_id} target_output_block_bytes and generator_buffer_blocks must both be positive"
+                f"unit {unit.resource_unit_id} target_output_block_bytes and generator_buffer_blocks must both be positive"
             )
-        if stage.max_concurrency is not None and int(stage.max_concurrency) <= 0:
-            raise ValueError(f"stage {stage.stage_id} max_concurrency must be > 0")
-        if stage.spill_mode not in {"streaming", "barrier"}:
-            raise ValueError(f"stage {stage.stage_id} has invalid spill_mode {stage.spill_mode!r}")
+        if unit.max_concurrency is not None and int(unit.max_concurrency) <= 0:
+            raise ValueError(f"unit {unit.resource_unit_id} max_concurrency must be > 0")
+        if not isinstance(unit.is_barrier, bool):
+            raise ValueError(f"unit {unit.resource_unit_id} is_barrier must be a boolean")
 
-        process_resources = stage.resident_per_actor if stage.backend == "ray_actor" else stage.per_task
-        if stage.is_ray_process:
-            if process_resources.cpu <= 0 and process_resources.gpu <= 0:
-                raise ValueError(f"Ray stage {stage.stage_id} must request CPU or GPU resources")
-            if process_resources.heap_bytes <= 0:
-                raise ValueError(f"Ray stage {stage.stage_id} must request non-zero heap_bytes")
+        process_resources = unit.resident_per_actor if unit.backend == "ray_actor" else unit.per_task
+        if process_resources.cpu <= 0 and process_resources.gpu <= 0:
+            raise ValueError(f"unit {unit.resource_unit_id} process commitment must request CPU or GPU resources")
+        if process_resources.heap_bytes <= 0:
+            raise ValueError(f"unit {unit.resource_unit_id} process commitment must request non-zero heap_bytes")
 
-        actor_pool_size = int(stage.actor_pool_size)
-        actor_prefetch_depth = int(stage.actor_prefetch_depth)
-        if stage.backend == "ray_actor":
+        actor_pool_size = int(unit.actor_pool_size)
+        actor_prefetch_depth = int(unit.actor_prefetch_depth)
+        if unit.backend == "ray_actor":
             if actor_pool_size <= 0:
-                raise ValueError(f"ray_actor stage {stage.stage_id} actor_pool_size must be > 0")
+                raise ValueError(f"ray_actor unit {unit.resource_unit_id} actor_pool_size must be > 0")
             if actor_prefetch_depth <= 0:
-                raise ValueError(f"ray_actor stage {stage.stage_id} actor_prefetch_depth must be > 0")
-            if stage.max_concurrency is not None:
-                raise ValueError(f"ray_actor stage {stage.stage_id} concurrency is owned by concrete actor slots")
-            if stage.per_task.cpu or stage.per_task.gpu or stage.per_task.heap_bytes:
+                raise ValueError(f"ray_actor unit {unit.resource_unit_id} actor_prefetch_depth must be > 0")
+            if unit.max_concurrency is not None:
+                raise ValueError(f"ray_actor unit {unit.resource_unit_id} concurrency is owned by concrete actor slots")
+            if unit.per_task.cpu or unit.per_task.gpu or unit.per_task.heap_bytes:
                 raise ValueError(
-                    f"ray_actor stage {stage.stage_id} invocation resources may only contain object-store bytes"
+                    f"ray_actor unit {unit.resource_unit_id} invocation resources may only contain object-store bytes"
                 )
         elif actor_pool_size != 0:
-            raise ValueError(f"actor_pool_size is only valid for ray_actor stages: {stage.stage_id}")
+            raise ValueError(f"actor_pool_size is only valid for ray_actor units: {unit.resource_unit_id}")
         elif actor_prefetch_depth != 1:
-            raise ValueError(f"actor_prefetch_depth is only configurable for ray_actor stages: {stage.stage_id}")
-        elif not stage.resident_per_actor.is_zero():
-            raise ValueError(f"resident_per_actor is only valid for ray_actor stages: {stage.stage_id}")
-        if stage.backend == "ray_task" and stage.max_concurrency is not None:
-            raise ValueError(f"ray_task stage {stage.stage_id} concurrency is owned by resource credit")
+            raise ValueError(f"actor_prefetch_depth is only configurable for ray_actor units: {unit.resource_unit_id}")
+        elif not unit.resident_per_actor.is_zero():
+            raise ValueError(f"resident_per_actor is only valid for ray_actor units: {unit.resource_unit_id}")
+        if unit.backend == "ray_task" and unit.max_concurrency is not None:
+            raise ValueError(f"ray_task unit {unit.resource_unit_id} concurrency is owned by resource credit")
 
     @staticmethod
     def _topological_order(
-        by_id: Mapping[str, StageResourceSpec],
+        by_id: Mapping[str, ResourceUnitSpec],
         downstream: Mapping[str, set[str]],
     ) -> tuple[str, ...]:
-        indegree = {stage_id: len(stage.input_stage_ids) for stage_id, stage in by_id.items()}
-        ready = [stage_id for stage_id, degree in indegree.items() if degree == 0]
+        indegree = {resource_unit_id: len(unit.input_unit_ids) for resource_unit_id, unit in by_id.items()}
+        ready = [resource_unit_id for resource_unit_id, degree in indegree.items() if degree == 0]
         heapq.heapify(ready)
         ordered: list[str] = []
         while ready:
-            stage_id = heapq.heappop(ready)
-            ordered.append(stage_id)
-            for child in sorted(downstream[stage_id]):
+            resource_unit_id = heapq.heappop(ready)
+            ordered.append(resource_unit_id)
+            for child in sorted(downstream[resource_unit_id]):
                 indegree[child] -= 1
                 if indegree[child] == 0:
                     heapq.heappush(ready, child)
         return tuple(ordered)
 
-    def stage_by_id(self, stage_id: str) -> StageResourceSpec:
-        key = str(stage_id)
-        for stage in self.stages:
-            if stage.stage_id == key:
-                return stage
-        raise KeyError(f"unknown stage_id {key!r}")
+    def unit_by_id(self, resource_unit_id: str) -> ResourceUnitSpec:
+        key = str(resource_unit_id)
+        for unit in self.units:
+            if unit.resource_unit_id == key:
+                return unit
+        raise KeyError(f"unknown resource_unit_id {key!r}")
 
-    def stage_id_for_physical_node(self, physical_node_id: str) -> str:
+    def unit_id_for_physical_node(self, physical_node_id: str) -> str:
         key = str(physical_node_id)
-        for stage in self.stages:
-            if stage.physical_node_id == key:
-                return stage.stage_id
+        for unit in self.units:
+            if unit.physical_node_id == key:
+                return unit.resource_unit_id
         raise KeyError(f"unknown physical_node_id {key!r}")
 
-    def topological_stage_ids(self) -> tuple[str, ...]:
-        by_id = {stage.stage_id: stage for stage in self.stages}
-        downstream: dict[str, set[str]] = {stage_id: set() for stage_id in by_id}
-        for stage in self.stages:
-            for parent in stage.input_stage_ids:
-                downstream[parent].add(stage.stage_id)
+    def topological_unit_ids(self) -> tuple[str, ...]:
+        by_id = {unit.resource_unit_id: unit for unit in self.units}
+        downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in by_id}
+        for unit in self.units:
+            for parent in unit.input_unit_ids:
+                downstream[parent].add(unit.resource_unit_id)
         return self._topological_order(by_id, downstream)
 
-    def reverse_topological_stage_ids(self) -> tuple[str, ...]:
-        return tuple(reversed(self.topological_stage_ids()))
+    def reverse_topological_unit_ids(self) -> tuple[str, ...]:
+        return tuple(reversed(self.topological_unit_ids()))
 
-    def downstream_fte_stage_ids_requiring_separate_slot(
+    def downstream_native_fragment_unit_ids_requiring_separate_slot(
         self,
-        source_stage_id: str,
+        source_unit_id: str,
     ) -> tuple[str, ...]:
-        """Return downstream FTE stages separated by a non-FTE boundary.
+        """Return downstream native fragment units separated by a remote-process boundary.
 
-        An FTE lease can normally hand its capacity directly to a downstream
-        FTE stage after it finishes.  That capacity is not transferable while
-        the FTE is blocked inside a nested Ray task or actor invocation: the
-        producer remains alive until the non-FTE continuation returns.  Every
-        FTE reachable after such a boundary therefore shares one additional
-        progress slot that admission must keep placeable.
+        A native fragment task can normally hand its capacity directly to a
+        downstream native fragment after it finishes. That capacity is not
+        transferable while the fragment is blocked inside a nested Ray task
+        or actor invocation: the producer remains alive until the remote
+        continuation returns. Every native fragment reachable after such a
+        boundary therefore shares one additional progress slot that admission
+        must keep placeable.
 
         The source itself counts as a boundary when it is not a Ray worker.
         Results follow the graph's deterministic topological order.  For a
         join, one boundary-crossing input path is sufficient to require the
         separate slot.
         """
-        source = self.stage_by_id(source_stage_id)
-        by_id = {stage.stage_id: stage for stage in self.stages}
-        downstream: dict[str, set[str]] = {stage_id: set() for stage_id in by_id}
-        for stage in self.stages:
-            for input_stage_id in stage.input_stage_ids:
-                downstream[input_stage_id].add(stage.stage_id)
+        source = self.unit_by_id(source_unit_id)
+        by_id = {unit.resource_unit_id: unit for unit in self.units}
+        downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in by_id}
+        for unit in self.units:
+            for input_unit_id in unit.input_unit_ids:
+                downstream[input_unit_id].add(unit.resource_unit_id)
 
-        crossed_non_fte: dict[str, bool] = {source.stage_id: source.backend != "ray_worker"}
-        ordered = self.topological_stage_ids()
-        for stage_id in ordered:
-            crossed = crossed_non_fte.get(stage_id)
+        crossed_remote_process: dict[str, bool] = {source.resource_unit_id: source.backend != "ray_worker"}
+        ordered = self.topological_unit_ids()
+        for resource_unit_id in ordered:
+            crossed = crossed_remote_process.get(resource_unit_id)
             if crossed is None:
                 continue
-            for child_id in downstream[stage_id]:
+            for child_id in downstream[resource_unit_id]:
                 child_crossed = crossed or by_id[child_id].backend != "ray_worker"
-                crossed_non_fte[child_id] = crossed_non_fte.get(child_id, False) or child_crossed
+                crossed_remote_process[child_id] = crossed_remote_process.get(child_id, False) or child_crossed
 
         return tuple(
-            stage_id
-            for stage_id in ordered
-            if stage_id != source.stage_id
-            and by_id[stage_id].backend == "ray_worker"
-            and crossed_non_fte.get(stage_id, False)
+            resource_unit_id
+            for resource_unit_id in ordered
+            if resource_unit_id != source.resource_unit_id
+            and by_id[resource_unit_id].backend == "ray_worker"
+            and crossed_remote_process.get(resource_unit_id, False)
         )
 
-    def task_identity(self, stage_id: str, *, partition_id: int | str, attempt_id: int | str) -> str:
-        stage = self.stage_by_id(stage_id)
+    def task_identity(self, resource_unit_id: str, *, partition_id: int | str, attempt_id: int | str) -> str:
+        unit = self.unit_by_id(resource_unit_id)
         partition = str(partition_id).strip()
         attempt = str(attempt_id).strip()
         if not partition:
             raise ValueError("partition_id must be non-empty")
         if not attempt:
             raise ValueError("attempt_id must be non-empty")
-        return f"task:{stage.stage_id}:partition:{partition}:attempt:{attempt}"
+        return f"task:{unit.resource_unit_id}:partition:{partition}:attempt:{attempt}"
 
     def validate_allocation(
         self,
@@ -633,14 +661,14 @@ class QueryExecutionGraph:
         require_full_minimum: bool = True,
     ) -> None:
         hard_capacity = _hard_resources(allocation.resources)
-        for stage in self.stages:
-            task_commitment = _hard_resources(stage.per_task)
-            actor_resident = stage.resident_per_actor if stage.backend == "ray_actor" else ResourceVector()
+        for unit in self.units:
+            task_commitment = _hard_resources(unit.per_task)
+            actor_resident = unit.resident_per_actor if unit.backend == "ray_actor" else ResourceVector()
             placement_commitment = actor_resident + task_commitment
             exceeded = placement_commitment.exceeded_dimensions(hard_capacity)
             if require_full_minimum and exceeded:
                 raise ValueError(
-                    f"stage {stage.stage_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
+                    f"unit {unit.resource_unit_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
                 )
             if (
                 require_full_minimum
@@ -650,50 +678,54 @@ class QueryExecutionGraph:
                     for node_allocation in allocation.node_allocations
                 )
             ):
-                raise ValueError(f"stage {stage.stage_id} maximum task does not fit any allocated Ray node")
-            if stage.backend == "ray_actor":
-                actor_pool = actor_resident.scale(stage.actor_pool_size)
+                raise ValueError(f"unit {unit.resource_unit_id} maximum task does not fit any allocated Ray node")
+            if unit.backend == "ray_actor":
+                actor_pool = actor_resident.scale(unit.actor_pool_size)
                 exceeded_actor = actor_pool.exceeded_dimensions(hard_capacity)
                 if require_full_minimum and exceeded_actor:
                     raise ValueError(
-                        f"stage {stage.stage_id} actor pool exceeds query allocation for {', '.join(exceeded_actor)}"
+                        f"unit {unit.resource_unit_id} actor pool exceeds query allocation for {', '.join(exceeded_actor)}"
                     )
                 placements = [
-                    placement for placement in allocation.actor_placements if placement.stage_id == stage.stage_id
+                    placement
+                    for placement in allocation.actor_placements
+                    if placement.resource_unit_id == unit.resource_unit_id
                 ]
-                if require_full_minimum and len(placements) != stage.actor_pool_size:
+                if require_full_minimum and len(placements) != unit.actor_pool_size:
                     raise ValueError(
-                        f"stage {stage.stage_id} requires exactly {stage.actor_pool_size} actor placements"
+                        f"unit {unit.resource_unit_id} requires exactly {unit.actor_pool_size} actor placements"
                     )
-                expected_indices = set(range(stage.actor_pool_size))
+                expected_indices = set(range(unit.actor_pool_size))
                 placement_indices = {placement.actor_index for placement in placements}
                 if placements and placement_indices != expected_indices:
-                    raise ValueError(f"stage {stage.stage_id} actor placement indices must be contiguous from zero")
+                    raise ValueError(
+                        f"unit {unit.resource_unit_id} actor placement indices must be contiguous from zero"
+                    )
                 for placement in placements:
                     if not placement_commitment.fits_within(
                         _hard_resources(allocation.resources_for_node(placement.node_id))
                     ):
                         raise ValueError(
-                            f"stage {stage.stage_id} actor {placement.actor_index} does not fit "
+                            f"unit {unit.resource_unit_id} actor {placement.actor_index} does not fit "
                             f"allocated Ray node {placement.node_id}"
                         )
 
-        known_stage_ids = {stage.stage_id for stage in self.stages if stage.backend == "ray_actor"}
-        unknown_actor_stages = sorted(
-            {placement.stage_id for placement in allocation.actor_placements} - known_stage_ids
+        known_actor_unit_ids = {unit.resource_unit_id for unit in self.units if unit.backend == "ray_actor"}
+        unknown_actor_units = sorted(
+            {placement.resource_unit_id for placement in allocation.actor_placements} - known_actor_unit_ids
         )
-        if unknown_actor_stages:
-            raise ValueError("actor placement references non-actor stage: " + ", ".join(unknown_actor_stages))
+        if unknown_actor_units:
+            raise ValueError("actor placement references non-actor unit: " + ", ".join(unknown_actor_units))
         if require_full_minimum:
             actor_commitment_by_node: dict[str, ResourceVector] = {}
             for placement in allocation.actor_placements:
-                stage = self.stage_by_id(placement.stage_id)
+                unit = self.unit_by_id(placement.resource_unit_id)
                 actor_commitment_by_node[placement.node_id] = (
                     actor_commitment_by_node.get(
                         placement.node_id,
                         ResourceVector(),
                     )
-                    + stage.resident_per_actor
+                    + unit.resident_per_actor
                 )
             for node_id, commitment in actor_commitment_by_node.items():
                 if not commitment.fits_within(_hard_resources(allocation.resources_for_node(node_id))):
@@ -709,19 +741,19 @@ class QueryExecutionGraph:
         return {
             "query_id": self.query_id,
             "plan_digest": self.plan_digest,
-            "stages": [stage.to_dict() for stage in self.stages],
-            "terminal_stage_ids": list(self.terminal_stage_ids),
+            "units": [unit.to_dict() for unit in self.units],
+            "terminal_unit_ids": list(self.terminal_unit_ids),
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> QueryExecutionGraph:
+    def from_dict(cls, payload: Mapping[str, Any]) -> QueryResourceGraph:
         values = dict(payload)
         _strict_fields(values, cls._FIELDS, cls.__name__)
         return cls(
             query_id=str(values["query_id"]),
             plan_digest=str(values["plan_digest"]),
-            stages=tuple(StageResourceSpec.from_dict(item) for item in values["stages"]),
-            terminal_stage_ids=tuple(str(item) for item in values["terminal_stage_ids"]),
+            units=tuple(ResourceUnitSpec.from_dict(item) for item in values["units"]),
+            terminal_unit_ids=tuple(str(item) for item in values["terminal_unit_ids"]),
         )
 
 
@@ -729,7 +761,7 @@ __all__ = [
     "ActorPlacement",
     "NodeResourceAllocation",
     "QueryAllocation",
-    "QueryExecutionGraph",
+    "QueryResourceGraph",
     "ResourceVector",
-    "StageResourceSpec",
+    "ResourceUnitSpec",
 ]

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -321,9 +321,10 @@ class QueryAllocation:
 class ResourceUnitSpec:
     """Resource accounting for one independently scheduled execution family.
 
-    A unit represents native fragment tasks, Ray task UDFs, or a Ray actor
-    pool. It does not gate pipeline execution; ``is_barrier`` only marks the
-    materialization boundary used to calculate the current reservation scope.
+    Native-fragment units retain graph identity and managed object-flow
+    windows, but do not own process resources: the node-local shared DuckDB
+    instance schedules their threads and manages their working memory. Ray
+    task and actor units own the process resources declared by their UDFs.
     """
 
     query_id: str
@@ -339,7 +340,6 @@ class ResourceUnitSpec:
     resident_per_actor: ResourceVector = field(default_factory=ResourceVector)
     actor_pool_size: int = 0
     actor_prefetch_depth: int = 1
-    is_barrier: bool = False
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "query_id",
@@ -355,7 +355,6 @@ class ResourceUnitSpec:
         "resident_per_actor",
         "actor_pool_size",
         "actor_prefetch_depth",
-        "is_barrier",
     )
 
     @property
@@ -377,7 +376,6 @@ class ResourceUnitSpec:
             "resident_per_actor": self.resident_per_actor.to_dict(),
             "actor_pool_size": int(self.actor_pool_size),
             "actor_prefetch_depth": int(self.actor_prefetch_depth),
-            "is_barrier": self.is_barrier,
         }
 
     @classmethod
@@ -399,7 +397,6 @@ class ResourceUnitSpec:
             resident_per_actor=ResourceVector.from_dict(values["resident_per_actor"]),
             actor_pool_size=int(values["actor_pool_size"]),
             actor_prefetch_depth=int(values["actor_prefetch_depth"]),
-            is_barrier=values["is_barrier"],
         )
 
 
@@ -526,14 +523,13 @@ class QueryResourceGraph:
             )
         if unit.max_concurrency is not None and int(unit.max_concurrency) <= 0:
             raise ValueError(f"unit {unit.resource_unit_id} max_concurrency must be > 0")
-        if not isinstance(unit.is_barrier, bool):
-            raise ValueError(f"unit {unit.resource_unit_id} is_barrier must be a boolean")
-
-        process_resources = unit.resident_per_actor if unit.backend == "ray_actor" else unit.per_task
-        if process_resources.cpu <= 0 and process_resources.gpu <= 0:
-            raise ValueError(f"unit {unit.resource_unit_id} process commitment must request CPU or GPU resources")
-        if process_resources.heap_bytes <= 0:
-            raise ValueError(f"unit {unit.resource_unit_id} process commitment must request non-zero heap_bytes")
+        process_resources = unit.resident_per_actor if unit.backend == "ray_actor" else _hard_resources(unit.per_task)
+        if unit.backend == "ray_worker":
+            if not process_resources.is_zero():
+                raise ValueError(f"native fragment unit {unit.resource_unit_id} process resources are owned by DuckDB")
+        else:
+            if process_resources.cpu <= 0 and process_resources.gpu <= 0:
+                raise ValueError(f"unit {unit.resource_unit_id} process commitment must request CPU or GPU resources")
 
         actor_pool_size = int(unit.actor_pool_size)
         actor_prefetch_depth = int(unit.actor_prefetch_depth)
@@ -599,50 +595,6 @@ class QueryResourceGraph:
 
     def reverse_topological_unit_ids(self) -> tuple[str, ...]:
         return tuple(reversed(self.topological_unit_ids()))
-
-    def downstream_native_fragment_unit_ids_requiring_separate_slot(
-        self,
-        source_unit_id: str,
-    ) -> tuple[str, ...]:
-        """Return downstream native fragment units separated by a remote-process boundary.
-
-        A native fragment task can normally hand its capacity directly to a
-        downstream native fragment after it finishes. That capacity is not
-        transferable while the fragment is blocked inside a nested Ray task
-        or actor invocation: the producer remains alive until the remote
-        continuation returns. Every native fragment reachable after such a
-        boundary therefore shares one additional progress slot that admission
-        must keep placeable.
-
-        The source itself counts as a boundary when it is not a Ray worker.
-        Results follow the graph's deterministic topological order.  For a
-        join, one boundary-crossing input path is sufficient to require the
-        separate slot.
-        """
-        source = self.unit_by_id(source_unit_id)
-        by_id = {unit.resource_unit_id: unit for unit in self.units}
-        downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in by_id}
-        for unit in self.units:
-            for input_unit_id in unit.input_unit_ids:
-                downstream[input_unit_id].add(unit.resource_unit_id)
-
-        crossed_remote_process: dict[str, bool] = {source.resource_unit_id: source.backend != "ray_worker"}
-        ordered = self.topological_unit_ids()
-        for resource_unit_id in ordered:
-            crossed = crossed_remote_process.get(resource_unit_id)
-            if crossed is None:
-                continue
-            for child_id in downstream[resource_unit_id]:
-                child_crossed = crossed or by_id[child_id].backend != "ray_worker"
-                crossed_remote_process[child_id] = crossed_remote_process.get(child_id, False) or child_crossed
-
-        return tuple(
-            resource_unit_id
-            for resource_unit_id in ordered
-            if resource_unit_id != source.resource_unit_id
-            and by_id[resource_unit_id].backend == "ray_worker"
-            and crossed_remote_process.get(resource_unit_id, False)
-        )
 
     def task_identity(self, resource_unit_id: str, *, partition_id: int | str, attempt_id: int | str) -> str:
         unit = self.unit_by_id(resource_unit_id)

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -31,14 +31,17 @@ def _strict_fields(payload: Mapping[str, Any], expected: tuple[str, ...], type_n
 
 @dataclass(frozen=True)
 class ResourceVector:
-    """Resources owned by a query, resource unit, task, or output window.
+    """Resources requested by work or attributed to a soft query budget.
 
     CPU and GPU are Ray logical resources and may be fractional. Byte resources
-    use integer accounting units. Query allocations treat CPU, GPU, and heap as
-    hard ownership while object-store bytes are a flow-control budget: live
-    ObjectRefs may temporarily exceed it under the bounded liveness policy and
-    Ray Core may spill them. A vector is never allowed to carry negative
-    capacity; subtraction that would underflow is a control-plane bug.
+    use integer accounting units. On a concrete task or actor, CPU, GPU, and
+    declared heap become real Ray Core scheduling requests. On a
+    ``QueryAllocation`` all four fields are soft admission/reservation shares:
+    existing work is not revoked after an overage, and one bounded liveness
+    path may escape a soft block. Object-store bytes additionally describe
+    spillable flow rather than process memory. A vector is never allowed to
+    carry negative capacity; subtraction that would underflow is a
+    control-plane bug.
     """
 
     cpu: float = 0.0
@@ -151,11 +154,12 @@ class ResourceVector:
 class NodeResourceAllocation:
     """One query's allocation attribution on one Ray node.
 
-    CPU, GPU, and heap are enforced when a task or actor is placed on this
-    node. The object-store component contributes to the query-wide soft
-    flow-control budget; per-node object-store debt is observable but is not a
-    separate QRM admission limit. Ray Core remains responsible for node-local
-    spill and OOM protection.
+    QRM uses CPU, GPU, and heap attribution to choose a feasible logical slot
+    before submission; Ray Core remains the physical placement authority and
+    actors are not pinned to these nodes. The object-store component contributes
+    only to the query-wide soft flow-control budget. Per-node debt is
+    observable, while Ray Core remains responsible for node-local spill and OOM
+    protection.
     """
 
     node_id: str
@@ -184,48 +188,6 @@ class NodeResourceAllocation:
         )
 
 
-@dataclass(frozen=True)
-class ActorPlacement:
-    """Coordinator-selected placement for one query-owned Ray actor."""
-
-    resource_unit_id: str
-    actor_index: int
-    node_id: str
-
-    _FIELDS: ClassVar[tuple[str, ...]] = ("resource_unit_id", "actor_index", "node_id")
-
-    def __post_init__(self) -> None:
-        resource_unit_id = str(self.resource_unit_id).strip()
-        node_id = str(self.node_id).strip()
-        actor_index = int(self.actor_index)
-        if not resource_unit_id:
-            raise ValueError("actor placement resource_unit_id must be non-empty")
-        if actor_index < 0:
-            raise ValueError("actor placement actor_index must be >= 0")
-        if not node_id:
-            raise ValueError("actor placement node_id must be non-empty")
-        object.__setattr__(self, "resource_unit_id", resource_unit_id)
-        object.__setattr__(self, "actor_index", actor_index)
-        object.__setattr__(self, "node_id", node_id)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "resource_unit_id": self.resource_unit_id,
-            "actor_index": self.actor_index,
-            "node_id": self.node_id,
-        }
-
-    @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> ActorPlacement:
-        values = dict(payload)
-        _strict_fields(values, cls._FIELDS, cls.__name__)
-        return cls(
-            resource_unit_id=str(values["resource_unit_id"]),
-            actor_index=int(values["actor_index"]),
-            node_id=str(values["node_id"]),
-        )
-
-
 def _resource_vectors_equivalent(left: ResourceVector, right: ResourceVector) -> bool:
     return (
         math.isclose(left.cpu, right.cpu, rel_tol=0.0, abs_tol=1e-9)
@@ -248,13 +210,11 @@ def _hard_resources(resources: ResourceVector) -> ResourceVector:
 class QueryAllocation:
     resources: ResourceVector
     node_allocations: tuple[NodeResourceAllocation, ...]
-    actor_placements: tuple[ActorPlacement, ...]
     generation: int
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "resources",
         "node_allocations",
-        "actor_placements",
         "generation",
     )
 
@@ -263,7 +223,6 @@ class QueryAllocation:
         if generation <= 0:
             raise ValueError("generation must be > 0")
         node_allocations = tuple(self.node_allocations)
-        actor_placements = tuple(self.actor_placements)
         node_ids = [allocation.node_id for allocation in node_allocations]
         if len(set(node_ids)) != len(node_ids):
             raise ValueError("query allocation contains duplicate node_id entries")
@@ -272,36 +231,13 @@ class QueryAllocation:
             aggregate = aggregate + node_allocation.resources
         if not _resource_vectors_equivalent(aggregate, self.resources):
             raise ValueError("query allocation resources must equal the sum of node_allocations")
-        placement_keys = [(placement.resource_unit_id, placement.actor_index) for placement in actor_placements]
-        if len(set(placement_keys)) != len(placement_keys):
-            raise ValueError("query allocation contains duplicate actor placements")
-        unknown_nodes = sorted({placement.node_id for placement in actor_placements} - set(node_ids))
-        if unknown_nodes:
-            raise ValueError("actor placement references unallocated node_id: " + ", ".join(unknown_nodes))
         object.__setattr__(self, "generation", generation)
         object.__setattr__(self, "node_allocations", node_allocations)
-        object.__setattr__(self, "actor_placements", actor_placements)
-
-    def resources_for_node(self, node_id: str) -> ResourceVector:
-        node_key = str(node_id)
-        for allocation in self.node_allocations:
-            if allocation.node_id == node_key:
-                return allocation.resources
-        raise KeyError(f"query has no allocation on Ray node {node_key!r}")
-
-    def actor_node_ids_for_unit(self, resource_unit_id: str) -> tuple[str, ...]:
-        unit_key = str(resource_unit_id)
-        placements = sorted(
-            (placement for placement in self.actor_placements if placement.resource_unit_id == unit_key),
-            key=lambda placement: placement.actor_index,
-        )
-        return tuple(placement.node_id for placement in placements)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "resources": self.resources.to_dict(),
             "node_allocations": [allocation.to_dict() for allocation in self.node_allocations],
-            "actor_placements": [placement.to_dict() for placement in self.actor_placements],
             "generation": self.generation,
         }
 
@@ -312,8 +248,66 @@ class QueryAllocation:
         return cls(
             resources=ResourceVector.from_dict(values["resources"]),
             node_allocations=tuple(NodeResourceAllocation.from_dict(item) for item in values["node_allocations"]),
-            actor_placements=tuple(ActorPlacement.from_dict(item) for item in values["actor_placements"]),
             generation=int(values["generation"]),
+        )
+
+
+@dataclass(frozen=True)
+class MaterializationBarrierSpec:
+    """A true distributed boundary inside one physical materializer node.
+
+    Barriers are execution events, not resource-owning operators.  The
+    materializer remains a normal native resource unit so its managed object
+    flow can be accounted without inventing a separate Stage abstraction.
+    Before completion only ``materialized_input_unit_ids`` feed that node;
+    after completion the same node may emit final work from its remaining
+    inputs before downstream execution continues.
+    """
+
+    query_id: str
+    barrier_id: str
+    physical_node_id: str
+    materializer_unit_id: str
+    materialized_input_unit_ids: tuple[str, ...]
+
+    _FIELDS: ClassVar[tuple[str, ...]] = (
+        "query_id",
+        "barrier_id",
+        "physical_node_id",
+        "materializer_unit_id",
+        "materialized_input_unit_ids",
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "query_id", str(self.query_id).strip())
+        object.__setattr__(self, "barrier_id", str(self.barrier_id).strip())
+        object.__setattr__(self, "physical_node_id", str(self.physical_node_id).strip())
+        object.__setattr__(self, "materializer_unit_id", str(self.materializer_unit_id).strip())
+        object.__setattr__(
+            self,
+            "materialized_input_unit_ids",
+            tuple(str(item).strip() for item in self.materialized_input_unit_ids),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "barrier_id": self.barrier_id,
+            "physical_node_id": self.physical_node_id,
+            "materializer_unit_id": self.materializer_unit_id,
+            "materialized_input_unit_ids": list(self.materialized_input_unit_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> MaterializationBarrierSpec:
+        values = dict(payload)
+        _strict_fields(values, cls._FIELDS, cls.__name__)
+        return cls(
+            query_id=str(values["query_id"]),
+            barrier_id=str(values["barrier_id"]),
+            physical_node_id=str(values["physical_node_id"]),
+            materializer_unit_id=str(values["materializer_unit_id"]),
+            materialized_input_unit_ids=tuple(str(item) for item in values["materialized_input_unit_ids"]),
         )
 
 
@@ -356,6 +350,23 @@ class ResourceUnitSpec:
         "actor_pool_size",
         "actor_prefetch_depth",
     )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "query_id", str(self.query_id).strip())
+        object.__setattr__(self, "resource_unit_id", str(self.resource_unit_id).strip())
+        object.__setattr__(self, "physical_node_id", str(self.physical_node_id).strip())
+        object.__setattr__(self, "unit_kind", str(self.unit_kind).strip())
+        object.__setattr__(self, "backend", str(self.backend).strip())
+        object.__setattr__(self, "input_unit_ids", tuple(str(item).strip() for item in self.input_unit_ids))
+        object.__setattr__(self, "target_output_block_bytes", int(self.target_output_block_bytes))
+        object.__setattr__(self, "generator_buffer_blocks", int(self.generator_buffer_blocks))
+        object.__setattr__(
+            self,
+            "max_concurrency",
+            None if self.max_concurrency is None else int(self.max_concurrency),
+        )
+        object.__setattr__(self, "actor_pool_size", int(self.actor_pool_size))
+        object.__setattr__(self, "actor_prefetch_depth", int(self.actor_prefetch_depth))
 
     @property
     def output_window_bytes(self) -> int:
@@ -408,11 +419,13 @@ class QueryResourceGraph:
     plan_digest: str
     units: tuple[ResourceUnitSpec, ...]
     terminal_unit_ids: tuple[str, ...]
+    materialization_barriers: tuple[MaterializationBarrierSpec, ...] = ()
 
     _FIELDS: ClassVar[tuple[str, ...]] = (
         "query_id",
         "plan_digest",
         "units",
+        "materialization_barriers",
         "terminal_unit_ids",
     )
 
@@ -420,7 +433,8 @@ class QueryResourceGraph:
         object.__setattr__(self, "query_id", str(self.query_id).strip())
         object.__setattr__(self, "plan_digest", str(self.plan_digest).strip())
         object.__setattr__(self, "units", tuple(self.units))
-        object.__setattr__(self, "terminal_unit_ids", tuple(str(item) for item in self.terminal_unit_ids))
+        object.__setattr__(self, "materialization_barriers", tuple(self.materialization_barriers))
+        object.__setattr__(self, "terminal_unit_ids", tuple(str(item).strip() for item in self.terminal_unit_ids))
         self._validate()
 
     def _validate(self) -> None:
@@ -467,6 +481,50 @@ class QueryResourceGraph:
         ordered = self._topological_order(by_id, downstream)
         if len(ordered) != len(by_id):
             raise ValueError("query resource graph contains a cycle")
+
+        barrier_ids: set[str] = set()
+        barrier_nodes: set[str] = set()
+        barrier_units: set[str] = set()
+        for barrier in self.materialization_barriers:
+            if str(barrier.query_id).strip() != self.query_id:
+                raise ValueError(
+                    f"barrier {barrier.barrier_id or '<empty>'} query_id {barrier.query_id!r} "
+                    f"does not match {self.query_id!r}"
+                )
+            barrier_id = str(barrier.barrier_id).strip()
+            physical_node_id = str(barrier.physical_node_id).strip()
+            materializer_unit_id = str(barrier.materializer_unit_id).strip()
+            if barrier_id != f"barrier:{self.query_id}:node:{physical_node_id}":
+                raise ValueError(f"invalid materialization barrier identity: {barrier_id!r}")
+            if not physical_node_id:
+                raise ValueError(f"barrier {barrier_id} physical_node_id must be non-empty")
+            if materializer_unit_id not in by_id:
+                raise ValueError(f"barrier {barrier_id} references missing materializer unit {materializer_unit_id}")
+            if by_id[materializer_unit_id].backend != "ray_worker":
+                raise ValueError(f"barrier {barrier_id} materializer must be a native fragment unit")
+            materialized_input_unit_ids = tuple(
+                str(resource_unit_id).strip() for resource_unit_id in barrier.materialized_input_unit_ids
+            )
+            if not materialized_input_unit_ids:
+                raise ValueError(f"barrier {barrier_id} must materialize at least one input unit")
+            if len(set(materialized_input_unit_ids)) != len(materialized_input_unit_ids):
+                raise ValueError(f"barrier {barrier_id} has duplicate materialized input units")
+            materializer_inputs = set(by_id[materializer_unit_id].input_unit_ids)
+            for input_unit_id in materialized_input_unit_ids:
+                if input_unit_id not in materializer_inputs:
+                    raise ValueError(
+                        f"barrier {barrier_id} materialized input {input_unit_id} "
+                        f"is not a direct input of {materializer_unit_id}"
+                    )
+            if barrier_id in barrier_ids:
+                raise ValueError(f"duplicate materialization barrier_id: {barrier_id}")
+            if physical_node_id in barrier_nodes:
+                raise ValueError(f"duplicate materialization barrier physical_node_id: {physical_node_id}")
+            if materializer_unit_id in barrier_units:
+                raise ValueError(f"duplicate materialization barrier unit: {materializer_unit_id}")
+            barrier_ids.add(barrier_id)
+            barrier_nodes.add(physical_node_id)
+            barrier_units.add(materializer_unit_id)
 
         for terminal in self.terminal_unit_ids:
             if downstream[terminal]:
@@ -596,6 +654,109 @@ class QueryResourceGraph:
     def reverse_topological_unit_ids(self) -> tuple[str, ...]:
         return tuple(reversed(self.topological_unit_ids()))
 
+    def barrier_for_physical_node(self, physical_node_id: str) -> MaterializationBarrierSpec:
+        key = str(physical_node_id)
+        for barrier in self.materialization_barriers:
+            if barrier.physical_node_id == key:
+                return barrier
+        raise KeyError(f"unknown materialization barrier physical_node_id {key!r}")
+
+    def ordered_materialization_barriers(self) -> tuple[MaterializationBarrierSpec, ...]:
+        rank = {resource_unit_id: index for index, resource_unit_id in enumerate(self.topological_unit_ids())}
+        return tuple(
+            sorted(
+                self.materialization_barriers,
+                key=lambda barrier: (rank[barrier.materializer_unit_id], barrier.barrier_id),
+            )
+        )
+
+    def eligible_resource_unit_ids(self, completed_barrier_ids: set[str] | frozenset[str]) -> tuple[str, ...]:
+        """Return units not hidden behind an unfinished true barrier.
+
+        The returned set is the current execution phase, not the set of tasks
+        that happen to be running.  Parallel branches up to their respective
+        first unfinished barriers remain eligible together.  Once a barrier
+        completes, reverse traversal stops at that boundary so the preceding
+        phase is retired instead of being reserved again.
+        """
+
+        completed = {str(barrier_id) for barrier_id in completed_barrier_ids}
+        ordered = self.topological_unit_ids()
+        by_id = {unit.resource_unit_id: unit for unit in self.units}
+        barrier_by_materializer = {barrier.materializer_unit_id: barrier for barrier in self.materialization_barriers}
+        pending = tuple(
+            barrier for barrier in self.ordered_materialization_barriers() if barrier.barrier_id not in completed
+        )
+
+        direct_downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in ordered}
+        for unit in self.units:
+            for input_unit_id in unit.input_unit_ids:
+                direct_downstream[input_unit_id].add(unit.resource_unit_id)
+        blocked: set[str] = set()
+        todo = [
+            downstream_unit_id
+            for barrier in pending
+            for downstream_unit_id in direct_downstream[barrier.materializer_unit_id]
+        ]
+        while todo:
+            resource_unit_id = todo.pop()
+            if resource_unit_id in blocked:
+                continue
+            blocked.add(resource_unit_id)
+            todo.extend(direct_downstream[resource_unit_id])
+
+        # Every first unfinished barrier is a target for the current phase.
+        # A terminal is also a target when no unfinished barrier withholds it.
+        targets = {barrier.materializer_unit_id for barrier in pending if barrier.materializer_unit_id not in blocked}
+        targets.update(
+            terminal_unit_id for terminal_unit_id in self.terminal_unit_ids if terminal_unit_id not in blocked
+        )
+        # A pending barrier on one branch can also block a downstream join fed
+        # by a branch whose own barrier has already completed.  Keep the
+        # unblocked side of every blocked edge eligible so that branch can
+        # stream up to the join's bounded input instead of being retired until
+        # the other branch catches up.
+        targets.update(
+            input_unit_id
+            for blocked_unit_id in blocked
+            for input_unit_id in by_id[blocked_unit_id].input_unit_ids
+            if input_unit_id not in blocked
+        )
+
+        eligible: set[str] = set()
+        todo = list(targets)
+        while todo:
+            resource_unit_id = todo.pop()
+            if resource_unit_id in eligible:
+                continue
+            eligible.add(resource_unit_id)
+            unit = by_id[resource_unit_id]
+            barrier = barrier_by_materializer.get(resource_unit_id)
+            if barrier is None:
+                todo.extend(unit.input_unit_ids)
+            elif barrier.barrier_id in completed:
+                materialized_inputs = set(barrier.materialized_input_unit_ids)
+                todo.extend(
+                    input_unit_id for input_unit_id in unit.input_unit_ids if input_unit_id not in materialized_inputs
+                )
+            else:
+                todo.extend(barrier.materialized_input_unit_ids)
+        return tuple(resource_unit_id for resource_unit_id in ordered if resource_unit_id in eligible)
+
+    def frontier_materialization_barriers(
+        self,
+        completed_barrier_ids: set[str] | frozenset[str],
+    ) -> tuple[MaterializationBarrierSpec, ...]:
+        """Return all unfinished barriers on the current parallel frontier."""
+
+        completed = {str(barrier_id) for barrier_id in completed_barrier_ids}
+        eligible = set(self.eligible_resource_unit_ids(completed))
+        return tuple(
+            barrier
+            for barrier in self.ordered_materialization_barriers()
+            if barrier.barrier_id not in completed and barrier.materializer_unit_id in eligible
+        )
+
     def task_identity(self, resource_unit_id: str, *, partition_id: int | str, attempt_id: int | str) -> str:
         unit = self.unit_by_id(resource_unit_id)
         partition = str(partition_id).strip()
@@ -610,78 +771,30 @@ class QueryResourceGraph:
         self,
         allocation: QueryAllocation,
         *,
-        require_full_minimum: bool = True,
+        eligible_unit_ids: tuple[str, ...] | None = None,
     ) -> None:
+        eligible = (
+            {unit.resource_unit_id for unit in self.units}
+            if eligible_unit_ids is None
+            else {str(resource_unit_id) for resource_unit_id in eligible_unit_ids}
+        )
+        unknown = sorted(eligible - {unit.resource_unit_id for unit in self.units})
+        if unknown:
+            raise ValueError(f"allocation validation references unknown eligible unit: {unknown[0]}")
         hard_capacity = _hard_resources(allocation.resources)
         for unit in self.units:
             task_commitment = _hard_resources(unit.per_task)
-            actor_resident = unit.resident_per_actor if unit.backend == "ray_actor" else ResourceVector()
-            placement_commitment = actor_resident + task_commitment
-            exceeded = placement_commitment.exceeded_dimensions(hard_capacity)
-            if require_full_minimum and exceeded:
-                raise ValueError(
-                    f"unit {unit.resource_unit_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
-                )
-            if (
-                require_full_minimum
-                and not task_commitment.is_zero()
-                and not any(
-                    placement_commitment.fits_within(_hard_resources(node_allocation.resources))
+            if unit.backend == "ray_task" and unit.resource_unit_id in eligible:
+                exceeded = task_commitment.exceeded_dimensions(hard_capacity)
+                if exceeded:
+                    raise ValueError(
+                        f"unit {unit.resource_unit_id} maximum task exceeds query allocation for {', '.join(exceeded)}"
+                    )
+                if not task_commitment.is_zero() and not any(
+                    task_commitment.fits_within(_hard_resources(node_allocation.resources))
                     for node_allocation in allocation.node_allocations
-                )
-            ):
-                raise ValueError(f"unit {unit.resource_unit_id} maximum task does not fit any allocated Ray node")
-            if unit.backend == "ray_actor":
-                actor_pool = actor_resident.scale(unit.actor_pool_size)
-                exceeded_actor = actor_pool.exceeded_dimensions(hard_capacity)
-                if require_full_minimum and exceeded_actor:
-                    raise ValueError(
-                        f"unit {unit.resource_unit_id} actor pool exceeds query allocation for {', '.join(exceeded_actor)}"
-                    )
-                placements = [
-                    placement
-                    for placement in allocation.actor_placements
-                    if placement.resource_unit_id == unit.resource_unit_id
-                ]
-                if require_full_minimum and len(placements) != unit.actor_pool_size:
-                    raise ValueError(
-                        f"unit {unit.resource_unit_id} requires exactly {unit.actor_pool_size} actor placements"
-                    )
-                expected_indices = set(range(unit.actor_pool_size))
-                placement_indices = {placement.actor_index for placement in placements}
-                if placements and placement_indices != expected_indices:
-                    raise ValueError(
-                        f"unit {unit.resource_unit_id} actor placement indices must be contiguous from zero"
-                    )
-                for placement in placements:
-                    if not placement_commitment.fits_within(
-                        _hard_resources(allocation.resources_for_node(placement.node_id))
-                    ):
-                        raise ValueError(
-                            f"unit {unit.resource_unit_id} actor {placement.actor_index} does not fit "
-                            f"allocated Ray node {placement.node_id}"
-                        )
-
-        known_actor_unit_ids = {unit.resource_unit_id for unit in self.units if unit.backend == "ray_actor"}
-        unknown_actor_units = sorted(
-            {placement.resource_unit_id for placement in allocation.actor_placements} - known_actor_unit_ids
-        )
-        if unknown_actor_units:
-            raise ValueError("actor placement references non-actor unit: " + ", ".join(unknown_actor_units))
-        if require_full_minimum:
-            actor_commitment_by_node: dict[str, ResourceVector] = {}
-            for placement in allocation.actor_placements:
-                unit = self.unit_by_id(placement.resource_unit_id)
-                actor_commitment_by_node[placement.node_id] = (
-                    actor_commitment_by_node.get(
-                        placement.node_id,
-                        ResourceVector(),
-                    )
-                    + unit.resident_per_actor
-                )
-            for node_id, commitment in actor_commitment_by_node.items():
-                if not commitment.fits_within(_hard_resources(allocation.resources_for_node(node_id))):
-                    raise ValueError(f"cumulative actor placements do not fit allocated Ray node {node_id}")
+                ):
+                    raise ValueError(f"unit {unit.resource_unit_id} maximum task does not fit any allocated Ray node")
 
     def normalized_digest(self) -> str:
         payload = self.to_dict()
@@ -694,6 +807,7 @@ class QueryResourceGraph:
             "query_id": self.query_id,
             "plan_digest": self.plan_digest,
             "units": [unit.to_dict() for unit in self.units],
+            "materialization_barriers": [barrier.to_dict() for barrier in self.materialization_barriers],
             "terminal_unit_ids": list(self.terminal_unit_ids),
         }
 
@@ -705,12 +819,15 @@ class QueryResourceGraph:
             query_id=str(values["query_id"]),
             plan_digest=str(values["plan_digest"]),
             units=tuple(ResourceUnitSpec.from_dict(item) for item in values["units"]),
+            materialization_barriers=tuple(
+                MaterializationBarrierSpec.from_dict(item) for item in values["materialization_barriers"]
+            ),
             terminal_unit_ids=tuple(str(item) for item in values["terminal_unit_ids"]),
         )
 
 
 __all__ = [
-    "ActorPlacement",
+    "MaterializationBarrierSpec",
     "NodeResourceAllocation",
     "QueryAllocation",
     "QueryResourceGraph",

--- a/duckdb/runners/ray/query_resource_graph.py
+++ b/duckdb/runners/ray/query_resource_graph.py
@@ -16,6 +16,17 @@ _RESOURCE_UNIT_KIND_BY_BACKEND = {
     "ray_task": "ray_task_udf",
     "ray_actor": "ray_actor_pool",
 }
+_RESOURCE_ABS_TOLERANCE = 1e-12
+_RESOURCE_REL_TOLERANCE = 1e-12
+
+
+def _float_resource_leq(value: float, capacity: float) -> bool:
+    return value <= capacity or math.isclose(
+        value,
+        capacity,
+        rel_tol=_RESOURCE_REL_TOLERANCE,
+        abs_tol=_RESOURCE_ABS_TOLERANCE,
+    )
 
 
 def _strict_fields(payload: Mapping[str, Any], expected: tuple[str, ...], type_name: str) -> None:
@@ -87,12 +98,17 @@ class ResourceVector:
             "heap_bytes": self.heap_bytes - other.heap_bytes,
             "object_store_bytes": self.object_store_bytes - other.object_store_bytes,
         }
-        underflow = [name for name, value in values.items() if value < 0]
+        underflow = [name for name in ("heap_bytes", "object_store_bytes") if values[name] < 0]
+        underflow.extend(
+            name
+            for name in ("cpu", "gpu")
+            if not _float_resource_leq(float(getattr(other, name)), float(getattr(self, name)))
+        )
         if underflow:
             raise ValueError(f"resource subtraction underflow: {', '.join(underflow)}")
         return ResourceVector(
-            cpu=values["cpu"],
-            gpu=values["gpu"],
+            cpu=max(0.0, values["cpu"]),
+            gpu=max(0.0, values["gpu"]),
             heap_bytes=int(values["heap_bytes"]),
             object_store_bytes=int(values["object_store_bytes"]),
         )
@@ -109,10 +125,23 @@ class ResourceVector:
         )
 
     def fits_within(self, capacity: ResourceVector) -> bool:
-        return all(getattr(self, name) <= getattr(capacity, name) for name in self._FIELDS)
+        return (
+            _float_resource_leq(self.cpu, capacity.cpu)
+            and _float_resource_leq(self.gpu, capacity.gpu)
+            and self.heap_bytes <= capacity.heap_bytes
+            and self.object_store_bytes <= capacity.object_store_bytes
+        )
 
     def exceeded_dimensions(self, capacity: ResourceVector) -> tuple[str, ...]:
-        return tuple(name for name in self._FIELDS if getattr(self, name) > getattr(capacity, name))
+        return tuple(
+            name
+            for name in self._FIELDS
+            if (
+                not _float_resource_leq(float(getattr(self, name)), float(getattr(capacity, name)))
+                if name in {"cpu", "gpu"}
+                else getattr(self, name) > getattr(capacity, name)
+            )
+        )
 
     def dominant_share(self, capacity: ResourceVector) -> float:
         shares: list[float] = []
@@ -500,8 +529,15 @@ class QueryResourceGraph:
                 raise ValueError(f"barrier {barrier_id} physical_node_id must be non-empty")
             if materializer_unit_id not in by_id:
                 raise ValueError(f"barrier {barrier_id} references missing materializer unit {materializer_unit_id}")
-            if by_id[materializer_unit_id].backend != "ray_worker":
+            materializer = by_id[materializer_unit_id]
+            if materializer.backend != "ray_worker":
                 raise ValueError(f"barrier {barrier_id} materializer must be a native fragment unit")
+            expected_materializer_physical_node_id = f"node:{physical_node_id}:native-fragment"
+            if materializer.physical_node_id != expected_materializer_physical_node_id:
+                raise ValueError(
+                    f"barrier {barrier_id} physical node {physical_node_id!r} does not match "
+                    f"materializer {materializer_unit_id} physical node {materializer.physical_node_id!r}"
+                )
             materialized_input_unit_ids = tuple(
                 str(resource_unit_id).strip() for resource_unit_id in barrier.materialized_input_unit_ids
             )
@@ -509,7 +545,7 @@ class QueryResourceGraph:
                 raise ValueError(f"barrier {barrier_id} must materialize at least one input unit")
             if len(set(materialized_input_unit_ids)) != len(materialized_input_unit_ids):
                 raise ValueError(f"barrier {barrier_id} has duplicate materialized input units")
-            materializer_inputs = set(by_id[materializer_unit_id].input_unit_ids)
+            materializer_inputs = set(materializer.input_unit_ids)
             for input_unit_id in materialized_input_unit_ids:
                 if input_unit_id not in materializer_inputs:
                     raise ValueError(
@@ -687,6 +723,7 @@ class QueryResourceGraph:
         pending = tuple(
             barrier for barrier in self.ordered_materialization_barriers() if barrier.barrier_id not in completed
         )
+        pending_materializer_unit_ids = {barrier.materializer_unit_id for barrier in pending}
 
         direct_downstream: dict[str, set[str]] = {resource_unit_id: set() for resource_unit_id in ordered}
         for unit in self.units:
@@ -705,9 +742,23 @@ class QueryResourceGraph:
             blocked.add(resource_unit_id)
             todo.extend(direct_downstream[resource_unit_id])
 
-        # Every first unfinished barrier is a target for the current phase.
+        # Every unfinished barrier whose materialized side is reachable is a
+        # target for the current phase.  The materializer itself can be
+        # structurally downstream of another barrier through a deferred input
+        # (for example, a broadcast build whose probe side contains a sort),
+        # while its independent materialized side is already executable.
+        # Treating the whole materializer as blocked would serialize those two
+        # materializations and would not match the task streams spawned by the
+        # distributed executor.
+        targets = {
+            barrier.materializer_unit_id
+            for barrier in pending
+            if not any(
+                input_unit_id in blocked or input_unit_id in pending_materializer_unit_ids
+                for input_unit_id in barrier.materialized_input_unit_ids
+            )
+        }
         # A terminal is also a target when no unfinished barrier withholds it.
-        targets = {barrier.materializer_unit_id for barrier in pending if barrier.materializer_unit_id not in blocked}
         targets.update(
             terminal_unit_id for terminal_unit_id in self.terminal_unit_ids if terminal_unit_id not in blocked
         )
@@ -716,12 +767,20 @@ class QueryResourceGraph:
         # unblocked side of every blocked edge eligible so that branch can
         # stream up to the join's bounded input instead of being retired until
         # the other branch catches up.
-        targets.update(
-            input_unit_id
-            for blocked_unit_id in blocked
-            for input_unit_id in by_id[blocked_unit_id].input_unit_ids
-            if input_unit_id not in blocked
-        )
+        for blocked_unit_id in blocked:
+            unit = by_id[blocked_unit_id]
+            barrier = barrier_by_materializer.get(blocked_unit_id)
+            if barrier is not None and barrier.barrier_id not in completed:
+                # A pending barrier's pre-materialization work is represented
+                # by targeting the materializer above.  Its deferred inputs do
+                # not execute until the barrier completes.
+                continue
+            retired_inputs = set() if barrier is None else set(barrier.materialized_input_unit_ids)
+            targets.update(
+                input_unit_id
+                for input_unit_id in unit.input_unit_ids
+                if input_unit_id not in blocked and input_unit_id not in retired_inputs
+            )
 
         eligible: set[str] = set()
         todo = list(targets)

--- a/duckdb/runners/ray/query_resource_graph_builder.py
+++ b/duckdb/runners/ray/query_resource_graph_builder.py
@@ -12,16 +12,16 @@ from duckdb.runners.ray.cluster_resource_coordinator import (
     ActorResourceBundle,
     QueryDemand,
 )
-from duckdb.runners.ray.query_execution_graph import (
-    QueryExecutionGraph,
+from duckdb.runners.ray.query_resource_graph import (
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 
 _GIB = 1024**3
 _MIB = 1024**2
-_DEFAULT_FTE_TASK_HEAP_BYTES = 2 * _GIB
-_DEFAULT_FTE_UDF_DRIVER_HEAP_BYTES = 512 * _MIB
+_DEFAULT_NATIVE_FRAGMENT_TASK_HEAP_BYTES = 2 * _GIB
+_DEFAULT_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES = 512 * _MIB
 _DEFAULT_UDF_TASK_HEAP_BYTES = 2 * _GIB
 _DEFAULT_UDF_ACTOR_HEAP_BYTES = 4 * _GIB
 _DEFAULT_TARGET_OUTPUT_BLOCK_BYTES = 128 * _MIB
@@ -93,85 +93,85 @@ def _env_positive_int(env: Mapping[str, str], name: str, default: int) -> int:
     return int(default) if raw is None or not str(raw).strip() else _positive_int(raw, name)
 
 
-def fte_stage_id_for_node(query_id: str, node_id: str | int) -> str:
+def native_fragment_unit_id_for_node(query_id: str, node_id: str | int) -> str:
     query = str(query_id).strip()
     node = str(node_id).strip()
     if not query or not node:
         raise ValueError("query_id and node_id must be non-empty")
-    return f"stage:{query}:node:{node}:fte"
+    return f"resource:{query}:fragment:node:{node}"
 
 
-def udf_stage_id_for_node(query_id: str, node_id: str | int) -> str:
+def udf_unit_id_for_node(query_id: str, node_id: str | int) -> str:
     query = str(query_id).strip()
     node = str(node_id).strip()
     if not query or not node:
         raise ValueError("query_id and node_id must be non-empty")
-    return f"stage:{query}:node:{node}:udf"
+    return f"resource:{query}:udf:node:{node}"
 
 
-def fte_stage_id_for_fragment(query_id: str, fragment_id: str) -> str:
+def native_fragment_unit_id_for_fragment(query_id: str, fragment_id: str) -> str:
     query = str(query_id).strip()
     fragment = str(fragment_id).strip()
     prefix = f"{query}:node:"
     if not fragment.startswith(prefix):
         if fragment.endswith(":node:") or ":node:" not in fragment:
-            raise ValueError(f"invalid FTE fragment_id: {fragment}")
+            raise ValueError(f"invalid native fragment_id: {fragment}")
         raise ValueError(f"fragment {fragment!r} does not belong to query {query!r}")
     node_id = fragment[len(prefix) :]
     if not node_id or ":" in node_id:
-        raise ValueError(f"invalid FTE fragment_id: {fragment}")
-    return fte_stage_id_for_node(query, node_id)
+        raise ValueError(f"invalid native fragment_id: {fragment}")
+    return native_fragment_unit_id_for_node(query, node_id)
 
 
 def _normalize_metadata(metadata: Mapping[str, Any]) -> tuple[str, dict[str, dict[str, Any]], tuple[str, ...]]:
     payload = dict(metadata)
-    _strict_fields(payload, _TOP_LEVEL_FIELDS, "execution stage metadata")
+    _strict_fields(payload, _TOP_LEVEL_FIELDS, "resource unit metadata")
     query_id = str(payload["query_id"]).strip()
     if not query_id:
-        raise ValueError("execution stage metadata query_id must be non-empty")
+        raise ValueError("resource unit metadata query_id must be non-empty")
     nodes: dict[str, dict[str, Any]] = {}
     for raw_node in payload["nodes"]:
         node = dict(raw_node)
-        _strict_fields(node, _NODE_FIELDS, "execution stage node")
+        _strict_fields(node, _NODE_FIELDS, "resource unit node")
         node_id = str(node["node_id"]).strip()
         if not node_id:
-            raise ValueError("execution stage node_id must be non-empty")
+            raise ValueError("resource unit node_id must be non-empty")
         if node_id in nodes:
-            raise ValueError(f"duplicate execution stage node_id: {node_id}")
+            raise ValueError(f"duplicate resource unit node_id: {node_id}")
         node["node_id"] = node_id
         node["node_name"] = str(node["node_name"]).strip()
         if not node["node_name"]:
-            raise ValueError(f"execution stage node {node_id} node_name must be non-empty")
+            raise ValueError(f"resource unit node {node_id} node_name must be non-empty")
         node["input_node_ids"] = tuple(str(item).strip() for item in node["input_node_ids"])
         node["num_partitions"] = _positive_int(node["num_partitions"], "num_partitions")
         node["is_sink"] = bool(node["is_sink"])
         node["is_blocking_materializing"] = bool(node["is_blocking_materializing"])
         if node["udf_payload"] is not None and not isinstance(node["udf_payload"], Mapping):
-            raise TypeError(f"execution stage node {node_id} udf_payload must be a mapping or None")
+            raise TypeError(f"resource unit node {node_id} udf_payload must be a mapping or None")
         node["udf_payload"] = None if node["udf_payload"] is None else dict(node["udf_payload"])
         nodes[node_id] = node
 
     for node_id, node in nodes.items():
         for input_node_id in node["input_node_ids"]:
             if input_node_id not in nodes:
-                raise ValueError(f"execution stage node {node_id} references missing input node {input_node_id}")
+                raise ValueError(f"resource unit node {node_id} references missing input node {input_node_id}")
     terminal_node_ids = tuple(str(item).strip() for item in payload["terminal_node_ids"])
     if not terminal_node_ids:
-        raise ValueError("execution stage metadata must contain terminal_node_ids")
+        raise ValueError("resource unit metadata must contain terminal_node_ids")
     for terminal in terminal_node_ids:
         if terminal not in nodes:
             raise ValueError(f"terminal node is not registered: {terminal}")
     return query_id, nodes, tuple(sorted(set(terminal_node_ids), key=_node_sort_key))
 
 
-def _udf_stage(
+def _udf_unit(
     query_id: str,
     node: Mapping[str, Any],
-    input_stage_id: str,
+    input_unit_id: str,
     env: Mapping[str, str],
     *,
     downstream_input_window_bytes: int = 0,
-) -> StageResourceSpec | None:
+) -> ResourceUnitSpec | None:
     payload = node["udf_payload"]
     if payload is None:
         return None
@@ -179,13 +179,13 @@ def _udf_stage(
     if backend not in {"ray_task", "ray_actor"}:
         return None
     node_id = str(node["node_id"])
-    expected_stage_id = udf_stage_id_for_node(query_id, node_id)
-    actual_stage_id = str(payload.get("stage_id") or "").strip()
-    if not actual_stage_id:
-        raise ValueError(f"Ray UDF node {node_id} is missing pre-registered stage_id")
-    if actual_stage_id != expected_stage_id:
+    expected_unit_id = udf_unit_id_for_node(query_id, node_id)
+    actual_unit_id = str(payload.get("resource_unit_id") or "").strip()
+    if not actual_unit_id:
+        raise ValueError(f"Ray UDF node {node_id} is missing pre-registered resource_unit_id")
+    if actual_unit_id != expected_unit_id:
         raise ValueError(
-            f"Ray UDF node {node_id} stage_id mismatch: got {actual_stage_id!r}, expected {expected_stage_id!r}"
+            f"Ray UDF node {node_id} resource_unit_id mismatch: got {actual_unit_id!r}, expected {expected_unit_id!r}"
         )
     payload_query_id = str(payload.get("query_id") or "").strip()
     if payload_query_id and payload_query_id != query_id:
@@ -252,13 +252,13 @@ def _udf_stage(
             heap_bytes=heap_bytes,
             object_store_bytes=input_window,
         )
-    return StageResourceSpec(
+    return ResourceUnitSpec(
         query_id=query_id,
-        stage_id=expected_stage_id,
+        resource_unit_id=expected_unit_id,
         physical_node_id=f"node:{node_id}:udf",
-        stage_kind="udf",
+        unit_kind="ray_actor_pool" if backend == "ray_actor" else "ray_task_udf",
         backend=backend,
-        input_stage_ids=(input_stage_id,),
+        input_unit_ids=(input_unit_id,),
         per_task=invocation_resources,
         target_output_block_bytes=target,
         generator_buffer_blocks=retention_blocks,
@@ -266,33 +266,35 @@ def _udf_stage(
         resident_per_actor=resident_per_actor,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        spill_mode="streaming",
+        is_barrier=False,
     )
 
 
-def build_query_execution_graph(
+def build_query_resource_graph(
     metadata: Mapping[str, Any],
     *,
     env: Mapping[str, str] | None = None,
-) -> QueryExecutionGraph:
+) -> QueryResourceGraph:
     environment = os.environ if env is None else env
     query_id, nodes, terminal_node_ids = _normalize_metadata(metadata)
-    fte_heap = _env_positive_int(environment, "VANE_FTE_TASK_HEAP_BYTES", _DEFAULT_FTE_TASK_HEAP_BYTES)
-    fte_target = _env_positive_int(
+    native_fragment_heap = _env_positive_int(
+        environment, "VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES", _DEFAULT_NATIVE_FRAGMENT_TASK_HEAP_BYTES
+    )
+    native_fragment_target = _env_positive_int(
         environment,
         "VANE_TARGET_OUTPUT_BLOCK_BYTES",
         _DEFAULT_TARGET_OUTPUT_BLOCK_BYTES,
     )
-    fte_udf_driver_heap = _env_positive_int(
+    native_fragment_udf_driver_heap = _env_positive_int(
         environment,
-        "VANE_FTE_UDF_DRIVER_HEAP_BYTES",
+        "VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES",
         max(
-            _DEFAULT_FTE_UDF_DRIVER_HEAP_BYTES,
-            fte_target * _GENERATOR_BUFFER_BLOCKS,
+            _DEFAULT_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES,
+            native_fragment_target * _GENERATOR_BUFFER_BLOCKS,
         ),
     )
 
-    output_stage_by_node: dict[str, str] = {}
+    output_unit_by_node: dict[str, str] = {}
     remote_udf_driver_node_ids: set[str] = set()
     downstream_node_ids: dict[str, list[str]] = {node_id: [] for node_id in nodes}
     for child_id, child in nodes.items():
@@ -338,76 +340,80 @@ def build_query_execution_graph(
             "ray_task",
             "ray_actor",
         }
-        output_stage_by_node[node_id] = (
-            udf_stage_id_for_node(query_id, node_id) if has_remote_udf else fte_stage_id_for_node(query_id, node_id)
+        output_unit_by_node[node_id] = (
+            udf_unit_id_for_node(query_id, node_id)
+            if has_remote_udf
+            else native_fragment_unit_id_for_node(query_id, node_id)
         )
         if has_remote_udf:
             # Distributed task fragments terminate at the native node feeding
-            # a remote UDF; the UDF node's own FTE stage is a logical wrapper.
-            # Both are orchestration stages, while the separately leased UDF
+            # a remote UDF; the UDF node's native fragment unit is a logical
+            # wrapper.
+            # Both are orchestration units, while the separately leased UDF
             # process owns the standalone heap commitment.
             remote_udf_driver_node_ids.add(node_id)
             remote_udf_driver_node_ids.update(node["input_node_ids"])
 
-    stages: list[StageResourceSpec] = []
+    units: list[ResourceUnitSpec] = []
     for node_id in sorted(nodes, key=_node_sort_key):
         node = nodes[node_id]
-        fte_stage_id = fte_stage_id_for_node(query_id, node_id)
-        input_stage_ids = tuple(output_stage_by_node[parent] for parent in node["input_node_ids"])
+        native_fragment_unit_id = native_fragment_unit_id_for_node(query_id, node_id)
+        input_unit_ids = tuple(output_unit_by_node[parent] for parent in node["input_node_ids"])
         is_sink = bool(node["is_sink"])
         is_blocking_materializing = bool(node["is_blocking_materializing"])
         remote_udf_driver = node_id in remote_udf_driver_node_ids
-        stages.append(
-            StageResourceSpec(
+        units.append(
+            ResourceUnitSpec(
                 query_id=query_id,
-                stage_id=fte_stage_id,
-                physical_node_id=f"node:{node_id}:fte",
-                stage_kind="sink" if is_sink else "fte",
+                resource_unit_id=native_fragment_unit_id,
+                physical_node_id=f"node:{node_id}:native-fragment",
+                unit_kind="native_fragment",
                 backend="ray_worker",
-                input_stage_ids=input_stage_ids,
+                input_unit_ids=input_unit_ids,
                 # A Ray UDF node runs its user code in a separately leased Ray
-                # process.  The parent FTE task is an in-process orchestration
-                # continuation in the shared RayWorkerActor, so charging the
-                # full standalone-process default again double-counts heap.
+                # process. The parent native fragment task is an in-process
+                # orchestration continuation in the shared RayWorkerActor, so
+                # charging the full standalone-process default again
+                # double-counts heap.
                 # Its incremental commitment is instead bounded by the paired
-                # stream window, with a conservative 512 MiB floor.  Native
-                # FTE stages retain the 2 GiB default for joins/sorts/spill.
+                # stream window, with a conservative 512 MiB floor. Native
+                # fragment units retain the 2 GiB default for joins/sorts/spill.
                 per_task=ResourceVector(
                     cpu=1,
-                    heap_bytes=fte_udf_driver_heap if remote_udf_driver else fte_heap,
+                    heap_bytes=native_fragment_udf_driver_heap if remote_udf_driver else native_fragment_heap,
                 ),
-                target_output_block_bytes=0 if is_sink else fte_target,
+                target_output_block_bytes=0 if is_sink else native_fragment_target,
                 generator_buffer_blocks=0 if is_sink else _GENERATOR_BUFFER_BLOCKS,
                 max_concurrency=int(node["num_partitions"]),
-                spill_mode="barrier" if is_blocking_materializing else "streaming",
+                is_barrier=is_blocking_materializing,
             )
         )
-        udf_stage = _udf_stage(
+        udf_unit = _udf_unit(
             query_id,
             node,
-            fte_stage_id,
+            native_fragment_unit_id,
             environment,
             downstream_input_window_bytes=downstream_input_windows[node_id],
         )
-        if udf_stage is not None:
-            stages.append(udf_stage)
+        if udf_unit is not None:
+            units.append(udf_unit)
 
-    terminals = tuple(output_stage_by_node[node_id] for node_id in terminal_node_ids)
-    preliminary = QueryExecutionGraph(
+    terminals = tuple(output_unit_by_node[node_id] for node_id in terminal_node_ids)
+    preliminary = QueryResourceGraph(
         query_id=query_id,
         plan_digest="sha256:pending",
-        stages=tuple(stages),
-        terminal_stage_ids=terminals,
+        units=tuple(units),
+        terminal_unit_ids=terminals,
     )
-    return QueryExecutionGraph(
+    return QueryResourceGraph(
         query_id=query_id,
         plan_digest=preliminary.normalized_digest(),
-        stages=preliminary.stages,
-        terminal_stage_ids=preliminary.terminal_stage_ids,
+        units=preliminary.units,
+        terminal_unit_ids=preliminary.terminal_unit_ids,
     )
 
 
-def _hard_task_commitment(stage: StageResourceSpec) -> ResourceVector:
+def _hard_task_commitment(unit: ResourceUnitSpec) -> ResourceVector:
     """Return resources that must be placed before a task can run.
 
     Retained inputs and generator output windows are spillable pipeline data.
@@ -415,9 +421,9 @@ def _hard_task_commitment(stage: StageResourceSpec) -> ResourceVector:
     budget instead of being reserved for every possible task at registration.
     """
     return ResourceVector(
-        cpu=stage.per_task.cpu,
-        gpu=stage.per_task.gpu,
-        heap_bytes=stage.per_task.heap_bytes,
+        cpu=unit.per_task.cpu,
+        gpu=unit.per_task.gpu,
+        heap_bytes=unit.per_task.heap_bytes,
     )
 
 
@@ -433,60 +439,63 @@ def _component_max(resources: list[ResourceVector]) -> ResourceVector:
 
 
 def build_query_demand(
-    graph: QueryExecutionGraph,
+    graph: QueryResourceGraph,
     cluster_capacity: ResourceVector,
     *,
     weight: float = 1.0,
     priority: int = 0,
 ) -> QueryDemand:
     actor_bundles: list[ActorResourceBundle] = []
-    fte_tasks: list[ResourceVector] = []
+    native_fragment_tasks: list[ResourceVector] = []
     ray_tasks: list[ResourceVector] = []
-    downstream_fte_tasks: list[ResourceVector] = []
-    stage_by_id = {stage.stage_id: stage for stage in graph.stages}
-    for stage in graph.stages:
-        commitment = _hard_task_commitment(stage)
-        if stage.backend == "ray_actor":
+    downstream_native_fragment_tasks: list[ResourceVector] = []
+    unit_by_id = {unit.resource_unit_id: unit for unit in graph.units}
+    for unit in graph.units:
+        commitment = _hard_task_commitment(unit)
+        if unit.backend == "ray_actor":
             actor_bundles.extend(
                 ActorResourceBundle(
-                    stage_id=stage.stage_id,
+                    resource_unit_id=unit.resource_unit_id,
                     actor_index=actor_index,
-                    resources=stage.resident_per_actor,
+                    resources=unit.resident_per_actor,
                 )
-                for actor_index in range(stage.actor_pool_size)
+                for actor_index in range(unit.actor_pool_size)
             )
-        elif stage.backend == "ray_task":
+        elif unit.backend == "ray_task":
             ray_tasks.append(commitment)
-        elif stage.backend == "ray_worker":
-            fte_tasks.append(commitment)
-    downstream_fte_stage_ids = {
-        downstream_stage_id
-        for stage in graph.stages
-        if stage.backend != "ray_worker"
-        for downstream_stage_id in (graph.downstream_fte_stage_ids_requiring_separate_slot(stage.stage_id))
+        elif unit.backend == "ray_worker":
+            native_fragment_tasks.append(commitment)
+    downstream_native_fragment_unit_ids = {
+        downstream_unit_id
+        for unit in graph.units
+        if unit.backend != "ray_worker"
+        for downstream_unit_id in (
+            graph.downstream_native_fragment_unit_ids_requiring_separate_slot(unit.resource_unit_id)
+        )
     }
-    downstream_fte_tasks.extend(
-        _hard_task_commitment(stage_by_id[stage_id])
-        for stage_id in graph.topological_stage_ids()
-        if stage_id in downstream_fte_stage_ids
+    downstream_native_fragment_tasks.extend(
+        _hard_task_commitment(unit_by_id[resource_unit_id])
+        for resource_unit_id in graph.topological_unit_ids()
+        if resource_unit_id in downstream_native_fragment_unit_ids
     )
     minimum = ResourceVector()
     for required_actor in actor_bundles:
         minimum = minimum + required_actor.resources
     task_bundles = tuple(
         bundle
-        # Reserve the nested Ray process before its parent FTE bundle.  The
-        # minimum is component-wise identical either way on one node, but the
+        # Reserve the nested Ray process before its parent native fragment
+        # bundle. The minimum is component-wise identical either way on one node, but the
         # order is placement-significant on heterogeneous/multi-node clusters
         # and must preserve continuation capacity.
-        # A non-FTE streaming producer can remain alive while a downstream FTE
-        # task drains it. Keep that progress slot separate from the FTE task
-        # that invoked the producer; QRM enforces the same shared reservation
-        # dynamically before admitting additional producers.
+        # A remote-process streaming producer can remain alive while a
+        # downstream native fragment task drains it. Keep that progress slot
+        # separate from the native fragment task that invoked the producer;
+        # QRM enforces the same shared reservation dynamically before
+        # admitting additional producers.
         for bundle in (
             _component_max(ray_tasks),
-            _component_max(fte_tasks),
-            _component_max(downstream_fte_tasks),
+            _component_max(native_fragment_tasks),
+            _component_max(downstream_native_fragment_tasks),
         )
         if not bundle.is_zero()
     )
@@ -513,8 +522,8 @@ def build_query_demand(
 
 __all__ = [
     "build_query_demand",
-    "build_query_execution_graph",
-    "fte_stage_id_for_fragment",
-    "fte_stage_id_for_node",
-    "udf_stage_id_for_node",
+    "build_query_resource_graph",
+    "native_fragment_unit_id_for_fragment",
+    "native_fragment_unit_id_for_node",
+    "udf_unit_id_for_node",
 ]

--- a/duckdb/runners/ray/query_resource_graph_builder.py
+++ b/duckdb/runners/ray/query_resource_graph_builder.py
@@ -347,12 +347,12 @@ def build_query_resource_graph(
     )
 
 
-def _hard_task_commitment(unit: ResourceUnitSpec) -> ResourceVector:
-    """Return resources that must be placed before a task can run.
+def _task_scheduling_request(unit: ResourceUnitSpec) -> ResourceVector:
+    """Return the concrete Ray Core request for one task invocation.
 
     Retained inputs and generator output windows are spillable pipeline data.
-    They are controlled dynamically by QRM against the query's object-store
-    budget instead of being reserved for every possible task at registration.
+    QRM accounts them dynamically instead of copying them into the process
+    request or a query-level placement model.
     """
     return ResourceVector(
         cpu=unit.per_task.cpu,
@@ -361,98 +361,11 @@ def _hard_task_commitment(unit: ResourceUnitSpec) -> ResourceVector:
     )
 
 
-def _component_max(resources: list[ResourceVector]) -> ResourceVector:
-    if not resources:
-        return ResourceVector()
-    return ResourceVector(
-        cpu=max(item.cpu for item in resources),
-        gpu=max(item.gpu for item in resources),
-        heap_bytes=max(item.heap_bytes for item in resources),
-        object_store_bytes=max(item.object_store_bytes for item in resources),
-    )
-
-
 def _sum_node_capacities(node_capacities: Sequence[NodeCapacity]) -> ResourceVector:
     total = ResourceVector()
     for node in node_capacities:
         total = total + node.resources
     return total
-
-
-def _resource_sort_key(resources: ResourceVector) -> tuple[float, float, int, int]:
-    return (
-        resources.gpu,
-        resources.cpu,
-        resources.heap_bytes,
-        resources.object_store_bytes,
-    )
-
-
-def _placement_bundles(
-    resource_shapes: list[ResourceVector],
-    node_capacities: Sequence[NodeCapacity],
-) -> tuple[ResourceVector, ...]:
-    """Return real-node envelopes covering every eligible task/actor shape.
-
-    A component-wise maximum across the whole phase can invent a task that no
-    node can run (for example, 4 CPU from one UDF plus 1 GPU from another UDF
-    on a split CPU/GPU cluster).  Instead, each candidate envelope contains
-    only execution shapes that fit one concrete node. Multiple shapes that
-    share a node still collapse to one reusable liveness bundle; heterogeneous
-    shapes that require different nodes remain separate bundles. Actor pool
-    multiplicity is deliberately excluded: one envelope proves that the first
-    actor can start, while the remaining fixed pool stays elastic in Ray Core.
-    """
-
-    execution_shapes = tuple(sorted(set(resource_shapes), key=_resource_sort_key, reverse=True))
-    if not execution_shapes:
-        return ()
-
-    candidates: list[tuple[str, ResourceVector, frozenset[int]]] = []
-    for node in sorted(node_capacities, key=lambda item: item.node_id):
-        covered = frozenset(
-            index for index, execution in enumerate(execution_shapes) if execution.fits_within(node.resources)
-        )
-        if not covered:
-            continue
-        envelope = _component_max([execution_shapes[index] for index in covered])
-        candidates.append((node.node_id, envelope, covered))
-
-    uncovered = set(range(len(execution_shapes)))
-    selected: list[tuple[str, ResourceVector, frozenset[int]]] = []
-    while uncovered:
-        usable = [candidate for candidate in candidates if candidate[2] & uncovered]
-        if not usable:
-            # Preserve the real unschedulable execution shapes. The coordinator
-            # will keep the query pending until a node capable of running them
-            # appears; never replace them with another fictional envelope.
-            selected.extend(("", execution_shapes[index], frozenset((index,))) for index in sorted(uncovered))
-            break
-        candidate = min(
-            usable,
-            key=lambda item: (
-                -len(item[2] & uncovered),
-                -item[1].gpu,
-                -item[1].cpu,
-                -item[1].heap_bytes,
-                item[0],
-            ),
-        )
-        selected.append(candidate)
-        uncovered.difference_update(candidate[2])
-
-    def placement_order(item: tuple[str, ResourceVector, frozenset[int]]) -> tuple[int, float, float, int, str]:
-        node_id, envelope, _covered = item
-        fit_count = sum(envelope.fits_within(node.resources) for node in node_capacities)
-        return (
-            fit_count,
-            -envelope.gpu,
-            -envelope.cpu,
-            -envelope.heap_bytes,
-            node_id,
-        )
-
-    return tuple(item[1] for item in sorted(selected, key=placement_order))
 
 
 def build_query_demand(
@@ -464,8 +377,6 @@ def build_query_demand(
     priority: int = 0,
 ) -> QueryDemand:
     nodes = tuple(node_capacities)
-    if not nodes:
-        raise ValueError("node_capacities must contain at least one Ray node")
     node_ids = [node.node_id for node in nodes]
     if len(set(node_ids)) != len(node_ids):
         raise ValueError("node_capacities contains duplicate Ray node IDs")
@@ -475,21 +386,15 @@ def build_query_demand(
     if unknown_eligible:
         raise ValueError(f"query demand references unknown eligible unit: {unknown_eligible[0]}")
     ray_tasks: list[ResourceVector] = []
-    actor_shapes: list[ResourceVector] = []
     actor_processes: list[ResourceVector] = []
     for unit in graph.units:
         if unit.resource_unit_id not in eligible:
             continue
-        commitment = _hard_task_commitment(unit)
+        commitment = _task_scheduling_request(unit)
         if unit.backend == "ray_task":
             ray_tasks.append(commitment)
         elif unit.backend == "ray_actor":
-            actor_shapes.append(unit.resident_per_actor)
             actor_processes.extend(unit.resident_per_actor for _actor_index in range(unit.actor_pool_size))
-    minimum = ResourceVector()
-    placement_bundles = _placement_bundles([*ray_tasks, *actor_shapes], nodes)
-    for placement_bundle in placement_bundles:
-        minimum = minimum + placement_bundle
     actor_maximum = ResourceVector()
     for actor_process in actor_processes:
         actor_maximum = actor_maximum + actor_process
@@ -503,17 +408,12 @@ def build_query_demand(
                 getattr(actor_maximum, field_name),
                 getattr(cluster_capacity, field_name),
             )
-        return max(
-            getattr(minimum, field_name),
-            elastic,
-        )
+        return elastic
 
     desired = ResourceVector(
-        # The smallest practical set of real-node task/actor envelopes is the
-        # only hard query-level placement minimum.
-        # Fixed actor pools are elastic allocation demand: all handles may be
-        # submitted to Ray Core, while pending/running process resources are
-        # charged to the phase's soft reservation at runtime.
+        # CPU/GPU/declared heap are aggregate soft targets only. Concrete UDF
+        # calls carry their real resource shape to Ray Core, including when a
+        # current cluster snapshot cannot fit that shape yet.
         cpu=elastic_target("cpu"),
         gpu=elastic_target("gpu"),
         heap_bytes=int(elastic_target("heap_bytes")),
@@ -521,11 +421,9 @@ def build_query_demand(
     )
     return QueryDemand(
         query_id=graph.query_id,
-        minimum=minimum,
         desired=desired,
         weight=weight,
         priority=priority,
-        placement_bundles=placement_bundles,
     )
 
 

--- a/duckdb/runners/ray/query_resource_graph_builder.py
+++ b/duckdb/runners/ray/query_resource_graph_builder.py
@@ -388,41 +388,45 @@ def _resource_sort_key(resources: ResourceVector) -> tuple[float, float, int, in
     )
 
 
-def _task_placement_bundles(
-    ray_tasks: list[ResourceVector],
+def _placement_bundles(
+    resource_shapes: list[ResourceVector],
     node_capacities: Sequence[NodeCapacity],
 ) -> tuple[ResourceVector, ...]:
-    """Return real node envelopes covering every eligible Ray task shape.
+    """Return real-node envelopes covering every eligible task/actor shape.
 
     A component-wise maximum across the whole phase can invent a task that no
     node can run (for example, 4 CPU from one UDF plus 1 GPU from another UDF
     on a split CPU/GPU cluster).  Instead, each candidate envelope contains
-    only task shapes that fit one concrete node.  Multiple shapes that share a
-    node still collapse to one reusable liveness bundle; heterogeneous shapes
-    that require different nodes remain separate bundles.
+    only execution shapes that fit one concrete node. Multiple shapes that
+    share a node still collapse to one reusable liveness bundle; heterogeneous
+    shapes that require different nodes remain separate bundles. Actor pool
+    multiplicity is deliberately excluded: one envelope proves that the first
+    actor can start, while the remaining fixed pool stays elastic in Ray Core.
     """
 
-    task_shapes = tuple(sorted(set(ray_tasks), key=_resource_sort_key, reverse=True))
-    if not task_shapes:
+    execution_shapes = tuple(sorted(set(resource_shapes), key=_resource_sort_key, reverse=True))
+    if not execution_shapes:
         return ()
 
     candidates: list[tuple[str, ResourceVector, frozenset[int]]] = []
     for node in sorted(node_capacities, key=lambda item: item.node_id):
-        covered = frozenset(index for index, task in enumerate(task_shapes) if task.fits_within(node.resources))
+        covered = frozenset(
+            index for index, execution in enumerate(execution_shapes) if execution.fits_within(node.resources)
+        )
         if not covered:
             continue
-        envelope = _component_max([task_shapes[index] for index in covered])
+        envelope = _component_max([execution_shapes[index] for index in covered])
         candidates.append((node.node_id, envelope, covered))
 
-    uncovered = set(range(len(task_shapes)))
+    uncovered = set(range(len(execution_shapes)))
     selected: list[tuple[str, ResourceVector, frozenset[int]]] = []
     while uncovered:
         usable = [candidate for candidate in candidates if candidate[2] & uncovered]
         if not usable:
-            # Preserve the real unschedulable task shapes.  The coordinator
+            # Preserve the real unschedulable execution shapes. The coordinator
             # will keep the query pending until a node capable of running them
             # appears; never replace them with another fictional envelope.
-            selected.extend(("", task_shapes[index], frozenset((index,))) for index in sorted(uncovered))
+            selected.extend(("", execution_shapes[index], frozenset((index,))) for index in sorted(uncovered))
             break
         candidate = min(
             usable,
@@ -471,6 +475,7 @@ def build_query_demand(
     if unknown_eligible:
         raise ValueError(f"query demand references unknown eligible unit: {unknown_eligible[0]}")
     ray_tasks: list[ResourceVector] = []
+    actor_shapes: list[ResourceVector] = []
     actor_processes: list[ResourceVector] = []
     for unit in graph.units:
         if unit.resource_unit_id not in eligible:
@@ -479,11 +484,12 @@ def build_query_demand(
         if unit.backend == "ray_task":
             ray_tasks.append(commitment)
         elif unit.backend == "ray_actor":
+            actor_shapes.append(unit.resident_per_actor)
             actor_processes.extend(unit.resident_per_actor for _actor_index in range(unit.actor_pool_size))
     minimum = ResourceVector()
-    task_bundles = _task_placement_bundles(ray_tasks, nodes)
-    for task_bundle in task_bundles:
-        minimum = minimum + task_bundle
+    placement_bundles = _placement_bundles([*ray_tasks, *actor_shapes], nodes)
+    for placement_bundle in placement_bundles:
+        minimum = minimum + placement_bundle
     actor_maximum = ResourceVector()
     for actor_process in actor_processes:
         actor_maximum = actor_maximum + actor_process
@@ -491,18 +497,20 @@ def build_query_demand(
     def elastic_target(field_name: str) -> int | float:
         task_uses_dimension = any(getattr(task, field_name) > 0 for task in ray_tasks)
         if task_uses_dimension:
-            return max(
-                getattr(minimum, field_name),
+            elastic = getattr(cluster_capacity, field_name)
+        else:
+            elastic = min(
+                getattr(actor_maximum, field_name),
                 getattr(cluster_capacity, field_name),
             )
-        return min(
-            getattr(actor_maximum, field_name),
-            getattr(cluster_capacity, field_name),
+        return max(
+            getattr(minimum, field_name),
+            elastic,
         )
 
     desired = ResourceVector(
-        # The smallest practical set of real-node task envelopes is the only
-        # hard query-level placement minimum.
+        # The smallest practical set of real-node task/actor envelopes is the
+        # only hard query-level placement minimum.
         # Fixed actor pools are elastic allocation demand: all handles may be
         # submitted to Ray Core, while pending/running process resources are
         # charged to the phase's soft reservation at runtime.
@@ -517,7 +525,7 @@ def build_query_demand(
         desired=desired,
         weight=weight,
         priority=priority,
-        task_bundles=task_bundles,
+        placement_bundles=placement_bundles,
     )
 
 

--- a/duckdb/runners/ray/query_resource_graph_builder.py
+++ b/duckdb/runners/ray/query_resource_graph_builder.py
@@ -3,16 +3,13 @@
 
 from __future__ import annotations
 
-import math
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
-from duckdb.runners.ray.cluster_resource_coordinator import (
-    ActorResourceBundle,
-    QueryDemand,
-)
+from duckdb.runners.ray.cluster_resource_coordinator import NodeCapacity, QueryDemand
 from duckdb.runners.ray.query_resource_graph import (
+    MaterializationBarrierSpec,
     QueryResourceGraph,
     ResourceUnitSpec,
     ResourceVector,
@@ -27,6 +24,8 @@ _NODE_FIELDS = (
     "node_name",
     "input_node_ids",
     "is_sink",
+    "is_materialization_barrier",
+    "materialized_input_node_ids",
     "num_partitions",
     "udf_payload",
 )
@@ -92,6 +91,14 @@ def udf_unit_id_for_node(query_id: str, node_id: str | int) -> str:
     return f"resource:{query}:udf:node:{node}"
 
 
+def materialization_barrier_id_for_node(query_id: str, node_id: str | int) -> str:
+    query = str(query_id).strip()
+    node = str(node_id).strip()
+    if not query or not node:
+        raise ValueError("query_id and node_id must be non-empty")
+    return f"barrier:{query}:node:{node}"
+
+
 def native_fragment_unit_id_for_fragment(query_id: str, fragment_id: str) -> str:
     query = str(query_id).strip()
     fragment = str(fragment_id).strip()
@@ -128,6 +135,15 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> tuple[str, dict[str, dic
         node["input_node_ids"] = tuple(str(item).strip() for item in node["input_node_ids"])
         node["num_partitions"] = _positive_int(node["num_partitions"], "num_partitions")
         node["is_sink"] = bool(node["is_sink"])
+        node["is_materialization_barrier"] = bool(node["is_materialization_barrier"])
+        node["materialized_input_node_ids"] = tuple(str(item).strip() for item in node["materialized_input_node_ids"])
+        if len(set(node["materialized_input_node_ids"])) != len(node["materialized_input_node_ids"]):
+            raise ValueError(f"resource unit node {node_id} has duplicate materialized input node ids")
+        if node["is_materialization_barrier"] != bool(node["materialized_input_node_ids"]):
+            raise ValueError(
+                f"resource unit node {node_id} must declare materialized inputs "
+                "if and only if it is a materialization barrier"
+            )
         if node["udf_payload"] is not None and not isinstance(node["udf_payload"], Mapping):
             raise TypeError(f"resource unit node {node_id} udf_payload must be a mapping or None")
         node["udf_payload"] = None if node["udf_payload"] is None else dict(node["udf_payload"])
@@ -137,6 +153,11 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> tuple[str, dict[str, dic
         for input_node_id in node["input_node_ids"]:
             if input_node_id not in nodes:
                 raise ValueError(f"resource unit node {node_id} references missing input node {input_node_id}")
+        for input_node_id in node["materialized_input_node_ids"]:
+            if input_node_id not in node["input_node_ids"]:
+                raise ValueError(
+                    f"resource unit node {node_id} materialized input {input_node_id} is not a direct input"
+                )
     terminal_node_ids = tuple(str(item).strip() for item in payload["terminal_node_ids"])
     if not terminal_node_ids:
         raise ValueError("resource unit metadata must contain terminal_node_ids")
@@ -151,8 +172,6 @@ def _udf_unit(
     node: Mapping[str, Any],
     input_unit_id: str,
     env: Mapping[str, str],
-    *,
-    downstream_input_window_bytes: int = 0,
 ) -> ResourceUnitSpec | None:
     payload = node["udf_payload"]
     if payload is None:
@@ -191,14 +210,6 @@ def _udf_unit(
             _env_positive_int(env, "VANE_TARGET_OUTPUT_BLOCK_BYTES", _DEFAULT_TARGET_OUTPUT_BLOCK_BYTES),
         ),
         "udf_task_input_max_bytes",
-    )
-    retention_window = max(
-        target * _GENERATOR_BUFFER_BLOCKS,
-        int(downstream_input_window_bytes),
-    )
-    retention_blocks = max(
-        _GENERATOR_BUFFER_BLOCKS,
-        math.ceil(retention_window / target),
     )
     if backend == "ray_actor":
         actor_size = _positive_int(payload.get("actor_pool_size"), "actor_pool_size")
@@ -239,7 +250,7 @@ def _udf_unit(
         input_unit_ids=(input_unit_id,),
         per_task=invocation_resources,
         target_output_block_bytes=target,
-        generator_buffer_blocks=retention_blocks,
+        generator_buffer_blocks=_GENERATOR_BUFFER_BLOCKS,
         max_concurrency=max_concurrency,
         resident_per_actor=resident_per_actor,
         actor_pool_size=actor_pool_size,
@@ -261,44 +272,6 @@ def build_query_resource_graph(
     )
 
     output_unit_by_node: dict[str, str] = {}
-    downstream_node_ids: dict[str, list[str]] = {node_id: [] for node_id in nodes}
-    for child_id, child in nodes.items():
-        for parent_id in child["input_node_ids"]:
-            downstream_node_ids[parent_id].append(child_id)
-
-    def remote_udf_submit_window(node_id: str) -> int | None:
-        payload = nodes[node_id]["udf_payload"]
-        if payload is None or str(payload.get("execution_backend") or "").strip() not in {
-            "ray_task",
-            "ray_actor",
-        }:
-            return None
-        default_window = payload.get(
-            "udf_output_target_max_bytes",
-            _env_positive_int(environment, "VANE_TARGET_OUTPUT_BLOCK_BYTES", _DEFAULT_TARGET_OUTPUT_BLOCK_BYTES),
-        )
-        return _positive_int(
-            payload.get("udf_task_input_max_bytes", default_window),
-            "udf_task_input_max_bytes",
-        )
-
-    downstream_input_windows: dict[str, int] = {}
-    for source_id in nodes:
-        pending = list(downstream_node_ids[source_id])
-        visited: set[str] = set()
-        windows: list[int] = []
-        while pending:
-            downstream_id = pending.pop()
-            if downstream_id in visited:
-                continue
-            visited.add(downstream_id)
-            window = remote_udf_submit_window(downstream_id)
-            if window is not None:
-                windows.append(window)
-                continue
-            pending.extend(downstream_node_ids[downstream_id])
-        downstream_input_windows[source_id] = max(windows, default=0)
-
     for node_id, node in nodes.items():
         udf_payload = node["udf_payload"]
         has_remote_udf = udf_payload is not None and str(udf_payload.get("execution_backend") or "").strip() in {
@@ -312,6 +285,7 @@ def build_query_resource_graph(
         )
 
     units: list[ResourceUnitSpec] = []
+    barriers: list[MaterializationBarrierSpec] = []
     for node_id in sorted(nodes, key=_node_sort_key):
         node = nodes[node_id]
         native_fragment_unit_id = native_fragment_unit_id_for_node(query_id, node_id)
@@ -335,12 +309,23 @@ def build_query_resource_graph(
                 max_concurrency=int(node["num_partitions"]),
             )
         )
+        if bool(node["is_materialization_barrier"]):
+            barriers.append(
+                MaterializationBarrierSpec(
+                    query_id=query_id,
+                    barrier_id=materialization_barrier_id_for_node(query_id, node_id),
+                    physical_node_id=node_id,
+                    materializer_unit_id=native_fragment_unit_id,
+                    materialized_input_unit_ids=tuple(
+                        output_unit_by_node[parent] for parent in node["materialized_input_node_ids"]
+                    ),
+                )
+            )
         udf_unit = _udf_unit(
             query_id,
             node,
             native_fragment_unit_id,
             environment,
-            downstream_input_window_bytes=downstream_input_windows[node_id],
         )
         if udf_unit is not None:
             units.append(udf_unit)
@@ -351,12 +336,14 @@ def build_query_resource_graph(
         plan_digest="sha256:pending",
         units=tuple(units),
         terminal_unit_ids=terminals,
+        materialization_barriers=tuple(barriers),
     )
     return QueryResourceGraph(
         query_id=query_id,
         plan_digest=preliminary.normalized_digest(),
         units=preliminary.units,
         terminal_unit_ids=preliminary.terminal_unit_ids,
+        materialization_barriers=preliminary.materialization_barriers,
     )
 
 
@@ -385,45 +372,143 @@ def _component_max(resources: list[ResourceVector]) -> ResourceVector:
     )
 
 
+def _sum_node_capacities(node_capacities: Sequence[NodeCapacity]) -> ResourceVector:
+    total = ResourceVector()
+    for node in node_capacities:
+        total = total + node.resources
+    return total
+
+
+def _resource_sort_key(resources: ResourceVector) -> tuple[float, float, int, int]:
+    return (
+        resources.gpu,
+        resources.cpu,
+        resources.heap_bytes,
+        resources.object_store_bytes,
+    )
+
+
+def _task_placement_bundles(
+    ray_tasks: list[ResourceVector],
+    node_capacities: Sequence[NodeCapacity],
+) -> tuple[ResourceVector, ...]:
+    """Return real node envelopes covering every eligible Ray task shape.
+
+    A component-wise maximum across the whole phase can invent a task that no
+    node can run (for example, 4 CPU from one UDF plus 1 GPU from another UDF
+    on a split CPU/GPU cluster).  Instead, each candidate envelope contains
+    only task shapes that fit one concrete node.  Multiple shapes that share a
+    node still collapse to one reusable liveness bundle; heterogeneous shapes
+    that require different nodes remain separate bundles.
+    """
+
+    task_shapes = tuple(sorted(set(ray_tasks), key=_resource_sort_key, reverse=True))
+    if not task_shapes:
+        return ()
+
+    candidates: list[tuple[str, ResourceVector, frozenset[int]]] = []
+    for node in sorted(node_capacities, key=lambda item: item.node_id):
+        covered = frozenset(index for index, task in enumerate(task_shapes) if task.fits_within(node.resources))
+        if not covered:
+            continue
+        envelope = _component_max([task_shapes[index] for index in covered])
+        candidates.append((node.node_id, envelope, covered))
+
+    uncovered = set(range(len(task_shapes)))
+    selected: list[tuple[str, ResourceVector, frozenset[int]]] = []
+    while uncovered:
+        usable = [candidate for candidate in candidates if candidate[2] & uncovered]
+        if not usable:
+            # Preserve the real unschedulable task shapes.  The coordinator
+            # will keep the query pending until a node capable of running them
+            # appears; never replace them with another fictional envelope.
+            selected.extend(("", task_shapes[index], frozenset((index,))) for index in sorted(uncovered))
+            break
+        candidate = min(
+            usable,
+            key=lambda item: (
+                -len(item[2] & uncovered),
+                -item[1].gpu,
+                -item[1].cpu,
+                -item[1].heap_bytes,
+                item[0],
+            ),
+        )
+        selected.append(candidate)
+        uncovered.difference_update(candidate[2])
+
+    def placement_order(item: tuple[str, ResourceVector, frozenset[int]]) -> tuple[int, float, float, int, str]:
+        node_id, envelope, _covered = item
+        fit_count = sum(envelope.fits_within(node.resources) for node in node_capacities)
+        return (
+            fit_count,
+            -envelope.gpu,
+            -envelope.cpu,
+            -envelope.heap_bytes,
+            node_id,
+        )
+
+    return tuple(item[1] for item in sorted(selected, key=placement_order))
+
+
 def build_query_demand(
     graph: QueryResourceGraph,
-    cluster_capacity: ResourceVector,
+    node_capacities: Sequence[NodeCapacity],
     *,
+    eligible_unit_ids: tuple[str, ...] | None = None,
     weight: float = 1.0,
     priority: int = 0,
 ) -> QueryDemand:
-    actor_bundles: list[ActorResourceBundle] = []
+    nodes = tuple(node_capacities)
+    if not nodes:
+        raise ValueError("node_capacities must contain at least one Ray node")
+    node_ids = [node.node_id for node in nodes]
+    if len(set(node_ids)) != len(node_ids):
+        raise ValueError("node_capacities contains duplicate Ray node IDs")
+    cluster_capacity = _sum_node_capacities(nodes)
+    eligible = set(graph.eligible_resource_unit_ids(set()) if eligible_unit_ids is None else eligible_unit_ids)
+    unknown_eligible = sorted(eligible - {unit.resource_unit_id for unit in graph.units})
+    if unknown_eligible:
+        raise ValueError(f"query demand references unknown eligible unit: {unknown_eligible[0]}")
     ray_tasks: list[ResourceVector] = []
+    actor_processes: list[ResourceVector] = []
     for unit in graph.units:
+        if unit.resource_unit_id not in eligible:
+            continue
         commitment = _hard_task_commitment(unit)
-        if unit.backend == "ray_actor":
-            actor_bundles.extend(
-                ActorResourceBundle(
-                    resource_unit_id=unit.resource_unit_id,
-                    actor_index=actor_index,
-                    resources=unit.resident_per_actor,
-                )
-                for actor_index in range(unit.actor_pool_size)
-            )
-        elif unit.backend == "ray_task":
+        if unit.backend == "ray_task":
             ray_tasks.append(commitment)
+        elif unit.backend == "ray_actor":
+            actor_processes.extend(unit.resident_per_actor for _actor_index in range(unit.actor_pool_size))
     minimum = ResourceVector()
-    for required_actor in actor_bundles:
-        minimum = minimum + required_actor.resources
-    task_bundles = tuple(bundle for bundle in (_component_max(ray_tasks),) if not bundle.is_zero())
+    task_bundles = _task_placement_bundles(ray_tasks, nodes)
     for task_bundle in task_bundles:
         minimum = minimum + task_bundle
+    actor_maximum = ResourceVector()
+    for actor_process in actor_processes:
+        actor_maximum = actor_maximum + actor_process
+
+    def elastic_target(field_name: str) -> int | float:
+        task_uses_dimension = any(getattr(task, field_name) > 0 for task in ray_tasks)
+        if task_uses_dimension:
+            return max(
+                getattr(minimum, field_name),
+                getattr(cluster_capacity, field_name),
+            )
+        return min(
+            getattr(actor_maximum, field_name),
+            getattr(cluster_capacity, field_name),
+        )
+
     desired = ResourceVector(
-        # Ray tasks can use elastic process headroom. Actor-only and pure
-        # native queries have no additional hard-process demand beyond their
-        # resident actor pool; native capacity is node-owned by DuckDB.
-        cpu=cluster_capacity.cpu if ray_tasks else minimum.cpu,
-        # GPU commitments remain fixed indivisible bundles. Only CPU and
-        # memory headroom participate in elastic DRF allocation.
-        gpu=minimum.gpu,
-        heap_bytes=(
-            cluster_capacity.heap_bytes if any(task.heap_bytes > 0 for task in ray_tasks) else minimum.heap_bytes
-        ),
+        # The smallest practical set of real-node task envelopes is the only
+        # hard query-level placement minimum.
+        # Fixed actor pools are elastic allocation demand: all handles may be
+        # submitted to Ray Core, while pending/running process resources are
+        # charged to the phase's soft reservation at runtime.
+        cpu=elastic_target("cpu"),
+        gpu=elastic_target("gpu"),
+        heap_bytes=int(elastic_target("heap_bytes")),
         object_store_bytes=cluster_capacity.object_store_bytes,
     )
     return QueryDemand(
@@ -432,7 +517,6 @@ def build_query_demand(
         desired=desired,
         weight=weight,
         priority=priority,
-        actor_bundles=tuple(actor_bundles),
         task_bundles=task_bundles,
     )
 
@@ -440,6 +524,7 @@ def build_query_demand(
 __all__ = [
     "build_query_demand",
     "build_query_resource_graph",
+    "materialization_barrier_id_for_node",
     "native_fragment_unit_id_for_fragment",
     "native_fragment_unit_id_for_node",
     "udf_unit_id_for_node",

--- a/duckdb/runners/ray/query_resource_graph_builder.py
+++ b/duckdb/runners/ray/query_resource_graph_builder.py
@@ -18,13 +18,7 @@ from duckdb.runners.ray.query_resource_graph import (
     ResourceVector,
 )
 
-_GIB = 1024**3
-_MIB = 1024**2
-_DEFAULT_NATIVE_FRAGMENT_TASK_HEAP_BYTES = 2 * _GIB
-_DEFAULT_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES = 512 * _MIB
-_DEFAULT_UDF_TASK_HEAP_BYTES = 2 * _GIB
-_DEFAULT_UDF_ACTOR_HEAP_BYTES = 4 * _GIB
-_DEFAULT_TARGET_OUTPUT_BLOCK_BYTES = 128 * _MIB
+_DEFAULT_TARGET_OUTPUT_BLOCK_BYTES = 128 * 1024**2
 _DEFAULT_RAY_ACTOR_PREFETCH_DEPTH = 2
 _GENERATOR_BUFFER_BLOCKS = 2
 _TOP_LEVEL_FIELDS = ("query_id", "nodes", "terminal_node_ids")
@@ -33,7 +27,6 @@ _NODE_FIELDS = (
     "node_name",
     "input_node_ids",
     "is_sink",
-    "is_blocking_materializing",
     "num_partitions",
     "udf_payload",
 )
@@ -65,16 +58,6 @@ def _positive_int(value: Any, name: str) -> int:
         raise ValueError(f"{name} must be a positive integer") from exc
     if parsed <= 0:
         raise ValueError(f"{name} must be a positive integer")
-    return parsed
-
-
-def _positive_float(value: Any, name: str) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a positive number") from exc
-    if parsed <= 0:
-        raise ValueError(f"{name} must be a positive number")
     return parsed
 
 
@@ -145,7 +128,6 @@ def _normalize_metadata(metadata: Mapping[str, Any]) -> tuple[str, dict[str, dic
         node["input_node_ids"] = tuple(str(item).strip() for item in node["input_node_ids"])
         node["num_partitions"] = _positive_int(node["num_partitions"], "num_partitions")
         node["is_sink"] = bool(node["is_sink"])
-        node["is_blocking_materializing"] = bool(node["is_blocking_materializing"])
         if node["udf_payload"] is not None and not isinstance(node["udf_payload"], Mapping):
             raise TypeError(f"resource unit node {node_id} udf_payload must be a mapping or None")
         node["udf_payload"] = None if node["udf_payload"] is None else dict(node["udf_payload"])
@@ -194,12 +176,8 @@ def _udf_unit(
     gpu = _nonnegative_float(payload.get("gpus", 0.0), "gpus")
     if cpu <= 0 and gpu <= 0:
         raise ValueError(f"Ray UDF node {node_id} must request CPU or GPU resources")
-    default_heap = (
-        _env_positive_int(env, "VANE_UDF_ACTOR_HEAP_BYTES", _DEFAULT_UDF_ACTOR_HEAP_BYTES)
-        if backend == "ray_actor"
-        else _env_positive_int(env, "VANE_UDF_TASK_HEAP_BYTES", _DEFAULT_UDF_TASK_HEAP_BYTES)
-    )
-    heap_bytes = _positive_int(payload.get("memory_bytes", default_heap), "memory_bytes")
+    declared_heap = payload.get("memory_bytes")
+    heap_bytes = 0 if declared_heap is None else _positive_int(declared_heap, "memory_bytes")
     target = _positive_int(
         payload.get(
             "udf_output_target_max_bytes",
@@ -266,7 +244,6 @@ def _udf_unit(
         resident_per_actor=resident_per_actor,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        is_barrier=False,
     )
 
 
@@ -277,25 +254,13 @@ def build_query_resource_graph(
 ) -> QueryResourceGraph:
     environment = os.environ if env is None else env
     query_id, nodes, terminal_node_ids = _normalize_metadata(metadata)
-    native_fragment_heap = _env_positive_int(
-        environment, "VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES", _DEFAULT_NATIVE_FRAGMENT_TASK_HEAP_BYTES
-    )
     native_fragment_target = _env_positive_int(
         environment,
         "VANE_TARGET_OUTPUT_BLOCK_BYTES",
         _DEFAULT_TARGET_OUTPUT_BLOCK_BYTES,
     )
-    native_fragment_udf_driver_heap = _env_positive_int(
-        environment,
-        "VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES",
-        max(
-            _DEFAULT_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES,
-            native_fragment_target * _GENERATOR_BUFFER_BLOCKS,
-        ),
-    )
 
     output_unit_by_node: dict[str, str] = {}
-    remote_udf_driver_node_ids: set[str] = set()
     downstream_node_ids: dict[str, list[str]] = {node_id: [] for node_id in nodes}
     for child_id, child in nodes.items():
         for parent_id in child["input_node_ids"]:
@@ -336,7 +301,7 @@ def build_query_resource_graph(
 
     for node_id, node in nodes.items():
         udf_payload = node["udf_payload"]
-        has_remote_udf = udf_payload is not None and str(udf_payload.get("execution_backend") or "") in {
+        has_remote_udf = udf_payload is not None and str(udf_payload.get("execution_backend") or "").strip() in {
             "ray_task",
             "ray_actor",
         }
@@ -345,14 +310,6 @@ def build_query_resource_graph(
             if has_remote_udf
             else native_fragment_unit_id_for_node(query_id, node_id)
         )
-        if has_remote_udf:
-            # Distributed task fragments terminate at the native node feeding
-            # a remote UDF; the UDF node's native fragment unit is a logical
-            # wrapper.
-            # Both are orchestration units, while the separately leased UDF
-            # process owns the standalone heap commitment.
-            remote_udf_driver_node_ids.add(node_id)
-            remote_udf_driver_node_ids.update(node["input_node_ids"])
 
     units: list[ResourceUnitSpec] = []
     for node_id in sorted(nodes, key=_node_sort_key):
@@ -360,8 +317,6 @@ def build_query_resource_graph(
         native_fragment_unit_id = native_fragment_unit_id_for_node(query_id, node_id)
         input_unit_ids = tuple(output_unit_by_node[parent] for parent in node["input_node_ids"])
         is_sink = bool(node["is_sink"])
-        is_blocking_materializing = bool(node["is_blocking_materializing"])
-        remote_udf_driver = node_id in remote_udf_driver_node_ids
         units.append(
             ResourceUnitSpec(
                 query_id=query_id,
@@ -370,22 +325,14 @@ def build_query_resource_graph(
                 unit_kind="native_fragment",
                 backend="ray_worker",
                 input_unit_ids=input_unit_ids,
-                # A Ray UDF node runs its user code in a separately leased Ray
-                # process. The parent native fragment task is an in-process
-                # orchestration continuation in the shared RayWorkerActor, so
-                # charging the full standalone-process default again
-                # double-counts heap.
-                # Its incremental commitment is instead bounded by the paired
-                # stream window, with a conservative 512 MiB floor. Native
-                # fragment units retain the 2 GiB default for joins/sorts/spill.
-                per_task=ResourceVector(
-                    cpu=1,
-                    heap_bytes=native_fragment_udf_driver_heap if remote_udf_driver else native_fragment_heap,
-                ),
+                # All native fragments on a Ray node execute inside one shared
+                # DuckDB DatabaseInstance. Its TaskScheduler, BufferManager,
+                # TemporaryMemoryManager, and memory_limit own native process
+                # resources; Vane only accounts cross-process object flow.
+                per_task=ResourceVector(),
                 target_output_block_bytes=0 if is_sink else native_fragment_target,
                 generator_buffer_blocks=0 if is_sink else _GENERATOR_BUFFER_BLOCKS,
                 max_concurrency=int(node["num_partitions"]),
-                is_barrier=is_blocking_materializing,
             )
         )
         udf_unit = _udf_unit(
@@ -446,10 +393,7 @@ def build_query_demand(
     priority: int = 0,
 ) -> QueryDemand:
     actor_bundles: list[ActorResourceBundle] = []
-    native_fragment_tasks: list[ResourceVector] = []
     ray_tasks: list[ResourceVector] = []
-    downstream_native_fragment_tasks: list[ResourceVector] = []
-    unit_by_id = {unit.resource_unit_id: unit for unit in graph.units}
     for unit in graph.units:
         commitment = _hard_task_commitment(unit)
         if unit.backend == "ray_actor":
@@ -463,50 +407,23 @@ def build_query_demand(
             )
         elif unit.backend == "ray_task":
             ray_tasks.append(commitment)
-        elif unit.backend == "ray_worker":
-            native_fragment_tasks.append(commitment)
-    downstream_native_fragment_unit_ids = {
-        downstream_unit_id
-        for unit in graph.units
-        if unit.backend != "ray_worker"
-        for downstream_unit_id in (
-            graph.downstream_native_fragment_unit_ids_requiring_separate_slot(unit.resource_unit_id)
-        )
-    }
-    downstream_native_fragment_tasks.extend(
-        _hard_task_commitment(unit_by_id[resource_unit_id])
-        for resource_unit_id in graph.topological_unit_ids()
-        if resource_unit_id in downstream_native_fragment_unit_ids
-    )
     minimum = ResourceVector()
     for required_actor in actor_bundles:
         minimum = minimum + required_actor.resources
-    task_bundles = tuple(
-        bundle
-        # Reserve the nested Ray process before its parent native fragment
-        # bundle. The minimum is component-wise identical either way on one node, but the
-        # order is placement-significant on heterogeneous/multi-node clusters
-        # and must preserve continuation capacity.
-        # A remote-process streaming producer can remain alive while a
-        # downstream native fragment task drains it. Keep that progress slot
-        # separate from the native fragment task that invoked the producer;
-        # QRM enforces the same shared reservation dynamically before
-        # admitting additional producers.
-        for bundle in (
-            _component_max(ray_tasks),
-            _component_max(native_fragment_tasks),
-            _component_max(downstream_native_fragment_tasks),
-        )
-        if not bundle.is_zero()
-    )
+    task_bundles = tuple(bundle for bundle in (_component_max(ray_tasks),) if not bundle.is_zero())
     for task_bundle in task_bundles:
         minimum = minimum + task_bundle
     desired = ResourceVector(
-        cpu=cluster_capacity.cpu,
+        # Ray tasks can use elastic process headroom. Actor-only and pure
+        # native queries have no additional hard-process demand beyond their
+        # resident actor pool; native capacity is node-owned by DuckDB.
+        cpu=cluster_capacity.cpu if ray_tasks else minimum.cpu,
         # GPU commitments remain fixed indivisible bundles. Only CPU and
         # memory headroom participate in elastic DRF allocation.
         gpu=minimum.gpu,
-        heap_bytes=cluster_capacity.heap_bytes,
+        heap_bytes=(
+            cluster_capacity.heap_bytes if any(task.heap_bytes > 0 for task in ray_tasks) else minimum.heap_bytes
+        ),
         object_store_bytes=cluster_capacity.object_store_bytes,
     )
     return QueryDemand(

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -156,12 +156,14 @@ class _TaskAdmissionPlan:
 
 @dataclass(frozen=True)
 class _DownstreamReservation:
-    """One shared resource bundle that keeps a downstream path runnable.
+    """One soft shared resource preference for a downstream runnable path.
 
     Unlike a per-parent continuation credit, this reservation is not charged
     once for every producer. Admission only proves that the bundle remains
     placeable after granting the producer. The real downstream task consumes
-    that capacity through its normal task lease when it becomes runnable.
+    that capacity through its normal task lease when it becomes runnable. If
+    preserving the bundle would prevent all progress, the existing bounded
+    liveness escape may start one hard-feasible task without preserving it.
     """
 
     reservation_id: str
@@ -221,7 +223,7 @@ class OutputBlockGrant:
 class OutputBlockLeaseOwner:
     """Shared lifetime owner carried with one query-produced ObjectRef."""
 
-    def __init__(self, manager: QueryResourceManager, lease: OutputBlockLease) -> None:
+    def __init__(self, manager: RayQueryResourceManager, lease: OutputBlockLease) -> None:
         self._manager = manager
         self._lease_id = str(lease.lease_id)
         self._state = str(lease.state)
@@ -287,8 +289,13 @@ class _ResourceUnitState:
     completed: bool = False
 
 
-class QueryResourceManager:
-    """Own all task and streaming-output resources for one immutable query DAG."""
+class RayQueryResourceManager:
+    """Own Ray execution and streaming-output resources for one query DAG.
+
+    DuckDB owns native-fragment CPU, heap, scheduling, and spill. Native units
+    remain in this graph only so Ray-side object-store windows, task leases,
+    backpressure, and liveness can be coordinated across native/UDF edges.
+    """
 
     def __init__(
         self,
@@ -325,21 +332,8 @@ class QueryResourceManager:
         self._reverse_topological_rank = {
             resource_unit_id: index for index, resource_unit_id in enumerate(self._reverse_topological_unit_ids)
         }
-        self._upstream_unit_ids: dict[str, tuple[str, ...]] = {}
-        for resource_unit_id in self._topological_unit_ids:
-            upstream: set[str] = set()
-            for input_unit_id in self._units[resource_unit_id].spec.input_unit_ids:
-                upstream.add(input_unit_id)
-                upstream.update(self._upstream_unit_ids[input_unit_id])
-            self._upstream_unit_ids[resource_unit_id] = tuple(
-                candidate for candidate in self._topological_unit_ids if candidate in upstream
-            )
         self._reachable_unit_ids: dict[str, tuple[str, ...]] = {}
         self._reachable_udf_unit_ids: dict[str, tuple[str, ...]] = {}
-        self._downstream_native_fragment_unit_ids_requiring_separate_slot = {
-            resource_unit_id: graph.downstream_native_fragment_unit_ids_requiring_separate_slot(resource_unit_id)
-            for resource_unit_id in self._topological_unit_ids
-        }
         for source_unit_id in self._topological_unit_ids:
             reachable: set[str] = set()
             pending = list(self._direct_downstream_unit_ids[source_unit_id])
@@ -390,7 +384,6 @@ class QueryResourceManager:
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
-        self._completed_barrier_unit_ids: set[str] = set()
         self._external_consumer_waiting = False
         self._cancelled = False
         self._cancel_reason = ""
@@ -593,21 +586,6 @@ class QueryResourceManager:
             unit.actor_ready = ready
             self._publish_change_locked()
 
-    def mark_barrier_unit_completed(self, resource_unit_id: str) -> bool:
-        """Record one blocking barrier as materialized without completing its output unit."""
-        unit_key = str(resource_unit_id)
-        with self._lock:
-            unit = self._units.get(unit_key)
-            if unit is None:
-                raise KeyError(f"unit is not registered: {unit_key}")
-            if not unit.spec.is_barrier:
-                raise ValueError(f"unit is not a blocking materializer: {unit_key}")
-            if self._barrier_unit_completed_locked(unit_key):
-                return False
-            self._completed_barrier_unit_ids.add(unit_key)
-            self._publish_change_locked()
-            return True
-
     def update_allocation(
         self,
         allocation: QueryAllocation,
@@ -635,75 +613,6 @@ class QueryResourceManager:
                 return
             self._allocation_admission_open = False
             self._publish_change_locked()
-
-    def task_eligible_node_ids(self, resource_unit_id: str) -> tuple[str, ...]:
-        """Return statically feasible placement nodes for one registered unit."""
-        with self._lock:
-            if not self._allocation_admission_open:
-                return ()
-            unit = self._units.get(str(resource_unit_id))
-            if unit is None:
-                raise KeyError(f"unit is not registered: {resource_unit_id}")
-            commitment = self._task_commitment(unit.spec)
-            allowed_actor_nodes = (
-                set(self.allocation.actor_node_ids_for_unit(unit.spec.resource_unit_id))
-                if unit.spec.backend == "ray_actor"
-                else None
-            )
-            if self._continuation_parent_unit_ids_by_ray_task.get(unit.spec.resource_unit_id):
-                return tuple(
-                    dict.fromkeys(
-                        credit.node_id
-                        for credit in self._continuation_credits.values()
-                        if credit.parent_active
-                        and credit.borrowed_by_task_lease_id is None
-                        and unit.spec.resource_unit_id in credit.eligible_unit_ids
-                        and commitment.fits_within(credit.resources)
-                    )
-                )
-            credit_template = self._continuation_credit_template_locked(unit.spec)
-            credit_resources = ResourceVector() if credit_template is None else credit_template[2]
-            downstream_reservations = self._downstream_reservations_locked(unit.spec)
-            allocation_by_node = {
-                allocation.node_id: allocation.resources for allocation in self.allocation.node_allocations
-            }
-            base_remaining: dict[str, ResourceVector] = {}
-            for node_id, capacity in allocation_by_node.items():
-                resident = self._actor_resident_usage_locked(node_id=node_id)
-                hard_capacity = _hard_resources(capacity)
-                if resident.fits_within(hard_capacity):
-                    base_remaining[node_id] = hard_capacity - resident
-
-            def preserves_registered_minimum(task_node_id: str) -> bool:
-                task_capacity = base_remaining.get(task_node_id)
-                if task_capacity is None or not commitment.fits_within(task_capacity):
-                    return False
-                after_task = dict(base_remaining)
-                after_task[task_node_id] = task_capacity - commitment
-                if credit_resources.is_zero():
-                    return self._remaining_preserves_downstream_locked(
-                        after_task,
-                        downstream_reservations,
-                    )
-                for credit_node_id in sorted(after_task):
-                    credit_capacity = after_task[credit_node_id]
-                    if not credit_resources.fits_within(credit_capacity):
-                        continue
-                    after_credit = dict(after_task)
-                    after_credit[credit_node_id] = credit_capacity - credit_resources
-                    if self._remaining_preserves_downstream_locked(
-                        after_credit,
-                        downstream_reservations,
-                    ):
-                        return True
-                return False
-
-            return tuple(
-                allocation.node_id
-                for allocation in self.allocation.node_allocations
-                if preserves_registered_minimum(allocation.node_id)
-                and (allowed_actor_nodes is None or allocation.node_id in allowed_actor_nodes)
-            )
 
     def try_acquire_task(self, request: TaskRequest) -> TaskGrant:
         with self._lock:
@@ -1031,23 +940,17 @@ class QueryResourceManager:
         if hard_exceeded:
             reason = "continuation_capacity" if credit_template is not None else f"hard_{hard_exceeded[0]}"
             return reason, False, empty_plan
-        object_store_unlimited = (
-            unit.spec.resource_unit_id
-            in self._materializing_object_store_unlimited_unit_ids_locked(
-                requested_unit_id=unit.spec.resource_unit_id,
-            )
-        )
         query_soft_blocked = (
-            not object_store_unlimited
-            and admission_commitment.object_store_bytes > 0
+            admission_commitment.object_store_bytes > 0
             and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         )
         downstream_reservations = self._downstream_reservations_locked(unit.spec)
+        downstream_reservation_soft_blocked = False
         if downstream_reservations:
             remaining = _hard_resources(self.allocation.resources) - _hard_resources(query_usage + admission_commitment)
             reservation_total = self._downstream_reservation_total(downstream_reservations)
             if not reservation_total.fits_within(remaining):
-                return "continuation_capacity", False, empty_plan
+                downstream_reservation_soft_blocked = True
 
         new_credit_plan: _NewContinuationCreditPlan | None = None
         if credit_template is not None:
@@ -1056,8 +959,19 @@ class QueryResourceManager:
                 request.node_id,
                 hard_commitment,
                 credit_resources,
+                allow_unallocated_task_node=unit.spec.backend == "ray_worker",
                 downstream_reservations=downstream_reservations,
             )
+            if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+                node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
+                    request.node_id,
+                    hard_commitment,
+                    credit_resources,
+                    allow_unallocated_task_node=unit.spec.backend == "ray_worker",
+                    downstream_reservations=(),
+                )
+                if node_blocked_reason is None:
+                    downstream_reservation_soft_blocked = True
             if node_blocked_reason is None:
                 new_credit_plan = _NewContinuationCreditPlan(
                     eligible_unit_ids=eligible_unit_ids,
@@ -1075,8 +989,18 @@ class QueryResourceManager:
                 request.node_id,
                 _hard_resources(admission_commitment),
                 allowed_node_ids=allowed_node_ids,
+                allow_unallocated_node=unit.spec.backend == "ray_worker",
                 downstream_reservations=downstream_reservations,
             )
+            if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+                node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
+                    request.node_id,
+                    _hard_resources(admission_commitment),
+                    allowed_node_ids=allowed_node_ids,
+                    allow_unallocated_node=unit.spec.backend == "ray_worker",
+                )
+                if node_blocked_reason is None:
+                    downstream_reservation_soft_blocked = True
         if node_blocked_reason is not None:
             return node_blocked_reason, node_fatal, empty_plan
 
@@ -1100,6 +1024,8 @@ class QueryResourceManager:
             new_credit=new_credit_plan,
             borrowed_credit_id=(None if borrowed_credit is None else borrowed_credit.credit_id),
         )
+        if downstream_reservation_soft_blocked:
+            return "unit_soft_limit", False, plan
         if active_unit_tasks > 0 and any(
             downstream_id not in self._started_unit_ids
             and self._units[downstream_id].runnable
@@ -1113,7 +1039,6 @@ class QueryResourceManager:
             soft_reason = self._unit_soft_block_reason_locked(
                 unit.spec.resource_unit_id,
                 commitment,
-                ignore_object_store=object_store_unlimited,
             )
             if soft_reason is not None:
                 return soft_reason, False, plan
@@ -1125,29 +1050,39 @@ class QueryResourceManager:
         commitment: ResourceVector,
         *,
         allowed_node_ids: set[str] | None,
+        allow_unallocated_node: bool = False,
         downstream_reservations: tuple[_DownstreamReservation, ...] = (),
     ) -> tuple[str, str | None, bool]:
         allocation_by_node = {
             item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
         }
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        if requested and requested not in allocation_by_node:
+        external_requested = bool(requested and requested not in allocation_by_node)
+        if external_requested and (
+            not allow_unallocated_node
+            or not commitment.is_zero()
+            or (allowed_node_ids is not None and requested not in allowed_node_ids)
+        ):
             return "", "node_not_allocated", True
 
-        static_candidates = [
-            node_id
-            for node_id, capacity in allocation_by_node.items()
-            if commitment.fits_within(capacity)
-            and (not requested or node_id == requested)
-            and (allowed_node_ids is None or node_id in allowed_node_ids)
-        ]
+        static_candidates = (
+            [requested]
+            if external_requested
+            else [
+                node_id
+                for node_id, capacity in allocation_by_node.items()
+                if commitment.fits_within(capacity)
+                and (not requested or node_id == requested)
+                and (allowed_node_ids is None or node_id in allowed_node_ids)
+            ]
+        )
         if not static_candidates:
             return "", "task_does_not_fit_allocated_node", True
 
         available_candidates: list[tuple[str, ResourceVector]] = []
         debt_detected = False
         for node_id in static_candidates:
-            capacity = allocation_by_node[node_id]
+            capacity = allocation_by_node.get(node_id, ResourceVector())
             usage = _hard_resources(self._node_usage_locked(node_id))
             if not usage.fits_within(capacity):
                 debt_detected = True
@@ -1191,6 +1126,7 @@ class QueryResourceManager:
         task_commitment: ResourceVector,
         credit_resources: ResourceVector,
         *,
+        allow_unallocated_task_node: bool = False,
         downstream_reservations: tuple[_DownstreamReservation, ...],
     ) -> tuple[str, str, str | None, bool]:
         """Place one parent task and its continuation ownership atomically."""
@@ -1198,14 +1134,19 @@ class QueryResourceManager:
             item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
         }
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        if requested and requested not in allocation_by_node:
+        external_requested = bool(requested and requested not in allocation_by_node)
+        if external_requested and (not allow_unallocated_task_node or not task_commitment.is_zero()):
             return "", "", "node_not_allocated", True
 
-        task_nodes = [
-            node_id
-            for node_id, capacity in allocation_by_node.items()
-            if task_commitment.fits_within(capacity) and (not requested or node_id == requested)
-        ]
+        task_nodes = (
+            [requested]
+            if external_requested
+            else [
+                node_id
+                for node_id, capacity in allocation_by_node.items()
+                if task_commitment.fits_within(capacity) and (not requested or node_id == requested)
+            ]
+        )
         if not task_nodes:
             return "", "", "task_does_not_fit_allocated_node", True
         credit_nodes = [
@@ -1218,9 +1159,9 @@ class QueryResourceManager:
         debt_detected = False
         for task_node_id in task_nodes:
             for credit_node_id in credit_nodes:
-                proposed: dict[str, ResourceVector] = {
-                    task_node_id: task_commitment,
-                }
+                proposed: dict[str, ResourceVector] = {}
+                if task_node_id in allocation_by_node:
+                    proposed[task_node_id] = task_commitment
                 proposed[credit_node_id] = proposed.get(credit_node_id, ResourceVector()) + credit_resources
                 remaining_by_node: dict[str, ResourceVector] = {}
                 feasible = True
@@ -1253,10 +1194,10 @@ class QueryResourceManager:
         task_node_id, credit_node_id, _ = min(
             candidates,
             key=lambda item: (
-                item[2][item[0]].gpu,
-                item[2][item[0]].cpu,
-                item[2][item[0]].heap_bytes,
-                item[2][item[0]].object_store_bytes,
+                item[2].get(item[0], ResourceVector()).gpu,
+                item[2].get(item[0], ResourceVector()).cpu,
+                item[2].get(item[0], ResourceVector()).heap_bytes,
+                item[2].get(item[0], ResourceVector()).object_store_bytes,
                 item[0],
                 item[1],
             ),
@@ -1357,89 +1298,16 @@ class QueryResourceManager:
             heap_bytes=spec.per_task.heap_bytes,
         )
 
-    def _first_pending_barrier_unit_id_locked(self) -> str | None:
-        """Return the first unfinished blocking unit in source-to-sink order."""
-        return next(
-            (
-                resource_unit_id
-                for resource_unit_id in self._topological_unit_ids
-                if self._units[resource_unit_id].spec.is_barrier
-                and not self._barrier_unit_completed_locked(resource_unit_id)
-            ),
-            None,
-        )
-
-    def _barrier_unit_completed_locked(self, resource_unit_id: str) -> bool:
-        return self._units[resource_unit_id].completed or resource_unit_id in self._completed_barrier_unit_ids
-
-    def _reservation_scope_unit_ids_locked(self) -> tuple[str, ...]:
-        """Return unfinished units eligible in the current reservation scope."""
-        barrier_unit_id = self._first_pending_barrier_unit_id_locked()
-        if barrier_unit_id is None:
-            return tuple(
-                resource_unit_id
-                for resource_unit_id in self._topological_unit_ids
-                if not self._units[resource_unit_id].completed
-            )
-        scope = set(self._upstream_unit_ids[barrier_unit_id])
-        scope.add(barrier_unit_id)
-        return tuple(
-            resource_unit_id
-            for resource_unit_id in self._topological_unit_ids
-            if resource_unit_id in scope and not self._units[resource_unit_id].completed
-        )
-
-    def _materializing_object_store_unlimited_unit_ids_locked(
-        self,
-        *,
-        requested_unit_id: str | None = None,
-    ) -> tuple[str, ...]:
-        """Return units whose data must be collectable beyond the soft budget.
-
-        Vane accounts a block to its producer even after the block becomes a
-        downstream input. Therefore the blocking unit and its direct input
-        producers share the spill exemption. DuckDB may concurrently start
-        nested materializers (notably chained broadcast joins), so a blocking
-        boundary becomes active when its own unit or one of its direct inputs
-        is requested or has started. The first unfinished boundary is always
-        active. Earlier streaming producers keep their normal soft budgets and
-        bounded liveness escape.
-        """
-        first_barrier_unit_id = self._first_pending_barrier_unit_id_locked()
-        if first_barrier_unit_id is None:
-            return ()
-        requested = None if requested_unit_id is None else str(requested_unit_id)
-        unlimited: set[str] = set()
-        for barrier_unit_id in self._topological_unit_ids:
-            barrier = self._units[barrier_unit_id]
-            if not barrier.spec.is_barrier or self._barrier_unit_completed_locked(barrier_unit_id):
-                continue
-            boundary = set(barrier.spec.input_unit_ids)
-            boundary.add(barrier_unit_id)
-            active = (
-                barrier_unit_id == first_barrier_unit_id
-                or requested in boundary
-                or bool(boundary & self._started_unit_ids)
-            )
-            if active:
-                unlimited.update(boundary)
-        return tuple(
-            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in unlimited
-        )
-
     def _continuation_credit_template_locked(
         self,
         parent: ResourceUnitSpec,
     ) -> tuple[tuple[str, ...], str, ResourceVector] | None:
         if parent.backend != "ray_worker":
             return None
-        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
         eligible_specs = tuple(
             self._units[resource_unit_id].spec
             for resource_unit_id in self._reachable_udf_unit_ids[parent.resource_unit_id]
-            if resource_unit_id in scope_unit_ids
-            and self._units[resource_unit_id].spec.backend == "ray_task"
-            and not self._units[resource_unit_id].completed
+            if self._units[resource_unit_id].spec.backend == "ray_task" and not self._units[resource_unit_id].completed
         )
         if not eligible_specs:
             return None
@@ -1538,12 +1406,11 @@ class QueryResourceManager:
         self,
         parent: ResourceUnitSpec,
     ) -> tuple[_DownstreamReservation, ...]:
-        """Return shared bundles required to keep this producer drainable.
+        """Return soft shared bundles that prefer a drainable producer path.
 
-        Query demand owns one transferable native-fragment bundle, while
-        nested Ray tasks
-        use the explicit per-parent continuation credit above. A streaming
-        actor boundary additionally needs one slot for every inactive
+        Native fragments do not consume Vane-owned process resources. Nested
+        Ray tasks use the explicit per-parent continuation credit above. A
+        streaming actor boundary additionally needs one slot for every inactive
         downstream Ray-task continuation: the actor input producer, actor call,
         and downstream consumer can all remain live while generator output is
         drained, so the transferable component-max process credit alone is not
@@ -1551,38 +1418,17 @@ class QueryResourceManager:
         input/output bytes use the query's dynamic object-store budget.
 
         Reservations include latent units: waiting for a unit to become
-        runnable is too late because an upstream producer may already have
-        consumed the last non-spillable process slot by then.
+        runnable is too late to bias upstream fanout. They remain soft so an
+        allocation at the graph's hard minimum can still start through the
+        bounded liveness escape.
         """
-        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
         reachable = tuple(
             self._units[resource_unit_id]
             for resource_unit_id in self._reachable_unit_ids[parent.resource_unit_id]
-            if resource_unit_id in scope_unit_ids and not self._units[resource_unit_id].completed
+            if not self._units[resource_unit_id].completed
         )
         reservations: list[_DownstreamReservation] = []
         allocation_node_ids = tuple(sorted(allocation.node_id for allocation in self.allocation.node_allocations))
-
-        inactive_native_fragments = tuple(
-            self._units[resource_unit_id].spec
-            for resource_unit_id in self._downstream_native_fragment_unit_ids_requiring_separate_slot[
-                parent.resource_unit_id
-            ]
-            if resource_unit_id in scope_unit_ids
-            and not self._units[resource_unit_id].completed
-            and self._active_task_count_for_unit_locked(resource_unit_id) == 0
-        )
-        if inactive_native_fragments:
-            resources = _component_max(tuple(self._task_commitment(unit) for unit in inactive_native_fragments))
-            if not resources.is_zero():
-                reservations.append(
-                    _DownstreamReservation(
-                        reservation_id=f"native-fragment:{parent.resource_unit_id}",
-                        unit_ids=tuple(unit.resource_unit_id for unit in inactive_native_fragments),
-                        resources=resources,
-                        allowed_node_ids=allocation_node_ids,
-                    )
-                )
 
         def is_after_streaming_actor(resource_unit_id: str) -> bool:
             if parent.backend == "ray_actor":
@@ -1657,24 +1503,9 @@ class QueryResourceManager:
         *,
         requested_unit_id: str | None,
     ) -> tuple[str, ...]:
-        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
-        object_store_unlimited_unit_ids = (
-            set(
-                self._materializing_object_store_unlimited_unit_ids_locked(
-                    requested_unit_id=requested_unit_id,
-                )
-            )
-            if field_name == "object_store_bytes"
-            else set()
-        )
         unit_ids: list[str] = []
         for resource_unit_id, unit in self._units.items():
-            if (
-                resource_unit_id not in scope_unit_ids
-                or resource_unit_id in object_store_unlimited_unit_ids
-                or not unit.runnable
-                or unit.completed
-            ):
+            if not unit.runnable or unit.completed:
                 continue
             task_demand = (
                 (requested_unit_id is not None and resource_unit_id == requested_unit_id)
@@ -1699,12 +1530,6 @@ class QueryResourceManager:
         live_unit_ids: tuple[str, ...],
     ) -> tuple[str, ...]:
         live = set(live_unit_ids)
-        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
-        object_store_unlimited_unit_ids = (
-            set(self._materializing_object_store_unlimited_unit_ids_locked())
-            if field_name == "object_store_bytes"
-            else set()
-        )
         continuation_ids: set[str] = set()
         for source_unit_id in live_unit_ids:
             if self._units[source_unit_id].spec.backend != "ray_worker":
@@ -1713,8 +1538,6 @@ class QueryResourceManager:
                 unit = self._units[resource_unit_id]
                 if (
                     resource_unit_id not in live
-                    and resource_unit_id in scope_unit_ids
-                    and resource_unit_id not in object_store_unlimited_unit_ids
                     and not unit.completed
                     and self._unit_dimension_commitment(unit.spec, field_name) > 0
                 ):
@@ -1750,24 +1573,17 @@ class QueryResourceManager:
         self,
         resource_unit_id: str,
         request: ResourceVector,
-        *,
-        ignore_object_store: bool = False,
     ) -> str | None:
-        # The current reservation scope defines which units receive a designated
-        # reservation; they are not an execution gate.  DuckDB can demand a
-        # downstream unit while an earlier blocking barrier is still pending
-        # (nested broadcast joins do this from concurrent materializers).
-        # Match Ray Data's allocator semantics: an out-of-scope unit has no
-        # per-unit budget, while query/node hard limits and the query's
-        # object-store soft limit still apply.
-        if resource_unit_id not in self._reservation_scope_unit_ids_locked():
-            return None
+        """Enforce dynamic shares among units with real runnable demand.
+
+        DuckDB owns native execution phases. QRM therefore does not infer a
+        static barrier scope: every active or queued unit participates in the
+        dimensions it actually requests, and unused capacity remains shared.
+        """
         usage_by_unit = {key: self._unit_usage_locked(key) for key in self._units}
         current = usage_by_unit[resource_unit_id]
         limits = self.allocation.resources
         for field_name in _RESOURCE_FIELDS:
-            if ignore_object_store and field_name == "object_store_bytes":
-                continue
             amount = getattr(request, field_name)
             if amount <= 0:
                 continue
@@ -2529,20 +2345,12 @@ class QueryResourceManager:
         delta = after - before
         object_limit = self.allocation.resources.object_store_bytes
         usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-        object_store_unlimited = (
-            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
-        )
-        if not object_store_unlimited and delta > 0 and usage_after.object_store_bytes > object_limit:
+        if delta > 0 and usage_after.object_store_bytes > object_limit:
             return "query_soft_object_store_bytes", False, delta
         if delta > 0:
-            try:
-                self.allocation.resources_for_node(task.node_id)
-            except KeyError:
-                return "node_not_allocated", True, delta
             soft = self._unit_soft_block_reason_locked(
                 unit.spec.resource_unit_id,
                 ResourceVector(object_store_bytes=delta),
-                ignore_object_store=object_store_unlimited,
             )
             if soft is not None:
                 return soft, False, delta
@@ -2964,9 +2772,6 @@ class QueryResourceManager:
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             usage = self._query_usage_locked()
-            barrier_unit_id = self._first_pending_barrier_unit_id_locked()
-            reservation_scope_unit_ids = self._reservation_scope_unit_ids_locked()
-            materializing_object_store_unlimited_unit_ids = self._materializing_object_store_unlimited_unit_ids_locked()
             preferred_task, grant_class = self._preferred_waiting_task_locked()
             allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
             reservation_source_unit_ids = {lease.resource_unit_id for lease in self._task_leases.values()} | {
@@ -3022,12 +2827,6 @@ class QueryResourceManager:
                     for node_id, resources in node_usage.items()
                 },
                 "reservation_ratio": self.reservation_ratio,
-                "reservation_scope": {
-                    "barrier_unit_id": barrier_unit_id,
-                    "resource_unit_ids": list(reservation_scope_unit_ids),
-                    "object_store_backpressure_disabled": bool(materializing_object_store_unlimited_unit_ids),
-                    "object_store_unlimited_unit_ids": list(materializing_object_store_unlimited_unit_ids),
-                },
                 "cancelled": self._cancelled,
                 "cancel_reason": self._cancel_reason,
                 "external_consumer_waiting": self._external_consumer_waiting,
@@ -3108,11 +2907,6 @@ class QueryResourceManager:
                         "queued_output_bytes": unit.queued_output_bytes,
                         "pending_output_count": unit.pending_output_count,
                         "completed": unit.completed,
-                        "materialization_completed": (self._barrier_unit_completed_locked(resource_unit_id)),
-                        "reservation_scope_eligible": resource_unit_id in reservation_scope_unit_ids,
-                        "object_store_backpressure_disabled": (
-                            resource_unit_id in materializing_object_store_unlimited_unit_ids
-                        ),
                         "usage": self._unit_usage_locked(resource_unit_id).to_dict(),
                         "active_task_count": self._active_task_count_for_unit_locked(resource_unit_id),
                     }
@@ -3149,7 +2943,7 @@ __all__ = [
     "OutputBlockLease",
     "OutputBlockLeaseOwner",
     "OutputBlockRequest",
-    "QueryResourceManager",
+    "RayQueryResourceManager",
     "TaskGrant",
     "TaskLease",
     "TaskRequest",

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import threading
+import time
 import uuid
 from collections import deque
 from collections.abc import Callable
@@ -20,6 +22,9 @@ from duckdb.runners.ray.query_resource_graph import (
 )
 
 _SOFT_TASK_BLOCK_REASONS = {
+    "query_soft_cpu",
+    "query_soft_gpu",
+    "query_soft_heap_bytes",
     "query_soft_object_store_bytes",
     "unit_soft_cpu",
     "unit_soft_gpu",
@@ -42,6 +47,9 @@ _OUTPUT_STATES = (
 _RESOURCE_FIELDS = ("cpu", "gpu", "heap_bytes", "object_store_bytes")
 _EPSILON = 1e-9
 _TERMINAL_IDENTITY_REPLAY_CAPACITY = 65_536
+_SOFT_RESERVATION_WARNING_DELAY_S = 60.0
+
+logger = logging.getLogger(__name__)
 
 
 def _resource_with_object_store(resources: ResourceVector, object_store_bytes: int) -> ResourceVector:
@@ -75,14 +83,27 @@ def _hard_positive_difference(left: ResourceVector, right: ResourceVector) -> Re
     return _positive_difference(_hard_resources(left), _hard_resources(right))
 
 
-def _component_max(resources: tuple[ResourceVector, ...]) -> ResourceVector:
-    if not resources:
-        return ResourceVector()
-    return ResourceVector(
-        cpu=max(item.cpu for item in resources),
-        gpu=max(item.gpu for item in resources),
-        heap_bytes=max(item.heap_bytes for item in resources),
-        object_store_bytes=max(item.object_store_bytes for item in resources),
+def _incremental_hard_exceeded_dimensions(
+    usage: ResourceVector,
+    incremental: ResourceVector,
+    capacity: ResourceVector,
+) -> tuple[str, ...]:
+    """Return hard dimensions in which this increment would exceed capacity.
+
+    Existing tasks and submitted actor processes are never revoked after a
+    soft allocation shrinks. Zero-increment native work and invocations on an
+    already submitted actor must therefore remain admissible even while that
+    fixed process usage is in debt.
+    """
+
+    current = _hard_resources(usage)
+    added = _hard_resources(incremental)
+    limit = _hard_resources(capacity)
+    return tuple(
+        field_name
+        for field_name in ("cpu", "gpu", "heap_bytes")
+        if getattr(added, field_name) > 0
+        and getattr(current, field_name) + getattr(added, field_name) > getattr(limit, field_name) + _EPSILON
     )
 
 
@@ -286,6 +307,10 @@ class _ResourceUnitState:
     pending_task_count: int = 0
     queued_output_bytes: int = 0
     pending_output_count: int = 0
+    bytes_task_outputs_generated: int = 0
+    num_task_outputs_generated: int = 0
+    num_outputs_of_finished_tasks: int = 0
+    num_tasks_finished: int = 0
     completed: bool = False
 
 
@@ -302,18 +327,24 @@ class RayQueryResourceManager:
         graph: QueryResourceGraph,
         allocation: QueryAllocation,
         *,
+        admission_open: bool = True,
         reservation_ratio: float = 0.5,
         on_change: Callable[[], None] | None = None,
+        on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
     ) -> None:
         ratio = float(reservation_ratio)
         if not math.isfinite(ratio) or ratio <= 0 or ratio > 1:
             raise ValueError("reservation_ratio must be in (0, 1]")
-        graph.validate_allocation(allocation)
+        graph.validate_allocation(
+            allocation,
+            eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open else ()),
+        )
         self.graph = graph
         self.allocation = allocation
-        self._allocation_admission_open = True
+        self._allocation_admission_open = bool(admission_open)
         self.reservation_ratio = ratio
         self._on_change = on_change
+        self._on_eligible_units_change = on_eligible_units_change
         self._lock = threading.RLock()
         self._admission_epoch = 0
         self._units = {
@@ -371,6 +402,12 @@ class RayQueryResourceManager:
         self._continuation_credit_by_parent: dict[str, str] = {}
         self._continuation_credit_by_borrower: dict[str, str] = {}
         self._active_attempt_leases: dict[tuple[str, str], str] = {}
+        # Submitted includes Ray Core PENDING actors as well as ready actors.
+        # Ray Data charges both states to logical operator usage because each
+        # handle already owns a real scheduling request even before placement.
+        self._submitted_actor_slots: set[tuple[str, int]] = set()
+        self._retiring_actor_unit_ids: set[str] = set()
+        self._actor_node_by_slot: dict[tuple[str, int], str] = {}
         self._active_actor_slots: dict[tuple[str, int], str] = {}
         self._queued_actor_slot_leases: dict[tuple[str, int], deque[str]] = {}
         self._terminal_attempts = BoundedSet[tuple[str, str]](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
@@ -378,13 +415,18 @@ class RayQueryResourceManager:
         self._waiting_output_blocks: dict[str, OutputBlockRequest] = {}
         self._output_leases: dict[str, OutputBlockLease] = {}
         self._output_lease_by_block: dict[str, str] = {}
+        self._observed_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
+        self._generated_output_count_by_task_lease: dict[str, int] = {}
         self._terminal_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
         self._active_liveness_task_lease_id: str | None = None
         self._active_liveness_path_task_lease_ids: set[str] = set()
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
+        self._completed_materialization_barrier_ids: set[str] = set()
         self._external_consumer_waiting = False
+        self._soft_allocation_debt_since: float | None = None
+        self._soft_allocation_warning_emitted = False
         self._cancelled = False
         self._cancel_reason = ""
 
@@ -415,10 +457,11 @@ class RayQueryResourceManager:
         resource_unit_id: str,
         *,
         runnable: bool,
-        actor_ready: bool | None = None,
         completed: bool = False,
     ) -> None:
         unit_key = str(resource_unit_id)
+        eligible_callback: Callable[[tuple[str, ...]], None] | None = None
+        eligible_unit_ids: tuple[str, ...] = ()
         with self._lock:
             unit = self._units.get(unit_key)
             if unit is None:
@@ -433,8 +476,6 @@ class RayQueryResourceManager:
                 unit.completed,
             )
             unit.runnable = bool(runnable) and not bool(completed)
-            if actor_ready is not None:
-                unit.actor_ready = bool(actor_ready)
             self._recompute_unit_queued_input_locked(unit_key)
             self._recompute_unit_queued_output_locked(unit_key)
             unit.completed = bool(completed)
@@ -448,7 +489,66 @@ class RayQueryResourceManager:
                 unit.completed,
             )
             if after != before:
+                if bool(completed) and not before[-1]:
+                    # Completion changes the eligible demand before the
+                    # coordinator can publish the corresponding allocation.
+                    # Preserve live leases, but fence every new grant from the
+                    # old generation during that handoff.
+                    self._allocation_admission_open = False
                 self._publish_change_locked()
+                if bool(completed) and not before[-1]:
+                    eligible_callback = self._on_eligible_units_change
+                    eligible_unit_ids = self._eligible_resource_unit_ids_locked()
+        if eligible_callback is not None:
+            eligible_callback(eligible_unit_ids)
+
+    def mark_materialization_barrier_completed_for_node(self, physical_node_id: str) -> bool:
+        """Advance the execution phase after a true barrier completes."""
+
+        barrier = self.graph.barrier_for_physical_node(str(physical_node_id))
+        eligible_callback: Callable[[tuple[str, ...]], None] | None = None
+        eligible_unit_ids: tuple[str, ...] = ()
+        with self._lock:
+            if barrier.barrier_id in self._completed_materialization_barrier_ids:
+                return False
+            self._completed_materialization_barrier_ids.add(barrier.barrier_id)
+            # The eligible set changes before the coordinator can publish the
+            # next phase allocation. Fence only new grants during that short
+            # handoff so downstream work cannot consume the previous phase's
+            # reservation; live tasks and output leases continue unchanged.
+            self._allocation_admission_open = False
+            self._publish_change_locked()
+            eligible_callback = self._on_eligible_units_change
+            eligible_unit_ids = self._eligible_resource_unit_ids_locked()
+        if eligible_callback is not None:
+            eligible_callback(eligible_unit_ids)
+        return True
+
+    def current_eligible_resource_unit_ids(self) -> tuple[str, ...]:
+        with self._lock:
+            return self._eligible_resource_unit_ids_locked()
+
+    def _eligible_resource_unit_ids_locked(self) -> tuple[str, ...]:
+        return tuple(
+            resource_unit_id
+            for resource_unit_id in self.graph.eligible_resource_unit_ids(self._completed_materialization_barrier_ids)
+            if not self._units[resource_unit_id].completed
+        )
+
+    def _frontier_materialization_barriers_locked(self) -> tuple[Any, ...]:
+        return self.graph.frontier_materialization_barriers(self._completed_materialization_barrier_ids)
+
+    def _materializing_object_store_unlimited_unit_ids_locked(self) -> tuple[str, ...]:
+        barriers = self._frontier_materialization_barriers_locked()
+        if not barriers:
+            return ()
+        boundary: set[str] = set()
+        for barrier in barriers:
+            boundary.update(barrier.materialized_input_unit_ids)
+            boundary.add(barrier.materializer_unit_id)
+        return tuple(
+            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in boundary
+        )
 
     def note_task_waiting(self, request: TaskRequest) -> None:
         """Register real queued work before attempting admission."""
@@ -468,12 +568,11 @@ class RayQueryResourceManager:
                 if request.retained_input_bytes is None
                 else int(request.retained_input_bytes)
             )
-            if retained < 0 or retained > unit.spec.per_task.object_store_bytes:
-                raise ValueError("queued task retained input is outside its unit resource spec")
+            if retained < 0:
+                raise ValueError("queued task retained input must be non-negative")
             key = (task_id, attempt_id)
             existing = self._waiting_task_inputs.get(key)
-            queued = max(1, retained)
-            value = (request, queued)
+            value = (request, retained)
             if existing is not None and existing != value:
                 raise ValueError("queued task identity was reused with different work")
             if existing is not None:
@@ -514,23 +613,25 @@ class RayQueryResourceManager:
         unit.pending_task_count = len(waiting)
         unit.queued_input_bytes = sum(waiting)
 
-    def note_output_waiting(self, request: OutputBlockRequest) -> None:
+    def note_output_waiting(self, request: OutputBlockRequest) -> str | None:
+        """Register one produced block, or return its fatal identity reason."""
+
         with self._lock:
-            if str(request.query_id) != self.graph.query_id:
-                raise ValueError("queued output query_id does not match resource manager")
+            fatal_reason, _unit, _task, _size = self._output_request_identity_error_locked(request)
+            if fatal_reason is not None:
+                return fatal_reason
             resource_unit_id = str(request.producer_unit_id)
-            if resource_unit_id not in self._units:
-                raise KeyError(f"unit is not registered: {resource_unit_id}")
             block_id = str(request.block_id).strip()
-            size_bytes = int(request.size_bytes)
-            if not block_id or size_bytes <= 0:
-                raise ValueError("queued output requires a non-empty block_id and positive size")
             existing = self._waiting_output_blocks.get(block_id)
             if existing is not None and existing != request:
                 raise ValueError("queued output block_id was reused with different work")
+            if existing is not None:
+                return None
+            self._record_output_observation_locked(request)
             self._waiting_output_blocks[block_id] = request
             self._recompute_unit_queued_output_locked(resource_unit_id)
             self._publish_change_locked()
+            return None
 
     def remove_output_waiter(self, block_id: str) -> bool:
         with self._lock:
@@ -565,6 +666,64 @@ class RayQueryResourceManager:
         unit.pending_output_count = len(waiting)
         unit.queued_output_bytes = sum(waiting) + leased_queue_bytes
 
+    def _output_request_identity_error_locked(
+        self,
+        request: OutputBlockRequest,
+    ) -> tuple[str | None, _ResourceUnitState | None, TaskLease | None, int]:
+        """Validate immutable output identity without applying resource policy."""
+
+        if self._cancelled:
+            return "query_cancelled", None, None, 0
+        if str(request.query_id) != self.graph.query_id:
+            return "query_id_mismatch", None, None, 0
+        unit = self._units.get(str(request.producer_unit_id))
+        if unit is None:
+            return "unit_not_registered", None, None, 0
+        block_id = str(request.block_id).strip()
+        if not block_id:
+            return "invalid_block_id", unit, None, 0
+        if block_id in self._terminal_output_blocks:
+            return "output_block_terminal", unit, None, 0
+        task = self._task_leases.get(str(request.task_lease_id))
+        if task is None:
+            return "task_lease_not_active", unit, None, 0
+        if task.resource_unit_id != unit.spec.resource_unit_id:
+            return "task_unit_mismatch", unit, task, 0
+        if task.attempt_id != str(request.attempt_id):
+            return "task_attempt_mismatch", unit, task, 0
+        if block_id in self._output_lease_by_block:
+            return "output_block_already_leased", unit, task, 0
+        size = int(request.size_bytes)
+        if size <= 0:
+            return "invalid_output_block_size", unit, task, size
+        return None, unit, task, size
+
+    def _record_output_observation_locked(self, request: OutputBlockRequest) -> bool:
+        """Learn one generated block size exactly once for dynamic estimation."""
+
+        block_id = str(request.block_id)
+        if block_id in self._observed_output_blocks:
+            return False
+        unit = self._units[str(request.producer_unit_id)]
+        unit.num_task_outputs_generated += 1
+        unit.bytes_task_outputs_generated += int(request.size_bytes)
+        task_lease_id = str(request.task_lease_id)
+        self._generated_output_count_by_task_lease[task_lease_id] = (
+            self._generated_output_count_by_task_lease.get(task_lease_id, 0) + 1
+        )
+        self._observed_output_blocks.add(block_id)
+        return True
+
+    def _record_task_finished_locked(self, lease: TaskLease) -> None:
+        """Fold one terminal task into the Ray Data-style output averages."""
+
+        unit = self._units[lease.resource_unit_id]
+        unit.num_tasks_finished += 1
+        unit.num_outputs_of_finished_tasks += self._generated_output_count_by_task_lease.pop(
+            lease.lease_id,
+            0,
+        )
+
     def set_external_consumer_waiting(self, waiting: bool) -> None:
         with self._lock:
             waiting = bool(waiting)
@@ -573,18 +732,179 @@ class RayQueryResourceManager:
             self._external_consumer_waiting = waiting
             self._publish_change_locked()
 
-    def set_unit_actor_ready(self, resource_unit_id: str, ready: bool) -> None:
+    def set_submitted_actor_slots(
+        self,
+        resource_unit_id: str,
+        actor_indices: set[int] | tuple[int, ...] | list[int] | range,
+    ) -> None:
+        """Publish the fixed actor handles submitted to Ray Core.
+
+        Submitted slots are logical process usage whether Ray Core reports the
+        actor READY or PENDING. Removing a slot is only valid after its task
+        leases have drained, normally during an execution-phase transition.
+        """
+
+        unit_key = str(resource_unit_id)
+        normalized: set[int] = set()
         with self._lock:
-            unit = self._units.get(str(resource_unit_id))
+            unit = self._units.get(unit_key)
             if unit is None:
-                raise KeyError(f"unit is not registered: {resource_unit_id}")
+                raise KeyError(f"unit is not registered: {unit_key}")
             if unit.spec.backend != "ray_actor":
-                raise ValueError(f"unit is not a Ray actor unit: {resource_unit_id}")
-            ready = bool(ready)
-            if unit.actor_ready == ready:
+                raise ValueError(f"unit is not a Ray actor unit: {unit_key}")
+            for raw_actor_index in actor_indices:
+                if isinstance(raw_actor_index, bool):
+                    raise TypeError("actor index must be an integer")
+                actor_index = int(raw_actor_index)
+                if actor_index < 0 or actor_index >= unit.spec.actor_pool_size:
+                    raise ValueError(f"actor index is outside pool {unit_key}: {actor_index}")
+                normalized.add(actor_index)
+
+            before = {
+                actor_index
+                for candidate_unit_id, actor_index in self._submitted_actor_slots
+                if candidate_unit_id == unit_key
+            }
+            if before == normalized:
                 return
-            unit.actor_ready = ready
+            if unit_key in self._retiring_actor_unit_ids:
+                raise RuntimeError(f"cannot change submitted slots for a retiring actor pool: {unit_key}")
+            removed = before - normalized
+            for actor_index in removed:
+                slot_key = (unit_key, actor_index)
+                if self._actor_slot_lease_count_locked(slot_key) > 0:
+                    raise RuntimeError(f"cannot remove actor slot with live leases: {unit_key}/{actor_index}")
+            self._submitted_actor_slots = {slot for slot in self._submitted_actor_slots if slot[0] != unit_key}
+            self._submitted_actor_slots.update((unit_key, actor_index) for actor_index in normalized)
+            for slot_key in tuple(self._actor_node_by_slot):
+                if slot_key[0] == unit_key and slot_key[1] not in normalized:
+                    self._actor_node_by_slot.pop(slot_key, None)
+            unit.actor_ready = any(
+                candidate_unit_id == unit_key for candidate_unit_id, _actor_index in self._actor_node_by_slot
+            )
             self._publish_change_locked()
+
+    def set_ready_actor_slots(
+        self,
+        resource_unit_id: str,
+        actor_node_ids: dict[int, str],
+    ) -> None:
+        """Publish the subset of a Ray Core actor pool that is currently ready."""
+
+        unit_key = str(resource_unit_id)
+        normalized: dict[int, str] = {}
+        with self._lock:
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
+            if unit.spec.backend != "ray_actor":
+                raise ValueError(f"unit is not a Ray actor unit: {unit_key}")
+            for raw_actor_index, raw_node_id in actor_node_ids.items():
+                if isinstance(raw_actor_index, bool):
+                    raise TypeError("actor index must be an integer")
+                actor_index = int(raw_actor_index)
+                node_id = str(raw_node_id or "").strip()
+                if actor_index < 0 or actor_index >= unit.spec.actor_pool_size:
+                    raise ValueError(f"actor index is outside pool {unit_key}: {actor_index}")
+                if not node_id:
+                    raise ValueError(f"actor {unit_key}/{actor_index} node_id must be non-empty")
+                normalized[actor_index] = node_id
+            submitted = {
+                actor_index
+                for candidate_unit_id, actor_index in self._submitted_actor_slots
+                if candidate_unit_id == unit_key
+            }
+            unknown_ready = sorted(set(normalized) - submitted)
+            if unknown_ready:
+                raise ValueError(f"ready actor slot was not submitted for {unit_key}: {unknown_ready[0]}")
+            before = {
+                actor_index: node_id
+                for (candidate_unit_id, actor_index), node_id in self._actor_node_by_slot.items()
+                if candidate_unit_id == unit_key
+            }
+            if before == normalized:
+                return
+            if unit_key in self._retiring_actor_unit_ids:
+                raise RuntimeError(f"cannot change ready slots for a retiring actor pool: {unit_key}")
+            removed_ready = set(before) - set(normalized)
+            for actor_index in removed_ready:
+                slot_key = (unit_key, actor_index)
+                if self._actor_slot_lease_count_locked(slot_key) > 0:
+                    raise RuntimeError(f"cannot remove ready actor slot with live leases: {unit_key}/{actor_index}")
+            for slot_key in tuple(self._actor_node_by_slot):
+                if slot_key[0] == unit_key:
+                    self._actor_node_by_slot.pop(slot_key, None)
+            self._actor_node_by_slot.update(
+                {(unit_key, actor_index): node_id for actor_index, node_id in normalized.items()}
+            )
+            unit.actor_ready = bool(normalized)
+            self._publish_change_locked()
+
+    def begin_actor_pool_retirement(self, resource_unit_id: str) -> bool:
+        """Atomically fence and uncharge one completed-phase actor pool.
+
+        A stale phase callback must not tear down a pool that is eligible in
+        the manager's current frontier.  Conversely, a real phase transition
+        may only retire a fully drained pool; live or prefetched invocations
+        indicate a barrier/lifecycle ordering bug and keep their slot
+        ownership intact.
+        """
+
+        unit_key = str(resource_unit_id)
+        with self._lock:
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
+            if unit.spec.backend != "ray_actor":
+                raise ValueError(f"unit is not a Ray actor unit: {unit_key}")
+            if unit_key in self._eligible_resource_unit_ids_locked():
+                return False
+
+            live_slots = sorted(
+                actor_index
+                for candidate_unit_id, actor_index in self._submitted_actor_slots
+                if candidate_unit_id == unit_key
+                and self._actor_slot_lease_count_locked((candidate_unit_id, actor_index)) > 0
+            )
+            if live_slots:
+                raise RuntimeError(f"cannot retire actor pool with live leases: {unit_key}/{live_slots[0]}")
+
+            if unit_key in self._retiring_actor_unit_ids:
+                return True
+            self._retiring_actor_unit_ids.add(unit_key)
+            for slot_key in tuple(self._actor_node_by_slot):
+                if slot_key[0] == unit_key:
+                    self._actor_node_by_slot.pop(slot_key, None)
+            unit.actor_ready = False
+            self._publish_change_locked()
+            return True
+
+    def complete_actor_pool_retirement(self, resource_unit_id: str) -> bool:
+        """Uncharge submitted actor processes after physical shutdown."""
+
+        unit_key = str(resource_unit_id)
+        with self._lock:
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
+            if unit.spec.backend != "ray_actor":
+                raise ValueError(f"unit is not a Ray actor unit: {unit_key}")
+            if unit_key not in self._retiring_actor_unit_ids:
+                return False
+            live_slots = sorted(
+                actor_index
+                for candidate_unit_id, actor_index in self._submitted_actor_slots
+                if candidate_unit_id == unit_key
+                and self._actor_slot_lease_count_locked((candidate_unit_id, actor_index)) > 0
+            )
+            if live_slots:
+                raise RuntimeError(
+                    f"cannot complete actor pool retirement with live leases: {unit_key}/{live_slots[0]}"
+                )
+            self._submitted_actor_slots = {slot for slot in self._submitted_actor_slots if slot[0] != unit_key}
+            self._retiring_actor_unit_ids.remove(unit_key)
+            self._publish_change_locked()
+            return True
 
     def update_allocation(
         self,
@@ -600,7 +920,7 @@ class RayQueryResourceManager:
                 )
             self.graph.validate_allocation(
                 allocation,
-                require_full_minimum=False,
+                eligible_unit_ids=(self._eligible_resource_unit_ids_locked() if admission_open else ()),
             )
             self.allocation = allocation
             self._allocation_admission_open = bool(admission_open)
@@ -843,8 +1163,6 @@ class RayQueryResourceManager:
         empty_plan = _TaskAdmissionPlan()
         if self._cancelled:
             return "query_cancelled", True, empty_plan
-        if not self._allocation_admission_open:
-            return "allocation_pending", False, empty_plan
         if str(request.query_id) != self.graph.query_id:
             return "query_id_mismatch", True, empty_plan
         unit = self._units.get(str(request.resource_unit_id))
@@ -852,6 +1170,10 @@ class RayQueryResourceManager:
             return "unit_not_registered", True, empty_plan
         if unit.completed:
             return "unit_completed", True, empty_plan
+        if not self._allocation_admission_open:
+            return "allocation_pending", False, empty_plan
+        if unit.spec.resource_unit_id not in self._eligible_resource_unit_ids_locked():
+            return "materialization_barrier_pending", False, empty_plan
         if not unit.runnable:
             return "unit_not_runnable", False, empty_plan
         if unit.spec.backend == "ray_actor" and not unit.actor_ready:
@@ -876,13 +1198,13 @@ class RayQueryResourceManager:
         free_actor_indices_by_node: dict[str, list[int]] | None = None
         if unit.spec.backend == "ray_actor":
             free_actor_indices_by_node = {}
-            for placement in self.allocation.actor_placements:
-                if placement.resource_unit_id != unit.spec.resource_unit_id:
+            for (candidate_unit_id, actor_slot_index), node_id in self._actor_node_by_slot.items():
+                if candidate_unit_id != unit.spec.resource_unit_id:
                     continue
-                slot_key = (unit.spec.resource_unit_id, placement.actor_index)
+                slot_key = (unit.spec.resource_unit_id, actor_slot_index)
                 if self._actor_slot_lease_count_locked(slot_key) >= unit.spec.actor_prefetch_depth:
                     continue
-                free_actor_indices_by_node.setdefault(placement.node_id, []).append(placement.actor_index)
+                free_actor_indices_by_node.setdefault(node_id, []).append(actor_slot_index)
             if not free_actor_indices_by_node:
                 return "actor_slot", False, empty_plan
 
@@ -894,22 +1216,34 @@ class RayQueryResourceManager:
         if retained < 0:
             return "invalid_retained_input_bytes", True, empty_plan
         resources = _resource_with_object_store(unit.spec.per_task, retained)
-        output_window = unit.spec.output_window_bytes
-        commitment = _resource_with_object_store(resources, retained + output_window)
+        pending_output_estimate = self._pending_output_estimate_per_task_locked(unit.spec)
+        commitment = _resource_with_object_store(
+            resources,
+            retained + pending_output_estimate,
+        )
         hard_commitment = _hard_resources(commitment)
         if hard_commitment.exceeded_dimensions(_hard_resources(self.allocation.resources)):
             return "task_exceeds_query_allocation", True, empty_plan
 
-        query_usage = self._query_usage_locked()
-        debt = _hard_positive_difference(query_usage, self.allocation.resources)
-        if not debt.is_zero():
+        execution_usage = self._query_usage_locked()
+        execution_debt = _hard_positive_difference(
+            execution_usage,
+            self.allocation.resources,
+        )
+        if not execution_debt.is_zero():
+            # Capacity shrink never revokes live task/continuation leases, but
+            # it fences another process request until those leases drain.
             return "allocation_debt", False, empty_plan
-
+        # Submitted actor processes are charged once for their full lifetime.
+        # Their invocations add no CPU/GPU/heap. A process request beyond the
+        # resulting query share is a soft block eligible for one bounded
+        # liveness escape; Ray Core remains the physical resource authority.
+        query_usage = self._soft_allocation_usage_locked()
         borrowed_credit = self._available_continuation_credit_locked(
             unit.spec,
             requested_node_id=request.node_id,
             resources=resources,
-            output_window_bytes=output_window,
+            output_window_bytes=pending_output_estimate,
             query_usage=query_usage,
         )
         credit_template = self._continuation_credit_template_locked(unit.spec)
@@ -924,7 +1258,7 @@ class RayQueryResourceManager:
             # become over-cap immediately after ownership transfer.
             prospective_task_usage = self._borrowed_task_usage_locked(
                 resources,
-                output_window,
+                pending_output_estimate,
                 borrowed_credit,
             )
             idle_output_excess = self._idle_continuation_output_excess_locked(
@@ -936,18 +1270,35 @@ class RayQueryResourceManager:
             )
 
         usage_after = query_usage + admission_commitment
-        hard_exceeded = _hard_resources(usage_after).exceeded_dimensions(_hard_resources(self.allocation.resources))
-        if hard_exceeded:
-            reason = "continuation_capacity" if credit_template is not None else f"hard_{hard_exceeded[0]}"
+        execution_hard_exceeded = _incremental_hard_exceeded_dimensions(
+            execution_usage,
+            admission_commitment,
+            self.allocation.resources,
+        )
+        if execution_hard_exceeded:
+            reason = "continuation_capacity" if credit_template is not None else f"hard_{execution_hard_exceeded[0]}"
             return reason, False, empty_plan
+        soft_hard_exceeded = _incremental_hard_exceeded_dimensions(
+            query_usage,
+            admission_commitment,
+            self.allocation.resources,
+        )
+        query_resource_soft_reason = None if not soft_hard_exceeded else f"query_soft_{soft_hard_exceeded[0]}"
+        object_store_backpressure_disabled = (
+            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
+        )
         query_soft_blocked = (
-            admission_commitment.object_store_bytes > 0
+            not object_store_backpressure_disabled
+            and admission_commitment.object_store_bytes > 0
             and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         )
         downstream_reservations = self._downstream_reservations_locked(unit.spec)
         downstream_reservation_soft_blocked = False
         if downstream_reservations:
-            remaining = _hard_resources(self.allocation.resources) - _hard_resources(query_usage + admission_commitment)
+            remaining = _positive_difference(
+                _hard_resources(self.allocation.resources),
+                _hard_resources(query_usage + admission_commitment),
+            )
             reservation_total = self._downstream_reservation_total(downstream_reservations)
             if not reservation_total.fits_within(remaining):
                 downstream_reservation_soft_blocked = True
@@ -980,31 +1331,51 @@ class RayQueryResourceManager:
                     resources=credit_resources,
                 )
         else:
-            allowed_node_ids = (
-                {borrowed_credit.node_id}
-                if borrowed_credit is not None
-                else (set(free_actor_indices_by_node) if free_actor_indices_by_node is not None else None)
-            )
-            node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
-                request.node_id,
-                _hard_resources(admission_commitment),
-                allowed_node_ids=allowed_node_ids,
-                allow_unallocated_node=unit.spec.backend == "ray_worker",
-                downstream_reservations=downstream_reservations,
-            )
-            if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+            if free_actor_indices_by_node is not None:
+                requested_node_id = "" if request.node_id is None else str(request.node_id).strip()
+                actor_node_ids = tuple(
+                    sorted(
+                        node_id
+                        for node_id in free_actor_indices_by_node
+                        if not requested_node_id or node_id == requested_node_id
+                    )
+                )
+                if not actor_node_ids:
+                    return "actor_node_unavailable", True, empty_plan
+                node_id = min(
+                    actor_node_ids,
+                    key=lambda candidate_node_id: (
+                        min(
+                            self._actor_slot_lease_count_locked((unit.spec.resource_unit_id, candidate_actor_index))
+                            for candidate_actor_index in free_actor_indices_by_node[candidate_node_id]
+                        ),
+                        candidate_node_id,
+                    ),
+                )
+                node_blocked_reason = None
+                node_fatal = False
+            else:
+                allowed_node_ids = {borrowed_credit.node_id} if borrowed_credit is not None else None
                 node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
                     request.node_id,
                     _hard_resources(admission_commitment),
                     allowed_node_ids=allowed_node_ids,
                     allow_unallocated_node=unit.spec.backend == "ray_worker",
+                    downstream_reservations=downstream_reservations,
                 )
-                if node_blocked_reason is None:
-                    downstream_reservation_soft_blocked = True
+                if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+                    node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
+                        request.node_id,
+                        _hard_resources(admission_commitment),
+                        allowed_node_ids=allowed_node_ids,
+                        allow_unallocated_node=unit.spec.backend == "ray_worker",
+                    )
+                    if node_blocked_reason is None:
+                        downstream_reservation_soft_blocked = True
         if node_blocked_reason is not None:
             return node_blocked_reason, node_fatal, empty_plan
 
-        actor_index = None
+        actor_index: int | None = None
         if free_actor_indices_by_node is not None:
             candidates = free_actor_indices_by_node.get(node_id, [])
             if not candidates:
@@ -1018,7 +1389,10 @@ class RayQueryResourceManager:
             )
         plan = _TaskAdmissionPlan(
             resources=resources,
-            output_window_bytes=output_window,
+            # This is the bounded streaming protocol window sent to the
+            # producer.  Soft accounting independently uses the learned
+            # pending-output estimate above, which may initially be zero.
+            output_window_bytes=unit.spec.output_window_bytes,
             node_id=node_id,
             actor_index=actor_index,
             new_credit=new_credit_plan,
@@ -1035,10 +1409,13 @@ class RayQueryResourceManager:
             return "unit_soft_limit", False, plan
         if query_soft_blocked:
             return "query_soft_object_store_bytes", False, plan
+        if query_resource_soft_reason is not None:
+            return query_resource_soft_reason, False, plan
         if borrowed_credit is None:
             soft_reason = self._unit_soft_block_reason_locked(
                 unit.spec.resource_unit_id,
                 commitment,
+                ignore_object_store=object_store_backpressure_disabled,
             )
             if soft_reason is not None:
                 return soft_reason, False, plan
@@ -1289,6 +1666,41 @@ class RayQueryResourceManager:
     def _unit_concurrency_cap(spec: ResourceUnitSpec) -> int | None:
         return spec.max_concurrency
 
+    def _pending_output_estimate_per_task_locked(self, spec: ResourceUnitSpec) -> int:
+        """Estimate unseen streaming-generator bytes for one running task.
+
+        Native fragment results are materialized atomically, so their protocol
+        window is only the initial estimate until exact result bytes replace
+        it. Ray UDF streams instead learn the average generated block size at
+        runtime, matching Ray Data's treatment of pending generator outputs.
+        The declared window caps the unseen-output estimate; it is not a hard
+        cap on an actual block.
+        """
+
+        if spec.target_output_block_bytes <= 0:
+            return 0
+        if spec.backend == "ray_worker":
+            return int(spec.output_window_bytes)
+        state = self._units[spec.resource_unit_id]
+        if state.num_task_outputs_generated <= 0:
+            return 0
+        pending_blocks = float(spec.generator_buffer_blocks)
+        if state.num_tasks_finished > 0:
+            pending_blocks = min(
+                pending_blocks,
+                state.num_outputs_of_finished_tasks / state.num_tasks_finished,
+            )
+        estimate = math.ceil(state.bytes_task_outputs_generated * pending_blocks / state.num_task_outputs_generated)
+        return min(int(spec.output_window_bytes), max(0, estimate))
+
+    def _pending_output_estimate_for_lease_locked(self, lease: TaskLease) -> int:
+        spec = self._units[lease.resource_unit_id].spec
+        if spec.backend == "ray_actor" and lease.lease_id not in self._active_actor_slots.values():
+            # Prefetched actor calls retain their inputs, but only the active
+            # call can currently populate that actor's generator buffer.
+            return 0
+        return self._pending_output_estimate_per_task_locked(spec)
+
     @staticmethod
     def _task_commitment(spec: ResourceUnitSpec) -> ResourceVector:
         """Return non-spillable process resources for one runnable task."""
@@ -1304,15 +1716,16 @@ class RayQueryResourceManager:
     ) -> tuple[tuple[str, ...], str, ResourceVector] | None:
         if parent.backend != "ray_worker":
             return None
+        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
         eligible_specs = tuple(
             self._units[resource_unit_id].spec
             for resource_unit_id in self._reachable_udf_unit_ids[parent.resource_unit_id]
-            if self._units[resource_unit_id].spec.backend == "ray_task" and not self._units[resource_unit_id].completed
+            if resource_unit_id in eligible_unit_ids
+            and self._units[resource_unit_id].spec.backend == "ray_task"
+            and not self._units[resource_unit_id].completed
         )
         if not eligible_specs:
             return None
-        commitments = tuple(self._task_commitment(spec) for spec in eligible_specs)
-        resources = _component_max(commitments)
         reservation_spec = max(
             eligible_specs,
             key=lambda spec: (
@@ -1320,6 +1733,11 @@ class RayQueryResourceManager:
                 -self._topological_unit_ids.index(spec.resource_unit_id),
             ),
         )
+        # A continuation credit is one real liveness path, not a synthetic
+        # component-wise maximum across heterogeneous downstream UDFs. Other
+        # task shapes retain their normal query allocation and can borrow this
+        # credit only when their concrete request fits it.
+        resources = self._task_commitment(reservation_spec)
         return (
             tuple(spec.resource_unit_id for spec in eligible_specs),
             reservation_spec.resource_unit_id,
@@ -1370,8 +1788,10 @@ class RayQueryResourceManager:
                 prospective_task_usage,
                 idle_output_excess,
             )
-            query_exceeded = _hard_resources(query_usage + incremental).exceeded_dimensions(
-                _hard_resources(self.allocation.resources)
+            query_exceeded = _incremental_hard_exceeded_dimensions(
+                query_usage,
+                incremental,
+                self.allocation.resources,
             )
             node_usage = _hard_resources(self._node_usage_locked(credit.node_id))
             node_exceeded = _hard_resources(node_usage + incremental).exceeded_dimensions(
@@ -1422,10 +1842,11 @@ class RayQueryResourceManager:
         allocation at the graph's hard minimum can still start through the
         bounded liveness escape.
         """
+        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
         reachable = tuple(
             self._units[resource_unit_id]
             for resource_unit_id in self._reachable_unit_ids[parent.resource_unit_id]
-            if not self._units[resource_unit_id].completed
+            if resource_unit_id in eligible_unit_ids and not self._units[resource_unit_id].completed
         )
         reservations: list[_DownstreamReservation] = []
         allocation_node_ids = tuple(sorted(allocation.node_id for allocation in self.allocation.node_allocations))
@@ -1459,33 +1880,6 @@ class RayQueryResourceManager:
                 )
             )
 
-        for unit in reachable:
-            spec = unit.spec
-            if spec.backend != "ray_actor":
-                continue
-            if self._active_task_count_for_unit_locked(spec.resource_unit_id) > 0:
-                continue
-            resources = self._task_commitment(spec)
-            if resources.is_zero():
-                continue
-            free_node_ids = tuple(
-                sorted(
-                    {
-                        placement.node_id
-                        for placement in self.allocation.actor_placements
-                        if placement.resource_unit_id == spec.resource_unit_id
-                        and (spec.resource_unit_id, placement.actor_index) not in self._active_actor_slots
-                    }
-                )
-            )
-            reservations.append(
-                _DownstreamReservation(
-                    reservation_id=f"actor:{spec.resource_unit_id}",
-                    unit_ids=(spec.resource_unit_id,),
-                    resources=resources,
-                    allowed_node_ids=free_node_ids,
-                )
-            )
         return tuple(reservations)
 
     @staticmethod
@@ -1503,10 +1897,17 @@ class RayQueryResourceManager:
         *,
         requested_unit_id: str | None,
     ) -> tuple[str, ...]:
+        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
         unit_ids: list[str] = []
         for resource_unit_id, unit in self._units.items():
-            if not unit.runnable or unit.completed:
+            if resource_unit_id not in eligible_unit_ids or unit.completed:
                 continue
+            has_submitted_actor = unit.spec.backend == "ray_actor" and any(
+                candidate_unit_id == resource_unit_id for candidate_unit_id, _actor_index in self._submitted_actor_slots
+            )
+            if not unit.runnable and not has_submitted_actor:
+                continue
+            actor_process_demand = has_submitted_actor and self._unit_uses_dimension(unit.spec, field_name)
             task_demand = (
                 (requested_unit_id is not None and resource_unit_id == requested_unit_id)
                 or unit.pending_task_count > 0
@@ -1517,9 +1918,13 @@ class RayQueryResourceManager:
                 or unit.queued_output_bytes > 0
                 or any(lease.producer_unit_id == resource_unit_id for lease in self._output_leases.values())
             )
-            if not task_demand and not (field_name == "object_store_bytes" and output_demand):
+            if (
+                not actor_process_demand
+                and not task_demand
+                and not (field_name == "object_store_bytes" and output_demand)
+            ):
                 continue
-            if self._unit_dimension_commitment(unit.spec, field_name) > 0:
+            if self._unit_uses_dimension(unit.spec, field_name):
                 unit_ids.append(resource_unit_id)
         return tuple(unit_ids)
 
@@ -1530,6 +1935,7 @@ class RayQueryResourceManager:
         live_unit_ids: tuple[str, ...],
     ) -> tuple[str, ...]:
         live = set(live_unit_ids)
+        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
         continuation_ids: set[str] = set()
         for source_unit_id in live_unit_ids:
             if self._units[source_unit_id].spec.backend != "ray_worker":
@@ -1538,8 +1944,9 @@ class RayQueryResourceManager:
                 unit = self._units[resource_unit_id]
                 if (
                     resource_unit_id not in live
+                    and resource_unit_id in eligible_unit_ids
                     and not unit.completed
-                    and self._unit_dimension_commitment(unit.spec, field_name) > 0
+                    and self._unit_uses_dimension(unit.spec, field_name)
                 ):
                     continuation_ids.add(resource_unit_id)
         return tuple(
@@ -1573,17 +1980,23 @@ class RayQueryResourceManager:
         self,
         resource_unit_id: str,
         request: ResourceVector,
+        *,
+        ignore_object_store: bool = False,
+        excluded_waiting_block_id: str | None = None,
     ) -> str | None:
-        """Enforce dynamic shares among units with real runnable demand.
-
-        DuckDB owns native execution phases. QRM therefore does not infer a
-        static barrier scope: every active or queued unit participates in the
-        dimensions it actually requests, and unused capacity remains shared.
-        """
-        usage_by_unit = {key: self._unit_usage_locked(key) for key in self._units}
+        """Enforce protected shares across current eligible resource units."""
+        usage_by_unit = {
+            key: self._unit_usage_locked(
+                key,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+            for key in self._units
+        }
         current = usage_by_unit[resource_unit_id]
         limits = self.allocation.resources
         for field_name in _RESOURCE_FIELDS:
+            if field_name == "object_store_bytes" and ignore_object_store:
+                continue
             amount = getattr(request, field_name)
             if amount <= 0:
                 continue
@@ -1632,9 +2045,21 @@ class RayQueryResourceManager:
         return None
 
     @staticmethod
-    def _unit_dimension_commitment(spec: ResourceUnitSpec, field_name: str) -> int | float:
+    def _unit_uses_dimension(spec: ResourceUnitSpec, field_name: str) -> bool:
         if field_name == "object_store_bytes":
-            return int(spec.per_task.object_store_bytes) + int(spec.output_window_bytes)
+            return bool(spec.per_task.object_store_bytes or spec.target_output_block_bytes)
+        resources = spec.resident_per_actor if spec.backend == "ray_actor" else spec.per_task
+        return getattr(resources, field_name) > 0
+
+    def _unit_dimension_commitment(self, spec: ResourceUnitSpec, field_name: str) -> int | float:
+        if field_name == "object_store_bytes":
+            # Ray Data does not impose a per-task object-store hard minimum.
+            # Known inputs/outputs and the learned generator estimate are
+            # charged to runtime usage; the default per-unit reservation below
+            # supplies the protected progress share.
+            return 0
+        if spec.backend == "ray_actor":
+            return getattr(spec.resident_per_actor, field_name) * spec.actor_pool_size
         return getattr(spec.per_task, field_name)
 
     def _unit_dimension_maximum_locked(
@@ -1643,6 +2068,13 @@ class RayQueryResourceManager:
         field_name: str,
     ) -> int | float:
         """Cap a soft share by tasks that can coexist under every hard dimension."""
+        if field_name == "object_store_bytes":
+            # Output sizes are data-dependent. Match Ray Data's unbounded
+            # operator maximum and let the query-level soft budget, output
+            # backpressure, spill, and liveness escape control the dimension.
+            return self.allocation.resources.object_store_bytes
+        if spec.backend == "ray_actor" and field_name != "object_store_bytes":
+            return getattr(spec.resident_per_actor, field_name) * spec.actor_pool_size
         concurrency = self._unit_concurrency_cap(spec)
         if spec.backend == "ray_actor":
             concurrency = spec.actor_pool_size
@@ -1841,7 +2273,7 @@ class RayQueryResourceManager:
         starving_unit_ids = [
             resource_unit_id
             for resource_unit_id in ordered_unit_ids
-            if self._units[resource_unit_id].queued_input_bytes > 0
+            if self._units[resource_unit_id].pending_task_count > 0
             and self._active_task_count_for_unit_locked(resource_unit_id) == 0
         ]
         preferred_unit_id = (starving_unit_ids or ordered_unit_ids)[0]
@@ -1908,7 +2340,7 @@ class RayQueryResourceManager:
             starving = [
                 resource_unit_id
                 for resource_unit_id in waiting_candidates
-                if self._units[resource_unit_id].queued_input_bytes > 0
+                if self._units[resource_unit_id].pending_task_count > 0
                 and self._active_task_count_for_unit_locked(resource_unit_id) == 0
             ]
             return (starving or waiting_candidates)[0]
@@ -1946,7 +2378,7 @@ class RayQueryResourceManager:
         starving = [
             resource_unit_id
             for resource_unit_id in runnable_candidates
-            if self._units[resource_unit_id].queued_input_bytes > 0
+            if self._units[resource_unit_id].pending_task_count > 0
             and self._active_task_count_for_unit_locked(resource_unit_id) == 0
         ]
         return (starving or runnable_candidates)[0]
@@ -2135,14 +2567,11 @@ class RayQueryResourceManager:
             if task.attempt_id != attempt_key:
                 raise RuntimeError(f"FTE task lease attempt mismatch: lease={task.attempt_id} result={attempt_key}")
             unit = self._units[task.resource_unit_id]
-            total_output_bytes = sum(int(request.size_bytes) for request in requests)
-            if total_output_bytes > task.output_window_bytes:
+            if unit.spec.backend != "ray_worker":
                 raise RuntimeError(
-                    f"FTE output bytes {total_output_bytes} exceed task window {task.output_window_bytes}: "
-                    f"query={task.query_id} unit={task.resource_unit_id} task_lease={task.lease_id} "
-                    f"attempt={task.attempt_id}"
+                    f"atomic FTE completion requires a native fragment lease: "
+                    f"{task.resource_unit_id} uses {unit.spec.backend}"
                 )
-
             seen_blocks: set[str] = set()
             for request in requests:
                 if str(request.query_id) != task.query_id:
@@ -2162,11 +2591,6 @@ class RayQueryResourceManager:
                 size_bytes = int(request.size_bytes)
                 if size_bytes <= 0:
                     raise RuntimeError(f"FTE output block size must be positive: {block_id}")
-                target_bytes = int(unit.spec.target_output_block_bytes)
-                if target_bytes <= 0 or size_bytes > target_bytes:
-                    raise RuntimeError(
-                        f"FTE output block {block_id} size {size_bytes} exceeds unit target {target_bytes}"
-                    )
 
             output_leases = tuple(
                 OutputBlockLease(
@@ -2185,12 +2609,15 @@ class RayQueryResourceManager:
                 )
                 for request in requests
             )
+            for request in requests:
+                self._record_output_observation_locked(request)
             for output_lease in output_leases:
                 self._output_leases[output_lease.lease_id] = output_lease
                 self._output_lease_by_block[output_lease.block_id] = output_lease.lease_id
             self._recompute_unit_queued_output_locked(task.resource_unit_id)
 
             self._task_leases.pop(task.lease_id, None)
+            self._record_task_finished_locked(task)
             self._on_task_lease_removed_locked(task)
             self._active_attempt_leases.pop((task.task_id, task.attempt_id), None)
             self._terminal_attempts.add((task.task_id, task.attempt_id))
@@ -2205,6 +2632,10 @@ class RayQueryResourceManager:
             if lease is None or lease.attempt_id != str(attempt_id):
                 return False
             self._task_leases.pop(lease_key, None)
+            if terminal:
+                self._record_task_finished_locked(lease)
+            else:
+                self._generated_output_count_by_task_lease.pop(lease.lease_id, None)
             self._on_task_lease_removed_locked(lease)
             self._active_attempt_leases.pop((lease.task_id, lease.attempt_id), None)
             if terminal:
@@ -2231,6 +2662,11 @@ class RayQueryResourceManager:
 
     def try_acquire_output_block(self, request: OutputBlockRequest) -> OutputBlockGrant:
         with self._lock:
+            fatal_reason, _unit, _task, _size = self._output_request_identity_error_locked(request)
+            if fatal_reason is not None:
+                return OutputBlockGrant(False, blocked_reason=fatal_reason, fatal=True)
+            if self._record_output_observation_locked(request):
+                self._publish_change_locked()
             blocked_reason, fatal, _ = self._normal_output_block_reason_locked(request)
             if blocked_reason is None:
                 return self._grant_output_block_locked(request, liveness=False)
@@ -2314,43 +2750,32 @@ class RayQueryResourceManager:
         self,
         request: OutputBlockRequest,
     ) -> tuple[str | None, bool, int]:
-        if self._cancelled:
-            return "query_cancelled", True, 0
-        if str(request.query_id) != self.graph.query_id:
-            return "query_id_mismatch", True, 0
-        unit = self._units.get(str(request.producer_unit_id))
-        if unit is None:
-            return "unit_not_registered", True, 0
+        fatal_reason, unit, task, size = self._output_request_identity_error_locked(request)
+        if fatal_reason is not None:
+            return fatal_reason, True, 0
+        assert unit is not None and task is not None
         block_id = str(request.block_id).strip()
-        if not block_id:
-            return "invalid_block_id", True, 0
-        if block_id in self._terminal_output_blocks:
-            return "output_block_terminal", True, 0
-        task = self._task_leases.get(str(request.task_lease_id))
-        if task is None:
-            return "task_lease_not_active", True, 0
-        if task.resource_unit_id != unit.spec.resource_unit_id:
-            return "task_unit_mismatch", True, 0
-        if task.attempt_id != str(request.attempt_id):
-            return "task_attempt_mismatch", True, 0
-        if block_id in self._output_lease_by_block:
-            return "output_block_already_leased", True, 0
-        size = int(request.size_bytes)
-        if size <= 0:
-            return "invalid_output_block_size", True, 0
-
-        live = self._live_output_bytes_for_task_locked(task.lease_id)
-        before = max(task.output_window_bytes, live)
-        after = max(task.output_window_bytes, live + size)
-        delta = after - before
+        excluded_waiter = block_id if self._waiting_output_blocks.get(block_id) == request else None
+        # Estimated objects still buffered inside a running generator are a
+        # separate Ray Data usage category from every managed ObjectRef that
+        # has already been exposed to the executor. Pulling this block adds its
+        # exact bytes; it does not replace the pending-generator estimate.
+        delta = size
         object_limit = self.allocation.resources.object_store_bytes
-        usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-        if delta > 0 and usage_after.object_store_bytes > object_limit:
+        usage_after = self._query_usage_locked(
+            excluded_waiting_block_id=excluded_waiter,
+        ) + ResourceVector(object_store_bytes=delta)
+        object_store_backpressure_disabled = (
+            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
+        )
+        if not object_store_backpressure_disabled and delta > 0 and usage_after.object_store_bytes > object_limit:
             return "query_soft_object_store_bytes", False, delta
         if delta > 0:
             soft = self._unit_soft_block_reason_locked(
                 unit.spec.resource_unit_id,
                 ResourceVector(object_store_bytes=delta),
+                ignore_object_store=object_store_backpressure_disabled,
+                excluded_waiting_block_id=excluded_waiter,
             )
             if soft is not None:
                 return soft, False, delta
@@ -2451,6 +2876,7 @@ class RayQueryResourceManager:
         task = self._task_leases.get(str(request.task_lease_id))
         if task is None:
             raise RuntimeError("cannot grant an output block without an active task lease")
+        self._record_output_observation_locked(request)
         lease = OutputBlockLease(
             lease_id=uuid.uuid4().hex,
             query_id=self.graph.query_id,
@@ -2531,6 +2957,8 @@ class RayQueryResourceManager:
             self._continuation_credit_by_parent.clear()
             self._continuation_credit_by_borrower.clear()
             self._active_attempt_leases.clear()
+            self._submitted_actor_slots.clear()
+            self._actor_node_by_slot.clear()
             self._active_actor_slots.clear()
             self._queued_actor_slot_leases.clear()
             self._waiting_task_inputs.clear()
@@ -2538,12 +2966,17 @@ class RayQueryResourceManager:
                 self._recompute_unit_queued_input_locked(resource_unit_id)
             self._output_leases.clear()
             self._output_lease_by_block.clear()
+            self._observed_output_blocks.clear()
+            self._generated_output_count_by_task_lease.clear()
             self._waiting_output_blocks.clear()
             for resource_unit_id in self._units:
                 self._recompute_unit_queued_output_locked(resource_unit_id)
             self._active_liveness_task_lease_id = None
             self._active_liveness_path_task_lease_ids.clear()
             self._active_liveness_output_lease_id = None
+            for unit in self._units.values():
+                if unit.spec.backend == "ray_actor":
+                    unit.actor_ready = False
             self._allocation_admission_open = False
             self._cancelled = True
             self._cancel_reason = str(reason)
@@ -2570,16 +3003,80 @@ class RayQueryResourceManager:
             lease.size_bytes for lease in self._output_leases.values() if lease.continuation_credit_id == credit_key
         )
 
+    def _scoped_output_bytes_for_task_locked(
+        self,
+        task_lease_id: str,
+        *,
+        states: set[str],
+        include_waiting: bool,
+        excluded_waiting_block_id: str | None = None,
+    ) -> int:
+        """Return actual output bytes owned by one task/continuation scope."""
+
+        task_key = str(task_lease_id)
+        credit_id = self._continuation_credit_by_borrower.get(task_key)
+        if credit_id is None:
+            leased = sum(
+                lease.size_bytes
+                for lease in self._output_leases.values()
+                if lease.task_lease_id == task_key and lease.state in states
+            )
+        else:
+            leased = sum(
+                lease.size_bytes
+                for lease in self._output_leases.values()
+                if lease.continuation_credit_id == credit_id and lease.state in states
+            )
+        if not include_waiting:
+            return leased
+        waiting = sum(
+            int(request.size_bytes)
+            for block_id, request in self._waiting_output_blocks.items()
+            if block_id != excluded_waiting_block_id and str(request.task_lease_id) == task_key
+        )
+        return leased + waiting
+
+    def _producer_output_bytes_for_task_locked(
+        self,
+        task_lease_id: str,
+        *,
+        excluded_waiting_block_id: str | None = None,
+    ) -> int:
+        return self._scoped_output_bytes_for_task_locked(
+            task_lease_id,
+            states={"generator_pending", "unit_queue"},
+            include_waiting=True,
+            excluded_waiting_block_id=excluded_waiting_block_id,
+        )
+
+    def _downstream_output_bytes_for_task_locked(self, task_lease_id: str) -> int:
+        return self._scoped_output_bytes_for_task_locked(
+            task_lease_id,
+            states={"downstream_input", "external_consumer"},
+            include_waiting=False,
+        )
+
     def _borrowed_task_usage_locked(
         self,
         resources: ResourceVector,
         output_window_bytes: int,
         credit: _ContinuationCredit,
+        *,
+        excluded_waiting_block_id: str | None = None,
     ) -> ResourceVector:
-        live_output = self._live_output_bytes_for_credit_locked(credit.credit_id)
+        borrower = credit.borrowed_by_task_lease_id
+        if borrower is None:
+            producer_output = 0
+            downstream_output = self._live_output_bytes_for_credit_locked(credit.credit_id)
+        else:
+            producer_output = self._producer_output_bytes_for_task_locked(
+                borrower,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+            downstream_output = self._downstream_output_bytes_for_task_locked(borrower)
         combined_commitment = _resource_with_object_store(
             resources,
-            resources.object_store_bytes + max(int(output_window_bytes), live_output),
+            resources.object_store_bytes + downstream_output + producer_output + int(output_window_bytes),
         )
         return _positive_difference(combined_commitment, credit.resources)
 
@@ -2600,21 +3097,32 @@ class RayQueryResourceManager:
             lease.size_bytes for lease in self._output_leases.values() if lease.producer_unit_id == resource_unit_id
         )
 
-    def _task_usage_locked(self, lease: TaskLease) -> ResourceVector:
+    def _task_usage_locked(
+        self,
+        lease: TaskLease,
+        *,
+        excluded_waiting_block_id: str | None = None,
+    ) -> ResourceVector:
+        output_estimate = self._pending_output_estimate_for_lease_locked(lease)
         credit_id = self._continuation_credit_by_borrower.get(lease.lease_id)
         if credit_id is None:
-            live_output = self._live_output_bytes_for_task_locked(lease.lease_id)
+            producer_output = self._producer_output_bytes_for_task_locked(
+                lease.lease_id,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+            downstream_output = self._downstream_output_bytes_for_task_locked(lease.lease_id)
             return _resource_with_object_store(
                 lease.resources,
-                lease.resources.object_store_bytes + max(lease.output_window_bytes, live_output),
+                lease.resources.object_store_bytes + downstream_output + producer_output + output_estimate,
             )
         credit = self._continuation_credits.get(credit_id)
         if credit is None or credit.borrowed_by_task_lease_id != lease.lease_id:
             raise RuntimeError("continuation credit accounting index is inconsistent")
         return self._borrowed_task_usage_locked(
             lease.resources,
-            lease.output_window_bytes,
+            output_estimate,
             credit,
+            excluded_waiting_block_id=excluded_waiting_block_id,
         )
 
     def _uncovered_inactive_output_bytes_locked(
@@ -2701,19 +3209,63 @@ class RayQueryResourceManager:
                     excess_by_unit[resource_unit_id] = excess_by_unit.get(resource_unit_id, 0) + excess
         return excess_by_unit
 
-    def _query_usage_locked(self) -> ResourceVector:
-        total = self._actor_resident_usage_locked()
+    def _query_usage_locked(
+        self,
+        *,
+        excluded_waiting_block_id: str | None = None,
+    ) -> ResourceVector:
+        # Invocation resources remain separate from fixed actor processes.
+        # Existing actor invocations have zero incremental CPU/GPU/heap, while
+        # submitted actor handles are charged by _soft_allocation_usage_locked.
+        total = ResourceVector()
         active_task_ids = set(self._task_leases)
         for credit in self._continuation_credits.values():
             total = total + credit.resources
         for lease in self._task_leases.values():
-            total = total + self._task_usage_locked(lease)
+            total = total + self._task_usage_locked(
+                lease,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
         total = total + ResourceVector(object_store_bytes=self._uncovered_inactive_output_bytes_locked(active_task_ids))
         return total
 
+    def _soft_allocation_usage_locked(self) -> ResourceVector:
+        return self._query_usage_locked() + self._actor_resident_usage_locked()
+
+    def _update_soft_allocation_warning_locked(
+        self,
+        debt: ResourceVector,
+        *,
+        now: float,
+    ) -> None:
+        if debt.is_zero():
+            self._soft_allocation_debt_since = None
+            return
+        if self._soft_allocation_debt_since is None:
+            self._soft_allocation_debt_since = now
+            return
+        if self._soft_allocation_warning_emitted:
+            return
+        duration = max(0.0, now - self._soft_allocation_debt_since)
+        if duration < _SOFT_RESERVATION_WARNING_DELAY_S:
+            return
+        self._soft_allocation_warning_emitted = True
+        logger.warning(
+            "Ray query %s has exceeded its soft resource reservation for %.1fs "
+            "(debt=%s, allocation=%s). Existing work and fixed actor pools may "
+            "continue, but new work can be backpressured or remain pending in "
+            "Ray Core. Persistent CPU/GPU/heap debt usually requires more "
+            "cluster resources or lower UDF concurrency; object-store debt may "
+            "spill and reduce throughput.",
+            self.graph.query_id,
+            duration,
+            debt.to_dict(),
+            self.allocation.resources.to_dict(),
+        )
+
     def _node_usage_locked(self, node_id: str) -> ResourceVector:
         node_key = str(node_id)
-        total = self._actor_resident_usage_locked(node_id=node_key)
+        total = ResourceVector()
         active_task_ids: set[str] = set()
         for credit in self._continuation_credits.values():
             if credit.node_id == node_key:
@@ -2731,8 +3283,13 @@ class RayQueryResourceManager:
         )
         return total
 
-    def _unit_usage_locked(self, resource_unit_id: str) -> ResourceVector:
-        total = self._actor_resident_usage_locked(resource_unit_id=resource_unit_id)
+    def _unit_usage_locked(
+        self,
+        resource_unit_id: str,
+        *,
+        excluded_waiting_block_id: str | None = None,
+    ) -> ResourceVector:
+        total = ResourceVector()
         active_task_ids: set[str] = set()
         for credit in self._continuation_credits.values():
             if credit.reservation_unit_id == resource_unit_id:
@@ -2741,7 +3298,10 @@ class RayQueryResourceManager:
             if lease.resource_unit_id != resource_unit_id:
                 continue
             active_task_ids.add(lease.lease_id)
-            task_usage = self._task_usage_locked(lease)
+            task_usage = self._task_usage_locked(
+                lease,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
             total = total + task_usage
         total = total + ResourceVector(
             object_store_bytes=self._uncovered_inactive_output_bytes_locked(
@@ -2749,6 +3309,10 @@ class RayQueryResourceManager:
                 resource_unit_id=resource_unit_id,
             )
         )
+        if self._units[resource_unit_id].spec.backend == "ray_actor":
+            total = total + self._actor_resident_usage_locked(
+                resource_unit_id=resource_unit_id,
+            )
         return total
 
     def _actor_resident_usage_locked(
@@ -2758,20 +3322,34 @@ class RayQueryResourceManager:
         resource_unit_id: str | None = None,
     ) -> ResourceVector:
         total = ResourceVector()
-        for placement in self.allocation.actor_placements:
-            if node_id is not None and placement.node_id != node_id:
+        for candidate_unit_id, actor_index in self._submitted_actor_slots:
+            actor_node_id = self._actor_node_by_slot.get((candidate_unit_id, actor_index))
+            if node_id is not None and actor_node_id != node_id:
                 continue
-            if resource_unit_id is not None and placement.resource_unit_id != resource_unit_id:
+            if resource_unit_id is not None and candidate_unit_id != resource_unit_id:
                 continue
-            unit = self._units.get(placement.resource_unit_id)
+            unit = self._units.get(candidate_unit_id)
             if unit is None:
-                raise RuntimeError("actor placement references an unknown query unit")
+                raise RuntimeError("submitted actor slot references an unknown query unit")
             total = total + unit.spec.resident_per_actor
         return total
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             usage = self._query_usage_locked()
+            soft_allocation_usage = self._soft_allocation_usage_locked()
+            soft_allocation_debt = _positive_difference(
+                soft_allocation_usage,
+                self.allocation.resources,
+            )
+            now = time.monotonic()
+            self._update_soft_allocation_warning_locked(
+                soft_allocation_debt,
+                now=now,
+            )
+            frontier_barriers = self._frontier_materialization_barriers_locked()
+            eligible_unit_ids = self._eligible_resource_unit_ids_locked()
+            object_store_unlimited_unit_ids = self._materializing_object_store_unlimited_unit_ids_locked()
             preferred_task, grant_class = self._preferred_waiting_task_locked()
             allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
             reservation_source_unit_ids = {lease.resource_unit_id for lease in self._task_leases.values()} | {
@@ -2790,17 +3368,49 @@ class RayQueryResourceManager:
                 | {lease.node_id for lease in self._task_leases.values()}
                 | {lease.node_id for lease in self._output_leases.values()}
                 | {credit.node_id for credit in self._continuation_credits.values()}
+                | set(self._actor_node_by_slot.values())
             )
             node_usage = {node_id: self._node_usage_locked(node_id) for node_id in node_ids}
+            actor_resident_usage_by_node = {
+                node_id: self._actor_resident_usage_locked(node_id=node_id)
+                for node_id in sorted(set(self._actor_node_by_slot.values()))
+            }
+            submitted_actor_slots = set(self._submitted_actor_slots)
+            ready_actor_slots = set(self._actor_node_by_slot)
             return {
                 "query_id": self.graph.query_id,
                 "graph": self.graph.to_dict(),
                 "allocation": self.allocation.to_dict(),
                 "usage": usage.to_dict(),
+                "soft_allocation_usage": soft_allocation_usage.to_dict(),
+                "actor_process_usage": self._actor_resident_usage_locked().to_dict(),
+                "actor_process_usage_by_ready_node": {
+                    node_id: resources.to_dict() for node_id, resources in actor_resident_usage_by_node.items()
+                },
+                "submitted_actor_slots": [
+                    f"{resource_unit_id}:{actor_index}"
+                    for resource_unit_id, actor_index in sorted(submitted_actor_slots)
+                ],
+                "pending_actor_slots": [
+                    f"{resource_unit_id}:{actor_index}"
+                    for resource_unit_id, actor_index in sorted(submitted_actor_slots - ready_actor_slots)
+                ],
+                "ready_actor_slots": {
+                    f"{resource_unit_id}:{actor_index}": node_id
+                    for (resource_unit_id, actor_index), node_id in sorted(self._actor_node_by_slot.items())
+                },
+                "retiring_actor_unit_ids": sorted(self._retiring_actor_unit_ids),
                 "allocation_debt": _hard_positive_difference(
                     usage,
                     self.allocation.resources,
                 ).to_dict(),
+                "soft_allocation_debt": soft_allocation_debt.to_dict(),
+                "soft_allocation_debt_duration_s": (
+                    0.0
+                    if self._soft_allocation_debt_since is None
+                    else max(0.0, now - self._soft_allocation_debt_since)
+                ),
+                "soft_allocation_warning_emitted": self._soft_allocation_warning_emitted,
                 "soft_object_store_debt_bytes": max(
                     0,
                     usage.object_store_bytes - self.allocation.resources.object_store_bytes,
@@ -2827,6 +3437,12 @@ class RayQueryResourceManager:
                     for node_id, resources in node_usage.items()
                 },
                 "reservation_ratio": self.reservation_ratio,
+                "execution_phase": {
+                    "frontier_barrier_ids": [barrier.barrier_id for barrier in frontier_barriers],
+                    "eligible_resource_unit_ids": list(eligible_unit_ids),
+                    "completed_barrier_ids": sorted(self._completed_materialization_barrier_ids),
+                    "object_store_unlimited_unit_ids": list(object_store_unlimited_unit_ids),
+                },
                 "cancelled": self._cancelled,
                 "cancel_reason": self._cancel_reason,
                 "external_consumer_waiting": self._external_consumer_waiting,
@@ -2906,7 +3522,27 @@ class RayQueryResourceManager:
                         "pending_task_count": unit.pending_task_count,
                         "queued_output_bytes": unit.queued_output_bytes,
                         "pending_output_count": unit.pending_output_count,
+                        "bytes_task_outputs_generated": unit.bytes_task_outputs_generated,
+                        "num_task_outputs_generated": unit.num_task_outputs_generated,
+                        "num_outputs_of_finished_tasks": unit.num_outputs_of_finished_tasks,
+                        "num_tasks_finished": unit.num_tasks_finished,
+                        "average_output_block_bytes": (
+                            None
+                            if unit.num_task_outputs_generated == 0
+                            else unit.bytes_task_outputs_generated / unit.num_task_outputs_generated
+                        ),
+                        "average_output_blocks_per_finished_task": (
+                            None
+                            if unit.num_tasks_finished == 0
+                            else unit.num_outputs_of_finished_tasks / unit.num_tasks_finished
+                        ),
+                        "pending_output_estimate_per_active_task_bytes": (
+                            self._pending_output_estimate_per_task_locked(unit.spec)
+                        ),
+                        "protocol_output_window_max_bytes": unit.spec.output_window_bytes,
                         "completed": unit.completed,
+                        "phase_eligible": resource_unit_id in eligible_unit_ids,
+                        "object_store_backpressure_disabled": (resource_unit_id in object_store_unlimited_unit_ids),
                         "usage": self._unit_usage_locked(resource_unit_id).to_dict(),
                         "active_task_count": self._active_task_count_for_unit_locked(resource_unit_id),
                     }

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -20,6 +20,7 @@ from duckdb.runners.ray.query_execution_graph import (
 )
 
 _SOFT_TASK_BLOCK_REASONS = {
+    "query_soft_object_store_bytes",
     "stage_soft_cpu",
     "stage_soft_gpu",
     "stage_soft_heap_bytes",
@@ -27,6 +28,7 @@ _SOFT_TASK_BLOCK_REASONS = {
     "stage_soft_limit",
 }
 _SOFT_OUTPUT_BLOCK_REASONS = {
+    "query_soft_object_store_bytes",
     "stage_soft_object_store_bytes",
     "stage_soft_limit",
 }
@@ -58,6 +60,19 @@ def _positive_difference(left: ResourceVector, right: ResourceVector) -> Resourc
         heap_bytes=max(0, left.heap_bytes - right.heap_bytes),
         object_store_bytes=max(0, left.object_store_bytes - right.object_store_bytes),
     )
+
+
+def _hard_resources(resources: ResourceVector) -> ResourceVector:
+    """Drop the spillable object-store flow-control dimension."""
+    return ResourceVector(
+        cpu=resources.cpu,
+        gpu=resources.gpu,
+        heap_bytes=resources.heap_bytes,
+    )
+
+
+def _hard_positive_difference(left: ResourceVector, right: ResourceVector) -> ResourceVector:
+    return _positive_difference(_hard_resources(left), _hard_resources(right))
 
 
 def _component_max(resources: tuple[ResourceVector, ...]) -> ResourceVector:
@@ -358,6 +373,7 @@ class QueryResourceManager:
         self._output_lease_by_block: dict[str, str] = {}
         self._terminal_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
         self._active_liveness_task_lease_id: str | None = None
+        self._active_liveness_path_task_lease_ids: set[str] = set()
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
@@ -599,12 +615,7 @@ class QueryResourceManager:
             stage = self._stages.get(str(stage_id))
             if stage is None:
                 raise KeyError(f"stage is not registered: {stage_id}")
-            commitment = ResourceVector(
-                cpu=stage.spec.per_task.cpu,
-                gpu=stage.spec.per_task.gpu,
-                heap_bytes=stage.spec.per_task.heap_bytes,
-                object_store_bytes=(stage.spec.per_task.object_store_bytes + stage.spec.output_window_bytes),
-            )
+            commitment = self._task_commitment(stage.spec)
             allowed_actor_nodes = (
                 set(self.allocation.actor_node_ids_for_stage(stage.spec.stage_id))
                 if stage.spec.backend == "ray_actor"
@@ -630,8 +641,9 @@ class QueryResourceManager:
             base_remaining: dict[str, ResourceVector] = {}
             for node_id, capacity in allocation_by_node.items():
                 resident = self._actor_resident_usage_locked(node_id=node_id)
-                if resident.fits_within(capacity):
-                    base_remaining[node_id] = capacity - resident
+                hard_capacity = _hard_resources(capacity)
+                if resident.fits_within(hard_capacity):
+                    base_remaining[node_id] = hard_capacity - resident
 
             def preserves_registered_minimum(task_node_id: str) -> bool:
                 task_capacity = base_remaining.get(task_node_id)
@@ -676,7 +688,10 @@ class QueryResourceManager:
             if fatal or blocked_reason not in _SOFT_TASK_BLOCK_REASONS:
                 return TaskGrant(False, blocked_reason=blocked_reason, fatal=fatal)
 
-            liveness_block = self._task_liveness_block_reason_locked(request)
+            liveness_block = self._task_liveness_block_reason_locked(
+                request,
+                plan,
+            )
             if liveness_block is not None:
                 return TaskGrant(False, blocked_reason=liveness_block)
             return self._grant_task_locked(
@@ -859,12 +874,18 @@ class QueryResourceManager:
                     liveness=False,
                 )
             request = selected.request
-            if self._active_liveness_task_lease_id is not None:
+            if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
+                str(request.stage_id),
+                selected.plan,
+            ):
                 return request, TaskGrant(
                     False,
                     blocked_reason="liveness_task_active",
                 )
-            if self._task_leases and not self._external_consumer_waiting:
+            if not self._active_tasks_allow_liveness_locked(
+                str(request.stage_id),
+                selected.plan,
+            ):
                 return request, TaskGrant(
                     False,
                     blocked_reason="liveness_not_needed",
@@ -937,11 +958,12 @@ class QueryResourceManager:
         resources = _resource_with_object_store(stage.spec.per_task, retained)
         output_window = stage.spec.output_window_bytes
         commitment = _resource_with_object_store(resources, retained + output_window)
-        if commitment.exceeded_dimensions(self.allocation.resources):
+        hard_commitment = _hard_resources(commitment)
+        if hard_commitment.exceeded_dimensions(_hard_resources(self.allocation.resources)):
             return "task_exceeds_query_allocation", True, empty_plan
 
         query_usage = self._query_usage_locked()
-        debt = _positive_difference(query_usage, self.allocation.resources)
+        debt = _hard_positive_difference(query_usage, self.allocation.resources)
         if not debt.is_zero():
             return "allocation_debt", False, empty_plan
 
@@ -975,13 +997,18 @@ class QueryResourceManager:
                 idle_output_excess,
             )
 
-        exceeded = (query_usage + admission_commitment).exceeded_dimensions(self.allocation.resources)
-        if exceeded:
-            reason = "continuation_capacity" if credit_template is not None else f"hard_{exceeded[0]}"
+        usage_after = query_usage + admission_commitment
+        hard_exceeded = _hard_resources(usage_after).exceeded_dimensions(_hard_resources(self.allocation.resources))
+        if hard_exceeded:
+            reason = "continuation_capacity" if credit_template is not None else f"hard_{hard_exceeded[0]}"
             return reason, False, empty_plan
+        query_soft_blocked = (
+            admission_commitment.object_store_bytes > 0
+            and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
+        )
         downstream_reservations = self._downstream_reservations_locked(stage.spec)
         if downstream_reservations:
-            remaining = self.allocation.resources - (query_usage + admission_commitment)
+            remaining = _hard_resources(self.allocation.resources) - _hard_resources(query_usage + admission_commitment)
             reservation_total = self._downstream_reservation_total(downstream_reservations)
             if not reservation_total.fits_within(remaining):
                 return "continuation_capacity", False, empty_plan
@@ -991,7 +1018,7 @@ class QueryResourceManager:
             eligible_stage_ids, reservation_stage_id, credit_resources = credit_template
             node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
                 request.node_id,
-                commitment,
+                hard_commitment,
                 credit_resources,
                 downstream_reservations=downstream_reservations,
             )
@@ -1010,7 +1037,7 @@ class QueryResourceManager:
             )
             node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
                 request.node_id,
-                admission_commitment,
+                _hard_resources(admission_commitment),
                 allowed_node_ids=allowed_node_ids,
                 downstream_reservations=downstream_reservations,
             )
@@ -1044,6 +1071,8 @@ class QueryResourceManager:
             for downstream_id in self._direct_downstream_stage_ids[stage.spec.stage_id]
         ):
             return "stage_soft_limit", False, plan
+        if query_soft_blocked:
+            return "query_soft_object_store_bytes", False, plan
         if borrowed_credit is None:
             soft_reason = self._stage_soft_block_reason_locked(stage.spec.stage_id, commitment)
             if soft_reason is not None:
@@ -1058,7 +1087,9 @@ class QueryResourceManager:
         allowed_node_ids: set[str] | None,
         downstream_reservations: tuple[_DownstreamReservation, ...] = (),
     ) -> tuple[str, str | None, bool]:
-        allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
+        allocation_by_node = {
+            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
+        }
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
         if requested and requested not in allocation_by_node:
             return "", "node_not_allocated", True
@@ -1077,7 +1108,7 @@ class QueryResourceManager:
         debt_detected = False
         for node_id in static_candidates:
             capacity = allocation_by_node[node_id]
-            usage = self._node_usage_locked(node_id)
+            usage = _hard_resources(self._node_usage_locked(node_id))
             if not usage.fits_within(capacity):
                 debt_detected = True
                 continue
@@ -1123,7 +1154,9 @@ class QueryResourceManager:
         downstream_reservations: tuple[_DownstreamReservation, ...],
     ) -> tuple[str, str, str | None, bool]:
         """Place one parent task and its continuation ownership atomically."""
-        allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
+        allocation_by_node = {
+            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
+        }
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
         if requested and requested not in allocation_by_node:
             return "", "", "node_not_allocated", True
@@ -1152,7 +1185,7 @@ class QueryResourceManager:
                 remaining_by_node: dict[str, ResourceVector] = {}
                 feasible = True
                 for node_id, capacity in allocation_by_node.items():
-                    usage = self._node_usage_locked(node_id)
+                    usage = _hard_resources(self._node_usage_locked(node_id))
                     if not usage.fits_within(capacity):
                         if node_id in proposed:
                             debt_detected = True
@@ -1199,7 +1232,7 @@ class QueryResourceManager:
     ) -> bool:
         remaining_by_node: dict[str, ResourceVector] = {}
         for node_id, capacity in allocation_by_node.items():
-            usage = self._node_usage_locked(node_id)
+            usage = _hard_resources(self._node_usage_locked(node_id))
             if node_id == parent_node_id:
                 usage = usage + parent_commitment
             if usage.fits_within(capacity):
@@ -1277,9 +1310,11 @@ class QueryResourceManager:
 
     @staticmethod
     def _task_commitment(spec: StageResourceSpec) -> ResourceVector:
-        return _resource_with_object_store(
-            spec.per_task,
-            spec.per_task.object_store_bytes + spec.output_window_bytes,
+        """Return non-spillable process resources for one runnable task."""
+        return ResourceVector(
+            cpu=spec.per_task.cpu,
+            gpu=spec.per_task.gpu,
+            heap_bytes=spec.per_task.heap_bytes,
         )
 
     def _continuation_credit_template_locked(
@@ -1325,7 +1360,9 @@ class QueryResourceManager:
             return None
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
         commitment = self._task_commitment(stage)
-        allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
+        allocation_by_node = {
+            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
+        }
         candidates = [
             credit
             for credit in self._continuation_credits.values()
@@ -1352,13 +1389,24 @@ class QueryResourceManager:
                 prospective_task_usage,
                 idle_output_excess,
             )
-            query_exceeded = (query_usage + incremental).exceeded_dimensions(self.allocation.resources)
-            node_usage = self._node_usage_locked(credit.node_id)
-            node_exceeded = (node_usage + incremental).exceeded_dimensions(allocation_by_node[credit.node_id])
+            query_exceeded = _hard_resources(query_usage + incremental).exceeded_dimensions(
+                _hard_resources(self.allocation.resources)
+            )
+            node_usage = _hard_resources(self._node_usage_locked(credit.node_id))
+            node_exceeded = _hard_resources(node_usage + incremental).exceeded_dimensions(
+                allocation_by_node[credit.node_id]
+            )
+            soft_debt = max(
+                0,
+                query_usage.object_store_bytes
+                + incremental.object_store_bytes
+                - self.allocation.resources.object_store_bytes,
+            )
             feasible = not query_exceeded and not node_exceeded
             return (
                 0 if feasible else 1,
                 len(query_exceeded) + len(node_exceeded),
+                soft_debt,
                 incremental.dominant_share(self.allocation.resources),
                 incremental.gpu,
                 incremental.cpu,
@@ -1384,13 +1432,13 @@ class QueryResourceManager:
         actor boundary additionally needs one slot for every inactive
         downstream Ray-task continuation: the actor input producer, actor call,
         and downstream consumer can all remain live while generator output is
-        drained, so the transferable component-max credit alone is not enough.
-        Actor process resources are resident, but each downstream actor stage
-        also needs an invocation input/output window on one of its pinned nodes.
+        drained, so the transferable component-max process credit alone is not
+        enough. Actor process resources are already resident; invocation
+        input/output bytes use the query's dynamic object-store budget.
 
         Reservations include latent stages: waiting for a stage to become
         runnable is too late because an upstream producer may already have
-        consumed the last heap or object-store slot by then.
+        consumed the last non-spillable process slot by then.
         """
         reachable = tuple(
             self._stages[stage_id]
@@ -1637,11 +1685,70 @@ class QueryResourceManager:
         per_task_amount = self._stage_dimension_commitment(spec, field_name)
         return per_task_amount * max(0, int(hard_bound))
 
-    def _task_liveness_block_reason_locked(self, request: TaskRequest) -> str | None:
-        if self._active_liveness_task_lease_id is not None:
+    def _active_tasks_allow_liveness_locked(
+        self,
+        stage_id: str,
+        plan: _TaskAdmissionPlan,
+    ) -> bool:
+        """Allow one escape only when it can drain an active upstream path."""
+        if not self._task_leases:
+            return True
+        stage_key = str(stage_id)
+        if self._active_task_count_for_stage_locked(stage_key) > 0:
+            return False
+        if plan.borrowed_credit_id is not None:
+            return True
+        return any(stage_key in self._reachable_stage_ids[lease.stage_id] for lease in self._task_leases.values())
+
+    def _continues_active_liveness_path_locked(
+        self,
+        stage_id: str,
+        plan: _TaskAdmissionPlan,
+    ) -> bool:
+        """Return whether a soft-blocked task continues the one escape path."""
+        active_lease_id = self._active_liveness_task_lease_id
+        if active_lease_id is None:
+            return False
+        stage_key = str(stage_id)
+        stage = self._stages.get(stage_key)
+        if stage is None:
+            return False
+        active_path_leases = tuple(
+            lease
+            for lease_id, lease in self._task_leases.items()
+            if lease_id in self._active_liveness_path_task_lease_ids
+        )
+        frontier = tuple(
+            lease
+            for lease in active_path_leases
+            if not any(
+                other.lease_id != lease.lease_id and other.stage_id in self._reachable_stage_ids[lease.stage_id]
+                for other in active_path_leases
+            )
+        )
+        continues_from_frontier = any(stage_key in self._reachable_stage_ids[lease.stage_id] for lease in frontier)
+        credit_id = plan.borrowed_credit_id
+        if credit_id is not None:
+            credit = self._continuation_credits.get(credit_id)
+            return (
+                continues_from_frontier
+                and credit is not None
+                and credit.parent_active
+                and credit.parent_task_lease_id in self._active_liveness_path_task_lease_ids
+                and credit.borrowed_by_task_lease_id is None
+            )
+        return continues_from_frontier
+
+    def _task_liveness_block_reason_locked(
+        self,
+        request: TaskRequest,
+        plan: _TaskAdmissionPlan,
+    ) -> str | None:
+        if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
+            str(request.stage_id),
+            plan,
+        ):
             return "liveness_task_active"
-        if self._task_leases and not self._external_consumer_waiting:
-            return "liveness_not_needed"
         if self._has_normal_task_candidate_locked():
             return "normal_candidate_available"
         preferred = self._preferred_liveness_stage_locked()
@@ -1649,6 +1756,11 @@ class QueryResourceManager:
             return "no_liveness_candidate"
         if preferred != str(request.stage_id):
             return "liveness_candidate_not_selected"
+        if not self._active_tasks_allow_liveness_locked(
+            str(request.stage_id),
+            plan,
+        ):
+            return "liveness_not_needed"
         return None
 
     def _has_normal_task_candidate_locked(self) -> bool:
@@ -1724,6 +1836,21 @@ class QueryResourceManager:
         soft = [item for item in evaluations if not item.fatal and item.reason in _SOFT_TASK_BLOCK_REASONS]
         if not soft:
             return None
+        if self._active_liveness_task_lease_id is not None:
+            path_candidates = [
+                item
+                for item in soft
+                if self._continues_active_liveness_path_locked(
+                    str(item.request.stage_id),
+                    item.plan,
+                )
+                and self._active_tasks_allow_liveness_locked(
+                    str(item.request.stage_id),
+                    item.plan,
+                )
+            ]
+            if path_candidates:
+                soft = path_candidates
         soft_stage_ids = {str(item.request.stage_id) for item in soft}
         ordered_stage_ids = [stage_id for stage_id in self._reverse_topological_stage_ids if stage_id in soft_stage_ids]
         starving_stage_ids = [
@@ -1741,12 +1868,21 @@ class QueryResourceManager:
         self,
         evaluations: tuple[_QueuedTaskEvaluation, ...],
     ) -> str | None:
-        if self._active_liveness_task_lease_id is not None:
-            return "liveness_task_active"
-        if self._task_leases and not self._external_consumer_waiting:
-            return "liveness_not_needed"
         if any(not item.fatal and item.reason is None for item in evaluations):
             return "normal_candidate_available"
+        selected = self._select_waiting_task_evaluation_locked(evaluations)
+        if selected is None:
+            return "no_liveness_candidate"
+        if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
+            str(selected.request.stage_id),
+            selected.plan,
+        ):
+            return "liveness_task_active"
+        if not self._active_tasks_allow_liveness_locked(
+            str(selected.request.stage_id),
+            selected.plan,
+        ):
+            return "liveness_not_needed"
         return None
 
     def _preferred_waiting_task_locked(self) -> tuple[TaskRequest | None, str]:
@@ -1764,11 +1900,21 @@ class QueryResourceManager:
                 for request, _ in self._waiting_task_inputs.values():
                     if str(request.stage_id) != stage_id:
                         continue
-                    reason, fatal, _ = self._normal_task_block_reason_locked(
+                    reason, fatal, plan = self._normal_task_block_reason_locked(
                         request,
                         hypothetical=True,
                     )
-                    if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
+                    path_allowed = self._active_liveness_task_lease_id is None or (
+                        self._continues_active_liveness_path_locked(
+                            stage_id,
+                            plan,
+                        )
+                        and self._active_tasks_allow_liveness_locked(
+                            stage_id,
+                            plan,
+                        )
+                    )
+                    if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
                         waiting_candidates.append(stage_id)
                         break
             if not waiting_candidates:
@@ -1793,11 +1939,21 @@ class QueryResourceManager:
                 node_id=None,
                 retained_input_bytes=stage.spec.per_task.object_store_bytes,
             )
-            reason, fatal, _ = self._normal_task_block_reason_locked(
+            reason, fatal, plan = self._normal_task_block_reason_locked(
                 request,
                 hypothetical=True,
             )
-            if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
+            path_allowed = self._active_liveness_task_lease_id is None or (
+                self._continues_active_liveness_path_locked(
+                    stage_id,
+                    plan,
+                )
+                and self._active_tasks_allow_liveness_locked(
+                    stage_id,
+                    plan,
+                )
+            )
+            if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
                 runnable_candidates.append(stage_id)
         if not runnable_candidates:
             return None
@@ -1819,6 +1975,14 @@ class QueryResourceManager:
             raise RuntimeError("cannot grant a query task lease without a concrete Ray node")
         if plan.new_credit is not None and plan.borrowed_credit_id is not None:
             raise RuntimeError("task admission cannot create and borrow a continuation credit")
+        continues_active_liveness = liveness and self._continues_active_liveness_path_locked(
+            str(request.stage_id),
+            plan,
+        )
+        if liveness and self._active_liveness_task_lease_id is not None and not continues_active_liveness:
+            raise RuntimeError("task liveness path changed during atomic admission")
+        if liveness and self._active_liveness_task_lease_id is None and self._active_liveness_path_task_lease_ids:
+            raise RuntimeError("task liveness path has no active root")
         stage = self._stages[str(request.stage_id)].spec
         actor_index = plan.actor_index
         lease_id = uuid.uuid4().hex
@@ -1882,7 +2046,9 @@ class QueryResourceManager:
         self._recompute_stage_queued_input_locked(lease.stage_id)
         self._started_stage_ids.add(lease.stage_id)
         if liveness:
-            self._active_liveness_task_lease_id = lease.lease_id
+            if self._active_liveness_task_lease_id is None:
+                self._active_liveness_task_lease_id = lease.lease_id
+            self._active_liveness_path_task_lease_ids.add(lease.lease_id)
             self._task_liveness_grants_total += 1
         self._publish_change_locked()
         return TaskGrant(True, lease=lease, liveness=liveness)
@@ -2041,8 +2207,7 @@ class QueryResourceManager:
             self._on_task_lease_removed_locked(task)
             self._active_attempt_leases.pop((task.task_id, task.attempt_id), None)
             self._terminal_attempts.add((task.task_id, task.attempt_id))
-            if self._active_liveness_task_lease_id == task.lease_id:
-                self._active_liveness_task_lease_id = None
+            self._maybe_clear_task_liveness_locked(task.lease_id)
             self._publish_change_locked()
             return output_leases
 
@@ -2057,14 +2222,29 @@ class QueryResourceManager:
             self._active_attempt_leases.pop((lease.task_id, lease.attempt_id), None)
             if terminal:
                 self._terminal_attempts.add((lease.task_id, lease.attempt_id))
-            if self._active_liveness_task_lease_id == lease_key:
-                self._active_liveness_task_lease_id = None
+            self._maybe_clear_task_liveness_locked(lease_key)
             self._publish_change_locked()
             return True
 
+    def _maybe_clear_task_liveness_locked(self, task_lease_id: str) -> None:
+        """Return one escape after its continuation path leaves the producer."""
+        task_key = str(task_lease_id)
+        if task_key not in self._active_liveness_path_task_lease_ids:
+            return
+        if task_key in self._task_leases:
+            return
+        if any(
+            output.task_lease_id == task_key and output.state in {"generator_pending", "stage_queue"}
+            for output in self._output_leases.values()
+        ):
+            return
+        self._active_liveness_path_task_lease_ids.remove(task_key)
+        if not self._active_liveness_path_task_lease_ids:
+            self._active_liveness_task_lease_id = None
+
     def try_acquire_output_block(self, request: OutputBlockRequest) -> OutputBlockGrant:
         with self._lock:
-            blocked_reason, fatal, delta = self._normal_output_block_reason_locked(request)
+            blocked_reason, fatal, _ = self._normal_output_block_reason_locked(request)
             if blocked_reason is None:
                 return self._grant_output_block_locked(request, liveness=False)
             if fatal or blocked_reason not in _SOFT_OUTPUT_BLOCK_REASONS:
@@ -2078,10 +2258,6 @@ class QueryResourceManager:
             preferred = self._preferred_output_liveness_stage_locked(request)
             if preferred != str(request.producer_stage_id):
                 return OutputBlockGrant(False, blocked_reason="liveness_output_candidate_not_selected")
-            if delta > 0:
-                usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-                if not usage_after.fits_within(self.allocation.resources):
-                    return OutputBlockGrant(False, blocked_reason="hard_object_store_bytes")
             return self._grant_output_block_locked(request, liveness=True)
 
     def try_acquire_next_queued_output_block(
@@ -2175,25 +2351,20 @@ class QueryResourceManager:
         size = int(request.size_bytes)
         if size <= 0:
             return "invalid_output_block_size", True, 0
-        object_limit = self.allocation.resources.object_store_bytes
-        if size > object_limit:
-            return "output_block_exceeds_query_limit", True, 0
 
         live = self._live_output_bytes_for_task_locked(task.lease_id)
         before = max(task.output_window_bytes, live)
         after = max(task.output_window_bytes, live + size)
         delta = after - before
+        object_limit = self.allocation.resources.object_store_bytes
+        usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
+        if delta > 0 and usage_after.object_store_bytes > object_limit:
+            return "query_soft_object_store_bytes", False, delta
         if delta > 0:
-            usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-            if not usage_after.fits_within(self.allocation.resources):
-                return "hard_object_store_bytes", False, delta
             try:
-                node_capacity = self.allocation.resources_for_node(task.node_id)
+                self.allocation.resources_for_node(task.node_id)
             except KeyError:
                 return "node_not_allocated", True, delta
-            node_usage_after = self._node_usage_locked(task.node_id) + ResourceVector(object_store_bytes=delta)
-            if not node_usage_after.fits_within(node_capacity):
-                return "node_capacity", False, delta
             soft = self._stage_soft_block_reason_locked(
                 stage.spec.stage_id,
                 ResourceVector(object_store_bytes=delta),
@@ -2334,13 +2505,13 @@ class QueryResourceManager:
                 raise ValueError(f"invalid output lease transition: {lease.state} -> {target}")
             self._output_leases[lease_key] = OutputBlockLease(**{**asdict(lease), "state": target})
             if target == "downstream_input" and self._active_liveness_output_lease_id == lease_key:
-                # The object remains physically leased and fully charged, but
-                # it no longer occupies the producer-side liveness escape.
-                # This is the ownership boundary that permits another block
-                # to complete a downstream compute batch without weakening
-                # query/node object-store hard limits.
+                # A liveness escape limits producer-side progress to one full
+                # block at a time. The handed-off object stays charged, while
+                # returning the token lets a partial downstream batch request
+                # its next block.
                 self._active_liveness_output_lease_id = None
             if target == "downstream_input":
+                self._maybe_clear_task_liveness_locked(lease.task_lease_id)
                 self._maybe_return_continuation_credit_locked(lease.task_lease_id)
             self._recompute_stage_queued_output_locked(lease.producer_stage_id)
             self._publish_change_locked()
@@ -2356,6 +2527,7 @@ class QueryResourceManager:
             self._terminal_output_blocks.add(lease.block_id)
             if self._active_liveness_output_lease_id == lease_key:
                 self._active_liveness_output_lease_id = None
+            self._maybe_clear_task_liveness_locked(lease.task_lease_id)
             self._maybe_return_continuation_credit_locked(lease.task_lease_id)
             self._recompute_stage_queued_output_locked(lease.producer_stage_id)
             self._publish_change_locked()
@@ -2385,6 +2557,7 @@ class QueryResourceManager:
             for stage_id in self._stages:
                 self._recompute_stage_queued_output_locked(stage_id)
             self._active_liveness_task_lease_id = None
+            self._active_liveness_path_task_lease_ids.clear()
             self._active_liveness_output_lease_id = None
             self._allocation_admission_open = False
             self._cancelled = True
@@ -2635,15 +2808,33 @@ class QueryResourceManager:
                 "graph": self.graph.to_dict(),
                 "allocation": self.allocation.to_dict(),
                 "usage": usage.to_dict(),
-                "allocation_debt": _positive_difference(usage, self.allocation.resources).to_dict(),
+                "allocation_debt": _hard_positive_difference(
+                    usage,
+                    self.allocation.resources,
+                ).to_dict(),
+                "soft_object_store_debt_bytes": max(
+                    0,
+                    usage.object_store_bytes - self.allocation.resources.object_store_bytes,
+                ),
                 "allocation_admission_open": self._allocation_admission_open,
                 "admission_epoch": int(self._admission_epoch),
                 "node_usage": {node_id: resources.to_dict() for node_id, resources in node_usage.items()},
                 "node_allocation_debt": {
-                    node_id: _positive_difference(
+                    node_id: _hard_positive_difference(
                         resources,
                         allocation_by_node.get(node_id, ResourceVector()),
                     ).to_dict()
+                    for node_id, resources in node_usage.items()
+                },
+                "node_soft_object_store_debt_bytes": {
+                    node_id: max(
+                        0,
+                        resources.object_store_bytes
+                        - allocation_by_node.get(
+                            node_id,
+                            ResourceVector(),
+                        ).object_store_bytes,
+                    )
                     for node_id, resources in node_usage.items()
                 },
                 "reservation_ratio": self.reservation_ratio,

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -325,6 +325,15 @@ class QueryResourceManager:
         self._reverse_topological_rank = {
             stage_id: index for index, stage_id in enumerate(self._reverse_topological_stage_ids)
         }
+        self._upstream_stage_ids: dict[str, tuple[str, ...]] = {}
+        for stage_id in self._topological_stage_ids:
+            upstream: set[str] = set()
+            for input_stage_id in self._stages[stage_id].spec.input_stage_ids:
+                upstream.add(input_stage_id)
+                upstream.update(self._upstream_stage_ids[input_stage_id])
+            self._upstream_stage_ids[stage_id] = tuple(
+                candidate for candidate in self._topological_stage_ids if candidate in upstream
+            )
         self._reachable_stage_ids: dict[str, tuple[str, ...]] = {}
         self._reachable_udf_stage_ids: dict[str, tuple[str, ...]] = {}
         self._downstream_fte_stage_ids_requiring_separate_slot = {
@@ -377,6 +386,7 @@ class QueryResourceManager:
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
+        self._completed_materializing_stage_ids: set[str] = set()
         self._external_consumer_waiting = False
         self._cancelled = False
         self._cancel_reason = ""
@@ -578,6 +588,21 @@ class QueryResourceManager:
                 return
             stage.actor_ready = ready
             self._publish_change_locked()
+
+    def mark_materializing_stage_completed(self, stage_id: str) -> bool:
+        """Advance a blocking phase without terminalizing its output stage."""
+        stage_key = str(stage_id)
+        with self._lock:
+            stage = self._stages.get(stage_key)
+            if stage is None:
+                raise KeyError(f"stage is not registered: {stage_key}")
+            if stage.spec.spill_mode != "barrier":
+                raise ValueError(f"stage is not a blocking materializer: {stage_key}")
+            if self._materializing_stage_completed_locked(stage_key):
+                return False
+            self._completed_materializing_stage_ids.add(stage_key)
+            self._publish_change_locked()
+            return True
 
     def update_allocation(
         self,
@@ -1002,8 +1027,12 @@ class QueryResourceManager:
         if hard_exceeded:
             reason = "continuation_capacity" if credit_template is not None else f"hard_{hard_exceeded[0]}"
             return reason, False, empty_plan
+        object_store_unlimited = stage.spec.stage_id in self._materializing_object_store_unlimited_stage_ids_locked(
+            requested_stage_id=stage.spec.stage_id,
+        )
         query_soft_blocked = (
-            admission_commitment.object_store_bytes > 0
+            not object_store_unlimited
+            and admission_commitment.object_store_bytes > 0
             and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         )
         downstream_reservations = self._downstream_reservations_locked(stage.spec)
@@ -1074,7 +1103,11 @@ class QueryResourceManager:
         if query_soft_blocked:
             return "query_soft_object_store_bytes", False, plan
         if borrowed_credit is None:
-            soft_reason = self._stage_soft_block_reason_locked(stage.spec.stage_id, commitment)
+            soft_reason = self._stage_soft_block_reason_locked(
+                stage.spec.stage_id,
+                commitment,
+                ignore_object_store=object_store_unlimited,
+            )
             if soft_reason is not None:
                 return soft_reason, False, plan
         return None, False, plan
@@ -1317,16 +1350,83 @@ class QueryResourceManager:
             heap_bytes=spec.per_task.heap_bytes,
         )
 
+    def _current_materializing_stage_id_locked(self) -> str | None:
+        """Return the first unfinished blocking stage in source-to-sink order."""
+        return next(
+            (
+                stage_id
+                for stage_id in self._topological_stage_ids
+                if self._stages[stage_id].spec.spill_mode == "barrier"
+                and not self._materializing_stage_completed_locked(stage_id)
+            ),
+            None,
+        )
+
+    def _materializing_stage_completed_locked(self, stage_id: str) -> bool:
+        return self._stages[stage_id].completed or stage_id in self._completed_materializing_stage_ids
+
+    def _materializing_phase_stage_ids_locked(self) -> tuple[str, ...]:
+        """Return unfinished stages eligible in the current materialization phase."""
+        barrier_stage_id = self._current_materializing_stage_id_locked()
+        if barrier_stage_id is None:
+            return tuple(stage_id for stage_id in self._topological_stage_ids if not self._stages[stage_id].completed)
+        phase = set(self._upstream_stage_ids[barrier_stage_id])
+        phase.add(barrier_stage_id)
+        return tuple(
+            stage_id
+            for stage_id in self._topological_stage_ids
+            if stage_id in phase and not self._stages[stage_id].completed
+        )
+
+    def _materializing_object_store_unlimited_stage_ids_locked(
+        self,
+        *,
+        requested_stage_id: str | None = None,
+    ) -> tuple[str, ...]:
+        """Return stages whose data must be collectable beyond the soft budget.
+
+        Vane accounts a block to its producer even after the block becomes a
+        downstream input. Therefore the blocking stage and its direct input
+        producers share the spill exemption. DuckDB may concurrently start
+        nested materializers (notably chained broadcast joins), so a blocking
+        boundary becomes active when its own stage or one of its direct inputs
+        is requested or has started. The first unfinished boundary is always
+        active. Earlier streaming producers keep their normal soft budgets and
+        bounded liveness escape.
+        """
+        first_barrier_stage_id = self._current_materializing_stage_id_locked()
+        if first_barrier_stage_id is None:
+            return ()
+        requested = None if requested_stage_id is None else str(requested_stage_id)
+        unlimited: set[str] = set()
+        for barrier_stage_id in self._topological_stage_ids:
+            barrier = self._stages[barrier_stage_id]
+            if barrier.spec.spill_mode != "barrier" or self._materializing_stage_completed_locked(barrier_stage_id):
+                continue
+            boundary = set(barrier.spec.input_stage_ids)
+            boundary.add(barrier_stage_id)
+            active = (
+                barrier_stage_id == first_barrier_stage_id
+                or requested in boundary
+                or bool(boundary & self._started_stage_ids)
+            )
+            if active:
+                unlimited.update(boundary)
+        return tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in unlimited)
+
     def _continuation_credit_template_locked(
         self,
         parent: StageResourceSpec,
     ) -> tuple[tuple[str, ...], str, ResourceVector] | None:
         if parent.backend != "ray_worker":
             return None
+        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
         eligible_specs = tuple(
             self._stages[stage_id].spec
             for stage_id in self._reachable_udf_stage_ids[parent.stage_id]
-            if self._stages[stage_id].spec.backend == "ray_task" and not self._stages[stage_id].completed
+            if stage_id in phase_stage_ids
+            and self._stages[stage_id].spec.backend == "ray_task"
+            and not self._stages[stage_id].completed
         )
         if not eligible_specs:
             return None
@@ -1440,10 +1540,11 @@ class QueryResourceManager:
         runnable is too late because an upstream producer may already have
         consumed the last non-spillable process slot by then.
         """
+        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
         reachable = tuple(
             self._stages[stage_id]
             for stage_id in self._reachable_stage_ids[parent.stage_id]
-            if not self._stages[stage_id].completed
+            if stage_id in phase_stage_ids and not self._stages[stage_id].completed
         )
         reservations: list[_DownstreamReservation] = []
         allocation_node_ids = tuple(sorted(allocation.node_id for allocation in self.allocation.node_allocations))
@@ -1451,7 +1552,9 @@ class QueryResourceManager:
         inactive_fte = tuple(
             self._stages[stage_id].spec
             for stage_id in self._downstream_fte_stage_ids_requiring_separate_slot[parent.stage_id]
-            if not self._stages[stage_id].completed and self._active_task_count_for_stage_locked(stage_id) == 0
+            if stage_id in phase_stage_ids
+            and not self._stages[stage_id].completed
+            and self._active_task_count_for_stage_locked(stage_id) == 0
         )
         if inactive_fte:
             resources = _component_max(tuple(self._task_commitment(stage) for stage in inactive_fte))
@@ -1537,9 +1640,24 @@ class QueryResourceManager:
         *,
         requested_stage_id: str | None,
     ) -> tuple[str, ...]:
+        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
+        object_store_unlimited_stage_ids = (
+            set(
+                self._materializing_object_store_unlimited_stage_ids_locked(
+                    requested_stage_id=requested_stage_id,
+                )
+            )
+            if field_name == "object_store_bytes"
+            else set()
+        )
         stage_ids: list[str] = []
         for stage_id, stage in self._stages.items():
-            if not stage.runnable or stage.completed:
+            if (
+                stage_id not in phase_stage_ids
+                or stage_id in object_store_unlimited_stage_ids
+                or not stage.runnable
+                or stage.completed
+            ):
                 continue
             task_demand = (
                 (requested_stage_id is not None and stage_id == requested_stage_id)
@@ -1564,6 +1682,12 @@ class QueryResourceManager:
         live_stage_ids: tuple[str, ...],
     ) -> tuple[str, ...]:
         live = set(live_stage_ids)
+        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
+        object_store_unlimited_stage_ids = (
+            set(self._materializing_object_store_unlimited_stage_ids_locked())
+            if field_name == "object_store_bytes"
+            else set()
+        )
         continuation_ids: set[str] = set()
         for source_stage_id in live_stage_ids:
             if self._stages[source_stage_id].spec.backend != "ray_worker":
@@ -1572,6 +1696,8 @@ class QueryResourceManager:
                 stage = self._stages[stage_id]
                 if (
                     stage_id not in live
+                    and stage_id in phase_stage_ids
+                    and stage_id not in object_store_unlimited_stage_ids
                     and not stage.completed
                     and self._stage_dimension_commitment(stage.spec, field_name) > 0
                 ):
@@ -1599,11 +1725,28 @@ class QueryResourceManager:
         selected = set(live_stage_ids) | set(continuation_stage_ids)
         return tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in selected)
 
-    def _stage_soft_block_reason_locked(self, stage_id: str, request: ResourceVector) -> str | None:
+    def _stage_soft_block_reason_locked(
+        self,
+        stage_id: str,
+        request: ResourceVector,
+        *,
+        ignore_object_store: bool = False,
+    ) -> str | None:
+        # Materialization phases define which stages receive a designated
+        # reservation; they are not an execution gate.  DuckDB can demand a
+        # downstream stage while an earlier blocking phase is still pending
+        # (nested broadcast joins do this from concurrent materializers).
+        # Match Ray Data's allocator semantics: an out-of-phase stage has no
+        # per-stage budget, while query/node hard limits and the query's
+        # object-store soft limit still apply.
+        if stage_id not in self._materializing_phase_stage_ids_locked():
+            return None
         usage_by_stage = {key: self._stage_usage_locked(key) for key in self._stages}
         current = usage_by_stage[stage_id]
         limits = self.allocation.resources
         for field_name in _RESOURCE_FIELDS:
+            if ignore_object_store and field_name == "object_store_bytes":
+                continue
             amount = getattr(request, field_name)
             if amount <= 0:
                 continue
@@ -2358,7 +2501,8 @@ class QueryResourceManager:
         delta = after - before
         object_limit = self.allocation.resources.object_store_bytes
         usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-        if delta > 0 and usage_after.object_store_bytes > object_limit:
+        object_store_unlimited = stage.spec.stage_id in self._materializing_object_store_unlimited_stage_ids_locked()
+        if not object_store_unlimited and delta > 0 and usage_after.object_store_bytes > object_limit:
             return "query_soft_object_store_bytes", False, delta
         if delta > 0:
             try:
@@ -2368,6 +2512,7 @@ class QueryResourceManager:
             soft = self._stage_soft_block_reason_locked(
                 stage.spec.stage_id,
                 ResourceVector(object_store_bytes=delta),
+                ignore_object_store=object_store_unlimited,
             )
             if soft is not None:
                 return soft, False, delta
@@ -2783,6 +2928,11 @@ class QueryResourceManager:
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             usage = self._query_usage_locked()
+            materializing_stage_id = self._current_materializing_stage_id_locked()
+            materializing_phase_stage_ids = self._materializing_phase_stage_ids_locked()
+            materializing_object_store_unlimited_stage_ids = (
+                self._materializing_object_store_unlimited_stage_ids_locked()
+            )
             preferred_task, grant_class = self._preferred_waiting_task_locked()
             allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
             reservation_source_stage_ids = {lease.stage_id for lease in self._task_leases.values()} | {
@@ -2838,6 +2988,12 @@ class QueryResourceManager:
                     for node_id, resources in node_usage.items()
                 },
                 "reservation_ratio": self.reservation_ratio,
+                "materializing_phase": {
+                    "barrier_stage_id": materializing_stage_id,
+                    "stage_ids": list(materializing_phase_stage_ids),
+                    "object_store_backpressure_disabled": bool(materializing_object_store_unlimited_stage_ids),
+                    "object_store_unlimited_stage_ids": list(materializing_object_store_unlimited_stage_ids),
+                },
                 "cancelled": self._cancelled,
                 "cancel_reason": self._cancel_reason,
                 "external_consumer_waiting": self._external_consumer_waiting,
@@ -2918,6 +3074,11 @@ class QueryResourceManager:
                         "queued_output_bytes": stage.queued_output_bytes,
                         "pending_output_count": stage.pending_output_count,
                         "completed": stage.completed,
+                        "materialization_completed": (self._materializing_stage_completed_locked(stage_id)),
+                        "phase_eligible": stage_id in materializing_phase_stage_ids,
+                        "object_store_backpressure_disabled": (
+                            stage_id in materializing_object_store_unlimited_stage_ids
+                        ),
                         "usage": self._stage_usage_locked(stage_id).to_dict(),
                         "active_task_count": self._active_task_count_for_stage_locked(stage_id),
                     }

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -426,9 +426,24 @@ class RayQueryResourceManager:
         barriers = self._frontier_materialization_barriers_locked()
         if not barriers:
             return ()
+        eligible = set(self._eligible_resource_unit_ids_locked())
         boundary: set[str] = set()
         for barrier in barriers:
-            boundary.update(barrier.materialized_input_unit_ids)
+            # A blocking materializer must be able to drain its complete input
+            # branch even after the direct input's accumulated bytes exceed the
+            # soft query budget.  Lifting the cap only on that direct input can
+            # deadlock a longer chain: the live materializer keeps a task lease
+            # while an upstream UDF needs another task to produce the remaining
+            # input, so the global-idle task escape cannot fire.  Follow only
+            # the explicitly materialized side upstream; deferred inputs such
+            # as a broadcast probe remain backpressured.
+            pending = list(barrier.materialized_input_unit_ids)
+            while pending:
+                resource_unit_id = pending.pop()
+                if resource_unit_id in boundary or resource_unit_id not in eligible:
+                    continue
+                boundary.add(resource_unit_id)
+                pending.extend(self._units[resource_unit_id].spec.input_unit_ids)
             boundary.add(barrier.materializer_unit_id)
         return tuple(
             resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in boundary

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from collections import deque
 from collections.abc import Callable
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from typing import Any
 
 from duckdb.runners.ray.admission_ledger import BoundedSet
@@ -48,6 +48,7 @@ _RESOURCE_FIELDS = ("cpu", "gpu", "heap_bytes", "object_store_bytes")
 _EPSILON = 1e-9
 _TERMINAL_IDENTITY_REPLAY_CAPACITY = 65_536
 _SOFT_RESERVATION_WARNING_DELAY_S = 60.0
+_DOWNSTREAM_PLACEMENT_SEARCH_STATE_LIMIT = 8_192
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +329,7 @@ class RayQueryResourceManager:
         allocation: QueryAllocation,
         *,
         admission_open: bool = True,
+        debt_neutral_only: bool = False,
         reservation_ratio: float = 0.5,
         on_change: Callable[[], None] | None = None,
         on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
@@ -335,13 +337,18 @@ class RayQueryResourceManager:
         ratio = float(reservation_ratio)
         if not math.isfinite(ratio) or ratio <= 0 or ratio > 1:
             raise ValueError("reservation_ratio must be in (0, 1]")
+        if debt_neutral_only and not admission_open:
+            raise ValueError("debt-neutral admission requires admission_open")
         graph.validate_allocation(
             allocation,
-            eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open else ()),
+            eligible_unit_ids=(
+                graph.eligible_resource_unit_ids(set()) if admission_open and not debt_neutral_only else ()
+            ),
         )
         self.graph = graph
         self.allocation = allocation
         self._allocation_admission_open = bool(admission_open)
+        self._allocation_debt_neutral_only = bool(debt_neutral_only)
         self.reservation_ratio = ratio
         self._on_change = on_change
         self._on_eligible_units_change = on_eligible_units_change
@@ -427,6 +434,8 @@ class RayQueryResourceManager:
         self._external_consumer_waiting = False
         self._soft_allocation_debt_since: float | None = None
         self._soft_allocation_warning_emitted = False
+        self._failed = False
+        self._failure_reason = ""
         self._cancelled = False
         self._cancel_reason = ""
 
@@ -466,6 +475,8 @@ class RayQueryResourceManager:
             unit = self._units.get(unit_key)
             if unit is None:
                 raise KeyError(f"unit is not registered: {unit_key}")
+            if unit.completed and not bool(completed):
+                raise RuntimeError(f"completed resource unit cannot become incomplete: {unit_key}")
             before = (
                 unit.runnable,
                 unit.actor_ready,
@@ -495,6 +506,7 @@ class RayQueryResourceManager:
                     # Preserve live leases, but fence every new grant from the
                     # old generation during that handoff.
                     self._allocation_admission_open = False
+                    self._allocation_debt_neutral_only = False
                 self._publish_change_locked()
                 if bool(completed) and not before[-1]:
                     eligible_callback = self._on_eligible_units_change
@@ -517,6 +529,7 @@ class RayQueryResourceManager:
             # handoff so downstream work cannot consume the previous phase's
             # reservation; live tasks and output leases continue unchanged.
             self._allocation_admission_open = False
+            self._allocation_debt_neutral_only = False
             self._publish_change_locked()
             eligible_callback = self._on_eligible_units_change
             eligible_unit_ids = self._eligible_resource_unit_ids_locked()
@@ -529,6 +542,8 @@ class RayQueryResourceManager:
             return self._eligible_resource_unit_ids_locked()
 
     def _eligible_resource_unit_ids_locked(self) -> tuple[str, ...]:
+        if self._cancelled:
+            return ()
         return tuple(
             resource_unit_id
             for resource_unit_id in self.graph.eligible_resource_unit_ids(self._completed_materialization_barrier_ids)
@@ -674,6 +689,8 @@ class RayQueryResourceManager:
 
         if self._cancelled:
             return "query_cancelled", None, None, 0
+        if self._failed:
+            return "query_failed", None, None, 0
         if str(request.query_id) != self.graph.query_id:
             return "query_id_mismatch", None, None, 0
         unit = self._units.get(str(request.producer_unit_id))
@@ -765,6 +782,13 @@ class RayQueryResourceManager:
                 for candidate_unit_id, actor_index in self._submitted_actor_slots
                 if candidate_unit_id == unit_key
             }
+            if normalized:
+                if self._cancelled:
+                    raise RuntimeError(f"cannot submit actor slots for a cancelled query: {unit_key}")
+                if self._failed:
+                    raise RuntimeError(f"cannot submit actor slots for a failed query: {unit_key}")
+                if unit_key not in self._eligible_resource_unit_ids_locked():
+                    raise RuntimeError(f"cannot submit actor slots outside the current execution phase: {unit_key}")
             if before == normalized:
                 return
             if unit_key in self._retiring_actor_unit_ids:
@@ -809,6 +833,13 @@ class RayQueryResourceManager:
                 if not node_id:
                     raise ValueError(f"actor {unit_key}/{actor_index} node_id must be non-empty")
                 normalized[actor_index] = node_id
+            if normalized:
+                if self._cancelled:
+                    raise RuntimeError(f"cannot publish ready actor slots for a cancelled query: {unit_key}")
+                if unit_key not in self._eligible_resource_unit_ids_locked():
+                    raise RuntimeError(
+                        f"cannot publish ready actor slots outside the current execution phase: {unit_key}"
+                    )
             submitted = {
                 actor_index
                 for candidate_unit_id, actor_index in self._submitted_actor_slots
@@ -839,6 +870,64 @@ class RayQueryResourceManager:
             )
             unit.actor_ready = bool(normalized)
             self._publish_change_locked()
+
+    def reconcile_actor_runtime_node(
+        self,
+        resource_unit_id: str,
+        actor_index: int,
+        node_id: str,
+    ) -> tuple[str, ...]:
+        """Move one reconstructed actor slot and its live calls atomically.
+
+        Ray may reconstruct an unpinned actor on another node.  The actor
+        process is the execution slot, so every active or prefetched call on
+        that slot must follow its new physical node before it can publish more
+        output.  Existing output leases stay where they were produced.
+        """
+
+        unit_key = str(resource_unit_id)
+        if isinstance(actor_index, bool):
+            raise TypeError("actor index must be an integer")
+        slot_index = int(actor_index)
+        node_key = str(node_id or "").strip()
+        if not node_key:
+            raise ValueError("reconstructed actor node_id must be non-empty")
+        with self._lock:
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
+            if unit.spec.backend != "ray_actor":
+                raise ValueError(f"unit is not a Ray actor unit: {unit_key}")
+            if slot_index < 0 or slot_index >= unit.spec.actor_pool_size:
+                raise ValueError(f"actor index is outside pool {unit_key}: {slot_index}")
+            slot_key = (unit_key, slot_index)
+            if slot_key not in self._submitted_actor_slots:
+                raise RuntimeError(f"reconstructed actor slot was not submitted: {unit_key}/{slot_index}")
+            if slot_key not in self._actor_node_by_slot:
+                raise RuntimeError(f"reconstructed actor slot was not ready: {unit_key}/{slot_index}")
+            if self._cancelled:
+                raise RuntimeError(f"cannot move an actor slot for a cancelled query: {unit_key}/{slot_index}")
+            if unit_key not in self._eligible_resource_unit_ids_locked():
+                raise RuntimeError(
+                    f"cannot move an actor slot outside the current execution phase: {unit_key}/{slot_index}"
+                )
+            if unit_key in self._retiring_actor_unit_ids:
+                raise RuntimeError(f"cannot move a retiring actor pool: {unit_key}")
+
+            moved_lease_ids: list[str] = []
+            for lease_id, lease in tuple(self._task_leases.items()):
+                if lease.resource_unit_id != unit_key or lease.actor_index != slot_index:
+                    continue
+                if lease.node_id != node_key:
+                    self._task_leases[lease_id] = replace(lease, node_id=node_key)
+                    moved_lease_ids.append(lease_id)
+
+            changed = self._actor_node_by_slot[slot_key] != node_key or bool(moved_lease_ids)
+            self._actor_node_by_slot[slot_key] = node_key
+            unit.actor_ready = True
+            if changed:
+                self._publish_change_locked()
+            return tuple(sorted(moved_lease_ids))
 
     def begin_actor_pool_retirement(self, resource_unit_id: str) -> bool:
         """Atomically fence and uncharge one completed-phase actor pool.
@@ -911,8 +1000,11 @@ class RayQueryResourceManager:
         allocation: QueryAllocation,
         *,
         admission_open: bool,
+        debt_neutral_only: bool = False,
     ) -> None:
         with self._lock:
+            if debt_neutral_only and not admission_open:
+                raise ValueError("debt-neutral admission requires admission_open")
             if allocation.generation <= self.allocation.generation:
                 raise ValueError(
                     "allocation generation must increase: "
@@ -920,10 +1012,13 @@ class RayQueryResourceManager:
                 )
             self.graph.validate_allocation(
                 allocation,
-                eligible_unit_ids=(self._eligible_resource_unit_ids_locked() if admission_open else ()),
+                eligible_unit_ids=(
+                    self._eligible_resource_unit_ids_locked() if admission_open and not debt_neutral_only else ()
+                ),
             )
             self.allocation = allocation
-            self._allocation_admission_open = bool(admission_open)
+            self._allocation_admission_open = bool(admission_open) and not self._failed and not self._cancelled
+            self._allocation_debt_neutral_only = bool(debt_neutral_only) and self._allocation_admission_open
             self._publish_change_locked()
 
     def close_admission(self) -> None:
@@ -932,6 +1027,7 @@ class RayQueryResourceManager:
             if not self._allocation_admission_open:
                 return
             self._allocation_admission_open = False
+            self._allocation_debt_neutral_only = False
             self._publish_change_locked()
 
     def try_acquire_task(self, request: TaskRequest) -> TaskGrant:
@@ -1163,6 +1259,8 @@ class RayQueryResourceManager:
         empty_plan = _TaskAdmissionPlan()
         if self._cancelled:
             return "query_cancelled", True, empty_plan
+        if self._failed:
+            return "query_failed", True, empty_plan
         if str(request.query_id) != self.graph.query_id:
             return "query_id_mismatch", True, empty_plan
         unit = self._units.get(str(request.resource_unit_id))
@@ -1223,22 +1321,24 @@ class RayQueryResourceManager:
         )
         hard_commitment = _hard_resources(commitment)
         if hard_commitment.exceeded_dimensions(_hard_resources(self.allocation.resources)):
+            if self._allocation_debt_neutral_only:
+                return "allocation_debt", False, empty_plan
             return "task_exceeds_query_allocation", True, empty_plan
 
         execution_usage = self._query_usage_locked()
-        execution_debt = _hard_positive_difference(
-            execution_usage,
-            self.allocation.resources,
-        )
-        if not execution_debt.is_zero():
-            # Capacity shrink never revokes live task/continuation leases, but
-            # it fences another process request until those leases drain.
-            return "allocation_debt", False, empty_plan
+        execution_debt = _hard_positive_difference(execution_usage, self.allocation.resources)
         # Submitted actor processes are charged once for their full lifetime.
         # Their invocations add no CPU/GPU/heap. A process request beyond the
         # resulting query share is a soft block eligible for one bounded
         # liveness escape; Ray Core remains the physical resource authority.
         query_usage = self._soft_allocation_usage_locked()
+        coordinator_debt_still_live = (
+            self._allocation_debt_neutral_only
+            and not _hard_positive_difference(
+                query_usage,
+                self.allocation.resources,
+            ).is_zero()
+        )
         borrowed_credit = self._available_continuation_credit_locked(
             unit.spec,
             requested_node_id=request.node_id,
@@ -1269,6 +1369,14 @@ class RayQueryResourceManager:
                 idle_output_excess,
             )
 
+        incremental_hard = _hard_resources(admission_commitment)
+        if (coordinator_debt_still_live or not execution_debt.is_zero()) and not incremental_hard.is_zero():
+            # Capacity shrink never revokes live work, but it does fence every
+            # new Ray process request until the debt drains. Zero-increment
+            # native work and calls on an existing actor remain admissible so
+            # they can consume outputs and make that drain possible.
+            return "allocation_debt", False, empty_plan
+
         usage_after = query_usage + admission_commitment
         execution_hard_exceeded = _incremental_hard_exceeded_dimensions(
             execution_usage,
@@ -1293,6 +1401,7 @@ class RayQueryResourceManager:
             and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         )
         downstream_reservations = self._downstream_reservations_locked(unit.spec)
+        placement_reservations = downstream_reservations
         downstream_reservation_soft_blocked = False
         if downstream_reservations:
             remaining = _positive_difference(
@@ -1302,6 +1411,10 @@ class RayQueryResourceManager:
             reservation_total = self._downstream_reservation_total(downstream_reservations)
             if not reservation_total.fits_within(remaining):
                 downstream_reservation_soft_blocked = True
+                # No node placement can repair a globally insufficient vector.
+                # Keep constructing a concrete plan for the bounded liveness
+                # escape, but avoid an unnecessary combinatorial search.
+                placement_reservations = ()
 
         new_credit_plan: _NewContinuationCreditPlan | None = None
         if credit_template is not None:
@@ -1311,9 +1424,9 @@ class RayQueryResourceManager:
                 hard_commitment,
                 credit_resources,
                 allow_unallocated_task_node=unit.spec.backend == "ray_worker",
-                downstream_reservations=downstream_reservations,
+                downstream_reservations=placement_reservations,
             )
-            if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+            if node_blocked_reason == "continuation_node_capacity" and placement_reservations:
                 node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
                     request.node_id,
                     hard_commitment,
@@ -1361,9 +1474,9 @@ class RayQueryResourceManager:
                     _hard_resources(admission_commitment),
                     allowed_node_ids=allowed_node_ids,
                     allow_unallocated_node=unit.spec.backend == "ray_worker",
-                    downstream_reservations=downstream_reservations,
+                    downstream_reservations=placement_reservations,
                 )
-                if node_blocked_reason == "continuation_node_capacity" and downstream_reservations:
+                if node_blocked_reason == "continuation_node_capacity" and placement_reservations:
                     node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
                         request.node_id,
                         _hard_resources(admission_commitment),
@@ -1456,17 +1569,19 @@ class RayQueryResourceManager:
         if not static_candidates:
             return "", "task_does_not_fit_allocated_node", True
 
-        available_candidates: list[tuple[str, ResourceVector]] = []
+        available_candidates: list[tuple[str, ResourceVector, bool]] = []
         debt_detected = False
         for node_id in static_candidates:
             capacity = allocation_by_node.get(node_id, ResourceVector())
-            usage = _hard_resources(self._node_usage_locked(node_id))
+            usage = self._node_hard_scheduling_usage_locked(node_id)
             if not usage.fits_within(capacity):
                 debt_detected = True
+                if commitment.is_zero():
+                    available_candidates.append((node_id, ResourceVector(), True))
                 continue
             remaining = capacity - usage
             if commitment.fits_within(remaining):
-                available_candidates.append((node_id, remaining))
+                available_candidates.append((node_id, remaining, False))
         if not available_candidates:
             return "", "node_allocation_debt" if debt_detected else "node_capacity", False
 
@@ -1485,9 +1600,10 @@ class RayQueryResourceManager:
                 return "", "continuation_node_capacity", False
             available_candidates = safe_candidates
 
-        node_id, _ = min(
+        node_id, _, _ = min(
             available_candidates,
             key=lambda item: (
+                item[2],
                 item[1].gpu - commitment.gpu,
                 item[1].cpu - commitment.cpu,
                 item[1].heap_bytes - commitment.heap_bytes,
@@ -1537,13 +1653,13 @@ class RayQueryResourceManager:
         for task_node_id in task_nodes:
             for credit_node_id in credit_nodes:
                 proposed: dict[str, ResourceVector] = {}
-                if task_node_id in allocation_by_node:
+                if task_node_id in allocation_by_node and not task_commitment.is_zero():
                     proposed[task_node_id] = task_commitment
                 proposed[credit_node_id] = proposed.get(credit_node_id, ResourceVector()) + credit_resources
                 remaining_by_node: dict[str, ResourceVector] = {}
                 feasible = True
                 for node_id, capacity in allocation_by_node.items():
-                    usage = _hard_resources(self._node_usage_locked(node_id))
+                    usage = self._node_hard_scheduling_usage_locked(node_id)
                     if not usage.fits_within(capacity):
                         if node_id in proposed:
                             debt_detected = True
@@ -1590,7 +1706,7 @@ class RayQueryResourceManager:
     ) -> bool:
         remaining_by_node: dict[str, ResourceVector] = {}
         for node_id, capacity in allocation_by_node.items():
-            usage = _hard_resources(self._node_usage_locked(node_id))
+            usage = self._node_hard_scheduling_usage_locked(node_id)
             if node_id == parent_node_id:
                 usage = usage + parent_commitment
             if usage.fits_within(capacity):
@@ -1606,6 +1722,15 @@ class RayQueryResourceManager:
         remaining_by_node: dict[str, ResourceVector],
         reservations: tuple[_DownstreamReservation, ...],
     ) -> bool:
+        """Prefer a feasible node layout without unbounded work under the lock.
+
+        Vector bin packing is NP-hard.  These reservations are deliberately
+        soft, so an exhaustive proof is neither required for correctness nor
+        safe on the admission hot path.  Accept the common best-fit layout in
+        linear time, then search a bounded number of alternate layouts before
+        conservatively applying soft backpressure.  The normal one-task
+        liveness escape still guarantees progress after a conservative miss.
+        """
         if not reservations:
             return True
 
@@ -1622,14 +1747,11 @@ class RayQueryResourceManager:
             )
         )
         initial = tuple(remaining_by_node[node_id] for node_id in node_ids)
-        failed_states: set[tuple[int, tuple[ResourceVector, ...]]] = set()
 
-        def place(index: int, remaining: tuple[ResourceVector, ...]) -> bool:
-            if index >= len(ordered):
-                return True
-            state = (index, remaining)
-            if state in failed_states:
-                return False
+        def candidate_states(
+            index: int,
+            remaining: tuple[ResourceVector, ...],
+        ) -> list[tuple[ResourceVector, ...]]:
             reservation = ordered[index]
             candidates: list[tuple[int, ResourceVector]] = []
             for node_id in reservation.allowed_node_ids:
@@ -1649,15 +1771,47 @@ class RayQueryResourceManager:
                     node_ids[item[0]],
                 )
             )
+            result: list[tuple[ResourceVector, ...]] = []
             for position, capacity_after in candidates:
                 updated = list(remaining)
                 updated[position] = capacity_after
-                if place(index + 1, tuple(updated)):
-                    return True
-            failed_states.add(state)
-            return False
+                result.append(tuple(updated))
+            return result
 
-        return place(0, initial)
+        # Most layouts succeed with deterministic best-fit-decreasing.  Run
+        # that path without retaining alternate states so thousands of latent
+        # downstream UDFs remain cheap and cannot overflow Python's stack.
+        greedy_remaining = initial
+        for index in range(len(ordered)):
+            candidates = candidate_states(index, greedy_remaining)
+            if not candidates:
+                break
+            greedy_remaining = candidates[0]
+        else:
+            return True
+
+        # Greedy can miss a feasible multi-dimensional layout.  Preserve the
+        # previous exact behavior for ordinary graphs, but cap pathological
+        # searches because the result controls only a soft reservation.
+        search_limit = max(
+            _DOWNSTREAM_PLACEMENT_SEARCH_STATE_LIMIT,
+            len(ordered) + 1,
+        )
+        pending: list[tuple[int, tuple[ResourceVector, ...]]] = [(0, initial)]
+        visited: set[tuple[int, tuple[ResourceVector, ...]]] = set()
+        while pending and len(visited) < search_limit:
+            index, remaining = pending.pop()
+            state = (index, remaining)
+            if state in visited:
+                continue
+            visited.add(state)
+            if index >= len(ordered):
+                return True
+            # Reverse the preferred order for the LIFO stack.
+            for candidate in reversed(candidate_states(index, remaining)):
+                pending.append((index + 1, candidate))
+
+        return False
 
     def _actor_slot_lease_count_locked(self, slot: tuple[str, int]) -> int:
         return int(slot in self._active_actor_slots) + len(self._queued_actor_slot_leases.get(slot, ()))
@@ -1793,7 +1947,7 @@ class RayQueryResourceManager:
                 incremental,
                 self.allocation.resources,
             )
-            node_usage = _hard_resources(self._node_usage_locked(credit.node_id))
+            node_usage = self._node_hard_scheduling_usage_locked(credit.node_id)
             node_exceeded = _hard_resources(node_usage + incremental).exceeded_dimensions(
                 allocation_by_node[credit.node_id]
             )
@@ -2249,21 +2403,23 @@ class RayQueryResourceManager:
         soft = [item for item in evaluations if not item.fatal and item.reason in _SOFT_TASK_BLOCK_REASONS]
         if not soft:
             return None
-        if self._active_liveness_task_lease_id is not None:
-            path_candidates = [
-                item
-                for item in soft
-                if self._continues_active_liveness_path_locked(
+        path_candidates = [
+            item
+            for item in soft
+            if self._active_tasks_allow_liveness_locked(
+                str(item.request.resource_unit_id),
+                item.plan,
+            )
+            and (
+                self._active_liveness_task_lease_id is None
+                or self._continues_active_liveness_path_locked(
                     str(item.request.resource_unit_id),
                     item.plan,
                 )
-                and self._active_tasks_allow_liveness_locked(
-                    str(item.request.resource_unit_id),
-                    item.plan,
-                )
-            ]
-            if path_candidates:
-                soft = path_candidates
+            )
+        ]
+        if path_candidates:
+            soft = path_candidates
         soft_unit_ids = {str(item.request.resource_unit_id) for item in soft}
         ordered_unit_ids = [
             resource_unit_id
@@ -2314,6 +2470,7 @@ class RayQueryResourceManager:
     def _preferred_liveness_unit_locked(self) -> str | None:
         if self._waiting_task_inputs:
             waiting_candidates: list[str] = []
+            path_candidates: list[str] = []
             for resource_unit_id in self.graph.reverse_topological_unit_ids():
                 for request, _ in self._waiting_task_inputs.values():
                     if str(request.resource_unit_id) != resource_unit_id:
@@ -2322,19 +2479,25 @@ class RayQueryResourceManager:
                         request,
                         hypothetical=True,
                     )
-                    path_allowed = self._active_liveness_task_lease_id is None or (
-                        self._continues_active_liveness_path_locked(
-                            resource_unit_id,
-                            plan,
-                        )
-                        and self._active_tasks_allow_liveness_locked(
+                    path_allowed = self._active_tasks_allow_liveness_locked(
+                        resource_unit_id,
+                        plan,
+                    ) and (
+                        self._active_liveness_task_lease_id is None
+                        or self._continues_active_liveness_path_locked(
                             resource_unit_id,
                             plan,
                         )
                     )
-                    if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
+                    if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
                         waiting_candidates.append(resource_unit_id)
+                        if path_allowed:
+                            path_candidates.append(resource_unit_id)
                         break
+            if path_candidates:
+                waiting_candidates = path_candidates
+            elif self._active_liveness_task_lease_id is not None:
+                return None
             if not waiting_candidates:
                 return None
             starving = [
@@ -2345,6 +2508,7 @@ class RayQueryResourceManager:
             ]
             return (starving or waiting_candidates)[0]
         runnable_candidates: list[str] = []
+        path_candidates = []
         for resource_unit_id in self.graph.reverse_topological_unit_ids():
             unit = self._units[resource_unit_id]
             if not unit.runnable or unit.completed:
@@ -2361,18 +2525,24 @@ class RayQueryResourceManager:
                 request,
                 hypothetical=True,
             )
-            path_allowed = self._active_liveness_task_lease_id is None or (
-                self._continues_active_liveness_path_locked(
-                    resource_unit_id,
-                    plan,
-                )
-                and self._active_tasks_allow_liveness_locked(
+            path_allowed = self._active_tasks_allow_liveness_locked(
+                resource_unit_id,
+                plan,
+            ) and (
+                self._active_liveness_task_lease_id is None
+                or self._continues_active_liveness_path_locked(
                     resource_unit_id,
                     plan,
                 )
             )
-            if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
+            if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
                 runnable_candidates.append(resource_unit_id)
+                if path_allowed:
+                    path_candidates.append(resource_unit_id)
+        if path_candidates:
+            runnable_candidates = path_candidates
+        elif self._active_liveness_task_lease_id is not None:
+            return None
         if not runnable_candidates:
             return None
         starving = [
@@ -2729,17 +2899,22 @@ class RayQueryResourceManager:
             if not soft_blocked:
                 return None, None
 
-            _, request, _, _ = min(soft_blocked, key=lambda item: item[0])
             if self._active_liveness_output_lease_id is not None:
+                _, request, _, _ = min(soft_blocked, key=lambda item: item[0])
                 return request, OutputBlockGrant(
                     False,
                     blocked_reason="liveness_output_active",
                 )
-            if not self._output_consumer_starving_locked(request.producer_unit_id):
+            liveness_candidates = [
+                item for item in soft_blocked if self._output_consumer_starving_locked(item[1].producer_unit_id)
+            ]
+            if not liveness_candidates:
+                _, request, _, _ = min(soft_blocked, key=lambda item: item[0])
                 return request, OutputBlockGrant(
                     False,
                     blocked_reason="output_liveness_not_needed",
                 )
+            _, request, _, _ = min(liveness_candidates, key=lambda item: item[0])
             return request, self._grant_output_block_locked(
                 request,
                 liveness=True,
@@ -2818,6 +2993,8 @@ class RayQueryResourceManager:
             unit = self._units[resource_unit_id]
             if not unit.runnable or unit.completed:
                 continue
+            if not self._output_consumer_starving_locked(resource_unit_id):
+                continue
             if resource_unit_id != str(current_request.producer_unit_id) and unit.queued_output_bytes <= 0:
                 continue
             if resource_unit_id == str(current_request.producer_unit_id):
@@ -2852,8 +3029,13 @@ class RayQueryResourceManager:
     def _output_consumer_starving_locked(self, producer_unit_id: str) -> bool:
         if self._external_consumer_waiting:
             return True
+        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
         downstream_ids = [
-            unit.resource_unit_id for unit in self.graph.units if str(producer_unit_id) in unit.input_unit_ids
+            unit.resource_unit_id
+            for unit in self.graph.units
+            if str(producer_unit_id) in unit.input_unit_ids
+            and unit.resource_unit_id in eligible_unit_ids
+            and not self._units[unit.resource_unit_id].completed
         ]
         if not downstream_ids:
             return False
@@ -2862,7 +3044,7 @@ class RayQueryResourceManager:
         # batch can be admitted.  Requiring queued_input_bytes == 0 creates a
         # cross-lease deadlock when the producer's sole liveness lease is the
         # partial bundle already waiting downstream.
-        return all(
+        return any(
             self._active_task_count_for_unit_locked(resource_unit_id) == 0 for resource_unit_id in downstream_ids
         )
 
@@ -2958,6 +3140,7 @@ class RayQueryResourceManager:
             self._continuation_credit_by_borrower.clear()
             self._active_attempt_leases.clear()
             self._submitted_actor_slots.clear()
+            self._retiring_actor_unit_ids.clear()
             self._actor_node_by_slot.clear()
             self._active_actor_slots.clear()
             self._queued_actor_slot_leases.clear()
@@ -2978,10 +3161,35 @@ class RayQueryResourceManager:
                 if unit.spec.backend == "ray_actor":
                     unit.actor_ready = False
             self._allocation_admission_open = False
+            self._allocation_debt_neutral_only = False
             self._cancelled = True
             self._cancel_reason = str(reason)
             self._publish_change_locked()
             return {"task_lease_count": task_count, "output_lease_count": output_count}
+
+    def fail(self, reason: str) -> dict[str, int]:
+        """Fence terminally failed work without releasing physical ownership.
+
+        A driver-side protocol or actor failure is not proof that already
+        submitted Ray work has stopped.  Keep every task, output, continuation,
+        and actor-process lease charged until ordered query teardown supplies
+        that proof; only new task/output/actor submission becomes fatal.
+        """
+
+        failure_reason = str(reason or "query_failed")
+        with self._lock:
+            counts = {
+                "task_lease_count": len(self._task_leases),
+                "output_lease_count": len(self._output_leases),
+            }
+            if self._cancelled or self._failed:
+                return counts
+            self._failed = True
+            self._failure_reason = failure_reason
+            self._allocation_admission_open = False
+            self._allocation_debt_neutral_only = False
+            self._publish_change_locked()
+            return counts
 
     def _active_task_count_for_unit_locked(self, resource_unit_id: str) -> int:
         return sum(1 for lease in self._task_leases.values() if lease.resource_unit_id == resource_unit_id)
@@ -3283,6 +3491,23 @@ class RayQueryResourceManager:
         )
         return total
 
+    def _node_hard_scheduling_usage_locked(self, node_id: str) -> ResourceVector:
+        """Return known physical process usage that competes on one node.
+
+        Submitted actors without a READY location can only be charged to the
+        query-wide soft allocation. Once Ray reports a concrete node, their
+        resident CPU/GPU/heap must also constrain node-affine task placement;
+        otherwise a task can be pinned behind its own actor while another
+        allocated node remains idle.
+        """
+
+        return _hard_resources(
+            self._node_usage_locked(node_id)
+            + self._actor_resident_usage_locked(
+                node_id=str(node_id),
+            )
+        )
+
     def _unit_usage_locked(
         self,
         resource_unit_id: str,
@@ -3416,6 +3641,7 @@ class RayQueryResourceManager:
                     usage.object_store_bytes - self.allocation.resources.object_store_bytes,
                 ),
                 "allocation_admission_open": self._allocation_admission_open,
+                "allocation_debt_neutral_only": self._allocation_debt_neutral_only,
                 "admission_epoch": int(self._admission_epoch),
                 "node_usage": {node_id: resources.to_dict() for node_id, resources in node_usage.items()},
                 "node_allocation_debt": {
@@ -3445,6 +3671,8 @@ class RayQueryResourceManager:
                 },
                 "cancelled": self._cancelled,
                 "cancel_reason": self._cancel_reason,
+                "failed": self._failed,
+                "failure_reason": self._failure_reason,
                 "external_consumer_waiting": self._external_consumer_waiting,
                 "liveness": {
                     "active_task_lease_id": self._active_liveness_task_lease_id,

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -12,29 +12,29 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from duckdb.runners.ray.admission_ledger import BoundedSet
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 
 _SOFT_TASK_BLOCK_REASONS = {
     "query_soft_object_store_bytes",
-    "stage_soft_cpu",
-    "stage_soft_gpu",
-    "stage_soft_heap_bytes",
-    "stage_soft_object_store_bytes",
-    "stage_soft_limit",
+    "unit_soft_cpu",
+    "unit_soft_gpu",
+    "unit_soft_heap_bytes",
+    "unit_soft_object_store_bytes",
+    "unit_soft_limit",
 }
 _SOFT_OUTPUT_BLOCK_REASONS = {
     "query_soft_object_store_bytes",
-    "stage_soft_object_store_bytes",
-    "stage_soft_limit",
+    "unit_soft_object_store_bytes",
+    "unit_soft_limit",
 }
 _OUTPUT_STATES = (
     "generator_pending",
-    "stage_queue",
+    "unit_queue",
     "downstream_input",
     "external_consumer",
     "released",
@@ -89,7 +89,7 @@ def _component_max(resources: tuple[ResourceVector, ...]) -> ResourceVector:
 @dataclass(frozen=True)
 class TaskRequest:
     query_id: str
-    stage_id: str
+    resource_unit_id: str
     task_id: str
     attempt_id: str
     node_id: str | None
@@ -100,7 +100,7 @@ class TaskRequest:
 class TaskLease:
     lease_id: str
     query_id: str
-    stage_id: str
+    resource_unit_id: str
     task_id: str
     attempt_id: str
     node_id: str
@@ -126,9 +126,9 @@ class TaskGrant:
 class _ContinuationCredit:
     credit_id: str
     parent_task_lease_id: str
-    parent_stage_id: str
-    eligible_stage_ids: tuple[str, ...]
-    reservation_stage_id: str
+    parent_unit_id: str
+    eligible_unit_ids: tuple[str, ...]
+    reservation_unit_id: str
     node_id: str
     resources: ResourceVector
     allocation_generation: int
@@ -138,8 +138,8 @@ class _ContinuationCredit:
 
 @dataclass(frozen=True)
 class _NewContinuationCreditPlan:
-    eligible_stage_ids: tuple[str, ...]
-    reservation_stage_id: str
+    eligible_unit_ids: tuple[str, ...]
+    reservation_unit_id: str
     node_id: str
     resources: ResourceVector
 
@@ -165,7 +165,7 @@ class _DownstreamReservation:
     """
 
     reservation_id: str
-    stage_ids: tuple[str, ...]
+    unit_ids: tuple[str, ...]
     resources: ResourceVector
     allowed_node_ids: tuple[str, ...]
 
@@ -186,7 +186,7 @@ class _QueuedTaskEvaluation:
 @dataclass(frozen=True)
 class OutputBlockRequest:
     query_id: str
-    producer_stage_id: str
+    producer_unit_id: str
     task_lease_id: str
     attempt_id: str
     block_id: str
@@ -197,7 +197,7 @@ class OutputBlockRequest:
 class OutputBlockLease:
     lease_id: str
     query_id: str
-    producer_stage_id: str
+    producer_unit_id: str
     task_lease_id: str
     attempt_id: str
     block_id: str
@@ -276,8 +276,8 @@ class OutputBlockLeaseOwner:
 
 
 @dataclass
-class _StageState:
-    spec: StageResourceSpec
+class _ResourceUnitState:
+    spec: ResourceUnitSpec
     runnable: bool = False
     actor_ready: bool = False
     queued_input_bytes: int = 0
@@ -292,7 +292,7 @@ class QueryResourceManager:
 
     def __init__(
         self,
-        graph: QueryExecutionGraph,
+        graph: QueryResourceGraph,
         allocation: QueryAllocation,
         *,
         reservation_ratio: float = 0.5,
@@ -309,65 +309,69 @@ class QueryResourceManager:
         self._on_change = on_change
         self._lock = threading.RLock()
         self._admission_epoch = 0
-        self._stages = {
-            stage.stage_id: _StageState(
-                spec=stage,
-                actor_ready=stage.backend != "ray_actor",
+        self._units = {
+            unit.resource_unit_id: _ResourceUnitState(
+                spec=unit,
+                actor_ready=unit.backend != "ray_actor",
             )
-            for stage in graph.stages
+            for unit in graph.units
         }
-        self._direct_downstream_stage_ids: dict[str, set[str]] = {stage.stage_id: set() for stage in graph.stages}
-        for stage in graph.stages:
-            for input_stage_id in stage.input_stage_ids:
-                self._direct_downstream_stage_ids[input_stage_id].add(stage.stage_id)
-        self._topological_stage_ids = graph.topological_stage_ids()
-        self._reverse_topological_stage_ids = graph.reverse_topological_stage_ids()
+        self._direct_downstream_unit_ids: dict[str, set[str]] = {unit.resource_unit_id: set() for unit in graph.units}
+        for unit in graph.units:
+            for input_unit_id in unit.input_unit_ids:
+                self._direct_downstream_unit_ids[input_unit_id].add(unit.resource_unit_id)
+        self._topological_unit_ids = graph.topological_unit_ids()
+        self._reverse_topological_unit_ids = graph.reverse_topological_unit_ids()
         self._reverse_topological_rank = {
-            stage_id: index for index, stage_id in enumerate(self._reverse_topological_stage_ids)
+            resource_unit_id: index for index, resource_unit_id in enumerate(self._reverse_topological_unit_ids)
         }
-        self._upstream_stage_ids: dict[str, tuple[str, ...]] = {}
-        for stage_id in self._topological_stage_ids:
+        self._upstream_unit_ids: dict[str, tuple[str, ...]] = {}
+        for resource_unit_id in self._topological_unit_ids:
             upstream: set[str] = set()
-            for input_stage_id in self._stages[stage_id].spec.input_stage_ids:
-                upstream.add(input_stage_id)
-                upstream.update(self._upstream_stage_ids[input_stage_id])
-            self._upstream_stage_ids[stage_id] = tuple(
-                candidate for candidate in self._topological_stage_ids if candidate in upstream
+            for input_unit_id in self._units[resource_unit_id].spec.input_unit_ids:
+                upstream.add(input_unit_id)
+                upstream.update(self._upstream_unit_ids[input_unit_id])
+            self._upstream_unit_ids[resource_unit_id] = tuple(
+                candidate for candidate in self._topological_unit_ids if candidate in upstream
             )
-        self._reachable_stage_ids: dict[str, tuple[str, ...]] = {}
-        self._reachable_udf_stage_ids: dict[str, tuple[str, ...]] = {}
-        self._downstream_fte_stage_ids_requiring_separate_slot = {
-            stage_id: graph.downstream_fte_stage_ids_requiring_separate_slot(stage_id)
-            for stage_id in self._topological_stage_ids
+        self._reachable_unit_ids: dict[str, tuple[str, ...]] = {}
+        self._reachable_udf_unit_ids: dict[str, tuple[str, ...]] = {}
+        self._downstream_native_fragment_unit_ids_requiring_separate_slot = {
+            resource_unit_id: graph.downstream_native_fragment_unit_ids_requiring_separate_slot(resource_unit_id)
+            for resource_unit_id in self._topological_unit_ids
         }
-        for source_stage_id in self._topological_stage_ids:
+        for source_unit_id in self._topological_unit_ids:
             reachable: set[str] = set()
-            pending = list(self._direct_downstream_stage_ids[source_stage_id])
+            pending = list(self._direct_downstream_unit_ids[source_unit_id])
             while pending:
-                stage_id = pending.pop()
-                if stage_id in reachable:
+                resource_unit_id = pending.pop()
+                if resource_unit_id in reachable:
                     continue
-                reachable.add(stage_id)
-                pending.extend(self._direct_downstream_stage_ids[stage_id])
-            ordered_reachable = tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in reachable)
-            self._reachable_stage_ids[source_stage_id] = ordered_reachable
-            self._reachable_udf_stage_ids[source_stage_id] = tuple(
-                stage_id for stage_id in ordered_reachable if self._stages[stage_id].spec.stage_kind == "udf"
+                reachable.add(resource_unit_id)
+                pending.extend(self._direct_downstream_unit_ids[resource_unit_id])
+            ordered_reachable = tuple(
+                resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in reachable
             )
-        self._continuation_parent_stage_ids_by_ray_task: dict[str, tuple[str, ...]] = {}
-        for stage_id in self._topological_stage_ids:
-            stage = self._stages[stage_id].spec
-            if stage.backend != "ray_task":
+            self._reachable_unit_ids[source_unit_id] = ordered_reachable
+            self._reachable_udf_unit_ids[source_unit_id] = tuple(
+                resource_unit_id
+                for resource_unit_id in ordered_reachable
+                if self._units[resource_unit_id].spec.backend in {"ray_task", "ray_actor"}
+            )
+        self._continuation_parent_unit_ids_by_ray_task: dict[str, tuple[str, ...]] = {}
+        for resource_unit_id in self._topological_unit_ids:
+            unit = self._units[resource_unit_id].spec
+            if unit.backend != "ray_task":
                 continue
-            parent_stage_ids = tuple(
-                parent_stage_id
-                for parent_stage_id in self._topological_stage_ids
-                if self._stages[parent_stage_id].spec.backend == "ray_worker"
-                and stage_id in self._reachable_udf_stage_ids[parent_stage_id]
+            parent_unit_ids = tuple(
+                parent_unit_id
+                for parent_unit_id in self._topological_unit_ids
+                if self._units[parent_unit_id].spec.backend == "ray_worker"
+                and resource_unit_id in self._reachable_udf_unit_ids[parent_unit_id]
             )
-            if parent_stage_ids:
-                self._continuation_parent_stage_ids_by_ray_task[stage_id] = parent_stage_ids
-        self._started_stage_ids: set[str] = set()
+            if parent_unit_ids:
+                self._continuation_parent_unit_ids_by_ray_task[resource_unit_id] = parent_unit_ids
+        self._started_unit_ids: set[str] = set()
         self._task_leases: dict[str, TaskLease] = {}
         self._continuation_credits: dict[str, _ContinuationCredit] = {}
         self._continuation_credit_by_parent: dict[str, str] = {}
@@ -386,7 +390,7 @@ class QueryResourceManager:
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
-        self._completed_materializing_stage_ids: set[str] = set()
+        self._completed_barrier_unit_ids: set[str] = set()
         self._external_consumer_waiting = False
         self._cancelled = False
         self._cancel_reason = ""
@@ -413,42 +417,42 @@ class QueryResourceManager:
         with self._lock:
             return int(self._admission_epoch)
 
-    def update_stage_state(
+    def update_unit_state(
         self,
-        stage_id: str,
+        resource_unit_id: str,
         *,
         runnable: bool,
         actor_ready: bool | None = None,
         completed: bool = False,
     ) -> None:
-        stage_key = str(stage_id)
+        unit_key = str(resource_unit_id)
         with self._lock:
-            stage = self._stages.get(stage_key)
-            if stage is None:
-                raise KeyError(f"stage is not registered: {stage_key}")
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
             before = (
-                stage.runnable,
-                stage.actor_ready,
-                stage.queued_input_bytes,
-                stage.pending_task_count,
-                stage.queued_output_bytes,
-                stage.pending_output_count,
-                stage.completed,
+                unit.runnable,
+                unit.actor_ready,
+                unit.queued_input_bytes,
+                unit.pending_task_count,
+                unit.queued_output_bytes,
+                unit.pending_output_count,
+                unit.completed,
             )
-            stage.runnable = bool(runnable) and not bool(completed)
+            unit.runnable = bool(runnable) and not bool(completed)
             if actor_ready is not None:
-                stage.actor_ready = bool(actor_ready)
-            self._recompute_stage_queued_input_locked(stage_key)
-            self._recompute_stage_queued_output_locked(stage_key)
-            stage.completed = bool(completed)
+                unit.actor_ready = bool(actor_ready)
+            self._recompute_unit_queued_input_locked(unit_key)
+            self._recompute_unit_queued_output_locked(unit_key)
+            unit.completed = bool(completed)
             after = (
-                stage.runnable,
-                stage.actor_ready,
-                stage.queued_input_bytes,
-                stage.pending_task_count,
-                stage.queued_output_bytes,
-                stage.pending_output_count,
-                stage.completed,
+                unit.runnable,
+                unit.actor_ready,
+                unit.queued_input_bytes,
+                unit.pending_task_count,
+                unit.queued_output_bytes,
+                unit.pending_output_count,
+                unit.completed,
             )
             if after != before:
                 self._publish_change_locked()
@@ -458,21 +462,21 @@ class QueryResourceManager:
         with self._lock:
             if str(request.query_id) != self.graph.query_id:
                 raise ValueError("queued task query_id does not match resource manager")
-            stage_id = str(request.stage_id)
-            stage = self._stages.get(stage_id)
-            if stage is None:
-                raise KeyError(f"stage is not registered: {stage_id}")
+            resource_unit_id = str(request.resource_unit_id)
+            unit = self._units.get(resource_unit_id)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {resource_unit_id}")
             task_id = str(request.task_id).strip()
             attempt_id = str(request.attempt_id).strip()
             if not task_id or not attempt_id:
                 raise ValueError("queued task identity must be non-empty")
             retained = (
-                stage.spec.per_task.object_store_bytes
+                unit.spec.per_task.object_store_bytes
                 if request.retained_input_bytes is None
                 else int(request.retained_input_bytes)
             )
-            if retained < 0 or retained > stage.spec.per_task.object_store_bytes:
-                raise ValueError("queued task retained input is outside its stage resource spec")
+            if retained < 0 or retained > unit.spec.per_task.object_store_bytes:
+                raise ValueError("queued task retained input is outside its unit resource spec")
             key = (task_id, attempt_id)
             existing = self._waiting_task_inputs.get(key)
             queued = max(1, retained)
@@ -482,8 +486,8 @@ class QueryResourceManager:
             if existing is not None:
                 return
             self._waiting_task_inputs[key] = value
-            stage.runnable = not stage.completed
-            self._recompute_stage_queued_input_locked(stage_id)
+            unit.runnable = not unit.completed
+            self._recompute_unit_queued_input_locked(resource_unit_id)
             self._publish_change_locked()
 
     def remove_task_waiter(self, task_id: str, attempt_id: str) -> bool:
@@ -494,7 +498,7 @@ class QueryResourceManager:
             )
             if value is None:
                 return False
-            self._recompute_stage_queued_input_locked(str(value[0].stage_id))
+            self._recompute_unit_queued_input_locked(str(value[0].resource_unit_id))
             self._publish_change_locked()
             return True
 
@@ -507,23 +511,23 @@ class QueryResourceManager:
             self._terminal_attempts.add(key)
             self._publish_change_locked()
 
-    def _recompute_stage_queued_input_locked(self, stage_id: str) -> None:
-        stage = self._stages[stage_id]
+    def _recompute_unit_queued_input_locked(self, resource_unit_id: str) -> None:
+        unit = self._units[resource_unit_id]
         waiting = [
             queued_bytes
             for request, queued_bytes in self._waiting_task_inputs.values()
-            if str(request.stage_id) == stage_id
+            if str(request.resource_unit_id) == resource_unit_id
         ]
-        stage.pending_task_count = len(waiting)
-        stage.queued_input_bytes = sum(waiting)
+        unit.pending_task_count = len(waiting)
+        unit.queued_input_bytes = sum(waiting)
 
     def note_output_waiting(self, request: OutputBlockRequest) -> None:
         with self._lock:
             if str(request.query_id) != self.graph.query_id:
                 raise ValueError("queued output query_id does not match resource manager")
-            stage_id = str(request.producer_stage_id)
-            if stage_id not in self._stages:
-                raise KeyError(f"stage is not registered: {stage_id}")
+            resource_unit_id = str(request.producer_unit_id)
+            if resource_unit_id not in self._units:
+                raise KeyError(f"unit is not registered: {resource_unit_id}")
             block_id = str(request.block_id).strip()
             size_bytes = int(request.size_bytes)
             if not block_id or size_bytes <= 0:
@@ -532,7 +536,7 @@ class QueryResourceManager:
             if existing is not None and existing != request:
                 raise ValueError("queued output block_id was reused with different work")
             self._waiting_output_blocks[block_id] = request
-            self._recompute_stage_queued_output_locked(stage_id)
+            self._recompute_unit_queued_output_locked(resource_unit_id)
             self._publish_change_locked()
 
     def remove_output_waiter(self, block_id: str) -> bool:
@@ -540,7 +544,7 @@ class QueryResourceManager:
             value = self._waiting_output_blocks.pop(str(block_id), None)
             if value is None:
                 return False
-            self._recompute_stage_queued_output_locked(str(value.producer_stage_id))
+            self._recompute_unit_queued_output_locked(str(value.producer_unit_id))
             self._publish_change_locked()
             return True
 
@@ -553,20 +557,20 @@ class QueryResourceManager:
             self._terminal_output_blocks.add(key)
             self._publish_change_locked()
 
-    def _recompute_stage_queued_output_locked(self, stage_id: str) -> None:
-        stage = self._stages[stage_id]
+    def _recompute_unit_queued_output_locked(self, resource_unit_id: str) -> None:
+        unit = self._units[resource_unit_id]
         waiting = [
             int(request.size_bytes)
             for request in self._waiting_output_blocks.values()
-            if str(request.producer_stage_id) == stage_id
+            if str(request.producer_unit_id) == resource_unit_id
         ]
         leased_queue_bytes = sum(
             lease.size_bytes
             for lease in self._output_leases.values()
-            if lease.producer_stage_id == stage_id and lease.state in {"generator_pending", "stage_queue"}
+            if lease.producer_unit_id == resource_unit_id and lease.state in {"generator_pending", "unit_queue"}
         )
-        stage.pending_output_count = len(waiting)
-        stage.queued_output_bytes = sum(waiting) + leased_queue_bytes
+        unit.pending_output_count = len(waiting)
+        unit.queued_output_bytes = sum(waiting) + leased_queue_bytes
 
     def set_external_consumer_waiting(self, waiting: bool) -> None:
         with self._lock:
@@ -576,31 +580,31 @@ class QueryResourceManager:
             self._external_consumer_waiting = waiting
             self._publish_change_locked()
 
-    def set_stage_actor_ready(self, stage_id: str, ready: bool) -> None:
+    def set_unit_actor_ready(self, resource_unit_id: str, ready: bool) -> None:
         with self._lock:
-            stage = self._stages.get(str(stage_id))
-            if stage is None:
-                raise KeyError(f"stage is not registered: {stage_id}")
-            if stage.spec.backend != "ray_actor":
-                raise ValueError(f"stage is not a Ray actor stage: {stage_id}")
+            unit = self._units.get(str(resource_unit_id))
+            if unit is None:
+                raise KeyError(f"unit is not registered: {resource_unit_id}")
+            if unit.spec.backend != "ray_actor":
+                raise ValueError(f"unit is not a Ray actor unit: {resource_unit_id}")
             ready = bool(ready)
-            if stage.actor_ready == ready:
+            if unit.actor_ready == ready:
                 return
-            stage.actor_ready = ready
+            unit.actor_ready = ready
             self._publish_change_locked()
 
-    def mark_materializing_stage_completed(self, stage_id: str) -> bool:
-        """Advance a blocking phase without terminalizing its output stage."""
-        stage_key = str(stage_id)
+    def mark_barrier_unit_completed(self, resource_unit_id: str) -> bool:
+        """Record one blocking barrier as materialized without completing its output unit."""
+        unit_key = str(resource_unit_id)
         with self._lock:
-            stage = self._stages.get(stage_key)
-            if stage is None:
-                raise KeyError(f"stage is not registered: {stage_key}")
-            if stage.spec.spill_mode != "barrier":
-                raise ValueError(f"stage is not a blocking materializer: {stage_key}")
-            if self._materializing_stage_completed_locked(stage_key):
+            unit = self._units.get(unit_key)
+            if unit is None:
+                raise KeyError(f"unit is not registered: {unit_key}")
+            if not unit.spec.is_barrier:
+                raise ValueError(f"unit is not a blocking materializer: {unit_key}")
+            if self._barrier_unit_completed_locked(unit_key):
                 return False
-            self._completed_materializing_stage_ids.add(stage_key)
+            self._completed_barrier_unit_ids.add(unit_key)
             self._publish_change_locked()
             return True
 
@@ -632,34 +636,34 @@ class QueryResourceManager:
             self._allocation_admission_open = False
             self._publish_change_locked()
 
-    def task_eligible_node_ids(self, stage_id: str) -> tuple[str, ...]:
-        """Return statically feasible placement nodes for one registered stage."""
+    def task_eligible_node_ids(self, resource_unit_id: str) -> tuple[str, ...]:
+        """Return statically feasible placement nodes for one registered unit."""
         with self._lock:
             if not self._allocation_admission_open:
                 return ()
-            stage = self._stages.get(str(stage_id))
-            if stage is None:
-                raise KeyError(f"stage is not registered: {stage_id}")
-            commitment = self._task_commitment(stage.spec)
+            unit = self._units.get(str(resource_unit_id))
+            if unit is None:
+                raise KeyError(f"unit is not registered: {resource_unit_id}")
+            commitment = self._task_commitment(unit.spec)
             allowed_actor_nodes = (
-                set(self.allocation.actor_node_ids_for_stage(stage.spec.stage_id))
-                if stage.spec.backend == "ray_actor"
+                set(self.allocation.actor_node_ids_for_unit(unit.spec.resource_unit_id))
+                if unit.spec.backend == "ray_actor"
                 else None
             )
-            if self._continuation_parent_stage_ids_by_ray_task.get(stage.spec.stage_id):
+            if self._continuation_parent_unit_ids_by_ray_task.get(unit.spec.resource_unit_id):
                 return tuple(
                     dict.fromkeys(
                         credit.node_id
                         for credit in self._continuation_credits.values()
                         if credit.parent_active
                         and credit.borrowed_by_task_lease_id is None
-                        and stage.spec.stage_id in credit.eligible_stage_ids
+                        and unit.spec.resource_unit_id in credit.eligible_unit_ids
                         and commitment.fits_within(credit.resources)
                     )
                 )
-            credit_template = self._continuation_credit_template_locked(stage.spec)
+            credit_template = self._continuation_credit_template_locked(unit.spec)
             credit_resources = ResourceVector() if credit_template is None else credit_template[2]
-            downstream_reservations = self._downstream_reservations_locked(stage.spec)
+            downstream_reservations = self._downstream_reservations_locked(unit.spec)
             allocation_by_node = {
                 allocation.node_id: allocation.resources for allocation in self.allocation.node_allocations
             }
@@ -754,19 +758,19 @@ class QueryResourceManager:
                     admission_epoch=int(self._admission_epoch),
                 )
 
-            # A non-root FTE stage becomes runnable when its first real split
+            # A non-root native fragment unit becomes runnable when its first real split
             # descriptor arrives.  Persistent task waiters perform this same
             # transition in note_task_waiting(); descriptor-owned backlog must
             # preserve it even though no individual waiter is registered.
-            request_stage = self._stages.get(str(request.stage_id))
+            request_unit = self._units.get(str(request.resource_unit_id))
             if (
                 str(request.query_id) == self.graph.query_id
-                and request_stage is not None
-                and not request_stage.completed
-                and not request_stage.runnable
+                and request_unit is not None
+                and not request_unit.completed
+                and not request_unit.runnable
             ):
-                request_stage.runnable = True
-                self._recompute_stage_queued_input_locked(str(request.stage_id))
+                request_unit.runnable = True
+                self._recompute_unit_queued_input_locked(str(request.resource_unit_id))
                 self._publish_change_locked()
 
             key = (str(request.task_id), str(request.attempt_id))
@@ -900,7 +904,7 @@ class QueryResourceManager:
                 )
             request = selected.request
             if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-                str(request.stage_id),
+                str(request.resource_unit_id),
                 selected.plan,
             ):
                 return request, TaskGrant(
@@ -908,7 +912,7 @@ class QueryResourceManager:
                     blocked_reason="liveness_task_active",
                 )
             if not self._active_tasks_allow_liveness_locked(
-                str(request.stage_id),
+                str(request.resource_unit_id),
                 selected.plan,
             ):
                 return request, TaskGrant(
@@ -934,14 +938,14 @@ class QueryResourceManager:
             return "allocation_pending", False, empty_plan
         if str(request.query_id) != self.graph.query_id:
             return "query_id_mismatch", True, empty_plan
-        stage = self._stages.get(str(request.stage_id))
-        if stage is None:
-            return "stage_not_registered", True, empty_plan
-        if stage.completed:
-            return "stage_completed", True, empty_plan
-        if not stage.runnable:
-            return "stage_not_runnable", False, empty_plan
-        if stage.spec.backend == "ray_actor" and not stage.actor_ready:
+        unit = self._units.get(str(request.resource_unit_id))
+        if unit is None:
+            return "unit_not_registered", True, empty_plan
+        if unit.completed:
+            return "unit_completed", True, empty_plan
+        if not unit.runnable:
+            return "unit_not_runnable", False, empty_plan
+        if unit.spec.backend == "ray_actor" and not unit.actor_ready:
             return "actor_not_ready", False, empty_plan
 
         task_key = str(request.task_id).strip()
@@ -955,33 +959,33 @@ class QueryResourceManager:
             if attempt in self._active_attempt_leases:
                 return "attempt_already_active", True, empty_plan
 
-        active_stage_tasks = self._active_task_count_for_stage_locked(stage.spec.stage_id)
-        concurrency_cap = self._stage_concurrency_cap(stage.spec)
-        if concurrency_cap is not None and active_stage_tasks >= concurrency_cap:
-            return "stage_concurrency", False, empty_plan
+        active_unit_tasks = self._active_task_count_for_unit_locked(unit.spec.resource_unit_id)
+        concurrency_cap = self._unit_concurrency_cap(unit.spec)
+        if concurrency_cap is not None and active_unit_tasks >= concurrency_cap:
+            return "unit_concurrency", False, empty_plan
 
         free_actor_indices_by_node: dict[str, list[int]] | None = None
-        if stage.spec.backend == "ray_actor":
+        if unit.spec.backend == "ray_actor":
             free_actor_indices_by_node = {}
             for placement in self.allocation.actor_placements:
-                if placement.stage_id != stage.spec.stage_id:
+                if placement.resource_unit_id != unit.spec.resource_unit_id:
                     continue
-                slot_key = (stage.spec.stage_id, placement.actor_index)
-                if self._actor_slot_lease_count_locked(slot_key) >= stage.spec.actor_prefetch_depth:
+                slot_key = (unit.spec.resource_unit_id, placement.actor_index)
+                if self._actor_slot_lease_count_locked(slot_key) >= unit.spec.actor_prefetch_depth:
                     continue
                 free_actor_indices_by_node.setdefault(placement.node_id, []).append(placement.actor_index)
             if not free_actor_indices_by_node:
                 return "actor_slot", False, empty_plan
 
         retained = (
-            stage.spec.per_task.object_store_bytes
+            unit.spec.per_task.object_store_bytes
             if request.retained_input_bytes is None
             else int(request.retained_input_bytes)
         )
         if retained < 0:
             return "invalid_retained_input_bytes", True, empty_plan
-        resources = _resource_with_object_store(stage.spec.per_task, retained)
-        output_window = stage.spec.output_window_bytes
+        resources = _resource_with_object_store(unit.spec.per_task, retained)
+        output_window = unit.spec.output_window_bytes
         commitment = _resource_with_object_store(resources, retained + output_window)
         hard_commitment = _hard_resources(commitment)
         if hard_commitment.exceeded_dimensions(_hard_resources(self.allocation.resources)):
@@ -993,13 +997,13 @@ class QueryResourceManager:
             return "allocation_debt", False, empty_plan
 
         borrowed_credit = self._available_continuation_credit_locked(
-            stage.spec,
+            unit.spec,
             requested_node_id=request.node_id,
             resources=resources,
             output_window_bytes=output_window,
             query_usage=query_usage,
         )
-        credit_template = self._continuation_credit_template_locked(stage.spec)
+        credit_template = self._continuation_credit_template_locked(unit.spec)
         credit_resources = ResourceVector() if credit_template is None else credit_template[2]
         admission_commitment = commitment + credit_resources
         if borrowed_credit is not None:
@@ -1027,15 +1031,18 @@ class QueryResourceManager:
         if hard_exceeded:
             reason = "continuation_capacity" if credit_template is not None else f"hard_{hard_exceeded[0]}"
             return reason, False, empty_plan
-        object_store_unlimited = stage.spec.stage_id in self._materializing_object_store_unlimited_stage_ids_locked(
-            requested_stage_id=stage.spec.stage_id,
+        object_store_unlimited = (
+            unit.spec.resource_unit_id
+            in self._materializing_object_store_unlimited_unit_ids_locked(
+                requested_unit_id=unit.spec.resource_unit_id,
+            )
         )
         query_soft_blocked = (
             not object_store_unlimited
             and admission_commitment.object_store_bytes > 0
             and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         )
-        downstream_reservations = self._downstream_reservations_locked(stage.spec)
+        downstream_reservations = self._downstream_reservations_locked(unit.spec)
         if downstream_reservations:
             remaining = _hard_resources(self.allocation.resources) - _hard_resources(query_usage + admission_commitment)
             reservation_total = self._downstream_reservation_total(downstream_reservations)
@@ -1044,7 +1051,7 @@ class QueryResourceManager:
 
         new_credit_plan: _NewContinuationCreditPlan | None = None
         if credit_template is not None:
-            eligible_stage_ids, reservation_stage_id, credit_resources = credit_template
+            eligible_unit_ids, reservation_unit_id, credit_resources = credit_template
             node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
                 request.node_id,
                 hard_commitment,
@@ -1053,8 +1060,8 @@ class QueryResourceManager:
             )
             if node_blocked_reason is None:
                 new_credit_plan = _NewContinuationCreditPlan(
-                    eligible_stage_ids=eligible_stage_ids,
-                    reservation_stage_id=reservation_stage_id,
+                    eligible_unit_ids=eligible_unit_ids,
+                    reservation_unit_id=reservation_unit_id,
                     node_id=credit_node_id,
                     resources=credit_resources,
                 )
@@ -1081,7 +1088,7 @@ class QueryResourceManager:
             actor_index = min(
                 candidates,
                 key=lambda index: (
-                    self._actor_slot_lease_count_locked((stage.spec.stage_id, index)),
+                    self._actor_slot_lease_count_locked((unit.spec.resource_unit_id, index)),
                     index,
                 ),
             )
@@ -1093,18 +1100,18 @@ class QueryResourceManager:
             new_credit=new_credit_plan,
             borrowed_credit_id=(None if borrowed_credit is None else borrowed_credit.credit_id),
         )
-        if active_stage_tasks > 0 and any(
-            downstream_id not in self._started_stage_ids
-            and self._stages[downstream_id].runnable
-            and not self._stages[downstream_id].completed
-            for downstream_id in self._direct_downstream_stage_ids[stage.spec.stage_id]
+        if active_unit_tasks > 0 and any(
+            downstream_id not in self._started_unit_ids
+            and self._units[downstream_id].runnable
+            and not self._units[downstream_id].completed
+            for downstream_id in self._direct_downstream_unit_ids[unit.spec.resource_unit_id]
         ):
-            return "stage_soft_limit", False, plan
+            return "unit_soft_limit", False, plan
         if query_soft_blocked:
             return "query_soft_object_store_bytes", False, plan
         if borrowed_credit is None:
-            soft_reason = self._stage_soft_block_reason_locked(
-                stage.spec.stage_id,
+            soft_reason = self._unit_soft_block_reason_locked(
+                unit.spec.resource_unit_id,
                 commitment,
                 ignore_object_store=object_store_unlimited,
             )
@@ -1338,11 +1345,11 @@ class QueryResourceManager:
         return int(slot in self._active_actor_slots) + len(self._queued_actor_slot_leases.get(slot, ()))
 
     @staticmethod
-    def _stage_concurrency_cap(spec: StageResourceSpec) -> int | None:
+    def _unit_concurrency_cap(spec: ResourceUnitSpec) -> int | None:
         return spec.max_concurrency
 
     @staticmethod
-    def _task_commitment(spec: StageResourceSpec) -> ResourceVector:
+    def _task_commitment(spec: ResourceUnitSpec) -> ResourceVector:
         """Return non-spillable process resources for one runnable task."""
         return ResourceVector(
             cpu=spec.per_task.cpu,
@@ -1350,83 +1357,89 @@ class QueryResourceManager:
             heap_bytes=spec.per_task.heap_bytes,
         )
 
-    def _current_materializing_stage_id_locked(self) -> str | None:
-        """Return the first unfinished blocking stage in source-to-sink order."""
+    def _first_pending_barrier_unit_id_locked(self) -> str | None:
+        """Return the first unfinished blocking unit in source-to-sink order."""
         return next(
             (
-                stage_id
-                for stage_id in self._topological_stage_ids
-                if self._stages[stage_id].spec.spill_mode == "barrier"
-                and not self._materializing_stage_completed_locked(stage_id)
+                resource_unit_id
+                for resource_unit_id in self._topological_unit_ids
+                if self._units[resource_unit_id].spec.is_barrier
+                and not self._barrier_unit_completed_locked(resource_unit_id)
             ),
             None,
         )
 
-    def _materializing_stage_completed_locked(self, stage_id: str) -> bool:
-        return self._stages[stage_id].completed or stage_id in self._completed_materializing_stage_ids
+    def _barrier_unit_completed_locked(self, resource_unit_id: str) -> bool:
+        return self._units[resource_unit_id].completed or resource_unit_id in self._completed_barrier_unit_ids
 
-    def _materializing_phase_stage_ids_locked(self) -> tuple[str, ...]:
-        """Return unfinished stages eligible in the current materialization phase."""
-        barrier_stage_id = self._current_materializing_stage_id_locked()
-        if barrier_stage_id is None:
-            return tuple(stage_id for stage_id in self._topological_stage_ids if not self._stages[stage_id].completed)
-        phase = set(self._upstream_stage_ids[barrier_stage_id])
-        phase.add(barrier_stage_id)
+    def _reservation_scope_unit_ids_locked(self) -> tuple[str, ...]:
+        """Return unfinished units eligible in the current reservation scope."""
+        barrier_unit_id = self._first_pending_barrier_unit_id_locked()
+        if barrier_unit_id is None:
+            return tuple(
+                resource_unit_id
+                for resource_unit_id in self._topological_unit_ids
+                if not self._units[resource_unit_id].completed
+            )
+        scope = set(self._upstream_unit_ids[barrier_unit_id])
+        scope.add(barrier_unit_id)
         return tuple(
-            stage_id
-            for stage_id in self._topological_stage_ids
-            if stage_id in phase and not self._stages[stage_id].completed
+            resource_unit_id
+            for resource_unit_id in self._topological_unit_ids
+            if resource_unit_id in scope and not self._units[resource_unit_id].completed
         )
 
-    def _materializing_object_store_unlimited_stage_ids_locked(
+    def _materializing_object_store_unlimited_unit_ids_locked(
         self,
         *,
-        requested_stage_id: str | None = None,
+        requested_unit_id: str | None = None,
     ) -> tuple[str, ...]:
-        """Return stages whose data must be collectable beyond the soft budget.
+        """Return units whose data must be collectable beyond the soft budget.
 
         Vane accounts a block to its producer even after the block becomes a
-        downstream input. Therefore the blocking stage and its direct input
+        downstream input. Therefore the blocking unit and its direct input
         producers share the spill exemption. DuckDB may concurrently start
         nested materializers (notably chained broadcast joins), so a blocking
-        boundary becomes active when its own stage or one of its direct inputs
+        boundary becomes active when its own unit or one of its direct inputs
         is requested or has started. The first unfinished boundary is always
         active. Earlier streaming producers keep their normal soft budgets and
         bounded liveness escape.
         """
-        first_barrier_stage_id = self._current_materializing_stage_id_locked()
-        if first_barrier_stage_id is None:
+        first_barrier_unit_id = self._first_pending_barrier_unit_id_locked()
+        if first_barrier_unit_id is None:
             return ()
-        requested = None if requested_stage_id is None else str(requested_stage_id)
+        requested = None if requested_unit_id is None else str(requested_unit_id)
         unlimited: set[str] = set()
-        for barrier_stage_id in self._topological_stage_ids:
-            barrier = self._stages[barrier_stage_id]
-            if barrier.spec.spill_mode != "barrier" or self._materializing_stage_completed_locked(barrier_stage_id):
+        for barrier_unit_id in self._topological_unit_ids:
+            barrier = self._units[barrier_unit_id]
+            if not barrier.spec.is_barrier or self._barrier_unit_completed_locked(barrier_unit_id):
                 continue
-            boundary = set(barrier.spec.input_stage_ids)
-            boundary.add(barrier_stage_id)
+            boundary = set(barrier.spec.input_unit_ids)
+            boundary.add(barrier_unit_id)
             active = (
-                barrier_stage_id == first_barrier_stage_id
+                barrier_unit_id == first_barrier_unit_id
                 or requested in boundary
-                or bool(boundary & self._started_stage_ids)
+                or bool(boundary & self._started_unit_ids)
             )
             if active:
                 unlimited.update(boundary)
-        return tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in unlimited)
+        return tuple(
+            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in unlimited
+        )
 
     def _continuation_credit_template_locked(
         self,
-        parent: StageResourceSpec,
+        parent: ResourceUnitSpec,
     ) -> tuple[tuple[str, ...], str, ResourceVector] | None:
         if parent.backend != "ray_worker":
             return None
-        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
+        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
         eligible_specs = tuple(
-            self._stages[stage_id].spec
-            for stage_id in self._reachable_udf_stage_ids[parent.stage_id]
-            if stage_id in phase_stage_ids
-            and self._stages[stage_id].spec.backend == "ray_task"
-            and not self._stages[stage_id].completed
+            self._units[resource_unit_id].spec
+            for resource_unit_id in self._reachable_udf_unit_ids[parent.resource_unit_id]
+            if resource_unit_id in scope_unit_ids
+            and self._units[resource_unit_id].spec.backend == "ray_task"
+            and not self._units[resource_unit_id].completed
         )
         if not eligible_specs:
             return None
@@ -1436,30 +1449,30 @@ class QueryResourceManager:
             eligible_specs,
             key=lambda spec: (
                 self._task_commitment(spec).dominant_share(self.allocation.resources),
-                -self._topological_stage_ids.index(spec.stage_id),
+                -self._topological_unit_ids.index(spec.resource_unit_id),
             ),
         )
         return (
-            tuple(spec.stage_id for spec in eligible_specs),
-            reservation_spec.stage_id,
+            tuple(spec.resource_unit_id for spec in eligible_specs),
+            reservation_spec.resource_unit_id,
             resources,
         )
 
     def _available_continuation_credit_locked(
         self,
-        stage: StageResourceSpec,
+        unit: ResourceUnitSpec,
         *,
         requested_node_id: str | None,
         resources: ResourceVector,
         output_window_bytes: int,
         query_usage: ResourceVector,
     ) -> _ContinuationCredit | None:
-        if stage.backend != "ray_task":
+        if unit.backend != "ray_task":
             return None
-        if not self._continuation_parent_stage_ids_by_ray_task.get(stage.stage_id):
+        if not self._continuation_parent_unit_ids_by_ray_task.get(unit.resource_unit_id):
             return None
         requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        commitment = self._task_commitment(stage)
+        commitment = self._task_commitment(unit)
         allocation_by_node = {
             item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
         }
@@ -1468,7 +1481,7 @@ class QueryResourceManager:
             for credit in self._continuation_credits.values()
             if credit.parent_active
             and credit.borrowed_by_task_lease_id is None
-            and stage.stage_id in credit.eligible_stage_ids
+            and unit.resource_unit_id in credit.eligible_unit_ids
             and commitment.fits_within(credit.resources)
             and (not requested or credit.node_id == requested)
             and credit.node_id in allocation_by_node
@@ -1523,11 +1536,12 @@ class QueryResourceManager:
 
     def _downstream_reservations_locked(
         self,
-        parent: StageResourceSpec,
+        parent: ResourceUnitSpec,
     ) -> tuple[_DownstreamReservation, ...]:
         """Return shared bundles required to keep this producer drainable.
 
-        Query demand owns one transferable FTE bundle, while nested Ray tasks
+        Query demand owns one transferable native-fragment bundle, while
+        nested Ray tasks
         use the explicit per-parent continuation credit above. A streaming
         actor boundary additionally needs one slot for every inactive
         downstream Ray-task continuation: the actor input producer, actor call,
@@ -1536,52 +1550,55 @@ class QueryResourceManager:
         enough. Actor process resources are already resident; invocation
         input/output bytes use the query's dynamic object-store budget.
 
-        Reservations include latent stages: waiting for a stage to become
+        Reservations include latent units: waiting for a unit to become
         runnable is too late because an upstream producer may already have
         consumed the last non-spillable process slot by then.
         """
-        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
+        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
         reachable = tuple(
-            self._stages[stage_id]
-            for stage_id in self._reachable_stage_ids[parent.stage_id]
-            if stage_id in phase_stage_ids and not self._stages[stage_id].completed
+            self._units[resource_unit_id]
+            for resource_unit_id in self._reachable_unit_ids[parent.resource_unit_id]
+            if resource_unit_id in scope_unit_ids and not self._units[resource_unit_id].completed
         )
         reservations: list[_DownstreamReservation] = []
         allocation_node_ids = tuple(sorted(allocation.node_id for allocation in self.allocation.node_allocations))
 
-        inactive_fte = tuple(
-            self._stages[stage_id].spec
-            for stage_id in self._downstream_fte_stage_ids_requiring_separate_slot[parent.stage_id]
-            if stage_id in phase_stage_ids
-            and not self._stages[stage_id].completed
-            and self._active_task_count_for_stage_locked(stage_id) == 0
+        inactive_native_fragments = tuple(
+            self._units[resource_unit_id].spec
+            for resource_unit_id in self._downstream_native_fragment_unit_ids_requiring_separate_slot[
+                parent.resource_unit_id
+            ]
+            if resource_unit_id in scope_unit_ids
+            and not self._units[resource_unit_id].completed
+            and self._active_task_count_for_unit_locked(resource_unit_id) == 0
         )
-        if inactive_fte:
-            resources = _component_max(tuple(self._task_commitment(stage) for stage in inactive_fte))
+        if inactive_native_fragments:
+            resources = _component_max(tuple(self._task_commitment(unit) for unit in inactive_native_fragments))
             if not resources.is_zero():
                 reservations.append(
                     _DownstreamReservation(
-                        reservation_id=f"fte:{parent.stage_id}",
-                        stage_ids=tuple(stage.stage_id for stage in inactive_fte),
+                        reservation_id=f"native-fragment:{parent.resource_unit_id}",
+                        unit_ids=tuple(unit.resource_unit_id for unit in inactive_native_fragments),
                         resources=resources,
                         allowed_node_ids=allocation_node_ids,
                     )
                 )
 
-        def is_after_streaming_actor(stage_id: str) -> bool:
+        def is_after_streaming_actor(resource_unit_id: str) -> bool:
             if parent.backend == "ray_actor":
                 return True
             return any(
-                candidate.spec.backend == "ray_actor" and stage_id in self._reachable_stage_ids[candidate.spec.stage_id]
+                candidate.spec.backend == "ray_actor"
+                and resource_unit_id in self._reachable_unit_ids[candidate.spec.resource_unit_id]
                 for candidate in reachable
             )
 
         actor_continuations = tuple(
-            stage.spec
-            for stage in reachable
-            if stage.spec.backend == "ray_task"
-            and is_after_streaming_actor(stage.spec.stage_id)
-            and self._active_task_count_for_stage_locked(stage.spec.stage_id) == 0
+            unit.spec
+            for unit in reachable
+            if unit.spec.backend == "ray_task"
+            and is_after_streaming_actor(unit.spec.resource_unit_id)
+            and self._active_task_count_for_unit_locked(unit.spec.resource_unit_id) == 0
         )
         for spec in actor_continuations:
             resources = self._task_commitment(spec)
@@ -1589,18 +1606,18 @@ class QueryResourceManager:
                 continue
             reservations.append(
                 _DownstreamReservation(
-                    reservation_id=f"actor_continuation:{parent.stage_id}:{spec.stage_id}",
-                    stage_ids=(spec.stage_id,),
+                    reservation_id=f"actor_continuation:{parent.resource_unit_id}:{spec.resource_unit_id}",
+                    unit_ids=(spec.resource_unit_id,),
                     resources=resources,
                     allowed_node_ids=allocation_node_ids,
                 )
             )
 
-        for stage in reachable:
-            spec = stage.spec
+        for unit in reachable:
+            spec = unit.spec
             if spec.backend != "ray_actor":
                 continue
-            if self._active_task_count_for_stage_locked(spec.stage_id) > 0:
+            if self._active_task_count_for_unit_locked(spec.resource_unit_id) > 0:
                 continue
             resources = self._task_commitment(spec)
             if resources.is_zero():
@@ -1610,15 +1627,15 @@ class QueryResourceManager:
                     {
                         placement.node_id
                         for placement in self.allocation.actor_placements
-                        if placement.stage_id == spec.stage_id
-                        and (spec.stage_id, placement.actor_index) not in self._active_actor_slots
+                        if placement.resource_unit_id == spec.resource_unit_id
+                        and (spec.resource_unit_id, placement.actor_index) not in self._active_actor_slots
                     }
                 )
             )
             reservations.append(
                 _DownstreamReservation(
-                    reservation_id=f"actor:{spec.stage_id}",
-                    stage_ids=(spec.stage_id,),
+                    reservation_id=f"actor:{spec.resource_unit_id}",
+                    unit_ids=(spec.resource_unit_id,),
                     resources=resources,
                     allowed_node_ids=free_node_ids,
                 )
@@ -1634,115 +1651,119 @@ class QueryResourceManager:
             total = total + reservation.resources
         return total
 
-    def _dimension_live_demand_stage_ids_locked(
+    def _dimension_live_demand_unit_ids_locked(
         self,
         field_name: str,
         *,
-        requested_stage_id: str | None,
+        requested_unit_id: str | None,
     ) -> tuple[str, ...]:
-        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
-        object_store_unlimited_stage_ids = (
+        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
+        object_store_unlimited_unit_ids = (
             set(
-                self._materializing_object_store_unlimited_stage_ids_locked(
-                    requested_stage_id=requested_stage_id,
+                self._materializing_object_store_unlimited_unit_ids_locked(
+                    requested_unit_id=requested_unit_id,
                 )
             )
             if field_name == "object_store_bytes"
             else set()
         )
-        stage_ids: list[str] = []
-        for stage_id, stage in self._stages.items():
+        unit_ids: list[str] = []
+        for resource_unit_id, unit in self._units.items():
             if (
-                stage_id not in phase_stage_ids
-                or stage_id in object_store_unlimited_stage_ids
-                or not stage.runnable
-                or stage.completed
+                resource_unit_id not in scope_unit_ids
+                or resource_unit_id in object_store_unlimited_unit_ids
+                or not unit.runnable
+                or unit.completed
             ):
                 continue
             task_demand = (
-                (requested_stage_id is not None and stage_id == requested_stage_id)
-                or stage.pending_task_count > 0
-                or self._active_task_count_for_stage_locked(stage_id) > 0
+                (requested_unit_id is not None and resource_unit_id == requested_unit_id)
+                or unit.pending_task_count > 0
+                or self._active_task_count_for_unit_locked(resource_unit_id) > 0
             )
             output_demand = (
-                stage.pending_output_count > 0
-                or stage.queued_output_bytes > 0
-                or any(lease.producer_stage_id == stage_id for lease in self._output_leases.values())
+                unit.pending_output_count > 0
+                or unit.queued_output_bytes > 0
+                or any(lease.producer_unit_id == resource_unit_id for lease in self._output_leases.values())
             )
             if not task_demand and not (field_name == "object_store_bytes" and output_demand):
                 continue
-            if self._stage_dimension_commitment(stage.spec, field_name) > 0:
-                stage_ids.append(stage_id)
-        return tuple(stage_ids)
+            if self._unit_dimension_commitment(unit.spec, field_name) > 0:
+                unit_ids.append(resource_unit_id)
+        return tuple(unit_ids)
 
-    def _dimension_continuation_stage_ids_locked(
+    def _dimension_continuation_unit_ids_locked(
         self,
         field_name: str,
         *,
-        live_stage_ids: tuple[str, ...],
+        live_unit_ids: tuple[str, ...],
     ) -> tuple[str, ...]:
-        live = set(live_stage_ids)
-        phase_stage_ids = set(self._materializing_phase_stage_ids_locked())
-        object_store_unlimited_stage_ids = (
-            set(self._materializing_object_store_unlimited_stage_ids_locked())
+        live = set(live_unit_ids)
+        scope_unit_ids = set(self._reservation_scope_unit_ids_locked())
+        object_store_unlimited_unit_ids = (
+            set(self._materializing_object_store_unlimited_unit_ids_locked())
             if field_name == "object_store_bytes"
             else set()
         )
         continuation_ids: set[str] = set()
-        for source_stage_id in live_stage_ids:
-            if self._stages[source_stage_id].spec.backend != "ray_worker":
+        for source_unit_id in live_unit_ids:
+            if self._units[source_unit_id].spec.backend != "ray_worker":
                 continue
-            for stage_id in self._reachable_udf_stage_ids[source_stage_id]:
-                stage = self._stages[stage_id]
+            for resource_unit_id in self._reachable_udf_unit_ids[source_unit_id]:
+                unit = self._units[resource_unit_id]
                 if (
-                    stage_id not in live
-                    and stage_id in phase_stage_ids
-                    and stage_id not in object_store_unlimited_stage_ids
-                    and not stage.completed
-                    and self._stage_dimension_commitment(stage.spec, field_name) > 0
+                    resource_unit_id not in live
+                    and resource_unit_id in scope_unit_ids
+                    and resource_unit_id not in object_store_unlimited_unit_ids
+                    and not unit.completed
+                    and self._unit_dimension_commitment(unit.spec, field_name) > 0
                 ):
-                    continuation_ids.add(stage_id)
-        return tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in continuation_ids)
+                    continuation_ids.add(resource_unit_id)
+        return tuple(
+            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in continuation_ids
+        )
 
-    def _dimension_reservation_stage_ids_locked(
+    def _dimension_reservation_unit_ids_locked(
         self,
         field_name: str,
         *,
-        requested_stage_id: str | None,
+        requested_unit_id: str | None,
     ) -> tuple[str, ...]:
-        live_stage_ids = self._dimension_live_demand_stage_ids_locked(
+        live_unit_ids = self._dimension_live_demand_unit_ids_locked(
             field_name,
-            requested_stage_id=requested_stage_id,
+            requested_unit_id=requested_unit_id,
         )
-        if requested_stage_id is not None and self._stages[requested_stage_id].spec.backend != "ray_worker":
+        if requested_unit_id is not None and self._units[requested_unit_id].spec.backend != "ray_worker":
             # A concrete downstream UDF borrows latent continuation reserves.
             # It releases its own lease before a later continuation needs them.
-            return live_stage_ids
-        continuation_stage_ids = self._dimension_continuation_stage_ids_locked(
+            return live_unit_ids
+        continuation_unit_ids = self._dimension_continuation_unit_ids_locked(
             field_name,
-            live_stage_ids=live_stage_ids,
+            live_unit_ids=live_unit_ids,
         )
-        selected = set(live_stage_ids) | set(continuation_stage_ids)
-        return tuple(stage_id for stage_id in self._topological_stage_ids if stage_id in selected)
+        selected = set(live_unit_ids) | set(continuation_unit_ids)
+        return tuple(
+            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in selected
+        )
 
-    def _stage_soft_block_reason_locked(
+    def _unit_soft_block_reason_locked(
         self,
-        stage_id: str,
+        resource_unit_id: str,
         request: ResourceVector,
         *,
         ignore_object_store: bool = False,
     ) -> str | None:
-        # Materialization phases define which stages receive a designated
+        # The current reservation scope defines which units receive a designated
         # reservation; they are not an execution gate.  DuckDB can demand a
-        # downstream stage while an earlier blocking phase is still pending
+        # downstream unit while an earlier blocking barrier is still pending
         # (nested broadcast joins do this from concurrent materializers).
-        # Match Ray Data's allocator semantics: an out-of-phase stage has no
-        # per-stage budget, while query/node hard limits and the query's
+        # Match Ray Data's allocator semantics: an out-of-scope unit has no
+        # per-unit budget, while query/node hard limits and the query's
         # object-store soft limit still apply.
-        if stage_id not in self._materializing_phase_stage_ids_locked():
+        if resource_unit_id not in self._reservation_scope_unit_ids_locked():
             return None
-        usage_by_stage = {key: self._stage_usage_locked(key) for key in self._stages}
-        current = usage_by_stage[stage_id]
+        usage_by_unit = {key: self._unit_usage_locked(key) for key in self._units}
+        current = usage_by_unit[resource_unit_id]
         limits = self.allocation.resources
         for field_name in _RESOURCE_FIELDS:
             if ignore_object_store and field_name == "object_store_bytes":
@@ -1750,65 +1771,63 @@ class QueryResourceManager:
             amount = getattr(request, field_name)
             if amount <= 0:
                 continue
-            dimension_stage_ids = self._dimension_reservation_stage_ids_locked(
+            dimension_unit_ids = self._dimension_reservation_unit_ids_locked(
                 field_name,
-                requested_stage_id=stage_id,
+                requested_unit_id=resource_unit_id,
             )
-            if stage_id not in dimension_stage_ids:
-                raise RuntimeError(f"stage {stage_id} requested undeclared {field_name} capacity")
+            if resource_unit_id not in dimension_unit_ids:
+                raise RuntimeError(f"unit {resource_unit_id} requested undeclared {field_name} capacity")
             limit = getattr(limits, field_name)
-            minimum_by_stage = {
-                key: self._stage_dimension_commitment(self._stages[key].spec, field_name) for key in dimension_stage_ids
+            minimum_by_unit = {
+                key: self._unit_dimension_commitment(self._units[key].spec, field_name) for key in dimension_unit_ids
             }
-            minimum_total = sum(minimum_by_stage.values())
+            minimum_total = sum(minimum_by_unit.values())
             if minimum_total <= limit + _EPSILON:
                 bonus_pool = max(0.0, limit - minimum_total) * self.reservation_ratio
-                bonus = bonus_pool / len(dimension_stage_ids)
-                reserved_by_stage = {key: minimum + bonus for key, minimum in minimum_by_stage.items()}
+                bonus = bonus_pool / len(dimension_unit_ids)
+                reserved_by_unit = {key: minimum + bonus for key, minimum in minimum_by_unit.items()}
             else:
                 reservation_pool = limit * self.reservation_ratio
-                reserved_by_stage = {
-                    key: reservation_pool * minimum / minimum_total for key, minimum in minimum_by_stage.items()
+                reserved_by_unit = {
+                    key: reservation_pool * minimum / minimum_total for key, minimum in minimum_by_unit.items()
                 }
-            maximum_by_stage = {
-                key: self._stage_dimension_maximum_locked(self._stages[key].spec, field_name)
-                for key in dimension_stage_ids
+            maximum_by_unit = {
+                key: self._unit_dimension_maximum_locked(self._units[key].spec, field_name)
+                for key in dimension_unit_ids
             }
-            reserved_by_stage = {
-                key: min(reserved, maximum_by_stage[key]) for key, reserved in reserved_by_stage.items()
-            }
+            reserved_by_unit = {key: min(reserved, maximum_by_unit[key]) for key, reserved in reserved_by_unit.items()}
             if field_name in {"heap_bytes", "object_store_bytes"}:
-                reserved_by_stage = {key: math.floor(reserved) for key, reserved in reserved_by_stage.items()}
-            reserved = reserved_by_stage[stage_id]
+                reserved_by_unit = {key: math.floor(reserved) for key, reserved in reserved_by_unit.items()}
+            reserved = reserved_by_unit[resource_unit_id]
             current_amount = getattr(current, field_name)
             if current_amount + amount <= reserved + _EPSILON:
                 continue
-            shared_pool = max(0.0, limit - sum(reserved_by_stage.values()))
+            shared_pool = max(0.0, limit - sum(reserved_by_unit.values()))
             shared_used = sum(
                 max(
                     0.0,
-                    getattr(usage_by_stage[key], field_name) - reserved_by_stage[key],
+                    getattr(usage_by_unit[key], field_name) - reserved_by_unit[key],
                 )
-                for key in dimension_stage_ids
+                for key in dimension_unit_ids
             )
             shared_need = amount - max(0.0, reserved - current_amount)
             if shared_used + shared_need > shared_pool + _EPSILON:
-                return f"stage_soft_{field_name}"
+                return f"unit_soft_{field_name}"
         return None
 
     @staticmethod
-    def _stage_dimension_commitment(spec: StageResourceSpec, field_name: str) -> int | float:
+    def _unit_dimension_commitment(spec: ResourceUnitSpec, field_name: str) -> int | float:
         if field_name == "object_store_bytes":
             return int(spec.per_task.object_store_bytes) + int(spec.output_window_bytes)
         return getattr(spec.per_task, field_name)
 
-    def _stage_dimension_maximum_locked(
+    def _unit_dimension_maximum_locked(
         self,
-        spec: StageResourceSpec,
+        spec: ResourceUnitSpec,
         field_name: str,
     ) -> int | float:
         """Cap a soft share by tasks that can coexist under every hard dimension."""
-        concurrency = self._stage_concurrency_cap(spec)
+        concurrency = self._unit_concurrency_cap(spec)
         if spec.backend == "ray_actor":
             concurrency = spec.actor_pool_size
         hard_bound = math.inf if concurrency is None else int(concurrency)
@@ -1825,36 +1844,36 @@ class QueryResourceManager:
             hard_bound = min(hard_bound, dimension_bound)
         if math.isinf(hard_bound):
             return getattr(self.allocation.resources, field_name)
-        per_task_amount = self._stage_dimension_commitment(spec, field_name)
+        per_task_amount = self._unit_dimension_commitment(spec, field_name)
         return per_task_amount * max(0, int(hard_bound))
 
     def _active_tasks_allow_liveness_locked(
         self,
-        stage_id: str,
+        resource_unit_id: str,
         plan: _TaskAdmissionPlan,
     ) -> bool:
         """Allow one escape only when it can drain an active upstream path."""
         if not self._task_leases:
             return True
-        stage_key = str(stage_id)
-        if self._active_task_count_for_stage_locked(stage_key) > 0:
+        unit_key = str(resource_unit_id)
+        if self._active_task_count_for_unit_locked(unit_key) > 0:
             return False
         if plan.borrowed_credit_id is not None:
             return True
-        return any(stage_key in self._reachable_stage_ids[lease.stage_id] for lease in self._task_leases.values())
+        return any(unit_key in self._reachable_unit_ids[lease.resource_unit_id] for lease in self._task_leases.values())
 
     def _continues_active_liveness_path_locked(
         self,
-        stage_id: str,
+        resource_unit_id: str,
         plan: _TaskAdmissionPlan,
     ) -> bool:
         """Return whether a soft-blocked task continues the one escape path."""
         active_lease_id = self._active_liveness_task_lease_id
         if active_lease_id is None:
             return False
-        stage_key = str(stage_id)
-        stage = self._stages.get(stage_key)
-        if stage is None:
+        unit_key = str(resource_unit_id)
+        unit = self._units.get(unit_key)
+        if unit is None:
             return False
         active_path_leases = tuple(
             lease
@@ -1865,11 +1884,14 @@ class QueryResourceManager:
             lease
             for lease in active_path_leases
             if not any(
-                other.lease_id != lease.lease_id and other.stage_id in self._reachable_stage_ids[lease.stage_id]
+                other.lease_id != lease.lease_id
+                and other.resource_unit_id in self._reachable_unit_ids[lease.resource_unit_id]
                 for other in active_path_leases
             )
         )
-        continues_from_frontier = any(stage_key in self._reachable_stage_ids[lease.stage_id] for lease in frontier)
+        continues_from_frontier = any(
+            unit_key in self._reachable_unit_ids[lease.resource_unit_id] for lease in frontier
+        )
         credit_id = plan.borrowed_credit_id
         if credit_id is not None:
             credit = self._continuation_credits.get(credit_id)
@@ -1888,19 +1910,19 @@ class QueryResourceManager:
         plan: _TaskAdmissionPlan,
     ) -> str | None:
         if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-            str(request.stage_id),
+            str(request.resource_unit_id),
             plan,
         ):
             return "liveness_task_active"
         if self._has_normal_task_candidate_locked():
             return "normal_candidate_available"
-        preferred = self._preferred_liveness_stage_locked()
+        preferred = self._preferred_liveness_unit_locked()
         if preferred is None:
             return "no_liveness_candidate"
-        if preferred != str(request.stage_id):
+        if preferred != str(request.resource_unit_id):
             return "liveness_candidate_not_selected"
         if not self._active_tasks_allow_liveness_locked(
-            str(request.stage_id),
+            str(request.resource_unit_id),
             plan,
         ):
             return "liveness_not_needed"
@@ -1916,16 +1938,16 @@ class QueryResourceManager:
                 if reason is None:
                     return True
             return False
-        for stage_id, stage in self._stages.items():
-            if not stage.runnable or stage.completed:
+        for resource_unit_id, unit in self._units.items():
+            if not unit.runnable or unit.completed:
                 continue
             request = TaskRequest(
                 query_id=self.graph.query_id,
-                stage_id=stage_id,
-                task_id=f"hypothetical:{stage_id}",
+                resource_unit_id=resource_unit_id,
+                task_id=f"hypothetical:{resource_unit_id}",
                 attempt_id="hypothetical",
                 node_id=None,
-                retained_input_bytes=stage.spec.per_task.object_store_bytes,
+                retained_input_bytes=unit.spec.per_task.object_store_bytes,
             )
             reason, _, _ = self._normal_task_block_reason_locked(
                 request,
@@ -1940,10 +1962,10 @@ class QueryResourceManager:
         request: TaskRequest,
         registration_order: int,
     ) -> tuple[int, int, int]:
-        stage_id = str(request.stage_id)
+        resource_unit_id = str(request.resource_unit_id)
         return (
-            self._reverse_topological_rank[stage_id],
-            self._active_task_count_for_stage_locked(stage_id),
+            self._reverse_topological_rank[resource_unit_id],
+            self._active_task_count_for_unit_locked(resource_unit_id),
             int(registration_order),
         )
 
@@ -1984,26 +2006,31 @@ class QueryResourceManager:
                 item
                 for item in soft
                 if self._continues_active_liveness_path_locked(
-                    str(item.request.stage_id),
+                    str(item.request.resource_unit_id),
                     item.plan,
                 )
                 and self._active_tasks_allow_liveness_locked(
-                    str(item.request.stage_id),
+                    str(item.request.resource_unit_id),
                     item.plan,
                 )
             ]
             if path_candidates:
                 soft = path_candidates
-        soft_stage_ids = {str(item.request.stage_id) for item in soft}
-        ordered_stage_ids = [stage_id for stage_id in self._reverse_topological_stage_ids if stage_id in soft_stage_ids]
-        starving_stage_ids = [
-            stage_id
-            for stage_id in ordered_stage_ids
-            if self._stages[stage_id].queued_input_bytes > 0 and self._active_task_count_for_stage_locked(stage_id) == 0
+        soft_unit_ids = {str(item.request.resource_unit_id) for item in soft}
+        ordered_unit_ids = [
+            resource_unit_id
+            for resource_unit_id in self._reverse_topological_unit_ids
+            if resource_unit_id in soft_unit_ids
         ]
-        preferred_stage_id = (starving_stage_ids or ordered_stage_ids)[0]
+        starving_unit_ids = [
+            resource_unit_id
+            for resource_unit_id in ordered_unit_ids
+            if self._units[resource_unit_id].queued_input_bytes > 0
+            and self._active_task_count_for_unit_locked(resource_unit_id) == 0
+        ]
+        preferred_unit_id = (starving_unit_ids or ordered_unit_ids)[0]
         return min(
-            (item for item in soft if str(item.request.stage_id) == preferred_stage_id),
+            (item for item in soft if str(item.request.resource_unit_id) == preferred_unit_id),
             key=lambda item: item.rank,
         )
 
@@ -2017,12 +2044,12 @@ class QueryResourceManager:
         if selected is None:
             return "no_liveness_candidate"
         if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-            str(selected.request.stage_id),
+            str(selected.request.resource_unit_id),
             selected.plan,
         ):
             return "liveness_task_active"
         if not self._active_tasks_allow_liveness_locked(
-            str(selected.request.stage_id),
+            str(selected.request.resource_unit_id),
             selected.plan,
         ):
             return "liveness_not_needed"
@@ -2036,12 +2063,12 @@ class QueryResourceManager:
             return selected.request, grant_class
         return None, ""
 
-    def _preferred_liveness_stage_locked(self) -> str | None:
+    def _preferred_liveness_unit_locked(self) -> str | None:
         if self._waiting_task_inputs:
             waiting_candidates: list[str] = []
-            for stage_id in self.graph.reverse_topological_stage_ids():
+            for resource_unit_id in self.graph.reverse_topological_unit_ids():
                 for request, _ in self._waiting_task_inputs.values():
-                    if str(request.stage_id) != stage_id:
+                    if str(request.resource_unit_id) != resource_unit_id:
                         continue
                     reason, fatal, plan = self._normal_task_block_reason_locked(
                         request,
@@ -2049,38 +2076,38 @@ class QueryResourceManager:
                     )
                     path_allowed = self._active_liveness_task_lease_id is None or (
                         self._continues_active_liveness_path_locked(
-                            stage_id,
+                            resource_unit_id,
                             plan,
                         )
                         and self._active_tasks_allow_liveness_locked(
-                            stage_id,
+                            resource_unit_id,
                             plan,
                         )
                     )
                     if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
-                        waiting_candidates.append(stage_id)
+                        waiting_candidates.append(resource_unit_id)
                         break
             if not waiting_candidates:
                 return None
             starving = [
-                stage_id
-                for stage_id in waiting_candidates
-                if self._stages[stage_id].queued_input_bytes > 0
-                and self._active_task_count_for_stage_locked(stage_id) == 0
+                resource_unit_id
+                for resource_unit_id in waiting_candidates
+                if self._units[resource_unit_id].queued_input_bytes > 0
+                and self._active_task_count_for_unit_locked(resource_unit_id) == 0
             ]
             return (starving or waiting_candidates)[0]
         runnable_candidates: list[str] = []
-        for stage_id in self.graph.reverse_topological_stage_ids():
-            stage = self._stages[stage_id]
-            if not stage.runnable or stage.completed:
+        for resource_unit_id in self.graph.reverse_topological_unit_ids():
+            unit = self._units[resource_unit_id]
+            if not unit.runnable or unit.completed:
                 continue
             request = TaskRequest(
                 query_id=self.graph.query_id,
-                stage_id=stage_id,
-                task_id=f"hypothetical:{stage_id}",
+                resource_unit_id=resource_unit_id,
+                task_id=f"hypothetical:{resource_unit_id}",
                 attempt_id="hypothetical",
                 node_id=None,
-                retained_input_bytes=stage.spec.per_task.object_store_bytes,
+                retained_input_bytes=unit.spec.per_task.object_store_bytes,
             )
             reason, fatal, plan = self._normal_task_block_reason_locked(
                 request,
@@ -2088,22 +2115,23 @@ class QueryResourceManager:
             )
             path_allowed = self._active_liveness_task_lease_id is None or (
                 self._continues_active_liveness_path_locked(
-                    stage_id,
+                    resource_unit_id,
                     plan,
                 )
                 and self._active_tasks_allow_liveness_locked(
-                    stage_id,
+                    resource_unit_id,
                     plan,
                 )
             )
             if not fatal and reason in _SOFT_TASK_BLOCK_REASONS and path_allowed:
-                runnable_candidates.append(stage_id)
+                runnable_candidates.append(resource_unit_id)
         if not runnable_candidates:
             return None
         starving = [
-            stage_id
-            for stage_id in runnable_candidates
-            if self._stages[stage_id].queued_input_bytes > 0 and self._active_task_count_for_stage_locked(stage_id) == 0
+            resource_unit_id
+            for resource_unit_id in runnable_candidates
+            if self._units[resource_unit_id].queued_input_bytes > 0
+            and self._active_task_count_for_unit_locked(resource_unit_id) == 0
         ]
         return (starving or runnable_candidates)[0]
 
@@ -2119,30 +2147,30 @@ class QueryResourceManager:
         if plan.new_credit is not None and plan.borrowed_credit_id is not None:
             raise RuntimeError("task admission cannot create and borrow a continuation credit")
         continues_active_liveness = liveness and self._continues_active_liveness_path_locked(
-            str(request.stage_id),
+            str(request.resource_unit_id),
             plan,
         )
         if liveness and self._active_liveness_task_lease_id is not None and not continues_active_liveness:
             raise RuntimeError("task liveness path changed during atomic admission")
         if liveness and self._active_liveness_task_lease_id is None and self._active_liveness_path_task_lease_ids:
             raise RuntimeError("task liveness path has no active root")
-        stage = self._stages[str(request.stage_id)].spec
+        unit = self._units[str(request.resource_unit_id)].spec
         actor_index = plan.actor_index
         lease_id = uuid.uuid4().hex
-        if stage.backend == "ray_actor":
+        if unit.backend == "ray_actor":
             if actor_index is None:
                 raise RuntimeError("Ray actor task admission requires a concrete actor slot")
-            actor_slot = (stage.stage_id, int(actor_index))
-            if self._actor_slot_lease_count_locked(actor_slot) >= stage.actor_prefetch_depth:
+            actor_slot = (unit.resource_unit_id, int(actor_index))
+            if self._actor_slot_lease_count_locked(actor_slot) >= unit.actor_prefetch_depth:
                 raise RuntimeError("Ray actor prefetch slot changed during atomic task admission")
-            execution_slot_id = f"ray_actor:{stage.stage_id}:{int(actor_index)}"
+            execution_slot_id = f"ray_actor:{unit.resource_unit_id}:{int(actor_index)}"
         else:
             actor_slot = None
-            execution_slot_id = f"{stage.backend}:{stage.stage_id}:{lease_id}"
+            execution_slot_id = f"{unit.backend}:{unit.resource_unit_id}:{lease_id}"
         lease = TaskLease(
             lease_id=lease_id,
             query_id=self.graph.query_id,
-            stage_id=str(request.stage_id),
+            resource_unit_id=str(request.resource_unit_id),
             task_id=str(request.task_id),
             attempt_id=str(request.attempt_id),
             node_id=str(plan.node_id),
@@ -2164,9 +2192,9 @@ class QueryResourceManager:
             new_credit = _ContinuationCredit(
                 credit_id=uuid.uuid4().hex,
                 parent_task_lease_id=lease.lease_id,
-                parent_stage_id=lease.stage_id,
-                eligible_stage_ids=plan.new_credit.eligible_stage_ids,
-                reservation_stage_id=plan.new_credit.reservation_stage_id,
+                parent_unit_id=lease.resource_unit_id,
+                eligible_unit_ids=plan.new_credit.eligible_unit_ids,
+                reservation_unit_id=plan.new_credit.reservation_unit_id,
                 node_id=plan.new_credit.node_id,
                 resources=plan.new_credit.resources,
                 allocation_generation=self.allocation.generation,
@@ -2179,15 +2207,15 @@ class QueryResourceManager:
                 borrowed_credit is None
                 or not borrowed_credit.parent_active
                 or borrowed_credit.borrowed_by_task_lease_id is not None
-                or lease.stage_id not in borrowed_credit.eligible_stage_ids
+                or lease.resource_unit_id not in borrowed_credit.eligible_unit_ids
                 or borrowed_credit.node_id != lease.node_id
             ):
                 raise RuntimeError("continuation credit changed during atomic task admission")
             borrowed_credit.borrowed_by_task_lease_id = lease.lease_id
             self._continuation_credit_by_borrower[lease.lease_id] = borrowed_credit.credit_id
         self._waiting_task_inputs.pop((lease.task_id, lease.attempt_id), None)
-        self._recompute_stage_queued_input_locked(lease.stage_id)
-        self._started_stage_ids.add(lease.stage_id)
+        self._recompute_unit_queued_input_locked(lease.resource_unit_id)
+        self._started_unit_ids.add(lease.resource_unit_id)
         if liveness:
             if self._active_liveness_task_lease_id is None:
                 self._active_liveness_task_lease_id = lease.lease_id
@@ -2208,7 +2236,7 @@ class QueryResourceManager:
 
     def _on_task_lease_removed_locked(self, lease: TaskLease) -> None:
         if lease.actor_index is not None:
-            actor_slot = (lease.stage_id, int(lease.actor_index))
+            actor_slot = (lease.resource_unit_id, int(lease.actor_index))
             owner = self._active_actor_slots.get(actor_slot)
             queued = self._queued_actor_slot_leases.get(actor_slot)
             if owner == lease.lease_id:
@@ -2290,12 +2318,12 @@ class QueryResourceManager:
                 raise RuntimeError(f"FTE task lease is not active: {lease_key}")
             if task.attempt_id != attempt_key:
                 raise RuntimeError(f"FTE task lease attempt mismatch: lease={task.attempt_id} result={attempt_key}")
-            stage = self._stages[task.stage_id]
+            unit = self._units[task.resource_unit_id]
             total_output_bytes = sum(int(request.size_bytes) for request in requests)
             if total_output_bytes > task.output_window_bytes:
                 raise RuntimeError(
                     f"FTE output bytes {total_output_bytes} exceed task window {task.output_window_bytes}: "
-                    f"query={task.query_id} stage={task.stage_id} task_lease={task.lease_id} "
+                    f"query={task.query_id} unit={task.resource_unit_id} task_lease={task.lease_id} "
                     f"attempt={task.attempt_id}"
                 )
 
@@ -2303,8 +2331,8 @@ class QueryResourceManager:
             for request in requests:
                 if str(request.query_id) != task.query_id:
                     raise RuntimeError("FTE output query_id does not match its task lease")
-                if str(request.producer_stage_id) != task.stage_id:
-                    raise RuntimeError("FTE output stage_id does not match its task lease")
+                if str(request.producer_unit_id) != task.resource_unit_id:
+                    raise RuntimeError("FTE output resource_unit_id does not match its task lease")
                 if str(request.task_lease_id) != task.lease_id:
                     raise RuntimeError("FTE output task_lease_id does not match its task lease")
                 if str(request.attempt_id) != task.attempt_id:
@@ -2318,23 +2346,23 @@ class QueryResourceManager:
                 size_bytes = int(request.size_bytes)
                 if size_bytes <= 0:
                     raise RuntimeError(f"FTE output block size must be positive: {block_id}")
-                target_bytes = int(stage.spec.target_output_block_bytes)
+                target_bytes = int(unit.spec.target_output_block_bytes)
                 if target_bytes <= 0 or size_bytes > target_bytes:
                     raise RuntimeError(
-                        f"FTE output block {block_id} size {size_bytes} exceeds stage target {target_bytes}"
+                        f"FTE output block {block_id} size {size_bytes} exceeds unit target {target_bytes}"
                     )
 
             output_leases = tuple(
                 OutputBlockLease(
                     lease_id=uuid.uuid4().hex,
                     query_id=task.query_id,
-                    producer_stage_id=task.stage_id,
+                    producer_unit_id=task.resource_unit_id,
                     task_lease_id=task.lease_id,
                     attempt_id=task.attempt_id,
                     block_id=str(request.block_id),
                     node_id=task.node_id,
                     size_bytes=int(request.size_bytes),
-                    state="stage_queue",
+                    state="unit_queue",
                     liveness=False,
                     allocation_generation=self.allocation.generation,
                     continuation_credit_id=None,
@@ -2344,7 +2372,7 @@ class QueryResourceManager:
             for output_lease in output_leases:
                 self._output_leases[output_lease.lease_id] = output_lease
                 self._output_lease_by_block[output_lease.block_id] = output_lease.lease_id
-            self._recompute_stage_queued_output_locked(task.stage_id)
+            self._recompute_unit_queued_output_locked(task.resource_unit_id)
 
             self._task_leases.pop(task.lease_id, None)
             self._on_task_lease_removed_locked(task)
@@ -2377,7 +2405,7 @@ class QueryResourceManager:
         if task_key in self._task_leases:
             return
         if any(
-            output.task_lease_id == task_key and output.state in {"generator_pending", "stage_queue"}
+            output.task_lease_id == task_key and output.state in {"generator_pending", "unit_queue"}
             for output in self._output_leases.values()
         ):
             return
@@ -2396,10 +2424,10 @@ class QueryResourceManager:
                 return OutputBlockGrant(False, blocked_reason="liveness_output_active")
             if self._has_normal_output_candidate_locked():
                 return OutputBlockGrant(False, blocked_reason="normal_output_candidate_available")
-            if not self._output_consumer_starving_locked(request.producer_stage_id):
+            if not self._output_consumer_starving_locked(request.producer_unit_id):
                 return OutputBlockGrant(False, blocked_reason="output_liveness_not_needed")
-            preferred = self._preferred_output_liveness_stage_locked(request)
-            if preferred != str(request.producer_stage_id):
+            preferred = self._preferred_output_liveness_unit_locked(request)
+            if preferred != str(request.producer_unit_id):
                 return OutputBlockGrant(False, blocked_reason="liveness_output_candidate_not_selected")
             return self._grant_output_block_locked(request, liveness=True)
 
@@ -2418,7 +2446,7 @@ class QueryResourceManager:
                     continue
                 rank = (
                     self._reverse_topological_rank.get(
-                        str(request.producer_stage_id),
+                        str(request.producer_unit_id),
                         len(self._reverse_topological_rank),
                     ),
                     order,
@@ -2444,7 +2472,7 @@ class QueryResourceManager:
                 return request, self._grant_output_block_locked(
                     request,
                     liveness=False,
-                    initial_state="stage_queue",
+                    initial_state="unit_queue",
                 )
             if not soft_blocked:
                 return None, None
@@ -2455,7 +2483,7 @@ class QueryResourceManager:
                     False,
                     blocked_reason="liveness_output_active",
                 )
-            if not self._output_consumer_starving_locked(request.producer_stage_id):
+            if not self._output_consumer_starving_locked(request.producer_unit_id):
                 return request, OutputBlockGrant(
                     False,
                     blocked_reason="output_liveness_not_needed",
@@ -2463,7 +2491,7 @@ class QueryResourceManager:
             return request, self._grant_output_block_locked(
                 request,
                 liveness=True,
-                initial_state="stage_queue",
+                initial_state="unit_queue",
             )
 
     def _normal_output_block_reason_locked(
@@ -2474,9 +2502,9 @@ class QueryResourceManager:
             return "query_cancelled", True, 0
         if str(request.query_id) != self.graph.query_id:
             return "query_id_mismatch", True, 0
-        stage = self._stages.get(str(request.producer_stage_id))
-        if stage is None:
-            return "stage_not_registered", True, 0
+        unit = self._units.get(str(request.producer_unit_id))
+        if unit is None:
+            return "unit_not_registered", True, 0
         block_id = str(request.block_id).strip()
         if not block_id:
             return "invalid_block_id", True, 0
@@ -2485,8 +2513,8 @@ class QueryResourceManager:
         task = self._task_leases.get(str(request.task_lease_id))
         if task is None:
             return "task_lease_not_active", True, 0
-        if task.stage_id != stage.spec.stage_id:
-            return "task_stage_mismatch", True, 0
+        if task.resource_unit_id != unit.spec.resource_unit_id:
+            return "task_unit_mismatch", True, 0
         if task.attempt_id != str(request.attempt_id):
             return "task_attempt_mismatch", True, 0
         if block_id in self._output_lease_by_block:
@@ -2501,7 +2529,9 @@ class QueryResourceManager:
         delta = after - before
         object_limit = self.allocation.resources.object_store_bytes
         usage_after = self._query_usage_locked() + ResourceVector(object_store_bytes=delta)
-        object_store_unlimited = stage.spec.stage_id in self._materializing_object_store_unlimited_stage_ids_locked()
+        object_store_unlimited = (
+            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
+        )
         if not object_store_unlimited and delta > 0 and usage_after.object_store_bytes > object_limit:
             return "query_soft_object_store_bytes", False, delta
         if delta > 0:
@@ -2509,8 +2539,8 @@ class QueryResourceManager:
                 self.allocation.resources_for_node(task.node_id)
             except KeyError:
                 return "node_not_allocated", True, delta
-            soft = self._stage_soft_block_reason_locked(
-                stage.spec.stage_id,
+            soft = self._unit_soft_block_reason_locked(
+                unit.spec.resource_unit_id,
                 ResourceVector(object_store_bytes=delta),
                 ignore_object_store=object_store_unlimited,
             )
@@ -2519,26 +2549,26 @@ class QueryResourceManager:
         return None, False, delta
 
     def _has_normal_output_candidate_locked(self) -> bool:
-        for stage_id in self.graph.reverse_topological_stage_ids():
-            stage = self._stages[stage_id]
-            if not stage.runnable or stage.completed or stage.queued_output_bytes <= 0:
+        for resource_unit_id in self.graph.reverse_topological_unit_ids():
+            unit = self._units[resource_unit_id]
+            if not unit.runnable or unit.completed or unit.queued_output_bytes <= 0:
                 continue
             task = next(
-                (lease for lease in self._task_leases.values() if lease.stage_id == stage_id),
+                (lease for lease in self._task_leases.values() if lease.resource_unit_id == resource_unit_id),
                 None,
             )
             if task is None:
                 continue
-            target = stage.spec.target_output_block_bytes
-            size = min(stage.queued_output_bytes, target if target > 0 else stage.queued_output_bytes)
+            target = unit.spec.target_output_block_bytes
+            size = min(unit.queued_output_bytes, target if target > 0 else unit.queued_output_bytes)
             if size <= 0:
                 continue
             request = OutputBlockRequest(
                 query_id=self.graph.query_id,
-                producer_stage_id=stage_id,
+                producer_unit_id=resource_unit_id,
                 task_lease_id=task.lease_id,
                 attempt_id=task.attempt_id,
-                block_id=f"hypothetical:{stage_id}:{task.lease_id}",
+                block_id=f"hypothetical:{resource_unit_id}:{task.lease_id}",
                 size_bytes=size,
             )
             reason, _, _ = self._normal_output_block_reason_locked(request)
@@ -2546,60 +2576,62 @@ class QueryResourceManager:
                 return True
         return False
 
-    def _preferred_output_liveness_stage_locked(
+    def _preferred_output_liveness_unit_locked(
         self,
         current_request: OutputBlockRequest,
     ) -> str | None:
         candidates: list[str] = []
-        for stage_id in self.graph.reverse_topological_stage_ids():
-            stage = self._stages[stage_id]
-            if not stage.runnable or stage.completed:
+        for resource_unit_id in self.graph.reverse_topological_unit_ids():
+            unit = self._units[resource_unit_id]
+            if not unit.runnable or unit.completed:
                 continue
-            if stage_id != str(current_request.producer_stage_id) and stage.queued_output_bytes <= 0:
+            if resource_unit_id != str(current_request.producer_unit_id) and unit.queued_output_bytes <= 0:
                 continue
-            if stage_id == str(current_request.producer_stage_id):
+            if resource_unit_id == str(current_request.producer_unit_id):
                 request = current_request
             else:
                 task = next(
-                    (lease for lease in self._task_leases.values() if lease.stage_id == stage_id),
+                    (lease for lease in self._task_leases.values() if lease.resource_unit_id == resource_unit_id),
                     None,
                 )
                 if task is None:
                     continue
-                target = stage.spec.target_output_block_bytes
+                target = unit.spec.target_output_block_bytes
                 size = min(
-                    stage.queued_output_bytes,
-                    target if target > 0 else stage.queued_output_bytes,
+                    unit.queued_output_bytes,
+                    target if target > 0 else unit.queued_output_bytes,
                 )
                 if size <= 0:
                     continue
                 request = OutputBlockRequest(
                     query_id=self.graph.query_id,
-                    producer_stage_id=stage_id,
+                    producer_unit_id=resource_unit_id,
                     task_lease_id=task.lease_id,
                     attempt_id=task.attempt_id,
-                    block_id=f"hypothetical-liveness:{stage_id}:{task.lease_id}",
+                    block_id=f"hypothetical-liveness:{resource_unit_id}:{task.lease_id}",
                     size_bytes=size,
                 )
             reason, fatal, _ = self._normal_output_block_reason_locked(request)
             if not fatal and reason in _SOFT_OUTPUT_BLOCK_REASONS:
-                candidates.append(stage_id)
+                candidates.append(resource_unit_id)
         return candidates[0] if candidates else None
 
-    def _output_consumer_starving_locked(self, producer_stage_id: str) -> bool:
+    def _output_consumer_starving_locked(self, producer_unit_id: str) -> bool:
         if self._external_consumer_waiting:
             return True
         downstream_ids = [
-            stage.stage_id for stage in self.graph.stages if str(producer_stage_id) in stage.input_stage_ids
+            unit.resource_unit_id for unit in self.graph.units if str(producer_unit_id) in unit.input_unit_ids
         ]
         if not downstream_ids:
             return False
-        # A downstream stage with a partial input bundle and no active task is
+        # A downstream unit with a partial input bundle and no active task is
         # still starving: it needs another producer block before its compute
         # batch can be admitted.  Requiring queued_input_bytes == 0 creates a
         # cross-lease deadlock when the producer's sole liveness lease is the
         # partial bundle already waiting downstream.
-        return all(self._active_task_count_for_stage_locked(stage_id) == 0 for stage_id in downstream_ids)
+        return all(
+            self._active_task_count_for_unit_locked(resource_unit_id) == 0 for resource_unit_id in downstream_ids
+        )
 
     def _grant_output_block_locked(
         self,
@@ -2614,7 +2646,7 @@ class QueryResourceManager:
         lease = OutputBlockLease(
             lease_id=uuid.uuid4().hex,
             query_id=self.graph.query_id,
-            producer_stage_id=str(request.producer_stage_id),
+            producer_unit_id=str(request.producer_unit_id),
             task_lease_id=str(request.task_lease_id),
             attempt_id=str(request.attempt_id),
             block_id=str(request.block_id),
@@ -2628,7 +2660,7 @@ class QueryResourceManager:
         self._output_leases[lease.lease_id] = lease
         self._output_lease_by_block[lease.block_id] = lease.lease_id
         self._waiting_output_blocks.pop(lease.block_id, None)
-        self._recompute_stage_queued_output_locked(lease.producer_stage_id)
+        self._recompute_unit_queued_output_locked(lease.producer_unit_id)
         if liveness:
             self._active_liveness_output_lease_id = lease.lease_id
             self._output_liveness_grants_total += 1
@@ -2658,7 +2690,7 @@ class QueryResourceManager:
             if target == "downstream_input":
                 self._maybe_clear_task_liveness_locked(lease.task_lease_id)
                 self._maybe_return_continuation_credit_locked(lease.task_lease_id)
-            self._recompute_stage_queued_output_locked(lease.producer_stage_id)
+            self._recompute_unit_queued_output_locked(lease.producer_unit_id)
             self._publish_change_locked()
             return True
 
@@ -2674,7 +2706,7 @@ class QueryResourceManager:
                 self._active_liveness_output_lease_id = None
             self._maybe_clear_task_liveness_locked(lease.task_lease_id)
             self._maybe_return_continuation_credit_locked(lease.task_lease_id)
-            self._recompute_stage_queued_output_locked(lease.producer_stage_id)
+            self._recompute_unit_queued_output_locked(lease.producer_unit_id)
             self._publish_change_locked()
             return True
 
@@ -2694,13 +2726,13 @@ class QueryResourceManager:
             self._active_actor_slots.clear()
             self._queued_actor_slot_leases.clear()
             self._waiting_task_inputs.clear()
-            for stage_id in self._stages:
-                self._recompute_stage_queued_input_locked(stage_id)
+            for resource_unit_id in self._units:
+                self._recompute_unit_queued_input_locked(resource_unit_id)
             self._output_leases.clear()
             self._output_lease_by_block.clear()
             self._waiting_output_blocks.clear()
-            for stage_id in self._stages:
-                self._recompute_stage_queued_output_locked(stage_id)
+            for resource_unit_id in self._units:
+                self._recompute_unit_queued_output_locked(resource_unit_id)
             self._active_liveness_task_lease_id = None
             self._active_liveness_path_task_lease_ids.clear()
             self._active_liveness_output_lease_id = None
@@ -2710,8 +2742,8 @@ class QueryResourceManager:
             self._publish_change_locked()
             return {"task_lease_count": task_count, "output_lease_count": output_count}
 
-    def _active_task_count_for_stage_locked(self, stage_id: str) -> int:
-        return sum(1 for lease in self._task_leases.values() if lease.stage_id == stage_id)
+    def _active_task_count_for_unit_locked(self, resource_unit_id: str) -> int:
+        return sum(1 for lease in self._task_leases.values() if lease.resource_unit_id == resource_unit_id)
 
     def _live_output_bytes_for_task_locked(self, task_lease_id: str) -> int:
         task_key = str(task_lease_id)
@@ -2755,8 +2787,10 @@ class QueryResourceManager:
             )
         )
 
-    def _live_output_bytes_for_stage_locked(self, stage_id: str) -> int:
-        return sum(lease.size_bytes for lease in self._output_leases.values() if lease.producer_stage_id == stage_id)
+    def _live_output_bytes_for_unit_locked(self, resource_unit_id: str) -> int:
+        return sum(
+            lease.size_bytes for lease in self._output_leases.values() if lease.producer_unit_id == resource_unit_id
+        )
 
     def _task_usage_locked(self, lease: TaskLease) -> ResourceVector:
         credit_id = self._continuation_credit_by_borrower.get(lease.lease_id)
@@ -2780,21 +2814,21 @@ class QueryResourceManager:
         active_task_ids: set[str],
         *,
         node_id: str | None = None,
-        stage_id: str | None = None,
+        resource_unit_id: str | None = None,
     ) -> int:
-        if stage_id is not None:
+        if resource_unit_id is not None:
             uncovered = sum(
                 output.size_bytes
                 for output in self._output_leases.values()
-                if output.producer_stage_id == stage_id
+                if output.producer_unit_id == resource_unit_id
                 and (
                     output.continuation_credit_id is None
                     or output.continuation_credit_id not in self._continuation_credits
                 )
                 and output.task_lease_id not in active_task_ids
             )
-            return uncovered + self._continuation_output_excess_by_stage_locked().get(
-                stage_id,
+            return uncovered + self._continuation_output_excess_by_unit_locked().get(
+                resource_unit_id,
                 0,
             )
         uncovered = 0
@@ -2824,8 +2858,8 @@ class QueryResourceManager:
                 uncovered += max(0, output_bytes - credit.resources.object_store_bytes)
         return uncovered
 
-    def _continuation_output_excess_by_stage_locked(self) -> dict[str, int]:
-        outputs_by_credit_and_stage: dict[str, dict[str, int]] = {}
+    def _continuation_output_excess_by_unit_locked(self) -> dict[str, int]:
+        outputs_by_credit_and_unit: dict[str, dict[str, int]] = {}
         for output in self._output_leases.values():
             credit_id = output.continuation_credit_id
             if credit_id is None or credit_id not in self._continuation_credits:
@@ -2834,28 +2868,30 @@ class QueryResourceManager:
             borrower = credit.borrowed_by_task_lease_id
             if borrower is not None and borrower in self._task_leases:
                 # Active borrower usage owns retained input plus aggregate
-                # outputs. Attribute that exact delta to the borrower stage;
-                # only idle-credit overflow needs cross-stage distribution.
+                # outputs. Attribute that exact delta to the borrower unit;
+                # only idle-credit overflow needs cross-unit distribution.
                 continue
-            by_stage = outputs_by_credit_and_stage.setdefault(credit_id, {})
-            by_stage[output.producer_stage_id] = by_stage.get(output.producer_stage_id, 0) + output.size_bytes
+            by_unit = outputs_by_credit_and_unit.setdefault(credit_id, {})
+            by_unit[output.producer_unit_id] = by_unit.get(output.producer_unit_id, 0) + output.size_bytes
 
-        topological_rank = {stage_id: index for index, stage_id in enumerate(self._topological_stage_ids)}
-        excess_by_stage: dict[str, int] = {}
-        for credit_id, bytes_by_stage in outputs_by_credit_and_stage.items():
+        topological_rank = {
+            resource_unit_id: index for index, resource_unit_id in enumerate(self._topological_unit_ids)
+        }
+        excess_by_unit: dict[str, int] = {}
+        for credit_id, bytes_by_unit in outputs_by_credit_and_unit.items():
             credit = self._continuation_credits[credit_id]
             remaining_covered = int(credit.resources.object_store_bytes)
-            for stage_id in sorted(
-                bytes_by_stage,
+            for resource_unit_id in sorted(
+                bytes_by_unit,
                 key=lambda key: (topological_rank.get(key, len(topological_rank)), key),
             ):
-                output_bytes = bytes_by_stage[stage_id]
+                output_bytes = bytes_by_unit[resource_unit_id]
                 covered = min(output_bytes, remaining_covered)
                 remaining_covered -= covered
                 excess = output_bytes - covered
                 if excess > 0:
-                    excess_by_stage[stage_id] = excess_by_stage.get(stage_id, 0) + excess
-        return excess_by_stage
+                    excess_by_unit[resource_unit_id] = excess_by_unit.get(resource_unit_id, 0) + excess
+        return excess_by_unit
 
     def _query_usage_locked(self) -> ResourceVector:
         total = self._actor_resident_usage_locked()
@@ -2887,14 +2923,14 @@ class QueryResourceManager:
         )
         return total
 
-    def _stage_usage_locked(self, stage_id: str) -> ResourceVector:
-        total = self._actor_resident_usage_locked(stage_id=stage_id)
+    def _unit_usage_locked(self, resource_unit_id: str) -> ResourceVector:
+        total = self._actor_resident_usage_locked(resource_unit_id=resource_unit_id)
         active_task_ids: set[str] = set()
         for credit in self._continuation_credits.values():
-            if credit.reservation_stage_id == stage_id:
+            if credit.reservation_unit_id == resource_unit_id:
                 total = total + credit.resources
         for lease in self._task_leases.values():
-            if lease.stage_id != stage_id:
+            if lease.resource_unit_id != resource_unit_id:
                 continue
             active_task_ids.add(lease.lease_id)
             task_usage = self._task_usage_locked(lease)
@@ -2902,7 +2938,7 @@ class QueryResourceManager:
         total = total + ResourceVector(
             object_store_bytes=self._uncovered_inactive_output_bytes_locked(
                 active_task_ids,
-                stage_id=stage_id,
+                resource_unit_id=resource_unit_id,
             )
         )
         return total
@@ -2911,41 +2947,39 @@ class QueryResourceManager:
         self,
         *,
         node_id: str | None = None,
-        stage_id: str | None = None,
+        resource_unit_id: str | None = None,
     ) -> ResourceVector:
         total = ResourceVector()
         for placement in self.allocation.actor_placements:
             if node_id is not None and placement.node_id != node_id:
                 continue
-            if stage_id is not None and placement.stage_id != stage_id:
+            if resource_unit_id is not None and placement.resource_unit_id != resource_unit_id:
                 continue
-            stage = self._stages.get(placement.stage_id)
-            if stage is None:
-                raise RuntimeError("actor placement references an unknown query stage")
-            total = total + stage.spec.resident_per_actor
+            unit = self._units.get(placement.resource_unit_id)
+            if unit is None:
+                raise RuntimeError("actor placement references an unknown query unit")
+            total = total + unit.spec.resident_per_actor
         return total
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             usage = self._query_usage_locked()
-            materializing_stage_id = self._current_materializing_stage_id_locked()
-            materializing_phase_stage_ids = self._materializing_phase_stage_ids_locked()
-            materializing_object_store_unlimited_stage_ids = (
-                self._materializing_object_store_unlimited_stage_ids_locked()
-            )
+            barrier_unit_id = self._first_pending_barrier_unit_id_locked()
+            reservation_scope_unit_ids = self._reservation_scope_unit_ids_locked()
+            materializing_object_store_unlimited_unit_ids = self._materializing_object_store_unlimited_unit_ids_locked()
             preferred_task, grant_class = self._preferred_waiting_task_locked()
             allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
-            reservation_source_stage_ids = {lease.stage_id for lease in self._task_leases.values()} | {
-                str(request.stage_id) for request, _ in self._waiting_task_inputs.values()
+            reservation_source_unit_ids = {lease.resource_unit_id for lease in self._task_leases.values()} | {
+                str(request.resource_unit_id) for request, _ in self._waiting_task_inputs.values()
             }
             downstream_reservations: dict[str, tuple[_DownstreamReservation, ...]] = {}
-            for stage_id in self._topological_stage_ids:
-                stage = self._stages[stage_id]
-                if stage_id not in reservation_source_stage_ids or stage.completed:
+            for resource_unit_id in self._topological_unit_ids:
+                unit = self._units[resource_unit_id]
+                if resource_unit_id not in reservation_source_unit_ids or unit.completed:
                     continue
-                reservations = self._downstream_reservations_locked(stage.spec)
+                reservations = self._downstream_reservations_locked(unit.spec)
                 if reservations:
-                    downstream_reservations[stage_id] = reservations
+                    downstream_reservations[resource_unit_id] = reservations
             node_ids = sorted(
                 set(allocation_by_node)
                 | {lease.node_id for lease in self._task_leases.values()}
@@ -2988,11 +3022,11 @@ class QueryResourceManager:
                     for node_id, resources in node_usage.items()
                 },
                 "reservation_ratio": self.reservation_ratio,
-                "materializing_phase": {
-                    "barrier_stage_id": materializing_stage_id,
-                    "stage_ids": list(materializing_phase_stage_ids),
-                    "object_store_backpressure_disabled": bool(materializing_object_store_unlimited_stage_ids),
-                    "object_store_unlimited_stage_ids": list(materializing_object_store_unlimited_stage_ids),
+                "reservation_scope": {
+                    "barrier_unit_id": barrier_unit_id,
+                    "resource_unit_ids": list(reservation_scope_unit_ids),
+                    "object_store_backpressure_disabled": bool(materializing_object_store_unlimited_unit_ids),
+                    "object_store_unlimited_unit_ids": list(materializing_object_store_unlimited_unit_ids),
                 },
                 "cancelled": self._cancelled,
                 "cancel_reason": self._cancel_reason,
@@ -3010,7 +3044,7 @@ class QueryResourceManager:
                         else {
                             "task_id": str(preferred_task.task_id),
                             "attempt_id": str(preferred_task.attempt_id),
-                            "stage_id": str(preferred_task.stage_id),
+                            "resource_unit_id": str(preferred_task.resource_unit_id),
                             "grant_class": grant_class,
                         }
                     ),
@@ -3018,71 +3052,71 @@ class QueryResourceManager:
                         {
                             "task_id": str(request.task_id),
                             "attempt_id": str(request.attempt_id),
-                            "stage_id": str(request.stage_id),
+                            "resource_unit_id": str(request.resource_unit_id),
                         }
                         for request, _ in self._waiting_task_inputs.values()
                     ],
-                    "live_demand_stage_ids": {
+                    "live_demand_unit_ids": {
                         field_name: list(
-                            self._dimension_live_demand_stage_ids_locked(
+                            self._dimension_live_demand_unit_ids_locked(
                                 field_name,
-                                requested_stage_id=None,
+                                requested_unit_id=None,
                             )
                         )
                         for field_name in _RESOURCE_FIELDS
                     },
-                    "continuation_stage_ids": {
+                    "continuation_unit_ids": {
                         field_name: list(
-                            self._dimension_continuation_stage_ids_locked(
+                            self._dimension_continuation_unit_ids_locked(
                                 field_name,
-                                live_stage_ids=self._dimension_live_demand_stage_ids_locked(
+                                live_unit_ids=self._dimension_live_demand_unit_ids_locked(
                                     field_name,
-                                    requested_stage_id=None,
+                                    requested_unit_id=None,
                                 ),
                             )
                         )
                         for field_name in _RESOURCE_FIELDS
                     },
-                    "reservation_stage_ids": {
+                    "reservation_unit_ids": {
                         field_name: list(
-                            self._dimension_reservation_stage_ids_locked(
+                            self._dimension_reservation_unit_ids_locked(
                                 field_name,
-                                requested_stage_id=None,
+                                requested_unit_id=None,
                             )
                         )
                         for field_name in _RESOURCE_FIELDS
                     },
                     "downstream_reservations": {
-                        stage_id: [
+                        resource_unit_id: [
                             {
                                 "reservation_id": reservation.reservation_id,
-                                "stage_ids": list(reservation.stage_ids),
+                                "unit_ids": list(reservation.unit_ids),
                                 "resources": reservation.resources.to_dict(),
                                 "allowed_node_ids": list(reservation.allowed_node_ids),
                             }
                             for reservation in reservations
                         ]
-                        for stage_id, reservations in downstream_reservations.items()
+                        for resource_unit_id, reservations in downstream_reservations.items()
                     },
                 },
-                "stages": {
-                    stage_id: {
-                        "runnable": stage.runnable,
-                        "actor_ready": stage.actor_ready,
-                        "queued_input_bytes": stage.queued_input_bytes,
-                        "pending_task_count": stage.pending_task_count,
-                        "queued_output_bytes": stage.queued_output_bytes,
-                        "pending_output_count": stage.pending_output_count,
-                        "completed": stage.completed,
-                        "materialization_completed": (self._materializing_stage_completed_locked(stage_id)),
-                        "phase_eligible": stage_id in materializing_phase_stage_ids,
+                "units": {
+                    resource_unit_id: {
+                        "runnable": unit.runnable,
+                        "actor_ready": unit.actor_ready,
+                        "queued_input_bytes": unit.queued_input_bytes,
+                        "pending_task_count": unit.pending_task_count,
+                        "queued_output_bytes": unit.queued_output_bytes,
+                        "pending_output_count": unit.pending_output_count,
+                        "completed": unit.completed,
+                        "materialization_completed": (self._barrier_unit_completed_locked(resource_unit_id)),
+                        "reservation_scope_eligible": resource_unit_id in reservation_scope_unit_ids,
                         "object_store_backpressure_disabled": (
-                            stage_id in materializing_object_store_unlimited_stage_ids
+                            resource_unit_id in materializing_object_store_unlimited_unit_ids
                         ),
-                        "usage": self._stage_usage_locked(stage_id).to_dict(),
-                        "active_task_count": self._active_task_count_for_stage_locked(stage_id),
+                        "usage": self._unit_usage_locked(resource_unit_id).to_dict(),
+                        "active_task_count": self._active_task_count_for_unit_locked(resource_unit_id),
                     }
-                    for stage_id, stage in self._stages.items()
+                    for resource_unit_id, unit in self._units.items()
                 },
                 "task_leases": {
                     lease_id: {
@@ -3092,12 +3126,12 @@ class QueryResourceManager:
                     for lease_id, lease in self._task_leases.items()
                 },
                 "active_actor_slots": {
-                    f"{stage_id}:{actor_index}": lease_id
-                    for (stage_id, actor_index), lease_id in self._active_actor_slots.items()
+                    f"{resource_unit_id}:{actor_index}": lease_id
+                    for (resource_unit_id, actor_index), lease_id in self._active_actor_slots.items()
                 },
                 "queued_actor_slots": {
-                    f"{stage_id}:{actor_index}": list(lease_ids)
-                    for (stage_id, actor_index), lease_ids in self._queued_actor_slot_leases.items()
+                    f"{resource_unit_id}:{actor_index}": list(lease_ids)
+                    for (resource_unit_id, actor_index), lease_ids in self._queued_actor_slot_leases.items()
                 },
                 "continuation_credits": {
                     credit_id: {

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -48,7 +48,6 @@ _RESOURCE_FIELDS = ("cpu", "gpu", "heap_bytes", "object_store_bytes")
 _EPSILON = 1e-9
 _TERMINAL_IDENTITY_REPLAY_CAPACITY = 65_536
 _SOFT_RESERVATION_WARNING_DELAY_S = 60.0
-_DOWNSTREAM_PLACEMENT_SEARCH_STATE_LIMIT = 8_192
 
 logger = logging.getLogger(__name__)
 
@@ -71,43 +70,6 @@ def _positive_difference(left: ResourceVector, right: ResourceVector) -> Resourc
     )
 
 
-def _hard_resources(resources: ResourceVector) -> ResourceVector:
-    """Drop the spillable object-store flow-control dimension."""
-    return ResourceVector(
-        cpu=resources.cpu,
-        gpu=resources.gpu,
-        heap_bytes=resources.heap_bytes,
-    )
-
-
-def _hard_positive_difference(left: ResourceVector, right: ResourceVector) -> ResourceVector:
-    return _positive_difference(_hard_resources(left), _hard_resources(right))
-
-
-def _incremental_hard_exceeded_dimensions(
-    usage: ResourceVector,
-    incremental: ResourceVector,
-    capacity: ResourceVector,
-) -> tuple[str, ...]:
-    """Return hard dimensions in which this increment would exceed capacity.
-
-    Existing tasks and submitted actor processes are never revoked after a
-    soft allocation shrinks. Zero-increment native work and invocations on an
-    already submitted actor must therefore remain admissible even while that
-    fixed process usage is in debt.
-    """
-
-    current = _hard_resources(usage)
-    added = _hard_resources(incremental)
-    limit = _hard_resources(capacity)
-    return tuple(
-        field_name
-        for field_name in ("cpu", "gpu", "heap_bytes")
-        if getattr(added, field_name) > 0
-        and getattr(current, field_name) + getattr(added, field_name) > getattr(limit, field_name) + _EPSILON
-    )
-
-
 @dataclass(frozen=True)
 class TaskRequest:
     query_id: str
@@ -125,7 +87,7 @@ class TaskLease:
     resource_unit_id: str
     task_id: str
     attempt_id: str
-    node_id: str
+    node_id: str | None
     execution_slot_id: str
     actor_index: int | None
     resources: ResourceVector
@@ -144,54 +106,12 @@ class TaskGrant:
     admission_epoch: int = 0
 
 
-@dataclass
-class _ContinuationCredit:
-    credit_id: str
-    parent_task_lease_id: str
-    parent_unit_id: str
-    eligible_unit_ids: tuple[str, ...]
-    reservation_unit_id: str
-    node_id: str
-    resources: ResourceVector
-    allocation_generation: int
-    borrowed_by_task_lease_id: str | None = None
-    parent_active: bool = True
-
-
-@dataclass(frozen=True)
-class _NewContinuationCreditPlan:
-    eligible_unit_ids: tuple[str, ...]
-    reservation_unit_id: str
-    node_id: str
-    resources: ResourceVector
-
-
 @dataclass(frozen=True)
 class _TaskAdmissionPlan:
     resources: ResourceVector = field(default_factory=ResourceVector)
     output_window_bytes: int = 0
-    node_id: str = ""
+    node_id: str | None = None
     actor_index: int | None = None
-    new_credit: _NewContinuationCreditPlan | None = None
-    borrowed_credit_id: str | None = None
-
-
-@dataclass(frozen=True)
-class _DownstreamReservation:
-    """One soft shared resource preference for a downstream runnable path.
-
-    Unlike a per-parent continuation credit, this reservation is not charged
-    once for every producer. Admission only proves that the bundle remains
-    placeable after granting the producer. The real downstream task consumes
-    that capacity through its normal task lease when it becomes runnable. If
-    preserving the bundle would prevent all progress, the existing bounded
-    liveness escape may start one hard-feasible task without preserving it.
-    """
-
-    reservation_id: str
-    unit_ids: tuple[str, ...]
-    resources: ResourceVector
-    allowed_node_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -225,12 +145,11 @@ class OutputBlockLease:
     task_lease_id: str
     attempt_id: str
     block_id: str
-    node_id: str
+    node_id: str | None
     size_bytes: int
     state: str
     liveness: bool
     allocation_generation: int
-    continuation_credit_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -329,7 +248,6 @@ class RayQueryResourceManager:
         allocation: QueryAllocation,
         *,
         admission_open: bool = True,
-        debt_neutral_only: bool = False,
         reservation_ratio: float = 0.5,
         on_change: Callable[[], None] | None = None,
         on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
@@ -337,18 +255,9 @@ class RayQueryResourceManager:
         ratio = float(reservation_ratio)
         if not math.isfinite(ratio) or ratio <= 0 or ratio > 1:
             raise ValueError("reservation_ratio must be in (0, 1]")
-        if debt_neutral_only and not admission_open:
-            raise ValueError("debt-neutral admission requires admission_open")
-        graph.validate_allocation(
-            allocation,
-            eligible_unit_ids=(
-                graph.eligible_resource_unit_ids(set()) if admission_open and not debt_neutral_only else ()
-            ),
-        )
         self.graph = graph
         self.allocation = allocation
         self._allocation_admission_open = bool(admission_open)
-        self._allocation_debt_neutral_only = bool(debt_neutral_only)
         self.reservation_ratio = ratio
         self._on_change = on_change
         self._on_eligible_units_change = on_eligible_units_change
@@ -370,44 +279,7 @@ class RayQueryResourceManager:
         self._reverse_topological_rank = {
             resource_unit_id: index for index, resource_unit_id in enumerate(self._reverse_topological_unit_ids)
         }
-        self._reachable_unit_ids: dict[str, tuple[str, ...]] = {}
-        self._reachable_udf_unit_ids: dict[str, tuple[str, ...]] = {}
-        for source_unit_id in self._topological_unit_ids:
-            reachable: set[str] = set()
-            pending = list(self._direct_downstream_unit_ids[source_unit_id])
-            while pending:
-                resource_unit_id = pending.pop()
-                if resource_unit_id in reachable:
-                    continue
-                reachable.add(resource_unit_id)
-                pending.extend(self._direct_downstream_unit_ids[resource_unit_id])
-            ordered_reachable = tuple(
-                resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in reachable
-            )
-            self._reachable_unit_ids[source_unit_id] = ordered_reachable
-            self._reachable_udf_unit_ids[source_unit_id] = tuple(
-                resource_unit_id
-                for resource_unit_id in ordered_reachable
-                if self._units[resource_unit_id].spec.backend in {"ray_task", "ray_actor"}
-            )
-        self._continuation_parent_unit_ids_by_ray_task: dict[str, tuple[str, ...]] = {}
-        for resource_unit_id in self._topological_unit_ids:
-            unit = self._units[resource_unit_id].spec
-            if unit.backend != "ray_task":
-                continue
-            parent_unit_ids = tuple(
-                parent_unit_id
-                for parent_unit_id in self._topological_unit_ids
-                if self._units[parent_unit_id].spec.backend == "ray_worker"
-                and resource_unit_id in self._reachable_udf_unit_ids[parent_unit_id]
-            )
-            if parent_unit_ids:
-                self._continuation_parent_unit_ids_by_ray_task[resource_unit_id] = parent_unit_ids
-        self._started_unit_ids: set[str] = set()
         self._task_leases: dict[str, TaskLease] = {}
-        self._continuation_credits: dict[str, _ContinuationCredit] = {}
-        self._continuation_credit_by_parent: dict[str, str] = {}
-        self._continuation_credit_by_borrower: dict[str, str] = {}
         self._active_attempt_leases: dict[tuple[str, str], str] = {}
         # Submitted includes Ray Core PENDING actors as well as ready actors.
         # Ray Data charges both states to logical operator usage because each
@@ -426,7 +298,6 @@ class RayQueryResourceManager:
         self._generated_output_count_by_task_lease: dict[str, int] = {}
         self._terminal_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
         self._active_liveness_task_lease_id: str | None = None
-        self._active_liveness_path_task_lease_ids: set[str] = set()
         self._active_liveness_output_lease_id: str | None = None
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
@@ -506,7 +377,6 @@ class RayQueryResourceManager:
                     # Preserve live leases, but fence every new grant from the
                     # old generation during that handoff.
                     self._allocation_admission_open = False
-                    self._allocation_debt_neutral_only = False
                 self._publish_change_locked()
                 if bool(completed) and not before[-1]:
                     eligible_callback = self._on_eligible_units_change
@@ -529,7 +399,6 @@ class RayQueryResourceManager:
             # handoff so downstream work cannot consume the previous phase's
             # reservation; live tasks and output leases continue unchanged.
             self._allocation_admission_open = False
-            self._allocation_debt_neutral_only = False
             self._publish_change_locked()
             eligible_callback = self._on_eligible_units_change
             eligible_unit_ids = self._eligible_resource_unit_ids_locked()
@@ -1000,25 +869,15 @@ class RayQueryResourceManager:
         allocation: QueryAllocation,
         *,
         admission_open: bool,
-        debt_neutral_only: bool = False,
     ) -> None:
         with self._lock:
-            if debt_neutral_only and not admission_open:
-                raise ValueError("debt-neutral admission requires admission_open")
             if allocation.generation <= self.allocation.generation:
                 raise ValueError(
                     "allocation generation must increase: "
                     f"current={self.allocation.generation} new={allocation.generation}"
                 )
-            self.graph.validate_allocation(
-                allocation,
-                eligible_unit_ids=(
-                    self._eligible_resource_unit_ids_locked() if admission_open and not debt_neutral_only else ()
-                ),
-            )
             self.allocation = allocation
             self._allocation_admission_open = bool(admission_open) and not self._failed and not self._cancelled
-            self._allocation_debt_neutral_only = bool(debt_neutral_only) and self._allocation_admission_open
             self._publish_change_locked()
 
     def close_admission(self) -> None:
@@ -1027,7 +886,6 @@ class RayQueryResourceManager:
             if not self._allocation_admission_open:
                 return
             self._allocation_admission_open = False
-            self._allocation_debt_neutral_only = False
             self._publish_change_locked()
 
     def try_acquire_task(self, request: TaskRequest) -> TaskGrant:
@@ -1228,22 +1086,9 @@ class RayQueryResourceManager:
                     liveness=False,
                 )
             request = selected.request
-            if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-                str(request.resource_unit_id),
-                selected.plan,
-            ):
-                return request, TaskGrant(
-                    False,
-                    blocked_reason="liveness_task_active",
-                )
-            if not self._active_tasks_allow_liveness_locked(
-                str(request.resource_unit_id),
-                selected.plan,
-            ):
-                return request, TaskGrant(
-                    False,
-                    blocked_reason="liveness_not_needed",
-                )
+            liveness_block = self._queued_liveness_block_reason_locked(evaluations)
+            if liveness_block is not None:
+                return request, TaskGrant(False, blocked_reason=liveness_block)
             return request, self._grant_task_locked(
                 request,
                 selected.plan,
@@ -1293,18 +1138,31 @@ class RayQueryResourceManager:
         if concurrency_cap is not None and active_unit_tasks >= concurrency_cap:
             return "unit_concurrency", False, empty_plan
 
-        free_actor_indices_by_node: dict[str, list[int]] | None = None
-        if unit.spec.backend == "ray_actor":
-            free_actor_indices_by_node = {}
-            for (candidate_unit_id, actor_slot_index), node_id in self._actor_node_by_slot.items():
-                if candidate_unit_id != unit.spec.resource_unit_id:
-                    continue
-                slot_key = (unit.spec.resource_unit_id, actor_slot_index)
-                if self._actor_slot_lease_count_locked(slot_key) >= unit.spec.actor_prefetch_depth:
-                    continue
-                free_actor_indices_by_node.setdefault(node_id, []).append(actor_slot_index)
-            if not free_actor_indices_by_node:
+        node_id: str | None = None
+        actor_index: int | None = None
+        if unit.spec.backend == "ray_worker":
+            node_id = "" if request.node_id is None else str(request.node_id).strip()
+            if not node_id:
+                return "ray_worker_node_required", True, empty_plan
+        elif unit.spec.backend == "ray_task":
+            if request.node_id is not None and str(request.node_id).strip():
+                return "ray_task_node_must_be_unset", True, empty_plan
+        elif unit.spec.backend == "ray_actor":
+            requested_node_id = "" if request.node_id is None else str(request.node_id).strip()
+            candidates = [
+                (self._actor_slot_lease_count_locked(slot), slot[1], ready_node_id)
+                for slot, ready_node_id in self._actor_node_by_slot.items()
+                if slot[0] == unit.spec.resource_unit_id
+                and (not requested_node_id or ready_node_id == requested_node_id)
+                and self._actor_slot_lease_count_locked(slot) < unit.spec.actor_prefetch_depth
+            ]
+            if not candidates:
+                if requested_node_id:
+                    return "actor_node_unavailable", True, empty_plan
                 return "actor_slot", False, empty_plan
+            _lease_count, actor_index, node_id = min(candidates)
+        else:
+            return "unsupported_backend", True, empty_plan
 
         retained = (
             unit.spec.per_task.object_store_bytes
@@ -1319,499 +1177,39 @@ class RayQueryResourceManager:
             resources,
             retained + pending_output_estimate,
         )
-        hard_commitment = _hard_resources(commitment)
-        if hard_commitment.exceeded_dimensions(_hard_resources(self.allocation.resources)):
-            if self._allocation_debt_neutral_only:
-                return "allocation_debt", False, empty_plan
-            return "task_exceeds_query_allocation", True, empty_plan
-
-        execution_usage = self._query_usage_locked()
-        execution_debt = _hard_positive_difference(execution_usage, self.allocation.resources)
-        # Submitted actor processes are charged once for their full lifetime.
-        # Their invocations add no CPU/GPU/heap. A process request beyond the
-        # resulting query share is a soft block eligible for one bounded
-        # liveness escape; Ray Core remains the physical resource authority.
-        query_usage = self._soft_allocation_usage_locked()
-        coordinator_debt_still_live = (
-            self._allocation_debt_neutral_only
-            and not _hard_positive_difference(
-                query_usage,
-                self.allocation.resources,
-            ).is_zero()
-        )
-        borrowed_credit = self._available_continuation_credit_locked(
-            unit.spec,
-            requested_node_id=request.node_id,
-            resources=resources,
-            output_window_bytes=pending_output_estimate,
-            query_usage=query_usage,
-        )
-        credit_template = self._continuation_credit_template_locked(unit.spec)
-        credit_resources = ResourceVector() if credit_template is None else credit_template[2]
-        admission_commitment = commitment + credit_resources
-        if borrowed_credit is not None:
-            # Query/node usage already contains the idle credit and any
-            # historical output bytes above its object-store window.  Predict
-            # the exact post-borrow task usage using the same aggregate-live-
-            # output formula as _task_usage_locked, then add only the delta.
-            # Comparing the new task in isolation can grant within the cap and
-            # become over-cap immediately after ownership transfer.
-            prospective_task_usage = self._borrowed_task_usage_locked(
-                resources,
-                pending_output_estimate,
-                borrowed_credit,
-            )
-            idle_output_excess = self._idle_continuation_output_excess_locked(
-                borrowed_credit,
-            )
-            admission_commitment = _positive_difference(
-                prospective_task_usage,
-                idle_output_excess,
-            )
-
-        incremental_hard = _hard_resources(admission_commitment)
-        if (coordinator_debt_still_live or not execution_debt.is_zero()) and not incremental_hard.is_zero():
-            # Capacity shrink never revokes live work, but it does fence every
-            # new Ray process request until the debt drains. Zero-increment
-            # native work and calls on an existing actor remain admissible so
-            # they can consume outputs and make that drain possible.
-            return "allocation_debt", False, empty_plan
-
-        usage_after = query_usage + admission_commitment
-        execution_hard_exceeded = _incremental_hard_exceeded_dimensions(
-            execution_usage,
-            admission_commitment,
-            self.allocation.resources,
-        )
-        if execution_hard_exceeded:
-            reason = "continuation_capacity" if credit_template is not None else f"hard_{execution_hard_exceeded[0]}"
-            return reason, False, empty_plan
-        soft_hard_exceeded = _incremental_hard_exceeded_dimensions(
-            query_usage,
-            admission_commitment,
-            self.allocation.resources,
-        )
-        query_resource_soft_reason = None if not soft_hard_exceeded else f"query_soft_{soft_hard_exceeded[0]}"
-        object_store_backpressure_disabled = (
-            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
-        )
-        query_soft_blocked = (
-            not object_store_backpressure_disabled
-            and admission_commitment.object_store_bytes > 0
-            and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
-        )
-        downstream_reservations = self._downstream_reservations_locked(unit.spec)
-        placement_reservations = downstream_reservations
-        downstream_reservation_soft_blocked = False
-        if downstream_reservations:
-            remaining = _positive_difference(
-                _hard_resources(self.allocation.resources),
-                _hard_resources(query_usage + admission_commitment),
-            )
-            reservation_total = self._downstream_reservation_total(downstream_reservations)
-            if not reservation_total.fits_within(remaining):
-                downstream_reservation_soft_blocked = True
-                # No node placement can repair a globally insufficient vector.
-                # Keep constructing a concrete plan for the bounded liveness
-                # escape, but avoid an unnecessary combinatorial search.
-                placement_reservations = ()
-
-        new_credit_plan: _NewContinuationCreditPlan | None = None
-        if credit_template is not None:
-            eligible_unit_ids, reservation_unit_id, credit_resources = credit_template
-            node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
-                request.node_id,
-                hard_commitment,
-                credit_resources,
-                allow_unallocated_task_node=unit.spec.backend == "ray_worker",
-                downstream_reservations=placement_reservations,
-            )
-            if node_blocked_reason == "continuation_node_capacity" and placement_reservations:
-                node_id, credit_node_id, node_blocked_reason, node_fatal = self._select_task_and_credit_nodes_locked(
-                    request.node_id,
-                    hard_commitment,
-                    credit_resources,
-                    allow_unallocated_task_node=unit.spec.backend == "ray_worker",
-                    downstream_reservations=(),
-                )
-                if node_blocked_reason is None:
-                    downstream_reservation_soft_blocked = True
-            if node_blocked_reason is None:
-                new_credit_plan = _NewContinuationCreditPlan(
-                    eligible_unit_ids=eligible_unit_ids,
-                    reservation_unit_id=reservation_unit_id,
-                    node_id=credit_node_id,
-                    resources=credit_resources,
-                )
-        else:
-            if free_actor_indices_by_node is not None:
-                requested_node_id = "" if request.node_id is None else str(request.node_id).strip()
-                actor_node_ids = tuple(
-                    sorted(
-                        node_id
-                        for node_id in free_actor_indices_by_node
-                        if not requested_node_id or node_id == requested_node_id
-                    )
-                )
-                if not actor_node_ids:
-                    return "actor_node_unavailable", True, empty_plan
-                node_id = min(
-                    actor_node_ids,
-                    key=lambda candidate_node_id: (
-                        min(
-                            self._actor_slot_lease_count_locked((unit.spec.resource_unit_id, candidate_actor_index))
-                            for candidate_actor_index in free_actor_indices_by_node[candidate_node_id]
-                        ),
-                        candidate_node_id,
-                    ),
-                )
-                node_blocked_reason = None
-                node_fatal = False
-            else:
-                allowed_node_ids = {borrowed_credit.node_id} if borrowed_credit is not None else None
-                node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
-                    request.node_id,
-                    _hard_resources(admission_commitment),
-                    allowed_node_ids=allowed_node_ids,
-                    allow_unallocated_node=unit.spec.backend == "ray_worker",
-                    downstream_reservations=placement_reservations,
-                )
-                if node_blocked_reason == "continuation_node_capacity" and placement_reservations:
-                    node_id, node_blocked_reason, node_fatal = self._select_task_node_locked(
-                        request.node_id,
-                        _hard_resources(admission_commitment),
-                        allowed_node_ids=allowed_node_ids,
-                        allow_unallocated_node=unit.spec.backend == "ray_worker",
-                    )
-                    if node_blocked_reason is None:
-                        downstream_reservation_soft_blocked = True
-        if node_blocked_reason is not None:
-            return node_blocked_reason, node_fatal, empty_plan
-
-        actor_index: int | None = None
-        if free_actor_indices_by_node is not None:
-            candidates = free_actor_indices_by_node.get(node_id, [])
-            if not candidates:
-                raise RuntimeError("selected actor node has no free concrete actor slot")
-            actor_index = min(
-                candidates,
-                key=lambda index: (
-                    self._actor_slot_lease_count_locked((unit.spec.resource_unit_id, index)),
-                    index,
-                ),
-            )
         plan = _TaskAdmissionPlan(
             resources=resources,
-            # This is the bounded streaming protocol window sent to the
-            # producer.  Soft accounting independently uses the learned
-            # pending-output estimate above, which may initially be zero.
             output_window_bytes=unit.spec.output_window_bytes,
             node_id=node_id,
             actor_index=actor_index,
-            new_credit=new_credit_plan,
-            borrowed_credit_id=(None if borrowed_credit is None else borrowed_credit.credit_id),
         )
-        if downstream_reservation_soft_blocked:
-            return "unit_soft_limit", False, plan
-        if active_unit_tasks > 0 and any(
-            downstream_id not in self._started_unit_ids
-            and self._units[downstream_id].runnable
-            and not self._units[downstream_id].completed
-            for downstream_id in self._direct_downstream_unit_ids[unit.spec.resource_unit_id]
+
+        query_usage = self._soft_allocation_usage_locked()
+        usage_after = query_usage + commitment
+        for field_name in ("cpu", "gpu", "heap_bytes"):
+            if getattr(commitment, field_name) <= 0:
+                continue
+            if getattr(usage_after, field_name) > getattr(self.allocation.resources, field_name) + _EPSILON:
+                return f"query_soft_{field_name}", False, plan
+
+        object_store_backpressure_disabled = (
+            unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
+        )
+        if (
+            not object_store_backpressure_disabled
+            and commitment.object_store_bytes > 0
+            and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
         ):
-            return "unit_soft_limit", False, plan
-        if query_soft_blocked:
             return "query_soft_object_store_bytes", False, plan
-        if query_resource_soft_reason is not None:
-            return query_resource_soft_reason, False, plan
-        if borrowed_credit is None:
-            soft_reason = self._unit_soft_block_reason_locked(
-                unit.spec.resource_unit_id,
-                commitment,
-                ignore_object_store=object_store_backpressure_disabled,
-            )
-            if soft_reason is not None:
-                return soft_reason, False, plan
+
+        soft_reason = self._unit_soft_block_reason_locked(
+            unit.spec.resource_unit_id,
+            commitment,
+            ignore_object_store=object_store_backpressure_disabled,
+        )
+        if soft_reason is not None:
+            return soft_reason, False, plan
         return None, False, plan
-
-    def _select_task_node_locked(
-        self,
-        requested_node_id: str | None,
-        commitment: ResourceVector,
-        *,
-        allowed_node_ids: set[str] | None,
-        allow_unallocated_node: bool = False,
-        downstream_reservations: tuple[_DownstreamReservation, ...] = (),
-    ) -> tuple[str, str | None, bool]:
-        allocation_by_node = {
-            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
-        }
-        requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        external_requested = bool(requested and requested not in allocation_by_node)
-        if external_requested and (
-            not allow_unallocated_node
-            or not commitment.is_zero()
-            or (allowed_node_ids is not None and requested not in allowed_node_ids)
-        ):
-            return "", "node_not_allocated", True
-
-        static_candidates = (
-            [requested]
-            if external_requested
-            else [
-                node_id
-                for node_id, capacity in allocation_by_node.items()
-                if commitment.fits_within(capacity)
-                and (not requested or node_id == requested)
-                and (allowed_node_ids is None or node_id in allowed_node_ids)
-            ]
-        )
-        if not static_candidates:
-            return "", "task_does_not_fit_allocated_node", True
-
-        available_candidates: list[tuple[str, ResourceVector, bool]] = []
-        debt_detected = False
-        for node_id in static_candidates:
-            capacity = allocation_by_node.get(node_id, ResourceVector())
-            usage = self._node_hard_scheduling_usage_locked(node_id)
-            if not usage.fits_within(capacity):
-                debt_detected = True
-                if commitment.is_zero():
-                    available_candidates.append((node_id, ResourceVector(), True))
-                continue
-            remaining = capacity - usage
-            if commitment.fits_within(remaining):
-                available_candidates.append((node_id, remaining, False))
-        if not available_candidates:
-            return "", "node_allocation_debt" if debt_detected else "node_capacity", False
-
-        if downstream_reservations:
-            safe_candidates = [
-                candidate
-                for candidate in available_candidates
-                if self._placement_preserves_downstream_locked(
-                    candidate[0],
-                    commitment,
-                    downstream_reservations,
-                    allocation_by_node,
-                )
-            ]
-            if not safe_candidates:
-                return "", "continuation_node_capacity", False
-            available_candidates = safe_candidates
-
-        node_id, _, _ = min(
-            available_candidates,
-            key=lambda item: (
-                item[2],
-                item[1].gpu - commitment.gpu,
-                item[1].cpu - commitment.cpu,
-                item[1].heap_bytes - commitment.heap_bytes,
-                item[1].object_store_bytes - commitment.object_store_bytes,
-                item[0],
-            ),
-        )
-        return node_id, None, False
-
-    def _select_task_and_credit_nodes_locked(
-        self,
-        requested_node_id: str | None,
-        task_commitment: ResourceVector,
-        credit_resources: ResourceVector,
-        *,
-        allow_unallocated_task_node: bool = False,
-        downstream_reservations: tuple[_DownstreamReservation, ...],
-    ) -> tuple[str, str, str | None, bool]:
-        """Place one parent task and its continuation ownership atomically."""
-        allocation_by_node = {
-            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
-        }
-        requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        external_requested = bool(requested and requested not in allocation_by_node)
-        if external_requested and (not allow_unallocated_task_node or not task_commitment.is_zero()):
-            return "", "", "node_not_allocated", True
-
-        task_nodes = (
-            [requested]
-            if external_requested
-            else [
-                node_id
-                for node_id, capacity in allocation_by_node.items()
-                if task_commitment.fits_within(capacity) and (not requested or node_id == requested)
-            ]
-        )
-        if not task_nodes:
-            return "", "", "task_does_not_fit_allocated_node", True
-        credit_nodes = [
-            node_id for node_id, capacity in allocation_by_node.items() if credit_resources.fits_within(capacity)
-        ]
-        if not credit_nodes:
-            return "", "", "continuation_does_not_fit_allocated_node", True
-
-        candidates: list[tuple[str, str, dict[str, ResourceVector]]] = []
-        debt_detected = False
-        for task_node_id in task_nodes:
-            for credit_node_id in credit_nodes:
-                proposed: dict[str, ResourceVector] = {}
-                if task_node_id in allocation_by_node and not task_commitment.is_zero():
-                    proposed[task_node_id] = task_commitment
-                proposed[credit_node_id] = proposed.get(credit_node_id, ResourceVector()) + credit_resources
-                remaining_by_node: dict[str, ResourceVector] = {}
-                feasible = True
-                for node_id, capacity in allocation_by_node.items():
-                    usage = self._node_hard_scheduling_usage_locked(node_id)
-                    if not usage.fits_within(capacity):
-                        if node_id in proposed:
-                            debt_detected = True
-                            feasible = False
-                            break
-                        continue
-                    usage_after = usage + proposed.get(node_id, ResourceVector())
-                    if not usage_after.fits_within(capacity):
-                        feasible = False
-                        break
-                    remaining_by_node[node_id] = capacity - usage_after
-                if not feasible:
-                    continue
-                if downstream_reservations and not self._remaining_preserves_downstream_locked(
-                    remaining_by_node,
-                    downstream_reservations,
-                ):
-                    continue
-                candidates.append((task_node_id, credit_node_id, remaining_by_node))
-
-        if not candidates:
-            reason = "node_allocation_debt" if debt_detected else "continuation_node_capacity"
-            return "", "", reason, False
-
-        task_node_id, credit_node_id, _ = min(
-            candidates,
-            key=lambda item: (
-                item[2].get(item[0], ResourceVector()).gpu,
-                item[2].get(item[0], ResourceVector()).cpu,
-                item[2].get(item[0], ResourceVector()).heap_bytes,
-                item[2].get(item[0], ResourceVector()).object_store_bytes,
-                item[0],
-                item[1],
-            ),
-        )
-        return task_node_id, credit_node_id, None, False
-
-    def _placement_preserves_downstream_locked(
-        self,
-        parent_node_id: str,
-        parent_commitment: ResourceVector,
-        reservations: tuple[_DownstreamReservation, ...],
-        allocation_by_node: dict[str, ResourceVector],
-    ) -> bool:
-        remaining_by_node: dict[str, ResourceVector] = {}
-        for node_id, capacity in allocation_by_node.items():
-            usage = self._node_hard_scheduling_usage_locked(node_id)
-            if node_id == parent_node_id:
-                usage = usage + parent_commitment
-            if usage.fits_within(capacity):
-                remaining_by_node[node_id] = capacity - usage
-
-        return self._remaining_preserves_downstream_locked(
-            remaining_by_node,
-            reservations,
-        )
-
-    def _remaining_preserves_downstream_locked(
-        self,
-        remaining_by_node: dict[str, ResourceVector],
-        reservations: tuple[_DownstreamReservation, ...],
-    ) -> bool:
-        """Prefer a feasible node layout without unbounded work under the lock.
-
-        Vector bin packing is NP-hard.  These reservations are deliberately
-        soft, so an exhaustive proof is neither required for correctness nor
-        safe on the admission hot path.  Accept the common best-fit layout in
-        linear time, then search a bounded number of alternate layouts before
-        conservatively applying soft backpressure.  The normal one-task
-        liveness escape still guarantees progress after a conservative miss.
-        """
-        if not reservations:
-            return True
-
-        node_ids = tuple(sorted(remaining_by_node))
-        node_index = {node_id: index for index, node_id in enumerate(node_ids)}
-        ordered = tuple(
-            sorted(
-                reservations,
-                key=lambda reservation: (
-                    len(reservation.allowed_node_ids),
-                    -reservation.resources.dominant_share(self.allocation.resources),
-                    reservation.reservation_id,
-                ),
-            )
-        )
-        initial = tuple(remaining_by_node[node_id] for node_id in node_ids)
-
-        def candidate_states(
-            index: int,
-            remaining: tuple[ResourceVector, ...],
-        ) -> list[tuple[ResourceVector, ...]]:
-            reservation = ordered[index]
-            candidates: list[tuple[int, ResourceVector]] = []
-            for node_id in reservation.allowed_node_ids:
-                position = node_index.get(node_id)
-                if position is None:
-                    continue
-                capacity = remaining[position]
-                if reservation.resources.fits_within(capacity):
-                    candidates.append((position, capacity - reservation.resources))
-            candidates.sort(
-                key=lambda item: (
-                    item[1].dominant_share(self.allocation.resources),
-                    item[1].gpu,
-                    item[1].cpu,
-                    item[1].heap_bytes,
-                    item[1].object_store_bytes,
-                    node_ids[item[0]],
-                )
-            )
-            result: list[tuple[ResourceVector, ...]] = []
-            for position, capacity_after in candidates:
-                updated = list(remaining)
-                updated[position] = capacity_after
-                result.append(tuple(updated))
-            return result
-
-        # Most layouts succeed with deterministic best-fit-decreasing.  Run
-        # that path without retaining alternate states so thousands of latent
-        # downstream UDFs remain cheap and cannot overflow Python's stack.
-        greedy_remaining = initial
-        for index in range(len(ordered)):
-            candidates = candidate_states(index, greedy_remaining)
-            if not candidates:
-                break
-            greedy_remaining = candidates[0]
-        else:
-            return True
-
-        # Greedy can miss a feasible multi-dimensional layout.  Preserve the
-        # previous exact behavior for ordinary graphs, but cap pathological
-        # searches because the result controls only a soft reservation.
-        search_limit = max(
-            _DOWNSTREAM_PLACEMENT_SEARCH_STATE_LIMIT,
-            len(ordered) + 1,
-        )
-        pending: list[tuple[int, tuple[ResourceVector, ...]]] = [(0, initial)]
-        visited: set[tuple[int, tuple[ResourceVector, ...]]] = set()
-        while pending and len(visited) < search_limit:
-            index, remaining = pending.pop()
-            state = (index, remaining)
-            if state in visited:
-                continue
-            visited.add(state)
-            if index >= len(ordered):
-                return True
-            # Reverse the preferred order for the LIFO stack.
-            for candidate in reversed(candidate_states(index, remaining)):
-                pending.append((index + 1, candidate))
-
-        return False
 
     def _actor_slot_lease_count_locked(self, slot: tuple[str, int]) -> int:
         return int(slot in self._active_actor_slots) + len(self._queued_actor_slot_leases.get(slot, ()))
@@ -1864,271 +1262,31 @@ class RayQueryResourceManager:
             heap_bytes=spec.per_task.heap_bytes,
         )
 
-    def _continuation_credit_template_locked(
-        self,
-        parent: ResourceUnitSpec,
-    ) -> tuple[tuple[str, ...], str, ResourceVector] | None:
-        if parent.backend != "ray_worker":
-            return None
-        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
-        eligible_specs = tuple(
-            self._units[resource_unit_id].spec
-            for resource_unit_id in self._reachable_udf_unit_ids[parent.resource_unit_id]
-            if resource_unit_id in eligible_unit_ids
-            and self._units[resource_unit_id].spec.backend == "ray_task"
-            and not self._units[resource_unit_id].completed
-        )
-        if not eligible_specs:
-            return None
-        reservation_spec = max(
-            eligible_specs,
-            key=lambda spec: (
-                self._task_commitment(spec).dominant_share(self.allocation.resources),
-                -self._topological_unit_ids.index(spec.resource_unit_id),
-            ),
-        )
-        # A continuation credit is one real liveness path, not a synthetic
-        # component-wise maximum across heterogeneous downstream UDFs. Other
-        # task shapes retain their normal query allocation and can borrow this
-        # credit only when their concrete request fits it.
-        resources = self._task_commitment(reservation_spec)
-        return (
-            tuple(spec.resource_unit_id for spec in eligible_specs),
-            reservation_spec.resource_unit_id,
-            resources,
-        )
-
-    def _available_continuation_credit_locked(
-        self,
-        unit: ResourceUnitSpec,
-        *,
-        requested_node_id: str | None,
-        resources: ResourceVector,
-        output_window_bytes: int,
-        query_usage: ResourceVector,
-    ) -> _ContinuationCredit | None:
-        if unit.backend != "ray_task":
-            return None
-        if not self._continuation_parent_unit_ids_by_ray_task.get(unit.resource_unit_id):
-            return None
-        requested = "" if requested_node_id is None else str(requested_node_id).strip()
-        commitment = self._task_commitment(unit)
-        allocation_by_node = {
-            item.node_id: _hard_resources(item.resources) for item in self.allocation.node_allocations
-        }
-        candidates = [
-            credit
-            for credit in self._continuation_credits.values()
-            if credit.parent_active
-            and credit.borrowed_by_task_lease_id is None
-            and unit.resource_unit_id in credit.eligible_unit_ids
-            and commitment.fits_within(credit.resources)
-            and (not requested or credit.node_id == requested)
-            and credit.node_id in allocation_by_node
-        ]
-        if not candidates:
-            return None
-
-        def candidate_rank(credit: _ContinuationCredit) -> tuple[Any, ...]:
-            prospective_task_usage = self._borrowed_task_usage_locked(
-                resources,
-                output_window_bytes,
-                credit,
-            )
-            idle_output_excess = self._idle_continuation_output_excess_locked(
-                credit,
-            )
-            incremental = _positive_difference(
-                prospective_task_usage,
-                idle_output_excess,
-            )
-            query_exceeded = _incremental_hard_exceeded_dimensions(
-                query_usage,
-                incremental,
-                self.allocation.resources,
-            )
-            node_usage = self._node_hard_scheduling_usage_locked(credit.node_id)
-            node_exceeded = _hard_resources(node_usage + incremental).exceeded_dimensions(
-                allocation_by_node[credit.node_id]
-            )
-            soft_debt = max(
-                0,
-                query_usage.object_store_bytes
-                + incremental.object_store_bytes
-                - self.allocation.resources.object_store_bytes,
-            )
-            feasible = not query_exceeded and not node_exceeded
-            return (
-                0 if feasible else 1,
-                len(query_exceeded) + len(node_exceeded),
-                soft_debt,
-                incremental.dominant_share(self.allocation.resources),
-                incremental.gpu,
-                incremental.cpu,
-                incremental.heap_bytes,
-                incremental.object_store_bytes,
-                credit.credit_id,
-            )
-
-        # Historical outputs differ per credit, so selecting by insertion
-        # order can repeatedly choose an infeasible borrower while another
-        # idle credit is immediately grantable. Rank the full prospective
-        # query+node transition and use credit_id only as the stable tie-break.
-        return min(candidates, key=candidate_rank)
-
-    def _downstream_reservations_locked(
-        self,
-        parent: ResourceUnitSpec,
-    ) -> tuple[_DownstreamReservation, ...]:
-        """Return soft shared bundles that prefer a drainable producer path.
-
-        Native fragments do not consume Vane-owned process resources. Nested
-        Ray tasks use the explicit per-parent continuation credit above. A
-        streaming actor boundary additionally needs one slot for every inactive
-        downstream Ray-task continuation: the actor input producer, actor call,
-        and downstream consumer can all remain live while generator output is
-        drained, so the transferable component-max process credit alone is not
-        enough. Actor process resources are already resident; invocation
-        input/output bytes use the query's dynamic object-store budget.
-
-        Reservations include latent units: waiting for a unit to become
-        runnable is too late to bias upstream fanout. They remain soft so an
-        allocation at the graph's hard minimum can still start through the
-        bounded liveness escape.
-        """
-        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
-        reachable = tuple(
-            self._units[resource_unit_id]
-            for resource_unit_id in self._reachable_unit_ids[parent.resource_unit_id]
-            if resource_unit_id in eligible_unit_ids and not self._units[resource_unit_id].completed
-        )
-        reservations: list[_DownstreamReservation] = []
-        allocation_node_ids = tuple(sorted(allocation.node_id for allocation in self.allocation.node_allocations))
-
-        def is_after_streaming_actor(resource_unit_id: str) -> bool:
-            if parent.backend == "ray_actor":
-                return True
-            return any(
-                candidate.spec.backend == "ray_actor"
-                and resource_unit_id in self._reachable_unit_ids[candidate.spec.resource_unit_id]
-                for candidate in reachable
-            )
-
-        actor_continuations = tuple(
-            unit.spec
-            for unit in reachable
-            if unit.spec.backend == "ray_task"
-            and is_after_streaming_actor(unit.spec.resource_unit_id)
-            and self._active_task_count_for_unit_locked(unit.spec.resource_unit_id) == 0
-        )
-        for spec in actor_continuations:
-            resources = self._task_commitment(spec)
-            if resources.is_zero():
-                continue
-            reservations.append(
-                _DownstreamReservation(
-                    reservation_id=f"actor_continuation:{parent.resource_unit_id}:{spec.resource_unit_id}",
-                    unit_ids=(spec.resource_unit_id,),
-                    resources=resources,
-                    allowed_node_ids=allocation_node_ids,
-                )
-            )
-
-        return tuple(reservations)
-
-    @staticmethod
-    def _downstream_reservation_total(
-        reservations: tuple[_DownstreamReservation, ...],
-    ) -> ResourceVector:
-        total = ResourceVector()
-        for reservation in reservations:
-            total = total + reservation.resources
-        return total
-
-    def _dimension_live_demand_unit_ids_locked(
-        self,
-        field_name: str,
-        *,
-        requested_unit_id: str | None,
-    ) -> tuple[str, ...]:
-        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
-        unit_ids: list[str] = []
-        for resource_unit_id, unit in self._units.items():
-            if resource_unit_id not in eligible_unit_ids or unit.completed:
-                continue
-            has_submitted_actor = unit.spec.backend == "ray_actor" and any(
-                candidate_unit_id == resource_unit_id for candidate_unit_id, _actor_index in self._submitted_actor_slots
-            )
-            if not unit.runnable and not has_submitted_actor:
-                continue
-            actor_process_demand = has_submitted_actor and self._unit_uses_dimension(unit.spec, field_name)
-            task_demand = (
-                (requested_unit_id is not None and resource_unit_id == requested_unit_id)
-                or unit.pending_task_count > 0
-                or self._active_task_count_for_unit_locked(resource_unit_id) > 0
-            )
-            output_demand = (
-                unit.pending_output_count > 0
-                or unit.queued_output_bytes > 0
-                or any(lease.producer_unit_id == resource_unit_id for lease in self._output_leases.values())
-            )
-            if (
-                not actor_process_demand
-                and not task_demand
-                and not (field_name == "object_store_bytes" and output_demand)
-            ):
-                continue
-            if self._unit_uses_dimension(unit.spec, field_name):
-                unit_ids.append(resource_unit_id)
-        return tuple(unit_ids)
-
-    def _dimension_continuation_unit_ids_locked(
-        self,
-        field_name: str,
-        *,
-        live_unit_ids: tuple[str, ...],
-    ) -> tuple[str, ...]:
-        live = set(live_unit_ids)
-        eligible_unit_ids = set(self._eligible_resource_unit_ids_locked())
-        continuation_ids: set[str] = set()
-        for source_unit_id in live_unit_ids:
-            if self._units[source_unit_id].spec.backend != "ray_worker":
-                continue
-            for resource_unit_id in self._reachable_udf_unit_ids[source_unit_id]:
-                unit = self._units[resource_unit_id]
-                if (
-                    resource_unit_id not in live
-                    and resource_unit_id in eligible_unit_ids
-                    and not unit.completed
-                    and self._unit_uses_dimension(unit.spec, field_name)
-                ):
-                    continuation_ids.add(resource_unit_id)
-        return tuple(
-            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in continuation_ids
-        )
-
     def _dimension_reservation_unit_ids_locked(
         self,
         field_name: str,
         *,
         requested_unit_id: str | None,
     ) -> tuple[str, ...]:
-        live_unit_ids = self._dimension_live_demand_unit_ids_locked(
-            field_name,
-            requested_unit_id=requested_unit_id,
+        """Return every resource-owning operator in the current phase.
+
+        Like Ray Data's reservation allocator, phase eligibility rather than
+        future node placement defines the reservation set. Operators may
+        temporarily receive less than one invocation's minimum; their real
+        requests can still enter Ray Core through the bounded liveness escape.
+        """
+
+        eligible = set(self._eligible_resource_unit_ids_locked())
+        selected = tuple(
+            resource_unit_id
+            for resource_unit_id in self._topological_unit_ids
+            if resource_unit_id in eligible
+            and not self._units[resource_unit_id].completed
+            and self._unit_uses_dimension(self._units[resource_unit_id].spec, field_name)
         )
-        if requested_unit_id is not None and self._units[requested_unit_id].spec.backend != "ray_worker":
-            # A concrete downstream UDF borrows latent continuation reserves.
-            # It releases its own lease before a later continuation needs them.
-            return live_unit_ids
-        continuation_unit_ids = self._dimension_continuation_unit_ids_locked(
-            field_name,
-            live_unit_ids=live_unit_ids,
-        )
-        selected = set(live_unit_ids) | set(continuation_unit_ids)
-        return tuple(
-            resource_unit_id for resource_unit_id in self._topological_unit_ids if resource_unit_id in selected
-        )
+        if requested_unit_id is not None and requested_unit_id not in selected:
+            raise RuntimeError(f"unit {requested_unit_id} requested undeclared {field_name} capacity")
+        return selected
 
     def _unit_soft_block_reason_locked(
         self,
@@ -2161,18 +1319,18 @@ class RayQueryResourceManager:
             if resource_unit_id not in dimension_unit_ids:
                 raise RuntimeError(f"unit {resource_unit_id} requested undeclared {field_name} capacity")
             limit = getattr(limits, field_name)
-            minimum_by_unit = {
+            baseline_by_unit = {
                 key: self._unit_dimension_commitment(self._units[key].spec, field_name) for key in dimension_unit_ids
             }
-            minimum_total = sum(minimum_by_unit.values())
-            if minimum_total <= limit + _EPSILON:
-                bonus_pool = max(0.0, limit - minimum_total) * self.reservation_ratio
+            baseline_total = sum(baseline_by_unit.values())
+            if baseline_total <= limit + _EPSILON:
+                bonus_pool = max(0.0, limit - baseline_total) * self.reservation_ratio
                 bonus = bonus_pool / len(dimension_unit_ids)
-                reserved_by_unit = {key: minimum + bonus for key, minimum in minimum_by_unit.items()}
+                reserved_by_unit = {key: baseline + bonus for key, baseline in baseline_by_unit.items()}
             else:
                 reservation_pool = limit * self.reservation_ratio
                 reserved_by_unit = {
-                    key: reservation_pool * minimum / minimum_total for key, minimum in minimum_by_unit.items()
+                    key: reservation_pool * baseline / baseline_total for key, baseline in baseline_by_unit.items()
                 }
             maximum_by_unit = {
                 key: self._unit_dimension_maximum_locked(self._units[key].spec, field_name)
@@ -2221,7 +1379,7 @@ class RayQueryResourceManager:
         spec: ResourceUnitSpec,
         field_name: str,
     ) -> int | float:
-        """Cap a soft share by tasks that can coexist under every hard dimension."""
+        """Cap a soft share by concurrency and the aggregate budget dimensions."""
         if field_name == "object_store_bytes":
             # Output sizes are data-dependent. Match Ray Data's unbounded
             # operator maximum and let the query-level soft budget, output
@@ -2232,7 +1390,7 @@ class RayQueryResourceManager:
         concurrency = self._unit_concurrency_cap(spec)
         if spec.backend == "ray_actor":
             concurrency = spec.actor_pool_size
-        hard_bound = math.inf if concurrency is None else int(concurrency)
+        coexistence_bound = math.inf if concurrency is None else int(concurrency)
         commitment = self._task_commitment(spec)
         for resource_field in _RESOURCE_FIELDS:
             per_task = getattr(commitment, resource_field)
@@ -2243,121 +1401,42 @@ class RayQueryResourceManager:
                 dimension_bound = int(limit) // int(per_task)
             else:
                 dimension_bound = math.floor((float(limit) + _EPSILON) / float(per_task))
-            hard_bound = min(hard_bound, dimension_bound)
-        if math.isinf(hard_bound):
+            coexistence_bound = min(coexistence_bound, dimension_bound)
+        if math.isinf(coexistence_bound):
             return getattr(self.allocation.resources, field_name)
         per_task_amount = self._unit_dimension_commitment(spec, field_name)
-        return per_task_amount * max(0, int(hard_bound))
-
-    def _active_tasks_allow_liveness_locked(
-        self,
-        resource_unit_id: str,
-        plan: _TaskAdmissionPlan,
-    ) -> bool:
-        """Allow one escape only when it can drain an active upstream path."""
-        if not self._task_leases:
-            return True
-        unit_key = str(resource_unit_id)
-        if self._active_task_count_for_unit_locked(unit_key) > 0:
-            return False
-        if plan.borrowed_credit_id is not None:
-            return True
-        return any(unit_key in self._reachable_unit_ids[lease.resource_unit_id] for lease in self._task_leases.values())
-
-    def _continues_active_liveness_path_locked(
-        self,
-        resource_unit_id: str,
-        plan: _TaskAdmissionPlan,
-    ) -> bool:
-        """Return whether a soft-blocked task continues the one escape path."""
-        active_lease_id = self._active_liveness_task_lease_id
-        if active_lease_id is None:
-            return False
-        unit_key = str(resource_unit_id)
-        unit = self._units.get(unit_key)
-        if unit is None:
-            return False
-        active_path_leases = tuple(
-            lease
-            for lease_id, lease in self._task_leases.items()
-            if lease_id in self._active_liveness_path_task_lease_ids
-        )
-        frontier = tuple(
-            lease
-            for lease in active_path_leases
-            if not any(
-                other.lease_id != lease.lease_id
-                and other.resource_unit_id in self._reachable_unit_ids[lease.resource_unit_id]
-                for other in active_path_leases
-            )
-        )
-        continues_from_frontier = any(
-            unit_key in self._reachable_unit_ids[lease.resource_unit_id] for lease in frontier
-        )
-        credit_id = plan.borrowed_credit_id
-        if credit_id is not None:
-            credit = self._continuation_credits.get(credit_id)
-            return (
-                continues_from_frontier
-                and credit is not None
-                and credit.parent_active
-                and credit.parent_task_lease_id in self._active_liveness_path_task_lease_ids
-                and credit.borrowed_by_task_lease_id is None
-            )
-        return continues_from_frontier
+        return per_task_amount * max(0, int(coexistence_bound))
 
     def _task_liveness_block_reason_locked(
         self,
         request: TaskRequest,
         plan: _TaskAdmissionPlan,
     ) -> str | None:
-        if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-            str(request.resource_unit_id),
-            plan,
-        ):
+        del plan
+        # Match Ray Data's global-idle escape: soft limits may be bypassed for
+        # one task only when no task is active anywhere in the current query.
+        if self._task_leases or self._active_liveness_task_lease_id is not None:
             return "liveness_task_active"
         if self._has_normal_task_candidate_locked():
             return "normal_candidate_available"
-        preferred = self._preferred_liveness_unit_locked()
-        if preferred is None:
-            return "no_liveness_candidate"
-        if preferred != str(request.resource_unit_id):
-            return "liveness_candidate_not_selected"
-        if not self._active_tasks_allow_liveness_locked(
-            str(request.resource_unit_id),
-            plan,
-        ):
-            return "liveness_not_needed"
+        if self._waiting_task_inputs:
+            evaluations = self._evaluate_waiting_tasks_locked(hypothetical=True)
+            selected = self._select_waiting_task_evaluation_locked(evaluations)
+            if selected is None:
+                return "no_liveness_candidate"
+            if selected.key != (str(request.task_id), str(request.attempt_id)):
+                return "liveness_candidate_not_selected"
         return None
 
     def _has_normal_task_candidate_locked(self) -> bool:
-        if self._waiting_task_inputs:
-            for waiting_request, _ in self._waiting_task_inputs.values():
-                reason, _, _ = self._normal_task_block_reason_locked(
-                    waiting_request,
-                    hypothetical=True,
-                )
-                if reason is None:
-                    return True
-            return False
-        for resource_unit_id, unit in self._units.items():
-            if not unit.runnable or unit.completed:
-                continue
-            request = TaskRequest(
-                query_id=self.graph.query_id,
-                resource_unit_id=resource_unit_id,
-                task_id=f"hypothetical:{resource_unit_id}",
-                attempt_id="hypothetical",
-                node_id=None,
-                retained_input_bytes=unit.spec.per_task.object_store_bytes,
-            )
-            reason, _, _ = self._normal_task_block_reason_locked(
-                request,
-                hypothetical=True,
-            )
-            if reason is None:
-                return True
-        return False
+        # Liveness arbitration must consider real dispatchable work only. A
+        # structurally runnable operator can have no input bundle or descriptor
+        # at this instant; inventing a hypothetical task for it would suppress
+        # the one escape needed by the actual upstream request that can produce
+        # its next input. This matches Ray Data's dispatchable-operator check.
+        return any(
+            not item.fatal and item.reason is None for item in self._evaluate_waiting_tasks_locked(hypothetical=True)
+        )
 
     def _waiting_task_rank_locked(
         self,
@@ -2403,23 +1482,6 @@ class RayQueryResourceManager:
         soft = [item for item in evaluations if not item.fatal and item.reason in _SOFT_TASK_BLOCK_REASONS]
         if not soft:
             return None
-        path_candidates = [
-            item
-            for item in soft
-            if self._active_tasks_allow_liveness_locked(
-                str(item.request.resource_unit_id),
-                item.plan,
-            )
-            and (
-                self._active_liveness_task_lease_id is None
-                or self._continues_active_liveness_path_locked(
-                    str(item.request.resource_unit_id),
-                    item.plan,
-                )
-            )
-        ]
-        if path_candidates:
-            soft = path_candidates
         soft_unit_ids = {str(item.request.resource_unit_id) for item in soft}
         ordered_unit_ids = [
             resource_unit_id
@@ -2447,16 +1509,8 @@ class RayQueryResourceManager:
         selected = self._select_waiting_task_evaluation_locked(evaluations)
         if selected is None:
             return "no_liveness_candidate"
-        if self._active_liveness_task_lease_id is not None and not self._continues_active_liveness_path_locked(
-            str(selected.request.resource_unit_id),
-            selected.plan,
-        ):
+        if self._task_leases or self._active_liveness_task_lease_id is not None:
             return "liveness_task_active"
-        if not self._active_tasks_allow_liveness_locked(
-            str(selected.request.resource_unit_id),
-            selected.plan,
-        ):
-            return "liveness_not_needed"
         return None
 
     def _preferred_waiting_task_locked(self) -> tuple[TaskRequest | None, str]:
@@ -2467,92 +1521,6 @@ class RayQueryResourceManager:
             return selected.request, grant_class
         return None, ""
 
-    def _preferred_liveness_unit_locked(self) -> str | None:
-        if self._waiting_task_inputs:
-            waiting_candidates: list[str] = []
-            path_candidates: list[str] = []
-            for resource_unit_id in self.graph.reverse_topological_unit_ids():
-                for request, _ in self._waiting_task_inputs.values():
-                    if str(request.resource_unit_id) != resource_unit_id:
-                        continue
-                    reason, fatal, plan = self._normal_task_block_reason_locked(
-                        request,
-                        hypothetical=True,
-                    )
-                    path_allowed = self._active_tasks_allow_liveness_locked(
-                        resource_unit_id,
-                        plan,
-                    ) and (
-                        self._active_liveness_task_lease_id is None
-                        or self._continues_active_liveness_path_locked(
-                            resource_unit_id,
-                            plan,
-                        )
-                    )
-                    if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
-                        waiting_candidates.append(resource_unit_id)
-                        if path_allowed:
-                            path_candidates.append(resource_unit_id)
-                        break
-            if path_candidates:
-                waiting_candidates = path_candidates
-            elif self._active_liveness_task_lease_id is not None:
-                return None
-            if not waiting_candidates:
-                return None
-            starving = [
-                resource_unit_id
-                for resource_unit_id in waiting_candidates
-                if self._units[resource_unit_id].pending_task_count > 0
-                and self._active_task_count_for_unit_locked(resource_unit_id) == 0
-            ]
-            return (starving or waiting_candidates)[0]
-        runnable_candidates: list[str] = []
-        path_candidates = []
-        for resource_unit_id in self.graph.reverse_topological_unit_ids():
-            unit = self._units[resource_unit_id]
-            if not unit.runnable or unit.completed:
-                continue
-            request = TaskRequest(
-                query_id=self.graph.query_id,
-                resource_unit_id=resource_unit_id,
-                task_id=f"hypothetical:{resource_unit_id}",
-                attempt_id="hypothetical",
-                node_id=None,
-                retained_input_bytes=unit.spec.per_task.object_store_bytes,
-            )
-            reason, fatal, plan = self._normal_task_block_reason_locked(
-                request,
-                hypothetical=True,
-            )
-            path_allowed = self._active_tasks_allow_liveness_locked(
-                resource_unit_id,
-                plan,
-            ) and (
-                self._active_liveness_task_lease_id is None
-                or self._continues_active_liveness_path_locked(
-                    resource_unit_id,
-                    plan,
-                )
-            )
-            if not fatal and reason in _SOFT_TASK_BLOCK_REASONS:
-                runnable_candidates.append(resource_unit_id)
-                if path_allowed:
-                    path_candidates.append(resource_unit_id)
-        if path_candidates:
-            runnable_candidates = path_candidates
-        elif self._active_liveness_task_lease_id is not None:
-            return None
-        if not runnable_candidates:
-            return None
-        starving = [
-            resource_unit_id
-            for resource_unit_id in runnable_candidates
-            if self._units[resource_unit_id].pending_task_count > 0
-            and self._active_task_count_for_unit_locked(resource_unit_id) == 0
-        ]
-        return (starving or runnable_candidates)[0]
-
     def _grant_task_locked(
         self,
         request: TaskRequest,
@@ -2560,19 +1528,15 @@ class RayQueryResourceManager:
         *,
         liveness: bool,
     ) -> TaskGrant:
-        if not str(plan.node_id).strip():
-            raise RuntimeError("cannot grant a query task lease without a concrete Ray node")
-        if plan.new_credit is not None and plan.borrowed_credit_id is not None:
-            raise RuntimeError("task admission cannot create and borrow a continuation credit")
-        continues_active_liveness = liveness and self._continues_active_liveness_path_locked(
-            str(request.resource_unit_id),
-            plan,
-        )
-        if liveness and self._active_liveness_task_lease_id is not None and not continues_active_liveness:
-            raise RuntimeError("task liveness path changed during atomic admission")
-        if liveness and self._active_liveness_task_lease_id is None and self._active_liveness_path_task_lease_ids:
-            raise RuntimeError("task liveness path has no active root")
         unit = self._units[str(request.resource_unit_id)].spec
+        if unit.backend == "ray_task":
+            if plan.node_id is not None:
+                raise RuntimeError("Ray task leases must leave placement to Ray Core")
+        elif not str(plan.node_id or "").strip():
+            raise RuntimeError(f"{unit.backend} task lease requires a concrete runtime node")
+        if liveness and (self._task_leases or self._active_liveness_task_lease_id is not None):
+            raise RuntimeError("task liveness state changed during atomic admission")
+
         actor_index = plan.actor_index
         lease_id = uuid.uuid4().hex
         if unit.backend == "ray_actor":
@@ -2591,7 +1555,7 @@ class RayQueryResourceManager:
             resource_unit_id=str(request.resource_unit_id),
             task_id=str(request.task_id),
             attempt_id=str(request.attempt_id),
-            node_id=str(plan.node_id),
+            node_id=plan.node_id,
             execution_slot_id=execution_slot_id,
             actor_index=actor_index,
             resources=plan.resources,
@@ -2606,107 +1570,33 @@ class RayQueryResourceManager:
                 self._active_actor_slots[actor_slot] = lease.lease_id
             else:
                 self._queued_actor_slot_leases.setdefault(actor_slot, deque()).append(lease.lease_id)
-        if plan.new_credit is not None:
-            new_credit = _ContinuationCredit(
-                credit_id=uuid.uuid4().hex,
-                parent_task_lease_id=lease.lease_id,
-                parent_unit_id=lease.resource_unit_id,
-                eligible_unit_ids=plan.new_credit.eligible_unit_ids,
-                reservation_unit_id=plan.new_credit.reservation_unit_id,
-                node_id=plan.new_credit.node_id,
-                resources=plan.new_credit.resources,
-                allocation_generation=self.allocation.generation,
-            )
-            self._continuation_credits[new_credit.credit_id] = new_credit
-            self._continuation_credit_by_parent[lease.lease_id] = new_credit.credit_id
-        elif plan.borrowed_credit_id is not None:
-            borrowed_credit = self._continuation_credits.get(plan.borrowed_credit_id)
-            if (
-                borrowed_credit is None
-                or not borrowed_credit.parent_active
-                or borrowed_credit.borrowed_by_task_lease_id is not None
-                or lease.resource_unit_id not in borrowed_credit.eligible_unit_ids
-                or borrowed_credit.node_id != lease.node_id
-            ):
-                raise RuntimeError("continuation credit changed during atomic task admission")
-            borrowed_credit.borrowed_by_task_lease_id = lease.lease_id
-            self._continuation_credit_by_borrower[lease.lease_id] = borrowed_credit.credit_id
         self._waiting_task_inputs.pop((lease.task_id, lease.attempt_id), None)
         self._recompute_unit_queued_input_locked(lease.resource_unit_id)
-        self._started_unit_ids.add(lease.resource_unit_id)
         if liveness:
-            if self._active_liveness_task_lease_id is None:
-                self._active_liveness_task_lease_id = lease.lease_id
-            self._active_liveness_path_task_lease_ids.add(lease.lease_id)
+            self._active_liveness_task_lease_id = lease.lease_id
             self._task_liveness_grants_total += 1
         self._publish_change_locked()
         return TaskGrant(True, lease=lease, liveness=liveness)
 
-    def _delete_continuation_credit_locked(self, credit_id: str) -> None:
-        credit = self._continuation_credits.pop(str(credit_id), None)
-        if credit is None:
-            return
-        if self._continuation_credit_by_parent.get(credit.parent_task_lease_id) == credit.credit_id:
-            self._continuation_credit_by_parent.pop(credit.parent_task_lease_id, None)
-        borrower = credit.borrowed_by_task_lease_id
-        if borrower is not None:
-            self._continuation_credit_by_borrower.pop(borrower, None)
-
     def _on_task_lease_removed_locked(self, lease: TaskLease) -> None:
-        if lease.actor_index is not None:
-            actor_slot = (lease.resource_unit_id, int(lease.actor_index))
-            owner = self._active_actor_slots.get(actor_slot)
-            queued = self._queued_actor_slot_leases.get(actor_slot)
-            if owner == lease.lease_id:
-                if queued:
-                    self._active_actor_slots[actor_slot] = queued.popleft()
-                    if not queued:
-                        self._queued_actor_slot_leases.pop(actor_slot, None)
-                else:
-                    self._active_actor_slots.pop(actor_slot, None)
-            elif queued and lease.lease_id in queued:
-                queued.remove(lease.lease_id)
+        if lease.actor_index is None:
+            return
+        actor_slot = (lease.resource_unit_id, int(lease.actor_index))
+        owner = self._active_actor_slots.get(actor_slot)
+        queued = self._queued_actor_slot_leases.get(actor_slot)
+        if owner == lease.lease_id:
+            if queued:
+                self._active_actor_slots[actor_slot] = queued.popleft()
                 if not queued:
                     self._queued_actor_slot_leases.pop(actor_slot, None)
             else:
-                raise RuntimeError("Ray actor slot ownership index is inconsistent")
-        self._maybe_return_continuation_credit_locked(lease.lease_id)
-
-        owned_credit_id = self._continuation_credit_by_parent.pop(
-            lease.lease_id,
-            None,
-        )
-        if owned_credit_id is not None:
-            credit = self._continuation_credits.get(owned_credit_id)
-            if credit is None or credit.parent_task_lease_id != lease.lease_id:
-                raise RuntimeError("continuation parent index is inconsistent")
-            credit.parent_active = False
-            if credit.borrowed_by_task_lease_id is None:
-                self._delete_continuation_credit_locked(credit.credit_id)
-
-    def _maybe_return_continuation_credit_locked(self, task_lease_id: str) -> None:
-        task_key = str(task_lease_id)
-        borrowed_credit_id = self._continuation_credit_by_borrower.get(task_key)
-        if borrowed_credit_id is None:
-            return
-        if task_key in self._task_leases or any(
-            output.task_lease_id == task_key and output.state not in {"downstream_input", "external_consumer"}
-            for output in self._output_leases.values()
-        ):
-            return
-        # Handoff is the continuation ownership boundary.  The physical output
-        # lease remains attached to borrowed_credit_id and therefore stays in
-        # the credit's aggregate object-store accounting, but the next child
-        # task may reuse the compute/heap reservation.  Holding the borrower
-        # until physical release deadlocks whenever downstream needs more than
-        # one upstream block to form its compute batch.
-        self._continuation_credit_by_borrower.pop(task_key, None)
-        credit = self._continuation_credits.get(borrowed_credit_id)
-        if credit is None or credit.borrowed_by_task_lease_id != task_key:
-            raise RuntimeError("continuation borrower index is inconsistent")
-        credit.borrowed_by_task_lease_id = None
-        if not credit.parent_active:
-            self._delete_continuation_credit_locked(credit.credit_id)
+                self._active_actor_slots.pop(actor_slot, None)
+        elif queued and lease.lease_id in queued:
+            queued.remove(lease.lease_id)
+            if not queued:
+                self._queued_actor_slot_leases.pop(actor_slot, None)
+        else:
+            raise RuntimeError("Ray actor slot ownership index is inconsistent")
 
     def release_task_lease(self, lease_id: str, *, attempt_id: str) -> bool:
         return self._release_task_lease(lease_id, attempt_id=attempt_id, terminal=True)
@@ -2775,7 +1665,6 @@ class RayQueryResourceManager:
                     state="unit_queue",
                     liveness=False,
                     allocation_generation=self.allocation.generation,
-                    continuation_credit_id=None,
                 )
                 for request in requests
             )
@@ -2815,20 +1704,13 @@ class RayQueryResourceManager:
             return True
 
     def _maybe_clear_task_liveness_locked(self, task_lease_id: str) -> None:
-        """Return one escape after its continuation path leaves the producer."""
+        """Return the single global-idle escape when its task terminates."""
         task_key = str(task_lease_id)
-        if task_key not in self._active_liveness_path_task_lease_ids:
+        if self._active_liveness_task_lease_id != task_key:
             return
         if task_key in self._task_leases:
             return
-        if any(
-            output.task_lease_id == task_key and output.state in {"generator_pending", "unit_queue"}
-            for output in self._output_leases.values()
-        ):
-            return
-        self._active_liveness_path_task_lease_ids.remove(task_key)
-        if not self._active_liveness_path_task_lease_ids:
-            self._active_liveness_task_lease_id = None
+        self._active_liveness_task_lease_id = None
 
     def try_acquire_output_block(self, request: OutputBlockRequest) -> OutputBlockGrant:
         with self._lock:
@@ -3071,7 +1953,6 @@ class RayQueryResourceManager:
             state=str(initial_state),
             liveness=liveness,
             allocation_generation=self.allocation.generation,
-            continuation_credit_id=self._continuation_credit_by_borrower.get(task.lease_id),
         )
         self._output_leases[lease.lease_id] = lease
         self._output_lease_by_block[lease.block_id] = lease.lease_id
@@ -3105,7 +1986,6 @@ class RayQueryResourceManager:
                 self._active_liveness_output_lease_id = None
             if target == "downstream_input":
                 self._maybe_clear_task_liveness_locked(lease.task_lease_id)
-                self._maybe_return_continuation_credit_locked(lease.task_lease_id)
             self._recompute_unit_queued_output_locked(lease.producer_unit_id)
             self._publish_change_locked()
             return True
@@ -3121,7 +2001,6 @@ class RayQueryResourceManager:
             if self._active_liveness_output_lease_id == lease_key:
                 self._active_liveness_output_lease_id = None
             self._maybe_clear_task_liveness_locked(lease.task_lease_id)
-            self._maybe_return_continuation_credit_locked(lease.task_lease_id)
             self._recompute_unit_queued_output_locked(lease.producer_unit_id)
             self._publish_change_locked()
             return True
@@ -3135,9 +2014,6 @@ class RayQueryResourceManager:
             for lease in self._task_leases.values():
                 self._terminal_attempts.add((lease.task_id, lease.attempt_id))
             self._task_leases.clear()
-            self._continuation_credits.clear()
-            self._continuation_credit_by_parent.clear()
-            self._continuation_credit_by_borrower.clear()
             self._active_attempt_leases.clear()
             self._submitted_actor_slots.clear()
             self._retiring_actor_unit_ids.clear()
@@ -3155,13 +2031,11 @@ class RayQueryResourceManager:
             for resource_unit_id in self._units:
                 self._recompute_unit_queued_output_locked(resource_unit_id)
             self._active_liveness_task_lease_id = None
-            self._active_liveness_path_task_lease_ids.clear()
             self._active_liveness_output_lease_id = None
             for unit in self._units.values():
                 if unit.spec.backend == "ray_actor":
                     unit.actor_ready = False
             self._allocation_admission_open = False
-            self._allocation_debt_neutral_only = False
             self._cancelled = True
             self._cancel_reason = str(reason)
             self._publish_change_locked()
@@ -3171,8 +2045,8 @@ class RayQueryResourceManager:
         """Fence terminally failed work without releasing physical ownership.
 
         A driver-side protocol or actor failure is not proof that already
-        submitted Ray work has stopped.  Keep every task, output, continuation,
-        and actor-process lease charged until ordered query teardown supplies
+        submitted Ray work has stopped. Keep every task, output, and actor-
+        process lease charged until ordered query teardown supplies
         that proof; only new task/output/actor submission becomes fatal.
         """
 
@@ -3187,7 +2061,6 @@ class RayQueryResourceManager:
             self._failed = True
             self._failure_reason = failure_reason
             self._allocation_admission_open = False
-            self._allocation_debt_neutral_only = False
             self._publish_change_locked()
             return counts
 
@@ -3196,20 +2069,7 @@ class RayQueryResourceManager:
 
     def _live_output_bytes_for_task_locked(self, task_lease_id: str) -> int:
         task_key = str(task_lease_id)
-        credit_id = self._continuation_credit_by_borrower.get(task_key)
-        if credit_id is not None:
-            # A continuation credit is a shared window for sequential nested
-            # tasks in one parent fragment.  Include objects handed off by
-            # earlier borrowers so the next output grant sees the aggregate
-            # physical footprint and charges any overflow exactly once.
-            return self._live_output_bytes_for_credit_locked(credit_id)
         return sum(lease.size_bytes for lease in self._output_leases.values() if lease.task_lease_id == task_key)
-
-    def _live_output_bytes_for_credit_locked(self, credit_id: str) -> int:
-        credit_key = str(credit_id)
-        return sum(
-            lease.size_bytes for lease in self._output_leases.values() if lease.continuation_credit_id == credit_key
-        )
 
     def _scoped_output_bytes_for_task_locked(
         self,
@@ -3219,22 +2079,12 @@ class RayQueryResourceManager:
         include_waiting: bool,
         excluded_waiting_block_id: str | None = None,
     ) -> int:
-        """Return actual output bytes owned by one task/continuation scope."""
-
         task_key = str(task_lease_id)
-        credit_id = self._continuation_credit_by_borrower.get(task_key)
-        if credit_id is None:
-            leased = sum(
-                lease.size_bytes
-                for lease in self._output_leases.values()
-                if lease.task_lease_id == task_key and lease.state in states
-            )
-        else:
-            leased = sum(
-                lease.size_bytes
-                for lease in self._output_leases.values()
-                if lease.continuation_credit_id == credit_id and lease.state in states
-            )
+        leased = sum(
+            lease.size_bytes
+            for lease in self._output_leases.values()
+            if lease.task_lease_id == task_key and lease.state in states
+        )
         if not include_waiting:
             return leased
         waiting = sum(
@@ -3264,42 +2114,6 @@ class RayQueryResourceManager:
             include_waiting=False,
         )
 
-    def _borrowed_task_usage_locked(
-        self,
-        resources: ResourceVector,
-        output_window_bytes: int,
-        credit: _ContinuationCredit,
-        *,
-        excluded_waiting_block_id: str | None = None,
-    ) -> ResourceVector:
-        borrower = credit.borrowed_by_task_lease_id
-        if borrower is None:
-            producer_output = 0
-            downstream_output = self._live_output_bytes_for_credit_locked(credit.credit_id)
-        else:
-            producer_output = self._producer_output_bytes_for_task_locked(
-                borrower,
-                excluded_waiting_block_id=excluded_waiting_block_id,
-            )
-            downstream_output = self._downstream_output_bytes_for_task_locked(borrower)
-        combined_commitment = _resource_with_object_store(
-            resources,
-            resources.object_store_bytes + downstream_output + producer_output + int(output_window_bytes),
-        )
-        return _positive_difference(combined_commitment, credit.resources)
-
-    def _idle_continuation_output_excess_locked(
-        self,
-        credit: _ContinuationCredit,
-    ) -> ResourceVector:
-        live_output = self._live_output_bytes_for_credit_locked(credit.credit_id)
-        return ResourceVector(
-            object_store_bytes=max(
-                0,
-                live_output - credit.resources.object_store_bytes,
-            )
-        )
-
     def _live_output_bytes_for_unit_locked(self, resource_unit_id: str) -> int:
         return sum(
             lease.size_bytes for lease in self._output_leases.values() if lease.producer_unit_id == resource_unit_id
@@ -3312,130 +2126,42 @@ class RayQueryResourceManager:
         excluded_waiting_block_id: str | None = None,
     ) -> ResourceVector:
         output_estimate = self._pending_output_estimate_for_lease_locked(lease)
-        credit_id = self._continuation_credit_by_borrower.get(lease.lease_id)
-        if credit_id is None:
-            producer_output = self._producer_output_bytes_for_task_locked(
-                lease.lease_id,
-                excluded_waiting_block_id=excluded_waiting_block_id,
-            )
-            downstream_output = self._downstream_output_bytes_for_task_locked(lease.lease_id)
-            return _resource_with_object_store(
-                lease.resources,
-                lease.resources.object_store_bytes + downstream_output + producer_output + output_estimate,
-            )
-        credit = self._continuation_credits.get(credit_id)
-        if credit is None or credit.borrowed_by_task_lease_id != lease.lease_id:
-            raise RuntimeError("continuation credit accounting index is inconsistent")
-        return self._borrowed_task_usage_locked(
-            lease.resources,
-            output_estimate,
-            credit,
+        producer_output = self._producer_output_bytes_for_task_locked(
+            lease.lease_id,
             excluded_waiting_block_id=excluded_waiting_block_id,
+        )
+        downstream_output = self._downstream_output_bytes_for_task_locked(lease.lease_id)
+        return _resource_with_object_store(
+            lease.resources,
+            lease.resources.object_store_bytes + downstream_output + producer_output + output_estimate,
         )
 
     def _uncovered_inactive_output_bytes_locked(
         self,
         active_task_ids: set[str],
         *,
-        node_id: str | None = None,
         resource_unit_id: str | None = None,
     ) -> int:
-        if resource_unit_id is not None:
-            uncovered = sum(
-                output.size_bytes
-                for output in self._output_leases.values()
-                if output.producer_unit_id == resource_unit_id
-                and (
-                    output.continuation_credit_id is None
-                    or output.continuation_credit_id not in self._continuation_credits
-                )
-                and output.task_lease_id not in active_task_ids
-            )
-            return uncovered + self._continuation_output_excess_by_unit_locked().get(
-                resource_unit_id,
-                0,
-            )
-        uncovered = 0
-        outputs_by_idle_credit: dict[str, int] = {}
-        for output in self._output_leases.values():
-            if node_id is not None and output.node_id != node_id:
-                continue
-            credit_id = output.continuation_credit_id
-            credit = self._continuation_credits.get(credit_id or "")
-            if credit is not None:
-                borrower = credit.borrowed_by_task_lease_id
-                if borrower is not None and borrower in self._task_leases:
-                    # The active borrower's task usage accounts the aggregate
-                    # output bytes for this credit, including prior borrowers.
-                    continue
-                outputs_by_idle_credit[credit.credit_id] = (
-                    outputs_by_idle_credit.get(credit.credit_id, 0) + output.size_bytes
-                )
-                continue
-            if output.task_lease_id not in active_task_ids:
-                uncovered += output.size_bytes
-        for credit_id, output_bytes in outputs_by_idle_credit.items():
-            credit = self._continuation_credits.get(credit_id)
-            if credit is None:
-                uncovered += output_bytes
-            else:
-                uncovered += max(0, output_bytes - credit.resources.object_store_bytes)
-        return uncovered
-
-    def _continuation_output_excess_by_unit_locked(self) -> dict[str, int]:
-        outputs_by_credit_and_unit: dict[str, dict[str, int]] = {}
-        for output in self._output_leases.values():
-            credit_id = output.continuation_credit_id
-            if credit_id is None or credit_id not in self._continuation_credits:
-                continue
-            credit = self._continuation_credits[credit_id]
-            borrower = credit.borrowed_by_task_lease_id
-            if borrower is not None and borrower in self._task_leases:
-                # Active borrower usage owns retained input plus aggregate
-                # outputs. Attribute that exact delta to the borrower unit;
-                # only idle-credit overflow needs cross-unit distribution.
-                continue
-            by_unit = outputs_by_credit_and_unit.setdefault(credit_id, {})
-            by_unit[output.producer_unit_id] = by_unit.get(output.producer_unit_id, 0) + output.size_bytes
-
-        topological_rank = {
-            resource_unit_id: index for index, resource_unit_id in enumerate(self._topological_unit_ids)
-        }
-        excess_by_unit: dict[str, int] = {}
-        for credit_id, bytes_by_unit in outputs_by_credit_and_unit.items():
-            credit = self._continuation_credits[credit_id]
-            remaining_covered = int(credit.resources.object_store_bytes)
-            for resource_unit_id in sorted(
-                bytes_by_unit,
-                key=lambda key: (topological_rank.get(key, len(topological_rank)), key),
-            ):
-                output_bytes = bytes_by_unit[resource_unit_id]
-                covered = min(output_bytes, remaining_covered)
-                remaining_covered -= covered
-                excess = output_bytes - covered
-                if excess > 0:
-                    excess_by_unit[resource_unit_id] = excess_by_unit.get(resource_unit_id, 0) + excess
-        return excess_by_unit
+        return sum(
+            output.size_bytes
+            for output in self._output_leases.values()
+            if output.task_lease_id not in active_task_ids
+            and (resource_unit_id is None or output.producer_unit_id == resource_unit_id)
+        )
 
     def _query_usage_locked(
         self,
         *,
         excluded_waiting_block_id: str | None = None,
     ) -> ResourceVector:
-        # Invocation resources remain separate from fixed actor processes.
-        # Existing actor invocations have zero incremental CPU/GPU/heap, while
-        # submitted actor handles are charged by _soft_allocation_usage_locked.
         total = ResourceVector()
         active_task_ids = set(self._task_leases)
-        for credit in self._continuation_credits.values():
-            total = total + credit.resources
         for lease in self._task_leases.values():
             total = total + self._task_usage_locked(
                 lease,
                 excluded_waiting_block_id=excluded_waiting_block_id,
             )
-        total = total + ResourceVector(object_store_bytes=self._uncovered_inactive_output_bytes_locked(active_task_ids))
-        return total
+        return total + ResourceVector(object_store_bytes=self._uncovered_inactive_output_bytes_locked(active_task_ids))
 
     def _soft_allocation_usage_locked(self) -> ResourceVector:
         return self._query_usage_locked() + self._actor_resident_usage_locked()
@@ -3471,43 +2197,6 @@ class RayQueryResourceManager:
             self.allocation.resources.to_dict(),
         )
 
-    def _node_usage_locked(self, node_id: str) -> ResourceVector:
-        node_key = str(node_id)
-        total = ResourceVector()
-        active_task_ids: set[str] = set()
-        for credit in self._continuation_credits.values():
-            if credit.node_id == node_key:
-                total = total + credit.resources
-        for lease in self._task_leases.values():
-            if lease.node_id != node_key:
-                continue
-            active_task_ids.add(lease.lease_id)
-            total = total + self._task_usage_locked(lease)
-        total = total + ResourceVector(
-            object_store_bytes=self._uncovered_inactive_output_bytes_locked(
-                active_task_ids,
-                node_id=node_key,
-            )
-        )
-        return total
-
-    def _node_hard_scheduling_usage_locked(self, node_id: str) -> ResourceVector:
-        """Return known physical process usage that competes on one node.
-
-        Submitted actors without a READY location can only be charged to the
-        query-wide soft allocation. Once Ray reports a concrete node, their
-        resident CPU/GPU/heap must also constrain node-affine task placement;
-        otherwise a task can be pinned behind its own actor while another
-        allocated node remains idle.
-        """
-
-        return _hard_resources(
-            self._node_usage_locked(node_id)
-            + self._actor_resident_usage_locked(
-                node_id=str(node_id),
-            )
-        )
-
     def _unit_usage_locked(
         self,
         resource_unit_id: str,
@@ -3516,9 +2205,6 @@ class RayQueryResourceManager:
     ) -> ResourceVector:
         total = ResourceVector()
         active_task_ids: set[str] = set()
-        for credit in self._continuation_credits.values():
-            if credit.reservation_unit_id == resource_unit_id:
-                total = total + credit.resources
         for lease in self._task_leases.values():
             if lease.resource_unit_id != resource_unit_id:
                 continue
@@ -3576,26 +2262,6 @@ class RayQueryResourceManager:
             eligible_unit_ids = self._eligible_resource_unit_ids_locked()
             object_store_unlimited_unit_ids = self._materializing_object_store_unlimited_unit_ids_locked()
             preferred_task, grant_class = self._preferred_waiting_task_locked()
-            allocation_by_node = {item.node_id: item.resources for item in self.allocation.node_allocations}
-            reservation_source_unit_ids = {lease.resource_unit_id for lease in self._task_leases.values()} | {
-                str(request.resource_unit_id) for request, _ in self._waiting_task_inputs.values()
-            }
-            downstream_reservations: dict[str, tuple[_DownstreamReservation, ...]] = {}
-            for resource_unit_id in self._topological_unit_ids:
-                unit = self._units[resource_unit_id]
-                if resource_unit_id not in reservation_source_unit_ids or unit.completed:
-                    continue
-                reservations = self._downstream_reservations_locked(unit.spec)
-                if reservations:
-                    downstream_reservations[resource_unit_id] = reservations
-            node_ids = sorted(
-                set(allocation_by_node)
-                | {lease.node_id for lease in self._task_leases.values()}
-                | {lease.node_id for lease in self._output_leases.values()}
-                | {credit.node_id for credit in self._continuation_credits.values()}
-                | set(self._actor_node_by_slot.values())
-            )
-            node_usage = {node_id: self._node_usage_locked(node_id) for node_id in node_ids}
             actor_resident_usage_by_node = {
                 node_id: self._actor_resident_usage_locked(node_id=node_id)
                 for node_id in sorted(set(self._actor_node_by_slot.values()))
@@ -3606,6 +2272,7 @@ class RayQueryResourceManager:
                 "query_id": self.graph.query_id,
                 "graph": self.graph.to_dict(),
                 "allocation": self.allocation.to_dict(),
+                "ray_core_owns_placement": True,
                 "usage": usage.to_dict(),
                 "soft_allocation_usage": soft_allocation_usage.to_dict(),
                 "actor_process_usage": self._actor_resident_usage_locked().to_dict(),
@@ -3625,10 +2292,6 @@ class RayQueryResourceManager:
                     for (resource_unit_id, actor_index), node_id in sorted(self._actor_node_by_slot.items())
                 },
                 "retiring_actor_unit_ids": sorted(self._retiring_actor_unit_ids),
-                "allocation_debt": _hard_positive_difference(
-                    usage,
-                    self.allocation.resources,
-                ).to_dict(),
                 "soft_allocation_debt": soft_allocation_debt.to_dict(),
                 "soft_allocation_debt_duration_s": (
                     0.0
@@ -3638,30 +2301,10 @@ class RayQueryResourceManager:
                 "soft_allocation_warning_emitted": self._soft_allocation_warning_emitted,
                 "soft_object_store_debt_bytes": max(
                     0,
-                    usage.object_store_bytes - self.allocation.resources.object_store_bytes,
+                    soft_allocation_usage.object_store_bytes - self.allocation.resources.object_store_bytes,
                 ),
                 "allocation_admission_open": self._allocation_admission_open,
-                "allocation_debt_neutral_only": self._allocation_debt_neutral_only,
                 "admission_epoch": int(self._admission_epoch),
-                "node_usage": {node_id: resources.to_dict() for node_id, resources in node_usage.items()},
-                "node_allocation_debt": {
-                    node_id: _hard_positive_difference(
-                        resources,
-                        allocation_by_node.get(node_id, ResourceVector()),
-                    ).to_dict()
-                    for node_id, resources in node_usage.items()
-                },
-                "node_soft_object_store_debt_bytes": {
-                    node_id: max(
-                        0,
-                        resources.object_store_bytes
-                        - allocation_by_node.get(
-                            node_id,
-                            ResourceVector(),
-                        ).object_store_bytes,
-                    )
-                    for node_id, resources in node_usage.items()
-                },
                 "reservation_ratio": self.reservation_ratio,
                 "execution_phase": {
                     "frontier_barrier_ids": [barrier.barrier_id for barrier in frontier_barriers],
@@ -3699,27 +2342,6 @@ class RayQueryResourceManager:
                         }
                         for request, _ in self._waiting_task_inputs.values()
                     ],
-                    "live_demand_unit_ids": {
-                        field_name: list(
-                            self._dimension_live_demand_unit_ids_locked(
-                                field_name,
-                                requested_unit_id=None,
-                            )
-                        )
-                        for field_name in _RESOURCE_FIELDS
-                    },
-                    "continuation_unit_ids": {
-                        field_name: list(
-                            self._dimension_continuation_unit_ids_locked(
-                                field_name,
-                                live_unit_ids=self._dimension_live_demand_unit_ids_locked(
-                                    field_name,
-                                    requested_unit_id=None,
-                                ),
-                            )
-                        )
-                        for field_name in _RESOURCE_FIELDS
-                    },
                     "reservation_unit_ids": {
                         field_name: list(
                             self._dimension_reservation_unit_ids_locked(
@@ -3728,18 +2350,6 @@ class RayQueryResourceManager:
                             )
                         )
                         for field_name in _RESOURCE_FIELDS
-                    },
-                    "downstream_reservations": {
-                        resource_unit_id: [
-                            {
-                                "reservation_id": reservation.reservation_id,
-                                "unit_ids": list(reservation.unit_ids),
-                                "resources": reservation.resources.to_dict(),
-                                "allowed_node_ids": list(reservation.allowed_node_ids),
-                            }
-                            for reservation in reservations
-                        ]
-                        for resource_unit_id, reservations in downstream_reservations.items()
                     },
                 },
                 "units": {
@@ -3790,13 +2400,6 @@ class RayQueryResourceManager:
                 "queued_actor_slots": {
                     f"{resource_unit_id}:{actor_index}": list(lease_ids)
                     for (resource_unit_id, actor_index), lease_ids in self._queued_actor_slot_leases.items()
-                },
-                "continuation_credits": {
-                    credit_id: {
-                        **asdict(credit),
-                        "resources": credit.resources.to_dict(),
-                    }
-                    for credit_id, credit in self._continuation_credits.items()
                 },
                 "output_leases": {lease_id: asdict(lease) for lease_id, lease in self._output_leases.items()},
             }

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -7,15 +7,15 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
-from duckdb.runners.ray.query_execution_graph import QueryAllocation, QueryExecutionGraph
+from duckdb.runners.ray.query_resource_graph import QueryAllocation, QueryResourceGraph
 from duckdb.runners.ray.query_resource_manager import QueryResourceManager
 
 _LOCK = threading.RLock()
 _MANAGERS: dict[str, QueryResourceManager] = {}
 
 
-def register_query_graph(
-    graph: QueryExecutionGraph,
+def register_query_resource_graph(
+    graph: QueryResourceGraph,
     allocation: QueryAllocation,
     *,
     reservation_ratio: float = 0.5,
@@ -33,7 +33,7 @@ def register_query_graph(
     query_id = graph.query_id
     with _LOCK:
         if query_id in _MANAGERS:
-            raise ValueError(f"query graph is already registered: {query_id}")
+            raise ValueError(f"query resource graph is already registered: {query_id}")
         _MANAGERS[query_id] = manager
     return manager
 
@@ -45,7 +45,7 @@ def get_query_resource_manager(query_id: str) -> QueryResourceManager:
     with _LOCK:
         manager = _MANAGERS.get(query_key)
     if manager is None:
-        raise KeyError(f"query graph is not registered: {query_key}")
+        raise KeyError(f"query resource graph is not registered: {query_key}")
     return manager
 
 
@@ -85,6 +85,6 @@ __all__ = [
     "clear_query_resource_managers",
     "get_query_resource_manager",
     "query_resource_manager_snapshot",
-    "register_query_graph",
+    "register_query_resource_graph",
     "release_query_resource_manager",
 ]

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -19,6 +19,7 @@ def register_query_resource_graph(
     allocation: QueryAllocation,
     *,
     admission_open: bool = True,
+    debt_neutral_only: bool = False,
     reservation_ratio: float = 0.5,
     on_change: Callable[[], None] | None = None,
     on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
@@ -28,14 +29,17 @@ def register_query_resource_graph(
     # Fixed Ray actor pools are submitted to Ray Core and may remain pending;
     # their process resources are soft phase usage, not placement admission.
     # Ray tasks still require one concrete runnable bundle in the allocation.
+    if debt_neutral_only and not admission_open:
+        raise ValueError("debt-neutral admission requires admission_open")
     graph.validate_allocation(
         allocation,
-        eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open else ()),
+        eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open and not debt_neutral_only else ()),
     )
     manager = RayQueryResourceManager(
         graph,
         allocation,
         admission_open=admission_open,
+        debt_neutral_only=debt_neutral_only,
         reservation_ratio=reservation_ratio,
         on_change=on_change,
         on_eligible_units_change=on_eligible_units_change,

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -18,17 +18,27 @@ def register_query_resource_graph(
     graph: QueryResourceGraph,
     allocation: QueryAllocation,
     *,
+    admission_open: bool = True,
     reservation_ratio: float = 0.5,
     on_change: Callable[[], None] | None = None,
+    on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
 ) -> RayQueryResourceManager:
     """Validate and atomically publish the only resource manager for a query."""
 
-    graph.validate_allocation(allocation)
+    # Fixed Ray actor pools are submitted to Ray Core and may remain pending;
+    # their process resources are soft phase usage, not placement admission.
+    # Ray tasks still require one concrete runnable bundle in the allocation.
+    graph.validate_allocation(
+        allocation,
+        eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open else ()),
+    )
     manager = RayQueryResourceManager(
         graph,
         allocation,
+        admission_open=admission_open,
         reservation_ratio=reservation_ratio,
         on_change=on_change,
+        on_eligible_units_change=on_eligible_units_change,
     )
     query_id = graph.query_id
     with _LOCK:
@@ -58,6 +68,16 @@ def query_resource_manager_snapshot(query_id: str) -> dict[str, Any]:
     return {} if manager is None else manager.snapshot()
 
 
+def mark_materialization_barrier_completed(query_id: str, physical_node_id: str) -> bool:
+    """Advance one driver-local query phase from a native barrier event."""
+
+    query_key = str(query_id or "").strip()
+    node_key = str(physical_node_id or "").strip()
+    if not query_key or not node_key:
+        raise ValueError("materialization barrier completion requires query_id and physical_node_id")
+    return get_query_resource_manager(query_key).mark_materialization_barrier_completed_for_node(node_key)
+
+
 def release_query_resource_manager(query_id: str, *, reason: str) -> dict[str, Any]:
     query_key = str(query_id or "").strip()
     if not query_key:
@@ -84,6 +104,7 @@ def clear_query_resource_managers() -> None:
 __all__ = [
     "clear_query_resource_managers",
     "get_query_resource_manager",
+    "mark_materialization_barrier_completed",
     "query_resource_manager_snapshot",
     "register_query_resource_graph",
     "release_query_resource_manager",

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -8,10 +8,10 @@ from collections.abc import Callable
 from typing import Any
 
 from duckdb.runners.ray.query_resource_graph import QueryAllocation, QueryResourceGraph
-from duckdb.runners.ray.query_resource_manager import QueryResourceManager
+from duckdb.runners.ray.query_resource_manager import RayQueryResourceManager
 
 _LOCK = threading.RLock()
-_MANAGERS: dict[str, QueryResourceManager] = {}
+_MANAGERS: dict[str, RayQueryResourceManager] = {}
 
 
 def register_query_resource_graph(
@@ -20,11 +20,11 @@ def register_query_resource_graph(
     *,
     reservation_ratio: float = 0.5,
     on_change: Callable[[], None] | None = None,
-) -> QueryResourceManager:
+) -> RayQueryResourceManager:
     """Validate and atomically publish the only resource manager for a query."""
 
     graph.validate_allocation(allocation)
-    manager = QueryResourceManager(
+    manager = RayQueryResourceManager(
         graph,
         allocation,
         reservation_ratio=reservation_ratio,
@@ -38,7 +38,7 @@ def register_query_resource_graph(
     return manager
 
 
-def get_query_resource_manager(query_id: str) -> QueryResourceManager:
+def get_query_resource_manager(query_id: str) -> RayQueryResourceManager:
     query_key = str(query_id or "").strip()
     if not query_key:
         raise ValueError("query_id must be non-empty")

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -26,9 +26,10 @@ def register_query_resource_graph(
 ) -> RayQueryResourceManager:
     """Validate and atomically publish the only resource manager for a query."""
 
-    # Fixed Ray actor pools are submitted to Ray Core and may remain pending;
-    # their process resources are soft phase usage, not placement admission.
-    # Ray tasks still require one concrete runnable bundle in the allocation.
+    # Registration proves that one concrete node can run every distinct Ray
+    # task/actor shape in the current phase. Fixed actor-pool multiplicity is
+    # still elastic: all handles may be submitted to Ray Core and remain
+    # pending, while their process resources are charged as soft phase usage.
     if debt_neutral_only and not admission_open:
         raise ValueError("debt-neutral admission requires admission_open")
     graph.validate_allocation(

--- a/duckdb/runners/ray/query_resource_runtime.py
+++ b/duckdb/runners/ray/query_resource_runtime.py
@@ -19,28 +19,16 @@ def register_query_resource_graph(
     allocation: QueryAllocation,
     *,
     admission_open: bool = True,
-    debt_neutral_only: bool = False,
     reservation_ratio: float = 0.5,
     on_change: Callable[[], None] | None = None,
     on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
 ) -> RayQueryResourceManager:
-    """Validate and atomically publish the only resource manager for a query."""
+    """Atomically publish the driver-local resource manager for a query."""
 
-    # Registration proves that one concrete node can run every distinct Ray
-    # task/actor shape in the current phase. Fixed actor-pool multiplicity is
-    # still elastic: all handles may be submitted to Ray Core and remain
-    # pending, while their process resources are charged as soft phase usage.
-    if debt_neutral_only and not admission_open:
-        raise ValueError("debt-neutral admission requires admission_open")
-    graph.validate_allocation(
-        allocation,
-        eligible_unit_ids=(graph.eligible_resource_unit_ids(set()) if admission_open and not debt_neutral_only else ()),
-    )
     manager = RayQueryResourceManager(
         graph,
         allocation,
         admission_open=admission_open,
-        debt_neutral_only=debt_neutral_only,
         reservation_ratio=reservation_ratio,
         on_change=on_change,
         on_eligible_units_change=on_eligible_units_change,

--- a/duckdb/runners/ray/query_runtime_protocol.py
+++ b/duckdb/runners/ray/query_runtime_protocol.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
+RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
+
+RAY_ACTOR_QUERY_ID_ENV = "VANE_INTERNAL_RAY_ACTOR_QUERY_ID"
+RAY_ACTOR_RESOURCE_UNIT_ID_ENV = "VANE_INTERNAL_RAY_ACTOR_RESOURCE_UNIT_ID"
+RAY_ACTOR_INDEX_ENV = "VANE_INTERNAL_RAY_ACTOR_INDEX"
+RAY_ACTOR_POOL_NONCE_ENV = "VANE_INTERNAL_RAY_ACTOR_POOL_NONCE"
+RAY_ACTOR_GENERATION_CAPABILITY_ENV = "VANE_INTERNAL_RAY_ACTOR_GENERATION_CAPABILITY"
+
+
+def ray_runtime_job_id(runtime_context: Any) -> str:
+    job_id_obj = runtime_context.get_job_id()
+    job_id_hex = getattr(job_id_obj, "hex", None)
+    job_id = str(job_id_hex() if callable(job_id_hex) else job_id_obj).strip()
+    if not job_id:
+        raise RuntimeError("Ray runtime context returned an empty job identity")
+    return job_id
+
+
+def query_runtime_actor_name(job_id: str) -> str:
+    job_key = str(job_id or "").strip()
+    if not job_key:
+        raise ValueError("Ray query runtime actor name requires a job identity")
+    return f"{RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX}{job_key}"
+
+
+__all__ = [
+    "RAY_ACTOR_GENERATION_CAPABILITY_ENV",
+    "RAY_ACTOR_INDEX_ENV",
+    "RAY_ACTOR_POOL_NONCE_ENV",
+    "RAY_ACTOR_QUERY_ID_ENV",
+    "RAY_ACTOR_RESOURCE_UNIT_ID_ENV",
+    "RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX",
+    "RAY_QUERY_RUNTIME_ACTOR_NAMESPACE",
+    "query_runtime_actor_name",
+    "ray_runtime_job_id",
+]

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -455,17 +455,20 @@ def _validate_fte_output_publication(
     partition_metadatas: list[PartitionMetadata],
     query_task_lease: dict[str, Any],
 ) -> tuple[int, ...]:
-    """Validate all FTE result bytes before the worker publishes any ObjectRef."""
+    """Validate FTE result metadata before the worker publishes ObjectRefs.
+
+    ``target_output_block_bytes`` and ``output_window_bytes`` are pending-output
+    estimates used by query admission. Native execution materializes its
+    result before its exact size is known, so either value may be exceeded (or
+    be zero for a sink). The manager replaces the estimate with these exact
+    bytes after publication and applies soft backpressure to subsequent work.
+    """
     lease_id = str(query_task_lease.get("lease_id") or "").strip()
     query_id = str(query_task_lease.get("query_id") or "").strip()
     resource_unit_id = str(query_task_lease.get("resource_unit_id") or "").strip()
     attempt_id = str(query_task_lease.get("attempt_id") or "").strip()
-    target_bytes = int(query_task_lease.get("target_output_block_bytes") or 0)
-    window_bytes = int(query_task_lease.get("output_window_bytes") or 0)
     if not lease_id or not query_id or not resource_unit_id or not attempt_id:
         raise RuntimeError("FTE output publication requires a complete query task lease identity")
-    if target_bytes <= 0 or window_bytes <= 0:
-        raise RuntimeError("FTE output publication requires positive target_output_block_bytes and output_window_bytes")
 
     normalized_sizes: list[int] = []
     for index, metadata in enumerate(partition_metadatas):
@@ -477,19 +480,7 @@ def _validate_fte_output_publication(
                 f"query={query_id} resource_unit={resource_unit_id} attempt={attempt_id}"
             )
         size_bytes = max(1, raw_size)
-        if size_bytes > target_bytes:
-            raise RuntimeError(
-                f"FTE output block {index} size {size_bytes} exceeds target {target_bytes}: "
-                f"query={query_id} resource_unit={resource_unit_id} task_lease={lease_id} attempt={attempt_id}"
-            )
         normalized_sizes.append(size_bytes)
-
-    total_bytes = sum(normalized_sizes)
-    if total_bytes > window_bytes:
-        raise RuntimeError(
-            f"FTE total output bytes {total_bytes} exceed task window {window_bytes}: "
-            f"query={query_id} resource_unit={resource_unit_id} task_lease={lease_id} attempt={attempt_id}"
-        )
     return tuple(normalized_sizes)
 
 

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -458,11 +458,11 @@ def _validate_fte_output_publication(
     """Validate all FTE result bytes before the worker publishes any ObjectRef."""
     lease_id = str(query_task_lease.get("lease_id") or "").strip()
     query_id = str(query_task_lease.get("query_id") or "").strip()
-    stage_id = str(query_task_lease.get("stage_id") or "").strip()
+    resource_unit_id = str(query_task_lease.get("resource_unit_id") or "").strip()
     attempt_id = str(query_task_lease.get("attempt_id") or "").strip()
     target_bytes = int(query_task_lease.get("target_output_block_bytes") or 0)
     window_bytes = int(query_task_lease.get("output_window_bytes") or 0)
-    if not lease_id or not query_id or not stage_id or not attempt_id:
+    if not lease_id or not query_id or not resource_unit_id or not attempt_id:
         raise RuntimeError("FTE output publication requires a complete query task lease identity")
     if target_bytes <= 0 or window_bytes <= 0:
         raise RuntimeError("FTE output publication requires positive target_output_block_bytes and output_window_bytes")
@@ -474,13 +474,13 @@ def _validate_fte_output_publication(
         if raw_size <= 0 and num_rows > 0:
             raise RuntimeError(
                 f"FTE output block {index} is missing positive size_bytes: "
-                f"query={query_id} stage={stage_id} attempt={attempt_id}"
+                f"query={query_id} resource_unit={resource_unit_id} attempt={attempt_id}"
             )
         size_bytes = max(1, raw_size)
         if size_bytes > target_bytes:
             raise RuntimeError(
                 f"FTE output block {index} size {size_bytes} exceeds target {target_bytes}: "
-                f"query={query_id} stage={stage_id} task_lease={lease_id} attempt={attempt_id}"
+                f"query={query_id} resource_unit={resource_unit_id} task_lease={lease_id} attempt={attempt_id}"
             )
         normalized_sizes.append(size_bytes)
 
@@ -488,7 +488,7 @@ def _validate_fte_output_publication(
     if total_bytes > window_bytes:
         raise RuntimeError(
             f"FTE total output bytes {total_bytes} exceed task window {window_bytes}: "
-            f"query={query_id} stage={stage_id} task_lease={lease_id} attempt={attempt_id}"
+            f"query={query_id} resource_unit={resource_unit_id} task_lease={lease_id} attempt={attempt_id}"
         )
     return tuple(normalized_sizes)
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -934,7 +934,7 @@ bool FlightExchange::CleanupAttemptStorage(const SinkAttemptMetadata &attempt_me
 	}
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = attempt_metadata.output_location;
+	cache_config.exchange_id = attempt_metadata.output_location;
 	cache_config.node_id = attempt_metadata.node_id;
 	cache_config.num_partitions = output_partition_count_;
 	cache_config.local_dirs = config_.local_dirs;
@@ -1028,7 +1028,7 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 		}
 		try {
 			ShuffleCacheConfig cache_config;
-			cache_config.shuffle_stage_id = attempt_metadata.output_location;
+			cache_config.exchange_id = attempt_metadata.output_location;
 			cache_config.node_id = attempt_metadata.node_id;
 			cache_config.num_partitions = output_partition_count_;
 			cache_config.local_dirs = config_.local_dirs;
@@ -1296,7 +1296,7 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 			return;
 		}
 		ShuffleCacheConfig cache_config;
-		cache_config.shuffle_stage_id = output_location;
+		cache_config.exchange_id = output_location;
 		cache_config.node_id = source_node_id;
 		cache_config.num_partitions = std::max<idx_t>(partition_id + 1, 1);
 		cache_config.local_dirs = config_.local_dirs;
@@ -1627,7 +1627,7 @@ std::unique_ptr<ExchangeSink> FlightExchangeManager::CreateSink(const ExchangeSi
 	RefreshRuntimeNodeId();
 	// Create a ShuffleCache for this sink instance
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = handle.output_location;
+	cache_config.exchange_id = handle.output_location;
 	cache_config.node_id = config_.node_id;
 	cache_config.num_partitions = handle.output_partition_count;
 	cache_config.local_dirs = config_.local_dirs;

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -755,19 +755,19 @@ DuckDBResult<void> ShuffleCache::EnsurePartitionDirectory(idx_t partition_idx) c
 
 std::string ShuffleCache::NodeDirectory() const {
 	auto base_dir = config_.local_dirs.empty() ? std::string() : config_.local_dirs[0];
-	auto stage = ShuffleCacheSanitizePathComponent(config_.shuffle_stage_id);
+	auto exchange = ShuffleCacheSanitizePathComponent(config_.exchange_id);
 	auto node = ShuffleCacheSanitizePathComponent(config_.node_id);
 	std::ostringstream ss;
-	ss << base_dir << "/shuffle_" << stage << "/node_" << node;
+	ss << base_dir << "/shuffle_" << exchange << "/node_" << node;
 	return ss.str();
 }
 
 std::string ShuffleCache::PartitionDirectory(idx_t partition_idx) const {
 	auto base_dir = config_.local_dirs[partition_idx % config_.local_dirs.size()];
-	auto stage = ShuffleCacheSanitizePathComponent(config_.shuffle_stage_id);
+	auto exchange = ShuffleCacheSanitizePathComponent(config_.exchange_id);
 	auto node = ShuffleCacheSanitizePathComponent(config_.node_id);
 	std::ostringstream ss;
-	ss << base_dir << "/shuffle_" << stage << "/node_" << node << "/partition_" << partition_idx;
+	ss << base_dir << "/shuffle_" << exchange << "/node_" << node << "/partition_" << partition_idx;
 	return ss.str();
 }
 
@@ -809,7 +809,7 @@ DuckDBResult<void> ShuffleCache::WriteAttemptManifest(idx_t sink_partition_id, i
 	auto manifest_path = ManifestFilePath();
 	std::ostringstream manifest;
 	manifest << "version=1\n";
-	manifest << "shuffle_stage_id=" << config_.shuffle_stage_id << "\n";
+	manifest << "exchange_id=" << config_.exchange_id << "\n";
 	manifest << "node_id=" << config_.node_id << "\n";
 	manifest << "sink_partition_id=" << sink_partition_id << "\n";
 	manifest << "attempt_id=" << attempt_id << "\n";
@@ -866,7 +866,7 @@ DuckDBResult<ShuffleAttemptManifest> ShuffleCache::ReadAttemptManifest(const Shu
 
 	ShuffleAttemptManifest manifest;
 	bool seen_version = false;
-	bool seen_shuffle_stage_id = false;
+	bool seen_exchange_id = false;
 	bool seen_node_id = false;
 	bool seen_sink_partition_id = false;
 	bool seen_attempt_id = false;
@@ -940,16 +940,16 @@ DuckDBResult<ShuffleAttemptManifest> ShuffleCache::ReadAttemptManifest(const Shu
 				return DuckDBResult<ShuffleAttemptManifest>::err(
 				    DuckDBError::value_error("unsupported shuffle attempt manifest version: " + value));
 			}
-		} else if (key == "shuffle_stage_id") {
-			auto dup_res = CheckDuplicateManifestField(seen_shuffle_stage_id, key);
+		} else if (key == "exchange_id") {
+			auto dup_res = CheckDuplicateManifestField(seen_exchange_id, key);
 			if (dup_res.is_err()) {
 				return DuckDBResult<ShuffleAttemptManifest>::err(dup_res.error());
 			}
 			if (value.empty()) {
 				return DuckDBResult<ShuffleAttemptManifest>::err(
-				    DuckDBError::value_error("shuffle attempt manifest empty shuffle_stage_id"));
+				    DuckDBError::value_error("shuffle attempt manifest empty exchange_id"));
 			}
-			manifest.shuffle_stage_id = std::move(value);
+			manifest.exchange_id = std::move(value);
 		} else if (key == "node_id") {
 			auto dup_res = CheckDuplicateManifestField(seen_node_id, key);
 			if (dup_res.is_err()) {
@@ -995,7 +995,7 @@ DuckDBResult<ShuffleAttemptManifest> ShuffleCache::ReadAttemptManifest(const Shu
 		return DuckDBResult<ShuffleAttemptManifest>::err(
 		    DuckDBError::io_error("failed to read shuffle attempt manifest: " + manifest_path));
 	}
-	if (!seen_version || !seen_shuffle_stage_id || !seen_node_id || !seen_sink_partition_id || !seen_attempt_id ||
+	if (!seen_version || !seen_exchange_id || !seen_node_id || !seen_sink_partition_id || !seen_attempt_id ||
 	    !seen_output_partition_count) {
 		return DuckDBResult<ShuffleAttemptManifest>::err(
 		    DuckDBError::value_error("shuffle attempt manifest missing required field: " + manifest_path));
@@ -1054,9 +1054,9 @@ DuckDBResult<ShufflePartitionFiles> ShuffleCache::GetPartitionFilesFromManifest(
 		return DuckDBResult<ShufflePartitionFiles>::err(manifest_res.error());
 	}
 	auto manifest = std::move(manifest_res.value());
-	if (manifest.shuffle_stage_id != config_.shuffle_stage_id) {
+	if (manifest.exchange_id != config_.exchange_id) {
 		return DuckDBResult<ShufflePartitionFiles>::err(
-		    DuckDBError::value_error("shuffle attempt manifest stage id mismatch"));
+		    DuckDBError::value_error("shuffle attempt manifest exchange id mismatch"));
 	}
 	if (!config_.node_id.empty() && manifest.node_id != config_.node_id) {
 		return DuckDBResult<ShufflePartitionFiles>::err(
@@ -1070,8 +1070,8 @@ DuckDBResult<idx_t> ShuffleCache::RemoveAttemptStorage() const {
 }
 
 DuckDBResult<idx_t> RemoveShuffleAttemptStorage(const ShuffleCacheConfig &config, const ShuffleStorage &storage) {
-	if (config.shuffle_stage_id.empty()) {
-		return DuckDBResult<idx_t>::err(DuckDBError::value_error("shuffle cache stage id is empty"));
+	if (config.exchange_id.empty()) {
+		return DuckDBResult<idx_t>::err(DuckDBError::value_error("shuffle cache exchange id is empty"));
 	}
 	if (config.node_id.empty()) {
 		return DuckDBResult<idx_t>::err(DuckDBError::value_error("shuffle cache node id is empty"));
@@ -1080,7 +1080,7 @@ DuckDBResult<idx_t> RemoveShuffleAttemptStorage(const ShuffleCacheConfig &config
 		return DuckDBResult<idx_t>::ok(0);
 	}
 
-	auto stage = ShuffleCacheSanitizePathComponent(config.shuffle_stage_id);
+	auto exchange = ShuffleCacheSanitizePathComponent(config.exchange_id);
 	auto node = ShuffleCacheSanitizePathComponent(config.node_id);
 	std::unordered_set<std::string> seen_attempt_dirs;
 	idx_t removed_total = 0;
@@ -1089,7 +1089,7 @@ DuckDBResult<idx_t> RemoveShuffleAttemptStorage(const ShuffleCacheConfig &config
 			continue;
 		}
 		std::ostringstream ss;
-		ss << base_dir << "/shuffle_" << stage << "/node_" << node;
+		ss << base_dir << "/shuffle_" << exchange << "/node_" << node;
 		auto attempt_dir = ss.str();
 		if (!seen_attempt_dirs.insert(attempt_dir).second) {
 			continue;

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
@@ -113,6 +113,10 @@ std::vector<PipelineNodeRef> BroadcastJoinNode::children() const {
 	return result;
 }
 
+std::vector<NodeID> BroadcastJoinNode::materialized_input_node_ids() const {
+	return broadcaster_ ? std::vector<NodeID> {broadcaster_->node_id()} : std::vector<NodeID> {};
+}
+
 std::vector<std::string> BroadcastJoinNode::multiline_display(bool /*verbose*/) const {
 	std::vector<std::string> res;
 	res.push_back("Broadcast Join");
@@ -433,6 +437,13 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		exchange->AllRequiredSinksFinished();
 		auto broadcast_handles = exchange->GetSourceHandles();
 		auto source_nodes = CollectSourceNodes(broadcast_handles);
+		auto barrier_result = fte_task_submitter->materialization_barrier_completed(self_shared->context().query_id(),
+		                                                                            self_shared->node_id());
+		if (barrier_result.is_err()) {
+			result_tx_ptr->close();
+			exchange->Close();
+			return DuckDBResult<void>::err(barrier_result.error());
+		}
 
 		while (true) {
 			auto receiver_task = BroadcastJoinNode::PollNextWithWait(*receiver_ptr);

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
@@ -433,6 +433,13 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		exchange->AllRequiredSinksFinished();
 		auto broadcast_handles = exchange->GetSourceHandles();
 		auto source_nodes = CollectSourceNodes(broadcast_handles);
+		auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
+		                                                                        self_shared->node_id());
+		if (phase_res.is_err()) {
+			result_tx_ptr->close();
+			exchange->Close();
+			return DuckDBResult<void>::err(phase_res.error());
+		}
 
 		while (true) {
 			auto receiver_task = BroadcastJoinNode::PollNextWithWait(*receiver_ptr);

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
@@ -57,7 +57,7 @@ void ValidateBroadcastJoinSide(JoinType join_type, BroadcastJoinSide broadcast_s
 }
 
 namespace {
-std::string MakeBroadcastShuffleStageId(const PipelineNodeContext &context) {
+std::string MakeBroadcastExchangeId(const PipelineNodeContext &context) {
 	std::string prefix = context.query_id().empty() ? std::string("query") : context.query_id();
 	return prefix + "_broadcast_shuffle_" + std::to_string(context.node_id());
 }
@@ -291,7 +291,7 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		    "BroadcastJoinNode now requires flight_shuffle exchange algorithm. Legacy in-memory path is removed.");
 	}
 
-	auto shuffle_stage_id = MakeBroadcastShuffleStageId(context_);
+	auto exchange_id = MakeBroadcastExchangeId(context_);
 	auto num_partitions = static_cast<idx_t>(1);
 
 	static auto broadcast_exchange_impl = [](std::shared_ptr<PipelineNodeImpl> self_shared_impl,
@@ -299,7 +299,7 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 	                                         std::shared_ptr<SubmittableTaskStream<WorkerTask>> receiver_ptr,
 	                                         std::shared_ptr<Sender<SubmittableTask<WorkerTask>>> result_tx_ptr,
 	                                         std::shared_ptr<FteTaskSubmitter> fte_task_submitter,
-	                                         std::string shuffle_stage_id, idx_t num_partitions,
+	                                         std::string exchange_id, idx_t num_partitions,
 	                                         ::duckdb::ClientContext *client_context,
 	                                         std::shared_ptr<ExchangeManager> exchange_mgr) -> DuckDBResult<void> {
 		auto self_shared = std::static_pointer_cast<BroadcastJoinNode>(self_shared_impl);
@@ -327,7 +327,7 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		// Create Exchange coordinator via ExchangeManager SPI (1 partition = broadcast)
 		ExchangeContext exchange_ctx;
 		exchange_ctx.query_id = self_shared->context().query_id();
-		exchange_ctx.exchange_id = shuffle_stage_id;
+		exchange_ctx.exchange_id = exchange_id;
 		exchange_mgr->SetContext(client_context);
 		auto exchange = std::shared_ptr<Exchange>(exchange_mgr->CreateExchange(exchange_ctx, num_partitions).release());
 
@@ -335,13 +335,13 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		auto sink_task_counter = std::make_shared<std::atomic<idx_t>>(0);
 
 		// Build sink plan builder using AddRemoteExchangeSinkPlan (shared with repartition)
-		auto plan_builder = [shuffle_stage_id, num_partitions, exchange, exchange_mgr,
+		auto plan_builder = [exchange_id, num_partitions, exchange, exchange_mgr,
 		                     sink_task_counter](DuckPhysicalPlanRef plan) {
 			auto repartition_spec = RepartitionSpec::create_into_partitions(num_partitions);
 			auto task_partition_id = sink_task_counter->fetch_add(1);
 			auto sink_handle_obj = exchange->AddSink(task_partition_id);
 			auto sink_instance = exchange->InstantiateSink(sink_handle_obj, /*attempt_id=*/0);
-			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, num_partitions, shuffle_stage_id,
+			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, num_partitions, exchange_id,
 			                                 sink_instance, exchange_mgr);
 		};
 		auto node_ref = std::static_pointer_cast<PipelineNodeImpl>(self_shared);
@@ -433,13 +433,6 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		exchange->AllRequiredSinksFinished();
 		auto broadcast_handles = exchange->GetSourceHandles();
 		auto source_nodes = CollectSourceNodes(broadcast_handles);
-		auto barrier_result = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
-		                                                                             self_shared->node_id());
-		if (barrier_result.is_err()) {
-			result_tx_ptr->close();
-			exchange->Close();
-			return DuckDBResult<void>::err(barrier_result.error());
-		}
 
 		while (true) {
 			auto receiver_task = BroadcastJoinNode::PollNextWithWait(*receiver_ptr);
@@ -454,8 +447,8 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 			source_task.source_task_count = 1;
 			source_task.replicated = true;
 			auto broadcast_plan =
-			    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, shuffle_stage_id, {}, {},
-			                                 exchange_mgr, source_nodes, optional_idx(self_shared->node_id()));
+			    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, exchange_id, {}, {}, exchange_mgr,
+			                                 source_nodes, optional_idx(self_shared->node_id()));
 			if (!broadcast_plan || !broadcast_plan->HasRoot()) {
 				result_tx_ptr->close();
 				exchange->Close();
@@ -480,10 +473,10 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 	};
 
 	auto exchange_mgr_copy = exchange_mgr_;
-	plan_context.spawn([self_shared, broadcaster_ptr, receiver_ptr, result_tx_ptr, fte_task_submitter, shuffle_stage_id,
+	plan_context.spawn([self_shared, broadcaster_ptr, receiver_ptr, result_tx_ptr, fte_task_submitter, exchange_id,
 	                    num_partitions, client_context, exchange_mgr_copy]() mutable -> DuckDBResult<void> {
 		return broadcast_exchange_impl(self_shared, broadcaster_ptr, receiver_ptr, result_tx_ptr, fte_task_submitter,
-		                               shuffle_stage_id, num_partitions, client_context, exchange_mgr_copy);
+		                               exchange_id, num_partitions, client_context, exchange_mgr_copy);
 	});
 	return SubmittableTaskStream<WorkerTask>::from_receiver(std::move(result_rx));
 }

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
@@ -433,12 +433,12 @@ SubmittableTaskStream<WorkerTask> BroadcastJoinNode::produce_tasks(PlanExecution
 		exchange->AllRequiredSinksFinished();
 		auto broadcast_handles = exchange->GetSourceHandles();
 		auto source_nodes = CollectSourceNodes(broadcast_handles);
-		auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
-		                                                                        self_shared->node_id());
-		if (phase_res.is_err()) {
+		auto barrier_result = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
+		                                                                             self_shared->node_id());
+		if (barrier_result.is_err()) {
 			result_tx_ptr->close();
 			exchange->Close();
-			return DuckDBResult<void>::err(phase_res.error());
+			return DuckDBResult<void>::err(barrier_result.error());
 		}
 
 		while (true) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
@@ -131,7 +131,7 @@ SubmittableTaskStream<WorkerTask> LimitNode::produce_tasks(PlanExecutionContext 
 		return input_plan;
 	};
 
-	if (!ChildHasMultiplePartitions(child_)) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}
@@ -197,7 +197,7 @@ SubmittableTaskStream<WorkerTask> StreamingLimitNode::produce_tasks(PlanExecutio
 		return input_plan;
 	};
 
-	if (!ChildHasMultiplePartitions(child_)) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}
@@ -259,7 +259,7 @@ SubmittableTaskStream<WorkerTask> LimitPercentNode::produce_tasks(PlanExecutionC
 		return input_plan;
 	};
 
-	if (!ChildHasMultiplePartitions(child_)) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
@@ -33,6 +33,30 @@ BoundLimitNode CopyBoundLimitNode(const BoundLimitNode &node) {
 	return BoundLimitNode();
 }
 
+bool LimitNode::is_materialization_barrier() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+std::vector<NodeID> LimitNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
+bool StreamingLimitNode::is_materialization_barrier() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+std::vector<NodeID> StreamingLimitNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
+bool LimitPercentNode::is_materialization_barrier() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+std::vector<NodeID> LimitPercentNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
 namespace {
 using PlanBuilder = MaterializedPlanBuilder;
 using PerTaskBuilderFactory = PerTaskMaterializedPlanBuilderFactory;

--- a/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
@@ -33,6 +33,18 @@ BoundLimitNode CopyBoundLimitNode(const BoundLimitNode &node) {
 	return BoundLimitNode();
 }
 
+bool LimitNode::is_blocking_materializing() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+bool StreamingLimitNode::is_blocking_materializing() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+bool LimitPercentNode::is_blocking_materializing() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
 namespace {
 using PlanBuilder = MaterializedPlanBuilder;
 using PerTaskBuilderFactory = PerTaskMaterializedPlanBuilderFactory;

--- a/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/limit.cpp
@@ -33,18 +33,6 @@ BoundLimitNode CopyBoundLimitNode(const BoundLimitNode &node) {
 	return BoundLimitNode();
 }
 
-bool LimitNode::is_blocking_materializing() const {
-	return ChildHasMultiplePartitions(child_);
-}
-
-bool StreamingLimitNode::is_blocking_materializing() const {
-	return ChildHasMultiplePartitions(child_);
-}
-
-bool LimitPercentNode::is_blocking_materializing() const {
-	return ChildHasMultiplePartitions(child_);
-}
-
 namespace {
 using PlanBuilder = MaterializedPlanBuilder;
 using PerTaskBuilderFactory = PerTaskMaterializedPlanBuilderFactory;
@@ -131,7 +119,7 @@ SubmittableTaskStream<WorkerTask> LimitNode::produce_tasks(PlanExecutionContext 
 		return input_plan;
 	};
 
-	if (!is_blocking_materializing()) {
+	if (!ChildHasMultiplePartitions(child_)) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}
@@ -197,7 +185,7 @@ SubmittableTaskStream<WorkerTask> StreamingLimitNode::produce_tasks(PlanExecutio
 		return input_plan;
 	};
 
-	if (!is_blocking_materializing()) {
+	if (!ChildHasMultiplePartitions(child_)) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}
@@ -259,7 +247,7 @@ SubmittableTaskStream<WorkerTask> LimitPercentNode::produce_tasks(PlanExecutionC
 		return input_plan;
 	};
 
-	if (!is_blocking_materializing()) {
+	if (!ChildHasMultiplePartitions(child_)) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -134,6 +134,14 @@ DuckDBResult<void> RunMaterializedCoordinator(const std::shared_ptr<PipelineNode
 		return DuckDBResult<void>::err(DuckDBError::internal_error(ex.what()));
 	}
 
+	auto phase_res =
+	    fte_task_submitter->blocking_materialization_completed(node->context().query_id(), node->node_id());
+	if (phase_res.is_err()) {
+		result_tx->close();
+		exchange->Close();
+		return DuckDBResult<void>::err(phase_res.error());
+	}
+
 	auto source_handles = exchange->GetSourceHandles();
 	auto source_nodes = CollectCoordinatorSourceNodes(source_handles);
 	auto estimated_cardinality = EstimateRowsFromHandles(source_handles);

--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -79,6 +79,11 @@ DuckDBResult<void> RunMaterializedCoordinator(const std::shared_ptr<PipelineNode
 		return DuckDBResult<void>::err(
 		    DuckDBError::invalid_state_error("materialized coordinator requires an ExchangeManager"));
 	}
+	if (!node->is_materialization_barrier()) {
+		result_tx->close();
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+		    "materialized coordinator requires a node declared as a materialization barrier"));
+	}
 
 	auto types_res = ResolveSchemaTypes(materialized_schema ? materialized_schema : node->config().schema());
 	if (types_res.is_err()) {
@@ -133,6 +138,14 @@ DuckDBResult<void> RunMaterializedCoordinator(const std::shared_ptr<PipelineNode
 		result_tx->close();
 		exchange->Close();
 		return DuckDBResult<void>::err(DuckDBError::internal_error(ex.what()));
+	}
+
+	auto barrier_result =
+	    fte_task_submitter->materialization_barrier_completed(node->context().query_id(), node->node_id());
+	if (barrier_result.is_err()) {
+		result_tx->close();
+		exchange->Close();
+		return DuckDBResult<void>::err(barrier_result.error());
 	}
 
 	auto source_handles = exchange->GetSourceHandles();

--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "duckdb/execution/distributed/pipeline_node/materialized_coordinator.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/exchange/exchange.hpp"
 #include "duckdb/execution/distributed/exchange/exchange_manager.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
@@ -196,6 +197,13 @@ SubmittableTaskStream<WorkerTask> ProduceWithMaterializedCoordinator(
     PlanExecutionContext &plan_context, const PipelineNodeRef &child, const std::shared_ptr<PipelineNodeImpl> &node,
     MaterializedPlanBuilder final_plan_builder, PerTaskMaterializedPlanBuilderFactory per_task_builder_factory,
     std::shared_ptr<ExchangeManager> exchange_mgr, SchemaRef materialized_schema) {
+	if (!node) {
+		throw InternalException("Materialized coordinator requires a pipeline node");
+	}
+	if (!node->is_blocking_materializing()) {
+		throw InternalException("Materialized coordinator node %s must be marked as blocking materializing",
+		                        node->name());
+	}
 	auto input_stream = child->produce_tasks(plan_context);
 
 	auto channel_pair = create_channel<SubmittableTask<WorkerTask>>(1);

--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -135,12 +135,12 @@ DuckDBResult<void> RunMaterializedCoordinator(const std::shared_ptr<PipelineNode
 		return DuckDBResult<void>::err(DuckDBError::internal_error(ex.what()));
 	}
 
-	auto phase_res =
+	auto barrier_result =
 	    fte_task_submitter->blocking_materialization_completed(node->context().query_id(), node->node_id());
-	if (phase_res.is_err()) {
+	if (barrier_result.is_err()) {
 		result_tx->close();
 		exchange->Close();
-		return DuckDBResult<void>::err(phase_res.error());
+		return DuckDBResult<void>::err(barrier_result.error());
 	}
 
 	auto source_handles = exchange->GetSourceHandles();

--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -135,14 +135,6 @@ DuckDBResult<void> RunMaterializedCoordinator(const std::shared_ptr<PipelineNode
 		return DuckDBResult<void>::err(DuckDBError::internal_error(ex.what()));
 	}
 
-	auto barrier_result =
-	    fte_task_submitter->blocking_materialization_completed(node->context().query_id(), node->node_id());
-	if (barrier_result.is_err()) {
-		result_tx->close();
-		exchange->Close();
-		return DuckDBResult<void>::err(barrier_result.error());
-	}
-
 	auto source_handles = exchange->GetSourceHandles();
 	auto source_nodes = CollectCoordinatorSourceNodes(source_handles);
 	auto estimated_cardinality = EstimateRowsFromHandles(source_handles);
@@ -199,10 +191,6 @@ SubmittableTaskStream<WorkerTask> ProduceWithMaterializedCoordinator(
     std::shared_ptr<ExchangeManager> exchange_mgr, SchemaRef materialized_schema) {
 	if (!node) {
 		throw InternalException("Materialized coordinator requires a pipeline node");
-	}
-	if (!node->is_blocking_materializing()) {
-		throw InternalException("Materialized coordinator node %s must be marked as blocking materializing",
-		                        node->name());
 	}
 	auto input_stream = child->produce_tasks(plan_context);
 

--- a/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
@@ -40,6 +40,10 @@ std::vector<PipelineNodeRef> ReservoirSampleNode::children() const {
 	return {child_};
 }
 
+std::vector<NodeID> ReservoirSampleNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
 SubmittableTaskStream<WorkerTask> ReservoirSampleNode::produce_tasks(PlanExecutionContext &plan_context) {
 	auto options_template = std::shared_ptr<SampleOptions>(options_ ? options_->Copy().release() : nullptr);
 	auto output_types = std::make_shared<vector<LogicalType>>(output_types_.begin(), output_types_.end());

--- a/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
@@ -60,7 +60,7 @@ SubmittableTaskStream<WorkerTask> ReservoirSampleNode::produce_tasks(PlanExecuti
 		return input_plan;
 	};
 
-	if (!options_template || options_template->is_percentage) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), std::move(single_stage_builder),
 		                                         plan_context.client_context());

--- a/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sample.cpp
@@ -60,7 +60,7 @@ SubmittableTaskStream<WorkerTask> ReservoirSampleNode::produce_tasks(PlanExecuti
 		return input_plan;
 	};
 
-	if (!is_blocking_materializing()) {
+	if (!options_template || options_template->is_percentage) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), std::move(single_stage_builder),
 		                                         plan_context.client_context());

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -549,6 +549,15 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		auto finish_profile_start = std::chrono::steady_clock::now();
 		exchange->AllRequiredSinksFinished();
+		if (self_shared->is_materialization_barrier()) {
+			auto barrier_result = fte_task_submitter->materialization_barrier_completed(
+			    self_shared->context().query_id(), self_shared->node_id());
+			if (barrier_result.is_err()) {
+				result_tx_ptr->close();
+				exchange->Close();
+				return DuckDBResult<void>::err(barrier_result.error());
+			}
+		}
 		auto send_res = send_new_source_handles("final");
 		if (send_res.is_err()) {
 			result_tx_ptr->close();

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -21,7 +21,7 @@ namespace distributed {
 
 namespace {
 
-std::string MakeShuffleStageId(const PipelineNodeContext &context) {
+std::string MakeExchangeId(const PipelineNodeContext &context) {
 	std::string prefix = context.query_id().empty() ? std::string("query") : context.query_id();
 	return prefix + "_shuffle_" + std::to_string(context.node_id());
 }
@@ -278,7 +278,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 	auto *client_context = plan_context.client_context();
 
 	auto exec_cfg = config_.execution_config();
-	auto shuffle_stage_id = MakeShuffleStageId(context_);
+	auto exchange_id = MakeExchangeId(context_);
 	if (!exec_cfg || exec_cfg->shuffle_algorithm() != "flight_shuffle") {
 		throw NotImplementedException("RepartitionNode requires shuffle_algorithm=flight_shuffle. "
 		                              "The legacy map_reduce materialize+transpose path has been removed.");
@@ -297,7 +297,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 	auto num_partitions = num_partitions_;
 	auto exchange_mgr = exchange_mgr_;
 
-	plan_context.spawn([self_shared, input_ptr, task_id_counter, result_tx_ptr, shuffle_stage_id, num_partitions,
+	plan_context.spawn([self_shared, input_ptr, task_id_counter, result_tx_ptr, exchange_id, num_partitions,
 	                    client_context, exchange_mgr, fte_task_submitter]() mutable -> DuckDBResult<void> {
 		auto repartition_profile_start = std::chrono::steady_clock::now();
 		// poll_next() is blocking (ChannelStream::recv() waits for data
@@ -332,7 +332,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 		// Create the Exchange coordinator via ExchangeManager SPI
 		distributed::ExchangeContext exchange_ctx;
 		exchange_ctx.query_id = self_shared->context().query_id();
-		exchange_ctx.exchange_id = shuffle_stage_id;
+		exchange_ctx.exchange_id = exchange_id;
 		exchange_mgr->SetContext(client_context);
 		auto exchange = std::shared_ptr<distributed::Exchange>(
 		    exchange_mgr->CreateExchange(exchange_ctx, num_partitions).release());
@@ -342,13 +342,13 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		// Build sink plan builder: RemoteExchangeSink
 		auto repartition_spec = self_shared->repartition_spec_;
-		auto plan_builder = [self_shared, repartition_spec, num_partitions, shuffle_stage_id, exchange, exchange_mgr,
+		auto plan_builder = [self_shared, repartition_spec, num_partitions, exchange_id, exchange, exchange_mgr,
 		                     sink_task_counter](DuckPhysicalPlanRef plan) {
 			// Each task gets its own sink handle via the Exchange SPI
 			auto task_partition_id = sink_task_counter->fetch_add(1);
 			auto sink_handle_obj = exchange->AddSink(task_partition_id);
 			auto sink_instance = exchange->InstantiateSink(sink_handle_obj, /*attempt_id=*/0);
-			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, num_partitions, shuffle_stage_id,
+			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, num_partitions, exchange_id,
 			                                 sink_instance, exchange_mgr, self_shared->collect_mark_join_build_summary_,
 			                                 CopyExpressions(self_shared->mark_join_build_expressions_));
 		};
@@ -432,7 +432,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 		auto sink_stream = SubmittableTaskStream<WorkerTask>(boxed<SubmittableTask<WorkerTask>>(std::move(stream)));
 		idx_t target_tasks = ResolveExchangeSourceTaskCount(num_partitions, self_shared->config_.execution_config());
 		auto sent_source_handle_keys = std::make_shared<std::unordered_set<std::string>>();
-		auto make_source_update_tasks = [self_shared, task_id_counter, result_tx_ptr, exchange_mgr, shuffle_stage_id,
+		auto make_source_update_tasks = [self_shared, task_id_counter, result_tx_ptr, exchange_mgr, exchange_id,
 		                                 num_partitions, output_types, estimated_cardinality,
 		                                 target_tasks](const std::vector<distributed::ExchangeSourceHandle> &handles,
 		                                               const char *reason) -> DuckDBResult<void> {
@@ -486,8 +486,8 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				source_task.source_task_count = target_tasks;
 				source_task.mark_join_build_summary = mark_join_build_summary;
 				auto plan =
-				    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, shuffle_stage_id, {}, {},
-				                                 exchange_mgr, source_nodes, optional_idx(self_shared->node_id()));
+				    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, exchange_id, {}, {}, exchange_mgr,
+				                                 source_nodes, optional_idx(self_shared->node_id()));
 				TaskContext task_context = TaskContext::from_node_context(
 				    self_shared->context().query_idx(), self_shared->node_id(), task_id_counter->next());
 				WorkerTask task(task_context, plan, self_shared->config_.execution_config(),
@@ -549,13 +549,6 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		auto finish_profile_start = std::chrono::steady_clock::now();
 		exchange->AllRequiredSinksFinished();
-		auto barrier_result = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
-		                                                                             self_shared->node_id());
-		if (barrier_result.is_err()) {
-			result_tx_ptr->close();
-			exchange->Close();
-			return DuckDBResult<void>::err(barrier_result.error());
-		}
 		auto send_res = send_new_source_handles("final");
 		if (send_res.is_err()) {
 			result_tx_ptr->close();

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -549,6 +549,13 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		auto finish_profile_start = std::chrono::steady_clock::now();
 		exchange->AllRequiredSinksFinished();
+		auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
+		                                                                        self_shared->node_id());
+		if (phase_res.is_err()) {
+			result_tx_ptr->close();
+			exchange->Close();
+			return DuckDBResult<void>::err(phase_res.error());
+		}
 		auto send_res = send_new_source_handles("final");
 		if (send_res.is_err()) {
 			result_tx_ptr->close();

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -549,12 +549,12 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		auto finish_profile_start = std::chrono::steady_clock::now();
 		exchange->AllRequiredSinksFinished();
-		auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
-		                                                                        self_shared->node_id());
-		if (phase_res.is_err()) {
+		auto barrier_result = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
+		                                                                             self_shared->node_id());
+		if (barrier_result.is_err()) {
 			result_tx_ptr->close();
 			exchange->Close();
-			return DuckDBResult<void>::err(phase_res.error());
+			return DuckDBResult<void>::err(barrier_result.error());
 		}
 		auto send_res = send_new_source_handles("final");
 		if (send_res.is_err()) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -579,7 +579,7 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 		return AddPhysicalOrderPlan(std::move(input_plan), *orders_ptr, *projections_ptr, is_index_sort);
 	};
 
-	if (!ChildHasMultiplePartitions(child_)) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), order_plan_builder, plan_context.client_context());
 	}
@@ -905,7 +905,7 @@ SubmittableTaskStream<WorkerTask> TopNNode::produce_tasks(PlanExecutionContext &
 	};
 
 	// Single-partition path: just use pipeline_instruction (no coordinator).
-	if (!ChildHasMultiplePartitions(child_)) {
+	if (!is_blocking_materializing()) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -818,13 +818,13 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 			DebugOrderByOutputs("range-output", range_mat_res.outputs);
 			DebugOrderByHandles("range-handles", range_handles);
 			auto range_estimated_cardinality = EstimateRowsFromHandles(range_handles, staging_estimated_cardinality);
-			auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
-			                                                                        self_shared->node_id());
-			if (phase_res.is_err()) {
+			auto barrier_result = fte_task_submitter->blocking_materialization_completed(
+			    self_shared->context().query_id(), self_shared->node_id());
+			if (barrier_result.is_err()) {
 				result_tx_ptr->close();
 				range_exchange->Close();
 				staging_exchange->Close();
-				return DuckDBResult<void>::err(phase_res.error());
+				return DuckDBResult<void>::err(barrier_result.error());
 			}
 
 			auto final_tasks =

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -40,14 +40,6 @@ static vector<BoundOrderByNode> CopyOrderBys(const vector<BoundOrderByNode> &ord
 	return copies;
 }
 
-bool OrderByNode::is_blocking_materializing() const {
-	return ChildHasMultiplePartitions(child_);
-}
-
-bool TopNNode::is_blocking_materializing() const {
-	return ChildHasMultiplePartitions(child_);
-}
-
 static void FixOrderByReferenceTypes(Expression &expr, const vector<LogicalType> &input_types) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
@@ -579,7 +571,7 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 		return AddPhysicalOrderPlan(std::move(input_plan), *orders_ptr, *projections_ptr, is_index_sort);
 	};
 
-	if (!is_blocking_materializing()) {
+	if (!ChildHasMultiplePartitions(child_)) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), order_plan_builder, plan_context.client_context());
 	}
@@ -818,14 +810,6 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 			DebugOrderByOutputs("range-output", range_mat_res.outputs);
 			DebugOrderByHandles("range-handles", range_handles);
 			auto range_estimated_cardinality = EstimateRowsFromHandles(range_handles, staging_estimated_cardinality);
-			auto barrier_result = fte_task_submitter->blocking_materialization_completed(
-			    self_shared->context().query_id(), self_shared->node_id());
-			if (barrier_result.is_err()) {
-				result_tx_ptr->close();
-				range_exchange->Close();
-				staging_exchange->Close();
-				return DuckDBResult<void>::err(barrier_result.error());
-			}
 
 			auto final_tasks =
 			    BuildExchangeSourceTasks(self_shared->context(), self_shared->config(), *task_id_counter, exchange_mgr,
@@ -905,7 +889,7 @@ SubmittableTaskStream<WorkerTask> TopNNode::produce_tasks(PlanExecutionContext &
 	};
 
 	// Single-partition path: just use pipeline_instruction (no coordinator).
-	if (!is_blocking_materializing()) {
+	if (!ChildHasMultiplePartitions(child_)) {
 		auto input_stream = child_->produce_tasks(plan_context);
 		return input_stream.pipeline_instruction(shared_from_this(), final_plan_builder, plan_context.client_context());
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -40,6 +40,14 @@ static vector<BoundOrderByNode> CopyOrderBys(const vector<BoundOrderByNode> &ord
 	return copies;
 }
 
+bool OrderByNode::is_blocking_materializing() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+bool TopNNode::is_blocking_materializing() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
 static void FixOrderByReferenceTypes(Expression &expr, const vector<LogicalType> &input_types) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
@@ -810,6 +818,14 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 			DebugOrderByOutputs("range-output", range_mat_res.outputs);
 			DebugOrderByHandles("range-handles", range_handles);
 			auto range_estimated_cardinality = EstimateRowsFromHandles(range_handles, staging_estimated_cardinality);
+			auto phase_res = fte_task_submitter->blocking_materialization_completed(self_shared->context().query_id(),
+			                                                                        self_shared->node_id());
+			if (phase_res.is_err()) {
+				result_tx_ptr->close();
+				range_exchange->Close();
+				staging_exchange->Close();
+				return DuckDBResult<void>::err(phase_res.error());
+			}
 
 			auto final_tasks =
 			    BuildExchangeSourceTasks(self_shared->context(), self_shared->config(), *task_id_counter, exchange_mgr,

--- a/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sort.cpp
@@ -40,6 +40,22 @@ static vector<BoundOrderByNode> CopyOrderBys(const vector<BoundOrderByNode> &ord
 	return copies;
 }
 
+bool OrderByNode::is_materialization_barrier() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+std::vector<NodeID> OrderByNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
+bool TopNNode::is_materialization_barrier() const {
+	return ChildHasMultiplePartitions(child_);
+}
+
+std::vector<NodeID> TopNNode::materialized_input_node_ids() const {
+	return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()} : std::vector<NodeID> {};
+}
+
 static void FixOrderByReferenceTypes(Expression &expr, const vector<LogicalType> &input_types) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
@@ -810,6 +826,14 @@ SubmittableTaskStream<WorkerTask> OrderByNode::produce_tasks(PlanExecutionContex
 			DebugOrderByOutputs("range-output", range_mat_res.outputs);
 			DebugOrderByHandles("range-handles", range_handles);
 			auto range_estimated_cardinality = EstimateRowsFromHandles(range_handles, staging_estimated_cardinality);
+			auto barrier_result = fte_task_submitter->materialization_barrier_completed(
+			    self_shared->context().query_id(), self_shared->node_id());
+			if (barrier_result.is_err()) {
+				result_tx_ptr->close();
+				range_exchange->Close();
+				staging_exchange->Close();
+				return DuckDBResult<void>::err(barrier_result.error());
+			}
 
 			auto final_tasks =
 			    BuildExchangeSourceTasks(self_shared->context(), self_shared->config(), *task_id_counter, exchange_mgr,

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -340,7 +340,7 @@ void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) c
 	}
 	const auto &flight_config = flight_manager->config();
 	vector<string> local_dirs(flight_config.local_dirs.begin(), flight_config.local_dirs.end());
-	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
+	serializer.WriteProperty(103, "exchange_id", exchange_id_);
 	serializer.WriteProperty(104, "node_id", flight_config.node_id);
 	serializer.WriteProperty(105, "num_partitions", num_partitions_);
 	serializer.WriteProperty(106, "repartition_type", static_cast<uint8_t>(repartition_type_));

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -338,7 +338,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 		handle_source_task_partition_ids.push_back(handle.source_task_partition_id);
 		handle_flight_server_epochs.push_back(handle.flight_server_epoch);
 	}
-	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
+	serializer.WriteProperty(103, "exchange_id", exchange_id_);
 	serializer.WriteProperty(104, "partition_indices", partition_indices_);
 	serializer.WriteProperty(105, "source_nodes", source_nodes_);
 	serializer.WriteProperty(106, "flight_timeout_seconds", flight_config.flight_timeout_seconds);

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1178,7 +1178,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		return make_uniq<PhysicalPivot>(physical_plan, std::move(types), std::move(bound_pivot), estimated_cardinality);
 	}
 	case PhysicalOperatorType::EXCHANGE_SINK: {
-		auto exchange_id = deserializer.ReadProperty<string>(103, "shuffle_stage_id");
+		auto exchange_id = deserializer.ReadProperty<string>(103, "exchange_id");
 		auto node_id = deserializer.ReadProperty<string>(104, "node_id");
 		auto num_partitions = deserializer.ReadProperty<idx_t>(105, "num_partitions");
 		auto repartition_type_raw = deserializer.ReadProperty<uint8_t>(106, "repartition_type");
@@ -1219,7 +1219,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		return unique_ptr<PhysicalOperator>(std::move(result));
 	}
 	case PhysicalOperatorType::EXCHANGE_SOURCE: {
-		auto exchange_id = deserializer.ReadProperty<string>(103, "shuffle_stage_id");
+		auto exchange_id = deserializer.ReadProperty<string>(103, "exchange_id");
 		auto partition_indices = deserializer.ReadProperty<vector<idx_t>>(104, "partition_indices");
 		auto source_nodes = deserializer.ReadProperty<vector<string>>(105, "source_nodes");
 		auto timeout_seconds = deserializer.ReadProperty<double>(106, "flight_timeout_seconds");

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange.hpp
@@ -3,9 +3,9 @@
 
 /**
  * @file exchange.hpp
- * @brief Abstract Exchange interface — per-stage coordinator.
+ * @brief Abstract Exchange interface — per-exchange coordinator.
  *
- * An Exchange object is created for each shuffle stage and manages the
+ * An Exchange object is created for each logical exchange and manages the
  * lifecycle of sinks and sources. The coordinator uses it to track which sinks
  * have completed and to produce source handles for downstream tasks.
  */
@@ -22,7 +22,7 @@
 namespace duckdb {
 namespace distributed {
 
-/// Abstract interface for coordinating a single shuffle stage's exchange.
+/// Abstract interface for coordinating one logical exchange.
 ///
 /// Lifecycle (coordinator side):
 ///   1. CreateExchange() via ExchangeManager

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
@@ -23,10 +23,10 @@ namespace distributed {
 
 // ─── Context ─────────────────────────────────────────────
 
-/// Context for creating an Exchange instance (one per shuffle stage).
+/// Context for creating one logical Exchange instance.
 struct ExchangeContext {
 	std::string query_id;
-	std::string exchange_id; // typically shuffle_stage_id
+	std::string exchange_id;
 };
 
 // ─── Sink Handles ────────────────────────────────────────

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_manager.hpp
@@ -37,8 +37,8 @@ class ExchangeManager {
 public:
 	virtual ~ExchangeManager() = default;
 
-	/// Create an Exchange for a shuffle stage.
-	/// Called once per shuffle stage on the coordinator.
+	/// Create an Exchange for a logical exchange.
+	/// Called once per logical exchange on the coordinator.
 	///
 	/// @param ctx                    Context with query/exchange identifiers
 	/// @param output_partition_count Number of output partitions for hash/range partitioning

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
@@ -49,7 +49,7 @@ struct ShuffleManifestPartitionFile {
 };
 
 struct ShuffleAttemptManifest {
-	std::string shuffle_stage_id;
+	std::string exchange_id;
 	std::string node_id;
 	idx_t sink_partition_id = 0;
 	idx_t attempt_id = 0;
@@ -58,7 +58,7 @@ struct ShuffleAttemptManifest {
 };
 
 struct ShuffleCacheConfig {
-	std::string shuffle_stage_id;
+	std::string exchange_id;
 	std::string node_id;
 	idx_t num_partitions = 0;
 	std::vector<std::string> local_dirs;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -78,7 +78,7 @@ private:
 				result = RemoveShuffleAttemptStorage(config, *cleanup_storage);
 			} else {
 				result = DuckDBResult<idx_t>::err(DuckDBError::invalid_state_error(
-				    "shuffle cleanup requires a live filesystem context for " + config.shuffle_stage_id));
+				    "shuffle cleanup requires a live filesystem context for " + config.exchange_id));
 			}
 			if (result.is_ok()) {
 				cleanup_complete = true;
@@ -245,7 +245,7 @@ public:
 			return DuckDBResult<WriteLease>::err(
 			    DuckDBError::value_error("pending shuffle cache requires an exchange id, query id, and cache"));
 		}
-		if (cache->config().shuffle_stage_id != exchange_id) {
+		if (cache->config().exchange_id != exchange_id) {
 			return DuckDBResult<WriteLease>::err(DuckDBError::value_error(
 			    "pending shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
 		}
@@ -300,7 +300,7 @@ public:
 			return DuckDBResult<void>::err(
 			    DuckDBError::value_error("shuffle cache registration requires an exchange id, query id, and cache"));
 		}
-		if (cache->config().shuffle_stage_id != exchange_id) {
+		if (cache->config().exchange_id != exchange_id) {
 			return DuckDBResult<void>::err(DuckDBError::value_error(
 			    "shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
 		}
@@ -385,7 +385,7 @@ public:
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight ticket attempt id does not match the published attempt"));
 		}
-		if (config.shuffle_stage_id != exchange_id || config.node_id != node_id) {
+		if (config.exchange_id != exchange_id || config.node_id != node_id) {
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight ticket exchange or node identity does not match"));
 		}
@@ -538,8 +538,7 @@ private:
 		}
 		const auto &left_config = left.state->config;
 		const auto &right_config = right_cache->config();
-		return left_config.shuffle_stage_id == right_config.shuffle_stage_id &&
-		       left_config.node_id == right_config.node_id &&
+		return left_config.exchange_id == right_config.exchange_id && left_config.node_id == right_config.node_id &&
 		       left_config.num_partitions == right_config.num_partitions &&
 		       left_config.local_dirs == right_config.local_dirs;
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/copy_finish.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/copy_finish.hpp
@@ -24,9 +24,6 @@ public:
 	bool is_sink() const override {
 		return true;
 	}
-	bool is_blocking_materializing() const override {
-		return true;
-	}
 	NodeID node_id() const override {
 		return ctx_.node_id();
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/copy_finish.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/copy_finish.hpp
@@ -24,6 +24,9 @@ public:
 	bool is_sink() const override {
 		return true;
 	}
+	bool is_blocking_materializing() const override {
+		return true;
+	}
 	NodeID node_id() const override {
 		return ctx_.node_id();
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
@@ -49,9 +49,6 @@ public:
 		return config_;
 	}
 	std::vector<PipelineNodeRef> children() const override;
-	bool is_blocking_materializing() const override {
-		return true;
-	}
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
@@ -49,6 +49,9 @@ public:
 		return config_;
 	}
 	std::vector<PipelineNodeRef> children() const override;
+	bool is_blocking_materializing() const override {
+		return true;
+	}
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
@@ -49,6 +49,10 @@ public:
 		return config_;
 	}
 	std::vector<PipelineNodeRef> children() const override;
+	bool is_materialization_barrier() const override {
+		return true;
+	}
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
@@ -30,7 +30,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
@@ -64,7 +63,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
@@ -99,7 +97,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
@@ -34,6 +34,8 @@ public:
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
 	}
+	bool is_materialization_barrier() const override;
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 
@@ -67,6 +69,8 @@ public:
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
 	}
+	bool is_materialization_barrier() const override;
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 
@@ -101,6 +105,8 @@ public:
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
 	}
+	bool is_materialization_barrier() const override;
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/limit.hpp
@@ -30,6 +30,7 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
@@ -63,6 +64,7 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
@@ -97,6 +99,7 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/materialized_coordinator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/materialized_coordinator.hpp
@@ -18,6 +18,9 @@ using PerTaskMaterializedPlanBuilderFactory = std::function<MaterializedPlanBuil
 
 bool ChildHasMultiplePartitions(const PipelineNodeRef &child);
 
+//! Produce a local-materialization phase followed by one coordinator task.
+//! The node must report is_blocking_materializing() so resource metadata and
+//! runtime phase completion share one contract; the implementation enforces it.
 SubmittableTaskStream<WorkerTask> ProduceWithMaterializedCoordinator(
     PlanExecutionContext &plan_context, const PipelineNodeRef &child, const std::shared_ptr<PipelineNodeImpl> &node,
     MaterializedPlanBuilder final_plan_builder, PerTaskMaterializedPlanBuilderFactory per_task_builder_factory = {},

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/materialized_coordinator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/materialized_coordinator.hpp
@@ -18,9 +18,6 @@ using PerTaskMaterializedPlanBuilderFactory = std::function<MaterializedPlanBuil
 
 bool ChildHasMultiplePartitions(const PipelineNodeRef &child);
 
-//! Produce a local-materialization phase followed by one coordinator task.
-//! The node must report is_blocking_materializing() so resource metadata and
-//! runtime phase completion share one contract; the implementation enforces it.
 SubmittableTaskStream<WorkerTask> ProduceWithMaterializedCoordinator(
     PlanExecutionContext &plan_context, const PipelineNodeRef &child, const std::shared_ptr<PipelineNodeImpl> &node,
     MaterializedPlanBuilder final_plan_builder, PerTaskMaterializedPlanBuilderFactory per_task_builder_factory = {},

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -115,9 +115,6 @@ public:
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) = 0;
 	virtual DuckDBResult<void> task_input_stream_exhausted(const std::string &query_id,
 	                                                       const std::unordered_set<SourceNodeId> &source_node_ids) = 0;
-	virtual DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) {
-		return DuckDBResult<void>::ok();
-	}
 	virtual DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                          double timeout_s) = 0;
 	virtual DuckDBResult<std::vector<MaterializedOutput>>
@@ -437,11 +434,6 @@ public:
 	virtual bool is_sink() const {
 		return false;
 	}
-	/// Returns true when this node must collect its complete distributed input
-	/// before the next pipeline phase can make progress.
-	virtual bool is_blocking_materializing() const {
-		return false;
-	}
 	virtual std::vector<std::string> multiline_display(bool verbose) const = 0;
 };
 
@@ -512,10 +504,6 @@ public:
 
 	bool is_sink() const override {
 		return op_->is_sink();
-	}
-
-	bool is_blocking_materializing() const override {
-		return op_->is_blocking_materializing();
 	}
 
 	const PipelineNodeRef &implementation() const {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -84,7 +84,7 @@ public:
 		    {"query_id", query_id_}, {"node_id", std::to_string(node_id_)}, {"node_name", node_name_}};
 		if (!query_id_.empty()) {
 			result.emplace("resource_query_id", query_id_);
-			result.emplace("resource_stage_id", "stage:" + query_id_ + ":node:" + std::to_string(node_id_) + ":fte");
+			result.emplace("resource_unit_id", "resource:" + query_id_ + ":fragment:node:" + std::to_string(node_id_));
 		}
 		return result;
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -115,6 +115,9 @@ public:
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) = 0;
 	virtual DuckDBResult<void> task_input_stream_exhausted(const std::string &query_id,
 	                                                       const std::unordered_set<SourceNodeId> &source_node_ids) = 0;
+	virtual DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) {
+		return DuckDBResult<void>::ok();
+	}
 	virtual DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                          double timeout_s) = 0;
 	virtual DuckDBResult<std::vector<MaterializedOutput>>
@@ -434,6 +437,11 @@ public:
 	virtual bool is_sink() const {
 		return false;
 	}
+	/// Returns true when this node must collect its complete distributed input
+	/// before the next pipeline phase can make progress.
+	virtual bool is_blocking_materializing() const {
+		return false;
+	}
 	virtual std::vector<std::string> multiline_display(bool verbose) const = 0;
 };
 
@@ -500,6 +508,14 @@ public:
 	// 获取节点名称
 	NodeName name() const {
 		return op_->name();
+	}
+
+	bool is_sink() const override {
+		return op_->is_sink();
+	}
+
+	bool is_blocking_materializing() const override {
+		return op_->is_blocking_materializing();
 	}
 
 	const PipelineNodeRef &implementation() const {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -115,6 +115,7 @@ public:
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) = 0;
 	virtual DuckDBResult<void> task_input_stream_exhausted(const std::string &query_id,
 	                                                       const std::unordered_set<SourceNodeId> &source_node_ids) = 0;
+	virtual DuckDBResult<void> materialization_barrier_completed(const std::string &query_id, NodeID node_id) = 0;
 	virtual DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                          double timeout_s) = 0;
 	virtual DuckDBResult<std::vector<MaterializedOutput>>
@@ -434,6 +435,17 @@ public:
 	virtual bool is_sink() const {
 		return false;
 	}
+	/// True only when downstream distributed tasks cannot be emitted until this
+	/// node has materialized its complete distributed input.
+	virtual bool is_materialization_barrier() const {
+		return false;
+	}
+	/// Physical child nodes whose complete distributed output must be
+	/// materialized before this barrier is released. Barrier nodes must
+	/// explicitly identify at least one input; non-barrier nodes return none.
+	virtual std::vector<NodeID> materialized_input_node_ids() const {
+		return {};
+	}
 	virtual std::vector<std::string> multiline_display(bool verbose) const = 0;
 };
 
@@ -504,6 +516,14 @@ public:
 
 	bool is_sink() const override {
 		return op_->is_sink();
+	}
+
+	bool is_materialization_barrier() const override {
+		return op_->is_materialization_barrier();
+	}
+
+	std::vector<NodeID> materialized_input_node_ids() const override {
+		return op_->materialized_input_node_ids();
 	}
 
 	const PipelineNodeRef &implementation() const {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
@@ -28,9 +28,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override {
-		return options_ && !options_->is_percentage;
-	}
 
 	std::vector<PipelineNodeRef> children() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
@@ -28,6 +28,10 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_materialization_barrier() const override {
+		return options_ && !options_->is_percentage;
+	}
+	std::vector<NodeID> materialized_input_node_ids() const override;
 
 	std::vector<PipelineNodeRef> children() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sample.hpp
@@ -28,6 +28,9 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override {
+		return options_ && !options_->is_percentage;
+	}
 
 	std::vector<PipelineNodeRef> children() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -54,9 +54,6 @@ public:
 	std::vector<PipelineNodeRef> children() const override;
 
 	std::vector<std::string> multiline_display(bool verbose) const override;
-	bool is_blocking_materializing() const override {
-		return true;
-	}
 
 	void EnableMarkJoinBuildSummary(vector<unique_ptr<Expression>> expressions) {
 		collect_mark_join_build_summary_ = true;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -64,6 +64,15 @@ public:
 		return collect_mark_join_build_summary_;
 	}
 
+	bool is_materialization_barrier() const override {
+		return collect_mark_join_build_summary_;
+	}
+
+	std::vector<NodeID> materialized_input_node_ids() const override {
+		return is_materialization_barrier() && child_ ? std::vector<NodeID> {child_->node_id()}
+		                                              : std::vector<NodeID> {};
+	}
+
 	// 生成任务流（核心方法）
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -54,6 +54,9 @@ public:
 	std::vector<PipelineNodeRef> children() const override;
 
 	std::vector<std::string> multiline_display(bool verbose) const override;
+	bool is_blocking_materializing() const override {
+		return true;
+	}
 
 	void EnableMarkJoinBuildSummary(vector<unique_ptr<Expression>> expressions) {
 		collect_mark_join_build_summary_ = true;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
@@ -31,6 +31,8 @@ public:
 	}
 
 	std::vector<PipelineNodeRef> children() const override;
+	bool is_materialization_barrier() const override;
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 
@@ -66,6 +68,8 @@ public:
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};
 	}
+	bool is_materialization_barrier() const override;
+	std::vector<NodeID> materialized_input_node_ids() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 	std::vector<std::string> multiline_display(bool verbose) const override;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
@@ -29,6 +29,7 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
@@ -62,6 +63,7 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
+	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sort.hpp
@@ -29,7 +29,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override;
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
@@ -63,7 +62,6 @@ public:
 	const PipelineNodeConfig &config() const override {
 		return config_;
 	}
-	bool is_blocking_materializing() const override;
 
 	std::vector<PipelineNodeRef> children() const override {
 		return {child_};

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -252,6 +252,10 @@ public:
 		return DuckDBResult<void>::ok();
 	}
 
+	DuckDBResult<void> materialization_barrier_completed(const std::string &query_id, NodeID node_id) override {
+		return worker_manager_->materialization_barrier_completed(query_id, node_id);
+	}
+
 	DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                  double timeout_s) override {
 		return worker_manager_->wait_fte_query(query_id, timeout_s);

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -252,10 +252,6 @@ public:
 		return DuckDBResult<void>::ok();
 	}
 
-	DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) override {
-		return worker_manager_->blocking_materialization_completed(query_id, node_id);
-	}
-
 	DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                  double timeout_s) override {
 		return worker_manager_->wait_fte_query(query_id, timeout_s);

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -252,6 +252,10 @@ public:
 		return DuckDBResult<void>::ok();
 	}
 
+	DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) override {
+		return worker_manager_->blocking_materialization_completed(query_id, node_id);
+	}
+
 	DuckDBResult<std::vector<MaterializedOutput>> wait_query_finished(const std::string &query_id,
 	                                                                  double timeout_s) override {
 		return worker_manager_->wait_fte_query(query_id, timeout_s);

--- a/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
@@ -127,12 +127,6 @@ public:
 		    DuckDBError::invalid_state_error("worker manager does not support FTE source exhaustion"));
 	}
 
-	/// Notify resource coordination that one blocking pipeline phase finished
-	/// collecting its complete input. The stage may still emit final tasks.
-	virtual DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) {
-		return DuckDBResult<void>::ok();
-	}
-
 	/// Submit task-stream events directly to the FTE task-update coordinator.
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) {
 		return DuckDBResult<void>::err(

--- a/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
@@ -127,6 +127,12 @@ public:
 		    DuckDBError::invalid_state_error("worker manager does not support FTE source exhaustion"));
 	}
 
+	/// Notify resource coordination that one blocking pipeline phase finished
+	/// collecting its complete input. The stage may still emit final tasks.
+	virtual DuckDBResult<void> blocking_materialization_completed(const std::string &query_id, NodeID node_id) {
+		return DuckDBResult<void>::ok();
+	}
+
 	/// Submit task-stream events directly to the FTE task-update coordinator.
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) {
 		return DuckDBResult<void>::err(

--- a/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
@@ -127,6 +127,13 @@ public:
 		    DuckDBError::invalid_state_error("worker manager does not support FTE source exhaustion"));
 	}
 
+	/// Notify the query resource controller that a true distributed
+	/// materialization boundary has finished and its downstream may start.
+	virtual DuckDBResult<void> materialization_barrier_completed(const std::string &query_id, NodeID node_id) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::invalid_state_error("worker manager does not support materialization barriers"));
+	}
+
 	/// Submit task-stream events directly to the FTE task-update coordinator.
 	virtual DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask> tasks) {
 		return DuckDBResult<void>::err(

--- a/external/duckdb/src/include/duckdb/execution/executor.hpp
+++ b/external/duckdb/src/include/duckdb/execution/executor.hpp
@@ -53,7 +53,6 @@ struct PipelineProgressSnapshot {
 	idx_t completed_pipeline_tasks = 0;
 	vector<string> operators;
 	vector<InsertionOrderPreservingMap<string>> operator_details;
-	vector<idx_t> stage_ids;
 };
 
 class Executor {

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1339,12 +1339,12 @@ TEST_CASE("Exchange: ShuffleCache write/read", "[distributed][exchange]") {
 	REQUIRE(files.total_bytes >= file.bytes);
 
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("stage_1", cache, "cache-basic-query").is_ok());
-	ScopedShuffleCacheRegistration registration("stage_1");
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("exchange_1", cache, "cache-basic-query").is_ok());
+	ScopedShuffleCacheRegistration registration("exchange_1");
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
 	source_config.expected_types = types;
-	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_1", "node_1", 1)});
+	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_1", "node_1", 1)});
 	RequireTwoColumnRows(rows, ids, names);
 }
 
@@ -1379,12 +1379,12 @@ TEST_CASE("Exchange: ShuffleCache flushes large BLOB buffers by actual allocatio
 	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::BLOB};
 	REQUIRE(cache->FlushAll(context, {"id", "payload"}).is_ok());
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("stage_large_blob", cache, "cache-blob-query").is_ok());
-	ScopedShuffleCacheRegistration registration("stage_large_blob");
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("exchange_large_blob", cache, "cache-blob-query").is_ok());
+	ScopedShuffleCacheRegistration registration("exchange_large_blob");
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_blob";
 	source_config.expected_types = types;
-	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_large_blob", "node_blob", 0)});
+	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_large_blob", "node_blob", 0)});
 	REQUIRE(rows.size() == ids.size());
 }
 
@@ -1580,12 +1580,12 @@ TEST_CASE("Exchange: ShuffleCache empty partition handling", "[distributed][exch
 	REQUIRE(cache->EnsureSchemaFile(context, types, {"id", "name"}).is_ok());
 	REQUIRE(cache->FlushAll(context, {"id", "name"}).is_ok());
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("stage_empty", cache, "cache-empty-query").is_ok());
-	ScopedShuffleCacheRegistration registration("stage_empty");
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("exchange_empty", cache, "cache-empty-query").is_ok());
+	ScopedShuffleCacheRegistration registration("exchange_empty");
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_empty";
 	source_config.expected_types = types;
-	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_empty", "node_empty", 0)});
+	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_empty", "node_empty", 0)});
 	REQUIRE(rows.empty());
 
 	vector<int32_t> ids = {9};
@@ -1627,12 +1627,13 @@ TEST_CASE("Exchange: ShuffleCache multiple chunks to same partition", "[distribu
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("stage_multi_chunk", cache, "cache-multi-chunk-query").is_ok());
-	ScopedShuffleCacheRegistration registration("stage_multi_chunk");
+	REQUIRE(
+	    ShuffleCacheRegistry::Instance().Register("exchange_multi_chunk", cache, "cache-multi-chunk-query").is_ok());
+	ScopedShuffleCacheRegistration registration("exchange_multi_chunk");
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
 	source_config.expected_types = types;
-	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_multi_chunk", "node_1", 0)});
+	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_multi_chunk", "node_1", 0)});
 	REQUIRE(rows.size() == 5);
 
 	// All rows should be present
@@ -1671,22 +1672,22 @@ TEST_CASE("Exchange: ShuffleCache write to multiple partitions", "[distributed][
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("stage_multi_part", cache, "cache-multi-part-query").is_ok());
-	ScopedShuffleCacheRegistration registration("stage_multi_part");
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("exchange_multi_part", cache, "cache-multi-part-query").is_ok());
+	ScopedShuffleCacheRegistration registration("exchange_multi_part");
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
 	source_config.expected_types = types;
 
 	// Partition 0 should have 2 rows
-	auto rows0 = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_multi_part", "node_1", 0)});
+	auto rows0 = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_multi_part", "node_1", 0)});
 	RequireTwoColumnRows(rows0, ids0, names0);
 
 	// Partition 1 should be empty
-	auto rows1 = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_multi_part", "node_1", 1)});
+	auto rows1 = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_multi_part", "node_1", 1)});
 	REQUIRE(rows1.empty());
 
 	// Partition 2 should have 1 row
-	auto rows2 = ReadSourceRows(context, source_config, {MakeSourceHandle("stage_multi_part", "node_1", 2)});
+	auto rows2 = ReadSourceRows(context, source_config, {MakeSourceHandle("exchange_multi_part", "node_1", 2)});
 	RequireTwoColumnRows(rows2, ids2, names2);
 }
 

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -480,18 +480,18 @@ TEST_CASE("Exchange: FlightExchangeTicket roundtrip", "[distributed][exchange]")
 }
 
 TEST_CASE("Exchange: FlightExchangeTicket parse errors", "[distributed][exchange]") {
-	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nstage\nnode\n1").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v2\nepoch\nstage\nnode\n1\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\n\nstage\nnode\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nexchange\nnode").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nexchange\nnode\n1").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v2\nepoch\nexchange\nnode\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\n\nexchange\nnode\n1\n2").is_err());
 	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\n\nnode\n1\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\n\n1\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n-1\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\n-2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\nnope\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\nnope").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1x\n2").is_err());
-	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\n2x").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\n\n1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n-1\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n1\n-2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\nnope\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n1\nnope").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n1x\n2").is_err());
+	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n1\n2x").is_err());
 }
 
 TEST_CASE("Exchange: Flight timeouts resolve from the worker environment", "[distributed][exchange]") {
@@ -529,43 +529,43 @@ TEST_CASE("Exchange: ShuffleCacheRegistry register/get/remove", "[distributed][e
 
 	// Create a ShuffleCache and register it
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "registry_test_stage";
+	config.exchange_id = "registry_test_exchange";
 	config.node_id = "node_1";
 	config.num_partitions = 2;
 	config.local_dirs = {TestCreatePath("registry_test")};
 
 	auto cache = std::make_shared<ShuffleCache>(std::move(config));
-	REQUIRE(registry.Register("registry_test_stage", cache, "registry-test-query").is_ok());
+	REQUIRE(registry.Register("registry_test_exchange", cache, "registry-test-query").is_ok());
 
 	// Get should return the same cache
-	auto retrieved = registry.Get("registry_test_stage");
+	auto retrieved = registry.Get("registry_test_exchange");
 	REQUIRE(retrieved != nullptr);
 	REQUIRE(retrieved.get() == cache.get());
 
 	// Get with unknown key returns nullptr
-	auto unknown = registry.Get("nonexistent_stage");
+	auto unknown = registry.Get("nonexistent_exchange");
 	REQUIRE(unknown == nullptr);
 
 	// Remove the cache
-	registry.Remove("registry_test_stage");
-	auto after_remove = registry.Get("registry_test_stage");
+	registry.Remove("registry_test_exchange");
+	auto after_remove = registry.Get("registry_test_exchange");
 	REQUIRE(after_remove == nullptr);
 
 	// Double remove is safe
-	registry.Remove("registry_test_stage");
+	registry.Remove("registry_test_exchange");
 }
 
 TEST_CASE("Exchange: ShuffleCacheRegistry multiple entries", "[distributed][exchange]") {
 	auto &registry = ShuffleCacheRegistry::Instance();
 
 	ShuffleCacheConfig config1;
-	config1.shuffle_stage_id = "multi_test_1";
+	config1.exchange_id = "multi_test_1";
 	config1.node_id = "node_1";
 	config1.num_partitions = 1;
 	config1.local_dirs = {TestCreatePath("registry_multi_1")};
 
 	ShuffleCacheConfig config2;
-	config2.shuffle_stage_id = "multi_test_2";
+	config2.exchange_id = "multi_test_2";
 	config2.node_id = "node_1";
 	config2.num_partitions = 1;
 	config2.local_dirs = {TestCreatePath("registry_multi_2")};
@@ -590,11 +590,11 @@ TEST_CASE("Exchange: ShuffleCacheRegistry multiple entries", "[distributed][exch
 TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descriptor identity",
           "[distributed][exchange]") {
 	auto &registry = ShuffleCacheRegistry::Instance();
-	const std::string exchange_id = "registry_identity_stage";
+	const std::string exchange_id = "registry_identity_exchange";
 	const std::string query_id = "registry-identity-query";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 2;
 	config.local_dirs = {TestCreatePath("registry_identity_a")};
@@ -614,7 +614,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry validates epoch, attempt, and descript
 	REQUIRE(registry.Get(exchange_id).get() == cache.get());
 
 	auto mismatched_config = config;
-	mismatched_config.shuffle_stage_id = "different-exchange";
+	mismatched_config.exchange_id = "different-exchange";
 	auto mismatched_cache = std::make_shared<ShuffleCache>(std::move(mismatched_config));
 	REQUIRE(registry.TrackPending(exchange_id, mismatched_cache, query_id, "epoch-a", 4).is_err());
 	REQUIRE(registry.Register(exchange_id, mismatched_cache, query_id, "epoch-a", 4).is_err());
@@ -630,11 +630,11 @@ TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases",
 	Connection conn(db);
 	auto &context = *conn.context;
 	auto &registry = ShuffleCacheRegistry::Instance();
-	const std::string exchange_id = "registry_lease_stage__sink_0__attempt_0";
+	const std::string exchange_id = "registry_lease_exchange__sink_0__attempt_0";
 	const std::string query_id = "registry-lease-query";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_lease")};
@@ -654,7 +654,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases",
 	auto lease = std::move(lease_result.value());
 	registry.RemoveForDeferredCleanup(exchange_id);
 
-	auto cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_stage");
+	auto cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_exchange");
 	REQUIRE(cleanup.registry_entries_removed == 0);
 	REQUIRE(cleanup.storage_entries_removed == 0);
 	REQUIRE(cleanup.cleanup_errors == 0);
@@ -663,7 +663,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry cleanup waits for active read leases",
 
 	lease.reset();
 	REQUIRE(cache->HasCommittedManifest());
-	cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_stage");
+	cleanup = registry.RemoveAndCleanupByPrefix("registry_lease_exchange");
 	REQUIRE(cleanup.cleanup_pending == 0);
 	REQUIRE(cleanup.cleanup_errors == 0);
 	REQUIRE(cleanup.storage_entries_removed > 0);
@@ -676,7 +676,7 @@ TEST_CASE("Exchange: ShuffleCacheRegistry retains and retries failed cleanup", "
 	const std::string exchange_id = "registry_cleanup_retry__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {"mock://shuffle"};
@@ -707,7 +707,7 @@ TEST_CASE("Exchange: object shuffle cleanup reconstructs storage without retaini
 	auto storage_root = TestCreatePath("registry_object_cleanup_context");
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {"mock://shuffle"};
@@ -754,7 +754,7 @@ TEST_CASE("Exchange: deferred cleanup retains exclusive attempt identity", "[dis
 	const std::string exchange_id = "registry_deferred_identity__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_deferred_identity")};
@@ -780,7 +780,7 @@ TEST_CASE("Exchange: unpublished sink attempts stay hidden and retain cleanup ow
 	const std::string exchange_id = "registry_pending_writer__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_pending_writer")};
@@ -831,7 +831,7 @@ TEST_CASE("Exchange: query close fences late cache publication until native exec
 	const std::string exchange_id = "registry_close_race__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_close_race")};
@@ -881,7 +881,7 @@ TEST_CASE("Exchange: late pending sink cannot delete a borrowed closed-query att
 	const std::string exchange_id = "registry_late_pending__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_late_pending")};
@@ -935,7 +935,7 @@ TEST_CASE("Exchange: query cleanup waits for native execution before deleting co
 	const std::string exchange_id = "registry_native_cleanup_fence__sink_0__attempt_0";
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = exchange_id;
+	config.exchange_id = exchange_id;
 	config.node_id = "node-a";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("registry_native_cleanup_fence")};
@@ -974,7 +974,7 @@ TEST_CASE("Exchange: Flight service isolates published attempts and rejects rele
 	Connection conn(db);
 	auto &context = *conn.context;
 	auto &registry = ShuffleCacheRegistry::Instance();
-	const std::string prefix = "overlapping-stage";
+	const std::string prefix = "overlapping-exchange";
 	const std::string exchange_a = prefix + "__instance_a__sink_0__attempt_1";
 	const std::string exchange_b = prefix + "__instance_b__sink_0__attempt_1";
 	const std::string epoch = "catalog-isolation-epoch";
@@ -983,7 +983,7 @@ TEST_CASE("Exchange: Flight service isolates published attempts and rejects rele
 
 	auto make_committed_cache = [&](const std::string &exchange_id, const std::string &dir, int32_t value) {
 		ShuffleCacheConfig config;
-		config.shuffle_stage_id = exchange_id;
+		config.exchange_id = exchange_id;
 		config.node_id = node_id;
 		config.num_partitions = 1;
 		config.local_dirs = {dir};
@@ -1065,7 +1065,7 @@ TEST_CASE("Exchange: process-local Flight shutdown is bounded and releases its s
 	const std::string node_id = "stalled-flight-shutdown-node";
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.exchange_id = exchange_id;
 	cache_config.node_id = node_id;
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("stalled_flight_shutdown")};
@@ -1309,7 +1309,7 @@ TEST_CASE("Exchange: ShuffleCache write/read", "[distributed][exchange]") {
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_1";
+	config.exchange_id = "exchange_1";
 	config.node_id = "node_1";
 	config.num_partitions = 2;
 	config.local_dirs = {TestCreatePath("exchange_cache_basic")};
@@ -1356,7 +1356,7 @@ TEST_CASE("Exchange: ShuffleCache flushes large BLOB buffers by actual allocatio
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_large_blob";
+	config.exchange_id = "exchange_large_blob";
 	config.node_id = "node_blob";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("exchange_cache_large_blob")};
@@ -1399,7 +1399,7 @@ TEST_CASE("Exchange: ShuffleCache bounds aggregate buffers across partitions", "
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_aggregate_buffer_budget";
+	config.exchange_id = "exchange_aggregate_buffer_budget";
 	config.node_id = "node_budget";
 	config.num_partitions = PARTITION_COUNT;
 	config.local_dirs = {TestCreatePath("exchange_cache_aggregate_buffer_budget")};
@@ -1478,7 +1478,7 @@ TEST_CASE("Exchange: ShuffleCache bounds aggregate buffers across partitions", "
 TEST_CASE("Exchange: ShuffleCache validates buffer byte settings", "[distributed][exchange]") {
 	auto make_config = []() {
 		ShuffleCacheConfig config;
-		config.shuffle_stage_id = "stage_invalid_buffer_budget";
+		config.exchange_id = "exchange_invalid_buffer_budget";
 		config.node_id = "node_budget";
 		config.num_partitions = 1;
 		config.local_dirs = {TestCreatePath("exchange_cache_invalid_buffer_budget")};
@@ -1509,7 +1509,7 @@ TEST_CASE("Exchange: ShuffleCache committed manifest replay via object storage b
 	auto storage = std::make_shared<MockObjectShuffleStorage>(root);
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "object_stage";
+	config.exchange_id = "object_exchange";
 	config.node_id = "node_object";
 	config.num_partitions = 2;
 	config.local_dirs = {"mock://object-root"};
@@ -1529,7 +1529,7 @@ TEST_CASE("Exchange: ShuffleCache committed manifest replay via object storage b
 
 	ShuffleCache replay_cache(
 	    ShuffleCacheConfig {
-	        "object_stage",
+	        "object_exchange",
 	        "node_object",
 	        2,
 	        {"mock://object-root"},
@@ -1565,7 +1565,7 @@ TEST_CASE("Exchange: ShuffleCache empty partition handling", "[distributed][exch
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_empty";
+	config.exchange_id = "exchange_empty";
 	config.node_id = "node_empty";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("exchange_cache_empty")};
@@ -1603,7 +1603,7 @@ TEST_CASE("Exchange: ShuffleCache multiple chunks to same partition", "[distribu
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_multi_chunk";
+	config.exchange_id = "exchange_multi_chunk";
 	config.node_id = "node_1";
 	config.num_partitions = 1;
 	config.local_dirs = {TestCreatePath("exchange_cache_multi_chunk")};
@@ -1647,7 +1647,7 @@ TEST_CASE("Exchange: ShuffleCache write to multiple partitions", "[distributed][
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_multi_part";
+	config.exchange_id = "exchange_multi_part";
 	config.node_id = "node_1";
 	config.num_partitions = 3;
 	config.local_dirs = {TestCreatePath("exchange_cache_multi_part")};
@@ -1713,7 +1713,7 @@ TEST_CASE("Exchange: local-disk sink starts and publishes the cluster-internal F
 	FlightExchangeManager manager(config, conn.context.get());
 	ExchangeContext exchange_context;
 	exchange_context.query_id = "process-local-default-query";
-	exchange_context.exchange_id = "process-local-default-stage";
+	exchange_context.exchange_id = "process-local-default-exchange";
 	auto exchange = manager.CreateExchange(exchange_context, 1);
 	auto instance = exchange->InstantiateSink(exchange->AddSink(0), 0);
 	auto sink = manager.CreateSink(instance);
@@ -2034,7 +2034,7 @@ TEST_CASE("Exchange: FlightExchange with no sinks has no unpublished source hand
 
 	ExchangeContext ctx;
 	ctx.query_id = "empty-query";
-	ctx.exchange_id = "empty-stage";
+	ctx.exchange_id = "empty-exchange";
 	auto exchange = manager.CreateExchange(ctx, 4);
 	exchange->AllRequiredSinksFinished();
 	REQUIRE(exchange->GetSourceHandles().empty());
@@ -2053,7 +2053,7 @@ TEST_CASE("Exchange: FlightExchange reduces MARK build summaries from selected a
 
 	ExchangeContext ctx;
 	ctx.query_id = "mark-summary-query";
-	ctx.exchange_id = "mark-summary-stage";
+	ctx.exchange_id = "mark-summary-exchange";
 	auto exchange = manager.CreateExchange(ctx, 3);
 	auto first = exchange->InstantiateSink(exchange->AddSink(0), 0);
 	auto first_retry = exchange->InstantiateSink(exchange->AddSink(0), 1);
@@ -2088,7 +2088,7 @@ TEST_CASE("Exchange: FlightExchange reduces MARK build summaries from selected a
 	exchange->Close();
 }
 
-TEST_CASE("Exchange: same logical stage has isolated exchange instances and directories", "[distributed][exchange]") {
+TEST_CASE("Exchange: same logical exchange has isolated instances and directories", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 
@@ -2103,7 +2103,7 @@ TEST_CASE("Exchange: same logical stage has isolated exchange instances and dire
 
 	ExchangeContext ctx;
 	ctx.query_id = "same-query";
-	ctx.exchange_id = "same-stage";
+	ctx.exchange_id = "same-exchange";
 	auto exchange_a = manager_a.CreateExchange(ctx, 1);
 	auto exchange_b = manager_b.CreateExchange(ctx, 1);
 	auto instance_a = exchange_a->InstantiateSink(exchange_a->AddSink(0), 0);
@@ -2113,12 +2113,12 @@ TEST_CASE("Exchange: same logical stage has isolated exchange instances and dire
 	REQUIRE(instance_b.output_location.find(ctx.exchange_id) == string::npos);
 
 	ShuffleCacheConfig cache_config_a;
-	cache_config_a.shuffle_stage_id = instance_a.output_location;
+	cache_config_a.exchange_id = instance_a.output_location;
 	cache_config_a.node_id = "node-a";
 	cache_config_a.num_partitions = 1;
 	cache_config_a.local_dirs = config_a.local_dirs;
 	ShuffleCacheConfig cache_config_b;
-	cache_config_b.shuffle_stage_id = instance_b.output_location;
+	cache_config_b.exchange_id = instance_b.output_location;
 	cache_config_b.node_id = "node-a";
 	cache_config_b.num_partitions = 1;
 	cache_config_b.local_dirs = config_b.local_dirs;
@@ -2152,7 +2152,7 @@ TEST_CASE("Exchange: FlightExchange accepts validated dynamically derived retry 
 	FlightExchangeManager manager(config, conn.context.get());
 	ExchangeContext ctx;
 	ctx.query_id = "dynamic-retry-query";
-	ctx.exchange_id = "diagnostic-stage";
+	ctx.exchange_id = "diagnostic-exchange";
 	auto exchange = manager.CreateExchange(ctx, 1);
 	auto sink = exchange->AddSink(0);
 	auto initial = exchange->InstantiateSink(sink, 0);
@@ -2337,7 +2337,7 @@ TEST_CASE("Exchange: failed unselected-attempt cleanup releases its retry claim"
 
 	ExchangeContext ctx;
 	ctx.query_id = "unselected-cleanup-retry-query";
-	ctx.exchange_id = "unselected-cleanup-retry-stage";
+	ctx.exchange_id = "unselected-cleanup-retry-exchange";
 	auto exchange = manager.CreateExchange(ctx, 1);
 	auto sink = exchange->AddSink(0);
 	auto selected = exchange->InstantiateSink(sink, 0);
@@ -2370,7 +2370,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 
 	// Create a ShuffleCache
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = "sink_test_stage";
+	cache_config.exchange_id = "sink_test_exchange";
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 2;
 	cache_config.local_dirs = {TestCreatePath("exchange_sink_test")};
@@ -2381,7 +2381,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	handle.sink_handle.task_partition_id = 0;
 	handle.attempt_id = 0;
 	handle.query_id = "sink-test-query";
-	handle.output_location = "sink_test_stage";
+	handle.output_location = "sink_test_exchange";
 	handle.output_partition_count = 2;
 
 	FlightExchangeSink sink(cache, handle, &context);
@@ -2408,7 +2408,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	REQUIRE(sink.GetMemoryUsage() == 0);
 
 	// Verify ShuffleCacheRegistry has the cache
-	auto registered = ShuffleCacheRegistry::Instance().Get("sink_test_stage");
+	auto registered = ShuffleCacheRegistry::Instance().Get("sink_test_exchange");
 	REQUIRE(registered != nullptr);
 	REQUIRE(registered.get() == cache.get());
 
@@ -2419,6 +2419,8 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	REQUIRE(manifest.good());
 	std::string manifest_contents((std::istreambuf_iterator<char>(manifest)), std::istreambuf_iterator<char>());
 	REQUIRE(manifest_contents.find("version=1") != std::string::npos);
+	REQUIRE(manifest_contents.find("exchange_id=sink_test_exchange") != std::string::npos);
+	REQUIRE(manifest_contents.find("shuffle_stage_id=") == std::string::npos);
 	REQUIRE(manifest_contents.find("sink_partition_id=0") != std::string::npos);
 	REQUIRE(manifest_contents.find("attempt_id=0") != std::string::npos);
 	REQUIRE(manifest_contents.find("file=0") != std::string::npos);
@@ -2427,11 +2429,11 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
 	source_config.expected_types = types;
-	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("sink_test_stage", "node_1", 0)});
+	auto rows = ReadSourceRows(context, source_config, {MakeSourceHandle("sink_test_exchange", "node_1", 0)});
 	RequireTwoColumnRows(rows, ids, names);
 
 	// Cleanup
-	ShuffleCacheRegistry::Instance().Remove("sink_test_stage");
+	ShuffleCacheRegistry::Instance().Remove("sink_test_exchange");
 }
 
 TEST_CASE("Exchange: FlightExchangeSink memory usage", "[distributed][exchange]") {
@@ -2439,7 +2441,7 @@ TEST_CASE("Exchange: FlightExchangeSink memory usage", "[distributed][exchange]"
 	Connection conn(db);
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = "sink_mem_test";
+	cache_config.exchange_id = "sink_mem_test";
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("exchange_sink_mem")};
@@ -2478,7 +2480,7 @@ TEST_CASE("Exchange: FlightExchangeSink abort retains partially flushed attempt 
 	const std::string query_id = "sink-abort-query";
 	const std::string exchange_id = "sink_abort__sink_0__attempt_0";
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.exchange_id = exchange_id;
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("exchange_sink_abort")};
@@ -2526,7 +2528,7 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 
 	// Prepare: write data via ShuffleCache and register it
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = "source_test_stage";
+	cache_config.exchange_id = "source_test_exchange";
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 2;
 	cache_config.local_dirs = {TestCreatePath("exchange_source_test")};
@@ -2552,7 +2554,7 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
 
 	// Register the cache
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_test_stage", cache, "source-test-query").is_ok());
+	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_test_exchange", cache, "source-test-query").is_ok());
 
 	// Create source and read partition 0
 	FlightExchangeConfig source_config;
@@ -2565,7 +2567,7 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 	ExchangeSourceHandle handle0;
 	handle0.partition_id = 0;
 	handle0.node_id = "node_1";
-	handle0.files.push_back(ExchangeSourceFile("source_test_stage", 0));
+	handle0.files.push_back(ExchangeSourceFile("source_test_exchange", 0));
 	source.AddSourceHandles({handle0});
 
 	REQUIRE(source.IsFinished() == false);
@@ -2588,7 +2590,7 @@ TEST_CASE("Exchange: FlightExchangeSource read from registry", "[distributed][ex
 	REQUIRE(source.IsFinished() == true);
 
 	source.Close();
-	ShuffleCacheRegistry::Instance().Remove("source_test_stage");
+	ShuffleCacheRegistry::Instance().Remove("source_test_exchange");
 }
 
 TEST_CASE("Exchange: FlightExchangeSource accepts RecordBatches larger than a standard vector",
@@ -2620,7 +2622,7 @@ TEST_CASE("Exchange: FlightExchangeSource accepts RecordBatches larger than a st
 	REQUIRE(file_output->Close().ok());
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = output_location;
+	cache_config.exchange_id = output_location;
 	cache_config.node_id = node_id;
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("exchange_source_oversized_cache")};
@@ -2660,7 +2662,7 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 	auto &context = *conn.context;
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = "source_multi_stage";
+	cache_config.exchange_id = "source_multi_exchange";
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 3;
 	cache_config.local_dirs = {TestCreatePath("exchange_source_multi")};
@@ -2679,7 +2681,8 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 
 	REQUIRE(cache->FlushAll(context, cache->BufferedNames()).is_ok());
 	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register("source_multi_stage", cache, "source-multi-test-query").is_ok());
+	REQUIRE(
+	    ShuffleCacheRegistry::Instance().Register("source_multi_exchange", cache, "source-multi-test-query").is_ok());
 
 	// Source reads both partitions
 	FlightExchangeConfig source_config;
@@ -2689,10 +2692,10 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 	ExchangeSourceHandle h0, h2;
 	h0.partition_id = 0;
 	h0.node_id = "node_1";
-	h0.files.push_back(ExchangeSourceFile("source_multi_stage", 0));
+	h0.files.push_back(ExchangeSourceFile("source_multi_exchange", 0));
 	h2.partition_id = 2;
 	h2.node_id = "node_1";
-	h2.files.push_back(ExchangeSourceFile("source_multi_stage", 0));
+	h2.files.push_back(ExchangeSourceFile("source_multi_exchange", 0));
 	source.AddSourceHandles({h0, h2});
 
 	vector<int32_t> read_ids;
@@ -2715,7 +2718,7 @@ TEST_CASE("Exchange: FlightExchangeSource multiple partitions", "[distributed][e
 	REQUIRE(read_ids[2] == 40);
 
 	source.Close();
-	ShuffleCacheRegistry::Instance().Remove("source_multi_stage");
+	ShuffleCacheRegistry::Instance().Remove("source_multi_exchange");
 }
 
 TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path", "[distributed][exchange]") {
@@ -2724,11 +2727,11 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	auto &context = *conn.context;
 
 	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::VARCHAR};
-	const string stage0 = "source_switch_stage_0";
-	const string stage1 = "source_switch_stage_1";
+	const string exchange0 = "source_switch_exchange_0";
+	const string exchange1 = "source_switch_exchange_1";
 
 	ShuffleCacheConfig cache0_config;
-	cache0_config.shuffle_stage_id = stage0;
+	cache0_config.exchange_id = exchange0;
 	cache0_config.node_id = "node_1";
 	cache0_config.num_partitions = 1;
 	cache0_config.local_dirs = {TestCreatePath("exchange_source_switch_0")};
@@ -2739,10 +2742,10 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	REQUIRE(cache0->WriteChunk(context, chunk0, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache0->FlushAll(context, cache0->BufferedNames()).is_ok());
 	REQUIRE(cache0->WriteAttemptManifest(0, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage0, cache0, "source-switch-test-query").is_ok());
+	REQUIRE(ShuffleCacheRegistry::Instance().Register(exchange0, cache0, "source-switch-test-query").is_ok());
 
 	ShuffleCacheConfig cache1_config;
-	cache1_config.shuffle_stage_id = stage1;
+	cache1_config.exchange_id = exchange1;
 	cache1_config.node_id = "node_1";
 	cache1_config.num_partitions = 1;
 	cache1_config.local_dirs = {TestCreatePath("exchange_source_switch_1")};
@@ -2753,7 +2756,7 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	REQUIRE(cache1->WriteChunk(context, chunk1, 0, {"id", "name"}).is_ok());
 	REQUIRE(cache1->FlushAll(context, cache1->BufferedNames()).is_ok());
 	REQUIRE(cache1->WriteAttemptManifest(1, 0).is_ok());
-	REQUIRE(ShuffleCacheRegistry::Instance().Register(stage1, cache1, "source-switch-test-query").is_ok());
+	REQUIRE(ShuffleCacheRegistry::Instance().Register(exchange1, cache1, "source-switch-test-query").is_ok());
 
 	FlightExchangeConfig source_config;
 	source_config.node_id = "node_1";
@@ -2762,12 +2765,12 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	ExchangeSourceHandle handle0;
 	handle0.partition_id = 0;
 	handle0.node_id = "node_1";
-	handle0.files.push_back(ExchangeSourceFile(stage0, 0));
+	handle0.files.push_back(ExchangeSourceFile(exchange0, 0));
 
 	ExchangeSourceHandle handle1;
 	handle1.partition_id = 0;
 	handle1.node_id = "node_1";
-	handle1.files.push_back(ExchangeSourceFile(stage1, 0));
+	handle1.files.push_back(ExchangeSourceFile(exchange1, 0));
 
 	source.AddSourceHandles({handle0, handle1});
 
@@ -2787,8 +2790,8 @@ TEST_CASE("Exchange: FlightExchangeSource switches local cache per handle path",
 	REQUIRE(read_names == vector<string>({"a", "b", "c", "d"}));
 
 	source.Close();
-	ShuffleCacheRegistry::Instance().Remove(stage0);
-	ShuffleCacheRegistry::Instance().Remove(stage1);
+	ShuffleCacheRegistry::Instance().Remove(exchange0);
+	ShuffleCacheRegistry::Instance().Remove(exchange1);
 }
 
 TEST_CASE("Exchange: FlightExchangeSource revalidates local handle attempt identity", "[distributed][exchange]") {
@@ -2799,7 +2802,7 @@ TEST_CASE("Exchange: FlightExchangeSource revalidates local handle attempt ident
 	const std::string query_id = "source-local-identity-query";
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.exchange_id = exchange_id;
 	cache_config.node_id = "node-local";
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("exchange_source_local_identity")};
@@ -2879,7 +2882,7 @@ TEST_CASE("Exchange: FlightExchangeSource close releases catalog borrow for quer
 	const std::string query_id = "source-close-cleanup-query";
 	const std::string exchange_id = "source_close_cleanup_attempt";
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.exchange_id = exchange_id;
 	cache_config.node_id = "node-1";
 	cache_config.num_partitions = 1;
 	cache_config.local_dirs = {TestCreatePath("exchange_source_close_cleanup")};
@@ -2926,12 +2929,12 @@ TEST_CASE("Exchange: End-to-end sink to source pipeline", "[distributed][exchang
 	Connection conn(db);
 	auto &context = *conn.context;
 
-	const std::string exchange_id = "e2e_test_stage";
+	const std::string exchange_id = "e2e_test_exchange";
 
 	// ─── Phase 1: Create exchange and write data via sink ───
 
 	ShuffleCacheConfig cache_config;
-	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.exchange_id = exchange_id;
 	cache_config.node_id = "node_1";
 	cache_config.num_partitions = 2;
 	cache_config.local_dirs = {TestCreatePath("exchange_e2e")};
@@ -3023,7 +3026,7 @@ TEST_CASE("Exchange: Multiple sinks to same exchange", "[distributed][exchange]"
 	const std::string output1 = exchange_id + "__sink_1__attempt_0";
 	auto make_cache = [&](const std::string &output_location, const std::string &dir) {
 		ShuffleCacheConfig cache_config;
-		cache_config.shuffle_stage_id = output_location;
+		cache_config.exchange_id = output_location;
 		cache_config.node_id = "node_1";
 		cache_config.num_partitions = 2;
 		cache_config.local_dirs = {TestCreatePath(dir)};

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -144,7 +144,7 @@ void SerializePreStrictRemoteExchangeSink(Serializer &serializer) {
 	serializer.WriteProperty(100, "type", PhysicalOperatorType::EXCHANGE_SINK);
 	serializer.WriteProperty(101, "types", types);
 	serializer.WriteProperty<idx_t>(102, "estimated_cardinality", 0);
-	serializer.WriteProperty(103, "shuffle_stage_id", string("legacy-sink"));
+	serializer.WriteProperty(103, "exchange_id", string("legacy-sink"));
 	serializer.WriteProperty(104, "node_id", string("legacy-node"));
 	serializer.WriteProperty<idx_t>(105, "num_partitions", 1);
 	serializer.WriteProperty<uint8_t>(106, "repartition_type", static_cast<uint8_t>(RepartitionSpec::Type::Random));
@@ -177,7 +177,7 @@ void SerializePreStrictRemoteExchangeSource(Serializer &serializer) {
 	serializer.WriteProperty(100, "type", PhysicalOperatorType::EXCHANGE_SOURCE);
 	serializer.WriteProperty(101, "types", types);
 	serializer.WriteProperty<idx_t>(102, "estimated_cardinality", 0);
-	serializer.WriteProperty(103, "shuffle_stage_id", string("legacy-source"));
+	serializer.WriteProperty(103, "exchange_id", string("legacy-source"));
 	serializer.WriteProperty(104, "partition_indices", partition_indices);
 	serializer.WriteProperty(105, "source_nodes", source_nodes);
 	serializer.WriteProperty(106, "flight_location_template", string("grpc://{node}:31337"));
@@ -1688,7 +1688,7 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	sink_handle.sink_handle.task_partition_id = 7;
 	sink_handle.attempt_id = 2;
 	sink_handle.query_id = "query-session-a";
-	sink_handle.output_location = "shuffle_stage__sink_7__attempt_2";
+	sink_handle.output_location = "exchange__sink_7__attempt_2";
 	sink_handle.output_partition_count = 4;
 	sink_handle.flight_host = "worker-only.internal";
 	sink_handle.flight_server_epoch = "sink-epoch";
@@ -1700,7 +1700,7 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	vector<unique_ptr<Expression>> partition_by;
-	auto &sink = plan.Make<PhysicalRemoteExchangeSink>(types, 123, "shuffle_stage", 4, RepartitionSpec::Type::Random,
+	auto &sink = plan.Make<PhysicalRemoteExchangeSink>(types, 123, "exchange", 4, RepartitionSpec::Type::Random,
 	                                                   std::move(partition_by), sink_handle, exchange_mgr);
 	vector<unique_ptr<Expression>> mark_join_build_expressions;
 	mark_join_build_expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
@@ -1722,12 +1722,12 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	REQUIRE(deserialized_op != nullptr);
 	auto *sink_ptr = dynamic_cast<PhysicalRemoteExchangeSink *>(deserialized_op.get());
 	REQUIRE(sink_ptr != nullptr);
-	REQUIRE(sink_ptr->ExchangeId() == "shuffle_stage");
+	REQUIRE(sink_ptr->ExchangeId() == "exchange");
 	REQUIRE(sink_ptr->NumPartitions() == 4);
 	REQUIRE(sink_ptr->SinkHandle().sink_handle.task_partition_id == 7);
 	REQUIRE(sink_ptr->SinkHandle().attempt_id == 2);
 	REQUIRE(sink_ptr->SinkHandle().query_id == "query-session-a");
-	REQUIRE(sink_ptr->SinkHandle().output_location == "shuffle_stage__sink_7__attempt_2");
+	REQUIRE(sink_ptr->SinkHandle().output_location == "exchange__sink_7__attempt_2");
 	REQUIRE(sink_ptr->SinkHandle().output_partition_count == 4);
 	REQUIRE(sink_ptr->SinkHandle().flight_host.empty());
 	REQUIRE(sink_ptr->SinkHandle().flight_server_epoch == "sink-epoch");
@@ -1759,7 +1759,7 @@ TEST_CASE("ApplyExchangeSinkInstanceToPlan validates runtime sink ownership",
 	flight_config.node_id = "node-1";
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 	auto &sink_op = plan.Make<PhysicalRemoteExchangeSink>(vector<LogicalType> {LogicalType::INTEGER}, 123,
-	                                                      "diagnostic-stage", 4, RepartitionSpec::Type::Random,
+	                                                      "diagnostic-exchange", 4, RepartitionSpec::Type::Random,
 	                                                      vector<unique_ptr<Expression>> {}, plan_handle, exchange_mgr);
 	auto &sink = sink_op.Cast<PhysicalRemoteExchangeSink>();
 	auto sample_options = make_uniq<SampleOptions>(42);
@@ -1924,7 +1924,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle0.flight_host = "flight-node-1.internal";
 	handle0.flight_port = 6123;
 	handle0.flight_server_epoch = "epoch-1";
-	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0));
+	handle0.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_0", 0));
 	source_handles.push_back(handle0);
 
 	distributed::ExchangeSourceHandle handle1;
@@ -1935,7 +1935,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle1.flight_host = "flight-node-2.internal";
 	handle1.flight_port = 6124;
 	handle1.flight_server_epoch = "epoch-2";
-	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_0", 0));
+	handle1.files.push_back(ExchangeSourceFile("exchange__sink_1__attempt_0", 0));
 	source_handles.push_back(handle1);
 
 	distributed::ExchangeSourceHandle handle2;
@@ -1946,7 +1946,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	handle2.flight_host = "flight-node-1.internal";
 	handle2.flight_port = 6123;
 	handle2.flight_server_epoch = "epoch-1";
-	handle2.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0));
+	handle2.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_0", 0));
 	source_handles.push_back(handle2);
 
 	distributed::FlightExchangeConfig flight_config;
@@ -1955,8 +1955,8 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	flight_config.flight_read_timeout_seconds = 3.25;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
-	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", partition_indices,
-	                                                       source_handles, exchange_mgr, source_nodes);
+	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "exchange", partition_indices, source_handles,
+	                                                       exchange_mgr, source_nodes);
 
 	MemoryStream stream(allocator);
 	SerializationOptions options;
@@ -1974,7 +1974,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(deserialized_op != nullptr);
 	auto *source_ptr = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
 	REQUIRE(source_ptr != nullptr);
-	REQUIRE(source_ptr->ExchangeId() == "shuffle_stage");
+	REQUIRE(source_ptr->ExchangeId() == "exchange");
 	REQUIRE(source_ptr->PartitionIndices() == partition_indices);
 	REQUIRE(source_ptr->SourceNodes() == source_nodes);
 	REQUIRE(source_ptr->SourceHandles().size() == source_handles.size());
@@ -1986,7 +1986,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[0].flight_port == 6123);
 	REQUIRE(source_ptr->SourceHandles()[0].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[0].files.size() == 1);
-	REQUIRE(source_ptr->SourceHandles()[0].files[0].path == "shuffle_stage__sink_0__attempt_0");
+	REQUIRE(source_ptr->SourceHandles()[0].files[0].path == "exchange__sink_0__attempt_0");
 	REQUIRE(source_ptr->SourceHandles()[1].partition_id == 0);
 	REQUIRE(source_ptr->SourceHandles()[1].source_task_partition_id == 11);
 	REQUIRE(source_ptr->SourceHandles()[1].attempt_id == 4);
@@ -1995,7 +1995,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[1].flight_port == 6124);
 	REQUIRE(source_ptr->SourceHandles()[1].flight_server_epoch == "epoch-2");
 	REQUIRE(source_ptr->SourceHandles()[1].files.size() == 1);
-	REQUIRE(source_ptr->SourceHandles()[1].files[0].path == "shuffle_stage__sink_1__attempt_0");
+	REQUIRE(source_ptr->SourceHandles()[1].files[0].path == "exchange__sink_1__attempt_0");
 	REQUIRE(source_ptr->SourceHandles()[2].partition_id == 1);
 	REQUIRE(source_ptr->SourceHandles()[2].source_task_partition_id == 10);
 	REQUIRE(source_ptr->SourceHandles()[2].attempt_id == 3);
@@ -2004,7 +2004,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[2].flight_port == 6123);
 	REQUIRE(source_ptr->SourceHandles()[2].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[2].files.size() == 1);
-	REQUIRE(source_ptr->SourceHandles()[2].files[0].path == "shuffle_stage__sink_0__attempt_0");
+	REQUIRE(source_ptr->SourceHandles()[2].files[0].path == "exchange__sink_0__attempt_0");
 	auto roundtrip_manager =
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
 	REQUIRE(roundtrip_manager != nullptr);
@@ -2082,7 +2082,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves runtime source b
 	flight_config.node_id = "node-1";
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
-	auto &source_op = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", vector<idx_t>(),
+	auto &source_op = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "exchange", vector<idx_t>(),
 	                                                          std::vector<distributed::ExchangeSourceHandle>(),
 	                                                          exchange_mgr, source_nodes, optional_idx(42));
 	auto &source = dynamic_cast<PhysicalRemoteExchangeSource &>(source_op);
@@ -2103,7 +2103,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves runtime source b
 	REQUIRE(deserialized_op != nullptr);
 	auto *source_ptr = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
 	REQUIRE(source_ptr != nullptr);
-	REQUIRE(source_ptr->ExchangeId() == "shuffle_stage");
+	REQUIRE(source_ptr->ExchangeId() == "exchange");
 	REQUIRE(source_ptr->PartitionIndices().empty());
 	REQUIRE(source_ptr->SourceHandles().empty());
 	REQUIRE(source_ptr->RuntimeSourceNodeId().IsValid());
@@ -2163,7 +2163,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	handle0.flight_host = "flight-node-1.internal";
 	handle0.flight_port = 5010;
 	handle0.flight_server_epoch = "epoch-1";
-	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_7", 0, 11));
+	handle0.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_7", 0, 11));
 	descriptor.source_handles.push_back(handle0);
 
 	distributed::ExchangeSourceHandle handle1;
@@ -2174,7 +2174,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	handle1.flight_host = "flight-node-2.internal";
 	handle1.flight_port = 5011;
 	handle1.flight_server_epoch = "epoch-2";
-	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_2", 0, 17));
+	handle1.files.push_back(ExchangeSourceFile("exchange__sink_1__attempt_2", 0, 17));
 	descriptor.source_handles.push_back(handle1);
 
 	auto roundtrip = distributed::ExchangeSourceTaskDescriptor::DeserializeFromBytes(descriptor.SerializeToBytes());
@@ -2194,7 +2194,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.source_handles[0].flight_port == 5010);
 	REQUIRE(roundtrip.source_handles[0].flight_server_epoch == "epoch-1");
 	REQUIRE(roundtrip.source_handles[0].files.size() == 1);
-	REQUIRE(roundtrip.source_handles[0].files[0].path == "shuffle_stage__sink_0__attempt_7");
+	REQUIRE(roundtrip.source_handles[0].files[0].path == "exchange__sink_0__attempt_7");
 	REQUIRE(roundtrip.source_handles[0].files[0].file_size == 11);
 	REQUIRE(roundtrip.source_handles[1].partition_id == 1);
 	REQUIRE(roundtrip.source_handles[1].source_task_partition_id == 22);
@@ -2204,7 +2204,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.source_handles[1].flight_port == 5011);
 	REQUIRE(roundtrip.source_handles[1].flight_server_epoch == "epoch-2");
 	REQUIRE(roundtrip.source_handles[1].files.size() == 1);
-	REQUIRE(roundtrip.source_handles[1].files[0].path == "shuffle_stage__sink_1__attempt_2");
+	REQUIRE(roundtrip.source_handles[1].files[0].path == "exchange__sink_1__attempt_2");
 	REQUIRE(roundtrip.source_handles[1].files[0].file_size == 17);
 }
 
@@ -2220,7 +2220,7 @@ TEST_CASE("ApplyExchangeSourceTasksToPlan patches runtime-bound exchange source"
 	flight_config.node_id = "node-1";
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
-	auto &source_op = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", vector<idx_t>(),
+	auto &source_op = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "exchange", vector<idx_t>(),
 	                                                          std::vector<distributed::ExchangeSourceHandle>(),
 	                                                          exchange_mgr, source_nodes, optional_idx(42));
 	auto &source = dynamic_cast<PhysicalRemoteExchangeSource &>(source_op);
@@ -2232,13 +2232,13 @@ TEST_CASE("ApplyExchangeSourceTasksToPlan patches runtime-bound exchange source"
 	handle0.partition_id = 0;
 	handle0.attempt_id = 5;
 	handle0.node_id = "node-1";
-	handle0.files.push_back(ExchangeSourceFile("shuffle_stage__sink_0__attempt_0", 0, 11));
+	handle0.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_0", 0, 11));
 	descriptor.source_handles.push_back(handle0);
 	distributed::ExchangeSourceHandle handle1;
 	handle1.partition_id = 1;
 	handle1.attempt_id = 6;
 	handle1.node_id = "node-2";
-	handle1.files.push_back(ExchangeSourceFile("shuffle_stage__sink_1__attempt_0", 0, 17));
+	handle1.files.push_back(ExchangeSourceFile("exchange__sink_1__attempt_0", 0, 17));
 	descriptor.source_handles.push_back(handle1);
 
 	std::unordered_map<idx_t, distributed::ExchangeSourceTaskDescriptor> tasks;
@@ -2253,13 +2253,13 @@ TEST_CASE("ApplyExchangeSourceTasksToPlan patches runtime-bound exchange source"
 	REQUIRE(source.SourceHandles()[0].attempt_id == 5);
 	REQUIRE(source.SourceHandles()[0].node_id == "node-1");
 	REQUIRE(source.SourceHandles()[0].files.size() == 1);
-	REQUIRE(source.SourceHandles()[0].files[0].path == "shuffle_stage__sink_0__attempt_0");
+	REQUIRE(source.SourceHandles()[0].files[0].path == "exchange__sink_0__attempt_0");
 	REQUIRE(source.SourceHandles()[0].files[0].file_size == 11);
 	REQUIRE(source.SourceHandles()[1].partition_id == 1);
 	REQUIRE(source.SourceHandles()[1].attempt_id == 6);
 	REQUIRE(source.SourceHandles()[1].node_id == "node-2");
 	REQUIRE(source.SourceHandles()[1].files.size() == 1);
-	REQUIRE(source.SourceHandles()[1].files[0].path == "shuffle_stage__sink_1__attempt_0");
+	REQUIRE(source.SourceHandles()[1].files[0].path == "exchange__sink_1__attempt_0");
 	REQUIRE(source.SourceHandles()[1].files[0].file_size == 17);
 }
 

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -201,7 +201,7 @@ void SerializeRemoteExchangeSourceWithoutReadTimeout(Serializer &serializer) {
 	vector<string> source_nodes = {"node-1"};
 	vector<idx_t> handle_partition_ids = {0};
 	vector<string> handle_node_ids = {"node-1"};
-	vector<string> handle_paths = {"shuffle-stage__sink_0__attempt_0"};
+	vector<string> handle_paths = {"exchange-id__sink_0__attempt_0"};
 	vector<int> handle_flight_ports = {6123};
 	vector<idx_t> handle_attempt_ids = {0};
 	vector<string> local_dirs = {"/tmp/vane-shuffle"};
@@ -211,7 +211,7 @@ void SerializeRemoteExchangeSourceWithoutReadTimeout(Serializer &serializer) {
 	serializer.WriteProperty(100, "type", PhysicalOperatorType::EXCHANGE_SOURCE);
 	serializer.WriteProperty(101, "types", types);
 	serializer.WriteProperty<idx_t>(102, "estimated_cardinality", 0);
-	serializer.WriteProperty(103, "shuffle_stage_id", string("shuffle-stage"));
+	serializer.WriteProperty(103, "exchange_id", string("exchange-id"));
 	serializer.WriteProperty(104, "partition_indices", partition_indices);
 	serializer.WriteProperty(105, "source_nodes", source_nodes);
 	serializer.WriteProperty<double>(106, "flight_timeout_seconds", 7.5);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -1401,6 +1401,10 @@ TEST_CASE("PhysicalPlanTranslator: partitioned MARK joins preserve global build 
 		REQUIRE(right_shuffle != nullptr);
 		REQUIRE_FALSE(left_shuffle->CollectsMarkJoinBuildSummary());
 		REQUIRE(right_shuffle->CollectsMarkJoinBuildSummary());
+		REQUIRE_FALSE(left_shuffle->is_materialization_barrier());
+		REQUIRE(right_shuffle->is_materialization_barrier());
+		REQUIRE(right_shuffle->materialized_input_node_ids() ==
+		        vector<NodeID> {right_shuffle->children()[0]->node_id()});
 		REQUIRE(NodeDisplayContains(right_shuffle->into_node(), "MARK build summary: global"));
 	}
 
@@ -1413,6 +1417,8 @@ TEST_CASE("PhysicalPlanTranslator: partitioned MARK joins preserve global build 
 			auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(child);
 			REQUIRE(shuffle != nullptr);
 			REQUIRE_FALSE(shuffle->CollectsMarkJoinBuildSummary());
+			REQUIRE_FALSE(shuffle->is_materialization_barrier());
+			REQUIRE(shuffle->materialized_input_node_ids().empty());
 			REQUIRE(shuffle->config().clustering_spec()->partition_by().size() == 1);
 		}
 	}

--- a/scripts/run_fast_tests.sh
+++ b/scripts/run_fast_tests.sh
@@ -114,11 +114,6 @@ if [[ -n "$junit_dir" ]]; then
   junit_dir="$(cd "$junit_dir" && pwd)"
 fi
 
-ray_object_store_bytes="$(
-  PYTHONPATH="tests${PYTHONPATH:+:${PYTHONPATH}}" \
-    python -c "from ray_test_profile import ray_test_object_store_bytes; print(ray_test_object_store_bytes())"
-)"
-
 run_pytest() {
   if ((process_timeout_seconds > 0)); then
     timeout \
@@ -143,8 +138,7 @@ run_reported_pytest() {
 }
 
 run_ray_pytest() {
-  VANE_TEST_RAY_OBJECT_STORE_BYTES="${ray_object_store_bytes}" \
-    run_reported_pytest "$@"
+  run_reported_pytest "$@"
 }
 
 run_owner_ray_pytest() {

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -26,11 +26,6 @@ pytest_args=(
   -o pythonpath=tests
 )
 
-ray_object_store_bytes="$(
-  PYTHONPATH="tests${PYTHONPATH:+:${PYTHONPATH}}" \
-    python -c "from ray_test_profile import ray_test_object_store_bytes; print(ray_test_object_store_bytes())"
-)"
-
 # Let the non-Ray process release all Python/native state before a fresh pytest
 # process starts the real Ray runtime.
 python -m pytest \
@@ -38,8 +33,7 @@ python -m pytest \
   -m "not external_service and not real_ray" \
   "${release_tests[@]}"
 
-VANE_TEST_RAY_OBJECT_STORE_BYTES="${ray_object_store_bytes}" \
-  python -m pytest \
+python -m pytest \
   "${pytest_args[@]}" \
   -m "not external_service and real_ray" \
   "${release_tests[@]}"

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -664,6 +664,14 @@ struct PyPhysicalPlanWrapper {
 			}
 			metadata[py::str("input_node_ids")] = std::move(input_node_ids);
 			metadata[py::str("is_sink")] = py::bool_(node->is_sink());
+			metadata[py::str("is_materialization_barrier")] = py::bool_(node->is_materialization_barrier());
+			py::list materialized_input_node_ids;
+			auto materialized_inputs = node->materialized_input_node_ids();
+			std::sort(materialized_inputs.begin(), materialized_inputs.end());
+			for (auto input_node_id : materialized_inputs) {
+				materialized_input_node_ids.append(py::str(std::to_string(input_node_id)));
+			}
+			metadata[py::str("materialized_input_node_ids")] = std::move(materialized_input_node_ids);
 			metadata[py::str("num_partitions")] = py::int_(std::max<size_t>(1, node->num_partitions()));
 			auto udf_entry = udf_by_node.find(node->node_id());
 			if (udf_entry == udf_by_node.end()) {
@@ -1147,6 +1155,23 @@ public:
 		} catch (const std::exception &e) {
 			return DuckDBResult<void>::err(
 			    DuckDBError(string("Python backend task_input_stream_exhausted failed: ") + e.what()));
+		}
+	}
+
+	DuckDBResult<void> materialization_barrier_completed(const string &query_id,
+	                                                     duckdb::distributed::NodeID node_id) override {
+		if (query_id.empty()) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::value_error("materialization barrier completion requires non-empty query_id"));
+		}
+		try {
+			duckdb::PythonGILWrapper gil;
+			auto backend = backend_.get();
+			backend.attr("materialization_barrier_completed")(query_id, std::to_string(node_id));
+			return DuckDBResult<void>::ok();
+		} catch (const std::exception &e) {
+			return DuckDBResult<void>::err(
+			    DuckDBError(string("Python backend materialization_barrier_completed failed: ") + e.what()));
 		}
 	}
 

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -664,7 +664,6 @@ struct PyPhysicalPlanWrapper {
 			}
 			metadata[py::str("input_node_ids")] = std::move(input_node_ids);
 			metadata[py::str("is_sink")] = py::bool_(node->is_sink());
-			metadata[py::str("is_blocking_materializing")] = py::bool_(node->is_blocking_materializing());
 			metadata[py::str("num_partitions")] = py::int_(std::max<size_t>(1, node->num_partitions()));
 			auto udf_entry = udf_by_node.find(node->node_id());
 			if (udf_entry == udf_by_node.end()) {

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -474,13 +474,15 @@ struct PyPhysicalPlanWrapper {
 		return original_payloads;
 	}
 
-	py::dict collect_execution_stages(py::object conn_obj) {
+	py::dict collect_query_resource_graph_metadata(py::object conn_obj) {
 		if (!IsInitialized() || !plan_ || !has_root()) {
-			throw duckdb::InternalException("DistributedPhysicalPlan must have a root before stage collection");
+			throw duckdb::InternalException(
+			    "DistributedPhysicalPlan must have a root before query resource graph metadata collection");
 		}
 		auto query_id = idx();
 		if (query_id.empty()) {
-			throw duckdb::InternalException("DistributedPhysicalPlan stage collection requires a query_id");
+			throw duckdb::InternalException(
+			    "DistributedPhysicalPlan query resource graph metadata collection requires a query_id");
 		}
 		if (plan_->query_id() != query_id) {
 			throw duckdb::InvalidInputException("DistributedPhysicalPlan query ownership mismatch: wrapper=%s plan=%s",
@@ -561,16 +563,17 @@ struct PyPhysicalPlanWrapper {
 		          [](const auto &left, const auto &right) { return left->node_id() < right->node_id(); });
 
 		if (physical_udfs.size() != pipeline_udfs.size()) {
-			throw duckdb::InternalException("physical/pipeline UDF stage count mismatch: physical=%llu pipeline=%llu",
-			                                static_cast<unsigned long long>(physical_udfs.size()),
-			                                static_cast<unsigned long long>(pipeline_udfs.size()));
+			throw duckdb::InternalException(
+			    "physical/pipeline UDF resource-unit count mismatch: physical=%llu pipeline=%llu",
+			    static_cast<unsigned long long>(physical_udfs.size()),
+			    static_cast<unsigned long long>(pipeline_udfs.size()));
 		}
 
-		struct PendingUDFStageAnnotation {
+		struct PendingUDFResourceUnitAnnotation {
 			UDFFunctionData *bind_data;
 			Value payload;
 		};
-		vector<PendingUDFStageAnnotation> pending_annotations;
+		vector<PendingUDFResourceUnitAnnotation> pending_annotations;
 		pending_annotations.reserve(physical_udfs.size());
 		std::unordered_map<duckdb::distributed::NodeID, idx_t> udf_by_node;
 		for (auto *bind_data : physical_udfs) {
@@ -599,7 +602,7 @@ struct PyPhysicalPlanWrapper {
 				    "physical/pipeline UDF backend mismatch for operator %s at node %llu: physical=%s pipeline=%s",
 				    identity, static_cast<unsigned long long>(node_id), physical_backend, pipeline_backend);
 			}
-			auto stage_id = "stage:" + query_id + ":node:" + std::to_string(node_id) + ":udf";
+			auto resource_unit_id = "resource:" + query_id + ":udf:node:" + std::to_string(node_id);
 			auto existing_query_id = UDFPayloadStringOrDefault(bind_data->payload, "query_id");
 			if (!existing_query_id.empty() && existing_query_id != query_id) {
 				throw duckdb::InvalidInputException(
@@ -612,17 +615,17 @@ struct PyPhysicalPlanWrapper {
 				    "pipeline UDF payload query ownership mismatch for operator %s at node %llu: payload=%s plan=%s",
 				    identity, static_cast<unsigned long long>(node_id), pipeline_payload_query_id, query_id);
 			}
-			auto existing_stage_id = UDFPayloadStringOrDefault(bind_data->payload, "stage_id");
-			if (!existing_stage_id.empty() && existing_stage_id != stage_id) {
+			auto existing_resource_unit_id = UDFPayloadStringOrDefault(bind_data->payload, "resource_unit_id");
+			if (!existing_resource_unit_id.empty() && existing_resource_unit_id != resource_unit_id) {
 				throw duckdb::InvalidInputException(
-				    "physical UDF stage identity mismatch for operator %s at node %llu: payload=%s expected=%s",
-				    identity, static_cast<unsigned long long>(node_id), existing_stage_id, stage_id);
+				    "physical UDF resource-unit identity mismatch for operator %s at node %llu: payload=%s expected=%s",
+				    identity, static_cast<unsigned long long>(node_id), existing_resource_unit_id, resource_unit_id);
 			}
-			auto pipeline_stage_id = UDFPayloadStringOrDefault(pipeline_bind_data->payload, "stage_id");
-			if (!pipeline_stage_id.empty() && pipeline_stage_id != stage_id) {
+			auto pipeline_resource_unit_id = UDFPayloadStringOrDefault(pipeline_bind_data->payload, "resource_unit_id");
+			if (!pipeline_resource_unit_id.empty() && pipeline_resource_unit_id != resource_unit_id) {
 				throw duckdb::InvalidInputException(
-				    "pipeline UDF stage identity mismatch for operator %s at node %llu: payload=%s expected=%s",
-				    identity, static_cast<unsigned long long>(node_id), pipeline_stage_id, stage_id);
+				    "pipeline UDF resource-unit identity mismatch for operator %s at node %llu: payload=%s expected=%s",
+				    identity, static_cast<unsigned long long>(node_id), pipeline_resource_unit_id, resource_unit_id);
 			}
 			if (bind_data->return_type != pipeline_bind_data->return_type ||
 			    bind_data->payload != pipeline_bind_data->payload ||
@@ -632,9 +635,9 @@ struct PyPhysicalPlanWrapper {
 				    static_cast<unsigned long long>(node_id));
 			}
 			auto annotated_payload = UDFPayloadWithStringField(bind_data->payload, "query_id", query_id);
-			annotated_payload = UDFPayloadWithStringField(annotated_payload, "stage_id", stage_id);
+			annotated_payload = UDFPayloadWithStringField(annotated_payload, "resource_unit_id", resource_unit_id);
 			auto annotation_index = pending_annotations.size();
-			pending_annotations.push_back(PendingUDFStageAnnotation {bind_data, std::move(annotated_payload)});
+			pending_annotations.push_back(PendingUDFResourceUnitAnnotation {bind_data, std::move(annotated_payload)});
 			if (!udf_by_node.emplace(node_id, annotation_index).second) {
 				throw duckdb::InternalException("duplicate pipeline UDF node identity: %llu",
 				                                static_cast<unsigned long long>(node_id));

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -660,7 +660,8 @@ struct PyPhysicalPlanWrapper {
 				input_node_ids.append(py::str(std::to_string(child->node_id())));
 			}
 			metadata[py::str("input_node_ids")] = std::move(input_node_ids);
-			metadata[py::str("is_sink")] = py::bool_(node->implementation()->is_sink());
+			metadata[py::str("is_sink")] = py::bool_(node->is_sink());
+			metadata[py::str("is_blocking_materializing")] = py::bool_(node->is_blocking_materializing());
 			metadata[py::str("num_partitions")] = py::int_(std::max<size_t>(1, node->num_partitions()));
 			auto udf_entry = udf_by_node.find(node->node_id());
 			if (udf_entry == udf_by_node.end()) {

--- a/src/duckdb_py/ray/native_fragment_executor.cpp
+++ b/src/duckdb_py/ray/native_fragment_executor.cpp
@@ -177,14 +177,6 @@ static std::string PipelineSnapshotName(const duckdb::PipelineProgressSnapshot &
 	return result.empty() ? "Pipeline" : result;
 }
 
-static py::list StageIdsToPyList(const duckdb::vector<duckdb::idx_t> &stage_ids) {
-	py::list out;
-	for (auto stage_id : stage_ids) {
-		out.append(py::int_(stage_id));
-	}
-	return out;
-}
-
 static py::list OperatorsToPyList(const duckdb::vector<std::string> &operators) {
 	py::list out;
 	for (const auto &op : operators) {
@@ -541,7 +533,6 @@ static py::dict BuildNativeTaskStatsDict(
 		pipeline["name"] = PipelineSnapshotName(snapshot);
 		pipeline["operators"] = OperatorsToPyList(snapshot.operators);
 		pipeline["operator_details"] = OperatorDetailsToPyList(snapshot.operator_details);
-		pipeline["stage_ids"] = StageIdsToPyList(snapshot.stage_ids);
 		pipeline["input_rows"] = py::int_(snapshot.input_rows);
 		pipeline["input_bytes"] = py::int_(snapshot.input_bytes);
 		pipeline["output_rows"] = py::int_(snapshot.output_rows);
@@ -625,7 +616,6 @@ static py::dict BuildOutputOnlyTaskStatsDict(
 	pipeline["name"] = operators ? OperatorListName(*operators) : "Result";
 	pipeline["operators"] = operators ? OperatorsToPyList(*operators) : py::list();
 	pipeline["operator_details"] = operator_details ? OperatorDetailsToPyList(*operator_details) : py::list();
-	pipeline["stage_ids"] = py::list();
 	pipeline["input_rows"] = py::int_(rows);
 	pipeline["input_bytes"] = py::int_(bytes);
 	pipeline["output_rows"] = py::int_(rows);
@@ -844,7 +834,6 @@ static py::dict BuildNativePipelineTopology(const duckdb::vector<duckdb::Pipelin
 		pipeline["pipeline_id"] = py::int_(snapshot.pipeline_index);
 		pipeline["operators"] = OperatorsToPyList(snapshot.operators);
 		pipeline["operator_details"] = OperatorDetailsToPyList(snapshot.operator_details);
-		pipeline["stage_ids"] = StageIdsToPyList(snapshot.stage_ids);
 		pipelines.append(std::move(pipeline));
 	}
 	py::dict topology;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -759,7 +759,8 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def("repr_ascii", &PyPhysicalPlanWrapper::repr_ascii)
 	    .def("repr_mermaid", &PyPhysicalPlanWrapper::repr_mermaid)
 	    .def("scan_task_descriptor_map", &PyPhysicalPlanWrapper::scan_task_descriptor_map)
-	    .def("collect_execution_stages", &PyPhysicalPlanWrapper::collect_execution_stages, py::arg("conn") = py::none())
+	    .def("collect_query_resource_graph_metadata", &PyPhysicalPlanWrapper::collect_query_resource_graph_metadata,
+	         py::arg("conn") = py::none())
 	    .def("collect_udf_nodes", &PyPhysicalPlanWrapper::collect_udf_nodes, py::arg("conn") = py::none())
 	    .def("collect_vllm_nodes", &PyPhysicalPlanWrapper::collect_vllm_nodes, py::arg("conn") = py::none())
 	    .def("set_udf_actor_handles", &PyPhysicalPlanWrapper::set_udf_actor_handles, py::arg("handles_map"),

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -2255,7 +2255,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 		    auto manifest_exists = [&](const ExchangeSinkInstanceHandle &instance, const std::string &node_id) {
 			    ShuffleCacheConfig cache_config;
-			    cache_config.shuffle_stage_id = instance.output_location;
+			    cache_config.exchange_id = instance.output_location;
 			    cache_config.node_id = node_id;
 			    cache_config.num_partitions = 1;
 			    cache_config.local_dirs = {local_dir};
@@ -2368,7 +2368,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 		    auto make_cache = [&](const std::string &output_location, const std::string &cache_node_id) {
 			    ShuffleCacheConfig cache_config;
-			    cache_config.shuffle_stage_id = output_location;
+			    cache_config.exchange_id = output_location;
 			    cache_config.node_id = cache_node_id;
 			    cache_config.num_partitions = 2;
 			    cache_config.local_dirs = {local_dir};
@@ -2444,12 +2444,12 @@ void register_ray_bindings(py::module_ &mod) {
 		    const string query_id = "query-cleanup";
 		    const string keep_query_id = "query-keep";
 		    const string node_id = "node-a";
-		    const string cleanup_stage = query_id + "_shuffle_1__sink_0__attempt_0";
-		    const string keep_stage = keep_query_id + "_shuffle_1__sink_0__attempt_0";
+		    const string cleanup_exchange = query_id + "_shuffle_1__sink_0__attempt_0";
+		    const string keep_exchange = keep_query_id + "_shuffle_1__sink_0__attempt_0";
 
-		    auto make_cache = [&](const string &stage_id) {
+		    auto make_cache = [&](const string &exchange_id) {
 			    ShuffleCacheConfig config;
-			    config.shuffle_stage_id = stage_id;
+			    config.exchange_id = exchange_id;
 			    config.node_id = node_id;
 			    config.num_partitions = 1;
 			    config.local_dirs = {local_dir};
@@ -2460,14 +2460,14 @@ void register_ray_bindings(py::module_ &mod) {
 		    ShuffleCacheRegistry::Instance().RemoveAndCleanupByPrefix(keep_query_id + "_");
 
 		    duckdb::LocalFileSystem fs;
-		    auto cleanup_node_dir = local_dir + "/shuffle_" + cleanup_stage + "/node_" + node_id;
+		    auto cleanup_node_dir = local_dir + "/shuffle_" + cleanup_exchange + "/node_" + node_id;
 		    auto cleanup_partition_dir = cleanup_node_dir + "/partition_0";
 		    fs.CreateDirectoriesRecursive(cleanup_partition_dir);
 		    {
 			    std::ofstream file(cleanup_partition_dir + "/batch.arrow", std::ios::out | std::ios::binary);
 			    file << "data";
 		    }
-		    auto keep_node_dir = local_dir + "/shuffle_" + keep_stage + "/node_" + node_id;
+		    auto keep_node_dir = local_dir + "/shuffle_" + keep_exchange + "/node_" + node_id;
 		    auto keep_partition_dir = keep_node_dir + "/partition_0";
 		    fs.CreateDirectoriesRecursive(keep_partition_dir);
 		    {
@@ -2475,15 +2475,16 @@ void register_ray_bindings(py::module_ &mod) {
 			    file << "keep";
 		    }
 
-		    auto cleanup_cache = make_cache(cleanup_stage);
-		    auto keep_cache = make_cache(keep_stage);
-		    auto cleanup_register = ShuffleCacheRegistry::Instance().Register(cleanup_stage, cleanup_cache, query_id);
-		    auto keep_register = ShuffleCacheRegistry::Instance().Register(keep_stage, keep_cache, keep_query_id);
+		    auto cleanup_cache = make_cache(cleanup_exchange);
+		    auto keep_cache = make_cache(keep_exchange);
+		    auto cleanup_register =
+		        ShuffleCacheRegistry::Instance().Register(cleanup_exchange, cleanup_cache, query_id);
+		    auto keep_register = ShuffleCacheRegistry::Instance().Register(keep_exchange, keep_cache, keep_query_id);
 		    if (cleanup_register.is_err() || keep_register.is_err()) {
 			    throw std::runtime_error("failed to register query cleanup test caches");
 		    }
-		    ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(cleanup_stage);
-		    auto cleanup_registry_after_defer = ShuffleCacheRegistry::Instance().Get(cleanup_stage) != nullptr;
+		    ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(cleanup_exchange);
+		    auto cleanup_registry_after_defer = ShuffleCacheRegistry::Instance().Get(cleanup_exchange) != nullptr;
 
 		    auto cleanup_result = ShuffleCacheRegistry::Instance().RemoveAndCleanupByPrefix(query_id + "_");
 		    py::dict out;
@@ -2491,8 +2492,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["storage_entries_removed"] = cleanup_result.storage_entries_removed;
 		    out["cleanup_errors"] = cleanup_result.cleanup_errors;
 		    out["cleanup_registry_after_defer"] = cleanup_registry_after_defer;
-		    out["cleanup_registry_after"] = ShuffleCacheRegistry::Instance().Get(cleanup_stage) != nullptr;
-		    out["keep_registry_after"] = ShuffleCacheRegistry::Instance().Get(keep_stage) != nullptr;
+		    out["cleanup_registry_after"] = ShuffleCacheRegistry::Instance().Get(cleanup_exchange) != nullptr;
+		    out["keep_registry_after"] = ShuffleCacheRegistry::Instance().Get(keep_exchange) != nullptr;
 		    out["cleanup_node_dir_exists_after"] = fs.DirectoryExists(cleanup_node_dir);
 		    out["keep_node_dir_exists_after"] = fs.DirectoryExists(keep_node_dir);
 
@@ -2506,7 +2507,7 @@ void register_ray_bindings(py::module_ &mod) {
 	    [](const std::string &local_dir) {
 		    using namespace duckdb::distributed;
 		    ShuffleCacheConfig config;
-		    config.shuffle_stage_id = "shuffle_cache_manifest_test__sink_3__attempt_2";
+		    config.exchange_id = "shuffle_cache_manifest_test__sink_3__attempt_2";
 		    config.node_id = "node-a";
 		    config.num_partitions = 2;
 		    config.local_dirs = {local_dir};
@@ -2551,7 +2552,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<LogicalType> types = {LogicalType::INTEGER};
 		    vector<string> names = {"value"};
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = "shuffle_cache_manifest_recovery_test__sink_0__attempt_1";
+		    write_config.exchange_id = "shuffle_cache_manifest_recovery_test__sink_0__attempt_1";
 		    write_config.node_id = "node-a";
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -2586,18 +2587,18 @@ void register_ray_bindings(py::module_ &mod) {
 			    throw std::runtime_error(manifest_files_res.error().what());
 		    }
 		    auto register_res = ShuffleCacheRegistry::Instance().Register(
-		        write_config.shuffle_stage_id, reader, "shuffle-cache-manifest-recovery-query", "", 1);
+		        write_config.exchange_id, reader, "shuffle-cache-manifest-recovery-query", "", 1);
 		    if (register_res.is_err()) {
 			    throw std::runtime_error(register_res.error().what());
 		    }
-		    ScopedShuffleCacheRegistrationForTest registration(write_config.shuffle_stage_id);
+		    ScopedShuffleCacheRegistrationForTest registration(write_config.exchange_id);
 		    FlightExchangeConfig source_config;
 		    source_config.node_id = write_config.node_id;
 		    ExchangeSourceHandle handle;
 		    handle.partition_id = 1;
 		    handle.attempt_id = 1;
 		    handle.node_id = write_config.node_id;
-		    handle.files.push_back(ExchangeSourceFile(write_config.shuffle_stage_id, 0));
+		    handle.files.push_back(ExchangeSourceFile(write_config.exchange_id, 0));
 		    auto values = ReadIntegerExchangeSourceForTest(context, source_config, std::move(handle));
 
 		    py::dict out;
@@ -2623,7 +2624,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<LogicalType> types = {LogicalType::INTEGER};
 		    vector<string> names = {"value"};
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = "shuffle_cache_uncommitted_invisible_test__sink_0__attempt_1";
+		    write_config.exchange_id = "shuffle_cache_uncommitted_invisible_test__sink_0__attempt_1";
 		    write_config.node_id = "node-a";
 		    write_config.num_partitions = 1;
 		    write_config.local_dirs = {local_dir};
@@ -2679,7 +2680,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    vector<LogicalType> types = {LogicalType::INTEGER};
 		    vector<string> names = {"value"};
 		    ShuffleCacheConfig config;
-		    config.shuffle_stage_id = "shuffle_cache_duckdb_fs_storage_test__sink_0__attempt_1";
+		    config.exchange_id = "shuffle_cache_duckdb_fs_storage_test__sink_0__attempt_1";
 		    config.node_id = "node-a";
 		    config.num_partitions = 1;
 		    config.local_dirs = {local_dir};
@@ -2711,18 +2712,18 @@ void register_ray_bindings(py::module_ &mod) {
 			    throw std::runtime_error(manifest_files_res.error().what());
 		    }
 		    auto register_res = ShuffleCacheRegistry::Instance().Register(
-		        config.shuffle_stage_id, reader, "shuffle-cache-duckdb-fs-storage-query", "", 1);
+		        config.exchange_id, reader, "shuffle-cache-duckdb-fs-storage-query", "", 1);
 		    if (register_res.is_err()) {
 			    throw std::runtime_error(register_res.error().what());
 		    }
-		    ScopedShuffleCacheRegistrationForTest registration(config.shuffle_stage_id);
+		    ScopedShuffleCacheRegistrationForTest registration(config.exchange_id);
 		    FlightExchangeConfig source_config;
 		    source_config.node_id = config.node_id;
 		    ExchangeSourceHandle handle;
 		    handle.partition_id = 0;
 		    handle.attempt_id = 1;
 		    handle.node_id = config.node_id;
-		    handle.files.push_back(ExchangeSourceFile(config.shuffle_stage_id, 0));
+		    handle.files.push_back(ExchangeSourceFile(config.exchange_id, 0));
 		    auto values = ReadIntegerExchangeSourceForTest(context, source_config, std::move(handle));
 
 		    py::dict out;
@@ -2757,7 +2758,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const auto run_id = UUID::ToString(UUID::GenerateRandomUUID());
 
 		    ShuffleCacheConfig config;
-		    config.shuffle_stage_id = "shuffle_cache_duckdb_fs_minio_storage_test_" + run_id + "__sink_0__attempt_1";
+		    config.exchange_id = "shuffle_cache_duckdb_fs_minio_storage_test_" + run_id + "__sink_0__attempt_1";
 		    config.node_id = "node-a";
 		    config.num_partitions = 1;
 		    config.local_dirs = {base_uri};
@@ -2803,7 +2804,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    handle.partition_id = 0;
 		    handle.attempt_id = 1;
 		    handle.node_id = config.node_id;
-		    handle.files.push_back(ExchangeSourceFile(config.shuffle_stage_id, 0));
+		    handle.files.push_back(ExchangeSourceFile(config.exchange_id, 0));
 		    auto values = ReadIntegerExchangeSourceForTest(context, source_config, std::move(handle));
 
 		    auto cleanup_res = reader.RemoveAttemptStorage();
@@ -2813,7 +2814,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 		    py::dict out;
 		    out["base_uri"] = base_uri;
-		    out["shuffle_stage_id"] = config.shuffle_stage_id;
+		    out["exchange_id"] = config.exchange_id;
 		    out["manifest_path"] = manifest_path;
 		    out["marker_path"] = marker_path;
 		    out["committed_manifest"] = committed_manifest_before_cleanup;
@@ -2859,7 +2860,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 		    auto make_config = [&](const std::string &scenario) {
 			    ShuffleCacheConfig config;
-			    config.shuffle_stage_id =
+			    config.exchange_id =
 			        "shuffle_cache_duckdb_fs_minio_fault_matrix_" + run_id + "_" + scenario + "__sink_0__attempt_1";
 			    config.node_id = node_id;
 			    config.num_partitions = 1;
@@ -2943,7 +2944,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    handle.attempt_id = 1;
 			    handle.node_id = config.node_id;
 			    ExchangeSourceFile file;
-			    file.path = config.shuffle_stage_id;
+			    file.path = config.exchange_id;
 			    file.file_size = 0;
 			    handle.files.push_back(std::move(file));
 			    std::vector<ExchangeSourceHandle> handles;
@@ -3150,7 +3151,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    auto &verify_fs = FileSystem::GetFileSystem(verify_context);
 			    auto verify_storage = MakeDuckDBFileSystemShuffleStorage(verify_fs);
 			    ShuffleCacheConfig lost_config;
-			    lost_config.shuffle_stage_id = lost_instance.output_location;
+			    lost_config.exchange_id = lost_instance.output_location;
 			    lost_config.node_id = lost_node_id;
 			    lost_config.num_partitions = 1;
 			    lost_config.local_dirs = {base_uri};
@@ -3169,7 +3170,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    auto lost_manifest_after_cleanup_error = lost_manifest_error_fresh();
 
 		    ShuffleCacheConfig selected_config;
-		    selected_config.shuffle_stage_id = selected_instance.output_location;
+		    selected_config.exchange_id = selected_instance.output_location;
 		    selected_config.node_id = selected_node_id;
 		    selected_config.num_partitions = 1;
 		    selected_config.local_dirs = {base_uri};
@@ -3226,7 +3227,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    py::dict out;
 		    try {
 			    ShuffleCacheConfig config;
-			    config.shuffle_stage_id = "shuffle_cache_object_storage_reject_test__sink_0__attempt_1";
+			    config.exchange_id = "shuffle_cache_object_storage_reject_test__sink_0__attempt_1";
 			    config.node_id = "node-a";
 			    config.num_partitions = 1;
 			    config.local_dirs = {"s3://bucket/shuffle"};
@@ -3255,7 +3256,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    auto storage = MakeDuckDBFileSystemShuffleStorage(fs);
 
 			    ShuffleCacheConfig config;
-			    config.shuffle_stage_id = "shuffle_cache_duckdb_fs_object_accept_test__sink_0__attempt_1";
+			    config.exchange_id = "shuffle_cache_duckdb_fs_object_accept_test__sink_0__attempt_1";
 			    config.node_id = "node-a";
 			    config.num_partitions = 1;
 			    config.local_dirs = {"s3://bucket/shuffle"};
@@ -3407,7 +3408,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    }
 
 		    ShuffleCacheConfig config;
-		    config.shuffle_stage_id = "shuffle_cache_fake_object_manifest_test__sink_0__attempt_7";
+		    config.exchange_id = "shuffle_cache_fake_object_manifest_test__sink_0__attempt_7";
 		    config.node_id = "node-a";
 		    config.num_partitions = 1;
 		    config.local_dirs = {local_dir};
@@ -3467,7 +3468,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const std::string server_epoch = "unpublished-local-manifest-epoch";
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = node_id;
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -3562,7 +3563,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const std::string server_epoch = "unpublished-shared-manifest-epoch";
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = writer_node_id;
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -3658,7 +3659,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const idx_t output_partition_id = 1;
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = writer_node_id;
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -3837,7 +3838,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const std::string output_location = "remote_exchange_source_local_dirs_roundtrip_test__sink_0__attempt_1";
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = current_node_id;
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -3965,7 +3966,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const std::string node_id = "node-a";
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = node_id;
 		    write_config.num_partitions = 2;
 		    write_config.local_dirs = {local_dir};
@@ -4046,7 +4047,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    const std::string node_id = "node-a";
 
 		    ShuffleCacheConfig write_config;
-		    write_config.shuffle_stage_id = output_location;
+		    write_config.exchange_id = output_location;
 		    write_config.node_id = node_id;
 		    write_config.num_partitions = 1;
 		    write_config.local_dirs = {local_dir};

--- a/src/duckdb_py/ray/worker.cpp
+++ b/src/duckdb_py/ray/worker.cpp
@@ -199,11 +199,6 @@ void RayWorkerRuntime::TaskInputStreamExhaustedForQuery(
 	ray_worker_handle_.attr("task_input_stream_exhausted_for_query")(query_id, py_source_node_ids);
 }
 
-void RayWorkerRuntime::BlockingMaterializationCompleted(const string &query_id, duckdb::distributed::NodeID node_id) {
-	duckdb::PythonGILWrapper gil;
-	ray_worker_handle_.attr("blocking_materialization_completed")(query_id, std::to_string(node_id));
-}
-
 RayWorkerRuntime::QueryStatus RayWorkerRuntime::FteQueryStatus(
     const string &query_id,
     const std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash>

--- a/src/duckdb_py/ray/worker.cpp
+++ b/src/duckdb_py/ray/worker.cpp
@@ -199,6 +199,11 @@ void RayWorkerRuntime::TaskInputStreamExhaustedForQuery(
 	ray_worker_handle_.attr("task_input_stream_exhausted_for_query")(query_id, py_source_node_ids);
 }
 
+void RayWorkerRuntime::BlockingMaterializationCompleted(const string &query_id, duckdb::distributed::NodeID node_id) {
+	duckdb::PythonGILWrapper gil;
+	ray_worker_handle_.attr("blocking_materialization_completed")(query_id, std::to_string(node_id));
+}
+
 RayWorkerRuntime::QueryStatus RayWorkerRuntime::FteQueryStatus(
     const string &query_id,
     const std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash>

--- a/src/duckdb_py/ray/worker.hpp
+++ b/src/duckdb_py/ray/worker.hpp
@@ -58,6 +58,7 @@ public:
 	void SubmitFteTaskEvents(const std::vector<WorkerTask> &tasks);
 	void TaskInputStreamExhaustedForQuery(const string &query_id,
 	                                      const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids);
+	void BlockingMaterializationCompleted(const string &query_id, duckdb::distributed::NodeID node_id);
 	QueryStatus
 	FteQueryStatus(const string &query_id,
 	               const std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash>

--- a/src/duckdb_py/ray/worker.hpp
+++ b/src/duckdb_py/ray/worker.hpp
@@ -58,7 +58,6 @@ public:
 	void SubmitFteTaskEvents(const std::vector<WorkerTask> &tasks);
 	void TaskInputStreamExhaustedForQuery(const string &query_id,
 	                                      const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids);
-	void BlockingMaterializationCompleted(const string &query_id, duckdb::distributed::NodeID node_id);
 	QueryStatus
 	FteQueryStatus(const string &query_id,
 	               const std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash>

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -982,6 +982,36 @@ DuckDBResult<void> RayWorkerManager::task_input_stream_exhausted_for_query(
 	return DuckDBResult<void>::ok();
 }
 
+DuckDBResult<void> RayWorkerManager::blocking_materialization_completed(const string &query_id,
+                                                                        duckdb::distributed::NodeID node_id) {
+	if (query_id.empty()) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::value_error("blocking materialization completion requires non-empty query_id"));
+	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
+
+	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
+	{
+		lock_guard<mutex> guard(mutex_);
+		workers.reserve(state_.ray_workers.size());
+		for (auto &kv : state_.ray_workers) {
+			workers.push_back(kv.second);
+		}
+	}
+	try {
+		for (auto &worker : workers) {
+			worker->BlockingMaterializationCompleted(query_id, node_id);
+		}
+	} catch (const std::exception &e) {
+		return DuckDBResult<void>::err(
+		    DuckDBError(string("Python error during blocking_materialization_completed: ") + e.what()));
+	}
+	return DuckDBResult<void>::ok();
+}
+
 DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>
 RayWorkerManager::wait_fte_query(const string &query_id, double timeout_s) {
 	return wait_fte_query(query_id, timeout_s, {});

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -982,6 +982,28 @@ DuckDBResult<void> RayWorkerManager::task_input_stream_exhausted_for_query(
 	return DuckDBResult<void>::ok();
 }
 
+DuckDBResult<void> RayWorkerManager::materialization_barrier_completed(const string &query_id,
+                                                                       duckdb::distributed::NodeID node_id) {
+	if (query_id.empty()) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::value_error("materialization barrier completion requires non-empty query_id"));
+	}
+	OperationGuard operation(*this);
+	if (!operation) {
+		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
+	}
+
+	try {
+		duckdb::PythonGILWrapper gil;
+		py::module_ resource_runtime = py::module_::import("duckdb.runners.ray.query_resource_runtime");
+		resource_runtime.attr("mark_materialization_barrier_completed")(query_id, std::to_string(node_id));
+	} catch (const std::exception &e) {
+		return DuckDBResult<void>::err(
+		    DuckDBError(string("Python error during materialization_barrier_completed: ") + e.what()));
+	}
+	return DuckDBResult<void>::ok();
+}
+
 DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>
 RayWorkerManager::wait_fte_query(const string &query_id, double timeout_s) {
 	return wait_fte_query(query_id, timeout_s, {});

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -982,36 +982,6 @@ DuckDBResult<void> RayWorkerManager::task_input_stream_exhausted_for_query(
 	return DuckDBResult<void>::ok();
 }
 
-DuckDBResult<void> RayWorkerManager::blocking_materialization_completed(const string &query_id,
-                                                                        duckdb::distributed::NodeID node_id) {
-	if (query_id.empty()) {
-		return DuckDBResult<void>::err(
-		    DuckDBError::value_error("blocking materialization completion requires non-empty query_id"));
-	}
-	OperationGuard operation(*this);
-	if (!operation) {
-		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
-	}
-
-	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
-	{
-		lock_guard<mutex> guard(mutex_);
-		workers.reserve(state_.ray_workers.size());
-		for (auto &kv : state_.ray_workers) {
-			workers.push_back(kv.second);
-		}
-	}
-	try {
-		for (auto &worker : workers) {
-			worker->BlockingMaterializationCompleted(query_id, node_id);
-		}
-	} catch (const std::exception &e) {
-		return DuckDBResult<void>::err(
-		    DuckDBError(string("Python error during blocking_materialization_completed: ") + e.what()));
-	}
-	return DuckDBResult<void>::ok();
-}
-
 DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>
 RayWorkerManager::wait_fte_query(const string &query_id, double timeout_s) {
 	return wait_fte_query(query_id, timeout_s, {});

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -50,6 +50,8 @@ public:
 	    duckdb::distributed::MaterializedOutputCallback on_output) override;
 	DuckDBResult<void> task_input_stream_exhausted_for_query(
 	    const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) override;
+	DuckDBResult<void> blocking_materialization_completed(const string &query_id,
+	                                                      duckdb::distributed::NodeID node_id) override;
 
 	void drop_query_fragments(const string &query_id);
 	void rethrow_submission_error(const string &query_id);

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -50,6 +50,8 @@ public:
 	    duckdb::distributed::MaterializedOutputCallback on_output) override;
 	DuckDBResult<void> task_input_stream_exhausted_for_query(
 	    const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) override;
+	DuckDBResult<void> materialization_barrier_completed(const string &query_id,
+	                                                     duckdb::distributed::NodeID node_id) override;
 
 	void drop_query_fragments(const string &query_id);
 	void rethrow_submission_error(const string &query_id);

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -50,8 +50,6 @@ public:
 	    duckdb::distributed::MaterializedOutputCallback on_output) override;
 	DuckDBResult<void> task_input_stream_exhausted_for_query(
 	    const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) override;
-	DuckDBResult<void> blocking_materialization_completed(const string &query_id,
-	                                                      duckdb::distributed::NodeID node_id) override;
 
 	void drop_query_fragments(const string &query_id);
 	void rethrow_submission_error(const string &query_id);

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -599,7 +599,7 @@ static unique_ptr<LazyRefDataChunk> ConvertPythonRefBundleResult(const py::handl
 		block.metadata.num_rows = PyDictIdx(meta, "num_rows");
 		block.metadata.size_bytes = PyDictIdx(meta, "size_bytes");
 		block.metadata.query_id = PyDictString(meta, "query_id");
-		block.metadata.operator_id = PyDictString(meta, "producer_stage_id");
+		block.metadata.operator_id = PyDictString(meta, "producer_unit_id");
 		block.metadata.attempt_id = PyDictString(meta, "attempt_id");
 		if (PyDictContains(meta, "slice_start") && PyDictContains(meta, "slice_end")) {
 			block.has_slice = true;

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1069,7 +1069,7 @@ struct ExecutorSlot {
 	std::deque<DispatcherCommand> cmd_queue;
 
 	// One scheduling lookahead for distributed Ray task admission. Active task
-	// concurrency is owned by QueryResourceManager task leases, not this slot.
+	// concurrency is owned by RayQueryResourceManager task leases, not this slot.
 	mutex task_admission_lock;
 	bool task_admission_request_pending = false;
 	bool task_admission_available = false;

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2675,7 +2675,7 @@ def test_provider_capability_error_redacts_upstream_credentials_and_round_trips(
     _, stream_metadata = make_stream_error_pair(
         {
             "query_id": "query",
-            "stage_id": "stage",
+            "resource_unit_id": "resource:query:node:1:udf",
             "task_lease_id": "lease",
             "attempt_id": "attempt",
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,11 +309,17 @@ def _ray_local_cluster():
                 for name, value in env_vars.items():
                     monkeypatch.setenv(name, value)
                 resources = ResourceAndLabelSpec().resolve(is_head=True)
+                object_store_options = ray_test_object_store_options()
+                # Cluster.add_node() substitutes a fixed 150 MiB test default
+                # when this argument is absent. Use the value produced by Ray's
+                # normal node resource resolver so this shared cluster follows
+                # the host/cgroup capacity just like ray.init(address="local").
+                object_store_options.setdefault("object_store_memory", resources.object_store_memory)
                 cluster.add_node(
                     include_dashboard=False,
                     num_cpus=resources.num_cpus,
                     num_gpus=resources.num_gpus,
-                    **ray_test_object_store_options(),
+                    **object_store_options,
                 )
 
         yield ray, cluster.address, env_vars

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
-from ray_test_profile import ray_test_object_store_bytes
+from ray_test_profile import ray_test_object_store_options
 
 import duckdb
 
@@ -313,7 +313,7 @@ def _ray_local_cluster():
                     include_dashboard=False,
                     num_cpus=resources.num_cpus,
                     num_gpus=resources.num_gpus,
-                    object_store_memory=ray_test_object_store_bytes(),
+                    **ray_test_object_store_options(),
                 )
 
         yield ray, cluster.address, env_vars

--- a/tests/fast/test_ai_release_contracts.py
+++ b/tests/fast/test_ai_release_contracts.py
@@ -197,7 +197,7 @@ def test_non_capability_provider_failures_are_safe_before_execution_wires(monkey
         _, ray_metadata = make_stream_error_pair(
             {
                 "query_id": "query",
-                "stage_id": "stage",
+                "resource_unit_id": "resource:query:node:1:udf",
                 "task_lease_id": "lease",
                 "attempt_id": "attempt",
             },

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -273,6 +273,66 @@ def test_equal_weight_queries_receive_equal_dominant_shares():
     assert allocation_a + allocation_b == total
 
 
+def test_weighted_drf_accounts_for_unequal_hard_minimum_shares():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n1", cpu=10, heap=1_000),),
+        heartbeat_timeout_s=30,
+    )
+    coordinator.register_query(
+        _demand(
+            "large-minimum",
+            minimum=_r(cpu=8, heap=800),
+            desired=_r(cpu=10, heap=1_000),
+        ),
+        now=0,
+    )
+    coordinator.register_query(
+        _demand(
+            "small-minimum",
+            minimum=_r(cpu=1, heap=100),
+            desired=_r(cpu=10, heap=1_000),
+        ),
+        now=0,
+    )
+
+    queries = coordinator.snapshot()["queries"]
+    large = ResourceVector.from_dict(queries["large-minimum"]["allocation"]["resources"])
+    small = ResourceVector.from_dict(queries["small-minimum"]["allocation"]["resources"])
+
+    assert large == _r(cpu=8, heap=800)
+    assert small == _r(cpu=2, heap=200)
+
+
+def test_weighted_drf_fills_non_dominant_minimum_plateau_without_changing_fair_share():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n1", cpu=10, heap=1_000),),
+        heartbeat_timeout_s=30,
+    )
+    coordinator.register_query(
+        _demand(
+            "cpu-heavy",
+            minimum=_r(cpu=8),
+            desired=_r(cpu=8, heap=1_000),
+        ),
+        now=0,
+    )
+    coordinator.register_query(
+        _demand(
+            "heap-progress",
+            minimum=_r(cpu=1),
+            desired=_r(cpu=1, heap=1_000),
+        ),
+        now=0,
+    )
+
+    queries = coordinator.snapshot()["queries"]
+    cpu_heavy = ResourceVector.from_dict(queries["cpu-heavy"]["allocation"]["resources"])
+    heap_progress = ResourceVector.from_dict(queries["heap-progress"]["allocation"]["resources"])
+
+    assert cpu_heavy == _r(cpu=8, heap=200)
+    assert heap_progress == _r(cpu=1, heap=800)
+
+
 def test_weighted_dominant_fairness_gives_double_share_to_weight_two_query():
     coordinator = ClusterQueryResourceCoordinator(
         (_node("n1", cpu=12, heap=1_200, store=1_200),),

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -481,6 +481,35 @@ def test_indivisible_gpu_task_bundle_must_fit_one_node_not_cluster_aggregate():
     assert coordinator.snapshot()["queries"]["gpu-task"]["state"] == "PENDING_RESOURCES"
 
 
+def test_task_bundle_matching_reassigns_an_earlier_best_fit():
+    coordinator = ClusterQueryResourceCoordinator(
+        (
+            _node("cpu-node", cpu=2, gpu=0.5),
+            _node("shared-node", cpu=2, gpu=1),
+            _node("gpu-node", cpu=1, gpu=2),
+        ),
+    )
+    cpu_bundle = _r(cpu=2)
+    mixed_bundle = _r(cpu=1.5, gpu=0.25)
+    gpu_bundle = _r(cpu=1, gpu=1)
+    minimum = cpu_bundle + mixed_bundle + gpu_bundle
+
+    allocation = coordinator.register_query(
+        QueryDemand(
+            query_id="alternating-path",
+            minimum=minimum,
+            desired=minimum,
+            task_bundles=(cpu_bundle, mixed_bundle, gpu_bundle),
+        ),
+        now=0,
+    )
+
+    assert coordinator.query_state("alternating-path", allocation.generation) == "RUNNING"
+    by_node = {item.node_id: item.resources for item in allocation.node_allocations}
+    assert by_node["gpu-node"] == gpu_bundle
+    assert {by_node["cpu-node"], by_node["shared-node"]} == {cpu_bundle, mixed_bundle}
+
+
 def test_minimum_task_vector_must_fit_one_node_not_cross_node_dimensions():
     coordinator = ClusterQueryResourceCoordinator(
         (

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -155,6 +155,25 @@ def test_ray_capacity_never_uses_host_memory_or_cpu_fallback(monkeypatch):
     assert capacities[0].resources == _r(cpu=2, heap=180, store=200)
 
 
+def test_soft_only_query_gets_node_allocation_without_native_hard_minimum():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("node-a", cpu=8, heap=1_000, store=400),),
+    )
+
+    allocation = coordinator.register_query(
+        _demand(
+            "native-only",
+            minimum=_r(),
+            desired=_r(store=400),
+        ),
+        now=0,
+    )
+
+    assert allocation.resources == _r(store=400)
+    assert allocation.node_allocations[0].node_id == "node-a"
+    assert allocation.node_allocations[0].resources == _r(store=400)
+
+
 @pytest.mark.parametrize(
     ("target_name", "attribute", "fail_on_call"),
     [
@@ -182,7 +201,7 @@ def test_register_query_failure_is_atomic_across_rebalance_phases(
     coordinator.register_query(
         _demand(
             "existing",
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=4, heap=400, store=400),
         ),
         now=0,
@@ -222,7 +241,7 @@ def test_register_query_failure_is_atomic_across_rebalance_phases(
     coordinator.register_query(
         _demand(
             "recovery",
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=3, heap=300, store=300),
         ),
         now=6,
@@ -252,12 +271,12 @@ def test_equal_weight_queries_receive_equal_dominant_shares():
     )
     demand_a = _demand(
         "a",
-        minimum=_r(cpu=1, heap=100, store=100),
+        minimum=_r(cpu=1, heap=100),
         desired=_r(cpu=12, heap=1_200, store=1_200),
     )
     demand_b = _demand(
         "b",
-        minimum=_r(cpu=1, heap=100, store=100),
+        minimum=_r(cpu=1, heap=100),
         desired=_r(cpu=12, heap=1_200, store=1_200),
     )
 
@@ -341,7 +360,7 @@ def test_weighted_dominant_fairness_gives_double_share_to_weight_two_query():
     coordinator.register_query(
         _demand(
             "weight-one",
-            minimum=_r(cpu=0.1, heap=10, store=10),
+            minimum=_r(cpu=0.1, heap=10),
             desired=_r(cpu=12, heap=1_200, store=1_200),
             weight=1,
         ),
@@ -350,7 +369,7 @@ def test_weighted_dominant_fairness_gives_double_share_to_weight_two_query():
     coordinator.register_query(
         _demand(
             "weight-two",
-            minimum=_r(cpu=0.1, heap=10, store=10),
+            minimum=_r(cpu=0.1, heap=10),
             desired=_r(cpu=12, heap=1_200, store=1_200),
             weight=2,
         ),
@@ -396,13 +415,38 @@ def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
     allocation = coordinator.register_query(
         _demand(
             "capped",
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=3, heap=300, store=400),
         ),
         now=0,
     )
 
     assert allocation.resources == _r(cpu=3, heap=300, store=400)
+
+
+def test_query_demand_rejects_object_store_hard_minimum_and_placement_bundles():
+    with pytest.raises(ValueError, match="minimum query resources may not hard-reserve object-store bytes"):
+        QueryDemand(
+            query_id="minimum-store",
+            minimum=_r(cpu=1, store=1),
+            desired=_r(cpu=1, store=10),
+            task_bundles=(_r(cpu=1, store=1),),
+        )
+
+    with pytest.raises(ValueError, match="task resource bundles may not hard-reserve object-store bytes"):
+        QueryDemand(
+            query_id="task-store",
+            minimum=_r(cpu=1),
+            desired=_r(cpu=1, store=10),
+            task_bundles=(_r(cpu=1, store=1),),
+        )
+
+    with pytest.raises(ValueError, match="actor resource bundles may not hard-reserve object-store bytes"):
+        ActorResourceBundle(
+            resource_unit_id="resource:actor-store",
+            actor_index=0,
+            resources=_r(cpu=1, store=1),
+        )
 
 
 def test_query_demand_rejects_elastic_gpu_headroom_before_registration():
@@ -531,7 +575,7 @@ def test_minimum_task_vector_must_fit_one_node_not_cross_node_dimensions():
             _node("memory-node", cpu=0, heap=199, store=199),
         )
     )
-    minimum = _r(cpu=2, heap=200, store=200)
+    minimum = _r(cpu=2, heap=200)
 
     allocation = coordinator.register_query(
         _demand("coherent-task", minimum=minimum, desired=minimum),
@@ -623,7 +667,7 @@ def test_capacity_shrink_preserves_observed_usage_as_debt_and_stops_new_admissio
     allocation = coordinator.register_query(
         _demand(
             "q",
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=4, heap=400, store=400),
         ),
         now=0,
@@ -722,7 +766,7 @@ def test_refresh_queries_updates_all_usage_and_heartbeats_atomically():
     def demand(query_id):
         return _demand(
             query_id,
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=8, heap=800, store=800),
         )
 
@@ -801,7 +845,7 @@ def test_node_allocations_never_exceed_any_node_capacity():
     coordinator.register_query(
         _demand(
             "cpu",
-            minimum=_r(cpu=1, heap=100, store=100),
+            minimum=_r(cpu=1, heap=100),
             desired=_r(cpu=4, heap=400, store=600),
         ),
         now=0,

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -50,7 +50,7 @@ def _demand(
         desired=desired,
         weight=weight,
         priority=priority,
-        task_bundles=() if minimum.is_zero() else (minimum,),
+        placement_bundles=() if minimum.is_zero() else (minimum,),
     )
 
 
@@ -407,21 +407,21 @@ def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
     assert allocation.resources == _r(cpu=3, heap=300, store=400)
 
 
-def test_query_demand_rejects_object_store_hard_minimum_and_task_bundles():
+def test_query_demand_rejects_object_store_hard_minimum_and_placement_bundles():
     with pytest.raises(ValueError, match="minimum query resources may not hard-reserve object-store bytes"):
         QueryDemand(
             query_id="minimum-store",
             minimum=_r(cpu=1, store=1),
             desired=_r(cpu=1, store=10),
-            task_bundles=(_r(cpu=1, store=1),),
+            placement_bundles=(_r(cpu=1, store=1),),
         )
 
-    with pytest.raises(ValueError, match="task resource bundles may not hard-reserve object-store bytes"):
+    with pytest.raises(ValueError, match="placement bundles may not hard-reserve object-store bytes"):
         QueryDemand(
             query_id="task-store",
             minimum=_r(cpu=1),
             desired=_r(cpu=1, store=10),
-            task_bundles=(_r(cpu=1, store=1),),
+            placement_bundles=(_r(cpu=1, store=1),),
         )
 
 
@@ -499,7 +499,7 @@ def test_task_bundle_matching_reassigns_an_earlier_best_fit():
             query_id="alternating-path",
             minimum=minimum,
             desired=minimum,
-            task_bundles=(cpu_bundle, mixed_bundle, gpu_bundle),
+            placement_bundles=(cpu_bundle, mixed_bundle, gpu_bundle),
         ),
         now=0,
     )
@@ -510,7 +510,7 @@ def test_task_bundle_matching_reassigns_an_earlier_best_fit():
     assert {by_node["cpu-node"], by_node["shared-node"]} == {cpu_bundle, mixed_bundle}
 
 
-def test_minimum_task_vector_must_fit_one_node_not_cross_node_dimensions():
+def test_minimum_placement_vector_must_fit_one_node_not_cross_node_dimensions():
     coordinator = ClusterQueryResourceCoordinator(
         (
             _node("cpu-node", cpu=2, heap=1, store=1),

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -306,6 +306,29 @@ def test_weighted_dominant_fairness_gives_double_share_to_weight_two_query():
     assert two.object_store_bytes / one.object_store_bytes == pytest.approx(2.0, rel=0.03)
 
 
+def test_object_store_budget_remains_fair_when_hard_minima_exhaust_cpu():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n1", cpu=2, heap=200, store=1_000),),
+        heartbeat_timeout_s=30,
+    )
+    for query_id in ("a", "b"):
+        coordinator.register_query(
+            _demand(
+                query_id,
+                minimum=_r(cpu=1, heap=100),
+                desired=_r(cpu=1, heap=100, store=1_000),
+            ),
+            now=0,
+        )
+
+    queries = coordinator.snapshot()["queries"]
+    allocation_a = ResourceVector.from_dict(queries["a"]["allocation"]["resources"])
+    allocation_b = ResourceVector.from_dict(queries["b"]["allocation"]["resources"])
+
+    assert allocation_a == _r(cpu=1, heap=100, store=500)
+    assert allocation_b == _r(cpu=1, heap=100, store=500)
+
+
 def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
     coordinator = ClusterQueryResourceCoordinator(
         (_node("n1", cpu=32, gpu=4, heap=32_000, store=32_000),),

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -39,29 +39,26 @@ def _node(
 def _demand(
     query_id: str,
     *,
-    minimum: ResourceVector,
     desired: ResourceVector,
     weight: float = 1,
     priority: int = 0,
 ) -> QueryDemand:
     return QueryDemand(
         query_id=query_id,
-        minimum=minimum,
         desired=desired,
         weight=weight,
         priority=priority,
-        placement_bundles=() if minimum.is_zero() else (minimum,),
     )
 
 
-def _inject_failure_once(monkeypatch, target, attribute, *, fail_on_call=1):
+def _inject_failure_once(monkeypatch, target, attribute):
     original = getattr(target, attribute)
-    calls = 0
+    called = False
 
     def fail_once(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == fail_on_call:
+        nonlocal called
+        if not called:
+            called = True
             raise RuntimeError(f"injected {attribute} failure")
         return original(*args, **kwargs)
 
@@ -134,60 +131,213 @@ def test_ray_capacity_never_uses_host_memory_or_cpu_fallback(monkeypatch):
     assert capacities[0].resources == _r(cpu=2, heap=180, store=200)
 
 
-def test_soft_only_query_gets_node_allocation_without_native_hard_minimum():
+def test_single_query_gets_aggregate_soft_budget_without_node_placement():
     coordinator = ClusterQueryResourceCoordinator(
-        (_node("node-a", cpu=8, heap=1_000, store=400),),
+        (
+            _node("node-a", cpu=4, gpu=1, heap=400, store=300),
+            _node("node-b", cpu=2, heap=200, store=100),
+        )
     )
 
     allocation = coordinator.register_query(
-        _demand(
-            "native-only",
-            minimum=_r(),
-            desired=_r(store=400),
-        ),
+        _demand("q", desired=_r(cpu=8, gpu=2, heap=800, store=800)),
         now=0,
     )
 
-    assert allocation.resources == _r(store=400)
-    assert allocation.node_allocations[0].node_id == "node-a"
-    assert allocation.node_allocations[0].resources == _r(store=400)
-    assert coordinator.query_state("native-only", allocation.generation) == "RUNNING"
+    assert allocation.resources == _r(cpu=6, gpu=1, heap=600, store=400)
+    assert allocation.to_dict() == {
+        "resources": _r(cpu=6, gpu=1, heap=600, store=400).to_dict(),
+        "generation": allocation.generation,
+    }
+    assert coordinator.query_state("q", allocation.generation) == "RUNNING"
+
+
+def test_zero_cluster_capacity_keeps_query_running_with_zero_soft_budget():
+    coordinator = ClusterQueryResourceCoordinator(())
+
+    allocation = coordinator.register_query(
+        _demand("q", desired=_r(cpu=1, gpu=1, heap=100, store=100)),
+        now=0,
+    )
+
+    assert allocation.resources.is_zero()
+    assert coordinator.query_state("q", allocation.generation) == "RUNNING"
+    assert coordinator.snapshot()["queries"]["q"]["state"] == "RUNNING"
+
+
+def test_query_shape_is_not_bin_packed_or_pre_admitted():
+    coordinator = ClusterQueryResourceCoordinator(
+        (
+            _node("gpu-a", cpu=4, gpu=1, store=100),
+            _node("gpu-b", cpu=4, gpu=1, store=100),
+        )
+    )
+
+    allocation = coordinator.register_query(
+        _demand("needs-two-gpus-per-task", desired=_r(cpu=1, gpu=2, store=200)),
+        now=0,
+    )
+
+    # No current node can run a 2-GPU task. The coordinator still publishes an
+    # aggregate soft budget and lets the real Ray request remain pending so the
+    # autoscaler can observe it.
+    assert allocation.resources == _r(cpu=1, gpu=2, store=200)
+    assert coordinator.query_state("needs-two-gpus-per-task", allocation.generation) == "RUNNING"
+
+
+def test_equal_weight_queries_share_every_contended_dimension():
+    coordinator = ClusterQueryResourceCoordinator((_node("n", cpu=8, gpu=2, heap=800, store=801),))
+    first = coordinator.register_query(
+        _demand("first", desired=_r(cpu=8, gpu=2, heap=800, store=801)),
+        now=0,
+    )
+    second = coordinator.register_query(
+        _demand("second", desired=_r(cpu=8, gpu=2, heap=800, store=801)),
+        now=0,
+    )
+
+    snapshot = coordinator.snapshot()["queries"]
+    first_resources = snapshot["first"]["allocation"]["resources"]
+    second_resources = snapshot["second"]["allocation"]["resources"]
+    assert first_resources == _r(cpu=4, gpu=1, heap=400, store=401).to_dict()
+    assert second_resources == _r(cpu=4, gpu=1, heap=400, store=400).to_dict()
+    assert first.generation < second.generation
+
+
+def test_weighted_queries_receive_weighted_max_min_shares():
+    coordinator = ClusterQueryResourceCoordinator((_node("n", cpu=9, gpu=3, heap=900, store=900),))
+    coordinator.register_query(
+        _demand("one", desired=_r(cpu=9, gpu=3, heap=900, store=900), weight=1),
+        now=0,
+    )
+    coordinator.register_query(
+        _demand("two", desired=_r(cpu=9, gpu=3, heap=900, store=900), weight=2),
+        now=0,
+    )
+
+    allocations = {
+        query_id: payload["allocation"]["resources"] for query_id, payload in coordinator.snapshot()["queries"].items()
+    }
+    assert allocations["one"] == _r(cpu=3, gpu=1, heap=300, store=300).to_dict()
+    assert allocations["two"] == _r(cpu=6, gpu=2, heap=600, store=600).to_dict()
+
+
+def test_noncompeting_resource_demands_each_use_the_full_dimension():
+    coordinator = ClusterQueryResourceCoordinator((_node("n", cpu=8, gpu=2, heap=800, store=600),))
+    coordinator.register_query(
+        _demand("cpu", desired=_r(cpu=8, heap=800)),
+        now=0,
+    )
+    coordinator.register_query(
+        _demand("gpu-store", desired=_r(gpu=2, store=600)),
+        now=0,
+    )
+
+    queries = coordinator.snapshot()["queries"]
+    assert queries["cpu"]["allocation"]["resources"] == _r(cpu=8, heap=800).to_dict()
+    assert queries["gpu-store"]["allocation"]["resources"] == _r(gpu=2, store=600).to_dict()
+
+
+def test_capacity_shrink_reduces_budget_but_records_only_soft_debt():
+    coordinator = ClusterQueryResourceCoordinator((_node("n", cpu=4, heap=400, store=400),))
+    allocation = coordinator.register_query(
+        _demand("q", desired=_r(cpu=4, heap=400, store=400)),
+        now=0,
+    )
+    allocation = coordinator.refresh_query(
+        "q",
+        observed_usage=_r(cpu=3, heap=300, store=250),
+        generation=allocation.generation,
+        now=1,
+    )
+
+    coordinator.update_node_capacities((_node("n", cpu=1, heap=100, store=100),))
+    query = coordinator.snapshot()["queries"]["q"]
+
+    assert query["state"] == "RUNNING"
+    assert query["allocation"]["resources"] == _r(cpu=1, heap=100, store=100).to_dict()
+    assert query["soft_allocation_debt"] == _r(cpu=2, heap=200, store=150).to_dict()
+    assert coordinator.query_state("q", query["allocation"]["generation"]) == "RUNNING"
+
+
+def test_capacity_recovery_expands_zero_budget_without_reregistering():
+    coordinator = ClusterQueryResourceCoordinator(())
+    allocation = coordinator.register_query(
+        _demand("q", desired=_r(cpu=2, heap=200, store=300)),
+        now=0,
+    )
+
+    coordinator.update_node_capacities((_node("new", cpu=2, heap=200, store=300),))
+    query = coordinator.snapshot()["queries"]["q"]
+
+    assert query["allocation"]["generation"] > allocation.generation
+    assert query["allocation"]["resources"] == _r(cpu=2, heap=200, store=300).to_dict()
+
+
+def test_refresh_queries_is_atomic_and_can_update_phase_demand():
+    coordinator = ClusterQueryResourceCoordinator((_node("n", cpu=4, heap=400, store=400),))
+    first = coordinator.register_query(_demand("first", desired=_r(cpu=4, heap=400)), now=0)
+    second = coordinator.register_query(_demand("second", desired=_r(store=400)), now=0)
+
+    before = coordinator.snapshot()
+    with pytest.raises(ValueError, match="generation sets must match"):
+        coordinator.refresh_queries(
+            observed_usage_by_query={"first": _r()},
+            generations={"second": second.generation},
+            now=1,
+        )
+    assert coordinator.snapshot() == before
+
+    generations = {query_id: payload["allocation"]["generation"] for query_id, payload in before["queries"].items()}
+    refreshed = coordinator.refresh_queries(
+        observed_usage_by_query={"first": _r(), "second": _r()},
+        generations=generations,
+        demands_by_query={
+            "first": _demand("first", desired=_r(store=400)),
+            "second": _demand("second", desired=_r(cpu=4, heap=400)),
+        },
+        now=2,
+    )
+
+    assert refreshed["first"].resources == _r(store=400)
+    assert refreshed["second"].resources == _r(cpu=4, heap=400)
+    assert first.generation < refreshed["first"].generation
+
+
+def test_generation_fencing_heartbeat_expiry_and_release():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n", cpu=1),),
+        heartbeat_timeout_s=10,
+    )
+    allocation = coordinator.register_query(_demand("q", desired=_r(cpu=1)), now=0)
 
     with pytest.raises(ValueError, match="stale allocation generation"):
-        coordinator.query_state("native-only", allocation.generation + 1)
-    with pytest.raises(KeyError, match="query is not registered"):
-        coordinator.query_state("missing", allocation.generation)
+        coordinator.heartbeat("q", allocation.generation + 1, now=1)
+    current = coordinator.heartbeat("q", allocation.generation, now=5)
+    assert coordinator.expire_queries(now=14.9) == ()
+    assert coordinator.expire_queries(now=15) == ("q",)
+    assert coordinator.release_query("q", current.generation) is False
+
+    replacement = coordinator.register_query(_demand("q", desired=_r(cpu=1)), now=20)
+    assert coordinator.release_query("q", replacement.generation + 1) is False
+    assert coordinator.release_query("q", replacement.generation) is True
 
 
 @pytest.mark.parametrize(
-    ("target_name", "attribute", "fail_on_call"),
+    ("target_name", "attribute"),
     [
-        pytest.param("module", "_QueryState", 1, id="state-construction"),
-        pytest.param("copy", "deepcopy", 1, id="state-staging"),
-        pytest.param("coordinator", "_rebalance_locked", 1, id="rebalance-entry"),
-        pytest.param("coordinator", "_place_bundle", 1, id="minimum-placement"),
-        pytest.param("coordinator", "_weighted_drf_extras", 1, id="fair-share"),
-        pytest.param("coordinator", "_place_divisible", 1, id="divisible-placement"),
-        pytest.param("module", "NodeResourceAllocation", 1, id="allocation-publication"),
-        pytest.param("module", "_hard_positive_difference", 2, id="debt-publication"),
+        pytest.param("module", "_QueryState", id="state-construction"),
+        pytest.param("copy", "deepcopy", id="state-staging"),
+        pytest.param("coordinator", "_rebalance_locked", id="rebalance"),
     ],
 )
-def test_register_query_failure_is_atomic_across_rebalance_phases(
-    monkeypatch,
-    target_name,
-    attribute,
-    fail_on_call,
-):
+def test_register_query_failure_is_atomic(monkeypatch, target_name, attribute):
     coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=8, gpu=1, heap=800, store=800),),
+        (_node("n", cpu=8, gpu=1, heap=800, store=800),),
         heartbeat_timeout_s=10,
     )
     coordinator.register_query(
-        _demand(
-            "existing",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=4, heap=400, store=400),
-        ),
+        _demand("existing", desired=_r(cpu=4, heap=400, store=400)),
         now=0,
     )
     before = coordinator.snapshot()
@@ -199,591 +349,24 @@ def test_register_query_failure_is_atomic_across_rebalance_phases(
         "copy": coordinator_module.copy,
         "coordinator": coordinator,
     }
-    _inject_failure_once(
-        monkeypatch,
-        targets[target_name],
-        attribute,
-        fail_on_call=fail_on_call,
-    )
+    _inject_failure_once(monkeypatch, targets[target_name], attribute)
 
-    actor_bundle = _r(cpu=1, gpu=1, heap=100)
     with pytest.raises(RuntimeError, match=f"injected {attribute} failure"):
         coordinator.register_query(
-            _demand(
-                "failed",
-                minimum=actor_bundle,
-                desired=_r(cpu=3, gpu=1, heap=300),
-            ),
+            _demand("failed", desired=_r(cpu=3, gpu=1, heap=300)),
             now=5,
         )
 
     assert coordinator.snapshot() == before
     assert coordinator._queries["existing"] is previous_state
     assert coordinator._next_sequence == previous_next_sequence
-
-    coordinator.register_query(
-        _demand(
-            "recovery",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=3, heap=300, store=300),
-        ),
-        now=6,
-    )
-    assert coordinator._queries["recovery"].sequence == previous_next_sequence
-    assert coordinator._next_sequence == previous_next_sequence + 1
-
-    registered = coordinator.snapshot()["queries"]
-    refreshed = coordinator.refresh_queries(
-        observed_usage_by_query={
-            "existing": _r(cpu=1, heap=100, store=100),
-            "recovery": _r(cpu=1, heap=100, store=100),
-        },
-        generations={query_id: query["allocation"]["generation"] for query_id, query in registered.items()},
-        now=7,
-    )
-    assert set(refreshed) == {"existing", "recovery"}
-    assert coordinator.expire_queries(now=16.9) == ()
-    assert coordinator.expire_queries(now=17) == ("existing", "recovery")
-    assert coordinator.snapshot()["queries"] == {}
+    assert "failed" not in coordinator._queries
 
 
-def test_equal_weight_queries_receive_equal_dominant_shares():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=12, heap=1_200, store=1_200),),
-        heartbeat_timeout_s=30,
-    )
-    demand_a = _demand(
-        "a",
-        minimum=_r(cpu=1, heap=100),
-        desired=_r(cpu=12, heap=1_200, store=1_200),
-    )
-    demand_b = _demand(
-        "b",
-        minimum=_r(cpu=1, heap=100),
-        desired=_r(cpu=12, heap=1_200, store=1_200),
-    )
-
-    coordinator.register_query(demand_a, now=0)
-    coordinator.register_query(demand_b, now=0)
-    snapshot = coordinator.snapshot()
-
-    allocation_a = ResourceVector.from_dict(snapshot["queries"]["a"]["allocation"]["resources"])
-    allocation_b = ResourceVector.from_dict(snapshot["queries"]["b"]["allocation"]["resources"])
-    total = _r(cpu=12, heap=1_200, store=1_200)
-    assert allocation_a.dominant_share(total) == pytest.approx(0.5, abs=0.01)
-    assert allocation_b.dominant_share(total) == pytest.approx(0.5, abs=0.01)
-    assert allocation_a + allocation_b == total
-
-
-def test_weighted_drf_accounts_for_unequal_hard_minimum_shares():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=10, heap=1_000),),
-        heartbeat_timeout_s=30,
-    )
-    coordinator.register_query(
-        _demand(
-            "large-minimum",
-            minimum=_r(cpu=8, heap=800),
-            desired=_r(cpu=10, heap=1_000),
-        ),
-        now=0,
-    )
-    coordinator.register_query(
-        _demand(
-            "small-minimum",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=10, heap=1_000),
-        ),
-        now=0,
-    )
-
-    queries = coordinator.snapshot()["queries"]
-    large = ResourceVector.from_dict(queries["large-minimum"]["allocation"]["resources"])
-    small = ResourceVector.from_dict(queries["small-minimum"]["allocation"]["resources"])
-
-    assert large == _r(cpu=8, heap=800)
-    assert small == _r(cpu=2, heap=200)
-
-
-def test_weighted_drf_fills_non_dominant_minimum_plateau_without_changing_fair_share():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=10, heap=1_000),),
-        heartbeat_timeout_s=30,
-    )
-    coordinator.register_query(
-        _demand(
-            "cpu-heavy",
-            minimum=_r(cpu=8),
-            desired=_r(cpu=8, heap=1_000),
-        ),
-        now=0,
-    )
-    coordinator.register_query(
-        _demand(
-            "heap-progress",
+def test_query_demand_rejects_removed_hard_admission_fields():
+    with pytest.raises(TypeError, match="minimum"):
+        QueryDemand(
+            query_id="q",
+            desired=_r(cpu=1),
             minimum=_r(cpu=1),
-            desired=_r(cpu=1, heap=1_000),
-        ),
-        now=0,
-    )
-
-    queries = coordinator.snapshot()["queries"]
-    cpu_heavy = ResourceVector.from_dict(queries["cpu-heavy"]["allocation"]["resources"])
-    heap_progress = ResourceVector.from_dict(queries["heap-progress"]["allocation"]["resources"])
-
-    assert cpu_heavy == _r(cpu=8, heap=200)
-    assert heap_progress == _r(cpu=1, heap=800)
-
-
-def test_weighted_dominant_fairness_gives_double_share_to_weight_two_query():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=12, heap=1_200, store=1_200),),
-        heartbeat_timeout_s=30,
-    )
-    coordinator.register_query(
-        _demand(
-            "weight-one",
-            minimum=_r(cpu=0.1, heap=10),
-            desired=_r(cpu=12, heap=1_200, store=1_200),
-            weight=1,
-        ),
-        now=0,
-    )
-    coordinator.register_query(
-        _demand(
-            "weight-two",
-            minimum=_r(cpu=0.1, heap=10),
-            desired=_r(cpu=12, heap=1_200, store=1_200),
-            weight=2,
-        ),
-        now=0,
-    )
-
-    queries = coordinator.snapshot()["queries"]
-    one = ResourceVector.from_dict(queries["weight-one"]["allocation"]["resources"])
-    two = ResourceVector.from_dict(queries["weight-two"]["allocation"]["resources"])
-
-    assert two.cpu / one.cpu == pytest.approx(2.0, rel=0.03)
-    assert two.heap_bytes / one.heap_bytes == pytest.approx(2.0, rel=0.03)
-    assert two.object_store_bytes / one.object_store_bytes == pytest.approx(2.0, rel=0.03)
-
-
-def test_object_store_budget_remains_fair_when_hard_minima_exhaust_cpu():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=2, heap=200, store=1_000),),
-        heartbeat_timeout_s=30,
-    )
-    for query_id in ("a", "b"):
-        coordinator.register_query(
-            _demand(
-                query_id,
-                minimum=_r(cpu=1, heap=100),
-                desired=_r(cpu=1, heap=100, store=1_000),
-            ),
-            now=0,
         )
-
-    queries = coordinator.snapshot()["queries"]
-    allocation_a = ResourceVector.from_dict(queries["a"]["allocation"]["resources"])
-    allocation_b = ResourceVector.from_dict(queries["b"]["allocation"]["resources"])
-
-    assert allocation_a == _r(cpu=1, heap=100, store=500)
-    assert allocation_b == _r(cpu=1, heap=100, store=500)
-
-
-def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=32, gpu=4, heap=32_000, store=32_000),),
-    )
-    allocation = coordinator.register_query(
-        _demand(
-            "capped",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=3, heap=300, store=400),
-        ),
-        now=0,
-    )
-
-    assert allocation.resources == _r(cpu=3, heap=300, store=400)
-
-
-def test_query_demand_rejects_object_store_hard_minimum_and_placement_bundles():
-    with pytest.raises(ValueError, match="minimum query resources may not hard-reserve object-store bytes"):
-        QueryDemand(
-            query_id="minimum-store",
-            minimum=_r(cpu=1, store=1),
-            desired=_r(cpu=1, store=10),
-            placement_bundles=(_r(cpu=1, store=1),),
-        )
-
-    with pytest.raises(ValueError, match="placement bundles may not hard-reserve object-store bytes"):
-        QueryDemand(
-            query_id="task-store",
-            minimum=_r(cpu=1),
-            desired=_r(cpu=1, store=10),
-            placement_bundles=(_r(cpu=1, store=1),),
-        )
-
-
-def test_query_demand_allocates_gpu_headroom_as_a_soft_divisible_share():
-    minimum = _r(cpu=1, gpu=1, heap=100)
-    desired = _r(cpu=4, gpu=4, heap=400)
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("gpu-node", cpu=4, gpu=4, heap=400),),
-    )
-
-    allocation = coordinator.register_query(
-        _demand(
-            "elastic-gpu",
-            minimum=minimum,
-            desired=desired,
-        ),
-        now=0,
-    )
-
-    assert allocation.resources == desired
-
-
-def test_gpu_task_bundle_receives_divisible_soft_headroom():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("gpu-node", cpu=4, gpu=1, heap=400, store=400),),
-    )
-    fixed_gpu_bundle = _r(cpu=1, gpu=1, heap=100)
-    desired = _r(cpu=4, gpu=1, heap=400, store=400)
-
-    allocation = coordinator.register_query(
-        _demand(
-            "fixed-gpu",
-            minimum=fixed_gpu_bundle,
-            desired=desired,
-        ),
-        now=0,
-    )
-
-    assert allocation.resources == desired
-
-
-def test_indivisible_gpu_task_bundle_must_fit_one_node_not_cluster_aggregate():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("n1", cpu=4, gpu=0.5, heap=1_000, store=1_000),
-            _node("n2", cpu=4, gpu=0.5, heap=1_000, store=1_000),
-        )
-    )
-    bundle = _r(cpu=1, gpu=1, heap=100)
-
-    allocation = coordinator.register_query(
-        _demand("gpu-task", minimum=bundle, desired=bundle),
-        now=0,
-    )
-
-    assert allocation.resources.is_zero()
-    assert coordinator.snapshot()["queries"]["gpu-task"]["state"] == "PENDING_RESOURCES"
-
-
-def test_task_bundle_matching_reassigns_an_earlier_best_fit():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("cpu-node", cpu=2, gpu=0.5),
-            _node("shared-node", cpu=2, gpu=1),
-            _node("gpu-node", cpu=1, gpu=2),
-        ),
-    )
-    cpu_bundle = _r(cpu=2)
-    mixed_bundle = _r(cpu=1.5, gpu=0.25)
-    gpu_bundle = _r(cpu=1, gpu=1)
-    minimum = cpu_bundle + mixed_bundle + gpu_bundle
-
-    allocation = coordinator.register_query(
-        QueryDemand(
-            query_id="alternating-path",
-            minimum=minimum,
-            desired=minimum,
-            placement_bundles=(cpu_bundle, mixed_bundle, gpu_bundle),
-        ),
-        now=0,
-    )
-
-    assert coordinator.query_state("alternating-path", allocation.generation) == "RUNNING"
-    by_node = {item.node_id: item.resources for item in allocation.node_allocations}
-    assert by_node["gpu-node"] == gpu_bundle
-    assert {by_node["cpu-node"], by_node["shared-node"]} == {cpu_bundle, mixed_bundle}
-
-
-def test_minimum_placement_vector_must_fit_one_node_not_cross_node_dimensions():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("cpu-node", cpu=2, heap=1, store=1),
-            _node("memory-node", cpu=0, heap=199, store=199),
-        )
-    )
-    minimum = _r(cpu=2, heap=200)
-
-    allocation = coordinator.register_query(
-        _demand("coherent-task", minimum=minimum, desired=minimum),
-        now=0,
-    )
-
-    assert allocation.resources.is_zero()
-    assert allocation.node_allocations == ()
-    assert coordinator.snapshot()["queries"]["coherent-task"]["state"] == "PENDING_RESOURCES"
-
-
-def test_gpu_task_minima_use_priority_then_fifo():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),
-            _node("n2", cpu=4, gpu=1, heap=1_000, store=1_000),
-        )
-    )
-    bundle = _r(cpu=1, gpu=1, heap=100)
-    low = _demand("low", minimum=bundle, desired=bundle, priority=0)
-    high_old = _demand("high-old", minimum=bundle, desired=bundle, priority=10)
-    high_new = _demand("high-new", minimum=bundle, desired=bundle, priority=10)
-
-    coordinator.register_query(high_old, now=0)
-    coordinator.register_query(high_new, now=1)
-    coordinator.register_query(low, now=2)
-    snapshot = coordinator.snapshot()["queries"]
-
-    assert snapshot["high-old"]["state"] == "RUNNING"
-    assert snapshot["high-new"]["state"] == "RUNNING"
-    assert snapshot["low"]["state"] == "PENDING_RESOURCES"
-    assert sum(snapshot[query_id]["allocation"]["resources"]["gpu"] for query_id in snapshot) == 2
-
-
-def test_live_usage_becomes_debt_when_priority_reassigns_soft_allocation():
-    coordinator = ClusterQueryResourceCoordinator((_node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),))
-    bundle = _r(cpu=1, gpu=1, heap=100)
-    low = coordinator.register_query(
-        _demand(
-            "low-running",
-            minimum=bundle,
-            desired=bundle,
-            priority=0,
-        ),
-        now=0,
-    )
-    low = coordinator.refresh_query(
-        "low-running",
-        observed_usage=bundle,
-        generation=low.generation,
-        now=1,
-    )
-
-    high = coordinator.register_query(
-        _demand(
-            "high-pending",
-            minimum=bundle,
-            desired=bundle,
-            priority=100,
-        ),
-        now=2,
-    )
-    queries = coordinator.snapshot()["queries"]
-
-    assert low.resources == bundle
-    assert high.resources == bundle
-    assert queries["low-running"]["state"] == "ALLOCATION_DEBT"
-    assert queries["low-running"]["allocation"]["resources"] == _r().to_dict()
-    assert queries["low-running"]["allocation_debt"] == bundle.to_dict()
-    assert queries["high-pending"]["state"] == "RUNNING"
-
-
-def test_capacity_shrink_preserves_observed_usage_as_debt_and_stops_new_admission():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=4, heap=400, store=400),),
-    )
-    allocation = coordinator.register_query(
-        _demand(
-            "q",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=4, heap=400, store=400),
-        ),
-        now=0,
-    )
-    coordinator.refresh_query(
-        "q",
-        observed_usage=_r(cpu=3, heap=300, store=300),
-        generation=allocation.generation,
-        now=1,
-    )
-
-    coordinator.update_node_capacities((_node("n1", cpu=2, heap=200, store=200),), now=2)
-    query = coordinator.snapshot()["queries"]["q"]
-
-    assert query["allocation"]["resources"] == _r(cpu=2, heap=200, store=200).to_dict()
-    assert query["observed_usage"] == _r(cpu=3, heap=300, store=300).to_dict()
-    assert query["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
-    assert query["soft_object_store_debt_bytes"] == 100
-    assert query["can_admit_new_tasks"] is False
-
-
-def test_object_store_overage_is_soft_debt_and_does_not_close_query_admission():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=4, heap=400, store=400),),
-    )
-    allocation = coordinator.register_query(
-        _demand(
-            "q",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=4, heap=400, store=400),
-        ),
-        now=0,
-    )
-
-    coordinator.refresh_query(
-        "q",
-        observed_usage=_r(cpu=1, heap=100, store=450),
-        generation=allocation.generation,
-        now=1,
-    )
-    query = coordinator.snapshot()["queries"]["q"]
-
-    assert query["state"] == "RUNNING"
-    assert query["allocation_debt"] == _r().to_dict()
-    assert query["soft_object_store_debt_bytes"] == 50
-    assert query["can_admit_new_tasks"] is True
-
-
-def test_stale_generation_cannot_refresh_or_release_newer_query_lease():
-    coordinator = ClusterQueryResourceCoordinator((_node("n1", cpu=4, heap=400, store=400),))
-    first = coordinator.register_query(
-        _demand("q", minimum=_r(cpu=1, heap=100), desired=_r(cpu=4, heap=400)),
-        now=0,
-    )
-    second = coordinator.refresh_query(
-        "q",
-        observed_usage=_r(cpu=1, heap=100),
-        generation=first.generation,
-        now=1,
-    )
-
-    with pytest.raises(ValueError, match="stale allocation generation"):
-        coordinator.refresh_query(
-            "q",
-            observed_usage=_r(),
-            generation=first.generation,
-            now=2,
-        )
-    assert coordinator.release_query("q", first.generation) is False
-    assert coordinator.release_query("q", second.generation) is True
-    assert coordinator.snapshot()["queries"] == {}
-
-
-def test_heartbeat_expiry_reclaims_query_allocation_idempotently():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=4, heap=400, store=400),),
-        heartbeat_timeout_s=10,
-    )
-    coordinator.register_query(
-        _demand("q", minimum=_r(cpu=1, heap=100), desired=_r(cpu=4, heap=400)),
-        now=5,
-    )
-
-    assert coordinator.expire_queries(now=14.9) == ()
-    assert coordinator.expire_queries(now=15) == ("q",)
-    assert coordinator.expire_queries(now=100) == ()
-    assert coordinator.snapshot()["queries"] == {}
-
-
-def test_refresh_queries_updates_all_usage_and_heartbeats_atomically():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=8, heap=800, store=800),),
-        heartbeat_timeout_s=10,
-    )
-
-    def demand(query_id):
-        return _demand(
-            query_id,
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=8, heap=800, store=800),
-        )
-
-    coordinator.register_query(demand("a"), now=0)
-    coordinator.register_query(demand("b"), now=0)
-    before = coordinator.snapshot()["queries"]
-
-    allocations = coordinator.refresh_queries(
-        observed_usage_by_query={
-            "a": _r(cpu=2, heap=200, store=150),
-            "b": _r(cpu=1, heap=120, store=100),
-        },
-        generations={query_id: query["allocation"]["generation"] for query_id, query in before.items()},
-        now=5,
-    )
-
-    after = coordinator.snapshot()["queries"]
-    assert set(allocations) == {"a", "b"}
-    assert len({allocation.generation for allocation in allocations.values()}) == 1
-    assert after["a"]["observed_usage"] == _r(cpu=2, heap=200, store=150).to_dict()
-    assert after["b"]["observed_usage"] == _r(cpu=1, heap=120, store=100).to_dict()
-    assert coordinator.expire_queries(now=14.9) == ()
-    assert coordinator.expire_queries(now=15) == ("a", "b")
-
-
-def test_refresh_queries_rejects_stale_batch_without_partial_mutation():
-    coordinator = ClusterQueryResourceCoordinator(
-        (_node("n1", cpu=8, heap=800, store=800),),
-        heartbeat_timeout_s=10,
-    )
-
-    def demand(query_id):
-        return _demand(
-            query_id,
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=8, heap=800),
-        )
-
-    coordinator.register_query(demand("a"), now=0)
-    coordinator.register_query(demand("b"), now=0)
-    before = coordinator.snapshot()["queries"]
-
-    with pytest.raises(ValueError, match="stale allocation generation"):
-        coordinator.refresh_queries(
-            observed_usage_by_query={"a": _r(cpu=2), "b": _r(cpu=3)},
-            generations={
-                "a": before["a"]["allocation"]["generation"],
-                "b": before["b"]["allocation"]["generation"] - 1,
-            },
-            now=5,
-        )
-
-    after = coordinator.snapshot()["queries"]
-    assert after["a"]["observed_usage"] == before["a"]["observed_usage"]
-    assert after["b"]["observed_usage"] == before["b"]["observed_usage"]
-    assert coordinator.expire_queries(now=10) == ("a", "b")
-
-
-def test_node_allocations_never_exceed_any_node_capacity():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("n1", cpu=2, gpu=1, heap=200, store=300),
-            _node("n2", cpu=4, gpu=0, heap=500, store=600),
-        )
-    )
-    bundle = _r(cpu=1, gpu=1, heap=100)
-    coordinator.register_query(
-        _demand(
-            "gpu",
-            minimum=bundle,
-            desired=_r(cpu=3, gpu=1, heap=300, store=300),
-        ),
-        now=0,
-    )
-    coordinator.register_query(
-        _demand(
-            "cpu",
-            minimum=_r(cpu=1, heap=100),
-            desired=_r(cpu=4, heap=400, store=600),
-        ),
-        now=0,
-    )
-
-    snapshot = coordinator.snapshot()
-    used_by_node = {node_id: _r() for node_id in snapshot["nodes"]}
-    for query in snapshot["queries"].values():
-        for node_id, payload in query["node_allocations"].items():
-            used_by_node[node_id] = used_by_node[node_id] + ResourceVector.from_dict(payload)
-    for node_id, payload in snapshot["nodes"].items():
-        assert used_by_node[node_id].fits_within(ResourceVector.from_dict(payload["resources"]))

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -166,7 +166,7 @@ def test_ray_capacity_never_uses_host_memory_or_cpu_fallback(monkeypatch):
         pytest.param("coordinator", "_weighted_drf_extras", 1, id="fair-share"),
         pytest.param("coordinator", "_place_divisible", 1, id="divisible-placement"),
         pytest.param("module", "NodeResourceAllocation", 1, id="allocation-publication"),
-        pytest.param("module", "_positive_difference", 2, id="debt-publication"),
+        pytest.param("module", "_hard_positive_difference", 2, id="debt-publication"),
     ],
 )
 def test_register_query_failure_is_atomic_across_rebalance_phases(
@@ -555,8 +555,36 @@ def test_capacity_shrink_preserves_observed_usage_as_debt_and_stops_new_admissio
 
     assert query["allocation"]["resources"] == _r(cpu=2, heap=200, store=200).to_dict()
     assert query["observed_usage"] == _r(cpu=3, heap=300, store=300).to_dict()
-    assert query["allocation_debt"] == _r(cpu=1, heap=100, store=100).to_dict()
+    assert query["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
+    assert query["soft_object_store_debt_bytes"] == 100
     assert query["can_admit_new_tasks"] is False
+
+
+def test_object_store_overage_is_soft_debt_and_does_not_close_query_admission():
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("n1", cpu=4, heap=400, store=400),),
+    )
+    allocation = coordinator.register_query(
+        _demand(
+            "q",
+            minimum=_r(cpu=1, heap=100),
+            desired=_r(cpu=4, heap=400, store=400),
+        ),
+        now=0,
+    )
+
+    coordinator.refresh_query(
+        "q",
+        observed_usage=_r(cpu=1, heap=100, store=450),
+        generation=allocation.generation,
+        now=1,
+    )
+    query = coordinator.snapshot()["queries"]["q"]
+
+    assert query["state"] == "RUNNING"
+    assert query["allocation_debt"] == _r().to_dict()
+    assert query["soft_object_store_debt_bytes"] == 50
+    assert query["can_admit_new_tasks"] is True
 
 
 def test_stale_generation_cannot_refresh_or_release_newer_query_lease():

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -1,21 +1,18 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import pickle
 from types import SimpleNamespace
 
 import pytest
 
 from duckdb.runners.ray import cluster_resource_coordinator as coordinator_module
 from duckdb.runners.ray.cluster_resource_coordinator import (
-    ActorResourceBundle,
     ClusterQueryResourceCoordinator,
-    ElasticGpuDemandError,
     NodeCapacity,
     QueryDemand,
     read_ray_node_capacities,
 )
-from duckdb.runners.ray.query_resource_graph import ActorPlacement, ResourceVector
+from duckdb.runners.ray.query_resource_graph import ResourceVector
 
 
 def _r(
@@ -46,32 +43,14 @@ def _demand(
     desired: ResourceVector,
     weight: float = 1,
     priority: int = 0,
-    actor_bundles: tuple[ResourceVector, ...] = (),
 ) -> QueryDemand:
-    tagged_actor_bundles = tuple(
-        ActorResourceBundle(
-            resource_unit_id="resource:actor",
-            actor_index=index,
-            resources=bundle,
-        )
-        for index, bundle in enumerate(actor_bundles)
-    )
-    actor_total = _r()
-    for bundle in actor_bundles:
-        actor_total = actor_total + bundle
-    task_bundles = ()
-    if actor_total.fits_within(minimum):
-        remainder = minimum - actor_total
-        if not remainder.is_zero():
-            task_bundles = (remainder,)
     return QueryDemand(
         query_id=query_id,
         minimum=minimum,
         desired=desired,
         weight=weight,
         priority=priority,
-        actor_bundles=tagged_actor_bundles,
-        task_bundles=task_bundles,
+        task_bundles=() if minimum.is_zero() else (minimum,),
     )
 
 
@@ -172,6 +151,12 @@ def test_soft_only_query_gets_node_allocation_without_native_hard_minimum():
     assert allocation.resources == _r(store=400)
     assert allocation.node_allocations[0].node_id == "node-a"
     assert allocation.node_allocations[0].resources == _r(store=400)
+    assert coordinator.query_state("native-only", allocation.generation) == "RUNNING"
+
+    with pytest.raises(ValueError, match="stale allocation generation"):
+        coordinator.query_state("native-only", allocation.generation + 1)
+    with pytest.raises(KeyError, match="query is not registered"):
+        coordinator.query_state("missing", allocation.generation)
 
 
 @pytest.mark.parametrize(
@@ -181,7 +166,6 @@ def test_soft_only_query_gets_node_allocation_without_native_hard_minimum():
         pytest.param("copy", "deepcopy", 1, id="state-staging"),
         pytest.param("coordinator", "_rebalance_locked", 1, id="rebalance-entry"),
         pytest.param("coordinator", "_place_bundle", 1, id="minimum-placement"),
-        pytest.param("module", "ActorPlacement", 1, id="actor-placement"),
         pytest.param("coordinator", "_weighted_drf_extras", 1, id="fair-share"),
         pytest.param("coordinator", "_place_divisible", 1, id="divisible-placement"),
         pytest.param("module", "NodeResourceAllocation", 1, id="allocation-publication"),
@@ -229,7 +213,6 @@ def test_register_query_failure_is_atomic_across_rebalance_phases(
                 "failed",
                 minimum=actor_bundle,
                 desired=_r(cpu=3, gpu=1, heap=300),
-                actor_bundles=(actor_bundle,),
             ),
             now=5,
         )
@@ -424,7 +407,7 @@ def test_query_desired_resources_are_downward_caps_not_capacity_overrides():
     assert allocation.resources == _r(cpu=3, heap=300, store=400)
 
 
-def test_query_demand_rejects_object_store_hard_minimum_and_placement_bundles():
+def test_query_demand_rejects_object_store_hard_minimum_and_task_bundles():
     with pytest.raises(ValueError, match="minimum query resources may not hard-reserve object-store bytes"):
         QueryDemand(
             query_id="minimum-store",
@@ -441,42 +424,27 @@ def test_query_demand_rejects_object_store_hard_minimum_and_placement_bundles():
             task_bundles=(_r(cpu=1, store=1),),
         )
 
-    with pytest.raises(ValueError, match="actor resource bundles may not hard-reserve object-store bytes"):
-        ActorResourceBundle(
-            resource_unit_id="resource:actor-store",
-            actor_index=0,
-            resources=_r(cpu=1, store=1),
-        )
 
-
-def test_query_demand_rejects_elastic_gpu_headroom_before_registration():
+def test_query_demand_allocates_gpu_headroom_as_a_soft_divisible_share():
     minimum = _r(cpu=1, gpu=1, heap=100)
+    desired = _r(cpu=4, gpu=4, heap=400)
+    coordinator = ClusterQueryResourceCoordinator(
+        (_node("gpu-node", cpu=4, gpu=4, heap=400),),
+    )
 
-    with pytest.raises(
-        ElasticGpuDemandError,
-        match=r"GPU resources cannot be elastic: minimum=1, desired=4",
-    ) as raised:
+    allocation = coordinator.register_query(
         _demand(
             "elastic-gpu",
             minimum=minimum,
-            desired=_r(cpu=4, gpu=4, heap=400),
-            actor_bundles=(minimum,),
-        )
+            desired=desired,
+        ),
+        now=0,
+    )
 
-    assert raised.value.to_dict() == {
-        "code": "ELASTIC_GPU_UNSUPPORTED",
-        "query_id": "elastic-gpu",
-        "resource": "gpu",
-        "minimum": 1.0,
-        "desired": 4.0,
-    }
-    restored = pickle.loads(pickle.dumps(raised.value))
-    assert isinstance(restored, ElasticGpuDemandError)
-    assert str(restored) == str(raised.value)
-    assert restored.to_dict() == raised.value.to_dict()
+    assert allocation.resources == desired
 
 
-def test_fixed_gpu_bundle_receives_only_divisible_cpu_and_memory_headroom():
+def test_gpu_task_bundle_receives_divisible_soft_headroom():
     coordinator = ClusterQueryResourceCoordinator(
         (_node("gpu-node", cpu=4, gpu=1, heap=400, store=400),),
     )
@@ -488,66 +456,11 @@ def test_fixed_gpu_bundle_receives_only_divisible_cpu_and_memory_headroom():
             "fixed-gpu",
             minimum=fixed_gpu_bundle,
             desired=desired,
-            actor_bundles=(fixed_gpu_bundle,),
         ),
         now=0,
     )
 
     assert allocation.resources == desired
-    assert allocation.actor_placements == (
-        ActorPlacement(resource_unit_id="resource:actor", actor_index=0, node_id="gpu-node"),
-    )
-
-
-def test_fractional_gpu_actor_bundles_are_placed_whole_on_heterogeneous_nodes():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("half-gpu", cpu=2, gpu=0.5, heap=200),
-            _node("quarter-gpu", cpu=1, gpu=0.25, heap=100),
-        )
-    )
-    bundle = _r(cpu=1, gpu=0.25, heap=100)
-    fixed_pool = bundle.scale(3)
-
-    allocation = coordinator.register_query(
-        _demand(
-            "fractional-gpu",
-            minimum=fixed_pool,
-            desired=fixed_pool,
-            actor_bundles=(bundle, bundle, bundle),
-        ),
-        now=0,
-    )
-
-    assert allocation.resources == fixed_pool
-    assert allocation.actor_placements == (
-        ActorPlacement(resource_unit_id="resource:actor", actor_index=0, node_id="quarter-gpu"),
-        ActorPlacement(resource_unit_id="resource:actor", actor_index=1, node_id="half-gpu"),
-        ActorPlacement(resource_unit_id="resource:actor", actor_index=2, node_id="half-gpu"),
-    )
-
-
-def test_indivisible_gpu_actor_bundle_must_fit_one_node_not_cluster_aggregate():
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("n1", cpu=4, gpu=0.5, heap=1_000, store=1_000),
-            _node("n2", cpu=4, gpu=0.5, heap=1_000, store=1_000),
-        )
-    )
-    bundle = _r(cpu=1, gpu=1, heap=100)
-
-    allocation = coordinator.register_query(
-        _demand(
-            "gpu",
-            minimum=bundle,
-            desired=bundle,
-            actor_bundles=(bundle,),
-        ),
-        now=0,
-    )
-
-    assert allocation.resources.is_zero()
-    assert coordinator.snapshot()["queries"]["gpu"]["state"] == "PENDING_RESOURCES"
 
 
 def test_indivisible_gpu_task_bundle_must_fit_one_node_not_cluster_aggregate():
@@ -587,19 +500,7 @@ def test_minimum_task_vector_must_fit_one_node_not_cross_node_dimensions():
     assert coordinator.snapshot()["queries"]["coherent-task"]["state"] == "PENDING_RESOURCES"
 
 
-def test_actor_bundle_resources_must_be_part_of_query_minimum():
-    bundle = _r(cpu=2, gpu=1, heap=200)
-
-    with pytest.raises(ValueError, match="exactly equal"):
-        _demand(
-            "gpu",
-            minimum=_r(cpu=1, gpu=1, heap=100),
-            desired=bundle,
-            actor_bundles=(bundle,),
-        )
-
-
-def test_gpu_actor_pools_use_priority_then_fifo_without_partial_bundle_grants():
+def test_gpu_task_minima_use_priority_then_fifo():
     coordinator = ClusterQueryResourceCoordinator(
         (
             _node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),
@@ -607,9 +508,9 @@ def test_gpu_actor_pools_use_priority_then_fifo_without_partial_bundle_grants():
         )
     )
     bundle = _r(cpu=1, gpu=1, heap=100)
-    low = _demand("low", minimum=bundle, desired=bundle, priority=0, actor_bundles=(bundle,))
-    high_old = _demand("high-old", minimum=bundle, desired=bundle, priority=10, actor_bundles=(bundle,))
-    high_new = _demand("high-new", minimum=bundle, desired=bundle, priority=10, actor_bundles=(bundle,))
+    low = _demand("low", minimum=bundle, desired=bundle, priority=0)
+    high_old = _demand("high-old", minimum=bundle, desired=bundle, priority=10)
+    high_new = _demand("high-new", minimum=bundle, desired=bundle, priority=10)
 
     coordinator.register_query(high_old, now=0)
     coordinator.register_query(high_new, now=1)
@@ -622,7 +523,7 @@ def test_gpu_actor_pools_use_priority_then_fifo_without_partial_bundle_grants():
     assert sum(snapshot[query_id]["allocation"]["resources"]["gpu"] for query_id in snapshot) == 2
 
 
-def test_running_gpu_actor_pool_is_not_preempted_by_later_high_priority_query():
+def test_live_usage_becomes_debt_when_priority_reassigns_soft_allocation():
     coordinator = ClusterQueryResourceCoordinator((_node("n1", cpu=4, gpu=1, heap=1_000, store=1_000),))
     bundle = _r(cpu=1, gpu=1, heap=100)
     low = coordinator.register_query(
@@ -631,7 +532,6 @@ def test_running_gpu_actor_pool_is_not_preempted_by_later_high_priority_query():
             minimum=bundle,
             desired=bundle,
             priority=0,
-            actor_bundles=(bundle,),
         ),
         now=0,
     )
@@ -648,16 +548,17 @@ def test_running_gpu_actor_pool_is_not_preempted_by_later_high_priority_query():
             minimum=bundle,
             desired=bundle,
             priority=100,
-            actor_bundles=(bundle,),
         ),
         now=2,
     )
     queries = coordinator.snapshot()["queries"]
 
     assert low.resources == bundle
-    assert high.resources.is_zero()
-    assert queries["low-running"]["state"] == "RUNNING"
-    assert queries["high-pending"]["state"] == "PENDING_RESOURCES"
+    assert high.resources == bundle
+    assert queries["low-running"]["state"] == "ALLOCATION_DEBT"
+    assert queries["low-running"]["allocation"]["resources"] == _r().to_dict()
+    assert queries["low-running"]["allocation_debt"] == bundle.to_dict()
+    assert queries["high-pending"]["state"] == "RUNNING"
 
 
 def test_capacity_shrink_preserves_observed_usage_as_debt_and_stops_new_admission():
@@ -838,7 +739,6 @@ def test_node_allocations_never_exceed_any_node_capacity():
             "gpu",
             minimum=bundle,
             desired=_r(cpu=3, gpu=1, heap=300, store=300),
-            actor_bundles=(bundle,),
         ),
         now=0,
     )
@@ -858,67 +758,3 @@ def test_node_allocations_never_exceed_any_node_capacity():
             used_by_node[node_id] = used_by_node[node_id] + ResourceVector.from_dict(payload)
     for node_id, payload in snapshot["nodes"].items():
         assert used_by_node[node_id].fits_within(ResourceVector.from_dict(payload["resources"]))
-
-
-def test_actor_placement_is_never_silently_migrated_after_node_loss():
-    actor = _r(cpu=1, gpu=1, heap=100)
-    coordinator = ClusterQueryResourceCoordinator(
-        (
-            _node("n1", cpu=2, gpu=1, heap=200),
-            _node("n2", cpu=2, gpu=1, heap=200),
-        )
-    )
-    first = coordinator.register_query(
-        _demand(
-            "actor-query",
-            minimum=actor,
-            desired=actor,
-            actor_bundles=(actor,),
-        )
-    )
-    assert first.actor_placements[0].node_id == "n1"
-
-    coordinator.update_node_capacities((_node("n2", cpu=2, gpu=1, heap=200),))
-    lost = coordinator.snapshot()["queries"]["actor-query"]
-
-    assert lost["state"] == "ACTOR_PLACEMENT_LOST"
-    assert lost["allocation"]["resources"] == _r().to_dict()
-    assert lost["allocation"]["actor_placements"] == []
-    assert lost["can_admit_new_tasks"] is False
-    assert "no longer available" in lost["rejection_reason"]
-
-    # Loss is terminal for this query generation. Returning capacity cannot
-    # make an already-running actor-backed executor appear migrated.
-    coordinator.update_node_capacities(
-        (
-            _node("n1", cpu=2, gpu=1, heap=200),
-            _node("n2", cpu=2, gpu=1, heap=200),
-        )
-    )
-    assert coordinator.snapshot()["queries"]["actor-query"]["state"] == "ACTOR_PLACEMENT_LOST"
-
-
-def test_pinned_actor_allocation_remains_valid_when_task_minimum_is_temporarily_unavailable():
-    actor = _r(cpu=1, gpu=1, heap=100)
-    task = _r(cpu=1, heap=100)
-    minimum = actor + task
-    coordinator = ClusterQueryResourceCoordinator((_node("n1", cpu=2, gpu=1, heap=200),))
-    coordinator.register_query(
-        _demand(
-            "actor-and-task",
-            minimum=minimum,
-            desired=minimum,
-            actor_bundles=(actor,),
-        )
-    )
-
-    coordinator.update_node_capacities((_node("n1", cpu=1, gpu=1, heap=100),))
-    pending = coordinator.snapshot()["queries"]["actor-and-task"]
-
-    assert pending["state"] == "PENDING_RESOURCES"
-    assert pending["allocation"]["resources"] == actor.to_dict()
-    assert pending["allocation"]["node_allocations"] == [{"node_id": "n1", "resources": actor.to_dict()}]
-    assert pending["allocation"]["actor_placements"] == [
-        {"resource_unit_id": "resource:actor", "actor_index": 0, "node_id": "n1"}
-    ]
-    assert pending["can_admit_new_tasks"] is False

--- a/tests/fast/test_cluster_resource_coordinator.py
+++ b/tests/fast/test_cluster_resource_coordinator.py
@@ -15,7 +15,7 @@ from duckdb.runners.ray.cluster_resource_coordinator import (
     QueryDemand,
     read_ray_node_capacities,
 )
-from duckdb.runners.ray.query_execution_graph import ActorPlacement, ResourceVector
+from duckdb.runners.ray.query_resource_graph import ActorPlacement, ResourceVector
 
 
 def _r(
@@ -50,7 +50,7 @@ def _demand(
 ) -> QueryDemand:
     tagged_actor_bundles = tuple(
         ActorResourceBundle(
-            stage_id="stage:actor",
+            resource_unit_id="resource:actor",
             actor_index=index,
             resources=bundle,
         )
@@ -390,7 +390,9 @@ def test_fixed_gpu_bundle_receives_only_divisible_cpu_and_memory_headroom():
     )
 
     assert allocation.resources == desired
-    assert allocation.actor_placements == (ActorPlacement(stage_id="stage:actor", actor_index=0, node_id="gpu-node"),)
+    assert allocation.actor_placements == (
+        ActorPlacement(resource_unit_id="resource:actor", actor_index=0, node_id="gpu-node"),
+    )
 
 
 def test_fractional_gpu_actor_bundles_are_placed_whole_on_heterogeneous_nodes():
@@ -415,9 +417,9 @@ def test_fractional_gpu_actor_bundles_are_placed_whole_on_heterogeneous_nodes():
 
     assert allocation.resources == fixed_pool
     assert allocation.actor_placements == (
-        ActorPlacement(stage_id="stage:actor", actor_index=0, node_id="quarter-gpu"),
-        ActorPlacement(stage_id="stage:actor", actor_index=1, node_id="half-gpu"),
-        ActorPlacement(stage_id="stage:actor", actor_index=2, node_id="half-gpu"),
+        ActorPlacement(resource_unit_id="resource:actor", actor_index=0, node_id="quarter-gpu"),
+        ActorPlacement(resource_unit_id="resource:actor", actor_index=1, node_id="half-gpu"),
+        ActorPlacement(resource_unit_id="resource:actor", actor_index=2, node_id="half-gpu"),
     )
 
 
@@ -812,5 +814,7 @@ def test_pinned_actor_allocation_remains_valid_when_task_minimum_is_temporarily_
     assert pending["state"] == "PENDING_RESOURCES"
     assert pending["allocation"]["resources"] == actor.to_dict()
     assert pending["allocation"]["node_allocations"] == [{"node_id": "n1", "resources": actor.to_dict()}]
-    assert pending["allocation"]["actor_placements"] == [{"stage_id": "stage:actor", "actor_index": 0, "node_id": "n1"}]
+    assert pending["allocation"]["actor_placements"] == [
+        {"resource_unit_id": "resource:actor", "actor_index": 0, "node_id": "n1"}
+    ]
     assert pending["can_admit_new_tasks"] is False

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -166,6 +166,7 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
+                "is_blocking_materializing": False,
                 "num_partitions": 4,
                 "udf_payload": None,
             },
@@ -174,6 +175,7 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["0"],
                 "is_sink": False,
+                "is_blocking_materializing": False,
                 "num_partitions": 4,
                 "udf_payload": {
                     "query_id": query_id,

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -54,11 +54,10 @@ def _graph(query_id: str) -> QueryResourceGraph:
 
 
 def _allocation() -> QueryAllocation:
-    resources = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
+    resources = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=40)
     return QueryAllocation(
         resources=resources,
         node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
-        actor_placements=(),
         generation=1,
     )
 
@@ -288,6 +287,7 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
         runner_cls, runner = _runner(asyncio.get_running_loop())
         manager = register_query_resource_graph(graph, _allocation())
         manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
+        manager.set_external_consumer_waiting(True)
         task_request = _task_request(
             runner,
             query_id,
@@ -354,7 +354,7 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
     asyncio.run(scenario())
 
 
-def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
+def test_driver_resource_change_batches_until_the_first_blocked_waiter():
     async def scenario():
         query_id = "query-single-admission-pump"
         graph = _graph(query_id)
@@ -393,7 +393,10 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
             active["lease"]["lease_id"],
             active["lease"]["attempt_id"],
         )
-        assert evaluated_task_ids == [f"task:pending:{index}" for index in range(6)]
+        assert evaluated_task_ids == [
+            *(f"task:pending:{index}" for index in range(6)),
+            *(f"task:pending:{index}" for index in range(1, 6)),
+        ]
         done, _ = await asyncio.wait(
             pending_tasks,
             timeout=1,
@@ -485,7 +488,7 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         assert not pending.done()
         waiting_unit = manager.snapshot()["units"][graph.units[0].resource_unit_id]
         assert waiting_unit["pending_task_count"] == 1
-        assert waiting_unit["queued_input_bytes"] == 1
+        assert waiting_unit["queued_input_bytes"] == 0
 
         cancelled = await runner_cls.cancel_query_task_lease_request(
             runner,
@@ -1225,7 +1228,7 @@ def test_driver_output_cancel_after_grant_releases_late_lease_and_restores_budge
     asyncio.run(scenario())
 
 
-def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
+def test_driver_output_pump_does_not_spin_after_soft_blocking():
     async def scenario():
         query_id = "query-single-output-admission-pump"
         graph = _graph(query_id)
@@ -1284,28 +1287,22 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
         for _ in range(10):
             await asyncio.sleep(0)
 
-        assert len([task for task in output_tasks if task.done()]) == 1
-        await runner_cls.release_query_output_block_lease(
-            runner,
-            owned[1][0]["request_id"],
-            owned[1][1]["lease"]["lease_id"],
-        )
+        assert all(not task.done() for task in output_tasks)
+        expected_evaluations = [f"blocked-output:{index}" for index in range(6)] * 2
+        assert evaluated_block_ids == expected_evaluations
         for _ in range(10):
             await asyncio.sleep(0)
-
-        granted_tasks = [task for task in output_tasks if task.done()]
-        assert len(granted_tasks) == 2
-        assert set(evaluated_block_ids) == {
-            *(f"blocked-output:{index}" for index in range(6)),
-        }
+        assert evaluated_block_ids == expected_evaluations
 
         for request, pending in zip(output_requests, output_tasks):
             if pending.done():
                 continue
-            assert await runner_cls.cancel_query_output_block_lease_request(
+            cancellation = await runner_cls.cancel_query_output_block_lease_request(
                 runner,
                 request,
-            ) == {"cancelled": True, "released": False}
+            )
+            assert cancellation["cancelled"] is True
+            assert isinstance(cancellation["released"], bool)
         results = await asyncio.gather(*output_tasks)
         for request, result in zip(output_requests, results):
             if result["granted"]:
@@ -1316,6 +1313,12 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
                 ) == {"released": True}
             else:
                 assert result["blocked_reason"] == "output_lease_request_cancelled"
+
+        await runner_cls.release_query_output_block_lease(
+            runner,
+            owned[1][0]["request_id"],
+            owned[1][1]["lease"]["lease_id"],
+        )
 
         assert await runner_cls.release_query_task_lease(
             runner,
@@ -2409,6 +2412,11 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
             assert demand == "demand"
             return allocation
 
+        def query_state(self, registered_query_id, generation):
+            assert registered_query_id == query_id
+            assert generation == allocation.generation
+            return "RUNNING"
+
         def release_query(self, released_query_id, generation):
             released.append((released_query_id, generation))
             return True
@@ -2479,6 +2487,11 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
 
         def register_query(self, _demand):
             return allocation
+
+        def query_state(self, registered_query_id, generation):
+            assert registered_query_id == query_id
+            assert generation == allocation.generation
+            return "RUNNING"
 
         def release_query(self, released_query_id, generation):
             assert released_query_id == query_id
@@ -2813,6 +2826,179 @@ def test_query_resource_signals_are_coalesced_before_event_loop_dispatch():
 
         assert task_pumps == ["query-coalesced"]
         assert output_pumps == ["query-coalesced"]
+
+    asyncio.run(scenario())
+
+
+def test_task_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
+    async def scenario():
+        query_id = "query-task-batch"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
+
+        active_request = _task_request(
+            runner,
+            query_id,
+            "request:batch:active",
+            "task:batch:active",
+        )
+        active = await runner_cls.acquire_query_task_lease(
+            runner,
+            active_request,
+        )
+        pending_requests = [
+            _task_request(
+                runner,
+                query_id,
+                f"request:batch:{index}",
+                f"task:batch:{index}",
+            )
+            for index in range(9)
+        ]
+        pending_tasks = [
+            asyncio.create_task(runner_cls.acquire_query_task_lease(runner, request)) for request in pending_requests
+        ]
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not any(task.done() for task in pending_tasks)
+
+        resources = ResourceVector(
+            cpu=10,
+            heap_bytes=1_000,
+            object_store_bytes=200,
+        )
+        manager.update_allocation(
+            QueryAllocation(
+                resources=resources,
+                node_allocations=(
+                    NodeResourceAllocation(
+                        node_id="node-a",
+                        resources=resources,
+                    ),
+                ),
+                generation=2,
+            ),
+            admission_open=True,
+        )
+        runner_cls._run_query_task_admission_pump(runner, query_id)
+
+        assert all(
+            runner._query_task_lease_requests[request["request_id"]]["status"] == "granted"
+            for request in pending_requests
+        )
+        grants = await asyncio.gather(*pending_tasks)
+        assert all(grant["granted"] for grant in grants)
+
+        for request, grant in zip(pending_requests, grants):
+            assert await runner_cls.release_query_task_lease(
+                runner,
+                request["request_id"],
+                grant["lease"]["lease_id"],
+                grant["lease"]["attempt_id"],
+            ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            active_request["request_id"],
+            active["lease"]["lease_id"],
+            active["lease"]["attempt_id"],
+        ) == {"released": True}
+
+    asyncio.run(scenario())
+
+
+def test_output_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
+    async def scenario():
+        query_id = "query-output-batch"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        initial_resources = ResourceVector(
+            cpu=1,
+            heap_bytes=101,
+            object_store_bytes=1,
+        )
+        manager = register_query_resource_graph(
+            graph,
+            QueryAllocation(
+                resources=initial_resources,
+                node_allocations=(
+                    NodeResourceAllocation(
+                        node_id="node-a",
+                        resources=initial_resources,
+                    ),
+                ),
+                generation=1,
+            ),
+        )
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
+        task_request = _task_request(
+            runner,
+            query_id,
+            "request:output-batch:task",
+            "task:output-batch",
+        )
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+
+        output_requests = [
+            {
+                "request_id": f"request:output-batch:{index}",
+                "query_id": query_id,
+                "producer_unit_id": graph.units[0].resource_unit_id,
+                "task_lease_id": task["lease"]["lease_id"],
+                "attempt_id": task["lease"]["attempt_id"],
+                "block_id": f"block:output-batch:{index}",
+                "size_bytes": 1,
+            }
+            for index in range(9)
+        ]
+        output_tasks = [
+            asyncio.create_task(runner_cls.acquire_query_output_block_lease(runner, request))
+            for request in output_requests
+        ]
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not any(task.done() for task in output_tasks)
+
+        expanded_resources = ResourceVector(
+            cpu=1,
+            heap_bytes=101,
+            object_store_bytes=100,
+        )
+        manager.update_allocation(
+            QueryAllocation(
+                resources=expanded_resources,
+                node_allocations=(
+                    NodeResourceAllocation(
+                        node_id="node-a",
+                        resources=expanded_resources,
+                    ),
+                ),
+                generation=2,
+            ),
+            admission_open=True,
+        )
+        runner_cls._run_query_output_admission_pump(runner, query_id)
+
+        assert all(
+            runner._query_output_lease_requests[request["request_id"]]["status"] == "granted"
+            for request in output_requests
+        )
+        grants = await asyncio.gather(*output_tasks)
+        assert all(grant["granted"] for grant in grants)
+
+        for request, grant in zip(output_requests, grants):
+            assert await runner_cls.release_query_output_block_lease(
+                runner,
+                request["request_id"],
+                grant["lease"]["lease_id"],
+            ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
 
     asyncio.run(scenario())
 

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -432,7 +432,7 @@ def test_driver_resource_change_event_drives_fte_owner_without_polling(monkeypat
 
     monkeypatch.setattr(
         fte_scheduler,
-        "has_fte_resource_admission_waiter",
+        "has_fte_resource_admission_demand",
         lambda query_id: query_id == "query-fte-resource-wake",
     )
 

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -12,16 +12,16 @@ from types import SimpleNamespace
 import pytest
 
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
-    register_query_graph,
+    register_query_resource_graph,
 )
 
 
@@ -32,24 +32,24 @@ def _clean_query_runtime():
     clear_query_resource_managers()
 
 
-def _graph(query_id: str) -> QueryExecutionGraph:
-    stage = StageResourceSpec(
+def _graph(query_id: str) -> QueryResourceGraph:
+    unit = ResourceUnitSpec(
         query_id=query_id,
-        stage_id=f"stage:{query_id}:udf",
+        resource_unit_id=f"resource:{query_id}:udf",
         physical_node_id="node:1:udf",
-        stage_kind="udf",
+        unit_kind="ray_task_udf",
         backend="ray_task",
-        input_stage_ids=(),
+        input_unit_ids=(),
         per_task=ResourceVector(cpu=1, heap_bytes=100),
         target_output_block_bytes=10,
         generator_buffer_blocks=2,
         max_concurrency=None,
     )
-    return QueryExecutionGraph(
+    return QueryResourceGraph(
         query_id=query_id,
         plan_digest="sha256:test-driver-query-leases",
-        stages=(stage,),
-        terminal_stage_ids=(stage.stage_id,),
+        units=(unit,),
+        terminal_unit_ids=(unit.resource_unit_id,),
     )
 
 
@@ -91,7 +91,7 @@ def _task_request(runner, query_id: str, request_id: str, task_id: str) -> dict:
     return {
         "request_id": request_id,
         "query_id": query_id,
-        "stage_id": f"stage:{query_id}:udf",
+        "resource_unit_id": f"resource:{query_id}:udf",
         "task_id": task_id,
         "attempt_id": f"attempt:{task_id}",
         "node_id": None,
@@ -108,13 +108,13 @@ def _task_request(runner, query_id: str, request_id: str, task_id: str) -> dict:
     }
 
 
-async def _fill_task_output_window(runner_cls, runner, query_id, stage_id, task, *, prefix):
+async def _fill_task_output_window(runner_cls, runner, query_id, resource_unit_id, task, *, prefix):
     owned = []
     for index in range(2):
         request = {
             "request_id": f"request:{prefix}:window:{index}",
             "query_id": query_id,
-            "producer_stage_id": stage_id,
+            "producer_unit_id": resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": f"block:{prefix}:window:{index}",
@@ -140,12 +140,12 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
         query_id = "query-lease-wakeup"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         first_request = _task_request(runner, query_id, "request:first", "task:first")
         first = await runner_cls.acquire_query_task_lease(runner, first_request)
@@ -177,7 +177,7 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
             {
                 "request_id": "output-request:block-1",
                 "query_id": query_id,
-                "producer_stage_id": graph.stages[0].stage_id,
+                "producer_unit_id": graph.units[0].resource_unit_id,
                 "task_lease_id": second["lease"]["lease_id"],
                 "attempt_id": second["lease"]["attempt_id"],
                 "block_id": "block-1",
@@ -186,7 +186,7 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
         )
         output_manager_lease_id = runner._query_output_lease_requests["output-request:block-1"]["manager_lease_id"]
         assert output["granted"]
-        assert output["lease"]["state"] == "stage_queue"
+        assert output["lease"]["state"] == "unit_queue"
         assert await runner_cls.handoff_query_output_block_lease(
             runner,
             "output-request:block-1",
@@ -233,8 +233,8 @@ def test_task_admission_rejects_unsigned_or_tampered_generation_capabilities():
         query_id = "query-admission-capability"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         valid_request = _task_request(
             runner,
@@ -286,8 +286,8 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
         query_id = "query-late-output-control"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         task_request = _task_request(
             runner,
             query_id,
@@ -298,7 +298,7 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
         output_request = {
             "request_id": "request:late-output",
             "query_id": query_id,
-            "producer_stage_id": graph.stages[0].stage_id,
+            "producer_unit_id": graph.units[0].resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:late-output",
@@ -359,12 +359,12 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
         query_id = "query-single-admission-pump"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
@@ -377,7 +377,7 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
         ]
         for _ in range(5):
             await asyncio.sleep(0)
-        assert manager.snapshot()["stages"][graph.stages[0].stage_id]["pending_task_count"] == 6
+        assert manager.snapshot()["units"][graph.units[0].resource_unit_id]["pending_task_count"] == 6
 
         evaluated_task_ids = []
         original_block_reason = manager._normal_task_block_reason_locked
@@ -469,12 +469,12 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         query_id = "query-lease-cancel"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
@@ -483,9 +483,9 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         for _ in range(3):
             await asyncio.sleep(0)
         assert not pending.done()
-        waiting_stage = manager.snapshot()["stages"][graph.stages[0].stage_id]
-        assert waiting_stage["pending_task_count"] == 1
-        assert waiting_stage["queued_input_bytes"] == 1
+        waiting_unit = manager.snapshot()["units"][graph.units[0].resource_unit_id]
+        assert waiting_unit["pending_task_count"] == 1
+        assert waiting_unit["queued_input_bytes"] == 1
 
         cancelled = await runner_cls.cancel_query_task_lease_request(
             runner,
@@ -496,7 +496,7 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         assert denial["granted"] is False
         assert denial["fatal"] is True
         assert denial["blocked_reason"] == "task_lease_request_cancelled"
-        assert manager.snapshot()["stages"][graph.stages[0].stage_id]["pending_task_count"] == 0
+        assert manager.snapshot()["units"][graph.units[0].resource_unit_id]["pending_task_count"] == 0
         assert pending_request["request_id"] not in runner._query_task_lease_requests
         assert active_request["request_id"] in runner._query_task_lease_requests
 
@@ -518,12 +518,12 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         query_id = "query-completion-gated-cancel"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         active_request = _task_request(
             runner,
@@ -602,8 +602,8 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
         query_id = "query-close-retains-live-task"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         request = _task_request(
             runner,
@@ -657,8 +657,8 @@ def test_completed_task_cleanup_retries_without_losing_its_ledger_owner(monkeypa
         query_id = "query-completion-cleanup-retry"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         request = _task_request(
             runner,
@@ -708,8 +708,8 @@ def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
         query_id = "query-close-before-completion-handoff"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         request = _task_request(
             runner,
@@ -778,8 +778,8 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
         query_id = f"query-missing-completion:{quiesce_first}"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         request = _task_request(
             runner,
@@ -874,8 +874,8 @@ def test_task_grant_is_published_in_the_admission_ledger_before_future_completio
         query_id = "query-single-task-ledger"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         request = _task_request(
             runner,
             query_id,
@@ -934,11 +934,11 @@ def test_query_resource_release_waits_for_late_submission_completion_handoff():
         graph = _graph(query_id)
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, allocation)
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, allocation)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = _Coordinator()
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
         runner._synchronize_query_allocations = lambda: ()
 
@@ -1003,17 +1003,17 @@ def test_query_resource_release_waits_for_late_submission_completion_handoff():
     asyncio.run(scenario())
 
 
-def test_driver_rejects_runtime_resources_that_diverge_from_registered_stage():
+def test_driver_rejects_runtime_resources_that_diverge_from_registered_unit():
     async def scenario():
         query_id = "query-lease-resource-mismatch"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         request = _task_request(runner, query_id, "request:mismatch", "task:mismatch")
         request["resources"]["heap_bytes"] = 99
 
@@ -1023,7 +1023,7 @@ def test_driver_rejects_runtime_resources_that_diverge_from_registered_stage():
         assert denial["fatal"] is True
         assert denial["blocked_reason"] == "task_resource_spec_mismatch"
         assert manager.snapshot()["task_leases"] == {}
-        assert manager.snapshot()["stages"][graph.stages[0].stage_id]["pending_task_count"] == 0
+        assert manager.snapshot()["units"][graph.units[0].resource_unit_id]["pending_task_count"] == 0
         assert runner._query_task_lease_requests == {}
         owner_identity = (query_id, "task:mismatch", "attempt:task:mismatch")
         assert owner_identity not in runner._query_task_request_owner_by_identity
@@ -1046,27 +1046,27 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
         query_id = "query-output-waiter-cancel"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         task_request = _task_request(runner, query_id, "request:task", "task:output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         owned = await _fill_task_output_window(
             runner_cls,
             runner,
             query_id,
-            stage_id,
+            resource_unit_id,
             task,
             prefix="cancel",
         )
         output_request = {
             "request_id": "request:output",
             "query_id": query_id,
-            "producer_stage_id": stage_id,
+            "producer_unit_id": resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "blocked-output",
@@ -1076,9 +1076,9 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
         for _ in range(3):
             await asyncio.sleep(0)
         assert pending.done() is False
-        stage_snapshot = manager.snapshot()["stages"][stage_id]
-        assert stage_snapshot["pending_output_count"] == 1
-        assert stage_snapshot["queued_output_bytes"] == 30
+        unit_snapshot = manager.snapshot()["units"][resource_unit_id]
+        assert unit_snapshot["pending_output_count"] == 1
+        assert unit_snapshot["queued_output_bytes"] == 30
 
         assert await runner_cls.cancel_query_output_block_lease_request(
             runner,
@@ -1087,7 +1087,7 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
         denial = await asyncio.wait_for(pending, timeout=1)
         assert denial["blocked_reason"] == "output_lease_request_cancelled"
         assert denial["fatal"] is True
-        assert manager.snapshot()["stages"][stage_id]["pending_output_count"] == 0
+        assert manager.snapshot()["units"][resource_unit_id]["pending_output_count"] == 0
         assert set(runner._query_output_lease_requests) == {request["request_id"] for request, _grant in owned}
 
         await _release_owned_outputs(runner_cls, runner, owned)
@@ -1108,19 +1108,19 @@ def test_driver_output_cancel_before_acquire_is_durable_and_restores_budget():
         query_id = "query-output-pre-cancel"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         task_request = _task_request(runner, query_id, "request:task", "task:pre-cancel-output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         output_request = {
             "request_id": "request:pre-cancel-output",
             "query_id": query_id,
-            "producer_stage_id": stage_id,
+            "producer_unit_id": resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:pre-cancel-output",
@@ -1143,10 +1143,12 @@ def test_driver_output_cancel_before_acquire_is_durable_and_restores_budget():
         snapshot = manager.snapshot()
         assert snapshot["output_leases"] == baseline["output_leases"]
         assert (
-            snapshot["stages"][stage_id]["pending_output_count"] == baseline["stages"][stage_id]["pending_output_count"]
+            snapshot["units"][resource_unit_id]["pending_output_count"]
+            == baseline["units"][resource_unit_id]["pending_output_count"]
         )
         assert (
-            snapshot["stages"][stage_id]["queued_output_bytes"] == baseline["stages"][stage_id]["queued_output_bytes"]
+            snapshot["units"][resource_unit_id]["queued_output_bytes"]
+            == baseline["units"][resource_unit_id]["queued_output_bytes"]
         )
 
         assert await runner_cls.release_query_task_lease(
@@ -1164,19 +1166,19 @@ def test_driver_output_cancel_after_grant_releases_late_lease_and_restores_budge
         query_id = "query-output-late-grant-cancel"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         task_request = _task_request(runner, query_id, "request:task", "task:late-grant-output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         output_request = {
             "request_id": "request:late-grant-output",
             "query_id": query_id,
-            "producer_stage_id": stage_id,
+            "producer_unit_id": resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:late-grant-output",
@@ -1199,10 +1201,12 @@ def test_driver_output_cancel_after_grant_releases_late_lease_and_restores_budge
         snapshot = manager.snapshot()
         assert snapshot["output_leases"] == baseline["output_leases"]
         assert (
-            snapshot["stages"][stage_id]["pending_output_count"] == baseline["stages"][stage_id]["pending_output_count"]
+            snapshot["units"][resource_unit_id]["pending_output_count"]
+            == baseline["units"][resource_unit_id]["pending_output_count"]
         )
         assert (
-            snapshot["stages"][stage_id]["queued_output_bytes"] == baseline["stages"][stage_id]["queued_output_bytes"]
+            snapshot["units"][resource_unit_id]["queued_output_bytes"]
+            == baseline["units"][resource_unit_id]["queued_output_bytes"]
         )
         replay = await runner_cls.acquire_query_output_block_lease(
             runner,
@@ -1226,20 +1230,20 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
         query_id = "query-single-output-admission-pump"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         task_request = _task_request(runner, query_id, "request:task", "task:output-pump")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         owned = await _fill_task_output_window(
             runner_cls,
             runner,
             query_id,
-            stage_id,
+            resource_unit_id,
             task,
             prefix="pump",
         )
@@ -1248,7 +1252,7 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
             {
                 "request_id": f"request:output:{index}",
                 "query_id": query_id,
-                "producer_stage_id": stage_id,
+                "producer_unit_id": resource_unit_id,
                 "task_lease_id": task["lease"]["lease_id"],
                 "attempt_id": task["lease"]["attempt_id"],
                 "block_id": f"blocked-output:{index}",
@@ -1328,7 +1332,7 @@ def test_task_attempt_rejects_a_second_request_id_instead_of_orphaning_future():
         query_id = "query-duplicate-task-owner"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1336,7 +1340,7 @@ def test_task_attempt_rejects_a_second_request_id_instead_of_orphaning_future():
                 query_id,
             ),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         active_request = _task_request(
             runner,
             query_id,
@@ -1384,7 +1388,7 @@ def test_output_block_rejects_a_second_request_id_instead_of_orphaning_future():
         query_id = "query-duplicate-output-owner"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1392,8 +1396,8 @@ def test_output_block_rejects_a_second_request_id_instead_of_orphaning_future():
                 query_id,
             ),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         task_request = _task_request(
             runner,
             query_id,
@@ -1405,14 +1409,14 @@ def test_output_block_rejects_a_second_request_id_instead_of_orphaning_future():
             runner_cls,
             runner,
             query_id,
-            stage_id,
+            resource_unit_id,
             task,
             prefix="duplicate",
         )
         first_request = {
             "request_id": "request:first-output-owner",
             "query_id": query_id,
-            "producer_stage_id": stage_id,
+            "producer_unit_id": resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:duplicate",
@@ -1456,7 +1460,7 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
         query_id = "query-terminal-request-replay"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1464,7 +1468,7 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
                 query_id,
             ),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         task_request = _task_request(
             runner,
@@ -1476,7 +1480,7 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
         output_request = {
             "request_id": "request:terminal-output",
             "query_id": query_id,
-            "producer_stage_id": graph.stages[0].stage_id,
+            "producer_unit_id": graph.units[0].resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:terminal",
@@ -1546,7 +1550,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner._query_task_terminal_controls = BoundedReplayMap(capacity=1)
         runner._query_task_terminal_attempts = BoundedReplayMap(capacity=1)
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1554,7 +1558,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
                 query_id,
             ),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         task_request = _task_request(
             runner,
@@ -1670,8 +1674,8 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
         assert len(runner._query_task_terminal_attempts) == 1
 
         clear_query_resource_managers()
-        next_manager = register_query_graph(graph, _allocation())
-        next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        next_manager = register_query_resource_graph(graph, _allocation())
+        next_manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
         assert len(runner._query_task_lease_request_tombstones) == 0
         assert len(runner._query_task_terminal_controls) == 0
@@ -1719,7 +1723,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
         stale_output_request = {
             "request_id": "request:stale-generation-output",
             "query_id": query_id,
-            "producer_stage_id": graph.stages[0].stage_id,
+            "producer_unit_id": graph.units[0].resource_unit_id,
             "task_lease_id": old_capability,
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:generation-fence",
@@ -1766,7 +1770,7 @@ def test_output_terminal_control_ack_survives_bounded_replay_payload_eviction():
         query_id = "query-output-terminal-after-eviction"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1774,7 +1778,7 @@ def test_output_terminal_control_ack_survives_bounded_replay_payload_eviction():
                 query_id,
             ),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         task_request = _task_request(
             runner,
@@ -1786,7 +1790,7 @@ def test_output_terminal_control_ack_survives_bounded_replay_payload_eviction():
         output_request = {
             "request_id": "request:output-terminal-after-eviction",
             "query_id": query_id,
-            "producer_stage_id": graph.stages[0].stage_id,
+            "producer_unit_id": graph.units[0].resource_unit_id,
             "task_lease_id": task["lease"]["lease_id"],
             "attempt_id": task["lease"]["attempt_id"],
             "block_id": "block:output-terminal-after-eviction",
@@ -1855,7 +1859,7 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
         query_id = "query-cancelled-request-replay"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(
@@ -1863,7 +1867,7 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
                 query_id,
             ),
         )
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         active_request = _task_request(
             runner,
@@ -1891,7 +1895,7 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
                 conflicting_cancel,
             )
         assert not original_waiter.done()
-        assert manager.snapshot()["stages"][graph.stages[0].stage_id]["pending_task_count"] == 1
+        assert manager.snapshot()["units"][graph.units[0].resource_unit_id]["pending_task_count"] == 1
 
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
@@ -1935,16 +1939,16 @@ def test_query_teardown_resolves_all_pending_admission_futures():
         graph = _graph(query_id)
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             allocation,
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = _CoordinatorStub()
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
 
         active_request = _task_request(runner, query_id, "request:active", "task:active")
@@ -1953,7 +1957,7 @@ def test_query_teardown_resolves_all_pending_admission_futures():
             runner_cls,
             runner,
             query_id,
-            stage_id,
+            resource_unit_id,
             active,
             prefix="teardown",
         )
@@ -1970,7 +1974,7 @@ def test_query_teardown_resolves_all_pending_admission_futures():
                 {
                     "request_id": "request:output",
                     "query_id": query_id,
-                    "producer_stage_id": stage_id,
+                    "producer_unit_id": resource_unit_id,
                     "task_lease_id": active["lease"]["lease_id"],
                     "attempt_id": active["lease"]["attempt_id"],
                     "block_id": "blocked-output",
@@ -2032,11 +2036,11 @@ def test_query_teardown_cleans_local_state_when_coordinator_lease_expired():
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner_cls._ensure_query_resource_admission_state(runner)
-        register_query_graph(graph, allocation)
+        register_query_resource_graph(graph, allocation)
         coordinator = _ExpiredCoordinator()
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = coordinator
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
         runner._synchronize_query_allocations = lambda: ()
 
@@ -2052,7 +2056,7 @@ def test_query_teardown_cleans_local_state_when_coordinator_lease_expired():
 
         with pytest.raises(KeyError):
             get_query_resource_manager(query_id)
-        assert runner._query_graphs == {}
+        assert runner._query_resource_graphs == {}
         assert runner._query_allocations == {}
         assert coordinator.calls == [(query_id, allocation.generation)]
 
@@ -2082,10 +2086,10 @@ def test_fragment_drop_waits_for_fte_admission_pump_before_registry_drop(monkeyp
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner_cls._ensure_query_resource_admission_state(runner)
-        register_query_graph(graph, allocation)
+        register_query_resource_graph(graph, allocation)
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = _CoordinatorStub()
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
         runner._synchronize_query_allocations = lambda: ()
 
@@ -2160,11 +2164,11 @@ def test_fragment_drop_keeps_query_resources_when_local_fte_registry_cannot_quie
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner_cls._ensure_query_resource_admission_state(runner)
-        manager = register_query_graph(graph, allocation)
+        manager = register_query_resource_graph(graph, allocation)
         coordinator = _CoordinatorStub()
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = coordinator
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
         runner._synchronize_query_allocations = lambda: ()
         runner._get_plan_runner = lambda: SimpleNamespace(
@@ -2185,7 +2189,7 @@ def test_fragment_drop_keeps_query_resources_when_local_fte_registry_cannot_quie
             )
 
         assert get_query_resource_manager(query_id) is manager
-        assert runner._query_graphs == {query_id: graph}
+        assert runner._query_resource_graphs == {query_id: graph}
         assert runner._query_allocations == {query_id: allocation}
         assert coordinator.released == []
         assert query_id in runner._query_resource_closing_queries
@@ -2219,11 +2223,11 @@ def test_fragment_drop_retains_query_owner_while_remote_teardown_is_incomplete(m
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner_cls._ensure_query_resource_admission_state(runner)
-        manager = register_query_graph(graph, allocation)
+        manager = register_query_resource_graph(graph, allocation)
         coordinator = _CoordinatorStub()
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = coordinator
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
         runner._synchronize_query_allocations = lambda: ()
         runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
@@ -2260,7 +2264,7 @@ def test_fragment_drop_retains_query_owner_while_remote_teardown_is_incomplete(m
         assert "planned worker teardown timeout" in str(exc_info.value)
         assert "active_teardown=1" in str(exc_info.value)
         assert get_query_resource_manager(query_id) is manager
-        assert runner._query_graphs == {query_id: graph}
+        assert runner._query_resource_graphs == {query_id: graph}
         assert runner._query_allocations == {query_id: allocation}
         assert coordinator.released == []
 
@@ -2387,7 +2391,7 @@ def test_owner_loop_sync_fence_timeout_isolated_to_query_until_callback_settles(
 
 
 def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
-    import duckdb.runners.ray.query_graph_builder as graph_builder
+    import duckdb.runners.ray.query_resource_graph_builder as graph_builder
     from duckdb.runners.ray.query_resource_runtime import (
         get_query_resource_manager,
     )
@@ -2411,7 +2415,7 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
 
     monkeypatch.setattr(
         graph_builder,
-        "build_query_execution_graph",
+        "build_query_resource_graph",
         lambda _metadata: graph,
     )
     monkeypatch.setattr(
@@ -2426,7 +2430,7 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
     runner = object.__new__(runner_cls)
     runner._duckdb_conn = None
     runner._query_resource_lock = threading.RLock()
-    runner._query_graphs = {}
+    runner._query_resource_graphs = {}
     runner._query_allocations = {}
     runner._query_resource_coordinator = _Coordinator()
     capacity = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
@@ -2438,7 +2442,7 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
 
     runner._open_query_resource_admission = fail_open
     plan = SimpleNamespace(
-        collect_execution_stages=lambda conn: object(),
+        collect_query_resource_graph_metadata=lambda conn: object(),
         idx=lambda: query_id,
     )
 
@@ -2454,12 +2458,12 @@ def test_query_registration_open_failure_rolls_back_every_owner(monkeypatch):
     with pytest.raises(KeyError):
         get_query_resource_manager(query_id)
     assert released == [(query_id, allocation.generation)]
-    assert runner._query_graphs == {}
+    assert runner._query_resource_graphs == {}
     assert runner._query_allocations == {}
 
 
 def test_query_registration_retains_failed_coordinator_release_for_retry(monkeypatch):
-    import duckdb.runners.ray.query_graph_builder as graph_builder
+    import duckdb.runners.ray.query_resource_graph_builder as graph_builder
     from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
     query_id = "query-registration-release-retry"
@@ -2484,7 +2488,7 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
                 raise RuntimeError("planned coordinator release failure")
             return True
 
-    monkeypatch.setattr(graph_builder, "build_query_execution_graph", lambda _metadata: graph)
+    monkeypatch.setattr(graph_builder, "build_query_resource_graph", lambda _metadata: graph)
     monkeypatch.setattr(graph_builder, "build_query_demand", lambda _graph, _capacity: "demand")
 
     from duckdb.runners.ray.driver import RayQueryDriverActor
@@ -2492,7 +2496,7 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     runner = object.__new__(runner_cls)
     runner._query_resource_lock = threading.RLock()
-    runner._query_graphs = {}
+    runner._query_resource_graphs = {}
     runner._query_allocations = {}
     runner._query_resource_coordinator = _Coordinator()
     capacity = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=20)
@@ -2503,7 +2507,7 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
     )
     runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
     plan = SimpleNamespace(
-        collect_execution_stages=lambda conn: object(),
+        collect_query_resource_graph_metadata=lambda conn: object(),
         idx=lambda: query_id,
     )
 
@@ -2516,7 +2520,7 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
             )
         )
 
-    assert runner._query_graphs == {query_id: graph}
+    assert runner._query_resource_graphs == {query_id: graph}
     assert runner._query_allocations == {query_id: allocation}
     assert get_query_resource_manager(query_id) is not None
 
@@ -2527,7 +2531,7 @@ def test_query_registration_retains_failed_coordinator_release_for_retry(monkeyp
     )
 
     assert runner._query_resource_coordinator.release_calls == 2
-    assert runner._query_graphs == {}
+    assert runner._query_resource_graphs == {}
     assert runner._query_allocations == {}
     with pytest.raises(KeyError):
         get_query_resource_manager(query_id)
@@ -2615,7 +2619,7 @@ def test_query_teardown_retries_manager_after_coordinator_release():
     coordinator = _Coordinator()
     runner._query_resource_lock = threading.RLock()
     runner._query_resource_coordinator = coordinator
-    runner._query_graphs = {query_id: graph}
+    runner._query_resource_graphs = {query_id: graph}
     runner._query_allocations = {query_id: allocation}
     runner._fence_query_resource_admission_for_teardown = lambda _query_id: None
     with runtime._LOCK:
@@ -2629,7 +2633,7 @@ def test_query_teardown_retries_manager_after_coordinator_release():
             )
 
         assert coordinator.release_calls == [(query_id, allocation.generation)]
-        assert runner._query_graphs == {}
+        assert runner._query_resource_graphs == {}
         assert runner._query_allocations == {}
         with runtime._LOCK:
             assert runtime._MANAGERS[query_id] is manager
@@ -2661,11 +2665,11 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
         graph = _graph(query_id)
         allocation = _allocation()
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, allocation)
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, allocation)
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         runner._query_resource_lock = threading.RLock()
         runner._query_resource_coordinator = _CoordinatorStub()
-        runner._query_graphs = {query_id: graph}
+        runner._query_resource_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
 
         active_request = _task_request(
@@ -2742,18 +2746,18 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
     asyncio.run(scenario())
 
 
-def test_task_admission_pump_resolves_waiter_when_stage_becomes_terminal():
+def test_task_admission_pump_resolves_waiter_when_unit_becomes_terminal():
     async def scenario():
-        query_id = "query-task-stage-terminal"
+        query_id = "query-task-unit-terminal"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(
+        manager = register_query_resource_graph(
             graph,
             _allocation(),
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
-        stage_id = graph.stages[0].stage_id
-        manager.update_stage_state(stage_id, runnable=True)
+        resource_unit_id = graph.units[0].resource_unit_id
+        manager.update_unit_state(resource_unit_id, runnable=True)
         active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         pending_request = _task_request(
@@ -2772,11 +2776,11 @@ def test_task_admission_pump_resolves_waiter_when_stage_becomes_terminal():
             await asyncio.sleep(0)
         assert not pending.done()
 
-        manager.update_stage_state(stage_id, runnable=False, completed=True)
+        manager.update_unit_state(resource_unit_id, runnable=False, completed=True)
         denial = await asyncio.wait_for(pending, timeout=1)
         assert denial["granted"] is False
         assert denial["fatal"] is True
-        assert denial["blocked_reason"] == "stage_completed"
+        assert denial["blocked_reason"] == "unit_completed"
         assert (
             await runner_cls.acquire_query_task_lease(
                 runner,
@@ -2818,7 +2822,7 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         query_id = "query-generation-reopen"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
-        register_query_graph(graph, _allocation())
+        register_query_resource_graph(graph, _allocation())
         delayed_old_request = _task_request(
             runner,
             query_id,
@@ -2840,7 +2844,7 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
             {
                 "request_id": "request:late-old-generation-output",
                 "query_id": query_id,
-                "producer_stage_id": graph.stages[0].stage_id,
+                "producer_unit_id": graph.units[0].resource_unit_id,
                 "task_lease_id": retired_task_lease_id,
                 "attempt_id": "attempt:retired-old-generation-task",
                 "block_id": "block:late-old-generation-output",
@@ -2872,7 +2876,7 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         closed_generation_cancel = dict(
             request_id="request:closed-generation-output",
             query_id=query_id,
-            producer_stage_id=graph.stages[0].stage_id,
+            producer_unit_id=graph.units[0].resource_unit_id,
             task_lease_id=retired_task_lease_id,
             attempt_id="attempt:retired-old-generation-task",
             block_id="block:closed-generation-output",
@@ -2885,8 +2889,8 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         assert len(runner._query_output_lease_request_tombstones) == 0
         clear_query_resource_managers()
 
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
 
         stale_grant = await runner_cls.acquire_query_task_lease(
@@ -2936,8 +2940,8 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
         runner._query_output_terminal_controls = BoundedReplayMap(capacity=1)
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        manager = register_query_resource_graph(graph, _allocation())
+        manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
 
         task_request = _task_request(
             runner,
@@ -2954,7 +2958,7 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
             return {
                 "request_id": f"request:signed-output:{index}",
                 "query_id": query_id,
-                "producer_stage_id": graph.stages[0].stage_id,
+                "producer_unit_id": graph.units[0].resource_unit_id,
                 "task_lease_id": task["lease"]["lease_id"],
                 "attempt_id": task["lease"]["attempt_id"],
                 "block_id": f"block:signed-output:{index}",
@@ -3019,8 +3023,8 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         ) == {"released": True}
 
         clear_query_resource_managers()
-        next_manager = register_query_graph(graph, _allocation())
-        next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        next_manager = register_query_resource_graph(graph, _allocation())
+        next_manager.update_unit_state(graph.units[0].resource_unit_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
 
         task_request = _task_request(

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -13,7 +13,6 @@ import pytest
 
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -57,7 +56,6 @@ def _allocation() -> QueryAllocation:
     resources = ResourceVector(cpu=1, heap_bytes=101, object_store_bytes=40)
     return QueryAllocation(
         resources=resources,
-        node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
         generation=1,
     )
 
@@ -2872,12 +2870,6 @@ def test_task_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
         manager.update_allocation(
             QueryAllocation(
                 resources=resources,
-                node_allocations=(
-                    NodeResourceAllocation(
-                        node_id="node-a",
-                        resources=resources,
-                    ),
-                ),
                 generation=2,
             ),
             admission_open=True,
@@ -2922,12 +2914,6 @@ def test_output_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
             graph,
             QueryAllocation(
                 resources=initial_resources,
-                node_allocations=(
-                    NodeResourceAllocation(
-                        node_id="node-a",
-                        resources=initial_resources,
-                    ),
-                ),
                 generation=1,
             ),
         )
@@ -2968,12 +2954,6 @@ def test_output_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
         manager.update_allocation(
             QueryAllocation(
                 resources=expanded_resources,
-                node_allocations=(
-                    NodeResourceAllocation(
-                        node_id="node-a",
-                        resources=expanded_resources,
-                    ),
-                ),
                 generation=2,
             ),
             admission_open=True,

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -15,13 +15,13 @@ import duckdb
 from duckdb._ray_cxx import validate_plan_serialization_for_submission
 from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.ray.cluster_resource_coordinator import NodeCapacity
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
@@ -90,7 +90,7 @@ class _FakePhysicalPlan:
     def session_config(self):
         return {}
 
-    def collect_execution_stages(self, conn=None):
+    def collect_query_resource_graph_metadata(self, conn=None):
         assert conn is not None
         self._events.append("collect_graph")
         return self._metadata
@@ -128,7 +128,7 @@ class _FakeCoordinator:
             node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
             actor_placements=tuple(
                 ActorPlacement(
-                    stage_id=bundle.stage_id,
+                    resource_unit_id=bundle.resource_unit_id,
                     actor_index=bundle.actor_index,
                     node_id="node-a",
                 )
@@ -179,7 +179,7 @@ def _metadata(query_id: str) -> dict:
                 "num_partitions": 4,
                 "udf_payload": {
                     "query_id": query_id,
-                    "stage_id": f"stage:{query_id}:node:1:udf",
+                    "resource_unit_id": f"resource:{query_id}:udf:node:1",
                     "execution_backend": "ray_actor",
                     "actor_pool_size": 1,
                     "cpus": 1.0,
@@ -227,7 +227,7 @@ def _runner(events, coordinator):
     runner._query_resource_coordinator = coordinator
     runner._query_resource_lock = threading.RLock()
     runner._query_allocations = {}
-    runner._query_graphs = {}
+    runner._query_resource_graphs = {}
     runner._active_udf_actors = []
     runner._active_udf_actors_by_plan = {}
     runner._active_vllm_actors = []
@@ -268,10 +268,10 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
         assert query_connection is not None
         assert session_config == {}
         assert graph.query_id == query_id
-        assert allocation.actor_node_ids_for_stage(f"stage:{query_id}:node:1:udf") == ("node-a",)
+        assert allocation.actor_node_ids_for_unit(f"resource:{query_id}:udf:node:1") == ("node-a",)
         manager = get_query_resource_manager(query_id)
-        actor_stage = manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]
-        assert actor_stage["actor_ready"] is False
+        actor_unit = manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]
+        assert actor_unit["actor_ready"] is False
         events.append("actors_created")
         pool = SimpleNamespace(shutdown=lambda: None)
         runner._active_udf_actors.append(pool)
@@ -294,16 +294,16 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
 
     def _wait_for_ready(_actor_pools):
         manager = get_query_resource_manager(query_id)
-        actor_stage = manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]
-        assert actor_stage["actor_ready"] is False
+        actor_unit = manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]
+        assert actor_unit["actor_ready"] is False
         events.append("actors_ready")
 
     runner._wait_for_udf_actors_ready = _wait_for_ready
 
     def _run_plan(plan, conn):
         manager = get_query_resource_manager(query_id)
-        actor_stage = manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]
-        assert actor_stage["actor_ready"] is False
+        actor_unit = manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]
+        assert actor_unit["actor_ready"] is False
         events.append("plan_runner")
         return "stream"
 
@@ -329,7 +329,7 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
         "actors_ready",
     ]
     manager = get_query_resource_manager(query_id)
-    assert manager.snapshot()["stages"][f"stage:{query_id}:node:1:udf"]["actor_ready"] is True
+    assert manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]["actor_ready"] is True
     assert runner.curr_streams[query_id] == "stream"
     assert runner._active_vllm_actors_by_plan[query_id] == [vllm_pool]
 
@@ -339,7 +339,7 @@ def test_run_plan_does_not_read_physical_plan_id_after_registration():
     coordinator = _FakeCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
-    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._mark_query_actor_units_ready = lambda _graph: None
     query_id = "query-single-use-plan-id"
     physical_plan = _RegistrationOnlyIdxPhysicalPlan(
         query_id,
@@ -375,7 +375,7 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
     )
 
     runner._precreate_udf_actors = lambda *_args, **_kwargs: startup_entered.set() or []
-    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._mark_query_actor_units_ready = lambda _graph: None
 
     async def _exercise() -> None:
         loop = asyncio.get_running_loop()
@@ -442,11 +442,11 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         blocker_release.set()
         executor.shutdown(wait=True)
 
-    with pytest.raises(KeyError, match="query graph is not registered"):
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)
     assert startup_entered.is_set() is False
     assert coordinator.released == [(query_id, 7)]
-    assert query_id not in runner._query_graphs
+    assert query_id not in runner._query_resource_graphs
     assert query_id not in runner._query_allocations
 
 
@@ -474,7 +474,7 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
 
     runner._precreate_udf_actors = _precreate_udf_actors
     runner._wait_for_udf_actors_ready = lambda _actors: None
-    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._mark_query_actor_units_ready = lambda _graph: None
     runner._drop_query_fragments_sync = _drop_query_fragments
 
     async def _exercise() -> None:
@@ -498,14 +498,14 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
 
     asyncio.run(_exercise())
 
-    with pytest.raises(KeyError, match="query graph is not registered"):
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)
     assert fragment_drops == [query_id]
     assert coordinator.released == [(query_id, 7)]
     assert query_id not in runner.curr_plans
     assert query_id not in runner.curr_streams
     assert query_id not in runner._plan_query_ids
-    assert query_id not in runner._query_graphs
+    assert query_id not in runner._query_resource_graphs
     assert query_id not in runner._query_allocations
 
 
@@ -534,7 +534,7 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
             )
         )
 
-    with pytest.raises(KeyError, match="query graph is not registered"):
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)
     assert coordinator.released == [(query_id, 7)]
     assert query_id not in runner.curr_plans
@@ -545,7 +545,7 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     monkeypatch,
 ):
     from duckdb.runners.ray import driver as driver_module
-    from duckdb.runners.ray.query_resource_runtime import register_query_graph
+    from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
 
     events: list[str] = []
     coordinator = _FakeCoordinator(events)
@@ -560,7 +560,7 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
             "copy_output_committed": True,
         },
     )
-    runner._mark_query_actor_stages_ready = lambda _graph: None
+    runner._mark_query_actor_units_ready = lambda _graph: None
     runner._build_local_progress_snapshot = lambda query_id, _started_at: {
         "query_id": query_id,
         "state": "FINISHED",
@@ -569,23 +569,23 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     runner._open_query_resource_admission = lambda _query_id: None
 
     streaming_query_id = "query-streaming-admission"
-    streaming_stage = StageResourceSpec(
+    streaming_unit = ResourceUnitSpec(
         query_id=streaming_query_id,
-        stage_id=f"stage:{streaming_query_id}:udf",
+        resource_unit_id=f"resource:{streaming_query_id}:udf",
         physical_node_id="node:streaming:udf",
-        stage_kind="udf",
+        unit_kind="ray_task_udf",
         backend="ray_task",
-        input_stage_ids=(),
+        input_unit_ids=(),
         per_task=ResourceVector(cpu=1, heap_bytes=128),
         target_output_block_bytes=64,
         generator_buffer_blocks=1,
         max_concurrency=None,
     )
-    streaming_graph = QueryExecutionGraph(
+    streaming_graph = QueryResourceGraph(
         query_id=streaming_query_id,
         plan_digest="sha256:streaming-admission",
-        stages=(streaming_stage,),
-        terminal_stage_ids=(streaming_stage.stage_id,),
+        units=(streaming_unit,),
+        terminal_unit_ids=(streaming_unit.resource_unit_id,),
     )
     streaming_resources = ResourceVector(
         cpu=2,
@@ -603,17 +603,17 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
         actor_placements=(),
         generation=1,
     )
-    streaming_manager = register_query_graph(
+    streaming_manager = register_query_resource_graph(
         streaming_graph,
         streaming_allocation,
     )
-    streaming_manager.update_stage_state(
-        streaming_stage.stage_id,
+    streaming_manager.update_unit_state(
+        streaming_unit.resource_unit_id,
         runnable=True,
         actor_ready=True,
     )
     coordinator.allocations[streaming_query_id] = streaming_allocation
-    runner._query_graphs[streaming_query_id] = streaming_graph
+    runner._query_resource_graphs[streaming_query_id] = streaming_graph
     runner._query_allocations[streaming_query_id] = streaming_allocation
 
     nodes_started = threading.Event()
@@ -649,7 +649,7 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     lease_request = {
         "request_id": "request:streaming-during-copy",
         "query_id": streaming_query_id,
-        "stage_id": streaming_stage.stage_id,
+        "resource_unit_id": streaming_unit.resource_unit_id,
         "task_id": "task:streaming-during-copy",
         "attempt_id": "attempt:streaming-during-copy",
         "node_id": None,
@@ -756,7 +756,7 @@ def test_pending_allocation_teardown_fences_query_id_reuse_until_remote_drop_fin
         _DeferredQueryAllocationTeardown,
         _PreparedQueryResourceRegistration,
     )
-    from duckdb.runners.ray.query_graph_builder import build_query_execution_graph
+    from duckdb.runners.ray.query_resource_graph_builder import build_query_resource_graph
 
     events: list[str] = []
     coordinator = _FakeCoordinator(events)
@@ -764,7 +764,7 @@ def test_pending_allocation_teardown_fences_query_id_reuse_until_remote_drop_fin
     runner._query_resource_lock = threading.Lock()
     runner._open_query_resource_admission = lambda _query_id: None
     query_id = "query-generation-fence"
-    graph = build_query_execution_graph(_metadata(query_id))
+    graph = build_query_resource_graph(_metadata(query_id))
     node = NodeCapacity(
         "node-a",
         ResourceVector(
@@ -841,7 +841,7 @@ def test_failed_allocation_teardown_remains_retryable():
     runner._query_allocation_teardowns_pending = {query_id: teardown}
     runner._query_allocation_teardowns_claimed = set()
     runner._query_allocation_teardown_futures = set()
-    runner._query_graphs = {query_id: object()}
+    runner._query_resource_graphs = {query_id: object()}
     runner._query_allocations = {
         query_id: SimpleNamespace(generation=teardown.generation + 1),
     }
@@ -861,7 +861,7 @@ def test_failed_allocation_teardown_remains_retryable():
     assert runner._query_allocation_teardowns_pending == {query_id: teardown}
     assert "transient remote teardown failure" in runner._query_terminal_errors[query_id]
 
-    runner._query_graphs = {}
+    runner._query_resource_graphs = {}
     runner._query_allocations = {}
     retry = runner_cls._synchronize_query_allocations(runner)
     assert retry == (teardown,)
@@ -894,11 +894,11 @@ def test_driver_rejects_non_serializable_plan_before_query_registration(entrypoi
     assert isinstance(exc_info.value, RemoteRayException)
     assert isinstance(exc_info.value.__cause__, duckdb.NotImplementedException)
     assert "INTENTIONALLY_NON_SERIALIZABLE operator cannot be serialized" in str(exc_info.value.__cause__)
-    with pytest.raises(KeyError, match="query graph is not registered"):
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)
     assert coordinator.released == []
     assert coordinator.allocations == {}
-    assert runner._query_graphs == {}
+    assert runner._query_resource_graphs == {}
     assert runner._query_allocations == {}
     assert query_id not in runner.curr_plans
     assert query_id not in runner.curr_streams
@@ -927,17 +927,17 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
         NodeCapacity,
     )
     from duckdb.runners.ray.driver import RayQueryDriverActor
-    from duckdb.runners.ray.query_graph_builder import (
+    from duckdb.runners.ray.query_resource_graph_builder import (
         build_query_demand,
-        build_query_execution_graph,
+        build_query_resource_graph,
     )
     from duckdb.runners.ray.query_resource_manager import TaskRequest
-    from duckdb.runners.ray.query_resource_runtime import register_query_graph
+    from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     runner = object.__new__(runner_cls)
     query_id = "query-driver-maintenance"
-    graph = build_query_execution_graph(_metadata(query_id))
+    graph = build_query_resource_graph(_metadata(query_id))
     initial_node = NodeCapacity(
         "node-a",
         ResourceVector(
@@ -953,18 +953,18 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
         initial_node.resources,
     )
     allocation = coordinator.register_query(demand, now=0)
-    manager = register_query_graph(graph, allocation)
-    for stage in graph.stages:
-        manager.update_stage_state(
-            stage.stage_id,
+    manager = register_query_resource_graph(graph, allocation)
+    for unit in graph.units:
+        manager.update_unit_state(
+            unit.resource_unit_id,
             runnable=True,
-            actor_ready=stage.backend != "ray_actor",
+            actor_ready=unit.backend != "ray_actor",
         )
-    fte_stage = next(stage for stage in graph.stages if stage.backend == "ray_worker")
+    fte_unit = next(unit for unit in graph.units if unit.backend == "ray_worker")
     task_grant = manager.try_acquire_task(
         TaskRequest(
             query_id=query_id,
-            stage_id=fte_stage.stage_id,
+            resource_unit_id=fte_unit.resource_unit_id,
             task_id="fte-task-1",
             attempt_id="fte-attempt-1",
             node_id="node-a",
@@ -974,7 +974,7 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
 
     runner._query_resource_lock = threading.RLock()
     runner._query_resource_coordinator = coordinator
-    runner._query_graphs = {query_id: graph}
+    runner._query_resource_graphs = {query_id: graph}
     runner._query_allocations = {query_id: allocation}
     runner._query_node_capacities = (initial_node,)
     runner._query_resource_admission_loop = None
@@ -1022,16 +1022,16 @@ def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
         NodeCapacity,
     )
     from duckdb.runners.ray.driver import RayQueryDriverActor
-    from duckdb.runners.ray.query_graph_builder import (
+    from duckdb.runners.ray.query_resource_graph_builder import (
         build_query_demand,
-        build_query_execution_graph,
+        build_query_resource_graph,
     )
-    from duckdb.runners.ray.query_resource_runtime import register_query_graph
+    from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     runner = object.__new__(runner_cls)
     query_id = "query-actor-node-loss"
-    graph = build_query_execution_graph(_metadata(query_id))
+    graph = build_query_resource_graph(_metadata(query_id))
     node_resources = ResourceVector(
         cpu=8,
         gpu=1,
@@ -1046,11 +1046,11 @@ def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
         build_query_demand(graph, node_resources),
         now=0,
     )
-    manager = register_query_graph(graph, allocation)
+    manager = register_query_resource_graph(graph, allocation)
     dropped = []
 
     runner._query_resource_coordinator = coordinator
-    runner._query_graphs = {query_id: graph}
+    runner._query_resource_graphs = {query_id: graph}
     runner._query_allocations = {query_id: allocation}
     runner._query_terminal_errors = {}
     runner._query_resource_lock = threading.Lock()

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -166,7 +166,6 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
-                "is_blocking_materializing": False,
                 "num_partitions": 4,
                 "udf_payload": None,
             },
@@ -175,7 +174,6 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["0"],
                 "is_sink": False,
-                "is_blocking_materializing": False,
                 "num_partitions": 4,
                 "udf_payload": {
                     "query_id": query_id,
@@ -960,11 +958,11 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
             runnable=True,
             actor_ready=unit.backend != "ray_actor",
         )
-    fte_unit = next(unit for unit in graph.units if unit.backend == "ray_worker")
+    native_fragment_unit = next(unit for unit in graph.units if unit.backend == "ray_worker")
     task_grant = manager.try_acquire_task(
         TaskRequest(
             query_id=query_id,
-            resource_unit_id=fte_unit.resource_unit_id,
+            resource_unit_id=native_fragment_unit.resource_unit_id,
             task_id="fte-task-1",
             attempt_id="fte-attempt-1",
             node_id="node-a",

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -16,7 +16,6 @@ from duckdb._ray_cxx import validate_plan_serialization_for_submission
 from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.ray.cluster_resource_coordinator import NodeCapacity
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -125,7 +124,6 @@ class _FakeCoordinator:
         )
         allocation = QueryAllocation(
             resources=resources,
-            node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
             generation=7,
         )
         self.allocations[demand.query_id] = allocation
@@ -161,23 +159,22 @@ class _FakeCoordinator:
         }
 
 
-class _PendingCoordinator(_FakeCoordinator):
+class _ZeroBudgetCoordinator(_FakeCoordinator):
     def register_query(self, demand):
         self._events.append("coordinator_register")
         allocation = QueryAllocation(
             resources=ResourceVector(),
-            node_allocations=(),
             generation=7,
         )
         self.allocations[demand.query_id] = allocation
-        self.states[demand.query_id] = "PENDING_RESOURCES"
+        self.states[demand.query_id] = "RUNNING"
         return allocation
 
 
-class _InvalidStateCoordinator(_FakeCoordinator):
+class _QueryStateMustNotBeReadCoordinator(_FakeCoordinator):
     def query_state(self, query_id, generation):
-        super().query_state(query_id, generation)
-        return "INVALID_STATE"
+        del query_id, generation
+        raise AssertionError("aggregate soft-budget registration must not query a legacy admission state")
 
 
 def _metadata(query_id: str) -> dict:
@@ -354,9 +351,9 @@ def test_driver_starts_plan_runner_without_waiting_for_lazy_actor_pool():
     assert runner._active_vllm_actors_by_plan[query_id] == [vllm_pool]
 
 
-def test_driver_keeps_query_pending_until_minimum_bundle_becomes_feasible():
+def test_driver_opens_admission_with_a_zero_soft_budget_for_ray_core_liveness():
     events = []
-    coordinator = _PendingCoordinator(events)
+    coordinator = _ZeroBudgetCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
     query_id = "query-pending-minimum"
@@ -375,34 +372,32 @@ def test_driver_keeps_query_pending_until_minimum_bundle_becomes_feasible():
 
     snapshot = get_query_resource_manager(query_id).snapshot()
     assert snapshot["allocation"]["resources"] == ResourceVector().to_dict()
-    assert snapshot["allocation_admission_open"] is False
+    assert snapshot["allocation_admission_open"] is True
+    assert snapshot["ray_core_owns_placement"] is True
     assert runner.curr_streams[query_id] == "stream"
 
 
-def test_driver_rolls_back_cluster_allocation_when_coordinator_state_is_invalid():
+def test_driver_does_not_read_a_legacy_coordinator_admission_state():
     events = []
-    coordinator = _InvalidStateCoordinator(events)
+    coordinator = _QueryStateMustNotBeReadCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
     query_id = "query-invalid-coordinator-state"
     physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
 
-    with pytest.raises(RuntimeError, match="coordinator returned invalid query state"):
-        asyncio.run(
-            runner_cls.run_plan(
-                runner,
-                _OWNER_ID,
-                _SESSION_ID,
-                _FakeLogicalPlan(physical_plan, events),
-            )
+    asyncio.run(
+        runner_cls.run_plan(
+            runner,
+            _OWNER_ID,
+            _SESSION_ID,
+            _FakeLogicalPlan(physical_plan, events),
         )
+    )
 
-    with pytest.raises(KeyError, match="query resource graph is not registered"):
-        get_query_resource_manager(query_id)
-    assert coordinator.released == [(query_id, 7)]
-    assert coordinator.allocations == {}
-    assert runner._query_resource_graphs == {}
-    assert runner._query_allocations == {}
+    assert get_query_resource_manager(query_id).allocation.generation == 7
+    assert coordinator.released == []
+    assert runner._query_resource_graphs[query_id].query_id == query_id
+    assert runner._query_allocations[query_id].generation == 7
 
 
 def test_run_plan_does_not_read_physical_plan_id_after_registration():
@@ -660,12 +655,6 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     )
     streaming_allocation = QueryAllocation(
         resources=streaming_resources,
-        node_allocations=(
-            NodeResourceAllocation(
-                node_id="node-a",
-                resources=streaming_resources,
-            ),
-        ),
         generation=1,
     )
     streaming_manager = register_query_resource_graph(
@@ -812,6 +801,29 @@ def test_registration_does_not_overwrite_a_newer_capacity_snapshot():
 
     assert capacity == newer.resources
     assert runner._query_node_capacities == (newer,)
+    assert runner._query_resource_last_capacity_refresh_at == 20.0
+    assert coordinator.capacity_updates == []
+
+
+def test_registration_does_not_overwrite_a_newer_empty_capacity_snapshot():
+    events: list[str] = []
+    coordinator = _FakeCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    older = NodeCapacity(
+        "node-old",
+        ResourceVector(cpu=2, object_store_bytes=1 * _GIB),
+    )
+    runner._query_node_capacities = ()
+    runner._query_resource_last_capacity_refresh_at = 20.0
+
+    capacity = runner_cls._apply_query_capacity_snapshot(
+        runner,
+        (older,),
+        snapshot_started_at=10.0,
+    )
+
+    assert capacity == ResourceVector()
+    assert runner._query_node_capacities == ()
     assert runner._query_resource_last_capacity_refresh_at == 20.0
     assert coordinator.capacity_updates == []
 
@@ -991,7 +1003,36 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
     )
 
 
-def test_driver_reattributes_soft_reservation_when_capacity_moves_nodes():
+def test_driver_maintenance_reuses_a_valid_empty_capacity_snapshot_after_gcs_failure():
+    from duckdb.runners.ray.cluster_resource_coordinator import ClusterQueryResourceCoordinator
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    runner._query_resource_lock = threading.RLock()
+    runner._query_resource_coordinator = ClusterQueryResourceCoordinator(())
+    runner._query_resource_graphs = {}
+    runner._query_allocations = {}
+    runner._query_node_capacities = ()
+    runner._query_resource_last_capacity_refresh_at = 5.0
+
+    def _capacity_unavailable():
+        raise RuntimeError("GCS temporarily unavailable")
+
+    runner._read_query_node_capacities = _capacity_unavailable
+
+    result = runner_cls._maintain_query_resources_once(runner, now=10)
+
+    assert result == {
+        "query_count": 0,
+        "capacity_cached": True,
+        "capacity_error": "GCS temporarily unavailable",
+    }
+    assert runner._query_node_capacities == ()
+    assert runner._query_resource_last_capacity_refresh_at == 5.0
+
+
+def test_driver_keeps_aggregate_soft_reservation_when_capacity_moves_nodes():
     from duckdb.runners.ray.cluster_resource_coordinator import (
         ClusterQueryResourceCoordinator,
         NodeCapacity,
@@ -1043,13 +1084,15 @@ def test_driver_reattributes_soft_reservation_when_capacity_moves_nodes():
     snapshot = manager.snapshot()
     assert snapshot["cancelled"] is False
     assert snapshot["allocation_admission_open"] is True
-    assert snapshot["allocation"]["node_allocations"][0]["node_id"] == "node-b"
+    assert snapshot["allocation"]["resources"] == allocation.resources.to_dict()
+    assert "node_allocations" not in snapshot["allocation"]
+    assert snapshot["ray_core_owns_placement"] is True
     assert coordinator.snapshot()["queries"][query_id]["state"] == "RUNNING"
     assert runner._query_terminal_errors == {}
     assert dropped == []
 
 
-def test_driver_keeps_debt_neutral_drain_admission_open_during_allocation_debt():
+def test_driver_keeps_drain_admission_open_after_soft_budget_shrink():
     from duckdb.runners.ray.driver import RayQueryDriverActor
     from duckdb.runners.ray.query_resource_manager import TaskRequest
     from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
@@ -1090,25 +1133,22 @@ def test_driver_keeps_debt_neutral_drain_admission_open_during_allocation_debt()
     initial_resources = ResourceVector(cpu=2, heap_bytes=200)
     initial_allocation = QueryAllocation(
         resources=initial_resources,
-        node_allocations=(NodeResourceAllocation("node-a", initial_resources),),
         generation=1,
     )
     manager = register_query_resource_graph(graph, initial_allocation)
     manager.update_unit_state(ray_task.resource_unit_id, runnable=True)
     manager.update_unit_state(native.resource_unit_id, runnable=True)
     for index in range(2):
-        grant = manager.try_acquire_task(
-            TaskRequest(query_id, ray_task.resource_unit_id, f"ray-{index}", "0", "node-a")
-        )
+        grant = manager.try_acquire_task(TaskRequest(query_id, ray_task.resource_unit_id, f"ray-{index}", "0", None))
         assert grant.granted
 
-    debt_allocation = QueryAllocation(resources=ResourceVector(), node_allocations=(), generation=2)
+    debt_allocation = QueryAllocation(resources=ResourceVector(), generation=2)
     runner._query_resource_coordinator = SimpleNamespace(
         snapshot=lambda: {
             "queries": {
                 query_id: {
                     "allocation": debt_allocation.to_dict(),
-                    "state": "ALLOCATION_DEBT",
+                    "state": "RUNNING",
                 }
             }
         }
@@ -1120,8 +1160,8 @@ def test_driver_keeps_debt_neutral_drain_admission_open_during_allocation_debt()
 
     snapshot = manager.snapshot()
     assert snapshot["allocation_admission_open"] is True
-    assert snapshot["allocation_debt_neutral_only"] is True
+    assert snapshot["soft_allocation_debt"] == ResourceVector(cpu=2, heap_bytes=200).to_dict()
     blocked = manager.try_acquire_task(TaskRequest(query_id, ray_task.resource_unit_id, "ray-new", "0", None))
-    assert not blocked.granted and blocked.blocked_reason == "allocation_debt"
+    assert not blocked.granted and blocked.blocked_reason == "liveness_task_active"
     drain = manager.try_acquire_task(TaskRequest(query_id, native.resource_unit_id, "native-drain", "0", "node-a"))
     assert drain.granted and not drain.liveness

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -174,6 +174,12 @@ class _PendingCoordinator(_FakeCoordinator):
         return allocation
 
 
+class _InvalidStateCoordinator(_FakeCoordinator):
+    def query_state(self, query_id, generation):
+        super().query_state(query_id, generation)
+        return "INVALID_STATE"
+
+
 def _metadata(query_id: str) -> dict:
     return {
         "query_id": query_id,
@@ -371,6 +377,32 @@ def test_driver_keeps_query_pending_until_minimum_bundle_becomes_feasible():
     assert snapshot["allocation"]["resources"] == ResourceVector().to_dict()
     assert snapshot["allocation_admission_open"] is False
     assert runner.curr_streams[query_id] == "stream"
+
+
+def test_driver_rolls_back_cluster_allocation_when_coordinator_state_is_invalid():
+    events = []
+    coordinator = _InvalidStateCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    runner._precreate_udf_actors = lambda *_args, **_kwargs: []
+    query_id = "query-invalid-coordinator-state"
+    physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
+
+    with pytest.raises(RuntimeError, match="coordinator returned invalid query state"):
+        asyncio.run(
+            runner_cls.run_plan(
+                runner,
+                _OWNER_ID,
+                _SESSION_ID,
+                _FakeLogicalPlan(physical_plan, events),
+            )
+        )
+
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
+        get_query_resource_manager(query_id)
+    assert coordinator.released == [(query_id, 7)]
+    assert coordinator.allocations == {}
+    assert runner._query_resource_graphs == {}
+    assert runner._query_allocations == {}
 
 
 def test_run_plan_does_not_read_physical_plan_id_after_registration():
@@ -912,7 +944,8 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
     query_snapshot = coordinator.snapshot()["queries"][query_id]
     manager_snapshot = manager.snapshot()
     assert manager_snapshot["soft_allocation_usage"] != manager_snapshot["usage"]
-    assert query_snapshot["observed_usage"] == manager_snapshot["usage"]
+    assert query_snapshot["observed_usage"] == manager_snapshot["soft_allocation_usage"]
+    assert query_snapshot["observed_usage"]["cpu"] > manager_snapshot["usage"]["cpu"]
     assert query_snapshot["expires_at"] == 35
     assert manager_snapshot["allocation"] == query_snapshot["allocation"]
     assert runner._query_node_capacities == (shrunk_node,)
@@ -1014,3 +1047,81 @@ def test_driver_reattributes_soft_reservation_when_capacity_moves_nodes():
     assert coordinator.snapshot()["queries"][query_id]["state"] == "RUNNING"
     assert runner._query_terminal_errors == {}
     assert dropped == []
+
+
+def test_driver_keeps_debt_neutral_drain_admission_open_during_allocation_debt():
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+    from duckdb.runners.ray.query_resource_manager import TaskRequest
+    from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    query_id = "query-allocation-debt-drain"
+    ray_task = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=f"resource:{query_id}:udf:node:1",
+        physical_node_id="node:1:udf",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(),
+        per_task=ResourceVector(cpu=1, heap_bytes=100),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=None,
+    )
+    native = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=f"resource:{query_id}:fragment:node:2",
+        physical_node_id="node:2:native-fragment",
+        unit_kind="native_fragment",
+        backend="ray_worker",
+        input_unit_ids=(),
+        per_task=ResourceVector(),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=4,
+    )
+    graph = QueryResourceGraph(
+        query_id=query_id,
+        plan_digest="sha256:allocation-debt-drain",
+        units=(ray_task, native),
+        terminal_unit_ids=(ray_task.resource_unit_id, native.resource_unit_id),
+    )
+    initial_resources = ResourceVector(cpu=2, heap_bytes=200)
+    initial_allocation = QueryAllocation(
+        resources=initial_resources,
+        node_allocations=(NodeResourceAllocation("node-a", initial_resources),),
+        generation=1,
+    )
+    manager = register_query_resource_graph(graph, initial_allocation)
+    manager.update_unit_state(ray_task.resource_unit_id, runnable=True)
+    manager.update_unit_state(native.resource_unit_id, runnable=True)
+    for index in range(2):
+        grant = manager.try_acquire_task(
+            TaskRequest(query_id, ray_task.resource_unit_id, f"ray-{index}", "0", "node-a")
+        )
+        assert grant.granted
+
+    debt_allocation = QueryAllocation(resources=ResourceVector(), node_allocations=(), generation=2)
+    runner._query_resource_coordinator = SimpleNamespace(
+        snapshot=lambda: {
+            "queries": {
+                query_id: {
+                    "allocation": debt_allocation.to_dict(),
+                    "state": "ALLOCATION_DEBT",
+                }
+            }
+        }
+    )
+    runner._query_resource_graphs = {query_id: graph}
+    runner._query_allocations = {query_id: initial_allocation}
+
+    runner_cls._synchronize_query_allocations(runner)
+
+    snapshot = manager.snapshot()
+    assert snapshot["allocation_admission_open"] is True
+    assert snapshot["allocation_debt_neutral_only"] is True
+    blocked = manager.try_acquire_task(TaskRequest(query_id, ray_task.resource_unit_id, "ray-new", "0", None))
+    assert not blocked.granted and blocked.blocked_reason == "allocation_debt"
+    drain = manager.try_acquire_task(TaskRequest(query_id, native.resource_unit_id, "native-drain", "0", "node-a"))
+    assert drain.granted and not drain.liveness

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -16,7 +16,6 @@ from duckdb._ray_cxx import validate_plan_serialization_for_submission
 from duckdb._ray_errors import RemoteRayException
 from duckdb.runners.ray.cluster_resource_coordinator import NodeCapacity
 from duckdb.runners.ray.query_resource_graph import (
-    ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
@@ -113,6 +112,7 @@ class _FakeCoordinator:
         self._events = events
         self.released = []
         self.allocations = {}
+        self.states = {}
         self.capacity_updates = []
 
     def register_query(self, demand):
@@ -126,35 +126,52 @@ class _FakeCoordinator:
         allocation = QueryAllocation(
             resources=resources,
             node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
-            actor_placements=tuple(
-                ActorPlacement(
-                    resource_unit_id=bundle.resource_unit_id,
-                    actor_index=bundle.actor_index,
-                    node_id="node-a",
-                )
-                for bundle in demand.actor_bundles
-            ),
             generation=7,
         )
         self.allocations[demand.query_id] = allocation
+        self.states[demand.query_id] = "RUNNING"
         return allocation
 
     def update_node_capacities(self, capacities):
         self.capacity_updates.append(tuple(capacities))
         return None
 
+    def query_state(self, query_id, generation):
+        allocation = self.allocations[query_id]
+        if int(generation) != allocation.generation:
+            raise ValueError("stale allocation generation")
+        return self.states[query_id]
+
     def release_query(self, query_id, generation):
         self.released.append((query_id, generation))
         self._events.append("coordinator_release")
         self.allocations.pop(query_id, None)
+        self.states.pop(query_id, None)
         return True
 
     def snapshot(self):
         return {
             "queries": {
-                query_id: {"allocation": allocation.to_dict()} for query_id, allocation in self.allocations.items()
+                query_id: {
+                    "allocation": allocation.to_dict(),
+                    "state": self.states[query_id],
+                }
+                for query_id, allocation in self.allocations.items()
             }
         }
+
+
+class _PendingCoordinator(_FakeCoordinator):
+    def register_query(self, demand):
+        self._events.append("coordinator_register")
+        allocation = QueryAllocation(
+            resources=ResourceVector(),
+            node_allocations=(),
+            generation=7,
+        )
+        self.allocations[demand.query_id] = allocation
+        self.states[demand.query_id] = "PENDING_RESOURCES"
+        return allocation
 
 
 def _metadata(query_id: str) -> dict:
@@ -166,6 +183,8 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 4,
                 "udf_payload": None,
             },
@@ -174,6 +193,8 @@ def _metadata(query_id: str) -> dict:
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["0"],
                 "is_sink": False,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 4,
                 "udf_payload": {
                     "query_id": query_id,
@@ -228,11 +249,17 @@ def _runner(events, coordinator):
     runner._query_resource_graphs = {}
     runner._active_udf_actors = []
     runner._active_udf_actors_by_plan = {}
+    runner._active_udf_actor_by_unit = {}
+    runner._query_udf_actor_nodes = {}
+    runner._query_udf_session_configs = {}
+    runner._query_udf_actor_activation_tasks = {}
     runner._active_vllm_actors = []
     runner._active_vllm_actors_by_plan = {}
     runner.curr_plans = {}
     runner.curr_streams = {}
     runner._plan_query_ids = {}
+    runner._query_terminal_errors = {}
+    runner._query_resource_admission_loop = None
     runner._leased_result_partition_refs = {}
     runner._result_partition_ref_counters = {}
     node_resources = ResourceVector(
@@ -255,26 +282,22 @@ def _runner(events, coordinator):
     return runner_cls, runner
 
 
-def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
+def test_driver_starts_plan_runner_without_waiting_for_lazy_actor_pool():
     events = []
     coordinator = _FakeCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
     query_id = "query-driver-order"
     physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
 
-    def _precreate(plan, graph, allocation, *, query_connection, session_config):
+    def _precreate(plan, graph, *, query_connection, session_config):
         assert query_connection is not None
         assert session_config == {}
         assert graph.query_id == query_id
-        assert allocation.actor_node_ids_for_unit(f"resource:{query_id}:udf:node:1") == ("node-a",)
         manager = get_query_resource_manager(query_id)
         actor_unit = manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]
         assert actor_unit["actor_ready"] is False
-        events.append("actors_created")
-        pool = SimpleNamespace(shutdown=lambda: None)
-        runner._active_udf_actors.append(pool)
-        runner._active_udf_actors_by_plan[query_id] = [pool]
-        return [pool]
+        events.append("actor_locators")
+        return []
 
     runner._precreate_udf_actors = _precreate
     vllm_pool = SimpleNamespace(shutdown=lambda: None)
@@ -289,14 +312,6 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
         return [vllm_pool]
 
     runner._precreate_vllm_actors = _precreate_vllm
-
-    def _wait_for_ready(_actor_pools):
-        manager = get_query_resource_manager(query_id)
-        actor_unit = manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]
-        assert actor_unit["actor_ready"] is False
-        events.append("actors_ready")
-
-    runner._wait_for_udf_actors_ready = _wait_for_ready
 
     def _run_plan(plan, conn):
         manager = get_query_resource_manager(query_id)
@@ -321,15 +336,41 @@ def test_driver_starts_plan_runner_before_opening_actor_readiness_gate():
         "collect_graph",
         "capacity",
         "coordinator_register",
-        "actors_created",
+        "actor_locators",
         "vllm_ready",
         "plan_runner",
-        "actors_ready",
     ]
     manager = get_query_resource_manager(query_id)
-    assert manager.snapshot()["units"][f"resource:{query_id}:udf:node:1"]["actor_ready"] is True
+    snapshot = manager.snapshot()
+    assert snapshot["units"][f"resource:{query_id}:udf:node:1"]["actor_ready"] is False
+    assert snapshot["submitted_actor_slots"] == []
     assert runner.curr_streams[query_id] == "stream"
     assert runner._active_vllm_actors_by_plan[query_id] == [vllm_pool]
+
+
+def test_driver_keeps_query_pending_until_minimum_bundle_becomes_feasible():
+    events = []
+    coordinator = _PendingCoordinator(events)
+    runner_cls, runner = _runner(events, coordinator)
+    runner._precreate_udf_actors = lambda *_args, **_kwargs: []
+    query_id = "query-pending-minimum"
+    metadata = _metadata(query_id)
+    metadata["nodes"][1]["udf_payload"]["execution_backend"] = "ray_task"
+    physical_plan = _FakePhysicalPlan(query_id, metadata, events)
+
+    asyncio.run(
+        runner_cls.run_plan(
+            runner,
+            _OWNER_ID,
+            _SESSION_ID,
+            _FakeLogicalPlan(physical_plan, events),
+        )
+    )
+
+    snapshot = get_query_resource_manager(query_id).snapshot()
+    assert snapshot["allocation"]["resources"] == ResourceVector().to_dict()
+    assert snapshot["allocation_admission_open"] is False
+    assert runner.curr_streams[query_id] == "stream"
 
 
 def test_run_plan_does_not_read_physical_plan_id_after_registration():
@@ -337,7 +378,6 @@ def test_run_plan_does_not_read_physical_plan_id_after_registration():
     coordinator = _FakeCoordinator(events)
     runner_cls, runner = _runner(events, coordinator)
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
-    runner._mark_query_actor_units_ready = lambda _graph: None
     query_id = "query-single-use-plan-id"
     physical_plan = _RegistrationOnlyIdxPhysicalPlan(
         query_id,
@@ -373,7 +413,6 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
     )
 
     runner._precreate_udf_actors = lambda *_args, **_kwargs: startup_entered.set() or []
-    runner._mark_query_actor_units_ready = lambda _graph: None
 
     async def _exercise() -> None:
         loop = asyncio.get_running_loop()
@@ -471,8 +510,6 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
         )
 
     runner._precreate_udf_actors = _precreate_udf_actors
-    runner._wait_for_udf_actors_ready = lambda _actors: None
-    runner._mark_query_actor_units_ready = lambda _graph: None
     runner._drop_query_fragments_sync = _drop_query_fragments
 
     async def _exercise() -> None:
@@ -514,7 +551,7 @@ def test_driver_rolls_back_graph_and_cluster_allocation_when_actor_initializatio
     query_id = "query-driver-rollback"
     physical_plan = _FakePhysicalPlan(query_id, _metadata(query_id), events)
 
-    def _fail_precreate(plan, graph, allocation, *, query_connection, session_config):
+    def _fail_precreate(plan, graph, *, query_connection, session_config):
         assert query_connection is not None
         assert session_config == {}
         events.append("actors_initializing")
@@ -558,7 +595,6 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
             "copy_output_committed": True,
         },
     )
-    runner._mark_query_actor_units_ready = lambda _graph: None
     runner._build_local_progress_snapshot = lambda query_id, _started_at: {
         "query_id": query_id,
         "state": "FINISHED",
@@ -598,7 +634,6 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
                 resources=streaming_resources,
             ),
         ),
-        actor_placements=(),
         generation=1,
     )
     streaming_manager = register_query_resource_graph(
@@ -608,9 +643,9 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     streaming_manager.update_unit_state(
         streaming_unit.resource_unit_id,
         runnable=True,
-        actor_ready=True,
     )
     coordinator.allocations[streaming_query_id] = streaming_allocation
+    coordinator.states[streaming_query_id] = "RUNNING"
     runner._query_resource_graphs[streaming_query_id] = streaming_graph
     runner._query_allocations[streaming_query_id] = streaming_allocation
 
@@ -749,126 +784,6 @@ def test_registration_does_not_overwrite_a_newer_capacity_snapshot():
     assert coordinator.capacity_updates == []
 
 
-def test_pending_allocation_teardown_fences_query_id_reuse_until_remote_drop_finishes():
-    from duckdb.runners.ray.driver import (
-        _DeferredQueryAllocationTeardown,
-        _PreparedQueryResourceRegistration,
-    )
-    from duckdb.runners.ray.query_resource_graph_builder import build_query_resource_graph
-
-    events: list[str] = []
-    coordinator = _FakeCoordinator(events)
-    runner_cls, runner = _runner(events, coordinator)
-    runner._query_resource_lock = threading.Lock()
-    runner._open_query_resource_admission = lambda _query_id: None
-    query_id = "query-generation-fence"
-    graph = build_query_resource_graph(_metadata(query_id))
-    node = NodeCapacity(
-        "node-a",
-        ResourceVector(
-            cpu=8,
-            gpu=1,
-            heap_bytes=16 * _GIB,
-            object_store_bytes=4 * _GIB,
-        ),
-    )
-    teardown = _DeferredQueryAllocationTeardown(
-        query_id=query_id,
-        generation=3,
-        reason="old generation lost actor placement",
-    )
-    runner._query_allocation_teardowns_pending = {query_id: teardown}
-    runner._query_allocation_teardowns_claimed = set()
-    runner._query_allocation_teardown_futures = set()
-    runner._query_terminal_errors = {}
-    drop_started = threading.Event()
-    allow_drop = threading.Event()
-
-    def _drop_query_fragments(actual_query_id, *, release_resources):
-        assert actual_query_id == query_id
-        assert release_resources is False
-        drop_started.set()
-        assert allow_drop.wait(timeout=2.0)
-
-    runner._drop_query_fragments_after_admission_fence_sync = _drop_query_fragments
-    worker = threading.Thread(
-        target=runner_cls._run_query_allocation_teardowns,
-        args=(runner, (teardown,)),
-    )
-    worker.start()
-    assert drop_started.wait(timeout=1.0)
-
-    prepared = _PreparedQueryResourceRegistration(
-        graph=graph,
-        node_capacities=(node,),
-        capacity_snapshot_started_at=time.monotonic(),
-    )
-    try:
-        with pytest.raises(RuntimeError, match="pending allocation-loss teardown"):
-            runner_cls._commit_query_resource_registration(
-                runner,
-                prepared,
-                deferred_teardowns=[],
-            )
-    finally:
-        allow_drop.set()
-        worker.join(timeout=1.0)
-    assert not worker.is_alive()
-    assert query_id not in runner._query_allocation_teardowns_pending
-
-    registered_graph, allocation = runner_cls._commit_query_resource_registration(
-        runner,
-        prepared,
-        deferred_teardowns=[],
-    )
-    assert registered_graph is graph
-    assert allocation.generation == 7
-
-
-def test_failed_allocation_teardown_remains_retryable():
-    from duckdb.runners.ray.driver import _DeferredQueryAllocationTeardown
-
-    events: list[str] = []
-    runner_cls, runner = _runner(events, _FakeCoordinator(events))
-    query_id = "query-teardown-retry"
-    teardown = _DeferredQueryAllocationTeardown(
-        query_id=query_id,
-        generation=4,
-        reason="old generation lost actor placement",
-    )
-    runner._query_allocation_teardowns_pending = {query_id: teardown}
-    runner._query_allocation_teardowns_claimed = set()
-    runner._query_allocation_teardown_futures = set()
-    runner._query_resource_graphs = {query_id: object()}
-    runner._query_allocations = {
-        query_id: SimpleNamespace(generation=teardown.generation + 1),
-    }
-    runner._query_terminal_errors = {query_id: teardown.reason}
-    attempts = 0
-
-    def _drop_query_fragments(_query_id, *, release_resources):
-        nonlocal attempts
-        assert release_resources is False
-        attempts += 1
-        if attempts == 1:
-            raise RuntimeError("transient remote teardown failure")
-
-    runner._drop_query_fragments_after_admission_fence_sync = _drop_query_fragments
-
-    runner_cls._run_query_allocation_teardowns(runner, (teardown,))
-    assert runner._query_allocation_teardowns_pending == {query_id: teardown}
-    assert "transient remote teardown failure" in runner._query_terminal_errors[query_id]
-
-    runner._query_resource_graphs = {}
-    runner._query_allocations = {}
-    retry = runner_cls._synchronize_query_allocations(runner)
-    assert retry == (teardown,)
-    runner_cls._run_query_allocation_teardowns(runner, retry)
-
-    assert attempts == 2
-    assert runner._query_allocation_teardowns_pending == {}
-
-
 @pytest.mark.parametrize("entrypoint", ["run_plan", "run_copy_plan"])
 def test_driver_rejects_non_serializable_plan_before_query_registration(entrypoint):
     events = []
@@ -948,7 +863,7 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
     coordinator = ClusterQueryResourceCoordinator((initial_node,), heartbeat_timeout_s=30)
     demand = build_query_demand(
         graph,
-        initial_node.resources,
+        (initial_node,),
     )
     allocation = coordinator.register_query(demand, now=0)
     manager = register_query_resource_graph(graph, allocation)
@@ -956,7 +871,6 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
         manager.update_unit_state(
             unit.resource_unit_id,
             runnable=True,
-            actor_ready=unit.backend != "ray_actor",
         )
     native_fragment_unit = next(unit for unit in graph.units if unit.backend == "ray_worker")
     task_grant = manager.try_acquire_task(
@@ -969,6 +883,9 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
         )
     )
     assert task_grant.granted
+    actor_unit = next(unit for unit in graph.units if unit.backend == "ray_actor")
+    manager.set_submitted_actor_slots(actor_unit.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor_unit.resource_unit_id, {0: "node-a"})
 
     runner._query_resource_lock = threading.RLock()
     runner._query_resource_coordinator = coordinator
@@ -994,6 +911,7 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
 
     query_snapshot = coordinator.snapshot()["queries"][query_id]
     manager_snapshot = manager.snapshot()
+    assert manager_snapshot["soft_allocation_usage"] != manager_snapshot["usage"]
     assert query_snapshot["observed_usage"] == manager_snapshot["usage"]
     assert query_snapshot["expires_at"] == 35
     assert manager_snapshot["allocation"] == query_snapshot["allocation"]
@@ -1013,8 +931,34 @@ def test_driver_maintenance_refreshes_ray_capacity_usage_and_heartbeat_atomicall
     assert coordinator.snapshot()["queries"][query_id]["expires_at"] == 40
     assert runner._query_resource_last_capacity_refresh_at == 5
 
+    grown_node = NodeCapacity(
+        "node-a",
+        ResourceVector(
+            cpu=16,
+            gpu=2,
+            heap_bytes=32 * _GIB,
+            object_store_bytes=8 * _GIB,
+        ),
+    )
+    runner_cls._maintain_query_resources_once(
+        runner,
+        capacities=(grown_node,),
+        now=15,
+    )
 
-def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
+    grown_allocation = coordinator.snapshot()["queries"][query_id]["allocation"]["resources"]
+    assert (
+        grown_allocation
+        == ResourceVector(
+            cpu=1,
+            gpu=1,
+            heap_bytes=4 * _GIB,
+            object_store_bytes=8 * _GIB,
+        ).to_dict()
+    )
+
+
+def test_driver_reattributes_soft_reservation_when_capacity_moves_nodes():
     from duckdb.runners.ray.cluster_resource_coordinator import (
         ClusterQueryResourceCoordinator,
         NodeCapacity,
@@ -1041,7 +985,7 @@ def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
         heartbeat_timeout_s=30,
     )
     allocation = coordinator.register_query(
-        build_query_demand(graph, node_resources),
+        build_query_demand(graph, (NodeCapacity("node-a", node_resources),)),
         now=0,
     )
     manager = register_query_resource_graph(graph, allocation)
@@ -1061,13 +1005,12 @@ def test_driver_cancels_query_when_fixed_actor_placement_node_is_lost():
     runner._get_plan_runner = lambda: SimpleNamespace(drop_query_fragments=_drop_query_fragments)
 
     coordinator.update_node_capacities((NodeCapacity("node-b", node_resources),))
-    teardowns = runner_cls._synchronize_query_allocations(runner)
-    runner_cls._run_query_allocation_teardowns(runner, teardowns)
+    runner_cls._synchronize_query_allocations(runner)
 
     snapshot = manager.snapshot()
-    assert snapshot["cancelled"] is True
-    assert snapshot["cancel_reason"] == "ray_actor_placement_lost"
-    assert snapshot["allocation_admission_open"] is False
-    assert coordinator.snapshot()["queries"][query_id]["state"] == "ACTOR_PLACEMENT_LOST"
-    assert "cannot migrate in place" in runner._query_terminal_errors[query_id]
-    assert dropped == [query_id]
+    assert snapshot["cancelled"] is False
+    assert snapshot["allocation_admission_open"] is True
+    assert snapshot["allocation"]["node_allocations"][0]["node_id"] == "node-b"
+    assert coordinator.snapshot()["queries"][query_id]["state"] == "RUNNING"
+    assert runner._query_terminal_errors == {}
+    assert dropped == []

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -588,7 +588,7 @@ def test_stateful_actor_loss_during_synchronous_submit_keeps_recoverability_cont
             self.actors = [Actor()]
             self._payload = {
                 "query_id": "query-submit",
-                "resource_unit_id": "stage-submit",
+                "resource_unit_id": "resource:test:udf:submit",
                 "execution_backend": "ray_actor",
                 "udf_output_target_max_bytes": 1,
             }
@@ -606,11 +606,11 @@ def test_stateful_actor_loss_during_synchronous_submit_keeps_recoverability_cont
             return SimpleNamespace(
                 lease={
                     "query_id": "query-submit",
-                    "resource_unit_id": "stage-submit",
+                    "resource_unit_id": "resource:test:udf:submit",
                     "lease_id": "lease-submit",
                     "attempt_id": "attempt-submit",
                     "node_id": "node-submit",
-                    "execution_slot_id": "ray_actor:stage-submit:0",
+                    "execution_slot_id": "ray_actor:resource:test:udf:submit:0",
                     "actor_index": 0,
                     "output_window_bytes": 2,
                 }

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -690,7 +690,6 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
             calls.append(
@@ -698,13 +697,12 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
                     "ray_options": ray_options,
                 }
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
@@ -732,7 +730,6 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -742,7 +739,6 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
     assert len(created) == 1
     assert "7" in handles_map
     assert len(calls) == 1
-    assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
 
 
 def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name(monkeypatch):
@@ -763,7 +759,6 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
             calls.append(
@@ -771,13 +766,12 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
                     "ray_options": ray_options,
                 }
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
@@ -806,7 +800,6 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
     query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=query_driver_handle,
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -823,7 +816,6 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
-    assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
     assert calls[0]["ray_options"]["num_cpus"] == 1.0
     _assert_actor_location_runtime_env(
         calls[0]["ray_options"]["runtime_env"]["env_vars"],
@@ -851,7 +843,6 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
             max_restarts=None,
             max_task_retries=None,
@@ -860,14 +851,13 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                 {
                     "payload": dict(payload),
                     "concurrency": concurrency,
-                    "actor_node_ids": list(actor_node_ids),
                     "max_restarts": max_restarts,
                     "max_task_retries": max_task_retries,
                 }
             )
             self.actors = ["stateful-actor"]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
@@ -897,7 +887,6 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:stateful": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -918,7 +907,6 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                 "resource_unit_id": "resource:test:stateful",
             },
             "concurrency": 1,
-            "actor_node_ids": ["node-a"],
             "max_restarts": 0,
             "max_task_retries": 0,
         }
@@ -938,7 +926,6 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
             max_restarts=MAX_ACTOR_RESTARTS,
             max_task_retries=None,
@@ -946,7 +933,7 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
             calls.append((max_restarts, max_task_retries))
             self.actors = ["side-effecting-actor"]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
@@ -975,7 +962,6 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
 
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:side-effects": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1020,7 +1006,6 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
             max_restarts=MAX_ACTOR_RESTARTS,
             max_task_retries=MAX_ACTOR_TASK_RETRIES,
@@ -1028,7 +1013,7 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
             calls.append((max_restarts, max_task_retries))
             self.actors = ["ordinary-actor"]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
@@ -1050,7 +1035,6 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
 
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:retry-policy": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1136,7 +1120,6 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
             calls.append(
@@ -1144,13 +1127,12 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
                     "ray_options": ray_options,
                 }
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
@@ -1178,7 +1160,6 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
 
     created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1195,7 +1176,6 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
-    assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
     assert calls[0]["ray_options"]["num_cpus"] == 1.0
     _assert_actor_location_runtime_env(
         calls[0]["ray_options"]["runtime_env"]["env_vars"],
@@ -1235,7 +1215,6 @@ def test_ray_plan_injects_session_context_for_explicit_subprocess_backends(monke
 
     created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_unit={},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config=session_config,
@@ -1276,12 +1255,11 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = [_InitRef(idx) for idx in range(concurrency)]
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = set()
             self._owns_actors = True
 
@@ -1311,9 +1289,6 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
 
     pools, handles = udf_ray.prepare_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={
-            "resource:test:deferred-ready": ("node-a", "node-b"),
-        },
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -2351,17 +2326,11 @@ def test_udf_actor_pool_constructor_cleans_partial_actor_creation(monkeypatch):
         def _build_actor_runtime_env(_ray_options):
             return {}
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            assert len(node_ids) == expected_count
-            return list(node_ids)
-
     with pytest.raises(RuntimeError, match="planned actor creation failure"):
         _Pool(
             payload={},
             concurrency=2,
             gpus_per_actor=0,
-            actor_node_ids=["a" * 56, "b" * 56],
         )
 
     assert killed == [("actor-0", True)]
@@ -2416,17 +2385,11 @@ def test_udf_actor_pool_constructor_exposes_partial_actor_when_cleanup_fails(mon
         def _build_actor_runtime_env(_ray_options):
             return {}
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            assert len(node_ids) == expected_count
-            return list(node_ids)
-
     with pytest.raises(RuntimeError, match="partial actor cleanup also failed") as exc_info:
         _Pool(
             payload={},
             concurrency=2,
             gpus_per_actor=0,
-            actor_node_ids=["a" * 56, "b" * 56],
         )
 
     owned_pools = exc_info.value.owned_actor_pools
@@ -2450,7 +2413,6 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
             calls.append(
@@ -2458,13 +2420,12 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
                     "ray_options": ray_options,
                 }
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
@@ -2492,7 +2453,6 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -2549,7 +2509,6 @@ def test_ensure_actor_pools_for_plan_publishes_driver_handle_for_ray_task(monkey
     query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={},
         query_driver_handle=query_driver_handle,
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -2580,7 +2539,6 @@ def test_ensure_actor_pools_for_plan_propagates_collect_errors(monkeypatch):
     with pytest.raises(RuntimeError, match="collect failed"):
         udf_ray.ensure_actor_pools_for_plan(
             _BadPlan(),
-            actor_node_ids_by_unit={},
             query_driver_handle=object(),
             query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
@@ -2627,7 +2585,6 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
     with pytest.raises(RuntimeError, match="create failed"):
         udf_ray.ensure_actor_pools_for_plan(
             plan,
-            actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
             query_driver_handle=object(),
             query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
@@ -2881,8 +2838,7 @@ def test_execute_native_udf_cleanup_does_not_deadlock_with_gil_held():
             {
                 "0": {
                     "actor_handles": ["actor-0"],
-                    "actor_node_ids": ["node-a"],
-                    "query_driver_handle": object(),
+                            "query_driver_handle": object(),
                     "query_generation_capability": "test-query-generation-capability",
                 }
             },
@@ -2943,7 +2899,7 @@ def test_physical_plan_rejects_legacy_list_executor_options(monkeypatch):
     assert build_call_count == 0
 
 
-def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
+def test_ensure_actor_pools_for_plan_publishes_runtime_actor_nodes(monkeypatch):
     import duckdb.execution.udf_ray as udf_ray
 
     class _FakeActorsObj:
@@ -2970,7 +2926,7 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
         def __init__(self, **kwargs):
             self.actors = actors
             self._init_refs = []
-            self.actor_node_ids = list(kwargs["actor_node_ids"])
+            self.actor_node_ids = ["node-a", "node-b"][: int(kwargs["concurrency"])]
             self._confirmed_ready = {0, 1}
 
     monkeypatch.setattr(udf_ray, "UDFActorPool", _FakeUDFActorPool)
@@ -2994,7 +2950,6 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -3052,7 +3007,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
         def __init__(self, **kwargs):
             self.actors = actors
             self._init_refs = init_refs
-            self.actor_node_ids = list(kwargs["actor_node_ids"])
+            self.actor_node_ids = [""] * int(kwargs["concurrency"])
             self._confirmed_ready = set()
 
     monkeypatch.setattr(udf_ray, "UDFActorPool", _FakeUDFActorPool)
@@ -3076,7 +3031,6 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
 
     _, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -298,43 +298,15 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
 
-    def _fake_prepare_actor_pools_for_plan(
-        plan,
-        *,
-        actor_node_ids_by_unit,
-        query_driver_handle,
-        query_generation_capability,
-        session_config,
-        conn=None,
-    ):
-        assert actor_node_ids_by_unit == {}
-        assert query_driver_handle is driver_handle
-        assert query_generation_capability == _QUERY_GENERATION_CAPABILITY
-        assert session_config == {"AWS_ACCESS_KEY_ID": "session-access-key"}
-        assert conn is query_connection
-        created = []
-        handles_map = {}
-        for node in plan.collect_udf_nodes(conn=conn):
-            payload = node.get("payload") or {}
-            if payload.get("execution_backend") in {"ray_task", "ray_actor"}:
-                handles_map[str(node["node_id"])] = {
-                    "query_driver_handle": query_driver_handle,
-                    "query_generation_capability": query_generation_capability,
-                    "session_config": dict(session_config),
-                }
-        if handles_map:
-            plan.set_udf_actor_handles(handles_map, conn=conn)
-        return created, handles_map
-
-    fake_mod = types.ModuleType("duckdb.execution.udf_ray")
-    fake_mod.prepare_actor_pools_for_plan = _fake_prepare_actor_pools_for_plan
-    monkeypatch.setitem(sys.modules, "duckdb.execution.udf_ray", fake_mod)
-
     driver_handle = object()
     runner = SimpleNamespace(
         _driver_handle=driver_handle,
-        _active_udf_actors=[],
         _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
+        _session_lock=threading.RLock(),
+        _plan_session_ids={"test-plan": "session-1"},
+        _query_udf_actor_nodes={},
+        _query_udf_session_configs={},
+        _active_udf_actor_by_unit={},
     )
     query_connection = object()
 
@@ -357,7 +329,6 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
         runner,
         plan,
         SimpleNamespace(query_id="test-plan", units=()),
-        SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
         query_connection=query_connection,
         session_config={"AWS_ACCESS_KEY_ID": "session-access-key"},
     )
@@ -378,23 +349,67 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     ]
 
 
+def test_precreate_udf_actors_preserves_zero_physical_node_id():
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    driver_handle = object()
+    runner = SimpleNamespace(
+        _driver_handle=driver_handle,
+        _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
+        _session_lock=threading.RLock(),
+        _plan_session_ids={"test-plan": "session-1"},
+        _query_udf_actor_nodes={},
+        _query_udf_session_configs={},
+        _active_udf_actor_by_unit={},
+    )
+    plan = _FakePlan(
+        [
+            {
+                "node_id": 0,
+                "payload": {
+                    "execution_backend": "ray_task",
+                    "gpus": 0.0,
+                },
+            }
+        ]
+    )
+
+    created = runner_cls._precreate_udf_actors(
+        runner,
+        plan,
+        SimpleNamespace(query_id="test-plan", units=()),
+        query_connection=object(),
+        session_config={},
+    )
+
+    assert created == []
+    assert plan.set_calls == [
+        {
+            "handles_map": {
+                "0": {
+                    "query_driver_handle": driver_handle,
+                    "query_generation_capability": _QUERY_GENERATION_CAPABILITY,
+                    "session_config": {},
+                }
+            }
+        }
+    ]
+
+
 def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
     from duckdb.runners.ray.driver import RayQueryDriverActor
 
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
 
-    def _fake_prepare_actor_pools_for_plan(*_args, **_kwargs):
-        return [], {}
-
-    fake_mod = types.ModuleType("duckdb.execution.udf_ray")
-    fake_mod.prepare_actor_pools_for_plan = _fake_prepare_actor_pools_for_plan
-    monkeypatch.setitem(sys.modules, "duckdb.execution.udf_ray", fake_mod)
-
     runner = SimpleNamespace(
         _driver_handle=object(),
-        _duckdb_conn=object(),
-        _active_udf_actors=[],
         _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
+        _session_lock=threading.RLock(),
+        _plan_session_ids={"test-plan": "session-1"},
+        _query_udf_actor_nodes={},
+        _query_udf_session_configs={},
+        _active_udf_actor_by_unit={},
     )
 
     plan = _FakePlan(
@@ -413,25 +428,25 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
         runner,
         plan,
         SimpleNamespace(query_id="test-plan", units=()),
-        SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
         query_connection=object(),
         session_config={},
     )
 
     assert created == []
-    assert plan.set_calls == []
+    assert plan.set_calls == [
+        {
+            "handles_map": {
+                "3": {
+                    "session_config": {},
+                }
+            }
+        }
+    ]
 
 
 @pytest.mark.parametrize(
     ("module_name", "factory_name", "method_name", "active_attr", "by_plan_attr"),
     [
-        (
-            "duckdb.execution.udf_ray",
-            "prepare_actor_pools_for_plan",
-            "_precreate_udf_actors",
-            "_active_udf_actors",
-            "_active_udf_actors_by_plan",
-        ),
         (
             "duckdb.execution.vllm",
             "ensure_named_vllm_pools_for_plan",
@@ -480,7 +495,6 @@ def test_precreate_retains_partially_created_actor_pool_for_teardown(
                 runner,
                 plan,
                 SimpleNamespace(query_id="test-plan", units=()),
-                SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
                 query_connection=object(),
                 session_config={},
             )
@@ -672,7 +686,8 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -743,7 +758,8 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -829,7 +845,8 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
             )
             self.actors = ["stateful-actor"]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -905,7 +922,8 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
             calls.append((max_restarts, max_task_retries))
             self.actors = ["side-effecting-actor"]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -983,7 +1001,8 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
             calls.append((max_restarts, max_task_retries))
             self.actors = ["ordinary-actor"]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = {0}
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -1104,7 +1123,8 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -1215,7 +1235,7 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
             class _Future:
                 def result(self, timeout=None):
                     resolved.append((actor_index, timeout))
-                    return None
+                    return ("node-a", "node-b")[actor_index]
 
             return _Future()
 
@@ -1231,6 +1251,7 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
         ):
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = [_InitRef(idx) for idx in range(concurrency)]
+            self.actor_node_ids = list(actor_node_ids)
             self._confirmed_ready = set()
             self._owns_actors = True
 
@@ -1268,13 +1289,772 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
     )
 
     assert resolved == []
-    assert handles["5"]["actor_dispatch_indices"] == [0, 1]
+    assert handles["5"]["actor_dispatch_indices"] == []
     assert plan.set_calls == [{"handles_map": handles}]
 
     udf_ray.wait_for_actor_pools_ready(pools)
 
     assert [actor_index for actor_index, _ in resolved] == [0, 1]
     assert pools[0]._confirmed_ready == {0, 1}
+
+
+def test_actor_pool_opens_after_first_ray_core_actor_becomes_ready(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+
+    class _Ref:
+        def __init__(self, node_id):
+            self.node_id = node_id
+
+        def future(self):
+            node_id = self.node_id
+
+            class _Future:
+                def result(self, timeout=None):
+                    return node_id
+
+            return _Future()
+
+    refs = [_Ref("node-a"), _Ref("node-b"), _Ref("node-c")]
+    wait_calls = []
+
+    def wait(pending, *, num_returns, timeout):
+        wait_calls.append((list(pending), num_returns, timeout))
+        if len(wait_calls) == 1:
+            return [refs[1]], [refs[0], refs[2]]
+        return [], list(pending)
+
+    fake_ray = types.SimpleNamespace(wait=wait, kill=lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.delenv("VANE_RAY_ACTOR_INIT_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("VANE_QUERY_DEADLINE_EPOCH_S", raising=False)
+    pool = SimpleNamespace(
+        actors=["actor-a", "actor-b", "actor-c"],
+        actor_node_ids=["", "", ""],
+        _init_refs=refs,
+        _confirmed_ready=set(),
+        _owns_actors=True,
+    )
+
+    ready = udf_ray.wait_for_first_actor_pool_ready(pool)
+
+    assert ready == {1: "node-b"}
+    assert pool.actor_node_ids == ["", "node-b", ""]
+    assert pool._confirmed_ready == {1}
+    assert wait_calls[0][1:] == (1, None)
+    assert wait_calls[1][1:] == (2, 0)
+
+
+def test_driver_publishes_later_actor_slots_as_ray_core_schedules_them():
+    from concurrent.futures import Future
+
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+
+    class _Ref:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    pending_future = Future()
+    pool = SimpleNamespace(
+        actor_node_ids=["node-a", ""],
+        _confirmed_ready={0},
+        _init_refs=[_Ref(Future()), _Ref(pending_future)],
+        _vane_retired=False,
+        _vane_init_errors={},
+        _vane_readiness_futures=[],
+    )
+    published = []
+    manager = SimpleNamespace(
+        set_ready_actor_slots=lambda resource_unit_id, nodes: published.append((resource_unit_id, dict(nodes)))
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+    )
+
+    runner_cls._watch_query_udf_actor_pool_readiness(
+        runner,
+        "q1",
+        "resource:q1:actor",
+        pool,
+        manager,
+    )
+    pending_future.set_result("node-b")
+
+    assert pool.actor_node_ids == ["node-a", "node-b"]
+    assert pool._confirmed_ready == {0, 1}
+    assert published == [
+        (
+            "resource:q1:actor",
+            {0: "node-a", 1: "node-b"},
+        )
+    ]
+
+
+def test_later_actor_init_failure_cancels_query_instead_of_shrinking_pool():
+    from concurrent.futures import Future
+
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+
+    class _Ref:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    pending_future = Future()
+    pool = SimpleNamespace(
+        actor_node_ids=["node-a", ""],
+        _confirmed_ready={0},
+        _init_refs=[_Ref(Future()), _Ref(pending_future)],
+        _vane_retired=False,
+        _vane_init_errors={},
+        _vane_readiness_futures=[],
+    )
+    cancellations = []
+    manager = SimpleNamespace(
+        set_ready_actor_slots=lambda *_args: pytest.fail("a failed actor must not join the ready set"),
+        cancel=cancellations.append,
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _query_resource_lock=threading.RLock(),
+        _query_terminal_errors={},
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+    )
+
+    runner_cls._watch_query_udf_actor_pool_readiness(
+        runner,
+        "q1",
+        "resource:q1:actor",
+        pool,
+        manager,
+    )
+    pending_future.set_exception(RuntimeError("warmup failed"))
+
+    assert isinstance(pool._vane_init_errors[1], RuntimeError)
+    assert cancellations == [runner._query_terminal_errors["q1"]]
+    assert "resource:q1:actor/actor-1" in cancellations[0]
+    assert "warmup failed" in cancellations[0]
+
+
+def test_retired_pool_ignores_late_actor_init_failure():
+    from concurrent.futures import Future
+
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+
+    class _Ref:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    pending_future = Future()
+    pool = SimpleNamespace(
+        actor_node_ids=[""],
+        _confirmed_ready=set(),
+        _init_refs=[_Ref(pending_future)],
+        _vane_retired=False,
+        _vane_init_errors={},
+        _vane_readiness_futures=[],
+    )
+    cancellations = []
+    manager = SimpleNamespace(
+        set_ready_actor_slots=lambda *_args: pytest.fail("a retired actor must not join the ready set"),
+        cancel=cancellations.append,
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _query_resource_lock=threading.RLock(),
+        _query_terminal_errors={},
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+    )
+
+    runner_cls._watch_query_udf_actor_pool_readiness(
+        runner,
+        "q1",
+        "resource:q1:actor",
+        pool,
+        manager,
+    )
+    with runner._session_lock:
+        pool._vane_retired = True
+    pending_future.set_exception(RuntimeError("killed during retirement"))
+
+    assert pool._vane_init_errors == {}
+    assert runner._query_terminal_errors == {}
+    assert cancellations == []
+
+
+def test_stale_execution_phase_callback_does_not_retire_current_actor_pool(
+    monkeypatch,
+):
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    shutdowns = []
+    pool = SimpleNamespace(
+        _vane_retired=False,
+        shutdown=lambda: shutdowns.append("shutdown"),
+    )
+    manager = SimpleNamespace(
+        begin_actor_pool_retirement=lambda _resource_unit_id: False,
+    )
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+        _active_udf_actors=[pool],
+        _active_udf_actors_by_plan={"q1": [pool]},
+    )
+
+    runner_cls._retire_udf_actor_pools_outside_phase(
+        runner,
+        "q1",
+        ("resource:q1:new-phase",),
+    )
+
+    assert shutdowns == []
+    assert pool._vane_retired is False
+    assert runner._active_udf_actor_by_unit["q1"]["resource:q1:actor"] is pool
+
+
+def test_phase_actor_retirement_serializes_plan_cleanup(monkeypatch):
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    shutdown_entered = threading.Event()
+    release_shutdown = threading.Event()
+    cleanup_finished = threading.Event()
+    shutdowns = []
+    errors = []
+
+    def shutdown():
+        shutdowns.append("shutdown")
+        shutdown_entered.set()
+        assert release_shutdown.wait(timeout=5)
+
+    pool = SimpleNamespace(_vane_retired=False, shutdown=shutdown)
+    retirements = []
+    manager = SimpleNamespace(
+        begin_actor_pool_retirement=lambda resource_unit_id: retirements.append(("begin", resource_unit_id)) or True,
+        complete_actor_pool_retirement=lambda resource_unit_id: (
+            retirements.append(("complete", resource_unit_id)) or True
+        ),
+    )
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+        _active_udf_actors=[pool],
+        _active_udf_actors_by_plan={"q1": [pool]},
+    )
+
+    def retire_phase():
+        try:
+            runner_cls._retire_udf_actor_pools_outside_phase(
+                runner,
+                "q1",
+                ("resource:q1:new-phase",),
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def cleanup_plan():
+        try:
+            runner_cls._cleanup_udf_actor_pools(runner, "q1")
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            cleanup_finished.set()
+
+    phase_thread = threading.Thread(target=retire_phase)
+    cleanup_thread = threading.Thread(target=cleanup_plan)
+    phase_thread.start()
+    assert shutdown_entered.wait(timeout=5)
+    cleanup_thread.start()
+    assert cleanup_finished.wait(timeout=0.05) is False
+    assert shutdowns == ["shutdown"]
+
+    release_shutdown.set()
+    phase_thread.join(timeout=5)
+    cleanup_thread.join(timeout=5)
+
+    assert phase_thread.is_alive() is False
+    assert cleanup_thread.is_alive() is False
+    assert errors == []
+    assert shutdowns == ["shutdown"]
+    assert retirements == [
+        ("begin", "resource:q1:actor"),
+        ("complete", "resource:q1:actor"),
+    ]
+    assert runner._active_udf_actor_by_unit["q1"] == {}
+    assert runner._active_udf_actors == []
+    assert "q1" not in runner._active_udf_actors_by_plan
+
+
+def test_plan_cleanup_serializes_late_phase_actor_retirement(monkeypatch):
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    shutdown_entered = threading.Event()
+    release_shutdown = threading.Event()
+    phase_finished = threading.Event()
+    shutdowns = []
+    errors = []
+
+    def shutdown():
+        shutdowns.append("shutdown")
+        shutdown_entered.set()
+        assert release_shutdown.wait(timeout=5)
+
+    pool = SimpleNamespace(_vane_retired=False, shutdown=shutdown)
+    manager_lookups = []
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda query_id: manager_lookups.append(query_id),
+    )
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _active_udf_actor_by_unit={"q1": {"resource:q1:actor": pool}},
+        _active_udf_actors=[pool],
+        _active_udf_actors_by_plan={"q1": [pool]},
+    )
+
+    def cleanup_plan():
+        try:
+            runner_cls._cleanup_udf_actor_pools(runner, "q1")
+        except BaseException as exc:
+            errors.append(exc)
+
+    def retire_phase():
+        try:
+            runner_cls._retire_udf_actor_pools_outside_phase(
+                runner,
+                "q1",
+                ("resource:q1:new-phase",),
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            phase_finished.set()
+
+    cleanup_thread = threading.Thread(target=cleanup_plan)
+    phase_thread = threading.Thread(target=retire_phase)
+    cleanup_thread.start()
+    assert shutdown_entered.wait(timeout=5)
+    phase_thread.start()
+    assert phase_finished.wait(timeout=0.05) is False
+    assert shutdowns == ["shutdown"]
+
+    release_shutdown.set()
+    cleanup_thread.join(timeout=5)
+    phase_thread.join(timeout=5)
+
+    assert cleanup_thread.is_alive() is False
+    assert phase_thread.is_alive() is False
+    assert errors == []
+    assert shutdowns == ["shutdown"]
+    assert manager_lookups == []
+    assert runner._active_udf_actor_by_unit == {}
+    assert runner._active_udf_actors == []
+    assert "q1" not in runner._active_udf_actors_by_plan
+
+
+def test_actor_activation_rechecks_phase_after_slow_pool_creation(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    eligibility_reads = 0
+    submitted = []
+
+    class _Manager:
+        def current_eligible_resource_unit_ids(self):
+            nonlocal eligibility_reads
+            eligibility_reads += 1
+            return (resource_unit_id,) if eligibility_reads == 1 else ()
+
+        def set_submitted_actor_slots(self, unit_id, actor_indices):
+            submitted.append((unit_id, set(actor_indices)))
+
+    manager = _Manager()
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+    shutdowns = []
+    pool = SimpleNamespace(
+        actors=["actor-0"],
+        shutdown=lambda: shutdowns.append("shutdown"),
+    )
+    monkeypatch.setattr(
+        udf_ray,
+        "prepare_actor_pools_for_nodes",
+        lambda *_args, **_kwargs: (
+            [pool],
+            {
+                "node-1": {
+                    "actor_handles": ["actor-0"],
+                    "actor_node_ids": [""],
+                    "actor_dispatch_indices": [],
+                    "actor_init_refs": [],
+                }
+            },
+        ),
+    )
+    runner = SimpleNamespace(
+        _query_resource_lock=threading.RLock(),
+        _session_lock=threading.RLock(),
+        _query_resource_graphs={
+            "q1": SimpleNamespace(unit_by_id=lambda _unit_id: SimpleNamespace(backend="ray_actor"))
+        },
+        _query_allocations={"q1": object()},
+        _query_udf_actor_nodes={
+            "q1": {
+                resource_unit_id: {
+                    "node_id": "node-1",
+                }
+            }
+        },
+        _query_udf_session_configs={"q1": {}},
+        _plan_session_ids={"q1": "session-1"},
+        _active_udf_actor_by_unit={"q1": {}},
+        _active_udf_actors=[],
+        _active_udf_actors_by_plan={},
+        _driver_handle=object(),
+    )
+
+    with pytest.raises(RuntimeError, match="phase ended while activating"):
+        runner_cls._activate_query_udf_actor_pool_sync(
+            runner,
+            {
+                "query_id": "q1",
+                "resource_unit_id": resource_unit_id,
+                "physical_node_id": "node-1",
+            },
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    assert eligibility_reads == 2
+    assert submitted == []
+    assert shutdowns == ["shutdown"]
+    assert runner._active_udf_actor_by_unit["q1"] == {}
+
+
+def test_phase_retirement_cancels_pending_actor_readiness_without_deadlock(
+    monkeypatch,
+):
+    import duckdb.execution.udf_ray as udf_ray
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    readiness_entered = threading.Event()
+    actor_killed = threading.Event()
+    submitted = []
+    retirements = []
+
+    class _Manager:
+        def current_eligible_resource_unit_ids(self):
+            return (resource_unit_id,)
+
+        def set_submitted_actor_slots(self, unit_id, actor_indices):
+            submitted.append((unit_id, set(actor_indices)))
+
+        def begin_actor_pool_retirement(self, unit_id):
+            retirements.append(("begin", unit_id))
+            return True
+
+        def complete_actor_pool_retirement(self, unit_id):
+            retirements.append(("complete", unit_id))
+            return True
+
+    manager = _Manager()
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+
+    def shutdown():
+        pool.actors = []
+        actor_killed.set()
+
+    pool = SimpleNamespace(
+        actors=["actor-0"],
+        actor_node_ids=[""],
+        _init_refs=[object()],
+        shutdown=shutdown,
+    )
+    monkeypatch.setattr(
+        udf_ray,
+        "prepare_actor_pools_for_nodes",
+        lambda *_args, **_kwargs: (
+            [pool],
+            {
+                "node-1": {
+                    "actor_handles": ["actor-0"],
+                    "actor_node_ids": [""],
+                    "actor_dispatch_indices": [],
+                    "actor_init_refs": list(pool._init_refs),
+                }
+            },
+        ),
+    )
+
+    def wait_for_first_ready(_pool):
+        readiness_entered.set()
+        assert actor_killed.wait(timeout=5)
+        raise RuntimeError("pending actor was killed during phase retirement")
+
+    monkeypatch.setattr(
+        udf_ray,
+        "wait_for_first_actor_pool_ready",
+        wait_for_first_ready,
+    )
+    runner = SimpleNamespace(
+        _query_resource_lock=threading.RLock(),
+        _session_lock=threading.RLock(),
+        _query_resource_graphs={
+            "q1": SimpleNamespace(unit_by_id=lambda _unit_id: SimpleNamespace(backend="ray_actor"))
+        },
+        _query_allocations={"q1": object()},
+        _query_udf_actor_nodes={"q1": {resource_unit_id: {"node_id": "node-1"}}},
+        _query_udf_session_configs={"q1": {}},
+        _plan_session_ids={"q1": "session-1"},
+        _active_udf_actor_by_unit={"q1": {}},
+        _active_udf_actors=[],
+        _active_udf_actors_by_plan={},
+        _driver_handle=object(),
+    )
+    activation_errors = []
+
+    def activate():
+        try:
+            runner_cls._activate_query_udf_actor_pool_sync(
+                runner,
+                {
+                    "query_id": "q1",
+                    "resource_unit_id": resource_unit_id,
+                    "physical_node_id": "node-1",
+                },
+                _QUERY_GENERATION_CAPABILITY,
+            )
+        except BaseException as exc:
+            activation_errors.append(exc)
+
+    activation_thread = threading.Thread(target=activate)
+    activation_thread.start()
+    assert readiness_entered.wait(timeout=5)
+
+    runner_cls._retire_udf_actor_pools_outside_phase(runner, "q1", ())
+    activation_thread.join(timeout=5)
+
+    assert activation_thread.is_alive() is False
+    assert len(activation_errors) == 1
+    assert "pending actor was killed" in str(activation_errors[0])
+    assert submitted == [(resource_unit_id, {0})]
+    assert retirements == [
+        ("begin", resource_unit_id),
+        ("complete", resource_unit_id),
+    ]
+    assert runner._active_udf_actor_by_unit["q1"] == {}
+    assert runner._active_udf_actors == []
+    assert "q1" not in runner._active_udf_actors_by_plan
+
+
+def test_actor_activation_retains_unpublished_pool_when_shutdown_fails(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    eligibility_reads = 0
+
+    class _Manager:
+        def current_eligible_resource_unit_ids(self):
+            nonlocal eligibility_reads
+            eligibility_reads += 1
+            return (resource_unit_id,) if eligibility_reads == 1 else ()
+
+    manager = _Manager()
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+
+    def shutdown():
+        raise RuntimeError("planned kill failure")
+
+    pool = SimpleNamespace(actors=["actor-0"], shutdown=shutdown)
+    monkeypatch.setattr(
+        udf_ray,
+        "prepare_actor_pools_for_nodes",
+        lambda *_args, **_kwargs: (
+            [pool],
+            {
+                "node-1": {
+                    "actor_handles": ["actor-0"],
+                    "actor_node_ids": [""],
+                    "actor_dispatch_indices": [],
+                    "actor_init_refs": [],
+                }
+            },
+        ),
+    )
+    runner = SimpleNamespace(
+        _query_resource_lock=threading.RLock(),
+        _session_lock=threading.RLock(),
+        _query_resource_graphs={
+            "q1": SimpleNamespace(unit_by_id=lambda _unit_id: SimpleNamespace(backend="ray_actor"))
+        },
+        _query_allocations={"q1": object()},
+        _query_udf_actor_nodes={"q1": {resource_unit_id: {"node_id": "node-1"}}},
+        _query_udf_session_configs={"q1": {}},
+        _plan_session_ids={"q1": "session-1"},
+        _active_udf_actor_by_unit={"q1": {}},
+        _active_udf_actors=[],
+        _active_udf_actors_by_plan={},
+        _driver_handle=object(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="activation failed and actor cleanup also failed.*planned kill failure",
+    ):
+        runner_cls._activate_query_udf_actor_pool_sync(
+            runner,
+            {
+                "query_id": "q1",
+                "resource_unit_id": resource_unit_id,
+                "physical_node_id": "node-1",
+            },
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    assert pool._vane_retired is True
+    assert runner._active_udf_actors == [pool]
+    assert runner._active_udf_actors_by_plan == {"q1": [pool]}
+    assert runner._active_udf_actor_by_unit["q1"] == {}
+
+
+def test_actor_readiness_cleanup_failure_keeps_registered_pool_owned(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    submitted = []
+
+    class _Manager:
+        def current_eligible_resource_unit_ids(self):
+            return (resource_unit_id,)
+
+        def set_submitted_actor_slots(self, unit_id, actor_indices):
+            submitted.append((unit_id, set(actor_indices)))
+
+    manager = _Manager()
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: manager,
+    )
+
+    def shutdown():
+        raise RuntimeError("planned readiness kill failure")
+
+    pool = SimpleNamespace(
+        actors=["actor-0"],
+        actor_node_ids=[""],
+        _init_refs=[object()],
+        shutdown=shutdown,
+    )
+    monkeypatch.setattr(
+        udf_ray,
+        "prepare_actor_pools_for_nodes",
+        lambda *_args, **_kwargs: (
+            [pool],
+            {
+                "node-1": {
+                    "actor_handles": ["actor-0"],
+                    "actor_node_ids": [""],
+                    "actor_dispatch_indices": [],
+                    "actor_init_refs": list(pool._init_refs),
+                }
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        udf_ray,
+        "wait_for_first_actor_pool_ready",
+        lambda _pool: (_ for _ in ()).throw(RuntimeError("planned readiness failure")),
+    )
+    runner = SimpleNamespace(
+        _query_resource_lock=threading.RLock(),
+        _session_lock=threading.RLock(),
+        _query_resource_graphs={
+            "q1": SimpleNamespace(unit_by_id=lambda _unit_id: SimpleNamespace(backend="ray_actor"))
+        },
+        _query_allocations={"q1": object()},
+        _query_udf_actor_nodes={"q1": {resource_unit_id: {"node_id": "node-1"}}},
+        _query_udf_session_configs={"q1": {}},
+        _plan_session_ids={"q1": "session-1"},
+        _active_udf_actor_by_unit={"q1": {}},
+        _active_udf_actors=[],
+        _active_udf_actors_by_plan={},
+        _driver_handle=object(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="activation failed and actor cleanup also failed.*planned readiness kill failure",
+    ):
+        runner_cls._activate_query_udf_actor_pool_sync(
+            runner,
+            {
+                "query_id": "q1",
+                "resource_unit_id": resource_unit_id,
+                "physical_node_id": "node-1",
+            },
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    assert submitted == [(resource_unit_id, {0})]
+    assert pool._vane_retired is True
+    assert runner._active_udf_actors == [pool]
+    assert runner._active_udf_actors_by_plan == {"q1": [pool]}
+    assert "q1" not in runner._active_udf_actor_by_unit
 
 
 def test_udf_actor_pool_shutdown_accepts_query_owned_kill_flag(monkeypatch):
@@ -1457,7 +2237,8 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
             )
             self.actors = [f"actor-{idx}" for idx in range(concurrency)]
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(actor_node_ids)
+            self._confirmed_ready = set(range(concurrency))
 
     fake_ray = types.ModuleType("ray")
     fake_ray.is_initialized = lambda: True
@@ -1957,10 +2738,11 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
     monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
 
     class _FakeUDFActorPool:
-        def __init__(self, **_kwargs):
+        def __init__(self, **kwargs):
             self.actors = actors
             self._init_refs = []
-            self._confirmed_ready = set()
+            self.actor_node_ids = list(kwargs["actor_node_ids"])
+            self._confirmed_ready = {0, 1}
 
     monkeypatch.setattr(udf_ray, "UDFActorPool", _FakeUDFActorPool)
 
@@ -2027,7 +2809,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
                 def result(self, timeout=None):
                     fake_ray.future_calls.append((ref, timeout))
                     fake_ray.init_refs_resolved = len(fake_ray.future_calls) == 2
-                    return None
+                    return ("node-a", "node-b")[ref.index]
 
             return _Future()
 
@@ -2037,9 +2819,10 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
     monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
 
     class _FakeUDFActorPool:
-        def __init__(self, **_kwargs):
+        def __init__(self, **kwargs):
             self.actors = actors
             self._init_refs = init_refs
+            self.actor_node_ids = list(kwargs["actor_node_ids"])
             self._confirmed_ready = set()
 
     monkeypatch.setattr(udf_ray, "UDFActorPool", _FakeUDFActorPool)
@@ -2069,5 +2852,5 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
     )
 
     assert [ref for ref, _timeout in fake_ray.future_calls] == init_refs
-    assert all(timeout > 0.0 for _ref, timeout in fake_ray.future_calls)
+    assert all(timeout is None for _ref, timeout in fake_ray.future_calls)
     assert handles_map["0"]["actor_dispatch_indices"] == [0, 1]

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -301,13 +301,13 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     def _fake_prepare_actor_pools_for_plan(
         plan,
         *,
-        actor_node_ids_by_stage,
+        actor_node_ids_by_unit,
         query_driver_handle,
         query_generation_capability,
         session_config,
         conn=None,
     ):
-        assert actor_node_ids_by_stage == {}
+        assert actor_node_ids_by_unit == {}
         assert query_driver_handle is driver_handle
         assert query_generation_capability == _QUERY_GENERATION_CAPABILITY
         assert session_config == {"AWS_ACCESS_KEY_ID": "session-access-key"}
@@ -356,8 +356,8 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     created = runner_cls._precreate_udf_actors(
         runner,
         plan,
-        SimpleNamespace(query_id="test-plan", stages=()),
-        SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+        SimpleNamespace(query_id="test-plan", units=()),
+        SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
         query_connection=query_connection,
         session_config={"AWS_ACCESS_KEY_ID": "session-access-key"},
     )
@@ -412,8 +412,8 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
     created = runner_cls._precreate_udf_actors(
         runner,
         plan,
-        SimpleNamespace(query_id="test-plan", stages=()),
-        SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+        SimpleNamespace(query_id="test-plan", units=()),
+        SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
         query_connection=object(),
         session_config={},
     )
@@ -479,8 +479,8 @@ def test_precreate_retains_partially_created_actor_pool_for_teardown(
             method(
                 runner,
                 plan,
-                SimpleNamespace(query_id="test-plan", stages=()),
-                SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
+                SimpleNamespace(query_id="test-plan", units=()),
+                SimpleNamespace(actor_node_ids_for_unit=lambda _resource_unit_id: ()),
                 query_connection=object(),
                 session_config={},
             )
@@ -588,7 +588,7 @@ def test_stateful_actor_loss_during_synchronous_submit_keeps_recoverability_cont
             self.actors = [Actor()]
             self._payload = {
                 "query_id": "query-submit",
-                "stage_id": "stage-submit",
+                "resource_unit_id": "stage-submit",
                 "execution_backend": "ray_actor",
                 "udf_output_target_max_bytes": 1,
             }
@@ -606,7 +606,7 @@ def test_stateful_actor_loss_during_synchronous_submit_keeps_recoverability_cont
             return SimpleNamespace(
                 lease={
                     "query_id": "query-submit",
-                    "stage_id": "stage-submit",
+                    "resource_unit_id": "stage-submit",
                     "lease_id": "lease-submit",
                     "attempt_id": "attempt-submit",
                     "node_id": "node-submit",
@@ -690,7 +690,7 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                 },
             }
         ]
@@ -698,7 +698,7 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -761,7 +761,7 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                 },
             }
         ]
@@ -770,7 +770,7 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
     query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=query_driver_handle,
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -782,7 +782,7 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
     assert calls[0]["payload"] == {
         "udf_name": "decode_images",
         "execution_backend": "ray_actor",
-        "stage_id": "stage:test:actor",
+        "resource_unit_id": "resource:test:actor",
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
@@ -849,7 +849,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                     "stateful": True,
                     "side_effects": True,
                     "actor_number": 1,
-                    "stage_id": "stage:test:stateful",
+                    "resource_unit_id": "resource:test:stateful",
                 },
             }
         ]
@@ -857,7 +857,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:stateful": ("node-a",)},
+        actor_node_ids_by_unit={"resource:test:stateful": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -874,7 +874,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                 "stateful": True,
                 "side_effects": True,
                 "actor_number": 1,
-                "stage_id": "stage:test:stateful",
+                "resource_unit_id": "resource:test:stateful",
             },
             "concurrency": 1,
             "actor_node_ids": ["node-a"],
@@ -924,7 +924,7 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
                     "execution_backend": "ray_actor",
                     "stateful": False,
                     "side_effects": True,
-                    "stage_id": "stage:test:side-effects",
+                    "resource_unit_id": "resource:test:side-effects",
                 },
             }
         ]
@@ -932,7 +932,7 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
 
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:side-effects": ("node-a",)},
+        actor_node_ids_by_unit={"resource:test:side-effects": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -951,13 +951,13 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
             "execution_backend": "ray_actor",
             "stateful": False,
             "side_effects": False,
-            "stage_id": "stage:test:retry-policy",
+            "resource_unit_id": "resource:test:retry-policy",
         },
         {
             "udf_name": "ai_prompt",
             "execution_backend": "ray_actor",
             "ai_operation": "prompt",
-            "stage_id": "stage:test:retry-policy",
+            "resource_unit_id": "resource:test:retry-policy",
         },
     ],
     ids=["stateless", "ai"],
@@ -1004,7 +1004,7 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
 
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:retry-policy": ("node-a",)},
+        actor_node_ids_by_unit={"resource:test:retry-policy": ("node-a",)},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1120,7 +1120,7 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
             "payload": {
                 "udf_name": "decode_images",
                 "execution_backend": "ray_actor",
-                "stage_id": "stage:test:actor",
+                "resource_unit_id": "resource:test:actor",
             },
         }
     ]
@@ -1130,7 +1130,7 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
 
     created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1142,7 +1142,7 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
     assert calls[0]["payload"] == {
         "udf_name": "decode_images",
         "execution_backend": "ray_actor",
-        "stage_id": "stage:test:actor",
+        "resource_unit_id": "resource:test:actor",
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
@@ -1185,7 +1185,7 @@ def test_ray_plan_injects_session_context_for_explicit_subprocess_backends(monke
 
     created, handles_map = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_stage={},
+        actor_node_ids_by_unit={},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config=session_config,
@@ -1251,7 +1251,7 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
                 "payload": {
                     "udf_name": "embed",
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:deferred-ready",
+                    "resource_unit_id": "resource:test:deferred-ready",
                 },
             }
         ]
@@ -1259,8 +1259,8 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
 
     pools, handles = udf_ray.prepare_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={
-            "stage:test:deferred-ready": ("node-a", "node-b"),
+        actor_node_ids_by_unit={
+            "resource:test:deferred-ready": ("node-a", "node-b"),
         },
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
@@ -1474,7 +1474,7 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                     "cpus": 1.0,
                 },
             }
@@ -1483,7 +1483,7 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1540,7 +1540,7 @@ def test_ensure_actor_pools_for_plan_publishes_driver_handle_for_ray_task(monkey
     query_driver_handle = object()
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={},
+        actor_node_ids_by_unit={},
         query_driver_handle=query_driver_handle,
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -1571,7 +1571,7 @@ def test_ensure_actor_pools_for_plan_propagates_collect_errors(monkeypatch):
     with pytest.raises(RuntimeError, match="collect failed"):
         udf_ray.ensure_actor_pools_for_plan(
             _BadPlan(),
-            actor_node_ids_by_stage={},
+            actor_node_ids_by_unit={},
             query_driver_handle=object(),
             query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
@@ -1608,7 +1608,7 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
                 "gpus": 0.0,
                 "payload": {
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                 },
             }
         ]
@@ -1617,7 +1617,7 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
     with pytest.raises(RuntimeError, match="create failed"):
         udf_ray.ensure_actor_pools_for_plan(
             plan,
-            actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+            actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
             query_driver_handle=object(),
             query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
@@ -1973,7 +1973,7 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
                 "gpus": 1.0,
                 "payload": {
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                     "gpus": 1.0,
                 },
             }
@@ -1982,7 +1982,7 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
 
     created, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
@@ -2053,7 +2053,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
                 "gpus": 0.0,
                 "payload": {
                     "execution_backend": "ray_actor",
-                    "stage_id": "stage:test:actor",
+                    "resource_unit_id": "resource:test:actor",
                     "gpus": 0.0,
                 },
             }
@@ -2062,7 +2062,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
 
     _, handles_map = udf_ray.ensure_actor_pools_for_plan(
         plan,
-        actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
+        actor_node_ids_by_unit={"resource:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
         query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -17,6 +17,24 @@ from types import SimpleNamespace
 import pytest
 
 _QUERY_GENERATION_CAPABILITY = "test-query-generation-capability"
+_TEST_QUERY_ID = "query:test"
+
+
+def _assert_actor_location_runtime_env(env_vars, resource_unit_id):
+    from duckdb.runners.ray import ray_env
+    from duckdb.runners.ray.query_runtime_protocol import (
+        RAY_ACTOR_GENERATION_CAPABILITY_ENV,
+        RAY_ACTOR_POOL_NONCE_ENV,
+        RAY_ACTOR_QUERY_ID_ENV,
+        RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
+    )
+
+    values = dict(env_vars)
+    assert values.pop(RAY_ACTOR_QUERY_ID_ENV) == _TEST_QUERY_ID
+    assert values.pop(RAY_ACTOR_RESOURCE_UNIT_ID_ENV) == resource_unit_id
+    assert values.pop(RAY_ACTOR_GENERATION_CAPABILITY_ENV) == _QUERY_GENERATION_CAPABILITY
+    assert values.pop(RAY_ACTOR_POOL_NONCE_ENV)
+    assert values == ray_env.build_session_runtime_env_vars({})
 
 
 class _FakePlan:
@@ -705,6 +723,7 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                 },
             }
@@ -777,6 +796,7 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                 },
             }
@@ -798,15 +818,17 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
     assert calls[0]["payload"] == {
         "udf_name": "decode_images",
         "execution_backend": "ray_actor",
+        "query_id": _TEST_QUERY_ID,
         "resource_unit_id": "resource:test:actor",
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
     assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
     assert calls[0]["ray_options"]["num_cpus"] == 1.0
-    from duckdb.runners.ray import ray_env
-
-    assert calls[0]["ray_options"]["runtime_env"]["env_vars"] == ray_env.build_session_runtime_env_vars({})
+    _assert_actor_location_runtime_env(
+        calls[0]["ray_options"]["runtime_env"]["env_vars"],
+        "resource:test:actor",
+    )
     assert handles_map["7"]["actor_handles"] == ["actor-0", "actor-1"]
     assert handles_map["7"]["query_driver_handle"] is query_driver_handle
     assert "ray_actor_pool_name" not in handles_map["7"]
@@ -866,6 +888,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                     "stateful": True,
                     "side_effects": True,
                     "actor_number": 1,
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:stateful",
                 },
             }
@@ -891,6 +914,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
                 "stateful": True,
                 "side_effects": True,
                 "actor_number": 1,
+                "query_id": _TEST_QUERY_ID,
                 "resource_unit_id": "resource:test:stateful",
             },
             "concurrency": 1,
@@ -942,6 +966,7 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
                     "execution_backend": "ray_actor",
                     "stateful": False,
                     "side_effects": True,
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:side-effects",
                 },
             }
@@ -969,12 +994,14 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
             "execution_backend": "ray_actor",
             "stateful": False,
             "side_effects": False,
+            "query_id": _TEST_QUERY_ID,
             "resource_unit_id": "resource:test:retry-policy",
         },
         {
             "udf_name": "ai_prompt",
             "execution_backend": "ray_actor",
             "ai_operation": "prompt",
+            "query_id": _TEST_QUERY_ID,
             "resource_unit_id": "resource:test:retry-policy",
         },
     ],
@@ -1140,6 +1167,7 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
             "payload": {
                 "udf_name": "decode_images",
                 "execution_backend": "ray_actor",
+                "query_id": _TEST_QUERY_ID,
                 "resource_unit_id": "resource:test:actor",
             },
         }
@@ -1162,15 +1190,17 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
     assert calls[0]["payload"] == {
         "udf_name": "decode_images",
         "execution_backend": "ray_actor",
+        "query_id": _TEST_QUERY_ID,
         "resource_unit_id": "resource:test:actor",
     }
     assert calls[0]["concurrency"] == 2
     assert calls[0]["gpus_per_actor"] == 0.0
     assert calls[0]["actor_node_ids"] == ["node-a", "node-b"]
     assert calls[0]["ray_options"]["num_cpus"] == 1.0
-    from duckdb.runners.ray import ray_env
-
-    assert calls[0]["ray_options"]["runtime_env"]["env_vars"] == ray_env.build_session_runtime_env_vars({})
+    _assert_actor_location_runtime_env(
+        calls[0]["ray_options"]["runtime_env"]["env_vars"],
+        "resource:test:actor",
+    )
     assert handles_map["9"]["actor_handles"] == ["actor-0", "actor-1"]
     assert injected == [handles_map]
 
@@ -1272,6 +1302,7 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
                 "payload": {
                     "udf_name": "embed",
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:deferred-ready",
                 },
             }
@@ -1396,7 +1427,7 @@ def test_driver_publishes_later_actor_slots_as_ray_core_schedules_them():
     ]
 
 
-def test_later_actor_init_failure_cancels_query_instead_of_shrinking_pool():
+def test_later_actor_init_failure_fences_query_without_releasing_live_owners():
     from concurrent.futures import Future
 
     from duckdb.runners.ray.driver import RayQueryDriverActor
@@ -1419,10 +1450,10 @@ def test_later_actor_init_failure_cancels_query_instead_of_shrinking_pool():
         _vane_init_errors={},
         _vane_readiness_futures=[],
     )
-    cancellations = []
+    failures = []
     manager = SimpleNamespace(
         set_ready_actor_slots=lambda *_args: pytest.fail("a failed actor must not join the ready set"),
-        cancel=cancellations.append,
+        fail=failures.append,
     )
     runner = SimpleNamespace(
         _session_lock=threading.RLock(),
@@ -1441,9 +1472,9 @@ def test_later_actor_init_failure_cancels_query_instead_of_shrinking_pool():
     pending_future.set_exception(RuntimeError("warmup failed"))
 
     assert isinstance(pool._vane_init_errors[1], RuntimeError)
-    assert cancellations == [runner._query_terminal_errors["q1"]]
-    assert "resource:q1:actor/actor-1" in cancellations[0]
-    assert "warmup failed" in cancellations[0]
+    assert failures == [runner._query_terminal_errors["q1"]]
+    assert "resource:q1:actor/actor-1" in failures[0]
+    assert "warmup failed" in failures[0]
 
 
 def test_retired_pool_ignores_late_actor_init_failure():
@@ -1469,10 +1500,10 @@ def test_retired_pool_ignores_late_actor_init_failure():
         _vane_init_errors={},
         _vane_readiness_futures=[],
     )
-    cancellations = []
+    failures = []
     manager = SimpleNamespace(
         set_ready_actor_slots=lambda *_args: pytest.fail("a retired actor must not join the ready set"),
-        cancel=cancellations.append,
+        fail=failures.append,
     )
     runner = SimpleNamespace(
         _session_lock=threading.RLock(),
@@ -1494,7 +1525,7 @@ def test_retired_pool_ignores_late_actor_init_failure():
 
     assert pool._vane_init_errors == {}
     assert runner._query_terminal_errors == {}
-    assert cancellations == []
+    assert failures == []
 
 
 def test_stale_execution_phase_callback_does_not_retire_current_actor_pool(
@@ -1766,6 +1797,202 @@ def test_actor_activation_rechecks_phase_after_slow_pool_creation(monkeypatch):
     assert submitted == []
     assert shutdowns == ["shutdown"]
     assert runner._active_udf_actor_by_unit["q1"] == {}
+
+
+def test_actor_activation_cleans_up_when_atomic_slot_publication_is_fenced(monkeypatch):
+    import duckdb.execution.udf_ray as udf_ray
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+
+    class _Manager:
+        @staticmethod
+        def current_eligible_resource_unit_ids():
+            return (resource_unit_id,)
+
+        @staticmethod
+        def set_submitted_actor_slots(_unit_id, _actor_indices):
+            raise RuntimeError("query was cancelled during actor creation")
+
+    monkeypatch.setattr(
+        resource_runtime,
+        "get_query_resource_manager",
+        lambda _query_id: _Manager(),
+    )
+    shutdowns = []
+    pool = SimpleNamespace(
+        actors=["actor-0"],
+        shutdown=lambda: shutdowns.append("shutdown"),
+    )
+    monkeypatch.setattr(
+        udf_ray,
+        "prepare_actor_pools_for_nodes",
+        lambda *_args, **_kwargs: (
+            [pool],
+            {
+                "node-1": {
+                    "actor_handles": ["actor-0"],
+                    "actor_node_ids": [""],
+                    "actor_dispatch_indices": [],
+                    "actor_init_refs": [],
+                }
+            },
+        ),
+    )
+    runner = SimpleNamespace(
+        _query_resource_lock=threading.RLock(),
+        _session_lock=threading.RLock(),
+        _query_resource_graphs={
+            "q1": SimpleNamespace(unit_by_id=lambda _unit_id: SimpleNamespace(backend="ray_actor"))
+        },
+        _query_allocations={"q1": object()},
+        _query_udf_actor_nodes={
+            "q1": {
+                resource_unit_id: {
+                    "node_id": "node-1",
+                }
+            }
+        },
+        _query_udf_session_configs={"q1": {}},
+        _plan_session_ids={"q1": "session-1"},
+        _active_udf_actor_by_unit={"q1": {}},
+        _active_udf_actors=[],
+        _active_udf_actors_by_plan={},
+        _driver_handle=object(),
+    )
+
+    with pytest.raises(RuntimeError, match="cancelled during actor creation"):
+        runner_cls._activate_query_udf_actor_pool_sync(
+            runner,
+            {
+                "query_id": "q1",
+                "resource_unit_id": resource_unit_id,
+                "physical_node_id": "node-1",
+            },
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    assert shutdowns == ["shutdown"]
+    assert runner._active_udf_actor_by_unit["q1"] == {}
+    assert runner._active_udf_actors == []
+    assert runner._active_udf_actors_by_plan == {}
+
+
+def test_actor_activation_recreates_retired_pool_after_phase_reentry(monkeypatch):
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    manager = SimpleNamespace(current_eligible_resource_unit_ids=lambda: (resource_unit_id,))
+    monkeypatch.setattr(resource_runtime, "get_query_resource_manager", lambda _query_id: manager)
+
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _query_udf_actor_lifecycle_locks={},
+        _query_udf_actor_activation_tasks={},
+        _active_udf_actor_by_unit={"q1": {}},
+        _verify_query_task_admission_capability=lambda **_kwargs: "generation-1",
+        _capability_targets_inactive_query_generation=lambda *_args: False,
+    )
+    activations = []
+
+    def activate_sync(_locator, _capability):
+        pool = SimpleNamespace(_vane_retired=False)
+        with runner._session_lock:
+            runner._active_udf_actor_by_unit["q1"][resource_unit_id] = pool
+        activations.append(pool)
+        return {"actor_handles": [f"actor-{len(activations)}"]}
+
+    runner._activate_query_udf_actor_pool_sync = activate_sync
+    locator = {
+        "query_id": "q1",
+        "resource_unit_id": resource_unit_id,
+        "physical_node_id": "node-1",
+    }
+
+    async def scenario():
+        stale = asyncio.create_task(asyncio.sleep(0, result={"actor_handles": ["retired-actor"]}))
+        await stale
+        runner._query_udf_actor_activation_tasks[("q1", resource_unit_id)] = stale
+        return await runner_cls.activate_query_udf_actor_pool(
+            runner,
+            locator,
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    assert asyncio.run(scenario()) == {"actor_handles": ["actor-1"]}
+    assert len(activations) == 1
+    assert runner._active_udf_actor_by_unit["q1"][resource_unit_id] is activations[0]
+
+
+def test_cancelled_actor_activation_waiter_keeps_shared_creation_cached(monkeypatch):
+    import duckdb.runners.ray.query_resource_runtime as resource_runtime
+    from duckdb.runners.ray.driver import RayQueryDriverActor
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    resource_unit_id = "resource:q1:actor"
+    manager = SimpleNamespace(current_eligible_resource_unit_ids=lambda: (resource_unit_id,))
+    monkeypatch.setattr(resource_runtime, "get_query_resource_manager", lambda _query_id: manager)
+
+    runner = SimpleNamespace(
+        _session_lock=threading.RLock(),
+        _query_udf_actor_lifecycle_locks={},
+        _query_udf_actor_activation_tasks={},
+        _active_udf_actor_by_unit={"q1": {}},
+        _verify_query_task_admission_capability=lambda **_kwargs: "generation-1",
+        _capability_targets_inactive_query_generation=lambda *_args: False,
+    )
+    activation_started = threading.Event()
+    release_activation = threading.Event()
+    activation_count = 0
+
+    def activate_sync(_locator, _capability):
+        nonlocal activation_count
+        activation_count += 1
+        activation_started.set()
+        assert release_activation.wait(timeout=5)
+        with runner._session_lock:
+            runner._active_udf_actor_by_unit["q1"][resource_unit_id] = SimpleNamespace(_vane_retired=False)
+        return {"actor_handles": ["actor-1"]}
+
+    runner._activate_query_udf_actor_pool_sync = activate_sync
+    locator = {
+        "query_id": "q1",
+        "resource_unit_id": resource_unit_id,
+        "physical_node_id": "node-1",
+    }
+
+    async def scenario():
+        waiter = asyncio.create_task(
+            runner_cls.activate_query_udf_actor_pool(
+                runner,
+                locator,
+                _QUERY_GENERATION_CAPABILITY,
+            )
+        )
+        assert await asyncio.to_thread(activation_started.wait, 5)
+        shared_task = runner._query_udf_actor_activation_tasks[("q1", resource_unit_id)]
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert runner._query_udf_actor_activation_tasks[("q1", resource_unit_id)] is shared_task
+        assert not shared_task.done()
+        release_activation.set()
+        await shared_task
+        return await runner_cls.activate_query_udf_actor_pool(
+            runner,
+            locator,
+            _QUERY_GENERATION_CAPABILITY,
+        )
+
+    try:
+        assert asyncio.run(scenario()) == {"actor_handles": ["actor-1"]}
+    finally:
+        release_activation.set()
+    assert activation_count == 1
 
 
 def test_phase_retirement_cancels_pending_actor_readiness_without_deadlock(
@@ -2255,6 +2482,7 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
                 "payload": {
                     "udf_name": "decode_images",
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                     "cpus": 1.0,
                 },
@@ -2389,6 +2617,7 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
                 "gpus": 0.0,
                 "payload": {
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                 },
             }
@@ -2755,6 +2984,7 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
                 "gpus": 1.0,
                 "payload": {
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                     "gpus": 1.0,
                 },
@@ -2836,6 +3066,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
                 "gpus": 0.0,
                 "payload": {
                     "execution_backend": "ray_actor",
+                    "query_id": _TEST_QUERY_ID,
                     "resource_unit_id": "resource:test:actor",
                     "gpus": 0.0,
                 },

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -322,12 +322,13 @@ def test_actor_gpu_reservation_follows_resolved_backend(
             max_restarts=None,
             max_task_retries=None,
         ):
+            self.actor_node_ids = list(actor_node_ids)
             ray_pool_calls.append(
                 {
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
+                    "actor_node_ids": list(self.actor_node_ids),
                     "ray_options": ray_options,
                     "max_restarts": max_restarts,
                     "max_task_retries": max_task_retries,
@@ -438,12 +439,13 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
             actor_node_ids,
             ray_options=None,
         ):
+            self.actor_node_ids = list(actor_node_ids)
             calls.append(
                 {
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(actor_node_ids),
+                    "actor_node_ids": list(self.actor_node_ids),
                     "ray_options": ray_options,
                 }
             )

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -343,14 +343,14 @@ def test_actor_gpu_reservation_follows_resolved_backend(
     monkeypatch.setattr(ray, "is_initialized", lambda: True)
     monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
     monkeypatch.setattr(udf_ray, "UDFActorPool", FakeRayPool)
-    stage_id = f"stage:test:gpu-order:{decorator_runner}:{resolved_runner}"
-    payload["stage_id"] = stage_id
+    resource_unit_id = f"resource:test:gpu-order:{decorator_runner}:{resolved_runner}"
+    payload["resource_unit_id"] = resource_unit_id
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)
         pools, _ = udf_ray.ensure_actor_pools_for_nodes(
             nodes,
-            actor_node_ids_by_stage={stage_id: ("node-a",)},
+            actor_node_ids_by_unit={resource_unit_id: ("node-a",)},
             query_driver_handle=object(),
             query_generation_capability="test-query-generation-capability",
             session_config={},
@@ -458,11 +458,11 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
     monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
     monkeypatch.setattr(udf_ray, "UDFActorPool", FakeRayPool)
 
-    stage_id = "stage:test:stateless-three-actor"
-    nodes[0]["payload"]["stage_id"] = stage_id
+    resource_unit_id = "resource:test:stateless-three-actor"
+    nodes[0]["payload"]["resource_unit_id"] = resource_unit_id
     pools, _ = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_stage={stage_id: ("node-a", "node-a", "node-a")},
+        actor_node_ids_by_unit={resource_unit_id: ("node-a", "node-a", "node-a")},
         query_driver_handle=object(),
         query_generation_capability="test-query-generation-capability",
         session_config={},

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -317,18 +317,16 @@ def test_actor_gpu_reservation_follows_resolved_backend(
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
             max_restarts=None,
             max_task_retries=None,
         ):
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             ray_pool_calls.append(
                 {
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(self.actor_node_ids),
                     "ray_options": ray_options,
                     "max_restarts": max_restarts,
                     "max_task_retries": max_task_retries,
@@ -352,7 +350,6 @@ def test_actor_gpu_reservation_follows_resolved_backend(
         warnings.simplefilter("error", RuntimeWarning)
         pools, _ = udf_ray.ensure_actor_pools_for_nodes(
             nodes,
-            actor_node_ids_by_unit={resource_unit_id: ("node-a",)},
             query_driver_handle=object(),
             query_generation_capability="test-query-generation-capability",
             session_config={},
@@ -362,7 +359,6 @@ def test_actor_gpu_reservation_follows_resolved_backend(
     assert len(ray_pool_calls) == 1
     assert ray_pool_calls[0]["concurrency"] == 1
     assert ray_pool_calls[0]["gpus_per_actor"] == gpus
-    assert ray_pool_calls[0]["actor_node_ids"] == ["node-a"]
     assert ray_pool_calls[0]["max_restarts"] == 0
     assert ray_pool_calls[0]["max_task_retries"] == 0
 
@@ -437,16 +433,14 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
             payload,
             concurrency,
             gpus_per_actor,
-            actor_node_ids,
             ray_options=None,
         ):
-            self.actor_node_ids = list(actor_node_ids)
+            self.actor_node_ids = ["node-a"] * concurrency
             calls.append(
                 {
                     "payload": dict(payload),
                     "concurrency": concurrency,
                     "gpus_per_actor": gpus_per_actor,
-                    "actor_node_ids": list(self.actor_node_ids),
                     "ray_options": ray_options,
                 }
             )
@@ -466,7 +460,6 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
     nodes[0]["payload"]["resource_unit_id"] = resource_unit_id
     pools, _ = udf_ray.ensure_actor_pools_for_nodes(
         nodes,
-        actor_node_ids_by_unit={resource_unit_id: ("node-a", "node-a", "node-a")},
         query_driver_handle=object(),
         query_generation_capability="test-query-generation-capability",
         session_config={},
@@ -475,4 +468,3 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
     assert len(pools) == 1
     assert calls[0]["concurrency"] == 3
     assert calls[0]["gpus_per_actor"] == 1.25
-    assert calls[0]["actor_node_ids"] == ["node-a", "node-a", "node-a"]

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -345,6 +345,7 @@ def test_actor_gpu_reservation_follows_resolved_backend(
     monkeypatch.setattr(udf_ray, "_is_vane_worker_process", lambda: False)
     monkeypatch.setattr(udf_ray, "UDFActorPool", FakeRayPool)
     resource_unit_id = f"resource:test:gpu-order:{decorator_runner}:{resolved_runner}"
+    payload["query_id"] = f"query:test:gpu-order:{decorator_runner}:{resolved_runner}"
     payload["resource_unit_id"] = resource_unit_id
 
     with warnings.catch_warnings():
@@ -461,6 +462,7 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
     monkeypatch.setattr(udf_ray, "UDFActorPool", FakeRayPool)
 
     resource_unit_id = "resource:test:stateless-three-actor"
+    nodes[0]["payload"]["query_id"] = "query:test:stateless-three-actor"
     nodes[0]["payload"]["resource_unit_id"] = resource_unit_id
     pools, _ = udf_ray.ensure_actor_pools_for_nodes(
         nodes,

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -1922,7 +1922,6 @@ def test_native_backend_query_status_builds_local_progress_snapshot():
                             "pipeline_id": 1,
                             "operators": ["TABLE_SCAN"],
                             "operator_details": [{}],
-                            "stage_ids": [],
                             "input_rows": 5,
                             "input_bytes": 128,
                             "output_rows": 5,
@@ -1964,7 +1963,6 @@ def test_native_backend_query_status_builds_local_progress_snapshot():
                     "pipeline_id": 1,
                     "operators": ["TABLE_SCAN"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             ],
         }
@@ -2001,7 +1999,6 @@ def test_native_progress_topology_ignores_live_counters_and_merges_stable_identi
                 "pipeline_id": 1,
                 "operators": ["STREAMING_UDF"],
                 "operator_details": [udf_details],
-                "stage_ids": [],
             }
         ]
         if include_copy_pipeline:
@@ -2010,7 +2007,6 @@ def test_native_progress_topology_ignores_live_counters_and_merges_stable_identi
                     "pipeline_id": 2,
                     "operators": ["COPY_TO_FILE"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             )
         return {"running_attempts": [{"task_stats": {"pipelines": pipelines}}]}
@@ -2034,13 +2030,11 @@ def test_native_progress_topology_ignores_live_counters_and_merges_stable_identi
                 "pipeline_id": 1,
                 "operators": ["STREAMING_UDF"],
                 "operator_details": [{"pipeline_role": "source", "udf_name": "ai_prompt"}],
-                "stage_ids": [],
             },
             {
                 "pipeline_id": 2,
                 "operators": ["COPY_TO_FILE"],
                 "operator_details": [{}],
-                "stage_ids": [],
             },
         ],
     }
@@ -2059,7 +2053,6 @@ def test_native_progress_topology_ignores_live_counters_and_merges_stable_identi
                                     "pipeline_id": 1,
                                     "operators": ["STREAMING_UDF"],
                                     "operator_details": [{}],
-                                    "stage_ids": [],
                                 }
                             ]
                         }
@@ -2092,7 +2085,6 @@ def test_native_progress_topology_unavailable_does_not_break_query_status(bad_me
                             "pipeline_id": 1,
                             "operators": ["TABLE_SCAN"],
                             "operator_details": [{}],
-                            "stage_ids": [],
                         }
                     ]
                 }
@@ -2133,7 +2125,6 @@ def test_native_progress_snapshot_normalizes_stable_identity_across_attempts():
                     "pipeline_id": 1,
                     "operators": ["STREAMING_UDF"],
                     "operator_details": [operator_details],
-                    "stage_ids": [],
                     "input_rows": input_rows,
                     "total_pipeline_tasks": 1,
                     "running_pipeline_tasks": 1,

--- a/tests/fast/test_fte_ray_backend_adapter.py
+++ b/tests/fast/test_fte_ray_backend_adapter.py
@@ -189,6 +189,9 @@ class _FakeCoordinator:
         self.calls.append(("task_input_stream_exhausted_for_query", (query_id, source_node_ids)))
         return self.exhaustion_handles
 
+    def materialization_barrier_completed(self, query_id, node_id):
+        self.calls.append(("materialization_barrier_completed", (query_id, node_id)))
+
     def wait_fte_query(self, query_id, timeout_s):
         self.calls.append(("wait_fte_query", (query_id, timeout_s)))
         return {"query_id": query_id, "finished": True, "failed": False}
@@ -226,6 +229,7 @@ def test_ray_worker_manager_backend_delegates_and_collects_result_handles():
     assert submitted[0].poll().output == "submitted"
 
     backend.task_input_stream_exhausted("query-a", ("source-a",))
+    backend.materialization_barrier_completed("query-a", "7")
     handles = backend.wait_query("query-a", 2.0)
 
     assert [handle.poll().output for handle in handles] == ["submitted", "exhausted", "popped"]
@@ -237,6 +241,7 @@ def test_ray_worker_manager_backend_delegates_and_collects_result_handles():
         ("worker_snapshots", ()),
         ("submit_tasks", (["task-a"],)),
         ("task_input_stream_exhausted_for_query", ("query-a", ["source-a"])),
+        ("materialization_barrier_completed", ("query-a", "7")),
         ("wait_fte_query", ("query-a", 2.0)),
         ("pop_fte_result_handles", ("query-a",)),
         ("fte_drop_query", ("query-a",)),

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -44,15 +44,13 @@ def _fixed_ray_runtime_node(monkeypatch):
     )
 
 
-def test_ray_udf_cpu_and_memory_defaults_are_nonzero(monkeypatch):
+def test_ray_udf_cpu_defaults_to_one_and_heap_is_unreserved_when_omitted():
     import duckdb.execution.udf_ray as fur
     from duckdb.execution.udf_task_admission import ray_udf_task_memory_bytes
 
-    monkeypatch.delenv("VANE_UDF_TASK_HEAP_BYTES", raising=False)
-    monkeypatch.delenv("VANE_UDF_ACTOR_HEAP_BYTES", raising=False)
     assert fur._payload_num_cpus({}) == 1.0
-    assert ray_udf_task_memory_bytes({"execution_backend": "ray_task"}) == 2 * _GIB
-    assert ray_udf_task_memory_bytes({"execution_backend": "ray_actor"}) == 4 * _GIB
+    assert ray_udf_task_memory_bytes({"execution_backend": "ray_task"}) == 0
+    assert ray_udf_task_memory_bytes({"execution_backend": "ray_actor"}) == 0
     with pytest.raises(ValueError, match="memory_bytes must be positive"):
         ray_udf_task_memory_bytes({"execution_backend": "ray_task", "memory_bytes": 0})
 
@@ -67,6 +65,20 @@ def test_ray_task_options_use_exact_logical_resources_and_fixed_pair_window():
         "num_cpus": 1.5,
         "num_gpus": 0.25,
         "memory": 3 * _GIB,
+        "max_retries": 2,
+        "_generator_backpressure_num_objects": 4,
+    }
+
+
+def test_ray_task_options_omit_undeclared_heap_and_remove_runtime_override():
+    import duckdb.execution.udf_ray as fur
+
+    options = fur._task_remote_options(1.5, 0.25, 0, 2, {"name": "task", "memory": 3 * _GIB})
+
+    assert options == {
+        "name": "task",
+        "num_cpus": 1.5,
+        "num_gpus": 0.25,
         "max_retries": 2,
         "_generator_backpressure_num_objects": 4,
     }
@@ -512,6 +524,61 @@ def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch)
     assert actor_options[0]["scheduling_strategy"].soft is False
     assert len(init_calls) == 1
     assert len(init_calls[0]) == 1
+
+
+def test_actor_pool_omits_undeclared_heap_and_removes_runtime_override(monkeypatch):
+    from duckdb.execution.udf_ray_actor_pool import UDFActorPoolBase
+
+    actor_options = []
+
+    class _Init:
+        def remote(self, *_args):
+            return "ready"
+
+    class _ActorHandle:
+        init_payload = _Init()
+
+    class _ActorFactory:
+        @classmethod
+        def options(cls, **options):
+            actor_options.append(options)
+            return SimpleNamespace(remote=lambda: _ActorHandle())
+
+    class _Pool(UDFActorPoolBase):
+        @staticmethod
+        def _actor_class(*_args):
+            return _ActorFactory
+
+        @staticmethod
+        def _resolve_actor_num_cpus(_payload):
+            return 1.0
+
+        @staticmethod
+        def _resolve_actor_memory_bytes(_payload):
+            return 0
+
+        @staticmethod
+        def _build_actor_runtime_env(_options):
+            return {}
+
+        @staticmethod
+        def _normalize_actor_node_ids(node_ids, *, expected_count):
+            return node_ids
+
+    fake_ray = SimpleNamespace(put=lambda value: ("payload-ref", value))
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    _Pool(
+        payload={
+            "execution_backend": "ray_actor",
+            "cpus": 1.0,
+        },
+        concurrency=1,
+        gpus_per_actor=0.0,
+        actor_node_ids=[_NODE_ID],
+        ray_options={"memory": 3 * _GIB},
+    )
+
+    assert "memory" not in actor_options[0]
 
 
 def test_actor_pool_thread_env_uses_payload_cpu_allocation(monkeypatch):

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -447,6 +447,7 @@ def test_materialized_task_publishes_unsplittable_row_for_soft_liveness():
 
 def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch):
     from duckdb.execution.udf_ray_actor_pool import UDFActorPoolBase
+    from duckdb.runners.ray.query_runtime_protocol import RAY_ACTOR_INDEX_ENV
 
     actor_options = []
     init_calls = []
@@ -520,6 +521,7 @@ def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch)
         "VANE_TORCH_INTEROP_THREADS": "1",
         "VANE_RAY_ACTOR_THREAD_POLICY": "managed",
         "EXPLICIT_ACTOR_ENV": "yes",
+        RAY_ACTOR_INDEX_ENV: "0",
     }
     assert actor_options[0]["scheduling_strategy"].node_id == _NODE_ID
     assert actor_options[0]["scheduling_strategy"].soft is False
@@ -649,6 +651,7 @@ def test_actor_pool_thread_env_uses_payload_cpu_allocation(monkeypatch):
 
 def test_actor_pool_default_thread_policy_defers_thread_env_to_ray(monkeypatch):
     from duckdb.execution.udf_ray_actor_pool import UDFActorPoolBase
+    from duckdb.runners.ray.query_runtime_protocol import RAY_ACTOR_INDEX_ENV
 
     actor_options = []
 
@@ -703,6 +706,7 @@ def test_actor_pool_default_thread_policy_defers_thread_env_to_ray(monkeypatch):
     assert env_vars == {
         "EXPLICIT_ACTOR_ENV": "yes",
         "VANE_RAY_ACTOR_THREAD_POLICY": "ray_native",
+        RAY_ACTOR_INDEX_ENV: "0",
     }
 
 

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -19,7 +19,6 @@ def _distributed_payload(**overrides):
         "execution_backend": "ray_task",
         "query_id": "q1",
         "resource_unit_id": "resource:q1:udf:node:1",
-        "node_id": _NODE_ID,
         "produce_ray_block_stream": True,
         "call_mode": "map_batches",
         "cpus": 1.0,
@@ -96,7 +95,7 @@ def test_task_payload_accepts_registered_downstream_retention_window_multiple():
         "query_id": payload["query_id"],
         "resource_unit_id": payload["resource_unit_id"],
         "attempt_id": "attempt-retention",
-        "node_id": _NODE_ID,
+        "node_id": None,
         "execution_slot_id": f"ray_task:{payload['resource_unit_id']}:lease-retention",
         "output_window_bytes": 64 * 1024,
     }
@@ -116,7 +115,7 @@ def test_task_payload_rejects_invalid_registered_retention_window(window):
         "query_id": payload["query_id"],
         "resource_unit_id": payload["resource_unit_id"],
         "attempt_id": "attempt-invalid-retention",
-        "node_id": _NODE_ID,
+        "node_id": None,
         "execution_slot_id": f"ray_task:{payload['resource_unit_id']}:lease-invalid-retention",
         "output_window_bytes": window,
     }
@@ -125,9 +124,7 @@ def test_task_payload_rejects_invalid_registered_retention_window(window):
         task_payload_with_lease(payload, lease)
 
 
-def test_ray_task_remote_keeps_options_available_for_lease_node_affinity():
-    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-
+def test_ray_task_remote_keeps_regular_ray_remote_options_available():
     import duckdb.execution.udf_ray as fur
     from duckdb.runners.ray.ray_env import build_session_runtime_env_vars
 
@@ -136,12 +133,7 @@ def test_ray_task_remote_keeps_options_available_for_lease_node_affinity():
         fur._build_ref_bundle_stream_remote,
     ):
         remote_fn = builder(1.0, 0.0, 2 * _GIB, 2, {}, build_session_runtime_env_vars({}))
-        scheduled = remote_fn.options(
-            scheduling_strategy=NodeAffinitySchedulingStrategy(
-                node_id=_NODE_ID,
-                soft=False,
-            )
-        )
+        scheduled = remote_fn.options(name="test-ray-task")
         assert callable(scheduled.remote)
 
 
@@ -251,7 +243,7 @@ def test_task_executor_consumes_pregranted_admission_with_exact_resources(monkey
         request_id="request-7",
         lease={
             "lease_id": "lease-7",
-            "node_id": _NODE_ID,
+            "node_id": None,
             "execution_slot_id": "ray_task:resource:q1:udf:node:1:lease-7",
         },
     )
@@ -276,9 +268,7 @@ def test_task_submission_starts_immediately_from_pregranted_lease(monkeypatch):
 
     class _Remote:
         def options(self, **options):
-            assert options["scheduling_strategy"].node_id == _NODE_ID
-            assert options["scheduling_strategy"].soft is False
-            return self
+            raise AssertionError(f"Ray task submission must not override placement: {options}")
 
         def remote(self, *args, **kwargs):
             submitted.append((args, kwargs))
@@ -297,7 +287,7 @@ def test_task_submission_starts_immediately_from_pregranted_lease(monkeypatch):
         "resource_unit_id": "resource:q1:udf:node:1",
         "lease_id": "lease-8",
         "attempt_id": "attempt-8",
-        "node_id": _NODE_ID,
+        "node_id": None,
         "execution_slot_id": "ray_task:resource:q1:udf:node:1:lease-8",
         "output_window_bytes": 2 * _DEFAULT_OUTPUT_TARGET,
     }
@@ -489,10 +479,6 @@ def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch)
                 "working_dir": "/tmp/actor-runtime",
             }
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            return node_ids
-
     fake_ray = SimpleNamespace(put=lambda value: ("payload-ref", value))
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     _Pool(
@@ -503,7 +489,6 @@ def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch)
         },
         concurrency=1,
         gpus_per_actor=1.0,
-        actor_node_ids=[_NODE_ID],
     )
 
     assert actor_options[0]["num_cpus"] == 2.0
@@ -523,8 +508,7 @@ def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch)
         "EXPLICIT_ACTOR_ENV": "yes",
         RAY_ACTOR_INDEX_ENV: "0",
     }
-    assert actor_options[0]["scheduling_strategy"].node_id == _NODE_ID
-    assert actor_options[0]["scheduling_strategy"].soft is False
+    assert "scheduling_strategy" not in actor_options[0]
     assert len(init_calls) == 1
     assert len(init_calls[0]) == 1
 
@@ -564,10 +548,6 @@ def test_actor_pool_omits_undeclared_heap_and_removes_runtime_override(monkeypat
         def _build_actor_runtime_env(_options):
             return {}
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            return node_ids
-
     fake_ray = SimpleNamespace(put=lambda value: ("payload-ref", value))
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     _Pool(
@@ -577,7 +557,6 @@ def test_actor_pool_omits_undeclared_heap_and_removes_runtime_override(monkeypat
         },
         concurrency=1,
         gpus_per_actor=0.0,
-        actor_node_ids=[_NODE_ID],
         ray_options={"memory": 3 * _GIB},
     )
 
@@ -620,10 +599,6 @@ def test_actor_pool_thread_env_uses_payload_cpu_allocation(monkeypatch):
         def _build_actor_runtime_env(_options):
             return {"env_vars": {"OMP_NUM_THREADS": "6"}}
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            return node_ids
-
     fake_ray = SimpleNamespace(put=lambda value: ("payload-ref", value))
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     _Pool(
@@ -634,7 +609,6 @@ def test_actor_pool_thread_env_uses_payload_cpu_allocation(monkeypatch):
         },
         concurrency=1,
         gpus_per_actor=1.0,
-        actor_node_ids=[_NODE_ID],
     )
 
     env_vars = actor_options[0]["runtime_env"]["env_vars"]
@@ -686,10 +660,6 @@ def test_actor_pool_default_thread_policy_defers_thread_env_to_ray(monkeypatch):
         def _build_actor_runtime_env(_options):
             return {"env_vars": {"EXPLICIT_ACTOR_ENV": "yes"}}
 
-        @staticmethod
-        def _normalize_actor_node_ids(node_ids, *, expected_count):
-            return node_ids
-
     fake_ray = SimpleNamespace(put=lambda value: ("payload-ref", value))
     monkeypatch.setitem(sys.modules, "ray", fake_ray)
     _Pool(
@@ -699,7 +669,6 @@ def test_actor_pool_default_thread_policy_defers_thread_env_to_ray(monkeypatch):
         },
         concurrency=1,
         gpus_per_actor=1.0,
-        actor_node_ids=[_NODE_ID],
     )
 
     env_vars = actor_options[0]["runtime_env"]["env_vars"]

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -18,7 +18,7 @@ def _distributed_payload(**overrides):
     payload = {
         "execution_backend": "ray_task",
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "node_id": _NODE_ID,
         "produce_ray_block_stream": True,
         "call_mode": "map_batches",
@@ -82,10 +82,10 @@ def test_task_payload_accepts_registered_downstream_retention_window_multiple():
     lease = {
         "lease_id": "lease-retention",
         "query_id": payload["query_id"],
-        "stage_id": payload["stage_id"],
+        "resource_unit_id": payload["resource_unit_id"],
         "attempt_id": "attempt-retention",
         "node_id": _NODE_ID,
-        "execution_slot_id": f"ray_task:{payload['stage_id']}:lease-retention",
+        "execution_slot_id": f"ray_task:{payload['resource_unit_id']}:lease-retention",
         "output_window_bytes": 64 * 1024,
     }
 
@@ -102,10 +102,10 @@ def test_task_payload_rejects_invalid_registered_retention_window(window):
     lease = {
         "lease_id": "lease-invalid-retention",
         "query_id": payload["query_id"],
-        "stage_id": payload["stage_id"],
+        "resource_unit_id": payload["resource_unit_id"],
         "attempt_id": "attempt-invalid-retention",
         "node_id": _NODE_ID,
-        "execution_slot_id": f"ray_task:{payload['stage_id']}:lease-invalid-retention",
+        "execution_slot_id": f"ray_task:{payload['resource_unit_id']}:lease-invalid-retention",
         "output_window_bytes": window,
     }
 
@@ -198,11 +198,11 @@ def test_actor_call_uses_fixed_four_raw_objects_for_two_logical_blocks():
     assert method.calls == [{"_generator_backpressure_num_objects": 4}]
 
 
-def test_distributed_payload_requires_registered_query_stage_and_new_protocol():
+def test_distributed_payload_requires_registered_resource_unit_and_new_protocol():
     import duckdb.execution.udf_ray as fur
 
     assert fur._ray_payload_requires_block_stream(_distributed_payload()) is True
-    for missing in ("query_id", "stage_id", "produce_ray_block_stream"):
+    for missing in ("query_id", "resource_unit_id", "produce_ray_block_stream"):
         payload = _distributed_payload()
         payload.pop(missing)
         with pytest.raises(RuntimeError):
@@ -240,7 +240,7 @@ def test_task_executor_consumes_pregranted_admission_with_exact_resources(monkey
         lease={
             "lease_id": "lease-7",
             "node_id": _NODE_ID,
-            "execution_slot_id": "ray_task:stage:q1:node:1:udf:lease-7",
+            "execution_slot_id": "ray_task:resource:q1:udf:node:1:lease-7",
         },
     )
     monkeypatch.setattr(executor, "_take_task_admission", lambda: admission)
@@ -282,11 +282,11 @@ def test_task_submission_starts_immediately_from_pregranted_lease(monkeypatch):
     )
     lease = {
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "lease_id": "lease-8",
         "attempt_id": "attempt-8",
         "node_id": _NODE_ID,
-        "execution_slot_id": "ray_task:stage:q1:node:1:udf:lease-8",
+        "execution_slot_id": "ray_task:resource:q1:udf:node:1:lease-8",
         "output_window_bytes": 2 * _DEFAULT_OUTPUT_TARGET,
     }
     admission = SimpleNamespace(driver=object(), request_id="request-8", lease=lease)
@@ -343,7 +343,7 @@ def test_task_stream_producer_yields_direct_block_then_bounded_metadata():
     assert outputs[1] == {
         "protocol_version": 1,
         "query_id": "q1",
-        "producer_stage_id": "stage:q1:node:1:udf",
+        "producer_unit_id": "resource:q1:udf:node:1",
         "task_lease_id": "lease-1",
         "attempt_id": "attempt-1",
         "block_id": "block:lease-1:0",

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -422,7 +422,7 @@ def test_materialized_task_splits_every_block_before_generator_publication():
     assert all(item["size_bytes"] <= 20 for item in metadata)
 
 
-def test_materialized_task_rejects_unsplittable_row_before_first_yield():
+def test_materialized_task_publishes_unsplittable_row_for_soft_liveness():
     import duckdb.execution.udf_ray as fur
     from duckdb import pickle as duckdb_pickle
 
@@ -438,10 +438,11 @@ def test_materialized_task_rejects_unsplittable_row_before_first_yield():
         output_window_bytes=64,
     )
     oversized = pa.table({"value": ["x" * 1024]})
-    stream = fur._iter_materialized_task_outputs(payload, [oversized])
+    outputs = list(fur._iter_materialized_task_outputs(payload, [oversized]))
 
-    with pytest.raises(RuntimeError, match="single output row.*32"):
-        next(stream)
+    assert outputs[0].equals(oversized)
+    assert outputs[1]["size_bytes"] > 32
+    assert outputs[1]["block_id"] == "block:lease-oversized:0"
 
 
 def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch):

--- a/tests/fast/test_query_execution_graph.py
+++ b/tests/fast/test_query_execution_graph.py
@@ -386,7 +386,7 @@ def test_legacy_intermediate_resource_dimension_is_rejected():
         ResourceVector.from_dict(payload)
 
 
-def test_allocation_validation_includes_task_heap_retained_input_and_output_window():
+def test_allocation_validation_keeps_heap_hard_and_object_windows_soft():
     stage = _stage(
         "stage:fragment-1:decode",
         per_task=_resources(cpu=1, heap_bytes=300, object_store_bytes=50),
@@ -411,14 +411,14 @@ def test_allocation_validation_includes_task_heap_retained_input_and_output_wind
             _resources(
                 cpu=4,
                 heap_bytes=300,
-                object_store_bytes=250,
+                object_store_bytes=1,
             ),
             generation=7,
         )
     )
 
 
-def test_allocation_rejects_one_output_window_larger_than_hard_object_store_limit():
+def test_allocation_accepts_one_output_window_larger_than_soft_object_store_budget():
     stage = _stage(
         "stage:fragment-1:decode",
         target_output_block_bytes=101,
@@ -430,8 +430,7 @@ def test_allocation_rejects_one_output_window_larger_than_hard_object_store_limi
         generation=1,
     )
 
-    with pytest.raises(ValueError, match="output window"):
-        graph.validate_allocation(allocation)
+    graph.validate_allocation(allocation)
 
 
 def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node():

--- a/tests/fast/test_query_graph_builder.py
+++ b/tests/fast/test_query_graph_builder.py
@@ -237,7 +237,7 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_reserves_fixed_actor_pool_and_downstream_fte_progress_slot():
+def test_query_demand_reserves_hard_actor_pool_and_downstream_fte_progress_slot():
     graph = build_query_execution_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
@@ -258,21 +258,38 @@ def test_query_demand_reserves_fixed_actor_pool_and_downstream_fte_progress_slot
                 cpu=1,
                 gpu=1,
                 heap_bytes=3 * GIB,
-                object_store_bytes=192 * MIB,
             ),
         ),
     )
     assert demand.task_bundles == (
-        ResourceVector(cpu=1, heap_bytes=1536 * MIB, object_store_bytes=256 * MIB),
-        ResourceVector(cpu=1, heap_bytes=2 * GIB, object_store_bytes=256 * MIB),
-        ResourceVector(cpu=1, heap_bytes=2 * GIB, object_store_bytes=256 * MIB),
+        ResourceVector(cpu=1, heap_bytes=1536 * MIB),
+        ResourceVector(cpu=1, heap_bytes=2 * GIB),
+        ResourceVector(cpu=1, heap_bytes=2 * GIB),
     )
     assert demand.minimum == ResourceVector(
         cpu=4,
         gpu=1,
         heap_bytes=3 * GIB + 4 * GIB + 1536 * MIB,
-        object_store_bytes=(192 + 256 + 256 + 256) * MIB,
     )
+
+
+def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38():
+    metadata = _metadata()
+    metadata["nodes"][2]["udf_payload"]["actor_pool_size"] = 2
+    graph = build_query_execution_graph(metadata, env={})
+    cluster = ResourceVector(
+        cpu=64,
+        gpu=4,
+        heap_bytes=64 * GIB,
+        object_store_bytes=512 * MIB,
+    )
+
+    demand = build_query_demand(graph, cluster)
+
+    assert demand.minimum.object_store_bytes == 0
+    assert demand.desired.object_store_bytes == 512 * MIB
+    assert all(bundle.resources.object_store_bytes == 0 for bundle in demand.actor_bundles)
+    assert all(bundle.object_store_bytes == 0 for bundle in demand.task_bundles)
 
 
 def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():

--- a/tests/fast/test_query_graph_builder.py
+++ b/tests/fast/test_query_graph_builder.py
@@ -27,6 +27,7 @@ def _metadata():
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
+                "is_blocking_materializing": False,
                 "num_partitions": 36,
                 "udf_payload": None,
             },
@@ -35,6 +36,7 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["1"],
                 "is_sink": False,
+                "is_blocking_materializing": False,
                 "num_partitions": 36,
                 "udf_payload": {
                     "execution_backend": "ray_task",
@@ -51,6 +53,7 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["2"],
                 "is_sink": False,
+                "is_blocking_materializing": False,
                 "num_partitions": 1,
                 "udf_payload": {
                     "execution_backend": "ray_actor",
@@ -68,6 +71,7 @@ def _metadata():
                 "node_name": "CopyFinish",
                 "input_node_ids": ["3"],
                 "is_sink": True,
+                "is_blocking_materializing": True,
                 "num_partitions": 1,
                 "udf_payload": None,
             },
@@ -91,6 +95,18 @@ def test_builder_registers_complete_pipeline_and_nested_udf_stages_before_execut
         fte_stage_id_for_node("query-7", "4"),
     )
     assert graph.terminal_stage_ids == (fte_stage_id_for_node("query-7", "4"),)
+    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "4")).spill_mode == "barrier"
+
+
+def test_builder_uses_native_materialization_metadata_instead_of_sink_shape():
+    metadata = _metadata()
+    metadata["nodes"][1]["is_blocking_materializing"] = True
+    metadata["nodes"][3]["is_blocking_materializing"] = False
+
+    graph = build_query_execution_graph(metadata, env={})
+
+    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "2")).spill_mode == "barrier"
+    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "4")).spill_mode == "streaming"
 
 
 def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():

--- a/tests/fast/test_query_graph_registration.py
+++ b/tests/fast/test_query_graph_registration.py
@@ -39,6 +39,25 @@ def test_physical_plan_exports_complete_deterministic_execution_stage_metadata(t
         assert graph.query_id == plan.idx()
         assert all(node["node_id"] for node in first["nodes"])
         assert all(node["num_partitions"] >= 1 for node in first["nodes"])
+        assert all(isinstance(node["is_blocking_materializing"], bool) for node in first["nodes"])
+    finally:
+        con.close()
+
+
+def test_stage_collection_marks_blocking_distributed_materializers(tmp_path):
+    con = duckdb.connect()
+    try:
+        relation = _parquet_relation(con, tmp_path).repartition(2).order("x")
+        plan = _physical_plan(relation, con, "graph-materializing")
+
+        metadata = plan.collect_execution_stages(conn=con)
+        materializing_names = {node["node_name"] for node in metadata["nodes"] if node["is_blocking_materializing"]}
+        graph = build_query_execution_graph(metadata, env={})
+
+        assert {"Repartition", "OrderBy"} <= materializing_names
+        assert {stage.physical_node_id for stage in graph.stages if stage.spill_mode == "barrier"} == {
+            f"node:{node['node_id']}:fte" for node in metadata["nodes"] if node["is_blocking_materializing"]
+        }
     finally:
         con.close()
 

--- a/tests/fast/test_query_graph_registration.py
+++ b/tests/fast/test_query_graph_registration.py
@@ -62,6 +62,38 @@ def test_stage_collection_marks_blocking_distributed_materializers(tmp_path):
         con.close()
 
 
+@pytest.mark.parametrize(
+    ("sample_clause", "expected_blocking"),
+    [
+        ("reservoir(3 ROWS)", True),
+        ("reservoir(50 PERCENT)", False),
+    ],
+)
+def test_stage_collection_classifies_reservoir_sample_materialization(
+    tmp_path,
+    sample_clause,
+    expected_blocking,
+):
+    con = duckdb.connect()
+    try:
+        path = tmp_path / "sample_input.parquet"
+        con.execute(f"COPY (SELECT i::BIGINT AS x FROM range(8) tbl(i)) TO '{path}' (FORMAT PARQUET)")
+        relation = con.sql(f"SELECT x FROM read_parquet('{path}') USING SAMPLE {sample_clause}")
+        plan = _physical_plan(relation, con, "graph-reservoir-sample")
+
+        metadata = plan.collect_execution_stages(conn=con)
+        (sample_node,) = (node for node in metadata["nodes"] if node["node_name"] == "ReservoirSample")
+        graph = build_query_execution_graph(metadata, env={})
+        sample_stage = next(
+            stage for stage in graph.stages if stage.physical_node_id == f"node:{sample_node['node_id']}:fte"
+        )
+
+        assert sample_node["is_blocking_materializing"] is expected_blocking
+        assert sample_stage.spill_mode == ("barrier" if expected_blocking else "streaming")
+    finally:
+        con.close()
+
+
 def test_stage_collection_does_not_treat_generic_inout_as_python_udf(tmp_path):
     con = duckdb.connect()
     try:

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -939,7 +939,7 @@ def test_current_phase_allocation_does_not_reserve_a_task_behind_a_barrier():
         graph.validate_allocation(current)
 
 
-def test_runtime_allocation_validation_can_leave_actor_pool_to_ray_core():
+def test_allocation_validation_requires_one_actor_shape_only_in_the_current_phase():
     actor = _unit(
         "resource:fragment-1:actor",
         backend="ray_actor",
@@ -956,7 +956,27 @@ def test_runtime_allocation_validation_can_leave_actor_pool_to_ray_core():
         generation=2,
     )
 
-    graph.validate_allocation(pending)
+    with pytest.raises(ValueError, match="actor process exceeds query allocation"):
+        graph.validate_allocation(pending)
+
+    fragmented = QueryAllocation(
+        resources=_resources(cpu=1, heap_bytes=300),
+        node_allocations=(
+            NodeResourceAllocation(
+                node_id="cpu-only",
+                resources=_resources(cpu=1, heap_bytes=0),
+            ),
+            NodeResourceAllocation(
+                node_id="memory-only",
+                resources=_resources(cpu=0, heap_bytes=300),
+            ),
+        ),
+        generation=2,
+    )
+    with pytest.raises(ValueError, match="actor process does not fit any allocated Ray node"):
+        graph.validate_allocation(fragmented)
+
+    graph.validate_allocation(pending, eligible_unit_ids=())
 
 
 def test_query_allocation_round_trip_requires_exact_per_node_sum():

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -4,7 +4,7 @@
 import pytest
 
 from duckdb.runners.ray.query_resource_graph import (
-    ActorPlacement,
+    MaterializationBarrierSpec,
     NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
@@ -34,7 +34,6 @@ def _allocation(resources: ResourceVector, *, generation: int) -> QueryAllocatio
     return QueryAllocation(
         resources=resources,
         node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
-        actor_placements=(),
         generation=generation,
     )
 
@@ -90,12 +89,32 @@ def _unit(
     )
 
 
-def _graph(*units: ResourceUnitSpec, terminals: tuple[str, ...]) -> QueryResourceGraph:
+def _graph(
+    *units: ResourceUnitSpec,
+    terminals: tuple[str, ...],
+    barriers: tuple[MaterializationBarrierSpec, ...] = (),
+) -> QueryResourceGraph:
     return QueryResourceGraph(
         query_id="q1",
         plan_digest="sha256:abc123",
         units=tuple(units),
         terminal_unit_ids=terminals,
+        materialization_barriers=barriers,
+    )
+
+
+def _barrier(
+    node_id: str,
+    unit: ResourceUnitSpec,
+    *,
+    materialized_inputs: tuple[str, ...] | None = None,
+) -> MaterializationBarrierSpec:
+    return MaterializationBarrierSpec(
+        query_id="q1",
+        barrier_id=f"barrier:q1:node:{node_id}",
+        physical_node_id=node_id,
+        materializer_unit_id=unit.resource_unit_id,
+        materialized_input_unit_ids=(unit.input_unit_ids if materialized_inputs is None else materialized_inputs),
     )
 
 
@@ -172,6 +191,187 @@ def test_graph_orders_units_deterministically_and_preserves_one_unit_identity_fo
     )
 
 
+def test_completed_barrier_retires_old_phase_before_next_phase_becomes_eligible():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=4)
+    first = _unit(
+        "resource:q1:first-barrier",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    middle = _unit("resource:q1:middle", inputs=(first.resource_unit_id,))
+    second = _unit(
+        "resource:q1:second-barrier",
+        inputs=(middle.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    sink = _unit("resource:q1:sink", inputs=(second.resource_unit_id,))
+    first_barrier = _barrier("first", first)
+    second_barrier = _barrier("second", second)
+    graph = _graph(
+        scan,
+        first,
+        middle,
+        second,
+        sink,
+        terminals=(sink.resource_unit_id,),
+        barriers=(first_barrier, second_barrier),
+    )
+
+    assert graph.eligible_resource_unit_ids(set()) == (
+        scan.resource_unit_id,
+        first.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({first_barrier.barrier_id}) == (
+        first.resource_unit_id,
+        middle.resource_unit_id,
+        second.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({first_barrier.barrier_id, second_barrier.barrier_id}) == (
+        second.resource_unit_id,
+        sink.resource_unit_id,
+    )
+
+
+def test_parallel_first_barriers_share_one_execution_phase_union():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=4)
+    left = _unit(
+        "resource:q1:left-barrier",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    right = _unit(
+        "resource:q1:right-barrier",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    join = _unit("resource:q1:join", inputs=(left.resource_unit_id, right.resource_unit_id))
+    left_barrier = _barrier("left", left)
+    right_barrier = _barrier("right", right)
+    graph = _graph(
+        scan,
+        left,
+        right,
+        join,
+        terminals=(join.resource_unit_id,),
+        barriers=(left_barrier, right_barrier),
+    )
+
+    assert graph.eligible_resource_unit_ids(set()) == (
+        scan.resource_unit_id,
+        left.resource_unit_id,
+        right.resource_unit_id,
+    )
+    assert tuple(barrier.barrier_id for barrier in graph.frontier_materialization_barriers(set())) == (
+        left_barrier.barrier_id,
+        right_barrier.barrier_id,
+    )
+    assert graph.eligible_resource_unit_ids({left_barrier.barrier_id}) == (
+        scan.resource_unit_id,
+        left.resource_unit_id,
+        right.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({left_barrier.barrier_id, right_barrier.barrier_id}) == (
+        left.resource_unit_id,
+        right.resource_unit_id,
+        join.resource_unit_id,
+    )
+
+
+def test_completed_parallel_barrier_opens_its_streaming_branch_before_sibling_barrier():
+    left_scan = _unit("resource:q1:left-scan", backend="ray_worker", max_concurrency=4)
+    left_barrier_unit = _unit(
+        "resource:q1:left-barrier",
+        inputs=(left_scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    left_stream = _unit(
+        "resource:q1:left-stream",
+        inputs=(left_barrier_unit.resource_unit_id,),
+    )
+    right_scan = _unit("resource:q1:right-scan", backend="ray_worker", max_concurrency=4)
+    right_barrier_unit = _unit(
+        "resource:q1:right-barrier",
+        inputs=(right_scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    join = _unit(
+        "resource:q1:join",
+        inputs=(left_stream.resource_unit_id, right_barrier_unit.resource_unit_id),
+    )
+    left_barrier = _barrier("left", left_barrier_unit)
+    right_barrier = _barrier("right", right_barrier_unit)
+    graph = _graph(
+        left_scan,
+        left_barrier_unit,
+        left_stream,
+        right_scan,
+        right_barrier_unit,
+        join,
+        terminals=(join.resource_unit_id,),
+        barriers=(left_barrier, right_barrier),
+    )
+
+    assert graph.eligible_resource_unit_ids({left_barrier.barrier_id}) == (
+        left_barrier_unit.resource_unit_id,
+        left_stream.resource_unit_id,
+        right_scan.resource_unit_id,
+        right_barrier_unit.resource_unit_id,
+    )
+
+
+def test_asymmetric_barrier_switches_from_materialized_to_deferred_input_branch():
+    build_scan = _unit("resource:q1:build-scan", backend="ray_worker", max_concurrency=4)
+    build_udf = _unit(
+        "resource:q1:build-udf",
+        inputs=(build_scan.resource_unit_id,),
+    )
+    probe_scan = _unit("resource:q1:probe-scan", backend="ray_worker", max_concurrency=4)
+    probe_udf = _unit(
+        "resource:q1:probe-udf",
+        inputs=(probe_scan.resource_unit_id,),
+    )
+    broadcast_join = _unit(
+        "resource:q1:broadcast-join",
+        inputs=(build_udf.resource_unit_id, probe_udf.resource_unit_id),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    sink = _unit("resource:q1:sink", inputs=(broadcast_join.resource_unit_id,))
+    barrier = _barrier(
+        "broadcast-join",
+        broadcast_join,
+        materialized_inputs=(build_udf.resource_unit_id,),
+    )
+    graph = _graph(
+        build_scan,
+        build_udf,
+        probe_scan,
+        probe_udf,
+        broadcast_join,
+        sink,
+        terminals=(sink.resource_unit_id,),
+        barriers=(barrier,),
+    )
+
+    assert graph.eligible_resource_unit_ids(set()) == (
+        build_scan.resource_unit_id,
+        build_udf.resource_unit_id,
+        broadcast_join.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({barrier.barrier_id}) == (
+        probe_scan.resource_unit_id,
+        probe_udf.resource_unit_id,
+        broadcast_join.resource_unit_id,
+        sink.resource_unit_id,
+    )
+
+
 def test_graph_serialization_round_trip_is_strict_and_stable():
     scan = _unit("resource:fragment-1:scan")
     sink = _unit(
@@ -181,12 +381,25 @@ def test_graph_serialization_round_trip_is_strict_and_stable():
         target_output_block_bytes=0,
         generator_buffer_blocks=0,
     )
-    graph = _graph(scan, sink, terminals=(sink.resource_unit_id,))
+    barrier = _barrier("sink", sink)
+    graph = _graph(
+        scan,
+        sink,
+        terminals=(sink.resource_unit_id,),
+        barriers=(barrier,),
+    )
 
     payload = graph.to_dict()
 
     assert QueryResourceGraph.from_dict(payload) == graph
-    assert list(payload) == ["query_id", "plan_digest", "units", "terminal_unit_ids"]
+    assert payload["materialization_barriers"][0]["materialized_input_unit_ids"] == [scan.resource_unit_id]
+    assert list(payload) == [
+        "query_id",
+        "plan_digest",
+        "units",
+        "materialization_barriers",
+        "terminal_unit_ids",
+    ]
     with pytest.raises(ValueError, match="unknown fields"):
         QueryResourceGraph.from_dict({**payload, "legacy_operator_specs": []})
 
@@ -194,6 +407,52 @@ def test_graph_serialization_round_trip_is_strict_and_stable():
     unit_payload["stage_id"] = unit_payload.pop("resource_unit_id")
     with pytest.raises(ValueError, match="unknown fields: stage_id"):
         ResourceUnitSpec.from_dict(unit_payload)
+
+
+def test_materialization_barrier_identity_is_canonicalized_before_frontier_traversal():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=1)
+    sink = _unit(
+        "resource:q1:sink",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=1,
+    )
+    barrier = MaterializationBarrierSpec(
+        query_id=" q1 ",
+        barrier_id=" barrier:q1:node:sink ",
+        physical_node_id=" sink ",
+        materializer_unit_id=f" {sink.resource_unit_id} ",
+        materialized_input_unit_ids=(f" {scan.resource_unit_id} ",),
+    )
+
+    graph = _graph(scan, sink, terminals=(sink.resource_unit_id,), barriers=(barrier,))
+
+    assert graph.materialization_barriers[0] == _barrier("sink", sink)
+    assert graph.eligible_resource_unit_ids({barrier.barrier_id}) == (sink.resource_unit_id,)
+
+
+def test_graph_rejects_barrier_id_for_a_different_physical_node():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=1)
+    sink = _unit(
+        "resource:q1:sink",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=1,
+    )
+    barrier = MaterializationBarrierSpec(
+        query_id="q1",
+        barrier_id="barrier:q1:node:other",
+        physical_node_id="sink",
+        materializer_unit_id=sink.resource_unit_id,
+        materialized_input_unit_ids=(scan.resource_unit_id,),
+    )
+
+    with pytest.raises(ValueError, match="invalid materialization barrier identity"):
+        _graph(scan, sink, terminals=(sink.resource_unit_id,), barriers=(barrier,))
 
 
 def test_graph_rejects_duplicate_unit_ids():
@@ -229,6 +488,41 @@ def test_graph_rejects_non_terminal_branch_and_terminal_with_downstream_unit():
 
     with pytest.raises(ValueError, match="terminal unit.*has downstream"):
         _graph(scan, used, terminals=(scan.resource_unit_id,))
+
+
+@pytest.mark.parametrize(
+    ("materialized_inputs", "message"),
+    [
+        ((), "at least one input"),
+        (("resource:q1:missing",), "is not a direct input"),
+        (("resource:q1:scan", "resource:q1:scan"), "duplicate materialized"),
+    ],
+)
+def test_graph_rejects_invalid_materialized_barrier_input_edges(
+    materialized_inputs,
+    message,
+):
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=4)
+    materializer = _unit(
+        "resource:q1:materializer",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _graph(
+            scan,
+            materializer,
+            terminals=(materializer.resource_unit_id,),
+            barriers=(
+                _barrier(
+                    "materializer",
+                    materializer,
+                    materialized_inputs=materialized_inputs,
+                ),
+            ),
+        )
 
 
 @pytest.mark.parametrize("backend", ["ray_task", "ray_actor"])
@@ -431,7 +725,6 @@ def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node
                 resources=_resources(cpu=0, heap_bytes=299, object_store_bytes=199),
             ),
         ),
-        actor_placements=(),
         generation=1,
     )
 
@@ -439,7 +732,7 @@ def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node
         graph.validate_allocation(allocation)
 
 
-def test_runtime_allocation_validation_accepts_pending_zero_capacity():
+def test_allocation_validation_can_skip_tasks_outside_the_current_phase():
     unit = _unit(
         "resource:fragment-1:decode",
         per_task=_resources(cpu=1, heap_bytes=300),
@@ -450,44 +743,80 @@ def test_runtime_allocation_validation_accepts_pending_zero_capacity():
     pending = QueryAllocation(
         resources=ResourceVector(),
         node_allocations=(),
-        actor_placements=(),
         generation=2,
     )
 
     with pytest.raises(ValueError, match="maximum task exceeds query allocation"):
         graph.validate_allocation(pending)
 
-    graph.validate_allocation(pending, require_full_minimum=False)
+    graph.validate_allocation(pending, eligible_unit_ids=())
 
 
-def test_allocation_rejects_cumulative_actor_placements_on_one_node():
-    actor = _unit(
-        "resource:fragment-1:gpu",
-        backend="ray_actor",
-        per_task=_resources(object_store_bytes=10),
-        resident_per_actor=_resources(cpu=1, gpu=1, heap_bytes=100),
+def test_current_phase_allocation_does_not_reserve_a_task_behind_a_barrier():
+    source = _unit(
+        "resource:q1:source",
+        backend="ray_worker",
+        per_task=ResourceVector(),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+    )
+    materializer = _unit(
+        "resource:q1:materializer",
+        inputs=(source.resource_unit_id,),
+        backend="ray_worker",
+        per_task=ResourceVector(),
         target_output_block_bytes=10,
         generator_buffer_blocks=2,
-        max_concurrency=None,
-        actor_pool_size=2,
     )
-    graph = _graph(actor, terminals=(actor.resource_unit_id,))
-    per_node = _resources(cpu=1, gpu=1, heap_bytes=100, object_store_bytes=30)
-    allocation = QueryAllocation(
-        resources=per_node.scale(2),
-        node_allocations=(
-            NodeResourceAllocation(node_id="node-a", resources=per_node),
-            NodeResourceAllocation(node_id="node-b", resources=per_node),
-        ),
-        actor_placements=(
-            ActorPlacement(resource_unit_id=actor.resource_unit_id, actor_index=0, node_id="node-a"),
-            ActorPlacement(resource_unit_id=actor.resource_unit_id, actor_index=1, node_id="node-a"),
-        ),
+    future_task = _unit(
+        "resource:q1:future-task",
+        inputs=(materializer.resource_unit_id,),
+        per_task=_resources(cpu=2, heap_bytes=300),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+    )
+    graph = _graph(
+        source,
+        materializer,
+        future_task,
+        terminals=(future_task.resource_unit_id,),
+        barriers=(_barrier("materializer", materializer),),
+    )
+    current = _allocation(
+        ResourceVector(object_store_bytes=20),
         generation=1,
     )
 
-    with pytest.raises(ValueError, match="cumulative actor placements"):
-        graph.validate_allocation(allocation)
+    assert graph.eligible_resource_unit_ids(set()) == (
+        source.resource_unit_id,
+        materializer.resource_unit_id,
+    )
+    graph.validate_allocation(
+        current,
+        eligible_unit_ids=graph.eligible_resource_unit_ids(set()),
+    )
+    with pytest.raises(ValueError, match="maximum task exceeds query allocation"):
+        graph.validate_allocation(current)
+
+
+def test_runtime_allocation_validation_can_leave_actor_pool_to_ray_core():
+    actor = _unit(
+        "resource:fragment-1:actor",
+        backend="ray_actor",
+        per_task=_resources(object_store_bytes=100),
+        resident_per_actor=_resources(cpu=1, heap_bytes=300),
+        target_output_block_bytes=100,
+        generator_buffer_blocks=2,
+        actor_pool_size=2,
+    )
+    graph = _graph(actor, terminals=(actor.resource_unit_id,))
+    pending = QueryAllocation(
+        resources=ResourceVector(),
+        node_allocations=(),
+        generation=2,
+    )
+
+    graph.validate_allocation(pending)
 
 
 def test_query_allocation_round_trip_requires_exact_per_node_sum():
@@ -504,7 +833,6 @@ def test_query_allocation_round_trip_requires_exact_per_node_sum():
                 resources=_resources(cpu=2, heap_bytes=200, object_store_bytes=250),
             ),
         ),
-        actor_placements=(),
         generation=9,
     )
 
@@ -513,6 +841,5 @@ def test_query_allocation_round_trip_requires_exact_per_node_sum():
         QueryAllocation(
             resources=resources,
             node_allocations=allocation.node_allocations[:1],
-            actor_placements=(),
             generation=9,
         )

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -53,9 +53,8 @@ def _unit(
     actor_pool_size: int = 0,
     actor_prefetch_depth: int = 1,
     unit_kind: str | None = None,
-    is_barrier: bool = False,
 ) -> ResourceUnitSpec:
-    requested = per_task or _resources()
+    requested = per_task if per_task is not None else (ResourceVector() if backend == "ray_worker" else _resources())
     if backend == "ray_actor":
         resident = resident_per_actor or ResourceVector(
             cpu=requested.cpu,
@@ -88,7 +87,6 @@ def _unit(
         resident_per_actor=resident,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        is_barrier=is_barrier,
     )
 
 
@@ -174,81 +172,6 @@ def test_graph_orders_units_deterministically_and_preserves_one_unit_identity_fo
     )
 
 
-def test_graph_identifies_downstream_native_fragment_slots_after_remote_process_boundaries():
-    first_native_fragment = _unit(
-        "resource:fragment-1:first-native_fragment",
-        backend="ray_worker",
-        max_concurrency=36,
-    )
-    direct_native_fragment = _unit(
-        "resource:fragment-1:direct-native_fragment",
-        inputs=(first_native_fragment.resource_unit_id,),
-        backend="ray_worker",
-        max_concurrency=36,
-    )
-    cpu_udf = _unit(
-        "resource:fragment-1:cpu-udf",
-        inputs=(direct_native_fragment.resource_unit_id,),
-    )
-    post_task_native_fragment = _unit(
-        "resource:fragment-2:post-task-native_fragment",
-        inputs=(cpu_udf.resource_unit_id,),
-        backend="ray_worker",
-        max_concurrency=36,
-    )
-    gpu_udf = _unit(
-        "resource:fragment-2:gpu-udf",
-        inputs=(post_task_native_fragment.resource_unit_id,),
-        backend="ray_actor",
-        per_task=_resources(gpu=1),
-        actor_pool_size=1,
-    )
-    post_actor_native_fragment = _unit(
-        "resource:fragment-3:post-actor-native_fragment",
-        inputs=(gpu_udf.resource_unit_id,),
-        backend="ray_worker",
-        max_concurrency=36,
-        target_output_block_bytes=0,
-        generator_buffer_blocks=0,
-    )
-    graph = _graph(
-        post_actor_native_fragment,
-        cpu_udf,
-        first_native_fragment,
-        gpu_udf,
-        direct_native_fragment,
-        post_task_native_fragment,
-        terminals=(post_actor_native_fragment.resource_unit_id,),
-    )
-
-    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
-        first_native_fragment.resource_unit_id
-    ) == (
-        post_task_native_fragment.resource_unit_id,
-        post_actor_native_fragment.resource_unit_id,
-    )
-    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
-        direct_native_fragment.resource_unit_id
-    ) == (
-        post_task_native_fragment.resource_unit_id,
-        post_actor_native_fragment.resource_unit_id,
-    )
-    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(cpu_udf.resource_unit_id) == (
-        post_task_native_fragment.resource_unit_id,
-        post_actor_native_fragment.resource_unit_id,
-    )
-    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
-        post_task_native_fragment.resource_unit_id
-    ) == (post_actor_native_fragment.resource_unit_id,)
-    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(gpu_udf.resource_unit_id) == (
-        post_actor_native_fragment.resource_unit_id,
-    )
-    assert (
-        graph.downstream_native_fragment_unit_ids_requiring_separate_slot(post_actor_native_fragment.resource_unit_id)
-        == ()
-    )
-
-
 def test_graph_serialization_round_trip_is_strict_and_stable():
     scan = _unit("resource:fragment-1:scan")
     sink = _unit(
@@ -266,6 +189,11 @@ def test_graph_serialization_round_trip_is_strict_and_stable():
     assert list(payload) == ["query_id", "plan_digest", "units", "terminal_unit_ids"]
     with pytest.raises(ValueError, match="unknown fields"):
         QueryResourceGraph.from_dict({**payload, "legacy_operator_specs": []})
+
+    unit_payload = dict(payload["units"][0])
+    unit_payload["stage_id"] = unit_payload.pop("resource_unit_id")
+    with pytest.raises(ValueError, match="unknown fields: stage_id"):
+        ResourceUnitSpec.from_dict(unit_payload)
 
 
 def test_graph_rejects_duplicate_unit_ids():
@@ -303,8 +231,8 @@ def test_graph_rejects_non_terminal_branch_and_terminal_with_downstream_unit():
         _graph(scan, used, terminals=(scan.resource_unit_id,))
 
 
-@pytest.mark.parametrize("backend", ["ray_task", "ray_actor", "ray_worker"])
-def test_graph_rejects_zero_heap_for_every_ray_python_process(backend):
+@pytest.mark.parametrize("backend", ["ray_task", "ray_actor"])
+def test_graph_accepts_undeclared_heap_for_ray_python_process(backend):
     unit = _unit(
         "resource:fragment-1:udf",
         backend=backend,
@@ -312,7 +240,21 @@ def test_graph_rejects_zero_heap_for_every_ray_python_process(backend):
         actor_pool_size=1 if backend == "ray_actor" else 0,
     )
 
-    with pytest.raises(ValueError, match="non-zero heap_bytes"):
+    graph = _graph(unit, terminals=(unit.resource_unit_id,))
+    registered = graph.unit_by_id(unit.resource_unit_id)
+    process_resources = registered.resident_per_actor if backend == "ray_actor" else registered.per_task
+
+    assert process_resources.heap_bytes == 0
+
+
+def test_graph_rejects_native_process_resources_owned_outside_duckdb():
+    unit = _unit(
+        "resource:fragment-1:native",
+        backend="ray_worker",
+        per_task=_resources(cpu=1, heap_bytes=256 * MIB, object_store_bytes=10),
+    )
+
+    with pytest.raises(ValueError, match="process resources are owned by DuckDB"):
         _graph(unit, terminals=(unit.resource_unit_id,))
 
 
@@ -394,14 +336,6 @@ def test_graph_rejects_invalid_actor_prefetch_depth():
     )
     with pytest.raises(ValueError, match="only configurable for ray_actor"):
         _graph(task, terminals=(task.resource_unit_id,))
-
-
-@pytest.mark.parametrize("is_barrier", [0, 1, "barrier", None])
-def test_graph_rejects_non_boolean_barrier_flag(is_barrier):
-    unit = _unit("resource:fragment-1:scan", is_barrier=is_barrier)
-
-    with pytest.raises(ValueError, match="is_barrier must be a boolean"):
-        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
 def test_graph_rejects_inconsistent_output_window_shape():

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -3,13 +3,13 @@
 
 import pytest
 
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 
 MIB = 1024 * 1024
@@ -39,8 +39,8 @@ def _allocation(resources: ResourceVector, *, generation: int) -> QueryAllocatio
     )
 
 
-def _stage(
-    stage_id: str,
+def _unit(
+    resource_unit_id: str,
     *,
     inputs: tuple[str, ...] = (),
     physical_node_id: str | None = None,
@@ -52,8 +52,9 @@ def _stage(
     max_concurrency: int | None = None,
     actor_pool_size: int = 0,
     actor_prefetch_depth: int = 1,
-    spill_mode: str = "streaming",
-) -> StageResourceSpec:
+    unit_kind: str | None = None,
+    is_barrier: bool = False,
+) -> ResourceUnitSpec:
     requested = per_task or _resources()
     if backend == "ray_actor":
         resident = resident_per_actor or ResourceVector(
@@ -65,13 +66,21 @@ def _stage(
     else:
         resident = ResourceVector()
         invocation = requested
-    return StageResourceSpec(
+    resolved_unit_kind = (
+        unit_kind
+        or {
+            "ray_worker": "native_fragment",
+            "ray_task": "ray_task_udf",
+            "ray_actor": "ray_actor_pool",
+        }[backend]
+    )
+    return ResourceUnitSpec(
         query_id="q1",
-        stage_id=stage_id,
-        physical_node_id=physical_node_id or stage_id.rsplit(":", 1)[-1],
-        stage_kind="udf" if "udf" in stage_id else "fte",
+        resource_unit_id=resource_unit_id,
+        physical_node_id=physical_node_id or resource_unit_id.rsplit(":", 1)[-1],
+        unit_kind=resolved_unit_kind,
         backend=backend,
-        input_stage_ids=inputs,
+        input_unit_ids=inputs,
         per_task=invocation,
         target_output_block_bytes=target_output_block_bytes,
         generator_buffer_blocks=generator_buffer_blocks,
@@ -79,16 +88,16 @@ def _stage(
         resident_per_actor=resident,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        spill_mode=spill_mode,
+        is_barrier=is_barrier,
     )
 
 
-def _graph(*stages: StageResourceSpec, terminals: tuple[str, ...]) -> QueryExecutionGraph:
-    return QueryExecutionGraph(
+def _graph(*units: ResourceUnitSpec, terminals: tuple[str, ...]) -> QueryResourceGraph:
+    return QueryResourceGraph(
         query_id="q1",
         plan_digest="sha256:abc123",
-        stages=tuple(stages),
-        terminal_stage_ids=terminals,
+        units=tuple(units),
+        terminal_unit_ids=terminals,
     )
 
 
@@ -137,169 +146,204 @@ def test_resource_vector_fit_and_dominant_share_include_every_dimension():
     assert not _resources(cpu=5).fits_within(capacity)
 
 
-def test_graph_orders_stages_deterministically_and_preserves_one_stage_identity_for_all_attempts():
-    scan = _stage("stage:fragment-1:scan", backend="ray_worker", max_concurrency=36)
-    cpu_udf = _stage("stage:fragment-1:cpu-udf", inputs=(scan.stage_id,))
-    gpu_udf = _stage(
-        "stage:fragment-1:gpu-udf",
-        inputs=(cpu_udf.stage_id,),
+def test_graph_orders_units_deterministically_and_preserves_one_unit_identity_for_all_attempts():
+    scan = _unit("resource:fragment-1:scan", backend="ray_worker", max_concurrency=36)
+    cpu_udf = _unit("resource:fragment-1:cpu-udf", inputs=(scan.resource_unit_id,))
+    gpu_udf = _unit(
+        "resource:fragment-1:gpu-udf",
+        inputs=(cpu_udf.resource_unit_id,),
         backend="ray_actor",
         per_task=_resources(cpu=1, gpu=1, heap_bytes=1024 * MIB),
         max_concurrency=None,
         actor_pool_size=1,
     )
-    graph = _graph(gpu_udf, scan, cpu_udf, terminals=(gpu_udf.stage_id,))
+    graph = _graph(gpu_udf, scan, cpu_udf, terminals=(gpu_udf.resource_unit_id,))
 
-    assert graph.topological_stage_ids() == (scan.stage_id, cpu_udf.stage_id, gpu_udf.stage_id)
-    assert graph.reverse_topological_stage_ids() == (gpu_udf.stage_id, cpu_udf.stage_id, scan.stage_id)
-    assert graph.stage_id_for_physical_node("scan") == scan.stage_id
-    assert graph.task_identity(scan.stage_id, partition_id=0, attempt_id="a1") == (
-        "task:stage:fragment-1:scan:partition:0:attempt:a1"
+    assert graph.topological_unit_ids() == (scan.resource_unit_id, cpu_udf.resource_unit_id, gpu_udf.resource_unit_id)
+    assert graph.reverse_topological_unit_ids() == (
+        gpu_udf.resource_unit_id,
+        cpu_udf.resource_unit_id,
+        scan.resource_unit_id,
     )
-    assert graph.task_identity(scan.stage_id, partition_id=35, attempt_id="a2").startswith(
-        "task:stage:fragment-1:scan:"
+    assert graph.unit_id_for_physical_node("scan") == scan.resource_unit_id
+    assert graph.task_identity(scan.resource_unit_id, partition_id=0, attempt_id="a1") == (
+        "task:resource:fragment-1:scan:partition:0:attempt:a1"
+    )
+    assert graph.task_identity(scan.resource_unit_id, partition_id=35, attempt_id="a2").startswith(
+        "task:resource:fragment-1:scan:"
     )
 
 
-def test_graph_identifies_downstream_fte_slots_after_non_fte_boundaries():
-    first_fte = _stage(
-        "stage:fragment-1:first-fte",
+def test_graph_identifies_downstream_native_fragment_slots_after_remote_process_boundaries():
+    first_native_fragment = _unit(
+        "resource:fragment-1:first-native_fragment",
         backend="ray_worker",
         max_concurrency=36,
     )
-    direct_fte = _stage(
-        "stage:fragment-1:direct-fte",
-        inputs=(first_fte.stage_id,),
+    direct_native_fragment = _unit(
+        "resource:fragment-1:direct-native_fragment",
+        inputs=(first_native_fragment.resource_unit_id,),
         backend="ray_worker",
         max_concurrency=36,
     )
-    cpu_udf = _stage(
-        "stage:fragment-1:cpu-udf",
-        inputs=(direct_fte.stage_id,),
+    cpu_udf = _unit(
+        "resource:fragment-1:cpu-udf",
+        inputs=(direct_native_fragment.resource_unit_id,),
     )
-    post_task_fte = _stage(
-        "stage:fragment-2:post-task-fte",
-        inputs=(cpu_udf.stage_id,),
+    post_task_native_fragment = _unit(
+        "resource:fragment-2:post-task-native_fragment",
+        inputs=(cpu_udf.resource_unit_id,),
         backend="ray_worker",
         max_concurrency=36,
     )
-    gpu_udf = _stage(
-        "stage:fragment-2:gpu-udf",
-        inputs=(post_task_fte.stage_id,),
+    gpu_udf = _unit(
+        "resource:fragment-2:gpu-udf",
+        inputs=(post_task_native_fragment.resource_unit_id,),
         backend="ray_actor",
         per_task=_resources(gpu=1),
         actor_pool_size=1,
     )
-    post_actor_fte = _stage(
-        "stage:fragment-3:post-actor-fte",
-        inputs=(gpu_udf.stage_id,),
+    post_actor_native_fragment = _unit(
+        "resource:fragment-3:post-actor-native_fragment",
+        inputs=(gpu_udf.resource_unit_id,),
         backend="ray_worker",
         max_concurrency=36,
         target_output_block_bytes=0,
         generator_buffer_blocks=0,
     )
     graph = _graph(
-        post_actor_fte,
+        post_actor_native_fragment,
         cpu_udf,
-        first_fte,
+        first_native_fragment,
         gpu_udf,
-        direct_fte,
-        post_task_fte,
-        terminals=(post_actor_fte.stage_id,),
+        direct_native_fragment,
+        post_task_native_fragment,
+        terminals=(post_actor_native_fragment.resource_unit_id,),
     )
 
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(first_fte.stage_id) == (
-        post_task_fte.stage_id,
-        post_actor_fte.stage_id,
+    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
+        first_native_fragment.resource_unit_id
+    ) == (
+        post_task_native_fragment.resource_unit_id,
+        post_actor_native_fragment.resource_unit_id,
     )
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(direct_fte.stage_id) == (
-        post_task_fte.stage_id,
-        post_actor_fte.stage_id,
+    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
+        direct_native_fragment.resource_unit_id
+    ) == (
+        post_task_native_fragment.resource_unit_id,
+        post_actor_native_fragment.resource_unit_id,
     )
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(cpu_udf.stage_id) == (
-        post_task_fte.stage_id,
-        post_actor_fte.stage_id,
+    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(cpu_udf.resource_unit_id) == (
+        post_task_native_fragment.resource_unit_id,
+        post_actor_native_fragment.resource_unit_id,
     )
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(post_task_fte.stage_id) == (post_actor_fte.stage_id,)
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(gpu_udf.stage_id) == (post_actor_fte.stage_id,)
-    assert graph.downstream_fte_stage_ids_requiring_separate_slot(post_actor_fte.stage_id) == ()
+    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(
+        post_task_native_fragment.resource_unit_id
+    ) == (post_actor_native_fragment.resource_unit_id,)
+    assert graph.downstream_native_fragment_unit_ids_requiring_separate_slot(gpu_udf.resource_unit_id) == (
+        post_actor_native_fragment.resource_unit_id,
+    )
+    assert (
+        graph.downstream_native_fragment_unit_ids_requiring_separate_slot(post_actor_native_fragment.resource_unit_id)
+        == ()
+    )
 
 
 def test_graph_serialization_round_trip_is_strict_and_stable():
-    scan = _stage("stage:fragment-1:scan")
-    sink = _stage(
-        "stage:fragment-2:sink",
-        inputs=(scan.stage_id,),
+    scan = _unit("resource:fragment-1:scan")
+    sink = _unit(
+        "resource:fragment-2:sink",
+        inputs=(scan.resource_unit_id,),
         backend="ray_worker",
         target_output_block_bytes=0,
         generator_buffer_blocks=0,
     )
-    graph = _graph(scan, sink, terminals=(sink.stage_id,))
+    graph = _graph(scan, sink, terminals=(sink.resource_unit_id,))
 
     payload = graph.to_dict()
 
-    assert QueryExecutionGraph.from_dict(payload) == graph
-    assert list(payload) == ["query_id", "plan_digest", "stages", "terminal_stage_ids"]
+    assert QueryResourceGraph.from_dict(payload) == graph
+    assert list(payload) == ["query_id", "plan_digest", "units", "terminal_unit_ids"]
     with pytest.raises(ValueError, match="unknown fields"):
-        QueryExecutionGraph.from_dict({**payload, "legacy_operator_specs": []})
+        QueryResourceGraph.from_dict({**payload, "legacy_operator_specs": []})
 
 
-def test_graph_rejects_duplicate_stage_ids():
-    first = _stage("stage:fragment-1:scan", physical_node_id="scan-a")
-    duplicate = _stage("stage:fragment-1:scan", physical_node_id="scan-b")
+def test_graph_rejects_duplicate_unit_ids():
+    first = _unit("resource:fragment-1:scan", physical_node_id="scan-a")
+    duplicate = _unit("resource:fragment-1:scan", physical_node_id="scan-b")
 
-    with pytest.raises(ValueError, match="duplicate stage_id"):
-        _graph(first, duplicate, terminals=(first.stage_id,))
+    with pytest.raises(ValueError, match="duplicate resource_unit_id"):
+        _graph(first, duplicate, terminals=(first.resource_unit_id,))
 
 
 def test_graph_rejects_missing_dependencies():
-    sink = _stage("stage:fragment-1:sink", inputs=("stage:fragment-1:missing",))
+    sink = _unit("resource:fragment-1:sink", inputs=("resource:fragment-1:missing",))
 
-    with pytest.raises(ValueError, match="missing input stage"):
-        _graph(sink, terminals=(sink.stage_id,))
+    with pytest.raises(ValueError, match="missing input unit"):
+        _graph(sink, terminals=(sink.resource_unit_id,))
 
 
 def test_graph_rejects_cycles():
-    left = _stage("stage:fragment-1:left", inputs=("stage:fragment-1:right",))
-    right = _stage("stage:fragment-1:right", inputs=(left.stage_id,))
+    left = _unit("resource:fragment-1:left", inputs=("resource:fragment-1:right",))
+    right = _unit("resource:fragment-1:right", inputs=(left.resource_unit_id,))
 
     with pytest.raises(ValueError, match="cycle"):
-        _graph(left, right, terminals=(right.stage_id,))
+        _graph(left, right, terminals=(right.resource_unit_id,))
 
 
-def test_graph_rejects_non_terminal_branch_and_terminal_with_downstream_stage():
-    scan = _stage("stage:fragment-1:scan")
-    used = _stage("stage:fragment-1:used", inputs=(scan.stage_id,))
-    orphan = _stage("stage:fragment-1:orphan")
+def test_graph_rejects_non_terminal_branch_and_terminal_with_downstream_unit():
+    scan = _unit("resource:fragment-1:scan")
+    used = _unit("resource:fragment-1:used", inputs=(scan.resource_unit_id,))
+    orphan = _unit("resource:fragment-1:orphan")
 
     with pytest.raises(ValueError, match="does not reach a terminal"):
-        _graph(scan, used, orphan, terminals=(used.stage_id,))
+        _graph(scan, used, orphan, terminals=(used.resource_unit_id,))
 
-    with pytest.raises(ValueError, match="terminal stage.*has downstream"):
-        _graph(scan, used, terminals=(scan.stage_id,))
+    with pytest.raises(ValueError, match="terminal unit.*has downstream"):
+        _graph(scan, used, terminals=(scan.resource_unit_id,))
 
 
 @pytest.mark.parametrize("backend", ["ray_task", "ray_actor", "ray_worker"])
 def test_graph_rejects_zero_heap_for_every_ray_python_process(backend):
-    stage = _stage(
-        "stage:fragment-1:udf",
+    unit = _unit(
+        "resource:fragment-1:udf",
         backend=backend,
         per_task=_resources(heap_bytes=0),
         actor_pool_size=1 if backend == "ray_actor" else 0,
     )
 
     with pytest.raises(ValueError, match="non-zero heap_bytes"):
-        _graph(stage, terminals=(stage.stage_id,))
+        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
-def test_graph_rejects_ray_stage_without_cpu_or_gpu_scheduling_resources():
-    stage = _stage(
-        "stage:fragment-1:udf",
+def test_graph_rejects_ray_unit_without_cpu_or_gpu_scheduling_resources():
+    unit = _unit(
+        "resource:fragment-1:udf",
         per_task=_resources(cpu=0, gpu=0),
     )
 
     with pytest.raises(ValueError, match="CPU or GPU"):
-        _graph(stage, terminals=(stage.stage_id,))
+        _graph(unit, terminals=(unit.resource_unit_id,))
+
+
+@pytest.mark.parametrize(
+    ("backend", "unit_kind"),
+    [
+        ("ray_worker", "ray_task_udf"),
+        ("ray_task", "native_fragment"),
+        ("ray_actor", "ray_task_udf"),
+    ],
+)
+def test_graph_rejects_resource_unit_kind_that_does_not_match_backend(backend, unit_kind):
+    unit = _unit(
+        "resource:fragment-1:mismatched-kind",
+        backend=backend,
+        actor_pool_size=1 if backend == "ray_actor" else 0,
+        unit_kind=unit_kind,
+    )
+
+    with pytest.raises(ValueError, match="does not match backend"):
+        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
 @pytest.mark.parametrize(
@@ -316,66 +360,66 @@ def test_graph_rejects_invalid_actor_pool(changes, message):
         "actor_pool_size": 1,
         **changes,
     }
-    stage = _stage("stage:fragment-1:gpu-udf", **params)
+    unit = _unit("resource:fragment-1:gpu-udf", **params)
 
     with pytest.raises(ValueError, match=message):
-        _graph(stage, terminals=(stage.stage_id,))
+        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
-def test_graph_rejects_actor_pool_on_non_actor_stage():
-    stage = _stage(
-        "stage:fragment-1:udf",
+def test_graph_rejects_actor_pool_on_non_actor_unit():
+    unit = _unit(
+        "resource:fragment-1:udf",
         backend="ray_task",
         actor_pool_size=1,
     )
 
     with pytest.raises(ValueError, match="only valid for ray_actor"):
-        _graph(stage, terminals=(stage.stage_id,))
+        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
 def test_graph_rejects_invalid_actor_prefetch_depth():
-    actor = _stage(
-        "stage:fragment-1:gpu-udf",
+    actor = _unit(
+        "resource:fragment-1:gpu-udf",
         backend="ray_actor",
         actor_pool_size=1,
         actor_prefetch_depth=0,
     )
     with pytest.raises(ValueError, match="actor_prefetch_depth"):
-        _graph(actor, terminals=(actor.stage_id,))
+        _graph(actor, terminals=(actor.resource_unit_id,))
 
-    task = _stage(
-        "stage:fragment-1:cpu-udf",
+    task = _unit(
+        "resource:fragment-1:cpu-udf",
         backend="ray_task",
         actor_prefetch_depth=2,
     )
     with pytest.raises(ValueError, match="only configurable for ray_actor"):
-        _graph(task, terminals=(task.stage_id,))
+        _graph(task, terminals=(task.resource_unit_id,))
 
 
-@pytest.mark.parametrize("spill_mode", ["disk", "unbounded", "legacy"])
-def test_graph_rejects_unknown_spill_mode(spill_mode):
-    stage = _stage("stage:fragment-1:scan", spill_mode=spill_mode)
+@pytest.mark.parametrize("is_barrier", [0, 1, "barrier", None])
+def test_graph_rejects_non_boolean_barrier_flag(is_barrier):
+    unit = _unit("resource:fragment-1:scan", is_barrier=is_barrier)
 
-    with pytest.raises(ValueError, match="spill_mode"):
-        _graph(stage, terminals=(stage.stage_id,))
+    with pytest.raises(ValueError, match="is_barrier must be a boolean"):
+        _graph(unit, terminals=(unit.resource_unit_id,))
 
 
 def test_graph_rejects_inconsistent_output_window_shape():
-    no_target = _stage(
-        "stage:fragment-1:no-target",
+    no_target = _unit(
+        "resource:fragment-1:no-target",
         target_output_block_bytes=0,
         generator_buffer_blocks=2,
     )
-    no_window = _stage(
-        "stage:fragment-1:no-window",
+    no_window = _unit(
+        "resource:fragment-1:no-window",
         target_output_block_bytes=16 * MIB,
         generator_buffer_blocks=0,
     )
 
     with pytest.raises(ValueError, match="both be zero"):
-        _graph(no_target, terminals=(no_target.stage_id,))
+        _graph(no_target, terminals=(no_target.resource_unit_id,))
     with pytest.raises(ValueError, match="both be positive"):
-        _graph(no_window, terminals=(no_window.stage_id,))
+        _graph(no_window, terminals=(no_window.resource_unit_id,))
 
 
 def test_legacy_intermediate_resource_dimension_is_rejected():
@@ -387,13 +431,13 @@ def test_legacy_intermediate_resource_dimension_is_rejected():
 
 
 def test_allocation_validation_keeps_heap_hard_and_object_windows_soft():
-    stage = _stage(
-        "stage:fragment-1:decode",
+    unit = _unit(
+        "resource:fragment-1:decode",
         per_task=_resources(cpu=1, heap_bytes=300, object_store_bytes=50),
         target_output_block_bytes=100,
         generator_buffer_blocks=2,
     )
-    graph = _graph(stage, terminals=(stage.stage_id,))
+    graph = _graph(unit, terminals=(unit.resource_unit_id,))
     allocation = _allocation(
         _resources(
             cpu=4,
@@ -419,12 +463,12 @@ def test_allocation_validation_keeps_heap_hard_and_object_windows_soft():
 
 
 def test_allocation_accepts_one_output_window_larger_than_soft_object_store_budget():
-    stage = _stage(
-        "stage:fragment-1:decode",
+    unit = _unit(
+        "resource:fragment-1:decode",
         target_output_block_bytes=101,
         generator_buffer_blocks=2,
     )
-    graph = _graph(stage, terminals=(stage.stage_id,))
+    graph = _graph(unit, terminals=(unit.resource_unit_id,))
     allocation = _allocation(
         _resources(cpu=4, heap_bytes=1024 * MIB, object_store_bytes=201),
         generation=1,
@@ -434,13 +478,13 @@ def test_allocation_accepts_one_output_window_larger_than_soft_object_store_budg
 
 
 def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node():
-    stage = _stage(
-        "stage:fragment-1:decode",
+    unit = _unit(
+        "resource:fragment-1:decode",
         per_task=_resources(cpu=2, heap_bytes=300, object_store_bytes=0),
         target_output_block_bytes=100,
         generator_buffer_blocks=2,
     )
-    graph = _graph(stage, terminals=(stage.stage_id,))
+    graph = _graph(unit, terminals=(unit.resource_unit_id,))
     allocation = QueryAllocation(
         resources=_resources(cpu=2, heap_bytes=300, object_store_bytes=200),
         node_allocations=(
@@ -462,13 +506,13 @@ def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node
 
 
 def test_runtime_allocation_validation_accepts_pending_zero_capacity():
-    stage = _stage(
-        "stage:fragment-1:decode",
+    unit = _unit(
+        "resource:fragment-1:decode",
         per_task=_resources(cpu=1, heap_bytes=300),
         target_output_block_bytes=100,
         generator_buffer_blocks=2,
     )
-    graph = _graph(stage, terminals=(stage.stage_id,))
+    graph = _graph(unit, terminals=(unit.resource_unit_id,))
     pending = QueryAllocation(
         resources=ResourceVector(),
         node_allocations=(),
@@ -483,8 +527,8 @@ def test_runtime_allocation_validation_accepts_pending_zero_capacity():
 
 
 def test_allocation_rejects_cumulative_actor_placements_on_one_node():
-    actor = _stage(
-        "stage:fragment-1:gpu",
+    actor = _unit(
+        "resource:fragment-1:gpu",
         backend="ray_actor",
         per_task=_resources(object_store_bytes=10),
         resident_per_actor=_resources(cpu=1, gpu=1, heap_bytes=100),
@@ -493,7 +537,7 @@ def test_allocation_rejects_cumulative_actor_placements_on_one_node():
         max_concurrency=None,
         actor_pool_size=2,
     )
-    graph = _graph(actor, terminals=(actor.stage_id,))
+    graph = _graph(actor, terminals=(actor.resource_unit_id,))
     per_node = _resources(cpu=1, gpu=1, heap_bytes=100, object_store_bytes=30)
     allocation = QueryAllocation(
         resources=per_node.scale(2),
@@ -502,8 +546,8 @@ def test_allocation_rejects_cumulative_actor_placements_on_one_node():
             NodeResourceAllocation(node_id="node-b", resources=per_node),
         ),
         actor_placements=(
-            ActorPlacement(stage_id=actor.stage_id, actor_index=0, node_id="node-a"),
-            ActorPlacement(stage_id=actor.stage_id, actor_index=1, node_id="node-a"),
+            ActorPlacement(resource_unit_id=actor.resource_unit_id, actor_index=0, node_id="node-a"),
+            ActorPlacement(resource_unit_id=actor.resource_unit_id, actor_index=1, node_id="node-a"),
         ),
         generation=1,
     )

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -5,7 +5,6 @@ import pytest
 
 from duckdb.runners.ray.query_resource_graph import (
     MaterializationBarrierSpec,
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -33,7 +32,6 @@ def _resources(
 def _allocation(resources: ResourceVector, *, generation: int) -> QueryAllocation:
     return QueryAllocation(
         resources=resources,
-        node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
         generation=generation,
     )
 
@@ -798,208 +796,27 @@ def test_legacy_intermediate_resource_dimension_is_rejected():
         ResourceVector.from_dict(payload)
 
 
-def test_allocation_validation_keeps_heap_hard_and_object_windows_soft():
-    unit = _unit(
-        "resource:fragment-1:decode",
-        per_task=_resources(cpu=1, heap_bytes=300, object_store_bytes=50),
-        target_output_block_bytes=100,
-        generator_buffer_blocks=2,
-    )
-    graph = _graph(unit, terminals=(unit.resource_unit_id,))
-    allocation = _allocation(
-        _resources(
-            cpu=4,
-            heap_bytes=299,
-            object_store_bytes=250,
-        ),
-        generation=7,
-    )
+def test_query_allocation_is_an_aggregate_soft_budget():
+    resources = _resources(cpu=0.5, heap_bytes=128, object_store_bytes=400)
+    allocation = QueryAllocation(resources=resources, generation=9)
 
-    with pytest.raises(ValueError, match="heap_bytes"):
-        graph.validate_allocation(allocation)
-
-    graph.validate_allocation(
-        _allocation(
-            _resources(
-                cpu=4,
-                heap_bytes=300,
-                object_store_bytes=1,
-            ),
-            generation=7,
-        )
-    )
-
-
-def test_allocation_accepts_one_output_window_larger_than_soft_object_store_budget():
-    unit = _unit(
-        "resource:fragment-1:decode",
-        target_output_block_bytes=101,
-        generator_buffer_blocks=2,
-    )
-    graph = _graph(unit, terminals=(unit.resource_unit_id,))
-    allocation = _allocation(
-        _resources(cpu=4, heap_bytes=1024 * MIB, object_store_bytes=201),
-        generation=1,
-    )
-
-    graph.validate_allocation(allocation)
-
-
-def test_allocation_rejects_aggregate_resources_that_do_not_form_a_runnable_node():
-    unit = _unit(
-        "resource:fragment-1:decode",
-        per_task=_resources(cpu=2, heap_bytes=300, object_store_bytes=0),
-        target_output_block_bytes=100,
-        generator_buffer_blocks=2,
-    )
-    graph = _graph(unit, terminals=(unit.resource_unit_id,))
-    allocation = QueryAllocation(
-        resources=_resources(cpu=2, heap_bytes=300, object_store_bytes=200),
-        node_allocations=(
-            NodeResourceAllocation(
-                node_id="cpu-only",
-                resources=_resources(cpu=2, heap_bytes=1, object_store_bytes=1),
-            ),
-            NodeResourceAllocation(
-                node_id="memory-only",
-                resources=_resources(cpu=0, heap_bytes=299, object_store_bytes=199),
-            ),
-        ),
-        generation=1,
-    )
-
-    with pytest.raises(ValueError, match="does not fit any allocated Ray node"):
-        graph.validate_allocation(allocation)
-
-
-def test_allocation_validation_can_skip_tasks_outside_the_current_phase():
-    unit = _unit(
-        "resource:fragment-1:decode",
-        per_task=_resources(cpu=1, heap_bytes=300),
-        target_output_block_bytes=100,
-        generator_buffer_blocks=2,
-    )
-    graph = _graph(unit, terminals=(unit.resource_unit_id,))
-    pending = QueryAllocation(
-        resources=ResourceVector(),
-        node_allocations=(),
-        generation=2,
-    )
-
-    with pytest.raises(ValueError, match="maximum task exceeds query allocation"):
-        graph.validate_allocation(pending)
-
-    graph.validate_allocation(pending, eligible_unit_ids=())
-
-
-def test_current_phase_allocation_does_not_reserve_a_task_behind_a_barrier():
-    source = _unit(
-        "resource:q1:source",
-        backend="ray_worker",
-        per_task=ResourceVector(),
-        target_output_block_bytes=0,
-        generator_buffer_blocks=0,
-    )
-    materializer = _unit(
-        "resource:q1:materializer",
-        inputs=(source.resource_unit_id,),
-        backend="ray_worker",
-        per_task=ResourceVector(),
-        target_output_block_bytes=10,
-        generator_buffer_blocks=2,
-    )
-    future_task = _unit(
-        "resource:q1:future-task",
-        inputs=(materializer.resource_unit_id,),
-        per_task=_resources(cpu=2, heap_bytes=300),
-        target_output_block_bytes=10,
-        generator_buffer_blocks=2,
-    )
-    graph = _graph(
-        source,
-        materializer,
-        future_task,
-        terminals=(future_task.resource_unit_id,),
-        barriers=(_barrier("materializer", materializer),),
-    )
-    current = _allocation(
-        ResourceVector(object_store_bytes=20),
-        generation=1,
-    )
-
-    assert graph.eligible_resource_unit_ids(set()) == (
-        source.resource_unit_id,
-        materializer.resource_unit_id,
-    )
-    graph.validate_allocation(
-        current,
-        eligible_unit_ids=graph.eligible_resource_unit_ids(set()),
-    )
-    with pytest.raises(ValueError, match="maximum task exceeds query allocation"):
-        graph.validate_allocation(current)
-
-
-def test_allocation_validation_requires_one_actor_shape_only_in_the_current_phase():
-    actor = _unit(
-        "resource:fragment-1:actor",
-        backend="ray_actor",
-        per_task=_resources(object_store_bytes=100),
-        resident_per_actor=_resources(cpu=1, heap_bytes=300),
-        target_output_block_bytes=100,
-        generator_buffer_blocks=2,
-        actor_pool_size=2,
-    )
-    graph = _graph(actor, terminals=(actor.resource_unit_id,))
-    pending = QueryAllocation(
-        resources=ResourceVector(),
-        node_allocations=(),
-        generation=2,
-    )
-
-    with pytest.raises(ValueError, match="actor process exceeds query allocation"):
-        graph.validate_allocation(pending)
-
-    fragmented = QueryAllocation(
-        resources=_resources(cpu=1, heap_bytes=300),
-        node_allocations=(
-            NodeResourceAllocation(
-                node_id="cpu-only",
-                resources=_resources(cpu=1, heap_bytes=0),
-            ),
-            NodeResourceAllocation(
-                node_id="memory-only",
-                resources=_resources(cpu=0, heap_bytes=300),
-            ),
-        ),
-        generation=2,
-    )
-    with pytest.raises(ValueError, match="actor process does not fit any allocated Ray node"):
-        graph.validate_allocation(fragmented)
-
-    graph.validate_allocation(pending, eligible_unit_ids=())
-
-
-def test_query_allocation_round_trip_requires_exact_per_node_sum():
-    resources = _resources(cpu=3, heap_bytes=300, object_store_bytes=400)
-    allocation = QueryAllocation(
-        resources=resources,
-        node_allocations=(
-            NodeResourceAllocation(
-                node_id="node-a",
-                resources=_resources(cpu=1, heap_bytes=100, object_store_bytes=150),
-            ),
-            NodeResourceAllocation(
-                node_id="node-b",
-                resources=_resources(cpu=2, heap_bytes=200, object_store_bytes=250),
-            ),
-        ),
-        generation=9,
-    )
-
+    assert allocation.resources == resources
     assert QueryAllocation.from_dict(allocation.to_dict()) == allocation
-    with pytest.raises(ValueError, match="sum of node_allocations"):
-        QueryAllocation(
-            resources=resources,
-            node_allocations=allocation.node_allocations[:1],
-            generation=9,
-        )
+    assert allocation.to_dict() == {
+        "resources": resources.to_dict(),
+        "generation": 9,
+    }
+
+
+def test_query_allocation_accepts_zero_budget_for_real_ray_core_pending_demand():
+    allocation = QueryAllocation(resources=ResourceVector(), generation=1)
+
+    assert allocation.resources.is_zero()
+
+
+def test_query_allocation_rejects_removed_node_placement_fields():
+    payload = QueryAllocation(resources=ResourceVector(), generation=1).to_dict()
+    payload["node_allocations"] = []
+
+    with pytest.raises(ValueError, match="unknown fields: node_allocations"):
+        QueryAllocation.from_dict(payload)

--- a/tests/fast/test_query_resource_graph.py
+++ b/tests/fast/test_query_resource_graph.py
@@ -72,10 +72,13 @@ def _unit(
             "ray_actor": "ray_actor_pool",
         }[backend]
     )
+    default_physical_node_id = resource_unit_id.rsplit(":", 1)[-1]
+    if backend == "ray_worker":
+        default_physical_node_id = f"node:{default_physical_node_id}:native-fragment"
     return ResourceUnitSpec(
         query_id="q1",
         resource_unit_id=resource_unit_id,
-        physical_node_id=physical_node_id or resource_unit_id.rsplit(":", 1)[-1],
+        physical_node_id=physical_node_id or default_physical_node_id,
         unit_kind=resolved_unit_kind,
         backend=backend,
         input_unit_ids=inputs,
@@ -137,6 +140,19 @@ def test_resource_vector_arithmetic_is_component_wise_and_non_mutating():
     assert left == _resources(cpu=1.5, gpu=0.25, heap_bytes=10, object_store_bytes=20)
 
 
+def test_resource_vector_tolerates_fractional_cpu_gpu_rounding():
+    capacity = _resources(cpu=0.3, gpu=0.3, heap_bytes=0)
+    summed = _resources(cpu=0.1, gpu=0.1, heap_bytes=0) + _resources(
+        cpu=0.2,
+        gpu=0.2,
+        heap_bytes=0,
+    )
+
+    assert summed.fits_within(capacity)
+    assert summed.exceeded_dimensions(capacity) == ()
+    assert capacity - summed == ResourceVector()
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -182,7 +198,7 @@ def test_graph_orders_units_deterministically_and_preserves_one_unit_identity_fo
         cpu_udf.resource_unit_id,
         scan.resource_unit_id,
     )
-    assert graph.unit_id_for_physical_node("scan") == scan.resource_unit_id
+    assert graph.unit_id_for_physical_node("node:scan:native-fragment") == scan.resource_unit_id
     assert graph.task_identity(scan.resource_unit_id, partition_id=0, attempt_id="a1") == (
         "task:resource:fragment-1:scan:partition:0:attempt:a1"
     )
@@ -207,8 +223,8 @@ def test_completed_barrier_retires_old_phase_before_next_phase_becomes_eligible(
         max_concurrency=4,
     )
     sink = _unit("resource:q1:sink", inputs=(second.resource_unit_id,))
-    first_barrier = _barrier("first", first)
-    second_barrier = _barrier("second", second)
+    first_barrier = _barrier("first-barrier", first)
+    second_barrier = _barrier("second-barrier", second)
     graph = _graph(
         scan,
         first,
@@ -234,6 +250,44 @@ def test_completed_barrier_retires_old_phase_before_next_phase_becomes_eligible(
     )
 
 
+def test_directly_adjacent_barrier_waits_for_upstream_materialized_output():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=4)
+    first = _unit(
+        "resource:q1:first-barrier",
+        inputs=(scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    second = _unit(
+        "resource:q1:second-barrier",
+        inputs=(first.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    sink = _unit("resource:q1:sink", inputs=(second.resource_unit_id,))
+    first_barrier = _barrier("first-barrier", first)
+    second_barrier = _barrier("second-barrier", second)
+    graph = _graph(
+        scan,
+        first,
+        second,
+        sink,
+        terminals=(sink.resource_unit_id,),
+        barriers=(first_barrier, second_barrier),
+    )
+
+    assert graph.eligible_resource_unit_ids(set()) == (
+        scan.resource_unit_id,
+        first.resource_unit_id,
+    )
+    assert graph.frontier_materialization_barriers(set()) == (first_barrier,)
+    assert graph.eligible_resource_unit_ids({first_barrier.barrier_id}) == (
+        first.resource_unit_id,
+        second.resource_unit_id,
+    )
+    assert graph.frontier_materialization_barriers({first_barrier.barrier_id}) == (second_barrier,)
+
+
 def test_parallel_first_barriers_share_one_execution_phase_union():
     scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=4)
     left = _unit(
@@ -249,8 +303,8 @@ def test_parallel_first_barriers_share_one_execution_phase_union():
         max_concurrency=4,
     )
     join = _unit("resource:q1:join", inputs=(left.resource_unit_id, right.resource_unit_id))
-    left_barrier = _barrier("left", left)
-    right_barrier = _barrier("right", right)
+    left_barrier = _barrier("left-barrier", left)
+    right_barrier = _barrier("right-barrier", right)
     graph = _graph(
         scan,
         left,
@@ -304,8 +358,8 @@ def test_completed_parallel_barrier_opens_its_streaming_branch_before_sibling_ba
         "resource:q1:join",
         inputs=(left_stream.resource_unit_id, right_barrier_unit.resource_unit_id),
     )
-    left_barrier = _barrier("left", left_barrier_unit)
-    right_barrier = _barrier("right", right_barrier_unit)
+    left_barrier = _barrier("left-barrier", left_barrier_unit)
+    right_barrier = _barrier("right-barrier", right_barrier_unit)
     graph = _graph(
         left_scan,
         left_barrier_unit,
@@ -367,6 +421,69 @@ def test_asymmetric_barrier_switches_from_materialized_to_deferred_input_branch(
     assert graph.eligible_resource_unit_ids({barrier.barrier_id}) == (
         probe_scan.resource_unit_id,
         probe_udf.resource_unit_id,
+        broadcast_join.resource_unit_id,
+        sink.resource_unit_id,
+    )
+
+
+def test_nested_deferred_barrier_materializes_in_parallel_without_reviving_retired_input():
+    build_scan = _unit("resource:q1:build-scan", backend="ray_worker", max_concurrency=4)
+    probe_scan = _unit("resource:q1:probe-scan", backend="ray_worker", max_concurrency=4)
+    probe_barrier_unit = _unit(
+        "resource:q1:probe-barrier",
+        inputs=(probe_scan.resource_unit_id,),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    probe_stream = _unit(
+        "resource:q1:probe-stream",
+        inputs=(probe_barrier_unit.resource_unit_id,),
+    )
+    broadcast_join = _unit(
+        "resource:q1:broadcast-join",
+        inputs=(build_scan.resource_unit_id, probe_stream.resource_unit_id),
+        backend="ray_worker",
+        max_concurrency=4,
+    )
+    sink = _unit("resource:q1:sink", inputs=(broadcast_join.resource_unit_id,))
+    probe_barrier = _barrier("probe-barrier", probe_barrier_unit)
+    broadcast_barrier = _barrier(
+        "broadcast-join",
+        broadcast_join,
+        materialized_inputs=(build_scan.resource_unit_id,),
+    )
+    graph = _graph(
+        build_scan,
+        probe_scan,
+        probe_barrier_unit,
+        probe_stream,
+        broadcast_join,
+        sink,
+        terminals=(sink.resource_unit_id,),
+        barriers=(probe_barrier, broadcast_barrier),
+    )
+
+    assert graph.eligible_resource_unit_ids(set()) == (
+        build_scan.resource_unit_id,
+        probe_scan.resource_unit_id,
+        probe_barrier_unit.resource_unit_id,
+        broadcast_join.resource_unit_id,
+    )
+    assert graph.frontier_materialization_barriers(set()) == (
+        probe_barrier,
+        broadcast_barrier,
+    )
+    assert graph.eligible_resource_unit_ids({probe_barrier.barrier_id}) == (
+        build_scan.resource_unit_id,
+        broadcast_join.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({broadcast_barrier.barrier_id}) == (
+        probe_scan.resource_unit_id,
+        probe_barrier_unit.resource_unit_id,
+    )
+    assert graph.eligible_resource_unit_ids({probe_barrier.barrier_id, broadcast_barrier.barrier_id}) == (
+        probe_barrier_unit.resource_unit_id,
+        probe_stream.resource_unit_id,
         broadcast_join.resource_unit_id,
         sink.resource_unit_id,
     )
@@ -452,6 +569,29 @@ def test_graph_rejects_barrier_id_for_a_different_physical_node():
     )
 
     with pytest.raises(ValueError, match="invalid materialization barrier identity"):
+        _graph(scan, sink, terminals=(sink.resource_unit_id,), barriers=(barrier,))
+
+
+def test_graph_rejects_barrier_for_a_different_materializer_physical_node():
+    scan = _unit("resource:q1:scan", backend="ray_worker", max_concurrency=1)
+    sink = _unit(
+        "resource:q1:sink",
+        inputs=(scan.resource_unit_id,),
+        physical_node_id="node:actual-sink:native-fragment",
+        backend="ray_worker",
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=1,
+    )
+    barrier = MaterializationBarrierSpec(
+        query_id="q1",
+        barrier_id="barrier:q1:node:reported-sink",
+        physical_node_id="reported-sink",
+        materializer_unit_id=sink.resource_unit_id,
+        materialized_input_unit_ids=(scan.resource_unit_id,),
+    )
+
+    with pytest.raises(ValueError, match="does not match materializer"):
         _graph(scan, sink, terminals=(sink.resource_unit_id,), barriers=(barrier,))
 
 

--- a/tests/fast/test_query_resource_graph_builder.py
+++ b/tests/fast/test_query_resource_graph_builder.py
@@ -3,7 +3,10 @@
 
 import pytest
 
-from duckdb.runners.ray.cluster_resource_coordinator import ActorResourceBundle
+from duckdb.runners.ray.cluster_resource_coordinator import (
+    ClusterQueryResourceCoordinator,
+    NodeCapacity,
+)
 from duckdb.runners.ray.query_resource_graph import ResourceVector
 from duckdb.runners.ray.query_resource_graph_builder import (
     build_query_demand,
@@ -17,6 +20,10 @@ GIB = 1024**3
 MIB = 1024**2
 
 
+def _single_node_cluster(resources: ResourceVector) -> tuple[NodeCapacity, ...]:
+    return (NodeCapacity("node-a", resources),)
+
+
 def _metadata():
     query_id = "query-7"
     return {
@@ -27,6 +34,8 @@ def _metadata():
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 36,
                 "udf_payload": None,
             },
@@ -35,6 +44,8 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["1"],
                 "is_sink": False,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 36,
                 "udf_payload": {
                     "execution_backend": "ray_task",
@@ -51,6 +62,8 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["2"],
                 "is_sink": False,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 1,
                 "udf_payload": {
                     "execution_backend": "ray_actor",
@@ -68,6 +81,8 @@ def _metadata():
                 "node_name": "CopyFinish",
                 "input_node_ids": ["3"],
                 "is_sink": True,
+                "is_materialization_barrier": False,
+                "materialized_input_node_ids": [],
                 "num_partitions": 1,
                 "udf_payload": None,
             },
@@ -152,7 +167,7 @@ def test_builder_uses_two_logical_output_blocks_for_all_streaming_units():
     assert gpu_udf.generator_buffer_blocks == 2
 
 
-def test_builder_sizes_upstream_retention_window_for_downstream_compute_batch():
+def test_builder_keeps_generator_buffer_independent_of_downstream_compute_batch():
     metadata = _metadata()
     producer = metadata["nodes"][1]["udf_payload"]
     consumer = metadata["nodes"][2]["udf_payload"]
@@ -163,8 +178,11 @@ def test_builder_sizes_upstream_retention_window_for_downstream_compute_batch():
     cpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "2"))
 
     assert cpu_udf.target_output_block_bytes == 1024
-    assert cpu_udf.generator_buffer_blocks == 64
-    assert cpu_udf.output_window_bytes == 64 * 1024
+    # The producer only shapes Ray's streaming-generator buffer. Downstream
+    # accumulation is represented by exact managed ObjectRefs, not by inflating
+    # every upstream task's pending-output estimate.
+    assert cpu_udf.generator_buffer_blocks == 2
+    assert cpu_udf.output_window_bytes == 2 * 1024
 
 
 def test_builder_leaves_udf_heap_unreserved_when_memory_is_not_declared():
@@ -178,9 +196,23 @@ def test_builder_leaves_udf_heap_unreserved_when_memory_is_not_declared():
     assert graph.unit_by_id(udf_unit_id_for_node("query-7", "3")).resident_per_actor.heap_bytes == 0
 
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
     assert demand.minimum.heap_bytes == 0
     assert demand.desired.heap_bytes == 0
+
+
+def test_builder_maps_materialized_physical_input_to_its_output_resource_unit():
+    metadata = _metadata()
+    materializer = metadata["nodes"][3]
+    materializer["node_name"] = "OrderBy"
+    materializer["is_materialization_barrier"] = True
+    materializer["materialized_input_node_ids"] = ["3"]
+
+    graph = build_query_resource_graph(metadata, env={})
+
+    assert len(graph.materialization_barriers) == 1
+    barrier = graph.materialization_barriers[0]
+    assert barrier.materialized_input_unit_ids == (udf_unit_id_for_node("query-7", "3"),)
 
 
 def test_builder_requires_declared_heap_to_be_positive():
@@ -209,6 +241,23 @@ def test_builder_rejects_missing_or_mismatched_preannotated_udf_resource_unit_id
         (lambda payload: payload.update({"legacy_operators": []}), "unknown fields"),
         (lambda payload: payload.update({"terminal_node_ids": ["missing"]}), "terminal node"),
         (lambda payload: payload["nodes"][1].update({"input_node_ids": ["missing"]}), "input node"),
+        (
+            lambda payload: payload["nodes"][1].update({"is_materialization_barrier": True}),
+            "if and only if",
+        ),
+        (
+            lambda payload: payload["nodes"][1].update({"materialized_input_node_ids": ["1", "1"]}),
+            "duplicate materialized",
+        ),
+        (
+            lambda payload: payload["nodes"][1].update(
+                {
+                    "is_materialization_barrier": True,
+                    "materialized_input_node_ids": ["4"],
+                }
+            ),
+            "not a direct input",
+        ),
     ],
 )
 def test_builder_rejects_incomplete_or_legacy_metadata(mutation, message):
@@ -234,11 +283,11 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_reserves_only_remote_process_bundles():
+def test_query_demand_hard_reserves_one_ray_task_and_soft_accounts_actor_processes():
     graph = build_query_resource_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
 
     assert demand.query_id == graph.query_id
     assert demand.desired == ResourceVector(
@@ -247,22 +296,10 @@ def test_query_demand_reserves_only_remote_process_bundles():
         heap_bytes=64 * GIB,
         object_store_bytes=64 * GIB,
     )
-    assert demand.actor_bundles == (
-        ActorResourceBundle(
-            resource_unit_id="resource:query-7:udf:node:3",
-            actor_index=0,
-            resources=ResourceVector(
-                cpu=1,
-                gpu=1,
-                heap_bytes=3 * GIB,
-            ),
-        ),
-    )
     assert demand.task_bundles == (ResourceVector(cpu=1, heap_bytes=1536 * MIB),)
     assert demand.minimum == ResourceVector(
-        cpu=2,
-        gpu=1,
-        heap_bytes=3 * GIB + 1536 * MIB,
+        cpu=1,
+        heap_bytes=1536 * MIB,
     )
 
 
@@ -273,13 +310,12 @@ def test_pure_native_query_demands_only_a_soft_object_store_budget():
     graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=8 * GIB)
 
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
 
     assert all(unit.backend == "ray_worker" for unit in graph.units)
     assert all(unit.per_task == ResourceVector() for unit in graph.units)
     assert demand.minimum == ResourceVector()
     assert demand.task_bundles == ()
-    assert demand.actor_bundles == ()
     assert demand.desired == ResourceVector(object_store_bytes=8 * GIB)
 
 
@@ -294,11 +330,10 @@ def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38
         object_store_bytes=512 * MIB,
     )
 
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
 
     assert demand.minimum.object_store_bytes == 0
     assert demand.desired.object_store_bytes == 512 * MIB
-    assert all(bundle.resources.object_store_bytes == 0 for bundle in demand.actor_bundles)
     assert all(bundle.object_store_bytes == 0 for bundle in demand.task_bundles)
 
 
@@ -308,15 +343,115 @@ def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():
     graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
 
-    assert demand.minimum.gpu == 2
-    assert demand.desired.gpu == 2
-    assert demand.actor_bundles[0].resources.gpu == 1
+    assert demand.minimum.gpu == 1
+    assert demand.desired.gpu == 4
     assert demand.task_bundles[0].gpu == 1
 
 
-def test_query_demand_reserves_every_fractional_gpu_actor_in_fixed_pool():
+def test_query_demand_uses_real_node_envelopes_for_heterogeneous_ray_tasks():
+    metadata = _metadata()
+    cpu_payload = metadata["nodes"][1]["udf_payload"]
+    cpu_payload["cpus"] = 4.0
+    cpu_payload.pop("memory_bytes")
+    gpu_payload = metadata["nodes"][2]["udf_payload"]
+    gpu_payload["execution_backend"] = "ray_task"
+    gpu_payload["cpus"] = 1.0
+    gpu_payload["gpus"] = 1.0
+    gpu_payload.pop("memory_bytes")
+    gpu_payload.pop("actor_pool_size")
+    graph = build_query_resource_graph(metadata, env={})
+    nodes = (
+        NodeCapacity(
+            "cpu-node",
+            ResourceVector(cpu=4, object_store_bytes=GIB),
+        ),
+        NodeCapacity(
+            "gpu-node",
+            ResourceVector(cpu=1, gpu=1, object_store_bytes=GIB),
+        ),
+    )
+
+    demand = build_query_demand(graph, nodes)
+
+    assert demand.task_bundles == (
+        ResourceVector(cpu=1, gpu=1),
+        ResourceVector(cpu=4),
+    )
+    assert demand.minimum == ResourceVector(cpu=5, gpu=1)
+    coordinator = ClusterQueryResourceCoordinator(nodes)
+    allocation = coordinator.register_query(demand, now=0)
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
+    graph.validate_allocation(allocation)
+
+
+def test_query_demand_collapses_heterogeneous_task_shapes_that_share_one_node():
+    metadata = _metadata()
+    cpu_payload = metadata["nodes"][1]["udf_payload"]
+    cpu_payload["cpus"] = 4.0
+    cpu_payload.pop("memory_bytes")
+    gpu_payload = metadata["nodes"][2]["udf_payload"]
+    gpu_payload["execution_backend"] = "ray_task"
+    gpu_payload["cpus"] = 1.0
+    gpu_payload["gpus"] = 1.0
+    gpu_payload.pop("memory_bytes")
+    gpu_payload.pop("actor_pool_size")
+    graph = build_query_resource_graph(metadata, env={})
+    nodes = (
+        NodeCapacity(
+            "combined-node",
+            ResourceVector(cpu=4, gpu=1, object_store_bytes=GIB),
+        ),
+    )
+
+    demand = build_query_demand(graph, nodes)
+
+    assert demand.task_bundles == (ResourceVector(cpu=4, gpu=1),)
+    assert demand.minimum == ResourceVector(cpu=4, gpu=1)
+
+
+def test_capacity_topology_change_rebuilds_task_capability_envelopes():
+    metadata = _metadata()
+    cpu_payload = metadata["nodes"][1]["udf_payload"]
+    cpu_payload["cpus"] = 4.0
+    cpu_payload.pop("memory_bytes")
+    gpu_payload = metadata["nodes"][2]["udf_payload"]
+    gpu_payload["execution_backend"] = "ray_task"
+    gpu_payload["cpus"] = 1.0
+    gpu_payload["gpus"] = 1.0
+    gpu_payload.pop("memory_bytes")
+    gpu_payload.pop("actor_pool_size")
+    graph = build_query_resource_graph(metadata, env={})
+    combined = (
+        NodeCapacity(
+            "combined-node",
+            ResourceVector(cpu=4, gpu=1, object_store_bytes=2 * GIB),
+        ),
+    )
+    split = (
+        NodeCapacity("cpu-node", ResourceVector(cpu=4, object_store_bytes=GIB)),
+        NodeCapacity("gpu-node", ResourceVector(cpu=1, gpu=1, object_store_bytes=GIB)),
+    )
+    coordinator = ClusterQueryResourceCoordinator(combined)
+    allocation = coordinator.register_query(build_query_demand(graph, combined), now=0)
+
+    coordinator.update_node_capacities(split, now=1)
+    pending = coordinator.snapshot()["queries"][graph.query_id]
+    assert pending["state"] == "PENDING_RESOURCES"
+
+    allocation = coordinator.refresh_queries(
+        observed_usage_by_query={graph.query_id: ResourceVector()},
+        generations={graph.query_id: pending["allocation"]["generation"]},
+        demands_by_query={graph.query_id: build_query_demand(graph, split)},
+        now=1,
+    )[graph.query_id]
+
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
+    graph.validate_allocation(allocation)
+
+
+def test_query_demand_does_not_turn_fixed_actor_pool_size_into_hard_admission():
     metadata = _metadata()
     actor_payload = metadata["nodes"][2]["udf_payload"]
     actor_payload["actor_pool_size"] = 3
@@ -324,14 +459,13 @@ def test_query_demand_reserves_every_fractional_gpu_actor_in_fixed_pool():
     graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
-    demand = build_query_demand(graph, cluster)
+    demand = build_query_demand(graph, _single_node_cluster(cluster))
     actor_unit = graph.unit_by_id(udf_unit_id_for_node("query-7", "3"))
 
     assert actor_unit.actor_pool_size == 3
-    assert [bundle.actor_index for bundle in demand.actor_bundles] == [0, 1, 2]
-    assert all(bundle.resources.gpu == 0.25 for bundle in demand.actor_bundles)
-    assert demand.minimum.gpu == 0.75
-    assert demand.desired.gpu == demand.minimum.gpu
+    assert actor_unit.resident_per_actor.gpu == 0.25
+    assert demand.minimum.gpu == 0
+    assert demand.desired.gpu == 0.75
 
 
 def test_fragment_identity_maps_directly_to_pre_registered_native_fragment_unit():

--- a/tests/fast/test_query_resource_graph_builder.py
+++ b/tests/fast/test_query_resource_graph_builder.py
@@ -197,7 +197,6 @@ def test_builder_leaves_udf_heap_unreserved_when_memory_is_not_declared():
 
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
     demand = build_query_demand(graph, _single_node_cluster(cluster))
-    assert demand.minimum.heap_bytes == 0
     assert demand.desired.heap_bytes == 0
 
 
@@ -283,7 +282,7 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_hard_reserves_task_and_actor_shapes_but_soft_accounts_actor_pool_size():
+def test_query_demand_is_an_aggregate_soft_target_for_current_ray_units():
     graph = build_query_resource_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
@@ -295,12 +294,6 @@ def test_query_demand_hard_reserves_task_and_actor_shapes_but_soft_accounts_acto
         gpu=1,
         heap_bytes=64 * GIB,
         object_store_bytes=64 * GIB,
-    )
-    assert demand.placement_bundles == (ResourceVector(cpu=1, gpu=1, heap_bytes=3 * GIB),)
-    assert demand.minimum == ResourceVector(
-        cpu=1,
-        gpu=1,
-        heap_bytes=3 * GIB,
     )
 
 
@@ -315,8 +308,6 @@ def test_pure_native_query_demands_only_a_soft_object_store_budget():
 
     assert all(unit.backend == "ray_worker" for unit in graph.units)
     assert all(unit.per_task == ResourceVector() for unit in graph.units)
-    assert demand.minimum == ResourceVector()
-    assert demand.placement_bundles == ()
     assert demand.desired == ResourceVector(object_store_bytes=8 * GIB)
 
 
@@ -333,12 +324,10 @@ def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38
 
     demand = build_query_demand(graph, _single_node_cluster(cluster))
 
-    assert demand.minimum.object_store_bytes == 0
     assert demand.desired.object_store_bytes == 512 * MIB
-    assert all(bundle.object_store_bytes == 0 for bundle in demand.placement_bundles)
 
 
-def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_placement_bundle():
+def test_ray_task_dimension_targets_the_current_aggregate_cluster_capacity():
     metadata = _metadata()
     metadata["nodes"][1]["udf_payload"]["gpus"] = 1.0
     graph = build_query_resource_graph(metadata, env={})
@@ -346,12 +335,10 @@ def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_placement_bundle()
 
     demand = build_query_demand(graph, _single_node_cluster(cluster))
 
-    assert demand.minimum.gpu == 1
     assert demand.desired.gpu == 4
-    assert demand.placement_bundles[0].gpu == 1
 
 
-def test_query_demand_uses_real_node_envelopes_for_heterogeneous_ray_tasks():
+def test_heterogeneous_ray_task_shapes_produce_one_aggregate_soft_target():
     metadata = _metadata()
     cpu_payload = metadata["nodes"][1]["udf_payload"]
     cpu_payload["cpus"] = 4.0
@@ -376,18 +363,17 @@ def test_query_demand_uses_real_node_envelopes_for_heterogeneous_ray_tasks():
 
     demand = build_query_demand(graph, nodes)
 
-    assert demand.placement_bundles == (
-        ResourceVector(cpu=1, gpu=1),
-        ResourceVector(cpu=4),
+    assert demand.desired == ResourceVector(
+        cpu=5,
+        gpu=1,
+        object_store_bytes=2 * GIB,
     )
-    assert demand.minimum == ResourceVector(cpu=5, gpu=1)
     coordinator = ClusterQueryResourceCoordinator(nodes)
     allocation = coordinator.register_query(demand, now=0)
     assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
-    graph.validate_allocation(allocation)
 
 
-def test_query_demand_collapses_heterogeneous_task_shapes_that_share_one_node():
+def test_query_demand_does_not_infer_node_placement_envelopes():
     metadata = _metadata()
     cpu_payload = metadata["nodes"][1]["udf_payload"]
     cpu_payload["cpus"] = 4.0
@@ -408,11 +394,10 @@ def test_query_demand_collapses_heterogeneous_task_shapes_that_share_one_node():
 
     demand = build_query_demand(graph, nodes)
 
-    assert demand.placement_bundles == (ResourceVector(cpu=4, gpu=1),)
-    assert demand.minimum == ResourceVector(cpu=4, gpu=1)
+    assert demand.desired == ResourceVector(cpu=4, gpu=1, object_store_bytes=GIB)
 
 
-def test_capacity_topology_change_rebuilds_placement_capability_envelopes():
+def test_capacity_topology_change_only_rebuilds_the_aggregate_soft_target():
     metadata = _metadata()
     cpu_payload = metadata["nodes"][1]["udf_payload"]
     cpu_payload["cpus"] = 4.0
@@ -438,22 +423,23 @@ def test_capacity_topology_change_rebuilds_placement_capability_envelopes():
     allocation = coordinator.register_query(build_query_demand(graph, combined), now=0)
 
     coordinator.update_node_capacities(split, now=1)
-    pending = coordinator.snapshot()["queries"][graph.query_id]
-    assert pending["state"] == "PENDING_RESOURCES"
+    current = coordinator.snapshot()["queries"][graph.query_id]
+    assert current["state"] == "RUNNING"
 
     allocation = coordinator.refresh_queries(
         observed_usage_by_query={graph.query_id: ResourceVector()},
-        generations={graph.query_id: pending["allocation"]["generation"]},
+        generations={graph.query_id: current["allocation"]["generation"]},
         demands_by_query={graph.query_id: build_query_demand(graph, split)},
         now=1,
     )[graph.query_id]
 
     assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
-    graph.validate_allocation(allocation)
+    assert allocation.resources == ResourceVector(cpu=5, gpu=1, object_store_bytes=2 * GIB)
 
 
-def test_query_demand_does_not_turn_fixed_actor_pool_size_into_hard_admission():
+def test_actor_only_demand_counts_the_fixed_pool_once_and_caps_it_to_capacity():
     metadata = _metadata()
+    metadata["nodes"][1]["udf_payload"] = None
     actor_payload = metadata["nodes"][2]["udf_payload"]
     actor_payload["actor_pool_size"] = 3
     actor_payload["gpus"] = 0.25
@@ -465,12 +451,38 @@ def test_query_demand_does_not_turn_fixed_actor_pool_size_into_hard_admission():
 
     assert actor_unit.actor_pool_size == 3
     assert actor_unit.resident_per_actor.gpu == 0.25
-    assert demand.minimum.gpu == 0.25
-    assert demand.desired.gpu == 0.75
+    assert demand.desired == ResourceVector(
+        cpu=3,
+        gpu=0.75,
+        heap_bytes=9 * GIB,
+        object_store_bytes=64 * GIB,
+    )
+
+
+def test_fixed_actor_pool_does_not_add_a_synthetic_task_continuation_floor():
+    metadata = _metadata()
+    task_payload = metadata["nodes"][1]["udf_payload"]
+    task_payload["cpus"] = 1.0
+    task_payload.pop("memory_bytes")
+    actor_payload = metadata["nodes"][2]["udf_payload"]
+    actor_payload["actor_pool_size"] = 4
+    actor_payload["cpus"] = 1.0
+    actor_payload["gpus"] = 0.0
+    actor_payload.pop("memory_bytes")
+    graph = build_query_resource_graph(metadata, env={})
+    four_cpus = _single_node_cluster(ResourceVector(cpu=4, object_store_bytes=GIB))
+
+    demand = build_query_demand(graph, four_cpus)
+    coordinator = ClusterQueryResourceCoordinator(four_cpus)
+    allocation = coordinator.register_query(demand, now=0)
+
+    assert demand.desired == ResourceVector(cpu=4, object_store_bytes=GIB)
+    assert allocation.resources == demand.desired
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
 
 
 @pytest.mark.parametrize("gpu_node_count", [1, 2])
-def test_actor_shape_stays_pending_until_one_concrete_node_can_run_it(gpu_node_count):
+def test_actor_shape_feasibility_is_left_to_the_real_ray_actor_request(gpu_node_count):
     metadata = _metadata()
     metadata["nodes"][1]["udf_payload"] = None
     actor_payload = metadata["nodes"][2]["udf_payload"]
@@ -485,19 +497,52 @@ def test_actor_shape_stays_pending_until_one_concrete_node_can_run_it(gpu_node_c
 
     demand = build_query_demand(graph, split)
 
-    assert demand.placement_bundles == (ResourceVector(cpu=1, gpu=2),)
-    assert demand.minimum == ResourceVector(cpu=1, gpu=2)
-    assert demand.desired.gpu == 2
+    assert demand.desired.gpu == min(gpu_node_count, 2)
     coordinator = ClusterQueryResourceCoordinator(split)
     allocation = coordinator.register_query(demand, now=0)
-    assert coordinator.query_state(graph.query_id, allocation.generation) == "PENDING_RESOURCES"
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
 
-    coordinator.update_node_capacities(
-        (NodeCapacity("gpu-capable", ResourceVector(cpu=4, gpu=2, object_store_bytes=2 * GIB)),),
-        now=1,
+
+def test_empty_capacity_snapshot_keeps_zero_soft_demand_runnable():
+    graph = build_query_resource_graph(_metadata(), env={})
+
+    demand = build_query_demand(graph, ())
+    coordinator = ClusterQueryResourceCoordinator(())
+    allocation = coordinator.register_query(demand, now=0)
+
+    assert demand.desired.is_zero()
+    assert allocation.resources.is_zero()
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "RUNNING"
+
+
+def test_completed_barrier_retires_prior_phase_ray_process_demand():
+    metadata = _metadata()
+    sink = metadata["nodes"][3]
+    sink["node_name"] = "OrderBy"
+    sink["is_materialization_barrier"] = True
+    sink["materialized_input_node_ids"] = ["3"]
+    graph = build_query_resource_graph(metadata, env={})
+    cluster = _single_node_cluster(ResourceVector(cpu=8, gpu=2, heap_bytes=16 * GIB, object_store_bytes=4 * GIB))
+    barrier = graph.materialization_barriers[0]
+
+    before = build_query_demand(
+        graph,
+        cluster,
+        eligible_unit_ids=graph.eligible_resource_unit_ids(set()),
     )
-    snapshot = coordinator.snapshot()["queries"][graph.query_id]
-    assert snapshot["state"] == "RUNNING"
+    after = build_query_demand(
+        graph,
+        cluster,
+        eligible_unit_ids=graph.eligible_resource_unit_ids({barrier.barrier_id}),
+    )
+
+    assert before.desired == ResourceVector(
+        cpu=8,
+        gpu=1,
+        heap_bytes=16 * GIB,
+        object_store_bytes=4 * GIB,
+    )
+    assert after.desired == ResourceVector(object_store_bytes=4 * GIB)
 
 
 def test_fragment_identity_maps_directly_to_pre_registered_native_fragment_unit():

--- a/tests/fast/test_query_resource_graph_builder.py
+++ b/tests/fast/test_query_resource_graph_builder.py
@@ -27,7 +27,6 @@ def _metadata():
                 "node_name": "ScanSource",
                 "input_node_ids": [],
                 "is_sink": False,
-                "is_blocking_materializing": False,
                 "num_partitions": 36,
                 "udf_payload": None,
             },
@@ -36,7 +35,6 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["1"],
                 "is_sink": False,
-                "is_blocking_materializing": False,
                 "num_partitions": 36,
                 "udf_payload": {
                     "execution_backend": "ray_task",
@@ -53,7 +51,6 @@ def _metadata():
                 "node_name": "StreamingUDF",
                 "input_node_ids": ["2"],
                 "is_sink": False,
-                "is_blocking_materializing": False,
                 "num_partitions": 1,
                 "udf_payload": {
                     "execution_backend": "ray_actor",
@@ -71,7 +68,6 @@ def _metadata():
                 "node_name": "CopyFinish",
                 "input_node_ids": ["3"],
                 "is_sink": True,
-                "is_blocking_materializing": True,
                 "num_partitions": 1,
                 "udf_payload": None,
             },
@@ -95,21 +91,9 @@ def test_builder_registers_complete_pipeline_and_nested_resource_units_before_ex
         native_fragment_unit_id_for_node("query-7", "4"),
     )
     assert graph.terminal_unit_ids == (native_fragment_unit_id_for_node("query-7", "4"),)
-    assert graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4")).is_barrier
 
 
-def test_builder_uses_native_materialization_metadata_instead_of_sink_shape():
-    metadata = _metadata()
-    metadata["nodes"][1]["is_blocking_materializing"] = True
-    metadata["nodes"][3]["is_blocking_materializing"] = False
-
-    graph = build_query_resource_graph(metadata, env={})
-
-    assert graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "2")).is_barrier
-    assert not graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4")).is_barrier
-
-
-def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():
+def test_builder_delegates_native_process_resources_and_counts_each_ray_process():
     graph = build_query_resource_graph(_metadata(), env={})
     cpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "2"))
     gpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "3"))
@@ -119,11 +103,10 @@ def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():
     native_sink = graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4"))
 
     assert scan.backend == "ray_worker"
-    # Node 1 is the task-producing feeder immediately before the remote UDF.
-    assert scan.per_task == ResourceVector(cpu=1, heap_bytes=512 * MIB)
-    assert cpu_udf_parent.per_task == ResourceVector(cpu=1, heap_bytes=512 * MIB)
-    assert gpu_udf_parent.per_task == ResourceVector(cpu=1, heap_bytes=512 * MIB)
-    assert native_sink.per_task == ResourceVector(cpu=1, heap_bytes=2 * GIB)
+    assert scan.per_task == ResourceVector()
+    assert cpu_udf_parent.per_task == ResourceVector()
+    assert gpu_udf_parent.per_task == ResourceVector()
+    assert native_sink.per_task == ResourceVector()
     assert cpu_udf.backend == "ray_task"
     assert cpu_udf.per_task == ResourceVector(cpu=1, heap_bytes=1536 * MIB, object_store_bytes=128 * MIB)
     assert cpu_udf.max_concurrency is None
@@ -184,25 +167,23 @@ def test_builder_sizes_upstream_retention_window_for_downstream_compute_batch():
     assert cpu_udf.output_window_bytes == 64 * 1024
 
 
-def test_builder_defaults_are_new_positive_production_limits_not_host_memory():
+def test_builder_leaves_udf_heap_unreserved_when_memory_is_not_declared():
     metadata = _metadata()
     del metadata["nodes"][1]["udf_payload"]["memory_bytes"]
     del metadata["nodes"][2]["udf_payload"]["memory_bytes"]
 
     graph = build_query_resource_graph(metadata, env={})
 
-    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "2")).per_task.heap_bytes == 2 * GIB
-    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "3")).resident_per_actor.heap_bytes == 4 * GIB
+    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "2")).per_task.heap_bytes == 0
+    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "3")).resident_per_actor.heap_bytes == 0
+
+    cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
+    demand = build_query_demand(graph, cluster)
+    assert demand.minimum.heap_bytes == 0
+    assert demand.desired.heap_bytes == 0
 
 
-def test_builder_accepts_only_positive_new_resource_configuration():
-    with pytest.raises(ValueError, match="VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES"):
-        build_query_resource_graph(_metadata(), env={"VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES": "0"})
-    with pytest.raises(ValueError, match="VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES"):
-        build_query_resource_graph(
-            _metadata(),
-            env={"VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES": "0"},
-        )
+def test_builder_requires_declared_heap_to_be_positive():
     with pytest.raises(ValueError, match="memory_bytes"):
         metadata = _metadata()
         metadata["nodes"][1]["udf_payload"]["memory_bytes"] = 0
@@ -253,7 +234,7 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_reserves_hard_actor_pool_and_downstream_native_fragment_progress_slot():
+def test_query_demand_reserves_only_remote_process_bundles():
     graph = build_query_resource_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
@@ -277,16 +258,29 @@ def test_query_demand_reserves_hard_actor_pool_and_downstream_native_fragment_pr
             ),
         ),
     )
-    assert demand.task_bundles == (
-        ResourceVector(cpu=1, heap_bytes=1536 * MIB),
-        ResourceVector(cpu=1, heap_bytes=2 * GIB),
-        ResourceVector(cpu=1, heap_bytes=2 * GIB),
-    )
+    assert demand.task_bundles == (ResourceVector(cpu=1, heap_bytes=1536 * MIB),)
     assert demand.minimum == ResourceVector(
-        cpu=4,
+        cpu=2,
         gpu=1,
-        heap_bytes=3 * GIB + 4 * GIB + 1536 * MIB,
+        heap_bytes=3 * GIB + 1536 * MIB,
     )
+
+
+def test_pure_native_query_demands_only_a_soft_object_store_budget():
+    metadata = _metadata()
+    for node in metadata["nodes"]:
+        node["udf_payload"] = None
+    graph = build_query_resource_graph(metadata, env={})
+    cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=8 * GIB)
+
+    demand = build_query_demand(graph, cluster)
+
+    assert all(unit.backend == "ray_worker" for unit in graph.units)
+    assert all(unit.per_task == ResourceVector() for unit in graph.units)
+    assert demand.minimum == ResourceVector()
+    assert demand.task_bundles == ()
+    assert demand.actor_bundles == ()
+    assert demand.desired == ResourceVector(object_store_bytes=8 * GIB)
 
 
 def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38():

--- a/tests/fast/test_query_resource_graph_builder.py
+++ b/tests/fast/test_query_resource_graph_builder.py
@@ -283,7 +283,7 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_hard_reserves_one_ray_task_and_soft_accounts_actor_processes():
+def test_query_demand_hard_reserves_task_and_actor_shapes_but_soft_accounts_actor_pool_size():
     graph = build_query_resource_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
@@ -296,10 +296,11 @@ def test_query_demand_hard_reserves_one_ray_task_and_soft_accounts_actor_process
         heap_bytes=64 * GIB,
         object_store_bytes=64 * GIB,
     )
-    assert demand.task_bundles == (ResourceVector(cpu=1, heap_bytes=1536 * MIB),)
+    assert demand.placement_bundles == (ResourceVector(cpu=1, gpu=1, heap_bytes=3 * GIB),)
     assert demand.minimum == ResourceVector(
         cpu=1,
-        heap_bytes=1536 * MIB,
+        gpu=1,
+        heap_bytes=3 * GIB,
     )
 
 
@@ -315,7 +316,7 @@ def test_pure_native_query_demands_only_a_soft_object_store_budget():
     assert all(unit.backend == "ray_worker" for unit in graph.units)
     assert all(unit.per_task == ResourceVector() for unit in graph.units)
     assert demand.minimum == ResourceVector()
-    assert demand.task_bundles == ()
+    assert demand.placement_bundles == ()
     assert demand.desired == ResourceVector(object_store_bytes=8 * GIB)
 
 
@@ -334,10 +335,10 @@ def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38
 
     assert demand.minimum.object_store_bytes == 0
     assert demand.desired.object_store_bytes == 512 * MIB
-    assert all(bundle.object_store_bytes == 0 for bundle in demand.task_bundles)
+    assert all(bundle.object_store_bytes == 0 for bundle in demand.placement_bundles)
 
 
-def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():
+def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_placement_bundle():
     metadata = _metadata()
     metadata["nodes"][1]["udf_payload"]["gpus"] = 1.0
     graph = build_query_resource_graph(metadata, env={})
@@ -347,7 +348,7 @@ def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():
 
     assert demand.minimum.gpu == 1
     assert demand.desired.gpu == 4
-    assert demand.task_bundles[0].gpu == 1
+    assert demand.placement_bundles[0].gpu == 1
 
 
 def test_query_demand_uses_real_node_envelopes_for_heterogeneous_ray_tasks():
@@ -375,7 +376,7 @@ def test_query_demand_uses_real_node_envelopes_for_heterogeneous_ray_tasks():
 
     demand = build_query_demand(graph, nodes)
 
-    assert demand.task_bundles == (
+    assert demand.placement_bundles == (
         ResourceVector(cpu=1, gpu=1),
         ResourceVector(cpu=4),
     )
@@ -407,11 +408,11 @@ def test_query_demand_collapses_heterogeneous_task_shapes_that_share_one_node():
 
     demand = build_query_demand(graph, nodes)
 
-    assert demand.task_bundles == (ResourceVector(cpu=4, gpu=1),)
+    assert demand.placement_bundles == (ResourceVector(cpu=4, gpu=1),)
     assert demand.minimum == ResourceVector(cpu=4, gpu=1)
 
 
-def test_capacity_topology_change_rebuilds_task_capability_envelopes():
+def test_capacity_topology_change_rebuilds_placement_capability_envelopes():
     metadata = _metadata()
     cpu_payload = metadata["nodes"][1]["udf_payload"]
     cpu_payload["cpus"] = 4.0
@@ -464,8 +465,39 @@ def test_query_demand_does_not_turn_fixed_actor_pool_size_into_hard_admission():
 
     assert actor_unit.actor_pool_size == 3
     assert actor_unit.resident_per_actor.gpu == 0.25
-    assert demand.minimum.gpu == 0
+    assert demand.minimum.gpu == 0.25
     assert demand.desired.gpu == 0.75
+
+
+@pytest.mark.parametrize("gpu_node_count", [1, 2])
+def test_actor_shape_stays_pending_until_one_concrete_node_can_run_it(gpu_node_count):
+    metadata = _metadata()
+    metadata["nodes"][1]["udf_payload"] = None
+    actor_payload = metadata["nodes"][2]["udf_payload"]
+    actor_payload["cpus"] = 1.0
+    actor_payload["gpus"] = 2.0
+    actor_payload.pop("memory_bytes")
+    graph = build_query_resource_graph(metadata, env={})
+    split = tuple(
+        NodeCapacity(f"gpu-{index}", ResourceVector(cpu=4, gpu=1, object_store_bytes=GIB))
+        for index in range(gpu_node_count)
+    )
+
+    demand = build_query_demand(graph, split)
+
+    assert demand.placement_bundles == (ResourceVector(cpu=1, gpu=2),)
+    assert demand.minimum == ResourceVector(cpu=1, gpu=2)
+    assert demand.desired.gpu == 2
+    coordinator = ClusterQueryResourceCoordinator(split)
+    allocation = coordinator.register_query(demand, now=0)
+    assert coordinator.query_state(graph.query_id, allocation.generation) == "PENDING_RESOURCES"
+
+    coordinator.update_node_capacities(
+        (NodeCapacity("gpu-capable", ResourceVector(cpu=4, gpu=2, object_store_bytes=2 * GIB)),),
+        now=1,
+    )
+    snapshot = coordinator.snapshot()["queries"][graph.query_id]
+    assert snapshot["state"] == "RUNNING"
 
 
 def test_fragment_identity_maps_directly_to_pre_registered_native_fragment_unit():

--- a/tests/fast/test_query_resource_graph_builder.py
+++ b/tests/fast/test_query_resource_graph_builder.py
@@ -4,13 +4,13 @@
 import pytest
 
 from duckdb.runners.ray.cluster_resource_coordinator import ActorResourceBundle
-from duckdb.runners.ray.query_execution_graph import ResourceVector
-from duckdb.runners.ray.query_graph_builder import (
+from duckdb.runners.ray.query_resource_graph import ResourceVector
+from duckdb.runners.ray.query_resource_graph_builder import (
     build_query_demand,
-    build_query_execution_graph,
-    fte_stage_id_for_fragment,
-    fte_stage_id_for_node,
-    udf_stage_id_for_node,
+    build_query_resource_graph,
+    native_fragment_unit_id_for_fragment,
+    native_fragment_unit_id_for_node,
+    udf_unit_id_for_node,
 )
 
 GIB = 1024**3
@@ -40,7 +40,7 @@ def _metadata():
                 "num_partitions": 36,
                 "udf_payload": {
                     "execution_backend": "ray_task",
-                    "stage_id": udf_stage_id_for_node(query_id, "2"),
+                    "resource_unit_id": udf_unit_id_for_node(query_id, "2"),
                     "cpus": 1.0,
                     "gpus": 0.0,
                     "memory_bytes": 1536 * MIB,
@@ -57,7 +57,7 @@ def _metadata():
                 "num_partitions": 1,
                 "udf_payload": {
                     "execution_backend": "ray_actor",
-                    "stage_id": udf_stage_id_for_node(query_id, "3"),
+                    "resource_unit_id": udf_unit_id_for_node(query_id, "3"),
                     "cpus": 1.0,
                     "gpus": 1.0,
                     "memory_bytes": 3 * GIB,
@@ -80,22 +80,22 @@ def _metadata():
     }
 
 
-def test_builder_registers_complete_pipeline_and_nested_udf_stages_before_execution():
-    graph = build_query_execution_graph(_metadata(), env={})
+def test_builder_registers_complete_pipeline_and_nested_resource_units_before_execution():
+    graph = build_query_resource_graph(_metadata(), env={})
 
     assert graph.query_id == "query-7"
     assert graph.plan_digest.startswith("sha256:")
-    assert len(graph.stages) == 6
-    assert graph.topological_stage_ids() == (
-        fte_stage_id_for_node("query-7", "1"),
-        fte_stage_id_for_node("query-7", "2"),
-        udf_stage_id_for_node("query-7", "2"),
-        fte_stage_id_for_node("query-7", "3"),
-        udf_stage_id_for_node("query-7", "3"),
-        fte_stage_id_for_node("query-7", "4"),
+    assert len(graph.units) == 6
+    assert graph.topological_unit_ids() == (
+        native_fragment_unit_id_for_node("query-7", "1"),
+        native_fragment_unit_id_for_node("query-7", "2"),
+        udf_unit_id_for_node("query-7", "2"),
+        native_fragment_unit_id_for_node("query-7", "3"),
+        udf_unit_id_for_node("query-7", "3"),
+        native_fragment_unit_id_for_node("query-7", "4"),
     )
-    assert graph.terminal_stage_ids == (fte_stage_id_for_node("query-7", "4"),)
-    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "4")).spill_mode == "barrier"
+    assert graph.terminal_unit_ids == (native_fragment_unit_id_for_node("query-7", "4"),)
+    assert graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4")).is_barrier
 
 
 def test_builder_uses_native_materialization_metadata_instead_of_sink_shape():
@@ -103,20 +103,20 @@ def test_builder_uses_native_materialization_metadata_instead_of_sink_shape():
     metadata["nodes"][1]["is_blocking_materializing"] = True
     metadata["nodes"][3]["is_blocking_materializing"] = False
 
-    graph = build_query_execution_graph(metadata, env={})
+    graph = build_query_resource_graph(metadata, env={})
 
-    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "2")).spill_mode == "barrier"
-    assert graph.stage_by_id(fte_stage_id_for_node("query-7", "4")).spill_mode == "streaming"
+    assert graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "2")).is_barrier
+    assert not graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4")).is_barrier
 
 
 def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():
-    graph = build_query_execution_graph(_metadata(), env={})
-    cpu_udf = graph.stage_by_id(udf_stage_id_for_node("query-7", "2"))
-    gpu_udf = graph.stage_by_id(udf_stage_id_for_node("query-7", "3"))
-    scan = graph.stage_by_id(fte_stage_id_for_node("query-7", "1"))
-    cpu_udf_parent = graph.stage_by_id(fte_stage_id_for_node("query-7", "2"))
-    gpu_udf_parent = graph.stage_by_id(fte_stage_id_for_node("query-7", "3"))
-    native_sink = graph.stage_by_id(fte_stage_id_for_node("query-7", "4"))
+    graph = build_query_resource_graph(_metadata(), env={})
+    cpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "2"))
+    gpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "3"))
+    scan = graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "1"))
+    cpu_udf_parent = graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "2"))
+    gpu_udf_parent = graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "3"))
+    native_sink = graph.unit_by_id(native_fragment_unit_id_for_node("query-7", "4"))
 
     assert scan.backend == "ray_worker"
     # Node 1 is the task-producing feeder immediately before the remote UDF.
@@ -136,31 +136,31 @@ def test_builder_counts_each_nested_ray_process_and_never_uses_zero_heap():
 
 
 def test_builder_configures_stateless_actor_prefetch_and_disables_it_for_stateful_udfs():
-    configured = build_query_execution_graph(
+    configured = build_query_resource_graph(
         _metadata(),
         env={"VANE_RAY_ACTOR_PREFETCH_DEPTH": "3"},
     )
-    assert configured.stage_by_id(udf_stage_id_for_node("query-7", "3")).actor_prefetch_depth == 3
+    assert configured.unit_by_id(udf_unit_id_for_node("query-7", "3")).actor_prefetch_depth == 3
 
     stateful_metadata = _metadata()
     stateful_metadata["nodes"][2]["udf_payload"]["stateful"] = True
-    stateful = build_query_execution_graph(
+    stateful = build_query_resource_graph(
         stateful_metadata,
         env={"VANE_RAY_ACTOR_PREFETCH_DEPTH": "3"},
     )
-    assert stateful.stage_by_id(udf_stage_id_for_node("query-7", "3")).actor_prefetch_depth == 1
+    assert stateful.unit_by_id(udf_unit_id_for_node("query-7", "3")).actor_prefetch_depth == 1
 
     with pytest.raises(ValueError, match="VANE_RAY_ACTOR_PREFETCH_DEPTH"):
-        build_query_execution_graph(
+        build_query_resource_graph(
             _metadata(),
             env={"VANE_RAY_ACTOR_PREFETCH_DEPTH": "0"},
         )
 
 
-def test_builder_uses_two_logical_output_blocks_for_all_streaming_stages():
-    graph = build_query_execution_graph(_metadata(), env={})
-    cpu_udf = graph.stage_by_id(udf_stage_id_for_node("query-7", "2"))
-    gpu_udf = graph.stage_by_id(udf_stage_id_for_node("query-7", "3"))
+def test_builder_uses_two_logical_output_blocks_for_all_streaming_units():
+    graph = build_query_resource_graph(_metadata(), env={})
+    cpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "2"))
+    gpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "3"))
 
     assert cpu_udf.target_output_block_bytes == 64 * MIB
     assert cpu_udf.generator_buffer_blocks == 2
@@ -176,8 +176,8 @@ def test_builder_sizes_upstream_retention_window_for_downstream_compute_batch():
     producer["udf_output_target_max_bytes"] = 1024
     consumer["udf_task_input_max_bytes"] = 64 * 1024
 
-    graph = build_query_execution_graph(metadata, env={})
-    cpu_udf = graph.stage_by_id(udf_stage_id_for_node("query-7", "2"))
+    graph = build_query_resource_graph(metadata, env={})
+    cpu_udf = graph.unit_by_id(udf_unit_id_for_node("query-7", "2"))
 
     assert cpu_udf.target_output_block_bytes == 1024
     assert cpu_udf.generator_buffer_blocks == 64
@@ -189,36 +189,36 @@ def test_builder_defaults_are_new_positive_production_limits_not_host_memory():
     del metadata["nodes"][1]["udf_payload"]["memory_bytes"]
     del metadata["nodes"][2]["udf_payload"]["memory_bytes"]
 
-    graph = build_query_execution_graph(metadata, env={})
+    graph = build_query_resource_graph(metadata, env={})
 
-    assert graph.stage_by_id(udf_stage_id_for_node("query-7", "2")).per_task.heap_bytes == 2 * GIB
-    assert graph.stage_by_id(udf_stage_id_for_node("query-7", "3")).resident_per_actor.heap_bytes == 4 * GIB
+    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "2")).per_task.heap_bytes == 2 * GIB
+    assert graph.unit_by_id(udf_unit_id_for_node("query-7", "3")).resident_per_actor.heap_bytes == 4 * GIB
 
 
 def test_builder_accepts_only_positive_new_resource_configuration():
-    with pytest.raises(ValueError, match="VANE_FTE_TASK_HEAP_BYTES"):
-        build_query_execution_graph(_metadata(), env={"VANE_FTE_TASK_HEAP_BYTES": "0"})
-    with pytest.raises(ValueError, match="VANE_FTE_UDF_DRIVER_HEAP_BYTES"):
-        build_query_execution_graph(
+    with pytest.raises(ValueError, match="VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES"):
+        build_query_resource_graph(_metadata(), env={"VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES": "0"})
+    with pytest.raises(ValueError, match="VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES"):
+        build_query_resource_graph(
             _metadata(),
-            env={"VANE_FTE_UDF_DRIVER_HEAP_BYTES": "0"},
+            env={"VANE_NATIVE_FRAGMENT_UDF_DRIVER_HEAP_BYTES": "0"},
         )
     with pytest.raises(ValueError, match="memory_bytes"):
         metadata = _metadata()
         metadata["nodes"][1]["udf_payload"]["memory_bytes"] = 0
-        build_query_execution_graph(metadata, env={})
+        build_query_resource_graph(metadata, env={})
 
 
-def test_builder_rejects_missing_or_mismatched_preannotated_udf_stage_identity():
+def test_builder_rejects_missing_or_mismatched_preannotated_udf_resource_unit_identity():
     missing = _metadata()
-    missing["nodes"][1]["udf_payload"].pop("stage_id")
-    with pytest.raises(ValueError, match="missing pre-registered stage_id"):
-        build_query_execution_graph(missing, env={})
+    missing["nodes"][1]["udf_payload"].pop("resource_unit_id")
+    with pytest.raises(ValueError, match="missing pre-registered resource_unit_id"):
+        build_query_resource_graph(missing, env={})
 
     mismatch = _metadata()
-    mismatch["nodes"][1]["udf_payload"]["stage_id"] = "stage:legacy:operator"
-    with pytest.raises(ValueError, match="stage_id mismatch"):
-        build_query_execution_graph(mismatch, env={})
+    mismatch["nodes"][1]["udf_payload"]["resource_unit_id"] = "resource:legacy:operator"
+    with pytest.raises(ValueError, match="resource_unit_id mismatch"):
+        build_query_resource_graph(mismatch, env={})
 
 
 @pytest.mark.parametrize(
@@ -235,7 +235,7 @@ def test_builder_rejects_incomplete_or_legacy_metadata(mutation, message):
     mutation(metadata)
 
     with pytest.raises(ValueError, match=message):
-        build_query_execution_graph(metadata, env={})
+        build_query_resource_graph(metadata, env={})
 
 
 def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
@@ -245,16 +245,16 @@ def test_plan_digest_is_stable_for_node_order_but_changes_with_resources():
     changed = _metadata()
     changed["nodes"][1]["udf_payload"]["memory_bytes"] += 1
 
-    graph_a = build_query_execution_graph(first, env={})
-    graph_b = build_query_execution_graph(reordered, env={})
-    graph_c = build_query_execution_graph(changed, env={})
+    graph_a = build_query_resource_graph(first, env={})
+    graph_b = build_query_resource_graph(reordered, env={})
+    graph_c = build_query_resource_graph(changed, env={})
 
     assert graph_a.plan_digest == graph_b.plan_digest
     assert graph_a.plan_digest != graph_c.plan_digest
 
 
-def test_query_demand_reserves_hard_actor_pool_and_downstream_fte_progress_slot():
-    graph = build_query_execution_graph(_metadata(), env={})
+def test_query_demand_reserves_hard_actor_pool_and_downstream_native_fragment_progress_slot():
+    graph = build_query_resource_graph(_metadata(), env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
     demand = build_query_demand(graph, cluster)
@@ -268,7 +268,7 @@ def test_query_demand_reserves_hard_actor_pool_and_downstream_fte_progress_slot(
     )
     assert demand.actor_bundles == (
         ActorResourceBundle(
-            stage_id="stage:query-7:node:3:udf",
+            resource_unit_id="resource:query-7:udf:node:3",
             actor_index=0,
             resources=ResourceVector(
                 cpu=1,
@@ -292,7 +292,7 @@ def test_query_demand_reserves_hard_actor_pool_and_downstream_fte_progress_slot(
 def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38():
     metadata = _metadata()
     metadata["nodes"][2]["udf_payload"]["actor_pool_size"] = 2
-    graph = build_query_execution_graph(metadata, env={})
+    graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(
         cpu=64,
         gpu=4,
@@ -311,7 +311,7 @@ def test_query_demand_treats_pipeline_windows_as_soft_budget_regression_issue_38
 def test_query_demand_reserves_gpu_ray_task_as_an_indivisible_task_bundle():
     metadata = _metadata()
     metadata["nodes"][1]["udf_payload"]["gpus"] = 1.0
-    graph = build_query_execution_graph(metadata, env={})
+    graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
     demand = build_query_demand(graph, cluster)
@@ -327,22 +327,24 @@ def test_query_demand_reserves_every_fractional_gpu_actor_in_fixed_pool():
     actor_payload = metadata["nodes"][2]["udf_payload"]
     actor_payload["actor_pool_size"] = 3
     actor_payload["gpus"] = 0.25
-    graph = build_query_execution_graph(metadata, env={})
+    graph = build_query_resource_graph(metadata, env={})
     cluster = ResourceVector(cpu=64, gpu=4, heap_bytes=64 * GIB, object_store_bytes=64 * GIB)
 
     demand = build_query_demand(graph, cluster)
-    actor_stage = graph.stage_by_id(udf_stage_id_for_node("query-7", "3"))
+    actor_unit = graph.unit_by_id(udf_unit_id_for_node("query-7", "3"))
 
-    assert actor_stage.actor_pool_size == 3
+    assert actor_unit.actor_pool_size == 3
     assert [bundle.actor_index for bundle in demand.actor_bundles] == [0, 1, 2]
     assert all(bundle.resources.gpu == 0.25 for bundle in demand.actor_bundles)
     assert demand.minimum.gpu == 0.75
     assert demand.desired.gpu == demand.minimum.gpu
 
 
-def test_fragment_identity_maps_directly_to_pre_registered_fte_stage():
-    assert fte_stage_id_for_fragment("query-7", "query-7:node:12") == fte_stage_id_for_node("query-7", "12")
+def test_fragment_identity_maps_directly_to_pre_registered_native_fragment_unit():
+    assert native_fragment_unit_id_for_fragment("query-7", "query-7:node:12") == native_fragment_unit_id_for_node(
+        "query-7", "12"
+    )
     with pytest.raises(ValueError, match="does not belong to query"):
-        fte_stage_id_for_fragment("query-7", "other:node:12")
-    with pytest.raises(ValueError, match="invalid FTE fragment_id"):
-        fte_stage_id_for_fragment("query-7", "query-7:task:12")
+        native_fragment_unit_id_for_fragment("query-7", "other:node:12")
+    with pytest.raises(ValueError, match="invalid native fragment_id"):
+        native_fragment_unit_id_for_fragment("query-7", "query-7:task:12")

--- a/tests/fast/test_query_resource_graph_registration.py
+++ b/tests/fast/test_query_resource_graph_registration.py
@@ -7,7 +7,7 @@ import uuid
 import pytest
 
 import duckdb
-from duckdb.runners.ray.query_graph_builder import build_query_execution_graph
+from duckdb.runners.ray.query_resource_graph_builder import build_query_resource_graph, udf_unit_id_for_node
 
 
 def _physical_plan(relation, con, prefix):
@@ -23,14 +23,14 @@ def _parquet_relation(con, tmp_path):
     return con.read_parquet(str(path))
 
 
-def test_physical_plan_exports_complete_deterministic_execution_stage_metadata(tmp_path):
+def test_physical_plan_exports_complete_deterministic_resource_unit_metadata(tmp_path):
     con = duckdb.connect()
     try:
         plan = _physical_plan(_parquet_relation(con, tmp_path), con, "graph-plain")
 
-        first = plan.collect_execution_stages(conn=con)
-        second = plan.collect_execution_stages(conn=con)
-        graph = build_query_execution_graph(first, env={})
+        first = plan.collect_query_resource_graph_metadata(conn=con)
+        second = plan.collect_query_resource_graph_metadata(conn=con)
+        graph = build_query_resource_graph(first, env={})
 
         assert first == second
         assert first["query_id"] == plan.idx()
@@ -44,19 +44,19 @@ def test_physical_plan_exports_complete_deterministic_execution_stage_metadata(t
         con.close()
 
 
-def test_stage_collection_marks_blocking_distributed_materializers(tmp_path):
+def test_resource_unit_collection_marks_blocking_distributed_materializers(tmp_path):
     con = duckdb.connect()
     try:
         relation = _parquet_relation(con, tmp_path).repartition(2).order("x")
         plan = _physical_plan(relation, con, "graph-materializing")
 
-        metadata = plan.collect_execution_stages(conn=con)
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
         materializing_names = {node["node_name"] for node in metadata["nodes"] if node["is_blocking_materializing"]}
-        graph = build_query_execution_graph(metadata, env={})
+        graph = build_query_resource_graph(metadata, env={})
 
         assert {"Repartition", "OrderBy"} <= materializing_names
-        assert {stage.physical_node_id for stage in graph.stages if stage.spill_mode == "barrier"} == {
-            f"node:{node['node_id']}:fte" for node in metadata["nodes"] if node["is_blocking_materializing"]
+        assert {unit.physical_node_id for unit in graph.units if unit.is_barrier} == {
+            f"node:{node['node_id']}:native-fragment" for node in metadata["nodes"] if node["is_blocking_materializing"]
         }
     finally:
         con.close()
@@ -69,7 +69,7 @@ def test_stage_collection_marks_blocking_distributed_materializers(tmp_path):
         ("reservoir(50 PERCENT)", False),
     ],
 )
-def test_stage_collection_classifies_reservoir_sample_materialization(
+def test_resource_unit_collection_classifies_reservoir_sample_materialization(
     tmp_path,
     sample_clause,
     expected_blocking,
@@ -81,20 +81,20 @@ def test_stage_collection_classifies_reservoir_sample_materialization(
         relation = con.sql(f"SELECT x FROM read_parquet('{path}') USING SAMPLE {sample_clause}")
         plan = _physical_plan(relation, con, "graph-reservoir-sample")
 
-        metadata = plan.collect_execution_stages(conn=con)
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
         (sample_node,) = (node for node in metadata["nodes"] if node["node_name"] == "ReservoirSample")
-        graph = build_query_execution_graph(metadata, env={})
-        sample_stage = next(
-            stage for stage in graph.stages if stage.physical_node_id == f"node:{sample_node['node_id']}:fte"
+        graph = build_query_resource_graph(metadata, env={})
+        sample_unit = next(
+            unit for unit in graph.units if unit.physical_node_id == f"node:{sample_node['node_id']}:native-fragment"
         )
 
         assert sample_node["is_blocking_materializing"] is expected_blocking
-        assert sample_stage.spill_mode == ("barrier" if expected_blocking else "streaming")
+        assert sample_unit.is_barrier is expected_blocking
     finally:
         con.close()
 
 
-def test_stage_collection_does_not_treat_generic_inout_as_python_udf(tmp_path):
+def test_resource_unit_collection_does_not_treat_generic_inout_as_python_udf(tmp_path):
     con = duckdb.connect()
     try:
         path = tmp_path / "generic_inout.parquet"
@@ -103,8 +103,8 @@ def test_stage_collection_does_not_treat_generic_inout_as_python_udf(tmp_path):
         relation = con.sql(f"SELECT * FROM unnest((SELECT [x, x + 1] FROM read_parquet('{path}')))")
         plan = _physical_plan(relation, con, "graph-generic-inout")
 
-        metadata = plan.collect_execution_stages(conn=con)
-        graph = build_query_execution_graph(metadata, env={})
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
+        graph = build_query_resource_graph(metadata, env={})
 
         assert graph.query_id == plan.idx()
         assert all(node["udf_payload"] is None for node in metadata["nodes"])
@@ -112,7 +112,7 @@ def test_stage_collection_does_not_treat_generic_inout_as_python_udf(tmp_path):
         con.close()
 
 
-def test_stage_collection_preannotates_ray_udf_payload_on_original_plan(tmp_path):
+def test_resource_unit_collection_preannotates_ray_udf_payload_on_original_plan(tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
 
@@ -131,7 +131,7 @@ def test_stage_collection_preannotates_ray_udf_payload_on_original_plan(tmp_path
         )
         plan = _physical_plan(relation, con, "graph-udf")
 
-        metadata = plan.collect_execution_stages(conn=con)
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
         udf_nodes = [node for node in metadata["nodes"] if node["udf_payload"] is not None]
         replay_nodes = plan.collect_udf_nodes(conn=con)
 
@@ -140,16 +140,16 @@ def test_stage_collection_preannotates_ray_udf_payload_on_original_plan(tmp_path
         payload = udf_nodes[0]["udf_payload"]
         replay_payload = replay_nodes[0]["payload"]
         assert payload["query_id"] == plan.idx()
-        assert payload["stage_id"].endswith(f":node:{udf_nodes[0]['node_id']}:udf")
+        assert payload["resource_unit_id"] == udf_unit_id_for_node(plan.idx(), udf_nodes[0]["node_id"])
         assert replay_payload["query_id"] == payload["query_id"]
-        assert replay_payload["stage_id"] == payload["stage_id"]
-        graph = build_query_execution_graph(metadata, env={})
-        assert graph.stage_by_id(payload["stage_id"]).backend == "ray_actor"
+        assert replay_payload["resource_unit_id"] == payload["resource_unit_id"]
+        graph = build_query_resource_graph(metadata, env={})
+        assert graph.unit_by_id(payload["resource_unit_id"]).backend == "ray_actor"
     finally:
         con.close()
 
 
-def test_stage_collection_preserves_distinct_stage_identity_for_nested_udfs(tmp_path):
+def test_resource_unit_collection_preserves_distinct_identity_for_nested_udfs(tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
 
@@ -179,27 +179,30 @@ def test_stage_collection_preserves_distinct_stage_identity_for_nested_udfs(tmp_
         )
         plan = _physical_plan(relation, con, "graph-nested-udf")
 
-        metadata = plan.collect_execution_stages(conn=con)
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
         udf_nodes = [node for node in metadata["nodes"] if node["udf_payload"] is not None]
         replay_nodes = plan.collect_udf_nodes(conn=con)
 
         assert len(udf_nodes) == 2
         assert len(replay_nodes) == 2
-        metadata_by_stage = {node["udf_payload"]["stage_id"]: node for node in udf_nodes}
-        replay_by_stage = {node["payload"]["stage_id"]: node for node in replay_nodes}
-        assert metadata_by_stage.keys() == replay_by_stage.keys()
+        metadata_by_unit = {node["udf_payload"]["resource_unit_id"]: node for node in udf_nodes}
+        replay_by_unit = {node["payload"]["resource_unit_id"]: node for node in replay_nodes}
+        assert metadata_by_unit.keys() == replay_by_unit.keys()
         assert {node["udf_payload"]["execution_backend"] for node in udf_nodes} == {
             "ray_task",
             "ray_actor",
         }
-        for stage_id, node in metadata_by_stage.items():
-            assert stage_id.endswith(f":node:{node['node_id']}:udf")
-            assert replay_by_stage[stage_id]["payload"]["execution_backend"] == node["udf_payload"]["execution_backend"]
+        for resource_unit_id, node in metadata_by_unit.items():
+            assert resource_unit_id == udf_unit_id_for_node(plan.idx(), node["node_id"])
+            assert (
+                replay_by_unit[resource_unit_id]["payload"]["execution_backend"]
+                == node["udf_payload"]["execution_backend"]
+            )
     finally:
         con.close()
 
 
-def test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeypatch, tmp_path):
+def test_resource_unit_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeypatch, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa
 
@@ -247,8 +250,8 @@ def test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeyp
         relation = left.join(right, "l.id = r.id").project("l.id, l.left_value, r.right_value")
         plan = _physical_plan(relation, con, "graph-branch-udfs")
 
-        metadata = plan.collect_execution_stages(conn=con)
-        assert metadata == plan.collect_execution_stages(conn=con)
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
+        assert metadata == plan.collect_query_resource_graph_metadata(conn=con)
         assert "Broadcast side: right" in plan.repr_ascii(False)
 
         udf_nodes = [node for node in metadata["nodes"] if node["udf_payload"] is not None]
@@ -264,23 +267,25 @@ def test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeyp
         assert right_node["udf_payload"]["cpus"] == 3.0
         assert left_node["udf_payload"]["memory_bytes"] == 1 << 30
         assert right_node["udf_payload"]["memory_bytes"] == 3 << 30
-        assert left_node["udf_payload"]["stage_id"].endswith(f":node:{left_node['node_id']}:udf")
-        assert right_node["udf_payload"]["stage_id"].endswith(f":node:{right_node['node_id']}:udf")
+        assert left_node["udf_payload"]["resource_unit_id"] == udf_unit_id_for_node(plan.idx(), left_node["node_id"])
+        assert right_node["udf_payload"]["resource_unit_id"] == udf_unit_id_for_node(plan.idx(), right_node["node_id"])
         assert left_node["udf_payload"]["_vane_udf_operator_id"] != right_node["udf_payload"]["_vane_udf_operator_id"]
 
         replay_by_name = {
             node["payload"]["udf_name"].rsplit(".", 1)[-1]: node for node in plan.collect_udf_nodes(conn=con)
         }
-        assert replay_by_name["left_udf"]["payload"]["stage_id"] == left_node["udf_payload"]["stage_id"]
-        assert replay_by_name["right_udf"]["payload"]["stage_id"] == right_node["udf_payload"]["stage_id"]
+        assert replay_by_name["left_udf"]["payload"]["resource_unit_id"] == left_node["udf_payload"]["resource_unit_id"]
+        assert (
+            replay_by_name["right_udf"]["payload"]["resource_unit_id"] == right_node["udf_payload"]["resource_unit_id"]
+        )
 
-        graph = build_query_execution_graph(metadata, env={})
-        left_stage = graph.stage_by_id(left_node["udf_payload"]["stage_id"])
-        right_stage = graph.stage_by_id(right_node["udf_payload"]["stage_id"])
-        assert left_stage.per_task.cpu == 1.0
-        assert right_stage.per_task.cpu == 3.0
-        assert left_stage.per_task.heap_bytes == 1 << 30
-        assert right_stage.per_task.heap_bytes == 3 << 30
+        graph = build_query_resource_graph(metadata, env={})
+        left_unit = graph.unit_by_id(left_node["udf_payload"]["resource_unit_id"])
+        right_unit = graph.unit_by_id(right_node["udf_payload"]["resource_unit_id"])
+        assert left_unit.per_task.cpu == 1.0
+        assert right_unit.per_task.cpu == 3.0
+        assert left_unit.per_task.heap_bytes == 1 << 30
+        assert right_unit.per_task.heap_bytes == 3 << 30
 
         operator_ids = [
             left_node["udf_payload"]["_vane_udf_operator_id"],
@@ -292,6 +297,6 @@ def test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeyp
             serialized_plan.replace(operator_ids[1].encode(), operator_ids[0].encode())
         ).clone(con)
         with pytest.raises(duckdb.InvalidInputException, match="duplicate physical UDF operator identity"):
-            corrupted_plan.collect_execution_stages(conn=con)
+            corrupted_plan.collect_query_resource_graph_metadata(conn=con)
     finally:
         con.close()

--- a/tests/fast/test_query_resource_graph_registration.py
+++ b/tests/fast/test_query_resource_graph_registration.py
@@ -7,7 +7,11 @@ import uuid
 import pytest
 
 import duckdb
-from duckdb.runners.ray.query_resource_graph_builder import build_query_resource_graph, udf_unit_id_for_node
+from duckdb.runners.ray.query_resource_graph_builder import (
+    build_query_resource_graph,
+    native_fragment_unit_id_for_node,
+    udf_unit_id_for_node,
+)
 
 
 def _physical_plan(relation, con, prefix):
@@ -39,6 +43,79 @@ def test_physical_plan_exports_complete_deterministic_resource_unit_metadata(tmp
         assert graph.query_id == plan.idx()
         assert all(node["node_id"] for node in first["nodes"])
         assert all(node["num_partitions"] >= 1 for node in first["nodes"])
+        assert all(
+            bool(node["materialized_input_node_ids"]) == node["is_materialization_barrier"] for node in first["nodes"]
+        )
+    finally:
+        con.close()
+
+
+@pytest.mark.parametrize(
+    ("transform", "expected_nodes"),
+    [
+        (lambda relation: relation.repartition(4), {"Repartition": False}),
+        (
+            lambda relation: relation.repartition(4).order("x"),
+            {"Repartition": False, "OrderBy": True},
+        ),
+        (
+            lambda relation: relation.repartition(4).limit(3),
+            {"Repartition": False, "StreamingLimit": True},
+        ),
+    ],
+)
+def test_physical_plan_marks_only_true_materialization_barriers(tmp_path, transform, expected_nodes):
+    con = duckdb.connect()
+    try:
+        plan = _physical_plan(transform(_parquet_relation(con, tmp_path)), con, "graph-barrier")
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
+        barrier_by_name = {
+            node["node_name"]: node["is_materialization_barrier"]
+            for node in metadata["nodes"]
+            if node["node_name"] in expected_nodes
+        }
+
+        assert barrier_by_name == expected_nodes
+        for node in metadata["nodes"]:
+            if node["node_name"] not in expected_nodes:
+                continue
+            assert bool(node["materialized_input_node_ids"]) == expected_nodes[node["node_name"]]
+            assert set(node["materialized_input_node_ids"]).issubset(node["input_node_ids"])
+        graph = build_query_resource_graph(metadata, env={})
+        assert {barrier.physical_node_id for barrier in graph.materialization_barriers} == {
+            node["node_id"] for node in metadata["nodes"] if node["is_materialization_barrier"]
+        }
+    finally:
+        con.close()
+
+
+def test_broadcast_join_barrier_materializes_only_broadcaster_input(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast")
+    monkeypatch.setenv("VANE_DISTRIBUTED_BROADCAST_JOIN_RECEIVER_REPARTITION", "0")
+    con = duckdb.connect()
+    try:
+        path = tmp_path / "broadcast_input.parquet"
+        con.execute(f"COPY (SELECT i::BIGINT AS x FROM range(8) tbl(i)) TO '{path}' (FORMAT PARQUET)")
+        relation = con.sql(f"SELECT l.x FROM read_parquet('{path}') l JOIN read_parquet('{path}') r ON l.x = r.x")
+        plan = _physical_plan(relation, con, "graph-broadcast")
+        metadata = plan.collect_query_resource_graph_metadata(conn=con)
+        broadcast = next(node for node in metadata["nodes"] if node["node_name"] == "BroadcastJoin")
+
+        assert len(broadcast["input_node_ids"]) == 2
+        assert len(broadcast["materialized_input_node_ids"]) == 1
+        assert set(broadcast["materialized_input_node_ids"]).issubset(broadcast["input_node_ids"])
+
+        graph = build_query_resource_graph(metadata, env={})
+        barrier = graph.barrier_for_physical_node(broadcast["node_id"])
+        assert barrier.materialized_input_unit_ids == (
+            native_fragment_unit_id_for_node(
+                graph.query_id,
+                broadcast["materialized_input_node_ids"][0],
+            ),
+        )
     finally:
         con.close()
 

--- a/tests/fast/test_query_resource_graph_registration.py
+++ b/tests/fast/test_query_resource_graph_registration.py
@@ -39,57 +39,6 @@ def test_physical_plan_exports_complete_deterministic_resource_unit_metadata(tmp
         assert graph.query_id == plan.idx()
         assert all(node["node_id"] for node in first["nodes"])
         assert all(node["num_partitions"] >= 1 for node in first["nodes"])
-        assert all(isinstance(node["is_blocking_materializing"], bool) for node in first["nodes"])
-    finally:
-        con.close()
-
-
-def test_resource_unit_collection_marks_blocking_distributed_materializers(tmp_path):
-    con = duckdb.connect()
-    try:
-        relation = _parquet_relation(con, tmp_path).repartition(2).order("x")
-        plan = _physical_plan(relation, con, "graph-materializing")
-
-        metadata = plan.collect_query_resource_graph_metadata(conn=con)
-        materializing_names = {node["node_name"] for node in metadata["nodes"] if node["is_blocking_materializing"]}
-        graph = build_query_resource_graph(metadata, env={})
-
-        assert {"Repartition", "OrderBy"} <= materializing_names
-        assert {unit.physical_node_id for unit in graph.units if unit.is_barrier} == {
-            f"node:{node['node_id']}:native-fragment" for node in metadata["nodes"] if node["is_blocking_materializing"]
-        }
-    finally:
-        con.close()
-
-
-@pytest.mark.parametrize(
-    ("sample_clause", "expected_blocking"),
-    [
-        ("reservoir(3 ROWS)", True),
-        ("reservoir(50 PERCENT)", False),
-    ],
-)
-def test_resource_unit_collection_classifies_reservoir_sample_materialization(
-    tmp_path,
-    sample_clause,
-    expected_blocking,
-):
-    con = duckdb.connect()
-    try:
-        path = tmp_path / "sample_input.parquet"
-        con.execute(f"COPY (SELECT i::BIGINT AS x FROM range(8) tbl(i)) TO '{path}' (FORMAT PARQUET)")
-        relation = con.sql(f"SELECT x FROM read_parquet('{path}') USING SAMPLE {sample_clause}")
-        plan = _physical_plan(relation, con, "graph-reservoir-sample")
-
-        metadata = plan.collect_query_resource_graph_metadata(conn=con)
-        (sample_node,) = (node for node in metadata["nodes"] if node["node_name"] == "ReservoirSample")
-        graph = build_query_resource_graph(metadata, env={})
-        sample_unit = next(
-            unit for unit in graph.units if unit.physical_node_id == f"node:{sample_node['node_id']}:native-fragment"
-        )
-
-        assert sample_node["is_blocking_materializing"] is expected_blocking
-        assert sample_unit.is_barrier is expected_blocking
     finally:
         con.close()
 

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -3,13 +3,13 @@
 
 import pytest
 
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     ActorPlacement,
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_manager import (
     OutputBlockRequest,
@@ -35,8 +35,8 @@ def _allocation(resources, *, generation=1, placements=(), nodes=None):
     )
 
 
-def _stage(
-    stage_id,
+def _unit(
+    resource_unit_id,
     *,
     inputs=(),
     resources=None,
@@ -47,8 +47,8 @@ def _stage(
     actor_pool_size=0,
     actor_prefetch_depth=1,
     resident=None,
-    stage_kind="udf",
-    spill_mode="streaming",
+    unit_kind=None,
+    is_barrier=False,
 ):
     requested = resources or _r(cpu=1, heap=10)
     if backend == "ray_actor":
@@ -61,13 +61,21 @@ def _stage(
     else:
         resident_resources = _r()
         task_resources = requested
-    return StageResourceSpec(
+    resolved_unit_kind = (
+        unit_kind
+        or {
+            "ray_worker": "native_fragment",
+            "ray_task": "ray_task_udf",
+            "ray_actor": "ray_actor_pool",
+        }[backend]
+    )
+    return ResourceUnitSpec(
         query_id="q",
-        stage_id=stage_id,
-        physical_node_id=stage_id.rsplit(":", 1)[-1],
-        stage_kind=stage_kind,
+        resource_unit_id=resource_unit_id,
+        physical_node_id=resource_unit_id.rsplit(":", 1)[-1],
+        unit_kind=resolved_unit_kind,
         backend=backend,
-        input_stage_ids=tuple(inputs),
+        input_unit_ids=tuple(inputs),
         per_task=task_resources,
         target_output_block_bytes=target,
         generator_buffer_blocks=blocks,
@@ -75,30 +83,30 @@ def _stage(
         resident_per_actor=resident_resources,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        spill_mode=spill_mode,
+        is_barrier=is_barrier,
     )
 
 
 def _manager(
-    *stages,
+    *units,
     resources=None,
     reservation_ratio=0.5,
     terminals=None,
     nodes=None,
     on_change=None,
 ):
-    graph = QueryExecutionGraph(
+    graph = QueryResourceGraph(
         query_id="q",
         plan_digest="sha256:test",
-        stages=tuple(stages),
-        terminal_stage_ids=tuple(terminals or (stages[-1].stage_id,)),
+        units=tuple(units),
+        terminal_unit_ids=tuple(terminals or (units[-1].resource_unit_id,)),
     )
     allocation_resources = resources or _r(cpu=100, gpu=1, heap=1_000, store=1_000)
     actor_placements = tuple(
-        ActorPlacement(stage_id=stage.stage_id, actor_index=actor_index, node_id="node-a")
-        for stage in stages
-        if stage.backend == "ray_actor"
-        for actor_index in range(stage.actor_pool_size)
+        ActorPlacement(resource_unit_id=unit.resource_unit_id, actor_index=actor_index, node_id="node-a")
+        for unit in units
+        if unit.backend == "ray_actor"
+        for actor_index in range(unit.actor_pool_size)
     )
     allocation = _allocation(
         allocation_resources,
@@ -114,30 +122,30 @@ def _manager(
     )
 
 
-def _ready(manager, *stage_ids, consumer_waiting=False):
-    for stage_id in stage_ids:
-        manager.update_stage_state(
-            stage_id,
+def _ready(manager, *unit_ids, consumer_waiting=False):
+    for resource_unit_id in unit_ids:
+        manager.update_unit_state(
+            resource_unit_id,
             runnable=True,
             actor_ready=True,
         )
     manager.set_external_consumer_waiting(consumer_waiting)
 
 
-def _task(stage_id, partition, attempt="0", retained=None, node_id=None):
+def _task(resource_unit_id, partition, attempt="0", retained=None, node_id=None):
     return TaskRequest(
         query_id="q",
-        stage_id=stage_id,
-        task_id=f"task:{stage_id}:partition:{partition}",
+        resource_unit_id=resource_unit_id,
+        task_id=f"task:{resource_unit_id}:partition:{partition}",
         attempt_id=str(attempt),
         node_id=node_id,
         retained_input_bytes=retained,
     )
 
 
-def test_task_admission_requires_runnable_registered_stage_and_ready_actor():
-    actor = _stage(
-        "stage:f:gpu",
+def test_task_admission_requires_runnable_registered_unit_and_ready_actor():
+    actor = _unit(
+        "resource:f:gpu",
         resources=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
         concurrency=1,
@@ -145,65 +153,65 @@ def test_task_admission_requires_runnable_registered_stage_and_ready_actor():
     )
     manager = _manager(actor, resources=_r(cpu=2, gpu=1, heap=500, store=500))
 
-    not_runnable = manager.try_acquire_task(_task(actor.stage_id, 0))
-    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=False)
-    not_ready = manager.try_acquire_task(_task(actor.stage_id, 0))
-    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=True)
-    granted = manager.try_acquire_task(_task(actor.stage_id, 0))
+    not_runnable = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=False)
+    not_ready = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    granted = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
 
-    assert not_runnable.blocked_reason == "stage_not_runnable"
+    assert not_runnable.blocked_reason == "unit_not_runnable"
     assert not_ready.blocked_reason == "actor_not_ready"
     assert granted.granted
     assert granted.lease.resources == actor.per_task
     assert granted.lease.output_window_bytes == 20
 
 
-def test_only_first_pending_materializing_phase_and_its_upstream_receive_reservations_without_gating():
-    source = _stage(
-        "stage:f:phase-source",
+def test_only_first_pending_reservation_scope_and_its_upstream_receive_reservations_without_gating():
+    source = _unit(
+        "resource:f:scope-source",
         resources=_r(cpu=1, heap=10),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    first_barrier = _stage(
-        "stage:f:phase-first-barrier",
-        inputs=(source.stage_id,),
+    first_barrier = _unit(
+        "resource:f:scope-first-barrier",
+        inputs=(source.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
-        spill_mode="barrier",
+        unit_kind="native_fragment",
+        is_barrier=True,
     )
-    between = _stage(
-        "stage:f:phase-between",
-        inputs=(first_barrier.stage_id,),
+    between = _unit(
+        "resource:f:scope-between",
+        inputs=(first_barrier.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    second_barrier = _stage(
-        "stage:f:phase-second-barrier",
-        inputs=(between.stage_id,),
+    second_barrier = _unit(
+        "resource:f:scope-second-barrier",
+        inputs=(between.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
-        spill_mode="barrier",
+        unit_kind="native_fragment",
+        is_barrier=True,
     )
-    terminal = _stage(
-        "stage:f:phase-terminal",
-        inputs=(second_barrier.stage_id,),
+    terminal = _unit(
+        "resource:f:scope-terminal",
+        inputs=(second_barrier.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
     manager = _manager(
         source,
@@ -215,85 +223,85 @@ def test_only_first_pending_materializing_phase_and_its_upstream_receive_reserva
     )
     _ready(
         manager,
-        source.stage_id,
-        first_barrier.stage_id,
-        between.stage_id,
-        second_barrier.stage_id,
-        terminal.stage_id,
+        source.resource_unit_id,
+        first_barrier.resource_unit_id,
+        between.resource_unit_id,
+        second_barrier.resource_unit_id,
+        terminal.resource_unit_id,
     )
-    for stage in (source, first_barrier, between, second_barrier, terminal):
-        manager.note_task_waiting(_task(stage.stage_id, "waiting"))
+    for unit in (source, first_barrier, between, second_barrier, terminal):
+        manager.note_task_waiting(_task(unit.resource_unit_id, "waiting"))
 
     first_snapshot = manager.snapshot()
-    unreserved_between = manager.try_acquire_task(_task(between.stage_id, 0))
+    unreserved_between = manager.try_acquire_task(_task(between.resource_unit_id, 0))
 
-    assert first_snapshot["materializing_phase"] == {
-        "barrier_stage_id": first_barrier.stage_id,
-        "stage_ids": [source.stage_id, first_barrier.stage_id],
+    assert first_snapshot["reservation_scope"] == {
+        "barrier_unit_id": first_barrier.resource_unit_id,
+        "resource_unit_ids": [source.resource_unit_id, first_barrier.resource_unit_id],
         "object_store_backpressure_disabled": True,
-        "object_store_unlimited_stage_ids": [
-            source.stage_id,
-            first_barrier.stage_id,
+        "object_store_unlimited_unit_ids": [
+            source.resource_unit_id,
+            first_barrier.resource_unit_id,
         ],
     }
-    assert first_snapshot["admission"]["reservation_stage_ids"]["cpu"] == [
-        source.stage_id,
-        first_barrier.stage_id,
+    assert first_snapshot["admission"]["reservation_unit_ids"]["cpu"] == [
+        source.resource_unit_id,
+        first_barrier.resource_unit_id,
     ]
     assert unreserved_between.granted
     assert unreserved_between.liveness is False
-    assert between.stage_id not in first_snapshot["admission"]["reservation_stage_ids"]["cpu"]
+    assert between.resource_unit_id not in first_snapshot["admission"]["reservation_unit_ids"]["cpu"]
     assert manager.release_task_lease(unreserved_between.lease.lease_id, attempt_id="0")
 
     with pytest.raises(ValueError, match="not a blocking materializer"):
-        manager.mark_materializing_stage_completed(source.stage_id)
-    assert manager.mark_materializing_stage_completed(first_barrier.stage_id)
-    assert not manager.mark_materializing_stage_completed(first_barrier.stage_id)
+        manager.mark_barrier_unit_completed(source.resource_unit_id)
+    assert manager.mark_barrier_unit_completed(first_barrier.resource_unit_id)
+    assert not manager.mark_barrier_unit_completed(first_barrier.resource_unit_id)
     second_snapshot = manager.snapshot()
 
-    assert second_snapshot["materializing_phase"]["barrier_stage_id"] == second_barrier.stage_id
-    assert second_snapshot["materializing_phase"]["stage_ids"] == [
-        source.stage_id,
-        first_barrier.stage_id,
-        between.stage_id,
-        second_barrier.stage_id,
+    assert second_snapshot["reservation_scope"]["barrier_unit_id"] == second_barrier.resource_unit_id
+    assert second_snapshot["reservation_scope"]["resource_unit_ids"] == [
+        source.resource_unit_id,
+        first_barrier.resource_unit_id,
+        between.resource_unit_id,
+        second_barrier.resource_unit_id,
     ]
-    assert second_snapshot["stages"][source.stage_id]["completed"] is False
-    assert second_snapshot["stages"][first_barrier.stage_id]["completed"] is False
-    assert second_snapshot["stages"][first_barrier.stage_id]["materialization_completed"] is True
-    assert second_snapshot["stages"][source.stage_id]["phase_eligible"] is True
-    assert second_snapshot["stages"][first_barrier.stage_id]["phase_eligible"] is True
-    assert second_snapshot["stages"][between.stage_id]["phase_eligible"] is True
-    assert second_snapshot["stages"][terminal.stage_id]["phase_eligible"] is False
-    assert manager.try_acquire_task(_task(between.stage_id, 1)).granted
-    assert manager.try_acquire_task(_task(first_barrier.stage_id, 1)).granted
+    assert second_snapshot["units"][source.resource_unit_id]["completed"] is False
+    assert second_snapshot["units"][first_barrier.resource_unit_id]["completed"] is False
+    assert second_snapshot["units"][first_barrier.resource_unit_id]["materialization_completed"] is True
+    assert second_snapshot["units"][source.resource_unit_id]["reservation_scope_eligible"] is True
+    assert second_snapshot["units"][first_barrier.resource_unit_id]["reservation_scope_eligible"] is True
+    assert second_snapshot["units"][between.resource_unit_id]["reservation_scope_eligible"] is True
+    assert second_snapshot["units"][terminal.resource_unit_id]["reservation_scope_eligible"] is False
+    assert manager.try_acquire_task(_task(between.resource_unit_id, 1)).granted
+    assert manager.try_acquire_task(_task(first_barrier.resource_unit_id, 1)).granted
 
 
 def test_blocking_materialization_disables_only_corresponding_object_store_soft_limits():
-    early = _stage(
-        "stage:f:spill-early",
+    early = _unit(
+        "resource:f:spill-early",
         resources=_r(cpu=1, heap=10),
         target=10,
         blocks=1,
     )
-    producer = _stage(
-        "stage:f:spill-producer",
-        inputs=(early.stage_id,),
+    producer = _unit(
+        "resource:f:spill-producer",
+        inputs=(early.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=10,
         blocks=1,
     )
-    barrier = _stage(
-        "stage:f:spill-barrier",
-        inputs=(producer.stage_id,),
+    barrier = _unit(
+        "resource:f:spill-barrier",
+        inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=10,
         blocks=1,
-        spill_mode="barrier",
+        is_barrier=True,
     )
-    terminal = _stage(
-        "stage:f:spill-terminal",
-        inputs=(barrier.stage_id,),
+    terminal = _unit(
+        "resource:f:spill-terminal",
+        inputs=(barrier.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=10,
         blocks=1,
@@ -305,17 +313,19 @@ def test_blocking_materialization_disables_only_corresponding_object_store_soft_
         terminal,
         resources=_r(cpu=4, heap=100, store=10),
     )
-    _ready(manager, early.stage_id, producer.stage_id, barrier.stage_id, terminal.stage_id)
+    _ready(
+        manager, early.resource_unit_id, producer.resource_unit_id, barrier.resource_unit_id, terminal.resource_unit_id
+    )
 
-    producer_task = manager.try_acquire_task(_task(producer.stage_id, 0, retained=0))
-    barrier_task = manager.try_acquire_task(_task(barrier.stage_id, 0, retained=0))
-    manager.note_task_waiting(_task(early.stage_id, "waiting", retained=0))
-    early_normal_reason = manager._normal_task_block_reason_locked(_task(early.stage_id, 0, retained=0))[0]
-    early_task = manager.try_acquire_task(_task(early.stage_id, 0, retained=0))
+    producer_task = manager.try_acquire_task(_task(producer.resource_unit_id, 0, retained=0))
+    barrier_task = manager.try_acquire_task(_task(barrier.resource_unit_id, 0, retained=0))
+    manager.note_task_waiting(_task(early.resource_unit_id, "waiting", retained=0))
+    early_normal_reason = manager._normal_task_block_reason_locked(_task(early.resource_unit_id, 0, retained=0))[0]
+    early_task = manager.try_acquire_task(_task(early.resource_unit_id, 0, retained=0))
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             query_id="q",
-            producer_stage_id=producer.stage_id,
+            producer_unit_id=producer.resource_unit_id,
             task_lease_id=producer_task.lease.lease_id,
             attempt_id="0",
             block_id="materialized-input",
@@ -331,37 +341,37 @@ def test_blocking_materialization_disables_only_corresponding_object_store_soft_
     assert early_task.blocked_reason == "liveness_not_needed"
     assert output.granted and output.liveness is False
     assert snapshot["usage"]["object_store_bytes"] > snapshot["allocation"]["resources"]["object_store_bytes"]
-    assert snapshot["materializing_phase"]["object_store_unlimited_stage_ids"] == [
-        producer.stage_id,
-        barrier.stage_id,
+    assert snapshot["reservation_scope"]["object_store_unlimited_unit_ids"] == [
+        producer.resource_unit_id,
+        barrier.resource_unit_id,
     ]
-    assert snapshot["admission"]["reservation_stage_ids"]["object_store_bytes"] == [
-        early.stage_id,
+    assert snapshot["admission"]["reservation_unit_ids"]["object_store_bytes"] == [
+        early.resource_unit_id,
     ]
 
 
 def test_nested_materializers_activate_spill_exemptions_on_real_demand():
-    inner_input = _stage("stage:f:nested-inner-input", resources=_r(cpu=1, heap=10))
-    receiver = _stage("stage:f:nested-receiver", resources=_r(cpu=1, heap=10))
-    inner_barrier = _stage(
-        "stage:f:nested-inner-barrier",
-        inputs=(inner_input.stage_id, receiver.stage_id),
+    inner_input = _unit("resource:f:nested-inner-input", resources=_r(cpu=1, heap=10))
+    receiver = _unit("resource:f:nested-receiver", resources=_r(cpu=1, heap=10))
+    inner_barrier = _unit(
+        "resource:f:nested-inner-barrier",
+        inputs=(inner_input.resource_unit_id, receiver.resource_unit_id),
         resources=_r(cpu=1, heap=10),
-        spill_mode="barrier",
+        is_barrier=True,
     )
-    middle_input = _stage("stage:f:nested-middle-input", resources=_r(cpu=1, heap=10))
-    middle_barrier = _stage(
-        "stage:f:nested-middle-barrier",
-        inputs=(middle_input.stage_id, inner_barrier.stage_id),
+    middle_input = _unit("resource:f:nested-middle-input", resources=_r(cpu=1, heap=10))
+    middle_barrier = _unit(
+        "resource:f:nested-middle-barrier",
+        inputs=(middle_input.resource_unit_id, inner_barrier.resource_unit_id),
         resources=_r(cpu=1, heap=10),
-        spill_mode="barrier",
+        is_barrier=True,
     )
-    outer_input = _stage("stage:f:nested-outer-input", resources=_r(cpu=1, heap=10))
-    outer_barrier = _stage(
-        "stage:f:nested-outer-barrier",
-        inputs=(outer_input.stage_id, middle_barrier.stage_id),
+    outer_input = _unit("resource:f:nested-outer-input", resources=_r(cpu=1, heap=10))
+    outer_barrier = _unit(
+        "resource:f:nested-outer-barrier",
+        inputs=(outer_input.resource_unit_id, middle_barrier.resource_unit_id),
         resources=_r(cpu=1, heap=10),
-        spill_mode="barrier",
+        is_barrier=True,
     )
     manager = _manager(
         inner_input,
@@ -375,39 +385,39 @@ def test_nested_materializers_activate_spill_exemptions_on_real_demand():
     )
     _ready(
         manager,
-        inner_input.stage_id,
-        receiver.stage_id,
-        inner_barrier.stage_id,
-        middle_input.stage_id,
-        middle_barrier.stage_id,
-        outer_input.stage_id,
-        outer_barrier.stage_id,
+        inner_input.resource_unit_id,
+        receiver.resource_unit_id,
+        inner_barrier.resource_unit_id,
+        middle_input.resource_unit_id,
+        middle_barrier.resource_unit_id,
+        outer_input.resource_unit_id,
+        outer_barrier.resource_unit_id,
     )
 
     initial = manager.snapshot()
-    outer_task = manager.try_acquire_task(_task(outer_input.stage_id, 0, retained=0))
+    outer_task = manager.try_acquire_task(_task(outer_input.resource_unit_id, 0, retained=0))
     after_outer_demand = manager.snapshot()
-    middle_task = manager.try_acquire_task(_task(middle_input.stage_id, 0, retained=0))
+    middle_task = manager.try_acquire_task(_task(middle_input.resource_unit_id, 0, retained=0))
     after_middle_demand = manager.snapshot()
 
-    assert initial["materializing_phase"]["barrier_stage_id"] == inner_barrier.stage_id
-    assert initial["materializing_phase"]["object_store_unlimited_stage_ids"] == [
-        inner_input.stage_id,
-        receiver.stage_id,
-        inner_barrier.stage_id,
+    assert initial["reservation_scope"]["barrier_unit_id"] == inner_barrier.resource_unit_id
+    assert initial["reservation_scope"]["object_store_unlimited_unit_ids"] == [
+        inner_input.resource_unit_id,
+        receiver.resource_unit_id,
+        inner_barrier.resource_unit_id,
     ]
     assert outer_task.granted and outer_task.liveness is False
-    assert outer_input.stage_id not in initial["admission"]["reservation_stage_ids"]["object_store_bytes"]
-    assert after_outer_demand["stages"][outer_input.stage_id]["object_store_backpressure_disabled"] is True
-    assert after_outer_demand["stages"][middle_input.stage_id]["object_store_backpressure_disabled"] is False
+    assert outer_input.resource_unit_id not in initial["admission"]["reservation_unit_ids"]["object_store_bytes"]
+    assert after_outer_demand["units"][outer_input.resource_unit_id]["object_store_backpressure_disabled"] is True
+    assert after_outer_demand["units"][middle_input.resource_unit_id]["object_store_backpressure_disabled"] is False
     assert middle_task.granted and middle_task.liveness is False
-    assert after_middle_demand["stages"][middle_input.stage_id]["object_store_backpressure_disabled"] is True
-    assert after_middle_demand["materializing_phase"]["barrier_stage_id"] == inner_barrier.stage_id
+    assert after_middle_demand["units"][middle_input.resource_unit_id]["object_store_backpressure_disabled"] is True
+    assert after_middle_demand["reservation_scope"]["barrier_unit_id"] == inner_barrier.resource_unit_id
 
 
 def test_actor_task_leases_own_distinct_concrete_actor_slots():
-    actor = _stage(
-        "stage:f:gpu",
+    actor = _unit(
+        "resource:f:gpu",
         resources=_r(store=40),
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
@@ -418,11 +428,11 @@ def test_actor_task_leases_own_distinct_concrete_actor_slots():
         actor,
         resources=_r(cpu=2, gpu=2, heap=200, store=500),
     )
-    _ready(manager, actor.stage_id)
+    _ready(manager, actor.resource_unit_id)
 
-    first = manager.try_acquire_task(_task(actor.stage_id, 0, retained=20))
-    second = manager.try_acquire_task(_task(actor.stage_id, 1, retained=20))
-    blocked = manager.try_acquire_task(_task(actor.stage_id, 2, retained=20))
+    first = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=20))
+    second = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=20))
+    blocked = manager.try_acquire_task(_task(actor.resource_unit_id, 2, retained=20))
 
     assert first.granted and second.granted
     assert {first.lease.actor_index, second.lease.actor_index} == {0, 1}
@@ -430,14 +440,14 @@ def test_actor_task_leases_own_distinct_concrete_actor_slots():
         first.lease.execution_slot_id,
         second.lease.execution_slot_id,
     } == {
-        f"ray_actor:{actor.stage_id}:0",
-        f"ray_actor:{actor.stage_id}:1",
+        f"ray_actor:{actor.resource_unit_id}:0",
+        f"ray_actor:{actor.resource_unit_id}:1",
     }
     assert blocked.granted is False
     assert blocked.blocked_reason == "actor_slot"
 
     assert manager.release_task_lease(first.lease.lease_id, attempt_id="0")
-    replacement = manager.try_acquire_task(_task(actor.stage_id, 2, retained=20))
+    replacement = manager.try_acquire_task(_task(actor.resource_unit_id, 2, retained=20))
     assert replacement.granted
     assert replacement.lease.actor_index == first.lease.actor_index
 
@@ -446,8 +456,8 @@ def test_actor_task_leases_own_distinct_concrete_actor_slots():
 
 
 def test_actor_prefetch_depth_queues_one_call_per_concrete_actor():
-    actor = _stage(
-        "stage:f:gpu-prefetch",
+    actor = _unit(
+        "resource:f:gpu-prefetch",
         resources=_r(store=40),
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
@@ -458,9 +468,9 @@ def test_actor_prefetch_depth_queues_one_call_per_concrete_actor():
         actor,
         resources=_r(cpu=2, gpu=2, heap=200, store=1_000),
     )
-    _ready(manager, actor.stage_id)
+    _ready(manager, actor.resource_unit_id)
 
-    grants = [manager.try_acquire_task(_task(actor.stage_id, partition, retained=20)) for partition in range(5)]
+    grants = [manager.try_acquire_task(_task(actor.resource_unit_id, partition, retained=20)) for partition in range(5)]
 
     assert all(grant.granted for grant in grants[:4])
     assert [grant.lease.actor_index for grant in grants[:4]] == [0, 1, 0, 1]
@@ -468,39 +478,39 @@ def test_actor_prefetch_depth_queues_one_call_per_concrete_actor():
     assert grants[4].blocked_reason == "actor_slot"
     snapshot = manager.snapshot()
     assert snapshot["active_actor_slots"] == {
-        f"{actor.stage_id}:0": grants[0].lease.lease_id,
-        f"{actor.stage_id}:1": grants[1].lease.lease_id,
+        f"{actor.resource_unit_id}:0": grants[0].lease.lease_id,
+        f"{actor.resource_unit_id}:1": grants[1].lease.lease_id,
     }
     assert snapshot["queued_actor_slots"] == {
-        f"{actor.stage_id}:0": [grants[2].lease.lease_id],
-        f"{actor.stage_id}:1": [grants[3].lease.lease_id],
+        f"{actor.resource_unit_id}:0": [grants[2].lease.lease_id],
+        f"{actor.resource_unit_id}:1": [grants[3].lease.lease_id],
     }
 
     assert manager.release_task_lease(grants[0].lease.lease_id, attempt_id="0")
     snapshot = manager.snapshot()
-    assert snapshot["active_actor_slots"][f"{actor.stage_id}:0"] == grants[2].lease.lease_id
-    assert f"{actor.stage_id}:0" not in snapshot["queued_actor_slots"]
+    assert snapshot["active_actor_slots"][f"{actor.resource_unit_id}:0"] == grants[2].lease.lease_id
+    assert f"{actor.resource_unit_id}:0" not in snapshot["queued_actor_slots"]
 
     assert manager.release_task_lease(grants[3].lease.lease_id, attempt_id="0")
-    assert f"{actor.stage_id}:1" not in manager.snapshot()["queued_actor_slots"]
+    assert f"{actor.resource_unit_id}:1" not in manager.snapshot()["queued_actor_slots"]
 
 
 def test_ray_tasks_receive_unique_resource_lease_slots():
-    stage = _stage("stage:f:cpu", concurrency=None)
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
+    unit = _unit("resource:f:cpu", concurrency=None)
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
 
-    first = manager.try_acquire_task(_task(stage.stage_id, 0))
-    second = manager.try_acquire_task(_task(stage.stage_id, 1))
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
 
     assert first.granted and second.granted
     assert first.lease.execution_slot_id != second.lease.execution_slot_id
-    assert first.lease.execution_slot_id == (f"ray_task:{stage.stage_id}:{first.lease.lease_id}")
+    assert first.lease.execution_slot_id == (f"ray_task:{unit.resource_unit_id}:{first.lease.lease_id}")
 
 
 def test_idle_actor_resident_resources_remain_charged_to_query_and_node():
-    actor = _stage(
-        "stage:f:gpu",
+    actor = _unit(
+        "resource:f:gpu",
         resources=_r(store=40),
         resident=_r(cpu=1, gpu=1, heap=100),
         backend="ray_actor",
@@ -517,21 +527,21 @@ def test_idle_actor_resident_resources_remain_charged_to_query_and_node():
     assert snapshot["node_usage"]["node-a"] == _r(cpu=1, gpu=1, heap=100).to_dict()
 
 
-def test_soft_reservation_only_divides_each_dimension_among_stages_that_need_it():
-    cpu_stages = []
+def test_soft_reservation_only_divides_each_dimension_among_units_that_need_it():
+    cpu_units = []
     for index in range(10):
-        cpu_stages.append(
-            _stage(
-                f"stage:f:cpu-{index}",
-                inputs=() if not cpu_stages else (cpu_stages[-1].stage_id,),
+        cpu_units.append(
+            _unit(
+                f"resource:f:cpu-{index}",
+                inputs=() if not cpu_units else (cpu_units[-1].resource_unit_id,),
                 resources=_r(cpu=1, heap=10),
                 target=0,
                 blocks=0,
             )
         )
-    gpu_stage = _stage(
-        "stage:f:gpu",
-        inputs=(cpu_stages[-1].stage_id,),
+    gpu_unit = _unit(
+        "resource:f:gpu",
+        inputs=(cpu_units[-1].resource_unit_id,),
         resources=_r(gpu=1, heap=20),
         target=0,
         blocks=0,
@@ -539,34 +549,34 @@ def test_soft_reservation_only_divides_each_dimension_among_stages_that_need_it(
         actor_pool_size=1,
     )
     manager = _manager(
-        *cpu_stages,
-        gpu_stage,
+        *cpu_units,
+        gpu_unit,
         resources=_r(cpu=10, gpu=1, heap=1_000, store=100),
     )
-    _ready(manager, *(stage.stage_id for stage in (*cpu_stages, gpu_stage)))
+    _ready(manager, *(unit.resource_unit_id for unit in (*cpu_units, gpu_unit)))
 
-    grant = manager.try_acquire_task(_task(gpu_stage.stage_id, 0))
+    grant = manager.try_acquire_task(_task(gpu_unit.resource_unit_id, 0))
 
     assert grant.granted
     assert grant.lease.resources.gpu == 0
-    assert gpu_stage.resident_per_actor.gpu == 1
+    assert gpu_unit.resident_per_actor.gpu == 1
 
 
-def test_stage_minimum_commitments_are_protected_before_shared_heap_borrowing():
-    cpu_stages = []
+def test_unit_minimum_commitments_are_protected_before_shared_heap_borrowing():
+    cpu_units = []
     for index in range(10):
-        cpu_stages.append(
-            _stage(
-                f"stage:f:cpu-{index}",
-                inputs=() if not cpu_stages else (cpu_stages[-1].stage_id,),
+        cpu_units.append(
+            _unit(
+                f"resource:f:cpu-{index}",
+                inputs=() if not cpu_units else (cpu_units[-1].resource_unit_id,),
                 resources=_r(cpu=1, heap=20),
                 target=0,
                 blocks=0,
             )
         )
-    gpu_stage = _stage(
-        "stage:f:gpu",
-        inputs=(cpu_stages[-1].stage_id,),
+    gpu_unit = _unit(
+        "resource:f:gpu",
+        inputs=(cpu_units[-1].resource_unit_id,),
         resources=_r(gpu=1, heap=40),
         target=0,
         blocks=0,
@@ -574,24 +584,24 @@ def test_stage_minimum_commitments_are_protected_before_shared_heap_borrowing():
         actor_pool_size=1,
     )
     manager = _manager(
-        *cpu_stages,
-        gpu_stage,
+        *cpu_units,
+        gpu_unit,
         resources=_r(cpu=100, gpu=1, heap=240, store=100),
     )
-    _ready(manager, *(stage.stage_id for stage in (*cpu_stages, gpu_stage)))
+    _ready(manager, *(unit.resource_unit_id for unit in (*cpu_units, gpu_unit)))
 
-    first_upstream = manager.try_acquire_task(_task(cpu_stages[0].stage_id, 0))
-    second_upstream = manager.try_acquire_task(_task(cpu_stages[0].stage_id, 1))
-    downstream = manager.try_acquire_task(_task(gpu_stage.stage_id, 0))
+    first_upstream = manager.try_acquire_task(_task(cpu_units[0].resource_unit_id, 0))
+    second_upstream = manager.try_acquire_task(_task(cpu_units[0].resource_unit_id, 1))
+    downstream = manager.try_acquire_task(_task(gpu_unit.resource_unit_id, 0))
 
     assert first_upstream.granted
     assert not second_upstream.granted
     assert downstream.granted
 
 
-def test_soft_heap_reservation_does_not_exceed_cross_dimension_stage_capacity():
-    gpu_actor = _stage(
-        "stage:f:gpu-actor",
+def test_soft_heap_reservation_does_not_exceed_cross_dimension_unit_capacity():
+    gpu_actor = _unit(
+        "resource:f:gpu-actor",
         resources=_r(gpu=1, heap=4),
         target=0,
         blocks=0,
@@ -599,9 +609,9 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_stage_capacity():
         backend="ray_actor",
         actor_pool_size=1,
     )
-    cpu_stage = _stage(
-        "stage:f:cpu",
-        inputs=(gpu_actor.stage_id,),
+    cpu_unit = _unit(
+        "resource:f:cpu",
+        inputs=(gpu_actor.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -609,14 +619,14 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_stage_capacity():
     )
     manager = _manager(
         gpu_actor,
-        cpu_stage,
+        cpu_unit,
         resources=_r(cpu=100, gpu=1, heap=20, store=20),
     )
-    _ready(manager, gpu_actor.stage_id, cpu_stage.stage_id)
+    _ready(manager, gpu_actor.resource_unit_id, cpu_unit.resource_unit_id)
 
-    actor_grant = manager.try_acquire_task(_task(gpu_actor.stage_id, 0))
-    cpu_grants = [manager.try_acquire_task(_task(cpu_stage.stage_id, partition)) for partition in range(8)]
-    denied = manager.try_acquire_task(_task(cpu_stage.stage_id, 8))
+    actor_grant = manager.try_acquire_task(_task(gpu_actor.resource_unit_id, 0))
+    cpu_grants = [manager.try_acquire_task(_task(cpu_unit.resource_unit_id, partition)) for partition in range(8)]
+    denied = manager.try_acquire_task(_task(cpu_unit.resource_unit_id, 8))
 
     assert actor_grant.granted
     assert all(grant.granted for grant in cpu_grants)
@@ -624,31 +634,31 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_stage_capacity():
     assert denied.blocked_reason == "hard_heap_bytes"
 
 
-def test_empty_runnable_stages_do_not_dilute_live_task_reservation():
-    stages = []
+def test_empty_runnable_units_do_not_dilute_live_task_reservation():
+    units = []
     for index in range(4):
-        stages.append(
-            _stage(
-                f"stage:f:demand-{index}",
-                inputs=() if not stages else (stages[-1].stage_id,),
+        units.append(
+            _unit(
+                f"resource:f:demand-{index}",
+                inputs=() if not units else (units[-1].resource_unit_id,),
                 resources=_r(cpu=1, heap=2),
                 target=0,
                 blocks=0,
             )
         )
-    live_stage = stages[-1]
+    live_unit = units[-1]
     manager = _manager(
-        *stages,
+        *units,
         resources=_r(cpu=8, heap=8, store=8),
     )
-    for stage in stages:
-        manager.update_stage_state(
-            stage.stage_id,
+    for unit in units:
+        manager.update_unit_state(
+            unit.resource_unit_id,
             runnable=True,
             actor_ready=True,
         )
 
-    requests = [_task(live_stage.stage_id, index) for index in range(3)]
+    requests = [_task(live_unit.resource_unit_id, index) for index in range(3)]
     for request in requests:
         manager.note_task_waiting(request)
 
@@ -656,22 +666,22 @@ def test_empty_runnable_stages_do_not_dilute_live_task_reservation():
 
     assert all(grant.granted for grant in grants)
     snapshot = manager.snapshot()
-    assert snapshot["stages"][live_stage.stage_id]["active_task_count"] == 3
+    assert snapshot["units"][live_unit.resource_unit_id]["active_task_count"] == 3
     assert all(
-        snapshot["stages"][stage.stage_id]["active_task_count"] == 0 for stage in stages if stage is not live_stage
+        snapshot["units"][unit.resource_unit_id]["active_task_count"] == 0 for unit in units if unit is not live_unit
     )
 
 
 def test_queued_admission_prefers_downstream_over_upstream_refill():
-    upstream = _stage(
-        "stage:f:upstream-refill",
+    upstream = _unit(
+        "resource:f:upstream-refill",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    downstream = _stage(
-        "stage:f:downstream-work",
-        inputs=(upstream.stage_id,),
+    downstream = _unit(
+        "resource:f:downstream-work",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -681,14 +691,14 @@ def test_queued_admission_prefers_downstream_over_upstream_refill():
         downstream,
         resources=_r(cpu=12, heap=12, store=12),
     )
-    manager.update_stage_state(upstream.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
 
-    held = [manager.try_acquire_task(_task(upstream.stage_id, index)) for index in range(5)]
+    held = [manager.try_acquire_task(_task(upstream.resource_unit_id, index)) for index in range(5)]
     assert all(grant.granted for grant in held)
 
-    manager.update_stage_state(downstream.stage_id, runnable=True, actor_ready=True)
-    upstream_waiter = _task(upstream.stage_id, "refill")
-    downstream_waiter = _task(downstream.stage_id, "ready")
+    manager.update_unit_state(downstream.resource_unit_id, runnable=True, actor_ready=True)
+    upstream_waiter = _task(upstream.resource_unit_id, "refill")
+    downstream_waiter = _task(downstream.resource_unit_id, "ready")
     manager.note_task_waiting(upstream_waiter)
     manager.note_task_waiting(downstream_waiter)
 
@@ -699,12 +709,12 @@ def test_queued_admission_prefers_downstream_over_upstream_refill():
     assert before["preferred_task"] == {
         "task_id": downstream_waiter.task_id,
         "attempt_id": downstream_waiter.attempt_id,
-        "stage_id": downstream.stage_id,
+        "resource_unit_id": downstream.resource_unit_id,
         "grant_class": "normal",
     }
-    assert before["reservation_stage_ids"]["heap_bytes"] == [
-        upstream.stage_id,
-        downstream.stage_id,
+    assert before["reservation_unit_ids"]["heap_bytes"] == [
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
     ]
     assert [item["task_id"] for item in before["waiting_tasks"]] == [
         upstream_waiter.task_id,
@@ -714,29 +724,29 @@ def test_queued_admission_prefers_downstream_over_upstream_refill():
     assert not upstream_result.fatal
     assert upstream_result.blocked_reason == "admission_turn"
     assert downstream_result.granted
-    assert downstream_result.lease.stage_id == downstream.stage_id
+    assert downstream_result.lease.resource_unit_id == downstream.resource_unit_id
 
 
 def test_driver_subset_yields_when_global_winner_is_fte_owned():
-    upstream = _stage(
-        "stage:f:driver-upstream",
+    upstream = _unit(
+        "resource:f:driver-upstream",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    downstream = _stage(
-        "stage:f:fte-downstream",
-        inputs=(upstream.stage_id,),
+    downstream = _unit(
+        "resource:f:fte-downstream",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
     manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.stage_id, downstream.stage_id)
-    driver_request = _task(upstream.stage_id, "driver")
-    fte_request = _task(downstream.stage_id, "fte")
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+    driver_request = _task(upstream.resource_unit_id, "driver")
+    fte_request = _task(downstream.resource_unit_id, "fte")
     manager.note_task_waiting(driver_request)
     manager.note_task_waiting(fte_request)
 
@@ -750,23 +760,23 @@ def test_driver_subset_yields_when_global_winner_is_fte_owned():
 
 
 def test_fte_request_yields_when_global_winner_is_driver_owned():
-    upstream = _stage(
-        "stage:f:fte-upstream",
+    upstream = _unit(
+        "resource:f:fte-upstream",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    downstream = _stage(
-        "stage:f:driver-downstream",
-        inputs=(upstream.stage_id,),
+    downstream = _unit(
+        "resource:f:driver-downstream",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
     manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.stage_id, downstream.stage_id)
-    fte_request = _task(upstream.stage_id, "fte")
-    driver_request = _task(downstream.stage_id, "driver")
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+    fte_request = _task(upstream.resource_unit_id, "fte")
+    driver_request = _task(downstream.resource_unit_id, "driver")
     manager.note_task_waiting(fte_request)
     manager.note_task_waiting(driver_request)
 
@@ -777,35 +787,35 @@ def test_fte_request_yields_when_global_winner_is_driver_owned():
     assert yielded.blocked_reason == "admission_turn"
     assert selected == driver_request
     assert granted.granted
-    assert granted.lease.stage_id == downstream.stage_id
+    assert granted.lease.resource_unit_id == downstream.resource_unit_id
 
 
 def test_descriptor_admission_is_not_persisted_and_retries_after_epoch_change():
-    stage = _stage(
-        "stage:f:descriptor-window",
+    unit = _unit(
+        "resource:f:descriptor-window",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         concurrency=1,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    manager = _manager(stage, resources=_r(cpu=2, heap=4, store=4))
-    _ready(manager, stage.stage_id)
+    manager = _manager(unit, resources=_r(cpu=2, heap=4, store=4))
+    _ready(manager, unit.resource_unit_id)
 
-    first = manager.try_acquire_task_descriptor(_task(stage.stage_id, 0))
+    first = manager.try_acquire_task_descriptor(_task(unit.resource_unit_id, 0))
     assert first.granted
     epoch_before_denial = manager.admission_epoch()
 
-    second_request = _task(stage.stage_id, 1)
+    second_request = _task(unit.resource_unit_id, 1)
     denied = manager.try_acquire_task_descriptor(second_request)
     snapshot = manager.snapshot()
 
     assert not denied.granted
-    assert denied.blocked_reason == "stage_concurrency"
+    assert denied.blocked_reason == "unit_concurrency"
     assert denied.admission_epoch == epoch_before_denial
     assert manager.admission_epoch() == epoch_before_denial
-    assert snapshot["stages"][stage.stage_id]["pending_task_count"] == 0
+    assert snapshot["units"][unit.resource_unit_id]["pending_task_count"] == 0
     assert snapshot["admission"]["waiting_tasks"] == []
 
     manager.release_task_lease(
@@ -817,57 +827,57 @@ def test_descriptor_admission_is_not_persisted_and_retries_after_epoch_change():
     assert replacement.granted
 
 
-def test_descriptor_admission_marks_non_root_fte_stage_runnable_without_waiter():
-    upstream = _stage(
-        "stage:f:descriptor-source",
+def test_descriptor_admission_marks_non_root_native_fragment_unit_runnable_without_waiter():
+    upstream = _unit(
+        "resource:f:descriptor-source",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    fte_stage = _stage(
-        "stage:f:descriptor-non-root",
-        inputs=(upstream.stage_id,),
+    native_fragment_unit = _unit(
+        "resource:f:descriptor-non-root",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    manager = _manager(upstream, fte_stage, resources=_r(cpu=4, heap=8, store=8))
-    manager.update_stage_state(upstream.stage_id, runnable=True)
-    assert manager.snapshot()["stages"][fte_stage.stage_id]["runnable"] is False
+    manager = _manager(upstream, native_fragment_unit, resources=_r(cpu=4, heap=8, store=8))
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
+    assert manager.snapshot()["units"][native_fragment_unit.resource_unit_id]["runnable"] is False
 
-    grant = manager.try_acquire_task_descriptor(_task(fte_stage.stage_id, 0))
+    grant = manager.try_acquire_task_descriptor(_task(native_fragment_unit.resource_unit_id, 0))
     snapshot = manager.snapshot()
 
     assert grant.granted
-    assert snapshot["stages"][fte_stage.stage_id]["runnable"] is True
-    assert snapshot["stages"][fte_stage.stage_id]["pending_task_count"] == 0
+    assert snapshot["units"][native_fragment_unit.resource_unit_id]["runnable"] is True
+    assert snapshot["units"][native_fragment_unit.resource_unit_id]["pending_task_count"] == 0
     assert snapshot["admission"]["waiting_tasks"] == []
 
 
 def test_descriptor_admission_yields_to_higher_rank_persistent_waiter():
-    upstream = _stage(
-        "stage:f:descriptor-upstream",
+    upstream = _unit(
+        "resource:f:descriptor-upstream",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    downstream = _stage(
-        "stage:f:persistent-downstream",
-        inputs=(upstream.stage_id,),
+    downstream = _unit(
+        "resource:f:persistent-downstream",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
     manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.stage_id, downstream.stage_id)
-    downstream_waiter = _task(downstream.stage_id, "driver")
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+    downstream_waiter = _task(downstream.resource_unit_id, "driver")
     manager.note_task_waiting(downstream_waiter)
 
-    descriptor = manager.try_acquire_task_descriptor(_task(upstream.stage_id, "fte"))
+    descriptor = manager.try_acquire_task_descriptor(_task(upstream.resource_unit_id, "fte"))
 
     assert not descriptor.granted
     assert descriptor.blocked_reason == "admission_turn"
@@ -877,21 +887,21 @@ def test_descriptor_admission_yields_to_higher_rank_persistent_waiter():
 
 
 def test_reregistering_same_task_waiter_does_not_publish_resource_change():
-    stage = _stage(
-        "stage:f:idempotent-waiter",
+    unit = _unit(
+        "resource:f:idempotent-waiter",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
     changes = []
     manager = _manager(
-        stage,
+        unit,
         resources=_r(cpu=2, heap=4, store=4),
         on_change=lambda: changes.append("changed"),
     )
-    manager.update_stage_state(stage.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
     changes.clear()
-    request = _task(stage.stage_id, 0)
+    request = _task(unit.resource_unit_id, 0)
 
     manager.note_task_waiting(request)
     manager.note_task_waiting(request)
@@ -899,47 +909,47 @@ def test_reregistering_same_task_waiter_does_not_publish_resource_change():
     assert changes == ["changed"]
 
 
-def test_reapplying_identical_stage_state_does_not_publish_resource_change():
-    stage = _stage(
-        "stage:f:idempotent-stage-state",
+def test_reapplying_identical_unit_state_does_not_publish_resource_change():
+    unit = _unit(
+        "resource:f:idempotent-unit-state",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
     changes = []
     manager = _manager(
-        stage,
+        unit,
         resources=_r(cpu=2, heap=4, store=4),
         on_change=lambda: changes.append("changed"),
     )
 
-    manager.update_stage_state(stage.stage_id, runnable=True, actor_ready=True)
-    manager.update_stage_state(stage.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
 
     assert changes == ["changed"]
 
 
 def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    bridge = _stage(
-        "stage:f:bridge-fte",
-        inputs=(parent.stage_id,),
+    bridge = _unit(
+        "resource:f:bridge-fte",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(bridge.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(bridge.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
@@ -950,9 +960,9 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
         child,
         resources=_r(cpu=100, heap=30, store=12),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grants = [manager.try_acquire_task(_task(parent.stage_id, partition)) for partition in range(4)]
+    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(4)]
 
     assert sum(grant.granted for grant in parent_grants) == 3
     assert parent_grants[3].blocked_reason == "continuation_capacity"
@@ -961,14 +971,14 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
     assert len(snapshot["continuation_credits"]) == 3
     assert all(credit["borrowed_by_task_lease_id"] is None for credit in snapshot["continuation_credits"].values())
     admission = snapshot["admission"]
-    assert admission["live_demand_stage_ids"]["heap_bytes"] == [parent.stage_id]
-    assert admission["continuation_stage_ids"]["heap_bytes"] == [child.stage_id]
-    assert admission["reservation_stage_ids"]["heap_bytes"] == [
-        parent.stage_id,
-        child.stage_id,
+    assert admission["live_demand_unit_ids"]["heap_bytes"] == [parent.resource_unit_id]
+    assert admission["continuation_unit_ids"]["heap_bytes"] == [child.resource_unit_id]
+    assert admission["reservation_unit_ids"]["heap_bytes"] == [
+        parent.resource_unit_id,
+        child.resource_unit_id,
     ]
 
-    child_requests = [_task(child.stage_id, partition) for partition in range(3)]
+    child_requests = [_task(child.resource_unit_id, partition) for partition in range(3)]
     for request in child_requests:
         manager.note_task_waiting(request)
     child_grants = [manager.try_acquire_queued_task(request) for request in child_requests]
@@ -980,7 +990,7 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
         grant.lease.lease_id for grant in child_grants
     }
 
-    fourth_child = _task(child.stage_id, 3)
+    fourth_child = _task(child.resource_unit_id, 3)
     manager.note_task_waiting(fourth_child)
     denied = manager.try_acquire_queued_task(fourth_child)
     assert not denied.granted
@@ -997,17 +1007,17 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
 
 
 def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowed():
-    parent = _stage(
-        "stage:f:parent-fte-normal-overflow",
+    parent = _unit(
+        "resource:f:parent-fte-normal-overflow",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf-normal-overflow",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf-normal-overflow",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
@@ -1017,11 +1027,11 @@ def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowe
         child,
         resources=_r(cpu=8, heap=40, store=40),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    assert manager.try_acquire_task(_task(parent.stage_id, 0)).granted
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    assert manager.try_acquire_task(_task(parent.resource_unit_id, 0)).granted
 
-    first_request = _task(child.stage_id, 0)
-    second_request = _task(child.stage_id, 1)
+    first_request = _task(child.resource_unit_id, 0)
+    second_request = _task(child.resource_unit_id, 1)
     manager.note_task_waiting(first_request)
     manager.note_task_waiting(second_request)
 
@@ -1046,26 +1056,26 @@ def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowe
 
 
 def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
     )
     manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    child_request = _task(child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    child_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
     child_grant = manager.try_acquire_queued_task(child_request)
 
@@ -1089,26 +1099,26 @@ def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
 
 
 def test_released_child_returns_credit_to_active_parent():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
     )
     manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    first_request = _task(child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    first_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
     first_child = manager.try_acquire_queued_task(first_request)
     assert parent_grant.granted and first_child.granted
@@ -1121,7 +1131,7 @@ def test_released_child_returns_credit_to_active_parent():
     assert snapshot["usage"]["heap_bytes"] == 10
     assert next(iter(snapshot["continuation_credits"].values()))["borrowed_by_task_lease_id"] is None
 
-    second_request = _task(child.stage_id, 1)
+    second_request = _task(child.resource_unit_id, 1)
     manager.note_task_waiting(second_request)
     second_child = manager.try_acquire_queued_task(second_request)
     assert second_child.granted
@@ -1129,17 +1139,17 @@ def test_released_child_returns_credit_to_active_parent():
 
 
 def test_continuation_credit_can_reserve_a_different_node_from_parent_fte():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
@@ -1153,14 +1163,14 @@ def test_continuation_credit_can_reserve_a_different_node_from_parent_fte():
             ("node-b", _r(cpu=1, heap=8, store=10)),
         ),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0, node_id="node-a"))
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0, node_id="node-a"))
     assert parent_grant.granted
     credit = next(iter(manager.snapshot()["continuation_credits"].values()))
     assert credit["node_id"] == "node-b"
 
-    child_request = _task(child.stage_id, 0)
+    child_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
     child_grant = manager.try_acquire_queued_task(child_request)
     assert child_grant.granted
@@ -1168,32 +1178,32 @@ def test_continuation_credit_can_reserve_a_different_node_from_parent_fte():
 
 
 def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=1,
     )
     manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    first_request = _task(child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    first_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
     first_child = manager.try_acquire_queued_task(first_request)
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             first_child.lease.lease_id,
             first_child.lease.attempt_id,
             "child-output",
@@ -1211,7 +1221,7 @@ def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
     credit = next(iter(snapshot["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == first_child.lease.lease_id
 
-    second_request = _task(child.stage_id, 1)
+    second_request = _task(child.resource_unit_id, 1)
     manager.note_task_waiting(second_request)
     denied = manager.try_acquire_queued_task(second_request)
     assert not denied.granted
@@ -1223,32 +1233,32 @@ def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
 
 
 def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_bytes():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=1,
     )
     manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    first_request = _task(child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    first_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
     first_child = manager.try_acquire_queued_task(first_request)
     first_output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             first_child.lease.lease_id,
             first_child.lease.attempt_id,
             "child-output-1",
@@ -1256,13 +1266,13 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
         )
     )
     assert parent_grant.granted and first_child.granted and first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         first_child.lease.lease_id,
         attempt_id=first_child.lease.attempt_id,
     )
 
-    second_request = _task(child.stage_id, 1)
+    second_request = _task(child.resource_unit_id, 1)
     manager.note_task_waiting(second_request)
     before_handoff = manager.try_acquire_queued_task(second_request)
     assert not before_handoff.granted
@@ -1281,7 +1291,7 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     second_output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             after_handoff.lease.lease_id,
             after_handoff.lease.attempt_id,
             "child-output-2",
@@ -1305,25 +1315,25 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
 
 
-def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
-    parent = _stage(
-        "stage:f:parent-fte",
+def test_cross_unit_credit_reuse_checks_historical_outputs_before_grant():
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    first_child = _stage(
-        "stage:f:child-a",
-        inputs=(parent.stage_id,),
+    first_child = _unit(
+        "resource:f:child-a",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=2,
     )
-    second_child = _stage(
-        "stage:f:child-b",
-        inputs=(first_child.stage_id,),
+    second_child = _unit(
+        "resource:f:child-b",
+        inputs=(first_child.resource_unit_id,),
         resources=_r(cpu=1, heap=8, store=10),
         target=10,
         blocks=1,
@@ -1334,16 +1344,16 @@ def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
         second_child,
         resources=_r(cpu=10, heap=10, store=20),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    first_request = _task(first_child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    first_request = _task(first_child.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
     first_grant = manager.try_acquire_queued_task(first_request)
     first_output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            first_child.stage_id,
+            first_child.resource_unit_id,
             first_grant.lease.lease_id,
             first_grant.lease.attempt_id,
             "child-a-output",
@@ -1351,7 +1361,7 @@ def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
         )
     )
     assert parent_grant.granted and first_grant.granted and first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         first_grant.lease.lease_id,
         attempt_id=first_grant.lease.attempt_id,
@@ -1359,7 +1369,7 @@ def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
     assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
     assert manager.snapshot()["usage"]["object_store_bytes"] == 15
 
-    second_request = _task(second_child.stage_id, 0, retained=10)
+    second_request = _task(second_child.resource_unit_id, 0, retained=10)
     manager.note_task_waiting(second_request)
     granted = manager.try_acquire_queued_task(second_request)
     assert granted.granted and granted.liveness
@@ -1370,17 +1380,17 @@ def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
 
 
 def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8, store=10),
         target=10,
         blocks=1,
@@ -1390,18 +1400,18 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
         child,
         resources=_r(cpu=20, heap=20, store=45),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parents = [manager.try_acquire_task(_task(parent.stage_id, partition)) for partition in range(2)]
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
     assert all(grant.granted for grant in parents)
 
-    first_request = _task(child.stage_id, 0, retained=10)
+    first_request = _task(child.resource_unit_id, 0, retained=10)
     manager.note_task_waiting(first_request)
     first_child = manager.try_acquire_queued_task(first_request)
     assert first_child.granted
     first_output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             first_child.lease.lease_id,
             first_child.lease.attempt_id,
             "historical-output",
@@ -1409,7 +1419,7 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
         )
     )
     assert first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
     assert manager.release_task_lease(
         first_child.lease.lease_id,
@@ -1421,7 +1431,7 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
         _allocation(_r(cpu=20, heap=20, store=40), generation=2),
         admission_open=True,
     )
-    second_request = _task(child.stage_id, 1, retained=10)
+    second_request = _task(child.resource_unit_id, 1, retained=10)
     manager.note_task_waiting(second_request)
     second_child = manager.try_acquire_queued_task(second_request)
 
@@ -1435,25 +1445,25 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
     assert borrowed_credit_ids == {historical_credit_id}
 
 
-def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
-    parent = _stage(
-        "stage:f:parent-fte",
+def test_cross_unit_idle_credit_output_excess_is_attributed_exactly_once():
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    first_child = _stage(
-        "stage:f:child-a",
-        inputs=(parent.stage_id,),
+    first_child = _unit(
+        "resource:f:child-a",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=2,
     )
-    second_child = _stage(
-        "stage:f:child-b",
-        inputs=(first_child.stage_id,),
+    second_child = _unit(
+        "resource:f:child-b",
+        inputs=(first_child.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=2,
@@ -1464,29 +1474,29 @@ def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
         second_child,
         resources=_r(cpu=10, heap=10, store=30),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
     manager.set_external_consumer_waiting(True)
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     assert parent_grant.granted
 
-    for index, stage in enumerate((first_child, second_child)):
-        request = _task(stage.stage_id, index)
+    for index, unit in enumerate((first_child, second_child)):
+        request = _task(unit.resource_unit_id, index)
         manager.note_task_waiting(request)
         grant = manager.try_acquire_queued_task(request)
         assert grant.granted
         output = manager.try_acquire_output_block(
             OutputBlockRequest(
                 "q",
-                stage.stage_id,
+                unit.resource_unit_id,
                 grant.lease.lease_id,
                 grant.lease.attempt_id,
-                f"cross-stage-output-{index}",
+                f"cross-unit-output-{index}",
                 15,
             )
         )
         assert output.granted
         assert output.liveness is (index == 1)
-        assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+        assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
         assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
         assert manager.release_task_lease(
             grant.lease.lease_id,
@@ -1495,28 +1505,28 @@ def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
 
     snapshot = manager.snapshot()
     assert snapshot["usage"]["object_store_bytes"] == 30
-    stage_store_usage = {
-        stage_id: stage_snapshot["usage"]["object_store_bytes"]
-        for stage_id, stage_snapshot in snapshot["stages"].items()
+    unit_store_usage = {
+        resource_unit_id: unit_snapshot["usage"]["object_store_bytes"]
+        for resource_unit_id, unit_snapshot in snapshot["units"].items()
     }
-    assert sum(stage_store_usage.values()) == 30
-    assert stage_store_usage[parent.stage_id] == 0
-    assert stage_store_usage[first_child.stage_id] == 15
-    assert stage_store_usage[second_child.stage_id] == 15
+    assert sum(unit_store_usage.values()) == 30
+    assert unit_store_usage[parent.resource_unit_id] == 0
+    assert unit_store_usage[first_child.resource_unit_id] == 15
+    assert unit_store_usage[second_child.resource_unit_id] == 15
 
 
-def test_continuation_stage_usage_matches_query_usage_for_active_and_idle_borrower():
-    parent = _stage(
-        "stage:f:parent-fte",
+def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrower():
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8, store=10),
         target=10,
         blocks=1,
@@ -1526,15 +1536,15 @@ def test_continuation_stage_usage_matches_query_usage_for_active_and_idle_borrow
         child,
         resources=_r(cpu=10, heap=10, store=35),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    request = _task(child.stage_id, 0, retained=10)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    request = _task(child.resource_unit_id, 0, retained=10)
     manager.note_task_waiting(request)
     child_grant = manager.try_acquire_queued_task(request)
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             child_grant.lease.lease_id,
             child_grant.lease.attempt_id,
             "active-credit-output",
@@ -1545,9 +1555,9 @@ def test_continuation_stage_usage_matches_query_usage_for_active_and_idle_borrow
 
     active = manager.snapshot()
     assert active["usage"]["object_store_bytes"] == 35
-    assert sum(stage["usage"]["object_store_bytes"] for stage in active["stages"].values()) == 35
+    assert sum(unit["usage"]["object_store_bytes"] for unit in active["units"].values()) == 35
 
-    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
     assert manager.release_task_lease(
         child_grant.lease.lease_id,
@@ -1555,21 +1565,21 @@ def test_continuation_stage_usage_matches_query_usage_for_active_and_idle_borrow
     )
     idle = manager.snapshot()
     assert idle["usage"]["object_store_bytes"] == 25
-    assert sum(stage["usage"]["object_store_bytes"] for stage in idle["stages"].values()) == 25
+    assert sum(unit["usage"]["object_store_bytes"] for unit in idle["units"].values()) == 25
 
 
-def test_live_output_from_deleted_continuation_credit_remains_in_stage_usage():
-    parent = _stage(
-        "stage:f:parent-fte",
+def test_live_output_from_deleted_continuation_credit_remains_in_unit_usage():
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=2,
@@ -1579,15 +1589,15 @@ def test_live_output_from_deleted_continuation_credit_remains_in_stage_usage():
         child,
         resources=_r(cpu=10, heap=10, store=20),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    request = _task(child.stage_id, 0)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(request)
     child_grant = manager.try_acquire_queued_task(request)
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             child_grant.lease.lease_id,
             child_grant.lease.attempt_id,
             "orphaned-credit-output",
@@ -1595,7 +1605,7 @@ def test_live_output_from_deleted_continuation_credit_remains_in_stage_usage():
         )
     )
     assert parent_grant.granted and child_grant.granted and output.granted
-    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
     assert manager.release_task_lease(
         child_grant.lease.lease_id,
@@ -1609,30 +1619,30 @@ def test_live_output_from_deleted_continuation_credit_remains_in_stage_usage():
     snapshot = manager.snapshot()
     assert snapshot["continuation_credits"] == {}
     assert snapshot["usage"]["object_store_bytes"] == 15
-    assert sum(stage["usage"]["object_store_bytes"] for stage in snapshot["stages"].values()) == 15
-    assert snapshot["stages"][child.stage_id]["usage"]["object_store_bytes"] == 15
+    assert sum(unit["usage"]["object_store_bytes"] for unit in snapshot["units"].values()) == 15
+    assert snapshot["units"][child.resource_unit_id]["usage"]["object_store_bytes"] == 15
 
 
 def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
-    parent = _stage(
-        "stage:f:parent-fte",
+    parent = _unit(
+        "resource:f:parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child-udf",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child-udf",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
     )
     manager = _manager(parent, child, resources=_r(cpu=20, heap=20, store=20))
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parents = [manager.try_acquire_task(_task(parent.stage_id, partition)) for partition in range(2)]
-    child_request = _task(child.stage_id, 0)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
+    child_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
     child_grant = manager.try_acquire_queued_task(child_request)
     assert all(grant.granted for grant in parents)
@@ -1648,24 +1658,24 @@ def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
 
 
 def test_parent_fte_admission_preserves_largest_nested_udf_commitment():
-    parent = _stage(
-        "stage:f:safe-parent",
+    parent = _unit(
+        "resource:f:safe-parent",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    first_child = _stage(
-        "stage:f:large-child-a",
-        inputs=(parent.stage_id,),
+    first_child = _unit(
+        "resource:f:large-child-a",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
     )
-    second_child = _stage(
-        "stage:f:large-child-b",
-        inputs=(first_child.stage_id,),
+    second_child = _unit(
+        "resource:f:large-child-b",
+        inputs=(first_child.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=0,
         blocks=0,
@@ -1676,16 +1686,16 @@ def test_parent_fte_admission_preserves_largest_nested_udf_commitment():
         second_child,
         resources=_r(cpu=10, heap=10, store=10),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    first_parent = manager.try_acquire_task(_task(parent.stage_id, 0))
-    second_parent = manager.try_acquire_task(_task(parent.stage_id, 1))
+    first_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    second_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
 
     assert first_parent.granted
     assert not second_parent.granted
     assert second_parent.blocked_reason == "continuation_capacity"
 
-    child_request = _task(first_child.stage_id, 0)
+    child_request = _task(first_child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
     child_grant = manager.try_acquire_queued_task(child_request)
 
@@ -1693,17 +1703,17 @@ def test_parent_fte_admission_preserves_largest_nested_udf_commitment():
 
 
 def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
-    parent = _stage(
-        "stage:f:placed-parent",
+    parent = _unit(
+        "resource:f:placed-parent",
         resources=_r(cpu=1, heap=4),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:pinned-child",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:pinned-child",
+        inputs=(parent.resource_unit_id,),
         resources=_r(gpu=1, heap=8),
         target=0,
         blocks=0,
@@ -1719,10 +1729,10 @@ def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
             ("node-b", _r(cpu=2, heap=10, store=10)),
         ),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    pinned_node_request = manager.try_acquire_task(_task(parent.stage_id, "bad-node", node_id="node-a"))
-    automatic_request = manager.try_acquire_task(_task(parent.stage_id, "auto-node"))
+    pinned_node_request = manager.try_acquire_task(_task(parent.resource_unit_id, "bad-node", node_id="node-a"))
+    automatic_request = manager.try_acquire_task(_task(parent.resource_unit_id, "auto-node"))
 
     assert not pinned_node_request.granted
     assert pinned_node_request.blocked_reason == "node_capacity"
@@ -1731,24 +1741,24 @@ def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
 
 
 def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservations():
-    producer = _stage(
-        "stage:f:placed-ray-task-producer",
+    producer = _unit(
+        "resource:f:placed-ray-task-producer",
         resources=_r(cpu=1, heap=1),
         target=1,
         blocks=1,
     )
-    consumer = _stage(
-        "stage:f:placed-fte-consumer",
-        inputs=(producer.stage_id,),
+    consumer = _unit(
+        "resource:f:placed-fte-consumer",
+        inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    actor = _stage(
-        "stage:f:placed-actor-consumer",
-        inputs=(consumer.stage_id,),
+    actor = _unit(
+        "resource:f:placed-actor-consumer",
+        inputs=(consumer.resource_unit_id,),
         resources=_r(),
         resident=_r(gpu=1, heap=10),
         target=2,
@@ -1766,11 +1776,11 @@ def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservation
             ("node-b", _r(cpu=2, heap=3, store=2)),
         ),
     )
-    manager.update_stage_state(producer.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
 
-    assert manager.task_eligible_node_ids(producer.stage_id) == ("node-a", "node-b")
-    pinned = manager.try_acquire_task(_task(producer.stage_id, "pinned", node_id="node-a"))
-    automatic = manager.try_acquire_task(_task(producer.stage_id, "automatic"))
+    assert manager.task_eligible_node_ids(producer.resource_unit_id) == ("node-a", "node-b")
+    pinned = manager.try_acquire_task(_task(producer.resource_unit_id, "pinned", node_id="node-a"))
+    automatic = manager.try_acquire_task(_task(producer.resource_unit_id, "automatic"))
 
     assert pinned.granted
     assert automatic.granted
@@ -1778,22 +1788,22 @@ def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservation
 
 
 def test_cold_topology_caps_upstream_fanout_until_direct_downstream_starts():
-    upstream = _stage(
-        "stage:f:upstream",
+    upstream = _unit(
+        "resource:f:upstream",
         resources=_r(cpu=1, heap=20),
         target=0,
         blocks=0,
     )
-    downstream = _stage(
-        "stage:f:downstream",
-        inputs=(upstream.stage_id,),
+    downstream = _unit(
+        "resource:f:downstream",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=40),
         target=0,
         blocks=0,
     )
-    terminal = _stage(
-        "stage:f:terminal",
-        inputs=(downstream.stage_id,),
+    terminal = _unit(
+        "resource:f:terminal",
+        inputs=(downstream.resource_unit_id,),
         resources=_r(cpu=1, heap=60),
         target=0,
         blocks=0,
@@ -1804,38 +1814,38 @@ def test_cold_topology_caps_upstream_fanout_until_direct_downstream_starts():
         terminal,
         resources=_r(cpu=10, heap=100, store=100),
     )
-    _ready(manager, upstream.stage_id, downstream.stage_id, terminal.stage_id)
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id, terminal.resource_unit_id)
 
-    first_upstream = manager.try_acquire_task(_task(upstream.stage_id, 0))
-    normal_reason = manager._normal_task_block_reason_locked(_task(upstream.stage_id, 1))[0]
-    second_upstream = manager.try_acquire_task(_task(upstream.stage_id, 1))
-    first_downstream = manager.try_acquire_task(_task(downstream.stage_id, 0))
+    first_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    normal_reason = manager._normal_task_block_reason_locked(_task(upstream.resource_unit_id, 1))[0]
+    second_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 1))
+    first_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
 
     assert first_upstream.granted
-    assert normal_reason == "stage_soft_limit"
+    assert normal_reason == "unit_soft_limit"
     assert not second_upstream.granted
     assert first_downstream.granted
 
 
 def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
-    producer = _stage(
-        "stage:f:image-cpu-producer",
+    producer = _unit(
+        "resource:f:image-cpu-producer",
         resources=_r(cpu=1, heap=2),
         target=1,
         blocks=1,
     )
-    consumer = _stage(
-        "stage:f:image-gpu-feeder",
-        inputs=(producer.stage_id,),
+    consumer = _unit(
+        "resource:f:image-gpu-feeder",
+        inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=1,
         blocks=1,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    gpu_actor = _stage(
-        "stage:f:image-gpu-actor",
-        inputs=(consumer.stage_id,),
+    gpu_actor = _unit(
+        "resource:f:image-gpu-actor",
+        inputs=(consumer.resource_unit_id,),
         resources=_r(),
         resident=_r(gpu=1, heap=20),
         target=1,
@@ -1849,26 +1859,26 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
         gpu_actor,
         resources=_r(cpu=36, gpu=1, heap=41, store=10),
     )
-    # The downstream stages are deliberately latent. Admission must reserve
+    # The downstream units are deliberately latent. Admission must reserve
     # them before their first input makes them runnable.
-    manager.update_stage_state(producer.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
 
-    producer_grants = [manager.try_acquire_task(_task(producer.stage_id, partition)) for partition in range(9)]
-    blocked_producer = manager.try_acquire_task(_task(producer.stage_id, 9))
+    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(9)]
+    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 9))
 
     assert all(grant.granted for grant in producer_grants)
     assert not blocked_producer.granted
     assert blocked_producer.blocked_reason == "continuation_capacity"
-    reservations = manager.snapshot()["admission"]["downstream_reservations"][producer.stage_id]
+    reservations = manager.snapshot()["admission"]["downstream_reservations"][producer.resource_unit_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"fte:{producer.stage_id}",
+        f"native-fragment:{producer.resource_unit_id}",
     ]
     assert sum(reservation["resources"]["object_store_bytes"] for reservation in reservations) == 0
 
-    manager.update_stage_state(consumer.stage_id, runnable=True, actor_ready=True)
-    consumer_grant = manager.try_acquire_task(_task(consumer.stage_id, 0))
-    manager.update_stage_state(gpu_actor.stage_id, runnable=True, actor_ready=True)
-    actor_grant = manager.try_acquire_task(_task(gpu_actor.stage_id, 0, retained=0))
+    manager.update_unit_state(consumer.resource_unit_id, runnable=True, actor_ready=True)
+    consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
+    manager.update_unit_state(gpu_actor.resource_unit_id, runnable=True, actor_ready=True)
+    actor_grant = manager.try_acquire_task(_task(gpu_actor.resource_unit_id, 0, retained=0))
 
     assert consumer_grant.granted
     assert actor_grant.granted and actor_grant.liveness
@@ -1885,15 +1895,15 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
 
 
 def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
-    upstream = _stage(
-        "stage:f:streaming-upstream",
+    upstream = _unit(
+        "resource:f:streaming-upstream",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    actor = _stage(
-        "stage:f:streaming-actor",
-        inputs=(upstream.stage_id,),
+    actor = _unit(
+        "resource:f:streaming-actor",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(),
         resident=_r(gpu=1, heap=4),
         target=0,
@@ -1902,21 +1912,21 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
         actor_pool_size=1,
         actor_prefetch_depth=3,
     )
-    downstream = _stage(
-        "stage:f:streaming-downstream",
-        inputs=(actor.stage_id,),
+    downstream = _unit(
+        "resource:f:streaming-downstream",
+        inputs=(actor.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
     )
-    terminal_fte = _stage(
-        "stage:f:streaming-terminal-fte",
-        inputs=(downstream.stage_id,),
+    terminal_fte = _unit(
+        "resource:f:streaming-terminal-fte",
+        inputs=(downstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
     manager = _manager(
         upstream,
@@ -1925,26 +1935,26 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
         terminal_fte,
         resources=_r(cpu=20, gpu=1, heap=24, store=20),
     )
-    manager.update_stage_state(upstream.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
 
-    upstream_grants = [manager.try_acquire_task(_task(upstream.stage_id, partition)) for partition in range(8)]
+    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(8)]
     assert all(grant.granted for grant in upstream_grants)
-    blocked_upstream = manager.try_acquire_task(_task(upstream.stage_id, 8))
+    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 8))
     assert not blocked_upstream.granted
     assert blocked_upstream.blocked_reason == "continuation_capacity"
     snapshot = manager.snapshot()
     assert snapshot["usage"]["heap_bytes"] == 20
-    reservations = snapshot["admission"]["downstream_reservations"][upstream.stage_id]
+    reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"fte:{upstream.stage_id}",
-        f"actor_continuation:{upstream.stage_id}:{downstream.stage_id}",
+        f"native-fragment:{upstream.resource_unit_id}",
+        f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
     ]
 
-    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=True)
-    actor_grant = manager.try_acquire_task(_task(actor.stage_id, 0, retained=0))
+    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
     assert actor_grant.granted
 
-    downstream_request = _task(downstream.stage_id, 0)
+    downstream_request = _task(downstream.resource_unit_id, 0)
     manager.note_task_waiting(downstream_request)
     before = manager.snapshot()
     downstream_grant = manager.try_acquire_queued_task(downstream_request)
@@ -1952,14 +1962,14 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
     assert before["admission"]["preferred_task"] == {
         "task_id": downstream_request.task_id,
         "attempt_id": downstream_request.attempt_id,
-        "stage_id": downstream.stage_id,
+        "resource_unit_id": downstream.resource_unit_id,
         "grant_class": "normal",
     }
     assert downstream_grant.granted
     assert not downstream_grant.liveness
     assert manager.snapshot()["usage"]["heap_bytes"] == 22
 
-    terminal_request = _task(terminal_fte.stage_id, 0)
+    terminal_request = _task(terminal_fte.resource_unit_id, 0)
     manager.note_task_waiting(terminal_request)
     terminal_grant = manager.try_acquire_queued_task(terminal_request)
 
@@ -1969,33 +1979,33 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
 
 
 def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
-    parent = _stage(
-        "stage:f:image-parent-fte",
+    parent = _unit(
+        "resource:f:image-parent-fte",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    producer = _stage(
-        "stage:f:image-nested-cpu",
-        inputs=(parent.stage_id,),
+    producer = _unit(
+        "resource:f:image-nested-cpu",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=4),
         target=1,
         blocks=1,
     )
-    consumer = _stage(
-        "stage:f:image-downstream-fte",
-        inputs=(producer.stage_id,),
+    consumer = _unit(
+        "resource:f:image-downstream-fte",
+        inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=3),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    actor = _stage(
-        "stage:f:image-downstream-actor",
-        inputs=(consumer.stage_id,),
+    actor = _unit(
+        "resource:f:image-downstream-actor",
+        inputs=(consumer.resource_unit_id,),
         resources=_r(),
         resident=_r(gpu=1, heap=10),
         target=1,
@@ -2012,17 +2022,17 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
         actor,
         resources=_r(cpu=3, gpu=1, heap=20, store=2),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    manager.update_stage_state(producer.stage_id, runnable=True, actor_ready=True)
-    producer_request = _task(producer.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
+    producer_request = _task(producer.resource_unit_id, 0)
     manager.note_task_waiting(producer_request)
     producer_grant = manager.try_acquire_queued_task(producer_request)
-    manager.update_stage_state(consumer.stage_id, runnable=True, actor_ready=True)
-    consumer_grant = manager.try_acquire_task(_task(consumer.stage_id, 0))
-    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=True)
-    actor_grant = manager.try_acquire_task(_task(actor.stage_id, 0, retained=0))
+    manager.update_unit_state(consumer.resource_unit_id, runnable=True, actor_ready=True)
+    consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
+    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
 
     assert parent_grant.granted
     assert producer_grant.granted
@@ -2040,42 +2050,42 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
 
 
 def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
-    parent = _stage(
-        "stage:f:image-parent-fte",
+    parent = _unit(
+        "resource:f:image-parent-fte",
         resources=_r(cpu=1, heap=1),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    direct_fte = _stage(
-        "stage:f:image-direct-fte",
-        inputs=(parent.stage_id,),
+    direct_fte = _unit(
+        "resource:f:image-direct-fte",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=1),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    cpu_udf = _stage(
-        "stage:f:image-cpu-udf",
-        inputs=(direct_fte.stage_id,),
+    cpu_udf = _unit(
+        "resource:f:image-cpu-udf",
+        inputs=(direct_fte.resource_unit_id,),
         resources=_r(cpu=1, heap=4),
         target=0,
         blocks=0,
     )
-    downstream_fte = _stage(
-        "stage:f:image-downstream-fte",
-        inputs=(cpu_udf.stage_id,),
+    downstream_fte = _unit(
+        "resource:f:image-downstream-fte",
+        inputs=(cpu_udf.resource_unit_id,),
         resources=_r(cpu=1, heap=4),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    gpu_actor = _stage(
-        "stage:f:image-gpu-actor",
-        inputs=(downstream_fte.stage_id,),
+    gpu_actor = _unit(
+        "resource:f:image-gpu-actor",
+        inputs=(downstream_fte.resource_unit_id,),
         resources=_r(),
         resident=_r(gpu=1, heap=8),
         target=0,
@@ -2091,31 +2101,31 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
         gpu_actor,
         resources=_r(cpu=36, gpu=1, heap=49),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grants = [manager.try_acquire_task(_task(parent.stage_id, partition)) for partition in range(8)]
+    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(8)]
 
     assert all(grant.granted for grant in parent_grants[:7])
     assert not parent_grants[7].granted
     assert parent_grants[7].blocked_reason == "continuation_capacity"
     snapshot = manager.snapshot()
     assert snapshot["usage"]["heap_bytes"] == 43
-    reservations = snapshot["admission"]["downstream_reservations"][parent.stage_id]
+    reservations = snapshot["admission"]["downstream_reservations"][parent.resource_unit_id]
     assert len(reservations) == 1
-    assert reservations[0]["reservation_id"] == f"fte:{parent.stage_id}"
-    assert reservations[0]["stage_ids"] == [downstream_fte.stage_id]
+    assert reservations[0]["reservation_id"] == f"native-fragment:{parent.resource_unit_id}"
+    assert reservations[0]["unit_ids"] == [downstream_fte.resource_unit_id]
     assert reservations[0]["resources"]["heap_bytes"] == 4
 
-    manager.update_stage_state(cpu_udf.stage_id, runnable=True, actor_ready=True)
-    cpu_request = _task(cpu_udf.stage_id, 0)
+    manager.update_unit_state(cpu_udf.resource_unit_id, runnable=True, actor_ready=True)
+    cpu_request = _task(cpu_udf.resource_unit_id, 0)
     manager.note_task_waiting(cpu_request)
     cpu_grant = manager.try_acquire_queued_task(cpu_request)
-    manager.update_stage_state(
-        downstream_fte.stage_id,
+    manager.update_unit_state(
+        downstream_fte.resource_unit_id,
         runnable=True,
         actor_ready=True,
     )
-    downstream_grant = manager.try_acquire_task(_task(downstream_fte.stage_id, 0))
+    downstream_grant = manager.try_acquire_task(_task(downstream_fte.resource_unit_id, 0))
 
     assert cpu_grant.granted
     assert downstream_grant.granted
@@ -2127,13 +2137,13 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
 
 
 def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=25, blocks=2)
-    manager = _manager(stage, resources=_r(cpu=10, heap=250, store=100))
-    _ready(manager, stage.stage_id, consumer_waiting=True)
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=25, blocks=2)
+    manager = _manager(unit, resources=_r(cpu=10, heap=250, store=100))
+    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
 
-    first = manager.try_acquire_task(_task(stage.stage_id, 0))
-    second = manager.try_acquire_task(_task(stage.stage_id, 1))
-    denied = manager.try_acquire_task(_task(stage.stage_id, 2))
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    denied = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
 
     assert first.granted and second.granted
     assert not denied.granted
@@ -2145,13 +2155,13 @@ def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
     assert snapshot["liveness"]["active_task_lease_id"] is None
 
 
-def test_soft_budget_does_not_start_extra_same_stage_work_while_task_is_active():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=30, blocks=2)
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, stage.stage_id, consumer_waiting=True)
+def test_soft_budget_does_not_start_extra_same_unit_work_while_task_is_active():
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=30, blocks=2)
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
 
-    first = manager.try_acquire_task(_task(stage.stage_id, 0))
-    second = manager.try_acquire_task(_task(stage.stage_id, 1))
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
 
     assert first.granted
     assert not second.granted
@@ -2159,18 +2169,18 @@ def test_soft_budget_does_not_start_extra_same_stage_work_while_task_is_active()
     assert manager.snapshot()["usage"]["object_store_bytes"] == 60
 
 
-def test_soft_budget_does_not_start_extra_borrower_while_same_stage_task_is_active():
-    parent = _stage(
-        "stage:f:parent",
+def test_soft_budget_does_not_start_extra_borrower_while_same_unit_task_is_active():
+    parent = _unit(
+        "resource:f:parent",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8, store=81),
     )
     manager = _manager(
@@ -2178,12 +2188,12 @@ def test_soft_budget_does_not_start_extra_borrower_while_same_stage_task_is_acti
         child,
         resources=_r(cpu=4, heap=20, store=150),
     )
-    _ready(manager, parent.stage_id, child.stage_id)
+    _ready(manager, parent.resource_unit_id, child.resource_unit_id)
 
-    first_parent = manager.try_acquire_task(_task(parent.stage_id, 0))
-    first = manager.try_acquire_task(_task(child.stage_id, 0, retained=81))
-    second_parent = manager.try_acquire_task(_task(parent.stage_id, 1))
-    second = manager.try_acquire_task(_task(child.stage_id, 1, retained=81))
+    first_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    first = manager.try_acquire_task(_task(child.resource_unit_id, 0, retained=81))
+    second_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
+    second = manager.try_acquire_task(_task(child.resource_unit_id, 1, retained=81))
 
     assert first_parent.granted
     assert first.granted
@@ -2195,11 +2205,11 @@ def test_soft_budget_does_not_start_extra_borrower_while_same_stage_task_is_acti
 
 
 def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=30))
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=1_000))
-    _ready(manager, stage.stage_id)
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=30))
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
+    _ready(manager, unit.resource_unit_id)
 
-    granted = manager.try_acquire_task(_task(stage.stage_id, 0, retained=31))
+    granted = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=31))
 
     assert granted.granted
     assert granted.lease.resources.object_store_bytes == 31
@@ -2207,11 +2217,11 @@ def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
 
 
 def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=81))
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, stage.stage_id)
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=81))
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, unit.resource_unit_id)
 
-    request = _task(stage.stage_id, 0, retained=81)
+    request = _task(unit.resource_unit_id, 0, retained=81)
     manager.note_task_waiting(request)
     granted = manager.try_acquire_queued_task(request)
 
@@ -2222,17 +2232,17 @@ def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
 
 @pytest.mark.parametrize("acquire_mode", ["queued", "next_queued"])
 def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acquire_mode):
-    parent = _stage(
-        "stage:f:parent",
+    parent = _unit(
+        "resource:f:parent",
         resources=_r(cpu=1, heap=2),
         target=60,
         blocks=2,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    child = _stage(
-        "stage:f:child",
-        inputs=(parent.stage_id,),
+    child = _unit(
+        "resource:f:child",
+        inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=8),
         target=10,
         blocks=2,
@@ -2242,10 +2252,10 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
         child,
         resources=_r(cpu=4, heap=20, store=100),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    child_request = _task(child.stage_id, 0)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    child_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
     if acquire_mode == "queued":
         child_grant = manager.try_acquire_queued_task(child_request)
@@ -2263,7 +2273,7 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            child.stage_id,
+            child.resource_unit_id,
             child_grant.lease.lease_id,
             child_grant.lease.attempt_id,
             "continuation-output",
@@ -2271,7 +2281,7 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
         )
     )
     assert output.granted and not output.liveness
-    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         parent_grant.lease.lease_id,
         attempt_id=parent_grant.lease.attempt_id,
@@ -2283,7 +2293,7 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
 
     producer_owned = manager.snapshot()
     assert producer_owned["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
-    blocked = manager.try_acquire_task(_task(parent.stage_id, 1))
+    blocked = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
     assert not blocked.granted
     assert blocked.blocked_reason == "liveness_task_active"
 
@@ -2295,17 +2305,17 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
 
 
 def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fanout():
-    parent = _stage(
-        "stage:f:parent",
+    parent = _unit(
+        "resource:f:parent",
         resources=_r(cpu=1, heap=2),
         target=60,
         blocks=2,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    first_actor = _stage(
-        "stage:f:actor-a",
-        inputs=(parent.stage_id,),
+    first_actor = _unit(
+        "resource:f:actor-a",
+        inputs=(parent.resource_unit_id,),
         resources=_r(store=20),
         target=10,
         blocks=2,
@@ -2313,9 +2323,9 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
         actor_pool_size=1,
         resident=_r(cpu=1, heap=8),
     )
-    sibling_actor = _stage(
-        "stage:f:actor-b",
-        inputs=(parent.stage_id,),
+    sibling_actor = _unit(
+        "resource:f:actor-b",
+        inputs=(parent.resource_unit_id,),
         resources=_r(store=20),
         target=10,
         blocks=2,
@@ -2323,21 +2333,21 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
         actor_pool_size=1,
         resident=_r(cpu=1, heap=8),
     )
-    sibling_task = _stage(
-        "stage:f:zz-task-b",
-        inputs=(sibling_actor.stage_id,),
+    sibling_task = _unit(
+        "resource:f:zz-task-b",
+        inputs=(sibling_actor.resource_unit_id,),
         resources=_r(cpu=1, heap=8, store=20),
         target=10,
         blocks=2,
     )
-    path_target = _stage(
-        "stage:f:aa-path",
-        inputs=(first_actor.stage_id,),
+    path_target = _unit(
+        "resource:f:aa-path",
+        inputs=(first_actor.resource_unit_id,),
         resources=_r(cpu=1, heap=10, store=20),
         target=10,
         blocks=2,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
     manager = _manager(
         parent,
@@ -2347,16 +2357,16 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
         path_target,
         resources=_r(cpu=8, heap=60, store=100),
         terminals=(
-            path_target.stage_id,
-            sibling_task.stage_id,
+            path_target.resource_unit_id,
+            sibling_task.resource_unit_id,
         ),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    manager.update_stage_state(first_actor.stage_id, runnable=True, actor_ready=True)
-    manager.update_stage_state(sibling_actor.stage_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    manager.update_unit_state(first_actor.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(sibling_actor.resource_unit_id, runnable=True, actor_ready=True)
 
-    first_request = _task(first_actor.stage_id, 0)
+    first_request = _task(first_actor.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
     selected, first_grant = manager.try_acquire_next_queued_task({(first_request.task_id, first_request.attempt_id)})
 
@@ -2364,7 +2374,7 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
     assert first_grant is not None
     assert parent_grant.granted and parent_grant.liveness
     assert first_grant.granted and first_grant.liveness
-    sibling_request = _task(sibling_actor.stage_id, 0)
+    sibling_request = _task(sibling_actor.resource_unit_id, 0)
     manager.note_task_waiting(sibling_request)
     sibling_grant = manager.try_acquire_queued_task(sibling_request)
     assert not sibling_grant.granted
@@ -2373,12 +2383,12 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
         sibling_request.task_id,
         sibling_request.attempt_id,
     )
-    sibling_task_request = _task(sibling_task.stage_id, 0)
+    sibling_task_request = _task(sibling_task.resource_unit_id, 0)
     manager.note_task_waiting(sibling_task_request)
     sibling_task_grant = manager.try_acquire_queued_task(sibling_task_request)
     assert not sibling_task_grant.granted
     assert sibling_task_grant.blocked_reason == "liveness_task_active"
-    path_request = _task(path_target.stage_id, 0)
+    path_request = _task(path_target.resource_unit_id, 0)
     manager.note_task_waiting(path_request)
     selected, path_grant = manager.try_acquire_next_queued_task(
         {
@@ -2401,7 +2411,7 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            first_actor.stage_id,
+            first_actor.resource_unit_id,
             first_grant.lease.lease_id,
             first_grant.lease.attempt_id,
             "actor-continuation-output",
@@ -2409,7 +2419,7 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
         )
     )
     assert output.granted and not output.liveness
-    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         parent_grant.lease.lease_id,
         attempt_id=parent_grant.lease.attempt_id,
@@ -2425,17 +2435,17 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
 
 
 def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
-    parent = _stage(
-        "stage:f:parent",
+    parent = _unit(
+        "resource:f:parent",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
-    actor = _stage(
-        "stage:f:actor",
-        inputs=(parent.stage_id,),
+    actor = _unit(
+        "resource:f:actor",
+        inputs=(parent.resource_unit_id,),
         resources=_r(store=81),
         target=10,
         blocks=2,
@@ -2443,14 +2453,14 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
         actor_pool_size=1,
         resident=_r(cpu=1, heap=8),
     )
-    downstream = _stage(
-        "stage:f:downstream",
-        inputs=(actor.stage_id,),
+    downstream = _unit(
+        "resource:f:downstream",
+        inputs=(actor.resource_unit_id,),
         resources=_r(cpu=1, heap=10, store=10),
         target=20,
         blocks=2,
         backend="ray_worker",
-        stage_kind="fte",
+        unit_kind="native_fragment",
     )
     manager = _manager(
         parent,
@@ -2458,10 +2468,10 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
         downstream,
         resources=_r(cpu=4, heap=30, store=100),
     )
-    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
-    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
-    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=True)
-    actor_request = _task(actor.stage_id, 0)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
+    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    actor_request = _task(actor.resource_unit_id, 0)
     manager.note_task_waiting(actor_request)
     selected, actor_grant = manager.try_acquire_next_queued_task({(actor_request.task_id, actor_request.attempt_id)})
 
@@ -2469,7 +2479,7 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
     assert actor_grant is not None
     assert parent_grant.granted and not parent_grant.liveness
     assert actor_grant.granted and actor_grant.liveness
-    downstream_grant = manager.try_acquire_task_descriptor(_task(downstream.stage_id, 0))
+    downstream_grant = manager.try_acquire_task_descriptor(_task(downstream.resource_unit_id, 0))
     assert downstream_grant.granted and downstream_grant.liveness
     assert manager.snapshot()["liveness"]["active_task_lease_id"] == actor_grant.lease.lease_id
 
@@ -2485,11 +2495,11 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
 
 
 def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=81))
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, stage.stage_id)
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=81))
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, unit.resource_unit_id)
 
-    first_request = _task(stage.stage_id, 0, retained=81)
+    first_request = _task(unit.resource_unit_id, 0, retained=81)
     manager.note_task_waiting(first_request)
     first = manager.try_acquire_queued_task(first_request)
     outputs = manager.finish_task_with_outputs(
@@ -2498,7 +2508,7 @@ def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
         outputs=(
             OutputBlockRequest(
                 query_id="q",
-                producer_stage_id=stage.stage_id,
+                producer_unit_id=unit.resource_unit_id,
                 task_lease_id=first.lease.lease_id,
                 attempt_id=first.lease.attempt_id,
                 block_id="first-output",
@@ -2510,7 +2520,7 @@ def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
     producer_owned = manager.snapshot()
     assert producer_owned["liveness"]["active_task_lease_id"] == first.lease.lease_id
     assert producer_owned["usage"]["object_store_bytes"] == 10
-    second_request = _task(stage.stage_id, 1, retained=81)
+    second_request = _task(unit.resource_unit_id, 1, retained=81)
     manager.note_task_waiting(second_request)
     denied = manager.try_acquire_queued_task(second_request)
     assert not denied.granted
@@ -2524,18 +2534,18 @@ def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
     assert second.granted and second.liveness
 
 
-def test_liveness_is_not_granted_while_another_runnable_stage_has_normal_capacity():
-    upstream = _stage("stage:f:upstream", resources=_r(cpu=1, heap=70), target=0, blocks=0)
-    blocked = _stage(
-        "stage:f:blocked",
-        inputs=(upstream.stage_id,),
+def test_liveness_is_not_granted_while_another_runnable_unit_has_normal_capacity():
+    upstream = _unit("resource:f:upstream", resources=_r(cpu=1, heap=70), target=0, blocks=0)
+    blocked = _unit(
+        "resource:f:blocked",
+        inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=30),
         target=0,
         blocks=0,
     )
-    runnable = _stage(
-        "stage:f:runnable",
-        inputs=(blocked.stage_id,),
+    runnable = _unit(
+        "resource:f:runnable",
+        inputs=(blocked.resource_unit_id,),
         resources=_r(cpu=1, heap=10),
         target=0,
         blocks=0,
@@ -2546,80 +2556,82 @@ def test_liveness_is_not_granted_while_another_runnable_stage_has_normal_capacit
         runnable,
         resources=_r(cpu=100, heap=100, store=100),
     )
-    _ready(manager, upstream.stage_id, blocked.stage_id, runnable.stage_id, consumer_waiting=True)
-    assert manager.try_acquire_task(_task(upstream.stage_id, 0)).granted
-    manager.note_task_waiting(_task(runnable.stage_id, 0))
+    _ready(
+        manager, upstream.resource_unit_id, blocked.resource_unit_id, runnable.resource_unit_id, consumer_waiting=True
+    )
+    assert manager.try_acquire_task(_task(upstream.resource_unit_id, 0)).granted
+    manager.note_task_waiting(_task(runnable.resource_unit_id, 0))
 
-    denied = manager.try_acquire_task(_task(blocked.stage_id, 0))
+    denied = manager.try_acquire_task(_task(blocked.resource_unit_id, 0))
 
     assert not denied.granted
     assert denied.blocked_reason == "normal_candidate_available"
 
 
 def test_task_lease_release_is_attempt_aware_and_idempotent():
-    stage = _stage("stage:f:decode")
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    grant = manager.try_acquire_task(_task(stage.stage_id, 0, attempt="a"))
+    unit = _unit("resource:f:decode")
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    grant = manager.try_acquire_task(_task(unit.resource_unit_id, 0, attempt="a"))
 
     assert manager.release_task_lease(grant.lease.lease_id, attempt_id="wrong") is False
     assert manager.release_task_lease(grant.lease.lease_id, attempt_id="a") is True
     assert manager.release_task_lease(grant.lease.lease_id, attempt_id="a") is False
-    replay = manager.try_acquire_task(_task(stage.stage_id, 0, attempt="a"))
-    retry = manager.try_acquire_task(_task(stage.stage_id, 0, attempt="b"))
+    replay = manager.try_acquire_task(_task(unit.resource_unit_id, 0, attempt="a"))
+    retry = manager.try_acquire_task(_task(unit.resource_unit_id, 0, attempt="b"))
     assert replay.blocked_reason == "attempt_terminal"
     assert retry.granted
 
 
 def test_abandoned_pre_submit_task_lease_can_reacquire_the_same_attempt():
-    stage = _stage("stage:f:decode")
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    first = manager.try_acquire_task(_task(stage.stage_id, 0, attempt="a"))
+    unit = _unit("resource:f:decode")
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0, attempt="a"))
 
     assert manager.abandon_task_lease(first.lease.lease_id, attempt_id="a") is True
     assert manager.abandon_task_lease(first.lease.lease_id, attempt_id="a") is False
 
-    replacement = manager.try_acquire_task(_task(stage.stage_id, 0, attempt="a"))
+    replacement = manager.try_acquire_task(_task(unit.resource_unit_id, 0, attempt="a"))
     assert replacement.granted
     assert replacement.lease.lease_id != first.lease.lease_id
 
 
 def test_output_blocks_replace_unused_task_window_without_double_counting():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=10), target=50, blocks=2)
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=1_000))
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=10), target=50, blocks=2)
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
     assert manager.snapshot()["usage"]["object_store_bytes"] == 110
 
     first = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block-1", 40)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-1", 40)
     )
     second = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block-2", 60)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-2", 60)
     )
 
     assert first.granted and second.granted
     assert manager.snapshot()["usage"]["object_store_bytes"] == 110
 
     third = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block-3", 25)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-3", 25)
     )
     assert third.granted
     assert manager.snapshot()["usage"]["object_store_bytes"] == 135
 
 
 def test_output_lease_transitions_preserve_bytes_and_release_after_task_completion():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=50, blocks=2)
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=50, blocks=2)
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
     block = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block-1", 80)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-1", 80)
     )
     before = manager.snapshot()["usage"]["object_store_bytes"]
 
-    for state in ("stage_queue", "downstream_input", "external_consumer"):
+    for state in ("unit_queue", "downstream_input", "external_consumer"):
         assert manager.transition_output_block(block.lease.lease_id, state) is True
         assert manager.snapshot()["usage"]["object_store_bytes"] == before
 
@@ -2631,13 +2643,13 @@ def test_output_lease_transitions_preserve_bytes_and_release_after_task_completi
 
 
 def test_released_output_block_identity_cannot_be_leased_again():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=50, blocks=2)
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=50, blocks=2)
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
     request = OutputBlockRequest(
         "q",
-        stage.stage_id,
+        unit.resource_unit_id,
         task.lease.lease_id,
         "0",
         "block-terminal",
@@ -2655,52 +2667,52 @@ def test_released_output_block_identity_cannot_be_leased_again():
 
 
 def test_fte_task_completion_atomically_transfers_window_to_output_leases():
-    stage = _stage(
-        "stage:f:fte",
+    unit = _unit(
+        "resource:f:fte",
         resources=_r(cpu=1, heap=100, store=5),
         target=10,
         blocks=2,
         backend="ray_worker",
     )
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
 
     leases = manager.finish_task_with_outputs(
         task.lease.lease_id,
         attempt_id="0",
         outputs=(
-            OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "fte-block-0", 8),
-            OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "fte-block-1", 9),
+            OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-0", 8),
+            OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-1", 9),
         ),
     )
 
     snapshot = manager.snapshot()
-    assert [lease.state for lease in leases] == ["stage_queue", "stage_queue"]
+    assert [lease.state for lease in leases] == ["unit_queue", "unit_queue"]
     assert snapshot["task_leases"] == {}
     assert set(snapshot["output_leases"]) == {lease.lease_id for lease in leases}
     assert snapshot["usage"] == _r(store=17).to_dict()
 
 
 def test_fte_task_completion_rejects_outputs_above_precommitted_window_without_mutation():
-    stage = _stage(
-        "stage:f:fte",
+    unit = _unit(
+        "resource:f:fte",
         resources=_r(cpu=1, heap=100),
         target=10,
         blocks=2,
         backend="ray_worker",
     )
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
 
     with pytest.raises(RuntimeError, match="output bytes 21 exceed task window 20"):
         manager.finish_task_with_outputs(
             task.lease.lease_id,
             attempt_id="0",
             outputs=(
-                OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "fte-block-0", 10),
-                OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "fte-block-1", 11),
+                OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-0", 10),
+                OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-1", 11),
             ),
         )
 
@@ -2710,15 +2722,15 @@ def test_fte_task_completion_rejects_outputs_above_precommitted_window_without_m
 
 
 def test_output_transition_rejects_skips_and_attempt_mismatch():
-    stage = _stage("stage:f:decode")
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode")
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
     mismatch = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "wrong", "block-wrong", 5)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "wrong", "block-wrong", 5)
     )
     block = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block-1", 5)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-1", 5)
     )
 
     assert mismatch.blocked_reason == "task_attempt_mismatch"
@@ -2727,26 +2739,26 @@ def test_output_transition_rejects_skips_and_attempt_mismatch():
 
 
 def test_oversized_output_block_uses_one_bounded_liveness_grant():
-    stage = _stage("stage:f:decode", target=50, blocks=2)
-    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, stage.stage_id, consumer_waiting=True)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode", target=50, blocks=2)
+    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
 
     granted = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "huge", 101)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "huge", 101)
     )
 
     assert granted.granted
     assert granted.liveness
     second = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "second", 1)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "second", 1)
     )
     assert not second.granted
     assert second.blocked_reason == "liveness_output_active"
-    assert manager.transition_output_block(granted.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(granted.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(granted.lease.lease_id, "downstream_input")
     next_block = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "second-after-handoff", 1)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "second-after-handoff", 1)
     )
     assert next_block.granted
     assert next_block.liveness
@@ -2754,10 +2766,10 @@ def test_oversized_output_block_uses_one_bounded_liveness_grant():
 
 
 def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
-    producer = _stage("stage:f:producer", resources=_r(cpu=1, heap=100), target=50, blocks=2)
-    consumer = _stage(
-        "stage:f:consumer",
-        inputs=(producer.stage_id,),
+    producer = _unit("resource:f:producer", resources=_r(cpu=1, heap=100), target=50, blocks=2)
+    consumer = _unit(
+        "resource:f:consumer",
+        inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=100),
         target=0,
         blocks=0,
@@ -2767,12 +2779,12 @@ def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
         consumer,
         resources=_r(cpu=10, heap=1_000, store=100),
     )
-    _ready(manager, producer.stage_id, consumer.stage_id, consumer_waiting=True)
-    producer_task = manager.try_acquire_task(_task(producer.stage_id, 0))
+    _ready(manager, producer.resource_unit_id, consumer.resource_unit_id, consumer_waiting=True)
+    producer_task = manager.try_acquire_task(_task(producer.resource_unit_id, 0))
     oversized = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
-            producer.stage_id,
+            producer.resource_unit_id,
             producer_task.lease.lease_id,
             "0",
             "oversized",
@@ -2782,23 +2794,23 @@ def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
 
     assert oversized.granted and oversized.liveness
     assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
-    downstream = manager.try_acquire_task(_task(consumer.stage_id, 0, retained=0))
+    downstream = manager.try_acquire_task(_task(consumer.resource_unit_id, 0, retained=0))
     assert downstream.granted
     assert not downstream.liveness
 
 
 def test_allocation_shrink_creates_debt_without_revoking_existing_leases():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=0, blocks=0)
-    manager = _manager(stage, resources=_r(cpu=4, heap=400, store=100))
-    _ready(manager, stage.stage_id)
-    leases = [manager.try_acquire_task(_task(stage.stage_id, idx)) for idx in range(3)]
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=0, blocks=0)
+    manager = _manager(unit, resources=_r(cpu=4, heap=400, store=100))
+    _ready(manager, unit.resource_unit_id)
+    leases = [manager.try_acquire_task(_task(unit.resource_unit_id, idx)) for idx in range(3)]
     assert all(grant.granted for grant in leases)
 
     manager.update_allocation(
         _allocation(_r(cpu=2, heap=200, store=100), generation=2),
         admission_open=True,
     )
-    denied = manager.try_acquire_task(_task(stage.stage_id, 4))
+    denied = manager.try_acquire_task(_task(unit.resource_unit_id, 4))
     snapshot = manager.snapshot()
 
     assert denied.blocked_reason == "allocation_debt"
@@ -2807,13 +2819,13 @@ def test_allocation_shrink_creates_debt_without_revoking_existing_leases():
 
 
 def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
-    stage = _stage("stage:f:pending", resources=_r(cpu=1, heap=100))
+    unit = _unit("resource:f:pending", resources=_r(cpu=1, heap=100))
     manager = _manager(
-        stage,
+        unit,
         resources=_r(cpu=2, heap=200, store=20),
     )
-    _ready(manager, stage.stage_id)
-    active = manager.try_acquire_task(_task(stage.stage_id, 1))
+    _ready(manager, unit.resource_unit_id)
+    active = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
     assert active.granted
 
     manager.update_allocation(
@@ -2821,7 +2833,7 @@ def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
         admission_open=False,
     )
 
-    blocked = manager.try_acquire_task(_task(stage.stage_id, 2))
+    blocked = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
     snapshot = manager.snapshot()
     expected_usage = _r(cpu=1, heap=100, store=20).to_dict()
     assert blocked.granted is False
@@ -2838,7 +2850,7 @@ def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
         active.lease.lease_id,
         attempt_id=active.lease.attempt_id,
     )
-    still_blocked = manager.try_acquire_task(_task(stage.stage_id, 3))
+    still_blocked = manager.try_acquire_task(_task(unit.resource_unit_id, 3))
     assert still_blocked.blocked_reason == "allocation_pending"
 
     restored = _r(cpu=2, heap=200, store=20)
@@ -2846,16 +2858,16 @@ def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
         _allocation(restored, generation=3),
         admission_open=True,
     )
-    assert manager.try_acquire_task(_task(stage.stage_id, 4)).granted
+    assert manager.try_acquire_task(_task(unit.resource_unit_id, 4)).granted
 
 
 def test_cancellation_releases_every_task_and_output_lease_idempotently():
-    stage = _stage("stage:f:decode")
-    manager = _manager(stage)
-    _ready(manager, stage.stage_id)
-    task = manager.try_acquire_task(_task(stage.stage_id, 0))
+    unit = _unit("resource:f:decode")
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
     block = manager.try_acquire_output_block(
-        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "block", 5)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block", 5)
     )
 
     first = manager.cancel("user_cancelled")
@@ -2874,8 +2886,8 @@ def test_cancellation_releases_every_task_and_output_lease_idempotently():
 
 
 def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
-    stage = _stage(
-        "stage:f:per-node",
+    unit = _unit(
+        "resource:f:per-node",
         resources=_r(cpu=1, heap=10),
         target=10,
         blocks=2,
@@ -2883,14 +2895,14 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
     )
     node_capacity = _r(cpu=1, heap=10, store=20)
     manager = _manager(
-        stage,
+        unit,
         resources=_r(cpu=2, heap=20, store=40),
         nodes=(("node-a", node_capacity), ("node-b", node_capacity)),
     )
-    _ready(manager, stage.stage_id)
+    _ready(manager, unit.resource_unit_id)
 
-    first = manager.try_acquire_task(_task(stage.stage_id, 1))
-    second = manager.try_acquire_task(_task(stage.stage_id, 2))
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
     assert first.granted and second.granted
     assert {first.lease.node_id, second.lease.node_id} == {"node-a", "node-b"}
 
@@ -2901,7 +2913,7 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
         outputs=(
             OutputBlockRequest(
                 query_id="q",
-                producer_stage_id=stage.stage_id,
+                producer_unit_id=unit.resource_unit_id,
                 task_lease_id=first.lease.lease_id,
                 attempt_id=first.lease.attempt_id,
                 block_id="block:node-owned",
@@ -2913,7 +2925,7 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
     assert output.node_id == first.lease.node_id
     assert manager.snapshot()["node_usage"][output.node_id]["object_store_bytes"] == 10
 
-    granted = manager.try_acquire_task(_task(stage.stage_id, 3, node_id=output.node_id))
+    granted = manager.try_acquire_task(_task(unit.resource_unit_id, 3, node_id=output.node_id))
     assert granted.granted
     assert granted.lease.node_id == output.node_id
     assert manager.snapshot()["node_soft_object_store_debt_bytes"][output.node_id] == 10

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -73,10 +73,13 @@ def _unit(
             "ray_actor": "ray_actor_pool",
         }[backend]
     )
+    physical_node_id = resource_unit_id.rsplit(":", 1)[-1]
+    if backend == "ray_worker":
+        physical_node_id = f"node:{physical_node_id}:native-fragment"
     return ResourceUnitSpec(
         query_id="q",
         resource_unit_id=resource_unit_id,
-        physical_node_id=resource_unit_id.rsplit(":", 1)[-1],
+        physical_node_id=physical_node_id,
         unit_kind=resolved_unit_kind,
         backend=backend,
         input_unit_ids=tuple(inputs),
@@ -320,6 +323,19 @@ def test_unit_completion_fences_old_allocation_until_eligible_demand_refreshes()
     assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).granted
 
 
+def test_completed_resource_unit_cannot_be_reopened():
+    unit = _unit("resource:f:finished", target=0, blocks=0)
+    manager = _manager(unit, resources=_r(cpu=1, heap=10))
+    manager.update_unit_state(unit.resource_unit_id, runnable=False, completed=True)
+
+    with pytest.raises(RuntimeError, match="completed resource unit cannot become incomplete"):
+        manager.update_unit_state(unit.resource_unit_id, runnable=True)
+
+    state = manager.snapshot()["units"][unit.resource_unit_id]
+    assert state["runnable"] is False
+    assert state["completed"] is True
+
+
 def test_actor_task_leases_own_distinct_concrete_actor_slots():
     actor = _unit(
         "resource:f:gpu",
@@ -528,6 +544,88 @@ def test_pending_actor_retirement_publishes_both_lifecycle_edges():
     assert manager.admission_epoch() == before_retirement + 2
 
 
+def test_cancelled_manager_cannot_republish_actor_process_usage():
+    actor = _unit(
+        "resource:f:cancelled-actor",
+        resources=_r(),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    manager = _manager(actor, resources=_r(cpu=1, heap=100))
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+
+    manager.cancel("planned cancellation")
+
+    assert manager.current_eligible_resource_unit_ids() == ()
+    with pytest.raises(RuntimeError, match="cancelled query"):
+        manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    with pytest.raises(RuntimeError, match="cancelled query"):
+        manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    snapshot = manager.snapshot()
+    assert snapshot["submitted_actor_slots"] == []
+    assert snapshot["ready_actor_slots"] == {}
+    assert snapshot["retiring_actor_unit_ids"] == []
+    assert snapshot["actor_process_usage"] == _r().to_dict()
+
+
+def test_failed_manager_fences_new_work_but_preserves_live_physical_usage():
+    actor = _unit(
+        "resource:f:failed-actor",
+        resources=_r(),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    manager = _manager(actor, resources=_r(cpu=1, heap=100, store=20))
+    _ready(manager, actor.resource_unit_id)
+    task = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    assert task.granted
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            actor.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "failed-query-output",
+            5,
+        )
+    )
+    assert output.granted
+
+    retained = manager.fail("planned terminal failure")
+
+    assert retained == {"task_lease_count": 1, "output_lease_count": 1}
+    snapshot = manager.snapshot()
+    assert snapshot["failed"] is True
+    assert snapshot["failure_reason"] == "planned terminal failure"
+    assert snapshot["cancelled"] is False
+    assert snapshot["allocation_admission_open"] is False
+    assert snapshot["actor_process_usage"] == _r(cpu=1, heap=100).to_dict()
+    assert len(snapshot["task_leases"]) == 1
+    assert len(snapshot["output_leases"]) == 1
+
+    blocked = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+    assert blocked.granted is False
+    assert blocked.fatal is True
+    assert blocked.blocked_reason == "query_failed"
+    with pytest.raises(RuntimeError, match="failed query"):
+        manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+
+    manager.update_allocation(
+        _allocation(_r(cpu=1, heap=100, store=20), generation=2),
+        admission_open=True,
+    )
+    assert manager.snapshot()["allocation_admission_open"] is False
+
+    manager.cancel("ordered teardown completed")
+    released = manager.snapshot()
+    assert released["actor_process_usage"] == _r().to_dict()
+    assert released["task_leases"] == {}
+    assert released["output_leases"] == {}
+
+
 def test_ray_tasks_receive_unique_resource_lease_slots():
     unit = _unit("resource:f:cpu", concurrency=None)
     manager = _manager(unit)
@@ -651,6 +749,68 @@ def test_ready_actor_outside_virtual_node_allocation_accepts_zero_increment_call
     assert snapshot["node_allocation_debt"]["actual-node"] == _r().to_dict()
 
 
+def test_reconstructed_actor_moves_ready_slot_and_prefetched_calls_atomically():
+    actor = _unit(
+        "resource:f:reconstructed-actor",
+        resources=_r(store=1),
+        resident=_r(cpu=1, heap=4),
+        backend="ray_actor",
+        actor_pool_size=1,
+        actor_prefetch_depth=2,
+    )
+    manager = _manager(
+        actor,
+        resources=_r(cpu=2, heap=8, store=20),
+        nodes=(("node-a", _r(cpu=1, heap=4, store=10)), ("node-b", _r(cpu=1, heap=4, store=10))),
+    )
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
+    active = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=1))
+    prefetched = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=1))
+    assert active.granted and prefetched.granted
+
+    moved = manager.reconcile_actor_runtime_node(actor.resource_unit_id, 0, "node-b")
+
+    assert set(moved) == {active.lease.lease_id, prefetched.lease.lease_id}
+    snapshot = manager.snapshot()
+    assert snapshot["ready_actor_slots"][f"{actor.resource_unit_id}:0"] == "node-b"
+    assert snapshot["task_leases"][active.lease.lease_id]["node_id"] == "node-b"
+    assert snapshot["task_leases"][prefetched.lease.lease_id]["node_id"] == "node-b"
+    assert manager.reconcile_actor_runtime_node(actor.resource_unit_id, 0, "node-b") == ()
+
+
+def test_ready_actor_process_moves_node_affine_ray_task_to_free_allocation():
+    actor = _unit(
+        "resource:f:resident-actor",
+        resources=_r(),
+        resident=_r(cpu=1),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    task = _unit(
+        "resource:f:node-affine-task",
+        resources=_r(cpu=1),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        actor,
+        task,
+        resources=_r(cpu=2),
+        nodes=(("node-a", _r(cpu=1)), ("node-b", _r(cpu=1))),
+        terminals=(actor.resource_unit_id, task.resource_unit_id),
+    )
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    manager.update_unit_state(task.resource_unit_id, runnable=True)
+
+    grant = manager.try_acquire_task(_task(task.resource_unit_id, 0))
+
+    assert grant.granted and not grant.liveness
+    assert grant.lease.node_id == "node-b"
+
+
 def test_actor_process_soft_debt_does_not_recharge_existing_actor_invocations():
     actor = _unit(
         "resource:f:soft-debt-actor",
@@ -716,7 +876,7 @@ def test_submitted_actor_debt_blocks_new_ray_process_but_not_actor_invocation():
 
     assert invocation.granted and not invocation.liveness
     assert not new_process.granted
-    assert new_process.blocked_reason == "normal_candidate_available"
+    assert new_process.blocked_reason == "node_allocation_debt"
     assert snapshot["soft_allocation_usage"] == _r(cpu=2, heap=200).to_dict()
     assert snapshot["allocation_debt"] == _r().to_dict()
     assert snapshot["soft_allocation_debt"] == _r(cpu=1, heap=100).to_dict()
@@ -826,7 +986,7 @@ def test_actor_process_heap_consumes_shared_soft_credit_before_new_ray_tasks():
     assert actor_grant.granted
     assert all(grant.granted for grant in cpu_grants)
     assert not denied.granted
-    assert denied.blocked_reason == "liveness_not_needed"
+    assert denied.blocked_reason == "node_capacity"
     assert (
         manager.snapshot()["soft_allocation_usage"]
         == _r(
@@ -2261,21 +2421,27 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
         terminal_native,
         resources=_r(cpu=20, gpu=1, heap=24, store=20),
     )
+    # Actor creation charges the complete process request as soon as it is
+    # submitted, before Ray Core publishes a concrete READY node. This keeps
+    # upstream fanout from consuming the continuation's physical capacity.
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.update_unit_state(upstream.resource_unit_id, runnable=True)
 
-    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(11)]
+    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(9)]
     assert all(grant.granted for grant in upstream_grants)
-    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 11))
+    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 9))
     assert not blocked_upstream.granted
     assert blocked_upstream.blocked_reason == "liveness_not_needed"
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 22
+    assert snapshot["usage"]["heap_bytes"] == 18
+    assert snapshot["soft_allocation_usage"]["heap_bytes"] == 22
     reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
         f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
     ]
 
-    _ready(manager, actor.resource_unit_id)
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
     actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
     assert actor_grant.granted
 
@@ -2288,11 +2454,11 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
         "task_id": downstream_request.task_id,
         "attempt_id": downstream_request.attempt_id,
         "resource_unit_id": downstream.resource_unit_id,
-        "grant_class": "liveness",
+        "grant_class": "normal",
     }
     assert downstream_grant.granted
-    assert downstream_grant.liveness
-    assert manager.snapshot()["usage"]["heap_bytes"] == 24
+    assert not downstream_grant.liveness
+    assert manager.snapshot()["usage"]["heap_bytes"] == 20
 
     terminal_request = _task(terminal_native.resource_unit_id, 0)
     manager.note_task_waiting(terminal_request)
@@ -2300,7 +2466,7 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
 
     assert terminal_grant.granted
     assert not terminal_grant.liveness
-    assert manager.snapshot()["usage"]["heap_bytes"] == 24
+    assert manager.snapshot()["usage"]["heap_bytes"] == 20
 
 
 def test_actor_process_bypass_leaves_downstream_ray_task_reservation_soft():
@@ -2344,6 +2510,71 @@ def test_actor_process_bypass_leaves_downstream_ray_task_reservation_soft():
     assert [reservation["reservation_id"] for reservation in reservations] == [
         f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
     ]
+
+
+def test_globally_insufficient_downstream_reservations_skip_node_search(monkeypatch):
+    upstream = _unit(
+        "resource:f:reservation-upstream",
+        resources=_r(cpu=1, heap=1),
+        target=0,
+        blocks=0,
+    )
+    actor = _unit(
+        "resource:f:reservation-actor",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(),
+        resident=_r(cpu=1),
+        target=0,
+        blocks=0,
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    downstream = _unit(
+        "resource:f:reservation-downstream",
+        inputs=(actor.resource_unit_id,),
+        resources=_r(cpu=1, heap=4),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        actor,
+        downstream,
+        resources=_r(cpu=2, heap=4),
+    )
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
+
+    def fail_if_searched(*args, **kwargs):
+        raise AssertionError("globally impossible reservations must not run node search")
+
+    monkeypatch.setattr(manager, "_remaining_preserves_downstream_locked", fail_if_searched)
+
+    reason, fatal, _ = manager._normal_task_block_reason_locked(_task(upstream.resource_unit_id, 0))
+
+    assert reason == "unit_soft_limit"
+    assert not fatal
+
+
+def test_downstream_reservation_placement_handles_thousands_without_recursion():
+    unit = _unit("resource:f:reservation-root", resources=_r(cpu=1))
+    manager = _manager(
+        unit,
+        resources=_r(cpu=2_000, heap=2_000),
+    )
+    reservations = tuple(
+        manager_module._DownstreamReservation(
+            reservation_id=f"reservation:{index}",
+            unit_ids=(f"resource:f:child-{index}",),
+            resources=_r(cpu=1, heap=1),
+            allowed_node_ids=("node-a",),
+        )
+        for index in range(1_500)
+    )
+
+    assert manager._remaining_preserves_downstream_locked(
+        {"node-a": _r(cpu=1_500, heap=1_500)},
+        reservations,
+    )
 
 
 def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
@@ -3381,6 +3612,180 @@ def test_oversized_output_block_uses_one_bounded_liveness_grant():
     assert manager.snapshot()["soft_object_store_debt_bytes"] == 102
 
 
+def test_queued_output_liveness_skips_higher_ranked_nonstarving_branch():
+    starving_producer = _unit("resource:f:a-producer", target=10, blocks=1)
+    starving_consumer = _unit(
+        "resource:f:a-consumer",
+        inputs=(starving_producer.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    busy_producer = _unit("resource:f:z-producer", target=10, blocks=1)
+    busy_consumer = _unit(
+        "resource:f:z-consumer",
+        inputs=(busy_producer.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        starving_producer,
+        starving_consumer,
+        busy_producer,
+        busy_consumer,
+        terminals=(starving_consumer.resource_unit_id, busy_consumer.resource_unit_id),
+        resources=_r(cpu=100, heap=1_000, store=10),
+    )
+    _ready(
+        manager,
+        starving_producer.resource_unit_id,
+        starving_consumer.resource_unit_id,
+        busy_producer.resource_unit_id,
+        busy_consumer.resource_unit_id,
+    )
+    starving_task = manager.try_acquire_task(_task(starving_producer.resource_unit_id, 0))
+    busy_task = manager.try_acquire_task(_task(busy_producer.resource_unit_id, 0))
+    busy_consumer_task = manager.try_acquire_task(_task(busy_consumer.resource_unit_id, 0, retained=0))
+    assert starving_task.granted and busy_task.granted and busy_consumer_task.granted
+
+    starving_request = OutputBlockRequest(
+        "q",
+        starving_producer.resource_unit_id,
+        starving_task.lease.lease_id,
+        starving_task.lease.attempt_id,
+        "starving-output",
+        11,
+    )
+    busy_request = OutputBlockRequest(
+        "q",
+        busy_producer.resource_unit_id,
+        busy_task.lease.lease_id,
+        busy_task.lease.attempt_id,
+        "busy-output",
+        11,
+    )
+    assert manager.note_output_waiting(starving_request) is None
+    assert manager.note_output_waiting(busy_request) is None
+    assert (
+        manager._reverse_topological_rank[busy_producer.resource_unit_id]
+        < manager._reverse_topological_rank[starving_producer.resource_unit_id]
+    )
+
+    selected, grant = manager.try_acquire_next_queued_output_block({starving_request.block_id, busy_request.block_id})
+
+    assert selected == starving_request
+    assert grant.granted and grant.liveness
+
+
+def test_output_liveness_ignores_consumers_behind_pending_barrier():
+    producer = _unit("resource:f:producer", target=10, blocks=1)
+    busy_consumer = _unit(
+        "resource:f:busy-consumer",
+        inputs=(producer.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    materialized_input = _unit(
+        "resource:f:materialized-input",
+        target=0,
+        blocks=0,
+    )
+    materializer = _unit(
+        "resource:f:materializer",
+        inputs=(materialized_input.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    deferred_consumer = _unit(
+        "resource:f:deferred-consumer",
+        inputs=(producer.resource_unit_id, materializer.resource_unit_id),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        producer,
+        busy_consumer,
+        materialized_input,
+        materializer,
+        deferred_consumer,
+        terminals=(busy_consumer.resource_unit_id, deferred_consumer.resource_unit_id),
+        resources=_r(cpu=100, heap=1_000, store=10),
+        barriers=(_barrier("materializer", materializer),),
+    )
+    _ready(
+        manager,
+        producer.resource_unit_id,
+        busy_consumer.resource_unit_id,
+        materialized_input.resource_unit_id,
+        materializer.resource_unit_id,
+        deferred_consumer.resource_unit_id,
+    )
+    producer_task = manager.try_acquire_task(_task(producer.resource_unit_id, 0))
+    busy_consumer_task = manager.try_acquire_task(_task(busy_consumer.resource_unit_id, 0, retained=0))
+
+    assert producer_task.granted and busy_consumer_task.granted
+    assert deferred_consumer.resource_unit_id not in manager.current_eligible_resource_unit_ids()
+    grant = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            producer.resource_unit_id,
+            producer_task.lease.lease_id,
+            producer_task.lease.attempt_id,
+            "over-budget-output",
+            11,
+        )
+    )
+
+    assert not grant.granted
+    assert grant.blocked_reason == "output_liveness_not_needed"
+
+
+def test_queued_task_liveness_skips_higher_ranked_unrelated_branch():
+    upstream = _unit("resource:f:a-upstream", target=0, blocks=0)
+    downstream = _unit(
+        "resource:f:a-downstream",
+        inputs=(upstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    unrelated = _unit("resource:f:z-unrelated", target=0, blocks=0)
+    manager = _manager(
+        upstream,
+        downstream,
+        unrelated,
+        terminals=(downstream.resource_unit_id, unrelated.resource_unit_id),
+        resources=_r(cpu=10, heap=1_000, store=100),
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
+        unrelated.resource_unit_id,
+    )
+    active = manager.try_acquire_task(_task(upstream.resource_unit_id, 0, retained=0))
+    assert active.granted
+    downstream_request = _task(downstream.resource_unit_id, 0, retained=101)
+    unrelated_request = _task(unrelated.resource_unit_id, 0, retained=101)
+    manager.note_task_waiting(downstream_request)
+    manager.note_task_waiting(unrelated_request)
+    assert (
+        manager._reverse_topological_rank[unrelated.resource_unit_id]
+        < manager._reverse_topological_rank[downstream.resource_unit_id]
+    )
+
+    selected, grant = manager.try_acquire_next_queued_task(
+        {
+            (downstream_request.task_id, downstream_request.attempt_id),
+            (unrelated_request.task_id, unrelated_request.attempt_id),
+        }
+    )
+
+    assert selected == downstream_request
+    assert grant.granted and grant.liveness
+
+
 def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
     producer = _unit("resource:f:producer", resources=_r(cpu=1, heap=100), target=50, blocks=2)
     consumer = _unit(
@@ -3432,6 +3837,87 @@ def test_allocation_shrink_creates_debt_without_revoking_existing_leases():
     assert denied.blocked_reason == "allocation_debt"
     assert snapshot["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
     assert len(snapshot["task_leases"]) == 3
+
+
+def test_allocation_debt_blocks_new_process_but_allows_zero_increment_drain_work():
+    ray_task = _unit(
+        "resource:f:ray-task",
+        resources=_r(cpu=1, heap=100),
+        target=0,
+        blocks=0,
+    )
+    actor = _unit(
+        "resource:f:actor",
+        resources=_r(),
+        resident=_r(cpu=1, heap=100),
+        target=0,
+        blocks=0,
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    native = _unit(
+        "resource:f:native",
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+    )
+    manager = _manager(
+        ray_task,
+        actor,
+        native,
+        resources=_r(cpu=4, heap=400, store=100),
+        terminals=(ray_task.resource_unit_id, actor.resource_unit_id, native.resource_unit_id),
+    )
+    _ready(manager, ray_task.resource_unit_id, actor.resource_unit_id, native.resource_unit_id)
+    active = [manager.try_acquire_task(_task(ray_task.resource_unit_id, index)) for index in range(2)]
+    assert all(grant.granted for grant in active)
+
+    manager.update_allocation(
+        _allocation(_r(cpu=1, heap=100, store=100), generation=2),
+        admission_open=True,
+        debt_neutral_only=True,
+    )
+
+    process = manager.try_acquire_task(_task(ray_task.resource_unit_id, "new"))
+    actor_call = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    native_drain = manager.try_acquire_task(_task(native.resource_unit_id, 0, node_id="node-a"))
+
+    assert not process.granted
+    assert process.blocked_reason == "allocation_debt"
+    assert actor_call.granted and not actor_call.liveness
+    assert native_drain.granted and not native_drain.liveness
+    assert manager.snapshot()["allocation_debt_neutral_only"] is True
+
+
+def test_allocation_debt_admission_recovers_immediately_after_live_leases_drain():
+    unit = _unit(
+        "resource:f:ray-task",
+        resources=_r(cpu=1, heap=100),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(unit, resources=_r(cpu=2, heap=200))
+    _ready(manager, unit.resource_unit_id)
+    active = [manager.try_acquire_task(_task(unit.resource_unit_id, index)) for index in range(2)]
+    assert all(grant.granted for grant in active)
+
+    manager.update_allocation(
+        _allocation(_r(cpu=1, heap=100), generation=2),
+        admission_open=True,
+        debt_neutral_only=True,
+    )
+    assert manager.try_acquire_task(_task(unit.resource_unit_id, "blocked")).blocked_reason == "allocation_debt"
+
+    for grant in active:
+        assert manager.release_task_lease(
+            grant.lease.lease_id,
+            attempt_id=grant.lease.attempt_id,
+        )
+
+    recovered = manager.try_acquire_task(_task(unit.resource_unit_id, "recovered"))
+    assert recovered.granted and not recovered.liveness
+    assert manager.snapshot()["allocation_debt_neutral_only"] is True
 
 
 def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -48,6 +48,7 @@ def _stage(
     actor_prefetch_depth=1,
     resident=None,
     stage_kind="udf",
+    spill_mode="streaming",
 ):
     requested = resources or _r(cpu=1, heap=10)
     if backend == "ray_actor":
@@ -74,7 +75,7 @@ def _stage(
         resident_per_actor=resident_resources,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        spill_mode="streaming",
+        spill_mode=spill_mode,
     )
 
 
@@ -155,6 +156,253 @@ def test_task_admission_requires_runnable_registered_stage_and_ready_actor():
     assert granted.granted
     assert granted.lease.resources == actor.per_task
     assert granted.lease.output_window_bytes == 20
+
+
+def test_only_first_pending_materializing_phase_and_its_upstream_receive_reservations_without_gating():
+    source = _stage(
+        "stage:f:phase-source",
+        resources=_r(cpu=1, heap=10),
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    first_barrier = _stage(
+        "stage:f:phase-first-barrier",
+        inputs=(source.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+        stage_kind="fte",
+        spill_mode="barrier",
+    )
+    between = _stage(
+        "stage:f:phase-between",
+        inputs=(first_barrier.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    second_barrier = _stage(
+        "stage:f:phase-second-barrier",
+        inputs=(between.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+        stage_kind="fte",
+        spill_mode="barrier",
+    )
+    terminal = _stage(
+        "stage:f:phase-terminal",
+        inputs=(second_barrier.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    manager = _manager(
+        source,
+        first_barrier,
+        between,
+        second_barrier,
+        terminal,
+        resources=_r(cpu=5, heap=100, store=100),
+    )
+    _ready(
+        manager,
+        source.stage_id,
+        first_barrier.stage_id,
+        between.stage_id,
+        second_barrier.stage_id,
+        terminal.stage_id,
+    )
+    for stage in (source, first_barrier, between, second_barrier, terminal):
+        manager.note_task_waiting(_task(stage.stage_id, "waiting"))
+
+    first_snapshot = manager.snapshot()
+    unreserved_between = manager.try_acquire_task(_task(between.stage_id, 0))
+
+    assert first_snapshot["materializing_phase"] == {
+        "barrier_stage_id": first_barrier.stage_id,
+        "stage_ids": [source.stage_id, first_barrier.stage_id],
+        "object_store_backpressure_disabled": True,
+        "object_store_unlimited_stage_ids": [
+            source.stage_id,
+            first_barrier.stage_id,
+        ],
+    }
+    assert first_snapshot["admission"]["reservation_stage_ids"]["cpu"] == [
+        source.stage_id,
+        first_barrier.stage_id,
+    ]
+    assert unreserved_between.granted
+    assert unreserved_between.liveness is False
+    assert between.stage_id not in first_snapshot["admission"]["reservation_stage_ids"]["cpu"]
+    assert manager.release_task_lease(unreserved_between.lease.lease_id, attempt_id="0")
+
+    with pytest.raises(ValueError, match="not a blocking materializer"):
+        manager.mark_materializing_stage_completed(source.stage_id)
+    assert manager.mark_materializing_stage_completed(first_barrier.stage_id)
+    assert not manager.mark_materializing_stage_completed(first_barrier.stage_id)
+    second_snapshot = manager.snapshot()
+
+    assert second_snapshot["materializing_phase"]["barrier_stage_id"] == second_barrier.stage_id
+    assert second_snapshot["materializing_phase"]["stage_ids"] == [
+        source.stage_id,
+        first_barrier.stage_id,
+        between.stage_id,
+        second_barrier.stage_id,
+    ]
+    assert second_snapshot["stages"][source.stage_id]["completed"] is False
+    assert second_snapshot["stages"][first_barrier.stage_id]["completed"] is False
+    assert second_snapshot["stages"][first_barrier.stage_id]["materialization_completed"] is True
+    assert second_snapshot["stages"][source.stage_id]["phase_eligible"] is True
+    assert second_snapshot["stages"][first_barrier.stage_id]["phase_eligible"] is True
+    assert second_snapshot["stages"][between.stage_id]["phase_eligible"] is True
+    assert second_snapshot["stages"][terminal.stage_id]["phase_eligible"] is False
+    assert manager.try_acquire_task(_task(between.stage_id, 1)).granted
+    assert manager.try_acquire_task(_task(first_barrier.stage_id, 1)).granted
+
+
+def test_blocking_materialization_disables_only_corresponding_object_store_soft_limits():
+    early = _stage(
+        "stage:f:spill-early",
+        resources=_r(cpu=1, heap=10),
+        target=10,
+        blocks=1,
+    )
+    producer = _stage(
+        "stage:f:spill-producer",
+        inputs=(early.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=10,
+        blocks=1,
+    )
+    barrier = _stage(
+        "stage:f:spill-barrier",
+        inputs=(producer.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=10,
+        blocks=1,
+        spill_mode="barrier",
+    )
+    terminal = _stage(
+        "stage:f:spill-terminal",
+        inputs=(barrier.stage_id,),
+        resources=_r(cpu=1, heap=10),
+        target=10,
+        blocks=1,
+    )
+    manager = _manager(
+        early,
+        producer,
+        barrier,
+        terminal,
+        resources=_r(cpu=4, heap=100, store=10),
+    )
+    _ready(manager, early.stage_id, producer.stage_id, barrier.stage_id, terminal.stage_id)
+
+    producer_task = manager.try_acquire_task(_task(producer.stage_id, 0, retained=0))
+    barrier_task = manager.try_acquire_task(_task(barrier.stage_id, 0, retained=0))
+    manager.note_task_waiting(_task(early.stage_id, "waiting", retained=0))
+    early_normal_reason = manager._normal_task_block_reason_locked(_task(early.stage_id, 0, retained=0))[0]
+    early_task = manager.try_acquire_task(_task(early.stage_id, 0, retained=0))
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            query_id="q",
+            producer_stage_id=producer.stage_id,
+            task_lease_id=producer_task.lease.lease_id,
+            attempt_id="0",
+            block_id="materialized-input",
+            size_bytes=25,
+        )
+    )
+    snapshot = manager.snapshot()
+
+    assert producer_task.granted and producer_task.liveness is False
+    assert barrier_task.granted and barrier_task.liveness is False
+    assert early_normal_reason == "query_soft_object_store_bytes"
+    assert not early_task.granted
+    assert early_task.blocked_reason == "liveness_not_needed"
+    assert output.granted and output.liveness is False
+    assert snapshot["usage"]["object_store_bytes"] > snapshot["allocation"]["resources"]["object_store_bytes"]
+    assert snapshot["materializing_phase"]["object_store_unlimited_stage_ids"] == [
+        producer.stage_id,
+        barrier.stage_id,
+    ]
+    assert snapshot["admission"]["reservation_stage_ids"]["object_store_bytes"] == [
+        early.stage_id,
+    ]
+
+
+def test_nested_materializers_activate_spill_exemptions_on_real_demand():
+    inner_input = _stage("stage:f:nested-inner-input", resources=_r(cpu=1, heap=10))
+    receiver = _stage("stage:f:nested-receiver", resources=_r(cpu=1, heap=10))
+    inner_barrier = _stage(
+        "stage:f:nested-inner-barrier",
+        inputs=(inner_input.stage_id, receiver.stage_id),
+        resources=_r(cpu=1, heap=10),
+        spill_mode="barrier",
+    )
+    middle_input = _stage("stage:f:nested-middle-input", resources=_r(cpu=1, heap=10))
+    middle_barrier = _stage(
+        "stage:f:nested-middle-barrier",
+        inputs=(middle_input.stage_id, inner_barrier.stage_id),
+        resources=_r(cpu=1, heap=10),
+        spill_mode="barrier",
+    )
+    outer_input = _stage("stage:f:nested-outer-input", resources=_r(cpu=1, heap=10))
+    outer_barrier = _stage(
+        "stage:f:nested-outer-barrier",
+        inputs=(outer_input.stage_id, middle_barrier.stage_id),
+        resources=_r(cpu=1, heap=10),
+        spill_mode="barrier",
+    )
+    manager = _manager(
+        inner_input,
+        receiver,
+        inner_barrier,
+        middle_input,
+        middle_barrier,
+        outer_input,
+        outer_barrier,
+        resources=_r(cpu=7, heap=100, store=10),
+    )
+    _ready(
+        manager,
+        inner_input.stage_id,
+        receiver.stage_id,
+        inner_barrier.stage_id,
+        middle_input.stage_id,
+        middle_barrier.stage_id,
+        outer_input.stage_id,
+        outer_barrier.stage_id,
+    )
+
+    initial = manager.snapshot()
+    outer_task = manager.try_acquire_task(_task(outer_input.stage_id, 0, retained=0))
+    after_outer_demand = manager.snapshot()
+    middle_task = manager.try_acquire_task(_task(middle_input.stage_id, 0, retained=0))
+    after_middle_demand = manager.snapshot()
+
+    assert initial["materializing_phase"]["barrier_stage_id"] == inner_barrier.stage_id
+    assert initial["materializing_phase"]["object_store_unlimited_stage_ids"] == [
+        inner_input.stage_id,
+        receiver.stage_id,
+        inner_barrier.stage_id,
+    ]
+    assert outer_task.granted and outer_task.liveness is False
+    assert outer_input.stage_id not in initial["admission"]["reservation_stage_ids"]["object_store_bytes"]
+    assert after_outer_demand["stages"][outer_input.stage_id]["object_store_backpressure_disabled"] is True
+    assert after_outer_demand["stages"][middle_input.stage_id]["object_store_backpressure_disabled"] is False
+    assert middle_task.granted and middle_task.liveness is False
+    assert after_middle_demand["stages"][middle_input.stage_id]["object_store_backpressure_disabled"] is True
+    assert after_middle_demand["materializing_phase"]["barrier_stage_id"] == inner_barrier.stage_id
 
 
 def test_actor_task_leases_own_distinct_concrete_actor_slots():

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import pytest
 
+from duckdb.runners.ray import query_resource_manager as manager_module
 from duckdb.runners.ray.query_resource_graph import (
-    ActorPlacement,
+    MaterializationBarrierSpec,
     NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
@@ -22,7 +25,7 @@ def _r(*, cpu=0.0, gpu=0.0, heap=0, store=0):
     return ResourceVector(cpu=cpu, gpu=gpu, heap_bytes=heap, object_store_bytes=store)
 
 
-def _allocation(resources, *, generation=1, placements=(), nodes=None):
+def _allocation(resources, *, generation=1, nodes=None):
     node_resources = (("node-a", resources),) if nodes is None else tuple(nodes)
     return QueryAllocation(
         resources=resources,
@@ -30,7 +33,6 @@ def _allocation(resources, *, generation=1, placements=(), nodes=None):
             NodeResourceAllocation(node_id=node_id, resources=node_capacity)
             for node_id, node_capacity in node_resources
         ),
-        actor_placements=tuple(placements),
         generation=generation,
     )
 
@@ -95,23 +97,19 @@ def _manager(
     terminals=None,
     nodes=None,
     on_change=None,
+    barriers=(),
+    on_eligible_units_change=None,
 ):
     graph = QueryResourceGraph(
         query_id="q",
         plan_digest="sha256:test",
         units=tuple(units),
         terminal_unit_ids=tuple(terminals or (units[-1].resource_unit_id,)),
+        materialization_barriers=tuple(barriers),
     )
     allocation_resources = resources or _r(cpu=100, gpu=1, heap=1_000, store=1_000)
-    actor_placements = tuple(
-        ActorPlacement(resource_unit_id=unit.resource_unit_id, actor_index=actor_index, node_id="node-a")
-        for unit in units
-        if unit.backend == "ray_actor"
-        for actor_index in range(unit.actor_pool_size)
-    )
     allocation = _allocation(
         allocation_resources,
-        placements=actor_placements,
         nodes=nodes,
     )
     graph.validate_allocation(allocation)
@@ -120,15 +118,35 @@ def _manager(
         allocation,
         reservation_ratio=reservation_ratio,
         on_change=on_change,
+        on_eligible_units_change=on_eligible_units_change,
+    )
+
+
+def _barrier(node_id, unit, *, materialized_inputs=None):
+    return MaterializationBarrierSpec(
+        query_id="q",
+        barrier_id=f"barrier:q:node:{node_id}",
+        physical_node_id=str(node_id),
+        materializer_unit_id=unit.resource_unit_id,
+        materialized_input_unit_ids=(
+            unit.input_unit_ids if materialized_inputs is None else tuple(materialized_inputs)
+        ),
     )
 
 
 def _ready(manager, *unit_ids, consumer_waiting=False):
     for resource_unit_id in unit_ids:
+        unit = manager.graph.unit_by_id(resource_unit_id)
+        if unit.backend == "ray_actor":
+            actor_indices = set(range(unit.actor_pool_size))
+            manager.set_submitted_actor_slots(resource_unit_id, actor_indices)
+            manager.set_ready_actor_slots(
+                resource_unit_id,
+                {actor_index: "node-a" for actor_index in actor_indices},
+            )
         manager.update_unit_state(
             resource_unit_id,
             runnable=True,
-            actor_ready=True,
         )
     manager.set_external_consumer_waiting(consumer_waiting)
 
@@ -153,11 +171,13 @@ def test_task_admission_requires_runnable_registered_unit_and_ready_actor():
         actor_pool_size=1,
     )
     manager = _manager(actor, resources=_r(cpu=2, gpu=1, heap=500, store=500))
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
 
     not_runnable = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
-    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=False)
+    manager.set_ready_actor_slots(actor.resource_unit_id, {})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
     not_ready = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
-    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
     granted = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
 
     assert not_runnable.blocked_reason == "unit_not_runnable"
@@ -192,6 +212,112 @@ def test_dynamic_reservations_follow_real_runnable_demand_without_static_scope()
         upstream.resource_unit_id,
         downstream.resource_unit_id,
     ]
+
+
+def test_barrier_completion_retires_old_eligible_units_and_opens_next_phase():
+    upstream = _unit(
+        "resource:f:upstream",
+        resources=_r(cpu=1, heap=10),
+        target=0,
+        blocks=0,
+    )
+    materializer = _unit(
+        "resource:f:materializer",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    downstream = _unit(
+        "resource:f:downstream",
+        inputs=(materializer.resource_unit_id,),
+        resources=_r(cpu=1, heap=20),
+        target=0,
+        blocks=0,
+    )
+    barrier = _barrier("materializer", materializer)
+    transitions = []
+    manager = _manager(
+        upstream,
+        materializer,
+        downstream,
+        resources=_r(cpu=2, heap=30),
+        barriers=(barrier,),
+        on_eligible_units_change=transitions.append,
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    )
+
+    blocked_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
+    assert blocked_downstream.blocked_reason == "materialization_barrier_pending"
+
+    assert manager.mark_materialization_barrier_completed_for_node("materializer") is True
+    assert manager.mark_materialization_barrier_completed_for_node("materializer") is False
+    assert transitions == [(materializer.resource_unit_id, downstream.resource_unit_id)]
+    assert manager.current_eligible_resource_unit_ids() == (
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    )
+
+    retired_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    opened_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
+    assert retired_upstream.blocked_reason == "allocation_pending"
+    assert opened_downstream.blocked_reason == "allocation_pending"
+    manager.update_allocation(
+        _allocation(_r(cpu=2, heap=30), generation=2),
+        admission_open=True,
+    )
+    retired_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    final_materializer = manager.try_acquire_task(_task(materializer.resource_unit_id, 0))
+    opened_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
+    assert retired_upstream.blocked_reason == "materialization_barrier_pending"
+    assert final_materializer.granted
+    assert opened_downstream.granted
+    assert manager.snapshot()["execution_phase"] == {
+        "frontier_barrier_ids": [],
+        "eligible_resource_unit_ids": [
+            materializer.resource_unit_id,
+            downstream.resource_unit_id,
+        ],
+        "completed_barrier_ids": [barrier.barrier_id],
+        "object_store_unlimited_unit_ids": [],
+    }
+
+
+def test_unit_completion_fences_old_allocation_until_eligible_demand_refreshes():
+    finished = _unit("resource:f:finished", target=0, blocks=0)
+    remaining = _unit("resource:f:remaining", target=0, blocks=0)
+    transitions = []
+    manager = _manager(
+        finished,
+        remaining,
+        resources=_r(cpu=2, heap=20),
+        terminals=(finished.resource_unit_id, remaining.resource_unit_id),
+        on_eligible_units_change=transitions.append,
+    )
+    _ready(manager, finished.resource_unit_id, remaining.resource_unit_id)
+
+    manager.update_unit_state(
+        finished.resource_unit_id,
+        runnable=False,
+        completed=True,
+    )
+
+    assert transitions == [(remaining.resource_unit_id,)]
+    assert manager.snapshot()["allocation_admission_open"] is False
+    assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).blocked_reason == "allocation_pending"
+
+    manager.update_allocation(
+        _allocation(_r(cpu=2, heap=20), generation=2),
+        admission_open=True,
+    )
+    assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).granted
 
 
 def test_actor_task_leases_own_distinct_concrete_actor_slots():
@@ -274,6 +400,134 @@ def test_actor_prefetch_depth_queues_one_call_per_concrete_actor():
     assert f"{actor.resource_unit_id}:1" not in manager.snapshot()["queued_actor_slots"]
 
 
+def test_actor_ready_slot_cannot_disappear_while_it_owns_prefetched_work():
+    actor = _unit(
+        "resource:f:actor-ready-fence",
+        resources=_r(store=10),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+        actor_prefetch_depth=2,
+    )
+    manager = _manager(
+        actor,
+        resources=_r(cpu=1, heap=100, store=100),
+    )
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
+    active = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    queued = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+
+    assert active.granted and queued.granted
+    with pytest.raises(RuntimeError, match="ready actor slot with live leases"):
+        manager.set_ready_actor_slots(actor.resource_unit_id, {})
+
+    assert manager.release_task_lease(
+        queued.lease.lease_id,
+        attempt_id=queued.lease.attempt_id,
+    )
+    assert manager.release_task_lease(
+        active.lease.lease_id,
+        attempt_id=active.lease.attempt_id,
+    )
+    manager.set_ready_actor_slots(actor.resource_unit_id, {})
+
+
+def test_actor_pool_retirement_is_phase_fenced_and_charged_until_shutdown():
+    actor = _unit(
+        "resource:f:actor-before-barrier",
+        resources=_r(),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    materializer = _unit(
+        "resource:f:materializer",
+        inputs=(actor.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    downstream = _unit(
+        "resource:f:after-barrier",
+        inputs=(materializer.resource_unit_id,),
+        resources=_r(cpu=1),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        actor,
+        materializer,
+        downstream,
+        resources=_r(cpu=2, heap=100, store=100),
+        barriers=(_barrier("materializer", materializer),),
+    )
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+
+    assert manager.begin_actor_pool_retirement(actor.resource_unit_id) is False
+    assert manager.mark_materialization_barrier_completed_for_node("materializer")
+    assert manager.begin_actor_pool_retirement(actor.resource_unit_id) is True
+    retiring = manager.snapshot()
+    assert retiring["retiring_actor_unit_ids"] == [actor.resource_unit_id]
+    assert retiring["ready_actor_slots"] == {}
+    assert retiring["actor_process_usage"] == _r(cpu=1, heap=100).to_dict()
+    with pytest.raises(RuntimeError, match="submitted slots for a retiring actor pool"):
+        manager.set_submitted_actor_slots(actor.resource_unit_id, set())
+
+    assert manager.complete_actor_pool_retirement(actor.resource_unit_id) is True
+    retired = manager.snapshot()
+    assert retired["retiring_actor_unit_ids"] == []
+    assert retired["submitted_actor_slots"] == []
+    assert retired["actor_process_usage"] == _r().to_dict()
+
+
+def test_pending_actor_retirement_publishes_both_lifecycle_edges():
+    actor = _unit(
+        "resource:f:pending-actor",
+        resources=_r(),
+        resident=_r(cpu=1),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    materializer = _unit(
+        "resource:f:pending-materializer",
+        inputs=(actor.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+    )
+    downstream = _unit(
+        "resource:f:pending-downstream",
+        inputs=(materializer.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+    )
+    manager = _manager(
+        actor,
+        materializer,
+        downstream,
+        barriers=(_barrier("pending-materializer", materializer),),
+    )
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    assert manager.mark_materialization_barrier_completed_for_node("pending-materializer")
+
+    before_retirement = manager.admission_epoch()
+    assert manager.begin_actor_pool_retirement(actor.resource_unit_id) is True
+    assert manager.admission_epoch() == before_retirement + 1
+    assert manager.begin_actor_pool_retirement(actor.resource_unit_id) is True
+    assert manager.admission_epoch() == before_retirement + 1
+
+    assert manager.complete_actor_pool_retirement(actor.resource_unit_id) is True
+    assert manager.admission_epoch() == before_retirement + 2
+
+
 def test_ray_tasks_receive_unique_resource_lease_slots():
     unit = _unit("resource:f:cpu", concurrency=None)
     manager = _manager(unit)
@@ -287,7 +541,7 @@ def test_ray_tasks_receive_unique_resource_lease_slots():
     assert first.lease.execution_slot_id == (f"ray_task:{unit.resource_unit_id}:{first.lease.lease_id}")
 
 
-def test_idle_actor_resident_resources_remain_charged_to_query_and_node():
+def test_idle_actor_process_resources_are_in_soft_allocation_usage():
     actor = _unit(
         "resource:f:gpu",
         resources=_r(store=40),
@@ -300,10 +554,172 @@ def test_idle_actor_resident_resources_remain_charged_to_query_and_node():
         actor,
         resources=_r(cpu=1, gpu=1, heap=100, store=200),
     )
+    _ready(manager, actor.resource_unit_id)
 
     snapshot = manager.snapshot()
-    assert snapshot["usage"] == _r(cpu=1, gpu=1, heap=100).to_dict()
-    assert snapshot["node_usage"]["node-a"] == _r(cpu=1, gpu=1, heap=100).to_dict()
+    assert snapshot["usage"] == _r().to_dict()
+    assert snapshot["node_usage"]["node-a"] == _r().to_dict()
+    assert snapshot["soft_allocation_usage"] == _r(cpu=1, gpu=1, heap=100).to_dict()
+    assert snapshot["actor_process_usage"] == _r(cpu=1, gpu=1, heap=100).to_dict()
+    assert (
+        snapshot["actor_process_usage_by_ready_node"]["node-a"]
+        == _r(
+            cpu=1,
+            gpu=1,
+            heap=100,
+        ).to_dict()
+    )
+
+
+def test_persistent_soft_actor_debt_warns_once_after_ray_data_delay(monkeypatch, caplog):
+    actor = _unit(
+        "resource:f:oversubscribed-actor",
+        resources=_r(store=40),
+        resident=_r(cpu=1, gpu=1, heap=100),
+        backend="ray_actor",
+        concurrency=None,
+        actor_pool_size=1,
+    )
+    graph = QueryResourceGraph(
+        query_id="q",
+        plan_digest="sha256:test",
+        units=(actor,),
+        terminal_unit_ids=(actor.resource_unit_id,),
+    )
+    allocation = _allocation(
+        _r(cpu=0.5, gpu=0.5, heap=50, store=200),
+    )
+    manager = RayQueryResourceManager(graph, allocation)
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    clock = [100.0]
+    monkeypatch.setattr(manager_module.time, "monotonic", lambda: clock[0])
+
+    with caplog.at_level(logging.WARNING, logger=manager_module.__name__):
+        first = manager.snapshot()
+        clock[0] += 59.9
+        manager.snapshot()
+        assert caplog.records == []
+        clock[0] += 0.1
+        warned = manager.snapshot()
+        clock[0] += 60
+        manager.snapshot()
+
+    assert first["soft_allocation_debt"] == _r(cpu=0.5, gpu=0.5, heap=50).to_dict()
+    assert warned["soft_allocation_debt_duration_s"] == pytest.approx(60.0)
+    assert warned["soft_allocation_warning_emitted"] is True
+    assert len(caplog.records) == 1
+    assert "new work can be backpressured" in caplog.records[0].getMessage()
+
+
+def test_ready_actor_outside_virtual_node_allocation_accepts_zero_increment_call():
+    actor = _unit(
+        "resource:f:external-actor",
+        resources=_r(store=10),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    graph = QueryResourceGraph(
+        query_id="q",
+        plan_digest="sha256:test",
+        units=(actor,),
+        terminal_unit_ids=(actor.resource_unit_id,),
+    )
+    allocation = _allocation(
+        _r(cpu=1, heap=100, store=100),
+        nodes=(("virtual-node", _r(cpu=1, heap=100, store=100)),),
+    )
+    manager = RayQueryResourceManager(graph, allocation)
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "actual-node"})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
+
+    grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+
+    assert grant.granted and not grant.liveness
+    assert grant.lease.node_id == "actual-node"
+    assert grant.lease.actor_index == 0
+    snapshot = manager.snapshot()
+    assert snapshot["node_usage"]["actual-node"] == _r(store=10).to_dict()
+    assert (
+        snapshot["actor_process_usage_by_ready_node"]["actual-node"]
+        == _r(
+            cpu=1,
+            heap=100,
+        ).to_dict()
+    )
+    assert snapshot["node_allocation_debt"]["actual-node"] == _r().to_dict()
+
+
+def test_actor_process_soft_debt_does_not_recharge_existing_actor_invocations():
+    actor = _unit(
+        "resource:f:soft-debt-actor",
+        resources=_r(),
+        resident=_r(cpu=1, gpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    graph = QueryResourceGraph(
+        query_id="q",
+        plan_digest="sha256:test",
+        units=(actor,),
+        terminal_unit_ids=(actor.resource_unit_id,),
+    )
+    allocation = _allocation(
+        _r(cpu=0.5, gpu=0.5, heap=50, store=100),
+    )
+    manager = RayQueryResourceManager(graph, allocation)
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
+    manager.update_unit_state(actor.resource_unit_id, runnable=True)
+
+    first = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+
+    assert first.granted and not first.liveness
+    assert first.lease.actor_index == 0
+    assert not second.granted
+    assert second.blocked_reason == "actor_slot"
+    assert manager.release_task_lease(
+        first.lease.lease_id,
+        attempt_id=first.lease.attempt_id,
+    )
+    replacement = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+    assert replacement.granted and not replacement.liveness
+
+
+def test_submitted_actor_debt_blocks_new_ray_process_but_not_actor_invocation():
+    actor = _unit(
+        "resource:f:oversubscribed-actor",
+        resources=_r(),
+        resident=_r(cpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=2,
+    )
+    ray_task = _unit(
+        "resource:f:new-ray-task",
+        resources=_r(cpu=1, heap=100),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        actor,
+        ray_task,
+        resources=_r(cpu=1, heap=100, store=100),
+        terminals=(actor.resource_unit_id, ray_task.resource_unit_id),
+    )
+    _ready(manager, actor.resource_unit_id, ray_task.resource_unit_id)
+
+    invocation = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    new_process = manager.try_acquire_task(_task(ray_task.resource_unit_id, 0))
+    snapshot = manager.snapshot()
+
+    assert invocation.granted and not invocation.liveness
+    assert not new_process.granted
+    assert new_process.blocked_reason == "normal_candidate_available"
+    assert snapshot["soft_allocation_usage"] == _r(cpu=2, heap=200).to_dict()
+    assert snapshot["allocation_debt"] == _r().to_dict()
+    assert snapshot["soft_allocation_debt"] == _r(cpu=1, heap=100).to_dict()
 
 
 def test_soft_reservation_only_divides_each_dimension_among_units_that_need_it():
@@ -378,7 +794,7 @@ def test_unit_minimum_commitments_are_protected_before_shared_heap_borrowing():
     assert downstream.granted
 
 
-def test_soft_heap_reservation_does_not_exceed_cross_dimension_unit_capacity():
+def test_actor_process_heap_consumes_shared_soft_credit_before_new_ray_tasks():
     gpu_actor = _unit(
         "resource:f:gpu-actor",
         resources=_r(gpu=1, heap=4),
@@ -410,7 +826,15 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_unit_capacity():
     assert actor_grant.granted
     assert all(grant.granted for grant in cpu_grants)
     assert not denied.granted
-    assert denied.blocked_reason == "hard_heap_bytes"
+    assert denied.blocked_reason == "liveness_not_needed"
+    assert (
+        manager.snapshot()["soft_allocation_usage"]
+        == _r(
+            cpu=8,
+            gpu=1,
+            heap=20,
+        ).to_dict()
+    )
 
 
 def test_native_fragment_uses_fte_node_outside_query_allocation_attribution():
@@ -449,7 +873,9 @@ def test_native_fragment_uses_fte_node_outside_query_allocation_attribution():
     assert snapshot["allocation"]["node_allocations"] == [
         {"node_id": "node-a", "resources": _r(store=100).to_dict()},
     ]
-    assert snapshot["node_usage"]["node-b"] == _r(store=40).to_dict()
+    # Native publication keeps its bounded FTE window until completion, and
+    # the exposed ObjectRef is an additional exact logical byte count.
+    assert snapshot["node_usage"]["node-b"] == _r(store=60).to_dict()
     assert snapshot["node_allocation_debt"]["node-b"] == _r().to_dict()
 
 
@@ -511,7 +937,6 @@ def test_empty_runnable_units_do_not_dilute_live_task_reservation():
         manager.update_unit_state(
             unit.resource_unit_id,
             runnable=True,
-            actor_ready=True,
         )
 
     requests = [_task(live_unit.resource_unit_id, index) for index in range(3)]
@@ -547,12 +972,12 @@ def test_queued_admission_prefers_downstream_over_upstream_refill():
         downstream,
         resources=_r(cpu=12, heap=12, store=12),
     )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
 
     held = [manager.try_acquire_task(_task(upstream.resource_unit_id, index)) for index in range(5)]
     assert all(grant.granted for grant in held)
 
-    manager.update_unit_state(downstream.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(downstream.resource_unit_id, runnable=True)
     upstream_waiter = _task(upstream.resource_unit_id, "refill")
     downstream_waiter = _task(downstream.resource_unit_id, "ready")
     manager.note_task_waiting(upstream_waiter)
@@ -755,7 +1180,7 @@ def test_reregistering_same_task_waiter_does_not_publish_resource_change():
         resources=_r(cpu=2, heap=4, store=4),
         on_change=lambda: changes.append("changed"),
     )
-    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
     changes.clear()
     request = _task(unit.resource_unit_id, 0)
 
@@ -779,8 +1204,8 @@ def test_reapplying_identical_unit_state_does_not_publish_resource_change():
         on_change=lambda: changes.append("changed"),
     )
 
-    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
-    manager.update_unit_state(unit.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
 
     assert changes == ["changed"]
 
@@ -816,7 +1241,7 @@ def test_parent_native_fragment_owns_transferable_credit_for_one_nested_udf_task
         child,
         resources=_r(cpu=100, heap=30, store=12),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(4)]
 
@@ -880,7 +1305,7 @@ def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowe
         child,
         resources=_r(cpu=8, heap=40, store=40),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     assert manager.try_acquire_task(_task(parent.resource_unit_id, 0)).granted
 
     first_request = _task(child.resource_unit_id, 0)
@@ -924,8 +1349,8 @@ def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
         target=0,
         blocks=0,
     )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     child_request = _task(child.resource_unit_id, 0)
@@ -968,7 +1393,7 @@ def test_released_child_returns_credit_to_active_parent():
         blocks=0,
     )
     manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     first_request = _task(child.resource_unit_id, 0)
@@ -1016,7 +1441,7 @@ def test_continuation_credit_can_reserve_a_different_node_from_parent_native_fra
             ("node-b", _r(cpu=1, heap=8, store=10)),
         ),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0, node_id="node-a"))
     assert parent_grant.granted
@@ -1028,6 +1453,50 @@ def test_continuation_credit_can_reserve_a_different_node_from_parent_native_fra
     child_grant = manager.try_acquire_queued_task(child_request)
     assert child_grant.granted
     assert child_grant.lease.node_id == "node-b"
+
+
+def test_native_continuation_reserves_one_real_heterogeneous_task_shape():
+    parent = _unit(
+        "resource:f:parent-native",
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    cpu_child = _unit(
+        "resource:f:cpu-child",
+        inputs=(parent.resource_unit_id,),
+        resources=_r(cpu=4),
+        target=0,
+        blocks=0,
+    )
+    gpu_child = _unit(
+        "resource:f:gpu-child",
+        inputs=(parent.resource_unit_id,),
+        resources=_r(cpu=1, gpu=1),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        parent,
+        cpu_child,
+        gpu_child,
+        terminals=(cpu_child.resource_unit_id, gpu_child.resource_unit_id),
+        resources=_r(cpu=5, gpu=1),
+        nodes=(
+            ("cpu-node", _r(cpu=4)),
+            ("gpu-node", _r(cpu=1, gpu=1)),
+        ),
+    )
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
+
+    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0, node_id="cpu-node"))
+
+    assert parent_grant.granted
+    credit = next(iter(manager.snapshot()["continuation_credits"].values()))
+    assert credit["resources"] == _r(cpu=1, gpu=1).to_dict()
+    assert credit["node_id"] == "gpu-node"
 
 
 def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
@@ -1046,8 +1515,8 @@ def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
         target=10,
         blocks=1,
     )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     first_request = _task(child.resource_unit_id, 0)
@@ -1101,8 +1570,8 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
         target=10,
         blocks=1,
     )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=30))
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     first_request = _task(child.resource_unit_id, 0)
@@ -1136,7 +1605,9 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     assert after_handoff.granted
     snapshot = manager.snapshot()
     assert first_output.lease.lease_id in snapshot["output_leases"]
-    assert snapshot["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
+    # The historical ObjectRef remains exact while the new running task adds
+    # one learned generator-buffer estimate.
+    assert snapshot["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
     credit = next(iter(snapshot["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
     assert snapshot["output_leases"][first_output.lease.lease_id]["continuation_credit_id"] == credit["credit_id"]
@@ -1155,7 +1626,7 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     with_both_outputs = manager.snapshot()
     # Recycling compute ownership never recycles bytes: both physical blocks
     # remain charged to the query and node flow-control budgets.
-    assert with_both_outputs["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
+    assert with_both_outputs["usage"] == _r(cpu=1, heap=8, store=30).to_dict()
     assert (
         with_both_outputs["output_leases"][second_output.lease.lease_id]["continuation_credit_id"]
         == credit["credit_id"]
@@ -1163,7 +1634,7 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
 
     assert manager.release_output_block(first_output.lease.lease_id)
     released = manager.snapshot()
-    assert released["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
+    assert released["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
     credit = next(iter(released["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
 
@@ -1197,7 +1668,7 @@ def test_cross_unit_credit_reuse_checks_historical_outputs_before_grant():
         second_child,
         resources=_r(cpu=10, heap=10, store=20),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     first_request = _task(first_child.resource_unit_id, 0)
@@ -1253,7 +1724,7 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
         child,
         resources=_r(cpu=20, heap=20, store=45),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
     assert all(grant.granted for grant in parents)
 
@@ -1325,9 +1796,9 @@ def test_cross_unit_idle_credit_output_excess_is_attributed_exactly_once():
         parent,
         first_child,
         second_child,
-        resources=_r(cpu=10, heap=10, store=30),
+        resources=_r(cpu=10, heap=10, store=35),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     manager.set_external_consumer_waiting(True)
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     assert parent_grant.granted
@@ -1387,9 +1858,9 @@ def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrowe
     manager = _manager(
         parent,
         child,
-        resources=_r(cpu=10, heap=10, store=35),
+        resources=_r(cpu=10, heap=10, store=45),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     request = _task(child.resource_unit_id, 0, retained=10)
     manager.note_task_waiting(request)
@@ -1407,8 +1878,8 @@ def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrowe
     assert parent_grant.granted and child_grant.granted and output.granted
 
     active = manager.snapshot()
-    assert active["usage"]["object_store_bytes"] == 35
-    assert sum(unit["usage"]["object_store_bytes"] for unit in active["units"].values()) == 35
+    assert active["usage"]["object_store_bytes"] == 45
+    assert sum(unit["usage"]["object_store_bytes"] for unit in active["units"].values()) == 45
 
     assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
@@ -1440,9 +1911,9 @@ def test_live_output_from_deleted_continuation_credit_remains_in_unit_usage():
     manager = _manager(
         parent,
         child,
-        resources=_r(cpu=10, heap=10, store=20),
+        resources=_r(cpu=10, heap=10, store=35),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(request)
@@ -1493,7 +1964,7 @@ def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
         blocks=0,
     )
     manager = _manager(parent, child, resources=_r(cpu=20, heap=20, store=20))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
     child_request = _task(child.resource_unit_id, 0)
     manager.note_task_waiting(child_request)
@@ -1539,7 +2010,7 @@ def test_parent_native_fragment_admission_preserves_largest_nested_udf_commitmen
         second_child,
         resources=_r(cpu=10, heap=10, store=10),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     first_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     second_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
@@ -1582,7 +2053,7 @@ def test_native_fragment_placement_does_not_reserve_pinned_actor_process_capacit
             ("node-b", _r(cpu=2, heap=10, store=10)),
         ),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     pinned_node_request = manager.try_acquire_task(_task(parent.resource_unit_id, "pinned-node", node_id="node-a"))
     automatic_request = manager.try_acquire_task(_task(parent.resource_unit_id, "auto-node"))
@@ -1590,7 +2061,7 @@ def test_native_fragment_placement_does_not_reserve_pinned_actor_process_capacit
     assert pinned_node_request.granted
     assert pinned_node_request.lease.node_id == "node-a"
     assert automatic_request.granted
-    assert automatic_request.lease.node_id == "node-a"
+    assert automatic_request.lease.node_id == "node-b"
 
 
 def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservations():
@@ -1629,7 +2100,7 @@ def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservation
             ("node-b", _r(cpu=2, heap=3, store=2)),
         ),
     )
-    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(producer.resource_unit_id, runnable=True)
 
     pinned = manager.try_acquire_task(_task(producer.resource_unit_id, "pinned", node_id="node-a"))
     automatic = manager.try_acquire_task(_task(producer.resource_unit_id, "automatic"))
@@ -1711,34 +2182,40 @@ def test_native_continuation_does_not_add_process_reservation_to_ray_task_fanout
         gpu_actor,
         resources=_r(cpu=36, gpu=1, heap=41, store=10),
     )
-    # The downstream units are deliberately latent. The actor's resident
-    # process remains hard-accounted, while the native continuation is owned
-    # by DuckDB and adds no Vane process reservation.
-    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
+    # The downstream units are deliberately latent. Actor process resources
+    # are scheduled by Ray Core, while the native continuation is owned by
+    # DuckDB and adds no Vane process reservation.
+    manager.update_unit_state(producer.resource_unit_id, runnable=True)
 
-    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(10)]
-    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 10))
+    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(20)]
+    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 20))
 
     assert all(grant.granted for grant in producer_grants)
     assert not blocked_producer.granted
     assert blocked_producer.blocked_reason == "hard_heap_bytes"
     assert producer.resource_unit_id not in manager.snapshot()["admission"]["downstream_reservations"]
 
-    manager.update_unit_state(consumer.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(consumer.resource_unit_id, runnable=True)
     consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
-    manager.update_unit_state(gpu_actor.resource_unit_id, runnable=True, actor_ready=True)
+    _ready(manager, gpu_actor.resource_unit_id)
     actor_grant = manager.try_acquire_task(_task(gpu_actor.resource_unit_id, 0, retained=0))
 
     assert consumer_grant.granted
-    assert actor_grant.granted and actor_grant.liveness
+    assert actor_grant.granted and not actor_grant.liveness
     assert actor_grant.lease.actor_index == 0
     assert (
         manager.snapshot()["usage"]
         == _r(
-            cpu=10,
-            gpu=1,
+            cpu=20,
             heap=40,
-            store=12,
+            store=1,
+        ).to_dict()
+    )
+    assert (
+        manager.snapshot()["actor_process_usage"]
+        == _r(
+            gpu=1,
+            heap=20,
         ).to_dict()
     )
 
@@ -1784,11 +2261,11 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
         terminal_native,
         resources=_r(cpu=20, gpu=1, heap=24, store=20),
     )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
 
-    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(9)]
+    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(11)]
     assert all(grant.granted for grant in upstream_grants)
-    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 9))
+    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 11))
     assert not blocked_upstream.granted
     assert blocked_upstream.blocked_reason == "liveness_not_needed"
     snapshot = manager.snapshot()
@@ -1798,7 +2275,7 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
         f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
     ]
 
-    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    _ready(manager, actor.resource_unit_id)
     actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
     assert actor_grant.granted
 
@@ -1811,10 +2288,10 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
         "task_id": downstream_request.task_id,
         "attempt_id": downstream_request.attempt_id,
         "resource_unit_id": downstream.resource_unit_id,
-        "grant_class": "normal",
+        "grant_class": "liveness",
     }
     assert downstream_grant.granted
-    assert not downstream_grant.liveness
+    assert downstream_grant.liveness
     assert manager.snapshot()["usage"]["heap_bytes"] == 24
 
     terminal_request = _task(terminal_native.resource_unit_id, 0)
@@ -1826,7 +2303,7 @@ def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot(
     assert manager.snapshot()["usage"]["heap_bytes"] == 24
 
 
-def test_hard_minimum_can_start_with_soft_actor_continuation_reservation():
+def test_actor_process_bypass_leaves_downstream_ray_task_reservation_soft():
     upstream = _unit(
         "resource:f:minimum-upstream",
         resources=_r(cpu=1, heap=2),
@@ -1856,13 +2333,13 @@ def test_hard_minimum_can_start_with_soft_actor_continuation_reservation():
         downstream,
         resources=_r(cpu=2, heap=6),
     )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
 
     grant = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
 
-    assert grant.granted and grant.liveness
+    assert grant.granted and not grant.liveness
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 6
+    assert snapshot["usage"]["heap_bytes"] == 2
     reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
         f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
@@ -1904,8 +2381,8 @@ def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
         backend="ray_actor",
         actor_pool_size=1,
     )
-    # Only the actor resident process and Ray task are hard-accounted. Both
-    # native fragments execute inside the node-owned DuckDB budget.
+    # Only the Ray task is QRM hard-accounted. Actor process resources are
+    # reported separately and both native fragments use DuckDB's own budget.
     manager = _manager(
         parent,
         producer,
@@ -1913,16 +2390,16 @@ def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
         actor,
         resources=_r(cpu=3, gpu=1, heap=20, store=2),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(producer.resource_unit_id, runnable=True)
     producer_request = _task(producer.resource_unit_id, 0)
     manager.note_task_waiting(producer_request)
     producer_grant = manager.try_acquire_queued_task(producer_request)
-    manager.update_unit_state(consumer.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(consumer.resource_unit_id, runnable=True)
     consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
-    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    _ready(manager, actor.resource_unit_id)
     actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
 
     assert parent_grant.granted
@@ -1933,9 +2410,15 @@ def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
         manager.snapshot()["usage"]
         == _r(
             cpu=1,
+            heap=4,
+            store=0,
+        ).to_dict()
+    )
+    assert (
+        manager.snapshot()["actor_process_usage"]
+        == _r(
             gpu=1,
-            heap=14,
-            store=2,
+            heap=10,
         ).to_dict()
     )
 
@@ -1992,25 +2475,24 @@ def test_native_fanout_is_capped_only_by_remote_continuation_credits():
         gpu_actor,
         resources=_r(cpu=36, gpu=1, heap=49),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
 
-    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(11)]
+    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(13)]
 
-    assert all(grant.granted for grant in parent_grants[:10])
-    assert not parent_grants[10].granted
-    assert parent_grants[10].blocked_reason == "continuation_capacity"
+    assert all(grant.granted for grant in parent_grants[:12])
+    assert not parent_grants[12].granted
+    assert parent_grants[12].blocked_reason == "continuation_capacity"
     snapshot = manager.snapshot()
     assert snapshot["usage"]["heap_bytes"] == 48
     assert parent.resource_unit_id not in snapshot["admission"]["downstream_reservations"]
 
-    manager.update_unit_state(cpu_udf.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(cpu_udf.resource_unit_id, runnable=True)
     cpu_request = _task(cpu_udf.resource_unit_id, 0)
     manager.note_task_waiting(cpu_request)
     cpu_grant = manager.try_acquire_queued_task(cpu_request)
     manager.update_unit_state(
         downstream_fte.resource_unit_id,
         runnable=True,
-        actor_ready=True,
     )
     downstream_grant = manager.try_acquire_task(_task(downstream_fte.resource_unit_id, 0))
 
@@ -2038,7 +2520,7 @@ def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
     assert denied.liveness is False
     snapshot = manager.snapshot()
     assert snapshot["usage"]["heap_bytes"] == 200
-    assert snapshot["usage"]["object_store_bytes"] == 100
+    assert snapshot["usage"]["object_store_bytes"] == 0
     assert snapshot["liveness"]["active_task_lease_id"] is None
 
 
@@ -2048,12 +2530,22 @@ def test_soft_budget_does_not_start_extra_same_unit_work_while_task_is_active():
     _ready(manager, unit.resource_unit_id, consumer_waiting=True)
 
     first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            first.lease.lease_id,
+            first.lease.attempt_id,
+            "learned-output",
+            30,
+        )
+    )
     second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
 
-    assert first.granted
+    assert first.granted and output.granted
     assert not second.granted
     assert second.blocked_reason == "liveness_not_needed"
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 60
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 90
 
 
 def test_soft_budget_does_not_start_extra_borrower_while_same_unit_task_is_active():
@@ -2088,7 +2580,7 @@ def test_soft_budget_does_not_start_extra_borrower_while_same_unit_task_is_activ
     assert second_parent.granted
     assert not second.granted
     assert second.blocked_reason == "liveness_not_needed"
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 101
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 81
 
 
 def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
@@ -2096,19 +2588,22 @@ def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
     _ready(manager, unit.resource_unit_id)
 
-    granted = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=31))
+    request = _task(unit.resource_unit_id, 0, retained=31)
+    manager.note_task_waiting(request)
+    assert manager.snapshot()["units"][unit.resource_unit_id]["queued_input_bytes"] == 31
+    granted = manager.try_acquire_queued_task(request)
 
     assert granted.granted
     assert granted.lease.resources.object_store_bytes == 31
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 51
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 31
 
 
 def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=81))
+    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=101))
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
     _ready(manager, unit.resource_unit_id)
 
-    request = _task(unit.resource_unit_id, 0, retained=81)
+    request = _task(unit.resource_unit_id, 0, retained=101)
     manager.note_task_waiting(request)
     granted = manager.try_acquire_queued_task(request)
 
@@ -2139,7 +2634,8 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
         child,
         resources=_r(cpu=4, heap=20, store=100),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
+    manager.set_external_consumer_waiting(True)
 
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
     child_request = _task(child.resource_unit_id, 0)
@@ -2154,7 +2650,9 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
         assert child_grant is not None
 
     assert parent_grant.granted and parent_grant.liveness
-    assert child_grant.granted and child_grant.liveness
+    # Before the first output, the Ray UDF has no pending-generator estimate,
+    # so it can continue the liveness path through normal admission.
+    assert child_grant.granted and not child_grant.liveness
     assert manager.snapshot()["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
 
     output = manager.try_acquire_output_block(
@@ -2167,7 +2665,7 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
             10,
         )
     )
-    assert output.granted and not output.liveness
+    assert output.granted and output.liveness
     assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         parent_grant.lease.lease_id,
@@ -2179,10 +2677,8 @@ def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acq
     )
 
     producer_owned = manager.snapshot()
-    assert producer_owned["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
-    blocked = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
-    assert not blocked.granted
-    assert blocked.blocked_reason == "liveness_task_active"
+    assert producer_owned["liveness"]["active_task_lease_id"] is None
+    assert producer_owned["liveness"]["active_output_lease_id"] == output.lease.lease_id
 
     assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
     handed_off = manager.snapshot()
@@ -2248,10 +2744,9 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
             sibling_task.resource_unit_id,
         ),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    manager.update_unit_state(first_actor.resource_unit_id, runnable=True, actor_ready=True)
-    manager.update_unit_state(sibling_actor.resource_unit_id, runnable=True, actor_ready=True)
+    _ready(manager, first_actor.resource_unit_id, sibling_actor.resource_unit_id)
 
     first_request = _task(first_actor.resource_unit_id, 0)
     manager.note_task_waiting(first_request)
@@ -2305,7 +2800,7 @@ def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fa
             10,
         )
     )
-    assert output.granted and not output.liveness
+    assert output.granted and output.liveness
     assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
     assert manager.release_task_lease(
         parent_grant.lease.lease_id,
@@ -2355,9 +2850,9 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
         downstream,
         resources=_r(cpu=4, heap=30, store=100),
     )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
+    manager.update_unit_state(parent.resource_unit_id, runnable=True)
     parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    manager.update_unit_state(actor.resource_unit_id, runnable=True, actor_ready=True)
+    _ready(manager, actor.resource_unit_id)
     actor_request = _task(actor.resource_unit_id, 0)
     manager.note_task_waiting(actor_request)
     selected, actor_grant = manager.try_acquire_next_queued_task({(actor_request.task_id, actor_request.attempt_id)})
@@ -2365,10 +2860,10 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
     assert selected == actor_request
     assert actor_grant is not None
     assert parent_grant.granted and not parent_grant.liveness
-    assert actor_grant.granted and actor_grant.liveness
+    assert actor_grant.granted and not actor_grant.liveness
     downstream_grant = manager.try_acquire_task_descriptor(_task(downstream.resource_unit_id, 0))
     assert downstream_grant.granted and downstream_grant.liveness
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] == actor_grant.lease.lease_id
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] == downstream_grant.lease.lease_id
 
     assert manager.release_task_lease(
         downstream_grant.lease.lease_id,
@@ -2382,11 +2877,15 @@ def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
 
 
 def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=81))
+    unit = _unit(
+        "resource:f:decode",
+        resources=_r(store=101),
+        backend="ray_worker",
+    )
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
     _ready(manager, unit.resource_unit_id)
 
-    first_request = _task(unit.resource_unit_id, 0, retained=81)
+    first_request = _task(unit.resource_unit_id, 0, retained=101)
     manager.note_task_waiting(first_request)
     first = manager.try_acquire_queued_task(first_request)
     outputs = manager.finish_task_with_outputs(
@@ -2407,7 +2906,7 @@ def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
     producer_owned = manager.snapshot()
     assert producer_owned["liveness"]["active_task_lease_id"] == first.lease.lease_id
     assert producer_owned["usage"]["object_store_bytes"] == 10
-    second_request = _task(unit.resource_unit_id, 1, retained=81)
+    second_request = _task(unit.resource_unit_id, 1, retained=101)
     manager.note_task_waiting(second_request)
     denied = manager.try_acquire_queued_task(second_request)
     assert not denied.granted
@@ -2484,28 +2983,236 @@ def test_abandoned_pre_submit_task_lease_can_reacquire_the_same_attempt():
     assert replacement.lease.lease_id != first.lease.lease_id
 
 
-def test_output_blocks_replace_unused_task_window_without_double_counting():
+def test_output_blocks_add_exact_refs_to_dynamic_pending_generator_estimate():
     unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=10), target=50, blocks=2)
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
     _ready(manager, unit.resource_unit_id)
     task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 110
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 10
 
     first = manager.try_acquire_output_block(
         OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-1", 40)
     )
     second = manager.try_acquire_output_block(
-        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-2", 60)
+        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-2", 50)
     )
 
     assert first.granted and second.granted
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 110
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 190
 
     third = manager.try_acquire_output_block(
         OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-3", 25)
     )
     assert third.granted
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 135
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["object_store_bytes"] == 202
+    unit_snapshot = snapshot["units"][unit.resource_unit_id]
+    assert unit_snapshot["bytes_task_outputs_generated"] == 115
+    assert unit_snapshot["num_task_outputs_generated"] == 3
+    assert unit_snapshot["average_output_block_bytes"] == pytest.approx(115 / 3)
+    assert unit_snapshot["pending_output_estimate_per_active_task_bytes"] == 77
+
+
+def test_finished_task_output_count_caps_dynamic_generator_estimate():
+    unit = _unit(
+        "resource:f:learned-output-count",
+        resources=_r(cpu=1, heap=10),
+        target=50,
+        blocks=2,
+    )
+    manager = _manager(unit, resources=_r(cpu=4, heap=40, store=1_000))
+    _ready(manager, unit.resource_unit_id)
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            first.lease.lease_id,
+            first.lease.attempt_id,
+            "one-block-task",
+            10,
+        )
+    )
+    assert output.granted
+    assert manager.release_output_block(output.lease.lease_id)
+    assert manager.release_task_lease(
+        first.lease.lease_id,
+        attempt_id=first.lease.attempt_id,
+    )
+
+    learned = manager.snapshot()["units"][unit.resource_unit_id]
+    assert learned["average_output_block_bytes"] == 10
+    assert learned["average_output_blocks_per_finished_task"] == 1
+    assert learned["pending_output_estimate_per_active_task_bytes"] == 10
+
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    assert second.granted
+    assert second.lease.output_window_bytes == 100
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 10
+
+
+def test_prefetched_actor_invocation_has_no_pending_generator_estimate():
+    actor = _unit(
+        "resource:f:actor-dynamic-output",
+        resources=_r(),
+        resident=_r(cpu=1, heap=10),
+        target=50,
+        blocks=2,
+        backend="ray_actor",
+        actor_pool_size=1,
+        actor_prefetch_depth=2,
+    )
+    manager = _manager(
+        actor,
+        resources=_r(cpu=1, heap=10, store=1_000),
+    )
+    _ready(manager, actor.resource_unit_id)
+    active = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
+    prefetched = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=0))
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            actor.resource_unit_id,
+            active.lease.lease_id,
+            active.lease.attempt_id,
+            "actor-first-output",
+            10,
+        )
+    )
+
+    assert active.granted and prefetched.granted and output.granted
+    # 10 exact output bytes + 20 estimated bytes for only the active call.
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 30
+    assert manager.release_task_lease(
+        active.lease.lease_id,
+        attempt_id=active.lease.attempt_id,
+    )
+    # The promoted call now uses the learned 10-byte/one-output estimate, while
+    # the first call's ObjectRef remains exact.
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 20
+
+
+def test_frontier_materializer_disables_object_store_backpressure_for_input():
+    upstream = _unit(
+        "resource:f:materializer-input",
+        resources=_r(cpu=1),
+        target=50,
+        blocks=2,
+    )
+    materializer = _unit(
+        "resource:f:blocking-materializer",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    downstream = _unit(
+        "resource:f:after-materializer",
+        inputs=(materializer.resource_unit_id,),
+        resources=_r(cpu=1),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        materializer,
+        downstream,
+        resources=_r(cpu=2, store=50),
+        barriers=(_barrier("blocking-materializer", materializer),),
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    )
+    task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            upstream.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "materializer-input-block",
+            50,
+        )
+    )
+
+    assert task.granted
+    assert output.granted and not output.liveness
+    snapshot = manager.snapshot()
+    assert snapshot["soft_object_store_debt_bytes"] == 100
+    assert snapshot["units"][upstream.resource_unit_id]["object_store_backpressure_disabled"] is True
+
+
+def test_asymmetric_frontier_lifts_object_store_cap_only_for_materialized_input():
+    build = _unit(
+        "resource:f:broadcast-build",
+        resources=_r(cpu=1),
+        target=50,
+        blocks=2,
+    )
+    probe = _unit(
+        "resource:f:broadcast-probe",
+        resources=_r(cpu=1),
+        target=50,
+        blocks=2,
+    )
+    materializer = _unit(
+        "resource:f:broadcast-join",
+        inputs=(build.resource_unit_id, probe.resource_unit_id),
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        unit_kind="native_fragment",
+    )
+    downstream = _unit(
+        "resource:f:after-broadcast",
+        inputs=(materializer.resource_unit_id,),
+        resources=_r(cpu=1),
+        target=0,
+        blocks=0,
+    )
+    barrier = _barrier(
+        "broadcast-join",
+        materializer,
+        materialized_inputs=(build.resource_unit_id,),
+    )
+    manager = _manager(
+        build,
+        probe,
+        materializer,
+        downstream,
+        resources=_r(cpu=3, store=100),
+        barriers=(barrier,),
+    )
+    _ready(
+        manager,
+        build.resource_unit_id,
+        probe.resource_unit_id,
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    )
+
+    before = manager.snapshot()
+    assert before["execution_phase"]["object_store_unlimited_unit_ids"] == [
+        build.resource_unit_id,
+        materializer.resource_unit_id,
+    ]
+    assert before["units"][build.resource_unit_id]["object_store_backpressure_disabled"] is True
+    assert before["units"][probe.resource_unit_id]["object_store_backpressure_disabled"] is False
+
+    assert manager.mark_materialization_barrier_completed_for_node("broadcast-join")
+    after = manager.snapshot()
+    assert after["execution_phase"]["object_store_unlimited_unit_ids"] == []
+    assert after["execution_phase"]["eligible_resource_unit_ids"] == [
+        probe.resource_unit_id,
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    ]
 
 
 def test_output_lease_transitions_preserve_bytes_and_release_after_task_completion():
@@ -2581,7 +3288,23 @@ def test_fte_task_completion_atomically_transfers_window_to_output_leases():
     assert snapshot["usage"] == _r(store=17).to_dict()
 
 
-def test_fte_task_completion_rejects_outputs_above_precommitted_window_without_mutation():
+def test_atomic_fte_completion_rejects_a_ray_udf_task_lease():
+    unit = _unit("resource:f:udf", target=10, blocks=2, backend="ray_task")
+    manager = _manager(unit)
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+
+    with pytest.raises(RuntimeError, match="requires a native fragment lease"):
+        manager.finish_task_with_outputs(
+            task.lease.lease_id,
+            attempt_id=task.lease.attempt_id,
+            outputs=(),
+        )
+
+    assert task.lease.lease_id in manager.snapshot()["task_leases"]
+
+
+def test_fte_task_completion_replaces_pending_estimate_with_oversized_exact_outputs():
     unit = _unit(
         "resource:f:native",
         resources=_r(cpu=1, heap=100),
@@ -2589,23 +3312,25 @@ def test_fte_task_completion_rejects_outputs_above_precommitted_window_without_m
         blocks=2,
         backend="ray_worker",
     )
-    manager = _manager(unit)
+    manager = _manager(unit, resources=_r(cpu=100, heap=1_000, store=20))
     _ready(manager, unit.resource_unit_id)
     task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
 
-    with pytest.raises(RuntimeError, match="output bytes 21 exceed task window 20"):
-        manager.finish_task_with_outputs(
-            task.lease.lease_id,
-            attempt_id="0",
-            outputs=(
-                OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-0", 10),
-                OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-1", 11),
-            ),
-        )
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 20
+    leases = manager.finish_task_with_outputs(
+        task.lease.lease_id,
+        attempt_id="0",
+        outputs=(
+            OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-0", 10),
+            OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "fte-block-1", 11),
+        ),
+    )
 
     snapshot = manager.snapshot()
-    assert set(snapshot["task_leases"]) == {task.lease.lease_id}
-    assert snapshot["output_leases"] == {}
+    assert snapshot["task_leases"] == {}
+    assert set(snapshot["output_leases"]) == {lease.lease_id for lease in leases}
+    assert snapshot["usage"]["object_store_bytes"] == 21
+    assert snapshot["soft_object_store_debt_bytes"] == 1
 
 
 def test_output_transition_rejects_skips_and_attempt_mismatch():
@@ -2637,19 +3362,23 @@ def test_oversized_output_block_uses_one_bounded_liveness_grant():
 
     assert granted.granted
     assert granted.liveness
-    second = manager.try_acquire_output_block(
-        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "second", 1)
+    second_request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        task.lease.lease_id,
+        "0",
+        "second",
+        1,
     )
+    second = manager.try_acquire_output_block(second_request)
     assert not second.granted
     assert second.blocked_reason == "liveness_output_active"
     assert manager.transition_output_block(granted.lease.lease_id, "unit_queue")
     assert manager.transition_output_block(granted.lease.lease_id, "downstream_input")
-    next_block = manager.try_acquire_output_block(
-        OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "second-after-handoff", 1)
-    )
+    next_block = manager.try_acquire_output_block(second_request)
     assert next_block.granted
     assert next_block.liveness
-    assert manager.snapshot()["soft_object_store_debt_bytes"] == 2
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 102
 
 
 def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
@@ -2680,7 +3409,7 @@ def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
     )
 
     assert oversized.granted and oversized.liveness
-    assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 101
     downstream = manager.try_acquire_task(_task(consumer.resource_unit_id, 0, retained=0))
     assert downstream.granted
     assert not downstream.liveness
@@ -2722,16 +3451,16 @@ def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
 
     blocked = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
     snapshot = manager.snapshot()
-    expected_usage = _r(cpu=1, heap=100, store=20).to_dict()
+    expected_usage = _r(cpu=1, heap=100).to_dict()
     assert blocked.granted is False
     assert blocked.blocked_reason == "allocation_pending"
     assert blocked.fatal is False
     assert snapshot["allocation_admission_open"] is False
     assert snapshot["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
-    assert snapshot["soft_object_store_debt_bytes"] == 20
+    assert snapshot["soft_object_store_debt_bytes"] == 0
     assert snapshot["node_usage"]["node-a"] == expected_usage
     assert snapshot["node_allocation_debt"]["node-a"] == _r(cpu=1, heap=100).to_dict()
-    assert snapshot["node_soft_object_store_debt_bytes"]["node-a"] == 20
+    assert snapshot["node_soft_object_store_debt_bytes"]["node-a"] == 0
 
     assert manager.release_task_lease(
         active.lease.lease_id,
@@ -2779,6 +3508,7 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
         target=10,
         blocks=2,
         concurrency=3,
+        backend="ray_worker",
     )
     node_capacity = _r(cpu=1, heap=10, store=20)
     manager = _manager(
@@ -2788,8 +3518,8 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
     )
     _ready(manager, unit.resource_unit_id)
 
-    first = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
-    second = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 1, node_id="node-a"))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 2, node_id="node-b"))
     assert first.granted and second.granted
     assert {first.lease.node_id, second.lease.node_id} == {"node-a", "node-b"}
 

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -1042,8 +1042,8 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     )
     assert second_output.granted
     with_both_outputs = manager.snapshot()
-    # Recycling compute ownership never recycles bytes: the two physical
-    # blocks consume two windows under the query/node hard cap.
+    # Recycling compute ownership never recycles bytes: both physical blocks
+    # remain charged to the query and node flow-control budgets.
     assert with_both_outputs["usage"] == _r(cpu=2, heap=10, store=20).to_dict()
     assert (
         with_both_outputs["output_leases"][second_output.lease.lease_id]["continuation_credit_id"]
@@ -1109,30 +1109,19 @@ def test_cross_stage_credit_reuse_checks_historical_outputs_before_grant():
         attempt_id=first_grant.lease.attempt_id,
     )
     assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 20
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 15
 
     second_request = _task(second_child.stage_id, 0, retained=10)
     manager.note_task_waiting(second_request)
-    denied = manager.try_acquire_queued_task(second_request)
-
-    assert not denied.granted
-    assert denied.blocked_reason == "hard_object_store_bytes"
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["object_store_bytes"] == 20
-    assert snapshot["node_usage"]["node-a"]["object_store_bytes"] == 20
-
-    manager.update_allocation(
-        _allocation(_r(cpu=10, heap=10, store=25), generation=2),
-        admission_open=True,
-    )
     granted = manager.try_acquire_queued_task(second_request)
-    assert granted.granted
+    assert granted.granted and granted.liveness
     admitted = manager.snapshot()
     assert admitted["usage"]["object_store_bytes"] == 25
     assert admitted["node_usage"]["node-a"]["object_store_bytes"] == 25
+    assert admitted["soft_object_store_debt_bytes"] == 5
 
 
-def test_continuation_borrow_selects_feasible_idle_credit_with_smallest_live_output_delta():
+def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta():
     parent = _stage(
         "stage:f:parent-fte",
         resources=_r(cpu=1, heap=2),
@@ -1195,7 +1184,7 @@ def test_continuation_borrow_selects_feasible_idle_credit_with_smallest_live_out
         if credit["borrowed_by_task_lease_id"] == second_child.lease.lease_id
     }
     assert len(borrowed_credit_ids) == 1
-    assert borrowed_credit_ids != {historical_credit_id}
+    assert borrowed_credit_ids == {historical_credit_id}
 
 
 def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
@@ -1228,6 +1217,7 @@ def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
         resources=_r(cpu=10, heap=10, store=30),
     )
     manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    manager.set_external_consumer_waiting(True)
     parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
     assert parent_grant.granted
 
@@ -1247,6 +1237,7 @@ def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
             )
         )
         assert output.granted
+        assert output.liveness is (index == 1)
         assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
         assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
         assert manager.release_task_lease(
@@ -1261,9 +1252,9 @@ def test_cross_stage_idle_credit_output_excess_is_attributed_exactly_once():
         for stage_id, stage_snapshot in snapshot["stages"].items()
     }
     assert sum(stage_store_usage.values()) == 30
-    reservation_stage_id = next(iter(snapshot["continuation_credits"].values()))["reservation_stage_id"]
-    assert stage_store_usage[reservation_stage_id] >= 20
-    assert sum(stage_store_usage.values()) - 20 == 10
+    assert stage_store_usage[parent.stage_id] == 0
+    assert stage_store_usage[first_child.stage_id] == 15
+    assert stage_store_usage[second_child.stage_id] == 15
 
 
 def test_continuation_stage_usage_matches_query_usage_for_active_and_idle_borrower():
@@ -1491,7 +1482,7 @@ def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
     assert automatic_request.lease.node_id == "node-b"
 
 
-def test_ray_task_placement_preserves_combined_fte_and_pinned_actor_reservations():
+def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservations():
     producer = _stage(
         "stage:f:placed-ray-task-producer",
         resources=_r(cpu=1, heap=1),
@@ -1529,12 +1520,11 @@ def test_ray_task_placement_preserves_combined_fte_and_pinned_actor_reservations
     )
     manager.update_stage_state(producer.stage_id, runnable=True, actor_ready=True)
 
-    assert manager.task_eligible_node_ids(producer.stage_id) == ("node-b",)
+    assert manager.task_eligible_node_ids(producer.stage_id) == ("node-a", "node-b")
     pinned = manager.try_acquire_task(_task(producer.stage_id, "pinned", node_id="node-a"))
     automatic = manager.try_acquire_task(_task(producer.stage_id, "automatic"))
 
-    assert not pinned.granted
-    assert pinned.blocked_reason == "continuation_node_capacity"
+    assert pinned.granted
     assert automatic.granted
     assert automatic.lease.node_id == "node-b"
 
@@ -1615,8 +1605,8 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
     # them before their first input makes them runnable.
     manager.update_stage_state(producer.stage_id, runnable=True, actor_ready=True)
 
-    producer_grants = [manager.try_acquire_task(_task(producer.stage_id, partition)) for partition in range(8)]
-    blocked_producer = manager.try_acquire_task(_task(producer.stage_id, 8))
+    producer_grants = [manager.try_acquire_task(_task(producer.stage_id, partition)) for partition in range(9)]
+    blocked_producer = manager.try_acquire_task(_task(producer.stage_id, 9))
 
     assert all(grant.granted for grant in producer_grants)
     assert not blocked_producer.granted
@@ -1624,9 +1614,8 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
     reservations = manager.snapshot()["admission"]["downstream_reservations"][producer.stage_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
         f"fte:{producer.stage_id}",
-        f"actor:{gpu_actor.stage_id}",
     ]
-    assert sum(reservation["resources"]["object_store_bytes"] for reservation in reservations) == 2
+    assert sum(reservation["resources"]["object_store_bytes"] for reservation in reservations) == 0
 
     manager.update_stage_state(consumer.stage_id, runnable=True, actor_ready=True)
     consumer_grant = manager.try_acquire_task(_task(consumer.stage_id, 0))
@@ -1634,15 +1623,15 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
     actor_grant = manager.try_acquire_task(_task(gpu_actor.stage_id, 0, retained=0))
 
     assert consumer_grant.granted
-    assert actor_grant.granted
+    assert actor_grant.granted and actor_grant.liveness
     assert actor_grant.lease.actor_index == 0
     assert (
         manager.snapshot()["usage"]
         == _r(
-            cpu=9,
+            cpu=10,
             gpu=1,
-            heap=38,
-            store=10,
+            heap=40,
+            store=11,
         ).to_dict()
     )
 
@@ -1889,7 +1878,7 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
     assert final_snapshot["usage"]["heap_bytes"] == 47
 
 
-def test_hard_heap_and_object_store_limits_are_never_bypassed_by_liveness():
+def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
     stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=25, blocks=2)
     manager = _manager(stage, resources=_r(cpu=10, heap=250, store=100))
     _ready(manager, stage.stage_id, consumer_waiting=True)
@@ -1908,6 +1897,55 @@ def test_hard_heap_and_object_store_limits_are_never_bypassed_by_liveness():
     assert snapshot["liveness"]["active_task_lease_id"] is None
 
 
+def test_soft_budget_does_not_start_extra_same_stage_work_while_task_is_active():
+    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100), target=30, blocks=2)
+    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, stage.stage_id, consumer_waiting=True)
+
+    first = manager.try_acquire_task(_task(stage.stage_id, 0))
+    second = manager.try_acquire_task(_task(stage.stage_id, 1))
+
+    assert first.granted
+    assert not second.granted
+    assert second.blocked_reason == "liveness_not_needed"
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 60
+
+
+def test_soft_budget_does_not_start_extra_borrower_while_same_stage_task_is_active():
+    parent = _stage(
+        "stage:f:parent",
+        resources=_r(cpu=1, heap=2),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    child = _stage(
+        "stage:f:child",
+        inputs=(parent.stage_id,),
+        resources=_r(cpu=1, heap=8, store=81),
+    )
+    manager = _manager(
+        parent,
+        child,
+        resources=_r(cpu=4, heap=20, store=150),
+    )
+    _ready(manager, parent.stage_id, child.stage_id)
+
+    first_parent = manager.try_acquire_task(_task(parent.stage_id, 0))
+    first = manager.try_acquire_task(_task(child.stage_id, 0, retained=81))
+    second_parent = manager.try_acquire_task(_task(parent.stage_id, 1))
+    second = manager.try_acquire_task(_task(child.stage_id, 1, retained=81))
+
+    assert first_parent.granted
+    assert first.granted
+    assert not first.liveness
+    assert second_parent.granted
+    assert not second.granted
+    assert second.blocked_reason == "liveness_not_needed"
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 101
+
+
 def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
     stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=30))
     manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=1_000))
@@ -1920,16 +1958,322 @@ def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
     assert manager.snapshot()["usage"]["object_store_bytes"] == 51
 
 
-def test_retained_input_larger_than_query_allocation_is_fatal():
-    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=30))
+def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
+    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=81))
     manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
     _ready(manager, stage.stage_id)
 
-    denied = manager.try_acquire_task(_task(stage.stage_id, 0, retained=81))
+    request = _task(stage.stage_id, 0, retained=81)
+    manager.note_task_waiting(request)
+    granted = manager.try_acquire_queued_task(request)
 
+    assert granted.granted
+    assert granted.liveness
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
+
+
+@pytest.mark.parametrize("acquire_mode", ["queued", "next_queued"])
+def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acquire_mode):
+    parent = _stage(
+        "stage:f:parent",
+        resources=_r(cpu=1, heap=2),
+        target=60,
+        blocks=2,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    child = _stage(
+        "stage:f:child",
+        inputs=(parent.stage_id,),
+        resources=_r(cpu=1, heap=8),
+        target=10,
+        blocks=2,
+    )
+    manager = _manager(
+        parent,
+        child,
+        resources=_r(cpu=4, heap=20, store=100),
+    )
+    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+
+    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
+    child_request = _task(child.stage_id, 0)
+    manager.note_task_waiting(child_request)
+    if acquire_mode == "queued":
+        child_grant = manager.try_acquire_queued_task(child_request)
+    else:
+        selected, child_grant = manager.try_acquire_next_queued_task(
+            {(child_request.task_id, child_request.attempt_id)}
+        )
+        assert selected == child_request
+        assert child_grant is not None
+
+    assert parent_grant.granted and parent_grant.liveness
+    assert child_grant.granted and child_grant.liveness
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            child.stage_id,
+            child_grant.lease.lease_id,
+            child_grant.lease.attempt_id,
+            "continuation-output",
+            10,
+        )
+    )
+    assert output.granted and not output.liveness
+    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.release_task_lease(
+        parent_grant.lease.lease_id,
+        attempt_id=parent_grant.lease.attempt_id,
+    )
+    assert manager.release_task_lease(
+        child_grant.lease.lease_id,
+        attempt_id=child_grant.lease.attempt_id,
+    )
+
+    producer_owned = manager.snapshot()
+    assert producer_owned["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
+    blocked = manager.try_acquire_task(_task(parent.stage_id, 1))
+    assert not blocked.granted
+    assert blocked.blocked_reason == "liveness_task_active"
+
+    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
+    handed_off = manager.snapshot()
+    assert handed_off["liveness"]["active_task_lease_id"] is None
+    assert handed_off["continuation_credits"] == {}
+    assert handed_off["usage"]["object_store_bytes"] == 10
+
+
+def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fanout():
+    parent = _stage(
+        "stage:f:parent",
+        resources=_r(cpu=1, heap=2),
+        target=60,
+        blocks=2,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    first_actor = _stage(
+        "stage:f:actor-a",
+        inputs=(parent.stage_id,),
+        resources=_r(store=20),
+        target=10,
+        blocks=2,
+        backend="ray_actor",
+        actor_pool_size=1,
+        resident=_r(cpu=1, heap=8),
+    )
+    sibling_actor = _stage(
+        "stage:f:actor-b",
+        inputs=(parent.stage_id,),
+        resources=_r(store=20),
+        target=10,
+        blocks=2,
+        backend="ray_actor",
+        actor_pool_size=1,
+        resident=_r(cpu=1, heap=8),
+    )
+    sibling_task = _stage(
+        "stage:f:zz-task-b",
+        inputs=(sibling_actor.stage_id,),
+        resources=_r(cpu=1, heap=8, store=20),
+        target=10,
+        blocks=2,
+    )
+    path_target = _stage(
+        "stage:f:aa-path",
+        inputs=(first_actor.stage_id,),
+        resources=_r(cpu=1, heap=10, store=20),
+        target=10,
+        blocks=2,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    manager = _manager(
+        parent,
+        first_actor,
+        sibling_actor,
+        sibling_task,
+        path_target,
+        resources=_r(cpu=8, heap=60, store=100),
+        terminals=(
+            path_target.stage_id,
+            sibling_task.stage_id,
+        ),
+    )
+    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
+    manager.update_stage_state(first_actor.stage_id, runnable=True, actor_ready=True)
+    manager.update_stage_state(sibling_actor.stage_id, runnable=True, actor_ready=True)
+
+    first_request = _task(first_actor.stage_id, 0)
+    manager.note_task_waiting(first_request)
+    selected, first_grant = manager.try_acquire_next_queued_task({(first_request.task_id, first_request.attempt_id)})
+
+    assert selected == first_request
+    assert first_grant is not None
+    assert parent_grant.granted and parent_grant.liveness
+    assert first_grant.granted and first_grant.liveness
+    sibling_request = _task(sibling_actor.stage_id, 0)
+    manager.note_task_waiting(sibling_request)
+    sibling_grant = manager.try_acquire_queued_task(sibling_request)
+    assert not sibling_grant.granted
+    assert sibling_grant.blocked_reason == "liveness_task_active"
+    assert manager.remove_task_waiter(
+        sibling_request.task_id,
+        sibling_request.attempt_id,
+    )
+    sibling_task_request = _task(sibling_task.stage_id, 0)
+    manager.note_task_waiting(sibling_task_request)
+    sibling_task_grant = manager.try_acquire_queued_task(sibling_task_request)
+    assert not sibling_task_grant.granted
+    assert sibling_task_grant.blocked_reason == "liveness_task_active"
+    path_request = _task(path_target.stage_id, 0)
+    manager.note_task_waiting(path_request)
+    selected, path_grant = manager.try_acquire_next_queued_task(
+        {
+            (sibling_task_request.task_id, sibling_task_request.attempt_id),
+            (path_request.task_id, path_request.attempt_id),
+        }
+    )
+    assert selected == path_request
+    assert path_grant is not None
+    assert path_grant.granted and path_grant.liveness
+    assert manager.release_task_lease(
+        path_grant.lease.lease_id,
+        attempt_id=path_grant.lease.attempt_id,
+    )
+    assert manager.remove_task_waiter(
+        sibling_task_request.task_id,
+        sibling_task_request.attempt_id,
+    )
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            first_actor.stage_id,
+            first_grant.lease.lease_id,
+            first_grant.lease.attempt_id,
+            "actor-continuation-output",
+            10,
+        )
+    )
+    assert output.granted and not output.liveness
+    assert manager.transition_output_block(output.lease.lease_id, "stage_queue")
+    assert manager.release_task_lease(
+        parent_grant.lease.lease_id,
+        attempt_id=parent_grant.lease.attempt_id,
+    )
+    assert manager.release_task_lease(
+        first_grant.lease.lease_id,
+        attempt_id=first_grant.lease.attempt_id,
+    )
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
+
+    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] is None
+
+
+def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
+    parent = _stage(
+        "stage:f:parent",
+        resources=_r(cpu=1, heap=2),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    actor = _stage(
+        "stage:f:actor",
+        inputs=(parent.stage_id,),
+        resources=_r(store=81),
+        target=10,
+        blocks=2,
+        backend="ray_actor",
+        actor_pool_size=1,
+        resident=_r(cpu=1, heap=8),
+    )
+    downstream = _stage(
+        "stage:f:downstream",
+        inputs=(actor.stage_id,),
+        resources=_r(cpu=1, heap=10, store=10),
+        target=20,
+        blocks=2,
+        backend="ray_worker",
+        stage_kind="fte",
+    )
+    manager = _manager(
+        parent,
+        actor,
+        downstream,
+        resources=_r(cpu=4, heap=30, store=100),
+    )
+    manager.update_stage_state(parent.stage_id, runnable=True, actor_ready=True)
+    parent_grant = manager.try_acquire_task(_task(parent.stage_id, 0))
+    manager.update_stage_state(actor.stage_id, runnable=True, actor_ready=True)
+    actor_request = _task(actor.stage_id, 0)
+    manager.note_task_waiting(actor_request)
+    selected, actor_grant = manager.try_acquire_next_queued_task({(actor_request.task_id, actor_request.attempt_id)})
+
+    assert selected == actor_request
+    assert actor_grant is not None
+    assert parent_grant.granted and not parent_grant.liveness
+    assert actor_grant.granted and actor_grant.liveness
+    downstream_grant = manager.try_acquire_task_descriptor(_task(downstream.stage_id, 0))
+    assert downstream_grant.granted and downstream_grant.liveness
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] == actor_grant.lease.lease_id
+
+    assert manager.release_task_lease(
+        downstream_grant.lease.lease_id,
+        attempt_id=downstream_grant.lease.attempt_id,
+    )
+    assert manager.release_task_lease(
+        actor_grant.lease.lease_id,
+        attempt_id=actor_grant.lease.attempt_id,
+    )
+    assert manager.snapshot()["liveness"]["active_task_lease_id"] is None
+
+
+def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
+    stage = _stage("stage:f:decode", resources=_r(cpu=1, heap=100, store=81))
+    manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
+    _ready(manager, stage.stage_id)
+
+    first_request = _task(stage.stage_id, 0, retained=81)
+    manager.note_task_waiting(first_request)
+    first = manager.try_acquire_queued_task(first_request)
+    outputs = manager.finish_task_with_outputs(
+        first.lease.lease_id,
+        attempt_id=first.lease.attempt_id,
+        outputs=(
+            OutputBlockRequest(
+                query_id="q",
+                producer_stage_id=stage.stage_id,
+                task_lease_id=first.lease.lease_id,
+                attempt_id=first.lease.attempt_id,
+                block_id="first-output",
+                size_bytes=10,
+            ),
+        ),
+    )
+
+    producer_owned = manager.snapshot()
+    assert producer_owned["liveness"]["active_task_lease_id"] == first.lease.lease_id
+    assert producer_owned["usage"]["object_store_bytes"] == 10
+    second_request = _task(stage.stage_id, 1, retained=81)
+    manager.note_task_waiting(second_request)
+    denied = manager.try_acquire_queued_task(second_request)
     assert not denied.granted
-    assert denied.fatal
-    assert denied.blocked_reason == "task_exceeds_query_allocation"
+    assert denied.blocked_reason == "liveness_task_active"
+
+    assert manager.transition_output_block(outputs[0].lease_id, "downstream_input")
+    handed_off = manager.snapshot()
+    assert handed_off["liveness"]["active_task_lease_id"] is None
+    assert handed_off["usage"]["object_store_bytes"] == 10
+    second = manager.try_acquire_queued_task(second_request)
+    assert second.granted and second.liveness
 
 
 def test_liveness_is_not_granted_while_another_runnable_stage_has_normal_capacity():
@@ -2134,20 +2478,65 @@ def test_output_transition_rejects_skips_and_attempt_mismatch():
         manager.transition_output_block(block.lease.lease_id, "external_consumer")
 
 
-def test_oversized_output_block_is_fatal_and_never_gets_liveness():
+def test_oversized_output_block_uses_one_bounded_liveness_grant():
     stage = _stage("stage:f:decode", target=50, blocks=2)
     manager = _manager(stage, resources=_r(cpu=10, heap=1_000, store=100))
     _ready(manager, stage.stage_id, consumer_waiting=True)
     task = manager.try_acquire_task(_task(stage.stage_id, 0))
 
-    denied = manager.try_acquire_output_block(
+    granted = manager.try_acquire_output_block(
         OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "huge", 101)
     )
 
-    assert not denied.granted
-    assert denied.fatal
-    assert denied.blocked_reason == "output_block_exceeds_query_limit"
-    assert denied.liveness is False
+    assert granted.granted
+    assert granted.liveness
+    second = manager.try_acquire_output_block(
+        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "second", 1)
+    )
+    assert not second.granted
+    assert second.blocked_reason == "liveness_output_active"
+    assert manager.transition_output_block(granted.lease.lease_id, "stage_queue")
+    assert manager.transition_output_block(granted.lease.lease_id, "downstream_input")
+    next_block = manager.try_acquire_output_block(
+        OutputBlockRequest("q", stage.stage_id, task.lease.lease_id, "0", "second-after-handoff", 1)
+    )
+    assert next_block.granted
+    assert next_block.liveness
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 2
+
+
+def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
+    producer = _stage("stage:f:producer", resources=_r(cpu=1, heap=100), target=50, blocks=2)
+    consumer = _stage(
+        "stage:f:consumer",
+        inputs=(producer.stage_id,),
+        resources=_r(cpu=1, heap=100),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        producer,
+        consumer,
+        resources=_r(cpu=10, heap=1_000, store=100),
+    )
+    _ready(manager, producer.stage_id, consumer.stage_id, consumer_waiting=True)
+    producer_task = manager.try_acquire_task(_task(producer.stage_id, 0))
+    oversized = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            producer.stage_id,
+            producer_task.lease.lease_id,
+            "0",
+            "oversized",
+            101,
+        )
+    )
+
+    assert oversized.granted and oversized.liveness
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
+    downstream = manager.try_acquire_task(_task(consumer.stage_id, 0, retained=0))
+    assert downstream.granted
+    assert not downstream.liveness
 
 
 def test_allocation_shrink_creates_debt_without_revoking_existing_leases():
@@ -2191,9 +2580,11 @@ def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
     assert blocked.blocked_reason == "allocation_pending"
     assert blocked.fatal is False
     assert snapshot["allocation_admission_open"] is False
-    assert snapshot["allocation_debt"] == expected_usage
+    assert snapshot["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
+    assert snapshot["soft_object_store_debt_bytes"] == 20
     assert snapshot["node_usage"]["node-a"] == expected_usage
-    assert snapshot["node_allocation_debt"]["node-a"] == expected_usage
+    assert snapshot["node_allocation_debt"]["node-a"] == _r(cpu=1, heap=100).to_dict()
+    assert snapshot["node_soft_object_store_debt_bytes"]["node-a"] == 20
 
     assert manager.release_task_lease(
         active.lease.lease_id,
@@ -2274,11 +2665,7 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
     assert output.node_id == first.lease.node_id
     assert manager.snapshot()["node_usage"][output.node_id]["object_store_bytes"] == 10
 
-    blocked = manager.try_acquire_task(_task(stage.stage_id, 3, node_id=output.node_id))
-    assert not blocked.granted
-    assert blocked.blocked_reason == "node_capacity"
-
-    assert manager.release_output_block(output.lease_id)
-    granted = manager.try_acquire_task(_task(stage.stage_id, 3, attempt="1", node_id=output.node_id))
+    granted = manager.try_acquire_task(_task(stage.stage_id, 3, node_id=output.node_id))
     assert granted.granted
     assert granted.lease.node_id == output.node_id
+    assert manager.snapshot()["node_soft_object_store_debt_bytes"][output.node_id] == 10

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -685,10 +685,18 @@ def test_persistent_soft_actor_debt_warns_once_after_ray_data_delay(monkeypatch,
         terminal_unit_ids=(actor.resource_unit_id,),
     )
     allocation = _allocation(
-        _r(cpu=0.5, gpu=0.5, heap=50, store=200),
+        _r(cpu=1, gpu=1, heap=100, store=200),
     )
     manager = RayQueryResourceManager(graph, allocation)
     manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    manager.update_allocation(
+        _allocation(
+            _r(cpu=0.5, gpu=0.5, heap=50, store=200),
+            generation=2,
+        ),
+        admission_open=True,
+        debt_neutral_only=True,
+    )
     clock = [100.0]
     monkeypatch.setattr(manager_module.time, "monotonic", lambda: clock[0])
 
@@ -826,12 +834,20 @@ def test_actor_process_soft_debt_does_not_recharge_existing_actor_invocations():
         terminal_unit_ids=(actor.resource_unit_id,),
     )
     allocation = _allocation(
-        _r(cpu=0.5, gpu=0.5, heap=50, store=100),
+        _r(cpu=1, gpu=1, heap=100, store=100),
     )
     manager = RayQueryResourceManager(graph, allocation)
     manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
     manager.update_unit_state(actor.resource_unit_id, runnable=True)
+    manager.update_allocation(
+        _allocation(
+            _r(cpu=0.5, gpu=0.5, heap=50, store=100),
+            generation=2,
+        ),
+        admission_open=True,
+        debt_neutral_only=True,
+    )
 
     first = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
     second = manager.try_acquire_task(_task(actor.resource_unit_id, 1))

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -1281,9 +1281,16 @@ def test_frontier_materializer_disables_object_store_backpressure_for_input():
     assert snapshot["units"][upstream.resource_unit_id]["object_store_backpressure_disabled"] is True
 
 
-def test_asymmetric_frontier_lifts_object_store_cap_only_for_materialized_input():
+def test_asymmetric_frontier_lifts_object_store_cap_for_materialized_branch_only():
+    build_source = _unit(
+        "resource:f:broadcast-build-source",
+        resources=_r(cpu=1),
+        target=50,
+        blocks=2,
+    )
     build = _unit(
         "resource:f:broadcast-build",
+        inputs=(build_source.resource_unit_id,),
         resources=_r(cpu=1),
         target=50,
         blocks=2,
@@ -1316,6 +1323,7 @@ def test_asymmetric_frontier_lifts_object_store_cap_only_for_materialized_input(
         materialized_inputs=(build.resource_unit_id,),
     )
     manager = _manager(
+        build_source,
         build,
         probe,
         materializer,
@@ -1325,6 +1333,7 @@ def test_asymmetric_frontier_lifts_object_store_cap_only_for_materialized_input(
     )
     _ready(
         manager,
+        build_source.resource_unit_id,
         build.resource_unit_id,
         probe.resource_unit_id,
         materializer.resource_unit_id,
@@ -1333,11 +1342,33 @@ def test_asymmetric_frontier_lifts_object_store_cap_only_for_materialized_input(
 
     before = manager.snapshot()
     assert before["execution_phase"]["object_store_unlimited_unit_ids"] == [
+        build_source.resource_unit_id,
         build.resource_unit_id,
         materializer.resource_unit_id,
     ]
+    assert before["units"][build_source.resource_unit_id]["object_store_backpressure_disabled"] is True
     assert before["units"][build.resource_unit_id]["object_store_backpressure_disabled"] is True
     assert before["units"][probe.resource_unit_id]["object_store_backpressure_disabled"] is False
+
+    materializing_task = manager.try_acquire_task(_task(materializer.resource_unit_id, 0, node_id="node-a"))
+    build_task = manager.try_acquire_task(_task(build.resource_unit_id, 0))
+    build_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            build.resource_unit_id,
+            build_task.lease.lease_id,
+            build_task.lease.attempt_id,
+            "accumulated-build-block",
+            100,
+        )
+    )
+    upstream_continuation = manager.try_acquire_task(_task(build_source.resource_unit_id, 0, retained=1))
+    deferred_probe = manager.try_acquire_task(_task(probe.resource_unit_id, 0, retained=1))
+
+    assert materializing_task.granted and build_task.granted and build_output.granted
+    assert upstream_continuation.granted and not upstream_continuation.liveness
+    assert not deferred_probe.granted
+    assert deferred_probe.blocked_reason == "materialization_barrier_pending"
 
     assert manager.mark_materialization_barrier_completed_for_node("broadcast-join")
     after = manager.snapshot()

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -8,7 +8,6 @@ import pytest
 from duckdb.runners.ray import query_resource_manager as manager_module
 from duckdb.runners.ray.query_resource_graph import (
     MaterializationBarrierSpec,
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -26,13 +25,9 @@ def _r(*, cpu=0.0, gpu=0.0, heap=0, store=0):
 
 
 def _allocation(resources, *, generation=1, nodes=None):
-    node_resources = (("node-a", resources),) if nodes is None else tuple(nodes)
+    del nodes
     return QueryAllocation(
         resources=resources,
-        node_allocations=tuple(
-            NodeResourceAllocation(node_id=node_id, resources=node_capacity)
-            for node_id, node_capacity in node_resources
-        ),
         generation=generation,
     )
 
@@ -115,7 +110,6 @@ def _manager(
         allocation_resources,
         nodes=nodes,
     )
-    graph.validate_allocation(allocation)
     return RayQueryResourceManager(
         graph,
         allocation,
@@ -277,7 +271,7 @@ def test_barrier_completion_retires_old_eligible_units_and_opens_next_phase():
         admission_open=True,
     )
     retired_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
-    final_materializer = manager.try_acquire_task(_task(materializer.resource_unit_id, 0))
+    final_materializer = manager.try_acquire_task(_task(materializer.resource_unit_id, 0, node_id="node-a"))
     opened_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
     assert retired_upstream.blocked_reason == "materialization_barrier_pending"
     assert final_materializer.granted
@@ -639,85 +633,51 @@ def test_ray_tasks_receive_unique_resource_lease_slots():
     assert first.lease.execution_slot_id == (f"ray_task:{unit.resource_unit_id}:{first.lease.lease_id}")
 
 
-def test_idle_actor_process_resources_are_in_soft_allocation_usage():
+def test_submitted_actor_processes_are_charged_once_to_soft_usage():
     actor = _unit(
-        "resource:f:gpu",
-        resources=_r(store=40),
-        resident=_r(cpu=1, gpu=1, heap=100),
+        "resource:f:actor",
+        resources=_r(store=10),
+        resident=_r(cpu=1, gpu=0.5, heap=100),
         backend="ray_actor",
-        concurrency=None,
-        actor_pool_size=1,
+        actor_pool_size=2,
+        actor_prefetch_depth=2,
     )
     manager = _manager(
         actor,
-        resources=_r(cpu=1, gpu=1, heap=100, store=200),
+        resources=_r(cpu=2, gpu=1, heap=200, store=100),
     )
-    _ready(manager, actor.resource_unit_id)
 
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0, 1})
     snapshot = manager.snapshot()
+
     assert snapshot["usage"] == _r().to_dict()
-    assert snapshot["node_usage"]["node-a"] == _r().to_dict()
-    assert snapshot["soft_allocation_usage"] == _r(cpu=1, gpu=1, heap=100).to_dict()
-    assert snapshot["actor_process_usage"] == _r(cpu=1, gpu=1, heap=100).to_dict()
+    assert snapshot["actor_process_usage"] == _r(cpu=2, gpu=1, heap=200).to_dict()
+    assert snapshot["soft_allocation_usage"] == _r(cpu=2, gpu=1, heap=200).to_dict()
+    assert snapshot["pending_actor_slots"] == [
+        f"{actor.resource_unit_id}:0",
+        f"{actor.resource_unit_id}:1",
+    ]
+
+    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a", 1: "node-b"})
+    _ready(manager, actor.resource_unit_id)
+    first = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+
+    assert first.granted and second.granted
+    # Invocations charge only their dynamic input/output bytes. The actor
+    # process CPU/GPU/heap is not multiplied by batches.
     assert (
-        snapshot["actor_process_usage_by_ready_node"]["node-a"]
+        manager.snapshot()["soft_allocation_usage"]
         == _r(
-            cpu=1,
+            cpu=2,
             gpu=1,
-            heap=100,
+            heap=200,
+            store=20,
         ).to_dict()
     )
 
 
-def test_persistent_soft_actor_debt_warns_once_after_ray_data_delay(monkeypatch, caplog):
-    actor = _unit(
-        "resource:f:oversubscribed-actor",
-        resources=_r(store=40),
-        resident=_r(cpu=1, gpu=1, heap=100),
-        backend="ray_actor",
-        concurrency=None,
-        actor_pool_size=1,
-    )
-    graph = QueryResourceGraph(
-        query_id="q",
-        plan_digest="sha256:test",
-        units=(actor,),
-        terminal_unit_ids=(actor.resource_unit_id,),
-    )
-    allocation = _allocation(
-        _r(cpu=1, gpu=1, heap=100, store=200),
-    )
-    manager = RayQueryResourceManager(graph, allocation)
-    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
-    manager.update_allocation(
-        _allocation(
-            _r(cpu=0.5, gpu=0.5, heap=50, store=200),
-            generation=2,
-        ),
-        admission_open=True,
-        debt_neutral_only=True,
-    )
-    clock = [100.0]
-    monkeypatch.setattr(manager_module.time, "monotonic", lambda: clock[0])
-
-    with caplog.at_level(logging.WARNING, logger=manager_module.__name__):
-        first = manager.snapshot()
-        clock[0] += 59.9
-        manager.snapshot()
-        assert caplog.records == []
-        clock[0] += 0.1
-        warned = manager.snapshot()
-        clock[0] += 60
-        manager.snapshot()
-
-    assert first["soft_allocation_debt"] == _r(cpu=0.5, gpu=0.5, heap=50).to_dict()
-    assert warned["soft_allocation_debt_duration_s"] == pytest.approx(60.0)
-    assert warned["soft_allocation_warning_emitted"] is True
-    assert len(caplog.records) == 1
-    assert "new work can be backpressured" in caplog.records[0].getMessage()
-
-
-def test_ready_actor_outside_virtual_node_allocation_accepts_zero_increment_call():
+def test_actor_invocation_uses_the_ready_actor_runtime_node():
     actor = _unit(
         "resource:f:external-actor",
         resources=_r(store=10),
@@ -725,17 +685,7 @@ def test_ready_actor_outside_virtual_node_allocation_accepts_zero_increment_call
         backend="ray_actor",
         actor_pool_size=1,
     )
-    graph = QueryResourceGraph(
-        query_id="q",
-        plan_digest="sha256:test",
-        units=(actor,),
-        terminal_unit_ids=(actor.resource_unit_id,),
-    )
-    allocation = _allocation(
-        _r(cpu=1, heap=100, store=100),
-        nodes=(("virtual-node", _r(cpu=1, heap=100, store=100)),),
-    )
-    manager = RayQueryResourceManager(graph, allocation)
+    manager = _manager(actor, resources=_r(cpu=1, heap=100, store=100))
     manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.set_ready_actor_slots(actor.resource_unit_id, {0: "actual-node"})
     manager.update_unit_state(actor.resource_unit_id, runnable=True)
@@ -745,81 +695,100 @@ def test_ready_actor_outside_virtual_node_allocation_accepts_zero_increment_call
     assert grant.granted and not grant.liveness
     assert grant.lease.node_id == "actual-node"
     assert grant.lease.actor_index == 0
-    snapshot = manager.snapshot()
-    assert snapshot["node_usage"]["actual-node"] == _r(store=10).to_dict()
-    assert (
-        snapshot["actor_process_usage_by_ready_node"]["actual-node"]
-        == _r(
-            cpu=1,
-            heap=100,
-        ).to_dict()
-    )
-    assert snapshot["node_allocation_debt"]["actual-node"] == _r().to_dict()
+    assert manager.snapshot()["actor_process_usage_by_ready_node"] == {
+        "actual-node": _r(cpu=1, heap=100).to_dict(),
+    }
 
 
-def test_reconstructed_actor_moves_ready_slot_and_prefetched_calls_atomically():
-    actor = _unit(
-        "resource:f:reconstructed-actor",
-        resources=_r(store=1),
-        resident=_r(cpu=1, heap=4),
-        backend="ray_actor",
-        actor_pool_size=1,
-        actor_prefetch_depth=2,
-    )
-    manager = _manager(
-        actor,
-        resources=_r(cpu=2, heap=8, store=20),
-        nodes=(("node-a", _r(cpu=1, heap=4, store=10)), ("node-b", _r(cpu=1, heap=4, store=10))),
-    )
-    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
-    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
-    manager.update_unit_state(actor.resource_unit_id, runnable=True)
-    active = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=1))
-    prefetched = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=1))
-    assert active.granted and prefetched.granted
-
-    moved = manager.reconcile_actor_runtime_node(actor.resource_unit_id, 0, "node-b")
-
-    assert set(moved) == {active.lease.lease_id, prefetched.lease.lease_id}
-    snapshot = manager.snapshot()
-    assert snapshot["ready_actor_slots"][f"{actor.resource_unit_id}:0"] == "node-b"
-    assert snapshot["task_leases"][active.lease.lease_id]["node_id"] == "node-b"
-    assert snapshot["task_leases"][prefetched.lease.lease_id]["node_id"] == "node-b"
-    assert manager.reconcile_actor_runtime_node(actor.resource_unit_id, 0, "node-b") == ()
-
-
-def test_ready_actor_process_moves_node_affine_ray_task_to_free_allocation():
-    actor = _unit(
-        "resource:f:resident-actor",
-        resources=_r(),
-        resident=_r(cpu=1),
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
+def test_ray_task_lease_is_unpinned_and_rejects_a_requested_node():
     task = _unit(
-        "resource:f:node-affine-task",
-        resources=_r(cpu=1),
+        "resource:f:ray-task",
+        resources=_r(cpu=1, gpu=0.25, heap=100),
         target=0,
         blocks=0,
     )
-    manager = _manager(
-        actor,
-        task,
-        resources=_r(cpu=2),
-        nodes=(("node-a", _r(cpu=1)), ("node-b", _r(cpu=1))),
-        terminals=(actor.resource_unit_id, task.resource_unit_id),
+    manager = _manager(task, resources=_r(cpu=2, gpu=1, heap=200))
+    _ready(manager, task.resource_unit_id)
+
+    pinned = manager.try_acquire_task(_task(task.resource_unit_id, "pinned", node_id="node-a"))
+    unpinned = manager.try_acquire_task(_task(task.resource_unit_id, "unpinned"))
+
+    assert pinned.fatal and pinned.blocked_reason == "ray_task_node_must_be_unset"
+    assert unpinned.granted and not unpinned.liveness
+    assert unpinned.lease.node_id is None
+    assert unpinned.lease.resources == _r(cpu=1, gpu=0.25, heap=100)
+
+
+def test_native_fragment_lease_keeps_actual_worker_node_but_no_process_charge():
+    native = _unit(
+        "resource:f:native",
+        resources=_r(store=10),
+        target=10,
+        blocks=2,
+        backend="ray_worker",
     )
-    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
-    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
-    manager.update_unit_state(task.resource_unit_id, runnable=True)
+    manager = _manager(native, resources=_r(store=100))
+    _ready(manager, native.resource_unit_id)
 
-    grant = manager.try_acquire_task(_task(task.resource_unit_id, 0))
+    missing = manager.try_acquire_task(_task(native.resource_unit_id, "missing"))
+    granted = manager.try_acquire_task(_task(native.resource_unit_id, "actual", node_id="node-b"))
 
-    assert grant.granted and not grant.liveness
-    assert grant.lease.node_id == "node-b"
+    assert missing.fatal and missing.blocked_reason == "ray_worker_node_required"
+    assert granted.granted
+    assert granted.lease.node_id == "node-b"
+    assert granted.lease.resources == _r(store=10)
+    assert manager.snapshot()["usage"] == _r(store=30).to_dict()
 
 
-def test_actor_process_soft_debt_does_not_recharge_existing_actor_invocations():
+def test_zero_soft_budget_submits_one_real_ray_task_for_liveness():
+    task = _unit(
+        "resource:f:autoscaling-demand",
+        resources=_r(cpu=4, gpu=2, heap=1_000),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(task, resources=_r())
+    _ready(manager, task.resource_unit_id)
+
+    first = manager.try_acquire_task(_task(task.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(task.resource_unit_id, 1))
+
+    assert first.granted and first.liveness
+    assert first.lease.node_id is None
+    assert first.lease.resources == _r(cpu=4, gpu=2, heap=1_000)
+    assert not second.granted and second.blocked_reason == "liveness_task_active"
+
+    assert manager.release_task_lease(first.lease.lease_id, attempt_id=first.lease.attempt_id)
+    third = manager.try_acquire_task(_task(task.resource_unit_id, 2))
+    assert third.granted and third.liveness
+
+
+@pytest.mark.parametrize(
+    ("resources", "reason"),
+    [
+        (_r(cpu=0.5, gpu=1, heap=100), "query_soft_cpu"),
+        (_r(cpu=1, gpu=0.5, heap=100), "query_soft_gpu"),
+        (_r(cpu=1, gpu=1, heap=99), "query_soft_heap_bytes"),
+    ],
+)
+def test_cpu_gpu_and_declared_heap_are_soft_backpressure_dimensions(resources, reason):
+    task = _unit(
+        "resource:f:shape",
+        resources=_r(cpu=1, gpu=1, heap=100),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(task, resources=resources)
+    _ready(manager, task.resource_unit_id)
+    request = _task(task.resource_unit_id, 0)
+
+    assert manager._normal_task_block_reason_locked(request)[0] == reason
+    grant = manager.try_acquire_task(request)
+
+    assert grant.granted and grant.liveness
+
+
+def test_fixed_actor_soft_debt_does_not_block_zero_increment_invocations():
     actor = _unit(
         "resource:f:soft-debt-actor",
         resources=_r(),
@@ -827,52 +796,31 @@ def test_actor_process_soft_debt_does_not_recharge_existing_actor_invocations():
         backend="ray_actor",
         actor_pool_size=1,
     )
-    graph = QueryResourceGraph(
-        query_id="q",
-        plan_digest="sha256:test",
-        units=(actor,),
-        terminal_unit_ids=(actor.resource_unit_id,),
-    )
-    allocation = _allocation(
-        _r(cpu=1, gpu=1, heap=100, store=100),
-    )
-    manager = RayQueryResourceManager(graph, allocation)
+    manager = _manager(actor, resources=_r(cpu=1, gpu=1, heap=100))
     manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
     manager.update_unit_state(actor.resource_unit_id, runnable=True)
     manager.update_allocation(
-        _allocation(
-            _r(cpu=0.5, gpu=0.5, heap=50, store=100),
-            generation=2,
-        ),
+        _allocation(_r(cpu=0.5, gpu=0.5, heap=50), generation=2),
         admission_open=True,
-        debt_neutral_only=True,
     )
 
-    first = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
-    second = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
+    invocation = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
+    snapshot = manager.snapshot()
 
-    assert first.granted and not first.liveness
-    assert first.lease.actor_index == 0
-    assert not second.granted
-    assert second.blocked_reason == "actor_slot"
-    assert manager.release_task_lease(
-        first.lease.lease_id,
-        attempt_id=first.lease.attempt_id,
-    )
-    replacement = manager.try_acquire_task(_task(actor.resource_unit_id, 1))
-    assert replacement.granted and not replacement.liveness
+    assert invocation.granted and not invocation.liveness
+    assert snapshot["soft_allocation_debt"] == _r(cpu=0.5, gpu=0.5, heap=50).to_dict()
 
 
-def test_submitted_actor_debt_blocks_new_ray_process_but_not_actor_invocation():
+def test_actor_debt_still_allows_one_real_ray_task_to_reach_ray_core():
     actor = _unit(
-        "resource:f:oversubscribed-actor",
+        "resource:f:resident-actor",
         resources=_r(),
         resident=_r(cpu=1, heap=100),
         backend="ray_actor",
-        actor_pool_size=2,
+        actor_pool_size=1,
     )
-    ray_task = _unit(
+    task = _unit(
         "resource:f:new-ray-task",
         resources=_r(cpu=1, heap=100),
         target=0,
@@ -880,1954 +828,200 @@ def test_submitted_actor_debt_blocks_new_ray_process_but_not_actor_invocation():
     )
     manager = _manager(
         actor,
-        ray_task,
-        resources=_r(cpu=1, heap=100, store=100),
-        terminals=(actor.resource_unit_id, ray_task.resource_unit_id),
+        task,
+        resources=_r(cpu=1, heap=100),
+        terminals=(actor.resource_unit_id, task.resource_unit_id),
     )
-    _ready(manager, actor.resource_unit_id, ray_task.resource_unit_id)
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
+    _ready(manager, task.resource_unit_id)
 
-    invocation = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
-    new_process = manager.try_acquire_task(_task(ray_task.resource_unit_id, 0))
-    snapshot = manager.snapshot()
+    first = manager.try_acquire_task(_task(task.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(task.resource_unit_id, 1))
 
-    assert invocation.granted and not invocation.liveness
-    assert not new_process.granted
-    assert new_process.blocked_reason == "node_allocation_debt"
-    assert snapshot["soft_allocation_usage"] == _r(cpu=2, heap=200).to_dict()
-    assert snapshot["allocation_debt"] == _r().to_dict()
-    assert snapshot["soft_allocation_debt"] == _r(cpu=1, heap=100).to_dict()
+    assert first.granted and first.liveness
+    assert not second.granted and second.blocked_reason == "liveness_task_active"
 
 
-def test_soft_reservation_only_divides_each_dimension_among_units_that_need_it():
-    cpu_units = []
-    for index in range(10):
-        cpu_units.append(
-            _unit(
-                f"resource:f:cpu-{index}",
-                inputs=() if not cpu_units else (cpu_units[-1].resource_unit_id,),
-                resources=_r(cpu=1, heap=10),
-                target=0,
-                blocks=0,
-            )
-        )
-    gpu_unit = _unit(
-        "resource:f:gpu",
-        inputs=(cpu_units[-1].resource_unit_id,),
-        resources=_r(gpu=1, heap=20),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    manager = _manager(
-        *cpu_units,
-        gpu_unit,
-        resources=_r(cpu=10, gpu=1, heap=1_000, store=100),
-    )
-    _ready(manager, *(unit.resource_unit_id for unit in (*cpu_units, gpu_unit)))
-
-    grant = manager.try_acquire_task(_task(gpu_unit.resource_unit_id, 0))
-
-    assert grant.granted
-    assert grant.lease.resources.gpu == 0
-    assert gpu_unit.resident_per_actor.gpu == 1
-
-
-def test_unit_minimum_commitments_are_protected_before_shared_heap_borrowing():
-    cpu_units = []
-    for index in range(10):
-        cpu_units.append(
-            _unit(
-                f"resource:f:cpu-{index}",
-                inputs=() if not cpu_units else (cpu_units[-1].resource_unit_id,),
-                resources=_r(cpu=1, heap=20),
-                target=0,
-                blocks=0,
-            )
-        )
-    gpu_unit = _unit(
-        "resource:f:gpu",
-        inputs=(cpu_units[-1].resource_unit_id,),
-        resources=_r(gpu=1, heap=40),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    manager = _manager(
-        *cpu_units,
-        gpu_unit,
-        resources=_r(cpu=100, gpu=1, heap=240, store=100),
-    )
-    _ready(manager, *(unit.resource_unit_id for unit in (*cpu_units, gpu_unit)))
-
-    first_upstream = manager.try_acquire_task(_task(cpu_units[0].resource_unit_id, 0))
-    second_upstream = manager.try_acquire_task(_task(cpu_units[0].resource_unit_id, 1))
-    downstream = manager.try_acquire_task(_task(gpu_unit.resource_unit_id, 0))
-
-    assert first_upstream.granted
-    assert not second_upstream.granted
-    assert downstream.granted
-
-
-def test_actor_process_heap_consumes_shared_soft_credit_before_new_ray_tasks():
-    gpu_actor = _unit(
-        "resource:f:gpu-actor",
-        resources=_r(gpu=1, heap=4),
-        target=0,
-        blocks=0,
-        concurrency=None,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    cpu_unit = _unit(
-        "resource:f:cpu",
-        inputs=(gpu_actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        concurrency=100,
-    )
-    manager = _manager(
-        gpu_actor,
-        cpu_unit,
-        resources=_r(cpu=100, gpu=1, heap=20, store=20),
-    )
-    _ready(manager, gpu_actor.resource_unit_id, cpu_unit.resource_unit_id)
-
-    actor_grant = manager.try_acquire_task(_task(gpu_actor.resource_unit_id, 0))
-    cpu_grants = [manager.try_acquire_task(_task(cpu_unit.resource_unit_id, partition)) for partition in range(8)]
-    denied = manager.try_acquire_task(_task(cpu_unit.resource_unit_id, 8))
-
-    assert actor_grant.granted
-    assert all(grant.granted for grant in cpu_grants)
-    assert not denied.granted
-    assert denied.blocked_reason == "node_capacity"
-    assert (
-        manager.snapshot()["soft_allocation_usage"]
-        == _r(
-            cpu=8,
-            gpu=1,
-            heap=20,
-        ).to_dict()
-    )
-
-
-def test_native_fragment_uses_fte_node_outside_query_allocation_attribution():
-    native = _unit(
-        "resource:f:native-external-node",
-        resources=_r(store=10),
-        target=10,
-        blocks=2,
-        backend="ray_worker",
-    )
-    manager = _manager(
-        native,
-        resources=_r(store=100),
-        nodes=(("node-a", _r(store=100)),),
-    )
-    _ready(manager, native.resource_unit_id)
-
-    task_grant = manager.try_acquire_task(
-        _task(native.resource_unit_id, 0, node_id="node-b"),
-    )
-
-    assert task_grant.granted
-    assert task_grant.lease.node_id == "node-b"
-    output_grant = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            query_id="q",
-            producer_unit_id=native.resource_unit_id,
-            task_lease_id=task_grant.lease.lease_id,
-            attempt_id=task_grant.lease.attempt_id,
-            block_id="native-external-output",
-            size_bytes=30,
-        )
-    )
-    assert output_grant.granted
-    snapshot = manager.snapshot()
-    assert snapshot["allocation"]["node_allocations"] == [
-        {"node_id": "node-a", "resources": _r(store=100).to_dict()},
-    ]
-    # Native publication keeps its bounded FTE window until completion, and
-    # the exposed ObjectRef is an additional exact logical byte count.
-    assert snapshot["node_usage"]["node-b"] == _r(store=60).to_dict()
-    assert snapshot["node_allocation_debt"]["node-b"] == _r().to_dict()
-
-
-def test_external_native_node_keeps_remote_continuation_on_allocated_node():
-    native = _unit(
-        "resource:f:native-external-parent",
+def test_persistent_soft_actor_debt_warns_once_after_ray_data_delay(monkeypatch, caplog):
+    actor = _unit(
+        "resource:f:oversubscribed-actor",
         resources=_r(),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-    )
-    remote = _unit(
-        "resource:f:remote-continuation",
-        inputs=(native.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        native,
-        remote,
-        resources=_r(cpu=1, heap=10),
-        nodes=(("node-a", _r(cpu=1, heap=10)),),
-    )
-    _ready(manager, native.resource_unit_id, remote.resource_unit_id)
-
-    native_grant = manager.try_acquire_task(
-        _task(native.resource_unit_id, 0, node_id="node-b"),
-    )
-
-    assert native_grant.granted
-    assert native_grant.lease.node_id == "node-b"
-    credits = manager.snapshot()["continuation_credits"]
-    assert len(credits) == 1
-    assert next(iter(credits.values()))["node_id"] == "node-a"
-    remote_grant = manager.try_acquire_task(_task(remote.resource_unit_id, 0, node_id="node-a"))
-    assert remote_grant.granted
-    assert remote_grant.lease.node_id == "node-a"
-
-
-def test_empty_runnable_units_do_not_dilute_live_task_reservation():
-    units = []
-    for index in range(4):
-        units.append(
-            _unit(
-                f"resource:f:demand-{index}",
-                inputs=() if not units else (units[-1].resource_unit_id,),
-                resources=_r(cpu=1, heap=2),
-                target=0,
-                blocks=0,
-            )
-        )
-    live_unit = units[-1]
-    manager = _manager(
-        *units,
-        resources=_r(cpu=8, heap=8, store=8),
-    )
-    for unit in units:
-        manager.update_unit_state(
-            unit.resource_unit_id,
-            runnable=True,
-        )
-
-    requests = [_task(live_unit.resource_unit_id, index) for index in range(3)]
-    for request in requests:
-        manager.note_task_waiting(request)
-
-    grants = [manager.try_acquire_task(request) for request in requests]
-
-    assert all(grant.granted for grant in grants)
-    snapshot = manager.snapshot()
-    assert snapshot["units"][live_unit.resource_unit_id]["active_task_count"] == 3
-    assert all(
-        snapshot["units"][unit.resource_unit_id]["active_task_count"] == 0 for unit in units if unit is not live_unit
-    )
-
-
-def test_queued_admission_prefers_downstream_over_upstream_refill():
-    upstream = _unit(
-        "resource:f:upstream-refill",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    downstream = _unit(
-        "resource:f:downstream-work",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        upstream,
-        downstream,
-        resources=_r(cpu=12, heap=12, store=12),
-    )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
-
-    held = [manager.try_acquire_task(_task(upstream.resource_unit_id, index)) for index in range(5)]
-    assert all(grant.granted for grant in held)
-
-    manager.update_unit_state(downstream.resource_unit_id, runnable=True)
-    upstream_waiter = _task(upstream.resource_unit_id, "refill")
-    downstream_waiter = _task(downstream.resource_unit_id, "ready")
-    manager.note_task_waiting(upstream_waiter)
-    manager.note_task_waiting(downstream_waiter)
-
-    before = manager.snapshot()["admission"]
-    upstream_result = manager.try_acquire_queued_task(upstream_waiter)
-    downstream_result = manager.try_acquire_queued_task(downstream_waiter)
-
-    assert before["preferred_task"] == {
-        "task_id": downstream_waiter.task_id,
-        "attempt_id": downstream_waiter.attempt_id,
-        "resource_unit_id": downstream.resource_unit_id,
-        "grant_class": "normal",
-    }
-    assert before["reservation_unit_ids"]["heap_bytes"] == [
-        upstream.resource_unit_id,
-        downstream.resource_unit_id,
-    ]
-    assert [item["task_id"] for item in before["waiting_tasks"]] == [
-        upstream_waiter.task_id,
-        downstream_waiter.task_id,
-    ]
-    assert not upstream_result.granted
-    assert not upstream_result.fatal
-    assert upstream_result.blocked_reason == "admission_turn"
-    assert downstream_result.granted
-    assert downstream_result.lease.resource_unit_id == downstream.resource_unit_id
-
-
-def test_driver_subset_yields_when_global_winner_is_fte_owned():
-    upstream = _unit(
-        "resource:f:driver-upstream",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    downstream = _unit(
-        "resource:f:native-downstream",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
-    driver_request = _task(upstream.resource_unit_id, "driver")
-    fte_request = _task(downstream.resource_unit_id, "fte")
-    manager.note_task_waiting(driver_request)
-    manager.note_task_waiting(fte_request)
-
-    selected, yielded = manager.try_acquire_next_queued_task({(driver_request.task_id, driver_request.attempt_id)})
-
-    assert selected == fte_request
-    assert not yielded.granted
-    assert yielded.blocked_reason == "admission_turn"
-    assert manager.snapshot()["task_leases"] == {}
-    assert manager.try_acquire_queued_task(fte_request).granted
-
-
-def test_fte_request_yields_when_global_winner_is_driver_owned():
-    upstream = _unit(
-        "resource:f:native-upstream",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    downstream = _unit(
-        "resource:f:driver-downstream",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
-    fte_request = _task(upstream.resource_unit_id, "fte")
-    driver_request = _task(downstream.resource_unit_id, "driver")
-    manager.note_task_waiting(fte_request)
-    manager.note_task_waiting(driver_request)
-
-    yielded = manager.try_acquire_queued_task(fte_request)
-    selected, granted = manager.try_acquire_next_queued_task({(driver_request.task_id, driver_request.attempt_id)})
-
-    assert not yielded.granted
-    assert yielded.blocked_reason == "admission_turn"
-    assert selected == driver_request
-    assert granted.granted
-    assert granted.lease.resource_unit_id == downstream.resource_unit_id
-
-
-def test_descriptor_admission_is_not_persisted_and_retries_after_epoch_change():
-    unit = _unit(
-        "resource:f:descriptor-window",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        concurrency=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(unit, resources=_r(cpu=2, heap=4, store=4))
-    _ready(manager, unit.resource_unit_id)
-
-    first = manager.try_acquire_task_descriptor(_task(unit.resource_unit_id, 0))
-    assert first.granted
-    epoch_before_denial = manager.admission_epoch()
-
-    second_request = _task(unit.resource_unit_id, 1)
-    denied = manager.try_acquire_task_descriptor(second_request)
-    snapshot = manager.snapshot()
-
-    assert not denied.granted
-    assert denied.blocked_reason == "unit_concurrency"
-    assert denied.admission_epoch == epoch_before_denial
-    assert manager.admission_epoch() == epoch_before_denial
-    assert snapshot["units"][unit.resource_unit_id]["pending_task_count"] == 0
-    assert snapshot["admission"]["waiting_tasks"] == []
-
-    manager.release_task_lease(
-        first.lease.lease_id,
-        attempt_id=first.lease.attempt_id,
-    )
-    assert manager.admission_epoch() > epoch_before_denial
-    replacement = manager.try_acquire_task_descriptor(second_request)
-    assert replacement.granted
-
-
-def test_descriptor_admission_marks_non_root_native_fragment_unit_runnable_without_waiter():
-    upstream = _unit(
-        "resource:f:descriptor-source",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    native_fragment_unit = _unit(
-        "resource:f:descriptor-non-root",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(upstream, native_fragment_unit, resources=_r(cpu=4, heap=8, store=8))
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
-    assert manager.snapshot()["units"][native_fragment_unit.resource_unit_id]["runnable"] is False
-
-    grant = manager.try_acquire_task_descriptor(_task(native_fragment_unit.resource_unit_id, 0))
-    snapshot = manager.snapshot()
-
-    assert grant.granted
-    assert snapshot["units"][native_fragment_unit.resource_unit_id]["runnable"] is True
-    assert snapshot["units"][native_fragment_unit.resource_unit_id]["pending_task_count"] == 0
-    assert snapshot["admission"]["waiting_tasks"] == []
-
-
-def test_descriptor_admission_yields_to_higher_rank_persistent_waiter():
-    upstream = _unit(
-        "resource:f:descriptor-upstream",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    downstream = _unit(
-        "resource:f:persistent-downstream",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(upstream, downstream, resources=_r(cpu=4, heap=8, store=8))
-    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
-    downstream_waiter = _task(downstream.resource_unit_id, "driver")
-    manager.note_task_waiting(downstream_waiter)
-
-    descriptor = manager.try_acquire_task_descriptor(_task(upstream.resource_unit_id, "fte"))
-
-    assert not descriptor.granted
-    assert descriptor.blocked_reason == "admission_turn"
-    snapshot = manager.snapshot()
-    assert [item["task_id"] for item in snapshot["admission"]["waiting_tasks"]] == [downstream_waiter.task_id]
-    assert manager.try_acquire_queued_task(downstream_waiter).granted
-
-
-def test_reregistering_same_task_waiter_does_not_publish_resource_change():
-    unit = _unit(
-        "resource:f:idempotent-waiter",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    changes = []
-    manager = _manager(
-        unit,
-        resources=_r(cpu=2, heap=4, store=4),
-        on_change=lambda: changes.append("changed"),
-    )
-    manager.update_unit_state(unit.resource_unit_id, runnable=True)
-    changes.clear()
-    request = _task(unit.resource_unit_id, 0)
-
-    manager.note_task_waiting(request)
-    manager.note_task_waiting(request)
-
-    assert changes == ["changed"]
-
-
-def test_reapplying_identical_unit_state_does_not_publish_resource_change():
-    unit = _unit(
-        "resource:f:idempotent-unit-state",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    changes = []
-    manager = _manager(
-        unit,
-        resources=_r(cpu=2, heap=4, store=4),
-        on_change=lambda: changes.append("changed"),
-    )
-
-    manager.update_unit_state(unit.resource_unit_id, runnable=True)
-    manager.update_unit_state(unit.resource_unit_id, runnable=True)
-
-    assert changes == ["changed"]
-
-
-def test_parent_native_fragment_owns_transferable_credit_for_one_nested_udf_task():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    bridge = _unit(
-        "resource:f:bridge-native",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(bridge.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        parent,
-        bridge,
-        child,
-        resources=_r(cpu=100, heap=30, store=12),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(4)]
-
-    assert sum(grant.granted for grant in parent_grants) == 3
-    assert parent_grants[3].blocked_reason == "continuation_capacity"
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 24
-    assert len(snapshot["continuation_credits"]) == 3
-    assert all(credit["borrowed_by_task_lease_id"] is None for credit in snapshot["continuation_credits"].values())
-    admission = snapshot["admission"]
-    assert admission["live_demand_unit_ids"]["heap_bytes"] == []
-    assert admission["continuation_unit_ids"]["heap_bytes"] == []
-    assert admission["reservation_unit_ids"]["heap_bytes"] == []
-
-    child_requests = [_task(child.resource_unit_id, partition) for partition in range(3)]
-    for request in child_requests:
-        manager.note_task_waiting(request)
-    child_grants = [manager.try_acquire_queued_task(request) for request in child_requests]
-
-    assert all(grant.granted for grant in child_grants)
-    borrowed = manager.snapshot()
-    assert borrowed["usage"]["heap_bytes"] == 24
-    assert {credit["borrowed_by_task_lease_id"] for credit in borrowed["continuation_credits"].values()} == {
-        grant.lease.lease_id for grant in child_grants
-    }
-
-    fourth_child = _task(child.resource_unit_id, 3)
-    manager.note_task_waiting(fourth_child)
-    denied = manager.try_acquire_queued_task(fourth_child)
-    assert not denied.granted
-    assert denied.blocked_reason == "hard_heap_bytes"
-
-    first_child = child_grants[0].lease
-    assert manager.release_task_lease(
-        first_child.lease_id,
-        attempt_id=first_child.attempt_id,
-    )
-    replacement = manager.try_acquire_queued_task(fourth_child)
-    assert replacement.granted
-    assert manager.snapshot()["usage"]["heap_bytes"] == 24
-
-
-def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowed():
-    parent = _unit(
-        "resource:f:parent-native-normal-overflow",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf-normal-overflow",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=8, heap=40, store=40),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    assert manager.try_acquire_task(_task(parent.resource_unit_id, 0)).granted
-
-    first_request = _task(child.resource_unit_id, 0)
-    second_request = _task(child.resource_unit_id, 1)
-    manager.note_task_waiting(first_request)
-    manager.note_task_waiting(second_request)
-
-    first = manager.try_acquire_queued_task(first_request)
-    second = manager.try_acquire_queued_task(second_request)
-
-    assert first.granted
-    assert second.granted
-    snapshot = manager.snapshot()
-    borrowed = [
-        credit
-        for credit in snapshot["continuation_credits"].values()
-        if credit["borrowed_by_task_lease_id"] is not None
-    ]
-    assert len(borrowed) == 1
-    assert borrowed[0]["borrowed_by_task_lease_id"] == first.lease.lease_id
-    assert all(
-        credit["borrowed_by_task_lease_id"] != second.lease.lease_id
-        for credit in snapshot["continuation_credits"].values()
-    )
-    assert snapshot["usage"] == _r(cpu=2, heap=16, store=0).to_dict()
-
-
-def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    child_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(child_request)
-    child_grant = manager.try_acquire_queued_task(child_request)
-
-    assert parent_grant.granted and child_grant.granted
-    assert manager.release_task_lease(
-        parent_grant.lease.lease_id,
-        attempt_id=parent_grant.lease.attempt_id,
-    )
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 8
-    assert len(snapshot["continuation_credits"]) == 1
-    assert next(iter(snapshot["continuation_credits"].values()))["parent_active"] is False
-
-    assert manager.release_task_lease(
-        child_grant.lease.lease_id,
-        attempt_id=child_grant.lease.attempt_id,
-    )
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 0
-    assert snapshot["continuation_credits"] == {}
-
-
-def test_released_child_returns_credit_to_active_parent():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=10))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    first_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(first_request)
-    first_child = manager.try_acquire_queued_task(first_request)
-    assert parent_grant.granted and first_child.granted
-
-    assert manager.release_task_lease(
-        first_child.lease.lease_id,
-        attempt_id=first_child.lease.attempt_id,
-    )
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 8
-    assert next(iter(snapshot["continuation_credits"].values()))["borrowed_by_task_lease_id"] is None
-
-    second_request = _task(child.resource_unit_id, 1)
-    manager.note_task_waiting(second_request)
-    second_child = manager.try_acquire_queued_task(second_request)
-    assert second_child.granted
-    assert manager.snapshot()["usage"]["heap_bytes"] == 8
-
-
-def test_continuation_credit_can_reserve_a_different_node_from_parent_native_fragment():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=2, heap=10, store=20),
-        nodes=(
-            ("node-a", _r(cpu=1, heap=2, store=10)),
-            ("node-b", _r(cpu=1, heap=8, store=10)),
-        ),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0, node_id="node-a"))
-    assert parent_grant.granted
-    credit = next(iter(manager.snapshot()["continuation_credits"].values()))
-    assert credit["node_id"] == "node-b"
-
-    child_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(child_request)
-    child_grant = manager.try_acquire_queued_task(child_request)
-    assert child_grant.granted
-    assert child_grant.lease.node_id == "node-b"
-
-
-def test_native_continuation_reserves_one_real_heterogeneous_task_shape():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    cpu_child = _unit(
-        "resource:f:cpu-child",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=4),
-        target=0,
-        blocks=0,
-    )
-    gpu_child = _unit(
-        "resource:f:gpu-child",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, gpu=1),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        parent,
-        cpu_child,
-        gpu_child,
-        terminals=(cpu_child.resource_unit_id, gpu_child.resource_unit_id),
-        resources=_r(cpu=5, gpu=1),
-        nodes=(
-            ("cpu-node", _r(cpu=4)),
-            ("gpu-node", _r(cpu=1, gpu=1)),
-        ),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0, node_id="cpu-node"))
-
-    assert parent_grant.granted
-    credit = next(iter(manager.snapshot()["continuation_credits"].values()))
-    assert credit["resources"] == _r(cpu=1, gpu=1).to_dict()
-    assert credit["node_id"] == "gpu-node"
-
-
-def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=20))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    first_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(first_request)
-    first_child = manager.try_acquire_queued_task(first_request)
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            first_child.lease.lease_id,
-            first_child.lease.attempt_id,
-            "child-output",
-            10,
-        )
-    )
-    assert parent_grant.granted and first_child.granted and output.granted
-
-    assert manager.release_task_lease(
-        first_child.lease.lease_id,
-        attempt_id=first_child.lease.attempt_id,
-    )
-    snapshot = manager.snapshot()
-    assert snapshot["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
-    credit = next(iter(snapshot["continuation_credits"].values()))
-    assert credit["borrowed_by_task_lease_id"] == first_child.lease.lease_id
-
-    second_request = _task(child.resource_unit_id, 1)
-    manager.note_task_waiting(second_request)
-    denied = manager.try_acquire_queued_task(second_request)
-    assert not denied.granted
-    assert denied.blocked_reason == "hard_heap_bytes"
-
-    assert manager.release_output_block(output.lease.lease_id)
-    second_child = manager.try_acquire_queued_task(second_request)
-    assert second_child.granted
-
-
-def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_bytes():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(parent, child, resources=_r(cpu=10, heap=10, store=30))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    first_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(first_request)
-    first_child = manager.try_acquire_queued_task(first_request)
-    first_output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            first_child.lease.lease_id,
-            first_child.lease.attempt_id,
-            "child-output-1",
-            10,
-        )
-    )
-    assert parent_grant.granted and first_child.granted and first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
-    assert manager.release_task_lease(
-        first_child.lease.lease_id,
-        attempt_id=first_child.lease.attempt_id,
-    )
-
-    second_request = _task(child.resource_unit_id, 1)
-    manager.note_task_waiting(second_request)
-    before_handoff = manager.try_acquire_queued_task(second_request)
-    assert not before_handoff.granted
-    assert before_handoff.blocked_reason == "hard_heap_bytes"
-
-    assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
-    after_handoff = manager.try_acquire_queued_task(second_request)
-    assert after_handoff.granted
-    snapshot = manager.snapshot()
-    assert first_output.lease.lease_id in snapshot["output_leases"]
-    # The historical ObjectRef remains exact while the new running task adds
-    # one learned generator-buffer estimate.
-    assert snapshot["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
-    credit = next(iter(snapshot["continuation_credits"].values()))
-    assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
-    assert snapshot["output_leases"][first_output.lease.lease_id]["continuation_credit_id"] == credit["credit_id"]
-
-    second_output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            after_handoff.lease.lease_id,
-            after_handoff.lease.attempt_id,
-            "child-output-2",
-            10,
-        )
-    )
-    assert second_output.granted
-    with_both_outputs = manager.snapshot()
-    # Recycling compute ownership never recycles bytes: both physical blocks
-    # remain charged to the query and node flow-control budgets.
-    assert with_both_outputs["usage"] == _r(cpu=1, heap=8, store=30).to_dict()
-    assert (
-        with_both_outputs["output_leases"][second_output.lease.lease_id]["continuation_credit_id"]
-        == credit["credit_id"]
-    )
-
-    assert manager.release_output_block(first_output.lease.lease_id)
-    released = manager.snapshot()
-    assert released["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
-    credit = next(iter(released["continuation_credits"].values()))
-    assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
-
-
-def test_cross_unit_credit_reuse_checks_historical_outputs_before_grant():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    first_child = _unit(
-        "resource:f:child-a",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=2,
-    )
-    second_child = _unit(
-        "resource:f:child-b",
-        inputs=(first_child.resource_unit_id,),
-        resources=_r(cpu=1, heap=8, store=10),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(
-        parent,
-        first_child,
-        second_child,
-        resources=_r(cpu=10, heap=10, store=20),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    first_request = _task(first_child.resource_unit_id, 0)
-    manager.note_task_waiting(first_request)
-    first_grant = manager.try_acquire_queued_task(first_request)
-    first_output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            first_child.resource_unit_id,
-            first_grant.lease.lease_id,
-            first_grant.lease.attempt_id,
-            "child-a-output",
-            15,
-        )
-    )
-    assert parent_grant.granted and first_grant.granted and first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
-    assert manager.release_task_lease(
-        first_grant.lease.lease_id,
-        attempt_id=first_grant.lease.attempt_id,
-    )
-    assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 15
-
-    second_request = _task(second_child.resource_unit_id, 0, retained=10)
-    manager.note_task_waiting(second_request)
-    granted = manager.try_acquire_queued_task(second_request)
-    assert granted.granted and granted.liveness
-    admitted = manager.snapshot()
-    assert admitted["usage"]["object_store_bytes"] == 25
-    assert admitted["node_usage"]["node-a"]["object_store_bytes"] == 25
-    assert admitted["soft_object_store_debt_bytes"] == 5
-
-
-def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8, store=10),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=20, heap=20, store=45),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
-    assert all(grant.granted for grant in parents)
-
-    first_request = _task(child.resource_unit_id, 0, retained=10)
-    manager.note_task_waiting(first_request)
-    first_child = manager.try_acquire_queued_task(first_request)
-    assert first_child.granted
-    first_output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            first_child.lease.lease_id,
-            first_child.lease.attempt_id,
-            "historical-output",
-            15,
-        )
-    )
-    assert first_output.granted
-    assert manager.transition_output_block(first_output.lease.lease_id, "unit_queue")
-    assert manager.transition_output_block(first_output.lease.lease_id, "downstream_input")
-    assert manager.release_task_lease(
-        first_child.lease.lease_id,
-        attempt_id=first_child.lease.attempt_id,
-    )
-    historical_credit_id = manager.snapshot()["output_leases"][first_output.lease.lease_id]["continuation_credit_id"]
-
+        resident=_r(cpu=1, gpu=1, heap=100),
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    manager = _manager(actor, resources=_r(cpu=1, gpu=1, heap=100))
+    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.update_allocation(
-        _allocation(_r(cpu=20, heap=20, store=40), generation=2),
+        _allocation(_r(cpu=0.5, gpu=0.5, heap=50), generation=2),
         admission_open=True,
     )
-    second_request = _task(child.resource_unit_id, 1, retained=10)
-    manager.note_task_waiting(second_request)
-    second_child = manager.try_acquire_queued_task(second_request)
+    clock = iter((0.0, 59.0, 60.0, 61.0))
+    monkeypatch.setattr(manager_module.time, "monotonic", lambda: next(clock))
 
-    assert second_child.granted
-    borrowed_credit_ids = {
-        credit_id
-        for credit_id, credit in manager.snapshot()["continuation_credits"].items()
-        if credit["borrowed_by_task_lease_id"] == second_child.lease.lease_id
-    }
-    assert len(borrowed_credit_ids) == 1
-    assert borrowed_credit_ids == {historical_credit_id}
+    with caplog.at_level(logging.WARNING):
+        first = manager.snapshot()
+        manager.snapshot()
+        warned = manager.snapshot()
+        manager.snapshot()
+
+    assert first["soft_allocation_debt"] == _r(cpu=0.5, gpu=0.5, heap=50).to_dict()
+    assert warned["soft_allocation_debt_duration_s"] == pytest.approx(60.0)
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1
+    assert "soft resource reservation" in messages[0]
 
 
-def test_cross_unit_idle_credit_output_excess_is_attributed_exactly_once():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
+def test_phase_reservations_include_all_eligible_resource_owners():
+    cpu = _unit(
+        "resource:f:cpu",
+        resources=_r(cpu=1, heap=10),
         target=0,
         blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    first_child = _unit(
-        "resource:f:child-a",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=2,
-    )
-    second_child = _unit(
-        "resource:f:child-b",
-        inputs=(first_child.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=2,
-    )
-    manager = _manager(
-        parent,
-        first_child,
-        second_child,
-        resources=_r(cpu=10, heap=10, store=35),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    manager.set_external_consumer_waiting(True)
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    assert parent_grant.granted
-
-    for index, unit in enumerate((first_child, second_child)):
-        request = _task(unit.resource_unit_id, index)
-        manager.note_task_waiting(request)
-        grant = manager.try_acquire_queued_task(request)
-        assert grant.granted
-        output = manager.try_acquire_output_block(
-            OutputBlockRequest(
-                "q",
-                unit.resource_unit_id,
-                grant.lease.lease_id,
-                grant.lease.attempt_id,
-                f"cross-unit-output-{index}",
-                15,
-            )
-        )
-        assert output.granted
-        assert output.liveness is (index == 1)
-        assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
-        assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
-        assert manager.release_task_lease(
-            grant.lease.lease_id,
-            attempt_id=grant.lease.attempt_id,
-        )
-
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["object_store_bytes"] == 30
-    unit_store_usage = {
-        resource_unit_id: unit_snapshot["usage"]["object_store_bytes"]
-        for resource_unit_id, unit_snapshot in snapshot["units"].items()
-    }
-    assert sum(unit_store_usage.values()) == 30
-    assert unit_store_usage[parent.resource_unit_id] == 0
-    assert unit_store_usage[first_child.resource_unit_id] == 15
-    assert unit_store_usage[second_child.resource_unit_id] == 15
-
-
-def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrower():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8, store=10),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=10, heap=10, store=45),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    request = _task(child.resource_unit_id, 0, retained=10)
-    manager.note_task_waiting(request)
-    child_grant = manager.try_acquire_queued_task(request)
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            child_grant.lease.lease_id,
-            child_grant.lease.attempt_id,
-            "active-credit-output",
-            25,
-        )
-    )
-    assert parent_grant.granted and child_grant.granted and output.granted
-
-    active = manager.snapshot()
-    assert active["usage"]["object_store_bytes"] == 45
-    assert sum(unit["usage"]["object_store_bytes"] for unit in active["units"].values()) == 45
-
-    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
-    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
-    assert manager.release_task_lease(
-        child_grant.lease.lease_id,
-        attempt_id=child_grant.lease.attempt_id,
-    )
-    idle = manager.snapshot()
-    assert idle["usage"]["object_store_bytes"] == 25
-    assert sum(unit["usage"]["object_store_bytes"] for unit in idle["units"].values()) == 25
-
-
-def test_live_output_from_deleted_continuation_credit_remains_in_unit_usage():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=2,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=10, heap=10, store=35),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(request)
-    child_grant = manager.try_acquire_queued_task(request)
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            child_grant.lease.lease_id,
-            child_grant.lease.attempt_id,
-            "orphaned-credit-output",
-            15,
-        )
-    )
-    assert parent_grant.granted and child_grant.granted and output.granted
-    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
-    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
-    assert manager.release_task_lease(
-        child_grant.lease.lease_id,
-        attempt_id=child_grant.lease.attempt_id,
-    )
-    assert manager.release_task_lease(
-        parent_grant.lease.lease_id,
-        attempt_id=parent_grant.lease.attempt_id,
-    )
-
-    snapshot = manager.snapshot()
-    assert snapshot["continuation_credits"] == {}
-    assert snapshot["usage"]["object_store_bytes"] == 15
-    assert sum(unit["usage"]["object_store_bytes"] for unit in snapshot["units"].values()) == 15
-    assert snapshot["units"][child.resource_unit_id]["usage"]["object_store_bytes"] == 15
-
-
-def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
-    parent = _unit(
-        "resource:f:parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child-udf",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(parent, child, resources=_r(cpu=20, heap=20, store=20))
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parents = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(2)]
-    child_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(child_request)
-    child_grant = manager.try_acquire_queued_task(child_request)
-    assert all(grant.granted for grant in parents)
-    assert child_grant.granted
-
-    released = manager.cancel("cancel credits")
-    snapshot = manager.snapshot()
-
-    assert released == {"task_lease_count": 3, "output_lease_count": 0}
-    assert snapshot["task_leases"] == {}
-    assert snapshot["continuation_credits"] == {}
-    assert snapshot["usage"] == _r().to_dict()
-
-
-def test_parent_native_fragment_admission_preserves_largest_nested_udf_commitment():
-    parent = _unit(
-        "resource:f:safe-parent",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    first_child = _unit(
-        "resource:f:large-child-a",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    second_child = _unit(
-        "resource:f:large-child-b",
-        inputs=(first_child.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        parent,
-        first_child,
-        second_child,
-        resources=_r(cpu=10, heap=10, store=10),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    first_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    second_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
-
-    assert first_parent.granted
-    assert not second_parent.granted
-    assert second_parent.blocked_reason == "continuation_capacity"
-
-    child_request = _task(first_child.resource_unit_id, 0)
-    manager.note_task_waiting(child_request)
-    child_grant = manager.try_acquire_queued_task(child_request)
-
-    assert child_grant.granted
-
-
-def test_native_fragment_placement_does_not_reserve_pinned_actor_process_capacity():
-    parent = _unit(
-        "resource:f:placed-parent",
-        resources=_r(cpu=1, heap=4),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:pinned-child",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(gpu=1, heap=8),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=4, gpu=1, heap=20, store=20),
-        nodes=(
-            ("node-a", _r(cpu=2, gpu=1, heap=10, store=10)),
-            ("node-b", _r(cpu=2, heap=10, store=10)),
-        ),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    pinned_node_request = manager.try_acquire_task(_task(parent.resource_unit_id, "pinned-node", node_id="node-a"))
-    automatic_request = manager.try_acquire_task(_task(parent.resource_unit_id, "auto-node"))
-
-    assert pinned_node_request.granted
-    assert pinned_node_request.lease.node_id == "node-a"
-    assert automatic_request.granted
-    assert automatic_request.lease.node_id == "node-b"
-
-
-def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservations():
-    producer = _unit(
-        "resource:f:placed-ray-task-producer",
-        resources=_r(cpu=1, heap=1),
-        target=1,
-        blocks=1,
-    )
-    consumer = _unit(
-        "resource:f:placed-native-consumer",
-        inputs=(producer.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
     )
     actor = _unit(
-        "resource:f:placed-actor-consumer",
-        inputs=(consumer.resource_unit_id,),
-        resources=_r(),
-        resident=_r(gpu=1, heap=10),
-        target=2,
-        blocks=1,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    manager = _manager(
-        producer,
-        consumer,
-        actor,
-        resources=_r(cpu=3, gpu=1, heap=15, store=4),
-        nodes=(
-            ("node-a", _r(cpu=1, gpu=1, heap=12, store=2)),
-            ("node-b", _r(cpu=2, heap=3, store=2)),
-        ),
-    )
-    manager.update_unit_state(producer.resource_unit_id, runnable=True)
-
-    pinned = manager.try_acquire_task(_task(producer.resource_unit_id, "pinned", node_id="node-a"))
-    automatic = manager.try_acquire_task(_task(producer.resource_unit_id, "automatic"))
-
-    assert pinned.granted
-    assert automatic.granted
-    assert automatic.lease.node_id == "node-b"
-
-
-def test_cold_topology_caps_upstream_fanout_until_direct_downstream_starts():
-    upstream = _unit(
-        "resource:f:upstream",
-        resources=_r(cpu=1, heap=20),
-        target=0,
-        blocks=0,
-    )
-    downstream = _unit(
-        "resource:f:downstream",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=40),
-        target=0,
-        blocks=0,
-    )
-    terminal = _unit(
-        "resource:f:terminal",
-        inputs=(downstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=60),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        upstream,
-        downstream,
-        terminal,
-        resources=_r(cpu=10, heap=100, store=100),
-    )
-    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id, terminal.resource_unit_id)
-
-    first_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
-    normal_reason = manager._normal_task_block_reason_locked(_task(upstream.resource_unit_id, 1))[0]
-    second_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 1))
-    first_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
-
-    assert first_upstream.granted
-    assert normal_reason == "unit_soft_limit"
-    assert not second_upstream.granted
-    assert first_downstream.granted
-
-
-def test_native_continuation_does_not_add_process_reservation_to_ray_task_fanout():
-    producer = _unit(
-        "resource:f:image-cpu-producer",
-        resources=_r(cpu=1, heap=2),
-        target=1,
-        blocks=1,
-    )
-    consumer = _unit(
-        "resource:f:image-gpu-feeder",
-        inputs=(producer.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=1,
-        blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    gpu_actor = _unit(
-        "resource:f:image-gpu-actor",
-        inputs=(consumer.resource_unit_id,),
-        resources=_r(),
+        "resource:f:actor",
+        inputs=(cpu.resource_unit_id,),
+        resources=_r(store=5),
         resident=_r(gpu=1, heap=20),
-        target=1,
-        blocks=1,
         backend="ray_actor",
         actor_pool_size=1,
     )
-    manager = _manager(
-        producer,
-        consumer,
-        gpu_actor,
-        resources=_r(cpu=36, gpu=1, heap=41, store=10),
-    )
-    # The downstream units are deliberately latent. Actor process resources
-    # are scheduled by Ray Core, while the native continuation is owned by
-    # DuckDB and adds no Vane process reservation.
-    manager.update_unit_state(producer.resource_unit_id, runnable=True)
-
-    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(20)]
-    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 20))
-
-    assert all(grant.granted for grant in producer_grants)
-    assert not blocked_producer.granted
-    assert blocked_producer.blocked_reason == "hard_heap_bytes"
-    assert producer.resource_unit_id not in manager.snapshot()["admission"]["downstream_reservations"]
-
-    manager.update_unit_state(consumer.resource_unit_id, runnable=True)
-    consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
-    _ready(manager, gpu_actor.resource_unit_id)
-    actor_grant = manager.try_acquire_task(_task(gpu_actor.resource_unit_id, 0, retained=0))
-
-    assert consumer_grant.granted
-    assert actor_grant.granted and not actor_grant.liveness
-    assert actor_grant.lease.actor_index == 0
-    assert (
-        manager.snapshot()["usage"]
-        == _r(
-            cpu=20,
-            heap=40,
-            store=1,
-        ).to_dict()
-    )
-    assert (
-        manager.snapshot()["actor_process_usage"]
-        == _r(
-            gpu=1,
-            heap=20,
-        ).to_dict()
-    )
-
-
-def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot():
-    upstream = _unit(
-        "resource:f:streaming-upstream",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    actor = _unit(
-        "resource:f:streaming-actor",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(),
-        resident=_r(gpu=1, heap=4),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-        actor_prefetch_depth=3,
-    )
-    downstream = _unit(
-        "resource:f:streaming-downstream",
+    native = _unit(
+        "resource:f:native",
         inputs=(actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    terminal_native = _unit(
-        "resource:f:streaming-terminal-native",
-        inputs=(downstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
+        resources=_r(store=5),
         backend="ray_worker",
-        unit_kind="native_fragment",
     )
-    manager = _manager(
-        upstream,
-        actor,
-        downstream,
-        terminal_native,
-        resources=_r(cpu=20, gpu=1, heap=24, store=20),
-    )
-    # Actor creation charges the complete process request as soon as it is
-    # submitted, before Ray Core publishes a concrete READY node. This keeps
-    # upstream fanout from consuming the continuation's physical capacity.
-    manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
+    manager = _manager(cpu, actor, native, resources=_r(cpu=4, gpu=1, heap=100, store=100))
 
-    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(9)]
-    assert all(grant.granted for grant in upstream_grants)
-    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 9))
-    assert not blocked_upstream.granted
-    assert blocked_upstream.blocked_reason == "liveness_not_needed"
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 18
-    assert snapshot["soft_allocation_usage"]["heap_bytes"] == 22
-    reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
-    assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
-    ]
+    reservations = manager.snapshot()["admission"]["reservation_unit_ids"]
 
-    manager.set_ready_actor_slots(actor.resource_unit_id, {0: "node-a"})
-    manager.update_unit_state(actor.resource_unit_id, runnable=True)
-    actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
-    assert actor_grant.granted
-
-    downstream_request = _task(downstream.resource_unit_id, 0)
-    manager.note_task_waiting(downstream_request)
-    before = manager.snapshot()
-    downstream_grant = manager.try_acquire_queued_task(downstream_request)
-
-    assert before["admission"]["preferred_task"] == {
-        "task_id": downstream_request.task_id,
-        "attempt_id": downstream_request.attempt_id,
-        "resource_unit_id": downstream.resource_unit_id,
-        "grant_class": "normal",
-    }
-    assert downstream_grant.granted
-    assert not downstream_grant.liveness
-    assert manager.snapshot()["usage"]["heap_bytes"] == 20
-
-    terminal_request = _task(terminal_native.resource_unit_id, 0)
-    manager.note_task_waiting(terminal_request)
-    terminal_grant = manager.try_acquire_queued_task(terminal_request)
-
-    assert terminal_grant.granted
-    assert not terminal_grant.liveness
-    assert manager.snapshot()["usage"]["heap_bytes"] == 20
-
-
-def test_actor_process_bypass_leaves_downstream_ray_task_reservation_soft():
-    upstream = _unit(
-        "resource:f:minimum-upstream",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    actor = _unit(
-        "resource:f:minimum-actor",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(),
-        resident=_r(cpu=1, heap=4),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    downstream = _unit(
-        "resource:f:minimum-downstream",
-        inputs=(actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        upstream,
-        actor,
-        downstream,
-        resources=_r(cpu=2, heap=6),
-    )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
-
-    grant = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
-
-    assert grant.granted and not grant.liveness
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 2
-    reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
-    assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
+    assert reservations["cpu"] == [cpu.resource_unit_id]
+    assert reservations["gpu"] == [actor.resource_unit_id]
+    assert reservations["heap_bytes"] == [cpu.resource_unit_id, actor.resource_unit_id]
+    assert reservations["object_store_bytes"] == [
+        actor.resource_unit_id,
+        native.resource_unit_id,
     ]
 
 
-def test_globally_insufficient_downstream_reservations_skip_node_search(monkeypatch):
-    upstream = _unit(
-        "resource:f:reservation-upstream",
-        resources=_r(cpu=1, heap=1),
+def test_allocation_shrink_keeps_live_lease_and_uses_liveness_after_drain():
+    task = _unit(
+        "resource:f:shrink",
+        resources=_r(cpu=1, heap=100),
         target=0,
         blocks=0,
     )
-    actor = _unit(
-        "resource:f:reservation-actor",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(),
-        resident=_r(cpu=1),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    downstream = _unit(
-        "resource:f:reservation-downstream",
-        inputs=(actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=4),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(
-        upstream,
-        actor,
-        downstream,
-        resources=_r(cpu=2, heap=4),
-    )
-    manager.update_unit_state(upstream.resource_unit_id, runnable=True)
+    manager = _manager(task, resources=_r(cpu=2, heap=200))
+    _ready(manager, task.resource_unit_id)
+    live = manager.try_acquire_task(_task(task.resource_unit_id, 0))
+    assert live.granted and not live.liveness
 
-    def fail_if_searched(*args, **kwargs):
-        raise AssertionError("globally impossible reservations must not run node search")
-
-    monkeypatch.setattr(manager, "_remaining_preserves_downstream_locked", fail_if_searched)
-
-    reason, fatal, _ = manager._normal_task_block_reason_locked(_task(upstream.resource_unit_id, 0))
-
-    assert reason == "unit_soft_limit"
-    assert not fatal
-
-
-def test_downstream_reservation_placement_handles_thousands_without_recursion():
-    unit = _unit("resource:f:reservation-root", resources=_r(cpu=1))
-    manager = _manager(
-        unit,
-        resources=_r(cpu=2_000, heap=2_000),
+    manager.update_allocation(
+        _allocation(_r(cpu=0.5, heap=50), generation=2),
+        admission_open=True,
     )
-    reservations = tuple(
-        manager_module._DownstreamReservation(
-            reservation_id=f"reservation:{index}",
-            unit_ids=(f"resource:f:child-{index}",),
-            resources=_r(cpu=1, heap=1),
-            allowed_node_ids=("node-a",),
-        )
-        for index in range(1_500)
-    )
-
-    assert manager._remaining_preserves_downstream_locked(
-        {"node-a": _r(cpu=1_500, heap=1_500)},
-        reservations,
-    )
-
-
-def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
-    parent = _unit(
-        "resource:f:image-parent-native",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    producer = _unit(
-        "resource:f:image-nested-cpu",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=4),
-        target=1,
-        blocks=1,
-    )
-    consumer = _unit(
-        "resource:f:image-downstream-native",
-        inputs=(producer.resource_unit_id,),
-        resources=_r(cpu=1, heap=3),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    actor = _unit(
-        "resource:f:image-downstream-actor",
-        inputs=(consumer.resource_unit_id,),
-        resources=_r(),
-        resident=_r(gpu=1, heap=10),
-        target=1,
-        blocks=1,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    # Only the Ray task is QRM hard-accounted. Actor process resources are
-    # reported separately and both native fragments use DuckDB's own budget.
-    manager = _manager(
-        parent,
-        producer,
-        consumer,
-        actor,
-        resources=_r(cpu=3, gpu=1, heap=20, store=2),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    manager.update_unit_state(producer.resource_unit_id, runnable=True)
-    producer_request = _task(producer.resource_unit_id, 0)
-    manager.note_task_waiting(producer_request)
-    producer_grant = manager.try_acquire_queued_task(producer_request)
-    manager.update_unit_state(consumer.resource_unit_id, runnable=True)
-    consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
-    _ready(manager, actor.resource_unit_id)
-    actor_grant = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
-
-    assert parent_grant.granted
-    assert producer_grant.granted
-    assert consumer_grant.granted
-    assert actor_grant.granted
-    assert (
-        manager.snapshot()["usage"]
-        == _r(
-            cpu=1,
-            heap=4,
-            store=0,
-        ).to_dict()
-    )
-    assert (
-        manager.snapshot()["actor_process_usage"]
-        == _r(
-            gpu=1,
-            heap=10,
-        ).to_dict()
-    )
-
-
-def test_native_fanout_is_capped_only_by_remote_continuation_credits():
-    parent = _unit(
-        "resource:f:image-parent-native",
-        resources=_r(cpu=1, heap=1),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    direct_fte = _unit(
-        "resource:f:image-direct-native",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=1),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    cpu_udf = _unit(
-        "resource:f:image-cpu-udf",
-        inputs=(direct_fte.resource_unit_id,),
-        resources=_r(cpu=1, heap=4),
-        target=0,
-        blocks=0,
-    )
-    downstream_fte = _unit(
-        "resource:f:image-downstream-native",
-        inputs=(cpu_udf.resource_unit_id,),
-        resources=_r(cpu=1, heap=4),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    gpu_actor = _unit(
-        "resource:f:image-gpu-actor",
-        inputs=(downstream_fte.resource_unit_id,),
-        resources=_r(),
-        resident=_r(gpu=1, heap=8),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    manager = _manager(
-        parent,
-        direct_fte,
-        cpu_udf,
-        downstream_fte,
-        gpu_actor,
-        resources=_r(cpu=36, gpu=1, heap=49),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-
-    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(13)]
-
-    assert all(grant.granted for grant in parent_grants[:12])
-    assert not parent_grants[12].granted
-    assert parent_grants[12].blocked_reason == "continuation_capacity"
+    blocked = manager.try_acquire_task(_task(task.resource_unit_id, 1))
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 48
-    assert parent.resource_unit_id not in snapshot["admission"]["downstream_reservations"]
 
-    manager.update_unit_state(cpu_udf.resource_unit_id, runnable=True)
-    cpu_request = _task(cpu_udf.resource_unit_id, 0)
-    manager.note_task_waiting(cpu_request)
-    cpu_grant = manager.try_acquire_queued_task(cpu_request)
-    manager.update_unit_state(
-        downstream_fte.resource_unit_id,
-        runnable=True,
-    )
-    downstream_grant = manager.try_acquire_task(_task(downstream_fte.resource_unit_id, 0))
+    assert live.lease.lease_id in snapshot["task_leases"]
+    assert snapshot["soft_allocation_debt"] == _r(cpu=0.5, heap=50).to_dict()
+    assert not blocked.granted and blocked.blocked_reason == "liveness_task_active"
 
-    assert cpu_grant.granted
-    assert downstream_grant.granted
-    final_snapshot = manager.snapshot()
-    assert cpu_grant.lease.lease_id in {
-        credit["borrowed_by_task_lease_id"] for credit in final_snapshot["continuation_credits"].values()
-    }
-    assert final_snapshot["usage"]["heap_bytes"] == 48
+    manager.release_task_lease(live.lease.lease_id, attempt_id=live.lease.attempt_id)
+    escaped = manager.try_acquire_task(_task(task.resource_unit_id, 2))
+    assert escaped.granted and escaped.liveness
 
 
-def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=25, blocks=2)
-    manager = _manager(unit, resources=_r(cpu=10, heap=250, store=100))
-    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
-
-    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
-    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
-    denied = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
-
-    assert first.granted and second.granted
-    assert not denied.granted
-    assert denied.blocked_reason == "hard_heap_bytes"
-    assert denied.liveness is False
-    snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 200
-    assert snapshot["usage"]["object_store_bytes"] == 0
-    assert snapshot["liveness"]["active_task_lease_id"] is None
-
-
-def test_soft_budget_does_not_start_extra_same_unit_work_while_task_is_active():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=30, blocks=2)
-    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
-
-    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            unit.resource_unit_id,
-            first.lease.lease_id,
-            first.lease.attempt_id,
-            "learned-output",
-            30,
-        )
-    )
-    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
-
-    assert first.granted and output.granted
-    assert not second.granted
-    assert second.blocked_reason == "liveness_not_needed"
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 90
-
-
-def test_soft_budget_does_not_start_extra_borrower_while_same_unit_task_is_active():
-    parent = _unit(
-        "resource:f:parent",
-        resources=_r(cpu=1, heap=2),
+def test_soft_reservations_protect_parallel_units_but_remain_bypassable_at_global_idle():
+    left = _unit(
+        "resource:f:left",
+        resources=_r(cpu=1, heap=10),
         target=0,
         blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
     )
-    child = _unit(
-        "resource:f:child",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8, store=81),
+    right = _unit(
+        "resource:f:right",
+        resources=_r(cpu=1, heap=10),
+        target=0,
+        blocks=0,
     )
     manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=4, heap=20, store=150),
+        left,
+        right,
+        resources=_r(cpu=2, heap=20),
+        terminals=(left.resource_unit_id, right.resource_unit_id),
     )
-    _ready(manager, parent.resource_unit_id, child.resource_unit_id)
+    _ready(manager, left.resource_unit_id, right.resource_unit_id)
 
-    first_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    first = manager.try_acquire_task(_task(child.resource_unit_id, 0, retained=81))
-    second_parent = manager.try_acquire_task(_task(parent.resource_unit_id, 1))
-    second = manager.try_acquire_task(_task(child.resource_unit_id, 1, retained=81))
+    left_grant = manager.try_acquire_task(_task(left.resource_unit_id, 0))
+    right_grant = manager.try_acquire_task(_task(right.resource_unit_id, 0))
+    extra_left = manager.try_acquire_task(_task(left.resource_unit_id, 1))
 
-    assert first_parent.granted
-    assert first.granted
-    assert not first.liveness
-    assert second_parent.granted
-    assert not second.granted
-    assert second.blocked_reason == "liveness_not_needed"
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 81
+    assert left_grant.granted and right_grant.granted
+    assert not extra_left.granted
+    assert extra_left.blocked_reason == "liveness_task_active"
+
+
+def test_descriptor_admission_does_not_persist_a_denied_request():
+    task = _unit(
+        "resource:f:descriptor",
+        resources=_r(cpu=1, heap=10),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(task, resources=_r())
+    request = _task(task.resource_unit_id, 0)
+
+    grant = manager.try_acquire_task_descriptor(request)
+
+    assert grant.granted and grant.liveness
+    assert manager.snapshot()["admission"]["waiting_tasks"] == []
+
+
+def test_idle_runnable_unit_without_real_work_does_not_suppress_liveness():
+    blocked = _unit(
+        "resource:f:blocked",
+        resources=_r(cpu=2),
+        target=0,
+        blocks=0,
+    )
+    idle = _unit(
+        "resource:f:idle",
+        resources=_r(cpu=0.25),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        blocked,
+        idle,
+        resources=_r(cpu=1),
+        terminals=(blocked.resource_unit_id, idle.resource_unit_id),
+    )
+    _ready(manager, blocked.resource_unit_id, idle.resource_unit_id)
+
+    grant = manager.try_acquire_task(_task(blocked.resource_unit_id, 0))
+
+    assert grant.granted and grant.liveness
+    assert manager.snapshot()["admission"]["waiting_tasks"] == []
+
+
+def test_identical_waiter_and_unit_state_updates_do_not_publish_spurious_edges():
+    changes = []
+    unit = _unit("resource:f:edge", target=0, blocks=0)
+    manager = _manager(unit, on_change=lambda: changes.append("changed"))
+    request = _task(unit.resource_unit_id, 0)
+
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
+    after_first_state = len(changes)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
+    assert len(changes) == after_first_state
+
+    manager.note_task_waiting(request)
+    after_first_waiter = len(changes)
+    manager.note_task_waiting(request)
+    assert len(changes) == after_first_waiter
 
 
 def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
@@ -2859,346 +1053,39 @@ def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
     assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
 
 
-@pytest.mark.parametrize("acquire_mode", ["queued", "next_queued"])
-def test_liveness_parent_lends_escape_to_one_continuation_path_until_handoff(acquire_mode):
-    parent = _unit(
-        "resource:f:parent",
-        resources=_r(cpu=1, heap=2),
-        target=60,
-        blocks=2,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    child = _unit(
-        "resource:f:child",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(cpu=1, heap=8),
-        target=10,
-        blocks=2,
-    )
-    manager = _manager(
-        parent,
-        child,
-        resources=_r(cpu=4, heap=20, store=100),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    manager.set_external_consumer_waiting(True)
-
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    child_request = _task(child.resource_unit_id, 0)
-    manager.note_task_waiting(child_request)
-    if acquire_mode == "queued":
-        child_grant = manager.try_acquire_queued_task(child_request)
-    else:
-        selected, child_grant = manager.try_acquire_next_queued_task(
-            {(child_request.task_id, child_request.attempt_id)}
-        )
-        assert selected == child_request
-        assert child_grant is not None
-
-    assert parent_grant.granted and parent_grant.liveness
-    # Before the first output, the Ray UDF has no pending-generator estimate,
-    # so it can continue the liveness path through normal admission.
-    assert child_grant.granted and not child_grant.liveness
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
-
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            child.resource_unit_id,
-            child_grant.lease.lease_id,
-            child_grant.lease.attempt_id,
-            "continuation-output",
-            10,
-        )
-    )
-    assert output.granted and output.liveness
-    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
-    assert manager.release_task_lease(
-        parent_grant.lease.lease_id,
-        attempt_id=parent_grant.lease.attempt_id,
-    )
-    assert manager.release_task_lease(
-        child_grant.lease.lease_id,
-        attempt_id=child_grant.lease.attempt_id,
-    )
-
-    producer_owned = manager.snapshot()
-    assert producer_owned["liveness"]["active_task_lease_id"] is None
-    assert producer_owned["liveness"]["active_output_lease_id"] == output.lease.lease_id
-
-    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
-    handed_off = manager.snapshot()
-    assert handed_off["liveness"]["active_task_lease_id"] is None
-    assert handed_off["continuation_credits"] == {}
-    assert handed_off["usage"]["object_store_bytes"] == 10
-
-
-def test_liveness_parent_allows_one_direct_actor_continuation_without_sibling_fanout():
-    parent = _unit(
-        "resource:f:parent",
-        resources=_r(cpu=1, heap=2),
-        target=60,
-        blocks=2,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    first_actor = _unit(
-        "resource:f:actor-a",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(store=20),
-        target=10,
-        blocks=2,
-        backend="ray_actor",
-        actor_pool_size=1,
-        resident=_r(cpu=1, heap=8),
-    )
-    sibling_actor = _unit(
-        "resource:f:actor-b",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(store=20),
-        target=10,
-        blocks=2,
-        backend="ray_actor",
-        actor_pool_size=1,
-        resident=_r(cpu=1, heap=8),
-    )
-    sibling_task = _unit(
-        "resource:f:zz-task-b",
-        inputs=(sibling_actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=8, store=20),
-        target=10,
-        blocks=2,
-    )
-    path_target = _unit(
-        "resource:f:aa-path",
-        inputs=(first_actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=10, store=20),
-        target=10,
-        blocks=2,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(
-        parent,
-        first_actor,
-        sibling_actor,
-        sibling_task,
-        path_target,
-        resources=_r(cpu=8, heap=60, store=100),
-        terminals=(
-            path_target.resource_unit_id,
-            sibling_task.resource_unit_id,
-        ),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    _ready(manager, first_actor.resource_unit_id, sibling_actor.resource_unit_id)
-
-    first_request = _task(first_actor.resource_unit_id, 0)
-    manager.note_task_waiting(first_request)
-    selected, first_grant = manager.try_acquire_next_queued_task({(first_request.task_id, first_request.attempt_id)})
-
-    assert selected == first_request
-    assert first_grant is not None
-    assert parent_grant.granted and parent_grant.liveness
-    assert first_grant.granted and first_grant.liveness
-    sibling_request = _task(sibling_actor.resource_unit_id, 0)
-    manager.note_task_waiting(sibling_request)
-    sibling_grant = manager.try_acquire_queued_task(sibling_request)
-    assert not sibling_grant.granted
-    assert sibling_grant.blocked_reason == "liveness_task_active"
-    assert manager.remove_task_waiter(
-        sibling_request.task_id,
-        sibling_request.attempt_id,
-    )
-    sibling_task_request = _task(sibling_task.resource_unit_id, 0)
-    manager.note_task_waiting(sibling_task_request)
-    sibling_task_grant = manager.try_acquire_queued_task(sibling_task_request)
-    assert not sibling_task_grant.granted
-    assert sibling_task_grant.blocked_reason == "liveness_task_active"
-    path_request = _task(path_target.resource_unit_id, 0)
-    manager.note_task_waiting(path_request)
-    selected, path_grant = manager.try_acquire_next_queued_task(
-        {
-            (sibling_task_request.task_id, sibling_task_request.attempt_id),
-            (path_request.task_id, path_request.attempt_id),
-        }
-    )
-    assert selected == path_request
-    assert path_grant is not None
-    assert path_grant.granted and path_grant.liveness
-    assert manager.release_task_lease(
-        path_grant.lease.lease_id,
-        attempt_id=path_grant.lease.attempt_id,
-    )
-    assert manager.remove_task_waiter(
-        sibling_task_request.task_id,
-        sibling_task_request.attempt_id,
-    )
-
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            "q",
-            first_actor.resource_unit_id,
-            first_grant.lease.lease_id,
-            first_grant.lease.attempt_id,
-            "actor-continuation-output",
-            10,
-        )
-    )
-    assert output.granted and output.liveness
-    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
-    assert manager.release_task_lease(
-        parent_grant.lease.lease_id,
-        attempt_id=parent_grant.lease.attempt_id,
-    )
-    assert manager.release_task_lease(
-        first_grant.lease.lease_id,
-        attempt_id=first_grant.lease.attempt_id,
-    )
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] == parent_grant.lease.lease_id
-
-    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] is None
-
-
-def test_liveness_actor_path_can_start_soft_blocked_downstream_fte():
-    parent = _unit(
-        "resource:f:parent",
-        resources=_r(cpu=1, heap=2),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    actor = _unit(
-        "resource:f:actor",
-        inputs=(parent.resource_unit_id,),
-        resources=_r(store=81),
-        target=10,
-        blocks=2,
-        backend="ray_actor",
-        actor_pool_size=1,
-        resident=_r(cpu=1, heap=8),
-    )
-    downstream = _unit(
-        "resource:f:downstream",
-        inputs=(actor.resource_unit_id,),
-        resources=_r(cpu=1, heap=10, store=10),
-        target=20,
-        blocks=2,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(
-        parent,
-        actor,
-        downstream,
-        resources=_r(cpu=4, heap=30, store=100),
-    )
-    manager.update_unit_state(parent.resource_unit_id, runnable=True)
-    parent_grant = manager.try_acquire_task(_task(parent.resource_unit_id, 0))
-    _ready(manager, actor.resource_unit_id)
-    actor_request = _task(actor.resource_unit_id, 0)
-    manager.note_task_waiting(actor_request)
-    selected, actor_grant = manager.try_acquire_next_queued_task({(actor_request.task_id, actor_request.attempt_id)})
-
-    assert selected == actor_request
-    assert actor_grant is not None
-    assert parent_grant.granted and not parent_grant.liveness
-    assert actor_grant.granted and not actor_grant.liveness
-    downstream_grant = manager.try_acquire_task_descriptor(_task(downstream.resource_unit_id, 0))
-    assert downstream_grant.granted and downstream_grant.liveness
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] == downstream_grant.lease.lease_id
-
-    assert manager.release_task_lease(
-        downstream_grant.lease.lease_id,
-        attempt_id=downstream_grant.lease.attempt_id,
-    )
-    assert manager.release_task_lease(
-        actor_grant.lease.lease_id,
-        attempt_id=actor_grant.lease.attempt_id,
-    )
-    assert manager.snapshot()["liveness"]["active_task_lease_id"] is None
-
-
-def test_liveness_task_credit_returns_after_outputs_leave_the_producer_queue():
-    unit = _unit(
-        "resource:f:decode",
-        resources=_r(store=101),
-        backend="ray_worker",
-    )
-    manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
-    _ready(manager, unit.resource_unit_id)
-
-    first_request = _task(unit.resource_unit_id, 0, retained=101)
-    manager.note_task_waiting(first_request)
-    first = manager.try_acquire_queued_task(first_request)
-    outputs = manager.finish_task_with_outputs(
-        first.lease.lease_id,
-        attempt_id=first.lease.attempt_id,
-        outputs=(
-            OutputBlockRequest(
-                query_id="q",
-                producer_unit_id=unit.resource_unit_id,
-                task_lease_id=first.lease.lease_id,
-                attempt_id=first.lease.attempt_id,
-                block_id="first-output",
-                size_bytes=10,
-            ),
-        ),
-    )
-
-    producer_owned = manager.snapshot()
-    assert producer_owned["liveness"]["active_task_lease_id"] == first.lease.lease_id
-    assert producer_owned["usage"]["object_store_bytes"] == 10
-    second_request = _task(unit.resource_unit_id, 1, retained=101)
-    manager.note_task_waiting(second_request)
-    denied = manager.try_acquire_queued_task(second_request)
-    assert not denied.granted
-    assert denied.blocked_reason == "liveness_task_active"
-
-    assert manager.transition_output_block(outputs[0].lease_id, "downstream_input")
-    handed_off = manager.snapshot()
-    assert handed_off["liveness"]["active_task_lease_id"] is None
-    assert handed_off["usage"]["object_store_bytes"] == 10
-    second = manager.try_acquire_queued_task(second_request)
-    assert second.granted and second.liveness
-
-
-def test_liveness_is_not_granted_while_another_runnable_unit_has_normal_capacity():
-    upstream = _unit("resource:f:upstream", resources=_r(cpu=1, heap=70), target=0, blocks=0)
-    blocked = _unit(
-        "resource:f:blocked",
-        inputs=(upstream.resource_unit_id,),
-        resources=_r(cpu=1, heap=30),
+def test_global_idle_liveness_is_bounded_to_one_task_across_units():
+    first = _unit(
+        "resource:f:first",
+        resources=_r(cpu=1, heap=100),
         target=0,
         blocks=0,
     )
-    runnable = _unit(
-        "resource:f:runnable",
-        inputs=(blocked.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
+    second = _unit(
+        "resource:f:second",
+        resources=_r(cpu=1, heap=100),
         target=0,
         blocks=0,
     )
     manager = _manager(
-        upstream,
-        blocked,
-        runnable,
-        resources=_r(cpu=100, heap=100, store=100),
+        first,
+        second,
+        resources=_r(),
+        terminals=(first.resource_unit_id, second.resource_unit_id),
     )
-    _ready(
-        manager, upstream.resource_unit_id, blocked.resource_unit_id, runnable.resource_unit_id, consumer_waiting=True
+    _ready(manager, first.resource_unit_id, second.resource_unit_id)
+
+    escaped = manager.try_acquire_task(_task(first.resource_unit_id, 0))
+    blocked = manager.try_acquire_task(_task(second.resource_unit_id, 0))
+
+    assert escaped.granted and escaped.liveness
+    assert not blocked.granted and blocked.blocked_reason == "liveness_task_active"
+
+    manager.release_task_lease(
+        escaped.lease.lease_id,
+        attempt_id=escaped.lease.attempt_id,
     )
-    assert manager.try_acquire_task(_task(upstream.resource_unit_id, 0)).granted
-    manager.note_task_waiting(_task(runnable.resource_unit_id, 0))
-
-    denied = manager.try_acquire_task(_task(blocked.resource_unit_id, 0))
-
-    assert not denied.granted
-    assert denied.blocked_reason == "normal_candidate_available"
+    next_escape = manager.try_acquire_task(_task(second.resource_unit_id, 1))
+    assert next_escape.granted and next_escape.liveness
 
 
 def test_task_lease_release_is_attempt_aware_and_idempotent():
@@ -3517,7 +1404,7 @@ def test_fte_task_completion_atomically_transfers_window_to_output_leases():
     )
     manager = _manager(unit)
     _ready(manager, unit.resource_unit_id)
-    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, node_id="node-a"))
 
     leases = manager.finish_task_with_outputs(
         task.lease.lease_id,
@@ -3561,7 +1448,7 @@ def test_fte_task_completion_replaces_pending_estimate_with_oversized_exact_outp
     )
     manager = _manager(unit, resources=_r(cpu=100, heap=1_000, store=20))
     _ready(manager, unit.resource_unit_id)
-    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, node_id="node-a"))
 
     assert manager.snapshot()["usage"]["object_store_bytes"] == 20
     leases = manager.finish_task_with_outputs(
@@ -3758,51 +1645,7 @@ def test_output_liveness_ignores_consumers_behind_pending_barrier():
     assert grant.blocked_reason == "output_liveness_not_needed"
 
 
-def test_queued_task_liveness_skips_higher_ranked_unrelated_branch():
-    upstream = _unit("resource:f:a-upstream", target=0, blocks=0)
-    downstream = _unit(
-        "resource:f:a-downstream",
-        inputs=(upstream.resource_unit_id,),
-        target=0,
-        blocks=0,
-    )
-    unrelated = _unit("resource:f:z-unrelated", target=0, blocks=0)
-    manager = _manager(
-        upstream,
-        downstream,
-        unrelated,
-        terminals=(downstream.resource_unit_id, unrelated.resource_unit_id),
-        resources=_r(cpu=10, heap=1_000, store=100),
-    )
-    _ready(
-        manager,
-        upstream.resource_unit_id,
-        downstream.resource_unit_id,
-        unrelated.resource_unit_id,
-    )
-    active = manager.try_acquire_task(_task(upstream.resource_unit_id, 0, retained=0))
-    assert active.granted
-    downstream_request = _task(downstream.resource_unit_id, 0, retained=101)
-    unrelated_request = _task(unrelated.resource_unit_id, 0, retained=101)
-    manager.note_task_waiting(downstream_request)
-    manager.note_task_waiting(unrelated_request)
-    assert (
-        manager._reverse_topological_rank[unrelated.resource_unit_id]
-        < manager._reverse_topological_rank[downstream.resource_unit_id]
-    )
-
-    selected, grant = manager.try_acquire_next_queued_task(
-        {
-            (downstream_request.task_id, downstream_request.attempt_id),
-            (unrelated_request.task_id, unrelated_request.attempt_id),
-        }
-    )
-
-    assert selected == downstream_request
-    assert grant.granted and grant.liveness
-
-
-def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
+def test_object_store_soft_debt_does_not_block_zero_input_downstream_compute():
     producer = _unit("resource:f:producer", resources=_r(cpu=1, heap=100), target=50, blocks=2)
     consumer = _unit(
         "resource:f:consumer",
@@ -3836,149 +1679,6 @@ def test_object_store_debt_does_not_block_debt_neutral_downstream_compute():
     assert not downstream.liveness
 
 
-def test_allocation_shrink_creates_debt_without_revoking_existing_leases():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=0, blocks=0)
-    manager = _manager(unit, resources=_r(cpu=4, heap=400, store=100))
-    _ready(manager, unit.resource_unit_id)
-    leases = [manager.try_acquire_task(_task(unit.resource_unit_id, idx)) for idx in range(3)]
-    assert all(grant.granted for grant in leases)
-
-    manager.update_allocation(
-        _allocation(_r(cpu=2, heap=200, store=100), generation=2),
-        admission_open=True,
-    )
-    denied = manager.try_acquire_task(_task(unit.resource_unit_id, 4))
-    snapshot = manager.snapshot()
-
-    assert denied.blocked_reason == "allocation_debt"
-    assert snapshot["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
-    assert len(snapshot["task_leases"]) == 3
-
-
-def test_allocation_debt_blocks_new_process_but_allows_zero_increment_drain_work():
-    ray_task = _unit(
-        "resource:f:ray-task",
-        resources=_r(cpu=1, heap=100),
-        target=0,
-        blocks=0,
-    )
-    actor = _unit(
-        "resource:f:actor",
-        resources=_r(),
-        resident=_r(cpu=1, heap=100),
-        target=0,
-        blocks=0,
-        backend="ray_actor",
-        actor_pool_size=1,
-    )
-    native = _unit(
-        "resource:f:native",
-        resources=_r(),
-        target=0,
-        blocks=0,
-        backend="ray_worker",
-    )
-    manager = _manager(
-        ray_task,
-        actor,
-        native,
-        resources=_r(cpu=4, heap=400, store=100),
-        terminals=(ray_task.resource_unit_id, actor.resource_unit_id, native.resource_unit_id),
-    )
-    _ready(manager, ray_task.resource_unit_id, actor.resource_unit_id, native.resource_unit_id)
-    active = [manager.try_acquire_task(_task(ray_task.resource_unit_id, index)) for index in range(2)]
-    assert all(grant.granted for grant in active)
-
-    manager.update_allocation(
-        _allocation(_r(cpu=1, heap=100, store=100), generation=2),
-        admission_open=True,
-        debt_neutral_only=True,
-    )
-
-    process = manager.try_acquire_task(_task(ray_task.resource_unit_id, "new"))
-    actor_call = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
-    native_drain = manager.try_acquire_task(_task(native.resource_unit_id, 0, node_id="node-a"))
-
-    assert not process.granted
-    assert process.blocked_reason == "allocation_debt"
-    assert actor_call.granted and not actor_call.liveness
-    assert native_drain.granted and not native_drain.liveness
-    assert manager.snapshot()["allocation_debt_neutral_only"] is True
-
-
-def test_allocation_debt_admission_recovers_immediately_after_live_leases_drain():
-    unit = _unit(
-        "resource:f:ray-task",
-        resources=_r(cpu=1, heap=100),
-        target=0,
-        blocks=0,
-    )
-    manager = _manager(unit, resources=_r(cpu=2, heap=200))
-    _ready(manager, unit.resource_unit_id)
-    active = [manager.try_acquire_task(_task(unit.resource_unit_id, index)) for index in range(2)]
-    assert all(grant.granted for grant in active)
-
-    manager.update_allocation(
-        _allocation(_r(cpu=1, heap=100), generation=2),
-        admission_open=True,
-        debt_neutral_only=True,
-    )
-    assert manager.try_acquire_task(_task(unit.resource_unit_id, "blocked")).blocked_reason == "allocation_debt"
-
-    for grant in active:
-        assert manager.release_task_lease(
-            grant.lease.lease_id,
-            attempt_id=grant.lease.attempt_id,
-        )
-
-    recovered = manager.try_acquire_task(_task(unit.resource_unit_id, "recovered"))
-    assert recovered.granted and not recovered.liveness
-    assert manager.snapshot()["allocation_debt_neutral_only"] is True
-
-
-def test_pending_allocation_preserves_live_node_debt_and_stops_new_admission():
-    unit = _unit("resource:f:pending", resources=_r(cpu=1, heap=100))
-    manager = _manager(
-        unit,
-        resources=_r(cpu=2, heap=200, store=20),
-    )
-    _ready(manager, unit.resource_unit_id)
-    active = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
-    assert active.granted
-
-    manager.update_allocation(
-        _allocation(_r(), generation=2, nodes=()),
-        admission_open=False,
-    )
-
-    blocked = manager.try_acquire_task(_task(unit.resource_unit_id, 2))
-    snapshot = manager.snapshot()
-    expected_usage = _r(cpu=1, heap=100).to_dict()
-    assert blocked.granted is False
-    assert blocked.blocked_reason == "allocation_pending"
-    assert blocked.fatal is False
-    assert snapshot["allocation_admission_open"] is False
-    assert snapshot["allocation_debt"] == _r(cpu=1, heap=100).to_dict()
-    assert snapshot["soft_object_store_debt_bytes"] == 0
-    assert snapshot["node_usage"]["node-a"] == expected_usage
-    assert snapshot["node_allocation_debt"]["node-a"] == _r(cpu=1, heap=100).to_dict()
-    assert snapshot["node_soft_object_store_debt_bytes"]["node-a"] == 0
-
-    assert manager.release_task_lease(
-        active.lease.lease_id,
-        attempt_id=active.lease.attempt_id,
-    )
-    still_blocked = manager.try_acquire_task(_task(unit.resource_unit_id, 3))
-    assert still_blocked.blocked_reason == "allocation_pending"
-
-    restored = _r(cpu=2, heap=200, store=20)
-    manager.update_allocation(
-        _allocation(restored, generation=3),
-        admission_open=True,
-    )
-    assert manager.try_acquire_task(_task(unit.resource_unit_id, 4)).granted
-
-
 def test_cancellation_releases_every_task_and_output_lease_idempotently():
     unit = _unit("resource:f:decode")
     manager = _manager(unit)
@@ -4003,7 +1703,7 @@ def test_cancellation_releases_every_task_and_output_lease_idempotently():
     assert manager.release_output_block(block.lease.lease_id) is False
 
 
-def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
+def test_native_task_and_materialized_output_preserve_the_actual_runtime_node():
     unit = _unit(
         "resource:f:per-node",
         resources=_r(cpu=1, heap=10),
@@ -4012,11 +1712,9 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
         concurrency=3,
         backend="ray_worker",
     )
-    node_capacity = _r(cpu=1, heap=10, store=20)
     manager = _manager(
         unit,
         resources=_r(cpu=2, heap=20, store=40),
-        nodes=(("node-a", node_capacity), ("node-b", node_capacity)),
     )
     _ready(manager, unit.resource_unit_id)
 
@@ -4042,9 +1740,9 @@ def test_task_and_materialized_output_ownership_stay_on_one_ray_node():
     )
     output = output_leases[0]
     assert output.node_id == first.lease.node_id
-    assert manager.snapshot()["node_usage"][output.node_id]["object_store_bytes"] == 10
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 10
 
     granted = manager.try_acquire_task(_task(unit.resource_unit_id, 3, node_id=output.node_id))
     assert granted.granted
     assert granted.lease.node_id == output.node_id
-    assert manager.snapshot()["node_soft_object_store_debt_bytes"][output.node_id] == 10
+    assert manager.snapshot()["ray_core_owns_placement"] is True

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -13,7 +13,7 @@ from duckdb.runners.ray.query_resource_graph import (
 )
 from duckdb.runners.ray.query_resource_manager import (
     OutputBlockRequest,
-    QueryResourceManager,
+    RayQueryResourceManager,
     TaskRequest,
 )
 
@@ -48,7 +48,6 @@ def _unit(
     actor_prefetch_depth=1,
     resident=None,
     unit_kind=None,
-    is_barrier=False,
 ):
     requested = resources or _r(cpu=1, heap=10)
     if backend == "ray_actor":
@@ -57,6 +56,9 @@ def _unit(
             gpu=requested.gpu,
             heap=requested.heap_bytes,
         )
+        task_resources = _r(store=requested.object_store_bytes)
+    elif backend == "ray_worker":
+        resident_resources = _r()
         task_resources = _r(store=requested.object_store_bytes)
     else:
         resident_resources = _r()
@@ -83,7 +85,6 @@ def _unit(
         resident_per_actor=resident_resources,
         actor_pool_size=actor_pool_size,
         actor_prefetch_depth=actor_prefetch_depth,
-        is_barrier=is_barrier,
     )
 
 
@@ -114,7 +115,7 @@ def _manager(
         nodes=nodes,
     )
     graph.validate_allocation(allocation)
-    return QueryResourceManager(
+    return RayQueryResourceManager(
         graph,
         allocation,
         reservation_ratio=reservation_ratio,
@@ -166,253 +167,31 @@ def test_task_admission_requires_runnable_registered_unit_and_ready_actor():
     assert granted.lease.output_window_bytes == 20
 
 
-def test_only_first_pending_reservation_scope_and_its_upstream_receive_reservations_without_gating():
-    source = _unit(
-        "resource:f:scope-source",
-        resources=_r(cpu=1, heap=10),
-        target=1,
+def test_dynamic_reservations_follow_real_runnable_demand_without_static_scope():
+    upstream = _unit("resource:f:upstream", resources=_r(cpu=1, heap=10, store=5), target=5, blocks=1)
+    downstream = _unit(
+        "resource:f:downstream",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(cpu=1, heap=10, store=5),
+        target=5,
         blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
     )
-    first_barrier = _unit(
-        "resource:f:scope-first-barrier",
-        inputs=(source.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=1,
-        blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-        is_barrier=True,
-    )
-    between = _unit(
-        "resource:f:scope-between",
-        inputs=(first_barrier.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=1,
-        blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    second_barrier = _unit(
-        "resource:f:scope-second-barrier",
-        inputs=(between.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=1,
-        blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-        is_barrier=True,
-    )
-    terminal = _unit(
-        "resource:f:scope-terminal",
-        inputs=(second_barrier.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=1,
-        blocks=1,
-        backend="ray_worker",
-        unit_kind="native_fragment",
-    )
-    manager = _manager(
-        source,
-        first_barrier,
-        between,
-        second_barrier,
-        terminal,
-        resources=_r(cpu=5, heap=100, store=100),
-    )
-    _ready(
-        manager,
-        source.resource_unit_id,
-        first_barrier.resource_unit_id,
-        between.resource_unit_id,
-        second_barrier.resource_unit_id,
-        terminal.resource_unit_id,
-    )
-    for unit in (source, first_barrier, between, second_barrier, terminal):
-        manager.note_task_waiting(_task(unit.resource_unit_id, "waiting"))
+    manager = _manager(upstream, downstream, resources=_r(cpu=2, heap=20, store=20))
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+    manager.note_task_waiting(_task(upstream.resource_unit_id, "waiting"))
+    manager.note_task_waiting(_task(downstream.resource_unit_id, "waiting"))
 
-    first_snapshot = manager.snapshot()
-    unreserved_between = manager.try_acquire_task(_task(between.resource_unit_id, 0))
-
-    assert first_snapshot["reservation_scope"] == {
-        "barrier_unit_id": first_barrier.resource_unit_id,
-        "resource_unit_ids": [source.resource_unit_id, first_barrier.resource_unit_id],
-        "object_store_backpressure_disabled": True,
-        "object_store_unlimited_unit_ids": [
-            source.resource_unit_id,
-            first_barrier.resource_unit_id,
-        ],
-    }
-    assert first_snapshot["admission"]["reservation_unit_ids"]["cpu"] == [
-        source.resource_unit_id,
-        first_barrier.resource_unit_id,
-    ]
-    assert unreserved_between.granted
-    assert unreserved_between.liveness is False
-    assert between.resource_unit_id not in first_snapshot["admission"]["reservation_unit_ids"]["cpu"]
-    assert manager.release_task_lease(unreserved_between.lease.lease_id, attempt_id="0")
-
-    with pytest.raises(ValueError, match="not a blocking materializer"):
-        manager.mark_barrier_unit_completed(source.resource_unit_id)
-    assert manager.mark_barrier_unit_completed(first_barrier.resource_unit_id)
-    assert not manager.mark_barrier_unit_completed(first_barrier.resource_unit_id)
-    second_snapshot = manager.snapshot()
-
-    assert second_snapshot["reservation_scope"]["barrier_unit_id"] == second_barrier.resource_unit_id
-    assert second_snapshot["reservation_scope"]["resource_unit_ids"] == [
-        source.resource_unit_id,
-        first_barrier.resource_unit_id,
-        between.resource_unit_id,
-        second_barrier.resource_unit_id,
-    ]
-    assert second_snapshot["units"][source.resource_unit_id]["completed"] is False
-    assert second_snapshot["units"][first_barrier.resource_unit_id]["completed"] is False
-    assert second_snapshot["units"][first_barrier.resource_unit_id]["materialization_completed"] is True
-    assert second_snapshot["units"][source.resource_unit_id]["reservation_scope_eligible"] is True
-    assert second_snapshot["units"][first_barrier.resource_unit_id]["reservation_scope_eligible"] is True
-    assert second_snapshot["units"][between.resource_unit_id]["reservation_scope_eligible"] is True
-    assert second_snapshot["units"][terminal.resource_unit_id]["reservation_scope_eligible"] is False
-    assert manager.try_acquire_task(_task(between.resource_unit_id, 1)).granted
-    assert manager.try_acquire_task(_task(first_barrier.resource_unit_id, 1)).granted
-
-
-def test_blocking_materialization_disables_only_corresponding_object_store_soft_limits():
-    early = _unit(
-        "resource:f:spill-early",
-        resources=_r(cpu=1, heap=10),
-        target=10,
-        blocks=1,
-    )
-    producer = _unit(
-        "resource:f:spill-producer",
-        inputs=(early.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=10,
-        blocks=1,
-    )
-    barrier = _unit(
-        "resource:f:spill-barrier",
-        inputs=(producer.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=10,
-        blocks=1,
-        is_barrier=True,
-    )
-    terminal = _unit(
-        "resource:f:spill-terminal",
-        inputs=(barrier.resource_unit_id,),
-        resources=_r(cpu=1, heap=10),
-        target=10,
-        blocks=1,
-    )
-    manager = _manager(
-        early,
-        producer,
-        barrier,
-        terminal,
-        resources=_r(cpu=4, heap=100, store=10),
-    )
-    _ready(
-        manager, early.resource_unit_id, producer.resource_unit_id, barrier.resource_unit_id, terminal.resource_unit_id
-    )
-
-    producer_task = manager.try_acquire_task(_task(producer.resource_unit_id, 0, retained=0))
-    barrier_task = manager.try_acquire_task(_task(barrier.resource_unit_id, 0, retained=0))
-    manager.note_task_waiting(_task(early.resource_unit_id, "waiting", retained=0))
-    early_normal_reason = manager._normal_task_block_reason_locked(_task(early.resource_unit_id, 0, retained=0))[0]
-    early_task = manager.try_acquire_task(_task(early.resource_unit_id, 0, retained=0))
-    output = manager.try_acquire_output_block(
-        OutputBlockRequest(
-            query_id="q",
-            producer_unit_id=producer.resource_unit_id,
-            task_lease_id=producer_task.lease.lease_id,
-            attempt_id="0",
-            block_id="materialized-input",
-            size_bytes=25,
-        )
-    )
     snapshot = manager.snapshot()
 
-    assert producer_task.granted and producer_task.liveness is False
-    assert barrier_task.granted and barrier_task.liveness is False
-    assert early_normal_reason == "query_soft_object_store_bytes"
-    assert not early_task.granted
-    assert early_task.blocked_reason == "liveness_not_needed"
-    assert output.granted and output.liveness is False
-    assert snapshot["usage"]["object_store_bytes"] > snapshot["allocation"]["resources"]["object_store_bytes"]
-    assert snapshot["reservation_scope"]["object_store_unlimited_unit_ids"] == [
-        producer.resource_unit_id,
-        barrier.resource_unit_id,
+    assert "reservation_scope" not in snapshot
+    assert snapshot["admission"]["reservation_unit_ids"]["cpu"] == [
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
     ]
     assert snapshot["admission"]["reservation_unit_ids"]["object_store_bytes"] == [
-        early.resource_unit_id,
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
     ]
-
-
-def test_nested_materializers_activate_spill_exemptions_on_real_demand():
-    inner_input = _unit("resource:f:nested-inner-input", resources=_r(cpu=1, heap=10))
-    receiver = _unit("resource:f:nested-receiver", resources=_r(cpu=1, heap=10))
-    inner_barrier = _unit(
-        "resource:f:nested-inner-barrier",
-        inputs=(inner_input.resource_unit_id, receiver.resource_unit_id),
-        resources=_r(cpu=1, heap=10),
-        is_barrier=True,
-    )
-    middle_input = _unit("resource:f:nested-middle-input", resources=_r(cpu=1, heap=10))
-    middle_barrier = _unit(
-        "resource:f:nested-middle-barrier",
-        inputs=(middle_input.resource_unit_id, inner_barrier.resource_unit_id),
-        resources=_r(cpu=1, heap=10),
-        is_barrier=True,
-    )
-    outer_input = _unit("resource:f:nested-outer-input", resources=_r(cpu=1, heap=10))
-    outer_barrier = _unit(
-        "resource:f:nested-outer-barrier",
-        inputs=(outer_input.resource_unit_id, middle_barrier.resource_unit_id),
-        resources=_r(cpu=1, heap=10),
-        is_barrier=True,
-    )
-    manager = _manager(
-        inner_input,
-        receiver,
-        inner_barrier,
-        middle_input,
-        middle_barrier,
-        outer_input,
-        outer_barrier,
-        resources=_r(cpu=7, heap=100, store=10),
-    )
-    _ready(
-        manager,
-        inner_input.resource_unit_id,
-        receiver.resource_unit_id,
-        inner_barrier.resource_unit_id,
-        middle_input.resource_unit_id,
-        middle_barrier.resource_unit_id,
-        outer_input.resource_unit_id,
-        outer_barrier.resource_unit_id,
-    )
-
-    initial = manager.snapshot()
-    outer_task = manager.try_acquire_task(_task(outer_input.resource_unit_id, 0, retained=0))
-    after_outer_demand = manager.snapshot()
-    middle_task = manager.try_acquire_task(_task(middle_input.resource_unit_id, 0, retained=0))
-    after_middle_demand = manager.snapshot()
-
-    assert initial["reservation_scope"]["barrier_unit_id"] == inner_barrier.resource_unit_id
-    assert initial["reservation_scope"]["object_store_unlimited_unit_ids"] == [
-        inner_input.resource_unit_id,
-        receiver.resource_unit_id,
-        inner_barrier.resource_unit_id,
-    ]
-    assert outer_task.granted and outer_task.liveness is False
-    assert outer_input.resource_unit_id not in initial["admission"]["reservation_unit_ids"]["object_store_bytes"]
-    assert after_outer_demand["units"][outer_input.resource_unit_id]["object_store_backpressure_disabled"] is True
-    assert after_outer_demand["units"][middle_input.resource_unit_id]["object_store_backpressure_disabled"] is False
-    assert middle_task.granted and middle_task.liveness is False
-    assert after_middle_demand["units"][middle_input.resource_unit_id]["object_store_backpressure_disabled"] is True
-    assert after_middle_demand["reservation_scope"]["barrier_unit_id"] == inner_barrier.resource_unit_id
 
 
 def test_actor_task_leases_own_distinct_concrete_actor_slots():
@@ -634,6 +413,83 @@ def test_soft_heap_reservation_does_not_exceed_cross_dimension_unit_capacity():
     assert denied.blocked_reason == "hard_heap_bytes"
 
 
+def test_native_fragment_uses_fte_node_outside_query_allocation_attribution():
+    native = _unit(
+        "resource:f:native-external-node",
+        resources=_r(store=10),
+        target=10,
+        blocks=2,
+        backend="ray_worker",
+    )
+    manager = _manager(
+        native,
+        resources=_r(store=100),
+        nodes=(("node-a", _r(store=100)),),
+    )
+    _ready(manager, native.resource_unit_id)
+
+    task_grant = manager.try_acquire_task(
+        _task(native.resource_unit_id, 0, node_id="node-b"),
+    )
+
+    assert task_grant.granted
+    assert task_grant.lease.node_id == "node-b"
+    output_grant = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            query_id="q",
+            producer_unit_id=native.resource_unit_id,
+            task_lease_id=task_grant.lease.lease_id,
+            attempt_id=task_grant.lease.attempt_id,
+            block_id="native-external-output",
+            size_bytes=30,
+        )
+    )
+    assert output_grant.granted
+    snapshot = manager.snapshot()
+    assert snapshot["allocation"]["node_allocations"] == [
+        {"node_id": "node-a", "resources": _r(store=100).to_dict()},
+    ]
+    assert snapshot["node_usage"]["node-b"] == _r(store=40).to_dict()
+    assert snapshot["node_allocation_debt"]["node-b"] == _r().to_dict()
+
+
+def test_external_native_node_keeps_remote_continuation_on_allocated_node():
+    native = _unit(
+        "resource:f:native-external-parent",
+        resources=_r(),
+        target=0,
+        blocks=0,
+        backend="ray_worker",
+    )
+    remote = _unit(
+        "resource:f:remote-continuation",
+        inputs=(native.resource_unit_id,),
+        resources=_r(cpu=1, heap=10),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        native,
+        remote,
+        resources=_r(cpu=1, heap=10),
+        nodes=(("node-a", _r(cpu=1, heap=10)),),
+    )
+    _ready(manager, native.resource_unit_id, remote.resource_unit_id)
+
+    native_grant = manager.try_acquire_task(
+        _task(native.resource_unit_id, 0, node_id="node-b"),
+    )
+
+    assert native_grant.granted
+    assert native_grant.lease.node_id == "node-b"
+    credits = manager.snapshot()["continuation_credits"]
+    assert len(credits) == 1
+    assert next(iter(credits.values()))["node_id"] == "node-a"
+    remote_grant = manager.try_acquire_task(_task(remote.resource_unit_id, 0, node_id="node-a"))
+    assert remote_grant.granted
+    assert remote_grant.lease.node_id == "node-a"
+
+
 def test_empty_runnable_units_do_not_dilute_live_task_reservation():
     units = []
     for index in range(4):
@@ -735,7 +591,7 @@ def test_driver_subset_yields_when_global_winner_is_fte_owned():
         blocks=0,
     )
     downstream = _unit(
-        "resource:f:fte-downstream",
+        "resource:f:native-downstream",
         inputs=(upstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
@@ -761,7 +617,7 @@ def test_driver_subset_yields_when_global_winner_is_fte_owned():
 
 def test_fte_request_yields_when_global_winner_is_driver_owned():
     upstream = _unit(
-        "resource:f:fte-upstream",
+        "resource:f:native-upstream",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -929,9 +785,9 @@ def test_reapplying_identical_unit_state_does_not_publish_resource_change():
     assert changes == ["changed"]
 
 
-def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
+def test_parent_native_fragment_owns_transferable_credit_for_one_nested_udf_task():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -939,7 +795,7 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
         unit_kind="native_fragment",
     )
     bridge = _unit(
-        "resource:f:bridge-fte",
+        "resource:f:bridge-native",
         inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
@@ -967,16 +823,13 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
     assert sum(grant.granted for grant in parent_grants) == 3
     assert parent_grants[3].blocked_reason == "continuation_capacity"
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 30
+    assert snapshot["usage"]["heap_bytes"] == 24
     assert len(snapshot["continuation_credits"]) == 3
     assert all(credit["borrowed_by_task_lease_id"] is None for credit in snapshot["continuation_credits"].values())
     admission = snapshot["admission"]
-    assert admission["live_demand_unit_ids"]["heap_bytes"] == [parent.resource_unit_id]
-    assert admission["continuation_unit_ids"]["heap_bytes"] == [child.resource_unit_id]
-    assert admission["reservation_unit_ids"]["heap_bytes"] == [
-        parent.resource_unit_id,
-        child.resource_unit_id,
-    ]
+    assert admission["live_demand_unit_ids"]["heap_bytes"] == []
+    assert admission["continuation_unit_ids"]["heap_bytes"] == []
+    assert admission["reservation_unit_ids"]["heap_bytes"] == []
 
     child_requests = [_task(child.resource_unit_id, partition) for partition in range(3)]
     for request in child_requests:
@@ -985,7 +838,7 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
 
     assert all(grant.granted for grant in child_grants)
     borrowed = manager.snapshot()
-    assert borrowed["usage"]["heap_bytes"] == 30
+    assert borrowed["usage"]["heap_bytes"] == 24
     assert {credit["borrowed_by_task_lease_id"] for credit in borrowed["continuation_credits"].values()} == {
         grant.lease.lease_id for grant in child_grants
     }
@@ -1003,12 +856,12 @@ def test_parent_fte_owns_transferable_credit_for_one_nested_udf_task():
     )
     replacement = manager.try_acquire_queued_task(fourth_child)
     assert replacement.granted
-    assert manager.snapshot()["usage"]["heap_bytes"] == 30
+    assert manager.snapshot()["usage"]["heap_bytes"] == 24
 
 
 def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowed():
     parent = _unit(
-        "resource:f:parent-fte-normal-overflow",
+        "resource:f:parent-native-normal-overflow",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1052,12 +905,12 @@ def test_nested_udf_uses_normal_allocation_after_continuation_reserve_is_borrowe
         credit["borrowed_by_task_lease_id"] != second.lease.lease_id
         for credit in snapshot["continuation_credits"].values()
     )
-    assert snapshot["usage"] == _r(cpu=3, heap=18, store=0).to_dict()
+    assert snapshot["usage"] == _r(cpu=2, heap=16, store=0).to_dict()
 
 
 def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1100,7 +953,7 @@ def test_borrowed_continuation_credit_outlives_parent_until_child_releases():
 
 def test_released_child_returns_credit_to_active_parent():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1128,19 +981,19 @@ def test_released_child_returns_credit_to_active_parent():
         attempt_id=first_child.lease.attempt_id,
     )
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 10
+    assert snapshot["usage"]["heap_bytes"] == 8
     assert next(iter(snapshot["continuation_credits"].values()))["borrowed_by_task_lease_id"] is None
 
     second_request = _task(child.resource_unit_id, 1)
     manager.note_task_waiting(second_request)
     second_child = manager.try_acquire_queued_task(second_request)
     assert second_child.granted
-    assert manager.snapshot()["usage"]["heap_bytes"] == 10
+    assert manager.snapshot()["usage"]["heap_bytes"] == 8
 
 
-def test_continuation_credit_can_reserve_a_different_node_from_parent_fte():
+def test_continuation_credit_can_reserve_a_different_node_from_parent_native_fragment():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1179,7 +1032,7 @@ def test_continuation_credit_can_reserve_a_different_node_from_parent_fte():
 
 def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1217,7 +1070,7 @@ def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
         attempt_id=first_child.lease.attempt_id,
     )
     snapshot = manager.snapshot()
-    assert snapshot["usage"] == _r(cpu=2, heap=10, store=10).to_dict()
+    assert snapshot["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
     credit = next(iter(snapshot["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == first_child.lease.lease_id
 
@@ -1234,7 +1087,7 @@ def test_child_outputs_keep_credit_borrowed_until_last_output_releases():
 
 def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_bytes():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1283,7 +1136,7 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     assert after_handoff.granted
     snapshot = manager.snapshot()
     assert first_output.lease.lease_id in snapshot["output_leases"]
-    assert snapshot["usage"] == _r(cpu=2, heap=10, store=10).to_dict()
+    assert snapshot["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
     credit = next(iter(snapshot["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
     assert snapshot["output_leases"][first_output.lease.lease_id]["continuation_credit_id"] == credit["credit_id"]
@@ -1302,7 +1155,7 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
     with_both_outputs = manager.snapshot()
     # Recycling compute ownership never recycles bytes: both physical blocks
     # remain charged to the query and node flow-control budgets.
-    assert with_both_outputs["usage"] == _r(cpu=2, heap=10, store=20).to_dict()
+    assert with_both_outputs["usage"] == _r(cpu=1, heap=8, store=20).to_dict()
     assert (
         with_both_outputs["output_leases"][second_output.lease.lease_id]["continuation_credit_id"]
         == credit["credit_id"]
@@ -1310,14 +1163,14 @@ def test_handed_off_child_output_recycles_credit_without_unaccounting_physical_b
 
     assert manager.release_output_block(first_output.lease.lease_id)
     released = manager.snapshot()
-    assert released["usage"] == _r(cpu=2, heap=10, store=10).to_dict()
+    assert released["usage"] == _r(cpu=1, heap=8, store=10).to_dict()
     credit = next(iter(released["continuation_credits"].values()))
     assert credit["borrowed_by_task_lease_id"] == after_handoff.lease.lease_id
 
 
 def test_cross_unit_credit_reuse_checks_historical_outputs_before_grant():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1381,7 +1234,7 @@ def test_cross_unit_credit_reuse_checks_historical_outputs_before_grant():
 
 def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1447,7 +1300,7 @@ def test_continuation_borrow_reuses_idle_credit_with_smallest_live_output_delta(
 
 def test_cross_unit_idle_credit_output_excess_is_attributed_exactly_once():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1517,7 +1370,7 @@ def test_cross_unit_idle_credit_output_excess_is_attributed_exactly_once():
 
 def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrower():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1570,7 +1423,7 @@ def test_continuation_unit_usage_matches_query_usage_for_active_and_idle_borrowe
 
 def test_live_output_from_deleted_continuation_credit_remains_in_unit_usage():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1625,7 +1478,7 @@ def test_live_output_from_deleted_continuation_credit_remains_in_unit_usage():
 
 def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
     parent = _unit(
-        "resource:f:parent-fte",
+        "resource:f:parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1657,7 +1510,7 @@ def test_query_cancellation_clears_idle_and_borrowed_continuation_credits():
     assert snapshot["usage"] == _r().to_dict()
 
 
-def test_parent_fte_admission_preserves_largest_nested_udf_commitment():
+def test_parent_native_fragment_admission_preserves_largest_nested_udf_commitment():
     parent = _unit(
         "resource:f:safe-parent",
         resources=_r(cpu=1, heap=2),
@@ -1702,7 +1555,7 @@ def test_parent_fte_admission_preserves_largest_nested_udf_commitment():
     assert child_grant.granted
 
 
-def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
+def test_native_fragment_placement_does_not_reserve_pinned_actor_process_capacity():
     parent = _unit(
         "resource:f:placed-parent",
         resources=_r(cpu=1, heap=4),
@@ -1731,13 +1584,13 @@ def test_parent_fte_placement_preserves_pinned_actor_continuation_node():
     )
     manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    pinned_node_request = manager.try_acquire_task(_task(parent.resource_unit_id, "bad-node", node_id="node-a"))
+    pinned_node_request = manager.try_acquire_task(_task(parent.resource_unit_id, "pinned-node", node_id="node-a"))
     automatic_request = manager.try_acquire_task(_task(parent.resource_unit_id, "auto-node"))
 
-    assert not pinned_node_request.granted
-    assert pinned_node_request.blocked_reason == "node_capacity"
+    assert pinned_node_request.granted
+    assert pinned_node_request.lease.node_id == "node-a"
     assert automatic_request.granted
-    assert automatic_request.lease.node_id == "node-b"
+    assert automatic_request.lease.node_id == "node-a"
 
 
 def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservations():
@@ -1748,7 +1601,7 @@ def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservation
         blocks=1,
     )
     consumer = _unit(
-        "resource:f:placed-fte-consumer",
+        "resource:f:placed-native-consumer",
         inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
@@ -1778,7 +1631,6 @@ def test_ray_task_placement_keeps_actor_invocation_bytes_out_of_hard_reservation
     )
     manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
 
-    assert manager.task_eligible_node_ids(producer.resource_unit_id) == ("node-a", "node-b")
     pinned = manager.try_acquire_task(_task(producer.resource_unit_id, "pinned", node_id="node-a"))
     automatic = manager.try_acquire_task(_task(producer.resource_unit_id, "automatic"))
 
@@ -1827,7 +1679,7 @@ def test_cold_topology_caps_upstream_fanout_until_direct_downstream_starts():
     assert first_downstream.granted
 
 
-def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
+def test_native_continuation_does_not_add_process_reservation_to_ray_task_fanout():
     producer = _unit(
         "resource:f:image-cpu-producer",
         resources=_r(cpu=1, heap=2),
@@ -1859,21 +1711,18 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
         gpu_actor,
         resources=_r(cpu=36, gpu=1, heap=41, store=10),
     )
-    # The downstream units are deliberately latent. Admission must reserve
-    # them before their first input makes them runnable.
+    # The downstream units are deliberately latent. The actor's resident
+    # process remains hard-accounted, while the native continuation is owned
+    # by DuckDB and adds no Vane process reservation.
     manager.update_unit_state(producer.resource_unit_id, runnable=True, actor_ready=True)
 
-    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(9)]
-    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 9))
+    producer_grants = [manager.try_acquire_task(_task(producer.resource_unit_id, partition)) for partition in range(10)]
+    blocked_producer = manager.try_acquire_task(_task(producer.resource_unit_id, 10))
 
     assert all(grant.granted for grant in producer_grants)
     assert not blocked_producer.granted
-    assert blocked_producer.blocked_reason == "continuation_capacity"
-    reservations = manager.snapshot()["admission"]["downstream_reservations"][producer.resource_unit_id]
-    assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"native-fragment:{producer.resource_unit_id}",
-    ]
-    assert sum(reservation["resources"]["object_store_bytes"] for reservation in reservations) == 0
+    assert blocked_producer.blocked_reason == "hard_heap_bytes"
+    assert producer.resource_unit_id not in manager.snapshot()["admission"]["downstream_reservations"]
 
     manager.update_unit_state(consumer.resource_unit_id, runnable=True, actor_ready=True)
     consumer_grant = manager.try_acquire_task(_task(consumer.resource_unit_id, 0))
@@ -1889,12 +1738,12 @@ def test_latent_fte_and_actor_reservations_cap_ray_task_fanout():
             cpu=10,
             gpu=1,
             heap=40,
-            store=11,
+            store=12,
         ).to_dict()
     )
 
 
-def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
+def test_upstream_fanout_preserves_remote_task_continuation_without_native_slot():
     upstream = _unit(
         "resource:f:streaming-upstream",
         resources=_r(cpu=1, heap=2),
@@ -1919,8 +1768,8 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
         target=0,
         blocks=0,
     )
-    terminal_fte = _unit(
-        "resource:f:streaming-terminal-fte",
+    terminal_native = _unit(
+        "resource:f:streaming-terminal-native",
         inputs=(downstream.resource_unit_id,),
         resources=_r(cpu=1, heap=2),
         target=0,
@@ -1932,21 +1781,20 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
         upstream,
         actor,
         downstream,
-        terminal_fte,
+        terminal_native,
         resources=_r(cpu=20, gpu=1, heap=24, store=20),
     )
     manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
 
-    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(8)]
+    upstream_grants = [manager.try_acquire_task(_task(upstream.resource_unit_id, partition)) for partition in range(9)]
     assert all(grant.granted for grant in upstream_grants)
-    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 8))
+    blocked_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 9))
     assert not blocked_upstream.granted
-    assert blocked_upstream.blocked_reason == "continuation_capacity"
+    assert blocked_upstream.blocked_reason == "liveness_not_needed"
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 20
+    assert snapshot["usage"]["heap_bytes"] == 22
     reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
     assert [reservation["reservation_id"] for reservation in reservations] == [
-        f"native-fragment:{upstream.resource_unit_id}",
         f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
     ]
 
@@ -1967,9 +1815,9 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
     }
     assert downstream_grant.granted
     assert not downstream_grant.liveness
-    assert manager.snapshot()["usage"]["heap_bytes"] == 22
+    assert manager.snapshot()["usage"]["heap_bytes"] == 24
 
-    terminal_request = _task(terminal_fte.resource_unit_id, 0)
+    terminal_request = _task(terminal_native.resource_unit_id, 0)
     manager.note_task_waiting(terminal_request)
     terminal_grant = manager.try_acquire_queued_task(terminal_request)
 
@@ -1978,9 +1826,52 @@ def test_upstream_fanout_preserves_concurrent_ray_task_and_fte_slots():
     assert manager.snapshot()["usage"]["heap_bytes"] == 24
 
 
-def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
+def test_hard_minimum_can_start_with_soft_actor_continuation_reservation():
+    upstream = _unit(
+        "resource:f:minimum-upstream",
+        resources=_r(cpu=1, heap=2),
+        target=0,
+        blocks=0,
+    )
+    actor = _unit(
+        "resource:f:minimum-actor",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(),
+        resident=_r(cpu=1, heap=4),
+        target=0,
+        blocks=0,
+        backend="ray_actor",
+        actor_pool_size=1,
+    )
+    downstream = _unit(
+        "resource:f:minimum-downstream",
+        inputs=(actor.resource_unit_id,),
+        resources=_r(cpu=1, heap=2),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        actor,
+        downstream,
+        resources=_r(cpu=2, heap=6),
+    )
+    manager.update_unit_state(upstream.resource_unit_id, runnable=True, actor_ready=True)
+
+    grant = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+
+    assert grant.granted and grant.liveness
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["heap_bytes"] == 6
+    reservations = snapshot["admission"]["downstream_reservations"][upstream.resource_unit_id]
+    assert [reservation["reservation_id"] for reservation in reservations] == [
+        f"actor_continuation:{upstream.resource_unit_id}:{downstream.resource_unit_id}",
+    ]
+
+
+def test_remote_process_usage_excludes_native_parent_and_downstream_fragments():
     parent = _unit(
-        "resource:f:image-parent-fte",
+        "resource:f:image-parent-native",
         resources=_r(cpu=1, heap=2),
         target=0,
         blocks=0,
@@ -1995,7 +1886,7 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
         blocks=1,
     )
     consumer = _unit(
-        "resource:f:image-downstream-fte",
+        "resource:f:image-downstream-native",
         inputs=(producer.resource_unit_id,),
         resources=_r(cpu=1, heap=3),
         target=0,
@@ -2013,8 +1904,8 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
         backend="ray_actor",
         actor_pool_size=1,
     )
-    # actor resident + invocation, one Ray task credit, the invoking FTE task,
-    # and one downstream FTE progress slot: this is the registered minimum.
+    # Only the actor resident process and Ray task are hard-accounted. Both
+    # native fragments execute inside the node-owned DuckDB budget.
     manager = _manager(
         parent,
         producer,
@@ -2041,17 +1932,17 @@ def test_registered_minimum_supports_parent_task_and_downstream_fte_progress():
     assert (
         manager.snapshot()["usage"]
         == _r(
-            cpu=3,
+            cpu=1,
             gpu=1,
-            heap=19,
+            heap=14,
             store=2,
         ).to_dict()
     )
 
 
-def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
+def test_native_fanout_is_capped_only_by_remote_continuation_credits():
     parent = _unit(
-        "resource:f:image-parent-fte",
+        "resource:f:image-parent-native",
         resources=_r(cpu=1, heap=1),
         target=0,
         blocks=0,
@@ -2059,7 +1950,7 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
         unit_kind="native_fragment",
     )
     direct_fte = _unit(
-        "resource:f:image-direct-fte",
+        "resource:f:image-direct-native",
         inputs=(parent.resource_unit_id,),
         resources=_r(cpu=1, heap=1),
         target=0,
@@ -2075,7 +1966,7 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
         blocks=0,
     )
     downstream_fte = _unit(
-        "resource:f:image-downstream-fte",
+        "resource:f:image-downstream-native",
         inputs=(cpu_udf.resource_unit_id,),
         resources=_r(cpu=1, heap=4),
         target=0,
@@ -2103,18 +1994,14 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
     )
     manager.update_unit_state(parent.resource_unit_id, runnable=True, actor_ready=True)
 
-    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(8)]
+    parent_grants = [manager.try_acquire_task(_task(parent.resource_unit_id, partition)) for partition in range(11)]
 
-    assert all(grant.granted for grant in parent_grants[:7])
-    assert not parent_grants[7].granted
-    assert parent_grants[7].blocked_reason == "continuation_capacity"
+    assert all(grant.granted for grant in parent_grants[:10])
+    assert not parent_grants[10].granted
+    assert parent_grants[10].blocked_reason == "continuation_capacity"
     snapshot = manager.snapshot()
-    assert snapshot["usage"]["heap_bytes"] == 43
-    reservations = snapshot["admission"]["downstream_reservations"][parent.resource_unit_id]
-    assert len(reservations) == 1
-    assert reservations[0]["reservation_id"] == f"native-fragment:{parent.resource_unit_id}"
-    assert reservations[0]["unit_ids"] == [downstream_fte.resource_unit_id]
-    assert reservations[0]["resources"]["heap_bytes"] == 4
+    assert snapshot["usage"]["heap_bytes"] == 48
+    assert parent.resource_unit_id not in snapshot["admission"]["downstream_reservations"]
 
     manager.update_unit_state(cpu_udf.resource_unit_id, runnable=True, actor_ready=True)
     cpu_request = _task(cpu_udf.resource_unit_id, 0)
@@ -2133,7 +2020,7 @@ def test_parent_fte_fanout_preserves_shared_fte_slot_across_nested_ray_task():
     assert cpu_grant.lease.lease_id in {
         credit["borrowed_by_task_lease_id"] for credit in final_snapshot["continuation_credits"].values()
     }
-    assert final_snapshot["usage"]["heap_bytes"] == 47
+    assert final_snapshot["usage"]["heap_bytes"] == 48
 
 
 def test_hard_heap_limit_is_never_bypassed_by_object_store_liveness():
@@ -2668,7 +2555,7 @@ def test_released_output_block_identity_cannot_be_leased_again():
 
 def test_fte_task_completion_atomically_transfers_window_to_output_leases():
     unit = _unit(
-        "resource:f:fte",
+        "resource:f:native",
         resources=_r(cpu=1, heap=100, store=5),
         target=10,
         blocks=2,
@@ -2696,7 +2583,7 @@ def test_fte_task_completion_atomically_transfers_window_to_output_leases():
 
 def test_fte_task_completion_rejects_outputs_above_precommitted_window_without_mutation():
     unit = _unit(
-        "resource:f:fte",
+        "resource:f:native",
         resources=_r(cpu=1, heap=100),
         target=10,
         blocks=2,

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -165,7 +165,7 @@ def test_native_barrier_event_advances_driver_local_execution_phase_once():
     upstream = ResourceUnitSpec(
         query_id="q",
         resource_unit_id="resource:q:upstream",
-        physical_node_id="upstream",
+        physical_node_id="node:upstream:native-fragment",
         unit_kind="native_fragment",
         backend="ray_worker",
         input_unit_ids=(),
@@ -177,7 +177,7 @@ def test_native_barrier_event_advances_driver_local_execution_phase_once():
     materializer = ResourceUnitSpec(
         query_id="q",
         resource_unit_id="resource:q:materializer",
-        physical_node_id="materializer",
+        physical_node_id="node:materializer:native-fragment",
         unit_kind="native_fragment",
         backend="ray_worker",
         input_unit_ids=(upstream.resource_unit_id,),
@@ -207,7 +207,7 @@ def test_native_barrier_event_advances_driver_local_execution_phase_once():
             MaterializationBarrierSpec(
                 query_id="q",
                 barrier_id="barrier:q:node:materializer",
-                physical_node_id=materializer.physical_node_id,
+                physical_node_id="materializer",
                 materializer_unit_id=materializer.resource_unit_id,
                 materialized_input_unit_ids=(upstream.resource_unit_id,),
             ),

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -5,7 +5,6 @@ import pytest
 
 from duckdb.runners.ray.query_resource_graph import (
     MaterializationBarrierSpec,
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -49,7 +48,6 @@ def _allocation(generation=1):
     resources = ResourceVector(cpu=4, heap_bytes=1_000, object_store_bytes=1_000)
     return QueryAllocation(
         resources=resources,
-        node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
         generation=generation,
     )
 
@@ -71,7 +69,7 @@ def test_runtime_registers_graph_atomically_and_rejects_every_duplicate():
         register_query_resource_graph(_graph("sha256:different"), _allocation())
 
 
-def test_runtime_graph_validation_finishes_before_registry_visibility():
+def test_runtime_accepts_a_soft_budget_smaller_than_one_concrete_task():
     unit = ResourceUnitSpec(
         query_id="q",
         resource_unit_id="resource:f:udf",
@@ -88,13 +86,13 @@ def test_runtime_graph_validation_finishes_before_registry_visibility():
     too_small_resources = ResourceVector(cpu=1, heap_bytes=99, object_store_bytes=1_000)
     too_small = QueryAllocation(
         resources=too_small_resources,
-        node_allocations=(NodeResourceAllocation(node_id="node-a", resources=too_small_resources),),
         generation=1,
     )
 
-    with pytest.raises(ValueError, match="heap_bytes"):
-        register_query_resource_graph(graph, too_small)
-    assert query_resource_manager_snapshot("q") == {}
+    manager = register_query_resource_graph(graph, too_small)
+
+    assert manager.allocation.resources == too_small_resources
+    assert query_resource_manager_snapshot("q")["ray_core_owns_placement"] is True
 
 
 def test_runtime_can_publish_pending_query_before_minimum_bundle_is_feasible():
@@ -113,7 +111,6 @@ def test_runtime_can_publish_pending_query_before_minimum_bundle_is_feasible():
     graph = QueryResourceGraph("q", "sha256:pending", (unit,), (unit.resource_unit_id,))
     pending = QueryAllocation(
         resources=ResourceVector(),
-        node_allocations=(),
         generation=1,
     )
 

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -34,7 +34,7 @@ def _graph(digest="sha256:a"):
         unit_kind="native_fragment",
         backend="ray_worker",
         input_unit_ids=(),
-        per_task=ResourceVector(cpu=1, heap_bytes=100),
+        per_task=ResourceVector(),
         target_output_block_bytes=10,
         generator_buffer_blocks=2,
         max_concurrency=4,
@@ -70,7 +70,19 @@ def test_runtime_registers_graph_atomically_and_rejects_every_duplicate():
 
 
 def test_runtime_graph_validation_finishes_before_registry_visibility():
-    graph = _graph()
+    unit = ResourceUnitSpec(
+        query_id="q",
+        resource_unit_id="resource:f:udf",
+        physical_node_id="udf",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(),
+        per_task=ResourceVector(cpu=1, heap_bytes=100),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+        max_concurrency=None,
+    )
+    graph = QueryResourceGraph("q", "sha256:remote", (unit,), (unit.resource_unit_id,))
     too_small_resources = ResourceVector(cpu=1, heap_bytes=99, object_store_bytes=1_000)
     too_small = QueryAllocation(
         resources=too_small_resources,

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -3,18 +3,18 @@
 
 import pytest
 
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
     get_query_resource_manager,
     query_resource_manager_snapshot,
-    register_query_graph,
+    register_query_resource_graph,
     release_query_resource_manager,
 )
 
@@ -27,19 +27,19 @@ def _clear_registry():
 
 
 def _graph(digest="sha256:a"):
-    stage = StageResourceSpec(
+    unit = ResourceUnitSpec(
         query_id="q",
-        stage_id="stage:f:scan",
+        resource_unit_id="resource:f:scan",
         physical_node_id="scan",
-        stage_kind="fte",
+        unit_kind="native_fragment",
         backend="ray_worker",
-        input_stage_ids=(),
+        input_unit_ids=(),
         per_task=ResourceVector(cpu=1, heap_bytes=100),
         target_output_block_bytes=10,
         generator_buffer_blocks=2,
         max_concurrency=4,
     )
-    return QueryExecutionGraph("q", digest, (stage,), (stage.stage_id,))
+    return QueryResourceGraph("q", digest, (unit,), (unit.resource_unit_id,))
 
 
 def _allocation(generation=1):
@@ -53,20 +53,20 @@ def _allocation(generation=1):
 
 
 def test_runtime_never_lazily_creates_manager_before_graph_registration():
-    with pytest.raises(KeyError, match="query graph is not registered"):
+    with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager("q")
     assert query_resource_manager_snapshot("q") == {}
 
 
 def test_runtime_registers_graph_atomically_and_rejects_every_duplicate():
-    manager = register_query_graph(_graph(), _allocation())
+    manager = register_query_resource_graph(_graph(), _allocation())
 
     assert get_query_resource_manager("q") is manager
     assert query_resource_manager_snapshot("q")["graph"]["plan_digest"] == "sha256:a"
     with pytest.raises(ValueError, match="already registered"):
-        register_query_graph(_graph(), _allocation())
+        register_query_resource_graph(_graph(), _allocation())
     with pytest.raises(ValueError, match="already registered"):
-        register_query_graph(_graph("sha256:different"), _allocation())
+        register_query_resource_graph(_graph("sha256:different"), _allocation())
 
 
 def test_runtime_graph_validation_finishes_before_registry_visibility():
@@ -80,12 +80,12 @@ def test_runtime_graph_validation_finishes_before_registry_visibility():
     )
 
     with pytest.raises(ValueError, match="heap_bytes"):
-        register_query_graph(graph, too_small)
+        register_query_resource_graph(graph, too_small)
     assert query_resource_manager_snapshot("q") == {}
 
 
 def test_runtime_release_cancels_and_removes_manager_idempotently():
-    register_query_graph(_graph(), _allocation())
+    register_query_resource_graph(_graph(), _allocation())
 
     first = release_query_resource_manager("q", reason="completed")
     second = release_query_resource_manager("q", reason="completed")

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -4,15 +4,18 @@
 import pytest
 
 from duckdb.runners.ray.query_resource_graph import (
+    MaterializationBarrierSpec,
     NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
     ResourceVector,
 )
+from duckdb.runners.ray.query_resource_manager import TaskRequest
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
     get_query_resource_manager,
+    mark_materialization_barrier_completed,
     query_resource_manager_snapshot,
     register_query_resource_graph,
     release_query_resource_manager,
@@ -47,7 +50,6 @@ def _allocation(generation=1):
     return QueryAllocation(
         resources=resources,
         node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
-        actor_placements=(),
         generation=generation,
     )
 
@@ -87,13 +89,63 @@ def test_runtime_graph_validation_finishes_before_registry_visibility():
     too_small = QueryAllocation(
         resources=too_small_resources,
         node_allocations=(NodeResourceAllocation(node_id="node-a", resources=too_small_resources),),
-        actor_placements=(),
         generation=1,
     )
 
     with pytest.raises(ValueError, match="heap_bytes"):
         register_query_resource_graph(graph, too_small)
     assert query_resource_manager_snapshot("q") == {}
+
+
+def test_runtime_can_publish_pending_query_before_minimum_bundle_is_feasible():
+    unit = ResourceUnitSpec(
+        query_id="q",
+        resource_unit_id="resource:f:udf",
+        physical_node_id="udf",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(),
+        per_task=ResourceVector(cpu=1, heap_bytes=100),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+        max_concurrency=None,
+    )
+    graph = QueryResourceGraph("q", "sha256:pending", (unit,), (unit.resource_unit_id,))
+    pending = QueryAllocation(
+        resources=ResourceVector(),
+        node_allocations=(),
+        generation=1,
+    )
+
+    manager = register_query_resource_graph(
+        graph,
+        pending,
+        admission_open=False,
+    )
+
+    assert manager.snapshot()["allocation_admission_open"] is False
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
+    blocked = manager.try_acquire_task(
+        TaskRequest(
+            query_id="q",
+            resource_unit_id=unit.resource_unit_id,
+            task_id="task:pending",
+            attempt_id="0",
+            node_id=None,
+        )
+    )
+    assert blocked.blocked_reason == "allocation_pending"
+
+    manager.update_allocation(_allocation(generation=2), admission_open=True)
+    assert manager.try_acquire_task(
+        TaskRequest(
+            query_id="q",
+            resource_unit_id=unit.resource_unit_id,
+            task_id="task:running",
+            attempt_id="0",
+            node_id=None,
+        )
+    ).granted
 
 
 def test_runtime_release_cancels_and_removes_manager_idempotently():
@@ -107,3 +159,70 @@ def test_runtime_release_cancels_and_removes_manager_idempotently():
     assert first["output_lease_count"] == 0
     assert second == {"released": False, "task_lease_count": 0, "output_lease_count": 0}
     assert query_resource_manager_snapshot("q") == {}
+
+
+def test_native_barrier_event_advances_driver_local_execution_phase_once():
+    upstream = ResourceUnitSpec(
+        query_id="q",
+        resource_unit_id="resource:q:upstream",
+        physical_node_id="upstream",
+        unit_kind="native_fragment",
+        backend="ray_worker",
+        input_unit_ids=(),
+        per_task=ResourceVector(),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+        max_concurrency=4,
+    )
+    materializer = ResourceUnitSpec(
+        query_id="q",
+        resource_unit_id="resource:q:materializer",
+        physical_node_id="materializer",
+        unit_kind="native_fragment",
+        backend="ray_worker",
+        input_unit_ids=(upstream.resource_unit_id,),
+        per_task=ResourceVector(),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+        max_concurrency=4,
+    )
+    downstream = ResourceUnitSpec(
+        query_id="q",
+        resource_unit_id="resource:q:downstream",
+        physical_node_id="downstream",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(materializer.resource_unit_id,),
+        per_task=ResourceVector(cpu=1),
+        target_output_block_bytes=10,
+        generator_buffer_blocks=2,
+        max_concurrency=None,
+    )
+    graph = QueryResourceGraph(
+        "q",
+        "sha256:barrier",
+        (upstream, materializer, downstream),
+        (downstream.resource_unit_id,),
+        (
+            MaterializationBarrierSpec(
+                query_id="q",
+                barrier_id="barrier:q:node:materializer",
+                physical_node_id=materializer.physical_node_id,
+                materializer_unit_id=materializer.resource_unit_id,
+                materialized_input_unit_ids=(upstream.resource_unit_id,),
+            ),
+        ),
+    )
+    manager = register_query_resource_graph(graph, _allocation())
+
+    assert manager.current_eligible_resource_unit_ids() == (
+        upstream.resource_unit_id,
+        materializer.resource_unit_id,
+    )
+    assert mark_materialization_barrier_completed("q", "materializer") is True
+    assert mark_materialization_barrier_completed("q", "materializer") is False
+    assert manager.current_eligible_resource_unit_ids() == (
+        materializer.resource_unit_id,
+        downstream.resource_unit_id,
+    )
+    assert manager.snapshot()["allocation_admission_open"] is False

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -1129,7 +1129,7 @@ def test_shuffle_cache_attempt_manifest_runtime_path(tmp_path):
     assert Path(result["committed_path"]).exists()
     manifest = result["manifest"]
     assert "version=1\n" in manifest
-    assert "shuffle_stage_id=shuffle_cache_manifest_test__sink_3__attempt_2\n" in manifest
+    assert "exchange_id=shuffle_cache_manifest_test__sink_3__attempt_2\n" in manifest
     assert "node_id=node-a\n" in manifest
     assert "sink_partition_id=3\n" in manifest
     assert "attempt_id=2\n" in manifest

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -15,7 +15,7 @@ try:
 except Exception:
     ray = None
 
-from ray_test_profile import ray_test_object_store_bytes
+from ray_test_profile import ray_test_object_store_options
 
 import duckdb
 from duckdb import runners as _runners
@@ -28,9 +28,8 @@ def _vane_shuffle_env(monkeypatch):
     monkeypatch.setenv("VANE_SHUFFLE_ALGORITHM", "flight_shuffle")
     monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", "/tmp/duckdb_shuffle")
     monkeypatch.setenv("RAY_DEDUP_LOGS", "0")
-    # The default shared test profile reserves a 2 GiB object store. Keep FTE's
-    # production block target, while sizing UDF windows so multi-actor tests
-    # fit the query's 50% allocation and wide-row batches remain whole.
+    # Keep FTE's production block target, while sizing UDF windows so the
+    # multi-actor fixtures remain lightweight and wide-row batches stay whole.
     monkeypatch.setenv("VANE_UDF_TARGET_MAX_BATCH_BYTES", str(16 * 1024**2))
 
 
@@ -392,7 +391,7 @@ def ray_runner_local_cluster(_vane_shuffle_env):
             logging_level="info",
             log_to_driver=True,
             num_cpus=1,
-            object_store_memory=ray_test_object_store_bytes(),
+            **ray_test_object_store_options(),
         )
 
     try:

--- a/tests/fast/test_ray_env.py
+++ b/tests/fast/test_ray_env.py
@@ -120,7 +120,7 @@ def test_node_local_flight_host_is_not_inherited_from_query_driver(monkeypatch):
 @pytest.mark.ray_cluster_owner
 def test_query_driver_rejects_flight_host_in_ray_job_runtime_env():
     import ray
-    from ray_test_profile import ray_test_object_store_bytes
+    from ray_test_profile import ray_test_object_store_options
 
     from duckdb.runners.ray.driver import RayQueryDriverClient
 
@@ -132,7 +132,7 @@ def test_query_driver_rejects_flight_host_in_ray_job_runtime_env():
             include_dashboard=False,
             log_to_driver=False,
             num_cpus=1,
-            object_store_memory=ray_test_object_store_bytes(),
+            **ray_test_object_store_options(),
             runtime_env={
                 "env_vars": {
                     "VANE_FLIGHT_ADVERTISE_HOST": "job-driver.example.internal",

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -52,7 +52,6 @@ from duckdb.runners.ray.fte_events import (
     WorkerReservationCompleted,
 )
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -417,12 +416,6 @@ def _register_test_query_resource_graph(query_id, fragment_ids, *, max_concurren
         graph,
         QueryAllocation(
             resources=allocation_resources,
-            node_allocations=(
-                NodeResourceAllocation(
-                    node_id=_test_ray_node_id(),
-                    resources=allocation_resources,
-                ),
-            ),
             generation=1,
         ),
     )
@@ -7114,7 +7107,6 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
     manager.update_allocation(
         QueryAllocation(
             resources=ResourceVector(),
-            node_allocations=(),
             generation=2,
         ),
         admission_open=False,
@@ -7148,81 +7140,10 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
     assert stats["resource_unit_submission_block_count"] == 0
 
 
-def test_fte_node_local_denial_keeps_probe_while_trying_another_worker(monkeypatch):
-    from duckdb.runners.ray.query_resource_manager import TaskGrant, TaskLease
-
-    query_id = "query-node-local-retry"
-    fragment_id = _install_manual_test_fragment(query_id, "8")
-    manager = get_query_resource_manager(query_id)
-    resource_unit_id = native_fragment_unit_id_for_fragment(query_id, fragment_id)
-    requests = []
-    lease = TaskLease(
-        lease_id="lease-node-b",
-        query_id=query_id,
-        resource_unit_id=resource_unit_id,
-        task_id="task-node-b",
-        attempt_id="attempt-node-b",
-        node_id="node-b",
-        execution_slot_id="ray_worker:node-b",
-        actor_index=None,
-        resources=ResourceVector(),
-        output_window_bytes=1,
-        liveness=False,
-        allocation_generation=1,
-    )
-
-    def try_descriptor(request):
-        requests.append(request)
-        if request.node_id == "node-a":
-            return TaskGrant(
-                False,
-                blocked_reason="node_capacity",
-                admission_epoch=manager.admission_epoch(),
-            )
-        return TaskGrant(
-            True,
-            lease=lease,
-            admission_epoch=manager.admission_epoch(),
-        )
-
-    monkeypatch.setattr(manager, "try_acquire_task_descriptor", try_descriptor)
-
-    with pytest.raises(FteWorkerReservationUnavailable) as exc_info:
-        worker_handle_mod._acquire_fte_partition_task_lease(
-            query_id=query_id,
-            fragment_execution_id=7,
-            fragment_id=fragment_id,
-            partition_id=0,
-            node_id="node-a",
-            retain_probe_on_node_local_denial=True,
-        )
-
-    assert exc_info.value.blocked_reason == "node_capacity"
-    assert exc_info.value.admission_epoch == manager.admission_epoch()
-    stats = worker_handle_mod.fte_registry_stats()
-    assert stats["resource_unit_submission_probe_count"] == 1
-    assert stats["resource_unit_submission_block_count"] == 0
-
-    granted = worker_handle_mod._acquire_fte_partition_task_lease(
-        query_id=query_id,
-        fragment_execution_id=7,
-        fragment_id=fragment_id,
-        partition_id=0,
-        node_id="node-b",
-        retain_probe_on_node_local_denial=True,
-    )
-
-    assert granted is lease
-    assert [request.node_id for request in requests] == ["node-a", "node-b"]
-    stats = worker_handle_mod.fte_registry_stats()
-    assert stats["resource_unit_submission_probe_count"] == 0
-    assert stats["resource_unit_submission_block_count"] == 0
-
-
-def test_fte_node_local_denials_block_only_after_all_workers_are_tried(monkeypatch):
+def test_fte_aggregate_soft_denial_does_not_retry_a_different_worker(monkeypatch):
     from duckdb.runners.ray.query_resource_manager import TaskGrant
 
-    query_id = "query-node-local-exhausted"
+    query_id = "query-aggregate-soft-denial"
     fragment_id = _install_manual_test_fragment(query_id, "8")
     manager = get_query_resource_manager(query_id)
     requests = []
@@ -7231,61 +7152,11 @@ def test_fte_node_local_denials_block_only_after_all_workers_are_tried(monkeypat
         requests.append(request)
         return TaskGrant(
             False,
-            blocked_reason="node_capacity",
+            blocked_reason="query_soft_object_store_bytes",
             admission_epoch=manager.admission_epoch(),
         )
 
     monkeypatch.setattr(manager, "try_acquire_task_descriptor", try_descriptor)
-
-    class _Worker:
-        _fte_healthy = True
-
-        def __init__(self, worker_id, node_id):
-            self.worker_id = worker_id
-            self.node_id = node_id
-
-    worker_a = _Worker("worker-a", "node-a")
-    worker_b = _Worker("worker-b", "node-b")
-
-    class _Coordinator:
-        def _select_fte_worker(self, *, exclude, **_kwargs):
-            return next(
-                (worker for worker in (worker_a, worker_b) if worker.worker_id not in exclude),
-                None,
-            )
-
-    placement = worker_handle_mod.FteWorkerPlacementManager(_Coordinator())
-
-    with pytest.raises(FteWorkerReservationUnavailable) as exc_info:
-        placement.acquire(
-            query_id=query_id,
-            fragment_id=fragment_id,
-            partition_id=0,
-        )
-
-    assert exc_info.value.blocked_reason == "node_capacity"
-    assert [request.node_id for request in requests] == ["node-a", "node-b"]
-    stats = worker_handle_mod.fte_registry_stats()
-    assert stats["resource_unit_submission_probe_count"] == 0
-    assert stats["resource_unit_submission_block_count"] == 1
-
-
-def test_fte_worker_selection_error_releases_retained_node_local_probe(monkeypatch):
-    from duckdb.runners.ray.query_resource_manager import TaskGrant
-
-    query_id = "query-node-local-selection-error"
-    fragment_id = _install_manual_test_fragment(query_id, "8")
-    manager = get_query_resource_manager(query_id)
-
-    monkeypatch.setattr(
-        manager,
-        "try_acquire_task_descriptor",
-        lambda _request: TaskGrant(
-            False,
-            blocked_reason="node_capacity",
-            admission_epoch=manager.admission_epoch(),
-        ),
-    )
 
     class _Worker:
         _fte_healthy = True
@@ -7298,8 +7169,38 @@ def test_fte_worker_selection_error_releases_retained_node_local_probe(monkeypat
         def _select_fte_worker(self, **_kwargs):
             nonlocal selection_count
             selection_count += 1
-            if selection_count == 1:
-                return _Worker()
+            return _Worker()
+
+    placement = worker_handle_mod.FteWorkerPlacementManager(_Coordinator())
+
+    with pytest.raises(FteWorkerReservationUnavailable) as exc_info:
+        placement.acquire(
+            query_id=query_id,
+            fragment_id=fragment_id,
+            partition_id=0,
+        )
+
+    assert exc_info.value.blocked_reason == "query_soft_object_store_bytes"
+    assert selection_count == 1
+    assert [request.node_id for request in requests] == ["node-a"]
+    stats = worker_handle_mod.fte_registry_stats()
+    assert stats["resource_unit_submission_probe_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 1
+
+
+def test_fte_worker_selection_error_does_not_create_a_qrm_probe(monkeypatch):
+    query_id = "query-worker-selection-error"
+    fragment_id = _install_manual_test_fragment(query_id, "8")
+    manager = get_query_resource_manager(query_id)
+
+    monkeypatch.setattr(
+        manager,
+        "try_acquire_task_descriptor",
+        lambda _request: (_ for _ in ()).throw(AssertionError("QRM must not be consulted before a worker is selected")),
+    )
+
+    class _Coordinator:
+        def _select_fte_worker(self, **_kwargs):
             raise RuntimeError("worker registry changed")
 
     placement = worker_handle_mod.FteWorkerPlacementManager(_Coordinator())

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -1202,6 +1202,34 @@ def test_fte_worker_command_dispatch_preserves_healthy_tail_and_new_outbox_comma
         fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
 
 
+def test_fte_worker_command_wrappers_publish_write_sink_state_without_commands(monkeypatch):
+    coordinator = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-sink-sync",
+    )
+    fragment_execution = SimpleNamespace(pop_worker_commands=lambda: [])
+    mutation_result = FragmentExecutionMutationResult.from_attempts([], [])
+    sink_syncs = []
+    dispatches = []
+    sentinel = object()
+    monkeypatch.setattr(
+        worker_commands_mod,
+        "_sync_write_sink_unit_for_fragment",
+        lambda execution: sink_syncs.append(execution),
+    )
+    monkeypatch.setattr(
+        coordinator,
+        "_execute_fte_fragment_execution_worker_commands",
+        lambda execution, commands: dispatches.append((execution, list(commands))) or sentinel,
+    )
+
+    assert coordinator._execute_fte_fragment_execution_outbox(fragment_execution) is sentinel
+    assert coordinator._execute_fte_fragment_execution_mutation_result(fragment_execution, mutation_result) is sentinel
+    assert sink_syncs == [fragment_execution, fragment_execution]
+    assert dispatches == [(fragment_execution, []), (fragment_execution, [])]
+
+
 def test_fte_worker_command_dispatch_publishes_only_successful_healthy_creates(monkeypatch):
     query_id = "query-command-create-outcomes"
     coordinator = RayWorkerActorHandle(
@@ -7120,6 +7148,174 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
     assert stats["resource_unit_submission_block_count"] == 0
 
 
+def test_fte_node_local_denial_keeps_probe_while_trying_another_worker(monkeypatch):
+    from duckdb.runners.ray.query_resource_manager import TaskGrant, TaskLease
+
+    query_id = "query-node-local-retry"
+    fragment_id = _install_manual_test_fragment(query_id, "8")
+    manager = get_query_resource_manager(query_id)
+    resource_unit_id = native_fragment_unit_id_for_fragment(query_id, fragment_id)
+    requests = []
+    lease = TaskLease(
+        lease_id="lease-node-b",
+        query_id=query_id,
+        resource_unit_id=resource_unit_id,
+        task_id="task-node-b",
+        attempt_id="attempt-node-b",
+        node_id="node-b",
+        execution_slot_id="ray_worker:node-b",
+        actor_index=None,
+        resources=ResourceVector(),
+        output_window_bytes=1,
+        liveness=False,
+        allocation_generation=1,
+    )
+
+    def try_descriptor(request):
+        requests.append(request)
+        if request.node_id == "node-a":
+            return TaskGrant(
+                False,
+                blocked_reason="node_capacity",
+                admission_epoch=manager.admission_epoch(),
+            )
+        return TaskGrant(
+            True,
+            lease=lease,
+            admission_epoch=manager.admission_epoch(),
+        )
+
+    monkeypatch.setattr(manager, "try_acquire_task_descriptor", try_descriptor)
+
+    with pytest.raises(FteWorkerReservationUnavailable) as exc_info:
+        worker_handle_mod._acquire_fte_partition_task_lease(
+            query_id=query_id,
+            fragment_execution_id=7,
+            fragment_id=fragment_id,
+            partition_id=0,
+            node_id="node-a",
+            retain_probe_on_node_local_denial=True,
+        )
+
+    assert exc_info.value.blocked_reason == "node_capacity"
+    assert exc_info.value.admission_epoch == manager.admission_epoch()
+    stats = worker_handle_mod.fte_registry_stats()
+    assert stats["resource_unit_submission_probe_count"] == 1
+    assert stats["resource_unit_submission_block_count"] == 0
+
+    granted = worker_handle_mod._acquire_fte_partition_task_lease(
+        query_id=query_id,
+        fragment_execution_id=7,
+        fragment_id=fragment_id,
+        partition_id=0,
+        node_id="node-b",
+        retain_probe_on_node_local_denial=True,
+    )
+
+    assert granted is lease
+    assert [request.node_id for request in requests] == ["node-a", "node-b"]
+    stats = worker_handle_mod.fte_registry_stats()
+    assert stats["resource_unit_submission_probe_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 0
+
+
+def test_fte_node_local_denials_block_only_after_all_workers_are_tried(monkeypatch):
+    from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+    query_id = "query-node-local-exhausted"
+    fragment_id = _install_manual_test_fragment(query_id, "8")
+    manager = get_query_resource_manager(query_id)
+    requests = []
+
+    def try_descriptor(request):
+        requests.append(request)
+        return TaskGrant(
+            False,
+            blocked_reason="node_capacity",
+            admission_epoch=manager.admission_epoch(),
+        )
+
+    monkeypatch.setattr(manager, "try_acquire_task_descriptor", try_descriptor)
+
+    class _Worker:
+        _fte_healthy = True
+
+        def __init__(self, worker_id, node_id):
+            self.worker_id = worker_id
+            self.node_id = node_id
+
+    worker_a = _Worker("worker-a", "node-a")
+    worker_b = _Worker("worker-b", "node-b")
+
+    class _Coordinator:
+        def _select_fte_worker(self, *, exclude, **_kwargs):
+            return next(
+                (worker for worker in (worker_a, worker_b) if worker.worker_id not in exclude),
+                None,
+            )
+
+    placement = worker_handle_mod.FteWorkerPlacementManager(_Coordinator())
+
+    with pytest.raises(FteWorkerReservationUnavailable) as exc_info:
+        placement.acquire(
+            query_id=query_id,
+            fragment_id=fragment_id,
+            partition_id=0,
+        )
+
+    assert exc_info.value.blocked_reason == "node_capacity"
+    assert [request.node_id for request in requests] == ["node-a", "node-b"]
+    stats = worker_handle_mod.fte_registry_stats()
+    assert stats["resource_unit_submission_probe_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 1
+
+
+def test_fte_worker_selection_error_releases_retained_node_local_probe(monkeypatch):
+    from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+    query_id = "query-node-local-selection-error"
+    fragment_id = _install_manual_test_fragment(query_id, "8")
+    manager = get_query_resource_manager(query_id)
+
+    monkeypatch.setattr(
+        manager,
+        "try_acquire_task_descriptor",
+        lambda _request: TaskGrant(
+            False,
+            blocked_reason="node_capacity",
+            admission_epoch=manager.admission_epoch(),
+        ),
+    )
+
+    class _Worker:
+        _fte_healthy = True
+        worker_id = "worker-a"
+        node_id = "node-a"
+
+    selection_count = 0
+
+    class _Coordinator:
+        def _select_fte_worker(self, **_kwargs):
+            nonlocal selection_count
+            selection_count += 1
+            if selection_count == 1:
+                return _Worker()
+            raise RuntimeError("worker registry changed")
+
+    placement = worker_handle_mod.FteWorkerPlacementManager(_Coordinator())
+
+    with pytest.raises(RuntimeError, match="worker registry changed"):
+        placement.acquire(
+            query_id=query_id,
+            fragment_id=fragment_id,
+            partition_id=0,
+        )
+
+    stats = worker_handle_mod.fte_registry_stats()
+    assert stats["resource_unit_submission_probe_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 0
+
+
 def test_fte_worker_capacity_tracks_all_node_waiters_without_a_second_cap(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,
@@ -10810,10 +11006,16 @@ def test_fte_status_handler_keeps_watcher_until_terminal_status(monkeypatch):
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
     watcher = _Watcher()
     fragment_execution = _FragmentExecution()
+    sink_syncs = []
     monkeypatch.setattr(
         worker_events_mod,
         "fragment_execution_key_for_fte_attempt",
         lambda _attempt_id: (query_id, fragment_id),
+    )
+    monkeypatch.setattr(
+        worker_events_mod,
+        "_sync_write_sink_unit_for_fragment",
+        lambda execution: sink_syncs.append(execution),
     )
     monkeypatch.setattr(handle, "_drain_fte_pending_tasks", lambda **_kwargs: [])
     worker_handle_mod._FTE_STATUS_WATCHERS[str(attempt_id)] = watcher
@@ -10828,6 +11030,7 @@ def test_fte_status_handler_keeps_watcher_until_terminal_status(monkeypatch):
         )
         assert watcher.stop_count == 0
         assert fragment_execution.statuses[-1]["task_stats"]["processed_input_rows"] == 5
+        assert sink_syncs == []
 
         handle._handles_for_task_status_changed_event(
             TaskStatusChanged.from_status(
@@ -10841,6 +11044,7 @@ def test_fte_status_handler_keeps_watcher_until_terminal_status(monkeypatch):
             "RUNNING",
             "FINISHED",
         ]
+        assert sink_syncs == [fragment_execution]
     finally:
         worker_handle_mod._FTE_STATUS_WATCHERS.pop(str(attempt_id), None)
         worker_handle_mod._FTE_FRAGMENT_EXECUTIONS.pop((query_id, fragment_id), None)

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -51,18 +51,18 @@ from duckdb.runners.ray.fte_events import (
     WorkerFailed,
     WorkerReservationCompleted,
 )
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
-from duckdb.runners.ray.query_graph_builder import fte_stage_id_for_fragment
+from duckdb.runners.ray.query_resource_graph_builder import native_fragment_unit_id_for_fragment
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
     get_query_resource_manager,
-    register_query_graph,
+    register_query_resource_graph,
 )
 from duckdb.runners.ray.worker_handle import RayWorkerActorHandle as _ProductionRayWorkerActorHandle
 
@@ -307,8 +307,8 @@ class _FakeTask:
         if query_id and node_id:
             self._context.setdefault("resource_query_id", query_id)
             self._context.setdefault(
-                "resource_stage_id",
-                f"stage:{query_id}:node:{node_id}:fte",
+                "resource_unit_id",
+                f"resource:{query_id}:fragment:node:{node_id}",
             )
         self._inputs = inputs or {}
         self._plan = plan if plan is not None else {"plan": name}
@@ -378,7 +378,7 @@ def _exchange_selector_payload(
     return payload
 
 
-def _register_test_query_graph(query_id, fragment_ids, *, max_concurrency=256):
+def _register_test_query_resource_graph(query_id, fragment_ids, *, max_concurrency=256):
     try:
         return get_query_resource_manager(query_id)
     except KeyError:
@@ -388,14 +388,14 @@ def _register_test_query_graph(query_id, fragment_ids, *, max_concurrency=256):
     fragment_ids.update(
         f"{query_id}:node:{node_id}" for node_id in ("scan", "exchange", "upstream-worker", "worker-retry")
     )
-    stages = tuple(
-        StageResourceSpec(
+    units = tuple(
+        ResourceUnitSpec(
             query_id=query_id,
-            stage_id=fte_stage_id_for_fragment(query_id, fragment_id),
-            physical_node_id=f"node:{fragment_id.rsplit(':node:', 1)[1]}:fte",
-            stage_kind="fte",
+            resource_unit_id=native_fragment_unit_id_for_fragment(query_id, fragment_id),
+            physical_node_id=f"node:{fragment_id.rsplit(':node:', 1)[1]}:native-fragment",
+            unit_kind="native_fragment",
             backend="ray_worker",
-            input_stage_ids=(),
+            input_unit_ids=(),
             per_task=ResourceVector(cpu=1, heap_bytes=10),
             target_output_block_bytes=1,
             generator_buffer_blocks=1,
@@ -403,18 +403,18 @@ def _register_test_query_graph(query_id, fragment_ids, *, max_concurrency=256):
         )
         for fragment_id in sorted(fragment_ids)
     )
-    graph = QueryExecutionGraph(
+    graph = QueryResourceGraph(
         query_id=query_id,
         plan_digest=f"sha256:test:{query_id}",
-        stages=stages,
-        terminal_stage_ids=tuple(stage.stage_id for stage in stages),
+        units=units,
+        terminal_unit_ids=tuple(unit.resource_unit_id for unit in units),
     )
     allocation_resources = ResourceVector(
         cpu=256,
         heap_bytes=2560,
         object_store_bytes=256,
     )
-    manager = register_query_graph(
+    manager = register_query_resource_graph(
         graph,
         QueryAllocation(
             resources=allocation_resources,
@@ -428,21 +428,21 @@ def _register_test_query_graph(query_id, fragment_ids, *, max_concurrency=256):
             generation=1,
         ),
     )
-    for stage in stages:
-        manager.update_stage_state(stage.stage_id, runnable=True)
+    for unit in units:
+        manager.update_unit_state(unit.resource_unit_id, runnable=True)
     return manager
 
 
 def _install_manual_test_fragment(query_id, node_id, *, partition_count=1):
     fragment_id = f"{query_id}:node:{node_id}"
-    _register_test_query_graph(query_id, [fragment_id])
+    _register_test_query_resource_graph(query_id, [fragment_id])
     fragment_execution = FteFragmentExecution(
         query_id,
         7,
         fragment_id=fragment_id,
         context={
             "resource_query_id": query_id,
-            "resource_stage_id": f"stage:{query_id}:node:{node_id}:fte",
+            "resource_unit_id": f"resource:{query_id}:fragment:node:{node_id}",
         },
         task_memory_bytes=10,
     )
@@ -467,8 +467,8 @@ def _patch_ray_worker_handle_test_state(monkeypatch):
     worker_handle_mod._FTE_WORKER_RESERVATION_GENERATIONS.clear()
     worker_handle_mod._FTE_PENDING_WORKER_RESERVATIONS.clear()
     worker_handle_mod._FTE_PARTITION_TASK_WAITERS.clear()
-    worker_handle_mod._FTE_STAGE_SUBMISSION_PROBES.clear()
-    worker_handle_mod._FTE_STAGE_SUBMISSION_BLOCKS.clear()
+    worker_handle_mod._FTE_RESOURCE_UNIT_SUBMISSION_PROBES.clear()
+    worker_handle_mod._FTE_RESOURCE_UNIT_SUBMISSION_BLOCKS.clear()
     worker_handle_mod._FTE_PARTITION_TASK_LEASES.clear()
     worker_handle_mod._FTE_RESULT_HANDLES_BY_QUERY.clear()
     worker_handle_mod._FTE_RETRY_DELAYS.clear()
@@ -507,7 +507,7 @@ def _patch_ray_worker_handle_test_state(monkeypatch):
                 continue
             stages_by_query.setdefault(query_id, set()).add(fragment_id)
         for query_id, fragment_ids in stages_by_query.items():
-            _register_test_query_graph(query_id, fragment_ids)
+            _register_test_query_resource_graph(query_id, fragment_ids)
         return original_submit_tasks(handle, tasks)
 
     original_get_or_create = RayWorkerActorHandle._get_or_create_fte_fragment_execution
@@ -516,14 +516,14 @@ def _patch_ray_worker_handle_test_state(monkeypatch):
         query_id = str(item["query_id"])
         fragment_id = str(item["fragment_id"])
         if ":node:" in fragment_id:
-            _register_test_query_graph(query_id, [fragment_id])
-            stage_id = fte_stage_id_for_fragment(query_id, fragment_id)
+            _register_test_query_resource_graph(query_id, [fragment_id])
+            resource_unit_id = native_fragment_unit_id_for_fragment(query_id, fragment_id)
             item = dict(item)
             item.setdefault("resource_query_id", query_id)
-            item.setdefault("resource_stage_id", stage_id)
+            item.setdefault("resource_unit_id", resource_unit_id)
             item["context"] = {
                 "resource_query_id": query_id,
-                "resource_stage_id": stage_id,
+                "resource_unit_id": resource_unit_id,
                 **dict(item.get("context") or {}),
             }
         return original_get_or_create(handle, item, *args, **kwargs)
@@ -599,7 +599,7 @@ def test_fte_materialized_sink_identity_is_independent_of_fragment_registration_
     second_query_id = "query-logical-fragment-order-b"
     node_ids = ("7", "42")
     for query_id in (first_query_id, second_query_id):
-        _register_test_query_graph(
+        _register_test_query_resource_graph(
             query_id,
             [f"{query_id}:node:{node_id}" for node_id in node_ids],
         )
@@ -656,8 +656,8 @@ def test_fte_materialized_sink_identity_distinguishes_explicit_fragments_in_one_
 
     def submit_fragments(resource_query_id, ordered_task_indices):
         execution_query_id = f"{resource_query_id}_orderby_42_final"
-        resource_stage_id = f"stage:{resource_query_id}:node:42:fte"
-        _register_test_query_graph(resource_query_id, [f"{resource_query_id}:node:42"])
+        resource_unit_id = f"resource:{resource_query_id}:fragment:node:42"
+        _register_test_query_resource_graph(resource_query_id, [f"{resource_query_id}:node:42"])
         request_offset = len(_create_requests(actor))
         handles = handle.submit_tasks(
             [
@@ -666,7 +666,7 @@ def test_fte_materialized_sink_identity_distinguishes_explicit_fragments_in_one_
                     context={
                         "query_id": execution_query_id,
                         "resource_query_id": resource_query_id,
-                        "resource_stage_id": resource_stage_id,
+                        "resource_unit_id": resource_unit_id,
                         "fragment_id": f"{execution_query_id}:orderby:42:OrderByFinal:{task_idx}",
                         "stable_task_partition_id": str(task_idx),
                     },
@@ -810,11 +810,11 @@ def test_submit_tasks_registers_fragment_and_creates_fte_task():
         "query_id": "query-1",
         "node_id": "17",
         "resource_query_id": "query-1",
-        "resource_stage_id": "stage:query-1:node:17:fte",
+        "resource_unit_id": "resource:query-1:fragment:node:17",
     }
     assert request["worker_runtime"] == "fte"
     assert request["fragment_plan"] is None
-    assert request["query_task_lease"]["stage_id"] == "stage:query-1:node:17:fte"
+    assert request["query_task_lease"]["resource_unit_id"] == "resource:query-1:fragment:node:17"
     assert request["query_task_lease"]["attempt_id"] == str(handles[0].task_id)
     assert request["query_task_lease"]["resources"]["heap_bytes"] == 10
     assert "duckdb_memory_bytes" not in request["query_task_lease"]
@@ -835,7 +835,7 @@ def test_submit_tasks_rejects_fragment_without_pre_registered_physical_node_id()
         plan={"plan": "aggregate"},
     )
 
-    with pytest.raises(ValueError, match="requires resource_query_id and resource_stage_id"):
+    with pytest.raises(ValueError, match="requires resource_query_id and resource_unit_id"):
         handle.submit_tasks([task])
 
     assert _create_requests(actor) == []
@@ -871,7 +871,7 @@ def test_submit_tasks_creates_fte_tasks_for_distinct_fragments():
     assert actor.fragment_calls == []
 
 
-def test_submit_tasks_coalesces_same_fragment_scan_splits_in_fte_stage():
+def test_submit_tasks_coalesces_same_fragment_scan_splits_in_fte_fragment_execution():
     actor = _FakeActor()
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
     task0 = _FakeTask(
@@ -934,7 +934,7 @@ def test_submit_tasks_allows_copy_tasks_with_attempt_aware_final_writes():
     assert task.plan_calls == 1
 
 
-def test_submit_tasks_rejects_variant_fragment_ids_outside_physical_stage_identity():
+def test_submit_tasks_rejects_variant_fragment_ids_outside_registered_resource_unit_identity():
     actor = _FakeActor()
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
     task0 = _FakeTask(
@@ -955,7 +955,7 @@ def test_submit_tasks_rejects_variant_fragment_ids_outside_physical_stage_identi
         },
         plan={"plan": "exchange-b"},
     )
-    with pytest.raises(ValueError, match="invalid FTE fragment_id"):
+    with pytest.raises(ValueError, match="invalid native fragment_id"):
         handle.submit_tasks([task0, task1])
 
     assert _create_requests(actor) == []
@@ -5173,13 +5173,13 @@ def test_fte_node_wait_placement_rechecks_terminal_partition_after_admission(mon
         fragment_id=fragment_id,
         context={
             "resource_query_id": query_id,
-            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+            "resource_unit_id": f"resource:{query_id}:fragment:node:7",
         },
         task_memory_bytes=64,
     )
     partition = stage.add_partition(0)
     next_partition = stage.add_partition(1)
-    _register_test_query_graph(query_id, [fragment_id])
+    _register_test_query_resource_graph(query_id, [fragment_id])
     monkeypatch.setitem(
         worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
         (query_id, fragment_id),
@@ -5257,7 +5257,7 @@ def test_fte_ready_attempt_releases_admission_when_partition_finishes_before_han
         fragment_id=fragment_id,
         context={
             "resource_query_id": query_id,
-            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+            "resource_unit_id": f"resource:{query_id}:fragment:node:7",
         },
         task_memory_bytes=64,
     )
@@ -5265,7 +5265,7 @@ def test_fte_ready_attempt_releases_admission_when_partition_finishes_before_han
     next_partition = stage.add_partition(1)
     with stage._state_lock:
         partition.mark_ready_for_execution()
-    _register_test_query_graph(query_id, [fragment_id])
+    _register_test_query_resource_graph(query_id, [fragment_id])
     monkeypatch.setitem(
         worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
         (query_id, fragment_id),
@@ -5343,12 +5343,12 @@ def test_fte_async_reservation_releases_admission_for_terminal_partition(monkeyp
         fragment_id=fragment_id,
         context={
             "resource_query_id": query_id,
-            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+            "resource_unit_id": f"resource:{query_id}:fragment:node:7",
         },
         task_memory_bytes=64,
     )
     partition = stage.add_partition(0)
-    _register_test_query_graph(query_id, [fragment_id])
+    _register_test_query_resource_graph(query_id, [fragment_id])
     monkeypatch.setitem(
         worker_handle_mod._FTE_FRAGMENT_EXECUTIONS,
         (query_id, fragment_id),
@@ -5454,7 +5454,7 @@ def test_fte_async_placement_releases_reservation_when_partition_finishes_before
         fragment_id=fragment_id,
         context={
             "resource_query_id": query_id,
-            "resource_stage_id": f"stage:{query_id}:node:7:fte",
+            "resource_unit_id": f"resource:{query_id}:fragment:node:7",
         },
         task_memory_bytes=64,
     )
@@ -5517,7 +5517,7 @@ def test_fte_async_placement_releases_reservation_when_partition_finishes_before
     ]
 
 
-def test_fte_registry_stats_reports_query_stage_partition_metrics(monkeypatch):
+def test_fte_registry_stats_reports_query_fragment_partition_metrics(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,
         "_fte_task_handle_cls",
@@ -5536,16 +5536,16 @@ def test_fte_registry_stats_reports_query_stage_partition_metrics(monkeypatch):
 
     stats = handle.fte_registry_stats()
     query = stats["queries"]["query-fte-metrics"]
-    stage = query["fragment_executions"]["query-fte-metrics:node:7"]
-    partition = stage["partitions"]["0"]
+    fragment = query["fragment_executions"]["query-fte-metrics:node:7"]
+    partition = fragment["partitions"]["0"]
 
     assert [str(task_handle.task_id) for task_handle in task_handles] == ["query-fte-metrics.0.0.0"]
     assert query["fragment_execution_count"] == 1
     assert query["partition_count"] == 1
     assert query["running_count"] == 1
     assert query["waiting_for_node_count"] == 0
-    assert stage["running_count"] == 1
-    assert stage["execution_class_counts"] == {"STANDARD": 1}
+    assert fragment["running_count"] == 1
+    assert fragment["execution_class_counts"] == {"STANDARD": 1}
     assert partition["state"] == "RUNNING"
     assert partition["owner_worker_id"] == "worker-0"
     assert partition["initial_split_count_by_source"] == {"7": 1}
@@ -6521,7 +6521,7 @@ def _completed_test_reservation(future, worker):
         fragment_id=future.fragment_id,
         partition_id=future.partition_id,
         worker=worker,
-        stage_id=fte_stage_id_for_fragment(future.query_id, future.fragment_id),
+        resource_unit_id=native_fragment_unit_id_for_fragment(future.query_id, future.fragment_id),
         task_lease_id=f"test-lease-{future.reservation_generation}",
         attempt_id=f"{future.query_id}.{future.fragment_execution_id}.{future.partition_id}.0",
     )
@@ -7099,11 +7099,11 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
         )
 
     assert exc_info.value.blocked_reason == "allocation_pending"
-    stage_id = fte_stage_id_for_fragment(query_id, fragment_id)
-    assert manager.snapshot()["stages"][stage_id]["pending_task_count"] == 0
+    resource_unit_id = native_fragment_unit_id_for_fragment(query_id, fragment_id)
+    assert manager.snapshot()["units"][resource_unit_id]["pending_task_count"] == 0
     stats = worker_handle_mod.fte_registry_stats()
     assert stats["partition_task_waiter_count"] == 0
-    assert stats["stage_submission_block_count"] == 1
+    assert stats["resource_unit_submission_block_count"] == 1
 
     worker_handle_mod.FteWorkerPlacementManager.release_owner(
         query_id=query_id,
@@ -7111,10 +7111,10 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
         partition_id=0,
     )
 
-    assert manager.snapshot()["stages"][stage_id]["pending_task_count"] == 0
+    assert manager.snapshot()["units"][resource_unit_id]["pending_task_count"] == 0
     stats = worker_handle_mod.fte_registry_stats()
     assert stats["partition_task_waiter_count"] == 0
-    assert stats["stage_submission_block_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 0
 
 
 def test_fte_worker_capacity_tracks_all_node_waiters_without_a_second_cap(monkeypatch):
@@ -7190,7 +7190,7 @@ def test_fte_worker_capacity_tracks_all_node_waiters_without_a_second_cap(monkey
 
 
 def test_fte_dynamic_exchange_running_window_defers_extra_partitions(monkeypatch):
-    _register_test_query_graph(
+    _register_test_query_resource_graph(
         "query-dynamic-window",
         ["query-dynamic-window:node:8"],
         max_concurrency=1,
@@ -7234,11 +7234,14 @@ def test_fte_dynamic_exchange_running_window_defers_extra_partitions(monkeypatch
     assert stage.partitions[1].ready_for_scheduling is False
     assert stage.partitions[1].execution_ready_deferred is True
     assert stage.partitions[1].node_wait_started_at is None
-    stage_id = fte_stage_id_for_fragment(
+    resource_unit_id = native_fragment_unit_id_for_fragment(
         "query-dynamic-window",
         stage.fragment_id,
     )
-    assert get_query_resource_manager("query-dynamic-window").snapshot()["stages"][stage_id]["pending_task_count"] == 0
+    assert (
+        get_query_resource_manager("query-dynamic-window").snapshot()["units"][resource_unit_id]["pending_task_count"]
+        == 0
+    )
     assert [call[1]["task_id"]["partition_id"] for call in actor.fte_calls if call[0] == "create"] == [0]
     assert [str(task_handle.task_id) for task_handle in handle.pop_fte_result_handles("query-dynamic-window")] == [
         "query-dynamic-window.0.0.0"
@@ -7259,7 +7262,7 @@ def test_fte_dynamic_exchange_running_window_defers_extra_partitions(monkeypatch
 def test_fte_submission_window_keeps_36_descriptors_but_only_7_in_qrm(monkeypatch):
     query_id = "query-36-descriptors-7-running"
     fragment_id = f"{query_id}:node:8"
-    _register_test_query_graph(query_id, [fragment_id], max_concurrency=7)
+    _register_test_query_resource_graph(query_id, [fragment_id], max_concurrency=7)
     monkeypatch.setattr(
         fragment_submission_mod,
         "_split_exchange_source_task_by_partition",
@@ -7288,19 +7291,19 @@ def test_fte_submission_window_keeps_36_descriptors_but_only_7_in_qrm(monkeypatc
 
     handles = handle.submit_tasks(tasks)
     stage = worker_handle_mod._FTE_FRAGMENT_EXECUTIONS[(query_id, fragment_id)]
-    stage_id = fte_stage_id_for_fragment(query_id, fragment_id)
+    resource_unit_id = native_fragment_unit_id_for_fragment(query_id, fragment_id)
     manager = get_query_resource_manager(query_id)
     snapshot = manager.snapshot()
     stats = handle.fte_registry_stats()
 
     assert len(stage.partitions) == 36
     assert [attempt.task_id.partition_id for attempt in handles] == list(range(7))
-    assert snapshot["stages"][stage_id]["active_task_count"] == 7
-    assert snapshot["stages"][stage_id]["pending_task_count"] == 0
+    assert snapshot["units"][resource_unit_id]["active_task_count"] == 7
+    assert snapshot["units"][resource_unit_id]["pending_task_count"] == 0
     assert stats["partition_task_waiter_count"] == 0
     assert stats["pending_worker_reservation_count"] == 0
-    assert stats["stage_submission_probe_count"] == 0
-    assert stats["stage_submission_block_count"] == 1
+    assert stats["resource_unit_submission_probe_count"] == 0
+    assert stats["resource_unit_submission_block_count"] == 1
     assert sum(partition.execution_ready_deferred for partition in stage.partitions.values()) == 29
     assert (
         sum(
@@ -7322,8 +7325,8 @@ def test_fte_submission_window_keeps_36_descriptors_but_only_7_in_qrm(monkeypatc
     stats = handle.fte_registry_stats()
 
     assert [attempt.task_id.partition_id for attempt in refill] == [7]
-    assert snapshot["stages"][stage_id]["active_task_count"] == 7
-    assert snapshot["stages"][stage_id]["pending_task_count"] == 0
+    assert snapshot["units"][resource_unit_id]["active_task_count"] == 7
+    assert snapshot["units"][resource_unit_id]["pending_task_count"] == 0
     assert stats["partition_task_waiter_count"] == 0
     assert stats["pending_worker_reservation_count"] == 0
     assert sum(partition.execution_ready_deferred for partition in stage.partitions.values()) == 28
@@ -7654,7 +7657,7 @@ def test_fte_resource_waiter_scan_isolates_failed_query():
     class _FragmentExecution:
         context = {
             "resource_query_id": resource_query_id,
-            "resource_stage_id": f"stage:{resource_query_id}:node:8:fte",
+            "resource_unit_id": f"resource:{resource_query_id}:fragment:node:8",
         }
 
         def __init__(self, error=None):
@@ -9933,7 +9936,7 @@ def test_fte_exchange_selector_event_requires_selector_payload(monkeypatch):
 
 
 def test_fte_exchange_selector_event_updates_running_and_pending_consumers(monkeypatch):
-    _register_test_query_graph(
+    _register_test_query_resource_graph(
         "query-fte-selector-mixed",
         ["query-fte-selector-mixed:node:8"],
         max_concurrency=1,
@@ -11950,7 +11953,7 @@ def test_ray_worker_fte_debug_logs_use_worker_topology(monkeypatch, capsys):
                     "lease_id": "lease-ray-log",
                     "query_id": "ray-log",
                     "execution_query_id": "ray-log",
-                    "stage_id": "stage:ray-log:node:scan:fte",
+                    "resource_unit_id": "resource:ray-log:fragment:node:scan",
                     "task_id": "ray-log.0.0",
                     "attempt_id": "ray-log.0.0.0",
                     "resources": {

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -115,7 +115,6 @@ class RayWorkerActorHandle(_ProductionRayWorkerActorHandle):
                     "pipeline_id": 1,
                     "operators": ["TABLE_SCAN"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             ],
         }
@@ -396,7 +395,7 @@ def _register_test_query_resource_graph(query_id, fragment_ids, *, max_concurren
             unit_kind="native_fragment",
             backend="ray_worker",
             input_unit_ids=(),
-            per_task=ResourceVector(cpu=1, heap_bytes=10),
+            per_task=ResourceVector(),
             target_output_block_bytes=1,
             generator_buffer_blocks=1,
             max_concurrency=max_concurrency,
@@ -526,7 +525,13 @@ def _patch_ray_worker_handle_test_state(monkeypatch):
                 "resource_unit_id": resource_unit_id,
                 **dict(item.get("context") or {}),
             }
-        return original_get_or_create(handle, item, *args, **kwargs)
+        fragment_execution = original_get_or_create(handle, item, *args, **kwargs)
+        # Keep the worker-reservation race tests exercising an explicit
+        # synthetic requirement. Production Ray native fragments pass None
+        # and delegate working-memory admission to DuckDB.
+        if fragment_execution.task_memory_bytes is None:
+            fragment_execution.task_memory_bytes = 10
+        return fragment_execution
 
     monkeypatch.setattr(RayWorkerActorHandle, "submit_tasks", _submit_tasks_with_registered_test_graph)
     monkeypatch.setattr(
@@ -816,7 +821,7 @@ def test_submit_tasks_registers_fragment_and_creates_fte_task():
     assert request["fragment_plan"] is None
     assert request["query_task_lease"]["resource_unit_id"] == "resource:query-1:fragment:node:17"
     assert request["query_task_lease"]["attempt_id"] == str(handles[0].task_id)
-    assert request["query_task_lease"]["resources"]["heap_bytes"] == 10
+    assert request["query_task_lease"]["resources"]["heap_bytes"] == 0
     assert "duckdb_memory_bytes" not in request["query_task_lease"]
     assert request["memory_requirement_bytes"] == 10
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -423,7 +423,6 @@ def _register_test_query_resource_graph(query_id, fragment_ids, *, max_concurren
                     resources=allocation_resources,
                 ),
             ),
-            actor_placements=(),
             generation=1,
         ),
     )
@@ -7088,7 +7087,6 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
         QueryAllocation(
             resources=ResourceVector(),
             node_allocations=(),
-            actor_placements=(),
             generation=2,
         ),
         admission_open=False,

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -271,7 +271,6 @@ def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_sl
                     resources=allocation_resources,
                 ),
             ),
-            actor_placements=(),
             generation=1,
         ),
     )

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -2363,13 +2363,13 @@ def test_fte_worker_command_outbox_pop_owns_attempt_scheduling_lock():
 
 
 def test_fte_fragment_without_native_heap_requirement_omits_request_memory():
-    stage = FteFragmentExecution(
+    fragment = FteFragmentExecution(
         "query-duckdb-memory",
         0,
         fragment_id="query-duckdb-memory:node:1",
         task_memory_bytes=None,
     )
-    partition = stage.add_partition(0)
+    partition = fragment.add_partition(0)
 
     scheduled = partition.start_attempt(
         worker_id="worker-a",

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -57,16 +57,16 @@ from duckdb.runners.ray.fte import (
 )
 from duckdb.runners.ray.fte_attempts import RunningAttempt
 from duckdb.runners.ray.fte_events import FteAddSplitsCommand
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
-    register_query_graph,
+    register_query_resource_graph,
 )
 
 
@@ -108,7 +108,7 @@ def test_fte_partition_admission_uses_non_persistent_descriptor_arbitration(monk
         "_fte_fragment_resource_identity",
         lambda query_id, _fragment_id: (
             query_id,
-            f"stage:{query_id}:node:scan:fte",
+            f"resource:{query_id}:fragment:node:scan",
         ),
     )
     monkeypatch.setattr(
@@ -236,32 +236,32 @@ async def _wait_for_terminal_task_status(manager, task_id, initial_status):
 
 
 def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_slots: int):
-    stage_id = f"stage:{query_id}:node:{node_id}:fte"
-    graph = QueryExecutionGraph(
+    resource_unit_id = f"resource:{query_id}:fragment:node:{node_id}"
+    graph = QueryResourceGraph(
         query_id=query_id,
         plan_digest=f"sha256:{query_id}",
-        stages=(
-            StageResourceSpec(
+        units=(
+            ResourceUnitSpec(
                 query_id=query_id,
-                stage_id=stage_id,
-                physical_node_id=f"node:{node_id}:fte",
-                stage_kind="fte",
+                resource_unit_id=resource_unit_id,
+                physical_node_id=f"node:{node_id}:native-fragment",
+                unit_kind="native_fragment",
                 backend="ray_worker",
-                input_stage_ids=(),
+                input_unit_ids=(),
                 per_task=ResourceVector(cpu=1, heap_bytes=2 * _GIB),
                 target_output_block_bytes=128 * _MIB,
                 generator_buffer_blocks=2,
                 max_concurrency=partitions,
             ),
         ),
-        terminal_stage_ids=(stage_id,),
+        terminal_unit_ids=(resource_unit_id,),
     )
     allocation_resources = ResourceVector(
         cpu=task_slots,
         heap_bytes=task_slots * 2 * _GIB,
         object_store_bytes=task_slots * 256 * _MIB,
     )
-    manager = register_query_graph(
+    manager = register_query_resource_graph(
         graph,
         QueryAllocation(
             resources=allocation_resources,
@@ -275,15 +275,15 @@ def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_sl
             generation=1,
         ),
     )
-    manager.update_stage_state(stage_id, runnable=True)
-    return manager, stage_id
+    manager.update_unit_state(resource_unit_id, runnable=True)
+    return manager, resource_unit_id
 
 
 def _install_fte_fragment(query_id: str, node_id: str, *, partitions: int, context=None):
     fragment_id = f"{query_id}:node:{node_id}"
     stage_context = {
         "resource_query_id": query_id,
-        "resource_stage_id": f"stage:{query_id}:node:{node_id}:fte",
+        "resource_unit_id": f"resource:{query_id}:fragment:node:{node_id}",
         **dict(context or {}),
     }
     stage = _fte_fragment_execution(
@@ -324,10 +324,10 @@ def test_fte_failure_retryability_parses_boolean_strings():
     assert _failure_allows_retry({"retryable": "false"}) is False
 
 
-def test_fte_stage_uses_one_global_lease_domain_for_all_36_partitions():
-    query_id = "q-fte-stage-leases"
+def test_fte_fragment_execution_uses_one_global_lease_domain_for_all_36_partitions():
+    query_id = "q-fte-fragment-execution-leases"
     clear_query_resource_managers()
-    manager, stage_id = _register_fte_query(query_id, "scan", partitions=36, task_slots=14)
+    manager, resource_unit_id = _register_fte_query(query_id, "scan", partitions=36, task_slots=14)
     _, fragment_id = _install_fte_fragment(query_id, "scan", partitions=36)
     worker = _PlacementWorker()
     placement = fte_fragment_scheduler.FteWorkerPlacementManager(_PlacementCoordinator(worker))
@@ -347,9 +347,9 @@ def test_fte_stage_uses_one_global_lease_domain_for_all_36_partitions():
 
         snapshot = manager.snapshot()
         assert len(reservations) == 14
-        assert {reservation.stage_id for reservation in reservations} == {stage_id}
+        assert {reservation.resource_unit_id for reservation in reservations} == {resource_unit_id}
         assert len({reservation.task_lease_id for reservation in reservations}) == 14
-        assert snapshot["stages"][stage_id]["active_task_count"] == 14
+        assert snapshot["units"][resource_unit_id]["active_task_count"] == 14
         assert snapshot["liveness"]["task_grants_total"] == 0
         assert len(snapshot["task_leases"]) == 14
     finally:
@@ -359,7 +359,7 @@ def test_fte_stage_uses_one_global_lease_domain_for_all_36_partitions():
 def test_fte_task_lease_uses_attempt_identity_and_releases_once_at_terminal():
     query_id = "q-fte-attempt-lease"
     clear_query_resource_managers()
-    manager, stage_id = _register_fte_query(query_id, "scan", partitions=1, task_slots=1)
+    manager, resource_unit_id = _register_fte_query(query_id, "scan", partitions=1, task_slots=1)
     stage, fragment_id = _install_fte_fragment(query_id, "scan", partitions=1)
     worker = _PlacementWorker()
     placement = fte_fragment_scheduler.FteWorkerPlacementManager(_PlacementCoordinator(worker))
@@ -367,7 +367,7 @@ def test_fte_task_lease_uses_attempt_identity_and_releases_once_at_terminal():
         reservation = placement.acquire(query_id=query_id, fragment_id=fragment_id, partition_id=0)
         expected_attempt = FteTaskAttemptId(stage.partitions[0].task_id, 0)
 
-        assert reservation.stage_id == stage_id
+        assert reservation.resource_unit_id == resource_unit_id
         assert reservation.attempt_id == str(expected_attempt)
         lease = manager.snapshot()["task_leases"][reservation.task_lease_id]
         assert lease["task_id"] == str(stage.partitions[0].task_id)
@@ -387,7 +387,7 @@ def test_internal_fte_query_uses_outer_query_resource_identity():
     execution_query_id = f"{resource_query_id}_orderby_stage"
     fragment_id = f"{execution_query_id}:orderby:2:stage:0"
     clear_query_resource_managers()
-    manager, stage_id = _register_fte_query(
+    manager, resource_unit_id = _register_fte_query(
         resource_query_id,
         "scan",
         partitions=1,
@@ -399,7 +399,7 @@ def test_internal_fte_query_uses_outer_query_resource_identity():
         fragment_id=fragment_id,
         context={
             "resource_query_id": resource_query_id,
-            "resource_stage_id": stage_id,
+            "resource_unit_id": resource_unit_id,
         },
     )
     stage.add_partition(0)
@@ -421,7 +421,7 @@ def test_internal_fte_query_uses_outer_query_resource_identity():
             reservation.attempt_id,
         )
 
-        assert reservation.stage_id == stage_id
+        assert reservation.resource_unit_id == resource_unit_id
         assert manager.snapshot()["task_leases"][reservation.task_lease_id]["query_id"] == resource_query_id
         assert payload["query_id"] == resource_query_id
         assert payload["execution_query_id"] == execution_query_id
@@ -474,11 +474,11 @@ def test_fte_worker_selection_or_reservation_failure_releases_task_lease(worker,
         _cleanup_fte_query(query_id)
 
 
-def test_fte_write_sink_updates_registered_stage_state_instead_of_registering_an_operator():
-    query_id = "q-write-sink-stage"
+def test_fte_write_sink_updates_registered_unit_state_instead_of_registering_an_operator():
+    query_id = "q-write-sink-unit"
     clear_query_resource_managers()
-    manager, stage_id = _register_fte_query(query_id, "sink", partitions=1, task_slots=1)
-    stage, fragment_id = _install_fte_fragment(
+    manager, resource_unit_id = _register_fte_query(query_id, "sink", partitions=1, task_slots=1)
+    fragment_execution, fragment_id = _install_fte_fragment(
         query_id,
         "sink",
         partitions=1,
@@ -490,22 +490,22 @@ def test_fte_write_sink_updates_registered_stage_state_instead_of_registering_an
         },
     )
     try:
-        fte_fragment_scheduler._sync_write_sink_stage_for_fragment(stage)
-        assert manager.snapshot()["stages"][stage_id]["runnable"] is False
+        fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
+        assert manager.snapshot()["units"][resource_unit_id]["runnable"] is False
 
-        stage.partitions[0].mark_ready_for_execution()
-        fte_fragment_scheduler._sync_write_sink_stage_for_fragment(stage)
-        assert manager.snapshot()["stages"][stage_id]["runnable"] is True
+        fragment_execution.partitions[0].mark_ready_for_execution()
+        fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
+        assert manager.snapshot()["units"][resource_unit_id]["runnable"] is True
         assert fragment_id == f"{query_id}:node:sink"
     finally:
         _cleanup_fte_query(query_id)
 
 
-def test_fte_write_sink_stage_snapshot_owns_fragment_state_lock():
-    query_id = "q-write-sink-stage-lock"
+def test_fte_write_sink_unit_snapshot_owns_fragment_state_lock():
+    query_id = "q-write-sink-unit-lock"
     clear_query_resource_managers()
-    _manager, _stage_id = _register_fte_query(query_id, "sink", partitions=1, task_slots=1)
-    stage, _fragment_id = _install_fte_fragment(
+    _manager, _resource_unit_id = _register_fte_query(query_id, "sink", partitions=1, task_slots=1)
+    fragment_execution, _fragment_id = _install_fte_fragment(
         query_id,
         "sink",
         partitions=1,
@@ -519,14 +519,14 @@ def test_fte_write_sink_stage_snapshot_owns_fragment_state_lock():
 
     class _LockCheckingPartitions(dict):
         def values(self):
-            assert stage._state_lock_owned_by_current_thread()
+            assert fragment_execution._state_lock_owned_by_current_thread()
             return super().values()
 
-    stage.partitions = _LockCheckingPartitions(stage.partitions)
+    fragment_execution.partitions = _LockCheckingPartitions(fragment_execution.partitions)
     try:
-        fte_fragment_scheduler._sync_write_sink_stage_for_fragment(stage)
+        fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
     finally:
-        stage.partitions = dict(stage.partitions)
+        fragment_execution.partitions = dict(fragment_execution.partitions)
         _cleanup_fte_query(query_id)
 
 
@@ -587,7 +587,7 @@ def test_registry_snapshot_is_observation_only(monkeypatch, snapshot_kind):
     _, fragment_id = _install_fte_fragment(query_id, "sink", partitions=1)
     monkeypatch.setattr(
         fte_fragment_scheduler,
-        "_sync_write_sink_stage_for_fragment",
+        "_sync_write_sink_unit_for_fragment",
         lambda _fragment: (_ for _ in ()).throw(AssertionError("progress collection must not mutate scheduler state")),
     )
     try:
@@ -4396,7 +4396,7 @@ def test_fte_fragment_execution_uses_logical_fragment_identity_for_materialized_
         "q",
         12,
         fragment_id="q:node:sample",
-        logical_fragment_identity='["ray-fte-logical-fragment-v1","node:sample:fte","node:sample"]',
+        logical_fragment_identity='["ray-fte-logical-fragment-v1","node:sample:native-fragment","node:sample"]',
         stable_task_identity_callback=lambda stable_task_identity, identity_key: registered_identities.append(
             (stable_task_identity, identity_key)
         ),
@@ -6211,7 +6211,7 @@ def test_ray_fte_worker_requires_exact_query_lease_heap():
                 "lease_id": "lease-qlease",
                 "query_id": "qlease",
                 "execution_query_id": "qlease",
-                "stage_id": "stage:qlease:node:scan:fte",
+                "resource_unit_id": "resource:qlease:fragment:node:scan",
                 "task_id": "qlease.0.0",
                 "attempt_id": "qlease.0.0.0",
                 "resources": {
@@ -6275,7 +6275,7 @@ def test_ray_fte_worker_rejects_lease_larger_than_node_capacity():
                 "lease_id": "lease-qoversize",
                 "query_id": "qoversize",
                 "execution_query_id": "qoversize",
-                "stage_id": "stage:qoversize:node:scan:fte",
+                "resource_unit_id": "resource:qoversize:fragment:node:scan",
                 "task_id": "qoversize.0.0",
                 "attempt_id": "qoversize.0.0.0",
                 "resources": {

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -248,7 +248,7 @@ def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_sl
                 unit_kind="native_fragment",
                 backend="ray_worker",
                 input_unit_ids=(),
-                per_task=ResourceVector(cpu=1, heap_bytes=2 * _GIB),
+                per_task=ResourceVector(),
                 target_output_block_bytes=128 * _MIB,
                 generator_buffer_blocks=2,
                 max_concurrency=partitions,
@@ -306,7 +306,6 @@ def _install_fte_fragment(query_id: str, node_id: str, *, partitions: int, conte
                     "pipeline_id": 1,
                     "operators": ["TABLE_SCAN"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             ],
         },
@@ -384,8 +383,8 @@ def test_fte_task_lease_uses_attempt_identity_and_releases_once_at_terminal():
 
 def test_internal_fte_query_uses_outer_query_resource_identity():
     resource_query_id = "q-fte-resource-owner"
-    execution_query_id = f"{resource_query_id}_orderby_stage"
-    fragment_id = f"{execution_query_id}:orderby:2:stage:0"
+    execution_query_id = f"{resource_query_id}_orderby_execution"
+    fragment_id = f"{execution_query_id}:orderby:2:fragment:0"
     clear_query_resource_managers()
     manager, resource_unit_id = _register_fte_query(
         resource_query_id,
@@ -611,7 +610,6 @@ def test_progress_registry_publishes_immutable_native_topology_before_fragment_e
                 "pipeline_id": 1,
                 "operators": ["TABLE_SCAN", "PROJECTION"],
                 "operator_details": [{}, {}],
-                "stage_ids": [],
             }
         ],
     }
@@ -674,7 +672,6 @@ def test_progress_topology_concurrent_registration_builds_exactly_once():
                     "pipeline_id": 1,
                     "operators": ["TABLE_SCAN"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             ],
         }
@@ -724,7 +721,6 @@ def test_progress_topology_failed_build_releases_ownership_for_retry():
                 "pipeline_id": 1,
                 "operators": ["TABLE_SCAN"],
                 "operator_details": [{}],
-                "stage_ids": [],
             }
         ],
     }
@@ -1702,7 +1698,7 @@ def test_task_descriptor_spooling_output_buffers_keep_partition_count_stable():
 
 
 def test_fte_exchange_tracker_selects_first_successful_attempt_only():
-    exchange = FteExchangeTracker("q", "stage-0")
+    exchange = FteExchangeTracker("q", "exchange-0")
     sink = exchange.add_sink(0)
 
     instance0 = exchange.instantiate_sink(sink, 0)
@@ -1717,7 +1713,7 @@ def test_fte_exchange_tracker_selects_first_successful_attempt_only():
         {
             "sink_handle": {
                 "query_id": "q",
-                "exchange_id": "stage-0",
+                "exchange_id": "exchange-0",
                 "partition_id": 0,
             },
             "attempt_id": 1,
@@ -1868,7 +1864,7 @@ def test_hash_exchange_selector_final_waits_for_all_sources():
 
 
 def test_fte_exchange_tracker_rejects_new_sinks_after_final():
-    exchange = FteExchangeTracker("q", "stage-final")
+    exchange = FteExchangeTracker("q", "exchange-final")
     sink = exchange.add_sink(0)
 
     exchange.sink_finished(sink, 0)
@@ -1885,7 +1881,7 @@ def test_fte_exchange_tracker_rejects_new_sinks_after_final():
 
 
 def test_fte_exchange_tracker_late_success_after_final_keeps_source_handles_stable():
-    exchange = FteExchangeTracker("q", "stage-late")
+    exchange = FteExchangeTracker("q", "exchange-late")
     sink0 = exchange.add_sink(0)
     sink1 = exchange.add_sink(1)
 
@@ -1906,7 +1902,7 @@ def test_fte_exchange_tracker_late_success_after_final_keeps_source_handles_stab
 
 
 def test_spooling_exchange_manager_late_success_after_final_does_not_replace_selected_files(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-late-spool")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-late-spool")
     sink = exchange.add_sink(0)
     selected = exchange.instantiate_sink(sink, 0)
     late = exchange.instantiate_sink(sink, 1)
@@ -1928,7 +1924,7 @@ def test_spooling_exchange_manager_late_success_after_final_does_not_replace_sel
 
 
 def test_spooling_exchange_manager_writes_markers_and_selected_source_handles(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(0)
 
     attempt0 = exchange.instantiate_sink(sink, 0)
@@ -1947,13 +1943,13 @@ def test_spooling_exchange_manager_writes_markers_and_selected_source_handles(tm
     assert handles[0].attempt_id == 1
     assert handles[0].files == (path1,)
     assert handles[0].attempt_path == attempt1.attempt_path
-    assert (tmp_path / "q" / "stage-0" / "sink_0" / "attempt_1" / "committed").exists()
-    assert (tmp_path / "q" / "stage-0" / "sink_0" / "attempt_1" / "manifest.json").exists()
+    assert (tmp_path / "q" / "exchange-0" / "sink_0" / "attempt_1" / "committed").exists()
+    assert (tmp_path / "q" / "exchange-0" / "sink_0" / "attempt_1" / "manifest.json").exists()
     assert path0 != path1
 
 
 def test_collect_spooling_output_stats_from_attempt_path(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(1)
     attempt = exchange.instantiate_sink(sink, 3)
     path0 = exchange.record_output_file(attempt, 0, "a", b"aaa")
@@ -1976,7 +1972,7 @@ def test_collect_spooling_output_stats_from_attempt_path(tmp_path):
 
 
 def test_spooling_exchange_manager_abort_cleanup_and_destroy_query(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(2)
     attempt0 = exchange.instantiate_sink(sink, 0)
     attempt1 = exchange.instantiate_sink(sink, 1)
@@ -1987,8 +1983,8 @@ def test_spooling_exchange_manager_abort_cleanup_and_destroy_query(tmp_path):
     exchange.finish_attempt(attempt1)
     exchange.sink_finished(sink, 1)
 
-    attempt0_dir = tmp_path / "q" / "stage-0" / "sink_2" / "attempt_0"
-    attempt1_dir = tmp_path / "q" / "stage-0" / "sink_2" / "attempt_1"
+    attempt0_dir = tmp_path / "q" / "exchange-0" / "sink_2" / "attempt_0"
+    attempt1_dir = tmp_path / "q" / "exchange-0" / "sink_2" / "attempt_1"
     assert (attempt0_dir / "aborted").exists()
     assert attempt1_dir.exists()
 
@@ -2001,7 +1997,7 @@ def test_spooling_exchange_manager_abort_cleanup_and_destroy_query(tmp_path):
 
 
 def test_spooling_exchange_manager_removes_committed_but_unselected_attempt(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(0)
     attempt0 = exchange.instantiate_sink(sink, 0)
     attempt1 = exchange.instantiate_sink(sink, 1)
@@ -2016,14 +2012,14 @@ def test_spooling_exchange_manager_removes_committed_but_unselected_attempt(tmp_
     assert len(handles) == 1
     assert handles[0].attempt_id == 1
     assert handles[0].files == (selected_path,)
-    assert (tmp_path / "q" / "stage-0" / "sink_0" / "attempt_0" / "committed").exists()
+    assert (tmp_path / "q" / "exchange-0" / "sink_0" / "attempt_0" / "committed").exists()
     assert exchange.cleanup_unselected_attempts() == 1
-    assert not (tmp_path / "q" / "stage-0" / "sink_0" / "attempt_0").exists()
-    assert (tmp_path / "q" / "stage-0" / "sink_0" / "attempt_1").exists()
+    assert not (tmp_path / "q" / "exchange-0" / "sink_0" / "attempt_0").exists()
+    assert (tmp_path / "q" / "exchange-0" / "sink_0" / "attempt_1").exists()
 
 
 def test_spooling_exchange_manager_duplicate_successful_attempts_select_one(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(0)
     attempt0 = exchange.instantiate_sink(sink, 0)
     attempt1 = exchange.instantiate_sink(sink, 1)
@@ -2044,7 +2040,7 @@ def test_spooling_exchange_manager_duplicate_successful_attempts_select_one(tmp_
 
 
 def test_two_stage_query_dag_worker_loss_uses_selected_attempt_for_final_result(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-upstream")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-upstream")
     upstream = _fte_fragment_execution(
         "q",
         11,
@@ -2347,6 +2343,21 @@ def test_fte_worker_command_outbox_pop_owns_attempt_scheduling_lock():
     assert acquired_during_copy is False
     assert popped == ["first"]
     assert stage._worker_command_outbox == []
+
+
+def test_fte_fragment_without_native_heap_requirement_omits_request_memory():
+    stage = FteFragmentExecution(
+        "query-duckdb-memory",
+        0,
+        fragment_id="query-duckdb-memory:node:1",
+        task_memory_bytes=None,
+    )
+    partition = stage.add_partition(0)
+
+    scheduled = partition.start_attempt()
+
+    assert partition.memory_requirement_bytes is None
+    assert "memory_requirement_bytes" not in scheduled.request
 
 
 def test_fte_add_partition_owns_state_lock_and_is_idempotent_under_concurrency():
@@ -3841,7 +3852,7 @@ def test_fte_fragment_execution_oom_is_terminal_for_fixed_heap():
 def test_fte_fragment_execution_finish_removes_descriptor_and_finalizes_exchange():
     worker = _FakeLiveWorker()
     storage = TaskDescriptorStorage()
-    exchange = FteExchangeTracker("q", "stage-5")
+    exchange = FteExchangeTracker("q", "exchange-5")
     stage = _fte_fragment_execution(
         "q",
         5,
@@ -3881,7 +3892,7 @@ def test_fte_fragment_execution_finish_cancels_unselected_running_attempts():
 
     winner_worker = _AccountingWorker("worker-winner")
     loser_worker = _AccountingWorker("worker-loser")
-    exchange = FteExchangeTracker("q", "stage-selected")
+    exchange = FteExchangeTracker("q", "exchange-selected")
     stage = _fte_fragment_execution(
         "q",
         61,
@@ -3949,7 +3960,7 @@ def test_fte_fragment_execution_handle_finished_status_marks_task_finished():
 def test_fte_fragment_execution_handle_finished_missing_stats_retries_exchange_attempt():
     worker = _FakeLiveWorker()
     storage = TaskDescriptorStorage()
-    exchange = FteExchangeTracker("q", "stage-missing-stats")
+    exchange = FteExchangeTracker("q", "exchange-missing-stats")
     stage = _fte_fragment_execution(
         "q",
         41,
@@ -4211,7 +4222,7 @@ def test_fte_fragment_execution_handle_failed_status_marks_stage_failed_when_att
 def test_fte_fragment_execution_worker_lost_uses_retry_attempt_as_durable_output(tmp_path):
     worker0 = _FakeLiveWorker("worker-a")
     worker1 = _FakeLiveWorker("worker-b")
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-fte-lost")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-fte-lost")
 
     def select_worker(partition):
         return worker0 if partition.next_attempt_number() == 0 else worker1
@@ -5350,7 +5361,7 @@ def test_fte_worker_task_manager_fte_update_before_execution_updates_descriptor_
 
 
 def test_fte_worker_task_manager_returns_spooling_output_stats(tmp_path):
-    exchange = SpoolingExchangeManager(tmp_path, "q", "stage-0")
+    exchange = SpoolingExchangeManager(tmp_path, "q", "exchange-0")
     sink = exchange.add_sink(0)
     attempt = exchange.instantiate_sink(sink, 0)
 
@@ -6234,6 +6245,57 @@ def test_ray_fte_worker_requires_exact_query_lease_heap():
         assert final["state"] == FteTaskState.FINISHED.value
 
         await manager.drop_query("qlease")
+
+    asyncio.run(run())
+
+
+def test_ray_fte_worker_accepts_native_task_with_zero_heap_lease():
+    async def execute_fn(request):
+        return {"ok": str(FteTaskAttemptId.coerce(request["task_id"]))}
+
+    async def run():
+        manager = _fte_worker_task_manager(
+            execute_fn,
+            admission_config=FteWorkerAdmissionConfig(
+                max_running_tasks=4,
+                mode="lease",
+                memory_budget_bytes=20,
+                task_memory_bytes=None,
+            ),
+            require_query_task_lease=True,
+        )
+        task_id = {
+            "query_id": "q-native-lease",
+            "fragment_execution_id": 0,
+            "partition_id": 0,
+            "attempt_id": 0,
+        }
+        status = await manager.create_task(
+            {
+                "task_id": task_id,
+                "fragment_id": "q-native-lease:node:scan",
+                "query_task_lease": {
+                    "lease_id": "lease-q-native",
+                    "query_id": "q-native-lease",
+                    "execution_query_id": "q-native-lease",
+                    "resource_unit_id": "resource:q-native-lease:fragment:node:scan",
+                    "task_id": "q-native-lease.0.0",
+                    "attempt_id": "q-native-lease.0.0.0",
+                    "resources": {
+                        "cpu": 0.0,
+                        "gpu": 0.0,
+                        "heap_bytes": 0,
+                        "object_store_bytes": 0,
+                    },
+                },
+            }
+        )
+
+        assert status["executor_task_memory_requirement_bytes"] == 0
+        final = await manager.wait_task_status(task_id, status["version"], timeout_s=1.0)
+        assert final["state"] == FteTaskState.FINISHED.value
+
+        await manager.drop_query("q-native-lease")
 
     asyncio.run(run())
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -59,7 +59,6 @@ from duckdb.runners.ray.fte import (
 from duckdb.runners.ray.fte_attempts import RunningAttempt
 from duckdb.runners.ray.fte_events import FteAddSplitsCommand
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -266,12 +265,6 @@ def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_sl
         graph,
         QueryAllocation(
             resources=allocation_resources,
-            node_allocations=(
-                NodeResourceAllocation(
-                    node_id="node-a",
-                    resources=allocation_resources,
-                ),
-            ),
             generation=1,
         ),
     )

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -7,6 +7,7 @@ import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -495,8 +496,25 @@ def test_fte_write_sink_updates_registered_unit_state_instead_of_registering_an_
         fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
         assert manager.snapshot()["units"][resource_unit_id]["runnable"] is True
         assert fragment_id == f"{query_id}:node:sink"
+
+        fragment_execution.partitions[0].finished = True
+        fragment_execution.partitions[0].ready_for_scheduling = False
+        fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
+        unit_state = manager.snapshot()["units"][resource_unit_id]
+        assert unit_state["runnable"] is False
+        assert unit_state["completed"] is False
+
+        fragment_execution.no_more_partitions = True
+        fte_fragment_scheduler._sync_write_sink_unit_for_fragment(fragment_execution)
+        assert manager.snapshot()["units"][resource_unit_id]["completed"] is True
     finally:
         _cleanup_fte_query(query_id)
+
+
+def test_fte_write_sink_treats_a_sealed_empty_partition_set_as_completed():
+    fragment_execution = SimpleNamespace(partitions={}, no_more_partitions=True)
+
+    assert fte_fragment_scheduler._write_sink_has_input(fragment_execution) == (False, True)
 
 
 def test_fte_write_sink_unit_snapshot_owns_fragment_state_lock():

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -2371,7 +2371,10 @@ def test_fte_fragment_without_native_heap_requirement_omits_request_memory():
     )
     partition = stage.add_partition(0)
 
-    scheduled = partition.start_attempt()
+    scheduled = partition.start_attempt(
+        worker_id="worker-a",
+        worker_incarnation_id="incarnation-worker-a",
+    )
 
     assert partition.memory_requirement_bytes is None
     assert "memory_requirement_bytes" not in scheduled.request

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -10,7 +10,7 @@ import uuid
 from pathlib import Path
 
 import pytest
-from ray_test_profile import ray_test_object_store_bytes
+from ray_test_profile import ray_test_object_store_options
 
 import duckdb
 
@@ -65,7 +65,6 @@ class _ControlFaultRayWorkerActorHandle(RayWorkerActorHandle):
                     "pipeline_id": 1,
                     "operators": ["TABLE_SCAN"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                 }
             ],
         }
@@ -290,7 +289,6 @@ def _register_fault_query(tasks) -> None:
         raise ValueError("fault query tasks must share one query_id")
     query_id = query_ids.pop()
     fragment_ids = sorted({f"{query_id}:node:{task.context()['node_id']}" for task in tasks})
-    heap_bytes = 64 * 1024 * 1024
     target_output_block_bytes = 1024 * 1024
     units = tuple(
         ResourceUnitSpec(
@@ -300,7 +298,7 @@ def _register_fault_query(tasks) -> None:
             unit_kind="native_fragment",
             backend="ray_worker",
             input_unit_ids=(),
-            per_task=ResourceVector(cpu=1, heap_bytes=heap_bytes),
+            per_task=ResourceVector(),
             target_output_block_bytes=target_output_block_bytes,
             generator_buffer_blocks=1,
             max_concurrency=max(1, len(tasks)),
@@ -309,7 +307,7 @@ def _register_fault_query(tasks) -> None:
     )
     allocation_resources = ResourceVector(
         cpu=max(1, len(tasks)),
-        heap_bytes=max(1, len(tasks)) * heap_bytes,
+        heap_bytes=max(1, len(tasks)) * 64 * 1024 * 1024,
         object_store_bytes=max(1, len(tasks)) * target_output_block_bytes,
     )
     manager = register_query_resource_graph(
@@ -382,7 +380,7 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
             include_dashboard=False,
             num_cpus=int(os.environ.get("VANE_TEST_RAY_NUM_CPUS", "4")),
             num_gpus=0,
-            object_store_memory=ray_test_object_store_bytes(),
+            **ray_test_object_store_options(),
         )
         ray.init(
             address=cluster.address,

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -325,7 +325,6 @@ def _register_fault_query(tasks) -> None:
                     resources=allocation_resources,
                 ),
             ),
-            actor_placements=(),
             generation=1,
         ),
     )
@@ -376,11 +375,19 @@ def _init_ray_for_fault_test(monkeypatch) -> None:
     # during session finalization, before its JUnit report is written.
     cluster = Cluster(shutdown_at_exit=False)
     try:
+        from ray._private.resource_and_label_spec import ResourceAndLabelSpec
+
+        resources = ResourceAndLabelSpec().resolve(is_head=True)
+        object_store_options = ray_test_object_store_options()
+        object_store_options.setdefault(
+            "object_store_memory",
+            resources.object_store_memory,
+        )
         cluster.add_node(
             include_dashboard=False,
             num_cpus=int(os.environ.get("VANE_TEST_RAY_NUM_CPUS", "4")),
             num_gpus=0,
-            **ray_test_object_store_options(),
+            **object_store_options,
         )
         ray.init(
             address=cluster.address,

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -31,17 +31,17 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     _stop_fte_status_watchers,
     ensure_fte_fragment_progress_topology,
 )
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
-from duckdb.runners.ray.query_graph_builder import fte_stage_id_for_fragment
+from duckdb.runners.ray.query_resource_graph_builder import native_fragment_unit_id_for_fragment
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
-    register_query_graph,
+    register_query_resource_graph,
 )
 from duckdb.runners.ray.worker_handle import RayWorkerActorHandle as _ProductionRayWorkerActorHandle
 
@@ -199,7 +199,7 @@ class _RayFteTask:
             "query_id": query_id,
             "node_id": node_id,
             "resource_query_id": query_id,
-            "resource_stage_id": fte_stage_id_for_fragment(query_id, fragment_id),
+            "resource_unit_id": native_fragment_unit_id_for_fragment(query_id, fragment_id),
         }
 
     def task_context(self):
@@ -243,7 +243,7 @@ class _NativeDynamicScanTask:
             "query_id": self.query_id,
             "node_id": self.fragment_node_id,
             "resource_query_id": self.query_id,
-            "resource_stage_id": fte_stage_id_for_fragment(self.query_id, fragment_id),
+            "resource_unit_id": native_fragment_unit_id_for_fragment(self.query_id, fragment_id),
         }
 
     def task_context(self):
@@ -292,14 +292,14 @@ def _register_fault_query(tasks) -> None:
     fragment_ids = sorted({f"{query_id}:node:{task.context()['node_id']}" for task in tasks})
     heap_bytes = 64 * 1024 * 1024
     target_output_block_bytes = 1024 * 1024
-    stages = tuple(
-        StageResourceSpec(
+    units = tuple(
+        ResourceUnitSpec(
             query_id=query_id,
-            stage_id=fte_stage_id_for_fragment(query_id, fragment_id),
-            physical_node_id=f"node:{fragment_id.rsplit(':node:', 1)[1]}:fte",
-            stage_kind="fte",
+            resource_unit_id=native_fragment_unit_id_for_fragment(query_id, fragment_id),
+            physical_node_id=f"node:{fragment_id.rsplit(':node:', 1)[1]}:native-fragment",
+            unit_kind="native_fragment",
             backend="ray_worker",
-            input_stage_ids=(),
+            input_unit_ids=(),
             per_task=ResourceVector(cpu=1, heap_bytes=heap_bytes),
             target_output_block_bytes=target_output_block_bytes,
             generator_buffer_blocks=1,
@@ -312,12 +312,12 @@ def _register_fault_query(tasks) -> None:
         heap_bytes=max(1, len(tasks)) * heap_bytes,
         object_store_bytes=max(1, len(tasks)) * target_output_block_bytes,
     )
-    manager = register_query_graph(
-        QueryExecutionGraph(
+    manager = register_query_resource_graph(
+        QueryResourceGraph(
             query_id=query_id,
             plan_digest=f"sha256:fault:{query_id}",
-            stages=stages,
-            terminal_stage_ids=tuple(stage.stage_id for stage in stages),
+            units=units,
+            terminal_unit_ids=tuple(unit.resource_unit_id for unit in units),
         ),
         QueryAllocation(
             resources=allocation_resources,
@@ -331,8 +331,8 @@ def _register_fault_query(tasks) -> None:
             generation=1,
         ),
     )
-    for stage in stages:
-        manager.update_stage_state(stage.stage_id, runnable=True)
+    for unit in units:
+        manager.update_unit_state(unit.resource_unit_id, runnable=True)
 
 
 def _init_ray_for_fault_test(monkeypatch) -> None:
@@ -535,7 +535,7 @@ def test_real_ray_actor_kill_replays_fte_task_on_replacement(monkeypatch):
         _clear_fte_state()
 
 
-def test_real_ray_actor_kill_without_replacement_fails_fte_stage(monkeypatch):
+def test_real_ray_actor_kill_without_replacement_fails_fte_fragment_execution(monkeypatch):
     monkeypatch.setenv("VANE_FTE_STATUS_WAIT_TIMEOUT_S", "5")
     monkeypatch.setenv("VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S", "0")
     _init_ray_for_fault_test(monkeypatch)

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -32,7 +32,6 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     ensure_fte_fragment_progress_topology,
 )
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -319,12 +318,6 @@ def _register_fault_query(tasks) -> None:
         ),
         QueryAllocation(
             resources=allocation_resources,
-            node_allocations=(
-                NodeResourceAllocation(
-                    node_id=str(ray.get_runtime_context().get_node_id()),
-                    resources=allocation_resources,
-                ),
-            ),
             generation=1,
         ),
     )

--- a/tests/fast/test_ray_fte_progress.py
+++ b/tests/fast/test_ray_fte_progress.py
@@ -43,7 +43,6 @@ def _topology(
                 "pipeline_id": pipeline_id,
                 "operators": operators,
                 "operator_details": (operator_details if operator_details is not None else [{} for _ in operators]),
-                "stage_ids": [],
             }
             for pipeline_id, operators, operator_details in pipelines
         ],
@@ -60,7 +59,7 @@ def test_progress_snapshot_includes_query_resource_manager():
             unit_kind="native_fragment",
             backend="ray_worker",
             input_unit_ids=(),
-            per_task=ResourceVector(cpu=1, heap_bytes=1),
+            per_task=ResourceVector(),
             target_output_block_bytes=1,
             generator_buffer_blocks=1,
             max_concurrency=1,
@@ -364,13 +363,11 @@ def test_progress_snapshot_publishes_native_topology_before_first_partition_runs
                 "pipeline_id": 1,
                 "operators": ["RESULT_COLLECTOR"],
                 "operator_details": [{}],
-                "stage_ids": [],
             },
             {
                 "pipeline_id": 2,
                 "operators": ["TABLE_SCAN", "PROJECTION", "RESULT_COLLECTOR"],
                 "operator_details": [{}, {}, {}],
-                "stage_ids": [],
             },
         ],
     }
@@ -414,13 +411,11 @@ def test_progress_snapshot_overlays_only_live_counters_matching_planned_topology
                 "pipeline_id": 1,
                 "operators": ["RESULT_COLLECTOR"],
                 "operator_details": [{}],
-                "stage_ids": [],
             },
             {
                 "pipeline_id": 2,
                 "operators": ["TABLE_SCAN", "PROJECTION", "RESULT_COLLECTOR"],
                 "operator_details": [{}, {}, {}],
-                "stage_ids": [],
             },
         ],
     }
@@ -491,7 +486,6 @@ def test_fragment_does_not_mix_deferred_partitions_with_native_pipeline_tasks():
                 "name": "ExchangeSource->Transform",
                 "operators": ["EXCHANGE_SOURCE", "PROJECTION"],
                 "operator_details": [{}, {}],
-                "stage_ids": [],
                 "total_pipeline_tasks": 36,
                 "queued_pipeline_tasks": 0,
                 "running_pipeline_tasks": 0,
@@ -503,7 +497,6 @@ def test_fragment_does_not_mix_deferred_partitions_with_native_pipeline_tasks():
                     "name": f"Pipeline{pipeline_id}",
                     "operators": ["PROJECTION"],
                     "operator_details": [{}],
-                    "stage_ids": [],
                     "total_pipeline_tasks": 1,
                     "queued_pipeline_tasks": int(pipeline_id <= 2),
                     "running_pipeline_tasks": int(pipeline_id in {3, 4}),

--- a/tests/fast/test_ray_fte_progress.py
+++ b/tests/fast/test_ray_fte_progress.py
@@ -20,7 +20,6 @@ from duckdb.runners.progress import (
 from duckdb.runners.ray.fte import FteTaskExecution
 from duckdb.runners.ray.progress import ProgressRenderer, build_progress_snapshot, format_progress_snapshot
 from duckdb.runners.ray.query_resource_graph import (
-    NodeResourceAllocation,
     QueryAllocation,
     QueryResourceGraph,
     ResourceUnitSpec,
@@ -73,12 +72,6 @@ def test_progress_snapshot_includes_query_resource_manager():
             ),
             QueryAllocation(
                 resources=ResourceVector(cpu=1, heap_bytes=2, object_store_bytes=1),
-                node_allocations=(
-                    NodeResourceAllocation(
-                        node_id="node-a",
-                        resources=ResourceVector(cpu=1, heap_bytes=2, object_store_bytes=1),
-                    ),
-                ),
                 generation=1,
             ),
         )

--- a/tests/fast/test_ray_fte_progress.py
+++ b/tests/fast/test_ray_fte_progress.py
@@ -79,7 +79,6 @@ def test_progress_snapshot_includes_query_resource_manager():
                         resources=ResourceVector(cpu=1, heap_bytes=2, object_store_bytes=1),
                     ),
                 ),
-                actor_placements=(),
                 generation=1,
             ),
         )

--- a/tests/fast/test_ray_fte_progress.py
+++ b/tests/fast/test_ray_fte_progress.py
@@ -19,17 +19,17 @@ from duckdb.runners.progress import (
 )
 from duckdb.runners.ray.fte import FteTaskExecution
 from duckdb.runners.ray.progress import ProgressRenderer, build_progress_snapshot, format_progress_snapshot
-from duckdb.runners.ray.query_execution_graph import (
+from duckdb.runners.ray.query_resource_graph import (
     NodeResourceAllocation,
     QueryAllocation,
-    QueryExecutionGraph,
+    QueryResourceGraph,
+    ResourceUnitSpec,
     ResourceVector,
-    StageResourceSpec,
 )
 from duckdb.runners.ray.query_resource_manager import TaskRequest
 from duckdb.runners.ray.query_resource_runtime import (
     clear_query_resource_managers,
-    register_query_graph,
+    register_query_resource_graph,
 )
 
 
@@ -53,24 +53,24 @@ def _topology(
 def test_progress_snapshot_includes_query_resource_manager():
     clear_query_resource_managers()
     try:
-        stage = StageResourceSpec(
+        unit = ResourceUnitSpec(
             query_id="q-progress",
-            stage_id="stage:q-progress:node:1:fte",
-            physical_node_id="node:1:fte",
-            stage_kind="fte",
+            resource_unit_id="resource:q-progress:fragment:node:1",
+            physical_node_id="node:1:native-fragment",
+            unit_kind="native_fragment",
             backend="ray_worker",
-            input_stage_ids=(),
+            input_unit_ids=(),
             per_task=ResourceVector(cpu=1, heap_bytes=1),
             target_output_block_bytes=1,
             generator_buffer_blocks=1,
             max_concurrency=1,
         )
-        manager = register_query_graph(
-            QueryExecutionGraph(
+        manager = register_query_resource_graph(
+            QueryResourceGraph(
                 query_id="q-progress",
                 plan_digest="sha256:q-progress",
-                stages=(stage,),
-                terminal_stage_ids=(stage.stage_id,),
+                units=(unit,),
+                terminal_unit_ids=(unit.resource_unit_id,),
             ),
             QueryAllocation(
                 resources=ResourceVector(cpu=1, heap_bytes=2, object_store_bytes=1),
@@ -84,8 +84,10 @@ def test_progress_snapshot_includes_query_resource_manager():
                 generation=1,
             ),
         )
-        manager.update_stage_state(stage.stage_id, runnable=True)
-        grant = manager.try_acquire_task(TaskRequest("q-progress", stage.stage_id, "task-1", "attempt-1", "node-a"))
+        manager.update_unit_state(unit.resource_unit_id, runnable=True)
+        grant = manager.try_acquire_task(
+            TaskRequest("q-progress", unit.resource_unit_id, "task-1", "attempt-1", "node-a")
+        )
         assert grant.granted
 
         snapshot = build_progress_snapshot(
@@ -93,7 +95,7 @@ def test_progress_snapshot_includes_query_resource_manager():
             "q-progress",
         )
 
-        assert snapshot["query"]["query_resource_manager"]["stages"][stage.stage_id]["active_task_count"] == 1
+        assert snapshot["query"]["query_resource_manager"]["units"][unit.resource_unit_id]["active_task_count"] == 1
     finally:
         clear_query_resource_managers()
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -32,14 +32,14 @@ from duckdb.runners.ray.worker import (
 @contextmanager
 def _registered_low_level_plan(plan, con, *, node_id=None):
     """Exercise the internal C++ runner under the mandatory graph contract."""
-    from duckdb.runners.ray.query_execution_graph import (
+    from duckdb.runners.ray.query_resource_graph import (
         NodeResourceAllocation,
         QueryAllocation,
         ResourceVector,
     )
-    from duckdb.runners.ray.query_graph_builder import build_query_execution_graph
+    from duckdb.runners.ray.query_resource_graph_builder import build_query_resource_graph
     from duckdb.runners.ray.query_resource_runtime import (
-        register_query_graph,
+        register_query_resource_graph,
         release_query_resource_manager,
     )
 
@@ -53,10 +53,10 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
     if not node_id:
         raise ValueError("low-level distributed plan registration requires a non-empty node_id")
 
-    graph = build_query_execution_graph(
-        plan.collect_execution_stages(conn=con),
+    graph = build_query_resource_graph(
+        plan.collect_query_resource_graph_metadata(conn=con),
         env={
-            "VANE_FTE_TASK_HEAP_BYTES": "1",
+            "VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES": "1",
             "VANE_TARGET_OUTPUT_BLOCK_BYTES": str(1024**2),
         },
     )
@@ -66,7 +66,7 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
         heap_bytes=1 << 50,
         object_store_bytes=1 << 50,
     )
-    manager = register_query_graph(
+    manager = register_query_resource_graph(
         graph,
         QueryAllocation(
             resources=allocation_resources,
@@ -80,9 +80,9 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
             generation=1,
         ),
     )
-    for stage in graph.stages:
-        manager.update_stage_state(
-            stage.stage_id,
+    for unit in graph.units:
+        manager.update_unit_state(
+            unit.resource_unit_id,
             runnable=True,
             actor_ready=True,
         )
@@ -113,7 +113,7 @@ class _DummyStream:
 
 class _FakeOutputLeaseOwner:
     def __init__(self) -> None:
-        self.states = ["stage_queue"]
+        self.states = ["unit_queue"]
         self.released = False
 
     def transition_to(self, state):
@@ -276,7 +276,7 @@ def _query_registration_stub(query_id: str):
         expected_plan_id=None,
     ):
         del query_connection, expected_plan_id
-        return SimpleNamespace(query_id=query_id, stages=()), object()
+        return SimpleNamespace(query_id=query_id, units=()), object()
 
     return _register
 
@@ -475,36 +475,36 @@ def _bind_test_query_resource_owner(
     *,
     query_id: str | None = None,
 ):
-    from duckdb.runners.ray.query_execution_graph import (
+    from duckdb.runners.ray.query_resource_graph import (
         NodeResourceAllocation,
         QueryAllocation,
-        QueryExecutionGraph,
+        QueryResourceGraph,
+        ResourceUnitSpec,
         ResourceVector,
-        StageResourceSpec,
     )
-    from duckdb.runners.ray.query_resource_runtime import register_query_graph
+    from duckdb.runners.ray.query_resource_runtime import register_query_resource_graph
 
     query_id = str(plan_id if query_id is None else query_id)
-    stage = StageResourceSpec(
+    unit = ResourceUnitSpec(
         query_id=query_id,
-        stage_id=f"stage:{query_id}:result",
+        resource_unit_id=f"resource:{query_id}:result",
         physical_node_id="result",
-        stage_kind="fte",
+        unit_kind="native_fragment",
         backend="ray_worker",
-        input_stage_ids=(),
+        input_unit_ids=(),
         per_task=ResourceVector(cpu=1, heap_bytes=1),
         target_output_block_bytes=1,
         generator_buffer_blocks=1,
         max_concurrency=1,
     )
-    graph = QueryExecutionGraph(
+    graph = QueryResourceGraph(
         query_id=query_id,
         plan_digest=f"sha256:{query_id}",
-        stages=(stage,),
-        terminal_stage_ids=(stage.stage_id,),
+        units=(unit,),
+        terminal_unit_ids=(unit.resource_unit_id,),
     )
     resources = ResourceVector(cpu=1, heap_bytes=1, object_store_bytes=1)
-    manager = register_query_graph(
+    manager = register_query_resource_graph(
         graph,
         QueryAllocation(
             resources=resources,
@@ -513,7 +513,7 @@ def _bind_test_query_resource_owner(
             generation=1,
         ),
     )
-    manager.update_stage_state(stage.stage_id, runnable=True)
+    manager.update_unit_state(unit.resource_unit_id, runnable=True)
     runner._plan_query_ids[str(plan_id)] = query_id
     runner._plan_session_ids[str(plan_id)] = _TEST_SESSION_ID
     runner._sessions[_TEST_SESSION_ID].plan_ids.add(str(plan_id))
@@ -682,7 +682,7 @@ def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypat
         "_register_query_resources",
         _query_registration_stub("slow-stream-startup"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
 
     def _cleanup(_self, plan_id):
         runner.curr_plans.pop(plan_id, None)
@@ -754,7 +754,7 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
         "_register_query_resources",
         _query_registration_stub("copy-plan"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda _self, _graph: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
         cls,
         "_drop_query_fragments_sync",
@@ -800,7 +800,7 @@ def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(
         "_register_query_resources",
         _query_registration_stub("copy-query-terminal"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
 
     def _teardown(_self, plan_id, query_id, *, drop_fragments):
         teardown_calls.append((plan_id, query_id, drop_fragments))
@@ -835,7 +835,7 @@ def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatc
         "_register_query_resources",
         _query_registration_stub("copy-progress-contract-failure"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(
         cls,
         "_build_local_progress_snapshot",
@@ -894,7 +894,7 @@ def test_query_driver_failure_immediately_after_commit_replays_success(monkeypat
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
     monkeypatch.setattr(
         scheduler_mod,
@@ -956,7 +956,7 @@ def test_query_driver_concurrent_startup_failure_preserves_unknown_copy_outcome(
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
     monkeypatch.setattr(
         scheduler_mod,
@@ -1021,7 +1021,7 @@ def test_query_driver_postcommit_startup_drain_cancellation_replays_success(monk
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
     monkeypatch.setattr(driver.asyncio, "gather", _tracked_gather)
     monkeypatch.setattr(
@@ -1081,7 +1081,7 @@ def test_query_driver_concurrent_copy_retries_share_one_write(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1124,7 +1124,7 @@ def test_query_driver_copy_result_logging_failure_replays_committed_success(monk
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
     monkeypatch.setattr(
@@ -1169,7 +1169,7 @@ def test_query_driver_committed_copy_teardown_is_retryable_without_reexecution(m
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1222,7 +1222,7 @@ def test_query_driver_copy_failure_is_replayed_without_reexecution(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     for operation in (
@@ -1278,7 +1278,7 @@ def test_query_driver_unknown_native_copy_outcome_is_structured_and_never_reexec
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     for operation in (
@@ -1338,7 +1338,7 @@ def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
         del query_connection
         plan_id = str(plan.idx())
         assert expected_plan_id == plan_id
-        return SimpleNamespace(query_id=plan_id, stages=()), object()
+        return SimpleNamespace(query_id=plan_id, units=()), object()
 
     def _teardown(_self, plan_id, query_id, *, drop_fragments):
         assert query_id == plan_id
@@ -1350,7 +1350,7 @@ def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _register)
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1518,7 +1518,7 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
         "_register_query_resources",
         _query_registration_stub(plan_id),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", _build_snapshot)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1569,7 +1569,7 @@ def test_query_driver_copy_operation_cancellation_waits_for_native_commit(monkey
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1623,7 +1623,7 @@ def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkey
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1689,7 +1689,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
         "_register_query_resources",
         _query_registration_stub("copy-startup-order"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", mark_actor_stages)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_stages)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
     monkeypatch.setattr(
@@ -1748,7 +1748,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
         "_register_query_resources",
         _query_registration_stub("copy-plan-before-startup-barriers"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", mark_actor_stages)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_stages)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
     monkeypatch.setattr(
@@ -1801,7 +1801,7 @@ def test_query_driver_copy_plan_failure_interrupts_startup_barriers(monkeypatch)
     )
     monkeypatch.setattr(
         cls,
-        "_mark_query_actor_stages_ready",
+        "_mark_query_actor_units_ready",
         lambda *_args: marked_ready.append(True),
     )
     monkeypatch.setattr(cls, "_teardown_plan_resources", teardown)
@@ -1865,7 +1865,7 @@ def test_query_driver_copy_startup_barrier_failure_tears_down_plan(
     )
     monkeypatch.setattr(
         cls,
-        "_mark_query_actor_stages_ready",
+        "_mark_query_actor_units_ready",
         lambda *_args: marked_ready.append(True),
     )
     monkeypatch.setattr(cls, "_teardown_plan_resources", teardown)
@@ -2836,7 +2836,7 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
         "_register_query_resources",
         _query_registration_stub("stream-plan"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda _self, _graph: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
         cls,
         "_release_query_resources",
@@ -2878,7 +2878,7 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
         "_register_query_resources",
         _query_registration_stub("failed-query"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_udf_actors)
     monkeypatch.setattr(
         cls,
@@ -4324,7 +4324,7 @@ def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
         "lease_id": "lease-native-descriptor",
         "query_id": "resource-query-native-descriptor",
         "execution_query_id": "query-native-descriptor",
-        "stage_id": "stage-native-descriptor",
+        "resource_unit_id": "stage-native-descriptor",
         "attempt_id": "query-native-descriptor.0.0.0",
         "target_output_block_bytes": 1,
         "output_window_bytes": 1,
@@ -4409,7 +4409,7 @@ def test_run_plan_return_cancellation_waits_for_native_execution(monkeypatch):
         "lease_id": "lease-native-cancel",
         "query_id": "resource-query-native-cancel",
         "execution_query_id": "query-native-cancel",
-        "stage_id": "stage-native-cancel",
+        "resource_unit_id": "stage-native-cancel",
         "attempt_id": "query-native-cancel.0.0.1",
         "target_output_block_bytes": 1,
         "output_window_bytes": 1,
@@ -4458,7 +4458,7 @@ def test_fte_output_publication_is_bounded_by_block_target_and_task_window():
     lease = {
         "lease_id": "lease-1",
         "query_id": "q",
-        "stage_id": "stage:q:node:1:fte",
+        "resource_unit_id": "resource:q:fragment:node:1",
         "attempt_id": "q.0.0.0",
         "target_output_block_bytes": 10,
         "output_window_bytes": 20,

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -39,7 +39,6 @@ def _registered_low_level_plan(
 ):
     """Exercise the internal C++ runner under the mandatory graph contract."""
     from duckdb.runners.ray.query_resource_graph import (
-        NodeResourceAllocation,
         QueryAllocation,
         ResourceVector,
     )
@@ -82,12 +81,6 @@ def _registered_low_level_plan(
         manager_holder["manager"].update_allocation(
             QueryAllocation(
                 resources=allocation_resources,
-                node_allocations=(
-                    NodeResourceAllocation(
-                        node_id=node_id,
-                        resources=allocation_resources,
-                    ),
-                ),
                 generation=generation,
             ),
             admission_open=True,
@@ -97,12 +90,6 @@ def _registered_low_level_plan(
         graph,
         QueryAllocation(
             resources=allocation_resources,
-            node_allocations=(
-                NodeResourceAllocation(
-                    node_id=node_id,
-                    resources=allocation_resources,
-                ),
-            ),
             generation=1,
         ),
         on_eligible_units_change=_refresh_phase_allocation,
@@ -355,7 +342,6 @@ def test_driver_connection_applies_duckdb_execution_width(monkeypatch):
 
 def test_driver_reconciles_reconstructed_actor_location_and_public_leases():
     from duckdb.runners.ray.query_resource_graph import (
-        NodeResourceAllocation,
         QueryAllocation,
         QueryResourceGraph,
         ResourceUnitSpec,
@@ -395,16 +381,6 @@ def test_driver_reconciles_reconstructed_actor_location_and_public_leases():
     )
     allocation = QueryAllocation(
         resources=resources,
-        node_allocations=(
-            NodeResourceAllocation(
-                node_id="node-a",
-                resources=ResourceVector(cpu=1, heap_bytes=4, object_store_bytes=10),
-            ),
-            NodeResourceAllocation(
-                node_id="node-b",
-                resources=ResourceVector(cpu=1, heap_bytes=4, object_store_bytes=10),
-            ),
-        ),
         generation=1,
     )
     manager = register_query_resource_graph(graph, allocation)
@@ -619,7 +595,6 @@ def _bind_test_query_resource_owner(
     query_id: str | None = None,
 ):
     from duckdb.runners.ray.query_resource_graph import (
-        NodeResourceAllocation,
         QueryAllocation,
         QueryResourceGraph,
         ResourceUnitSpec,
@@ -651,7 +626,6 @@ def _bind_test_query_resource_owner(
         graph,
         QueryAllocation(
             resources=resources,
-            node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
             generation=1,
         ),
     )

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -353,6 +353,116 @@ def test_driver_connection_applies_duckdb_execution_width(monkeypatch):
     assert statements == ["SET threads=7"]
 
 
+def test_driver_reconciles_reconstructed_actor_location_and_public_leases():
+    from duckdb.runners.ray.query_resource_graph import (
+        NodeResourceAllocation,
+        QueryAllocation,
+        QueryResourceGraph,
+        ResourceUnitSpec,
+        ResourceVector,
+    )
+    from duckdb.runners.ray.query_resource_manager import TaskRequest
+    from duckdb.runners.ray.query_resource_runtime import (
+        register_query_resource_graph,
+        release_query_resource_manager,
+    )
+
+    cls, runner = _make_local_query_driver_actor()
+    runner._ensure_query_resource_admission_state()
+    query_id = "query-reconstructed-actor-location"
+    resource_unit_id = "resource:query-reconstructed-actor-location:actor"
+    resources = ResourceVector(cpu=2, heap_bytes=8, object_store_bytes=20)
+    unit = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=resource_unit_id,
+        physical_node_id="7",
+        unit_kind="ray_actor_pool",
+        backend="ray_actor",
+        input_unit_ids=(),
+        per_task=ResourceVector(object_store_bytes=1),
+        target_output_block_bytes=1,
+        generator_buffer_blocks=2,
+        max_concurrency=None,
+        resident_per_actor=ResourceVector(cpu=1, heap_bytes=4),
+        actor_pool_size=1,
+        actor_prefetch_depth=1,
+    )
+    graph = QueryResourceGraph(
+        query_id=query_id,
+        plan_digest="sha256:reconstructed-actor-location",
+        units=(unit,),
+        terminal_unit_ids=(resource_unit_id,),
+    )
+    allocation = QueryAllocation(
+        resources=resources,
+        node_allocations=(
+            NodeResourceAllocation(
+                node_id="node-a",
+                resources=ResourceVector(cpu=1, heap_bytes=4, object_store_bytes=10),
+            ),
+            NodeResourceAllocation(
+                node_id="node-b",
+                resources=ResourceVector(cpu=1, heap_bytes=4, object_store_bytes=10),
+            ),
+        ),
+        generation=1,
+    )
+    manager = register_query_resource_graph(graph, allocation)
+    try:
+        manager.set_submitted_actor_slots(resource_unit_id, {0})
+        manager.set_ready_actor_slots(resource_unit_id, {0: "node-a"})
+        manager.update_unit_state(resource_unit_id, runnable=True)
+        grant = manager.try_acquire_task(
+            TaskRequest(
+                query_id=query_id,
+                resource_unit_id=resource_unit_id,
+                task_id="task:actor:0",
+                attempt_id="attempt:0",
+                node_id=None,
+                retained_input_bytes=1,
+            )
+        )
+        assert grant.granted
+        pool = SimpleNamespace(
+            _vane_retired=False,
+            _vane_location_nonce="pool-nonce",
+            actors=[object()],
+            actor_node_ids=["node-a"],
+            _confirmed_ready={0},
+        )
+        runner._active_udf_actor_by_unit = {query_id: {resource_unit_id: pool}}
+        generation_capability = runner._issue_query_task_admission_capability(query_id)
+        runner._query_task_lease_requests["public-request"] = {
+            "manager_lease_id": grant.lease.lease_id,
+            "lease": {"node_id": "node-a"},
+        }
+
+        result = asyncio.run(
+            cls.report_query_udf_actor_location(
+                runner,
+                {
+                    "query_id": query_id,
+                    "resource_unit_id": resource_unit_id,
+                    "actor_index": 0,
+                    "pool_nonce": "pool-nonce",
+                    "node_id": "node-b",
+                },
+                generation_capability,
+            )
+        )
+
+        assert result == {
+            "accepted": True,
+            "node_id": "node-b",
+            "moved_task_lease_count": 1,
+        }
+        assert pool.actor_node_ids == ["node-b"]
+        assert manager.snapshot()["task_leases"][grant.lease.lease_id]["node_id"] == "node-b"
+        assert runner._query_task_lease_requests["public-request"]["lease"]["node_id"] == "node-b"
+    finally:
+        release_query_resource_manager(query_id, reason="test complete")
+
+
 @pytest.mark.parametrize(
     ("lease_timeout", "heartbeat_interval", "message"),
     [

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -56,7 +56,6 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
     graph = build_query_resource_graph(
         plan.collect_query_resource_graph_metadata(conn=con),
         env={
-            "VANE_NATIVE_FRAGMENT_TASK_HEAP_BYTES": "1",
             "VANE_TARGET_OUTPUT_BLOCK_BYTES": str(1024**2),
         },
     )
@@ -492,7 +491,7 @@ def _bind_test_query_resource_owner(
         unit_kind="native_fragment",
         backend="ray_worker",
         input_unit_ids=(),
-        per_task=ResourceVector(cpu=1, heap_bytes=1),
+        per_task=ResourceVector(),
         target_output_block_bytes=1,
         generator_buffer_blocks=1,
         max_concurrency=1,
@@ -1648,21 +1647,21 @@ def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkey
     assert not any("CancelledError" in warning for warning in outcome.cleanup_warnings)
 
 
-def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(monkeypatch):
+def test_query_driver_copy_opens_actor_unit_after_topology_and_actor_barriers(monkeypatch):
     import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
 
     cls, runner = _make_local_query_driver_actor()
     physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-startup-order")
     logical_plan = _FakeLogicalPlan(physical_plan)
     plan_started = threading.Event()
-    actor_stage_open = threading.Event()
+    actor_unit_open = threading.Event()
     events: list[str] = []
 
     class _PlanRunner:
         def run_copy_plan(self, _plan, _conn):
             events.append("plan-started")
             plan_started.set()
-            assert actor_stage_open.wait(timeout=2.0)
+            assert actor_unit_open.wait(timeout=2.0)
             events.append("plan-finished")
             return _committed_copy_result(ok=True)
 
@@ -1676,9 +1675,9 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
         assert actor_pools == ["actor-pool"]
         events.append("actors-ready")
 
-    def mark_actor_stages(_self, _graph):
-        events.append("actor-stage-open")
-        actor_stage_open.set()
+    def mark_actor_units(_self, _graph):
+        events.append("actor-unit-open")
+        actor_unit_open.set()
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
@@ -1689,7 +1688,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
         "_register_query_resources",
         _query_registration_stub("copy-startup-order"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_stages)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_units)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
     monkeypatch.setattr(
@@ -1702,7 +1701,7 @@ def test_query_driver_copy_opens_actor_stage_after_topology_and_actor_barriers(m
 
     assert outcome.result["ok"] is True
     assert outcome.write_state == "committed"
-    open_index = events.index("actor-stage-open")
+    open_index = events.index("actor-unit-open")
     assert events.index("topology-ready") < open_index
     assert events.index("actors-ready") < open_index
     assert open_index < events.index("plan-finished")
@@ -1736,8 +1735,8 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
         assert release_barriers.wait(timeout=2.0)
         events.append("actors-ready")
 
-    def mark_actor_stages(_self, _graph):
-        events.append("actor-stage-open")
+    def mark_actor_units(_self, _graph):
+        events.append("actor-unit-open")
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
     monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
@@ -1748,7 +1747,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
         "_register_query_resources",
         _query_registration_stub("copy-plan-before-startup-barriers"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_stages)
+    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_units)
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
     monkeypatch.setattr(
@@ -1767,7 +1766,7 @@ def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypa
 
     assert outcome.result["rows_copied"] == 0
     assert outcome.write_state == "committed"
-    open_index = events.index("actor-stage-open")
+    open_index = events.index("actor-unit-open")
     assert events.index("plan-finished") < events.index("topology-ready") < open_index
     assert events.index("plan-finished") < events.index("actors-ready") < open_index
 
@@ -4324,7 +4323,7 @@ def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
         "lease_id": "lease-native-descriptor",
         "query_id": "resource-query-native-descriptor",
         "execution_query_id": "query-native-descriptor",
-        "resource_unit_id": "stage-native-descriptor",
+        "resource_unit_id": "resource:test:fragment:native-descriptor",
         "attempt_id": "query-native-descriptor.0.0.0",
         "target_output_block_bytes": 1,
         "output_window_bytes": 1,
@@ -4409,7 +4408,7 @@ def test_run_plan_return_cancellation_waits_for_native_execution(monkeypatch):
         "lease_id": "lease-native-cancel",
         "query_id": "resource-query-native-cancel",
         "execution_query_id": "query-native-cancel",
-        "resource_unit_id": "stage-native-cancel",
+        "resource_unit_id": "resource:test:fragment:native-cancel",
         "attempt_id": "query-native-cancel.0.0.1",
         "target_output_block_bytes": 1,
         "output_window_bytes": 1,
@@ -6250,10 +6249,7 @@ def test_describe_native_progress_materializes_deferred_clone_without_execution(
     assert topology["schema"] == "pipeline_topology"
     assert topology["pipelines"]
     assert any("TABLE_SCAN" in pipeline["operators"] for pipeline in topology["pipelines"])
-    assert all(
-        set(pipeline) == {"pipeline_id", "operators", "operator_details", "stage_ids"}
-        for pipeline in topology["pipelines"]
-    )
+    assert all(set(pipeline) == {"pipeline_id", "operators", "operator_details"} for pipeline in topology["pipelines"])
     result_collector_roles = {
         pipeline["operator_details"][index].get("pipeline_role")
         for pipeline in topology["pipelines"]
@@ -6295,7 +6291,6 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
     class _CapturingWorker:
         def __init__(self):
             self.tasks = []
-            self.blocking_materialization_completions = []
 
         def submit_tasks(self, tasks):
             self.tasks.extend(tasks)
@@ -6323,10 +6318,6 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
 
         def task_input_stream_exhausted_for_query(self, _query_id, _source_node_ids):
             return []
-
-        def blocking_materialization_completed(self, query_id, node_id):
-            self.blocking_materialization_completions.append((query_id, node_id))
-            return True
 
         def prepare_shutdown(self):
             return None
@@ -6393,8 +6384,6 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
 
     assert sink_topologies
     assert len(sink_results) == len(sink_topologies)
-    assert len(worker.blocking_materialization_completions) == 1
-    assert worker.blocking_materialization_completions[0][0] == plan.idx()
     assert all(result.flight_port > 0 for result in sink_results)
     assert all(result.completion_status == "executed" for result in sink_results)
     ordinary_result = runner.execute_native(con.cursor(), _make_test_physical_plan(con), None, None)

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -30,7 +30,13 @@ from duckdb.runners.ray.worker import (
 
 
 @contextmanager
-def _registered_low_level_plan(plan, con, *, node_id=None):
+def _registered_low_level_plan(
+    plan,
+    con,
+    *,
+    node_id=None,
+    refresh_phase_allocation=False,
+):
     """Exercise the internal C++ runner under the mandatory graph contract."""
     from duckdb.runners.ray.query_resource_graph import (
         NodeResourceAllocation,
@@ -65,6 +71,28 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
         heap_bytes=1 << 50,
         object_store_bytes=1 << 50,
     )
+    generation = 1
+    manager_holder = {}
+
+    def _refresh_phase_allocation(_eligible_unit_ids):
+        nonlocal generation
+        if not refresh_phase_allocation:
+            return
+        generation += 1
+        manager_holder["manager"].update_allocation(
+            QueryAllocation(
+                resources=allocation_resources,
+                node_allocations=(
+                    NodeResourceAllocation(
+                        node_id=node_id,
+                        resources=allocation_resources,
+                    ),
+                ),
+                generation=generation,
+            ),
+            admission_open=True,
+        )
+
     manager = register_query_resource_graph(
         graph,
         QueryAllocation(
@@ -75,15 +103,15 @@ def _registered_low_level_plan(plan, con, *, node_id=None):
                     resources=allocation_resources,
                 ),
             ),
-            actor_placements=(),
             generation=1,
         ),
+        on_eligible_units_change=_refresh_phase_allocation,
     )
+    manager_holder["manager"] = manager
     for unit in graph.units:
         manager.update_unit_state(
             unit.resource_unit_id,
             runnable=True,
-            actor_ready=True,
         )
     try:
         yield graph
@@ -225,6 +253,12 @@ def _make_local_query_driver_actor():
     runner.plan_runner = None
     runner._active_udf_actors = []
     runner._active_udf_actors_by_plan = {}
+    runner._active_udf_actor_by_unit = {}
+    runner._query_udf_actor_lifecycle_locks = {}
+    runner._query_udf_actor_nodes = {}
+    runner._query_udf_session_configs = {}
+    runner._query_udf_actor_activation_tasks = {}
+    runner._query_resource_admission_loop = None
     runner._active_vllm_actors = []
     runner._active_vllm_actors_by_plan = {}
     runner._plan_runner_lifecycle_lock = threading.RLock()
@@ -508,7 +542,6 @@ def _bind_test_query_resource_owner(
         QueryAllocation(
             resources=resources,
             node_allocations=(NodeResourceAllocation(node_id="node-a", resources=resources),),
-            actor_placements=(),
             generation=1,
         ),
     )
@@ -613,7 +646,6 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
         plan,
         plan_id,
         _graph,
-        _allocation,
         _query_connection,
         _session_config,
     ):
@@ -681,7 +713,6 @@ def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypat
         "_register_query_resources",
         _query_registration_stub("slow-stream-startup"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
 
     def _cleanup(_self, plan_id):
         runner.curr_plans.pop(plan_id, None)
@@ -732,7 +763,6 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
         _self,
         _plan,
         _graph,
-        _allocation,
         *,
         query_connection,
         session_config,
@@ -753,7 +783,6 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
         "_register_query_resources",
         _query_registration_stub("copy-plan"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
         cls,
         "_drop_query_fragments_sync",
@@ -780,7 +809,7 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
     assert captured["lifecycle"] == ["snapshot", "teardown"]
 
 
-def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(monkeypatch):
+def test_query_driver_committed_copy_preserves_late_actor_initialization_warning(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-plan-terminal")
     logical_plan = _FakeLogicalPlan(physical_plan)
@@ -788,7 +817,7 @@ def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(
 
     class _PlanRunner:
         def run_copy_plan(self, _plan, _conn):
-            runner._query_terminal_errors["copy-query-terminal"] = "fixed Ray actor placement was lost"
+            runner._query_terminal_errors["copy-query-terminal"] = "Ray actor UDF pool initialization failed"
             return _committed_copy_result(ok=True)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
@@ -799,7 +828,6 @@ def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(
         "_register_query_resources",
         _query_registration_stub("copy-query-terminal"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
 
     def _teardown(_self, plan_id, query_id, *, drop_fragments):
         teardown_calls.append((plan_id, query_id, drop_fragments))
@@ -814,7 +842,7 @@ def test_query_driver_committed_copy_preserves_terminal_actor_placement_warning(
     ]
     assert outcome.write_state == "committed"
     assert outcome.cleanup_state == "complete"
-    assert any("fixed Ray actor placement was lost" in warning for warning in outcome.cleanup_warnings)
+    assert any("Ray actor UDF pool initialization failed" in warning for warning in outcome.cleanup_warnings)
 
 
 def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatch):
@@ -834,7 +862,6 @@ def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatc
         "_register_query_resources",
         _query_registration_stub("copy-progress-contract-failure"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(
         cls,
         "_build_local_progress_snapshot",
@@ -861,194 +888,6 @@ def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatc
     assert outcome.final_progress_snapshot is None
     assert len(outcome.cleanup_warnings) == 1
     assert "progress finalization failed: RuntimeError: invalid progress topology" in outcome.cleanup_warnings[0]
-
-
-def test_query_driver_failure_immediately_after_commit_replays_success(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    plan_id = "copy-failure-immediately-after-commit"
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
-    plan_finished = threading.Event()
-    plan_calls = 0
-    teardown_calls = []
-
-    class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            nonlocal plan_calls
-            plan_calls += 1
-            plan_finished.set()
-            return _committed_copy_result(rows_copied=5)
-
-    def _fail_after_commit(_self, _actors):
-        assert plan_finished.wait(timeout=2.0)
-        raise RuntimeError("injected immediately-after-commit failure")
-
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
-        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
-        cls._release_plan_session_state(runner, actual_plan_id)
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_after_commit)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
-    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        lambda *_args, **_kwargs: plan_finished.wait(timeout=2.0),
-    )
-
-    first = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-    replayed = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-
-    assert first == replayed
-    assert first.write_state == "committed"
-    assert first.cleanup_state == "complete"
-    assert first.final_progress_snapshot is None
-    assert any("injected immediately-after-commit failure" in warning for warning in first.cleanup_warnings), (
-        first.cleanup_warnings
-    )
-    assert plan_calls == 1
-    assert teardown_calls == [(plan_id, plan_id, True)]
-
-
-def test_query_driver_concurrent_startup_failure_preserves_unknown_copy_outcome(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    plan_id = "copy-startup-failure-outcome-unknown"
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
-    plan_finished = threading.Event()
-    plan_calls = 0
-    teardown_calls = []
-    unknown_result = {
-        "rows_copied": 5,
-        "copy_output_committed": False,
-        "copy_output_outcome_unknown": True,
-        "copy_output_outcome_error": "committed-marker readback was inconclusive",
-        "copy_output_base_path": "s3://bucket/out",
-        "copy_output_run_id": "run-startup-unknown",
-        "copy_output_manifest_path": "s3://bucket/out.duckdb_commit/run-startup-unknown/manifest.txt",
-        "copy_output_committed_marker_path": "s3://bucket/out.duckdb_commit/run-startup-unknown/committed",
-    }
-
-    class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            nonlocal plan_calls
-            plan_calls += 1
-            plan_finished.set()
-            return unknown_result
-
-    def _fail_after_copy(_self, _actors):
-        assert plan_finished.wait(timeout=2.0)
-        raise RuntimeError("injected concurrent COPY startup failure")
-
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
-        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
-        cls._release_plan_session_state(runner, actual_plan_id)
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_after_copy)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
-    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        lambda *_args, **_kwargs: plan_finished.wait(timeout=2.0),
-    )
-
-    for _ in range(2):
-        with pytest.raises(driver.CopyOutcomeUnknownError) as error:
-            asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-        assert error.value.run_id == "run-startup-unknown"
-        assert any("injected concurrent COPY startup failure" in warning for warning in error.value.cleanup_warnings)
-        assert "injected concurrent COPY startup failure" in str(error.value)
-        assert error.value.safe_to_retry is False
-
-    assert plan_calls == 1
-    assert teardown_calls == [(plan_id, plan_id, True)]
-
-
-def test_query_driver_postcommit_startup_drain_cancellation_replays_success(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    plan_id = "copy-postcommit-startup-drain-cancellation"
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
-    plan_finished = threading.Event()
-    topology_started = threading.Event()
-    topology_release = threading.Event()
-    teardown_finished = threading.Event()
-    startup_drain_started = threading.Event()
-    plan_calls = 0
-    original_gather = asyncio.gather
-
-    class _PlanRunner:
-        @staticmethod
-        def run_copy_plan(_plan, _conn):
-            nonlocal plan_calls
-            plan_calls += 1
-            plan_finished.set()
-            return _committed_copy_result(rows_copied=19)
-
-    def _fail_actor_barrier(_self, _actors):
-        assert plan_finished.wait(timeout=2.0)
-        raise RuntimeError("actor barrier failed after commit")
-
-    def _wait_for_topology(*_args, **_kwargs):
-        topology_started.set()
-        assert topology_release.wait(timeout=2.0)
-
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
-        assert actual_plan_id == plan_id
-        assert drop_fragments is True
-        cls._release_plan_session_state(runner, actual_plan_id)
-        teardown_finished.set()
-
-    def _tracked_gather(*args, **kwargs):
-        startup_drain_started.set()
-        return original_gather(*args, **kwargs)
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_actor_barrier)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
-    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
-    monkeypatch.setattr(driver.asyncio, "gather", _tracked_gather)
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        _wait_for_topology,
-    )
-
-    async def _cancel_during_startup_drain():
-        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
-        assert await asyncio.to_thread(topology_started.wait, 1.0)
-        assert await asyncio.to_thread(teardown_finished.wait, 1.0)
-        assert await asyncio.to_thread(startup_drain_started.wait, 1.0)
-        operation_task = runner._copy_operations_inflight[plan_id].task
-        operation_task.cancel()
-        await asyncio.sleep(0)
-        topology_release.set()
-        outcome = await asyncio.wait_for(copy_task, timeout=1.0)
-        replayed = await _run_actor_copy_plan(runner, logical_plan)
-        return outcome, replayed
-
-    outcome, replayed = asyncio.run(_cancel_during_startup_drain())
-
-    assert outcome == replayed
-    assert outcome.write_state == "committed"
-    assert outcome.result["rows_copied"] == 19
-    assert any("actor barrier failed after commit" in warning for warning in outcome.cleanup_warnings)
-    assert plan_calls == 1
 
 
 def test_query_driver_concurrent_copy_retries_share_one_write(monkeypatch):
@@ -1080,7 +919,6 @@ def test_query_driver_concurrent_copy_retries_share_one_write(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1123,7 +961,6 @@ def test_query_driver_copy_result_logging_failure_replays_committed_success(monk
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
     monkeypatch.setattr(
@@ -1168,7 +1005,6 @@ def test_query_driver_committed_copy_teardown_is_retryable_without_reexecution(m
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1221,7 +1057,6 @@ def test_query_driver_copy_failure_is_replayed_without_reexecution(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     for operation in (
@@ -1277,7 +1112,6 @@ def test_query_driver_unknown_native_copy_outcome_is_structured_and_never_reexec
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
     for operation in (
@@ -1349,7 +1183,6 @@ def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _register)
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1517,7 +1350,6 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
         "_register_query_resources",
         _query_registration_stub(plan_id),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", _build_snapshot)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1568,7 +1400,6 @@ def test_query_driver_copy_operation_cancellation_waits_for_native_commit(monkey
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1622,7 +1453,6 @@ def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkey
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1647,238 +1477,39 @@ def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkey
     assert not any("CancelledError" in warning for warning in outcome.cleanup_warnings)
 
 
-def test_query_driver_copy_opens_actor_unit_after_topology_and_actor_barriers(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
+def test_query_driver_copy_starts_without_eager_actor_or_topology_barriers(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
-    physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-startup-order")
-    logical_plan = _FakeLogicalPlan(physical_plan)
-    plan_started = threading.Event()
-    actor_unit_open = threading.Event()
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr("copy-lazy-actor-startup"))
     events: list[str] = []
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            events.append("plan-started")
-            plan_started.set()
-            assert actor_unit_open.wait(timeout=2.0)
-            events.append("plan-finished")
-            return _committed_copy_result(ok=True)
+        @staticmethod
+        def run_copy_plan(_plan, _conn):
+            events.append("plan")
+            return _committed_copy_result(rows_copied=1)
 
-    def wait_for_topology(query_id, *, timeout_s):
-        assert query_id == "copy-startup-order"
-        assert timeout_s > 0
-        assert plan_started.wait(timeout=2.0)
-        events.append("topology-ready")
-
-    def wait_for_actors(_self, actor_pools):
-        assert actor_pools == ["actor-pool"]
-        events.append("actors-ready")
-
-    def mark_actor_units(_self, _graph):
-        events.append("actor-unit-open")
-        actor_unit_open.set()
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
+    monkeypatch.setattr(
+        cls,
+        "_precreate_udf_actors",
+        lambda *_args, **_kwargs: events.append("actor-locators") or [],
+    )
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
     monkeypatch.setattr(
         cls,
         "_register_query_resources",
-        _query_registration_stub("copy-startup-order"),
+        _query_registration_stub("copy-lazy-actor-startup"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_units)
+    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {"state": "FINISHED"})
     monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        wait_for_topology,
-    )
 
     outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
 
-    assert outcome.result["ok"] is True
+    assert outcome.result["rows_copied"] == 1
     assert outcome.write_state == "committed"
-    open_index = events.index("actor-unit-open")
-    assert events.index("topology-ready") < open_index
-    assert events.index("actors-ready") < open_index
-    assert open_index < events.index("plan-finished")
-
-
-def test_query_driver_copy_accepts_plan_success_before_startup_barriers(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr("copy-plan-before-startup-barriers"))
-    plan_finished = threading.Event()
-    release_barriers = threading.Event()
-    events: list[str] = []
-
-    class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            events.append("plan-finished")
-            plan_finished.set()
-            return _committed_copy_result(rows_copied=0)
-
-    def wait_for_topology(query_id, *, timeout_s):
-        assert query_id == "copy-plan-before-startup-barriers"
-        assert timeout_s > 0
-        assert plan_finished.wait(timeout=2.0)
-        assert release_barriers.wait(timeout=2.0)
-        events.append("topology-ready")
-
-    def wait_for_actors(_self, actor_pools):
-        assert actor_pools == ["actor-pool"]
-        assert plan_finished.wait(timeout=2.0)
-        assert release_barriers.wait(timeout=2.0)
-        events.append("actors-ready")
-
-    def mark_actor_units(_self, _graph):
-        events.append("actor-unit-open")
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(
-        cls,
-        "_register_query_resources",
-        _query_registration_stub("copy-plan-before-startup-barriers"),
-    )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", mark_actor_units)
-    monkeypatch.setattr(cls, "_teardown_plan_resources", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(cls, "_build_local_progress_snapshot", lambda *_args: {})
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        wait_for_topology,
-    )
-
-    release_thread = threading.Thread(
-        target=lambda: (plan_finished.wait(timeout=2.0), release_barriers.set()),
-        daemon=True,
-    )
-    release_thread.start()
-    outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-    release_thread.join(timeout=2.0)
-
-    assert outcome.result["rows_copied"] == 0
-    assert outcome.write_state == "committed"
-    open_index = events.index("actor-unit-open")
-    assert events.index("plan-finished") < events.index("topology-ready") < open_index
-    assert events.index("plan-finished") < events.index("actors-ready") < open_index
-
-
-def test_query_driver_copy_plan_failure_interrupts_startup_barriers(monkeypatch):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr("copy-plan-startup-failure"))
-    teardown_started = threading.Event()
-    marked_ready = []
-
-    class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            raise ValueError("native plan startup failed")
-
-    def wait_until_teardown(*_args, **_kwargs):
-        assert teardown_started.wait(timeout=2.0)
-
-    def teardown(*_args, **_kwargs):
-        teardown_started.set()
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_until_teardown)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(
-        cls,
-        "_register_query_resources",
-        _query_registration_stub("copy-plan-startup-failure"),
-    )
-    monkeypatch.setattr(
-        cls,
-        "_mark_query_actor_units_ready",
-        lambda *_args: marked_ready.append(True),
-    )
-    monkeypatch.setattr(cls, "_teardown_plan_resources", teardown)
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        wait_until_teardown,
-    )
-
-    with pytest.raises(ValueError, match="native plan startup failed"):
-        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-
-    assert teardown_started.is_set()
-    assert marked_ready == []
-
-
-@pytest.mark.parametrize(
-    ("failing_barrier", "error_type", "message"),
-    [
-        ("actor", RuntimeError, "actor init failed"),
-        ("topology", TimeoutError, "topology init timed out"),
-    ],
-)
-def test_query_driver_copy_startup_barrier_failure_tears_down_plan(
-    monkeypatch,
-    failing_barrier,
-    error_type,
-    message,
-):
-    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
-
-    cls, runner = _make_local_query_driver_actor()
-    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(f"copy-{failing_barrier}-barrier-failure"))
-    teardown_started = threading.Event()
-    marked_ready = []
-
-    class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
-            assert teardown_started.wait(timeout=2.0)
-            return {"ok": True}
-
-    def wait_for_actors(*_args):
-        if failing_barrier == "actor":
-            raise RuntimeError(message)
-
-    def wait_for_topology(*_args, **_kwargs):
-        if failing_barrier == "topology":
-            raise TimeoutError(message)
-
-    def teardown(*_args, **_kwargs):
-        teardown_started.set()
-
-    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
-    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", wait_for_actors)
-    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
-    monkeypatch.setattr(
-        cls,
-        "_register_query_resources",
-        _query_registration_stub(f"copy-{failing_barrier}-barrier-failure"),
-    )
-    monkeypatch.setattr(
-        cls,
-        "_mark_query_actor_units_ready",
-        lambda *_args: marked_ready.append(True),
-    )
-    monkeypatch.setattr(cls, "_teardown_plan_resources", teardown)
-    monkeypatch.setattr(
-        scheduler_mod,
-        "wait_for_fte_query_progress_topology",
-        wait_for_topology,
-    )
-
-    with pytest.raises(error_type, match=message):
-        asyncio.run(_run_actor_copy_plan(runner, logical_plan))
-
-    assert teardown_started.is_set()
-    assert marked_ready == []
+    assert events == ["actor-locators", "plan"]
+    assert not hasattr(cls, "_wait_for_udf_actors_ready")
+    assert not hasattr(cls, "_mark_query_actor_units_ready")
 
 
 def test_ray_query_driver_client_copy_refreshes_progress_and_uses_final_snapshot(monkeypatch):
@@ -2814,7 +2445,6 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
         _self,
         _plan,
         _graph,
-        _allocation,
         *,
         query_connection,
         session_config,
@@ -2835,7 +2465,6 @@ def test_query_driver_run_plan_passes_distributed_physical_plan_wrapper(monkeypa
         "_register_query_resources",
         _query_registration_stub("stream-plan"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda _self, _graph: None)
     monkeypatch.setattr(
         cls,
         "_release_query_resources",
@@ -2877,7 +2506,6 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
         "_register_query_resources",
         _query_registration_stub("failed-query"),
     )
-    monkeypatch.setattr(cls, "_mark_query_actor_units_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_udf_actors)
     monkeypatch.setattr(
         cls,
@@ -4453,7 +4081,7 @@ def test_normalize_native_task_result_rejects_legacy_shapes():
         _normalize_native_task_result(([], [], None))
 
 
-def test_fte_output_publication_is_bounded_by_block_target_and_task_window():
+def test_fte_output_publication_validates_metadata_without_hard_estimate_caps():
     lease = {
         "lease_id": "lease-1",
         "query_id": "q",
@@ -4468,13 +4096,18 @@ def test_fte_output_publication_is_bounded_by_block_target_and_task_window():
         lease,
     ) == (10, 1)
 
-    with pytest.raises(RuntimeError, match="block 0.*11.*target 10"):
-        _validate_fte_output_publication([PartitionMetadata(1, 11)], lease)
-    with pytest.raises(RuntimeError, match="total output bytes 21.*window 20"):
+    assert _validate_fte_output_publication([PartitionMetadata(1, 11)], lease) == (11,)
+    assert _validate_fte_output_publication(
+        [PartitionMetadata(1, 10), PartitionMetadata(1, 10), PartitionMetadata(0, 0)],
+        lease,
+    ) == (10, 10, 1)
+    assert (
         _validate_fte_output_publication(
-            [PartitionMetadata(1, 10), PartitionMetadata(1, 10), PartitionMetadata(0, 0)],
-            lease,
+            [],
+            {**lease, "target_output_block_bytes": 0, "output_window_bytes": 0},
         )
+        == ()
+    )
     with pytest.raises(RuntimeError, match="missing positive size_bytes"):
         _validate_fte_output_publication([PartitionMetadata(1, 0)], lease)
 
@@ -5891,7 +5524,7 @@ def test_get_next_partition_rejects_non_metadata_aware_fragment():
         )
 
 
-def test_get_next_partition_surfaces_terminal_actor_placement_loss_before_delivery():
+def test_get_next_partition_surfaces_late_actor_initialization_failure_before_delivery():
     cls, runner = _make_local_query_driver_actor()
     plan_id = "plan-placement-lost"
     query_id = "query-placement-lost"
@@ -5899,7 +5532,7 @@ def test_get_next_partition_surfaces_terminal_actor_placement_loss_before_delive
     undelivered = object()
     runner.curr_streams[plan_id] = _DummyStream([undelivered])
     runner.curr_plans[plan_id] = object()
-    runner._query_terminal_errors[query_id] = "fixed Ray actor placement was lost"
+    runner._query_terminal_errors[query_id] = "Ray actor UDF pool initialization failed"
     teardown_calls = []
 
     def _teardown(actual_plan_id, actual_query_id, *, drop_fragments):
@@ -5908,7 +5541,7 @@ def test_get_next_partition_surfaces_terminal_actor_placement_loss_before_delive
 
     runner._teardown_plan_resources = _teardown
 
-    with pytest.raises(RuntimeError, match="fixed Ray actor placement was lost"):
+    with pytest.raises(RuntimeError, match="Ray actor UDF pool initialization failed"):
         asyncio.run(
             cls.get_next_partition(
                 runner,
@@ -6559,6 +6192,36 @@ def test_run_plan_uses_distributed_worker_path(tmp_path):
         payload = ray.get(parts[0].object_ref)
     assert isinstance(payload, pa.Table)
     assert payload.to_pylist() == [{"c0": 1}, {"c0": 2}, {"c0": 3}]
+    con.close()
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.usefixtures("ray_local")
+def test_run_plan_continues_with_final_tasks_after_order_by_barrier(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    ray = pytest.importorskip("ray")
+
+    con = duckdb.connect()
+    src = tmp_path / "barrier_order_input.parquet"
+    con.sql("SELECT i::BIGINT AS x FROM range(32) tbl(i)").write_parquet(str(src))
+    relation = con.read_parquet(str(src)).repartition(4).order("x DESC")
+    plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+
+    with _registered_low_level_plan(
+        plan,
+        con,
+        refresh_phase_allocation=True,
+    ) as graph:
+        assert len(graph.materialization_barriers) == 1
+        parts = list(iter(runner.run_plan(plan, con)))
+        tables = ray.get([part.object_ref for part in parts])
+
+    assert all(isinstance(table, pa.Table) for table in tables)
+    assert [value for table in tables for value in table.column(0).to_pylist()] == list(reversed(range(32)))
     con.close()
 
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6295,6 +6295,7 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
     class _CapturingWorker:
         def __init__(self):
             self.tasks = []
+            self.blocking_materialization_completions = []
 
         def submit_tasks(self, tasks):
             self.tasks.extend(tasks)
@@ -6322,6 +6323,10 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
 
         def task_input_stream_exhausted_for_query(self, _query_id, _source_node_ids):
             return []
+
+        def blocking_materialization_completed(self, query_id, node_id):
+            self.blocking_materialization_completions.append((query_id, node_id))
+            return True
 
         def prepare_shutdown(self):
             return None
@@ -6388,6 +6393,8 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
 
     assert sink_topologies
     assert len(sink_results) == len(sink_topologies)
+    assert len(worker.blocking_materialization_completions) == 1
+    assert worker.blocking_materialization_completions[0][0] == plan.idx()
     assert all(result.flight_port > 0 for result in sink_results)
     assert all(result.completion_status == "executed" for result in sink_results)
     ordinary_result = runner.execute_native(con.cursor(), _make_test_physical_plan(con), None, None)

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -115,7 +115,7 @@ def _lease():
     return {
         "lease_id": "lease-1",
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "task_id": "task-1",
         "attempt_id": "attempt-1",
         "actor_index": None,
@@ -202,7 +202,7 @@ def test_stream_blocks_never_exceed_duckdb_vector_size():
     target_bytes = 1024**3
     payload = {
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "task_lease_id": "lease-1",
         "attempt_id": "attempt-1",
         "udf_output_target_max_bytes": target_bytes,

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -215,6 +215,28 @@ def test_stream_blocks_never_exceed_duckdb_vector_size():
     assert [block.num_rows for block in blocks] == [DUCKDB_STANDARD_VECTOR_SIZE, 37]
 
 
+def test_stream_blocks_keep_unsplittable_rows_as_complete_soft_target_blocks():
+    pa = pytest.importorskip("pyarrow")
+    from duckdb.execution._common import estimate_table_bytes
+    from duckdb.execution.udf_ray_stream_protocol import iter_bounded_stream_blocks
+
+    target_bytes = 32
+    payload = {
+        "query_id": "q1",
+        "resource_unit_id": "resource:q1:udf:node:1",
+        "task_lease_id": "lease-1",
+        "attempt_id": "attempt-1",
+        "udf_output_target_max_bytes": target_bytes,
+        "output_window_bytes": target_bytes * 2,
+    }
+    values = ["a", "x" * 1024, "b"]
+
+    blocks = list(iter_bounded_stream_blocks(pa.table({"value": values}), payload))
+
+    assert [block.column("value").to_pylist() for block in blocks] == [["a"], [values[1]], ["b"]]
+    assert estimate_table_bytes(blocks[1]) > target_bytes
+
+
 def test_adapter_advances_generator_asynchronously_and_never_gets_data_ref():
     fake_ray = _FakeRay()
     block_ref = _Ref("large-block")

--- a/tests/fast/test_ray_test_profile.py
+++ b/tests/fast/test_ray_test_profile.py
@@ -3,23 +3,21 @@
 
 import pytest
 from ray_test_profile import (
-    DEFAULT_RAY_OBJECT_STORE_BYTES,
     RAY_OBJECT_STORE_BYTES_ENV,
-    ray_test_object_store_bytes,
+    ray_test_object_store_options,
 )
 
 
-def test_ray_test_object_store_defaults_to_two_gib(monkeypatch):
+def test_ray_test_object_store_follows_ray_by_default(monkeypatch):
     monkeypatch.delenv(RAY_OBJECT_STORE_BYTES_ENV, raising=False)
 
-    assert ray_test_object_store_bytes() == 2 * 1024**3
-    assert ray_test_object_store_bytes() == DEFAULT_RAY_OBJECT_STORE_BYTES
+    assert ray_test_object_store_options() == {}
 
 
 def test_ray_test_object_store_allows_override(monkeypatch):
     monkeypatch.setenv(RAY_OBJECT_STORE_BYTES_ENV, str(3 * 1024**3))
 
-    assert ray_test_object_store_bytes() == 3 * 1024**3
+    assert ray_test_object_store_options() == {"object_store_memory": 3 * 1024**3}
 
 
 @pytest.mark.parametrize("value", ["", "0", "-1", "not-an-integer"])
@@ -27,4 +25,4 @@ def test_ray_test_object_store_rejects_invalid_values(monkeypatch, value):
     monkeypatch.setenv(RAY_OBJECT_STORE_BYTES_ENV, value)
 
     with pytest.raises(ValueError, match=RAY_OBJECT_STORE_BYTES_ENV):
-        ray_test_object_store_bytes()
+        ray_test_object_store_options()

--- a/tests/fast/test_ray_udf_plan_replay.py
+++ b/tests/fast/test_ray_udf_plan_replay.py
@@ -311,7 +311,7 @@ def _assert_no_udf_direct_output_conversion():
     return counters
 
 
-def test_execute_native_rejects_ray_scalar_without_registered_query_graph(tmp_path, monkeypatch):
+def test_execute_native_rejects_ray_scalar_without_registered_query_resource_graph(tmp_path, monkeypatch):
     pytest.importorskip("pyarrow")
     pytest.importorskip("ray")
 
@@ -463,7 +463,7 @@ def test_ray_runner_replays_map_batches_udf_via_task_plan_pickle(tmp_path, monke
     con.close()
 
 
-def test_map_batches_ray_task_rejects_direct_execution_without_query_graph(tmp_path, monkeypatch):
+def test_map_batches_ray_task_rejects_direct_execution_without_query_resource_graph(tmp_path, monkeypatch):
     pytest.importorskip("pyarrow")
     pytest.importorskip("ray")
     import pyarrow as pa

--- a/tests/fast/test_ray_worker_cuda_visibility.py
+++ b/tests/fast/test_ray_worker_cuda_visibility.py
@@ -7,7 +7,7 @@ import pytest
 
 ray = pytest.importorskip("ray")
 
-from ray_test_profile import ray_test_object_store_bytes
+from ray_test_profile import ray_test_object_store_options
 
 import duckdb.runners.ray.worker as worker_mod
 from duckdb.runners.ray.worker_pool import _persistent_worker_runtime_env
@@ -145,7 +145,7 @@ def test_zero_gpu_ray_worker_preserves_non_contiguous_node_cuda_visibility(monke
             log_to_driver=True,
             num_cpus=1,
             num_gpus=2,
-            object_store_memory=ray_test_object_store_bytes(),
+            **ray_test_object_store_options(),
         )
     actor = None
     try:

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -35,14 +35,14 @@ def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
     return lifecycle
 
 
-def test_blocking_materialization_completion_routes_native_node_to_query_stage(monkeypatch):
+def test_blocking_materialization_completion_routes_native_node_to_resource_unit(monkeypatch):
     from duckdb.runners.ray import query_resource_runtime
 
     calls: list[str] = []
 
     class Manager:
-        def mark_materializing_stage_completed(self, stage_id: str) -> bool:
-            calls.append(stage_id)
+        def mark_barrier_unit_completed(self, resource_unit_id: str) -> bool:
+            calls.append(resource_unit_id)
             return True
 
     def get_manager(query_id: str) -> Manager:
@@ -53,7 +53,7 @@ def test_blocking_materialization_completion_routes_native_node_to_query_stage(m
     lifecycle = _lifecycle(object())
 
     assert lifecycle.blocking_materialization_completed("query-a", "42") is True
-    assert calls == ["stage:query-a:node:42:fte"]
+    assert calls == ["resource:query-a:fragment:node:42"]
 
     with pytest.raises(ValueError, match="requires query_id and node_id"):
         lifecycle.blocking_materialization_completed("", "42")

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -35,6 +35,30 @@ def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
     return lifecycle
 
 
+def test_blocking_materialization_completion_routes_native_node_to_query_stage(monkeypatch):
+    from duckdb.runners.ray import query_resource_runtime
+
+    calls: list[str] = []
+
+    class Manager:
+        def mark_materializing_stage_completed(self, stage_id: str) -> bool:
+            calls.append(stage_id)
+            return True
+
+    def get_manager(query_id: str) -> Manager:
+        assert query_id == "query-a"
+        return Manager()
+
+    monkeypatch.setattr(query_resource_runtime, "get_query_resource_manager", get_manager)
+    lifecycle = _lifecycle(object())
+
+    assert lifecycle.blocking_materialization_completed("query-a", "42") is True
+    assert calls == ["stage:query-a:node:42:fte"]
+
+    with pytest.raises(ValueError, match="requires query_id and node_id"):
+        lifecycle.blocking_materialization_completed("", "42")
+
+
 def test_worker_finish_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
     from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
 

--- a/tests/fast/test_ray_worker_lifecycle.py
+++ b/tests/fast/test_ray_worker_lifecycle.py
@@ -35,30 +35,6 @@ def _lifecycle(actor: object) -> FteWorkerLifecycleMixin:
     return lifecycle
 
 
-def test_blocking_materialization_completion_routes_native_node_to_resource_unit(monkeypatch):
-    from duckdb.runners.ray import query_resource_runtime
-
-    calls: list[str] = []
-
-    class Manager:
-        def mark_barrier_unit_completed(self, resource_unit_id: str) -> bool:
-            calls.append(resource_unit_id)
-            return True
-
-    def get_manager(query_id: str) -> Manager:
-        assert query_id == "query-a"
-        return Manager()
-
-    monkeypatch.setattr(query_resource_runtime, "get_query_resource_manager", get_manager)
-    lifecycle = _lifecycle(object())
-
-    assert lifecycle.blocking_materialization_completed("query-a", "42") is True
-    assert calls == ["resource:query-a:fragment:node:42"]
-
-    with pytest.raises(ValueError, match="requires query_id and node_id"):
-        lifecycle.blocking_materialization_completed("", "42")
-
-
 def test_worker_finish_shutdown_waits_for_graceful_rpc_before_kill(monkeypatch):
     from duckdb.runners.ray import fragment_worker_lifecycle as lifecycle_module
 

--- a/tests/fast/test_udf.py
+++ b/tests/fast/test_udf.py
@@ -481,7 +481,7 @@ def _run_subprocess_lazy_byte_submit_probe(tmp_path):
 
 
 def test_map_batches_requires_strict_streaming_contract():
-    """Ray stages always use the graph-owned direct block stream."""
+    """Ray resource units always use the graph-owned direct block stream."""
     import duckdb
 
     def identity(table):

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -51,7 +51,6 @@ def test_subprocess_actor_warmup_attribute_error_fails_startup():
 def test_udf_resource_and_layout_validation_has_no_silent_fallbacks():
     from duckdb.execution._udf_runtime import UDFExecutor as RuntimeUDFExecutor
     from duckdb.execution.udf_ray_config import payload_num_cpus, payload_num_gpus, stream_output_enabled
-    from duckdb.execution.udf_ray_env import normalize_actor_node_ids
     from duckdb.execution.udf_threading import payload_cpu_thread_count
 
     with pytest.raises(ValueError, match="cpus"):
@@ -66,8 +65,6 @@ def test_udf_resource_and_layout_validation_has_no_silent_fallbacks():
         stream_output_enabled({"stream_output": "true"})
     with pytest.raises(ValueError, match="cpus"):
         payload_cpu_thread_count({"cpus": "invalid"})
-    with pytest.raises(ValueError, match="actor node IDs"):
-        normalize_actor_node_ids(["node-a"], expected_count=2)
 
     def identity(table):
         return table
@@ -6729,7 +6726,6 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
     import duckdb.execution.udf_ray as udf_ray
 
     captured = {}
-    submitted_nodes = []
 
     class _Pregranted:
         def __init__(self, **kwargs):
@@ -6737,14 +6733,6 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
             self.generator = kwargs["submitter"](dict(kwargs["admission"].lease))
 
     monkeypatch.setattr(udf_ray, "TaskLeaseObjectRefGenerator", _Pregranted)
-    monkeypatch.setattr(
-        udf_ray,
-        "_submit_ray_remote",
-        lambda remote_fn, node_id, *args, **kwargs: (
-            submitted_nodes.append(str(node_id)),
-            remote_fn.remote(*args, **kwargs),
-        )[1],
-    )
     executor, run_stream, _ = _ray_task_executor(stream_result="generator")
     table = pa.table({"x": [1, 2]})
     lease = {
@@ -6752,7 +6740,8 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
         "resource_unit_id": "resource:query-submit:udf:node:1",
         "lease_id": "lease-42",
         "attempt_id": "attempt-42",
-        "node_id": "node-a",
+        "node_id": None,
+        "actor_index": None,
         "execution_slot_id": "ray_task:resource:query-submit:udf:node:1:lease-42",
         "output_window_bytes": 256 * 1024**2,
     }
@@ -6764,7 +6753,6 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
     assert isinstance(result, _Pregranted)
     assert result.generator == "generator"
     assert captured["admission"] is admission
-    assert submitted_nodes == ["node-a"]
     assert len(run_stream.calls) == 1
 
     args, kwargs = run_stream.calls[0]
@@ -6772,6 +6760,7 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
     assert args[0]["execution_backend"] == "ray_task"
     assert args[0]["task_lease_id"] == "lease-42"
     assert args[0]["attempt_id"] == "attempt-42"
+    assert "node_id" not in args[0]
     assert len(args[1]) == 1
     assert args[1][0].to_pydict() == {"x": [1, 2]}
 
@@ -6780,7 +6769,6 @@ def test_ray_task_submit_ref_bundle_with_id_uses_pregranted_lease(monkeypatch):
     import duckdb.execution.udf_ray as udf_ray
 
     captured = {}
-    submitted_nodes = []
 
     class _Pregranted:
         def __init__(self, **kwargs):
@@ -6788,21 +6776,14 @@ def test_ray_task_submit_ref_bundle_with_id_uses_pregranted_lease(monkeypatch):
             self.generator = kwargs["submitter"](dict(kwargs["admission"].lease))
 
     monkeypatch.setattr(udf_ray, "TaskLeaseObjectRefGenerator", _Pregranted)
-    monkeypatch.setattr(
-        udf_ray,
-        "_submit_ray_remote",
-        lambda remote_fn, node_id, *args, **kwargs: (
-            submitted_nodes.append(str(node_id)),
-            remote_fn.remote(*args, **kwargs),
-        )[1],
-    )
     executor, _, run_ref_stream = _ray_task_executor(ref_stream_result="ref-generator")
     lease = {
         "query_id": "query-submit",
         "resource_unit_id": "resource:query-submit:udf:node:1",
         "lease_id": "lease-7",
         "attempt_id": "attempt-7",
-        "node_id": "node-a",
+        "node_id": None,
+        "actor_index": None,
         "execution_slot_id": "ray_task:resource:query-submit:udf:node:1:lease-7",
         "output_window_bytes": 256 * 1024**2,
     }
@@ -6820,7 +6801,6 @@ def test_ray_task_submit_ref_bundle_with_id_uses_pregranted_lease(monkeypatch):
     assert isinstance(result, _Pregranted)
     assert result.generator == "ref-generator"
     assert captured["admission"] is admission
-    assert submitted_nodes == ["node-a"]
     assert len(run_ref_stream.calls) == 1
 
     args, kwargs = run_ref_stream.calls[0]
@@ -6828,6 +6808,7 @@ def test_ray_task_submit_ref_bundle_with_id_uses_pregranted_lease(monkeypatch):
     assert kwargs["payload"]["execution_backend"] == "ray_task"
     assert kwargs["payload"]["task_lease_id"] == "lease-7"
     assert kwargs["payload"]["attempt_id"] == "attempt-7"
+    assert "node_id" not in kwargs["payload"]
     assert kwargs["slices"] == [(0, 1)]
     assert kwargs["metadata"] == [{"num_rows": 1, "size_bytes": 8}]
     assert kwargs["names"] == ["x"]

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -8571,14 +8571,14 @@ def test_subprocess_executor_close_releases_queued_ref_bundle_results():
     assert all(ref._closed for ref in refs)
 
 
-def test_ray_actor_init_has_default_timeout(monkeypatch):
+def test_ray_actor_init_waits_for_ray_core_capacity_without_default_timeout(monkeypatch):
     import duckdb.execution.udf_ray_actor_pool as actor_pool_mod
 
     monkeypatch.delenv("VANE_QUERY_DEADLINE_EPOCH_S", raising=False)
     monkeypatch.delenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", raising=False)
     monkeypatch.delenv("VANE_RAY_ACTOR_INIT_TIMEOUT_S", raising=False)
 
-    assert actor_pool_mod._actor_init_timeout_s() > 0.0
+    assert actor_pool_mod._actor_init_timeout_s() is None
 
 
 def test_subprocess_close_kill_releases_active_local_shm_leases(monkeypatch):

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -2804,7 +2804,7 @@ def test_ray_task_ref_bundle_stream_flushes_compute_tail_after_finished_submitti
     )
     payload.update(
         query_id="query-tail",
-        stage_id="stage:query-tail:node:1:udf",
+        resource_unit_id="resource:query-tail:udf:node:1",
         task_lease_id="lease-tail",
         attempt_id="attempt-tail",
         node_id="node-a",
@@ -2849,7 +2849,7 @@ def test_ray_task_ref_bundle_map_batches_without_batch_size_passes_entire_block(
     )
     payload.update(
         query_id="query-whole-block",
-        stage_id="stage:query-whole-block:node:1:udf",
+        resource_unit_id="resource:query-whole-block:udf:node:1",
         task_lease_id="lease-whole-block",
         attempt_id="attempt-whole-block",
         node_id="node-a",
@@ -6712,7 +6712,7 @@ def _ray_task_executor(*, stream_result="stream-ref", ref_stream_result="ref-str
             "call_mode": "map_batches",
             "execution_backend": "ray_task",
             "query_id": "query-submit",
-            "stage_id": "stage:query-submit:node:1:udf",
+            "resource_unit_id": "resource:query-submit:udf:node:1",
             "produce_ray_block_stream": True,
             "udf_output_target_max_bytes": 128 * 1024**2,
             "udf_task_input_max_bytes": 128 * 1024**2,
@@ -6749,11 +6749,11 @@ def test_ray_task_submit_with_id_uses_generator_remote_with_pregranted_lease(mon
     table = pa.table({"x": [1, 2]})
     lease = {
         "query_id": "query-submit",
-        "stage_id": "stage:query-submit:node:1:udf",
+        "resource_unit_id": "resource:query-submit:udf:node:1",
         "lease_id": "lease-42",
         "attempt_id": "attempt-42",
         "node_id": "node-a",
-        "execution_slot_id": "ray_task:stage:query-submit:node:1:udf:lease-42",
+        "execution_slot_id": "ray_task:resource:query-submit:udf:node:1:lease-42",
         "output_window_bytes": 256 * 1024**2,
     }
     admission = types.SimpleNamespace(driver=object(), request_id="request-42", lease=lease)
@@ -6799,11 +6799,11 @@ def test_ray_task_submit_ref_bundle_with_id_uses_pregranted_lease(monkeypatch):
     executor, _, run_ref_stream = _ray_task_executor(ref_stream_result="ref-generator")
     lease = {
         "query_id": "query-submit",
-        "stage_id": "stage:query-submit:node:1:udf",
+        "resource_unit_id": "resource:query-submit:udf:node:1",
         "lease_id": "lease-7",
         "attempt_id": "attempt-7",
         "node_id": "node-a",
-        "execution_slot_id": "ray_task:stage:query-submit:node:1:udf:lease-7",
+        "execution_slot_id": "ray_task:resource:query-submit:udf:node:1:lease-7",
         "output_window_bytes": 256 * 1024**2,
     }
     admission = types.SimpleNamespace(driver=object(), request_id="request-7", lease=lease)

--- a/tests/fast/test_udf_ray_actor_row_preserving.py
+++ b/tests/fast/test_udf_ray_actor_row_preserving.py
@@ -41,7 +41,7 @@ def _rows_payload(fn: Any) -> dict[str, Any]:
         "actor_number": 1,
         "produce_ray_block_stream": True,
         "query_id": "query-row-preserving",
-        "stage_id": "stage-row-preserving",
+        "resource_unit_id": "stage-row-preserving",
         "task_lease_id": "lease-row-preserving",
         "attempt_id": "attempt-row-preserving",
         "node_id": "node-row-preserving",

--- a/tests/fast/test_udf_ray_actor_row_preserving.py
+++ b/tests/fast/test_udf_ray_actor_row_preserving.py
@@ -41,7 +41,7 @@ def _rows_payload(fn: Any) -> dict[str, Any]:
         "actor_number": 1,
         "produce_ray_block_stream": True,
         "query_id": "query-row-preserving",
-        "resource_unit_id": "stage-row-preserving",
+        "resource_unit_id": "resource:test:udf:row-preserving",
         "task_lease_id": "lease-row-preserving",
         "attempt_id": "attempt-row-preserving",
         "node_id": "node-row-preserving",

--- a/tests/fast/test_udf_ray_actor_row_preserving.py
+++ b/tests/fast/test_udf_ray_actor_row_preserving.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import sys
 import types
+from concurrent.futures import Future
 from typing import Any
 
 import pyarrow as pa
@@ -51,13 +52,58 @@ def _rows_payload(fn: Any) -> dict[str, Any]:
 
 
 class _FakeRuntimeContext:
+    def __init__(self, ray_module: _FakeRayModule) -> None:
+        self._ray_module = ray_module
+
     def get_node_id(self) -> str:
-        return "node-row-preserving"
+        return self._ray_module.node_id
+
+    def get_job_id(self) -> str:
+        return "job-row-preserving"
+
+    @property
+    def was_current_actor_reconstructed(self) -> bool:
+        return self._ray_module.reconstructed
+
+
+class _FakeReportRef:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self._result = result
+
+    def future(self) -> Future:
+        future = Future()
+        future.set_result(dict(self._result))
+        return future
+
+
+class _FakeReportMethod:
+    def __init__(self, ray_module: _FakeRayModule) -> None:
+        self._ray_module = ray_module
+
+    def remote(self, payload: dict[str, Any], capability: str) -> _FakeReportRef:
+        self._ray_module.location_reports.append((dict(payload), str(capability)))
+        return _FakeReportRef(
+            {
+                "accepted": True,
+                "node_id": payload["node_id"],
+                "moved_task_lease_count": 1,
+            }
+        )
+
+
+class _FakeDriver:
+    def __init__(self, ray_module: _FakeRayModule) -> None:
+        self.report_query_udf_actor_location = _FakeReportMethod(ray_module)
 
 
 class _FakeRayModule(types.ModuleType):
     def __init__(self) -> None:
         super().__init__("ray")
+        self.node_id = "node-row-preserving"
+        self.reconstructed = False
+        self.location_reports: list[tuple[dict[str, Any], str]] = []
+        self._runtime_context = _FakeRuntimeContext(self)
+        self._driver = _FakeDriver(self)
 
     def remote(self, *args: Any, **kwargs: Any):
         if len(args) == 1 and callable(args[0]) and not kwargs:
@@ -69,7 +115,12 @@ class _FakeRayModule(types.ModuleType):
         return deco
 
     def get_runtime_context(self) -> _FakeRuntimeContext:
-        return _FakeRuntimeContext()
+        return self._runtime_context
+
+    def get_actor(self, name: str, *, namespace: str) -> _FakeDriver:
+        assert name == "vane-query-runtime-job-row-preserving"
+        assert namespace == "vane"
+        return self._driver
 
 
 @pytest.fixture()
@@ -175,3 +226,82 @@ def test_actor_rows_mode_reuses_executor_across_calls(fake_ray):
     assert actor.executor is executor_after_first
     assert first[0].to_pydict() == {"keep": ["a"], "y": [2]}
     assert second[0].to_pydict() == {"keep": ["b"], "y": [6]}
+
+
+def test_reconstructed_actor_reconciles_new_node_before_user_code(fake_ray, monkeypatch):
+    from duckdb.runners.ray.query_runtime_protocol import (
+        RAY_ACTOR_GENERATION_CAPABILITY_ENV,
+        RAY_ACTOR_INDEX_ENV,
+        RAY_ACTOR_POOL_NONCE_ENV,
+        RAY_ACTOR_QUERY_ID_ENV,
+        RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
+    )
+
+    payload = _rows_payload(_AddOne)
+    payload["actor_index"] = 0
+    fake_ray.node_id = "node-after-restart"
+    fake_ray.reconstructed = True
+    monkeypatch.setenv(RAY_ACTOR_QUERY_ID_ENV, payload["query_id"])
+    monkeypatch.setenv(RAY_ACTOR_RESOURCE_UNIT_ID_ENV, payload["resource_unit_id"])
+    monkeypatch.setenv(RAY_ACTOR_INDEX_ENV, "0")
+    monkeypatch.setenv(RAY_ACTOR_POOL_NONCE_ENV, "pool-nonce")
+    monkeypatch.setenv(RAY_ACTOR_GENERATION_CAPABILITY_ENV, "generation-capability")
+    actor = _make_actor(payload)
+
+    blocks = _data_blocks(list(actor.run_block_stream(pa.table({"x": [1], "keep": ["a"]}))))
+
+    assert blocks[0].to_pydict() == {"keep": ["a"], "y": [2]}
+    assert len(fake_ray.location_reports) == 2
+    report, capability = fake_ray.location_reports[-1]
+    assert report == {
+        "query_id": payload["query_id"],
+        "resource_unit_id": payload["resource_unit_id"],
+        "actor_index": 0,
+        "pool_nonce": "pool-nonce",
+        "node_id": "node-after-restart",
+    }
+    assert capability == "generation-capability"
+
+
+def test_reconstructed_actor_reconciles_new_node_before_ref_bundle_materialization(fake_ray, monkeypatch):
+    import duckdb.execution.udf_ray_actor_runtime as actor_runtime
+    from duckdb.runners.ray.query_runtime_protocol import (
+        RAY_ACTOR_GENERATION_CAPABILITY_ENV,
+        RAY_ACTOR_INDEX_ENV,
+        RAY_ACTOR_POOL_NONCE_ENV,
+        RAY_ACTOR_QUERY_ID_ENV,
+        RAY_ACTOR_RESOURCE_UNIT_ID_ENV,
+    )
+
+    payload = _rows_payload(_AddOne)
+    payload["actor_index"] = 0
+    fake_ray.node_id = "node-after-restart"
+    fake_ray.reconstructed = True
+    monkeypatch.setenv(RAY_ACTOR_QUERY_ID_ENV, payload["query_id"])
+    monkeypatch.setenv(RAY_ACTOR_RESOURCE_UNIT_ID_ENV, payload["resource_unit_id"])
+    monkeypatch.setenv(RAY_ACTOR_INDEX_ENV, "0")
+    monkeypatch.setenv(RAY_ACTOR_POOL_NONCE_ENV, "pool-nonce")
+    monkeypatch.setenv(RAY_ACTOR_GENERATION_CAPABILITY_ENV, "generation-capability")
+    actor = _make_actor(payload)
+    original_materialize = actor_runtime._apply_ref_bundle_slices
+
+    def materialize_after_reconciliation(*args, **kwargs):
+        assert len(fake_ray.location_reports) == 2
+        return original_materialize(*args, **kwargs)
+
+    monkeypatch.setattr(actor_runtime, "_apply_ref_bundle_slices", materialize_after_reconciliation)
+    block = pa.table({"x": [1], "keep": ["a"]})
+
+    blocks = _data_blocks(
+        list(
+            actor.run_ref_bundle_stream(
+                block,
+                slices=[(0, 1)],
+                metadata=[{"num_rows": 1}],
+                names=["x", "keep"],
+            )
+        )
+    )
+
+    assert blocks[0].to_pydict() == {"keep": ["a"], "y": [2]}
+    assert len(fake_ray.location_reports) == 2

--- a/tests/fast/test_udf_ray_ready.py
+++ b/tests/fast/test_udf_ray_ready.py
@@ -222,6 +222,42 @@ def test_existing_actor_handles_require_explicit_dispatch_eligibility():
     assert executor._actor_init_errors[0] == "ray actor does not expose __ray_ready__ readiness probe"
 
 
+def test_pending_actor_learns_runtime_node_and_joins_dispatch_set():
+    from concurrent.futures import Future
+
+    from duckdb.execution.udf_ray import RemoteUDFExecutor, UDFActorPool
+
+    class _Ref:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    actors = [_Actor(), _Actor()]
+    first_future = Future()
+    second_future = Future()
+    pool = UDFActorPool._from_handles(
+        actors,
+        payload=_payload(actor_pool_size=2),
+        actor_node_ids=["node-a", ""],
+        actor_dispatch_indices={0},
+        actor_init_refs=[_Ref(first_future), _Ref(second_future)],
+    )
+    executor = RemoteUDFExecutor(
+        pool,
+        _payload(actor_pool_size=2),
+        query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
+    )
+
+    second_future.set_result("node-b")
+    executor._refresh_actor_readiness()
+
+    assert executor._actor_node_ids == ["node-a", "node-b"]
+    assert executor._ready_actor_set == {0, 1}
+
+
 def test_actor_executor_uses_explicit_query_driver_handle():
     from duckdb.execution.udf_ray import _build_ray_actor_executor
 
@@ -267,11 +303,19 @@ def test_actor_executor_uses_explicit_query_driver_handle():
     assert executor._task_admission._driver is query_driver_handle
 
 
-def test_actor_executor_options_reject_missing_or_invalid_coordinator_identity():
+def test_actor_executor_options_allow_pending_identity_but_require_it_for_ready_slots():
     from duckdb.execution.udf_ray import _build_udf_executor_options
 
     actor = _Actor()
-    with pytest.raises(ValueError, match="actor node IDs are required"):
+    pending = _build_udf_executor_options(
+        actor_handles=[actor],
+        actor_node_ids=None,
+        actor_dispatch_indices=set(),
+        actor_init_refs=[object()],
+    )
+    assert pending["actor_node_ids"] == [""]
+    assert pending["actor_dispatch_indices"] == []
+    with pytest.raises(ValueError, match="dispatch-ready actors require runtime node IDs"):
         _build_udf_executor_options(
             actor_handles=[actor],
             actor_node_ids=None,

--- a/tests/fast/test_udf_ray_ready.py
+++ b/tests/fast/test_udf_ray_ready.py
@@ -13,7 +13,7 @@ def _payload(**overrides):
     value = {
         "execution_backend": "ray_actor",
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "produce_ray_block_stream": True,
         "actor_pool_size": 1,
         "cpus": 1.0,
@@ -76,11 +76,11 @@ def _run_after_lease(executor, monkeypatch, *, actor_index=0):
 
     lease = {
         "query_id": executor._payload["query_id"],
-        "stage_id": executor._payload["stage_id"],
+        "resource_unit_id": executor._payload["resource_unit_id"],
         "lease_id": f"lease-{actor_index}",
         "attempt_id": f"attempt-{actor_index}",
         "node_id": "node-a",
-        "execution_slot_id": f"ray_actor:{executor._payload['stage_id']}:{actor_index}",
+        "execution_slot_id": f"ray_actor:{executor._payload['resource_unit_id']}:{actor_index}",
         "actor_index": actor_index,
         "output_window_bytes": executor._payload["output_window_bytes"],
     }

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -1922,7 +1922,7 @@ def test_metadata_transition_is_atomic_with_concurrent_capacity_refresh(
         collector.shutdown()
 
 
-def test_inflight_block_keeps_item_capacity_from_read_admission():
+def test_inflight_block_survives_temporary_downstream_backpressure():
     fake_ray = _FakeRay()
     driver = _Driver()
     holder = {}
@@ -1959,9 +1959,8 @@ def test_inflight_block_keeps_item_capacity_from_read_admission():
             time.sleep(0.005)
         assert holder["generator"].read_count == 1
 
-        # The pair is already in flight. A temporary downstream backpressure
-        # update may prevent delivery, but it cannot retroactively revoke the
-        # item-size admission under which the block was consumed.
+        # The pair is already in flight. Temporary downstream backpressure may
+        # prevent delivery, but restoring capacity must resume it.
         assert collector.drain_results(zero_capacity) == []
         fake_ray.make_ready(holder["metadata_ref"])
         zero_capacity_events = []
@@ -3367,7 +3366,7 @@ def test_pending_output_control_futures_do_not_withhold_task_or_stream_cleanup()
         collector.shutdown()
 
 
-def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queue():
+def test_block_larger_than_soft_item_target_uses_one_bounded_delivery():
     fake_ray = _FakeRay()
     driver = _Driver()
 
@@ -3389,13 +3388,13 @@ def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queu
         events = _drain_until(
             collector,
             {7: {"rows": 1, "bytes": 128, "item_bytes": 128}},
-            predicate=lambda values: any(item[2] == "error" for item in values),
+            predicate=lambda values: any(item[2] in {"complete", "error"} for item in values),
         )
-        assert len(events) == 1
-        assert events[0][2] == "error"
-        assert "exceeds downstream item capacity" in events[0][3]
-        assert driver.acquire_query_output_block_lease.calls == []
-        assert len(driver.release_query_task_lease_after_completion.calls) == 1
+        assert [item[2] for item in events] == ["data", "complete"]
+        assert len(driver.acquire_query_output_block_lease.calls) == 1
+        request = driver.acquire_query_output_block_lease.calls[0][0][0]
+        assert request["size_bytes"] == 129
+        assert len(driver.release_query_task_lease.calls) == 1
     finally:
         collector.shutdown()
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -3146,7 +3146,7 @@ def test_remote_provider_capability_error_preserves_safe_details():
     def submitter(lease):
         payload = {
             "query_id": lease["query_id"],
-            "stage_id": lease["stage_id"],
+            "resource_unit_id": lease["resource_unit_id"],
             "task_lease_id": lease["lease_id"],
             "attempt_id": lease["attempt_id"],
         }

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -19,13 +19,13 @@ from duckdb.execution.ray_stream_adapter import (
     RayStreamCleanupWait,
     TaskLeaseObjectRefGenerator,
 )
+from duckdb.execution.udf_ray_stream_protocol import validate_stream_block_metadata
 from duckdb.execution.udf_stream_result_collector import (
     UDFStreamResultCollector,
     _OutputLeaseToken,
     _ReadyEvent,
     _StreamRecord,
 )
-from duckdb.execution.udf_ray_stream_protocol import validate_stream_block_metadata
 from duckdb.execution.udf_task_admission import TaskAdmission
 
 _CLEANUP_SUBMISSION_SCOPE = "query:test-cleanup"

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -265,7 +265,7 @@ class _Driver:
             "lease": {
                 "lease_id": f"task-lease-{self.next_task}",
                 "query_id": request["query_id"],
-                "stage_id": request["stage_id"],
+                "resource_unit_id": request["resource_unit_id"],
                 "task_id": request["task_id"],
                 "attempt_id": request["attempt_id"],
                 "resources": {
@@ -290,12 +290,12 @@ class _Driver:
             "lease": {
                 "lease_id": f"output-lease-{self.next_output}",
                 "query_id": request["query_id"],
-                "producer_stage_id": request["producer_stage_id"],
+                "producer_unit_id": request["producer_unit_id"],
                 "task_lease_id": request["task_lease_id"],
                 "attempt_id": request["attempt_id"],
                 "block_id": request["block_id"],
                 "size_bytes": request["size_bytes"],
-                "state": "stage_queue",
+                "state": "unit_queue",
                 "liveness": False,
                 "allocation_generation": 1,
             },
@@ -309,7 +309,7 @@ def _metadata(lease, *, index=0, size_bytes=64, rows=1):
     return {
         "protocol_version": 1,
         "query_id": lease["query_id"],
-        "producer_stage_id": lease["stage_id"],
+        "producer_unit_id": lease["resource_unit_id"],
         "task_lease_id": lease["lease_id"],
         "attempt_id": lease["attempt_id"],
         "block_id": f"block:{lease['lease_id']}:{index}",
@@ -323,7 +323,7 @@ def _source(fake_ray, driver, *, request_id, submitter):
     request = {
         "request_id": request_id,
         "query_id": "q1",
-        "stage_id": "stage:q1:node:1:udf",
+        "resource_unit_id": "resource:q1:udf:node:1",
         "task_id": f"task:{request_id}",
         "attempt_id": f"attempt:{request_id}",
         "retained_input_bytes": 0,
@@ -2411,7 +2411,7 @@ def test_output_grant_transition_is_atomic_with_slot_cancellation():
         request = {
             "request_id": f"output-request:{metadata['block_id']}",
             "query_id": metadata["query_id"],
-            "producer_stage_id": metadata["producer_stage_id"],
+            "producer_unit_id": metadata["producer_unit_id"],
             "task_lease_id": metadata["task_lease_id"],
             "attempt_id": metadata["attempt_id"],
             "block_id": metadata["block_id"],
@@ -2496,7 +2496,7 @@ def test_terminal_record_releases_completed_output_lease_with_exact_rpc_contract
     metadata = _metadata(lease)
     output_request = {
         "query_id": metadata["query_id"],
-        "producer_stage_id": metadata["producer_stage_id"],
+        "producer_unit_id": metadata["producer_unit_id"],
         "task_lease_id": metadata["task_lease_id"],
         "attempt_id": metadata["attempt_id"],
         "block_id": metadata["block_id"],
@@ -2936,7 +2936,7 @@ def test_real_ray_generator_wait_is_non_consuming_and_preserves_pair_order():
         metadata = {
             "protocol_version": 1,
             "query_id": lease["query_id"],
-            "producer_stage_id": lease["stage_id"],
+            "producer_unit_id": lease["resource_unit_id"],
             "task_lease_id": lease["lease_id"],
             "attempt_id": lease["attempt_id"],
             "block_id": "real-ray:block:0",
@@ -3084,7 +3084,7 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
     def submitter(lease):
         payload = {
             "query_id": lease["query_id"],
-            "stage_id": lease["stage_id"],
+            "resource_unit_id": lease["resource_unit_id"],
             "task_lease_id": lease["lease_id"],
             "attempt_id": lease["attempt_id"],
         }

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -25,6 +25,7 @@ from duckdb.execution.udf_stream_result_collector import (
     _ReadyEvent,
     _StreamRecord,
 )
+from duckdb.execution.udf_ray_stream_protocol import validate_stream_block_metadata
 from duckdb.execution.udf_task_admission import TaskAdmission
 
 _CLEANUP_SUBMISSION_SCOPE = "query:test-cleanup"
@@ -317,6 +318,21 @@ def _metadata(lease, *, index=0, size_bytes=64, rows=1):
         "num_rows": rows,
         "names": ["value"],
     }
+
+
+def test_v1_stream_metadata_rejects_the_removed_producer_stage_field():
+    metadata = _metadata(
+        {
+            "query_id": "q1",
+            "resource_unit_id": "resource:q1:udf:node:1",
+            "lease_id": "lease-1",
+            "attempt_id": "attempt-1",
+        }
+    )
+    metadata["producer_stage_id"] = metadata.pop("producer_unit_id")
+
+    with pytest.raises(ValueError, match="unknown=producer_stage_id"):
+        validate_stream_block_metadata(metadata)
 
 
 def _source(fake_ray, driver, *, request_id, submitter):

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -108,7 +108,7 @@ def _payload():
     return {
         "execution_backend": "ray_task",
         "query_id": "q",
-        "stage_id": "stage:q:node:3:udf",
+        "resource_unit_id": "resource:q:udf:node:3",
         "cpus": 1.0,
         "gpus": 0.0,
         "memory_bytes": 256,
@@ -188,7 +188,7 @@ def _grant(request):
         "lease": {
             "lease_id": "lease-1",
             "query_id": request["query_id"],
-            "stage_id": request["stage_id"],
+            "resource_unit_id": request["resource_unit_id"],
             "task_id": request["task_id"],
             "attempt_id": request["attempt_id"],
             "node_id": "node-a",

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -1437,12 +1437,11 @@ def test_video_source_udf_cpu_allocation_must_be_positive(monkeypatch):
         video_reader._video_source_udf_kwargs()
 
 
-def test_video_source_udf_memory_is_stage_specific(monkeypatch):
+def test_video_source_udf_memory_is_source_specific(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 
     monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_BACKEND", "ray_task")
     monkeypatch.setenv("VANE_VIDEO_SOURCE_UDF_MEMORY_BYTES", "268435456")
-    monkeypatch.setenv("VANE_UDF_TASK_HEAP_BYTES", "1073741824")
     monkeypatch.delenv("VANE_VIDEO_SOURCE_UDF_OUTPUT_BATCH_SIZE", raising=False)
 
     expected_peak = video_reader._video_source_peak_memory_bytes(

--- a/tests/fast/test_vllm_e2e.py
+++ b/tests/fast/test_vllm_e2e.py
@@ -5,7 +5,7 @@ import importlib
 import os
 
 import pytest
-from ray_test_profile import ray_test_object_store_bytes
+from ray_test_profile import ray_test_object_store_options
 
 pytestmark = [pytest.mark.real_ray, pytest.mark.ray_cluster_owner, pytest.mark.gpu]
 
@@ -36,7 +36,7 @@ def test_vllm_e2e_basic():
     ray.init(
         address="local",
         include_dashboard=False,
-        object_store_memory=ray_test_object_store_bytes(),
+        **ray_test_object_store_options(),
     )
 
     import duckdb

--- a/tests/ray_test_profile.py
+++ b/tests/ray_test_profile.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 
 import os
 
-DEFAULT_RAY_OBJECT_STORE_BYTES = 2 * 1024**3
 RAY_OBJECT_STORE_BYTES_ENV = "VANE_TEST_RAY_OBJECT_STORE_BYTES"
 
 
-def ray_test_object_store_bytes() -> int:
-    """Return the object-store capacity for a test-owned Ray cluster."""
-    raw_value = os.environ.get(RAY_OBJECT_STORE_BYTES_ENV, str(DEFAULT_RAY_OBJECT_STORE_BYTES))
+def ray_test_object_store_options() -> dict[str, int]:
+    """Return an explicit object-store override for a test-owned Ray cluster."""
+    raw_value = os.environ.get(RAY_OBJECT_STORE_BYTES_ENV)
+    if raw_value is None:
+        return {}
     try:
         value = int(raw_value)
     except ValueError as exc:
         raise ValueError(f"{RAY_OBJECT_STORE_BYTES_ENV} must be a positive integer, got {raw_value!r}") from exc
     if value <= 0:
         raise ValueError(f"{RAY_OBJECT_STORE_BYTES_ENV} must be a positive integer, got {raw_value!r}")
-    return value
+    return {"object_store_memory": value}

--- a/tests/slow/test_expression_udf_side_effect_fault.py
+++ b/tests/slow/test_expression_udf_side_effect_fault.py
@@ -59,7 +59,7 @@ class FakePlan:
                 "payload": {
                     "execution_backend": "ray_actor",
                     "side_effects": True,
-                    "stage_id": "stage:side-effect-fault",
+                    "resource_unit_id": "resource:side-effect-fault",
                 },
             }
         ]
@@ -120,7 +120,7 @@ try:
     node_id = ray.get_runtime_context().get_node_id()
     created, _ = udf_ray.ensure_actor_pools_for_plan(
         FakePlan(),
-        actor_node_ids_by_stage={"stage:side-effect-fault": (node_id,)},
+        actor_node_ids_by_unit={"resource:side-effect-fault": (node_id,)},
         query_driver_handle=object(),
         query_generation_capability="test-query-generation-capability",
         session_config={},


### PR DESCRIPTION
## Summary

This PR replaces Vane's fixed per-query admission and placement model with a Ray Data-style soft resource and backpressure controller for distributed UDF execution.

### Execution and resource model

- Replace the overloaded Vane `Stage`/`QueryExecutionGraph` terminology with a strict `QueryResourceGraph` of independently scheduled `ResourceUnit`s:
  - `native_fragment`: native DuckDB work plus managed cross-process object flow;
  - `ray_task_udf`: one Ray task execution family;
  - `ray_actor_pool`: one fixed Ray actor pool, charged once per submitted process.
- Leave native CPU, heap, scheduling, and spill to DuckDB's shared node-local execution engine. QRM manages Ray UDF resources and the managed object flow across native/UDF edges.
- Represent only true distributed blocking boundaries as `MaterializationBarrier` events. Broadcast build, multi-partition global limit/sort/Top-N, fixed-row reservoir sample, and MARK-build summary repartition expose the exact input side they materialize. Normal repartition remains streaming.
- Derive the current execution phase dynamically from unfinished barriers. Parallel branches up to their first unfinished barriers share one eligible frontier; completing a barrier retires its old materialized side and recomputes demand for the new frontier.

### Soft reservation and Ray Core placement

- Derive aggregate CPU, GPU, Ray logical heap, and object-store capacity from live Ray nodes. By default Vane uses 50% of Ray's reported object-store capacity as its spillable soft budget.
- Divide each resource dimension across live queries with weighted soft max-min allocation. A zero-budget query remains runnable; there is no hard query pre-admission, PlacementFloor, bin-packing model, or Vane task-continuation envelope.
- Split each query allocation into protected per-unit reservations and a shared pool (50/50 by default), so an operator can borrow idle capacity without permanently starving parallel branches.
- Submit concrete UDF tasks and actors with their real CPU/GPU/user-declared heap shapes and no Vane-selected node. Ray Core owns placement, pending demand, reconstruction, and autoscaling.
- Make UDF heap optional: absent `memory_bytes` means `0` in Vane accounting and omits Ray's `memory` option.
- Submit every handle in a fixed actor pool, count READY and PENDING actors once as process usage, start execution after the first actor becomes ready, and let remaining actors join later. Actor pools are created lazily when their resource unit enters the current phase and retired when it leaves.

### Dynamic object-store backpressure

- Estimate only Vane-managed logical bytes: retained task inputs, queue contents, exact output leases, learned generator-buffer output, and external-consumer state. This is not Plasma resident memory and does not globally deduplicate repeated ObjectRefs.
- Track produced blocks through `generator_pending -> unit_queue -> downstream_input -> external_consumer -> released`, and wake admission directly from lease/state changes rather than relying on coordinator polling.
- Apply query-wide and per-unit soft backpressure before admitting another task or pulling another generator block.
- For the current blocking materializer, disable object-store soft backpressure across the complete explicitly materialized upstream branch plus the materializer itself. Deferred branches, such as a broadcast probe, remain backpressured. This lets the blocking side finish and lets Ray Core spill cold objects without treating physical memory as unlimited.
- Allow bounded liveness escapes matching Ray Data's intent: one task when the query has no active task, and one complete output block when strict backpressure would otherwise stop a starving consumer.
- Keep existing work alive after allocation shrink and emit a warning only after soft-reservation debt persists for 60 seconds; the warning describes likely throughput/capacity pressure rather than a correctness failure.

### Configuration and compatibility

- Normal clusters no longer require per-machine heap or object-store byte tuning. Test-owned Ray clusters also follow Ray's host/cgroup sizing by default; `VANE_TEST_RAY_OBJECT_STORE_BYTES` remains an explicit specialized-test override.
- Remove old Stage-oriented resource protocol fields and fallback paths. Package and stream protocol versions are unchanged.
- Rename DuckDB shuffle-cache `stage_id` terminology to `exchange_id`; DuckDB's own local executor stage terminology is otherwise untouched.

## Validation

- Rebased onto `upstream/main` at `990c9a6329`.
- Incremental Release native build/install succeeded.
- Native distributed suite: 182 test cases and 7,967 assertions passed.
- Focused resource graph, builder, QRM, and driver registration suite: 141 passed.
- Release suite: 504 passed, 1 skipped, 15 deselected; real-Ray release shard: 11 passed, 509 deselected.
- Complete fast launcher:
  - non-Ray: 6,467 passed, 27 skipped, 117 deselected, 8 xfailed, 1 xpassed;
  - shared Ray: 100 passed, 6 skipped, 6,514 deselected;
  - every isolated Ray-owner fault/recovery shard passed; vLLM skipped because it is unavailable locally.
- Full workspace format checks and full pre-commit range passed, including ruff, mypy, workflow validation, clang-format, and shfmt.
- Two consecutive final local review rounds found no remaining correctness issues.

Closes #38
