### PR TITLE
[fix](distributed) Enforce strict Flight endpoint contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 - Imported the official DuckDB baseline as a squashed Git subtree and retained
   Vane engine customizations as monorepo commits, so normal clones no longer
   require submodule initialization or carry DuckDB's complete commit history.
+- Made distributed exchange plans and task results a strict same-version
+  contract. Local-disk shuffle now requires an explicit producer identity,
+  advertised Flight host, port, and service epoch; missing or pre-contract
+  endpoint metadata is rejected instead of inferred.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 - Imported the official DuckDB baseline as a squashed Git subtree and retained
   Vane engine customizations as monorepo commits, so normal clones no longer
   require submodule initialization or carry DuckDB's complete commit history.
+
 ### Fixed
 
 - Released per-database runner cache entries after relation write failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,6 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 - Imported the official DuckDB baseline as a squashed Git subtree and retained
   Vane engine customizations as monorepo commits, so normal clones no longer
   require submodule initialization or carry DuckDB's complete commit history.
-- Made distributed exchange plans and task results a strict same-version
-  contract. Local-disk shuffle now requires an explicit producer identity,
-  advertised Flight host, port, and service epoch; missing or pre-contract
-  endpoint metadata is rejected instead of inferred.
-
 ### Fixed
 
 - Released per-database runner cache entries after relation write failures

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,8 @@ Vane supports plaintext Arrow Flight inside a controlled, isolated Ray cluster. 
 
 Each worker process owns at most one lazily started Flight service. A Flight ticket identifies a live published exchange attempt and partition; it is not an authentication or authorization credential. The service validates the ticket format, service epoch, producer identity, selected attempt, committed manifest, partition, query lifecycle, and reader lease.
 
+Distributed exchange plans and task results are a same-version contract and do not support mixed-version endpoint metadata. Drain in-flight distributed queries and recreate persistent Ray worker actors when upgrading Vane.
+
 Vane does not provide confidentiality between users or jobs in one Ray cluster, protection from a malicious worker, or per-query authorization for this transport. Deploy mutually untrusted workloads in separate Ray clusters and separate networks.
 
 The worker's Ray private address is used for binding and advertisement by default. Operators may set `VANE_FLIGHT_BIND_HOST=0.0.0.0` when container networking requires a wildcard listener, but `VANE_FLIGHT_ADVERTISE_HOST` must be a routable non-wildcard address. The advertised-host override belongs to the worker node's environment and is not copied from the driver to every worker. Vane rejects this override in a Ray Job or actor runtime environment because Ray inherits those values across nodes. Firewall, Security Group, or NetworkPolicy rules must restrict the configured or dynamically allocated `DUCKDB_FLIGHT_PORT` to the same Ray cluster. Do not expose it through a public Service, Ingress, LoadBalancer, or NodePort.

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -647,12 +647,12 @@ class RayWorkerActor:
         num_gpus: int,
         duckdb_memory_bytes: int,
         task_heap_capacity_bytes: int,
-        flight_advertise_host_fallback: str = "",
+        ray_node_ip_address: str = "",
     ) -> None:
         scrub_shared_runtime_session_env()
-        flight_advertise_host_fallback = str(flight_advertise_host_fallback or "").strip()
-        if flight_advertise_host_fallback and not os.environ.get("VANE_FLIGHT_ADVERTISE_HOST", "").strip():
-            os.environ["VANE_FLIGHT_ADVERTISE_HOST"] = flight_advertise_host_fallback
+        ray_node_ip_address = str(ray_node_ip_address or "").strip()
+        if ray_node_ip_address and not os.environ.get("VANE_FLIGHT_ADVERTISE_HOST", "").strip():
+            os.environ["VANE_FLIGHT_ADVERTISE_HOST"] = ray_node_ip_address
         duckdb_memory_bytes = int(duckdb_memory_bytes)
         task_heap_capacity_bytes = int(task_heap_capacity_bytes)
         if duckdb_memory_bytes <= 0:

--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -111,7 +111,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
                     num_gpus=int(node["Resources"].get("GPU", 0)),
                     duckdb_memory_bytes=memory_layout.worker_duckdb_memory_bytes,
                     task_heap_capacity_bytes=memory_layout.task_heap_capacity_bytes,
-                    flight_advertise_host_fallback=node_manager_address,
+                    ray_node_ip_address=node_manager_address,
                 )
                 actors.append((node, worker_id, actor))
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -521,19 +521,15 @@ void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, co
 		throw InvalidInputException("finished Flight sink port must be non-negative");
 	}
 	auto flight_host = instance.flight_host;
