### PR TITLE
[fix](fte) Keep native progress topology stable

### DIFF
--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -747,6 +747,7 @@ class _NativeFteRegisteredFragment:
     dynamic_exchange_source_node_ids: set[str] = field(default_factory=set)
     partitions: dict[str, _NativeFteRegisteredPartition] = field(default_factory=dict)
     progress_topology: dict[str, Any] | None = None
+    progress_topology_unavailable: bool = False
 
 
 class _NativeFteProgressRegistry:
@@ -1014,15 +1015,60 @@ class _NativeFteProgressRegistry:
         for raw_pipeline in raw_pipelines:
             if not isinstance(raw_pipeline, Mapping):
                 raise TypeError("native progress pipeline entries must be mappings")
+            raw_operator_details = raw_pipeline["operator_details"]
+            if type(raw_operator_details) is not list:
+                raise TypeError("native progress operator_details must be a list")
+            operator_details: list[dict[str, Any]] = []
+            for raw_details in raw_operator_details:
+                if not isinstance(raw_details, Mapping):
+                    raise TypeError("native progress operator details must be mappings")
+                # Live native stats include counters in operator_details. Those
+                # values evolve during execution and are not topology. Keep
+                # only the fields consumed as stable display identity.
+                operator_details.append(
+                    {key: raw_details[key] for key in ("udf_name", "pipeline_role") if key in raw_details}
+                )
             pipelines.append(
                 {
                     "pipeline_id": raw_pipeline["pipeline_id"],
                     "operators": raw_pipeline["operators"],
-                    "operator_details": raw_pipeline["operator_details"],
+                    "operator_details": operator_details,
                     "stage_ids": raw_pipeline["stage_ids"],
                 }
             )
         return validate_pipeline_topology({"schema": "pipeline_topology", "pipelines": pipelines})
