### PR TITLE
[fix](udf) Restore concurrent Ray block prefetch

### DIFF
--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -107,6 +107,7 @@ class _StreamRecord:
     wait_future: Any | None = None
     completion_future: Any | None = None
     terminal_signal_observed: bool = False
+    data_credit_reserved: bool = False
 
 
 class AsyncResultCollector:
@@ -382,14 +383,11 @@ class AsyncResultCollector:
     def _pending_data_count_locked(self, slot_id: int) -> int:
         ready = sum(1 for event in self._ready_by_slot.get(slot_id, ()) if event.kind == "data")
         in_progress = sum(
-            1
-            for record in self._records.values()
-            if record.slot_id == slot_id
-            and (record.phase != "block" or (record.wait_kind == "data" and record.wait_future is not None))
+            1 for record in self._records.values() if record.slot_id == slot_id and record.data_credit_reserved
         )
         return ready + in_progress
 
-    def _may_read_block_locked(self, record: _StreamRecord) -> bool:
+    def _may_prefetch_block_locked(self, record: _StreamRecord) -> bool:
         capacity = self._capacity_by_slot.get(record.slot_id)
         if capacity is None or capacity.rows <= 0:
             return False
@@ -397,7 +395,22 @@ class AsyncResultCollector:
             return False
         if capacity.item_bytes is not None and capacity.item_bytes <= 0:
             return False
-        return self._pending_data_count_locked(record.slot_id) < capacity.rows
+        return True
+
+    def _reserve_data_credit_locked(self, record: _StreamRecord) -> bool:
+        if record.data_credit_reserved:
+            return True
+        capacity = self._capacity_by_slot.get(record.slot_id)
+        if capacity is None or capacity.rows <= 0:
+            return False
+        if capacity.bytes is not None and capacity.bytes <= 0:
+            return False
+        if capacity.item_bytes is not None and capacity.item_bytes <= 0:
+            return False
+        if self._pending_data_count_locked(record.slot_id) >= capacity.rows:
+            return False
+        record.data_credit_reserved = True
+        return True
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
@@ -452,17 +465,25 @@ class AsyncResultCollector:
         elif record.metadata_ref is not None:
             kind = "metadata"
             future = self._object_ref_future(record.metadata_ref)
-        elif record.phase == "metadata" or (record.phase == "block" and self._may_read_block_locked(record)):
+        elif record.phase == "metadata" and self._reserve_data_credit_locked(record):
+            # The block ObjectRef was prefetched without consuming downstream
+            # DATA capacity. Reserve one complete event before pulling its paired
+            # metadata and keep that reservation through output-lease admission.
             kind = "data"
-            if record.phase == "block":
-                capacity = self._capacity_by_slot.get(record.slot_id)
-                if capacity is None:
-                    raise RuntimeError("Ray UDF block read was scheduled without downstream capacity")
-                # Consuming the block ObjectRef is the admission point for the
-                # whole block/metadata pair. Keep its per-item limit stable;
-                # downstream capacity may legitimately fall to zero before the
-                # metadata ObjectRef becomes ready.
-                record.block_item_capacity_bytes = capacity.item_bytes
+            future = asyncio.run_coroutine_threadsafe(
+                record.adapter.read_next_ref_async(),
+                self._loop,
+            )
+        elif record.phase == "block" and self._may_prefetch_block_locked(record):
+            kind = "data"
+            capacity = self._capacity_by_slot.get(record.slot_id)
+            if capacity is None:
+                raise RuntimeError("Ray UDF block read was scheduled without downstream capacity")
+            # Prefetch one block ObjectRef per active stream so independent
+            # producers can overlap. The paired metadata transition above is
+            # still capacity-reserved, and the producer task lease bounds the
+            # stream's physical output window.
+            record.block_item_capacity_bytes = capacity.item_bytes
             future = asyncio.run_coroutine_threadsafe(
                 record.adapter.read_next_ref_async(),
                 self._loop,
@@ -637,6 +658,8 @@ class AsyncResultCollector:
     def _accept_metadata(self, record: _StreamRecord, metadata: Any) -> None:
         if record.phase != "metadata" or record.block_ref is None:
             raise RuntimeError("Ray UDF stream metadata arrived without its block")
+        if not record.data_credit_reserved:
+            raise RuntimeError("Ray UDF stream metadata arrived without reserved downstream DATA capacity")
         if isinstance(metadata, dict) and metadata.get("event_kind") == "error":
             remote_error = validate_stream_error_metadata(metadata)
             self._validate_task_identity(record, remote_error)
@@ -761,8 +784,11 @@ class AsyncResultCollector:
         with self._cv:
             stale = self._records.get((record.slot_id, record.submit_id)) is not record
             if not stale:
+                if not record.data_credit_reserved:
+                    raise RuntimeError("Ray UDF output lease completed without reserved downstream DATA capacity")
                 self._active_output_leases[(token.request_id, token.lease_id)] = token
                 self._ready_by_slot[record.slot_id].append(event)
+                record.data_credit_reserved = False
                 record.phase = "block"
                 record.block_ref = None
                 record.metadata = None

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -354,29 +354,32 @@ def test_zero_capacity_does_not_consume_block_or_metadata_objects():
         collector.shutdown()
 
 
-def test_scheduled_block_read_reserves_data_capacity_across_streams():
+def test_block_prefetch_overlaps_streams_without_oversubscribing_data_capacity():
     fake_ray = _FakeRay()
     driver = _Driver()
+    block_refs = {}
+    metadata_refs = {}
 
-    def submitter(lease):
-        return _Generator(
-            [
-                _Ref(f"block-{lease['lease_id']}", ready=False, is_block=True),
-                _Ref(_metadata(lease)),
-            ],
-            completed=False,
-        )
+    def submitter(submit_id):
+        def submit(lease):
+            block_ref = _Ref(f"block-{lease['lease_id']}", ready=False, is_block=True)
+            metadata_ref = _Ref(_metadata(lease), ready=False)
+            block_refs[submit_id] = block_ref
+            metadata_refs[submit_id] = metadata_ref
+            return _Generator([block_ref, metadata_ref], completed=False)
+
+        return submit
 
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         10,
-        _source(fake_ray, driver, request_id="reserved-read-1", submitter=submitter),
+        _source(fake_ray, driver, request_id="prefetch-read-1", submitter=submitter(10)),
     )
     collector.track_generator_ref(
         1,
         11,
-        _source(fake_ray, driver, request_id="reserved-read-2", submitter=submitter),
+        _source(fake_ray, driver, request_id="prefetch-read-2", submitter=submitter(11)),
     )
     capacity = {1: {"rows": 1, "bytes": 128, "item_bytes": 128}}
     try:
@@ -387,18 +390,65 @@ def test_scheduled_block_read_reserves_data_capacity_across_streams():
                 for record in collector._records.values()
                 if record.wait_kind == "data" and record.wait_future is not None
             ]
-        assert scheduled == [10]
+        assert scheduled == [10, 11]
+
+        fake_ray.make_ready(block_refs[10])
+        fake_ray.make_ready(block_refs[11])
+        deadline = time.monotonic() + 2.0
+        reserved = []
+        while time.monotonic() < deadline:
+            with collector._cv:
+                reserved = [record.submit_id for record in collector._records.values() if record.data_credit_reserved]
+                prefetched = [record.submit_id for record in collector._records.values() if record.phase == "metadata"]
+            if len(reserved) == 1 and prefetched == [10, 11]:
+                break
+            time.sleep(0.005)
+        assert len(reserved) == 1
+        assert prefetched == [10, 11]
 
         # A dispatcher capacity refresh must not grant the same downstream
-        # credit to the second stream while the first read remains in flight.
+        # DATA credit to the second prefetched stream while the first metadata
+        # read remains in flight.
         assert collector.drain_results(capacity) == []
         with collector._cv:
-            scheduled = [
-                record.submit_id
-                for record in collector._records.values()
-                if record.wait_kind == "data" and record.wait_future is not None
+            assert [
+                record.submit_id for record in collector._records.values() if record.data_credit_reserved
+            ] == reserved
+
+        first_submit = reserved[0]
+        second_submit = 11 if first_submit == 10 else 10
+        fake_ray.make_ready(metadata_refs[first_submit])
+        first_events = _drain_until(
+            collector,
+            capacity,
+            predicate=lambda values: any(item[2] == "data" for item in values),
+        )
+        assert [item[1] for item in first_events if item[2] == "data"] == [first_submit]
+
+        # The previous drain consumed the only advertised credit. A fresh
+        # capacity snapshot admits the already-prefetched peer metadata.
+        assert collector.drain_results(capacity) == []
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with collector._cv:
+                if any(
+                    record.submit_id == second_submit and record.data_credit_reserved
+                    for record in collector._records.values()
+                ):
+                    break
+            time.sleep(0.005)
+        with collector._cv:
+            assert [record.submit_id for record in collector._records.values() if record.data_credit_reserved] == [
+                second_submit
             ]
-        assert scheduled == [10]
+
+        fake_ray.make_ready(metadata_refs[second_submit])
+        second_events = _drain_until(
+            collector,
+            capacity,
+            predicate=lambda values: any(item[2] == "data" for item in values),
+        )
+        assert [item[1] for item in second_events if item[2] == "data"] == [second_submit]
     finally:
         collector.cancel_slot(1)
         collector.shutdown()
@@ -860,7 +910,7 @@ def test_one_slow_stream_cannot_block_a_ready_stream():
     try:
         events = _drain_until(
             collector,
-            {3: {"rows": 2, "bytes": 256, "item_bytes": 128}},
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
             predicate=lambda values: any(item[1] == 31 and item[2] == "data" for item in values),
         )
         fast_data = next(item for item in events if item[1] == 31 and item[2] == "data")


### PR DESCRIPTION
## Summary

- decouple one-block ObjectRef prefetch for each admitted active stream from downstream DATA-event admission, so a slow producer no longer occupies the only output credit before its block is ready
- reserve DATA capacity atomically before pulling paired metadata and retain that reservation through output-lease admission; ready DATA events and in-progress reservations remain within the advertised event capacity
- add capacity-one regression coverage for overlapping stream prefetch, strict metadata admission, and progress when one stream is slow

The streaming breaker remains enabled. This changes the collector scheduling point inside that path rather than selecting a different physical plan.

## Performance

On the 10,000-image classification benchmark with identical model/data caches and dependencies:

| Revision | Runtime |
| --- | ---: |
| Parent of #221 (`5ef1edd2e0`) | 29.27s |
| #245 head before this fix (`4db06af388`) | 70.89s |
| This branch (`f32f570b43`) | 29.57s |

All compared runs produced 10,000 rows with identical `(image_url, label)` sets.

## Validation

- affected collector/adapter/lifecycle/process tests: `339 passed`
- collector concurrency race tests: 50 repeated runs passed
- release suite: `448 passed, 1 skipped, 11 deselected`; real-Ray release shard: `7 passed, 453 deselected`
- complete fast suite: non-Ray `6056 passed, 28 skipped, 104 deselected, 8 xfailed, 1 xpassed`; shared-cluster Ray `87 passed, 6 skipped, 6104 deselected`; all 6 runnable isolated Ray-owner tests passed and the vLLM-only test skipped
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- two consecutive clean review passes after the final implementation changes

Closes #260

Related: #80, #221, #38, #245