### PR TITLE
[fix](ray) Bound ambiguous COPY reconciliation

### DIFF
--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -54,6 +54,7 @@ _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 _CLIENT_DETACH_REPLAY_CAPACITY = 65_536
 _COPY_OPERATION_REPLAY_CAPACITY = 1_024
 _DEFAULT_PROGRESS_TOPOLOGY_INIT_TIMEOUT_S = 60.0
+_DEFAULT_COPY_RECONCILIATION_TIMEOUT_S = 30.0
 _RUNTIME_ATTACH_TIMEOUT_S = 300.0
 _RUNTIME_ATTACH_RETRY_INTERVAL_S = 0.05
 _RUNTIME_ATTACH_CLEANUP_ATTEMPTS = 3
@@ -157,6 +158,18 @@ def _client_owner_lease_settings() -> tuple[float, float]:
             "VANE_RAY_CLIENT_LEASE_TIMEOUT_S"
         )
     return lease_timeout, heartbeat_interval
+
+
+def _copy_reconciliation_timeout_s() -> float:
+    value = float(
+        os.environ.get(
+            "VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S",
+            str(_DEFAULT_COPY_RECONCILIATION_TIMEOUT_S),
+        )
+    )
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S must be finite and > 0")
+    return value
 
 
 def _runtime_error_candidates(error: BaseException) -> list[BaseException]:
@@ -4847,6 +4860,7 @@ class RayQueryDriverActor:
         operation_id: str,
         *,
         session_id: str | None,
+        wait_timeout_s: float | None = None,
     ) -> CopyPlanRecovery:
         self._ensure_copy_operation_state()
         owner_key = str(owner_id).strip()
@@ -4874,8 +4888,29 @@ class RayQueryDriverActor:
                 session_id=session_key,
                 operation_id=operation_key,
             )
+            if wait_timeout_s is not None:
+                # asyncio.wait leaves a pending task running. Reconciliation
+                # timing out must never cancel a COPY that may still commit.
+                done, _ = await asyncio.wait(
+                    {in_flight.task},
+                    timeout=wait_timeout_s,
+                )
+                if not done:
+                    terminal = self._copy_operation_terminal.get(operation_key)
+                    if terminal is not None:
+                        self._validate_copy_operation_identity(
+                            terminal,
+                            owner_id=owner_key,
+                            session_id=session_key,
+                            operation_id=operation_key,
+                        )
+                        return self._copy_terminal_recovery(operation_key, terminal)
+                    raise CopyOutcomeUnknownError(operation_key)
             try:
-                outcome = await self._await_copy_operation(in_flight.task)
+                if wait_timeout_s is None:
+                    outcome = await self._await_copy_operation(in_flight.task)
+                else:
+                    outcome = in_flight.task.result()
             except asyncio.CancelledError:
                 raise
             except BaseException as operation_error:
@@ -4912,11 +4947,12 @@ class RayQueryDriverActor:
         session_id: str,
         operation_id: str,
     ) -> CopyPlanRecovery:
-        """Read or await an existing COPY outcome without submitting a write."""
+        """Read or briefly await an existing COPY outcome without submitting a write."""
         return await self._recover_copy_operation(
             owner_id,
             operation_id,
             session_id=session_id,
+            wait_timeout_s=_copy_reconciliation_timeout_s(),
         )
 
     async def _retry_copy_cleanup_for_operation(
@@ -6003,8 +6039,9 @@ class RayQueryDriverClient:
         session_id: str,
         operation_id: str,
         operation_error: BaseException,
+        reconciliation_timeout_s: float,
     ) -> CopyPlanOutcome:
-        """Resolve an ambiguous COPY response without ever resubmitting it."""
+        """Resolve an ambiguous COPY response with one bounded read-only wait."""
         try:
             recovery_future = runner.recover_copy_plan.remote(
                 self._owner_id,
@@ -6013,29 +6050,25 @@ class RayQueryDriverClient:
             )
         except BaseException:
             raise CopyOutcomeUnknownError(operation_id) from operation_error
