### PR TITLE
[fix](distributed) Leave COPY cleanup to operators

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -45,26 +45,6 @@
 namespace duckdb {
 namespace distributed {
 
-inline std::pair<bool, idx_t> DirectWriteLifecycleCleanupMinAgeMsFromEnv() {
-	const char *env = std::getenv("VANE_DISTRIBUTED_COPY_DIRECT_WRITE_CLEANUP_MIN_AGE_MS");
-	if (!env || !*env) {
-		return std::make_pair(true, static_cast<idx_t>(24ULL * 60ULL * 60ULL * 1000ULL));
-	}
-
-	auto lower = StringUtil::Lower(std::string(env));
-	if (lower == "0" || lower == "false" || lower == "no" || lower == "off" || lower == "disabled") {
-		return std::make_pair(false, idx_t(0));
-	}
-
-	errno = 0;
-	char *end = nullptr;
-	auto value = std::strtoull(env, &end, 10);
-	if (errno != 0 || end == env || *end != '\0') {
-		return std::make_pair(true, static_cast<idx_t>(24ULL * 60ULL * 60ULL * 1000ULL));
-	}
-	return std::make_pair(true, static_cast<idx_t>(value));
-}
-
 inline size_t FteEventBurstLimit() {
 	const char *env = std::getenv("VANE_FTE_EVENT_BURST_LIMIT");
 	if (!env || !*env) {
@@ -593,13 +573,9 @@ public:
 		find_sink(pipeline_node);
 
 		if (sink_node && sink_node->staging_root_base().empty()) {
+			// Persist lifecycle metadata for explicit operator-managed cleanup. Starting a COPY must not age out
+			// other runs: elapsed time alone does not establish that another run is abandoned.
 			auto &fs = FileSystem::GetFileSystem(*client_context_);
-			auto cleanup_policy = DirectWriteLifecycleCleanupMinAgeMsFromEnv();
-			if (cleanup_policy.first) {
-				(void)CleanupExpiredDistributedCopyDirectWriteRuns(fs, sink_node->spec().file_path,
-				                                                   cleanup_policy.second);
-			}
-
 			auto lifecycle_res =
 			    WriteDistributedCopyDirectWriteLifecycle(fs, sink_node->spec().file_path, sink_node->staging_run_id());
 			if (lifecycle_res.is_err()) {

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6187,6 +6187,69 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
 
 
 @pytest.mark.usefixtures("ray_local")
+def test_run_copy_plan_leaves_stale_direct_write_cleanup_to_explicit_api(tmp_path, monkeypatch):
+    captured = []
+    monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
+
+    class _DummyRunner:
+        def run_write(self, relation):
+            captured.append(relation)
+            return {"ok": True}
+
+    import duckdb.runners as runners_mod
+    from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
+
+    monkeypatch.setattr(runners_mod, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
+
+    con = duckdb.connect()
+    src = tmp_path / "copy_explicit_cleanup_input.parquet"
+    dst = tmp_path / "copy_explicit_cleanup_output"
+    dst.mkdir()
+    con.sql("select 1 as x union all select 2 as x").write_parquet(str(src))
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    con.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
+    assert captured, "expected write relation to be captured"
+
+    plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        captured[0],
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+
+    stale_run_id = "run-explicit-cleanup"
+    stale_lifecycle = duckdb.ray_cxx.register_copy_direct_write_run_lifecycle(
+        str(dst),
+        stale_run_id,
+        created_epoch_ms=1,
+    )
+    stale_file = dst / f"_vane_direct_write_{stale_run_id}" / "w_failed" / "part.parquet"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_bytes(b"stale")
+
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+    with _registered_low_level_plan(plan, con):
+        result = runner.run_copy_plan(plan, con)
+
+    assert result["copy_output_committed"] is True
+    assert stale_file.is_file()
+    assert Path(stale_lifecycle["copy_output_lifecycle_path"]).is_file()
+
+    cleanup = cleanup_copy_direct_write_lifecycle_once(
+        str(dst),
+        min_age_ms=1,
+    )
+
+    assert cleanup["scanned_runs"] == 2
+    assert cleanup["cleaned_runs"] == 1
+    assert cleanup["committed_runs"] == 1
+    assert cleanup["cleaned_run_ids"] == [{"base_path": str(dst), "run_id": stale_run_id}]
+    assert not stale_file.exists()
+    assert not Path(stale_lifecycle["copy_output_commit_dir"]).exists()
+    assert Path(result["copy_output_committed_marker_path"]).is_file()
+    con.close()
+
+
+@pytest.mark.usefixtures("ray_local")
 def test_run_copy_plan_local_staging_env_preserves_rename_path(tmp_path, monkeypatch):
     captured = []
     monkeypatch.setenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", "1")


### PR DESCRIPTION
## Summary

- Stop direct-write COPY startup from scanning and deleting other runs solely because their lifecycle age exceeds a threshold.
- Remove the private `VANE_DISTRIBUTED_COPY_DIRECT_WRITE_CLEANUP_MIN_AGE_MS` startup policy while retaining lifecycle registration, immediate cleanup of the current failed run, and the explicit one-shot/loop cleanup APIs.
- Add a real-Ray regression proving that a new COPY leaves an old uncommitted run untouched until the explicit cleanup API is invoked, while committed output remains protected.

Compatibility impact: stale direct-write runs are no longer reclaimed implicitly when another COPY starts. Applications or operators that want age-based reclamation must schedule the existing explicit lifecycle cleanup API.

## Related issue

Closes #255

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The removed environment variable was an internal implementation detail; the public explicit cleanup APIs are unchanged.

## Validation

- `scripts/format workspace --changed`
- `pre-commit run --files external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp tests/fast/test_ray_result_contract.py`
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `python -m pytest -q tests/fast/test_ray_result_contract.py::test_run_copy_plan_leaves_stale_direct_write_cleanup_to_explicit_api` (1 passed)
- `scripts/run_release_tests.sh` (448 passed, 1 skipped; real-Ray shard: 8 passed)
- `scripts/run_native_tests.sh '[distributed]'` (115 cases, 3885 assertions)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

No dependencies, copied code, model assets, datasets, or security-sensitive interfaces are added by this change.
