### PR TITLE
[fix](extensions) Keep extension loading self-contained

### DIFF
--- a/cmake/duckdb_loader.cmake
+++ b/cmake/duckdb_loader.cmake
@@ -53,8 +53,8 @@ _duckdb_set_default(DISABLE_UNITY OFF)
 
 # Extension configuration
 _duckdb_set_default(DISABLE_BUILTIN_EXTENSIONS OFF)
-_duckdb_set_default(ENABLE_EXTENSION_AUTOINSTALL ON)
-_duckdb_set_default(ENABLE_EXTENSION_AUTOLOADING ON)
+_duckdb_set_default(ENABLE_EXTENSION_AUTOINSTALL OFF)
+_duckdb_set_default(ENABLE_EXTENSION_AUTOLOADING OFF)
 
 # Performance options - enable optimizations by default
 _duckdb_set_default(NATIVE_ARCH OFF)

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -505,8 +505,11 @@ def _configure_duckdb_s3(
 
     try:
         conn.execute("LOAD httpfs")
-    except Exception:
-        conn.execute("INSTALL httpfs; LOAD httpfs")
+    except Exception as exc:
+        raise RuntimeError(
+            "Ray S3 configuration requires the statically linked httpfs extension; "
+            "runtime extension installation is disabled"
+        ) from exc
 
     def _q(s: str) -> str:
         return s.replace("'", "''")

--- a/external/duckdb/extension/generated_extension_loader.cpp.in
+++ b/external/duckdb/extension/generated_extension_loader.cpp.in
@@ -1,5 +1,6 @@
 #include "duckdb/main/extension/generated_extension_loader.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -13,6 +14,15 @@ vector<string> LinkedExtensions(){
     vector<string> VEC = {${EXT_NAME_VECTOR_INITIALIZER}
     };
     return VEC;
+}
+
+bool ExtensionHelper::IsExtensionLinked(const string &extension) {
+    for (auto &ext_name : LinkedExtensions()) {
+        if (StringUtil::CIEquals(ext_name, extension)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ExtensionHelper::LoadAllExtensions(DuckDB &db) {

--- a/external/duckdb/extension/loader/dummy_static_extension_loader.cpp
+++ b/external/duckdb/extension/loader/dummy_static_extension_loader.cpp
@@ -8,6 +8,10 @@ void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
 	// nop
 }
 
+bool ExtensionHelper::IsExtensionLinked(const string &) {
+	return false;
+}
+
 vector<string> ExtensionHelper::LoadedExtensionTestPaths() {
 	return {};
 }

--- a/external/duckdb/src/include/duckdb/main/extension_helper.hpp
+++ b/external/duckdb/src/include/duckdb/main/extension_helper.hpp
@@ -94,6 +94,7 @@ struct ExtensionInstallOptions {
 class ExtensionHelper {
 public:
 	static void LoadAllExtensions(DuckDB &db);
+	static bool IsExtensionLinked(const string &extension);
 	static vector<string> LoadedExtensionTestPaths();
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
 

--- a/external/duckdb/src/main/database.cpp
+++ b/external/duckdb/src/main/database.cpp
@@ -238,7 +238,9 @@ void DatabaseInstance::LoadExtensionSettings() {
 			auto &value = option.second;
 
 			auto extension_name = ExtensionHelper::FindExtensionInEntries(name, EXTENSION_SETTINGS);
-			if (extension_name.empty()) {
+			if (extension_name.empty() || ExtensionHelper::IsExtensionLinked(extension_name)) {
+				// Statically linked extensions are loaded after Initialize. Keep
+				// their settings pending until their options are registered.
 				continue;
 			}
 			if (!ExtensionHelper::TryAutoLoadExtension(*this, extension_name)) {
@@ -259,9 +261,43 @@ void DatabaseInstance::LoadExtensionSettings() {
 
 		con.Commit();
 	}
-	if (!config.options.unrecognized_options.empty()) {
-		ThrowExtensionSetUnrecognizedOptions(config.options.unrecognized_options);
+
+	case_insensitive_map_t<Value> unknown_options;
+	for (auto &option : config.options.unrecognized_options) {
+		auto extension_name = ExtensionHelper::FindExtensionInEntries(option.first, EXTENSION_SETTINGS);
+		if (!extension_name.empty() && ExtensionHelper::IsExtensionLinked(extension_name)) {
+			continue;
+		}
+		if (!extension_name.empty()) {
+			throw InvalidInputException("Configuration option \"%s\" belongs to extension \"%s\", which is not "
+			                            "statically linked into this build",
+			                            option.first, extension_name);
+		}
+		unknown_options.insert(option);
 	}
+	if (!unknown_options.empty()) {
+		ThrowExtensionSetUnrecognizedOptions(unknown_options);
+	}
+}
+
+static void ApplyStaticallyLinkedExtensionSettings(DatabaseInstance &instance,
+                                                   const case_insensitive_map_t<Value> &extension_settings) {
+	if (extension_settings.empty()) {
+		return;
+	}
+
+	Connection con(instance);
+	con.BeginTransaction();
+	for (auto &setting : extension_settings) {
+		ExtensionOption extension_option;
+		if (!instance.config.TryGetExtensionOption(setting.first, extension_option)) {
+			throw InternalException("Statically linked extension did not provide the '%s' config setting",
+			                        setting.first);
+		}
+		PhysicalSet::SetExtensionVariable(*con.context, extension_option, setting.first, SetScope::GLOBAL,
+		                                  setting.second);
+	}
+	con.Commit();
 }
 
 static duckdb_ext_api_v1 CreateAPIv1Wrapper() {
@@ -334,8 +370,15 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 
 DuckDB::DuckDB(const char *path, DBConfig *new_config) : instance(make_shared_ptr<DatabaseInstance>()) {
 	instance->Initialize(path, new_config);
+	// Extension registration consumes matching entries from
+	// unrecognized_options. Preserve their original values so callbacks and
+	// type conversion can run once the statically linked extensions are loaded.
+	auto static_extension_settings = instance->config.options.unrecognized_options;
 	if (instance->config.options.load_extensions) {
 		ExtensionHelper::LoadAllExtensions(*this);
+		ApplyStaticallyLinkedExtensionSettings(*instance, static_extension_settings);
+	} else if (!static_extension_settings.empty()) {
+		ThrowExtensionSetUnrecognizedOptions(static_extension_settings);
 	}
 	instance->db_manager->FinalizeStartup();
 }

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -976,13 +976,15 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj, py::o
 		throw duckdb::InternalException("Logical plan is empty and no relation is available");
 	}
 
-	py::object planning_conn = ResolveConnectionForSnapshot(conn_obj, connection_snapshot_);
+	py::object planning_conn = ResolvePlanningConnectionForSnapshot(conn_obj, source_connection_, connection_snapshot_);
 	auto &conn_wrapper = ExtractPyConnectionWrapper(planning_conn);
 	// Resolved environment/profile credentials are the session baseline. Replay
 	// the source connection last so an explicit SET on that connection keeps
 	// DuckDB's normal explicit-config-over-environment precedence.
 	ApplyEffectiveVaneSessionConfig(conn_wrapper.con.GetConnection(), effective_session_config);
-	ApplyConnectionSnapshot(planning_conn, connection_snapshot_, effective_session_config.is_none());
+	const bool shares_source_database = ConnectionsShareDatabaseInstance(planning_conn, source_connection_);
+	ApplyConnectionSnapshot(planning_conn, connection_snapshot_, effective_session_config.is_none(),
+	                        !shares_source_database);
 	if (!udf_registrations_.is_none()) {
 		conn_wrapper.ApplyDistributedPythonUDFRegistrations(udf_registrations_);
 	}

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -8,6 +8,8 @@ struct PyPhysicalPlanWrapper;
 struct PyLogicalPlan {
 	string query_id_;
 	string serialized_logical_plan_;
+	// Driver-local source connection; intentionally omitted from pickle state.
+	py::object source_connection_ = py::none();
 	duckdb::shared_ptr<duckdb::Relation> relation_;
 	py::object udf_registrations_ = py::none();
 	py::object connection_snapshot_ = py::none();
@@ -79,6 +81,26 @@ static py::dict CopyPyDict(const py::dict &source) {
 		result[item.first] = item.second;
 	}
 	return result;
+}
+
+static bool IsExtensionSecuritySetting(const string &lower_name) {
+	return lower_name == "allow_unsigned_extensions" || lower_name == "autoinstall_known_extensions" ||
+	       lower_name == "autoload_known_extensions";
+}
+
+static py::dict SanitizeBootstrapConfig(const py::dict &config) {
+	py::dict sanitized;
+	// Preserve absent options so file-backed connections keep DuckDB's
+	// configuration identity; Vane's build defaults all three settings to OFF.
+	for (auto item : config) {
+		auto name = duckdb::StringUtil::Lower(py::str(item.first).cast<string>());
+		if (IsExtensionSecuritySetting(name)) {
+			sanitized[py::str(name)] = py::str("false");
+			continue;
+		}
+		sanitized[item.first] = item.second;
+	}
+	return sanitized;
 }
 
 static py::object LookupBootstrapSnapshot(const py::object &snapshot_obj) {
@@ -225,16 +247,29 @@ static bool PythonObjectsEqual(const py::handle &lhs, const py::handle &rhs) {
 	return compare_result == 1;
 }
 
+static string BootstrapDatabasePath(const py::object &bootstrap_obj) {
+	if (bootstrap_obj.is_none() || !py::isinstance<py::dict>(bootstrap_obj)) {
+		return ":memory:";
+	}
+	auto bootstrap = bootstrap_obj.cast<py::dict>();
+	if (!bootstrap.contains(py::str("database")) || bootstrap[py::str("database")].is_none()) {
+		return ":memory:";
+	}
+	return py::str(bootstrap[py::str("database")]).cast<string>();
+}
+
+static bool BootstrapUsesInMemoryDatabase(const py::object &bootstrap_obj) {
+	auto database = BootstrapDatabasePath(bootstrap_obj);
+	return duckdb::DBConfig::IsInMemoryDatabase(database.c_str());
+}
+
 static py::object CreateConnectionFromBootstrapSnapshot(const py::object &bootstrap_obj) {
 	if (IsDefaultBootstrapSnapshot(bootstrap_obj)) {
 		return py::cast(DuckDBPyConnection::Connect(py::str(":memory:"), false, py::dict()));
 	}
 
 	auto bootstrap = bootstrap_obj.cast<py::dict>();
-	py::object database_obj = py::str(":memory:");
-	if (bootstrap.contains(py::str("database")) && !bootstrap[py::str("database")].is_none()) {
-		database_obj = py::str(bootstrap[py::str("database")]);
-	}
+	auto database = BootstrapDatabasePath(bootstrap_obj);
 
 	bool read_only = false;
 	if (bootstrap.contains(py::str("read_only")) && !bootstrap[py::str("read_only")].is_none()) {
@@ -246,7 +281,21 @@ static py::object CreateConnectionFromBootstrapSnapshot(const py::object &bootst
 	    py::isinstance<py::dict>(bootstrap[py::str("config")])) {
 		config = CopyPyDict(bootstrap[py::str("config")].cast<py::dict>());
 	}
-	return py::cast(DuckDBPyConnection::Connect(database_obj, read_only, config));
+	auto connection = DuckDBPyConnection::Connect(py::str(database), read_only, SanitizeBootstrapConfig(config));
+	// Keep the source bootstrap identity for connection matching even though
+	// worker extension security settings are forced off.
+	connection->SetConnectionBootstrapConfig(database, read_only, config);
+	return py::cast(std::move(connection));
+}
+
+static py::object CreateSnapshotBaselineConnection(DuckDBPyConnection &source_conn, const py::object &bootstrap_obj) {
+	if (BootstrapUsesInMemoryDatabase(bootstrap_obj)) {
+		return CreateConnectionFromBootstrapSnapshot(bootstrap_obj);
+	}
+	// A fresh cursor preserves the existing file-database baseline: database-
+	// global settings remain defaults while connection-local overrides differ.
+	// It also avoids reopening a live file with sanitized bootstrap settings.
+	return py::cast(source_conn.Cursor());
 }
 
 static bool ConnectionMatchesBootstrapSnapshot(py::object conn_obj, const py::object &snapshot_obj) {
@@ -259,6 +308,20 @@ static bool ConnectionMatchesBootstrapSnapshot(py::object conn_obj, const py::ob
 	return PythonObjectsEqual(actual_bootstrap, normalized_required);
 }
 
+static bool ConnectionsShareDatabaseInstance(const py::object &lhs_obj, const py::object &rhs_obj) {
+	if (lhs_obj.is_none() || rhs_obj.is_none()) {
+		return false;
+	}
+	auto &lhs_wrapper = ExtractPyConnectionWrapper(lhs_obj);
+	auto &rhs_wrapper = ExtractPyConnectionWrapper(rhs_obj);
+	if (lhs_wrapper.con.ConnectionIsClosed() || rhs_wrapper.con.ConnectionIsClosed()) {
+		return false;
+	}
+	auto &lhs = lhs_wrapper.con.GetConnection();
+	auto &rhs = rhs_wrapper.con.GetConnection();
+	return &duckdb::DatabaseInstance::GetDatabase(*lhs.context) == &duckdb::DatabaseInstance::GetDatabase(*rhs.context);
+}
+
 static py::object ResolveConnectionForSnapshot(py::object conn_obj, const py::object &snapshot_obj) {
 	auto bootstrap_obj = LookupBootstrapSnapshot(snapshot_obj);
 	if (bootstrap_obj.is_none() || IsDefaultBootstrapSnapshot(bootstrap_obj)) {
@@ -268,6 +331,23 @@ static py::object ResolveConnectionForSnapshot(py::object conn_obj, const py::ob
 		return conn_obj;
 	}
 	return CreateConnectionFromBootstrapSnapshot(bootstrap_obj);
+}
+
+static py::object ResolvePlanningConnectionForSnapshot(py::object conn_obj, const py::object &source_conn_obj,
+                                                       const py::object &snapshot_obj) {
+	auto bootstrap_obj = LookupBootstrapSnapshot(snapshot_obj);
+	if (bootstrap_obj.is_none() || IsDefaultBootstrapSnapshot(bootstrap_obj) ||
+	    ConnectionMatchesBootstrapSnapshot(conn_obj, snapshot_obj)) {
+		return conn_obj;
+	}
+	if (!BootstrapUsesInMemoryDatabase(bootstrap_obj) && !source_conn_obj.is_none() &&
+	    ConnectionMatchesBootstrapSnapshot(source_conn_obj, snapshot_obj)) {
+		// The source DatabaseInstance may still be alive. Reopening its file with
+		// the sanitized worker configuration violates DuckDB's instance cache;
+		// a cursor shares that instance without running database initialization.
+		return py::cast(ExtractPyConnectionWrapper(source_conn_obj).Cursor());
+	}
+	return ResolveConnectionForSnapshot(conn_obj, snapshot_obj);
 }
 
 struct QueryPythonReplayState {
@@ -297,10 +377,19 @@ struct ConnectionSettingRecord {
 	string scope;
 };
 
+static void EnforceExtensionSecuritySettings(duckdb::Connection &conn) {
+	// Snapshot replay can run with a query-local result collector installed, so
+	// update the configuration without executing SET statements.
+	auto &config = duckdb::DBConfig::GetConfig(*conn.context);
+	config.SetOptionByName("allow_unsigned_extensions", duckdb::Value::BOOLEAN(false));
+	config.SetOptionByName("autoinstall_known_extensions", duckdb::Value::BOOLEAN(false));
+	config.SetOptionByName("autoload_known_extensions", duckdb::Value::BOOLEAN(false));
+}
+
 static bool ShouldSkipConnectionSettingSnapshot(const string &name, const string &input_type) {
 	auto lower_name = duckdb::StringUtil::Lower(name);
 	auto upper_input_type = duckdb::StringUtil::Upper(input_type);
-	if (lower_name == "duckdb_api") {
+	if (lower_name == "duckdb_api" || IsExtensionSecuritySetting(lower_name)) {
 		return true;
 	}
 	if (upper_input_type.find('[') != string::npos) {
@@ -456,7 +545,7 @@ static void ApplyEffectiveVaneSessionConfig(duckdb::Connection &conn, const py::
 	ApplyVaneSessionConfigValues(conn, config_obj.cast<py::dict>());
 }
 
-static std::vector<string> QueryLoadedExtensionNames(DuckDBPyConnection &conn_wrapper) {
+static std::vector<string> QueryLoadedNonStaticExtensionNames(DuckDBPyConnection &conn_wrapper) {
 	std::vector<string> extensions;
 	auto result =
 	    ExecuteSnapshotQuery(conn_wrapper.con.GetConnection(), "SELECT extension_name "
@@ -503,19 +592,18 @@ static std::vector<ConnectionSettingRecord> QueryConnectionSettings(DuckDBPyConn
 	return settings;
 }
 
-static void TryLoadSnapshotExtension(DuckDBPyConnection &conn_wrapper, const string &extension_name,
-                                     bool allow_install) {
-	auto &conn = conn_wrapper.con.GetConnection();
-	try {
-		ExecuteSnapshotQuery(conn, "LOAD " + extension_name);
-		return;
-	} catch (...) {
-	}
-	if (!allow_install) {
+static void RejectNonStaticRayExtensions(const std::vector<string> &extension_names) {
+	if (extension_names.empty()) {
 		return;
 	}
-	ExecuteSnapshotQuery(conn, "INSTALL " + extension_name);
-	ExecuteSnapshotQuery(conn, "LOAD " + extension_name);
+	auto joined_names = extension_names.front();
+	for (idx_t index = 1; index < extension_names.size(); index++) {
+		joined_names += ", " + extension_names[index];
+	}
+	throw duckdb::InvalidInputException("Ray distributed execution supports only statically linked extensions; "
+	                                    "non-static extensions are not supported: "
+	                                    "%s",
+	                                    joined_names);
 }
 
 static bool VaneRaySessionLifecycleEnabled() {
@@ -528,24 +616,17 @@ static bool VaneRaySessionLifecycleEnabled() {
 
 static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 	auto bootstrap_obj = conn_wrapper.ExportConnectionBootstrapConfig();
-	auto loaded_extensions = QueryLoadedExtensionNames(conn_wrapper);
+	auto non_static_extensions = QueryLoadedNonStaticExtensionNames(conn_wrapper);
+	RejectNonStaticRayExtensions(non_static_extensions);
 	auto source_settings = QueryConnectionSettings(conn_wrapper);
 
-	auto default_conn_obj = CreateConnectionFromBootstrapSnapshot(bootstrap_obj);
+	auto default_conn_obj = CreateSnapshotBaselineConnection(conn_wrapper, bootstrap_obj);
 	auto &default_conn = ExtractPyConnectionWrapper(default_conn_obj);
-	for (const auto &extension_name : loaded_extensions) {
-		TryLoadSnapshotExtension(default_conn, extension_name, false);
-	}
 	auto default_settings = QueryConnectionSettings(default_conn);
 	std::unordered_map<string, string> default_setting_values;
 	default_setting_values.reserve(default_settings.size());
 	for (const auto &record : default_settings) {
 		default_setting_values[duckdb::StringUtil::Lower(record.name)] = record.value;
-	}
-
-	py::list extensions_obj;
-	for (const auto &extension_name : loaded_extensions) {
-		extensions_obj.append(py::str(extension_name));
 	}
 
 	py::list settings_obj;
@@ -577,7 +658,9 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 	if (has_bootstrap) {
 		snapshot_obj[py::str("bootstrap")] = NormalizeBootstrapSnapshot(bootstrap_obj);
 	}
-	snapshot_obj[py::str("extensions")] = std::move(extensions_obj);
+	// Keep the field for snapshot compatibility; capture rejects any non-static
+	// extension before reaching this point.
+	snapshot_obj[py::str("extensions")] = py::list();
 	snapshot_obj[py::str("settings")] = std::move(settings_obj);
 	if (VaneRaySessionLifecycleEnabled()) {
 		conn_wrapper.MarkVaneRaySessionOpened();
@@ -586,7 +669,7 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 }
 
 static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snapshot_obj,
-                                    bool apply_session_config = true) {
+                                    bool apply_session_config = true, bool enforce_extension_security = true) {
 	if (snapshot_obj.is_none()) {
 		return;
 	}
@@ -594,22 +677,31 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		throw duckdb::InvalidInputException("Connection snapshot must be a dict");
 	}
 
-	auto &conn_wrapper = ExtractPyConnectionWrapper(conn_obj);
 	auto snapshot = snapshot_obj.cast<py::dict>();
+	std::vector<string> extension_names;
 	if (snapshot.contains(py::str("extensions"))) {
 		auto extensions_obj = snapshot[py::str("extensions")];
 		if (!extensions_obj.is_none() && py::isinstance<py::list>(extensions_obj)) {
 			for (auto item : extensions_obj.cast<py::list>()) {
 				auto extension_name = py::str(item).cast<string>();
-				if (extension_name.empty()) {
-					continue;
+				if (!extension_name.empty()) {
+					extension_names.push_back(std::move(extension_name));
 				}
-				TryLoadSnapshotExtension(conn_wrapper, extension_name, true);
 			}
 		}
 	}
+	RejectNonStaticRayExtensions(extension_names);
+
+	auto &conn_wrapper = ExtractPyConnectionWrapper(conn_obj);
+	auto &conn = conn_wrapper.con.GetConnection();
+	if (enforce_extension_security) {
+		// Distributed snapshot replay never inherits settings that permit
+		// runtime downloads or unsigned extension binaries.
+		EnforceExtensionSecuritySettings(conn);
+	}
+
 	if (apply_session_config) {
-		ApplyVaneSessionConfig(conn_wrapper.con.GetConnection(), snapshot_obj);
+		ApplyVaneSessionConfig(conn, snapshot_obj);
 	}
 
 	if (!snapshot.contains(py::str("settings"))) {
@@ -633,7 +725,7 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		auto input_type = setting_obj.contains(py::str("input_type"))
 		                      ? py::str(setting_obj[py::str("input_type")]).cast<string>()
 		                      : string("VARCHAR");
-		if (setting_name.empty()) {
+		if (setting_name.empty() || IsExtensionSecuritySetting(duckdb::StringUtil::Lower(setting_name))) {
 			continue;
 		}
 		string sql_value;
@@ -642,7 +734,7 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		} else {
 			sql_value = QuoteSQLStringLiteral(setting_value);
 		}
-		ExecuteSnapshotQuery(conn_wrapper.con.GetConnection(), "SET " + setting_name + " = " + sql_value);
+		ExecuteSnapshotQuery(conn, "SET " + setting_name + " = " + sql_value);
 	}
 }
 

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -759,6 +759,7 @@ void register_ray_bindings(py::module_ &mod) {
 			                if (connection_owner && !connection_owner.is_none() &&
 			                    py::isinstance<DuckDBPyConnection>(connection_owner)) {
 				                auto &conn_wrapper = connection_owner.cast<DuckDBPyConnection &>();
+				                plan.source_connection_ = connection_owner;
 				                auto registrations = conn_wrapper.ExportDistributedPythonUDFRegistrations();
 				                if (py::len(registrations) > 0) {
 					                plan.udf_registrations_ = std::move(registrations);

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -102,6 +102,81 @@ def test_duckdb_source_id_matches_recorded_source_tree():
     assert duckdb.__git_revision__ == embedded_source_id
 
 
+def test_release_runtime_is_self_contained_by_default():
+    connection = duckdb.connect()
+    settings = dict(
+        connection.execute(
+            """
+            SELECT name, value
+            FROM duckdb_settings()
+            WHERE name IN (
+                'allow_unsigned_extensions',
+                'autoinstall_known_extensions',
+                'autoload_known_extensions'
+            )
+            """
+        ).fetchall()
+    )
+    static_extensions = {
+        name: (installed, loaded)
+        for name, installed, loaded in connection.execute(
+            """
+            SELECT extension_name, installed, loaded
+            FROM duckdb_extensions()
+            WHERE install_mode = 'STATICALLY_LINKED'
+            """
+        ).fetchall()
+    }
+
+    expected_extensions = {"core_functions", "httpfs", "icu", "json", "parquet"}
+    if platform.system() == "Linux" and sys.maxsize > 2**32:
+        expected_extensions.add("jemalloc")
+
+    assert settings == {
+        "allow_unsigned_extensions": "false",
+        "autoinstall_known_extensions": "false",
+        "autoload_known_extensions": "false",
+    }
+    assert static_extensions == {name: (True, True) for name in expected_extensions}
+
+
+@pytest.mark.parametrize(
+    ("setting_name", "setting_value", "expected"),
+    [
+        ("http_timeout", "41", 41),
+        ("binary_as_string", "true", True),
+        ("calendar", "gregorian", "gregorian"),
+    ],
+)
+def test_static_extension_settings_are_available_during_connect(tmp_path, setting_name, setting_value, expected):
+    extension_directory = tmp_path / "extensions"
+    connection = duckdb.connect(
+        config={
+            setting_name: setting_value,
+            "extension_directory": str(extension_directory),
+            "custom_extension_repository": "http://127.0.0.1:9",
+        }
+    )
+
+    assert connection.execute(f"SELECT current_setting('{setting_name}')").fetchone()[0] == expected
+    assert not extension_directory.exists()
+
+
+def test_dynamic_extension_settings_are_rejected_during_connect_without_installing(tmp_path):
+    extension_directory = tmp_path / "extensions"
+
+    with pytest.raises(duckdb.InvalidInputException, match="sqlite_all_varchar.*sqlite_scanner.*not statically linked"):
+        duckdb.connect(
+            config={
+                "sqlite_all_varchar": "true",
+                "extension_directory": str(extension_directory),
+                "custom_extension_repository": "http://127.0.0.1:9",
+            }
+        )
+
+    assert not extension_directory.exists()
+
+
 def test_exported_tree_without_manifest_computes_source_id(tmp_path, monkeypatch):
     expected = "a" * 40
 

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -412,6 +412,192 @@ def test_pickled_physical_plan_replays_connection_snapshot_on_execute_native():
     assert worker_cursor.execute("SELECT current_setting('TimeZone')").fetchone()[0] == "UTC"
 
 
+def test_snapshot_replay_rejects_non_static_extensions_without_installing(tmp_path):
+    ray_cxx = _require_ray_cxx()
+
+    source_conn = duckdb.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-missing-extension",
+    )
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    state = list(physical_plan.__getstate__())
+    snapshot = dict(state[6])
+    snapshot["extensions"] = ["sqlite_scanner"]
+    state[6] = snapshot
+
+    replay_plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+    replay_plan.__setstate__(tuple(state))
+
+    extension_directory = tmp_path / "extensions"
+    worker_connection = duckdb.connect(
+        config={
+            "autoinstall_known_extensions": "false",
+            "autoload_known_extensions": "false",
+            "extension_directory": str(extension_directory),
+        }
+    )
+    worker_connection.execute("SET custom_extension_repository = 'http://127.0.0.1:9'")
+
+    with pytest.raises(Exception) as exc_info:
+        ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            worker_connection.cursor(),
+            replay_plan,
+        )
+
+    message = str(exc_info.value)
+    assert "supports only statically linked extensions" in message
+    assert "sqlite_scanner" in message
+    assert "Failed to download extension" not in message
+    assert not extension_directory.exists()
+
+
+def test_snapshot_bootstrap_is_sanitized_before_connect(tmp_path):
+    ray_cxx = _require_ray_cxx()
+
+    source_conn = duckdb.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-bootstrap-extension-security",
+    )
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    state = list(physical_plan.__getstate__())
+    snapshot = dict(state[6])
+    extension_directory = tmp_path / "bootstrap-extensions"
+    snapshot["bootstrap"] = {
+        "database": ":memory:",
+        "read_only": False,
+        "config": {
+            "allow_unsigned_extensions": "true",
+            "autoinstall_known_extensions": "true",
+            "autoload_known_extensions": "true",
+            "custom_extension_repository": "http://127.0.0.1:9",
+            "extension_directory": str(extension_directory),
+            "sqlite_all_varchar": "true",
+        },
+    }
+    snapshot["extensions"] = ["sqlite_scanner"]
+    state[6] = snapshot
+
+    replay_plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+    replay_plan.__setstate__(tuple(state))
+
+    with pytest.raises(Exception) as exc_info:
+        ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            duckdb.connect().cursor(),
+            replay_plan,
+        )
+
+    assert not extension_directory.exists()
+    message = str(exc_info.value)
+    assert "sqlite_all_varchar" in message
+    assert "sqlite_scanner" in message
+    assert "not statically linked" in message
+
+
+def test_snapshot_bootstrap_applies_static_extension_settings_after_connect(tmp_path):
+    ray_cxx = _require_ray_cxx()
+
+    source_conn = duckdb.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql(
+            """
+            SELECT
+                CAST(current_setting('http_timeout') AS BIGINT) AS timeout,
+                CAST(current_setting('allow_unsigned_extensions') AS BOOLEAN) AS allow_unsigned,
+                CAST(current_setting('autoinstall_known_extensions') AS BOOLEAN) AS autoinstall,
+                CAST(current_setting('autoload_known_extensions') AS BOOLEAN) AS autoload
+            """
+        ),
+        "snapshot-bootstrap-static-extension-setting",
+    )
+    state = list(logical_plan.__getstate__())
+    snapshot = dict(state[3])
+    extension_directory = tmp_path / "bootstrap-extensions"
+    snapshot["bootstrap"] = {
+        "database": ":memory:",
+        "read_only": False,
+        "config": {
+            "allow_unsigned_extensions": "true",
+            "autoinstall_known_extensions": "true",
+            "autoload_known_extensions": "true",
+            "custom_extension_repository": "http://127.0.0.1:9",
+            "extension_directory": str(extension_directory),
+            "http_timeout": "41",
+        },
+    }
+    snapshot["settings"] = [
+        setting for setting in snapshot.get("settings", []) if setting.get("name", "").lower() != "http_timeout"
+    ]
+    state[3] = snapshot
+
+    replay_logical_plan = ray_cxx.PyLogicalPlan.__new__(ray_cxx.PyLogicalPlan)
+    replay_logical_plan.__setstate__(tuple(state))
+    physical_plan = replay_logical_plan.to_physical_plan(duckdb.connect())
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        duckdb.connect().cursor(),
+        restored_plan,
+    )
+
+    table = _table_from_native_result(result)
+    assert [table.column(index).to_pylist() for index in range(4)] == [
+        [41],
+        [False],
+        [False],
+        [False],
+    ]
+    assert not extension_directory.exists()
+
+
+def test_snapshot_replay_keeps_extension_security_settings_disabled():
+    ray_cxx = _require_ray_cxx()
+    snapshot_setting_names = (
+        "autoinstall_known_extensions",
+        "autoload_known_extensions",
+    )
+    setting_names = (
+        "allow_unsigned_extensions",
+        *snapshot_setting_names,
+    )
+    settings_query = f"""
+        SELECT name, value
+        FROM duckdb_settings()
+        WHERE name IN ({", ".join(repr(name) for name in setting_names)})
+        ORDER BY name
+    """
+
+    source_connection = duckdb.connect()
+    for name in snapshot_setting_names:
+        source_connection.execute(f"SET {name} = true")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_connection.sql("SELECT 1"),
+        "snapshot-extension-security-settings",
+    )
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    state = list(physical_plan.__getstate__())
+    snapshot = dict(state[6])
+    captured_setting_names = {setting["name"].lower() for setting in snapshot["settings"]}
+    assert captured_setting_names.isdisjoint(setting_names)
+    snapshot["settings"] = [
+        *snapshot["settings"],
+        *({"name": name, "value": "true", "input_type": "BOOLEAN"} for name in setting_names),
+    ]
+    state[6] = snapshot
+    replay_plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+    replay_plan.__setstate__(tuple(state))
+
+    worker_connection = duckdb.connect(config={name: "true" for name in setting_names})
+    assert dict(worker_connection.execute(settings_query).fetchall()) == {name: "true" for name in setting_names}
+
+    ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        worker_connection.cursor(),
+        replay_plan,
+    )
+
+    assert dict(worker_connection.execute(settings_query).fetchall()) == {name: "false" for name in setting_names}
+
+
 def test_pickled_physical_plan_replays_bootstrap_and_runtime_connection_snapshot():
     ray_cxx = _require_ray_cxx()
 
@@ -437,20 +623,106 @@ def test_pickled_physical_plan_replays_bootstrap_and_runtime_connection_snapshot
     assert table.column(1).to_pylist() == ["UTC"]
 
 
+def test_logical_plan_capture_planning_and_execution_preserve_file_database_security_config(tmp_path):
+    ray_cxx = _require_ray_cxx()
+    database_path = str(tmp_path / "capture-bootstrap.duckdb")
+    setting_names = (
+        "allow_unsigned_extensions",
+        "autoinstall_known_extensions",
+        "autoload_known_extensions",
+    )
+    settings_query = f"""
+        SELECT name, value
+        FROM duckdb_settings()
+        WHERE name IN ({", ".join(repr(name) for name in setting_names)})
+        ORDER BY name
+    """
+    source_conn = duckdb.connect(
+        database_path,
+        config={name: "true" for name in setting_names},
+    )
+    source_settings = dict(source_conn.execute(settings_query).fetchall())
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1 AS value"),
+        "file-security-setting",
+    )
+
+    assert logical_plan.idx() == "file-security-setting"
+    assert source_settings == {name: "true" for name in setting_names}
+
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+
+    assert physical_plan.idx() == "file-security-setting"
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+    assert dict(source_conn.execute(settings_query).fetchall()) == source_settings
+    source_conn.close()
+    del logical_plan
+    del physical_plan
+    gc.collect()
+
+    worker_conn = duckdb.connect(config={name: "true" for name in setting_names})
+    assert dict(worker_conn.execute(settings_query).fetchall()) == {name: "true" for name in setting_names}
+
+    restored_result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        worker_conn.cursor(),
+        restored_plan,
+    )
+
+    assert _table_from_native_result(restored_result).column(0).to_pylist() == [1]
+
+
+def test_file_database_table_scan_reopens_bootstrap_on_worker(tmp_path):
+    ray_cxx = _require_ray_cxx()
+    database_path = str(tmp_path / "table-scan-bootstrap.duckdb")
+    source_conn = duckdb.connect(database_path)
+    source_conn.execute("CREATE TABLE numbers AS SELECT i AS value FROM range(10) data(i)")
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT sum(value) AS total FROM numbers"),
+        "snapshot-file-table-scan",
+    )
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    restored_plan = pickle.loads(pickle.dumps(physical_plan))
+
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        duckdb.connect().cursor(),
+        restored_plan,
+    )
+
+    assert _table_from_native_result(result).column(0).to_pylist() == [45]
+
+
 def test_effective_session_config_reaches_nondefault_bootstrap_connection(tmp_path):
     ray_cxx = _require_ray_cxx()
     database_path = str(tmp_path / "session-bootstrap.duckdb")
     source_conn = duckdb.connect(database_path)
     source_conn.execute("LOAD httpfs")
-    source_conn.execute("SET GLOBAL s3_access_key_id='source-placeholder-key'")
-    relation = source_conn.sql("SELECT CAST(current_setting('s3_access_key_id') AS VARCHAR) AS access_key")
+    source_conn.execute("SET GLOBAL s3_access_key_id='database-key'")
+    source_conn.execute("SET GLOBAL s3_secret_access_key='database-secret'")
+    source_conn.execute("SET GLOBAL s3_session_token='database-token'")
+    relation = source_conn.sql(
+        "SELECT current_setting('s3_access_key_id') AS access_key, "
+        "current_setting('s3_secret_access_key') AS secret_key, "
+        "current_setting('s3_session_token') AS session_token"
+    )
     logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
         relation,
         "snapshot-effective-session-config",
     )
+    assert logical_plan.has_explicit_s3_credentials() is False
+    snapshot_setting_names = {setting["name"].lower() for setting in logical_plan.__getstate__()[3]["settings"]}
+    assert snapshot_setting_names.isdisjoint(
+        {
+            "s3_access_key_id",
+            "s3_secret_access_key",
+            "s3_session_token",
+        }
+    )
     effective_config = {
         "AWS_ACCESS_KEY_ID": "resolved-profile-key",
         "AWS_SECRET_ACCESS_KEY": "resolved-profile-secret",
+        "AWS_SESSION_TOKEN": "resolved-profile-token",
     }
 
     physical_plan = logical_plan.to_physical_plan(
@@ -464,7 +736,33 @@ def test_effective_session_config_reaches_nondefault_bootstrap_connection(tmp_pa
         effective_session_config=effective_config,
     )
 
-    assert _table_from_native_result(result).column(0).to_pylist() == ["resolved-profile-key"]
+    table = _table_from_native_result(result)
+    assert [table.column(index).to_pylist() for index in range(3)] == [
+        ["resolved-profile-key"],
+        ["resolved-profile-secret"],
+        ["resolved-profile-token"],
+    ]
+
+
+def test_file_database_snapshot_baseline_ignores_database_target_settings(tmp_path):
+    ray_cxx = _require_ray_cxx()
+    database_path = str(tmp_path / "read-only-bootstrap.duckdb")
+    duckdb.connect(database_path).close()
+    source_conn = duckdb.connect(database_path, config={"access_mode": "READ_ONLY"})
+
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1 AS value"),
+        "snapshot-file-target-settings",
+    )
+    snapshot_setting_names = {setting["name"].lower() for setting in logical_plan.__getstate__()[3]["settings"]}
+
+    assert snapshot_setting_names.isdisjoint({"access_mode", "temp_directory"})
+    physical_plan = logical_plan.to_physical_plan(duckdb.connect())
+    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        duckdb.connect().cursor(),
+        physical_plan,
+    )
+    assert _table_from_native_result(result).column(0).to_pylist() == [1]
 
 
 def test_explicit_connection_s3_settings_override_effective_session_config():

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -10506,6 +10506,27 @@ def test_configure_duckdb_s3_applies_static_credentials_only_to_connection_conte
     assert all("SET GLOBAL" not in statement for statement in statements)
 
 
+def test_configure_duckdb_s3_does_not_install_httpfs_when_load_fails():
+    statements = []
+
+    class _FakeConnection:
+        def execute(self, statement):
+            statements.append(statement)
+            raise RuntimeError("httpfs is unavailable")
+
+    with pytest.raises(RuntimeError, match="runtime extension installation is disabled") as exc_info:
+        worker_mod._configure_duckdb_s3(
+            _FakeConnection(),
+            {
+                "AWS_ACCESS_KEY_ID": "access-key",
+                "AWS_SECRET_ACCESS_KEY": "secret-key",
+            },
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert statements == ["LOAD httpfs"]
+
+
 def test_configure_duckdb_s3_preserves_scheme_less_endpoint_authority():
     statements = []
 


### PR DESCRIPTION
## Summary

Extension-owned connection settings were parsed before statically linked extensions were registered. Disabling automatic extension loading therefore broke public `duckdb.connect(config=...)` calls, while Ray replay and S3 setup could still attempt runtime extension installation.

This change:

- disables extension autoload and autoinstall by default;
- applies settings owned by statically linked extensions after they are loaded;
- restricts Ray execution to statically linked extensions and removes worker-side installation.

## Related issue

Closes #119

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in `AstroVela/vane-website`.

The existing security documentation already describes the intended restrictive posture.

## Validation

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Incremental Release native build and install
- Affected tests: 265 passed, 1 skipped
- `scripts/run_release_tests.sh`: 453 passed, 1 skipped; real-Ray 7 passed

## Checklist

- [x] The change is focused and includes tests.
- [x] Public behavior and compatibility impact are documented.
- [x] No new dependencies, copied code, model assets, or datasets are included.
- [x] No credentials, private endpoints, generated data, or build artifacts are included.
- [x] Extension security and network-access implications have been considered.
- [x] Native changes were compiled and relevant checks passed.