-        while True:
-            try:
-                recovery = resolve_object_refs_blocking(
-                    recovery_future,
-                    honor_query_deadline=False,
-                )
-            except BaseException as recovery_error:
-                if _runtime_error_is_wait_timeout(recovery_error):
-                    # Rewait on the same read-only ObjectRef. A new RPC is not
-                    # needed and the write operation must never be resubmitted.
-                    continue
-                unknown_error = next(
-                    (
-                        candidate
-                        for candidate in _runtime_error_candidates(recovery_error)
-                        if isinstance(candidate, CopyOutcomeUnknownError)
-                    ),
-                    None,
-                )
-                if unknown_error is not None:
-                    raise unknown_error
-                raise CopyOutcomeUnknownError(operation_id) from operation_error
-            break
+        try:
+            recovery = resolve_object_refs_blocking(
+                recovery_future,
+                timeout=reconciliation_timeout_s,
+                honor_query_deadline=False,
+                honor_object_get_timeout=False,
+            )
+        except BaseException as recovery_error:
+            unknown_error = next(
+                (
+                    candidate
+                    for candidate in _runtime_error_candidates(recovery_error)
+                    if isinstance(candidate, CopyOutcomeUnknownError)
+                ),
+                None,
+            )
+            if unknown_error is not None:
+                raise unknown_error
+            raise CopyOutcomeUnknownError(operation_id) from operation_error
         if not isinstance(recovery, CopyPlanRecovery):
             raise CopyOutcomeUnknownError(operation_id) from operation_error
         if recovery.operation_id != operation_id:
@@ -6183,6 +6216,7 @@ class RayQueryDriverClient:
         import time as _time
 
         _t0 = _time.time()
+        reconciliation_timeout_s = _copy_reconciliation_timeout_s()
 
         try:
             session_id, _, runner = self._ensure_session(plan)
@@ -6211,6 +6245,7 @@ class RayQueryDriverClient:
                         session_id=session_id,
                         operation_id=plan_id,
                         operation_error=operation_error,
+                        reconciliation_timeout_s=reconciliation_timeout_s,
                     )
                 else:
                     try:
@@ -6224,6 +6259,7 @@ class RayQueryDriverClient:
                             session_id=session_id,
                             operation_id=plan_id,
                             operation_error=response_error,
+                            reconciliation_timeout_s=reconciliation_timeout_s,
                         )
                 final_progress_snapshot = outcome.final_progress_snapshot
                 completed = True

--- a/duckdb/runners/ray/safe_get.py
+++ b/duckdb/runners/ray/safe_get.py
@@ -31,6 +31,7 @@ def configured_ray_get_timeout_s(
     timeout: float | None = None,
     *,
     honor_query_deadline: bool = True,
+    honor_object_get_timeout: bool = True,
 ) -> float | None:
     resolved_timeout = max(0.0, float(timeout)) if timeout is not None else None
     deadline = _positive_float_env("VANE_QUERY_DEADLINE_EPOCH_S") if honor_query_deadline else None
