### PR TITLE
[fix](vllm) Validate native structured responses

### DIFF
--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -7,6 +7,7 @@ import json
 import math
 from collections import Counter, deque
 from dataclasses import dataclass
+from datetime import date
 
 import numpy as np
 import pyarrow as pa
@@ -554,6 +555,32 @@ def test_ai_prompt_vllm_relation_validates_pydantic_output_and_preserves_nulls(m
     assert Counter(prompt for _prefix, prompts in executor.submissions for prompt in prompts) == Counter(
         ["valid", "invalid"]
     )
+
+
+def test_ai_prompt_vllm_relation_uses_pydantic_json_validation(monkeypatch):
+    pydantic = pytest.importorskip("pydantic")
+    import duckdb.execution.vllm as vllm_executor
+
+    class Answer(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(strict=True)
+
+        due: date
+
+    executor = _RecordingNativeVLLMExecutor({"valid": '{"due":"2026-01-02"}'})
+    monkeypatch.setattr(vllm_executor, "build_executor", lambda _model, _options: executor)
+    conn = vane.connect()
+    source = conn.sql("select 'valid'::VARCHAR as question")
+
+    result = vane.ai.prompt(
+        source,
+        "question",
+        provider="vllm",
+        return_format=Answer,
+    )
+
+    assert result.fetchall() == [('{"due":"2026-01-02"}',)]
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
 
 
 def test_ai_prompt_vllm_relation_rejects_pydantic_validation_failure(monkeypatch):

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -134,7 +134,8 @@ class MockProvider(Provider):
 class _RecordingNativeVLLMExecutor:
     """Minimal executor used to exercise the native PhysicalVLLM bridge."""
 
-    def __init__(self) -> None:
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        self.responses = responses
         self.submissions: list[tuple[str | None, tuple[str, ...]]] = []
         self.ready = deque()
         self.finished = False
@@ -144,7 +145,12 @@ class _RecordingNativeVLLMExecutor:
     def submit(self, prefix, prompts, rows) -> None:
         prompt_values = tuple(prompts)
         self.submissions.append((prefix, prompt_values))
-        self.ready.append(([f"generated:{prompt}" for prompt in prompt_values], rows))
+        output_values = (
+            [f"generated:{prompt}" for prompt in prompt_values]
+            if self.responses is None
+            else [self.responses[prompt] for prompt in prompt_values]
+        )
+        self.ready.append((output_values, rows))
 
     def take_ready_result(self):
         try:
@@ -474,6 +480,7 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_outp
 
     assert result.columns == ["answer"]
     assert "VLLM_PROJECT" in result.explain()
+    assert "STREAMING_UDF" not in result.explain()
     assert Counter(result.fetchall()) == Counter(
         [
             ("generated:Answer briefly.\n\nquestion",),
@@ -494,6 +501,91 @@ def test_ai_prompt_vllm_relation_uses_one_native_lifecycle_and_returns_only_outp
     assert [prompt for _prefix, prompts in executor.submissions for prompt in prompts] == [
         "Answer briefly.\n\nquestion",
     ]
+
+
+def test_ai_prompt_vllm_relation_validates_pydantic_output_and_preserves_nulls(monkeypatch):
+    pydantic = pytest.importorskip("pydantic")
+    import duckdb.execution.vllm as vllm_executor
+
+    class Answer(pydantic.BaseModel):
+        answer: str
+        validated: bool = True
+
+        @pydantic.field_validator("answer")
+        @classmethod
+        def answer_must_be_approved(cls, value: str) -> str:
+            if value != "approved":
+                raise ValueError("answer must be approved")
+            return value
+
+    executor = _RecordingNativeVLLMExecutor(
+        {
+            "valid": '{"answer":"approved"}',
+            "invalid": '{"answer":"rejected"}',
+        }
+    )
+    monkeypatch.setattr(vllm_executor, "build_executor", lambda _model, _options: executor)
+    conn = vane.connect()
+    source = conn.sql(
+        "select * from (values (1, 'valid'::VARCHAR), (2, 'invalid'::VARCHAR), "
+        "(3, NULL::VARCHAR)) source(id, question) order by id"
+    )
+
+    result = vane.ai.prompt(
+        source,
+        "question",
+        provider="vllm",
+        return_format=Answer,
+        prompt_options={"on_error": "ignore"},
+    )
+
+    plan = result.explain()
+    assert "VLLM_PROJECT" in plan
+    assert "STREAMING_UDF" in plan
+    assert Counter(result.fetchall()) == Counter(
+        [
+            ('{"answer":"approved","validated":true}',),
+            (None,),
+            (None,),
+        ]
+    )
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
+    assert Counter(prompt for _prefix, prompts in executor.submissions for prompt in prompts) == Counter(
+        ["valid", "invalid"]
+    )
+
+
+def test_ai_prompt_vllm_relation_rejects_pydantic_validation_failure(monkeypatch):
+    pydantic = pytest.importorskip("pydantic")
+    import duckdb.execution.vllm as vllm_executor
+
+    class Answer(pydantic.BaseModel):
+        answer: str
+
+        @pydantic.field_validator("answer")
+        @classmethod
+        def answer_must_be_approved(cls, value: str) -> str:
+            if value != "approved":
+                raise ValueError("answer must be approved")
+            return value
+
+    executor = _RecordingNativeVLLMExecutor({"invalid": '{"answer":"rejected"}'})
+    monkeypatch.setattr(vllm_executor, "build_executor", lambda _model, _options: executor)
+    conn = vane.connect()
+    source = conn.sql("select 'invalid'::VARCHAR as question")
+    result = vane.ai.prompt(
+        source,
+        "question",
+        provider="vllm",
+        return_format=Answer,
+    )
+
+    with pytest.raises(Exception, match="answer must be approved"):
+        result.fetchall()
+
+    assert executor.finished_count == 1
+    assert executor.shutdown_count == 1
 
 
 def test_ai_prompt_vllm_relation_restores_opaque_secrets_at_local_executor_creation(monkeypatch):

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -45,7 +45,7 @@ import numpy as np
 import pyarrow as pa
 
 import duckdb
-from vane._expression_udf import _build_actor_map_batches_expression
+from vane._expression_udf import _build_actor_map_batches_expression, _build_map_batches_expression
 from vane._expressions import as_expression, is_expression
 from vane.ai.options import (
     AnthropicPromptOptions,
@@ -657,6 +657,37 @@ class _PromptBatch:
         return pa.table({self._output_column: results})
 
 
+class _ValidateVLLMStructuredOutputBatch:
+    """Apply the Pydantic runtime contract to native vLLM output."""
+
+    def __init__(
+        self,
+        return_format: Any,
+        input_column: str,
+        output_column: str,
+        on_error: _OnError,
+    ) -> None:
+        self._return_format = return_format
+        self._input_column = input_column
+        self._output_column = output_column
+        self._on_error = on_error
+
+    def __call__(self, table: pa.Table) -> pa.Table:
+        results: list[str | None] = []
+        for raw_text in table.column(self._input_column).to_pylist():
+            if raw_text is None:
+                results.append(None)
+                continue
+            try:
+                validated = self._return_format.model_validate(json.loads(raw_text))
+                results.append(validated.model_dump_json())
+            except Exception:
+                if self._on_error == "raise":
+                    raise
+                results.append(None)
+        return pa.table({self._output_column: pa.array(results, type=pa.string())})
+
+
 def _build_ai_batch_expression(
     wrapper: Any,
     *,
@@ -934,7 +965,30 @@ def _prompt_relation(
             if isinstance(relation_alias, str) and relation_alias
             else duckdb.ColumnExpression(column)
         )
-        expression = _build_native_vllm_expression(column_expr, descriptor).alias(output_column)
+        expression = _build_native_vllm_expression(column_expr, descriptor)
+        native_return_format = descriptor.return_format
+        if hasattr(native_return_format, "model_validate"):
+            input_column = "__vane_vllm_response"
+            raw_on_error = descriptor.vllm_options.get("on_error", "raise")
+            validation_on_error: _OnError = (
+                "ignore" if str(raw_on_error).strip().lower() in {"ignore", "log", "null"} else "raise"
+            )
+            validator = _ValidateVLLMStructuredOutputBatch(
+                native_return_format,
+                input_column,
+                output_column,
+                validation_on_error,
+            )
+            expression = _build_map_batches_expression(
+                validator.__call__,
+                name="validate_vllm_structured_output",
+                inputs={input_column: expression},
+                schema={output_column: "VARCHAR"},
+                batch_size=None,
+                row_preserving=True,
+                gpus=0,
+            )
+        expression = expression.alias(output_column)
         return rel.select(expression)
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -679,7 +679,7 @@ class _ValidateVLLMStructuredOutputBatch:
                 results.append(None)
                 continue
             try:
-                validated = self._return_format.model_validate(json.loads(raw_text))
+                validated = self._return_format.model_validate_json(raw_text)
                 results.append(validated.model_dump_json())
             except Exception:
                 if self._on_error == "raise":


### PR DESCRIPTION
## Summary

Native vLLM relation prompts now apply a supplied Pydantic return model after structured decoding. The row-preserving validation stage validates each raw JSON response with model_validate_json() and serializes the validated model, restoring custom validators, coercion, defaults, and malformed-output detection before results are exposed.

Non-raising error policies return NULL for invalid responses, while the default raise policy fails the query. NULL propagation and the relation-scoped PhysicalVLLM lifecycle remain intact. Plain JSON Schema dictionaries continue to use the pure native path without an additional Python UDF.

## Related issue

close: #252

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in AstroVela/vane-website.

This restores the documented return_format contract without changing the public API.

## Validation

- scripts/format root --changed — passed.
- python -m ruff check vane/ai/functions.py tests/ai/test_expression_ai_functions.py — passed.
- python -m pytest tests/ai/test_expression_ai_functions.py -q — 40 passed.
- python -m pytest tests/ai/test_expression_ai_functions.py tests/fast/test_expression_udf_map_batches.py -q — 64 passed.
- scripts/run_release_tests.sh — 448 passed, 1 skipped, 11 deselected; the real-Ray shard passed 7 tests with 453 deselected.
- Ray logical/physical plan round-trip and submission serialization smoke check — one VLLM node and one validation UDF node; serialization passed.
- git diff --check — passed.

No real-model or GPU-backed vLLM inference was run; native execution used the recording executor test double.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No new repository dependency or external asset is introduced.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. Validation runs in the existing task UDF boundary and adds no network or remote-code surface.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks. This change is Python-only and passed the checks listed above.