### PR TITLE
[fix](ray) Contain late FTE split additions

### DIFF
--- a/duckdb/runners/fte/fte_failures.py
+++ b/duckdb/runners/fte/fte_failures.py
@@ -20,6 +20,23 @@ _MEMORY_FAILURE_CODES = frozenset(
 )
 
 
+class FteTaskTerminalControlError(RuntimeError):
+    """A mutable control reached a known task after it became terminal."""
+
+    def __init__(
+        self,
+        *,
+        operation: str,
+        task_id: FteTaskAttemptId,
+        status: Mapping[str, Any],
+    ) -> None:
+        self.operation = str(operation)
+        self.task_id = task_id
+        self.status = dict(status)
+        operation_text = self.operation.replace("_", " ")
+        super().__init__(f"cannot {operation_text} to terminal task {task_id}")
+
+
 def _normalized_error_token(value: Any) -> str:
     return str(value or "").strip().upper().replace("-", "_").replace(" ", "_")
 

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -42,7 +42,7 @@ class FteSplitSubmissionCancelled(InterruptedError):
 
 
 class FteSplitQueueTerminal(RuntimeError):
-    """The target task became terminal while split submission was backpressured."""
+    """The target task became terminal while a split submission was in flight."""
 
     def __init__(self, attempt_id: Any, status: Mapping[str, Any]) -> None:
         self.attempt_id = attempt_id

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -36,6 +36,7 @@ from duckdb.runners.fte.fte_descriptor import (
 )
 from duckdb.runners.fte.fte_exchange import collect_spooling_output_stats
 from duckdb.runners.fte.fte_failures import (
+    FteTaskTerminalControlError,
     _failure_exception_matches,
     _failure_payload,
     _normalize_failure_payload,
@@ -801,7 +802,11 @@ class FteTaskExecution:
     def add_splits(self, source_node_id: str, splits: list[Mapping[str, Any]]) -> TaskStatus:
         with self._status_lock:
             if self.status.state in _TERMINAL_STATES:
-                raise RuntimeError(f"cannot add splits to terminal task {self.task_id}")
+                raise FteTaskTerminalControlError(
+                    operation="add_splits",
+                    task_id=self.task_id,
+                    status=self.status_payload(),
+                )
             source_node_id = str(source_node_id)
             if source_node_id in self.no_more_split_sources:
                 raise RuntimeError(f"source {source_node_id} is already marked no_more_splits")

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -8,7 +8,9 @@ import time
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
-from duckdb.runners.fte import FteTaskAttemptId, validate_fte_status_identity
+from duckdb.runners.fte import FteTaskAttemptId, FteTaskState, validate_fte_status_identity
+from duckdb.runners.fte.fte_scheduler import FteSplitQueueTerminal
+from duckdb.runners.fte.fte_state import _TERMINAL_STATES
 from duckdb.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_REGISTRY_LOCK,
@@ -61,6 +63,36 @@ class FteWorkerTaskControlMixin:
     if TYPE_CHECKING:
 
         def _drop_fragment_registration_state(self, query_id: str) -> None: ...
+
+    @staticmethod
+    def _validated_fte_add_splits_status(
+        task_id: str | dict[str, Any],
+        raw_status: Any,
+    ) -> dict[str, Any]:
+        if not isinstance(raw_status, dict):
+            raise TypeError("worker actor fte_add_splits must return a dict")
+        status = dict(raw_status)
+        if status.get("_fte_control_applied") is not False:
+            return status
+        attempt_id = FteTaskAttemptId.coerce(task_id)
+        validate_fte_status_identity(status, attempt_id)
+        if status.get("_fte_control_operation") != "fte_add_splits":
+            raise RuntimeError(
+                "FTE add-splits control operation mismatch: "
+                f"task={attempt_id} actual={status.get('_fte_control_operation')!r}"
+            )
+        raw_state = status.get("state")
+        try:
+            state = raw_state if isinstance(raw_state, FteTaskState) else FteTaskState(str(raw_state))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"unknown FTE task state in rejected add-splits control: {raw_state!r}") from exc
+        if state not in _TERMINAL_STATES:
+            raise RuntimeError(
+                f"FTE add-splits control was not applied to non-terminal task {attempt_id}: {state.value}"
+            )
+        status.pop("_fte_control_operation", None)
+        status.pop("_fte_control_applied", None)
+        raise FteSplitQueueTerminal(attempt_id, status)
 
     def _fte_control_rpc(
         self,
@@ -367,9 +399,7 @@ class FteWorkerTaskControlMixin:
         splits: list[dict[str, Any]],
     ) -> dict[str, Any]:
         raw_status = self._enqueue_ordered_fte_control_rpc("fte_add_splits", task_id, source_node_id, splits)