+
+    @staticmethod
+    def _merge_progress_topologies(
+        current: Mapping[str, Any],
+        incoming: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        merged = copy.deepcopy(dict(current))
+        pipelines = merged["pipelines"]
+        pipelines_by_id = {pipeline["pipeline_id"]: pipeline for pipeline in pipelines}
+        for incoming_pipeline in incoming["pipelines"]:
+            pipeline_id = incoming_pipeline["pipeline_id"]
+            current_pipeline = pipelines_by_id.get(pipeline_id)
+            if current_pipeline is None:
+                copied = copy.deepcopy(incoming_pipeline)
+                pipelines.append(copied)
+                pipelines_by_id[pipeline_id] = copied
+                continue
+            if (
+                current_pipeline["operators"] != incoming_pipeline["operators"]
+                or current_pipeline["stage_ids"] != incoming_pipeline["stage_ids"]
+            ):
+                return None
+            for current_details, incoming_details in zip(
+                current_pipeline["operator_details"],
+                incoming_pipeline["operator_details"],
+                strict=True,
+            ):
+                for key, value in incoming_details.items():
+                    if key in current_details and current_details[key] != value:
+                        return None
+                    current_details.setdefault(key, copy.deepcopy(value))
+        return validate_pipeline_topology(merged)
 
     @classmethod
     def _merge_fragment_progress_topology_locked(
@@ -1030,16 +1076,28 @@ class _NativeFteProgressRegistry:
         fragment: _NativeFteRegisteredFragment,
         metrics: Mapping[str, Any],
     ) -> None:
-        for task_stats in cls._task_stats_from_partition_metrics(metrics):
-            topology = cls._topology_from_task_stats(task_stats)
-            if topology is None:
-                continue
-            if fragment.progress_topology is None:
-                fragment.progress_topology = topology
-            elif fragment.progress_topology != topology:
-                raise RuntimeError(
-                    f"native fragment progress topology changed after publication: {fragment.fragment_id}"
-                )
+        if fragment.progress_topology_unavailable:
+            return
+        try:
+            for task_stats in cls._task_stats_from_partition_metrics(metrics):
+                topology = cls._topology_from_task_stats(task_stats)
+                if topology is None:
+                    continue
+                if fragment.progress_topology is None:
+                    fragment.progress_topology = topology
+                    continue
+                merged = cls._merge_progress_topologies(fragment.progress_topology, topology)
+                if merged is None:
+                    fragment.progress_topology = None
+                    fragment.progress_topology_unavailable = True
+                    return
+                fragment.progress_topology = merged
+        except Exception:
+            # Progress is observational. Malformed or genuinely conflicting
+            # snapshots must not break fte_query_status, which is also the
+            # native completion-detection path.
+            fragment.progress_topology = None
+            fragment.progress_topology_unavailable = True
 
     @staticmethod
     def _placeholder_partition_metrics(partition: _NativeFteRegisteredPartition) -> dict[str, Any]:

--- a/duckdb/runners/progress.py
+++ b/duckdb/runners/progress.py
@@ -22,7 +22,7 @@ def progress_enabled(runner_type: str | None = None) -> bool:
     value = os.getenv("VANE_PROGRESS", "auto").strip().lower()
     if value in _FALSE_VALUES:
         return False
-    runner = (runner_type or os.getenv("VANE_RUNNER", "")).strip().lower() or "ray"
+    runner = (runner_type or os.getenv("VANE_RUNNER") or "").strip().lower() or "ray"
     return runner in {"local", "ray"} or value not in ("", "auto")
 
 
@@ -329,7 +329,15 @@ def _pipeline_stats_with_progress_topology(
 ) -> list[dict[str, Any]]:
     """Keep native topology stable while overlaying matching live counters."""
     topology = validate_pipeline_topology(progress_topology, allow_empty=True)
-    topology_by_id = {pipeline["pipeline_id"]: pipeline for pipeline in topology["pipelines"]}
+    topology_pipelines = topology["pipelines"]
+    if not topology_pipelines:
+        # An empty topology means pipeline-level progress is unavailable. Keep
+        # the surrounding live stats usable for fragment/query totals without
+        # trying to align pipeline entries against a topology that was
+        # deliberately discarded.
+        return [{**dict(stats), "pipelines": []} for stats in live_stats_items]
+
+    topology_by_id = {pipeline["pipeline_id"]: pipeline for pipeline in topology_pipelines}
     zero_pipelines = [
         {
             **copy.deepcopy(pipeline),
@@ -342,7 +350,7 @@ def _pipeline_stats_with_progress_topology(
             "running_pipeline_tasks": 0,
             "completed_pipeline_tasks": 0,
         }
-        for pipeline in topology["pipelines"]
+        for pipeline in topology_pipelines
     ]
     aligned_stats: list[dict[str, Any]] = [{"pipelines": zero_pipelines}]
     for stats in live_stats_items:
@@ -360,7 +368,18 @@ def _pipeline_stats_with_progress_topology(
             operators = pipeline.get("operators")
             if operators != planned["operators"]:
                 raise RuntimeError(f"live progress pipeline {pipeline_id} operators do not match topology")
-            aligned_pipelines.append(pipeline)
+            aligned_pipeline = dict(pipeline)
+            live_operator_details = pipeline.get("operator_details")
+            aligned_operator_details: list[dict[str, Any]] = []
+            for index, planned_details in enumerate(planned["operator_details"]):
+                # Stable identity comes from the topology. Fill it into a
+                # detached live entry so partial attempts render consistently,
+                # while retaining live-only counters and the original stats.
+                details = copy.deepcopy(_operator_detail_at(live_operator_details, index))
+                details.update(copy.deepcopy(planned_details))
+                aligned_operator_details.append(details)
+            aligned_pipeline["operator_details"] = aligned_operator_details
+            aligned_pipelines.append(aligned_pipeline)
         aligned["pipelines"] = aligned_pipelines
         aligned_stats.append(aligned)
     return aligned_stats
@@ -414,6 +433,7 @@ def build_progress_snapshot(
     requested_query_id = str(query_id)
     queries = registry_stats.get("queries") or {}
     query = queries.get(requested_query_id) or {}
+    query_payload: dict[str, Any]
     if isinstance(query, dict):
         query_payload = {"query_id": str(query.get("query_id") or requested_query_id)}
         for key in ("failed", "finished"):

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -588,12 +588,8 @@ def test_ai_sql_full_local_copy_in_subprocess(tmp_path, expression, expected):
     script = f"""
 import vane
 from vane.ai import provider as provider_registry
-from duckdb.runners.fte.backends.native.backend import _NativeFteProgressRegistry
 from tests.ai.test_expression_ai_sql import MockProvider
 
-# Keep this teardown regression focused on #214. Live UDF counters currently
-# trigger the independent progress-topology failure tracked by #239.
-_NativeFteProgressRegistry._topology_from_task_stats = staticmethod(lambda _task_stats: None)
 provider_registry.PROVIDERS["mock_ai_sql"] = lambda name=None, **options: MockProvider()
 vane.configure(runner="local")
 conn = vane.connect()

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -25,6 +25,8 @@ from duckdb.runners.fte.backends.native import (
 from duckdb.runners.fte.backends.native.backend import (
     _BackgroundEventLoop,
     _flight_exchange_node_id_from_env,
+    _NativeFteProgressRegistry,
+    _NativeFteRegisteredFragment,
 )
 from duckdb.runners.fte.fte_config import FTE_WORKER_RUNTIME
 from duckdb.runners.progress import build_progress_snapshot
@@ -1442,6 +1444,222 @@ def test_native_backend_query_status_builds_local_progress_snapshot():
         release.set()
         backend.drop_query("query-progress")
         backend.shutdown()
+
+
+def test_native_progress_topology_ignores_live_counters_and_merges_stable_identity():
+    fragment = _NativeFteRegisteredFragment(
+        query_id="query-progress-topology",
+        fragment_id="query-progress-topology:scan",
+        fragment_execution_id=0,
+    )
+
+    def metrics(counter: str, *, include_udf_name: bool, include_copy_pipeline: bool):
+        udf_details = {
+            "pipeline_role": "source",
+            "udf_completed_input_rows": counter,
+        }
+        if include_udf_name:
+            udf_details["udf_name"] = "ai_prompt"
+        pipelines = [
+            {
+                "pipeline_id": 1,
+                "operators": ["STREAMING_UDF"],
+                "operator_details": [udf_details],
+                "stage_ids": [],
+            }
+        ]
+        if include_copy_pipeline:
+            pipelines.append(
+                {
+                    "pipeline_id": 2,
+                    "operators": ["COPY_TO_FILE"],
+                    "operator_details": [{}],
+                    "stage_ids": [],
+                }
+            )
+        return {"running_attempts": [{"task_stats": {"pipelines": pipelines}}]}
+
+    initial_metrics = metrics("0", include_udf_name=False, include_copy_pipeline=False)
+    updated_metrics = metrics("1", include_udf_name=True, include_copy_pipeline=True)
+    _NativeFteProgressRegistry._merge_fragment_progress_topology_locked(fragment, initial_metrics)
+    _NativeFteProgressRegistry._merge_fragment_progress_topology_locked(fragment, updated_metrics)
+
+    assert fragment.progress_topology_unavailable is False
+    assert (
+        updated_metrics["running_attempts"][0]["task_stats"]["pipelines"][0]["operator_details"][0][
+            "udf_completed_input_rows"
+        ]
+        == "1"
+    )
+    assert fragment.progress_topology == {
+        "schema": "pipeline_topology",
+        "pipelines": [
+            {
+                "pipeline_id": 1,
+                "operators": ["STREAMING_UDF"],
+                "operator_details": [{"pipeline_role": "source", "udf_name": "ai_prompt"}],
+                "stage_ids": [],
+            },
+            {
+                "pipeline_id": 2,
+                "operators": ["COPY_TO_FILE"],
+                "operator_details": [{}],
+                "stage_ids": [],
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "bad_metrics",
+    [
+        pytest.param(
+            {
+                "running_attempts": [
+                    {
+                        "task_stats": {
+                            "pipelines": [
+                                {
+                                    "pipeline_id": 1,
+                                    "operators": ["STREAMING_UDF"],
+                                    "operator_details": [{}],
+                                    "stage_ids": [],
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            id="conflicting-operators",
+        ),
+        pytest.param({"running_attempts": "not-a-sequence"}, id="malformed-attempts"),
+    ],
+)
+def test_native_progress_topology_unavailable_does_not_break_query_status(bad_metrics):
+    query_id = "query-progress-unavailable"
+    fragment_id = f"{query_id}:scan"
+    registry = _NativeFteProgressRegistry()
+    registry.register_requests(
+        [
+            {
+                "task_id": _task_id(0, query_id=query_id),
+                "fragment_id": fragment_id,
+            }
+        ]
+    )
+    initial_metrics = {
+        "running_attempts": [
+            {
+                "task_stats": {
+                    "pipelines": [
+                        {
+                            "pipeline_id": 1,
+                            "operators": ["TABLE_SCAN"],
+                            "operator_details": [{}],
+                            "stage_ids": [],
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    registry.record_partition_metrics(query_id, fragment_id, "0", initial_metrics)
+    registry.record_partition_metrics(query_id, fragment_id, "0", bad_metrics)
+    registry.record_partition_metrics(query_id, fragment_id, "0", initial_metrics)
+
+    status = registry.query_status(query_id)
+    assert status["fragment_executions"][fragment_id]["progress_topology"] == {
+        "schema": "pipeline_topology",
+        "pipelines": [],
+    }
+    snapshot = build_progress_snapshot({"queries": {query_id: status}}, query_id)
+    assert snapshot["fragments"][0]["pipelines"] == []
+
+
+def test_native_progress_snapshot_normalizes_stable_identity_across_attempts():
+    query_id = "query-progress-stable-identity"
+    fragment_id = f"{query_id}:scan"
+    registry = _NativeFteProgressRegistry()
+    registry.register_requests(
+        [
+            {
+                "task_id": _task_id(0, query_id=query_id),
+                "fragment_id": fragment_id,
+            }
+        ]
+    )
+
+    def task_stats(operator_details, input_rows):
+        return {
+            "pipelines": [
+                {
+                    "pipeline_id": 1,
+                    "operators": ["STREAMING_UDF"],
+                    "operator_details": [operator_details],
+                    "stage_ids": [],
+                    "input_rows": input_rows,
+                    "total_pipeline_tasks": 1,
+                    "running_pipeline_tasks": 1,
+                }
+            ]
+        }
+
+    registry.record_partition_metrics(
+        query_id,
+        fragment_id,
+        "0",
+        {
+            "state": "RUNNING",
+            "running_attempts": [
+                {
+                    "task_stats": task_stats(
+                        {
+                            "pipeline_role": "source",
+                            "udf_completed_input_rows": "1",
+                        },
+                        1,
+                    )
+                },
+                {
+                    "task_stats": task_stats(
+                        {
+                            "pipeline_role": "source",
+                            "udf_name": "ai_prompt",
+                            "udf_completed_input_rows": "2",
+                        },
+                        2,
+                    )
+                },
+            ],
+        },
+    )
+
+    status = registry.query_status(query_id)
+    snapshot = build_progress_snapshot({"queries": {query_id: status}}, query_id)
+    first_attempt_details = status["fragment_executions"][fragment_id]["partitions"]["0"]["running_attempts"][0][
+        "task_stats"
+    ]["pipelines"][0]["operator_details"][0]
+    assert first_attempt_details == {
+        "pipeline_role": "source",
+        "udf_completed_input_rows": "1",
+    }
+    assert snapshot["fragments"][0]["pipelines"] == [
+        {
+            "id": "1.1",
+            "display_id": "1.1",
+            "name": "ai_prompt(source)",
+            "state": "R",
+            "processed_rows": 3,
+            "processed_bytes": 0,
+            "output_rows": 0,
+            "output_bytes": 0,
+            "queued_pipeline_tasks": 0,
+            "running_pipeline_tasks": 2,
+            "completed_pipeline_tasks": 0,
+            "total_pipeline_tasks": 2,
+        }
+    ]
 
 
 def test_native_backend_progress_query_status_uses_cached_task_stats(monkeypatch):


### PR DESCRIPTION
## Summary

- Exclude live native UDF counters from fragment progress topology and monotonically merge stable pipeline identity.
- Degrade malformed or conflicting topology to unavailable so `fte_query_status()` can continue detecting query completion.
- Normalize progress rendering for unavailable or partial topology, remove the Issue #239 test workaround, and add regression coverage.

This fixes local AI SQL COPY failures without changing public APIs or compatibility contracts.

## Related issue

close: #239

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- `env -u PYTHONPATH .venv/bin/python -m pytest -q tests/fast/test_fte_native_backend.py tests/fast/test_ray_fte_progress.py` (109 passed)
- `env -u PYTHONPATH .venv/bin/python -m pytest -q tests/ai/test_expression_ai_sql.py::test_ai_sql_full_local_copy_in_subprocess` (2 passed)
- `scripts/run_release_tests.sh` (non-Ray: 448 passed, 1 skipped, 11 deselected; real-Ray: 7 passed, 453 deselected)
- `scripts/format root --changed`
- `env -u PYTHONPATH .venv/bin/pre-commit run --files duckdb/runners/fte/backends/native/backend.py duckdb/runners/progress.py tests/ai/test_expression_ai_sql.py tests/fast/test_fte_native_backend.py`
- Manual local-runner AI SQL COPY with `VANE_PROGRESS=1` (rendered successfully; output `text-model:describe`)
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.

No native source changed, so a native rebuild was not required. The change only handles observational progress metadata and does not alter UDF execution, serialization, remote-code, or network trust boundaries.