-	if (flight_host.empty() && flight_port > 0) {
-		// Compatibility for worker results produced before flight_host was
-		// carried separately from worker identity.
-		flight_host = node_id;
+	if (node_id.empty()) {
+		throw InvalidInputException("finished Flight sink is missing its worker identity");
 	}
+	const bool uses_network_transport = FlightExchangeUsesNetworkTransport(config_);
 	const bool has_flight_endpoint = !flight_host.empty() || flight_port > 0 || !instance.flight_server_epoch.empty();
-	if (!FlightExchangeUsesNetworkTransport(config_) && has_flight_endpoint) {
+	if (!uses_network_transport && has_flight_endpoint) {
 		throw InvalidInputException("non-local-disk Flight sink cannot publish a Flight endpoint");
 	}
-	if (has_flight_endpoint) {
-		if (node_id.empty()) {
-			throw InvalidInputException("finished Flight sink is missing its worker identity");
-		}
+	if (uses_network_transport) {
 		bool flight_host_is_wildcard = false;
 		if (!flight_host.empty()) {
 			auto flight_host_res = ParseFlightHost(flight_host);
@@ -751,14 +747,13 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 	auto build_source_file = [&](const SinkAttemptMetadata &attempt_metadata, idx_t partition_id) {
 		ExchangeSourceFile file;
 		file.path = attempt_metadata.output_location;
-		auto source_node_id = attempt_metadata.node_id.empty() ? config_.node_id : attempt_metadata.node_id;
-		if (file.path.empty() || source_node_id.empty() || config_.local_dirs.empty()) {
+		if (file.path.empty() || attempt_metadata.node_id.empty() || config_.local_dirs.empty()) {
 			return file;
 		}
 		try {
 			ShuffleCacheConfig cache_config;
 			cache_config.shuffle_stage_id = attempt_metadata.output_location;
-			cache_config.node_id = std::move(source_node_id);
+			cache_config.node_id = attempt_metadata.node_id;
 			cache_config.num_partitions = output_partition_count_;
 			cache_config.local_dirs = config_.local_dirs;
 			auto manifest_cache = MakeFlightExchangeShuffleCache(cache_config, config_, context_);
@@ -949,14 +944,44 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	}
 
 	auto partition_id = handle.partition_id;
-	auto source_node_id = handle.node_id.empty() ? config_.node_id : handle.node_id;
+	if (handle.node_id.empty()) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    DuckDBError::invalid_state_error("Flight exchange source handle is missing its producer identity"));
+	}
+	const auto &source_node_id = handle.node_id;
 	if (handle.files.empty() || handle.files[0].path.empty()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
 		    DuckDBError::invalid_state_error("Flight exchange source handle is missing its catalog identity"));
 	}
 	auto output_location = handle.files[0].path;
-	auto source_flight_host = handle.flight_host.empty() ? source_node_id : handle.flight_host;
+	auto source_flight_host = handle.flight_host;
 	auto source_flight_port = handle.flight_port;
+	const bool uses_object_storage = FlightExchangeUsesObjectStorage(config_);
+	const bool uses_network_transport = FlightExchangeUsesNetworkTransport(config_);
+	const bool has_flight_endpoint =
+	    !source_flight_host.empty() || source_flight_port != 0 || !handle.flight_server_epoch.empty();
+	if (!uses_network_transport && has_flight_endpoint) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    DuckDBError::invalid_state_error("non-local-disk Flight source handle cannot contain a Flight endpoint"));
+	}
+	if (uses_network_transport) {
+		if (source_flight_host.empty() || source_flight_port <= 0 || handle.flight_server_epoch.empty()) {
+			return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(DuckDBError::invalid_state_error(
+			    "local-disk Flight source handle requires producer identity, host, port, and server epoch"));
+		}
+		auto source_flight_host_res = ParseFlightHost(source_flight_host);
+		if (source_flight_host_res.is_err()) {
+			return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(DuckDBError::invalid_state_error(
+			    std::string("Flight exchange source handle has an invalid advertised host: ") +
+			    source_flight_host_res.error().what()));
+		}
+		const bool source_flight_host_is_wildcard = source_flight_host_res.value().is_wildcard;
+		source_flight_host = std::move(source_flight_host_res.value().host);
+		if (source_flight_host_is_wildcard || source_flight_host == "*") {
+			return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+			    DuckDBError::invalid_state_error("Flight exchange source handle advertises a wildcard host"));
+		}
+	}
 
 	auto stream = make_uniq<PartitionStreamState>();
 	stream->expected_types.insert(stream->expected_types.end(), config_.expected_types.begin(),
@@ -965,7 +990,6 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	DuckDBResult<ShufflePartitionFiles> files_res = DuckDBResult<ShufflePartitionFiles>::err(
 	    DuckDBError::invalid_state_error("uninitialized exchange source file result"));
 	std::shared_ptr<ShuffleCache> file_cache;
-	const bool uses_object_storage = FlightExchangeUsesObjectStorage(config_);
 	const bool uses_process_local_registry = !uses_object_storage && source_node_id == config_.node_id;
 	auto replay_object_manifest = [&]() {
 		if (config_.local_dirs.empty()) {
@@ -1035,31 +1059,6 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		    output_location + " source_node_id=" + source_node_id + " partition=" + std::to_string(partition_id) +
 		    ": " + files_res.error().what()));
 	}
-	if (handle.flight_server_epoch.empty()) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    DuckDBError::invalid_state_error("remote Flight exchange source handle is missing its server epoch"));
-	}
-	auto source_flight_host_res = ParseFlightHost(source_flight_host);
-	if (source_flight_host_res.is_err()) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(DuckDBError::invalid_state_error(
-		    std::string("remote Flight exchange source handle has an invalid advertised host: ") +
-		    source_flight_host_res.error().what()));
-	}
-	const bool source_flight_host_is_wildcard = source_flight_host_res.value().is_wildcard;
-	source_flight_host = std::move(source_flight_host_res.value().host);
-	if (source_flight_host.empty()) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    DuckDBError::invalid_state_error("remote Flight exchange source handle is missing its advertised host"));
-	}
-	if (source_flight_host_is_wildcard || source_flight_host == "*") {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    DuckDBError::invalid_state_error("remote Flight exchange source handle advertises a wildcard host"));
-	}
-	if (source_flight_port <= 0) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    DuckDBError::invalid_state_error("remote Flight exchange source handle is missing its port"));
-	}
-
 	auto location = BuildFlightLocation(source_flight_host, source_flight_port);
 	auto client_res = ConnectFlightExchangeClient(location);
 	if (client_res.is_err()) {

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -123,7 +123,7 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	    deserializer.ReadPropertyWithDefault<idx_t>(4, "output_partition_count");
 	result.sink_instance.flight_server_epoch = deserializer.ReadProperty<string>(5, "flight_server_epoch");
 	result.sink_instance.query_id = deserializer.ReadProperty<string>(6, "query_id");
-	result.sink_instance.flight_host = deserializer.ReadPropertyWithExplicitDefault<string>(7, "flight_host", "");
+	result.sink_instance.flight_host = deserializer.ReadProperty<string>(7, "flight_host");
 	return result;
 }
 

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -98,7 +98,7 @@ ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deseriali
 			});
 			handle.attempt_id = obj.ReadPropertyWithExplicitDefault<idx_t>(5, "attempt_id", 0);
 			handle.flight_server_epoch = obj.ReadProperty<string>(6, "flight_server_epoch");