-        if not isinstance(raw_status, dict):
-            raise TypeError("worker actor fte_add_splits must return a dict")
-        return dict(raw_status)
+        return self._validated_fte_add_splits_status(task_id, raw_status)
 
     def enqueue_fte_add_splits(
         self,
@@ -386,9 +416,7 @@ class FteWorkerTaskControlMixin:
             splits,
             cancel_event=cancel_event,
         )
-        if not isinstance(raw_status, dict):
-            raise TypeError("worker actor fte_add_splits must return a dict")
-        return dict(raw_status)
+        return self._validated_fte_add_splits_status(task_id, raw_status)
 
     def fte_no_more_splits(
         self,

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -74,6 +74,17 @@ class FteWorkerTaskControlMixin:
         status = dict(raw_status)
         if status.get("_fte_control_applied") is not False:
             return status
+        status = FteWorkerTaskControlMixin._validated_terminal_fte_add_splits_status(
+            task_id,
+            status,
+        )
+        raise FteSplitQueueTerminal(FteTaskAttemptId.coerce(task_id), status)
+
+    @staticmethod
+    def _validated_terminal_fte_add_splits_status(
+        task_id: str | dict[str, Any],
+        status: dict[str, Any],
+    ) -> dict[str, Any]:
         attempt_id = FteTaskAttemptId.coerce(task_id)
         validate_fte_status_identity(status, attempt_id)
         if status.get("_fte_control_operation") != "fte_add_splits":
@@ -92,7 +103,7 @@ class FteWorkerTaskControlMixin:
             )
         status.pop("_fte_control_operation", None)
         status.pop("_fte_control_applied", None)
-        raise FteSplitQueueTerminal(attempt_id, status)
+        return status
 
     def _fte_control_rpc(
         self,
@@ -695,7 +706,12 @@ class FteWorkerTaskControlMixin:
                         f"task={task_key} expected={expected_operation!r} "
                         f"actual={status.get('_fte_control_operation')!r}"
                     )
-                if status.get("_fte_control_applied") is not True:
+                if expected_operation == "fte_add_splits" and status.get("_fte_control_applied") is False:
+                    status = self._validated_terminal_fte_add_splits_status(
+                        task_key,
+                        status,
+                    )
+                elif status.get("_fte_control_applied") is not True:
                     raise RuntimeError(
                         f"FTE control barrier operation was not applied: task={task_key} operation={expected_operation}"
                     )

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -32,6 +32,7 @@ from duckdb.runners.fte import (
 )
 from duckdb.runners.fte.debug_memory import describe_result_payload, log_debug, process_memory_snapshot
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
+from duckdb.runners.fte.fte_failures import FteTaskTerminalControlError
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.fte_scheduler_config import _fte_control_rpc_timeout_s
@@ -87,6 +88,8 @@ def _fte_applied_control_status(
     operation: str,
     task_id: str | dict[str, Any],
     status: dict[str, Any],
+    *,
+    applied: bool | None = None,
 ) -> dict[str, Any]:
     result = dict(status)
     expected = FteTaskAttemptId.coerce(task_id)
@@ -97,7 +100,9 @@ def _fte_applied_control_status(
             f"FTE control {operation} returned a mismatched task identity for {expected}: {exc}"
         ) from exc
     result["_fte_control_operation"] = str(operation)
