### PR TITLE
[fix](distributed) Canonicalize COPY lifecycle paths and discover object-store runs

### DIFF
--- a/duckdb/runners/ray/lifecycle.py
+++ b/duckdb/runners/ray/lifecycle.py
@@ -118,6 +118,9 @@ def cleanup_copy_direct_write_lifecycle_once(
     direct-write COPY results. It delegates correctness decisions to the C++
     manifest/marker aware scanner: committed runs are skipped, active runs are
     kept, and only lifecycle-registered stale uncommitted runs are removed.
+
+    The caller must ensure that no COPY is running for any supplied base path.
+    Elapsed time does not prove that an uncommitted run is abandoned.
     """
     import duckdb
 
@@ -150,7 +153,11 @@ def run_copy_direct_write_lifecycle_cleanup_loop(
     sleep_fn: Callable[[float], None] | None = None,
     on_iteration: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
-    """Run direct-write lifecycle cleanup periodically until stopped."""
+    """Run direct-write lifecycle cleanup periodically until stopped.
+
+    The caller must keep every supplied base path free of concurrent COPY
+    operations for the lifetime of the loop.
+    """
     if max_iterations is not None and max_iterations <= 0:
         raise ValueError("max_iterations must be positive when provided")
     if interval_seconds < 0:
@@ -214,7 +221,10 @@ def _install_signal_handlers(stop_event: threading.Event) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Cleanup stale uncommitted Vane direct-write COPY runs.",
+        description=(
+            "Cleanup stale uncommitted Vane direct-write COPY runs. "
+            "Run only while COPY is quiesced for every supplied base path."
+        ),
     )
     parser.add_argument(
         "--base-path",

--- a/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
@@ -81,9 +81,15 @@ SubmittableTaskStream<WorkerTask> CopySinkNode::produce_tasks(PlanExecutionConte
 	if (!client_context) {
 		throw InvalidInputException("CopySinkNode requires ClientContext for plan cloning");
 	}
+	auto &fs = FileSystem::GetFileSystem(*client_context);
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, spec_);
+	if (canonical_res.is_err()) {
+		throw InvalidInputException(canonical_res.error().what());
+	}
+	auto remote_base = std::move(canonical_res).value();
 
 	return input_stream.map_tasks([self, node_id_val, node_ctx, staging_root_base, staging_run_id, client_context,
-	                               fragment_plan_cache,
+	                               remote_base, fragment_plan_cache,
 	                               fragment_plan_cache_lock](SubmittableTask<WorkerTask> task) mutable {
 		auto *old_task = task.task();
 		if (!old_task) {
@@ -126,7 +132,7 @@ SubmittableTaskStream<WorkerTask> CopySinkNode::produce_tasks(PlanExecutionConte
 		auto merged_ctx = MergeTaskContext(old_task->context(), node_ctx);
 		merged_ctx["copy_output_base"] = staging_root_base;
 		merged_ctx["copy_output_run_id"] = staging_run_id;
-		merged_ctx["copy_output_remote_base"] = self->spec_.file_path;
+		merged_ctx["copy_output_remote_base"] = remote_base;
 		WorkerTask new_task(ctx, fragment_plan, old_task->config(), std::move(merged_ctx));
 		new_task.mutable_inputs() = old_task->inputs();
 		return SubmittableTask<WorkerTask>(std::move(new_task));

--- a/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
@@ -82,14 +82,14 @@ SubmittableTaskStream<WorkerTask> CopySinkNode::produce_tasks(PlanExecutionConte
 		throw InvalidInputException("CopySinkNode requires ClientContext for plan cloning");
 	}
 	auto &fs = FileSystem::GetFileSystem(*client_context);
-	auto canonical_res = CanonicalDistributedCopyBasePath(fs, spec_);
-	if (canonical_res.is_err()) {
-		throw InvalidInputException(canonical_res.error().what());
+	auto worker_base_res = CanonicalDistributedCopyBasePath(fs, spec_.file_path);
+	if (worker_base_res.is_err()) {
+		throw InvalidInputException(worker_base_res.error().what());
 	}
-	auto remote_base = std::move(canonical_res).value();
+	auto worker_base = std::move(worker_base_res).value();
 
 	return input_stream.map_tasks([self, node_id_val, node_ctx, staging_root_base, staging_run_id, client_context,
-	                               remote_base, fragment_plan_cache,
+	                               worker_base, fragment_plan_cache,
 	                               fragment_plan_cache_lock](SubmittableTask<WorkerTask> task) mutable {
 		auto *old_task = task.task();
 		if (!old_task) {
@@ -132,7 +132,7 @@ SubmittableTaskStream<WorkerTask> CopySinkNode::produce_tasks(PlanExecutionConte
 		auto merged_ctx = MergeTaskContext(old_task->context(), node_ctx);
 		merged_ctx["copy_output_base"] = staging_root_base;
 		merged_ctx["copy_output_run_id"] = staging_run_id;
-		merged_ctx["copy_output_remote_base"] = remote_base;
+		merged_ctx["copy_output_remote_base"] = worker_base;
 		WorkerTask new_task(ctx, fragment_plan, old_task->config(), std::move(merged_ctx));
 		new_task.mutable_inputs() = old_task->inputs();
 		return SubmittableTask<WorkerTask>(std::move(new_task));

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -1178,33 +1178,81 @@ CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(files_res.error());
 	}
 	auto files = std::move(files_res).value();
+	std::string remove_last_contents;
 	if (!remove_last.empty()) {
 		auto remove_last_it = std::find(files.begin(), files.end(), remove_last);
-		if (remove_last_it != files.end()) {
-			files.erase(remove_last_it);
-			files.push_back(remove_last);
+		if (remove_last_it == files.end()) {
+			return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(DuckDBError::io_error(
+			    "distributed COPY cleanup registration missing from prefix listing: " + remove_last));
 		}
+		auto contents_res = ReadDistributedCopyTextFile(fs, remove_last);
+		if (contents_res.is_err()) {
+			return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(contents_res.error());
+		}
+		remove_last_contents = std::move(contents_res).value();
+		files.erase(remove_last_it);
 	}
 
 	DistributedCopyPrefixCleanupResult result;
-	result.existed = !files.empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix);
+	result.existed = !files.empty() || !remove_last.empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix);
 	auto remove_res = RemoveDistributedCopyFiles(fs, files);
 	if (remove_res.is_err()) {
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remove_res.error());
 	}
 
+	auto restore_registration_after_failure =
+	    [&](const std::string &cleanup_error) -> DuckDBResult<DistributedCopyPrefixCleanupResult> {
+		try {
+			auto parent = StringUtil::GetFilePath(remove_last);
+			if (!parent.empty()) {
+				fs.CreateDirectoriesRecursive(parent);
+			}
+		} catch (const std::exception &ex) {
+			return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(DuckDBError::io_error(StringUtil::Format(
+			    "%s; additionally failed to recreate lifecycle directory: %s", cleanup_error, ex.what())));
+		}
+		auto restore_res = WriteDistributedCopyTextFileAtomically(fs, remove_last, remove_last_contents);
+		if (restore_res.is_err()) {
+			return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(DuckDBError::io_error(
+			    cleanup_error +
+			    "; additionally failed to restore lifecycle registration: " + restore_res.error().what()));
+		}
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(
+		    DuckDBError::io_error(cleanup_error + "; lifecycle registration restored for retry"));
+	};
+
+	if (!remove_last.empty()) {
+		try {
+			fs.RemoveFile(remove_last);
+		} catch (const std::exception &ex) {
+			return restore_registration_after_failure(StringUtil::Format(
+			    "failed to remove distributed COPY cleanup registration \"%s\": %s", remove_last, ex.what()));
+		}
+	}
+
+	std::string directory_removal_error;
 	try {
 		fs.RemoveDirectory(prefix);
-	} catch (...) {
+	} catch (const std::exception &ex) {
+		directory_removal_error =
+		    StringUtil::Format("failed to remove distributed COPY prefix \"%s\": %s", prefix, ex.what());
 	}
 
 	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, prefix);
 	if (remaining_res.is_err()) {
+		if (!remove_last.empty()) {
+			return restore_registration_after_failure(remaining_res.error().what());
+		}
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remaining_res.error());
 	}
 	if (!remaining_res.value().empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix)) {
-		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(
-		    DuckDBError::io_error("distributed COPY prefix still exists after cleanup: " + prefix));
+		auto cleanup_error = directory_removal_error.empty()
+		                         ? "distributed COPY prefix still exists after cleanup: " + prefix
+		                         : directory_removal_error;
+		if (!remove_last.empty()) {
+			return restore_registration_after_failure(cleanup_error);
+		}
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(DuckDBError::io_error(cleanup_error));
 	}
 	result.removed = result.existed;
 	return DuckDBResult<DistributedCopyPrefixCleanupResult>::ok(std::move(result));

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -38,9 +38,52 @@ inline idx_t DistributedCopyElapsedMillis(std::chrono::steady_clock::time_point 
 	return static_cast<idx_t>(value > max_value ? max_value : value);
 }
 
+inline std::string ResolveDistributedCopyListedPath(FileSystem &fs, const std::string &directory,
+                                                    const std::string &listed_path) {
+	if (listed_path.empty() || listed_path.find("://") != std::string::npos) {
+		return listed_path;
+	}
+
+	auto directory_protocol = directory.find("://");
+	auto separator = directory_protocol == std::string::npos ? fs.PathSeparator(directory) : std::string("/");
+	if (directory_protocol != std::string::npos) {
+		auto trim_leading_separators = [&](std::string &path) {
+			while (!separator.empty() && StringUtil::StartsWith(path, separator)) {
+				path.erase(0, separator.size());
+			}
+		};
+		auto protocol_end = directory_protocol + 3;
+		auto directory_suffix = directory.substr(protocol_end);
+		const bool preserve_root_separator = StringUtil::StartsWith(directory_suffix, separator);
+		trim_leading_separators(directory_suffix);
+
+		auto listed_suffix = listed_path;
+		const bool listed_path_is_rooted = StringUtil::StartsWith(listed_suffix, separator);
+		trim_leading_separators(listed_suffix);
+		if (listed_path_is_rooted || listed_suffix == directory_suffix ||
+		    StringUtil::StartsWith(listed_suffix, directory_suffix + separator)) {
+			return directory.substr(0, protocol_end) + (preserve_root_separator ? separator : std::string()) +
+			       listed_suffix;
+		}
+	}
+
+	if (fs.IsPathAbsolute(listed_path)) {
+		return listed_path;
+	}
+	auto normalized_directory = directory;
+	StringUtil::RTrim(normalized_directory, separator);
+	if (listed_path == normalized_directory || StringUtil::StartsWith(listed_path, normalized_directory + separator)) {
+		return listed_path;
+	}
+	if (StringUtil::EndsWith(directory, separator)) {
+		return directory + listed_path;
+	}
+	return fs.JoinPath(directory, listed_path);
+}
+
 inline void ListDistributedCopyFilesRecursive(FileSystem &fs, const std::string &dir, std::vector<std::string> &out) {
 	fs.ListFiles(dir, [&](const std::string &path, bool is_dir) {
-		auto full_path = fs.JoinPath(dir, path);
+		auto full_path = ResolveDistributedCopyListedPath(fs, dir, path);
 		if (is_dir) {
 			ListDistributedCopyFilesRecursive(fs, full_path, out);
 		} else {

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -13,9 +13,12 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/main/client_context.hpp"
 
+#include <algorithm>
+#include <cerrno>
 #include <chrono>
 #include <limits>
 #include <sstream>
@@ -45,19 +48,18 @@ inline void ListDistributedCopyFilesRecursive(FileSystem &fs, const std::string 
 	});
 }
 
+inline void SortAndDeduplicateDistributedCopyPaths(std::vector<std::string> &paths) {
+	std::sort(paths.begin(), paths.end());
+	paths.erase(std::unique(paths.begin(), paths.end()), paths.end());
+}
+
 inline void RemoveDistributedCopyDirectoryTree(FileSystem &fs, const std::string &dir) {
 	if (dir.empty()) {
 		return;
 	}
-	try {
-		if (!fs.DirectoryExists(dir)) {
-			return;
-		}
-	} catch (...) {
-		return;
-	}
 
 	std::vector<std::string> child_dirs;
+	std::vector<std::string> child_files;
 	try {
 		fs.ListFiles(dir, [&](const std::string &path, bool is_dir) {
 			auto full_path = fs.JoinPath(dir, path);
@@ -65,14 +67,20 @@ inline void RemoveDistributedCopyDirectoryTree(FileSystem &fs, const std::string
 				child_dirs.push_back(full_path);
 				return;
 			}
-			try {
-				fs.RemoveFile(full_path);
-			} catch (...) {
-			}
+			child_files.push_back(full_path);
 		});
 	} catch (...) {
 	}
 
+	SortAndDeduplicateDistributedCopyPaths(child_files);
+	for (const auto &child_file : child_files) {
+		try {
+			fs.RemoveFile(child_file);
+		} catch (...) {
+		}
+	}
+
+	SortAndDeduplicateDistributedCopyPaths(child_dirs);
 	for (auto &child_dir : child_dirs) {
 		RemoveDistributedCopyDirectoryTree(fs, child_dir);
 	}
@@ -126,6 +134,41 @@ inline bool DistributedCopyFileExistsNoThrow(FileSystem &fs, const std::string &
 	}
 }
 
+inline DuckDBResult<bool> CheckDistributedCopyFileExists(FileSystem &fs, const std::string &path) {
+	if (path.empty()) {
+		return DuckDBResult<bool>::ok(false);
+	}
+	const bool is_remote = FileSystem::IsRemoteFile(path);
+	try {
+		auto flags = FileFlags::FILE_FLAGS_READ;
+		if (!is_remote) {
+			flags |= FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
+		}
+		auto handle = fs.OpenFile(path, flags);
+		if (!handle) {
+			if (!is_remote) {
+				return DuckDBResult<bool>::ok(false);
+			}
+			return DuckDBResult<bool>::err(
+			    DuckDBError::io_error("remote distributed COPY object check returned no file handle: " + path));
+		}
+	} catch (const std::exception &ex) {
+		ErrorData error(ex);
+		const auto &extra_info = error.ExtraInfo();
+		auto http_status = extra_info.find("status_code");
+		if (http_status != extra_info.end() && http_status->second == "404") {
+			return DuckDBResult<bool>::ok(false);
+		}
+		auto error_number = extra_info.find("errno");
+		if (error_number != extra_info.end() && error_number->second == std::to_string(ENOENT)) {
+			return DuckDBResult<bool>::ok(false);
+		}
+		return DuckDBResult<bool>::err(DuckDBError::io_error(
+		    StringUtil::Format("failed to check distributed COPY object \"%s\": %s", path, ex.what())));
+	}
+	return DuckDBResult<bool>::ok(true);
+}
+
 inline bool DistributedCopyDirectoryExistsNoThrow(FileSystem &fs, const std::string &path) {
 	if (path.empty()) {
 		return false;
@@ -135,6 +178,39 @@ inline bool DistributedCopyDirectoryExistsNoThrow(FileSystem &fs, const std::str
 	} catch (...) {
 		return false;
 	}
+}
+
+inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs, const std::string &base_path) {
+	auto canonical_base_path = base_path;
+	StringUtil::RTrim(canonical_base_path, fs.PathSeparator(canonical_base_path));
+	if (canonical_base_path.empty()) {
+		return DuckDBResult<std::string>::err(
+		    DuckDBError::value_error("distributed COPY requires non-empty base_path"));
+	}
+	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
+}
+
+inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs, const DistributedCopySpec &spec) {
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, spec.file_path);
+	if (canonical_res.is_err()) {
+		return canonical_res;
+	}
+	auto canonical_base_path = std::move(canonical_res).value();
+	if (!spec.use_tmp_file) {
+		return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
+	}
+
+	auto base_name = StringUtil::GetFileName(canonical_base_path);
+	if (StringUtil::StartsWith(base_name, "tmp_")) {
+		base_name = base_name.substr(4);
+	}
+	if (base_name.empty()) {
+		return DuckDBResult<std::string>::err(
+		    DuckDBError::value_error("distributed COPY requires non-empty canonical base_path"));
+	}
+	auto directory = StringUtil::GetFilePath(canonical_base_path);
+	canonical_base_path = directory.empty() ? base_name : fs.JoinPath(directory, base_name);
+	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
 }
 
 inline DuckDBResult<idx_t> ParseDistributedCopyFinalizeIdx(const std::string &value, const std::string &field) {
@@ -334,14 +410,16 @@ inline idx_t DistributedCopyCurrentEpochMillis() {
 inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &fs, const std::string &base_path,
                                                                    const std::string &run_id,
                                                                    idx_t created_epoch_ms = 0) {
-	if (base_path.empty()) {
-		return DuckDBResult<void>::err(DuckDBError::value_error("direct-write lifecycle requires non-empty base_path"));
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<void>::err(canonical_res.error());
 	}
 	if (run_id.empty()) {
 		return DuckDBResult<void>::err(DuckDBError::value_error("direct-write lifecycle requires non-empty run_id"));
 	}
+	auto canonical_base_path = std::move(canonical_res).value();
 
-	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
 	if (DistributedCopyFileExistsNoThrow(fs, paths.committed_marker_path)) {
 		return DuckDBResult<void>::ok();
 	}
@@ -356,11 +434,12 @@ inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &f
 		    StringUtil::Format("failed to create direct-write lifecycle dir \"%s\": %s", paths.commit_dir, ex.what())));
 	}
 
-	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(base_path, run_id, fs.PathSeparator(base_path));
+	auto direct_write_run_dir =
+	    BuildCopyDirectWriteRunDirectory(canonical_base_path, run_id, fs.PathSeparator(canonical_base_path));
 	std::ostringstream lifecycle;
 	lifecycle << "version=1\n";
 	lifecycle << "mode=direct_write\n";
-	lifecycle << "base_path=" << base_path << "\n";
+	lifecycle << "base_path=" << canonical_base_path << "\n";
 	lifecycle << "run_id=" << run_id << "\n";
 	lifecycle << "created_epoch_ms=" << created_epoch_ms << "\n";
 	lifecycle << "direct_write_run_dir=" << direct_write_run_dir << "\n";
@@ -703,27 +782,26 @@ inline bool DistributedCopyDirectWriteFinalPathBelongsToRun(FileSystem &fs, cons
 
 inline DuckDBResult<DistributedCopyResult>
 ReadCommittedDistributedCopyDirectWriteResult(FileSystem &fs, const std::string &base_path, const std::string &run_id) {
-	if (base_path.empty()) {
-		return DuckDBResult<DistributedCopyResult>::err(
-		    DuckDBError::value_error("direct-write committed reader requires non-empty base_path"));
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyResult>::err(canonical_res.error());
 	}
 	if (run_id.empty()) {
 		return DuckDBResult<DistributedCopyResult>::err(
 		    DuckDBError::value_error("direct-write committed reader requires non-empty run_id"));
 	}
 
-	auto normalized_base_path = base_path;
-	StringUtil::RTrim(normalized_base_path, fs.PathSeparator(normalized_base_path));
-	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, normalized_base_path, run_id);
+	auto canonical_base_path = std::move(canonical_res).value();
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
 	auto manifest_root = "direct:" + run_id;
-	auto read_res = ReadDistributedCopyFinalizeManifest(fs, commit_paths, normalized_base_path, manifest_root, true);
+	auto read_res = ReadDistributedCopyFinalizeManifest(fs, commit_paths, canonical_base_path, manifest_root, true);
 	if (read_res.is_err()) {
 		return DuckDBResult<DistributedCopyResult>::err(read_res.error());
 	}
 
 	auto result = std::move(read_res).value();
 	for (const auto &info : result.files) {
-		if (!DistributedCopyDirectWriteFinalPathBelongsToRun(fs, normalized_base_path, run_id, info.final_path)) {
+		if (!DistributedCopyDirectWriteFinalPathBelongsToRun(fs, canonical_base_path, run_id, info.final_path)) {
 			return DuckDBResult<DistributedCopyResult>::err(DuckDBError::invalid_state_error(StringUtil::Format(
 			    "distributed COPY direct-write committed manifest file is outside run output: \"%s\"",
 			    info.final_path)));
@@ -779,16 +857,6 @@ CleanupDistributedCopyDirectWriteUnselectedFiles(FileSystem &fs, const std::stri
 		return;
 	}
 
-	try {
-		if (!fs.DirectoryExists(direct_write_run_dir)) {
-			return;
-		}
-	} catch (const std::exception &ex) {
-		return;
-	} catch (...) {
-		return;
-	}
-
 	std::unordered_set<std::string> selected_paths;
 	for (const auto &info : selected_files) {
 		if (!info.final_path.empty()) {
@@ -838,14 +906,6 @@ CleanupDistributedCopyDirectTargetUnselectedFiles(FileSystem &fs, const std::str
 	}
 
 	for (const auto &dir : scan_dirs) {
-		try {
-			if (!fs.DirectoryExists(dir)) {
-				continue;
-			}
-		} catch (...) {
-			continue;
-		}
-
 		std::vector<std::string> all_files;
 		try {
 			ListDistributedCopyFilesRecursive(fs, dir, all_files);
@@ -897,6 +957,107 @@ inline bool DistributedCopyUsesDirectTargetLayout(FileSystem &fs, const std::str
 	return false;
 }
 
+struct DistributedCopyPrefixCleanupResult {
+	bool existed = false;
+	bool removed = false;
+};
+
+inline DuckDBResult<std::vector<std::string>> ListDistributedCopyFilesUnderPrefix(FileSystem &fs,
+                                                                                  const std::string &prefix) {
+	std::vector<std::string> files;
+	try {
+		ListDistributedCopyFilesRecursive(fs, prefix, files);
+	} catch (const std::exception &ex) {
+		return DuckDBResult<std::vector<std::string>>::err(DuckDBError::io_error(
+		    StringUtil::Format("failed to list distributed COPY prefix \"%s\": %s", prefix, ex.what())));
+	}
+	SortAndDeduplicateDistributedCopyPaths(files);
+	return DuckDBResult<std::vector<std::string>>::ok(std::move(files));
+}
+
+inline DuckDBResult<void> RemoveDistributedCopyFiles(FileSystem &fs, const std::vector<std::string> &files) {
+	for (const auto &file : files) {
+		try {
+			fs.RemoveFile(file);
+		} catch (const std::exception &ex) {
+			return DuckDBResult<void>::err(DuckDBError::io_error(
+			    StringUtil::Format("failed to remove distributed COPY object \"%s\": %s", file, ex.what())));
+		}
+	}
+	return DuckDBResult<void>::ok();
+}
+
+inline DuckDBResult<DistributedCopyPrefixCleanupResult>
+CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
+                             const std::string &remove_last = std::string()) {
+	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, prefix);
+	if (files_res.is_err()) {
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(files_res.error());
+	}
+	auto files = std::move(files_res).value();
+	if (!remove_last.empty()) {
+		auto remove_last_it = std::find(files.begin(), files.end(), remove_last);
+		if (remove_last_it != files.end()) {
+			files.erase(remove_last_it);
+			files.push_back(remove_last);
+		}
+	}
+
+	DistributedCopyPrefixCleanupResult result;
+	result.existed = !files.empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix);
+	auto remove_res = RemoveDistributedCopyFiles(fs, files);
+	if (remove_res.is_err()) {
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remove_res.error());
+	}
+
+	try {
+		fs.RemoveDirectory(prefix);
+	} catch (...) {
+	}
+
+	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, prefix);
+	if (remaining_res.is_err()) {
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remaining_res.error());
+	}
+	if (!remaining_res.value().empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix)) {
+		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(
+		    DuckDBError::io_error("distributed COPY prefix still exists after cleanup: " + prefix));
+	}
+	result.removed = result.existed;
+	return DuckDBResult<DistributedCopyPrefixCleanupResult>::ok(std::move(result));
+}
+
+inline DuckDBResult<void> CleanupDistributedCopyDirectTargetFilesForRun(FileSystem &fs, const std::string &base_path,
+                                                                        const std::string &run_id) {
+	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
+	if (files_res.is_err()) {
+		return DuckDBResult<void>::err(files_res.error());
+	}
+
+	std::vector<std::string> run_files;
+	for (const auto &file : files_res.value()) {
+		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(file), run_id)) {
+			run_files.push_back(file);
+		}
+	}
+	auto remove_res = RemoveDistributedCopyFiles(fs, run_files);
+	if (remove_res.is_err()) {
+		return remove_res;
+	}
+
+	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
+	if (remaining_res.is_err()) {
+		return DuckDBResult<void>::err(remaining_res.error());
+	}
+	for (const auto &file : remaining_res.value()) {
+		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(file), run_id)) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::io_error("distributed COPY direct-target object still exists after cleanup: " + file));
+		}
+	}
+	return DuckDBResult<void>::ok();
+}
+
 struct DistributedCopyDirectWriteRunCleanupResult {
 	bool skipped_committed = false;
 	bool data_run_dir_existed = false;
@@ -908,43 +1069,48 @@ struct DistributedCopyDirectWriteRunCleanupResult {
 inline DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>
 CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::string &base_path,
                                                 const std::string &run_id) {
-	if (base_path.empty()) {
-		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
-		    DuckDBError::value_error("direct-write cleanup requires non-empty base_path"));
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(canonical_res.error());
 	}
 	if (run_id.empty()) {
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
 		    DuckDBError::value_error("direct-write cleanup requires non-empty run_id"));
 	}
+	auto canonical_base_path = std::move(canonical_res).value();
 
 	DistributedCopyDirectWriteRunCleanupResult result;
-	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
-	if (DistributedCopyFileExistsNoThrow(fs, commit_paths.committed_marker_path)) {
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+	auto committed_res = CheckDistributedCopyFileExists(fs, commit_paths.committed_marker_path);
+	if (committed_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(committed_res.error());
+	}
+	if (committed_res.value()) {
 		result.skipped_committed = true;
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::ok(std::move(result));
 	}
 
-	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(base_path, run_id, fs.PathSeparator(base_path));
-	result.data_run_dir_existed = DistributedCopyDirectoryExistsNoThrow(fs, direct_write_run_dir);
-	if (result.data_run_dir_existed) {
-		RemoveDistributedCopyDirectoryTree(fs, direct_write_run_dir);
-		if (DistributedCopyDirectoryExistsNoThrow(fs, direct_write_run_dir)) {
-			return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
-			    DuckDBError::io_error("failed to cleanup direct-write run dir: " + direct_write_run_dir));
-		}
-		result.data_run_dir_removed = true;
+	auto direct_write_run_dir =
+	    BuildCopyDirectWriteRunDirectory(canonical_base_path, run_id, fs.PathSeparator(canonical_base_path));
+	auto data_cleanup_res = CleanupDistributedCopyPrefix(fs, direct_write_run_dir);
+	if (data_cleanup_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(data_cleanup_res.error());
+	}
+	result.data_run_dir_existed = data_cleanup_res.value().existed;
+	result.data_run_dir_removed = data_cleanup_res.value().removed;
+
+	auto direct_target_cleanup_res = CleanupDistributedCopyDirectTargetFilesForRun(fs, canonical_base_path, run_id);
+	if (direct_target_cleanup_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(direct_target_cleanup_res.error());
 	}
 
-	CleanupDistributedCopyDirectTargetUnselectedFiles(fs, base_path, run_id, {});
-
-	result.commit_dir_existed = DistributedCopyDirectoryExistsNoThrow(fs, commit_paths.commit_dir);
-	if (result.commit_dir_existed) {
-		RemoveDistributedCopyDirectoryTree(fs, commit_paths.commit_dir);
-		if (DistributedCopyDirectoryExistsNoThrow(fs, commit_paths.commit_dir)) {
-			return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
-			    DuckDBError::io_error("failed to cleanup direct-write commit dir: " + commit_paths.commit_dir));
-		}
-		result.commit_dir_removed = true;
+	auto commit_cleanup_res = CleanupDistributedCopyPrefix(fs, commit_paths.commit_dir, commit_paths.lifecycle_path);
+	if (commit_cleanup_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(commit_cleanup_res.error());
+	}
+	result.commit_dir_existed = commit_cleanup_res.value().existed;
+	result.commit_dir_removed = commit_cleanup_res.value().removed;
+	if (result.commit_dir_removed) {
 		RemoveDistributedCopyDirectoryIfEmpty(fs, StringUtil::GetFilePath(commit_paths.commit_dir));
 	}
 
@@ -965,53 +1131,52 @@ struct DistributedCopyDirectWriteCleanupScanResult {
 inline DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>
 CleanupExpiredDistributedCopyDirectWriteRuns(FileSystem &fs, const std::string &base_path, idx_t min_age_ms,
                                              idx_t now_epoch_ms = 0) {
-	if (base_path.empty()) {
-		return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::err(
-		    DuckDBError::value_error("direct-write cleanup scan requires non-empty base_path"));
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::err(canonical_res.error());
 	}
 	if (now_epoch_ms == 0) {
 		now_epoch_ms = DistributedCopyCurrentEpochMillis();
 	}
+	auto canonical_base_path = std::move(canonical_res).value();
 
 	DistributedCopyDirectWriteCleanupScanResult result;
-	auto commit_root = base_path + ".duckdb_commit";
-	if (!DistributedCopyDirectoryExistsNoThrow(fs, commit_root)) {
-		return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::ok(std::move(result));
-	}
+	auto commit_root = canonical_base_path + ".duckdb_commit";
 
 	std::vector<std::string> run_ids;
-	try {
-		fs.ListFiles(commit_root, [&](const std::string &path, bool is_dir) {
-			if (!is_dir) {
-				return;
-			}
-			auto run_id = StringUtil::GetFileName(path);
-			if (run_id.empty()) {
-				run_id = path;
-				StringUtil::RTrim(run_id, fs.PathSeparator(run_id));
-				run_id = StringUtil::GetFileName(run_id);
-			}
-			if (!run_id.empty()) {
-				run_ids.push_back(run_id);
-			}
-		});
-	} catch (const std::exception &ex) {
-		return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::err(DuckDBError::io_error(
-		    StringUtil::Format("failed to list direct-write commit root \"%s\": %s", commit_root, ex.what())));
+	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, commit_root);
+	if (files_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::err(files_res.error());
 	}
+	for (const auto &path : files_res.value()) {
+		if (StringUtil::GetFileName(path) != DISTRIBUTED_COPY_DIRECT_WRITE_LIFECYCLE_FILE) {
+			continue;
+		}
+		auto run_id = StringUtil::GetFileName(StringUtil::GetFilePath(path));
+		if (run_id.empty()) {
+			continue;
+		}
+		auto expected_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+		if (path == expected_paths.lifecycle_path) {
+			run_ids.push_back(std::move(run_id));
+		}
+	}
+	SortAndDeduplicateDistributedCopyPaths(run_ids);
 
 	for (const auto &run_id : run_ids) {
 		result.scanned_runs++;
-		auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
-		if (DistributedCopyFileExistsNoThrow(fs, paths.committed_marker_path)) {
+		auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+		auto committed_res = CheckDistributedCopyFileExists(fs, paths.committed_marker_path);
+		if (committed_res.is_err()) {
+			result.errors++;
+			result.error_messages.push_back(committed_res.error().what());
+			continue;
+		}
+		if (committed_res.value()) {
 			result.committed_runs++;
 			continue;
 		}
-		if (!DistributedCopyFileExistsNoThrow(fs, paths.lifecycle_path)) {
-			result.skipped_unregistered_runs++;
-			continue;
-		}
-		auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, paths, base_path, run_id);
+		auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, paths, canonical_base_path, run_id);
 		if (lifecycle_res.is_err()) {
 			result.errors++;
 			result.error_messages.push_back(lifecycle_res.error().what());
@@ -1023,7 +1188,7 @@ CleanupExpiredDistributedCopyDirectWriteRuns(FileSystem &fs, const std::string &
 			continue;
 		}
 
-		auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, base_path, run_id);
+		auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, canonical_base_path, run_id);
 		if (cleanup_res.is_err()) {
 			result.errors++;
 			result.error_messages.push_back(cleanup_res.error().what());
@@ -1102,16 +1267,11 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 	result.files = std::move(files);
 	auto &fs = FileSystem::GetFileSystem(context);
 
-	std::string base_path = spec.file_path;
-	StringUtil::RTrim(base_path, fs.PathSeparator(base_path));
-	if (spec.use_tmp_file) {
-		auto base = StringUtil::GetFileName(base_path);
-		auto dir = StringUtil::GetFilePath(base_path);
-		if (base.rfind("tmp_", 0) == 0) {
-			base = base.substr(4);
-		}
-		base_path = dir.empty() ? base : fs.JoinPath(dir, base);
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, spec);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyResult>::err(canonical_res.error());
 	}
+	auto base_path = std::move(canonical_res).value();
 
 	const bool output_is_dir = spec.partition_output || spec.per_thread_output || spec.rotate;
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -253,6 +253,12 @@ inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs
 
 	auto canonical_base_path = base_path;
 	auto protocol = canonical_base_path.find("://");
+	if (protocol == 1 && fs.PathSeparator(canonical_base_path) == "\\" && fs.IsPathAbsolute(canonical_base_path)) {
+		protocol = std::string::npos;
+	}
+	if (protocol == std::string::npos) {
+		canonical_base_path = fs.ConvertSeparators(canonical_base_path);
+	}
 	auto separator = protocol == std::string::npos ? fs.PathSeparator(canonical_base_path) : std::string("/");
 	if (separator.empty()) {
 		return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
@@ -1334,18 +1340,19 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::ok(std::move(result));
 	}
 
-	auto worker_base_path = canonical_base_path;
 	auto lifecycle_exists_res = CheckDistributedCopyFileExists(fs, commit_paths.lifecycle_path);
 	if (lifecycle_exists_res.is_err()) {
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_exists_res.error());
 	}
-	if (lifecycle_exists_res.value()) {
-		auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, canonical_base_path, run_id);
-		if (lifecycle_res.is_err()) {
-			return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_res.error());
-		}
-		worker_base_path = std::move(lifecycle_res).value().worker_base_path;
+	if (!lifecycle_exists_res.value()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::io_error(
+		    "direct-write cleanup requires lifecycle registration: " + commit_paths.lifecycle_path));
 	}
+	auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, canonical_base_path, run_id);
+	if (lifecycle_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_res.error());
+	}
+	auto worker_base_path = std::move(lifecycle_res).value().worker_base_path;
 	return CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(fs, canonical_base_path, worker_base_path,
 	                                                                     run_id);
 }

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -106,7 +106,7 @@ inline void RemoveDistributedCopyDirectoryTree(FileSystem &fs, const std::string
 	std::vector<std::string> child_files;
 	try {
 		fs.ListFiles(dir, [&](const std::string &path, bool is_dir) {
-			auto full_path = fs.JoinPath(dir, path);
+			auto full_path = ResolveDistributedCopyListedPath(fs, dir, path);
 			if (is_dir) {
 				child_dirs.push_back(full_path);
 				return;
@@ -225,11 +225,46 @@ inline bool DistributedCopyDirectoryExistsNoThrow(FileSystem &fs, const std::str
 }
 
 inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs, const std::string &base_path) {
-	auto canonical_base_path = base_path;
-	StringUtil::RTrim(canonical_base_path, fs.PathSeparator(canonical_base_path));
-	if (canonical_base_path.empty()) {
+	if (base_path.empty()) {
 		return DuckDBResult<std::string>::err(
 		    DuckDBError::value_error("distributed COPY requires non-empty base_path"));
+	}
+
+	auto canonical_base_path = base_path;
+	auto protocol = canonical_base_path.find("://");
+	auto separator = protocol == std::string::npos ? fs.PathSeparator(canonical_base_path) : std::string("/");
+	if (separator.empty()) {
+		return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
+	}
+	idx_t root_length = 0;
+	if (protocol != std::string::npos) {
+		auto authority_start = protocol + 3;
+		auto authority_end = canonical_base_path.find(separator, authority_start);
+		if (authority_end == std::string::npos && authority_start < canonical_base_path.size()) {
+			canonical_base_path += separator;
+			root_length = canonical_base_path.size();
+		} else if (authority_end != std::string::npos) {
+			root_length = authority_end + separator.size();
+		}
+	} else if (fs.IsPathAbsolute(canonical_base_path)) {
+		if (separator == "\\" && StringUtil::StartsWith(canonical_base_path, separator + separator)) {
+			auto authority_end = canonical_base_path.find(separator, separator.size() * 2);
+			if (authority_end != std::string::npos) {
+				auto share_end = canonical_base_path.find(separator, authority_end + separator.size());
+				root_length =
+				    share_end == std::string::npos ? canonical_base_path.size() : share_end + separator.size();
+			}
+		} else if (StringUtil::StartsWith(canonical_base_path, separator)) {
+			root_length = separator.size();
+		} else {
+			auto root_end = canonical_base_path.find(separator);
+			if (root_end != std::string::npos) {
+				root_length = root_end + separator.size();
+			}
+		}
+	}
+	while (canonical_base_path.size() > root_length && StringUtil::EndsWith(canonical_base_path, separator)) {
+		canonical_base_path.resize(canonical_base_path.size() - separator.size());
 	}
 	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
 }

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -38,6 +38,25 @@ inline idx_t DistributedCopyElapsedMillis(std::chrono::steady_clock::time_point 
 	return static_cast<idx_t>(value > max_value ? max_value : value);
 }
 
+inline bool DistributedCopyExceptionIsNotFound(const std::exception &ex) {
+	ErrorData error(ex);
+	const auto &extra_info = error.ExtraInfo();
+	auto http_status = extra_info.find("status_code");
+	if (http_status != extra_info.end() && http_status->second == "404") {
+		return true;
+	}
+	auto error_number = extra_info.find("errno");
+	if (error_number != extra_info.end() && error_number->second == std::to_string(ENOENT)) {
+		return true;
+	}
+
+	// pybind11 exposes fsspec FileNotFoundError only through the formatted
+	// exception text, without DuckDB errno/status metadata.
+	const std::string message = ex.what();
+	return StringUtil::StartsWith(message, "FileNotFoundError:") ||
+	       StringUtil::Contains(message, "\nFileNotFoundError:");
+}
+
 inline std::string ResolveDistributedCopyListedPath(FileSystem &fs, const std::string &directory,
                                                     const std::string &listed_path) {
 	if (listed_path.empty() || listed_path.find("://") != std::string::npos) {
@@ -56,6 +75,7 @@ inline std::string ResolveDistributedCopyListedPath(FileSystem &fs, const std::s
 		auto directory_suffix = directory.substr(protocol_end);
 		const bool preserve_root_separator = StringUtil::StartsWith(directory_suffix, separator);
 		trim_leading_separators(directory_suffix);
+		StringUtil::RTrim(directory_suffix, separator);
 
 		auto listed_suffix = listed_path;
 		const bool listed_path_is_rooted = StringUtil::StartsWith(listed_suffix, separator);
@@ -82,14 +102,22 @@ inline std::string ResolveDistributedCopyListedPath(FileSystem &fs, const std::s
 }
 
 inline void ListDistributedCopyFilesRecursive(FileSystem &fs, const std::string &dir, std::vector<std::string> &out) {
-	fs.ListFiles(dir, [&](const std::string &path, bool is_dir) {
-		auto full_path = ResolveDistributedCopyListedPath(fs, dir, path);
-		if (is_dir) {
-			ListDistributedCopyFilesRecursive(fs, full_path, out);
-		} else {
-			out.push_back(full_path);
+	bool saw_entry = false;
+	try {
+		fs.ListFiles(dir, [&](const std::string &path, bool is_dir) {
+			saw_entry = true;
+			auto full_path = ResolveDistributedCopyListedPath(fs, dir, path);
+			if (is_dir) {
+				ListDistributedCopyFilesRecursive(fs, full_path, out);
+			} else {
+				out.push_back(full_path);
+			}
+		});
+	} catch (const std::exception &ex) {
+		if (saw_entry || !DistributedCopyExceptionIsNotFound(ex)) {
+			throw;
 		}
-	});
+	}
 }
 
 inline void SortAndDeduplicateDistributedCopyPaths(std::vector<std::string> &paths) {
@@ -197,14 +225,7 @@ inline DuckDBResult<bool> CheckDistributedCopyFileExists(FileSystem &fs, const s
 			    DuckDBError::io_error("remote distributed COPY object check returned no file handle: " + path));
 		}
 	} catch (const std::exception &ex) {
-		ErrorData error(ex);
-		const auto &extra_info = error.ExtraInfo();
-		auto http_status = extra_info.find("status_code");
-		if (http_status != extra_info.end() && http_status->second == "404") {
-			return DuckDBResult<bool>::ok(false);
-		}
-		auto error_number = extra_info.find("errno");
-		if (error_number != extra_info.end() && error_number->second == std::to_string(ENOENT)) {
+		if (DistributedCopyExceptionIsNotFound(ex)) {
 			return DuckDBResult<bool>::ok(false);
 		}
 		return DuckDBResult<bool>::err(DuckDBError::io_error(
@@ -251,8 +272,14 @@ inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs
 			auto authority_end = canonical_base_path.find(separator, separator.size() * 2);
 			if (authority_end != std::string::npos) {
 				auto share_end = canonical_base_path.find(separator, authority_end + separator.size());
-				root_length =
-				    share_end == std::string::npos ? canonical_base_path.size() : share_end + separator.size();
+				auto share_start = authority_end + separator.size();
+				if (share_end == std::string::npos && share_start < canonical_base_path.size()) {
+					canonical_base_path += separator;
+					root_length = canonical_base_path.size();
+				} else {
+					root_length =
+					    share_end == std::string::npos ? canonical_base_path.size() : share_end + separator.size();
+				}
 			}
 		} else if (StringUtil::StartsWith(canonical_base_path, separator)) {
 			root_length = separator.size();
@@ -897,10 +924,12 @@ inline bool DistributedCopyPathIsInDirectory(const std::string &path, const std:
 	if (path.empty() || directory.empty()) {
 		return false;
 	}
-	auto normalized_directory = directory;
-	StringUtil::RTrim(normalized_directory, separator);
-	if (normalized_directory.empty()) {
-		return false;
+	auto normalized_directory = NormalizeCopyDirectWriteRoot(directory, separator);
+	if (separator.empty()) {
+		return path == normalized_directory;
+	}
+	if (StringUtil::EndsWith(normalized_directory, separator)) {
+		return StringUtil::StartsWith(path, normalized_directory);
 	}
 	return path == normalized_directory || StringUtil::StartsWith(path, normalized_directory + separator);
 }

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <limits>
 #include <sstream>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace duckdb {
@@ -211,6 +212,19 @@ inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs
 	auto directory = StringUtil::GetFilePath(canonical_base_path);
 	canonical_base_path = directory.empty() ? base_name : fs.JoinPath(directory, base_name);
 	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
+}
+
+inline std::string DistributedCopyTemporaryBasePath(FileSystem &fs, const std::string &canonical_base_path) {
+	auto base_name = StringUtil::GetFileName(canonical_base_path);
+	auto directory = StringUtil::GetFilePath(canonical_base_path);
+	auto temporary_name = "tmp_" + base_name;
+	return directory.empty() ? temporary_name : fs.JoinPath(directory, temporary_name);
+}
+
+inline bool DistributedCopyWorkerBaseMatchesCanonical(FileSystem &fs, const std::string &canonical_base_path,
+                                                      const std::string &worker_base_path) {
+	return worker_base_path == canonical_base_path ||
+	       worker_base_path == DistributedCopyTemporaryBasePath(fs, canonical_base_path);
 }
 
 inline DuckDBResult<idx_t> ParseDistributedCopyFinalizeIdx(const std::string &value, const std::string &field) {
@@ -407,9 +421,10 @@ inline idx_t DistributedCopyCurrentEpochMillis() {
 	return static_cast<idx_t>(std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
 }
 
-inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &fs, const std::string &base_path,
-                                                                   const std::string &run_id,
-                                                                   idx_t created_epoch_ms = 0) {
+inline DuckDBResult<void>
+WriteDistributedCopyDirectWriteLifecycle(FileSystem &fs, const std::string &base_path, const std::string &run_id,
+                                         idx_t created_epoch_ms = 0,
+                                         const std::string &worker_base_path = std::string()) {
 	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
 	if (canonical_res.is_err()) {
 		return DuckDBResult<void>::err(canonical_res.error());
@@ -418,6 +433,16 @@ inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &f
 		return DuckDBResult<void>::err(DuckDBError::value_error("direct-write lifecycle requires non-empty run_id"));
 	}
 	auto canonical_base_path = std::move(canonical_res).value();
+	auto canonical_worker_res =
+	    CanonicalDistributedCopyBasePath(fs, worker_base_path.empty() ? canonical_base_path : worker_base_path);
+	if (canonical_worker_res.is_err()) {
+		return DuckDBResult<void>::err(canonical_worker_res.error());
+	}
+	auto canonical_worker_base_path = std::move(canonical_worker_res).value();
+	if (!DistributedCopyWorkerBaseMatchesCanonical(fs, canonical_base_path, canonical_worker_base_path)) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::value_error("direct-write lifecycle worker_base_path is outside the COPY namespace"));
+	}
 
 	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
 	if (DistributedCopyFileExistsNoThrow(fs, paths.committed_marker_path)) {
@@ -434,12 +459,13 @@ inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &f
 		    StringUtil::Format("failed to create direct-write lifecycle dir \"%s\": %s", paths.commit_dir, ex.what())));
 	}
 
-	auto direct_write_run_dir =
-	    BuildCopyDirectWriteRunDirectory(canonical_base_path, run_id, fs.PathSeparator(canonical_base_path));
+	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(canonical_worker_base_path, run_id,
+	                                                             fs.PathSeparator(canonical_worker_base_path));
 	std::ostringstream lifecycle;
-	lifecycle << "version=1\n";
+	lifecycle << "version=2\n";
 	lifecycle << "mode=direct_write\n";
 	lifecycle << "base_path=" << canonical_base_path << "\n";
+	lifecycle << "worker_base_path=" << canonical_worker_base_path << "\n";
 	lifecycle << "run_id=" << run_id << "\n";
 	lifecycle << "created_epoch_ms=" << created_epoch_ms << "\n";
 	lifecycle << "direct_write_run_dir=" << direct_write_run_dir << "\n";
@@ -448,6 +474,7 @@ inline DuckDBResult<void> WriteDistributedCopyDirectWriteLifecycle(FileSystem &f
 
 struct DistributedCopyDirectWriteLifecycleInfo {
 	std::string base_path;
+	std::string worker_base_path;
 	std::string run_id;
 	idx_t created_epoch_ms = 0;
 };
@@ -467,8 +494,11 @@ ReadDistributedCopyDirectWriteLifecycle(FileSystem &fs, const DistributedCopyFin
 	bool seen_version = false;
 	bool seen_mode = false;
 	bool seen_base_path = false;
+	bool seen_worker_base_path = false;
 	bool seen_run_id = false;
 	bool seen_created_epoch_ms = false;
+	bool seen_direct_write_run_dir = false;
+	std::string direct_write_run_dir;
 	DistributedCopyDirectWriteLifecycleInfo info;
 
 	std::istringstream input(text_res.value());
@@ -495,7 +525,7 @@ ReadDistributedCopyDirectWriteLifecycle(FileSystem &fs, const DistributedCopyFin
 				    DuckDBError::value_error("direct-write lifecycle duplicate version"));
 			}
 			seen_version = true;
-			if (value != "1") {
+			if (value != "2") {
 				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
 				    DuckDBError::value_error("unsupported direct-write lifecycle version: " + value));
 			}
@@ -520,6 +550,17 @@ ReadDistributedCopyDirectWriteLifecycle(FileSystem &fs, const DistributedCopyFin
 				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
 				    DuckDBError::value_error("direct-write lifecycle base_path mismatch"));
 			}
+		} else if (key == "worker_base_path") {
+			if (seen_worker_base_path) {
+				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
+				    DuckDBError::value_error("direct-write lifecycle duplicate worker_base_path"));
+			}
+			seen_worker_base_path = true;
+			info.worker_base_path = std::move(value);
+			if (!DistributedCopyWorkerBaseMatchesCanonical(fs, expected_base_path, info.worker_base_path)) {
+				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
+				    DuckDBError::value_error("direct-write lifecycle worker_base_path mismatch"));
+			}
 		} else if (key == "run_id") {
 			if (seen_run_id) {
 				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
@@ -543,16 +584,28 @@ ReadDistributedCopyDirectWriteLifecycle(FileSystem &fs, const DistributedCopyFin
 			}
 			info.created_epoch_ms = created_res.value();
 		} else if (key == "direct_write_run_dir") {
-			continue;
+			if (seen_direct_write_run_dir) {
+				return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
+				    DuckDBError::value_error("direct-write lifecycle duplicate direct_write_run_dir"));
+			}
+			seen_direct_write_run_dir = true;
+			direct_write_run_dir = std::move(value);
 		} else {
 			return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
 			    DuckDBError::value_error("direct-write lifecycle unknown field: " + key));
 		}
 	}
 
-	if (!seen_version || !seen_mode || !seen_base_path || !seen_run_id || !seen_created_epoch_ms) {
+	if (!seen_version || !seen_mode || !seen_base_path || !seen_worker_base_path || !seen_run_id ||
+	    !seen_created_epoch_ms || !seen_direct_write_run_dir) {
 		return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
 		    DuckDBError::value_error("direct-write lifecycle missing required fields"));
+	}
+	auto expected_run_dir = BuildCopyDirectWriteRunDirectory(info.worker_base_path, expected_run_id,
+	                                                         fs.PathSeparator(info.worker_base_path));
+	if (direct_write_run_dir != expected_run_dir) {
+		return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::err(
+		    DuckDBError::value_error("direct-write lifecycle direct_write_run_dir mismatch"));
 	}
 	return DuckDBResult<DistributedCopyDirectWriteLifecycleInfo>::ok(std::move(info));
 }
@@ -793,6 +846,11 @@ ReadCommittedDistributedCopyDirectWriteResult(FileSystem &fs, const std::string 
 
 	auto canonical_base_path = std::move(canonical_res).value();
 	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+	auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, canonical_base_path, run_id);
+	if (lifecycle_res.is_err()) {
+		return DuckDBResult<DistributedCopyResult>::err(lifecycle_res.error());
+	}
+	auto worker_base_path = std::move(lifecycle_res).value().worker_base_path;
 	auto manifest_root = "direct:" + run_id;
 	auto read_res = ReadDistributedCopyFinalizeManifest(fs, commit_paths, canonical_base_path, manifest_root, true);
 	if (read_res.is_err()) {
@@ -801,7 +859,7 @@ ReadCommittedDistributedCopyDirectWriteResult(FileSystem &fs, const std::string 
 
 	auto result = std::move(read_res).value();
 	for (const auto &info : result.files) {
-		if (!DistributedCopyDirectWriteFinalPathBelongsToRun(fs, canonical_base_path, run_id, info.final_path)) {
+		if (!DistributedCopyDirectWriteFinalPathBelongsToRun(fs, worker_base_path, run_id, info.final_path)) {
 			return DuckDBResult<DistributedCopyResult>::err(DuckDBError::invalid_state_error(StringUtil::Format(
 			    "distributed COPY direct-write committed manifest file is outside run output: \"%s\"",
 			    info.final_path)));
@@ -1027,15 +1085,21 @@ CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
 	return DuckDBResult<DistributedCopyPrefixCleanupResult>::ok(std::move(result));
 }
 
-inline DuckDBResult<void> CleanupDistributedCopyDirectTargetFilesForRun(FileSystem &fs, const std::string &base_path,
-                                                                        const std::string &run_id) {
-	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
-	if (files_res.is_err()) {
-		return DuckDBResult<void>::err(files_res.error());
+inline DuckDBResult<void>
+CleanupDistributedCopyDirectTargetFilesForRun(FileSystem &fs, const std::string &base_path, const std::string &run_id,
+                                              const std::vector<std::string> *listed_files = nullptr) {
+	std::vector<std::string> owned_files;
+	if (!listed_files) {
+		auto files_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
+		if (files_res.is_err()) {
+			return DuckDBResult<void>::err(files_res.error());
+		}
+		owned_files = std::move(files_res).value();
+		listed_files = &owned_files;
 	}
 
 	std::vector<std::string> run_files;
-	for (const auto &file : files_res.value()) {
+	for (const auto &file : *listed_files) {
 		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(file), run_id)) {
 			run_files.push_back(file);
 		}
@@ -1045,12 +1109,12 @@ inline DuckDBResult<void> CleanupDistributedCopyDirectTargetFilesForRun(FileSyst
 		return remove_res;
 	}
 
-	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
-	if (remaining_res.is_err()) {
-		return DuckDBResult<void>::err(remaining_res.error());
-	}
-	for (const auto &file : remaining_res.value()) {
-		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(file), run_id)) {
+	for (const auto &file : run_files) {
+		auto exists_res = CheckDistributedCopyFileExists(fs, file);
+		if (exists_res.is_err()) {
+			return DuckDBResult<void>::err(exists_res.error());
+		}
+		if (exists_res.value()) {
 			return DuckDBResult<void>::err(
 			    DuckDBError::io_error("distributed COPY direct-target object still exists after cleanup: " + file));
 		}
@@ -1067,8 +1131,9 @@ struct DistributedCopyDirectWriteRunCleanupResult {
 };
 
 inline DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>
-CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::string &base_path,
-                                                const std::string &run_id) {
+CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(
+    FileSystem &fs, const std::string &base_path, const std::string &worker_base_path, const std::string &run_id,
+    const std::vector<std::string> *listed_worker_files = nullptr) {
 	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
 	if (canonical_res.is_err()) {
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(canonical_res.error());
@@ -1078,6 +1143,15 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 		    DuckDBError::value_error("direct-write cleanup requires non-empty run_id"));
 	}
 	auto canonical_base_path = std::move(canonical_res).value();
+	auto canonical_worker_res = CanonicalDistributedCopyBasePath(fs, worker_base_path);
+	if (canonical_worker_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(canonical_worker_res.error());
+	}
+	auto canonical_worker_base_path = std::move(canonical_worker_res).value();
+	if (!DistributedCopyWorkerBaseMatchesCanonical(fs, canonical_base_path, canonical_worker_base_path)) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
+		    DuckDBError::value_error("direct-write cleanup worker base is outside the COPY namespace"));
+	}
 
 	DistributedCopyDirectWriteRunCleanupResult result;
 	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
@@ -1090,8 +1164,8 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::ok(std::move(result));
 	}
 
-	auto direct_write_run_dir =
-	    BuildCopyDirectWriteRunDirectory(canonical_base_path, run_id, fs.PathSeparator(canonical_base_path));
+	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(canonical_worker_base_path, run_id,
+	                                                             fs.PathSeparator(canonical_worker_base_path));
 	auto data_cleanup_res = CleanupDistributedCopyPrefix(fs, direct_write_run_dir);
 	if (data_cleanup_res.is_err()) {
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(data_cleanup_res.error());
@@ -1099,7 +1173,8 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 	result.data_run_dir_existed = data_cleanup_res.value().existed;
 	result.data_run_dir_removed = data_cleanup_res.value().removed;
 
-	auto direct_target_cleanup_res = CleanupDistributedCopyDirectTargetFilesForRun(fs, canonical_base_path, run_id);
+	auto direct_target_cleanup_res =
+	    CleanupDistributedCopyDirectTargetFilesForRun(fs, canonical_worker_base_path, run_id, listed_worker_files);
 	if (direct_target_cleanup_res.is_err()) {
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(direct_target_cleanup_res.error());
 	}
@@ -1115,6 +1190,45 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 	}
 
 	return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::ok(std::move(result));
+}
+
+inline DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>
+CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::string &base_path,
+                                                const std::string &run_id) {
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(canonical_res.error());
+	}
+	if (run_id.empty()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
+		    DuckDBError::value_error("direct-write cleanup requires non-empty run_id"));
+	}
+	auto canonical_base_path = std::move(canonical_res).value();
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+	auto committed_res = CheckDistributedCopyFileExists(fs, commit_paths.committed_marker_path);
+	if (committed_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(committed_res.error());
+	}
+	if (committed_res.value()) {
+		DistributedCopyDirectWriteRunCleanupResult result;
+		result.skipped_committed = true;
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::ok(std::move(result));
+	}
+
+	auto worker_base_path = canonical_base_path;
+	auto lifecycle_exists_res = CheckDistributedCopyFileExists(fs, commit_paths.lifecycle_path);
+	if (lifecycle_exists_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_exists_res.error());
+	}
+	if (lifecycle_exists_res.value()) {
+		auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, canonical_base_path, run_id);
+		if (lifecycle_res.is_err()) {
+			return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_res.error());
+		}
+		worker_base_path = std::move(lifecycle_res).value().worker_base_path;
+	}
+	return CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(fs, canonical_base_path, worker_base_path,
+	                                                                     run_id);
 }
 
 struct DistributedCopyDirectWriteCleanupScanResult {
@@ -1163,6 +1277,11 @@ CleanupExpiredDistributedCopyDirectWriteRuns(FileSystem &fs, const std::string &
 	}
 	SortAndDeduplicateDistributedCopyPaths(run_ids);
 
+	struct StaleRun {
+		std::string run_id;
+		std::string worker_base_path;
+	};
+	std::vector<StaleRun> stale_runs;
 	for (const auto &run_id : run_ids) {
 		result.scanned_runs++;
 		auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
@@ -1187,8 +1306,39 @@ CleanupExpiredDistributedCopyDirectWriteRuns(FileSystem &fs, const std::string &
 			result.active_runs++;
 			continue;
 		}
+		stale_runs.push_back({run_id, lifecycle.worker_base_path});
+	}
 
-		auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, canonical_base_path, run_id);
+	std::unordered_map<std::string, std::vector<std::string>> listed_worker_files;
+	std::unordered_map<std::string, std::string> worker_listing_errors;
+	for (const auto &stale_run : stale_runs) {
+		if (listed_worker_files.find(stale_run.worker_base_path) != listed_worker_files.end() ||
+		    worker_listing_errors.find(stale_run.worker_base_path) != worker_listing_errors.end()) {
+			continue;
+		}
+		auto files_res = ListDistributedCopyFilesUnderPrefix(fs, stale_run.worker_base_path);
+		if (files_res.is_err()) {
+			worker_listing_errors.emplace(stale_run.worker_base_path, files_res.error().what());
+			continue;
+		}
+		listed_worker_files.emplace(stale_run.worker_base_path, std::move(files_res).value());
+	}
+
+	for (const auto &stale_run : stale_runs) {
+		auto listing_error = worker_listing_errors.find(stale_run.worker_base_path);
+		if (listing_error != worker_listing_errors.end()) {
+			result.errors++;
+			result.error_messages.push_back(listing_error->second);
+			continue;
+		}
+		auto listed_files = listed_worker_files.find(stale_run.worker_base_path);
+		if (listed_files == listed_worker_files.end()) {
+			result.errors++;
+			result.error_messages.push_back("missing distributed COPY worker-prefix listing");
+			continue;
+		}
+		auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(
+		    fs, canonical_base_path, stale_run.worker_base_path, stale_run.run_id, &listed_files->second);
 		if (cleanup_res.is_err()) {
 			result.errors++;
 			result.error_messages.push_back(cleanup_res.error().what());
@@ -1199,7 +1349,7 @@ CleanupExpiredDistributedCopyDirectWriteRuns(FileSystem &fs, const std::string &
 			continue;
 		}
 		result.cleaned_runs++;
-		result.cleaned_run_ids.push_back(run_id);
+		result.cleaned_run_ids.push_back(stale_run.run_id);
 	}
 
 	return DuckDBResult<DistributedCopyDirectWriteCleanupScanResult>::ok(std::move(result));
@@ -1272,6 +1422,15 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 		return DuckDBResult<DistributedCopyResult>::err(canonical_res.error());
 	}
 	auto base_path = std::move(canonical_res).value();
+	auto worker_base_res = CanonicalDistributedCopyBasePath(fs, spec.file_path);
+	if (worker_base_res.is_err()) {
+		return DuckDBResult<DistributedCopyResult>::err(worker_base_res.error());
+	}
+	auto worker_base_path = std::move(worker_base_res).value();
+	if (!DistributedCopyWorkerBaseMatchesCanonical(fs, base_path, worker_base_path)) {
+		return DuckDBResult<DistributedCopyResult>::err(
+		    DuckDBError::value_error("distributed COPY worker base is outside the canonical output namespace"));
+	}
 
 	const bool output_is_dir = spec.partition_output || spec.per_thread_output || spec.rotate;
 
@@ -1331,6 +1490,14 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 	} else if (direct_write_commit_enabled) {
 		commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, direct_write_run_id);
 		direct_write_manifest_root = "direct:" + direct_write_run_id;
+		auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, base_path, direct_write_run_id);
+		if (lifecycle_res.is_err()) {
+			return DuckDBResult<DistributedCopyResult>::err(lifecycle_res.error());
+		}
+		if (lifecycle_res.value().worker_base_path != worker_base_path) {
+			return DuckDBResult<DistributedCopyResult>::err(
+			    DuckDBError::invalid_state_error("distributed COPY direct-write worker base changed before finalize"));
+		}
 
 		if (DistributedCopyFileExistsNoThrow(fs, commit_paths.committed_marker_path)) {
 			auto committed_res =
@@ -1340,18 +1507,25 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 			}
 			auto committed_result = std::move(committed_res).value();
 			for (const auto &info : committed_result.files) {
+				if (!DistributedCopyDirectWriteFinalPathBelongsToRun(fs, worker_base_path, direct_write_run_id,
+				                                                     info.final_path)) {
+					return DuckDBResult<DistributedCopyResult>::err(DuckDBError::invalid_state_error(StringUtil::Format(
+					    "distributed COPY direct-write committed manifest file is outside worker output: \"%s\"",
+					    info.final_path)));
+				}
 				auto validate_res = ValidateDistributedCopyDirectWriteFinalFile(fs, info);
 				if (validate_res.is_err()) {
 					return DuckDBResult<DistributedCopyResult>::err(validate_res.error());
 				}
 			}
 			committed_result.finalize_ms = DistributedCopyElapsedMillis(finalize_started);
-			auto direct_write_run_dir =
-			    BuildCopyDirectWriteRunDirectory(base_path, direct_write_run_id, fs.PathSeparator(base_path));
+			auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(worker_base_path, direct_write_run_id,
+			                                                             fs.PathSeparator(worker_base_path));
 			auto cleanup_started = std::chrono::steady_clock::now();
 			CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_run_dir, committed_result.files);
-			if (DistributedCopyUsesDirectTargetLayout(fs, base_path, committed_result.files, direct_write_run_id)) {
-				CleanupDistributedCopyDirectTargetUnselectedFiles(fs, base_path, direct_write_run_id,
+			if (DistributedCopyUsesDirectTargetLayout(fs, worker_base_path, committed_result.files,
+			                                          direct_write_run_id)) {
+				CleanupDistributedCopyDirectTargetUnselectedFiles(fs, worker_base_path, direct_write_run_id,
 				                                                  committed_result.files);
 			}
 			committed_result.cleanup_ms = DistributedCopyElapsedMillis(cleanup_started);
@@ -1461,6 +1635,11 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 				return DuckDBResult<DistributedCopyResult>::err(DuckDBError(StringUtil::Format(
 				    "Distributed COPY direct-write finalize contains duplicate final path \"%s\"", info.final_path)));
 			}
+			if (direct_write_commit_enabled && !DistributedCopyDirectWriteFinalPathBelongsToRun(
+			                                       fs, worker_base_path, direct_write_run_id, info.final_path)) {
+				return DuckDBResult<DistributedCopyResult>::err(DuckDBError::invalid_state_error(StringUtil::Format(
+				    "distributed COPY direct-write final path is outside worker output: \"%s\"", info.final_path)));
+			}
 
 			auto validate_res = ValidateDistributedCopyDirectWriteFinalFile(fs, info);
 			if (validate_res.is_err()) {
@@ -1482,8 +1661,8 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 				return DuckDBResult<DistributedCopyResult>::err(marker_res.error());
 			}
 			AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, true);
-			direct_write_cleanup_run_dir =
-			    BuildCopyDirectWriteRunDirectory(base_path, direct_write_run_id, fs.PathSeparator(base_path));
+			direct_write_cleanup_run_dir = BuildCopyDirectWriteRunDirectory(worker_base_path, direct_write_run_id,
+			                                                                fs.PathSeparator(worker_base_path));
 		}
 	} else {
 		std::unordered_set<std::string> planned_final_paths;
@@ -1587,8 +1766,8 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 	if (!direct_write_cleanup_run_dir.empty()) {
 		auto cleanup_started = std::chrono::steady_clock::now();
 		CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_cleanup_run_dir, result.files);
-		if (DistributedCopyUsesDirectTargetLayout(fs, base_path, result.files, direct_write_run_id)) {
-			CleanupDistributedCopyDirectTargetUnselectedFiles(fs, base_path, direct_write_run_id, result.files);
+		if (DistributedCopyUsesDirectTargetLayout(fs, worker_base_path, result.files, direct_write_run_id)) {
+			CleanupDistributedCopyDirectTargetUnselectedFiles(fs, worker_base_path, direct_write_run_id, result.files);
 		}
 		result.cleanup_ms += DistributedCopyElapsedMillis(cleanup_started);
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -191,6 +191,18 @@ inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs
 	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
 }
 
+inline std::string DistributedCopyPathInDirectory(FileSystem &fs, const std::string &directory,
+                                                  const std::string &base_name) {
+	if (directory.empty()) {
+		return base_name;
+	}
+	auto separator = fs.PathSeparator(directory);
+	if (StringUtil::EndsWith(directory, separator)) {
+		return directory + base_name;
+	}
+	return fs.JoinPath(directory, base_name);
+}
+
 inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs, const DistributedCopySpec &spec) {
 	auto canonical_res = CanonicalDistributedCopyBasePath(fs, spec.file_path);
 	if (canonical_res.is_err()) {
@@ -210,7 +222,7 @@ inline DuckDBResult<std::string> CanonicalDistributedCopyBasePath(FileSystem &fs
 		    DuckDBError::value_error("distributed COPY requires non-empty canonical base_path"));
 	}
 	auto directory = StringUtil::GetFilePath(canonical_base_path);
-	canonical_base_path = directory.empty() ? base_name : fs.JoinPath(directory, base_name);
+	canonical_base_path = DistributedCopyPathInDirectory(fs, directory, base_name);
 	return DuckDBResult<std::string>::ok(std::move(canonical_base_path));
 }
 
@@ -218,7 +230,7 @@ inline std::string DistributedCopyTemporaryBasePath(FileSystem &fs, const std::s
 	auto base_name = StringUtil::GetFileName(canonical_base_path);
 	auto directory = StringUtil::GetFilePath(canonical_base_path);
 	auto temporary_name = "tmp_" + base_name;
-	return directory.empty() ? temporary_name : fs.JoinPath(directory, temporary_name);
+	return DistributedCopyPathInDirectory(fs, directory, temporary_name);
 }
 
 inline bool DistributedCopyWorkerBaseMatchesCanonical(FileSystem &fs, const std::string &canonical_base_path,

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
@@ -125,31 +125,56 @@ inline bool CopySpecNeedsDirectory(const DistributedCopySpec &spec) {
 	return spec.partition_output || spec.per_thread_output || spec.rotate;
 }
 
-inline std::string BuildCopyDirectWriteRunDirectory(const std::string &base_path, const std::string &run_id,
-                                                    const std::string &separator = "/") {
+inline std::string NormalizeCopyDirectWriteRoot(const std::string &base_path, const std::string &separator) {
+	if (base_path.empty()) {
+		return ".";
+	}
+	if (separator.empty()) {
+		return base_path;
+	}
+
 	auto root = base_path;
 	StringUtil::RTrim(root, separator);
 	if (root.empty()) {
-		root = ".";
+		return separator;
 	}
+
+	auto protocol = base_path.find("://");
+	if (protocol != std::string::npos) {
+		auto authority_end = base_path.find(separator, protocol + 3);
+		if (authority_end != std::string::npos && root.size() <= authority_end) {
+			return base_path.substr(0, authority_end + separator.size());
+		}
+	}
+	return root;
+}
+
+inline std::string BuildCopyPathUnderRoot(const std::string &root, const std::string &name,
+                                          const std::string &separator) {
+	if (separator.empty() || StringUtil::EndsWith(root, separator)) {
+		return root + name;
+	}
+	return root + separator + name;
+}
+
+inline std::string BuildCopyDirectWriteRunDirectory(const std::string &base_path, const std::string &run_id,
+                                                    const std::string &separator = "/") {
+	auto root = NormalizeCopyDirectWriteRoot(base_path, separator);
 	if (run_id.empty()) {
 		return root;
 	}
-	return root + separator + DISTRIBUTED_COPY_DIRECT_WRITE_RUN_PREFIX + run_id;
+	return BuildCopyPathUnderRoot(root, DISTRIBUTED_COPY_DIRECT_WRITE_RUN_PREFIX + run_id, separator);
 }
 
 inline std::string BuildCopyDirectWriteTaskDirectory(const std::string &base_path, const std::string &run_id,
                                                      const std::string &worker_dir_name,
                                                      const std::string &separator = "/") {
 	if (run_id.empty()) {
-		auto root = base_path;
-		StringUtil::RTrim(root, separator);
-		if (root.empty()) {
-			root = ".";
-		}
-		return root + separator + worker_dir_name;
+		auto root = NormalizeCopyDirectWriteRoot(base_path, separator);
+		return BuildCopyPathUnderRoot(root, worker_dir_name, separator);
 	}
-	return BuildCopyDirectWriteRunDirectory(base_path, run_id, separator) + separator + worker_dir_name;
+	auto run_directory = BuildCopyDirectWriteRunDirectory(base_path, run_id, separator);
+	return BuildCopyPathUnderRoot(run_directory, worker_dir_name, separator);
 }
 
 inline std::string BuildCopyDirectTargetFileName(const std::string &run_id, const std::string &worker_dir_name,
@@ -160,12 +185,8 @@ inline std::string BuildCopyDirectTargetFileName(const std::string &run_id, cons
 inline std::string BuildCopyDirectTargetFilePath(const std::string &base_path, const std::string &run_id,
                                                  const std::string &worker_dir_name, const std::string &file_name,
                                                  const std::string &separator = "/") {
-	auto root = base_path;
-	StringUtil::RTrim(root, separator);
-	if (root.empty()) {
-		root = ".";
-	}
-	return root + separator + BuildCopyDirectTargetFileName(run_id, worker_dir_name, file_name);
+	auto root = NormalizeCopyDirectWriteRoot(base_path, separator);
+	return BuildCopyPathUnderRoot(root, BuildCopyDirectTargetFileName(run_id, worker_dir_name, file_name), separator);
 }
 
 inline std::string BuildCopyDirectTargetFilenamePattern(const std::string &run_id, const std::string &worker_dir_name) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
@@ -138,6 +138,9 @@ inline std::string NormalizeCopyDirectWriteRoot(const std::string &base_path, co
 	if (root.empty()) {
 		return separator;
 	}
+	if (separator == "\\" && root.size() == 2 && root[1] == ':' && base_path.size() > root.size()) {
+		return root + separator;
+	}
 
 	auto protocol = base_path.find("://");
 	if (protocol != std::string::npos) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/sink.hpp
@@ -51,9 +51,11 @@ public:
 
 		// Direct-write is the default for every filesystem. Workers write
 		// visible run-prefixed output files under the requested output path.
-		// Shared local filesystems can opt back into staging + MoveFile/rename
-		// with VANE_DISTRIBUTED_COPY_LOCAL_STAGING=1.
-		if (!local_staging_enabled) {
+		// USE_TMP_FILE must retain DuckDB's non-conflicting temporary path in
+		// direct-write mode: coordinator staging is not visible for node-local
+		// outputs, and replacing a multi-file result cannot safely destroy the
+		// previous node-local target.
+		if (!local_staging_enabled || spec_.use_tmp_file) {
 			staging_root_base_ = "";
 		} else {
 			staging_root_base_ = spec_.file_path + ".duckdb_staging";

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -573,6 +573,7 @@ public:
 		find_sink(pipeline_node);
 
 		std::string sink_base_path;
+		std::string sink_worker_base_path;
 		if (sink_node) {
 			auto &fs = FileSystem::GetFileSystem(*client_context_);
 			auto canonical_res = CanonicalDistributedCopyBasePath(fs, sink_node->spec());
@@ -580,14 +581,19 @@ public:
 				return DuckDBResult<PlanResult>::err(canonical_res.error());
 			}
 			sink_base_path = std::move(canonical_res).value();
+			auto worker_base_res = CanonicalDistributedCopyBasePath(fs, sink_node->spec().file_path);
+			if (worker_base_res.is_err()) {
+				return DuckDBResult<PlanResult>::err(worker_base_res.error());
+			}
+			sink_worker_base_path = std::move(worker_base_res).value();
 		}
 
 		if (sink_node && sink_node->staging_root_base().empty()) {
 			// Persist lifecycle metadata for explicit operator-managed cleanup. Starting a COPY must not age out
 			// other runs: elapsed time alone does not establish that another run is abandoned.
 			auto &fs = FileSystem::GetFileSystem(*client_context_);
-			auto lifecycle_res =
-			    WriteDistributedCopyDirectWriteLifecycle(fs, sink_base_path, sink_node->staging_run_id());
+			auto lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(
+			    fs, sink_base_path, sink_node->staging_run_id(), 0, sink_worker_base_path);
 			if (lifecycle_res.is_err()) {
 				return DuckDBResult<PlanResult>::err(lifecycle_res.error());
 			}

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -572,12 +572,22 @@ public:
 		};
 		find_sink(pipeline_node);
 
+		std::string sink_base_path;
+		if (sink_node) {
+			auto &fs = FileSystem::GetFileSystem(*client_context_);
+			auto canonical_res = CanonicalDistributedCopyBasePath(fs, sink_node->spec());
+			if (canonical_res.is_err()) {
+				return DuckDBResult<PlanResult>::err(canonical_res.error());
+			}
+			sink_base_path = std::move(canonical_res).value();
+		}
+
 		if (sink_node && sink_node->staging_root_base().empty()) {
 			// Persist lifecycle metadata for explicit operator-managed cleanup. Starting a COPY must not age out
 			// other runs: elapsed time alone does not establish that another run is abandoned.
 			auto &fs = FileSystem::GetFileSystem(*client_context_);
 			auto lifecycle_res =
-			    WriteDistributedCopyDirectWriteLifecycle(fs, sink_node->spec().file_path, sink_node->staging_run_id());
+			    WriteDistributedCopyDirectWriteLifecycle(fs, sink_base_path, sink_node->staging_run_id());
 			if (lifecycle_res.is_err()) {
 				return DuckDBResult<PlanResult>::err(lifecycle_res.error());
 			}
@@ -651,8 +661,7 @@ public:
 		auto cleanup_sink_output = [&]() {
 			auto &fs = FileSystem::GetFileSystem(*client_context_);
 			if (sink_node->staging_root_base().empty()) {
-				CleanupDistributedCopyUncommittedDirectWriteRun(fs, sink_node->spec().file_path,
-				                                                sink_node->staging_run_id());
+				CleanupDistributedCopyUncommittedDirectWriteRun(fs, sink_base_path, sink_node->staging_run_id());
 				return;
 			}
 			auto staging_root = fs.JoinPath(sink_node->staging_root_base(), sink_node->staging_run_id());

--- a/external/duckdb/test/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/test/execution/distributed/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_EXECUTION_DISTRIBUTED_SOURCES
     test_udf_per_thread.cpp
     test_udf_serialization.cpp
     test_clustering_spec.cpp
+    test_copy_finalize.cpp
     test_execute_plan.cpp
     test_physical_operator_visitor.cpp
     test_physical_plan_translator_visitor.cpp

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -196,6 +196,17 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	auto literal_res = CanonicalDistributedCopyBasePath(fs, spec);
 	REQUIRE(literal_res.is_ok());
 	REQUIRE(literal_res.value() == fs.JoinPath(parent, "tmp_copy-output"));
+
+	auto root = fs.PathSeparator(std::string());
+	auto root_output_path = root + "copy-output";
+	auto root_temporary_output_path = root + "tmp_copy-output";
+	spec.file_path = root_temporary_output_path;
+	spec.use_tmp_file = true;
+	auto root_temporary_res = CanonicalDistributedCopyBasePath(fs, spec);
+	REQUIRE(root_temporary_res.is_ok());
+	REQUIRE(root_temporary_res.value() == root_output_path);
+	REQUIRE(DistributedCopyTemporaryBasePath(fs, root_output_path) == root_temporary_output_path);
+	REQUIRE(DistributedCopyWorkerBaseMatchesCanonical(fs, root_output_path, root_temporary_output_path));
 }
 
 TEST_CASE("Distributed COPY temporary direct output preserves the canonical target",

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -14,6 +14,9 @@ namespace {
 
 class FileOnlyRecursiveListFileSystem : public LocalFileSystem {
 public:
+	explicit FileOnlyRecursiveListFileSystem(bool qualified_paths_p = false) : qualified_paths(qualified_paths_p) {
+	}
+
 	bool DirectoryExists(const string &, optional_ptr<FileOpener> = nullptr) override {
 		return false;
 	}
@@ -37,19 +40,23 @@ private:
 				found = ListObjectKeys(root, full_path, callback) || found;
 				return;
 			}
-			auto relative_path = full_path.substr(root.size());
-			auto separator = backing_fs.PathSeparator(relative_path);
-			if (StringUtil::StartsWith(relative_path, separator)) {
-				relative_path = relative_path.substr(separator.size());
+			auto callback_path = full_path;
+			if (!qualified_paths) {
+				callback_path = full_path.substr(root.size());
+				auto separator = backing_fs.PathSeparator(callback_path);
+				if (StringUtil::StartsWith(callback_path, separator)) {
+					callback_path = callback_path.substr(separator.size());
+				}
 			}
-			callback(relative_path, false);
-			callback(relative_path, false);
+			callback(callback_path, false);
+			callback(callback_path, false);
 			found = true;
 		});
 		return found;
 	}
 
 	LocalFileSystem backing_fs;
+	bool qualified_paths;
 };
 
 class CountingFileOnlyRecursiveListFileSystem : public FileOnlyRecursiveListFileSystem {
@@ -273,6 +280,26 @@ TEST_CASE("Distributed COPY temporary direct output preserves the canonical targ
 	REQUIRE(ReadDistributedCopyTextFile(fs, output_path).value() == "old");
 }
 
+TEST_CASE("Distributed COPY resolves relative and qualified list paths",
+          "[distributed][copy][lifecycle][object-storage][path]") {
+	LocalFileSystem fs;
+	const string directory = "memory://bucket/out.duckdb_commit";
+	const string qualified_path = directory + "/run/lifecycle.txt";
+
+	REQUIRE(ResolveDistributedCopyListedPath(fs, directory, "run/lifecycle.txt") == qualified_path);
+	REQUIRE(ResolveDistributedCopyListedPath(fs, directory, qualified_path) == qualified_path);
+	REQUIRE(ResolveDistributedCopyListedPath(fs, directory, "/bucket/out.duckdb_commit/run/lifecycle.txt") ==
+	        qualified_path);
+	REQUIRE(ResolveDistributedCopyListedPath(fs, directory, "bucket/out.duckdb_commit/run/lifecycle.txt") ==
+	        qualified_path);
+
+	auto local_directory = TestCreatePath("copy_finalize_qualified_list_path");
+	auto local_path = fs.JoinPath(local_directory, "lifecycle.txt");
+	REQUIRE(ResolveDistributedCopyListedPath(fs, local_directory, local_path) == local_path);
+	auto root = fs.PathSeparator(std::string());
+	REQUIRE(ResolveDistributedCopyListedPath(fs, root, "lifecycle.txt") == root + "lifecycle.txt");
+}
+
 TEST_CASE("Distributed COPY strict marker checks use the portable local missing-file contract",
           "[distributed][copy][lifecycle][path]") {
 	auto marker_path = TestCreatePath("copy_finalize_missing_local_marker");
@@ -391,6 +418,28 @@ TEST_CASE("Direct-write cleanup fails closed when committed marker status is unk
 	REQUIRE(StringUtil::Contains(cleanup.error_messages[0], "injected marker check failure"));
 	REQUIRE(local_fs.FileExists(data_file));
 	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+}
+
+TEST_CASE("Expired direct-write cleanup accepts qualified file-only listings",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_qualified_file_listing");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-qualified";
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto data_file = local_fs.JoinPath(base_path, run_id + "_w_failed_part.parquet");
+	WriteTestFile(local_fs, data_file, "stale");
+
+	FileOnlyRecursiveListFileSystem qualified_fs(true);
+	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(qualified_fs, base_path, 1, 10);
+	REQUIRE(cleanup_res.is_ok());
+	REQUIRE(cleanup_res.value().scanned_runs == 1);
+	REQUIRE(cleanup_res.value().cleaned_runs == 1);
+	REQUIRE(cleanup_res.value().errors == 0);
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
 }
 
 TEST_CASE("Direct-write cleanup keeps lifecycle registration until metadata cleanup finishes",

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -207,6 +207,28 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	auto root = fs.PathSeparator(std::string());
 	auto root_output_path = root + "copy-output";
 	auto root_temporary_output_path = root + "tmp_copy-output";
+	auto root_res = CanonicalDistributedCopyBasePath(fs, root + root + root);
+	REQUIRE(root_res.is_ok());
+	REQUIRE(root_res.value() == root);
+	auto root_paths = BuildDistributedCopyFinalizeCommitPaths(fs, root_res.value(), "run-root");
+	REQUIRE(root_paths.commit_dir == root + ".duckdb_commit" + root + "run-root");
+
+	auto authority_root_res = CanonicalDistributedCopyBasePath(fs, "s3://bucket///");
+	REQUIRE(authority_root_res.is_ok());
+	REQUIRE(authority_root_res.value() == "s3://bucket/");
+	auto authority_root_without_separator_res = CanonicalDistributedCopyBasePath(fs, "s3://bucket");
+	REQUIRE(authority_root_without_separator_res.is_ok());
+	REQUIRE(authority_root_without_separator_res.value() == "s3://bucket/");
+	auto authority_paths =
+	    BuildDistributedCopyFinalizeCommitPaths(fs, authority_root_res.value(), "run-authority-root");
+	REQUIRE(authority_paths.commit_dir == "s3://bucket/.duckdb_commit/run-authority-root");
+	auto authority_prefix_res = CanonicalDistributedCopyBasePath(fs, "s3://bucket/prefix///");
+	REQUIRE(authority_prefix_res.is_ok());
+	REQUIRE(authority_prefix_res.value() == "s3://bucket/prefix");
+	auto empty_authority_root_res = CanonicalDistributedCopyBasePath(fs, "file:////");
+	REQUIRE(empty_authority_root_res.is_ok());
+	REQUIRE(empty_authority_root_res.value() == "file:///");
+
 	spec.file_path = root_temporary_output_path;
 	spec.use_tmp_file = true;
 	auto root_temporary_res = CanonicalDistributedCopyBasePath(fs, spec);
@@ -298,6 +320,23 @@ TEST_CASE("Distributed COPY resolves relative and qualified list paths",
 	REQUIRE(ResolveDistributedCopyListedPath(fs, local_directory, local_path) == local_path);
 	auto root = fs.PathSeparator(std::string());
 	REQUIRE(ResolveDistributedCopyListedPath(fs, root, "lifecycle.txt") == root + "lifecycle.txt");
+}
+
+TEST_CASE("Distributed COPY removes directory trees from qualified file-only listings",
+          "[distributed][copy][lifecycle][object-storage][path]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_qualified_directory_cleanup");
+	auto &local_fs = test_dir.fs;
+	auto cleanup_root = local_fs.JoinPath(test_dir.path, "cleanup");
+	auto first_file = local_fs.JoinPath(cleanup_root, "first.txt");
+	auto nested_file = local_fs.JoinPath(cleanup_root, "nested", "second.txt");
+	WriteTestFile(local_fs, first_file, "first");
+	WriteTestFile(local_fs, nested_file, "second");
+
+	FileOnlyRecursiveListFileSystem qualified_fs(true);
+	RemoveDistributedCopyDirectoryTree(qualified_fs, cleanup_root);
+
+	REQUIRE_FALSE(local_fs.FileExists(first_file));
+	REQUIRE_FALSE(local_fs.FileExists(nested_file));
 }
 
 TEST_CASE("Distributed COPY strict marker checks use the portable local missing-file contract",

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -52,6 +52,23 @@ private:
 	LocalFileSystem backing_fs;
 };
 
+class CountingFileOnlyRecursiveListFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+	               FileOpener *opener = nullptr) override {
+		list_calls[directory]++;
+		return FileOnlyRecursiveListFileSystem::ListFiles(directory, callback, opener);
+	}
+
+	idx_t ListCallCount(const string &directory) const {
+		auto entry = list_calls.find(directory);
+		return entry == list_calls.end() ? 0 : entry->second;
+	}
+
+private:
+	std::unordered_map<string, idx_t> list_calls;
+};
+
 class MarkerCheckFailureFileSystem : public FileOnlyRecursiveListFileSystem {
 public:
 	explicit MarkerCheckFailureFileSystem(string marker_path) : marker_path(std::move(marker_path)) {
@@ -181,6 +198,70 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	REQUIRE(literal_res.value() == fs.JoinPath(parent, "tmp_copy-output"));
 }
 
+TEST_CASE("Distributed COPY temporary direct output preserves the canonical target",
+          "[distributed][copy][lifecycle][path]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_temporary_replacement");
+	auto &fs = test_dir.fs;
+	auto output_path = fs.JoinPath(test_dir.path, "copy-output");
+	auto temporary_output_path = fs.JoinPath(test_dir.path, "tmp_copy-output");
+	const string run_id = "run-tmp";
+	auto worker_file = BuildCopyDirectTargetFilePath(temporary_output_path, run_id, "w_0", "part.parquet");
+	const string replacement_contents = "replacement";
+
+	WriteTestFile(fs, output_path, "old");
+	WriteTestFile(fs, worker_file, replacement_contents);
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, output_path, run_id, 1, temporary_output_path).is_ok());
+
+	DuckDB db(nullptr);
+	Connection connection(db);
+	DistributedCopySpec spec;
+	spec.file_path = temporary_output_path;
+	spec.use_tmp_file = true;
+	spec.file_extension = "parquet";
+
+	auto make_files = [&]() {
+		vector<DistributedCopyFileInfo> files;
+		DistributedCopyFileInfo file;
+		file.staging_path = worker_file;
+		file.row_count = 2;
+		file.file_size_bytes = replacement_contents.size();
+		files.push_back(std::move(file));
+		return files;
+	};
+
+	auto first_res = FinalizeCopyFiles(spec, "", make_files(), *connection.context, run_id);
+	REQUIRE(first_res.is_ok());
+	auto first = std::move(first_res).value();
+	REQUIRE(first.output_base_path == output_path);
+	REQUIRE(first.output_direct_write);
+	REQUIRE(first.output_committed);
+	REQUIRE(first.rows_copied == 2);
+	REQUIRE(first.files.size() == 1);
+	REQUIRE(first.files[0].final_path == worker_file);
+	REQUIRE(fs.FileExists(output_path));
+	REQUIRE(ReadDistributedCopyTextFile(fs, output_path).value() == "old");
+	REQUIRE(ReadDistributedCopyTextFile(fs, first.files[0].final_path).value() == replacement_contents);
+	REQUIRE_FALSE(fs.DirectoryExists(temporary_output_path + ".duckdb_commit"));
+
+	auto committed_res = ReadCommittedDistributedCopyDirectWriteResult(fs, output_path, run_id);
+	REQUIRE(committed_res.is_ok());
+	REQUIRE(committed_res.value().rows_copied == 2);
+	REQUIRE(committed_res.value().files[0].final_path == worker_file);
+
+	const string stale_run_id = "run-tmp-stale";
+	auto stale_worker_file =
+	    BuildCopyDirectTargetFilePath(temporary_output_path, stale_run_id, "w_failed", "part.parquet");
+	WriteTestFile(fs, stale_worker_file, "stale");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, output_path, stale_run_id, 1, temporary_output_path).is_ok());
+	auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, output_path, stale_run_id);
+	REQUIRE(cleanup_res.is_ok());
+	REQUIRE_FALSE(cleanup_res.value().skipped_committed);
+	REQUIRE_FALSE(fs.FileExists(stale_worker_file));
+	REQUIRE(fs.FileExists(worker_file));
+	REQUIRE(fs.FileExists(output_path));
+	REQUIRE(ReadDistributedCopyTextFile(fs, output_path).value() == "old");
+}
+
 TEST_CASE("Distributed COPY strict marker checks use the portable local missing-file contract",
           "[distributed][copy][lifecycle][path]") {
 	auto marker_path = TestCreatePath("copy_finalize_missing_local_marker");
@@ -217,6 +298,7 @@ TEST_CASE("Expired direct-write cleanup discovers file-only object listings",
 	auto base_path = local_fs.JoinPath(test_dir.path, "out");
 
 	const string stale_run_id = "run-stale";
+	const string second_stale_run_id = "run-stale-two";
 	const string active_run_id = "run-active";
 	const string committed_run_id = "run-committed";
 
@@ -228,6 +310,10 @@ TEST_CASE("Expired direct-write cleanup discovers file-only object listings",
 	WriteTestFile(local_fs, stale_direct_target_file, "stale direct target");
 	auto stale_paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, stale_run_id);
 	WriteTestFile(local_fs, stale_paths.manifest_path, "partial");
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, second_stale_run_id, 2).is_ok());
+	auto second_stale_direct_target_file = local_fs.JoinPath(base_path, second_stale_run_id + "_w_failed_part.parquet");
+	WriteTestFile(local_fs, second_stale_direct_target_file, "second stale direct target");
 
 	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, active_run_id, 95).is_ok());
 	auto active_file =
@@ -246,20 +332,22 @@ TEST_CASE("Expired direct-write cleanup discovers file-only object listings",
 	auto unregistered_path = local_fs.JoinPath(base_path + ".duckdb_commit", "run-without-lifecycle", "manifest.txt");
 	WriteTestFile(local_fs, unregistered_path, "not registered");
 
-	FileOnlyRecursiveListFileSystem object_fs;
+	CountingFileOnlyRecursiveListFileSystem object_fs;
 	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(object_fs, base_path, 10, 100);
 	REQUIRE(cleanup_res.is_ok());
 	auto cleanup = std::move(cleanup_res).value();
 
-	REQUIRE(cleanup.scanned_runs == 3);
-	REQUIRE(cleanup.cleaned_runs == 1);
+	REQUIRE(cleanup.scanned_runs == 4);
+	REQUIRE(cleanup.cleaned_runs == 2);
 	REQUIRE(cleanup.committed_runs == 1);
 	REQUIRE(cleanup.active_runs == 1);
 	REQUIRE(cleanup.skipped_unregistered_runs == 0);
 	REQUIRE(cleanup.errors == 0);
-	REQUIRE(cleanup.cleaned_run_ids == vector<string> {stale_run_id});
+	REQUIRE(cleanup.cleaned_run_ids == vector<string> {stale_run_id, second_stale_run_id});
+	REQUIRE(object_fs.ListCallCount(base_path) == 1);
 	REQUIRE_FALSE(local_fs.FileExists(stale_file));
 	REQUIRE_FALSE(local_fs.FileExists(stale_direct_target_file));
+	REQUIRE_FALSE(local_fs.FileExists(second_stale_direct_target_file));
 	REQUIRE_FALSE(local_fs.FileExists(stale_paths.lifecycle_path));
 	REQUIRE_FALSE(local_fs.FileExists(stale_paths.manifest_path));
 	REQUIRE(local_fs.FileExists(active_file));

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -76,6 +76,43 @@ private:
 	std::unordered_map<string, idx_t> list_calls;
 };
 
+class MissingPrefixFileOnlyRecursiveListFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	explicit MissingPrefixFileOnlyRecursiveListFileSystem(string missing_prefix)
+	    : missing_prefix(std::move(missing_prefix)) {
+	}
+
+	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+	               FileOpener *opener = nullptr) override {
+		if (directory == missing_prefix) {
+			throw IOException({{"errno", std::to_string(ENOENT)}}, "injected missing prefix");
+		}
+		return FileOnlyRecursiveListFileSystem::ListFiles(directory, callback, opener);
+	}
+
+private:
+	string missing_prefix;
+};
+
+class ErrnoListFileSystem : public LocalFileSystem {
+public:
+	explicit ErrnoListFileSystem(int error_number, bool emit_entry = false)
+	    : error_number(error_number), emit_entry(emit_entry) {
+	}
+
+	bool ListFiles(const string &, const std::function<void(const string &, bool)> &callback,
+	               FileOpener * = nullptr) override {
+		if (emit_entry) {
+			callback("partial", false);
+		}
+		throw IOException({{"errno", std::to_string(error_number)}}, "injected list failure");
+	}
+
+private:
+	int error_number;
+	bool emit_entry;
+};
+
 class MarkerCheckFailureFileSystem : public FileOnlyRecursiveListFileSystem {
 public:
 	explicit MarkerCheckFailureFileSystem(string marker_path) : marker_path(std::move(marker_path)) {
@@ -114,6 +151,18 @@ public:
 
 private:
 	string marker_path;
+};
+
+class WindowsPathFileSystem : public LocalFileSystem {
+public:
+	string PathSeparator(const string &) override {
+		return "\\";
+	}
+
+	bool IsPathAbsolute(const string &path) override {
+		return StringUtil::StartsWith(path, "\\\\") ||
+		       (path.size() >= 3 && path[1] == ':' && (path[2] == '\\' || path[2] == '/'));
+	}
 };
 
 class RemoteMarkerStatusFileSystem : public LocalFileSystem {
@@ -212,6 +261,13 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	REQUIRE(root_res.value() == root);
 	auto root_paths = BuildDistributedCopyFinalizeCommitPaths(fs, root_res.value(), "run-root");
 	REQUIRE(root_paths.commit_dir == root + ".duckdb_commit" + root + "run-root");
+	auto root_run_dir = BuildCopyDirectWriteRunDirectory(root, "run-root", root);
+	REQUIRE(root_run_dir == root + "_vane_direct_write_run-root");
+	REQUIRE(BuildCopyDirectWriteTaskDirectory(root, "run-root", "w_0", root) == root_run_dir + root + "w_0");
+	auto root_direct_target = BuildCopyDirectTargetFilePath(root, "run-root", "w_0", "part.parquet");
+	REQUIRE(root_direct_target == root + "run-root_w_0_part.parquet");
+	REQUIRE(DistributedCopyPathIsInDirectory(root_direct_target, root, root));
+	REQUIRE(DistributedCopyDirectWriteFinalPathBelongsToRun(fs, root, "run-root", root_direct_target));
 
 	auto authority_root_res = CanonicalDistributedCopyBasePath(fs, "s3://bucket///");
 	REQUIRE(authority_root_res.is_ok());
@@ -222,12 +278,34 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	auto authority_paths =
 	    BuildDistributedCopyFinalizeCommitPaths(fs, authority_root_res.value(), "run-authority-root");
 	REQUIRE(authority_paths.commit_dir == "s3://bucket/.duckdb_commit/run-authority-root");
+	REQUIRE(BuildCopyDirectWriteRunDirectory(authority_root_res.value(), "run-authority-root") ==
+	        "s3://bucket/_vane_direct_write_run-authority-root");
+	auto authority_direct_target =
+	    BuildCopyDirectTargetFilePath(authority_root_res.value(), "run-authority-root", "w_0", "part.parquet");
+	REQUIRE(DistributedCopyDirectWriteFinalPathBelongsToRun(fs, authority_root_res.value(), "run-authority-root",
+	                                                        authority_direct_target));
 	auto authority_prefix_res = CanonicalDistributedCopyBasePath(fs, "s3://bucket/prefix///");
 	REQUIRE(authority_prefix_res.is_ok());
 	REQUIRE(authority_prefix_res.value() == "s3://bucket/prefix");
 	auto empty_authority_root_res = CanonicalDistributedCopyBasePath(fs, "file:////");
 	REQUIRE(empty_authority_root_res.is_ok());
 	REQUIRE(empty_authority_root_res.value() == "file:///");
+	REQUIRE(BuildCopyDirectWriteRunDirectory(empty_authority_root_res.value(), "run-file-root") ==
+	        "file:///_vane_direct_write_run-file-root");
+	auto file_root_direct_target =
+	    BuildCopyDirectTargetFilePath(empty_authority_root_res.value(), "run-file-root", "w_0", "part.parquet");
+	REQUIRE(DistributedCopyDirectWriteFinalPathBelongsToRun(fs, empty_authority_root_res.value(), "run-file-root",
+	                                                        file_root_direct_target));
+
+	WindowsPathFileSystem windows_fs;
+	auto unc_root_res = CanonicalDistributedCopyBasePath(windows_fs, R"(\\server\share)");
+	REQUIRE(unc_root_res.is_ok());
+	REQUIRE(unc_root_res.value() == R"(\\server\share\)");
+	auto unc_paths = BuildDistributedCopyFinalizeCommitPaths(windows_fs, unc_root_res.value(), "run-unc-root");
+	REQUIRE(unc_paths.commit_dir == R"(\\server\share\.duckdb_commit\run-unc-root)");
+	auto unc_prefix_res = CanonicalDistributedCopyBasePath(windows_fs, R"(\\server\share\prefix\\)");
+	REQUIRE(unc_prefix_res.is_ok());
+	REQUIRE(unc_prefix_res.value() == R"(\\server\share\prefix)");
 
 	spec.file_path = root_temporary_output_path;
 	spec.use_tmp_file = true;
@@ -314,6 +392,10 @@ TEST_CASE("Distributed COPY resolves relative and qualified list paths",
 	        qualified_path);
 	REQUIRE(ResolveDistributedCopyListedPath(fs, directory, "bucket/out.duckdb_commit/run/lifecycle.txt") ==
 	        qualified_path);
+	const string authority_root = "memory://bucket/";
+	REQUIRE(ResolveDistributedCopyListedPath(fs, authority_root, "bucket/key") == "memory://bucket/key");
+	REQUIRE(ResolveDistributedCopyListedPath(fs, authority_root, "/bucket/key") == "memory://bucket/key");
+	REQUIRE(ResolveDistributedCopyListedPath(fs, "memory:///", "key") == "memory:///key");
 
 	auto local_directory = TestCreatePath("copy_finalize_qualified_list_path");
 	auto local_path = fs.JoinPath(local_directory, "lifecycle.txt");
@@ -337,6 +419,26 @@ TEST_CASE("Distributed COPY removes directory trees from qualified file-only lis
 
 	REQUIRE_FALSE(local_fs.FileExists(first_file));
 	REQUIRE_FALSE(local_fs.FileExists(nested_file));
+}
+
+TEST_CASE("Distributed COPY treats only not-found list failures as empty",
+          "[distributed][copy][lifecycle][object-storage]") {
+	ErrnoListFileSystem missing_fs(ENOENT);
+	auto missing_res = ListDistributedCopyFilesUnderPrefix(missing_fs, "/missing");
+	REQUIRE(missing_res.is_ok());
+	REQUIRE(missing_res.value().empty());
+
+	std::runtime_error python_missing("FileNotFoundError: /missing");
+	REQUIRE(DistributedCopyExceptionIsNotFound(python_missing));
+
+	ErrnoListFileSystem partial_missing_fs(ENOENT, true);
+	auto partial_missing_res = ListDistributedCopyFilesUnderPrefix(partial_missing_fs, "/partial");
+	REQUIRE(partial_missing_res.is_err());
+
+	ErrnoListFileSystem denied_fs(EACCES);
+	auto denied_res = ListDistributedCopyFilesUnderPrefix(denied_fs, "/denied");
+	REQUIRE(denied_res.is_err());
+	REQUIRE(StringUtil::Contains(denied_res.error().what(), "injected list failure"));
 }
 
 TEST_CASE("Distributed COPY strict marker checks use the portable local missing-file contract",
@@ -472,6 +574,29 @@ TEST_CASE("Expired direct-write cleanup accepts qualified file-only listings",
 
 	FileOnlyRecursiveListFileSystem qualified_fs(true);
 	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(qualified_fs, base_path, 1, 10);
+	REQUIRE(cleanup_res.is_ok());
+	REQUIRE(cleanup_res.value().scanned_runs == 1);
+	REQUIRE(cleanup_res.value().cleaned_runs == 1);
+	REQUIRE(cleanup_res.value().errors == 0);
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+}
+
+TEST_CASE("Expired direct-target cleanup accepts a missing legacy run prefix",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_missing_legacy_run_prefix");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-direct-target";
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_failed", "part.parquet");
+	WriteTestFile(local_fs, data_file, "stale");
+	auto missing_run_prefix = BuildCopyDirectWriteRunDirectory(base_path, run_id, local_fs.PathSeparator(base_path));
+
+	MissingPrefixFileOnlyRecursiveListFileSystem object_fs(missing_run_prefix);
+	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(object_fs, base_path, 1, 10);
 	REQUIRE(cleanup_res.is_ok());
 	REQUIRE(cleanup_res.value().scanned_runs == 1);
 	REQUIRE(cleanup_res.value().cleaned_runs == 1);

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -197,6 +197,27 @@ private:
 	string failed_path;
 };
 
+class DirectoryRemovalFailureFileSystem : public LocalFileSystem {
+public:
+	explicit DirectoryRemovalFailureFileSystem(string failed_path) : failed_path(std::move(failed_path)) {
+	}
+
+	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+		if (fail_removal && directory == failed_path) {
+			throw IOException("injected directory removal failure");
+		}
+		LocalFileSystem::RemoveDirectory(directory, opener);
+	}
+
+	void AllowRemoval() {
+		fail_removal = false;
+	}
+
+private:
+	string failed_path;
+	bool fail_removal = true;
+};
+
 class CopyFinalizeTestDirectory {
 public:
 	explicit CopyFinalizeTestDirectory(const string &name) : path(TestCreatePath(name)) {
@@ -662,4 +683,35 @@ TEST_CASE("Direct-write cleanup requires lifecycle registration", "[distributed]
 	REQUIRE(cleanup_res.is_err());
 	REQUIRE(StringUtil::Contains(cleanup_res.error().what(), "requires lifecycle registration"));
 	REQUIRE(fs.FileExists(data_file));
+}
+
+TEST_CASE("Direct-write cleanup restores lifecycle when directory removal fails", "[distributed][copy][lifecycle]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_restore_lifecycle");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-retry-directory";
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_failed", "part.parquet");
+	WriteTestFile(local_fs, data_file, "stale");
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	WriteTestFile(local_fs, paths.manifest_path, "partial");
+
+	DirectoryRemovalFailureFileSystem failing_fs(paths.commit_dir);
+	auto first_cleanup = CleanupDistributedCopyUncommittedDirectWriteRun(failing_fs, base_path, run_id);
+
+	REQUIRE(first_cleanup.is_err());
+	REQUIRE(StringUtil::Contains(first_cleanup.error().what(), "injected directory removal failure"));
+	REQUIRE(StringUtil::Contains(first_cleanup.error().what(), "lifecycle registration restored for retry"));
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	REQUIRE_FALSE(local_fs.FileExists(paths.manifest_path));
+	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE(local_fs.DirectoryExists(paths.commit_dir));
+
+	failing_fs.AllowRemoval();
+	auto retry_cleanup = CleanupDistributedCopyUncommittedDirectWriteRun(failing_fs, base_path, run_id);
+
+	REQUIRE(retry_cleanup.is_ok());
+	REQUIRE(retry_cleanup.value().commit_dir_removed);
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(local_fs.DirectoryExists(paths.commit_dir));
 }

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/execution/distributed/copy_finalize.hpp"
+
+using namespace duckdb;
+using namespace duckdb::distributed;
+
+namespace {
+
+class FileOnlyRecursiveListFileSystem : public LocalFileSystem {
+public:
+	bool DirectoryExists(const string &, optional_ptr<FileOpener> = nullptr) override {
+		return false;
+	}
+
+	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+	               FileOpener * = nullptr) override {
+		return ListObjectKeys(directory, directory, callback);
+	}
+
+	string GetName() const override {
+		return "FileOnlyRecursiveListFileSystem";
+	}
+
+private:
+	bool ListObjectKeys(const string &root, const string &directory,
+	                    const std::function<void(const string &, bool)> &callback) {
+		bool found = false;
+		backing_fs.ListFiles(directory, [&](const string &path, bool is_dir) {
+			auto full_path = backing_fs.JoinPath(directory, path);
+			if (is_dir) {
+				found = ListObjectKeys(root, full_path, callback) || found;
+				return;
+			}
+			auto relative_path = full_path.substr(root.size());
+			auto separator = backing_fs.PathSeparator(relative_path);
+			if (StringUtil::StartsWith(relative_path, separator)) {
+				relative_path = relative_path.substr(separator.size());
+			}
+			callback(relative_path, false);
+			callback(relative_path, false);
+			found = true;
+		});
+		return found;
+	}
+
+	LocalFileSystem backing_fs;
+};
+
+class MarkerCheckFailureFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	explicit MarkerCheckFailureFileSystem(string marker_path) : marker_path(std::move(marker_path)) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == marker_path) {
+			throw IOException("injected marker check failure");
+		}
+		return LocalFileSystem::OpenFile(path, flags, opener);
+	}
+
+private:
+	string marker_path;
+};
+
+class MissingLocalMarkerFileSystem : public LocalFileSystem {
+public:
+	explicit MissingLocalMarkerFileSystem(string marker_path) : marker_path(std::move(marker_path)) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == marker_path) {
+			used_null_if_missing = flags.ReturnNullIfNotExists();
+			if (used_null_if_missing) {
+				return nullptr;
+			}
+			throw IOException("injected platform-specific missing-file error");
+		}
+		return LocalFileSystem::OpenFile(path, flags, opener);
+	}
+
+	bool used_null_if_missing = false;
+
+private:
+	string marker_path;
+};
+
+class RemoteMarkerStatusFileSystem : public LocalFileSystem {
+public:
+	explicit RemoteMarkerStatusFileSystem(string status_code) : status_code(std::move(status_code)) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &, FileOpenFlags flags, optional_ptr<FileOpener> = nullptr) override {
+		used_null_if_missing = flags.ReturnNullIfNotExists();
+		throw Exception({{"status_code", status_code}}, ExceptionType::HTTP, "injected remote marker response");
+	}
+
+	bool used_null_if_missing = false;
+
+private:
+	string status_code;
+};
+
+class FileRemovalFailureFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	explicit FileRemovalFailureFileSystem(string failed_path) : failed_path(std::move(failed_path)) {
+	}
+
+	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == failed_path) {
+			throw IOException("injected object removal failure");
+		}
+		LocalFileSystem::RemoveFile(path, opener);
+	}
+
+private:
+	string failed_path;
+};
+
+class CopyFinalizeTestDirectory {
+public:
+	explicit CopyFinalizeTestDirectory(const string &name) : path(TestCreatePath(name)) {
+		if (fs.DirectoryExists(path)) {
+			fs.RemoveDirectory(path);
+		}
+		fs.CreateDirectoriesRecursive(path);
+	}
+
+	~CopyFinalizeTestDirectory() {
+		try {
+			if (fs.DirectoryExists(path)) {
+				fs.RemoveDirectory(path);
+			}
+		} catch (...) {
+		}
+	}
+
+	LocalFileSystem fs;
+	string path;
+};
+
+void WriteTestFile(FileSystem &fs, const string &path, const string &contents) {
+	auto parent = StringUtil::GetFilePath(path);
+	if (!parent.empty() && !fs.DirectoryExists(parent)) {
+		fs.CreateDirectoriesRecursive(parent);
+	}
+	auto write_res = WriteDistributedCopyTextFileAtomically(fs, path, contents);
+	REQUIRE(write_res.is_ok());
+}
+
+} // namespace
+
+TEST_CASE("Distributed COPY canonical base path handles temporary and trailing paths",
+          "[distributed][copy][lifecycle][path]") {
+	LocalFileSystem fs;
+	auto parent = TestCreatePath("copy_finalize_canonical_path");
+	DistributedCopySpec spec;
+	auto output_path = fs.JoinPath(parent, "copy-output");
+	spec.file_path = output_path + fs.PathSeparator(output_path);
+
+	auto trailing_res = CanonicalDistributedCopyBasePath(fs, spec);
+	REQUIRE(trailing_res.is_ok());
+	REQUIRE(trailing_res.value() == output_path);
+
+	spec.file_path = fs.JoinPath(parent, "tmp_copy-output");
+	spec.use_tmp_file = true;
+	auto temporary_res = CanonicalDistributedCopyBasePath(fs, spec);
+	REQUIRE(temporary_res.is_ok());
+	REQUIRE(temporary_res.value() == output_path);
+
+	spec.use_tmp_file = false;
+	auto literal_res = CanonicalDistributedCopyBasePath(fs, spec);
+	REQUIRE(literal_res.is_ok());
+	REQUIRE(literal_res.value() == fs.JoinPath(parent, "tmp_copy-output"));
+}
+
+TEST_CASE("Distributed COPY strict marker checks use the portable local missing-file contract",
+          "[distributed][copy][lifecycle][path]") {
+	auto marker_path = TestCreatePath("copy_finalize_missing_local_marker");
+	MissingLocalMarkerFileSystem fs(marker_path);
+
+	auto exists_res = CheckDistributedCopyFileExists(fs, marker_path);
+
+	REQUIRE(exists_res.is_ok());
+	REQUIRE_FALSE(exists_res.value());
+	REQUIRE(fs.used_null_if_missing);
+}
+
+TEST_CASE("Distributed COPY strict marker checks distinguish remote missing and access failures",
+          "[distributed][copy][lifecycle][object-storage]") {
+	const string marker_path = "s3://bucket/out.duckdb_commit/run/committed";
+
+	RemoteMarkerStatusFileSystem missing_fs("404");
+	auto missing_res = CheckDistributedCopyFileExists(missing_fs, marker_path);
+	REQUIRE(missing_res.is_ok());
+	REQUIRE_FALSE(missing_res.value());
+	REQUIRE_FALSE(missing_fs.used_null_if_missing);
+
+	RemoteMarkerStatusFileSystem forbidden_fs("403");
+	auto forbidden_res = CheckDistributedCopyFileExists(forbidden_fs, marker_path);
+	REQUIRE(forbidden_res.is_err());
+	REQUIRE(StringUtil::Contains(forbidden_res.error().what(), "injected remote marker response"));
+	REQUIRE_FALSE(forbidden_fs.used_null_if_missing);
+}
+
+TEST_CASE("Expired direct-write cleanup discovers file-only object listings",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_file_only_listing");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+
+	const string stale_run_id = "run-stale";
+	const string active_run_id = "run-active";
+	const string committed_run_id = "run-committed";
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, stale_run_id, 1).is_ok());
+	auto stale_run_dir = BuildCopyDirectWriteRunDirectory(base_path, stale_run_id, local_fs.PathSeparator(base_path));
+	auto stale_file = local_fs.JoinPath(stale_run_dir, "w_failed", "part.parquet");
+	WriteTestFile(local_fs, stale_file, "stale");
+	auto stale_direct_target_file = local_fs.JoinPath(base_path, stale_run_id + "_w_failed_part.parquet");
+	WriteTestFile(local_fs, stale_direct_target_file, "stale direct target");
+	auto stale_paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, stale_run_id);
+	WriteTestFile(local_fs, stale_paths.manifest_path, "partial");
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, active_run_id, 95).is_ok());
+	auto active_file =
+	    local_fs.JoinPath(BuildCopyDirectWriteRunDirectory(base_path, active_run_id, local_fs.PathSeparator(base_path)),
+	                      "w_running", "part.parquet");
+	WriteTestFile(local_fs, active_file, "active");
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, committed_run_id, 1).is_ok());
+	auto committed_file = local_fs.JoinPath(
+	    BuildCopyDirectWriteRunDirectory(base_path, committed_run_id, local_fs.PathSeparator(base_path)), "w_selected",
+	    "part.parquet");
+	WriteTestFile(local_fs, committed_file, "committed");
+	auto committed_paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, committed_run_id);
+	REQUIRE(WriteDistributedCopyFinalizeCommittedMarker(local_fs, committed_paths).is_ok());
+
+	auto unregistered_path = local_fs.JoinPath(base_path + ".duckdb_commit", "run-without-lifecycle", "manifest.txt");
+	WriteTestFile(local_fs, unregistered_path, "not registered");
+
+	FileOnlyRecursiveListFileSystem object_fs;
+	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(object_fs, base_path, 10, 100);
+	REQUIRE(cleanup_res.is_ok());
+	auto cleanup = std::move(cleanup_res).value();
+
+	REQUIRE(cleanup.scanned_runs == 3);
+	REQUIRE(cleanup.cleaned_runs == 1);
+	REQUIRE(cleanup.committed_runs == 1);
+	REQUIRE(cleanup.active_runs == 1);
+	REQUIRE(cleanup.skipped_unregistered_runs == 0);
+	REQUIRE(cleanup.errors == 0);
+	REQUIRE(cleanup.cleaned_run_ids == vector<string> {stale_run_id});
+	REQUIRE_FALSE(local_fs.FileExists(stale_file));
+	REQUIRE_FALSE(local_fs.FileExists(stale_direct_target_file));
+	REQUIRE_FALSE(local_fs.FileExists(stale_paths.lifecycle_path));
+	REQUIRE_FALSE(local_fs.FileExists(stale_paths.manifest_path));
+	REQUIRE(local_fs.FileExists(active_file));
+	REQUIRE(local_fs.FileExists(committed_file));
+	REQUIRE(local_fs.FileExists(committed_paths.committed_marker_path));
+	REQUIRE(local_fs.FileExists(unregistered_path));
+}
+
+TEST_CASE("Direct-write cleanup fails closed when committed marker status is unknown",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_marker_check_failure");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-unknown-commit";
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto data_file = local_fs.JoinPath(base_path, run_id + "_w_failed_part.parquet");
+	WriteTestFile(local_fs, data_file, "must survive");
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+
+	MarkerCheckFailureFileSystem object_fs(paths.committed_marker_path);
+	auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(object_fs, base_path, 1, 10);
+	REQUIRE(cleanup_res.is_ok());
+	auto cleanup = std::move(cleanup_res).value();
+
+	REQUIRE(cleanup.scanned_runs == 1);
+	REQUIRE(cleanup.cleaned_runs == 0);
+	REQUIRE(cleanup.errors == 1);
+	REQUIRE(cleanup.error_messages.size() == 1);
+	REQUIRE(StringUtil::Contains(cleanup.error_messages[0], "injected marker check failure"));
+	REQUIRE(local_fs.FileExists(data_file));
+	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+}
+
+TEST_CASE("Direct-write cleanup keeps lifecycle registration until metadata cleanup finishes",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_retryable_metadata_cleanup");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-retry-metadata";
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto data_file = local_fs.JoinPath(base_path, run_id + "_w_failed_part.parquet");
+	WriteTestFile(local_fs, data_file, "stale");
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	WriteTestFile(local_fs, paths.manifest_path, "partial");
+
+	FileRemovalFailureFileSystem failing_fs(paths.manifest_path);
+	auto first_cleanup = CleanupDistributedCopyUncommittedDirectWriteRun(failing_fs, base_path, run_id);
+	REQUIRE(first_cleanup.is_err());
+	REQUIRE(StringUtil::Contains(first_cleanup.error().what(), "injected object removal failure"));
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	REQUIRE(local_fs.FileExists(paths.manifest_path));
+	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+
+	FileOnlyRecursiveListFileSystem retry_fs;
+	auto retry_cleanup = CleanupExpiredDistributedCopyDirectWriteRuns(retry_fs, base_path, 1, 10);
+	REQUIRE(retry_cleanup.is_ok());
+	REQUIRE(retry_cleanup.value().scanned_runs == 1);
+	REQUIRE(retry_cleanup.value().cleaned_runs == 1);
+	REQUIRE(retry_cleanup.value().errors == 0);
+	REQUIRE_FALSE(local_fs.FileExists(paths.manifest_path));
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+}

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -306,6 +306,18 @@ TEST_CASE("Distributed COPY canonical base path handles temporary and trailing p
 	auto unc_prefix_res = CanonicalDistributedCopyBasePath(windows_fs, R"(\\server\share\prefix\\)");
 	REQUIRE(unc_prefix_res.is_ok());
 	REQUIRE(unc_prefix_res.value() == R"(\\server\share\prefix)");
+	auto drive_root_res = CanonicalDistributedCopyBasePath(windows_fs, R"(C:\\)");
+	REQUIRE(drive_root_res.is_ok());
+	REQUIRE(drive_root_res.value() == R"(C:\)");
+	REQUIRE(NormalizeCopyDirectWriteRoot(drive_root_res.value(), R"(\)") == R"(C:\)");
+	REQUIRE(BuildCopyDirectWriteRunDirectory(drive_root_res.value(), "", R"(\)") == R"(C:\)");
+	REQUIRE(BuildCopyDirectWriteRunDirectory(drive_root_res.value(), "run-drive-root", R"(\)") ==
+	        R"(C:\_vane_direct_write_run-drive-root)");
+	REQUIRE_FALSE(DistributedCopyPathIsInDirectory(R"(C:)", drive_root_res.value(), R"(\)"));
+	REQUIRE(DistributedCopyPathIsInDirectory(R"(C:\run-drive-root_w_0_part.parquet)", drive_root_res.value(), R"(\)"));
+	auto forward_slash_drive_root_res = CanonicalDistributedCopyBasePath(windows_fs, "C:////");
+	REQUIRE(forward_slash_drive_root_res.is_ok());
+	REQUIRE(forward_slash_drive_root_res.value() == R"(C:\)");
 
 	spec.file_path = root_temporary_output_path;
 	spec.use_tmp_file = true;
@@ -635,4 +647,19 @@ TEST_CASE("Direct-write cleanup keeps lifecycle registration until metadata clea
 	REQUIRE(retry_cleanup.value().errors == 0);
 	REQUIRE_FALSE(local_fs.FileExists(paths.manifest_path));
 	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+}
+
+TEST_CASE("Direct-write cleanup requires lifecycle registration", "[distributed][copy][lifecycle]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_requires_lifecycle");
+	auto &fs = test_dir.fs;
+	auto base_path = fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-unregistered";
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_failed", "part.parquet");
+	WriteTestFile(fs, data_file, "must survive");
+
+	auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, base_path, run_id);
+
+	REQUIRE(cleanup_res.is_err());
+	REQUIRE(StringUtil::Contains(cleanup_res.error().what(), "requires lifecycle registration"));
+	REQUIRE(fs.FileExists(data_file));
 }

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1391,7 +1391,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    return out;
 	    },
 	    py::arg("base_path"), py::arg("run_id"),
-	    "Best-effort cleanup for an uncommitted direct-write distributed COPY run.");
+	    "Cleanup a lifecycle-registered uncommitted direct-write distributed COPY run.");
 
 	m.def(
 	    "register_copy_direct_write_run_lifecycle",
@@ -4454,6 +4454,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    write_file(stale_file, stale_body);
 
 		    auto stale_commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, stale_run_id);
+		    auto stale_lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, stale_run_id);
+		    if (stale_lifecycle_res.is_err()) {
+			    throw std::runtime_error(stale_lifecycle_res.error().what());
+		    }
 		    std::vector<DistributedCopyFileInfo> stale_files;
 		    stale_files.push_back(make_file_info(stale_file, 1, stale_body.size()));
 		    auto stale_manifest_res = WriteDistributedCopyFinalizeManifest(fs, stale_commit_paths, final_root,
@@ -4468,6 +4472,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    write_file(committed_file, committed_body);
 
 		    auto committed_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, committed_run_id);
+		    auto committed_lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, committed_run_id);
+		    if (committed_lifecycle_res.is_err()) {
+			    throw std::runtime_error(committed_lifecycle_res.error().what());
+		    }
 		    std::vector<DistributedCopyFileInfo> committed_files;
 		    committed_files.push_back(make_file_info(committed_file, 1, committed_body.size()));
 		    auto committed_manifest_res = WriteDistributedCopyFinalizeManifest(

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -4076,6 +4076,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    };
 
 		    auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, run_id);
+		    auto lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, run_id);
+		    if (lifecycle_res.is_err()) {
+			    throw std::runtime_error(lifecycle_res.error().what());
+		    }
 		    auto first_res = FinalizeCopyFiles(spec, "", make_files(), context, run_id);
 		    auto replay_loser_dir = BuildCopyDirectWriteTaskDirectory(final_root, run_id, "w_replay_loser");
 		    auto replay_loser_file = replay_loser_dir + "/part.parquet";
@@ -4175,6 +4179,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    };
 
 		    auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, run_id);
+		    auto lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, run_id);
+		    if (lifecycle_res.is_err()) {
+			    throw std::runtime_error(lifecycle_res.error().what());
+		    }
 		    auto first_res = FinalizeCopyFiles(spec, "", make_files(), context, run_id);
 		    write_file(replay_loser_file, "replay_loser");
 		    auto second_res = FinalizeCopyFiles(spec, "", make_files(), context, run_id);
@@ -4223,7 +4231,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 	m.def(
 	    "distributed_copy_sink_mode_for_test",
-	    [](const std::string &output_path) {
+	    [](const std::string &output_path, bool use_tmp_file) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
@@ -4232,6 +4240,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    spec.file_path = output_path;
 		    spec.file_extension = "parquet";
 		    spec.per_thread_output = true;
+		    spec.use_tmp_file = use_tmp_file;
 		    try {
 			    auto sink = std::make_shared<CopySinkNode>(1, PipelineNodeRef(), std::move(spec));
 			    out["construct_error"] = false;
@@ -4250,7 +4259,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    }
 		    return out;
 	    },
-	    py::arg("output_path"), "Return distributed COPY sink mode for an output path.");
+	    py::arg("output_path"), py::arg("use_tmp_file") = false,
+	    "Return distributed COPY sink mode for an output path.");
 
 	m.def(
 	    "distributed_copy_direct_write_local_invisible_file_commit_for_test",
@@ -4281,6 +4291,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    files.push_back(std::move(info));
 
 		    auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, run_id);
+		    auto lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, run_id);
+		    if (lifecycle_res.is_err()) {
+			    throw std::runtime_error(lifecycle_res.error().what());
+		    }
 		    auto finalize_res = FinalizeCopyFiles(spec, "", std::move(files), context, run_id);
 
 		    py::dict out;
@@ -4342,6 +4356,10 @@ void register_ray_bindings(py::module_ &mod) {
 		    selected_files.push_back(std::move(selected_info));
 
 		    auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, final_root, run_id);
+		    auto lifecycle_res = WriteDistributedCopyDirectWriteLifecycle(fs, final_root, run_id);
+		    if (lifecycle_res.is_err()) {
+			    throw std::runtime_error(lifecycle_res.error().what());
+		    }
 		    auto manifest_res =
 		        WriteDistributedCopyFinalizeManifest(fs, commit_paths, final_root, "direct:" + run_id, selected_files);
 		    if (manifest_res.is_err()) {

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1404,13 +1404,19 @@ void register_ray_bindings(py::module_ &mod) {
 		    auto &context = *conn.context;
 		    auto &fs = FileSystem::GetFileSystem(context);
 
-		    auto register_res = WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id, created_epoch_ms);
+		    auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+		    if (canonical_res.is_err()) {
+			    throw py::value_error(canonical_res.error().what());
+		    }
+		    auto canonical_base_path = std::move(canonical_res).value();
+		    auto register_res =
+		        WriteDistributedCopyDirectWriteLifecycle(fs, canonical_base_path, run_id, created_epoch_ms);
 		    if (register_res.is_err()) {
 			    throw py::value_error(register_res.error().what());
 		    }
-		    auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+		    auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
 		    py::dict out;
-		    out["copy_output_base_path"] = base_path;
+		    out["copy_output_base_path"] = canonical_base_path;
 		    out["copy_output_run_id"] = run_id;
 		    out["copy_output_commit_dir"] = paths.commit_dir;
 		    out["copy_output_lifecycle_path"] = paths.lifecycle_path;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -1830,12 +1830,15 @@ def test_distributed_copy_direct_write_uncommitted_stale_cleanup(tmp_path):
 def test_cleanup_uncommitted_copy_direct_write_run_public_api(tmp_path):
     base = tmp_path / "copy_direct_public_cleanup"
     stale_run_id = "run-public-stale"
+    stale_registration = duckdb.ray_cxx.register_copy_direct_write_run_lifecycle(
+        str(base),
+        stale_run_id,
+    )
     stale_run_dir = base / f"_vane_direct_write_{stale_run_id}" / "w_failed"
     stale_file = stale_run_dir / "part.parquet"
     stale_file.parent.mkdir(parents=True)
     stale_file.write_bytes(b"stale")
-    stale_commit_dir = Path(str(base) + ".duckdb_commit") / stale_run_id
-    stale_commit_dir.mkdir(parents=True)
+    stale_commit_dir = Path(stale_registration["copy_output_commit_dir"])
     (stale_commit_dir / "manifest.txt").write_text("partial\n")
 
     stale = duckdb.ray_cxx.cleanup_uncommitted_copy_direct_write_run(str(base), stale_run_id)
@@ -1849,12 +1852,15 @@ def test_cleanup_uncommitted_copy_direct_write_run_public_api(tmp_path):
     assert not stale_commit_dir.exists()
 
     committed_run_id = "run-public-committed"
+    committed_registration = duckdb.ray_cxx.register_copy_direct_write_run_lifecycle(
+        str(base),
+        committed_run_id,
+    )
     committed_run_dir = base / f"_vane_direct_write_{committed_run_id}" / "w_selected"
     committed_file = committed_run_dir / "part.parquet"
     committed_file.parent.mkdir(parents=True)
     committed_file.write_bytes(b"committed")
-    committed_commit_dir = Path(str(base) + ".duckdb_commit") / committed_run_id
-    committed_commit_dir.mkdir(parents=True)
+    committed_commit_dir = Path(committed_registration["copy_output_commit_dir"])
     (committed_commit_dir / "manifest.txt").write_text("committed manifest\n")
     (committed_commit_dir / "committed").write_text("committed\n")
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -1917,6 +1917,37 @@ def test_cleanup_expired_copy_direct_write_runs_public_api(tmp_path):
     assert Path(committed["copy_output_lifecycle_path"]).exists()
 
 
+def test_copy_direct_write_lifecycle_uses_trimmed_base_path(tmp_path):
+    base = tmp_path / "copy_direct_trimmed_lifecycle"
+    base.mkdir()
+    raw_base = str(base) + os.sep
+    run_id = "run-trailing-separator"
+
+    registered = duckdb.ray_cxx.register_copy_direct_write_run_lifecycle(
+        raw_base,
+        run_id,
+        created_epoch_ms=1,
+    )
+    selected_file = base / f"{run_id}_w_selected_part.parquet"
+    selected_file.write_bytes(b"committed")
+    canonical_commit_dir = Path(str(base) + ".duckdb_commit") / run_id
+    canonical_commit_dir.mkdir(parents=True, exist_ok=True)
+    (canonical_commit_dir / "committed").write_text("committed\n")
+
+    cleanup = duckdb.ray_cxx.cleanup_expired_copy_direct_write_runs(
+        raw_base,
+        min_age_ms=1,
+        now_epoch_ms=10,
+    )
+
+    assert registered["copy_output_base_path"] == str(base)
+    assert Path(registered["copy_output_lifecycle_path"]).parent == canonical_commit_dir
+    assert cleanup["scanned_runs"] == 1
+    assert cleanup["cleaned_runs"] == 0
+    assert cleanup["committed_runs"] == 1
+    assert selected_file.exists()
+
+
 def test_copy_direct_write_lifecycle_cleanup_once_public_api(tmp_path):
     from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
 

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -1744,6 +1744,20 @@ def test_distributed_copy_sink_mode_local_staging_env_preserves_staging(monkeypa
     assert result["uses_visible_direct_target"] is False
 
 
+def test_distributed_copy_sink_mode_tmp_file_preserves_node_local_direct_write(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", "1")
+
+    result = duckdb.ray_cxx.distributed_copy_sink_mode_for_test(
+        str(tmp_path / "tmp_out"),
+        use_tmp_file=True,
+    )
+
+    assert result["construct_error"] is False, result["error"]
+    assert result["staging_root_base"] == ""
+    assert result["uses_direct_write"] is True
+    assert result["uses_visible_direct_target"] is True
+
+
 def test_distributed_copy_sink_mode_remote_rejects_local_staging_env(monkeypatch):
     monkeypatch.setenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", "1")
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6240,7 +6240,7 @@ def test_run_copy_plan_trailing_separator_uses_one_lifecycle_namespace(tmp_path,
 
 
 @pytest.mark.usefixtures("ray_local")
-def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeypatch):
+def test_run_copy_plan_existing_file_uses_final_lifecycle_namespace(tmp_path, monkeypatch):
     captured = []
     monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
 
@@ -6257,12 +6257,10 @@ def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeyp
     src = tmp_path / "copy_tmp_file_input.parquet"
     dst = tmp_path / "copy_tmp_file_output.parquet"
     con.sql("select 1 as x union all select 2 as x").write_parquet(str(src))
+    con.sql("select 0 as x").write_parquet(str(dst))
 
     monkeypatch.setenv("VANE_RUNNER", "ray")
-    con.sql(f"select * from read_parquet('{src}')").write_parquet(
-        str(dst),
-        use_tmp_file=True,
-    )
+    con.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected write relation to be captured"
 
     plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
@@ -6274,6 +6272,7 @@ def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeyp
         result = runner.run_copy_plan(plan, con)
 
     assert result["copy_output_base_path"] == str(dst)
+    assert result["copy_output_direct_write"] is True
     assert result["copy_output_committed"] is True
     assert Path(result["copy_output_lifecycle_path"]).parent == Path(result["copy_output_commit_dir"])
     assert Path(result["copy_output_committed_marker_path"]).parent == Path(result["copy_output_commit_dir"])
@@ -6281,6 +6280,11 @@ def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeyp
     committed_paths = [Path(entry["final_path"]) for entry in result["files"]]
     assert committed_paths
     assert all(path.is_file() for path in committed_paths)
+    temporary_base = tmp_path / f"tmp_{dst.name}"
+    assert all(path.parent == temporary_base for path in committed_paths)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    assert sorted(row[0] for row in con.read_parquet([str(path) for path in committed_paths]).fetchall()) == [1, 2]
+    assert con.read_parquet(str(dst)).fetchall() == [(0,)]
 
     cleanup = duckdb.ray_cxx.cleanup_expired_copy_direct_write_runs(
         str(dst),
@@ -6291,6 +6295,7 @@ def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeyp
     assert cleanup["cleaned_runs"] == 0
     assert cleanup["committed_runs"] == 1
     assert all(path.is_file() for path in committed_paths)
+    assert not Path(str(temporary_base) + ".duckdb_staging").exists()
     con.close()
 
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6187,6 +6187,114 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
 
 
 @pytest.mark.usefixtures("ray_local")
+def test_run_copy_plan_trailing_separator_uses_one_lifecycle_namespace(tmp_path, monkeypatch):
+    captured = []
+    monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
+
+    class _DummyRunner:
+        def run_write(self, relation):
+            captured.append(relation)
+            return {"ok": True}
+
+    import duckdb.runners as runners_mod
+
+    monkeypatch.setattr(runners_mod, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
+
+    con = duckdb.connect()
+    src = tmp_path / "copy_trailing_separator_input.parquet"
+    dst = tmp_path / "copy_trailing_separator_output"
+    dst.mkdir()
+    raw_dst = str(dst) + os.sep
+    con.sql("select 1 as x union all select 2 as x").write_parquet(str(src))
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    con.sql(f"select * from read_parquet('{src}')").write_parquet(raw_dst)
+    assert captured, "expected write relation to be captured"
+
+    plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        captured[0],
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+    with _registered_low_level_plan(plan, con):
+        result = runner.run_copy_plan(plan, con)
+
+    assert result["copy_output_base_path"] == str(dst)
+    assert result["copy_output_committed"] is True
+    assert Path(result["copy_output_lifecycle_path"]).parent == Path(result["copy_output_commit_dir"])
+    assert Path(result["copy_output_committed_marker_path"]).parent == Path(result["copy_output_commit_dir"])
+    committed_paths = [Path(entry["final_path"]) for entry in result["files"]]
+    assert committed_paths
+    assert all(path.is_file() for path in committed_paths)
+
+    cleanup = duckdb.ray_cxx.cleanup_expired_copy_direct_write_runs(
+        raw_dst,
+        min_age_ms=0,
+    )
+
+    assert cleanup["scanned_runs"] == 1
+    assert cleanup["cleaned_runs"] == 0
+    assert cleanup["committed_runs"] == 1
+    assert all(path.is_file() for path in committed_paths)
+    con.close()
+
+
+@pytest.mark.usefixtures("ray_local")
+def test_run_copy_plan_tmp_file_uses_final_lifecycle_namespace(tmp_path, monkeypatch):
+    captured = []
+    monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
+
+    class _DummyRunner:
+        def run_write(self, relation):
+            captured.append(relation)
+            return {"ok": True}
+
+    import duckdb.runners as runners_mod
+
+    monkeypatch.setattr(runners_mod, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
+
+    con = duckdb.connect()
+    src = tmp_path / "copy_tmp_file_input.parquet"
+    dst = tmp_path / "copy_tmp_file_output.parquet"
+    con.sql("select 1 as x union all select 2 as x").write_parquet(str(src))
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    con.sql(f"select * from read_parquet('{src}')").write_parquet(
+        str(dst),
+        use_tmp_file=True,
+    )
+    assert captured, "expected write relation to be captured"
+
+    plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        captured[0],
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+    with _registered_low_level_plan(plan, con):
+        result = runner.run_copy_plan(plan, con)
+
+    assert result["copy_output_base_path"] == str(dst)
+    assert result["copy_output_committed"] is True
+    assert Path(result["copy_output_lifecycle_path"]).parent == Path(result["copy_output_commit_dir"])
+    assert Path(result["copy_output_committed_marker_path"]).parent == Path(result["copy_output_commit_dir"])
+    assert not (tmp_path / f"tmp_{dst.name}.duckdb_commit").exists()
+    committed_paths = [Path(entry["final_path"]) for entry in result["files"]]
+    assert committed_paths
+    assert all(path.is_file() for path in committed_paths)
+
+    cleanup = duckdb.ray_cxx.cleanup_expired_copy_direct_write_runs(
+        str(dst),
+        min_age_ms=0,
+    )
+
+    assert cleanup["scanned_runs"] == 1
+    assert cleanup["cleaned_runs"] == 0
+    assert cleanup["committed_runs"] == 1
+    assert all(path.is_file() for path in committed_paths)
+    con.close()
+
+
+@pytest.mark.usefixtures("ray_local")
 def test_run_copy_plan_leaves_stale_direct_write_cleanup_to_explicit_api(tmp_path, monkeypatch):
     captured = []
     monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)


### PR DESCRIPTION
## Summary

- canonicalize the distributed COPY base path across lifecycle registration, finalization, committed-result reads, and cleanup, including trailing separators, POSIX/filesystem roots, URI authority roots, Windows drive/UNC share roots, and DuckDB `USE_TMP_FILE` physical names
- preserve root semantics when building direct-write run, task, and target paths and when validating that manifest paths remain inside the registered worker namespace
- record both the canonical result namespace and the worker-write namespace in lifecycle v2; `USE_TMP_FILE` keeps node-local direct writes under DuckDB non-conflicting `tmp_<name>` path while canonical lifecycle/manifest metadata remains under the requested output path
- preserve the pre-existing canonical target during temporary direct writes; the committed manifest file list is authoritative, and finalize/replay reject lifecycle or file paths that leave the registered worker/run namespace
- require lifecycle registration for explicit uncommitted-run cleanup instead of falling back to a guessed canonical worker path
- discover registered runs from exact `<base>.duckdb_commit/<run>/lifecycle.txt` object keys instead of directory callbacks, so S3-compatible file-only listings work
- preserve relative, absolute, rooted, scheme-less qualified, and protocol-qualified `ListFiles` callback paths, including PythonFilesystem/fsspec names, in recursive listing and directory-tree cleanup
- treat a wholly missing prefix as empty while keeping permission failures and partial listings fail-closed, so direct-target cleanup does not require a legacy run directory
- list each unique worker output prefix once per cleanup scan, group stale-run files from that snapshot, verify removed objects individually, fail closed when committed-marker status is uncertain, and restore lifecycle registration if final metadata-directory cleanup cannot be confirmed
- document that explicit cleanup requires every supplied base path to be quiesced; elapsed age is not a liveness proof

## Compatibility

This is an intentional clean break: lifecycle metadata is version 2, with no legacy namespace scan, migration, dual lookup, guessed worker-path fallback, or cleanup of unregistered runs.

Explicit cleanup is operator-managed and must run only while no concurrent COPY targets the same base path.

## Validation

- `scripts/format workspace --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- affected COPY/finalize Python tests: 6 passed
- native lifecycle tests: 14 cases, 186 assertions passed
- `scripts/run_release_tests.sh`: 455 passed, 1 skipped; real-Ray shard 10 passed
- rebased on current `upstream/main` (`eb6c2bae`)

Closes #254
Closes #255