-			handle.flight_host = obj.ReadPropertyWithExplicitDefault<string>(7, "flight_host", handle.node_id);
+			handle.flight_host = obj.ReadProperty<string>(7, "flight_host");
 		});
 		result.source_handles.push_back(std::move(handle));
 	});

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -309,13 +309,13 @@ void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) c
 	serializer.WriteProperty(106, "repartition_type", static_cast<uint8_t>(repartition_type_));
 	serializer.WriteProperty(107, "partition_by", partition_by_);
 	serializer.WriteProperty(108, "local_dirs", local_dirs);
-	serializer.WriteProperty(111, "sink_task_partition_id", sink_handle_.sink_handle.task_partition_id);
-	serializer.WriteProperty(112, "sink_attempt_id", sink_handle_.attempt_id);
-	serializer.WriteProperty(113, "sink_output_location", sink_handle_.output_location);
-	serializer.WriteProperty(114, "range_boundaries", range_boundaries_);
-	serializer.WriteProperty(115, "range_order_modifiers", range_order_modifiers_);
-	serializer.WriteProperty(116, "flight_server_epoch", sink_handle_.flight_server_epoch);
-	serializer.WriteProperty(117, "query_id", sink_handle_.query_id);
+	serializer.WriteProperty(109, "sink_task_partition_id", sink_handle_.sink_handle.task_partition_id);
+	serializer.WriteProperty(110, "sink_attempt_id", sink_handle_.attempt_id);
+	serializer.WriteProperty(111, "sink_output_location", sink_handle_.output_location);
+	serializer.WriteProperty(112, "range_boundaries", range_boundaries_);
+	serializer.WriteProperty(113, "range_order_modifiers", range_order_modifiers_);
+	serializer.WriteProperty(114, "flight_server_epoch", sink_handle_.flight_server_epoch);
+	serializer.WriteProperty(115, "query_id", sink_handle_.query_id);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -338,17 +338,17 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(103, "shuffle_stage_id", exchange_id_);
 	serializer.WriteProperty(104, "partition_indices", partition_indices_);
 	serializer.WriteProperty(105, "source_nodes", source_nodes_);