-    result["_fte_control_applied"] = str(result.get("state") or "").upper() != "UNKNOWN"
+    result["_fte_control_applied"] = (
+        str(result.get("state") or "").upper() != "UNKNOWN" if applied is None else bool(applied)
+    )
     return result
 
 
@@ -956,7 +961,17 @@ class RayWorkerActor:
         splits: list[dict[str, Any]],
         _fte_control_dependency: Any = None,
     ) -> dict[str, Any]:
-        status = await self._get_fte_task_manager().add_splits(task_id, source_node_id, splits)
+        try:
+            status = await self._get_fte_task_manager().add_splits(task_id, source_node_id, splits)
+        except FteTaskTerminalControlError as exc:
+            if exc.operation != "add_splits":
+                raise
+            return _fte_applied_control_status(
+                "fte_add_splits",
+                task_id,
+                exc.status,
+                applied=False,
+            )
         return _fte_applied_control_status("fte_add_splits", task_id, status)
 
     @ray.method(concurrency_group="control")

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -1279,6 +1279,17 @@ def test_fte_late_add_splits_terminal_status_uses_task_status_path(
             assert worker_handle_mod._FTE_WORKER_HANDLES.get(handle.worker_id) is handle
         assert scheduler.stats().event_counts.get("WorkerFailed", 0) == 0
         assert other_scheduler.stats().event_counts.get("WorkerFailed", 0) == 0
+        assert handle.fte_drop_query(query_id) == {
+            "tasks_removed": 1,
+            "tasks_canceled": 0,
+            "fragments_removed": 2,
+        }
+        assert handle._has_fte_control_state_for_query(query_id) is False
+        assert handle._has_fte_teardown_state_for_query(query_id) is False
+        assert handle._fte_healthy is True
+        with worker_handle_mod._FTE_REGISTRY_LOCK:
+            assert worker_handle_mod._FTE_WORKER_HANDLES.get(handle.worker_id) is handle
+        assert other_scheduler.stats().event_counts.get("WorkerFailed", 0) == 0
     finally:
         fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
         fte_fragment_scheduler_mod._drop_fte_registry_for_query(other_query_id)

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -33,6 +33,7 @@ from duckdb.runners.ray.fte import (
     AssignmentResult,
     FteFragmentExecution,
     FteTaskAttemptId,
+    FteTaskExecution,
     FteTaskState,
     FteWorkerReservationUnavailable,
     NodeRequirements,
@@ -1098,6 +1099,220 @@ def test_fte_split_backpressure_terminal_status_uses_task_status_path(monkeypatc
         assert stats.event_counts.get("WorkerFailed", 0) == 0
     finally:
         fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+@pytest.mark.parametrize(
+    ("terminal_state", "failure"),
+    [
+        pytest.param(FteTaskState.FINISHED, None, id="finished"),
+        pytest.param(
+            FteTaskState.FAILED,
+            {
+                "error_code": "GENERIC_INTERNAL_ERROR",
+                "message": "planned task failure",
+            },
+            id="failed",
+        ),
+        pytest.param(
+            FteTaskState.CANCELED,
+            {
+                "error_code": "TASK_CANCELED",
+                "message": "planned task cancellation",
+            },
+            id="canceled",
+        ),
+        pytest.param(
+            FteTaskState.ABORTED,
+            {
+                "error_code": "TASK_ABORTED",
+                "message": "planned task abort",
+            },
+            id="aborted",
+        ),
+    ],
+)
+def test_fte_late_add_splits_terminal_status_uses_task_status_path(
+    monkeypatch,
+    terminal_state,
+    failure,
+):
+    query_id = f"query-late-add-splits-{terminal_state.value.lower()}"
+    other_query_id = f"{query_id}-other"
+    attempt_id = FteTaskAttemptId.coerce(
+        {
+            "query_id": query_id,
+            "fragment_execution_id": 0,
+            "partition_id": 0,
+            "attempt_id": 0,
+        }
+    )
+
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {
+            "task_id": attempt_id.to_dict(),
+            "dynamic_scan_source_node_ids": ["7"],
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+    execution._transition(terminal_state, failure=failure)
+    terminal_status = execution.status_payload()
+
+    class _TaskManager:
+        @staticmethod
+        async def add_splits(task_id, source_node_id, splits):
+            assert FteTaskAttemptId.coerce(task_id) == attempt_id
+            assert source_node_id == "7"
+            assert splits == [{"sequence_id": 1, "kind": "scan_task", "data": b"a"}]
+            execution.add_splits(source_node_id, splits)
+            raise AssertionError("terminal add_splits must not return normally")
+
+    class _WorkerEndpoint:
+        @staticmethod
+        def _get_fte_task_manager():
+            return _TaskManager()
+
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+    class _LateTerminalAddActor(_FakeActor):
+        def _fte_wait_split_queue_has_space(
+            self,
+            task_id,
+            source_node_id=None,
+            max_buffered_splits=None,
+            timeout_s=None,
+        ):
+            self.fte_calls.append(
+                (
+                    "wait_split_queue",
+                    task_id,
+                    source_node_id,
+                    max_buffered_splits,
+                    timeout_s,
+                )
+            )
+            return {
+                "has_space": True,
+                "terminal": False,
+                "buffered_splits": 0,
+                "status": {
+                    "state": FteTaskState.RUNNING.value,
+                    "task_id": task_id,
+                },
+            }
+
+        def _fte_add_splits(self, task_id, source_node_id, splits, dependency=None):
+            self.fte_calls.append(("add_splits", task_id, source_node_id, splits))
+            return asyncio.run(
+                actor_class.fte_add_splits(
+                    _WorkerEndpoint(),
+                    task_id,
+                    source_node_id,
+                    splits,
+                    dependency,
+                )
+            )
+
+        def _fte_no_more_splits(self, *_args, **_kwargs):
+            raise AssertionError("terminal task must skip trailing controls")
+
+    actor = _LateTerminalAddActor()
+    handle = RayWorkerActorHandle(
+        actor,
+        memory_capacity_bytes=1 << 60,
+        worker_id=f"worker-late-add-splits-{terminal_state.value.lower()}",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+    add_command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id=handle.worker_id,
+        worker=handle,
+        attempt_id=attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"a"},),
+    )
+    no_more_command = FteNoMoreSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id=handle.worker_id,
+        worker=handle,
+        attempt_id=attempt_id,
+        source_node_id="7",
+    )
+    captured_events = []
+    monkeypatch.setattr(
+        handle,
+        "_handles_for_task_status_changed_event",
+        lambda event: captured_events.append(event) or [],
+    )
+    worker_handle_mod.open_fte_registry_for_query(query_id)
+    worker_handle_mod.open_fte_registry_for_query(other_query_id)
+    other_scheduler = worker_commands_mod._FTE_SCHEDULERS.get_or_create(other_query_id)
+    handle._bind_fte_scheduler_handlers(other_scheduler)
+
+    try:
+        handle._execute_fte_fragment_execution_worker_commands(
+            stage,
+            [add_command, no_more_command],
+        )
+        scheduler = worker_commands_mod._FTE_SCHEDULERS.get(query_id)
+        assert scheduler is not None
+        scheduler.drain()
+
+        assert len(captured_events) == 1
+        assert captured_events[0].status == terminal_status
+        assert [call[0] for call in actor.fte_calls] == [
+            "wait_split_queue",
+            "add_splits",
+        ]
+        assert handle._fte_healthy is True
+        with worker_handle_mod._FTE_REGISTRY_LOCK:
+            assert worker_handle_mod._FTE_WORKER_HANDLES.get(handle.worker_id) is handle
+        assert scheduler.stats().event_counts.get("WorkerFailed", 0) == 0
+        assert other_scheduler.stats().event_counts.get("WorkerFailed", 0) == 0
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(other_query_id)
+
+
+def test_fte_late_add_splits_unknown_attempt_remains_strict_error():
+    task_id = {
+        "query_id": "query-late-add-splits-unknown",
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 0,
+    }
+
+    class _TaskManager:
+        @staticmethod
+        async def add_splits(_task_id, _source_node_id, _splits):
+            raise KeyError("unknown FTE task attempt")
+
+    class _WorkerEndpoint:
+        @staticmethod
+        def _get_fte_task_manager():
+            return _TaskManager()
+
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+
+    with pytest.raises(KeyError, match="unknown FTE task attempt"):
+        asyncio.run(
+            actor_class.fte_add_splits(
+                _WorkerEndpoint(),
+                task_id,
+                "7",
+                [{"sequence_id": 1, "kind": "scan_task", "data": b"a"}],
+            )
+        )
 
 
 def test_interruptible_fte_control_ref_preserves_completed_query_deadline():
@@ -2302,6 +2517,76 @@ def test_fte_worker_actor_handle_async_control_requires_dict_response(monkeypatc
         handle.enqueue_fte_no_more_splits(task_id, "7")
     with pytest.raises(TypeError, match="worker actor fte_update_task must return a dict"):
         handle.enqueue_fte_update_task(task_id, {"output_buffers": {"version": 1}})
+
+
+@pytest.mark.parametrize(
+    ("invalid_response", "error_pattern"),
+    [
+        pytest.param(
+            {
+                "state": FteTaskState.RUNNING.value,
+                "_fte_control_operation": "fte_add_splits",
+                "_fte_control_applied": False,
+            },
+            "not applied to non-terminal task",
+            id="non-terminal",
+        ),
+        pytest.param(
+            {
+                "state": FteTaskState.FAILED.value,
+                "_fte_control_operation": "fte_update_task",
+                "_fte_control_applied": False,
+            },
+            "control operation mismatch",
+            id="operation-mismatch",
+        ),
+        pytest.param(
+            {
+                "state": FteTaskState.FAILED.value,
+                "_fte_control_operation": "fte_add_splits",
+                "_fte_control_applied": False,
+                "partition_id": 2,
+            },
+            "status identity mismatch",
+            id="identity-mismatch",
+        ),
+    ],
+)
+def test_fte_worker_actor_handle_rejects_invalid_unapplied_add_status(
+    monkeypatch,
+    invalid_response,
+    error_pattern,
+):
+    task_id = {
+        "query_id": "query-invalid-unapplied-add",
+        "fragment_execution_id": 0,
+        "partition_id": 1,
+        "attempt_id": 0,
+    }
+    status = {
+        **invalid_response,
+        "task_id": {
+            **task_id,
+            "partition_id": invalid_response.get("partition_id", task_id["partition_id"]),
+        },
+    }
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-invalid-unapplied-add",
+    )
+    monkeypatch.setattr(
+        handle,
+        "_enqueue_ordered_fte_control_rpc",
+        lambda *_args, **_kwargs: status,
+    )
+
+    with pytest.raises(RuntimeError, match=error_pattern):
+        handle.enqueue_fte_add_splits(
+            task_id,
+            "7",
+            [{"sequence_id": 1}],
+        )
 
 
 def test_fte_worker_actor_handle_async_control_waits_for_remote_failure(monkeypatch):


### PR DESCRIPTION
## Summary

- Keep terminal `FteTaskExecution.add_splits` updates strict while carrying the existing terminal status through a dedicated internal error.
- Encode that expected race as an unapplied Ray control response, validate its operation, task identity, and terminal state on the driver, then route it through the existing task-status path.
- Avoid quarantining a healthy worker or broadcasting `WorkerFailed` to unrelated queries; real control failures, unknown attempts, and malformed responses remain strict errors.
- Cover `FINISHED`, `FAILED`, `CANCELED`, and `ABORTED` races plus negative protocol cases and cross-query isolation.

## Related issue

Closes #259

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `python -m pytest --import-mode=importlib -o pythonpath=tests tests/fast/test_ray_fte.py tests/fast/test_ray_fragment_submission.py -q`: 390 passed
- `scripts/run_release_tests.sh`: 448 passed, 1 skipped; real-Ray shard 7 passed
- Linux x86-64, Python 3.12.13; rebuilt the current upstream native baseline in the isolated worktree to validate its DuckDB SourceID before the release gate

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.