### PR TITLE
[fix](distributed) Bound stalled Flight server shutdown

### DIFF
--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -113,11 +113,13 @@ DuckDBResult<ParsedFlightHost> ParseFlightHost(std::string host) {
 struct LocalFlightServiceState {
 	std::mutex mutex;
 	std::unique_ptr<FlightServer> server;
+	bool shutting_down = false;
 	std::string bind_host;
 	std::string advertise_host;
 	int requested_port = 0;
 	int actual_port = 0;
 	std::string server_epoch;
+	std::chrono::milliseconds shutdown_grace_period {FlightServerConfig::DEFAULT_SHUTDOWN_GRACE_PERIOD};
 };
 
 LocalFlightServiceState &LocalFlightService() {
@@ -315,6 +317,10 @@ DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightServiceCon
 
 	auto &service = LocalFlightService();
 	std::lock_guard<std::mutex> guard(service.mutex);
+	if (service.shutting_down) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::invalid_state_error("process-local Flight service is shutting down"));
+	}
 	if (service.server) {
 		if (service.bind_host != bind_host || service.advertise_host != advertise_host ||
 		    service.requested_port != config.port) {
@@ -325,6 +331,13 @@ DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightServiceCon
 			        << " advertised as " << advertise_host;
 			return DuckDBResult<void>::err(DuckDBError::invalid_state_error(message.str()));
 		}
+		if (service.shutdown_grace_period != config.shutdown_grace_period) {
+			std::ostringstream message;
+			message << "process-local Flight service already uses a shutdown grace period of "
+			        << service.shutdown_grace_period.count() << " ms; refusing conflicting grace period "
+			        << config.shutdown_grace_period.count() << " ms";
+			return DuckDBResult<void>::err(DuckDBError::invalid_state_error(message.str()));
+		}
 		return DuckDBResult<void>::ok();
 	}
 
@@ -332,6 +345,7 @@ DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightServiceCon
 	server_config.bind_host = bind_host;
 	server_config.port = config.port;
 	server_config.server_epoch = UUID::ToString(UUID::GenerateRandomUUID());