-	serializer.WriteProperty(107, "flight_timeout_seconds", flight_config.flight_timeout_seconds);
-	serializer.WriteProperty(108, "source_handle_partition_ids", handle_partition_ids);
-	serializer.WriteProperty(109, "source_handle_node_ids", handle_node_ids);
-	serializer.WriteProperty(110, "source_handle_paths", handle_paths);
-	serializer.WriteProperty(111, "source_handle_flight_ports", handle_flight_ports);
-	serializer.WritePropertyWithDefault(112, "runtime_source_node_id", runtime_source_node_id_, optional_idx());
-	serializer.WriteProperty(113, "source_handle_attempt_ids", handle_attempt_ids);
-	serializer.WriteProperty(114, "local_dirs", local_dirs);
-	serializer.WriteProperty(115, "source_handle_flight_server_epochs", handle_flight_server_epochs);
-	serializer.WriteProperty(116, "source_catalog_handles_explicit", true);
-	serializer.WriteProperty(118, "source_handle_flight_hosts", handle_flight_hosts);
+	serializer.WriteProperty(106, "flight_timeout_seconds", flight_config.flight_timeout_seconds);
+	serializer.WriteProperty(107, "source_handle_partition_ids", handle_partition_ids);
+	serializer.WriteProperty(108, "source_handle_node_ids", handle_node_ids);
+	serializer.WriteProperty(109, "source_handle_paths", handle_paths);
+	serializer.WriteProperty(110, "source_handle_flight_ports", handle_flight_ports);
+	serializer.WritePropertyWithDefault(111, "runtime_source_node_id", runtime_source_node_id_, optional_idx());
+	serializer.WriteProperty(112, "source_handle_attempt_ids", handle_attempt_ids);
+	serializer.WriteProperty(113, "local_dirs", local_dirs);
+	serializer.WriteProperty(114, "source_handle_flight_server_epochs", handle_flight_server_epochs);
+	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
+	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1143,26 +1143,21 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto repartition_type_raw = deserializer.ReadProperty<uint8_t>(106, "repartition_type");
 		auto partition_by = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(107, "partition_by");
 		auto local_dirs = deserializer.ReadProperty<vector<string>>(108, "local_dirs");
-		// Consume node-local service fields emitted by older plans, but never
-		// use driver-provided listener configuration on a worker.
-		(void)deserializer.ReadPropertyWithExplicitDefault<string>(109, "flight_bind_host", "");
-		(void)deserializer.ReadPropertyWithExplicitDefault<int>(110, "flight_port", 0);
 		auto repartition_type = static_cast<RepartitionSpec::Type>(repartition_type_raw);
 		// Create sink handle for this exchange
 		distributed::ExchangeSinkInstanceHandle sink_handle;
 		sink_handle.sink_handle.task_partition_id =
-		    deserializer.ReadPropertyWithDefault<idx_t>(111, "sink_task_partition_id");
-		sink_handle.attempt_id = deserializer.ReadPropertyWithDefault<idx_t>(112, "sink_attempt_id");
+		    deserializer.ReadPropertyWithDefault<idx_t>(109, "sink_task_partition_id");
+		sink_handle.attempt_id = deserializer.ReadPropertyWithDefault<idx_t>(110, "sink_attempt_id");
 		sink_handle.output_partition_count = num_partitions;
 		sink_handle.output_location =
-		    deserializer.ReadPropertyWithExplicitDefault<string>(113, "sink_output_location", exchange_id);
+		    deserializer.ReadPropertyWithExplicitDefault<string>(111, "sink_output_location", exchange_id);
 		auto range_boundaries =
-		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(114, "range_boundaries", {});
+		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(112, "range_boundaries", {});
 		auto range_order_modifiers =
-		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(115, "range_order_modifiers", {});
-		sink_handle.flight_server_epoch = deserializer.ReadProperty<string>(116, "flight_server_epoch");
-		sink_handle.query_id = deserializer.ReadProperty<string>(117, "query_id");
-		(void)deserializer.ReadPropertyWithExplicitDefault<bool>(118, "allow_insecure_flight", false);
+		    deserializer.ReadPropertyWithExplicitDefault<vector<string>>(113, "range_order_modifiers", {});
+		sink_handle.flight_server_epoch = deserializer.ReadProperty<string>(114, "flight_server_epoch");
+		sink_handle.query_id = deserializer.ReadProperty<string>(115, "query_id");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
@@ -1177,30 +1172,25 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto exchange_id = deserializer.ReadProperty<string>(103, "shuffle_stage_id");
 		auto partition_indices = deserializer.ReadProperty<vector<idx_t>>(104, "partition_indices");
 		auto source_nodes = deserializer.ReadProperty<vector<string>>(105, "source_nodes");
-		// Older plans carried a driver-derived location template. Endpoint
-		// selection now comes exclusively from the producing worker.
-		(void)deserializer.ReadPropertyWithExplicitDefault<string>(106, "flight_location_template", "");
-		auto timeout_seconds = deserializer.ReadProperty<double>(107, "flight_timeout_seconds");
+		auto timeout_seconds = deserializer.ReadProperty<double>(106, "flight_timeout_seconds");
 		auto source_handle_partition_ids =
-		    deserializer.ReadPropertyWithDefault<vector<idx_t>>(108, "source_handle_partition_ids");
+		    deserializer.ReadPropertyWithDefault<vector<idx_t>>(107, "source_handle_partition_ids");
 		auto source_handle_node_ids =
-		    deserializer.ReadPropertyWithDefault<vector<string>>(109, "source_handle_node_ids");
-		auto source_handle_paths = deserializer.ReadPropertyWithDefault<vector<string>>(110, "source_handle_paths");
+		    deserializer.ReadPropertyWithDefault<vector<string>>(108, "source_handle_node_ids");
+		auto source_handle_paths = deserializer.ReadPropertyWithDefault<vector<string>>(109, "source_handle_paths");
 		auto source_handle_flight_ports =