@@ -39,7 +40,7 @@ def configured_ray_get_timeout_s(
         if remaining <= 0.0:
             raise QueryDeadlineExceeded("query deadline expired before Ray ObjectRef get")
         resolved_timeout = remaining if resolved_timeout is None else min(resolved_timeout, remaining)
-    configured = _positive_float_env("VANE_RAY_OBJECT_GET_TIMEOUT_S")
+    configured = _positive_float_env("VANE_RAY_OBJECT_GET_TIMEOUT_S") if honor_object_get_timeout else None
     if configured is not None:
         resolved_timeout = configured if resolved_timeout is None else min(resolved_timeout, configured)
     return resolved_timeout
@@ -128,6 +129,7 @@ def resolve_object_refs_blocking(
     *,
     timeout: float | None = None,
     honor_query_deadline: bool = True,
+    honor_object_get_timeout: bool = True,
     on_wait: Callable[[], None] | None = None,
     wait_interval_s: float = 0.5,
 ) -> Any:
@@ -137,10 +139,13 @@ def resolve_object_refs_blocking(
     call site; native pollers and other worker-owned threads wait through the
     ObjectRef concurrent-future bridge. When ``on_wait`` is provided, one total
     timeout is divided into bounded waits and the callback runs between them.
+    Callers with a dedicated hard timeout may opt out of the process-wide
+    ObjectRef timeout without disabling that explicit bound.
     """
     timeout = configured_ray_get_timeout_s(
         timeout,
         honor_query_deadline=honor_query_deadline,
+        honor_object_get_timeout=honor_object_get_timeout,
     )
     wait_interval_s = float(wait_interval_s)
     if on_wait is not None and wait_interval_s <= 0:

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -354,6 +354,41 @@ def test_client_owner_lease_settings_accept_one_third_heartbeat_interval(
     assert driver._client_owner_lease_settings() == (30.0, 10.0)
 
 
+@pytest.mark.parametrize("raw", ["0", "-1", "nan", "inf", "invalid"])
+def test_copy_reconciliation_timeout_rejects_unsafe_values(monkeypatch, raw):
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", raw)
+
+    with pytest.raises(ValueError):
+        driver._copy_reconciliation_timeout_s()
+
+
+def test_copy_reconciliation_timeout_reads_environment(monkeypatch):
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "0.25")
+
+    assert driver._copy_reconciliation_timeout_s() == 0.25
+
+
+def test_invalid_copy_reconciliation_timeout_prevents_write_submission(monkeypatch):
+    calls = []
+
+    class _RemoteMethod:
+        @staticmethod
+        def remote(*args):
+            calls.append(args)
+            return object()
+
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(run_copy_plan=_RemoteMethod())
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "0")
+
+    with pytest.raises(ValueError, match="VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S"):
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("invalid-reconciliation-timeout"))
+
+    assert calls == []
+
+
 def test_driver_constructor_scrubs_inherited_session_environment(monkeypatch):
     cls = driver.RayQueryDriverActor.__ray_metadata__.modified_class
     monkeypatch.setenv("AWS_ISSUE75_INHERITED_SECRET", "inherited-aws")
@@ -1183,6 +1218,65 @@ def test_query_driver_unknown_copy_recovery_never_submits_a_write():
     assert error.value.operation_id == "unknown-copy-operation"
 
 
+def test_query_driver_copy_recovery_timeout_preserves_inflight_write(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    operation_id = "copy-recovery-timeout"
+    outcome = driver.CopyPlanOutcome(
+        operation_id=operation_id,
+        result=_committed_copy_result(rows_copied=17),
+        final_progress_snapshot={"state": "FINISHED"},
+    )
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "0.01")
+
+    async def _exercise():
+        cls._ensure_copy_operation_state(runner)
+        release = asyncio.Event()
+
+        async def _finish_copy():
+            await release.wait()
+            return outcome
+
+        operation_task = asyncio.create_task(_finish_copy())
+        runner._copy_operation_identities[operation_id] = (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+        )
+        runner._copy_operations_inflight[operation_id] = driver._CopyOperationInFlight(
+            owner_id=_TEST_RUNTIME_OWNER_ID,
+            session_id=_TEST_SESSION_ID,
+            task=operation_task,
+        )
+        try:
+            with pytest.raises(driver.CopyOutcomeUnknownError, match=operation_id) as error:
+                await cls.recover_copy_plan(
+                    runner,
+                    _TEST_RUNTIME_OWNER_ID,
+                    _TEST_SESSION_ID,
+                    operation_id,
+                )
+
+            assert error.value.operation_id == operation_id
+            assert operation_task.done() is False
+            assert operation_task.cancelled() is False
+
+            release.set()
+            await operation_task
+            recovered = await cls.recover_copy_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                operation_id,
+            )
+            assert recovered.outcome == outcome
+            assert recovered.error is None
+        finally:
+            release.set()
+            if not operation_task.done():
+                await operation_task
+
+    asyncio.run(_exercise())
+
+
 def test_copy_outcome_unknown_error_preserves_operation_id_across_serialization():
     error = driver.CopyOutcomeUnknownError("unknown-copy-operation")
 
@@ -1726,6 +1820,7 @@ def test_ray_query_driver_client_recovers_ambiguous_copy_without_resubmission(mo
             outcome=outcome,
         )
 
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "30")
     monkeypatch.setattr(driver, "progress_enabled", lambda: False)
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
     monkeypatch.setattr(
@@ -1759,7 +1854,90 @@ def test_ray_query_driver_client_recovers_ambiguous_copy_without_resubmission(mo
         (
             recovery_ref,
             {
+                "timeout": 30.0,
                 "honor_query_deadline": False,
+                "honor_object_get_timeout": False,
+            },
+        ),
+    ]
+
+
+def test_ray_query_driver_client_bounds_pending_copy_recovery_without_resubmission(monkeypatch):
+    copy_future = object()
+    recovery_future = object()
+    plan = _FakePhysicalPlanWithoutPlanAttr("copy-pending-recovery")
+    resolutions = []
+    recovery_waits = 0
+
+    class _RemoteMethod:
+        def __init__(self, result):
+            self.result = result
+            self.calls = []
+
+        def remote(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    run_copy_plan = _RemoteMethod(copy_future)
+    recover_copy_plan = _RemoteMethod(recovery_future)
+    client = object.__new__(driver.RayQueryDriverClient)
+    client._owner_id = _TEST_RUNTIME_OWNER_ID
+    _initialize_test_query_driver_client(client, {_TEST_SESSION_ID: {}})
+    client.runner = SimpleNamespace(
+        run_copy_plan=run_copy_plan,
+        recover_copy_plan=recover_copy_plan,
+    )
+
+    def _resolve(ref, **kwargs):
+        nonlocal recovery_waits
+        resolutions.append((ref, kwargs))
+        if ref is copy_future:
+            raise FutureTimeoutError("COPY response wait timed out")
+        assert ref is recovery_future
+        recovery_waits += 1
+        if recovery_waits == 1:
+            raise FutureTimeoutError("COPY recovery wait timed out")
+        raise PermissionError("recovery ObjectRef was waited more than once")
+
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "0.25")
+    monkeypatch.setenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", "0")
+    monkeypatch.setattr(driver, "progress_enabled", lambda: False)
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
+    monkeypatch.setattr(
+        driver.ray,
+        "cancel",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("ambiguous COPY recovery must not cancel the write")
+        ),
+    )
+
+    with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+        client.run_copy_plan(plan)
+
+    assert error.value.operation_id == "copy-pending-recovery"
+    assert recovery_waits == 1
+    assert run_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan,
+        )
+    ]
+    assert recover_copy_plan.calls == [
+        (
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            "copy-pending-recovery",
+        )
+    ]
+    assert resolutions == [
+        (copy_future, {}),
+        (
+            recovery_future,
+            {
+                "timeout": 0.25,
+                "honor_query_deadline": False,
+                "honor_object_get_timeout": False,
             },
         ),
     ]
@@ -2194,6 +2372,7 @@ def test_ray_query_driver_client_copy_failure_recovers_without_cancel_or_close(m
             error=RuntimeError("planned COPY failure"),
         )
 
+    monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", "30")
     monkeypatch.setattr(driver, "progress_enabled", lambda: False)
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
     monkeypatch.setattr(driver.ray, "cancel", lambda ref, *, force: cancelled.append((ref, force)))
@@ -2208,7 +2387,9 @@ def test_ray_query_driver_client_copy_failure_recovers_without_cancel_or_close(m
         (
             recovery_future,
             {
+                "timeout": 30.0,
                 "honor_query_deadline": False,
+                "honor_object_get_timeout": False,
             },
         ),
     ]

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -392,6 +392,40 @@ def test_ray_safe_get_timeout_envs_preserve_zero(monkeypatch, env_name):
         assert safe_get.configured_ray_get_timeout_s() == 0.0
 
 
+def test_ray_get_explicit_timeout_can_ignore_global_wait_limits(monkeypatch):
+    from duckdb.runners.ray import safe_get
+
+    class FakeFuture:
+        def __init__(self):
+            self.calls = []
+
+        def result(self, timeout=None):
+            self.calls.append(timeout)
+            return "resolved"
+
+    class FakeRef:
+        def __init__(self, future):
+            self._future = future
+
+        def future(self):
+            return self._future
+
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", "0")
+    monkeypatch.setenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", "0")
+    future = FakeFuture()
+
+    assert (
+        safe_get.resolve_object_refs_blocking(
+            FakeRef(future),
+            timeout=2.5,
+            honor_query_deadline=False,
+            honor_object_get_timeout=False,
+        )
+        == "resolved"
+    )
+    assert future.calls == [2.5]
+
+
 def test_ray_get_in_async_actor_background_thread_uses_object_ref_future(monkeypatch):
     from duckdb.runners.ray import safe_get
 


### PR DESCRIPTION
## Summary

- Replace the unbounded ambiguous-COPY recovery loop with one read-only recovery RPC and one bounded wait.
- Use a dedicated 30-second reconciliation timeout, configurable through VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S and validated before write submission.
- Keep an in-flight COPY running when reconciliation times out; never cancel or resubmit the write, and return CopyOutcomeUnknownError with the original operation ID when the outcome cannot be proven.
- Ignore the query deadline and the process-wide ObjectRef wait timeout only for this dedicated recovery wait, while retaining its explicit hard bound.

This follows a fail-stop policy for ambiguous write completion. Durable recovery after query-driver actor replacement remains the separate scope of #179.

## Related issue

Closes #180

## Documentation impact

- [x] No user-facing documentation update is required. The change only bounds an internal failure-reconciliation path and preserves the existing COPY API.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      AstroVela/vane-website.

## Validation

- scripts/format root --changed
- pre-commit hooks on all four changed files, including ruff and mypy
- Asyncio debug and warnings-as-errors reconciliation matrix: 13 passed
- scripts/run_release_tests.sh
  - non-Ray: 448 passed, 1 skipped, 11 deselected
  - real Ray: 7 passed, 453 deselected
- VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh
  - non-Ray: 5772 passed, 44 skipped, 104 deselected, 8 xfailed, 1 xpassed
  - shared Ray cluster: 84 passed, 13 skipped, 5832 deselected
  - test-owned Ray clusters: 7 passed
- Rebased onto upstream/main 1ecd510d. The newly incorporated upstream change is Python-only, so no native rebuild was required; the installed native extension remains at SourceID dff80a3000.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No new dependencies or assets are introduced.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.