+	server_config.shutdown_grace_period = config.shutdown_grace_period;
 	auto server = std::unique_ptr<FlightServer>(new FlightServer(server_config));
 	auto start_res = server->Start();
 	if (start_res.is_err()) {
@@ -342,6 +356,7 @@ DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightServiceCon
 	service.requested_port = config.port;
 	service.actual_port = server->port();
 	service.server_epoch = std::move(server_config.server_epoch);
+	service.shutdown_grace_period = config.shutdown_grace_period;
 	service.server = std::move(server);
 	std::cerr << "Started plaintext cluster-internal Flight shuffle service at "
 	          << BuildFlightLocation(service.advertise_host, service.actual_port)
@@ -371,21 +386,32 @@ std::string CurrentLocalFlightServerEpoch() {
 
 DuckDBResult<void> ShutdownLocalFlightServerInternal() {
 	auto &service = LocalFlightService();
-	std::lock_guard<std::mutex> guard(service.mutex);
-	if (!service.server) {
-		return DuckDBResult<void>::ok();
+	std::unique_ptr<FlightServer> server;
+	{
+		std::lock_guard<std::mutex> guard(service.mutex);
+		if (service.shutting_down) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::invalid_state_error("process-local Flight service is already shutting down"));
+		}
+		if (!service.server) {
+			return DuckDBResult<void>::ok();
+		}
+		service.shutting_down = true;
+		server = std::move(service.server);
+		service.bind_host.clear();
+		service.advertise_host.clear();
+		service.requested_port = 0;
+		service.actual_port = 0;
+		service.server_epoch.clear();
+		service.shutdown_grace_period = FlightServerConfig::DEFAULT_SHUTDOWN_GRACE_PERIOD;
 	}
-	auto stop_res = service.server->Stop();
-	if (stop_res.is_err()) {
-		return stop_res;
+	auto stop_res = server->Stop();
+	server.reset();
+	{
+		std::lock_guard<std::mutex> guard(service.mutex);
+		service.shutting_down = false;
 	}
-	service.server.reset();
-	service.bind_host.clear();
-	service.advertise_host.clear();
-	service.requested_port = 0;
-	service.actual_port = 0;
-	service.server_epoch.clear();
-	return DuckDBResult<void>::ok();
+	return stop_res;
 }
 
 std::string BuildSinkOutputLocation(const std::string &exchange_instance_id, const ExchangeSinkHandle &handle,

--- a/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_server.cpp
@@ -318,10 +318,7 @@ FlightServer::~FlightServer() {
 	if (!server_thread_.joinable()) {
 		return;
 	}
-	if (impl_ && impl_->server()) {
-		(void)impl_->server()->Shutdown();
-	}
-	server_thread_.join();
+	(void)Stop();
 }
 
 const FlightServerConfig &FlightServer::config() const {
@@ -363,12 +360,14 @@ DuckDBResult<void> FlightServer::Stop() {
 	if (!impl_ || !impl_->server()) {
 		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("flight server not initialized"));
 	}
-	auto status = impl_->server()->Shutdown();
+	if (!server_thread_.joinable()) {
+		return DuckDBResult<void>::ok();
+	}
+	auto deadline = std::chrono::system_clock::now() + config_.shutdown_grace_period;
+	auto status = impl_->server()->Shutdown(&deadline);
+	server_thread_.join();
 	if (!status.ok()) {
 		return DuckDBResult<void>::err(FlightServerArrowToError(status, "shutdown flight server"));
-	}
-	if (server_thread_.joinable()) {
-		server_thread_.join();
 	}
 	return DuckDBResult<void>::ok();
 }

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -51,6 +51,7 @@ struct FlightServiceConfig {
 	std::string bind_host;
 	std::string advertise_host;
 	int port = 0;
+	std::chrono::milliseconds shutdown_grace_period {FlightServerConfig::DEFAULT_SHUTDOWN_GRACE_PERIOD};
 };
 
 inline std::string ResolveFlightExchangeEnvString(const char *name) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_server.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_server.hpp
@@ -5,6 +5,7 @@
 
 #include "duckdb/execution/distributed/common_types.hpp"
 
+#include <chrono>
 #include <string>
 #include <memory>
 #include <thread>
@@ -13,9 +14,12 @@ namespace duckdb {
 namespace distributed {
 
 struct FlightServerConfig {
+	static constexpr std::chrono::milliseconds DEFAULT_SHUTDOWN_GRACE_PERIOD {5000};
+
 	std::string bind_host;
 	int port = 0;
 	std::string server_epoch;
+	std::chrono::milliseconds shutdown_grace_period {DEFAULT_SHUTDOWN_GRACE_PERIOD};
 };
 
 //! Build a Flight TCP URI, adding URI brackets around an IPv6 host.

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <set>
 #include <fstream>
+#include <future>
 #include <iterator>
 #include <utility>
 #include <cstdlib>
@@ -823,6 +824,104 @@ TEST_CASE("Exchange: Flight service isolates published attempts and rejects rele
 	registry.RemoveAndCleanupByPrefix(prefix);
 }
 
+TEST_CASE("Exchange: process-local Flight shutdown is bounded and releases its service lock",
+          "[distributed][exchange]") {
+	struct ServiceGuard {
+		~ServiceGuard() {
+			FlightExchangeManager::ShutdownLocalFlightServer();
+		}
+	} guard;
+	REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
+
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string exchange_id = "stalled-flight-shutdown__sink_0__attempt_0";
+	const std::string query_id = "stalled-flight-shutdown-query";
+	const std::string node_id = "stalled-flight-shutdown-node";
+
+	ShuffleCacheConfig cache_config;
+	cache_config.shuffle_stage_id = exchange_id;
+	cache_config.node_id = node_id;
+	cache_config.num_partitions = 1;
+	cache_config.local_dirs = {TestCreatePath("stalled_flight_shutdown")};
+	auto cache = std::make_shared<ShuffleCache>(std::move(cache_config));
+	const std::string payload(256 * 1024, 'x');
+	for (idx_t batch = 0; batch < 64; batch++) {
+		DataChunk chunk;
+		chunk.Initialize(Allocator::DefaultAllocator(), {LogicalType::BLOB});
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BLOB_RAW(payload));
+		REQUIRE(cache->WriteChunk(context, chunk, 0, {"payload"}).is_ok());
+	}
+	REQUIRE(cache->FlushAll(context, {"payload"}).is_ok());
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+
+	FlightServiceConfig service_config;
+	service_config.bind_host = "127.0.0.1";
+	service_config.advertise_host = "127.0.0.1";
+	service_config.port = 0;
+	service_config.shutdown_grace_period = std::chrono::seconds(1);
+	REQUIRE(FlightExchangeManager::EnsureLocalFlightServerStarted(service_config).is_ok());
+	const auto port = FlightExchangeManager::GetLocalFlightServerPort();
+	const auto epoch = FlightExchangeManager::GetLocalFlightServerEpoch();
+	REQUIRE(port > 0);
+	REQUIRE(!epoch.empty());
+	REQUIRE(registry.Register(exchange_id, cache, query_id, epoch, 0).is_ok());
+
+	auto location = arrow::flight::Location::Parse("grpc://127.0.0.1:" + std::to_string(port));
+	REQUIRE(location.ok());
+	auto client_result = arrow::flight::FlightClient::Connect(std::move(location).ValueOrDie());
+	REQUIRE(client_result.ok());
+	auto client = std::move(client_result).ValueOrDie();
+	FlightExchangeTicket ticket;
+	ticket.server_epoch = epoch;
+	ticket.exchange_instance_id = exchange_id;
+	ticket.node_id = node_id;
+	ticket.attempt_id = 0;
+	ticket.partition_idx = 0;
+	arrow::flight::Ticket flight_ticket;
+	flight_ticket.ticket = ticket.Serialize();
+	auto reader_result = client->DoGet(flight_ticket);
+	REQUIRE(reader_result.ok());
+	auto reader = std::move(reader_result).ValueOrDie();
+	REQUIRE(reader->GetSchema().ok());
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	auto stop_future =
+	    std::async(std::launch::async, []() { return FlightExchangeManager::ShutdownLocalFlightServer(); });
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	auto port_future =
+	    std::async(std::launch::async, []() { return FlightExchangeManager::GetLocalFlightServerPort(); });
+	const bool port_lookup_ready = port_future.wait_for(std::chrono::milliseconds(250)) == std::future_status::ready;
+	auto start_future = std::async(
+	    std::launch::async, [&]() { return FlightExchangeManager::EnsureLocalFlightServerStarted(service_config); });
+	const bool concurrent_start_ready =
+	    start_future.wait_for(std::chrono::milliseconds(250)) == std::future_status::ready;
+	const bool stopped_while_reader_open = stop_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
+	if (!stopped_while_reader_open) {
+		reader->Cancel();
+	}
+	auto stop_result = stop_future.get();
+	const auto observed_port = port_future.get();
+	auto concurrent_start_result = start_future.get();
+	reader->Cancel();
+	if (concurrent_start_result.is_ok()) {
+		REQUIRE(FlightExchangeManager::ShutdownLocalFlightServer().is_ok());
+	}
+
+	REQUIRE(stop_result.is_ok());
+	REQUIRE(port_lookup_ready);
+	REQUIRE(observed_port == 0);
+	REQUIRE(concurrent_start_ready);
+	REQUIRE(concurrent_start_result.is_err());
+	REQUIRE_THAT(concurrent_start_result.error().what(), Catch::Matchers::Contains("shutting down"));
+	REQUIRE(stopped_while_reader_open);
+	registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
 // ═══════════════════════════════════════════════════════════
 // ShuffleCache (IPC Stream format)
 // ═══════════════════════════════════════════════════════════
@@ -1567,6 +1666,12 @@ TEST_CASE("Exchange: process-local Flight service has immutable network config a
 	auto conflicting_start = FlightExchangeManager::EnsureLocalFlightServerStarted(conflicting_config);
 	REQUIRE(conflicting_start.is_err());
 	REQUIRE_THAT(conflicting_start.error().what(), Catch::Matchers::Contains("refusing conflicting address"));
+
+	auto conflicting_grace_config = service_config;
+	conflicting_grace_config.shutdown_grace_period += std::chrono::milliseconds(1);
+	auto conflicting_grace_start = FlightExchangeManager::EnsureLocalFlightServerStarted(conflicting_grace_config);
+	REQUIRE(conflicting_grace_start.is_err());
+	REQUIRE_THAT(conflicting_grace_start.error().what(), Catch::Matchers::Contains("conflicting grace period"));
 
 	manager_a.Shutdown();
 	object_storage_manager.Shutdown();


### PR DESCRIPTION
## Summary

- bound Flight server shutdown with a five-second grace deadline shared by explicit stop and destruction
- remove the process-local server from published state under the service mutex, then stop and destroy it outside the lock; concurrent starts fail fast while shutdown is active
- add a real Arrow Flight regression that leaves a 16 MiB `DoGet` stream unconsumed and verifies bounded shutdown, non-blocking endpoint lookup, and non-blocking start rejection

## Root cause

The server used Arrow Flight `Shutdown()` without a deadline and immediately joined its serving thread. A remote client that stopped consuming a `DoGet` stream could keep the gRPC handler active indefinitely. The process-local service mutex remained held across that wait, extending the stall to endpoint lookups and service starts.

The fix passes Arrow a bounded shutdown deadline so gRPC cancels stalled transport calls after the grace period. The process-local lifecycle publishes an empty endpoint before the blocking stop and tracks a `shutting_down` state until the old server has been fully destroyed.

## Verification

- `scripts/format duckdb --changed`
- regression test before fix: failed because shutdown did not finish while the reader remained open
- `scripts/run_native_tests.sh "[distributed][exchange]"` — 47 cases, 616 assertions passed
- `scripts/run_native_tests.sh "[distributed]"` — 116 cases, 3970 assertions passed
- regression test repeated 10 times successfully
- native package rebuilt with the required incremental PEP 517 build directory
- `scripts/run_release_tests.sh` — 448 non-Ray tests passed, 1 skipped; 7 real-Ray tests passed

Closes #258