-		    deserializer.ReadPropertyWithDefault<vector<int>>(111, "source_handle_flight_ports");
-		auto runtime_source_node_id = deserializer.ReadPropertyWithDefault<optional_idx>(112, "runtime_source_node_id");
+		    deserializer.ReadPropertyWithDefault<vector<int>>(110, "source_handle_flight_ports");
+		auto runtime_source_node_id = deserializer.ReadPropertyWithDefault<optional_idx>(111, "runtime_source_node_id");
 		auto source_handle_attempt_ids =
-		    deserializer.ReadPropertyWithDefault<vector<idx_t>>(113, "source_handle_attempt_ids");
-		auto local_dirs = deserializer.ReadPropertyWithDefault<vector<string>>(114, "local_dirs");
+		    deserializer.ReadPropertyWithDefault<vector<idx_t>>(112, "source_handle_attempt_ids");
+		auto local_dirs = deserializer.ReadPropertyWithDefault<vector<string>>(113, "local_dirs");
 		auto source_handle_flight_server_epochs =
-		    deserializer.ReadProperty<vector<string>>(115, "source_handle_flight_server_epochs");
-		auto source_catalog_handles_explicit = deserializer.ReadProperty<bool>(116, "source_catalog_handles_explicit");
+		    deserializer.ReadProperty<vector<string>>(114, "source_handle_flight_server_epochs");
+		auto source_catalog_handles_explicit = deserializer.ReadProperty<bool>(115, "source_catalog_handles_explicit");
 		if (!source_catalog_handles_explicit) {
 			throw SerializationException("remote exchange source requires explicit catalog handles");
 		}
-		(void)deserializer.ReadPropertyWithExplicitDefault<bool>(117, "allow_insecure_flight", false);
-		auto source_handle_flight_hosts =
-		    deserializer.ReadPropertyWithDefault<vector<string>>(118, "source_handle_flight_hosts");
+		auto source_handle_flight_hosts = deserializer.ReadProperty<vector<string>>(116, "source_handle_flight_hosts");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
@@ -1209,11 +1199,6 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 		std::vector<distributed::ExchangeSourceHandle> source_handles;
-		if (source_handle_flight_hosts.empty()) {
-			// Compatibility for source handles serialized before advertised
-			// hosts were separated from worker identity.
-			source_handle_flight_hosts = source_handle_node_ids;
-		}
 		if (source_handle_partition_ids.size() != source_handle_node_ids.size() ||
 		    source_handle_partition_ids.size() != source_handle_paths.size() ||
 		    source_handle_partition_ids.size() != source_handle_flight_ports.size() ||

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1232,6 +1232,77 @@ TEST_CASE("Exchange: remote local-disk source rejects non-canonical numeric IPv4
 	}
 }
 
+TEST_CASE("Exchange: local-disk source requires explicit producer and endpoint metadata",
+          "[distributed][exchange][security]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	FlightExchangeConfig config;
+	config.node_id = "reader-node";
+	config.local_dirs = {TestCreatePath("exchange_remote_strict_endpoint")};
+	config.expected_types = {LogicalType::INTEGER};
+
+	auto read_handle = [&](ExchangeSourceHandle handle) {
+		FlightExchangeSource source(config, conn.context.get());
+		source.AddSourceHandles({std::move(handle)});
+		DataChunk output;
+		output.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+		source.ReadChunk(output);
+	};
+
+	ExchangeSourceHandle complete;
+	complete.partition_id = 0;
+	complete.attempt_id = 1;
+	complete.node_id = "writer-worker";
+	complete.flight_host = "flight-writer.internal";
+	complete.flight_port = 5010;
+	complete.flight_server_epoch = "writer-epoch";
+	complete.files.push_back(ExchangeSourceFile("strict-endpoint-attempt", 0));
+
+	auto missing_identity = complete;
+	missing_identity.node_id.clear();
+	REQUIRE_THROWS_WITH(read_handle(std::move(missing_identity)), Catch::Matchers::Contains("producer identity"));
+
+	auto missing_host = complete;
+	missing_host.flight_host.clear();
+	REQUIRE_THROWS_WITH(read_handle(std::move(missing_host)),
+	                    Catch::Matchers::Contains("requires producer identity, host, port, and server epoch"));
+
+	auto missing_port = complete;
+	missing_port.flight_port = 0;
+	REQUIRE_THROWS_WITH(read_handle(std::move(missing_port)),
+	                    Catch::Matchers::Contains("requires producer identity, host, port, and server epoch"));
+
+	auto missing_epoch = complete;
+	missing_epoch.flight_server_epoch.clear();
+	REQUIRE_THROWS_WITH(read_handle(std::move(missing_epoch)),
+	                    Catch::Matchers::Contains("requires producer identity, host, port, and server epoch"));
+}
+
+TEST_CASE("Exchange: object-storage source rejects Flight endpoint metadata", "[distributed][exchange][security]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	FlightExchangeConfig config;
+	config.node_id = "reader-node";
+	config.local_dirs = {"s3://bucket/shuffle"};
+	config.expected_types = {LogicalType::INTEGER};
+	FlightExchangeSource source(config, conn.context.get());
+
+	ExchangeSourceHandle handle;
+	handle.partition_id = 0;
+	handle.attempt_id = 1;
+	handle.node_id = "writer-worker";
+	handle.flight_host = "flight-writer.internal";
+	handle.flight_port = 5010;
+	handle.flight_server_epoch = "writer-epoch";
+	handle.files.push_back(ExchangeSourceFile("s3://bucket/shuffle/strict-endpoint-attempt", 0));
+	source.AddSourceHandles({std::move(handle)});
+
+	DataChunk output;
+	output.Initialize(Allocator::DefaultAllocator(), {LogicalType::INTEGER});
+	REQUIRE_THROWS_WITH(source.ReadChunk(output),
+	                    Catch::Matchers::Contains("non-local-disk Flight source handle cannot contain"));
+}
+
 TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][exchange]") {
 	FlightExchangeConfig config;
 	config.node_id = "node_1";
@@ -1269,30 +1340,50 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	REQUIRE(inst1.output_location.find(ctx.exchange_id) == string::npos);
 	REQUIRE(inst0.output_location.find("__sink_0__attempt_0") != string::npos);
 	REQUIRE(inst1.output_location.find("__sink_1__attempt_0") != string::npos);
+	inst0.flight_host = "flight-worker-0.internal";
+	inst0.flight_server_epoch = "worker-0-epoch";
+	inst1.flight_host = "flight-worker-1.internal";
+	inst1.flight_server_epoch = "worker-1-epoch";
 
 	auto wrong_query = inst0;
 	wrong_query.query_id = "other-query";
-	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_query, "", 0), Catch::Matchers::Contains("query does not match"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_query, "worker-0", 5000),
+	                    Catch::Matchers::Contains("query does not match"));
 	auto wrong_location = inst0;
 	wrong_location.output_location += "__wrong";
-	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_location, "", 0),
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_location, "worker-0", 5000),
 	                    Catch::Matchers::Contains("output location does not match"));
 	auto wrong_partition_count = inst0;
 	wrong_partition_count.output_partition_count++;
-	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_partition_count, "", 0),
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_partition_count, "worker-0", 5000),
 	                    Catch::Matchers::Contains("partition count does not match"));
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(inst0, "worker-0", -1),
 	                    Catch::Matchers::Contains("port must be non-negative"));
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(sink_handle0, 99),
 	                    Catch::Matchers::Contains("attempt was not instantiated"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(inst0, "", 5000),
+	                    Catch::Matchers::Contains("missing its worker identity"));
+	auto missing_host = inst0;
+	missing_host.flight_host.clear();
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(missing_host, "worker-0", 5000),
+	                    Catch::Matchers::Contains("endpoint requires host, port, and server epoch"));
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(inst0, "worker-0", 0),
+	                    Catch::Matchers::Contains("endpoint requires host, port, and server epoch"));
+	auto missing_epoch = inst0;
+	missing_epoch.flight_server_epoch.clear();
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(missing_epoch, "worker-0", 5000),
+	                    Catch::Matchers::Contains("endpoint requires host, port, and server epoch"));
 
 	// Finish sinks
-	inst0.flight_server_epoch = "worker-0-epoch";
 	exchange->SinkFinished(inst0, "worker-0", 5000);
 	exchange->SinkFinished(inst0, "worker-0", 5000);
 	auto wrong_node = inst0;
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_node, "worker-other", 5000),
 	                    Catch::Matchers::Contains("node does not match"));
+	auto wrong_host = inst0;
+	wrong_host.flight_host = "flight-worker-other.internal";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_host, "worker-0", 5000),
+	                    Catch::Matchers::Contains("host does not match"));
 	auto wrong_port = inst0;
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_port, "worker-0", 5001),
 	                    Catch::Matchers::Contains("port does not match"));
@@ -1300,7 +1391,7 @@ TEST_CASE("Exchange: FlightExchange coordinator lifecycle", "[distributed][excha
 	wrong_epoch.flight_server_epoch = "worker-other-epoch";
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(wrong_epoch, "worker-0", 5000),
 	                    Catch::Matchers::Contains("epoch does not match"));
-	exchange->SinkFinished(sink_handle1, 0);
+	exchange->SinkFinished(inst1, "worker-1", 5001);
 	exchange->AllRequiredSinksFinished();
 
 	// Source handles should cover all partitions
@@ -1578,6 +1669,11 @@ TEST_CASE("Exchange: failed unselected-attempt cleanup releases its retry claim"
 	auto selected = exchange->InstantiateSink(sink, 0);
 	auto unselected = exchange->InstantiateSink(sink, 1);
 
+	auto endpoint_bearing = selected;
+	endpoint_bearing.flight_host = "flight-worker.internal";
+	endpoint_bearing.flight_server_epoch = "worker-epoch";
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(endpoint_bearing, "worker-selected", 5010),
+	                    Catch::Matchers::Contains("non-local-disk Flight sink cannot publish"));
 	exchange->SinkFinished(selected, "worker-selected", 0);
 	REQUIRE_THROWS_WITH(exchange->SinkFinished(unselected, "worker-unselected", 0),
 	                    Catch::Matchers::Contains("requires ClientContext"));

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -129,7 +129,7 @@ TableFunction MakeTestInOutFunction() {
 	return func;
 }
 
-void SerializeLegacyRemoteExchangeSink(Serializer &serializer) {
+void SerializePreStrictRemoteExchangeSink(Serializer &serializer) {
 	vector<LogicalType> types = {LogicalType::INTEGER};
 	vector<unique_ptr<Expression>> partition_by;
 	vector<string> local_dirs = {"/legacy/local"};
@@ -157,7 +157,7 @@ void SerializeLegacyRemoteExchangeSink(Serializer &serializer) {
 	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
 }
 
-void SerializeLegacyRemoteExchangeSource(Serializer &serializer) {
+void SerializePreStrictRemoteExchangeSource(Serializer &serializer) {
 	vector<LogicalType> types = {LogicalType::INTEGER};
 	vector<idx_t> partition_indices = {0};
 	vector<string> source_nodes = {"legacy-node"};
@@ -187,6 +187,48 @@ void SerializeLegacyRemoteExchangeSource(Serializer &serializer) {
 	serializer.WriteProperty(116, "source_catalog_handles_explicit", true);
 	serializer.WriteProperty(117, "allow_insecure_flight", true);
 	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
+}
+
+string SerializeSinkDescriptorWithoutFlightHost() {
+	MemoryStream stream(Allocator::DefaultAllocator());
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty<idx_t>(1, "task_partition_id", 0);
+	serializer.WriteProperty<idx_t>(2, "attempt_id", 0);
+	serializer.WriteProperty(3, "output_location", string("pre-strict-sink"));
+	serializer.WriteProperty<idx_t>(4, "output_partition_count", 1);
+	serializer.WriteProperty(5, "flight_server_epoch", string("pre-strict-epoch"));
+	serializer.WriteProperty(6, "query_id", string("pre-strict-query"));
+	serializer.End();
+	return string(reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
+}
+
+string SerializeSourceDescriptorWithoutFlightHost() {
+	MemoryStream stream(Allocator::DefaultAllocator());
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty(1, "partition_indices", vector<idx_t> {0});
+	serializer.WriteList(2, "source_handles", 1, [&](Serializer::List &list, idx_t) {
+		list.WriteObject([&](Serializer &obj) {
+			obj.WriteProperty<idx_t>(1, "partition_id", 0);
+			obj.WriteProperty(2, "node_id", string("pre-strict-node"));
+			obj.WriteProperty<int>(3, "flight_port", 5010);
+			obj.WriteList(4, "files", 1, [&](Serializer::List &files, idx_t) {
+				files.WriteObject([&](Serializer &file_obj) {
+					file_obj.WriteProperty(1, "path", string("pre-strict-source"));
+					file_obj.WriteProperty<size_t>(2, "file_size", 0);
+					file_obj.WriteProperty<idx_t>(3, "rows", 0);
+				});
+			});
+			obj.WriteProperty<idx_t>(5, "attempt_id", 0);
+			obj.WriteProperty(6, "flight_server_epoch", string("pre-strict-epoch"));
+		});
+	});
+	serializer.WriteProperty<idx_t>(3, "source_partition_count", 1);
+	serializer.WriteProperty<idx_t>(4, "source_task_count", 1);
+	serializer.WriteProperty<bool>(5, "replicated", false);
+	serializer.End();
+	return string(reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
 }
 
 } // namespace
@@ -1330,6 +1372,13 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	REQUIRE(roundtrip.sink_instance.flight_server_epoch == "endpoint-epoch");
 }
 
+TEST_CASE("Exchange task descriptors reject missing advertised hosts", "[serialization][physical_plan][exchange]") {
+	REQUIRE_THROWS(distributed::ExchangeSinkInstanceTaskDescriptor::DeserializeFromBytes(
+	    SerializeSinkDescriptorWithoutFlightHost()));
+	REQUIRE_THROWS(
+	    distributed::ExchangeSourceTaskDescriptor::DeserializeFromBytes(SerializeSourceDescriptorWithoutFlightHost()));
+}
+
 TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source handles",
           "[serialization][physical_plan][exchange]") {
 	Allocator allocator;
@@ -1428,8 +1477,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(roundtrip_manager->config().flight_timeout_seconds == 7.5);
 }
 
-TEST_CASE("Legacy remote exchange payloads ignore node-local service config and derive missing advertised hosts",
-          "[serialization][physical_plan][exchange]") {
+TEST_CASE("Remote exchange plans reject pre-strict endpoint payloads", "[serialization][physical_plan][exchange]") {
 	{
 		Allocator allocator;
 		PhysicalPlan plan(allocator);
@@ -1437,20 +1485,13 @@ TEST_CASE("Legacy remote exchange payloads ignore node-local service config and 
 		SerializationOptions options;
 		BinarySerializer serializer(stream, options);
 		serializer.Begin();
-		SerializeLegacyRemoteExchangeSink(serializer);
+		SerializePreStrictRemoteExchangeSink(serializer);
 		serializer.End();
 
 		stream.Rewind();
 		BinaryDeserializer deserializer(stream);
 		deserializer.Begin();
-		auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
-		deserializer.End();
-		auto *sink = dynamic_cast<PhysicalRemoteExchangeSink *>(deserialized_op.get());
-		REQUIRE(sink != nullptr);
-		auto manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(sink->GetExchangeManager());
-		REQUIRE(manager != nullptr);
-		REQUIRE(manager->config().node_id == "legacy-node");
-		REQUIRE(manager->config().local_dirs == vector<string> {"/legacy/local"});
+		REQUIRE_THROWS(PhysicalOperator::Deserialize(deserializer, plan));
 	}
 
 	{
@@ -1460,22 +1501,13 @@ TEST_CASE("Legacy remote exchange payloads ignore node-local service config and 
 		SerializationOptions options;
 		BinarySerializer serializer(stream, options);
 		serializer.Begin();
-		SerializeLegacyRemoteExchangeSource(serializer);
+		SerializePreStrictRemoteExchangeSource(serializer);
 		serializer.End();
 
 		stream.Rewind();
 		BinaryDeserializer deserializer(stream);
 		deserializer.Begin();
-		auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
-		deserializer.End();
-		auto *source = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
-		REQUIRE(source != nullptr);
-		auto manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source->GetExchangeManager());
-		REQUIRE(manager != nullptr);
-		REQUIRE(source->SourceHandles().size() == 1);
-		REQUIRE(source->SourceHandles()[0].node_id == "legacy-node");
-		REQUIRE(source->SourceHandles()[0].flight_host == "legacy-node");
-		REQUIRE(source->SourceHandles()[0].flight_port == 31337);
+		REQUIRE_THROWS(PhysicalOperator::Deserialize(deserializer, plan));
 	}
 }
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -9679,7 +9679,7 @@ def test_start_ray_workers_keeps_flight_host_worker_local_and_skips_nested_warmu
         assert "env_overrides" not in remote_calls[index]
         assert remote_calls[index]["duckdb_memory_bytes"] == 256
         assert remote_calls[index]["task_heap_capacity_bytes"] == 615
-        assert remote_calls[index]["flight_advertise_host_fallback"] == address
+        assert remote_calls[index]["ray_node_ip_address"] == address
     assert get_calls == []
 
 

--- a/tests/fast/test_ray_worker_cuda_visibility.py
+++ b/tests/fast/test_ray_worker_cuda_visibility.py
@@ -25,7 +25,7 @@ class _RuntimeContext:
         ("flight.node.internal", "flight.node.internal"),
     ],
 )
-def test_ray_worker_init_uses_node_address_only_as_flight_host_fallback(
+def test_ray_worker_init_uses_ray_node_address_for_flight_host(
     monkeypatch,
     node_local_host,
     expected_host,
@@ -45,7 +45,7 @@ def test_ray_worker_init_uses_node_address_only_as_flight_host_fallback(
         num_gpus=0,
         duckdb_memory_bytes=128 * 1024**2,
         task_heap_capacity_bytes=128 * 1024**2,
-        flight_advertise_host_fallback="10.0.0.1",
+        ray_node_ip_address="10.0.0.1",
     )
 
     assert worker_mod.os.environ["VANE_FLIGHT_ADVERTISE_HOST"] == expected_host


### PR DESCRIPTION
## Summary

This follow-up to #233 removes legacy endpoint inference and mixed-version plan handling from distributed Flight shuffle.

It:

- requires every completed sink and source handle to carry an explicit producer identity;
- requires local-disk shuffle to publish a complete advertised host, positive port, and service epoch;
- rejects Flight endpoint metadata for object-storage and other non-network exchange paths;
- makes the advertised host mandatory in exchange task descriptors;
- removes reads of earlier node-local listener and security-policy plan fields, and uses a strict current plan layout;
- retains the Ray private node address as the normal worker-local advertised address while removing fallback terminology from the actor interface;
- documents the same-version contract and the drain/recreate requirement for upgrades.

Pre-contract plans and task descriptors are intentionally rejected. Object-storage manifest replay and same-process registry reads still do not fall back to Flight.

## Related issue

Closes #247

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`SECURITY.md` describes the strict endpoint contract and upgrade boundary.

## Validation

- `scripts/format workspace --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Incremental non-editable native install with `SKBUILD_BUILD_DIR="$PWD/build/python-release"` and `SKBUILD_CMAKE_BUILD_TYPE=Release`
- `scripts/run_native_tests.sh "[distributed][exchange]"` — 46 cases, 531 assertions passed
- `build/native-cxx20/test/unittest "[serialization][physical_plan][exchange]"` — 10 cases, 133 assertions passed
- Affected Python files excluding the separately owned real-Ray case — 222 passed, 1 deselected
- `scripts/run_release_tests.sh` — 439 passed, 1 skipped; real-Ray shard 7 passed
- Two consecutive post-fix code-review passes with no remaining findings

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.