### PR TITLE
[fix](udf) Use Ray Data-style generator readiness

### DIFF
--- a/duckdb/execution/ray_control_deadline.py
+++ b/duckdb/execution/ray_control_deadline.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import heapq
+import math
+import threading
+import time
+from collections.abc import Callable
+
+
+class RayControlScheduledCall:
+    """One cancellable callback owned by the process-wide deadline clock."""
+
+    def __init__(
+        self,
+        scheduler: RayControlDeadlineScheduler,
+        callback: Callable[[], None],
+    ) -> None:
+        self._scheduler = scheduler
+        self._callback: Callable[[], None] | None = callback
+        self._scheduled = False
+
+    def cancel(self) -> None:
+        self._scheduler.cancel(self)
+
+
+class RayControlDeadlineScheduler:
+    """One process clock for control stalls, retries, and response timeouts."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._queue: list[tuple[float, int, RayControlScheduledCall]] = []
+        self._next_sequence = 0
+        self._thread: threading.Thread | None = None
+
+    def create(self, callback: Callable[[], None]) -> RayControlScheduledCall:
+        if not callable(callback):
+            raise TypeError("Ray control deadline callback must be callable")
+        return RayControlScheduledCall(self, callback)
+
+    def ensure_started(self) -> None:
+        """Start before a caller transfers work that requires a deadline."""
+        with self._condition:
+            if self._thread is not None:
+                return
+            thread = threading.Thread(
+                target=self._run,
+                daemon=True,
+                name="vane-ray-control-deadlines",
+            )
+            # Publish only a successfully started thread so a later caller can
+            # retry a transient start failure.
+            thread.start()
+            self._thread = thread
+
+    def schedule(self, call: RayControlScheduledCall, delay_s: float) -> None:
+        delay = float(delay_s)
+        if not math.isfinite(delay):
+            raise ValueError("Ray control deadline delay must be finite")
+        self.schedule_at(call, time.monotonic() + max(0.0, delay))
+
+    def schedule_at(self, call: RayControlScheduledCall, deadline: float) -> None:
+        target = float(deadline)
+        if not math.isfinite(target):
+            raise ValueError("Ray control deadline must be finite")
+        self.ensure_started()
+        with self._condition:
+            if call._scheduler is not self:
+                raise RuntimeError("scheduled call belongs to a different deadline scheduler")
+            if call._callback is None:
+                return
+            if call._scheduled:
+                raise RuntimeError("scheduled call is already armed")
+            call._scheduled = True
+            self._next_sequence += 1
+            heapq.heappush(
+                self._queue,
+                (target, self._next_sequence, call),
+            )
+            self._condition.notify()
+
+    def cancel(self, call: RayControlScheduledCall) -> None:
+        with self._condition:
+            if call._scheduler is not self:
+                raise RuntimeError("scheduled call belongs to a different deadline scheduler")
+            # Clearing the callback also releases everything captured by a
+            # cancelled heap entry before that entry reaches the queue head.
+            call._callback = None
+            call._scheduled = False
+            self._condition.notify()
+
+    def _run(self) -> None:
+        while True:
+            callback: Callable[[], None] | None = None
+            with self._condition:
+                while callback is None:
+                    while self._queue and self._queue[0][2]._callback is None:
+                        heapq.heappop(self._queue)
+                    if not self._queue:
+                        self._condition.wait()
+                        continue
+                    deadline, _sequence, call = self._queue[0]
+                    remaining = deadline - time.monotonic()
+                    if remaining > 0:
+                        self._condition.wait(timeout=remaining)
+                        continue
+                    heapq.heappop(self._queue)
+                    callback = call._callback
+                    call._callback = None
+                    call._scheduled = False
+            if callback is not None:
+                try:
+                    callback()
+                except BaseException:
+                    # Deadline owners provide their own terminal/retry policy.
+                    # One malformed callback must not terminate the clock.
+                    pass
+
+
+RAY_CONTROL_DEADLINE_SCHEDULER = RayControlDeadlineScheduler()
+
+
+__all__ = [
+    "RAY_CONTROL_DEADLINE_SCHEDULER",
+    "RayControlDeadlineScheduler",
+    "RayControlScheduledCall",
+]

--- a/duckdb/execution/ray_control_deadline.py
+++ b/duckdb/execution/ray_control_deadline.py
@@ -43,9 +43,10 @@ class RayControlDeadlineScheduler:
     def create_inline(self, callback: Callable[[], None]) -> RayControlScheduledCall:
         """Create an internal callback that is safe to run on the clock.
 
-        Potentially blocking owner work must use
-        ``create_ray_control_deadline`` from ``ray_control_submission`` so the
-        clock only hands that work to the bounded callback executor.
+        Owner-facing deadlines must use ``create_ray_control_deadline`` from
+        ``ray_control_submission``. Its callback is restricted to a controlled
+        state transition; blocking abandonment belongs to the separate
+        completion domain.
         """
         if not callable(callback):
             raise TypeError("Ray control deadline callback must be callable")

--- a/duckdb/execution/ray_control_deadline.py
+++ b/duckdb/execution/ray_control_deadline.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 
 
 class RayControlScheduledCall:
-    """One cancellable callback owned by the process-wide deadline clock."""
+    """One cancellable, one-shot callback owned by the deadline clock."""
 
     def __init__(
         self,
@@ -21,13 +21,18 @@ class RayControlScheduledCall:
         self._scheduler = scheduler
         self._callback: Callable[[], None] | None = callback
         self._scheduled = False
+        self._cancelled = False
 
     def cancel(self) -> None:
         self._scheduler.cancel(self)
 
+    def cancelled(self) -> bool:
+        with self._scheduler._condition:
+            return self._cancelled
+
 
 class RayControlDeadlineScheduler:
-    """One process clock for control stalls, retries, and response timeouts."""
+    """One process clock that runs only bounded, non-blocking bookkeeping."""
 
     def __init__(self) -> None:
         self._condition = threading.Condition()
@@ -35,7 +40,13 @@ class RayControlDeadlineScheduler:
         self._next_sequence = 0
         self._thread: threading.Thread | None = None
 
-    def create(self, callback: Callable[[], None]) -> RayControlScheduledCall:
+    def create_inline(self, callback: Callable[[], None]) -> RayControlScheduledCall:
+        """Create an internal callback that is safe to run on the clock.
+
+        Potentially blocking owner work must use
+        ``create_ray_control_deadline`` from ``ray_control_submission`` so the
+        clock only hands that work to the bounded callback executor.
+        """
         if not callable(callback):
             raise TypeError("Ray control deadline callback must be callable")
         return RayControlScheduledCall(self, callback)
@@ -69,7 +80,7 @@ class RayControlDeadlineScheduler:
         with self._condition:
             if call._scheduler is not self:
                 raise RuntimeError("scheduled call belongs to a different deadline scheduler")
-            if call._callback is None:
+            if call._callback is None or call._cancelled:
                 return
             if call._scheduled:
                 raise RuntimeError("scheduled call is already armed")
@@ -87,6 +98,7 @@ class RayControlDeadlineScheduler:
                 raise RuntimeError("scheduled call belongs to a different deadline scheduler")
             # Clearing the callback also releases everything captured by a
             # cancelled heap entry before that entry reaches the queue head.
+            call._cancelled = True
             call._callback = None
             call._scheduled = False
             self._condition.notify()

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -561,6 +561,7 @@ def _dispatch_ray_control_callback(
     callback: Callable[[], None],
     *,
     still_owned: Callable[[], bool] = lambda: True,
+    retry_rejected: bool = True,
     retry_delay_s: float = _RAY_CONTROL_CALLBACK_RETRY_INITIAL_DELAY_S,
 ) -> None:
     """Hand one callback to its isolated, bounded ownership domain."""
@@ -591,6 +592,7 @@ def _dispatch_ray_control_callback(
                 owner_scope,
                 callback,
                 still_owned=still_owned,
+                retry_rejected=retry_rejected,
                 retry_delay_s=next_retry_delay,
             )
         )
@@ -605,7 +607,11 @@ def _dispatch_ray_control_callback(
             invoke,
         )
     except BaseException:
-        retry_dispatch()
+        if retry_rejected:
+            retry_dispatch()
+        return
+
+    if not retry_rejected:
         return
 
     def resubmit_rejected_dispatch(done: Future[Any]) -> None:
@@ -647,7 +653,12 @@ def dispatch_ray_control_abandonment(
     owner_scope: str,
     callback: Callable[[], None],
 ) -> None:
-    """Run potentially blocking best-effort abandonment off state workers."""
+    """Attempt blocking abandonment once, off state workers.
+
+    The caller has already published durable remote cleanup ownership, so an
+    exhausted completion domain drops this local optimization instead of
+    retaining an unbounded retry chain.
+    """
     owner_key = str(owner_scope or "").strip()
     if not owner_key:
         raise ValueError("Ray control abandonment requires an explicit owner scope")
@@ -657,6 +668,7 @@ def dispatch_ray_control_abandonment(
         _RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR,
         f"{owner_key}:abandonment",
         callback,
+        retry_rejected=False,
     )
 
 

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from concurrent.futures import Future
+from typing import Any, TypeVar
+
+_RAY_CONTROL_SUBMISSION_WORKERS = 4
+
+_T = TypeVar("_T")
+
+
+class _RayControlSubmissionExecutor:
+    """Fixed daemon workers for Ray calls whose submission may block."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._queue: queue.SimpleQueue[tuple[Future[Any], Callable[[], Any]]] = queue.SimpleQueue()
+        self._threads: list[threading.Thread] = []
+
+    def submit(self, callback: Callable[[], _T]) -> Future[_T]:
+        with self._lock:
+            while len(self._threads) < _RAY_CONTROL_SUBMISSION_WORKERS:
+                index = len(self._threads)
+                thread = threading.Thread(
+                    target=self._run,
+                    daemon=True,
+                    name=f"vane-ray-control-submit-{index}",
+                )
+                thread.start()
+                self._threads.append(thread)
+        future: Future[_T] = Future()
+        self._queue.put((future, callback))
+        return future
+
+    def _run(self) -> None:
+        while True:
+            future, callback = self._queue.get()
+            result: Any = None
+            try:
+                try:
+                    if not future.set_running_or_notify_cancel():
+                        continue
+                    result = callback()
+                except BaseException as exc:
+                    if not future.done():
+                        try:
+                            future.set_exception(exc)
+                        except BaseException:
+                            pass
+                else:
+                    try:
+                        future.set_result(result)
+                    except BaseException:
+                        # The Future becomes terminal before callbacks run. A
+                        # malformed callback must not reduce the fixed worker set.
+                        pass
+            finally:
+                # A worker blocks indefinitely in the next queue.get(). Do not
+                # let its frame retain the previous stream owner or ObjectRef.
+                result = None
+                del callback
+                del future
+
+
+_RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()
+
+
+def submit_ray_control(callback: Callable[[], _T]) -> Future[_T]:
+    """Submit one Ray control call without occupying its owner thread."""
+    return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(callback)
+
+
+__all__ = ["submit_ray_control"]

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -314,6 +314,7 @@ class _RayControlSubmissionExecutor:
 
             result: Any = None
             error: BaseException | None = None
+            retire_stalled_worker = False
             try:
                 result = callback()
             except BaseException as exc:
@@ -372,9 +373,9 @@ class _RayControlSubmissionExecutor:
                             )
                     self._condition.notify_all()
                 self._fail_submissions(rejected, rejection_message)
-                if retire_stalled_worker:
-                    return
-                idle_deadline = time.monotonic() + self._idle_timeout_s
+            if retire_stalled_worker:
+                return
+            idle_deadline = time.monotonic() + self._idle_timeout_s
 
     def _reject_queued_submissions_locked(self) -> list[Future[Any]]:
         """Fail admitted-but-unclaimed work when stalled capacity is spent."""

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -13,6 +13,7 @@ from concurrent.futures import Future
 from typing import Any, TypeVar
 
 _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S = 30.0
+_RAY_CONTROL_SUBMISSION_STALL_TIMEOUT_S = 1.0
 _RAY_CONTROL_SUBMISSION_MAX_WORKERS = 32
 _RAY_CONTROL_SUBMISSION_MAX_PENDING = 4096
 _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER = 256
@@ -42,6 +43,12 @@ class _RayControlSubmissionWorker:
     ) -> None:
         self.executor = executor
         self.sequence = int(sequence)
+        # These fields are protected by the executor condition. A stalled
+        # worker remains tracked until its callback actually returns, but no
+        # longer consumes one of the schedulable worker slots.
+        self.running_future: Future[Any] | None = None
+        self.stall_deadline: float | None = None
+        self.stalled = False
         self.thread = threading.Thread(
             target=self._run,
             daemon=True,
@@ -56,20 +63,26 @@ class _RayControlSubmissionWorker:
 
 
 class _RayControlSubmissionExecutor:
-    """Bounded workers with FIFO ordering inside each admitted owner scope."""
+    """Bounded active/stalled workers with per-owner FIFO ordering."""
 
     def __init__(
         self,
         *,
         idle_timeout_s: float = _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S,
+        stall_timeout_s: float = _RAY_CONTROL_SUBMISSION_STALL_TIMEOUT_S,
         max_workers: int = _RAY_CONTROL_SUBMISSION_MAX_WORKERS,
+        max_stalled_workers: int | None = None,
         max_pending_submissions: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING,
         max_pending_per_owner: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER,
     ) -> None:
         if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
             raise ValueError("Ray control submission idle timeout must be finite and positive")
+        if not math.isfinite(stall_timeout_s) or stall_timeout_s <= 0:
+            raise ValueError("Ray control submission stall timeout must be finite and positive")
+        resolved_max_stalled_workers = max_workers if max_stalled_workers is None else max_stalled_workers
         for name, value in (
             ("max_workers", max_workers),
+            ("max_stalled_workers", resolved_max_stalled_workers),
             ("max_pending_submissions", max_pending_submissions),
             ("max_pending_per_owner", max_pending_per_owner),
         ):
@@ -77,15 +90,20 @@ class _RayControlSubmissionExecutor:
                 raise ValueError(f"Ray control submission {name} must be a positive integer")
         if max_pending_submissions < max_workers:
             raise ValueError("Ray control submission pending capacity must be at least max_workers")
+        if max_pending_submissions <= resolved_max_stalled_workers:
+            raise ValueError("Ray control submission pending capacity must exceed max_stalled_workers")
         self._condition = threading.Condition()
         self._owners: dict[str, _RayControlSubmissionOwner] = {}
         self._ready_owners: deque[str] = deque()
         self._workers: dict[int, _RayControlSubmissionWorker] = {}
         self._next_sequence = 0
-        self._running_callbacks = 0
+        self._watchdog_thread: threading.Thread | None = None
+        self._next_watchdog_sequence = 0
         self._pending_submissions = 0
         self._idle_timeout_s = float(idle_timeout_s)
+        self._stall_timeout_s = float(stall_timeout_s)
         self._max_workers = int(max_workers)
+        self._max_stalled_workers = int(resolved_max_stalled_workers)
         self._max_pending_submissions = int(max_pending_submissions)
         self._max_pending_per_owner = int(max_pending_per_owner)
 
@@ -108,6 +126,11 @@ class _RayControlSubmissionExecutor:
 
         future.add_done_callback(discard_cancelled_submission)
         with self._condition:
+            if self._stalled_worker_count_locked() > self._max_stalled_workers:
+                raise RuntimeError(
+                    "Ray control submission stalled callback capacity is exhausted: "
+                    f"capacity={self._max_stalled_workers}"
+                )
             owner = self._owners.get(owner_key)
             owner_pending = 0 if owner is None else len(owner.queue) + int(owner.running)
             if owner_pending >= self._max_pending_per_owner:
@@ -126,7 +149,7 @@ class _RayControlSubmissionExecutor:
                 owner.ready = True
                 self._ready_owners.append(owner_key)
             try:
-                self._start_worker_if_needed_locked()
+                self._start_workers_if_needed_locked()
             except BaseException:
                 queued_future, _queued_callback = owner.queue.pop()
                 assert queued_future is future
@@ -173,29 +196,61 @@ class _RayControlSubmissionExecutor:
                     self._owners.pop(owner_key, None)
             self._condition.notify_all()
 
-    def _start_worker_if_needed_locked(self) -> None:
+    def _stalled_worker_count_locked(self) -> int:
+        return sum(worker.stalled for worker in self._workers.values())
+
+    def _active_worker_count_locked(self) -> int:
+        return sum(not worker.stalled for worker in self._workers.values())
+
+    def _active_running_callback_count_locked(self) -> int:
+        return sum(worker.running_future is not None and not worker.stalled for worker in self._workers.values())
+
+    def _ensure_watchdog_started_locked(self) -> None:
+        if self._watchdog_thread is not None:
+            return
+        sequence = self._next_watchdog_sequence
+        self._next_watchdog_sequence += 1
+        thread = threading.Thread(
+            target=self._run_watchdog,
+            daemon=True,
+            name=f"vane-ray-control-submit-watchdog-{sequence}",
+        )
+        # Publish only a successfully started watchdog. Starting it while the
+        # condition is held ensures it observes the published reference before
+        # it can inspect executor state.
+        thread.start()
+        self._watchdog_thread = thread
+
+    def _start_workers_if_needed_locked(self) -> None:
+        if self._stalled_worker_count_locked() > self._max_stalled_workers:
+            return
         desired_workers = min(
             self._max_workers,
-            self._running_callbacks + len(self._ready_owners),
+            self._active_running_callback_count_locked() + len(self._ready_owners),
         )
-        if len(self._workers) >= desired_workers:
+        if desired_workers <= 0:
             return
-        sequence = self._next_sequence
-        self._next_sequence += 1
-        worker = _RayControlSubmissionWorker(
-            self,
-            sequence=sequence,
-        )
-        self._workers[sequence] = worker
-        try:
-            worker.start()
-        except BaseException:
-            self._workers.pop(sequence, None)
-            raise
+        self._ensure_watchdog_started_locked()
+        while self._active_worker_count_locked() < desired_workers:
+            sequence = self._next_sequence
+            self._next_sequence += 1
+            worker = _RayControlSubmissionWorker(
+                self,
+                sequence=sequence,
+            )
+            self._workers[sequence] = worker
+            try:
+                worker.start()
+            except BaseException:
+                self._workers.pop(sequence, None)
+                raise
 
     def _claim_submission_locked(
         self,
+        worker: _RayControlSubmissionWorker,
     ) -> tuple[_RayControlSubmissionOwner, Future[Any], Callable[[], Any]] | None:
+        if worker.stalled:
+            return None
         while self._ready_owners:
             owner_key = self._ready_owners.popleft()
             owner = self._owners.get(owner_key)
@@ -206,7 +261,9 @@ class _RayControlSubmissionExecutor:
                 future, callback = owner.queue.popleft()
                 if future.set_running_or_notify_cancel():
                     owner.running = True
-                    self._running_callbacks += 1
+                    worker.running_future = future
+                    worker.stall_deadline = time.monotonic() + self._stall_timeout_s
+                    self._condition.notify_all()
                     return owner, future, callback
                 self._pending_submissions -= 1
                 del callback
@@ -217,9 +274,13 @@ class _RayControlSubmissionExecutor:
     def _run_worker(self, worker: _RayControlSubmissionWorker) -> None:
         idle_deadline = time.monotonic() + self._idle_timeout_s
         while True:
+            rejected: list[Future[Any]] = []
+            rejection_message = ""
             with self._condition:
-                claimed = self._claim_submission_locked()
+                claimed = self._claim_submission_locked(worker)
                 while claimed is None:
+                    if worker.stalled:
+                        return
                     remaining = idle_deadline - time.monotonic()
                     if remaining <= 0:
                         if self._workers.get(worker.sequence) is worker:
@@ -227,17 +288,27 @@ class _RayControlSubmissionExecutor:
                         self._condition.notify_all()
                         return
                     self._condition.wait(timeout=remaining)
-                    claimed = self._claim_submission_locked()
+                    claimed = self._claim_submission_locked(worker)
                 owner, future, callback = claimed
 
             result: Any = None
+            error: BaseException | None = None
             try:
-                try:
-                    result = callback()
-                except BaseException as exc:
+                result = callback()
+            except BaseException as exc:
+                error = exc
+            finally:
+                # Only callback invocation time determines whether this worker
+                # is stalled. Future callbacks may perform arbitrary owner-side
+                # bookkeeping and must not consume the submission deadline.
+                with self._condition:
+                    worker.stall_deadline = None
+                    self._condition.notify_all()
+            try:
+                if error is not None:
                     if not future.done():
                         try:
-                            future.set_exception(exc)
+                            future.set_exception(error)
                         except BaseException:
                             pass
                 else:
@@ -249,19 +320,118 @@ class _RayControlSubmissionExecutor:
                         pass
             finally:
                 result = None
+                error = None
                 del callback
                 del future
                 with self._condition:
+                    worker.running_future = None
                     owner.running = False
-                    self._running_callbacks -= 1
                     self._pending_submissions -= 1
                     if owner.queue:
                         owner.ready = True
                         self._ready_owners.append(owner.owner_scope)
                     elif self._owners.get(owner.owner_scope) is owner:
                         self._owners.pop(owner.owner_scope, None)
+                    retire_stalled_worker = worker.stalled
+                    if retire_stalled_worker and self._workers.get(worker.sequence) is worker:
+                        self._workers.pop(worker.sequence, None)
+                    try:
+                        self._start_workers_if_needed_locked()
+                    except BaseException as exc:
+                        if self._active_worker_count_locked() == 0 and self._ready_owners:
+                            rejected = self._reject_queued_submissions_locked()
+                            rejection_message = (
+                                f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
+                            )
                     self._condition.notify_all()
+                self._fail_submissions(rejected, rejection_message)
+                if retire_stalled_worker:
+                    return
                 idle_deadline = time.monotonic() + self._idle_timeout_s
+
+    def _reject_queued_submissions_locked(self) -> list[Future[Any]]:
+        """Fail admitted-but-unclaimed work when stalled capacity is spent."""
+        rejected: list[Future[Any]] = []
+        self._ready_owners.clear()
+        for owner_key, owner in tuple(self._owners.items()):
+            owner.ready = False
+            while owner.queue:
+                future, callback = owner.queue.popleft()
+                rejected.append(future)
+                self._pending_submissions -= 1
+                del callback
+            if not owner.running and self._owners.get(owner_key) is owner:
+                self._owners.pop(owner_key, None)
+        return rejected
+
+    @staticmethod
+    def _fail_submissions(futures: list[Future[Any]], message: str) -> None:
+        for future in futures:
+            if future.done():
+                continue
+            try:
+                future.set_exception(RuntimeError(message))
+            except BaseException:
+                pass
+
+    def _run_watchdog(self) -> None:
+        current = threading.current_thread()
+        while True:
+            rejected: list[Future[Any]] = []
+            rejection_message = ""
+            with self._condition:
+                deadlines = [
+                    worker.stall_deadline
+                    for worker in self._workers.values()
+                    if worker.running_future is not None and not worker.stalled and worker.stall_deadline is not None
+                ]
+                if not deadlines:
+                    # Keep one watchdog while a schedulable worker can claim
+                    # already-admitted FIFO work without another submit call.
+                    # Once those workers retire, the watchdog may retire too.
+                    if self._active_worker_count_locked() == 0:
+                        if self._watchdog_thread is current:
+                            self._watchdog_thread = None
+                        self._condition.notify_all()
+                        return
+                    self._condition.wait(timeout=self._idle_timeout_s)
+                    continue
+                remaining = min(deadlines) - time.monotonic()
+                if remaining > 0:
+                    self._condition.wait(timeout=remaining)
+                    continue
+                now = time.monotonic()
+                for worker in self._workers.values():
+                    deadline = worker.stall_deadline
+                    if (
+                        worker.running_future is not None
+                        and not worker.stalled
+                        and deadline is not None
+                        and deadline <= now
+                    ):
+                        worker.stalled = True
+                        worker.stall_deadline = None
+                if self._stalled_worker_count_locked() > self._max_stalled_workers:
+                    # At most max_workers callbacks can cross the threshold in
+                    # one watchdog pass. Stop admitting more until enough of
+                    # those callbacks return, bounding live callback workers by
+                    # max_stalled_workers + max_workers.
+                    rejected = self._reject_queued_submissions_locked()
+                    rejection_message = (
+                        "Ray control submission stalled callback capacity "
+                        f"is exhausted: capacity={self._max_stalled_workers}"
+                    )
+                else:
+                    try:
+                        self._start_workers_if_needed_locked()
+                    except BaseException as exc:
+                        if self._active_worker_count_locked() == 0 and self._ready_owners:
+                            rejected = self._reject_queued_submissions_locked()
+                            rejection_message = (
+                                f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
+                            )
+                self._condition.notify_all()
+            self._fail_submissions(rejected, rejection_message)
 
 
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -12,6 +12,12 @@ from collections.abc import Callable
 from concurrent.futures import Future
 from typing import Any, TypeVar
 
+from duckdb.execution.ray_control_deadline import (
+    RAY_CONTROL_DEADLINE_SCHEDULER,
+    RayControlDeadlineScheduler,
+    RayControlScheduledCall,
+)
+
 _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S = 30.0
 _RAY_CONTROL_SUBMISSION_STALL_TIMEOUT_S = 1.0
 _RAY_CONTROL_SUBMISSION_MAX_WORKERS = 32
@@ -43,11 +49,13 @@ class _RayControlSubmissionWorker:
     ) -> None:
         self.executor = executor
         self.sequence = int(sequence)
-        # These fields are protected by the executor condition. A stalled
-        # worker remains tracked until its callback actually returns, but no
-        # longer consumes one of the schedulable worker slots.
+        # Identity/deadline fields are protected by the executor condition. The
+        # two timestamps are deliberately published before taking that lock so
+        # deadline handling cannot mistake lock contention for a stalled call.
         self.running_future: Future[Any] | None = None
-        self.stall_deadline: float | None = None
+        self.deadline_call: RayControlScheduledCall | None = None
+        self.callback_finished_at: float | None = None
+        self.completion_finished_at: float | None = None
         self.stalled = False
         self.thread = threading.Thread(
             target=self._run,
@@ -74,6 +82,7 @@ class _RayControlSubmissionExecutor:
         max_stalled_workers: int | None = None,
         max_pending_submissions: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING,
         max_pending_per_owner: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER,
+        deadline_scheduler: RayControlDeadlineScheduler | None = None,
     ) -> None:
         if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
             raise ValueError("Ray control submission idle timeout must be finite and positive")
@@ -97,9 +106,8 @@ class _RayControlSubmissionExecutor:
         self._ready_owners: deque[str] = deque()
         self._workers: dict[int, _RayControlSubmissionWorker] = {}
         self._next_sequence = 0
-        self._watchdog_thread: threading.Thread | None = None
-        self._next_watchdog_sequence = 0
         self._pending_submissions = 0
+        self._deadline_scheduler = RAY_CONTROL_DEADLINE_SCHEDULER if deadline_scheduler is None else deadline_scheduler
         self._idle_timeout_s = float(idle_timeout_s)
         self._stall_timeout_s = float(stall_timeout_s)
         self._max_workers = int(max_workers)
@@ -114,6 +122,9 @@ class _RayControlSubmissionExecutor:
             raise ValueError("Ray control submission requires an explicit owner scope")
         if not callable(callback):
             raise TypeError("Ray control submission callback must be callable")
+        # A submission cannot be allowed to run until the clock that owns its
+        # invocation and completion deadlines is available.
+        self._deadline_scheduler.ensure_started()
         future: Future[_T] = Future()
         executor_ref = weakref.ref(self)
 
@@ -205,22 +216,6 @@ class _RayControlSubmissionExecutor:
     def _active_running_callback_count_locked(self) -> int:
         return sum(worker.running_future is not None and not worker.stalled for worker in self._workers.values())
 
-    def _ensure_watchdog_started_locked(self) -> None:
-        if self._watchdog_thread is not None:
-            return
-        sequence = self._next_watchdog_sequence
-        self._next_watchdog_sequence += 1
-        thread = threading.Thread(
-            target=self._run_watchdog,
-            daemon=True,
-            name=f"vane-ray-control-submit-watchdog-{sequence}",
-        )
-        # Publish only a successfully started watchdog. Starting it while the
-        # condition is held ensures it observes the published reference before
-        # it can inspect executor state.
-        thread.start()
-        self._watchdog_thread = thread
-
     def _start_workers_if_needed_locked(self) -> None:
         if self._stalled_worker_count_locked() > self._max_stalled_workers:
             return
@@ -230,7 +225,6 @@ class _RayControlSubmissionExecutor:
         )
         if desired_workers <= 0:
             return
-        self._ensure_watchdog_started_locked()
         while self._active_worker_count_locked() < desired_workers:
             sequence = self._next_sequence
             self._next_sequence += 1
@@ -260,9 +254,24 @@ class _RayControlSubmissionExecutor:
             while owner.queue:
                 future, callback = owner.queue.popleft()
                 if future.set_running_or_notify_cancel():
+                    callback_deadline = time.monotonic() + self._stall_timeout_s
+                    deadline_call: RayControlScheduledCall
+
+                    def deadline_elapsed() -> None:
+                        self._worker_deadline_elapsed(
+                            worker,
+                            deadline_call,
+                            phase="callback",
+                            deadline=callback_deadline,
+                        )
+
+                    deadline_call = self._deadline_scheduler.create(deadline_elapsed)
+                    self._deadline_scheduler.schedule_at(deadline_call, callback_deadline)
                     owner.running = True
                     worker.running_future = future
-                    worker.stall_deadline = time.monotonic() + self._stall_timeout_s
+                    worker.deadline_call = deadline_call
+                    worker.callback_finished_at = None
+                    worker.completion_finished_at = None
                     self._condition.notify_all()
                     return owner, future, callback
                 self._pending_submissions -= 1
@@ -297,13 +306,10 @@ class _RayControlSubmissionExecutor:
                 result = callback()
             except BaseException as exc:
                 error = exc
-            finally:
-                # Only callback invocation time determines whether this worker
-                # is stalled. Future callbacks may perform arbitrary owner-side
-                # bookkeeping and must not consume the submission deadline.
-                with self._condition:
-                    worker.stall_deadline = None
-                    self._condition.notify_all()
+            # Publish progress before any executor lock acquisition. The
+            # deadline clock can then distinguish a returned callback from a
+            # callback stalled behind unrelated condition-lock contention.
+            worker.callback_finished_at = time.monotonic()
             try:
                 if error is not None:
                     if not future.done():
@@ -319,11 +325,20 @@ class _RayControlSubmissionExecutor:
                         # malformed callback must not terminate this pool worker.
                         pass
             finally:
+                # ``Future.set_result`` and ``set_exception`` invoke registered
+                # callbacks inline. They are part of the bounded work phase as
+                # well: a blocked completion callback must release a schedulable
+                # slot for unrelated owners.
+                worker.completion_finished_at = time.monotonic()
                 result = None
                 error = None
                 del callback
                 del future
                 with self._condition:
+                    deadline_call = worker.deadline_call
+                    worker.deadline_call = None
+                    if deadline_call is not None:
+                        deadline_call.cancel()
                     worker.running_future = None
                     owner.running = False
                     self._pending_submissions -= 1
@@ -374,64 +389,89 @@ class _RayControlSubmissionExecutor:
             except BaseException:
                 pass
 
-    def _run_watchdog(self) -> None:
-        current = threading.current_thread()
-        while True:
-            rejected: list[Future[Any]] = []
-            rejection_message = ""
-            with self._condition:
-                deadlines = [
-                    worker.stall_deadline
-                    for worker in self._workers.values()
-                    if worker.running_future is not None and not worker.stalled and worker.stall_deadline is not None
-                ]
-                if not deadlines:
-                    # Keep one watchdog while a schedulable worker can claim
-                    # already-admitted FIFO work without another submit call.
-                    # Once those workers retire, the watchdog may retire too.
-                    if self._active_worker_count_locked() == 0:
-                        if self._watchdog_thread is current:
-                            self._watchdog_thread = None
+    def _worker_deadline_elapsed(
+        self,
+        worker: _RayControlSubmissionWorker,
+        call: RayControlScheduledCall,
+        *,
+        phase: str,
+        deadline: float,
+    ) -> None:
+        """Replace a genuinely stalled worker without inferring from lock delay."""
+        rejected: list[Future[Any]] = []
+        rejection_message = ""
+        with self._condition:
+            if (
+                self._workers.get(worker.sequence) is not worker
+                or worker.running_future is None
+                or worker.stalled
+                or worker.deadline_call is not call
+            ):
+                return
+
+            finished_at = worker.callback_finished_at if phase == "callback" else worker.completion_finished_at
+            phase_finished_in_time = finished_at is not None and finished_at <= deadline
+            if phase == "callback" and phase_finished_in_time:
+                assert finished_at is not None
+                completion_deadline = finished_at + self._stall_timeout_s
+                completion_finished_at = worker.completion_finished_at
+                if completion_finished_at is not None and completion_finished_at <= completion_deadline:
+                    worker.deadline_call = None
+                    self._condition.notify_all()
+                    return
+                if completion_finished_at is None:
+                    completion_call: RayControlScheduledCall
+
+                    def completion_deadline_elapsed() -> None:
+                        self._worker_deadline_elapsed(
+                            worker,
+                            completion_call,
+                            phase="completion",
+                            deadline=completion_deadline,
+                        )
+
+                    completion_call = self._deadline_scheduler.create(completion_deadline_elapsed)
+                    worker.deadline_call = completion_call
+                    try:
+                        self._deadline_scheduler.schedule_at(
+                            completion_call,
+                            completion_deadline,
+                        )
+                    except BaseException:
+                        # Losing deadline supervision is equivalent to losing a
+                        # schedulable worker: retire it after completion and let
+                        # a replacement own unrelated queued work.
+                        worker.deadline_call = None
+                    else:
                         self._condition.notify_all()
                         return
-                    self._condition.wait(timeout=self._idle_timeout_s)
-                    continue
-                remaining = min(deadlines) - time.monotonic()
-                if remaining > 0:
-                    self._condition.wait(timeout=remaining)
-                    continue
-                now = time.monotonic()
-                for worker in self._workers.values():
-                    deadline = worker.stall_deadline
-                    if (
-                        worker.running_future is not None
-                        and not worker.stalled
-                        and deadline is not None
-                        and deadline <= now
-                    ):
-                        worker.stalled = True
-                        worker.stall_deadline = None
-                if self._stalled_worker_count_locked() > self._max_stalled_workers:
-                    # At most max_workers callbacks can cross the threshold in
-                    # one watchdog pass. Stop admitting more until enough of
-                    # those callbacks return, bounding live callback workers by
-                    # max_stalled_workers + max_workers.
-                    rejected = self._reject_queued_submissions_locked()
-                    rejection_message = (
-                        "Ray control submission stalled callback capacity "
-                        f"is exhausted: capacity={self._max_stalled_workers}"
-                    )
-                else:
-                    try:
-                        self._start_workers_if_needed_locked()
-                    except BaseException as exc:
-                        if self._active_worker_count_locked() == 0 and self._ready_owners:
-                            rejected = self._reject_queued_submissions_locked()
-                            rejection_message = (
-                                f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
-                            )
+            elif phase == "completion" and phase_finished_in_time:
+                worker.deadline_call = None
                 self._condition.notify_all()
-            self._fail_submissions(rejected, rejection_message)
+                return
+
+            worker.stalled = True
+            worker.deadline_call = None
+            if self._stalled_worker_count_locked() > self._max_stalled_workers:
+                # At most max_workers callbacks can cross the threshold at one
+                # deadline. Stop admitting more until they return, bounding live
+                # callback workers by max_stalled_workers + max_workers.
+                rejected = self._reject_queued_submissions_locked()
+                rejection_message = (
+                    "Ray control submission stalled callback capacity "
+                    f"is exhausted: capacity={self._max_stalled_workers}"
+                )
+            else:
+                try:
+                    self._start_workers_if_needed_locked()
+                except BaseException as exc:
+                    if self._active_worker_count_locked() == 0 and self._ready_owners:
+                        rejected = self._reject_queued_submissions_locked()
+                        rejection_message = (
+                            f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
+                        )
+            self._condition.notify_all()
+        self._fail_submissions(rejected, rejection_message)
 
 
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -23,6 +23,11 @@ _RAY_CONTROL_SUBMISSION_STALL_TIMEOUT_S = 1.0
 _RAY_CONTROL_SUBMISSION_MAX_WORKERS = 32
 _RAY_CONTROL_SUBMISSION_MAX_PENDING = 4096
 _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER = 256
+_RAY_CONTROL_DEADLINE_CALLBACK_MAX_WORKERS = 32
+_RAY_CONTROL_DEADLINE_CALLBACK_MAX_STALLED_WORKERS = 32
+_RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S = 0.01
+_RAY_CONTROL_DEADLINE_CALLBACK_RETRY_MAX_DELAY_S = 1.0
+_RAY_CONTROL_DEADLINE_LOCK_RETRY_DELAY_S = 0.001
 
 _T = TypeVar("_T")
 _Submission = tuple[Future[Any], Callable[[], Any]]
@@ -60,7 +65,7 @@ class _RayControlSubmissionWorker:
         self.thread = threading.Thread(
             target=self._run,
             daemon=True,
-            name=f"vane-ray-control-submit-{sequence}",
+            name=f"{executor._thread_name_prefix}-{sequence}",
         )
 
     def start(self) -> None:
@@ -83,6 +88,7 @@ class _RayControlSubmissionExecutor:
         max_pending_submissions: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING,
         max_pending_per_owner: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER,
         deadline_scheduler: RayControlDeadlineScheduler | None = None,
+        thread_name_prefix: str = "vane-ray-control-submit",
     ) -> None:
         if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
             raise ValueError("Ray control submission idle timeout must be finite and positive")
@@ -101,6 +107,9 @@ class _RayControlSubmissionExecutor:
             raise ValueError("Ray control submission pending capacity must be at least max_workers")
         if max_pending_submissions <= resolved_max_stalled_workers:
             raise ValueError("Ray control submission pending capacity must exceed max_stalled_workers")
+        resolved_thread_name_prefix = str(thread_name_prefix or "").strip()
+        if not resolved_thread_name_prefix:
+            raise ValueError("Ray control submission thread name prefix must not be empty")
         self._condition = threading.Condition()
         self._owners: dict[str, _RayControlSubmissionOwner] = {}
         self._ready_owners: deque[str] = deque()
@@ -114,6 +123,7 @@ class _RayControlSubmissionExecutor:
         self._max_stalled_workers = int(resolved_max_stalled_workers)
         self._max_pending_submissions = int(max_pending_submissions)
         self._max_pending_per_owner = int(max_pending_per_owner)
+        self._thread_name_prefix = resolved_thread_name_prefix
 
     def submit(self, owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
         """Admit one callback atomically or raise before it can run."""
@@ -265,7 +275,7 @@ class _RayControlSubmissionExecutor:
                             deadline=callback_deadline,
                         )
 
-                    deadline_call = self._deadline_scheduler.create(deadline_elapsed)
+                    deadline_call = self._deadline_scheduler.create_inline(deadline_elapsed)
                     self._deadline_scheduler.schedule_at(deadline_call, callback_deadline)
                     owner.running = True
                     worker.running_future = future
@@ -382,12 +392,26 @@ class _RayControlSubmissionExecutor:
     @staticmethod
     def _fail_submissions(futures: list[Future[Any]], message: str) -> None:
         for future in futures:
-            if future.done():
-                continue
-            try:
-                future.set_exception(RuntimeError(message))
-            except BaseException:
-                pass
+
+            def fail_submission(
+                rejected_future: Future[Any] = future,
+                rejection_message: str = message,
+            ) -> None:
+                if rejected_future.done():
+                    return
+                try:
+                    rejected_future.set_exception(RuntimeError(rejection_message))
+                except BaseException:
+                    pass
+
+            def submission_is_pending(rejected_future: Future[Any] = future) -> bool:
+                return not rejected_future.done()
+
+            _dispatch_ray_control_callback(
+                f"submission-failure:{id(future):x}",
+                fail_submission,
+                still_owned=submission_is_pending,
+            )
 
     def _worker_deadline_elapsed(
         self,
@@ -397,84 +421,210 @@ class _RayControlSubmissionExecutor:
         phase: str,
         deadline: float,
     ) -> None:
-        """Replace a genuinely stalled worker without inferring from lock delay."""
-        rejected: list[Future[Any]] = []
-        rejection_message = ""
-        with self._condition:
-            if (
-                self._workers.get(worker.sequence) is not worker
-                or worker.running_future is None
-                or worker.stalled
-                or worker.deadline_call is not call
-            ):
-                return
-
-            finished_at = worker.callback_finished_at if phase == "callback" else worker.completion_finished_at
-            phase_finished_in_time = finished_at is not None and finished_at <= deadline
-            if phase == "callback" and phase_finished_in_time:
-                assert finished_at is not None
-                completion_deadline = finished_at + self._stall_timeout_s
-                completion_finished_at = worker.completion_finished_at
-                if completion_finished_at is not None and completion_finished_at <= completion_deadline:
-                    worker.deadline_call = None
-                    self._condition.notify_all()
-                    return
-                if completion_finished_at is None:
-                    completion_call: RayControlScheduledCall
-
-                    def completion_deadline_elapsed() -> None:
-                        self._worker_deadline_elapsed(
-                            worker,
-                            completion_call,
-                            phase="completion",
-                            deadline=completion_deadline,
-                        )
-
-                    completion_call = self._deadline_scheduler.create(completion_deadline_elapsed)
-                    worker.deadline_call = completion_call
-                    try:
-                        self._deadline_scheduler.schedule_at(
-                            completion_call,
-                            completion_deadline,
-                        )
-                    except BaseException:
-                        # Losing deadline supervision is equivalent to losing a
-                        # schedulable worker: retire it after completion and let
-                        # a replacement own unrelated queued work.
-                        worker.deadline_call = None
-                    else:
-                        self._condition.notify_all()
-                        return
-            elif phase == "completion" and phase_finished_in_time:
-                worker.deadline_call = None
-                self._condition.notify_all()
-                return
-
-            worker.stalled = True
-            worker.deadline_call = None
-            if self._stalled_worker_count_locked() > self._max_stalled_workers:
-                # At most max_workers callbacks can cross the threshold at one
-                # deadline. Stop admitting more until they return, bounding live
-                # callback workers by max_stalled_workers + max_workers.
-                rejected = self._reject_queued_submissions_locked()
-                rejection_message = (
-                    "Ray control submission stalled callback capacity "
-                    f"is exhausted: capacity={self._max_stalled_workers}"
+        """Replace a genuinely stalled worker without occupying the clock."""
+        if not self._condition.acquire(blocking=False):
+            # Executor bookkeeping can briefly contend with a worker that has
+            # already published its lock-free phase timestamps. Retry the
+            # inspection instead of delaying every unrelated process deadline.
+            retry_call = self._deadline_scheduler.create_inline(
+                lambda: self._worker_deadline_elapsed(
+                    worker,
+                    call,
+                    phase=phase,
+                    deadline=deadline,
                 )
-            else:
-                try:
-                    self._start_workers_if_needed_locked()
-                except BaseException as exc:
-                    if self._active_worker_count_locked() == 0 and self._ready_owners:
-                        rejected = self._reject_queued_submissions_locked()
-                        rejection_message = (
-                            f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
-                        )
-            self._condition.notify_all()
+            )
+            self._deadline_scheduler.schedule(
+                retry_call,
+                _RAY_CONTROL_DEADLINE_LOCK_RETRY_DELAY_S,
+            )
+            return
+        try:
+            rejected, rejection_message = self._worker_deadline_elapsed_locked(
+                worker,
+                call,
+                phase=phase,
+                deadline=deadline,
+            )
+        finally:
+            self._condition.release()
         self._fail_submissions(rejected, rejection_message)
 
+    def _worker_deadline_elapsed_locked(
+        self,
+        worker: _RayControlSubmissionWorker,
+        call: RayControlScheduledCall,
+        *,
+        phase: str,
+        deadline: float,
+    ) -> tuple[list[Future[Any]], str]:
+        """Apply one deadline transition while ``_condition`` is held."""
+        rejected: list[Future[Any]] = []
+        rejection_message = ""
+        if (
+            self._workers.get(worker.sequence) is not worker
+            or worker.running_future is None
+            or worker.stalled
+            or worker.deadline_call is not call
+        ):
+            return rejected, rejection_message
 
+        finished_at = worker.callback_finished_at if phase == "callback" else worker.completion_finished_at
+        phase_finished_in_time = finished_at is not None and finished_at <= deadline
+        if phase == "callback" and phase_finished_in_time:
+            assert finished_at is not None
+            completion_deadline = finished_at + self._stall_timeout_s
+            completion_finished_at = worker.completion_finished_at
+            if completion_finished_at is not None and completion_finished_at <= completion_deadline:
+                worker.deadline_call = None
+                self._condition.notify_all()
+                return rejected, rejection_message
+            if completion_finished_at is None:
+                completion_call: RayControlScheduledCall
+
+                def completion_deadline_elapsed() -> None:
+                    self._worker_deadline_elapsed(
+                        worker,
+                        completion_call,
+                        phase="completion",
+                        deadline=completion_deadline,
+                    )
+
+                completion_call = self._deadline_scheduler.create_inline(completion_deadline_elapsed)
+                worker.deadline_call = completion_call
+                try:
+                    self._deadline_scheduler.schedule_at(
+                        completion_call,
+                        completion_deadline,
+                    )
+                except BaseException:
+                    # Losing deadline supervision is equivalent to losing a
+                    # schedulable worker: retire it after completion and let a
+                    # replacement own unrelated queued work.
+                    worker.deadline_call = None
+                else:
+                    self._condition.notify_all()
+                    return rejected, rejection_message
+        elif phase == "completion" and phase_finished_in_time:
+            worker.deadline_call = None
+            self._condition.notify_all()
+            return rejected, rejection_message
+
+        worker.stalled = True
+        worker.deadline_call = None
+        if self._stalled_worker_count_locked() > self._max_stalled_workers:
+            # At most max_workers callbacks can cross the threshold at one
+            # deadline. Stop admitting more until they return, bounding live
+            # callback workers by max_stalled_workers + max_workers.
+            rejected = self._reject_queued_submissions_locked()
+            rejection_message = (
+                f"Ray control submission stalled callback capacity is exhausted: capacity={self._max_stalled_workers}"
+            )
+        else:
+            try:
+                self._start_workers_if_needed_locked()
+            except BaseException as exc:
+                if self._active_worker_count_locked() == 0 and self._ready_owners:
+                    rejected = self._reject_queued_submissions_locked()
+                    rejection_message = (
+                        f"Ray control submission replacement worker is unavailable: {type(exc).__name__}: {exc}"
+                    )
+        self._condition.notify_all()
+        return rejected, rejection_message
+
+
+_RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR = _RayControlSubmissionExecutor(
+    max_workers=_RAY_CONTROL_DEADLINE_CALLBACK_MAX_WORKERS,
+    max_stalled_workers=_RAY_CONTROL_DEADLINE_CALLBACK_MAX_STALLED_WORKERS,
+    max_pending_per_owner=1,
+    thread_name_prefix="vane-ray-control-deadline-callback",
+)
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()
+
+
+def _dispatch_ray_control_callback(
+    owner_scope: str,
+    callback: Callable[[], None],
+    *,
+    still_owned: Callable[[], bool] = lambda: True,
+    retry_delay_s: float = _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S,
+) -> None:
+    """Hand potentially blocking work to the bounded, recoverable pool."""
+    if not still_owned():
+        return
+
+    def invoke() -> None:
+        if not still_owned():
+            return
+        try:
+            callback()
+        except BaseException:
+            # Scheduled owners implement their own terminal/retry policy. Keep
+            # a malformed owner callback from consuming a reusable worker.
+            pass
+
+    next_retry_delay = min(
+        max(float(retry_delay_s), _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S) * 2,
+        _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_MAX_DELAY_S,
+    )
+
+    def retry_dispatch() -> None:
+        if not still_owned():
+            return
+        retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create_inline(
+            lambda: _dispatch_ray_control_callback(
+                owner_scope,
+                callback,
+                still_owned=still_owned,
+                retry_delay_s=next_retry_delay,
+            )
+        )
+        RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
+            retry_call,
+            retry_delay_s,
+        )
+
+    try:
+        dispatch_future = _RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR.submit(
+            owner_scope,
+            invoke,
+        )
+    except BaseException:
+        retry_dispatch()
+        return
+
+    def resubmit_rejected_dispatch(done: Future[Any]) -> None:
+        try:
+            done.result()
+        except BaseException:
+            retry_dispatch()
+
+    # This is an executor-owned ``concurrent.futures.Future``; the callback is
+    # internal and cannot be replaced by an owner implementation.
+    dispatch_future.add_done_callback(resubmit_rejected_dispatch)
+
+
+def create_ray_control_deadline(
+    owner_scope: str,
+    callback: Callable[[], None],
+) -> RayControlScheduledCall:
+    """Create a cancellable deadline whose owner work never runs on the clock."""
+    owner_key = str(owner_scope or "").strip()
+    if not owner_key:
+        raise ValueError("Ray control deadline requires an explicit owner scope")
+    if not callable(callback):
+        raise TypeError("Ray control deadline callback must be callable")
+    scheduled_call: RayControlScheduledCall
+
+    def deadline_elapsed() -> None:
+        _dispatch_ray_control_callback(
+            f"{owner_key}:deadline:{id(scheduled_call):x}",
+            callback,
+            still_owned=lambda: not scheduled_call.cancelled(),
+        )
+
+    scheduled_call = RAY_CONTROL_DEADLINE_SCHEDULER.create_inline(deadline_elapsed)
+    return scheduled_call
 
 
 def submit_ray_control(owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
@@ -482,4 +632,4 @@ def submit_ray_control(owner_scope: str, callback: Callable[[], _T]) -> Future[_
     return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(owner_scope, callback)
 
 
-__all__ = ["submit_ray_control"]
+__all__ = ["create_ray_control_deadline", "submit_ray_control"]

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -23,10 +23,12 @@ _RAY_CONTROL_SUBMISSION_STALL_TIMEOUT_S = 1.0
 _RAY_CONTROL_SUBMISSION_MAX_WORKERS = 32
 _RAY_CONTROL_SUBMISSION_MAX_PENDING = 4096
 _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER = 256
-_RAY_CONTROL_DEADLINE_CALLBACK_MAX_WORKERS = 32
-_RAY_CONTROL_DEADLINE_CALLBACK_MAX_STALLED_WORKERS = 32
-_RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S = 0.01
-_RAY_CONTROL_DEADLINE_CALLBACK_RETRY_MAX_DELAY_S = 1.0
+_RAY_CONTROL_STATE_CALLBACK_MAX_WORKERS = 32
+_RAY_CONTROL_STATE_CALLBACK_MAX_STALLED_WORKERS = 32
+_RAY_CONTROL_COMPLETION_CALLBACK_MAX_WORKERS = 32
+_RAY_CONTROL_COMPLETION_CALLBACK_MAX_STALLED_WORKERS = 32
+_RAY_CONTROL_CALLBACK_RETRY_INITIAL_DELAY_S = 0.01
+_RAY_CONTROL_CALLBACK_RETRY_MAX_DELAY_S = 1.0
 _RAY_CONTROL_DEADLINE_LOCK_RETRY_DELAY_S = 0.001
 
 _T = TypeVar("_T")
@@ -389,8 +391,12 @@ class _RayControlSubmissionExecutor:
                 self._owners.pop(owner_key, None)
         return rejected
 
-    @staticmethod
-    def _fail_submissions(futures: list[Future[Any]], message: str) -> None:
+    def _fail_submissions(self, futures: list[Future[Any]], message: str) -> None:
+        failure_executor = (
+            _RAY_CONTROL_STATE_CALLBACK_EXECUTOR
+            if self is _RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR
+            else _RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR
+        )
         for future in futures:
 
             def fail_submission(
@@ -408,6 +414,7 @@ class _RayControlSubmissionExecutor:
                 return not rejected_future.done()
 
             _dispatch_ray_control_callback(
+                failure_executor,
                 f"submission-failure:{id(future):x}",
                 fail_submission,
                 still_owned=submission_is_pending,
@@ -533,23 +540,30 @@ class _RayControlSubmissionExecutor:
         return rejected, rejection_message
 
 
-_RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR = _RayControlSubmissionExecutor(
-    max_workers=_RAY_CONTROL_DEADLINE_CALLBACK_MAX_WORKERS,
-    max_stalled_workers=_RAY_CONTROL_DEADLINE_CALLBACK_MAX_STALLED_WORKERS,
+_RAY_CONTROL_STATE_CALLBACK_EXECUTOR = _RayControlSubmissionExecutor(
+    max_workers=_RAY_CONTROL_STATE_CALLBACK_MAX_WORKERS,
+    max_stalled_workers=_RAY_CONTROL_STATE_CALLBACK_MAX_STALLED_WORKERS,
     max_pending_per_owner=1,
-    thread_name_prefix="vane-ray-control-deadline-callback",
+    thread_name_prefix="vane-ray-control-state",
+)
+_RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR = _RayControlSubmissionExecutor(
+    max_workers=_RAY_CONTROL_COMPLETION_CALLBACK_MAX_WORKERS,
+    max_stalled_workers=_RAY_CONTROL_COMPLETION_CALLBACK_MAX_STALLED_WORKERS,
+    max_pending_per_owner=1,
+    thread_name_prefix="vane-ray-control-completion",
 )
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()
 
 
 def _dispatch_ray_control_callback(
+    executor: _RayControlSubmissionExecutor,
     owner_scope: str,
     callback: Callable[[], None],
     *,
     still_owned: Callable[[], bool] = lambda: True,
-    retry_delay_s: float = _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S,
+    retry_delay_s: float = _RAY_CONTROL_CALLBACK_RETRY_INITIAL_DELAY_S,
 ) -> None:
-    """Hand potentially blocking work to the bounded, recoverable pool."""
+    """Hand one callback to its isolated, bounded ownership domain."""
     if not still_owned():
         return
 
@@ -564,8 +578,8 @@ def _dispatch_ray_control_callback(
             pass
 
     next_retry_delay = min(
-        max(float(retry_delay_s), _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_INITIAL_DELAY_S) * 2,
-        _RAY_CONTROL_DEADLINE_CALLBACK_RETRY_MAX_DELAY_S,
+        max(float(retry_delay_s), _RAY_CONTROL_CALLBACK_RETRY_INITIAL_DELAY_S) * 2,
+        _RAY_CONTROL_CALLBACK_RETRY_MAX_DELAY_S,
     )
 
     def retry_dispatch() -> None:
@@ -573,6 +587,7 @@ def _dispatch_ray_control_callback(
             return
         retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create_inline(
             lambda: _dispatch_ray_control_callback(
+                executor,
                 owner_scope,
                 callback,
                 still_owned=still_owned,
@@ -585,7 +600,7 @@ def _dispatch_ray_control_callback(
         )
 
     try:
-        dispatch_future = _RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR.submit(
+        dispatch_future = executor.submit(
             owner_scope,
             invoke,
         )
@@ -608,7 +623,7 @@ def create_ray_control_deadline(
     owner_scope: str,
     callback: Callable[[], None],
 ) -> RayControlScheduledCall:
-    """Create a cancellable deadline whose owner work never runs on the clock."""
+    """Create a deadline for a controlled, non-blocking state transition."""
     owner_key = str(owner_scope or "").strip()
     if not owner_key:
         raise ValueError("Ray control deadline requires an explicit owner scope")
@@ -618,6 +633,7 @@ def create_ray_control_deadline(
 
     def deadline_elapsed() -> None:
         _dispatch_ray_control_callback(
+            _RAY_CONTROL_STATE_CALLBACK_EXECUTOR,
             f"{owner_key}:deadline:{id(scheduled_call):x}",
             callback,
             still_owned=lambda: not scheduled_call.cancelled(),
@@ -627,9 +643,30 @@ def create_ray_control_deadline(
     return scheduled_call
 
 
+def dispatch_ray_control_abandonment(
+    owner_scope: str,
+    callback: Callable[[], None],
+) -> None:
+    """Run potentially blocking best-effort abandonment off state workers."""
+    owner_key = str(owner_scope or "").strip()
+    if not owner_key:
+        raise ValueError("Ray control abandonment requires an explicit owner scope")
+    if not callable(callback):
+        raise TypeError("Ray control abandonment callback must be callable")
+    _dispatch_ray_control_callback(
+        _RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR,
+        f"{owner_key}:abandonment",
+        callback,
+    )
+
+
 def submit_ray_control(owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
     """Submit one Ray control call with bounded, owner-ordered execution."""
     return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(owner_scope, callback)
 
 
-__all__ = ["create_ray_control_deadline", "submit_ray_control"]
+__all__ = [
+    "create_ray_control_deadline",
+    "dispatch_ray_control_abandonment",
+    "submit_ray_control",
+]

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -4,33 +4,44 @@
 from __future__ import annotations
 
 import math
-import queue
 import threading
+import time
+import weakref
+from collections import deque
 from collections.abc import Callable
 from concurrent.futures import Future
 from typing import Any, TypeVar
 
 _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S = 30.0
+_RAY_CONTROL_SUBMISSION_MAX_WORKERS = 32
+_RAY_CONTROL_SUBMISSION_MAX_PENDING = 4096
+_RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER = 256
 
 _T = TypeVar("_T")
+_Submission = tuple[Future[Any], Callable[[], Any]]
+
+
+class _RayControlSubmissionOwner:
+    """FIFO submission state for one ownership scope."""
+
+    def __init__(self, owner_scope: str) -> None:
+        self.owner_scope = str(owner_scope)
+        self.queue: deque[_Submission] = deque()
+        self.running = False
+        self.ready = False
 
 
 class _RayControlSubmissionWorker:
-    """Serialize potentially blocking submissions for one ownership scope."""
+    """One daemon in the bounded process-wide control submission pool."""
 
     def __init__(
         self,
         executor: _RayControlSubmissionExecutor,
-        owner_scope: str,
         *,
         sequence: int,
-        idle_timeout_s: float,
     ) -> None:
         self.executor = executor
-        self.owner_scope = str(owner_scope)
-        self.accepting = True
-        self.queue: queue.Queue[tuple[Future[Any], Callable[[], Any]]] = queue.Queue()
-        self.idle_timeout_s = float(idle_timeout_s)
+        self.sequence = int(sequence)
         self.thread = threading.Thread(
             target=self._run,
             daemon=True,
@@ -40,26 +51,188 @@ class _RayControlSubmissionWorker:
     def start(self) -> None:
         self.thread.start()
 
-    def submit(self, callback: Callable[[], _T]) -> Future[_T]:
-        if not self.accepting:
-            raise RuntimeError("Ray control submission worker is retired")
+    def _run(self) -> None:
+        self.executor._run_worker(self)
+
+
+class _RayControlSubmissionExecutor:
+    """Bounded workers with FIFO ordering inside each admitted owner scope."""
+
+    def __init__(
+        self,
+        *,
+        idle_timeout_s: float = _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S,
+        max_workers: int = _RAY_CONTROL_SUBMISSION_MAX_WORKERS,
+        max_pending_submissions: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING,
+        max_pending_per_owner: int = _RAY_CONTROL_SUBMISSION_MAX_PENDING_PER_OWNER,
+    ) -> None:
+        if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
+            raise ValueError("Ray control submission idle timeout must be finite and positive")
+        for name, value in (
+            ("max_workers", max_workers),
+            ("max_pending_submissions", max_pending_submissions),
+            ("max_pending_per_owner", max_pending_per_owner),
+        ):
+            if type(value) is not int or value <= 0:
+                raise ValueError(f"Ray control submission {name} must be a positive integer")
+        if max_pending_submissions < max_workers:
+            raise ValueError("Ray control submission pending capacity must be at least max_workers")
+        self._condition = threading.Condition()
+        self._owners: dict[str, _RayControlSubmissionOwner] = {}
+        self._ready_owners: deque[str] = deque()
+        self._workers: dict[int, _RayControlSubmissionWorker] = {}
+        self._next_sequence = 0
+        self._running_callbacks = 0
+        self._pending_submissions = 0
+        self._idle_timeout_s = float(idle_timeout_s)
+        self._max_workers = int(max_workers)
+        self._max_pending_submissions = int(max_pending_submissions)
+        self._max_pending_per_owner = int(max_pending_per_owner)
+
+    def submit(self, owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
+        """Admit one callback atomically or raise before it can run."""
+        owner_key = str(owner_scope or "").strip()
+        if not owner_key:
+            raise ValueError("Ray control submission requires an explicit owner scope")
+        if not callable(callback):
+            raise TypeError("Ray control submission callback must be callable")
         future: Future[_T] = Future()
-        self.queue.put((future, callback))
+        executor_ref = weakref.ref(self)
+
+        def discard_cancelled_submission(done: Future[_T]) -> None:
+            if not done.cancelled():
+                return
+            executor = executor_ref()
+            if executor is not None:
+                executor._discard_cancelled_submission(owner_key, done)
+
+        future.add_done_callback(discard_cancelled_submission)
+        with self._condition:
+            owner = self._owners.get(owner_key)
+            owner_pending = 0 if owner is None else len(owner.queue) + int(owner.running)
+            if owner_pending >= self._max_pending_per_owner:
+                raise RuntimeError(
+                    f"Ray control submission owner queue is full: owner={owner_key} "
+                    f"capacity={self._max_pending_per_owner}"
+                )
+            if self._pending_submissions >= self._max_pending_submissions:
+                raise RuntimeError(f"Ray control submission queue is full: capacity={self._max_pending_submissions}")
+            if owner is None:
+                owner = _RayControlSubmissionOwner(owner_key)
+                self._owners[owner_key] = owner
+            owner.queue.append((future, callback))
+            self._pending_submissions += 1
+            if not owner.running and not owner.ready:
+                owner.ready = True
+                self._ready_owners.append(owner_key)
+            try:
+                self._start_worker_if_needed_locked()
+            except BaseException:
+                queued_future, _queued_callback = owner.queue.pop()
+                assert queued_future is future
+                self._pending_submissions -= 1
+                if not owner.queue and not owner.running:
+                    if owner.ready:
+                        self._ready_owners = deque(
+                            queued_owner for queued_owner in self._ready_owners if queued_owner != owner_key
+                        )
+                        owner.ready = False
+                    if self._owners.get(owner_key) is owner:
+                        self._owners.pop(owner_key, None)
+                raise
+            self._condition.notify_all()
         return future
 
-    def _run(self) -> None:
-        while True:
-            try:
-                future, callback = self.queue.get(timeout=self.idle_timeout_s)
-            except queue.Empty:
-                if self.executor._retire_if_idle(self):
-                    return
+    def _discard_cancelled_submission(
+        self,
+        owner_key: str,
+        future: Future[Any],
+    ) -> None:
+        """Reclaim a queued cancellation even if every worker is blocked."""
+        discarded_callback: Callable[[], Any] | None = None
+        with self._condition:
+            owner = self._owners.get(owner_key)
+            if owner is None:
+                return
+            for index, (queued_future, callback) in enumerate(owner.queue):
+                if queued_future is not future:
+                    continue
+                del owner.queue[index]
+                discarded_callback = callback
+                self._pending_submissions -= 1
+                break
+            if discarded_callback is None:
+                return
+            if not owner.queue and not owner.running:
+                if owner.ready:
+                    self._ready_owners = deque(
+                        queued_owner for queued_owner in self._ready_owners if queued_owner != owner_key
+                    )
+                    owner.ready = False
+                if self._owners.get(owner_key) is owner:
+                    self._owners.pop(owner_key, None)
+            self._condition.notify_all()
+
+    def _start_worker_if_needed_locked(self) -> None:
+        desired_workers = min(
+            self._max_workers,
+            self._running_callbacks + len(self._ready_owners),
+        )
+        if len(self._workers) >= desired_workers:
+            return
+        sequence = self._next_sequence
+        self._next_sequence += 1
+        worker = _RayControlSubmissionWorker(
+            self,
+            sequence=sequence,
+        )
+        self._workers[sequence] = worker
+        try:
+            worker.start()
+        except BaseException:
+            self._workers.pop(sequence, None)
+            raise
+
+    def _claim_submission_locked(
+        self,
+    ) -> tuple[_RayControlSubmissionOwner, Future[Any], Callable[[], Any]] | None:
+        while self._ready_owners:
+            owner_key = self._ready_owners.popleft()
+            owner = self._owners.get(owner_key)
+            if owner is None or owner.running or not owner.ready:
                 continue
+            owner.ready = False
+            while owner.queue:
+                future, callback = owner.queue.popleft()
+                if future.set_running_or_notify_cancel():
+                    owner.running = True
+                    self._running_callbacks += 1
+                    return owner, future, callback
+                self._pending_submissions -= 1
+                del callback
+            if self._owners.get(owner_key) is owner:
+                self._owners.pop(owner_key, None)
+        return None
+
+    def _run_worker(self, worker: _RayControlSubmissionWorker) -> None:
+        idle_deadline = time.monotonic() + self._idle_timeout_s
+        while True:
+            with self._condition:
+                claimed = self._claim_submission_locked()
+                while claimed is None:
+                    remaining = idle_deadline - time.monotonic()
+                    if remaining <= 0:
+                        if self._workers.get(worker.sequence) is worker:
+                            self._workers.pop(worker.sequence, None)
+                        self._condition.notify_all()
+                        return
+                    self._condition.wait(timeout=remaining)
+                    claimed = self._claim_submission_locked()
+                owner, future, callback = claimed
+
             result: Any = None
             try:
                 try:
-                    if not future.set_running_or_notify_cancel():
-                        continue
                     result = callback()
                 except BaseException as exc:
                     if not future.done():
@@ -72,74 +245,30 @@ class _RayControlSubmissionWorker:
                         future.set_result(result)
                     except BaseException:
                         # The Future becomes terminal before callbacks run. A
-                        # malformed callback must not terminate this scope's
-                        # submission worker.
+                        # malformed callback must not terminate this pool worker.
                         pass
             finally:
-                # The next queue wait must not retain the previous stream owner
-                # or ObjectRef through this worker's frame.
                 result = None
                 del callback
                 del future
-
-
-class _RayControlSubmissionExecutor:
-    """One independently progressing worker per admitted control owner."""
-
-    def __init__(
-        self,
-        *,
-        idle_timeout_s: float = _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S,
-    ) -> None:
-        if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
-            raise ValueError("Ray control submission idle timeout must be finite and positive")
-        self._lock = threading.Lock()
-        self._workers: dict[str, _RayControlSubmissionWorker] = {}
-        self._next_sequence = 0
-        self._idle_timeout_s = float(idle_timeout_s)
-
-    def submit(self, owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
-        owner_key = str(owner_scope or "").strip()
-        if not owner_key:
-            raise ValueError("Ray control submission requires an explicit owner scope")
-        if not callable(callback):
-            raise TypeError("Ray control submission callback must be callable")
-        with self._lock:
-            worker = self._workers.get(owner_key)
-            if worker is None or not worker.accepting:
-                worker = _RayControlSubmissionWorker(
-                    self,
-                    owner_key,
-                    sequence=self._next_sequence,
-                    idle_timeout_s=self._idle_timeout_s,
-                )
-                self._next_sequence += 1
-                self._workers[owner_key] = worker
-                try:
-                    worker.start()
-                except BaseException:
-                    worker.accepting = False
-                    if self._workers.get(owner_key) is worker:
-                        self._workers.pop(owner_key, None)
-                    raise
-            return worker.submit(callback)
-
-    def _retire_if_idle(self, worker: _RayControlSubmissionWorker) -> bool:
-        with self._lock:
-            owner_key = worker.owner_scope
-            if self._workers.get(owner_key) is not worker or not worker.queue.empty():
-                return False
-            worker.accepting = False
-            self._workers.pop(owner_key, None)
-            worker.owner_scope = ""
-            return True
+                with self._condition:
+                    owner.running = False
+                    self._running_callbacks -= 1
+                    self._pending_submissions -= 1
+                    if owner.queue:
+                        owner.ready = True
+                        self._ready_owners.append(owner.owner_scope)
+                    elif self._owners.get(owner.owner_scope) is owner:
+                        self._owners.pop(owner.owner_scope, None)
+                    self._condition.notify_all()
+                idle_deadline = time.monotonic() + self._idle_timeout_s
 
 
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()
 
 
 def submit_ray_control(owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
-    """Submit one Ray control call on its admitted owner's isolated worker."""
+    """Submit one Ray control call with bounded, owner-ordered execution."""
     return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(owner_scope, callback)
 
 

--- a/duckdb/execution/ray_control_submission.py
+++ b/duckdb/execution/ray_control_submission.py
@@ -3,43 +3,58 @@
 
 from __future__ import annotations
 
+import math
 import queue
 import threading
 from collections.abc import Callable
 from concurrent.futures import Future
 from typing import Any, TypeVar
 
-_RAY_CONTROL_SUBMISSION_WORKERS = 4
+_RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S = 30.0
 
 _T = TypeVar("_T")
 
 
-class _RayControlSubmissionExecutor:
-    """Fixed daemon workers for Ray calls whose submission may block."""
+class _RayControlSubmissionWorker:
+    """Serialize potentially blocking submissions for one ownership scope."""
 
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._queue: queue.SimpleQueue[tuple[Future[Any], Callable[[], Any]]] = queue.SimpleQueue()
-        self._threads: list[threading.Thread] = []
+    def __init__(
+        self,
+        executor: _RayControlSubmissionExecutor,
+        owner_scope: str,
+        *,
+        sequence: int,
+        idle_timeout_s: float,
+    ) -> None:
+        self.executor = executor
+        self.owner_scope = str(owner_scope)
+        self.accepting = True
+        self.queue: queue.Queue[tuple[Future[Any], Callable[[], Any]]] = queue.Queue()
+        self.idle_timeout_s = float(idle_timeout_s)
+        self.thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name=f"vane-ray-control-submit-{sequence}",
+        )
+
+    def start(self) -> None:
+        self.thread.start()
 
     def submit(self, callback: Callable[[], _T]) -> Future[_T]:
-        with self._lock:
-            while len(self._threads) < _RAY_CONTROL_SUBMISSION_WORKERS:
-                index = len(self._threads)
-                thread = threading.Thread(
-                    target=self._run,
-                    daemon=True,
-                    name=f"vane-ray-control-submit-{index}",
-                )
-                thread.start()
-                self._threads.append(thread)
+        if not self.accepting:
+            raise RuntimeError("Ray control submission worker is retired")
         future: Future[_T] = Future()
-        self._queue.put((future, callback))
+        self.queue.put((future, callback))
         return future
 
     def _run(self) -> None:
         while True:
-            future, callback = self._queue.get()
+            try:
+                future, callback = self.queue.get(timeout=self.idle_timeout_s)
+            except queue.Empty:
+                if self.executor._retire_if_idle(self):
+                    return
+                continue
             result: Any = None
             try:
                 try:
@@ -57,22 +72,75 @@ class _RayControlSubmissionExecutor:
                         future.set_result(result)
                     except BaseException:
                         # The Future becomes terminal before callbacks run. A
-                        # malformed callback must not reduce the fixed worker set.
+                        # malformed callback must not terminate this scope's
+                        # submission worker.
                         pass
             finally:
-                # A worker blocks indefinitely in the next queue.get(). Do not
-                # let its frame retain the previous stream owner or ObjectRef.
+                # The next queue wait must not retain the previous stream owner
+                # or ObjectRef through this worker's frame.
                 result = None
                 del callback
                 del future
 
 
+class _RayControlSubmissionExecutor:
+    """One independently progressing worker per admitted control owner."""
+
+    def __init__(
+        self,
+        *,
+        idle_timeout_s: float = _RAY_CONTROL_SUBMISSION_IDLE_TIMEOUT_S,
+    ) -> None:
+        if not math.isfinite(idle_timeout_s) or idle_timeout_s <= 0:
+            raise ValueError("Ray control submission idle timeout must be finite and positive")
+        self._lock = threading.Lock()
+        self._workers: dict[str, _RayControlSubmissionWorker] = {}
+        self._next_sequence = 0
+        self._idle_timeout_s = float(idle_timeout_s)
+
+    def submit(self, owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
+        owner_key = str(owner_scope or "").strip()
+        if not owner_key:
+            raise ValueError("Ray control submission requires an explicit owner scope")
+        if not callable(callback):
+            raise TypeError("Ray control submission callback must be callable")
+        with self._lock:
+            worker = self._workers.get(owner_key)
+            if worker is None or not worker.accepting:
+                worker = _RayControlSubmissionWorker(
+                    self,
+                    owner_key,
+                    sequence=self._next_sequence,
+                    idle_timeout_s=self._idle_timeout_s,
+                )
+                self._next_sequence += 1
+                self._workers[owner_key] = worker
+                try:
+                    worker.start()
+                except BaseException:
+                    worker.accepting = False
+                    if self._workers.get(owner_key) is worker:
+                        self._workers.pop(owner_key, None)
+                    raise
+            return worker.submit(callback)
+
+    def _retire_if_idle(self, worker: _RayControlSubmissionWorker) -> bool:
+        with self._lock:
+            owner_key = worker.owner_scope
+            if self._workers.get(owner_key) is not worker or not worker.queue.empty():
+                return False
+            worker.accepting = False
+            self._workers.pop(owner_key, None)
+            worker.owner_scope = ""
+            return True
+
+
 _RAY_CONTROL_SUBMISSION_EXECUTOR = _RayControlSubmissionExecutor()
 
 
-def submit_ray_control(callback: Callable[[], _T]) -> Future[_T]:
-    """Submit one Ray control call without occupying its owner thread."""
-    return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(callback)
+def submit_ray_control(owner_scope: str, callback: Callable[[], _T]) -> Future[_T]:
+    """Submit one Ray control call on its admitted owner's isolated worker."""
+    return _RAY_CONTROL_SUBMISSION_EXECUTOR.submit(owner_scope, callback)
 
 
 __all__ = ["submit_ray_control"]

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -19,13 +19,17 @@ _REQUIRED_CORE_WORKER_METHODS = (
 
 @dataclass(frozen=True)
 class RayStreamCleanupOperation:
-    """One terminal transition scheduled by the collector and run off its loop."""
+    """One terminal transition scheduled by the collector and run off its loop.
+
+    ``release_wait`` only detaches operation-local attempt state. It must not
+    call methods on the observed Future; those can invoke arbitrary callbacks.
+    """
 
     operation: Callable[[], Any]
     submission_scope: str
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
-    abandon_wait: Callable[[Any], None] | None = None
+    release_wait: Callable[[Any], None] | None = None
 
     def __post_init__(self) -> None:
         scope = str(self.submission_scope or "").strip()
@@ -192,14 +196,10 @@ class TaskLeaseObjectRefGenerator:
             self._released = True
         return True
 
-    def _abandon_release_task_wait(self, response_future: Any) -> None:
+    def _release_task_wait(self, response_future: Any) -> None:
         with self._lock:
             if self._release_response_future is response_future:
                 self._release_response_future = None
-        try:
-            response_future.cancel()
-        except BaseException:
-            pass
 
     def release_task_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return (
@@ -208,7 +208,7 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                abandon_wait=self._abandon_release_task_wait,
+                release_wait=self._release_task_wait,
             ),
         )
 
@@ -291,14 +291,10 @@ class TaskLeaseObjectRefGenerator:
             self._completion_ref = None
         return True
 
-    def _abandon_task_cleanup_wait(self, response_future: Any) -> None:
+    def _release_task_cleanup_wait(self, response_future: Any) -> None:
         with self._lock:
             if self._task_cleanup_response_future is response_future:
                 self._task_cleanup_response_future = None
-        try:
-            response_future.cancel()
-        except BaseException:
-            pass
 
     @property
     def cancellation_started(self) -> bool:
@@ -334,7 +330,7 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                abandon_wait=self._abandon_task_cleanup_wait,
+                release_wait=self._release_task_cleanup_wait,
             ),
         )
 
@@ -346,7 +342,7 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                abandon_wait=self._abandon_task_cleanup_wait,
+                release_wait=self._release_task_cleanup_wait,
             ),
         )
 
@@ -607,7 +603,7 @@ class RayStreamAdapter:
                     submission_scope=operation.submission_scope,
                     retry_on_error=operation.retry_on_error,
                     retry_on_incomplete=operation.retry_on_incomplete,
-                    abandon_wait=operation.abandon_wait,
+                    release_wait=operation.release_wait,
                 )
                 for operation in source_operations
             ]

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -492,13 +492,17 @@ class RayStreamAdapter:
             if generator is None or completion_ref is None:
                 return True
             release_owner = self._release_owner
-            if self._terminal_kind == "cancel":
-                if release_owner is not None and not release_owner.generator_cancellation_complete:
-                    return False
-                if release_owner is None and not self._generator_cancelled and self._cancel_generator is not None:
-                    return False
+            if release_owner is not None and not release_owner.terminal_cleanup_complete:
+                return False
+            if (
+                self._terminal_kind == "cancel"
+                and release_owner is None
+                and not self._generator_cancelled
+                and self._cancel_generator is not None
+            ):
+                return False
             if self._active_reads or self._active_core_calls:
-                # The event loop retries after the in-flight call exits;
+                # The cleanup scheduler retries after the in-flight call exits;
                 # retirement prevents any new call from starting.
                 return False
             self._stream_cleanup_active = True

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any
 
 _REQUIRED_GENERATOR_METHODS = ("__anext__", "completed")
+_REQUIRED_RAY_METHODS = ("wait",)
 _REQUIRED_CORE_WORKER_METHODS = (
     "async_delete_object_ref_stream",
     "is_object_ref_stream_finished",
@@ -16,6 +17,9 @@ _REQUIRED_CORE_WORKER_METHODS = (
 
 def validate_ray_stream_contract(ray_module: Any) -> None:
     version = str(getattr(ray_module, "__version__", "")).strip() or "unknown"
+    missing_ray = [name for name in _REQUIRED_RAY_METHODS if not callable(getattr(ray_module, name, None))]
+    if missing_ray:
+        raise RuntimeError(f"Ray {version!r} runtime contract is missing: " + ", ".join(missing_ray))
     object_ref_generator = getattr(ray_module, "ObjectRefGenerator", None)
     if object_ref_generator is None:
         raise RuntimeError(f"Ray {version!r} ObjectRefGenerator implementation is unavailable")
@@ -197,6 +201,13 @@ class RayStreamAdapter:
     @property
     def driver(self) -> Any | None:
         return None if self._leased is None else self._leased.driver
+
+    @property
+    def waitable(self) -> Any:
+        """Return the generator used for non-consuming readiness probes."""
+        if self._generator is None:
+            raise RuntimeError("Ray stream has no active ObjectRefGenerator")
+        return self._generator
 
     async def read_next_ref_async(self) -> Any:
         if self._generator is None:

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -147,10 +147,6 @@ class TaskLeaseObjectRefGenerator:
         try:
             admission.handoff()
             self._validate_and_bind_completion()
-            self._driver.mark_query_task_lease_submitted.remote(
-                self._request_id,
-                str(lease["lease_id"]),
-            )
         except BaseException as submission_error:
             cleanup_errors: list[BaseException] = []
             try:

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -4,80 +4,48 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
 from typing import Any
 
-from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
-
-RAY_STREAM_CLEANUP_CONTROL = "control"
-RAY_STREAM_CLEANUP_OUTPUT = "output"
-RAY_STREAM_CLEANUP_CANCELLATION = "cancellation"
-RAY_STREAM_CLEANUP_CORE = "core"
-_RAY_STREAM_CLEANUP_LANES = frozenset(
-    {
-        RAY_STREAM_CLEANUP_CONTROL,
-        RAY_STREAM_CLEANUP_OUTPUT,
-        RAY_STREAM_CLEANUP_CANCELLATION,
-        RAY_STREAM_CLEANUP_CORE,
-    }
-)
 _REQUIRED_GENERATOR_METHODS = ("__anext__", "completed")
 _REQUIRED_RAY_METHODS = ("wait",)
 _REQUIRED_CORE_WORKER_METHODS = (
     "async_delete_object_ref_stream",
     "is_object_ref_stream_finished",
 )
-_TASK_LEASE_CONTROL_ACK_TIMEOUT_S = 5.0
 
 
 @dataclass(frozen=True)
 class RayStreamCleanupOperation:
-    """One terminal operation assigned to a bounded failure-isolation lane."""
+    """One non-blocking terminal transition driven by the collector loop."""
 
-    lane: str
     operation: Callable[[], Any]
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
-
-    def __post_init__(self) -> None:
-        if self.lane not in _RAY_STREAM_CLEANUP_LANES:
-            raise ValueError(f"invalid Ray stream cleanup lane: {self.lane}")
 
     def __call__(self) -> Any:
         return self.operation()
 
 
-def resolve_ray_control_ack(response_ref: Any, *, field: str) -> dict[str, Any]:
-    """Require driver acceptance before dropping a local resource owner."""
-    if isinstance(response_ref, dict):
-        response = response_ref
-    else:
-        response = resolve_object_refs_blocking(
-            response_ref,
-            timeout=_TASK_LEASE_CONTROL_ACK_TIMEOUT_S,
-            honor_query_deadline=False,
-            honor_object_get_timeout=False,
-        )
+def validate_ray_control_ack(response: Any, *, field: str) -> dict[str, Any]:
+    """Require driver acceptance before completing a cleanup ticket."""
     if not isinstance(response, dict) or response.get(field) is not True:
         raise RuntimeError(f"Ray task lease control handoff was not accepted: {field}")
     return response
 
 
-def _run_cleanup_operations(label: str, operations: Sequence[Callable[[], Any]]) -> None:
-    errors: list[BaseException] = []
-    for operation in operations:
-        try:
-            result = operation()
-        except BaseException as exc:
-            errors.append(exc)
-            continue
-        if result is False and isinstance(operation, RayStreamCleanupOperation) and operation.retry_on_incomplete:
-            errors.append(RuntimeError("Ray stream cleanup ownership transfer remained incomplete"))
-    if errors:
-        details = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
-        raise RuntimeError(f"{label}: {details}") from errors[0]
+def ray_object_ref_future(response_ref: Any) -> Any:
+    """Return the public concurrent Future used by the cleanup event loop."""
+    future_method = getattr(response_ref, "future", None)
+    if not callable(future_method):
+        raise TypeError("Ray control ObjectRef does not expose future()")
+    future = future_method()
+    missing = [name for name in ("add_done_callback", "done", "result") if not callable(getattr(future, name, None))]
+    if missing:
+        raise TypeError("Ray control ObjectRef future is missing: " + ", ".join(missing))
+    return future
 
 
 def validate_ray_stream_contract(ray_module: Any) -> None:
@@ -128,15 +96,12 @@ class TaskLeaseObjectRefGenerator:
         self._lease: dict[str, Any] | None = lease
         self._lease_identity = dict(lease)
         self._released = False
-        self._release_submission_active = False
-        self._release_response_ref: Any | None = None
+        self._release_response_future: Any | None = None
         self._cancelled = False
         self._task_cleanup_handed_off = False
-        self._task_cleanup_handoff_active = False
-        self._task_cleanup_response_ref: Any | None = None
+        self._task_cleanup_response_future: Any | None = None
         self._cancel_generator: Any | None = None
         self._generator_cancel_submitted = False
-        self._generator_cancel_submission_active = False
         self._lock = threading.Lock()
         try:
             self._generator = submitter(dict(lease))
@@ -144,51 +109,21 @@ class TaskLeaseObjectRefGenerator:
             self._lease = None
             admission.release()
             raise
-        try:
-            admission.handoff()
-            self._validate_and_bind_completion()
-        except BaseException as submission_error:
-            cleanup_errors: list[BaseException] = []
-            try:
-                self.cancel()
-            except BaseException as exc:
-                cleanup_errors.append(exc)
-            try:
-                admission.release()
-            except BaseException as exc:
-                cleanup_errors.append(exc)
-            if cleanup_errors:
-                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
-                raise RuntimeError(
-                    "Ray UDF task submission setup failed and cleanup was incomplete: "
-                    f"submission={type(submission_error).__name__}: {submission_error}; "
-                    f"cleanup={details}"
-                ) from submission_error
-            raise
+        # Stream-contract validation belongs to RayStreamAdapter, which is
+        # constructed by AsyncResultCollector under its durable cleanup-ticket
+        # owner.  Once remote work exists, this constructor must not discover a
+        # post-submit error that has no scheduler available to retain an
+        # asynchronous driver handoff.
+        admission.handoff()
 
-    def _validate_and_bind_completion(self) -> None:
-        generator = self._generator
-        if generator is None:
-            raise RuntimeError("Ray UDF task stream is unavailable")
-        version = str(getattr(self._ray, "__version__", "")).strip() or "unknown"
-        missing = [name for name in _REQUIRED_GENERATOR_METHODS if not callable(getattr(generator, name, None))]
-        if missing:
-            raise TypeError(
-                f"Ray {version!r} stream source is not an ObjectRefGenerator; missing " + ", ".join(missing)
-            )
-        worker = getattr(generator, "worker", None)
-        core_worker = getattr(worker, "core_worker", None)
-        missing_core = [
-            name for name in _REQUIRED_CORE_WORKER_METHODS if not callable(getattr(core_worker, name, None))
-        ]
-        if missing_core:
-            raise TypeError(
-                f"Ray {version!r} stream source is missing required CoreWorker contract: " + ", ".join(missing_core)
-            )
-        completion_ref = generator.completed()
+    def _bind_completion_ref(self, completion_ref: Any) -> None:
         if completion_ref is None:
             raise RuntimeError("Ray stream completion ObjectRef is unavailable")
         with self._lock:
+            if self._cancelled or self._generator is None:
+                raise RuntimeError("cannot bind completion ownership to an inactive Ray stream")
+            if self._completion_ref is not None and self._completion_ref is not completion_ref:
+                raise RuntimeError("Ray stream completion ObjectRef changed after binding")
             self._completion_ref = completion_ref
 
     @property
@@ -209,58 +144,42 @@ class TaskLeaseObjectRefGenerator:
         with self._lock:
             return self._generator
 
-    @property
-    def completion_ref(self) -> Any | None:
-        with self._lock:
-            return self._completion_ref
-
-    @property
-    def start(self) -> Any:
-        with self._lock:
-            if self._cancelled or self._generator is None:
-                raise RuntimeError("Ray UDF task stream is not active")
-            return self._generator
-
-    def _release_task(self) -> bool:
+    def _release_task(self) -> bool | Any:
         with self._lock:
             if self._released or self._task_cleanup_handed_off:
                 return True
-            if self._cancelled or self._release_submission_active or self._task_cleanup_handoff_active:
+            if self._cancelled:
                 return False
-            self._release_submission_active = True
             lease = self._lease_identity
             driver = self._driver
             request_id = self._request_id
-            response_ref = self._release_response_ref
+            response_future = self._release_response_future
         try:
-            if response_ref is None:
+            if response_future is None:
                 response_ref = driver.release_query_task_lease.remote(
                     request_id,
                     str(lease["lease_id"]),
                     str(lease["attempt_id"]),
                 )
+                response_future = ray_object_ref_future(response_ref)
                 with self._lock:
-                    self._release_response_ref = response_ref
-            resolve_ray_control_ack(response_ref, field="released")
-        except BaseException as exc:
+                    self._release_response_future = response_future
+            if not response_future.done():
+                return response_future
+            validate_ray_control_ack(response_future.result(), field="released")
+        except BaseException:
             with self._lock:
-                self._release_submission_active = False
-                if not isinstance(exc, TimeoutError) and self._release_response_ref is response_ref:
-                    self._release_response_ref = None
+                if self._release_response_future is response_future:
+                    self._release_response_future = None
             raise
         with self._lock:
-            self._release_submission_active = False
-            self._release_response_ref = None
+            self._release_response_future = None
             self._released = True
         return True
-
-    def release_task(self) -> bool:
-        return self._release_task()
 
     def release_task_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 self._release_task,
                 retry_on_error=True,
                 retry_on_incomplete=True,
@@ -279,40 +198,38 @@ class TaskLeaseObjectRefGenerator:
         with self._lock:
             if self._cancel_generator is None:
                 return self._generator_cancel_submitted or not self._cancelled
-            if self._generator_cancel_submission_active:
-                return False
-            self._generator_cancel_submission_active = True
             generator = self._cancel_generator
             ray_module = self._ray
             force = self._execution_backend == "ray_task"
         try:
             ray_module.cancel(generator, force=force, recursive=True)
         except BaseException:
-            with self._lock:
-                self._generator_cancel_submission_active = False
             raise
         with self._lock:
-            self._generator_cancel_submission_active = False
             self._generator_cancel_submitted = True
             if self._cancel_generator is generator:
                 self._cancel_generator = None
         return True
 
-    def _handoff_task_completion(self) -> bool:
+    def _handoff_task_completion(self) -> bool | Any:
         with self._lock:
             if self._released or self._task_cleanup_handed_off:
                 return True
-            if self._release_submission_active or self._task_cleanup_handoff_active:
-                return False
-            self._task_cleanup_handoff_active = True
             lease = self._lease_identity
             driver = self._driver
             request_id = self._request_id
             completion_ref = self._completion_ref
-            response_ref = self._task_cleanup_response_ref
+            response_future = self._task_cleanup_response_future
+            if completion_ref is None:
+                if not self._generator_cancel_submitted:
+                    raise RuntimeError(
+                        "Ray task lease cannot be handed to query teardown before generator cancellation is submitted"
+                    )
+                ack_field = "handed_off"
+            else:
+                ack_field = "scheduled"
         try:
-            ack_field = "handed_off" if completion_ref is None else "scheduled"
-            if response_ref is None:
+            if response_future is None:
                 if completion_ref is None:
                     response_ref = driver.handoff_query_task_lease_to_teardown.remote(
                         request_id,
@@ -329,18 +246,19 @@ class TaskLeaseObjectRefGenerator:
                         str(lease["attempt_id"]),
                         [completion_ref],
                     )
+                response_future = ray_object_ref_future(response_ref)
                 with self._lock:
-                    self._task_cleanup_response_ref = response_ref
-            resolve_ray_control_ack(response_ref, field=ack_field)
-        except BaseException as exc:
+                    self._task_cleanup_response_future = response_future
+            if not response_future.done():
+                return response_future
+            validate_ray_control_ack(response_future.result(), field=ack_field)
+        except BaseException:
             with self._lock:
-                self._task_cleanup_handoff_active = False
-                if not isinstance(exc, TimeoutError) and self._task_cleanup_response_ref is response_ref:
-                    self._task_cleanup_response_ref = None
+                if self._task_cleanup_response_future is response_future:
+                    self._task_cleanup_response_future = None
             raise
         with self._lock:
-            self._task_cleanup_handoff_active = False
-            self._task_cleanup_response_ref = None
+            self._task_cleanup_response_future = None
             self._task_cleanup_handed_off = True
             self._completion_ref = None
         return True
@@ -351,11 +269,7 @@ class TaskLeaseObjectRefGenerator:
             return self._cancelled
 
     def _generator_cancellation_complete_locked(self) -> bool:
-        return (
-            not self._cancelled
-            or self._generator_cancel_submitted
-            or (self._cancel_generator is None and not self._generator_cancel_submission_active)
-        )
+        return not self._cancelled or self._generator_cancel_submitted or self._cancel_generator is None
 
     @property
     def generator_cancellation_complete(self) -> bool:
@@ -373,14 +287,12 @@ class TaskLeaseObjectRefGenerator:
         self._begin_cancellation(cancel_generator=True)
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
-                self._handoff_task_completion,
+                self._submit_generator_cancel,
                 retry_on_error=True,
                 retry_on_incomplete=True,
             ),
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CANCELLATION,
-                self._submit_generator_cancel,
+                self._handoff_task_completion,
                 retry_on_error=True,
                 retry_on_incomplete=True,
             ),
@@ -390,29 +302,11 @@ class TaskLeaseObjectRefGenerator:
         self._begin_cancellation(cancel_generator=False)
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 self._handoff_task_completion,
                 retry_on_error=True,
                 retry_on_incomplete=True,
             ),
         )
-
-    def cancel(self) -> bool:
-        _run_cleanup_operations(
-            "Ray UDF task cancellation failed",
-            self.cancel_operations(),
-        )
-        self.retire_local_state()
-        return self.terminal_cleanup_complete
-
-    def retire_failed(self) -> bool:
-        """Retire a terminally failed task without cancelling completed work."""
-        _run_cleanup_operations(
-            "Ray UDF failed task retirement failed",
-            self.retire_failed_operations(),
-        )
-        self.retire_local_state()
-        return self.terminal_cleanup_complete
 
     def retire_local_state(self) -> None:
         """Drop client-side task payload ownership after terminal cleanup."""
@@ -447,7 +341,6 @@ class RayStreamAdapter:
         self._stream_cleanup_active = False
         self._terminal_kind = ""
         self._cancel_generator: Any | None = None
-        self._generator_cancel_active = False
         self._generator_cancelled = False
         self._lifecycle = threading.Condition()
         self._active_reads = 0
@@ -472,12 +365,12 @@ class RayStreamAdapter:
             raise TypeError(
                 f"Ray {version!r} stream source is missing required CoreWorker contract: " + ", ".join(missing_core)
             )
-        if self._leased is not None:
-            self._completion_ref = self._leased.completion_ref
-        else:
-            self._completion_ref = self._generator.completed()
-        if self._completion_ref is None:
+        completion_ref = self._generator.completed()
+        if completion_ref is None:
             raise RuntimeError("Ray stream completion ObjectRef is unavailable")
+        if self._leased is not None:
+            self._leased._bind_completion_ref(completion_ref)
+        self._completion_ref = completion_ref
 
     @property
     def task_lease(self) -> dict[str, Any] | None:
@@ -558,13 +451,6 @@ class RayStreamAdapter:
         with self._lifecycle:
             self._drained = True
 
-    def release_task(self) -> None:
-        with self._lifecycle:
-            leased = self._leased if self._leased is not None else self._release_owner
-        if leased is not None:
-            leased.release_task()
-            self._drop_release_owner_if_complete(leased)
-
     @staticmethod
     def _delete_object_ref_stream(generator: Any, completion_ref: Any) -> None:
         worker = generator.worker
@@ -587,16 +473,11 @@ class RayStreamAdapter:
             if self._terminal_kind == "cancel":
                 if release_owner is not None and not release_owner.generator_cancellation_complete:
                     return False
-                if (
-                    release_owner is None
-                    and not self._generator_cancelled
-                    and (self._cancel_generator is not None or self._generator_cancel_active)
-                ):
+                if release_owner is None and not self._generator_cancelled and self._cancel_generator is not None:
                     return False
             if self._active_reads or self._active_core_calls:
-                # Cleanup lanes must never wait behind a stuck generator read.
-                # The bounded owner retries this operation after the in-flight
-                # call exits; retirement prevents any new call from starting.
+                # The event loop retries after the in-flight call exits;
+                # retirement prevents any new call from starting.
                 return False
             self._stream_cleanup_active = True
         try:
@@ -616,21 +497,14 @@ class RayStreamAdapter:
 
     def _run_unleased_generator_cancel(self) -> bool:
         with self._lifecycle:
-            if self._generator_cancel_active:
-                return False
             generator = self._cancel_generator
             if generator is None:
                 return True
-            self._generator_cancel_active = True
         try:
             self._ray.cancel(generator, force=True, recursive=True)
         except BaseException:
-            with self._lifecycle:
-                self._generator_cancel_active = False
-                self._lifecycle.notify_all()
             raise
         with self._lifecycle:
-            self._generator_cancel_active = False
             self._generator_cancelled = True
             if self._cancel_generator is generator:
                 self._cancel_generator = None
@@ -652,43 +526,12 @@ class RayStreamAdapter:
         self._drop_release_owner_if_complete(leased)
         return result
 
-    def retire(self) -> None:
-        """Deterministically retire a fully drained Ray generator stream.
-
-        Ray keeps task metadata and dependency lineage until the language
-        frontend deletes the ObjectRef stream.  Relying on ObjectRefGenerator's
-        ``__del__`` makes that cleanup depend on incidental Python references in
-        this long-lived multiplexer, so terminal streams are retired explicitly.
-        """
-        _run_cleanup_operations(
-            "Ray stream retirement failed",
-            self.retire_operations(),
-        )
-
     def retire_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        """Build deterministic cleanup for a fully drained generator stream."""
         return self._prepare_terminal_operations("retire")
-
-    def cancel(self) -> None:
-        _run_cleanup_operations(
-            "Ray stream cancellation failed",
-            self.cancel_operations(),
-        )
 
     def cancel_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return self._prepare_terminal_operations("cancel")
-
-    def retire_failed(self) -> None:
-        """Retire a terminal failure without racing it with ``ray.cancel``.
-
-        Once Ray has published task completion, or a Vane stream has emitted
-        its terminal error pair, force-cancelling the generator can race the
-        normal task reply in Ray's CoreWorker.  The task lease still follows
-        the failure path, but the already-ending remote work is left alone.
-        """
-        _run_cleanup_operations(
-            "Ray failed stream retirement failed",
-            self.retire_failed_operations(),
-        )
 
     def retire_failed_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return self._prepare_terminal_operations("failed")
@@ -734,7 +577,6 @@ class RayStreamAdapter:
             leased.retire_local_state()
             leased_operations = [
                 RayStreamCleanupOperation(
-                    operation.lane,
                     partial(self._leased_operation, leased, operation.operation),
                     retry_on_error=operation.retry_on_error,
                     retry_on_incomplete=operation.retry_on_incomplete,
@@ -743,7 +585,6 @@ class RayStreamAdapter:
             ]
 
         stream_operation = RayStreamCleanupOperation(
-            RAY_STREAM_CLEANUP_CORE,
             self._run_pending_stream_cleanup,
             retry_on_error=True,
             retry_on_incomplete=True,
@@ -752,7 +593,6 @@ class RayStreamAdapter:
         if terminal_kind == "cancel" and leased is None:
             operations.append(
                 RayStreamCleanupOperation(
-                    RAY_STREAM_CLEANUP_CANCELLATION,
                     self._run_unleased_generator_cancel,
                     retry_on_error=True,
                     retry_on_incomplete=True,
@@ -767,21 +607,16 @@ class RayStreamAdapter:
             stream_complete = self._cleanup_generator is None and not self._stream_cleanup_active
             release_complete = self._release_owner is None
             generator_complete = (
-                self._terminal_kind != "cancel"
-                or self._generator_cancelled
-                or (self._cancel_generator is None and not self._generator_cancel_active)
+                self._terminal_kind != "cancel" or self._generator_cancelled or self._cancel_generator is None
             )
             return self._retired and stream_complete and release_complete and generator_complete
 
 
 __all__ = [
-    "RAY_STREAM_CLEANUP_CANCELLATION",
-    "RAY_STREAM_CLEANUP_CONTROL",
-    "RAY_STREAM_CLEANUP_CORE",
-    "RAY_STREAM_CLEANUP_OUTPUT",
     "RayStreamAdapter",
     "RayStreamCleanupOperation",
     "TaskLeaseObjectRefGenerator",
-    "resolve_ray_control_ack",
+    "ray_object_ref_future",
     "validate_ray_stream_contract",
+    "validate_ray_control_ack",
 ]

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import threading
+import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
@@ -19,17 +20,12 @@ _REQUIRED_CORE_WORKER_METHODS = (
 
 @dataclass(frozen=True)
 class RayStreamCleanupOperation:
-    """One terminal transition scheduled by the collector and run off its loop.
-
-    ``release_wait`` only detaches operation-local attempt state. It must not
-    call methods on the observed Future; those can invoke arbitrary callbacks.
-    """
+    """One terminal transition scheduled by the collector and run off its loop."""
 
     operation: Callable[[], Any]
     submission_scope: str
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
-    release_wait: Callable[[Any], None] | None = None
 
     def __post_init__(self) -> None:
         scope = str(self.submission_scope or "").strip()
@@ -39,6 +35,32 @@ class RayStreamCleanupOperation:
 
     def __call__(self) -> Any:
         return self.operation()
+
+
+@dataclass(frozen=True)
+class RayStreamCleanupWait:
+    """One retryable control response whose late acknowledgement remains valid.
+
+    ``accept`` validates the resolved response and commits only bounded local
+    state; it must not call methods on another Future.
+    """
+
+    future: Any
+    accept: Callable[[Any], Any]
+
+    def __post_init__(self) -> None:
+        missing = [
+            name for name in ("add_done_callback", "done", "result") if not callable(getattr(self.future, name, None))
+        ]
+        if missing:
+            raise TypeError("Ray stream cleanup Future is missing: " + ", ".join(missing))
+        if not callable(self.accept):
+            raise TypeError("Ray stream cleanup response acceptor must be callable")
+
+    def complete(self) -> None:
+        if not self.future.done():
+            raise RuntimeError("Ray stream cleanup response is still pending")
+        self.accept(self.future.result())
 
 
 def validate_ray_control_ack(response: Any, *, field: str) -> dict[str, Any]:
@@ -111,10 +133,8 @@ class TaskLeaseObjectRefGenerator:
         self._lease: dict[str, Any] | None = lease
         self._lease_identity = dict(lease)
         self._released = False
-        self._release_response_future: Any | None = None
         self._cancelled = False
         self._task_cleanup_handed_off = False
-        self._task_cleanup_response_future: Any | None = None
         self._cancel_generator: Any | None = None
         self._generator_cancel_submitted = False
         self._lock = threading.Lock()
@@ -163,7 +183,7 @@ class TaskLeaseObjectRefGenerator:
         with self._lock:
             return self._generator
 
-    def _release_task(self) -> bool | Any:
+    def _release_task(self) -> bool | RayStreamCleanupWait:
         with self._lock:
             if self._released or self._task_cleanup_handed_off:
                 return True
@@ -172,34 +192,22 @@ class TaskLeaseObjectRefGenerator:
             lease = self._lease_identity
             driver = self._driver
             request_id = self._request_id
-            response_future = self._release_response_future
-        try:
-            if response_future is None:
-                response_ref = driver.release_query_task_lease.remote(
-                    request_id,
-                    str(lease["lease_id"]),
-                    str(lease["attempt_id"]),
-                )
-                response_future = ray_object_ref_future(response_ref)
-                with self._lock:
-                    self._release_response_future = response_future
-            if not response_future.done():
-                return response_future
-            validate_ray_control_ack(response_future.result(), field="released")
-        except BaseException:
-            with self._lock:
-                if self._release_response_future is response_future:
-                    self._release_response_future = None
-            raise
-        with self._lock:
-            self._release_response_future = None
-            self._released = True
-        return True
+        response_ref = driver.release_query_task_lease.remote(
+            request_id,
+            str(lease["lease_id"]),
+            str(lease["attempt_id"]),
+        )
+        response_future = ray_object_ref_future(response_ref)
+        owner_ref = weakref.ref(self)
 
-    def _release_task_wait(self, response_future: Any) -> None:
-        with self._lock:
-            if self._release_response_future is response_future:
-                self._release_response_future = None
+        def accept(response: Any) -> None:
+            validate_ray_control_ack(response, field="released")
+            owner = owner_ref()
+            if owner is not None:
+                with owner._lock:
+                    owner._released = True
+
+        return RayStreamCleanupWait(response_future, accept)
 
     def release_task_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return (
@@ -208,7 +216,6 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                release_wait=self._release_task_wait,
             ),
         )
 
@@ -239,7 +246,7 @@ class TaskLeaseObjectRefGenerator:
                 self._cancel_generator = None
         return True
 
-    def _handoff_task_completion(self) -> bool | Any:
+    def _handoff_task_completion(self) -> bool | RayStreamCleanupWait:
         with self._lock:
             if self._released or self._task_cleanup_handed_off:
                 return True
@@ -247,7 +254,6 @@ class TaskLeaseObjectRefGenerator:
             driver = self._driver
             request_id = self._request_id
             completion_ref = self._completion_ref
-            response_future = self._task_cleanup_response_future
             if completion_ref is None:
                 if not self._generator_cancel_submitted:
                     raise RuntimeError(
@@ -256,45 +262,34 @@ class TaskLeaseObjectRefGenerator:
                 ack_field = "handed_off"
             else:
                 ack_field = "scheduled"
-        try:
-            if response_future is None:
-                if completion_ref is None:
-                    response_ref = driver.handoff_query_task_lease_to_teardown.remote(
-                        request_id,
-                        str(lease["lease_id"]),
-                        str(lease["attempt_id"]),
-                    )
-                else:
-                    # Ray resolves only top-level ObjectRef arguments. Nesting
-                    # the completion ref transfers ownership immediately
-                    # without making this RPC wait for the remote task itself.
-                    response_ref = driver.release_query_task_lease_after_completion.remote(
-                        request_id,
-                        str(lease["lease_id"]),
-                        str(lease["attempt_id"]),
-                        [completion_ref],
-                    )
-                response_future = ray_object_ref_future(response_ref)
-                with self._lock:
-                    self._task_cleanup_response_future = response_future
-            if not response_future.done():
-                return response_future
-            validate_ray_control_ack(response_future.result(), field=ack_field)
-        except BaseException:
-            with self._lock:
-                if self._task_cleanup_response_future is response_future:
-                    self._task_cleanup_response_future = None
-            raise
-        with self._lock:
-            self._task_cleanup_response_future = None
-            self._task_cleanup_handed_off = True
-            self._completion_ref = None
-        return True
+        if completion_ref is None:
+            response_ref = driver.handoff_query_task_lease_to_teardown.remote(
+                request_id,
+                str(lease["lease_id"]),
+                str(lease["attempt_id"]),
+            )
+        else:
+            # Ray resolves only top-level ObjectRef arguments. Nesting the
+            # completion ref transfers ownership immediately without making
+            # this RPC wait for the remote task itself.
+            response_ref = driver.release_query_task_lease_after_completion.remote(
+                request_id,
+                str(lease["lease_id"]),
+                str(lease["attempt_id"]),
+                [completion_ref],
+            )
+        response_future = ray_object_ref_future(response_ref)
+        owner_ref = weakref.ref(self)
 
-    def _release_task_cleanup_wait(self, response_future: Any) -> None:
-        with self._lock:
-            if self._task_cleanup_response_future is response_future:
-                self._task_cleanup_response_future = None
+        def accept(response: Any) -> None:
+            validate_ray_control_ack(response, field=ack_field)
+            owner = owner_ref()
+            if owner is not None:
+                with owner._lock:
+                    owner._task_cleanup_handed_off = True
+                    owner._completion_ref = None
+
+        return RayStreamCleanupWait(response_future, accept)
 
     @property
     def cancellation_started(self) -> bool:
@@ -330,7 +325,6 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                release_wait=self._release_task_cleanup_wait,
             ),
         )
 
@@ -342,7 +336,6 @@ class TaskLeaseObjectRefGenerator:
                 submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
-                release_wait=self._release_task_cleanup_wait,
             ),
         )
 
@@ -546,6 +539,19 @@ class RayStreamAdapter:
         operation: Callable[[], Any],
     ) -> Any:
         result = operation()
+        if isinstance(result, RayStreamCleanupWait):
+            adapter_ref = weakref.ref(self)
+            leased_ref = weakref.ref(leased)
+            accept_response = result.accept
+
+            def accept(response: Any) -> None:
+                accept_response(response)
+                adapter = adapter_ref()
+                release_owner = leased_ref()
+                if adapter is not None and release_owner is not None:
+                    adapter._drop_release_owner_if_complete(release_owner)
+
+            return RayStreamCleanupWait(result.future, accept)
         self._drop_release_owner_if_complete(leased)
         return result
 
@@ -603,7 +609,6 @@ class RayStreamAdapter:
                     submission_scope=operation.submission_scope,
                     retry_on_error=operation.retry_on_error,
                     retry_on_incomplete=operation.retry_on_incomplete,
-                    release_wait=operation.release_wait,
                 )
                 for operation in source_operations
             ]
@@ -629,6 +634,7 @@ class RayStreamAdapter:
 __all__ = [
     "RayStreamAdapter",
     "RayStreamCleanupOperation",
+    "RayStreamCleanupWait",
     "TaskLeaseObjectRefGenerator",
     "ray_object_ref_future",
     "validate_ray_stream_contract",

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -24,6 +24,7 @@ class RayStreamCleanupOperation:
     operation: Callable[[], Any]
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
+    abandon_wait: Callable[[Any], None] | None = None
 
     def __call__(self) -> Any:
         return self.operation()
@@ -32,7 +33,7 @@ class RayStreamCleanupOperation:
 def validate_ray_control_ack(response: Any, *, field: str) -> dict[str, Any]:
     """Require driver acceptance before completing a cleanup ticket."""
     if not isinstance(response, dict) or response.get(field) is not True:
-        raise RuntimeError(f"Ray task lease control handoff was not accepted: {field}")
+        raise RuntimeError(f"Ray UDF control handoff was not accepted: {field}")
     return response
 
 
@@ -177,12 +178,22 @@ class TaskLeaseObjectRefGenerator:
             self._released = True
         return True
 
+    def _abandon_release_task_wait(self, response_future: Any) -> None:
+        with self._lock:
+            if self._release_response_future is response_future:
+                self._release_response_future = None
+        try:
+            response_future.cancel()
+        except BaseException:
+            pass
+
     def release_task_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
         return (
             RayStreamCleanupOperation(
                 self._release_task,
                 retry_on_error=True,
                 retry_on_incomplete=True,
+                abandon_wait=self._abandon_release_task_wait,
             ),
         )
 
@@ -263,6 +274,15 @@ class TaskLeaseObjectRefGenerator:
             self._completion_ref = None
         return True
 
+    def _abandon_task_cleanup_wait(self, response_future: Any) -> None:
+        with self._lock:
+            if self._task_cleanup_response_future is response_future:
+                self._task_cleanup_response_future = None
+        try:
+            response_future.cancel()
+        except BaseException:
+            pass
+
     @property
     def cancellation_started(self) -> bool:
         with self._lock:
@@ -295,6 +315,7 @@ class TaskLeaseObjectRefGenerator:
                 self._handoff_task_completion,
                 retry_on_error=True,
                 retry_on_incomplete=True,
+                abandon_wait=self._abandon_task_cleanup_wait,
             ),
         )
 
@@ -305,6 +326,7 @@ class TaskLeaseObjectRefGenerator:
                 self._handoff_task_completion,
                 retry_on_error=True,
                 retry_on_incomplete=True,
+                abandon_wait=self._abandon_task_cleanup_wait,
             ),
         )
 
@@ -580,6 +602,7 @@ class RayStreamAdapter:
                     partial(self._leased_operation, leased, operation.operation),
                     retry_on_error=operation.retry_on_error,
                     retry_on_incomplete=operation.retry_on_incomplete,
+                    abandon_wait=operation.abandon_wait,
                 )
                 for operation in source_operations
             ]

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -19,7 +19,7 @@ _REQUIRED_CORE_WORKER_METHODS = (
 
 @dataclass(frozen=True)
 class RayStreamCleanupOperation:
-    """One non-blocking terminal transition driven by the collector loop."""
+    """One terminal transition scheduled by the collector and run off its loop."""
 
     operation: Callable[[], Any]
     retry_on_error: bool = False
@@ -38,7 +38,7 @@ def validate_ray_control_ack(response: Any, *, field: str) -> dict[str, Any]:
 
 
 def ray_object_ref_future(response_ref: Any) -> Any:
-    """Return the public concurrent Future used by the cleanup event loop."""
+    """Return the public concurrent Future used to observe a Ray control reply."""
     future_method = getattr(response_ref, "future", None)
     if not callable(future_method):
         raise TypeError("Ray control ObjectRef does not expose future()")

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import threading
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
@@ -22,9 +23,16 @@ class RayStreamCleanupOperation:
     """One terminal transition scheduled by the collector and run off its loop."""
 
     operation: Callable[[], Any]
+    submission_scope: str
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
     abandon_wait: Callable[[Any], None] | None = None
+
+    def __post_init__(self) -> None:
+        scope = str(self.submission_scope or "").strip()
+        if not scope:
+            raise ValueError("Ray stream cleanup requires an explicit submission scope")
+        object.__setattr__(self, "submission_scope", scope)
 
     def __call__(self) -> Any:
         return self.operation()
@@ -84,12 +92,15 @@ class TaskLeaseObjectRefGenerator:
             admission.release()
             raise
         request_id = str(admission.request_id or "").strip()
+        submission_scope = str(admission.submission_scope or "").strip()
         lease = dict(admission.lease)
-        if not request_id or not str(lease.get("lease_id") or ""):
+        query_id = str(lease.get("query_id") or "").strip()
+        if not request_id or not submission_scope or not str(lease.get("lease_id") or "") or not query_id:
             admission.release()
             raise ValueError("pregranted Ray UDF task admission is missing identity")
         self._ray = active_ray_module
         self._driver = admission.driver
+        self._submission_scope = submission_scope
         self._request_id = request_id
         self._execution_backend = "ray_actor" if lease.get("actor_index") is not None else "ray_task"
         self._generator: Any | None = None
@@ -134,6 +145,10 @@ class TaskLeaseObjectRefGenerator:
     @property
     def driver(self) -> Any:
         return self._driver
+
+    @property
+    def submission_scope(self) -> str:
+        return self._submission_scope
 
     @property
     def lease(self) -> dict[str, Any] | None:
@@ -191,6 +206,7 @@ class TaskLeaseObjectRefGenerator:
         return (
             RayStreamCleanupOperation(
                 self._release_task,
+                submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
                 abandon_wait=self._abandon_release_task_wait,
@@ -308,11 +324,13 @@ class TaskLeaseObjectRefGenerator:
         return (
             RayStreamCleanupOperation(
                 self._submit_generator_cancel,
+                submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
             ),
             RayStreamCleanupOperation(
                 self._handoff_task_completion,
+                submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
                 abandon_wait=self._abandon_task_cleanup_wait,
@@ -324,6 +342,7 @@ class TaskLeaseObjectRefGenerator:
         return (
             RayStreamCleanupOperation(
                 self._handoff_task_completion,
+                submission_scope=self._submission_scope,
                 retry_on_error=True,
                 retry_on_incomplete=True,
                 abandon_wait=self._abandon_task_cleanup_wait,
@@ -352,6 +371,9 @@ class RayStreamAdapter:
         self._ray = active_ray_module
         self._source = source
         self._leased = source if isinstance(source, TaskLeaseObjectRefGenerator) else None
+        self._submission_scope = (
+            self._leased.submission_scope if self._leased is not None else f"stream:{uuid.uuid4().hex}"
+        )
         self._task_request_identity = "" if self._leased is None else self._leased.request_id
         self._generator = self._leased.generator if self._leased is not None else source
         self._completion_ref: Any | None = None
@@ -403,6 +425,10 @@ class RayStreamAdapter:
     @property
     def task_request_id(self) -> str:
         return self._task_request_identity
+
+    @property
+    def submission_scope(self) -> str:
+        return self._submission_scope
 
     @property
     def driver(self) -> Any | None:
@@ -604,6 +630,7 @@ class RayStreamAdapter:
             leased_operations = [
                 RayStreamCleanupOperation(
                     partial(self._leased_operation, leased, operation.operation),
+                    submission_scope=operation.submission_scope,
                     retry_on_error=operation.retry_on_error,
                     retry_on_incomplete=operation.retry_on_incomplete,
                     abandon_wait=operation.abandon_wait,
@@ -613,6 +640,7 @@ class RayStreamAdapter:
 
         stream_operation = RayStreamCleanupOperation(
             self._run_pending_stream_cleanup,
+            submission_scope=self._submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
         )
@@ -621,6 +649,7 @@ class RayStreamAdapter:
             operations.append(
                 RayStreamCleanupOperation(
                     self._run_unleased_generator_cancel,
+                    submission_scope=self._submission_scope,
                     retry_on_error=True,
                     retry_on_incomplete=True,
                 )

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -4,15 +4,80 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
+from duckdb.runners.ray.safe_get import resolve_object_refs_blocking
+
+RAY_STREAM_CLEANUP_CONTROL = "control"
+RAY_STREAM_CLEANUP_OUTPUT = "output"
+RAY_STREAM_CLEANUP_CANCELLATION = "cancellation"
+RAY_STREAM_CLEANUP_CORE = "core"
+_RAY_STREAM_CLEANUP_LANES = frozenset(
+    {
+        RAY_STREAM_CLEANUP_CONTROL,
+        RAY_STREAM_CLEANUP_OUTPUT,
+        RAY_STREAM_CLEANUP_CANCELLATION,
+        RAY_STREAM_CLEANUP_CORE,
+    }
+)
 _REQUIRED_GENERATOR_METHODS = ("__anext__", "completed")
 _REQUIRED_RAY_METHODS = ("wait",)
 _REQUIRED_CORE_WORKER_METHODS = (
     "async_delete_object_ref_stream",
     "is_object_ref_stream_finished",
 )
+_TASK_LEASE_CONTROL_ACK_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class RayStreamCleanupOperation:
+    """One terminal operation assigned to a bounded failure-isolation lane."""
+
+    lane: str
+    operation: Callable[[], Any]
+    retry_on_error: bool = False
+    retry_on_incomplete: bool = False
+
+    def __post_init__(self) -> None:
+        if self.lane not in _RAY_STREAM_CLEANUP_LANES:
+            raise ValueError(f"invalid Ray stream cleanup lane: {self.lane}")
+
+    def __call__(self) -> Any:
+        return self.operation()
+
+
+def resolve_ray_control_ack(response_ref: Any, *, field: str) -> dict[str, Any]:
+    """Require driver acceptance before dropping a local resource owner."""
+    if isinstance(response_ref, dict):
+        response = response_ref
+    else:
+        response = resolve_object_refs_blocking(
+            response_ref,
+            timeout=_TASK_LEASE_CONTROL_ACK_TIMEOUT_S,
+            honor_query_deadline=False,
+            honor_object_get_timeout=False,
+        )
+    if not isinstance(response, dict) or response.get(field) is not True:
+        raise RuntimeError(f"Ray task lease control handoff was not accepted: {field}")
+    return response
+
+
+def _run_cleanup_operations(label: str, operations: Sequence[Callable[[], Any]]) -> None:
+    errors: list[BaseException] = []
+    for operation in operations:
+        try:
+            result = operation()
+        except BaseException as exc:
+            errors.append(exc)
+            continue
+        if result is False and isinstance(operation, RayStreamCleanupOperation) and operation.retry_on_incomplete:
+            errors.append(RuntimeError("Ray stream cleanup ownership transfer remained incomplete"))
+    if errors:
+        details = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+        raise RuntimeError(f"{label}: {details}") from errors[0]
 
 
 def validate_ray_stream_contract(ray_module: Any) -> None:
@@ -57,11 +122,21 @@ class TaskLeaseObjectRefGenerator:
         self._ray = active_ray_module
         self._driver = admission.driver
         self._request_id = request_id
+        self._execution_backend = "ray_actor" if lease.get("actor_index") is not None else "ray_task"
         self._generator: Any | None = None
+        self._completion_ref: Any | None = None
         self._lease: dict[str, Any] | None = lease
-        self._submitted = False
+        self._lease_identity = dict(lease)
         self._released = False
+        self._release_submission_active = False
+        self._release_response_ref: Any | None = None
         self._cancelled = False
+        self._task_cleanup_handed_off = False
+        self._task_cleanup_handoff_active = False
+        self._task_cleanup_response_ref: Any | None = None
+        self._cancel_generator: Any | None = None
+        self._generator_cancel_submitted = False
+        self._generator_cancel_submission_active = False
         self._lock = threading.Lock()
         try:
             self._generator = submitter(dict(lease))
@@ -69,12 +144,56 @@ class TaskLeaseObjectRefGenerator:
             self._lease = None
             admission.release()
             raise
-        admission.handoff()
-        self._submitted = True
-        self._driver.mark_query_task_lease_submitted.remote(
-            self._request_id,
-            str(lease["lease_id"]),
-        )
+        try:
+            admission.handoff()
+            self._validate_and_bind_completion()
+            self._driver.mark_query_task_lease_submitted.remote(
+                self._request_id,
+                str(lease["lease_id"]),
+            )
+        except BaseException as submission_error:
+            cleanup_errors: list[BaseException] = []
+            try:
+                self.cancel()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            try:
+                admission.release()
+            except BaseException as exc:
+                cleanup_errors.append(exc)
+            if cleanup_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                raise RuntimeError(
+                    "Ray UDF task submission setup failed and cleanup was incomplete: "
+                    f"submission={type(submission_error).__name__}: {submission_error}; "
+                    f"cleanup={details}"
+                ) from submission_error
+            raise
+
+    def _validate_and_bind_completion(self) -> None:
+        generator = self._generator
+        if generator is None:
+            raise RuntimeError("Ray UDF task stream is unavailable")
+        version = str(getattr(self._ray, "__version__", "")).strip() or "unknown"
+        missing = [name for name in _REQUIRED_GENERATOR_METHODS if not callable(getattr(generator, name, None))]
+        if missing:
+            raise TypeError(
+                f"Ray {version!r} stream source is not an ObjectRefGenerator; missing " + ", ".join(missing)
+            )
+        worker = getattr(generator, "worker", None)
+        core_worker = getattr(worker, "core_worker", None)
+        missing_core = [
+            name for name in _REQUIRED_CORE_WORKER_METHODS if not callable(getattr(core_worker, name, None))
+        ]
+        if missing_core:
+            raise TypeError(
+                f"Ray {version!r} stream source is missing required CoreWorker contract: " + ", ".join(missing_core)
+            )
+        completion_ref = generator.completed()
+        if completion_ref is None:
+            raise RuntimeError("Ray stream completion ObjectRef is unavailable")
+        with self._lock:
+            self._completion_ref = completion_ref
 
     @property
     def request_id(self) -> str:
@@ -86,11 +205,18 @@ class TaskLeaseObjectRefGenerator:
 
     @property
     def lease(self) -> dict[str, Any] | None:
-        return None if self._lease is None else dict(self._lease)
+        with self._lock:
+            return None if self._lease is None else dict(self._lease)
 
     @property
     def generator(self) -> Any | None:
-        return self._generator
+        with self._lock:
+            return self._generator
+
+    @property
+    def completion_ref(self) -> Any | None:
+        with self._lock:
+            return self._completion_ref
 
     @property
     def start(self) -> Any:
@@ -99,47 +225,198 @@ class TaskLeaseObjectRefGenerator:
                 raise RuntimeError("Ray UDF task stream is not active")
             return self._generator
 
-    def release_task(self) -> None:
+    def _release_task(self) -> bool:
         with self._lock:
-            if self._released or self._lease is None:
-                return
+            if self._released or self._task_cleanup_handed_off:
+                return True
+            if self._cancelled or self._release_submission_active or self._task_cleanup_handoff_active:
+                return False
+            self._release_submission_active = True
+            lease = self._lease_identity
+            driver = self._driver
+            request_id = self._request_id
+            response_ref = self._release_response_ref
+        try:
+            if response_ref is None:
+                response_ref = driver.release_query_task_lease.remote(
+                    request_id,
+                    str(lease["lease_id"]),
+                    str(lease["attempt_id"]),
+                )
+                with self._lock:
+                    self._release_response_ref = response_ref
+            resolve_ray_control_ack(response_ref, field="released")
+        except BaseException as exc:
+            with self._lock:
+                self._release_submission_active = False
+                if not isinstance(exc, TimeoutError) and self._release_response_ref is response_ref:
+                    self._release_response_ref = None
+            raise
+        with self._lock:
+            self._release_submission_active = False
+            self._release_response_ref = None
             self._released = True
-            lease = dict(self._lease)
-        self._driver.release_query_task_lease.remote(
-            self._request_id,
-            str(lease["lease_id"]),
-            str(lease["attempt_id"]),
+        return True
+
+    def release_task(self) -> bool:
+        return self._release_task()
+
+    def release_task_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                self._release_task,
+                retry_on_error=True,
+                retry_on_incomplete=True,
+            ),
         )
 
-    def cancel(self) -> None:
+    def _begin_cancellation(self, *, cancel_generator: bool) -> None:
         with self._lock:
-            if self._cancelled:
-                return
-            self._cancelled = True
-            generator = self._generator
-            submitted = self._submitted
-            self._released = True
-            self._generator = None
-        if generator is not None:
-            self._ray.cancel(generator, force=True, recursive=True)
-        self._driver.cancel_query_task_lease_request.remote(
-            self._request_id,
-            submitted=bool(submitted),
+            if not self._cancelled:
+                self._cancelled = True
+                if cancel_generator:
+                    self._cancel_generator = self._generator
+                self._generator = None
+
+    def _submit_generator_cancel(self) -> bool:
+        with self._lock:
+            if self._cancel_generator is None:
+                return self._generator_cancel_submitted or not self._cancelled
+            if self._generator_cancel_submission_active:
+                return False
+            self._generator_cancel_submission_active = True
+            generator = self._cancel_generator
+            ray_module = self._ray
+            force = self._execution_backend == "ray_task"
+        try:
+            ray_module.cancel(generator, force=force, recursive=True)
+        except BaseException:
+            with self._lock:
+                self._generator_cancel_submission_active = False
+            raise
+        with self._lock:
+            self._generator_cancel_submission_active = False
+            self._generator_cancel_submitted = True
+            if self._cancel_generator is generator:
+                self._cancel_generator = None
+        return True
+
+    def _handoff_task_completion(self) -> bool:
+        with self._lock:
+            if self._released or self._task_cleanup_handed_off:
+                return True
+            if self._release_submission_active or self._task_cleanup_handoff_active:
+                return False
+            self._task_cleanup_handoff_active = True
+            lease = self._lease_identity
+            driver = self._driver
+            request_id = self._request_id
+            completion_ref = self._completion_ref
+            response_ref = self._task_cleanup_response_ref
+        try:
+            ack_field = "handed_off" if completion_ref is None else "scheduled"
+            if response_ref is None:
+                if completion_ref is None:
+                    response_ref = driver.handoff_query_task_lease_to_teardown.remote(
+                        request_id,
+                        str(lease["lease_id"]),
+                        str(lease["attempt_id"]),
+                    )
+                else:
+                    # Ray resolves only top-level ObjectRef arguments. Nesting
+                    # the completion ref transfers ownership immediately
+                    # without making this RPC wait for the remote task itself.
+                    response_ref = driver.release_query_task_lease_after_completion.remote(
+                        request_id,
+                        str(lease["lease_id"]),
+                        str(lease["attempt_id"]),
+                        [completion_ref],
+                    )
+                with self._lock:
+                    self._task_cleanup_response_ref = response_ref
+            resolve_ray_control_ack(response_ref, field=ack_field)
+        except BaseException as exc:
+            with self._lock:
+                self._task_cleanup_handoff_active = False
+                if not isinstance(exc, TimeoutError) and self._task_cleanup_response_ref is response_ref:
+                    self._task_cleanup_response_ref = None
+            raise
+        with self._lock:
+            self._task_cleanup_handoff_active = False
+            self._task_cleanup_response_ref = None
+            self._task_cleanup_handed_off = True
+            self._completion_ref = None
+        return True
+
+    @property
+    def cancellation_started(self) -> bool:
+        with self._lock:
+            return self._cancelled
+
+    def _generator_cancellation_complete_locked(self) -> bool:
+        return (
+            not self._cancelled
+            or self._generator_cancel_submitted
+            or (self._cancel_generator is None and not self._generator_cancel_submission_active)
         )
 
-    def retire_failed(self) -> None:
+    @property
+    def generator_cancellation_complete(self) -> bool:
+        with self._lock:
+            return self._generator_cancellation_complete_locked()
+
+    @property
+    def terminal_cleanup_complete(self) -> bool:
+        with self._lock:
+            task_complete = self._released or self._task_cleanup_handed_off
+            generator_complete = self._generator_cancellation_complete_locked()
+            return task_complete and generator_complete
+
+    def cancel_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        self._begin_cancellation(cancel_generator=True)
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                self._handoff_task_completion,
+                retry_on_error=True,
+                retry_on_incomplete=True,
+            ),
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CANCELLATION,
+                self._submit_generator_cancel,
+                retry_on_error=True,
+                retry_on_incomplete=True,
+            ),
+        )
+
+    def retire_failed_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        self._begin_cancellation(cancel_generator=False)
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                self._handoff_task_completion,
+                retry_on_error=True,
+                retry_on_incomplete=True,
+            ),
+        )
+
+    def cancel(self) -> bool:
+        _run_cleanup_operations(
+            "Ray UDF task cancellation failed",
+            self.cancel_operations(),
+        )
+        self.retire_local_state()
+        return self.terminal_cleanup_complete
+
+    def retire_failed(self) -> bool:
         """Retire a terminally failed task without cancelling completed work."""
-        with self._lock:
-            if self._cancelled:
-                return
-            self._cancelled = True
-            submitted = self._submitted
-            self._released = True
-            self._generator = None
-        self._driver.cancel_query_task_lease_request.remote(
-            self._request_id,
-            submitted=bool(submitted),
+        _run_cleanup_operations(
+            "Ray UDF failed task retirement failed",
+            self.retire_failed_operations(),
         )
+        self.retire_local_state()
+        return self.terminal_cleanup_complete
 
     def retire_local_state(self) -> None:
         """Drop client-side task payload ownership after terminal cleanup."""
@@ -163,11 +440,22 @@ class RayStreamAdapter:
         self._ray = active_ray_module
         self._source = source
         self._leased = source if isinstance(source, TaskLeaseObjectRefGenerator) else None
+        self._task_request_identity = "" if self._leased is None else self._leased.request_id
         self._generator = self._leased.generator if self._leased is not None else source
         self._completion_ref: Any | None = None
         self._drained = False
-        self._task_released = False
         self._retired = False
+        self._release_owner: TaskLeaseObjectRefGenerator | None = None
+        self._cleanup_generator: Any | None = None
+        self._cleanup_completion_ref: Any | None = None
+        self._stream_cleanup_active = False
+        self._terminal_kind = ""
+        self._cancel_generator: Any | None = None
+        self._generator_cancel_active = False
+        self._generator_cancelled = False
+        self._lifecycle = threading.Condition()
+        self._active_reads = 0
+        self._active_core_calls = 0
         self._validate_generator_if_started()
 
     def _validate_generator_if_started(self) -> None:
@@ -188,77 +476,185 @@ class RayStreamAdapter:
             raise TypeError(
                 f"Ray {version!r} stream source is missing required CoreWorker contract: " + ", ".join(missing_core)
             )
-        self._completion_ref = self._generator.completed()
+        if self._leased is not None:
+            self._completion_ref = self._leased.completion_ref
+        else:
+            self._completion_ref = self._generator.completed()
+        if self._completion_ref is None:
+            raise RuntimeError("Ray stream completion ObjectRef is unavailable")
 
     @property
     def task_lease(self) -> dict[str, Any] | None:
-        return None if self._leased is None else self._leased.lease
+        with self._lifecycle:
+            leased = self._leased
+        return None if leased is None else leased.lease
 
     @property
     def task_request_id(self) -> str:
-        return "" if self._leased is None else self._leased.request_id
+        return self._task_request_identity
 
     @property
     def driver(self) -> Any | None:
-        return None if self._leased is None else self._leased.driver
+        with self._lifecycle:
+            leased = self._leased
+        return None if leased is None else leased.driver
 
     @property
     def waitable(self) -> Any:
         """Return the generator used for non-consuming readiness probes."""
-        if self._generator is None:
-            raise RuntimeError("Ray stream has no active ObjectRefGenerator")
-        return self._generator
+        with self._lifecycle:
+            if self._retired or self._generator is None:
+                raise RuntimeError("Ray stream has no active ObjectRefGenerator")
+            return self._generator
 
     async def read_next_ref_async(self) -> Any:
-        if self._generator is None:
-            raise RuntimeError("Ray stream has not acquired its task lease")
-        if self._drained:
-            raise StopAsyncIteration
-        ref = await self._generator.__anext__()
-        if hasattr(ref, "is_nil") and ref.is_nil():
-            raise RuntimeError("Ray generator returned a nil ObjectRef")
-        return ref
+        with self._lifecycle:
+            generator = self._generator
+            if self._retired or generator is None:
+                raise RuntimeError("Ray stream has not acquired its task lease")
+            if self._drained:
+                raise StopAsyncIteration
+            if self._active_reads:
+                raise RuntimeError("Ray ObjectRefGenerator does not support concurrent reads")
+            self._active_reads += 1
+        try:
+            ref = await generator.__anext__()
+            if hasattr(ref, "is_nil") and ref.is_nil():
+                raise RuntimeError("Ray generator returned a nil ObjectRef")
+            return ref
+        finally:
+            with self._lifecycle:
+                self._active_reads -= 1
+                if self._active_reads < 0:
+                    raise RuntimeError("Ray stream active read count underflow")
+                self._lifecycle.notify_all()
 
     @property
     def completion_ref(self) -> Any:
-        if self._completion_ref is None:
+        with self._lifecycle:
+            completion_ref = self._completion_ref
+        if completion_ref is None:
             raise RuntimeError("Ray stream completion ObjectRef is unavailable")
-        return self._completion_ref
+        return completion_ref
 
     def stream_finished(self) -> bool:
-        if self._generator is None:
-            return self._drained
-        return bool(self._generator.worker.core_worker.is_object_ref_stream_finished(self.completion_ref))
+        with self._lifecycle:
+            generator = self._generator
+            completion_ref = self._completion_ref
+            drained = self._drained
+            if generator is None or completion_ref is None:
+                return drained
+            self._active_core_calls += 1
+        try:
+            return bool(generator.worker.core_worker.is_object_ref_stream_finished(completion_ref))
+        finally:
+            with self._lifecycle:
+                self._active_core_calls -= 1
+                if self._active_core_calls < 0:
+                    raise RuntimeError("Ray stream active CoreWorker call count underflow")
+                self._lifecycle.notify_all()
 
     def is_terminal_ref(self, ref: Any) -> bool:
-        return self._generator is not None and ref == self._completion_ref
+        with self._lifecycle:
+            return self._generator is not None and ref == self._completion_ref
 
     def mark_drained(self) -> None:
-        self._drained = True
+        with self._lifecycle:
+            self._drained = True
 
     def release_task(self) -> None:
-        if self._task_released:
-            return
-        self._task_released = True
-        if self._leased is not None:
-            self._leased.release_task()
+        with self._lifecycle:
+            leased = self._leased if self._leased is not None else self._release_owner
+        if leased is not None:
+            leased.release_task()
+            self._drop_release_owner_if_complete(leased)
 
     @staticmethod
     def _delete_object_ref_stream(generator: Any, completion_ref: Any) -> None:
         worker = generator.worker
         core_worker = worker.core_worker
+        core_worker.async_delete_object_ref_stream(completion_ref)
+        # Ray's ObjectRefGenerator.__del__ unconditionally deletes through
+        # ``generator.worker``. Detach only after the explicit delete succeeds;
+        # a synchronous failure retains the worker for a bounded retry.
+        generator.worker = None
+
+    def _run_pending_stream_cleanup(self) -> bool:
+        with self._lifecycle:
+            if self._stream_cleanup_active:
+                return False
+            generator = self._cleanup_generator
+            completion_ref = self._cleanup_completion_ref
+            if generator is None or completion_ref is None:
+                return True
+            release_owner = self._release_owner
+            if self._terminal_kind == "cancel":
+                if release_owner is not None and not release_owner.generator_cancellation_complete:
+                    return False
+                if (
+                    release_owner is None
+                    and not self._generator_cancelled
+                    and (self._cancel_generator is not None or self._generator_cancel_active)
+                ):
+                    return False
+            if self._active_reads or self._active_core_calls:
+                # Cleanup lanes must never wait behind a stuck generator read.
+                # The bounded owner retries this operation after the in-flight
+                # call exits; retirement prevents any new call from starting.
+                return False
+            self._stream_cleanup_active = True
         try:
-            core_worker.async_delete_object_ref_stream(completion_ref)
-        finally:
-            # Ray 2.55's ObjectRefGenerator.__del__ unconditionally deletes the
-            # stream through ``generator.worker``.  We retire streams
-            # explicitly, so leaving that worker attached performs a second
-            # delete when the last local reference is dropped.  Under sustained
-            # streaming load that duplicate CoreWorker call can block the
-            # collector thread and, in a RayWorkerActor, the whole FTE consumer.
-            # Detach only after capturing the pinned CoreWorker/ref above; the
-            # adapter is terminal at every call site and must not be reused.
-            generator.worker = None
+            self._delete_object_ref_stream(generator, completion_ref)
+        except BaseException:
+            with self._lifecycle:
+                self._stream_cleanup_active = False
+                self._lifecycle.notify_all()
+            raise
+        with self._lifecycle:
+            self._stream_cleanup_active = False
+            if self._cleanup_generator is generator and self._cleanup_completion_ref is completion_ref:
+                self._cleanup_generator = None
+                self._cleanup_completion_ref = None
+            self._lifecycle.notify_all()
+        return True
+
+    def _run_unleased_generator_cancel(self) -> bool:
+        with self._lifecycle:
+            if self._generator_cancel_active:
+                return False
+            generator = self._cancel_generator
+            if generator is None:
+                return True
+            self._generator_cancel_active = True
+        try:
+            self._ray.cancel(generator, force=True, recursive=True)
+        except BaseException:
+            with self._lifecycle:
+                self._generator_cancel_active = False
+                self._lifecycle.notify_all()
+            raise
+        with self._lifecycle:
+            self._generator_cancel_active = False
+            self._generator_cancelled = True
+            if self._cancel_generator is generator:
+                self._cancel_generator = None
+            self._lifecycle.notify_all()
+        return True
+
+    def _drop_release_owner_if_complete(self, leased: TaskLeaseObjectRefGenerator) -> None:
+        with self._lifecycle:
+            if self._release_owner is leased and leased.terminal_cleanup_complete:
+                self._release_owner = None
+            self._lifecycle.notify_all()
+
+    def _leased_operation(
+        self,
+        leased: TaskLeaseObjectRefGenerator,
+        operation: Callable[[], Any],
+    ) -> Any:
+        result = operation()
+        self._drop_release_owner_if_complete(leased)
+        return result
 
     def retire(self) -> None:
         """Deterministically retire a fully drained Ray generator stream.
@@ -268,40 +664,22 @@ class RayStreamAdapter:
         ``__del__`` makes that cleanup depend on incidental Python references in
         this long-lived multiplexer, so terminal streams are retired explicitly.
         """
-        if self._retired:
-            return
-        self._retired = True
-        leased = self._leased
-        generator = self._generator
-        completion_ref = self._completion_ref
-        self.release_task()
-        self._source = None
-        self._leased = None
-        self._generator = None
-        self._completion_ref = None
-        if leased is not None:
-            leased.retire_local_state()
-        if generator is not None and completion_ref is not None:
-            self._delete_object_ref_stream(generator, completion_ref)
+        _run_cleanup_operations(
+            "Ray stream retirement failed",
+            self.retire_operations(),
+        )
+
+    def retire_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        return self._prepare_terminal_operations("retire")
 
     def cancel(self) -> None:
-        if self._retired:
-            return
-        self._retired = True
-        leased = self._leased
-        generator = self._generator
-        completion_ref = self._completion_ref
-        self._source = None
-        self._leased = None
-        self._generator = None
-        self._completion_ref = None
-        if leased is not None:
-            leased.cancel()
-            leased.retire_local_state()
-        elif generator is not None:
-            self._ray.cancel(generator, force=True, recursive=True)
-        if generator is not None and completion_ref is not None:
-            self._delete_object_ref_stream(generator, completion_ref)
+        _run_cleanup_operations(
+            "Ray stream cancellation failed",
+            self.cancel_operations(),
+        )
+
+    def cancel_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        return self._prepare_terminal_operations("cancel")
 
     def retire_failed(self) -> None:
         """Retire a terminal failure without racing it with ``ray.cancel``.
@@ -311,25 +689,103 @@ class RayStreamAdapter:
         normal task reply in Ray's CoreWorker.  The task lease still follows
         the failure path, but the already-ending remote work is left alone.
         """
-        if self._retired:
-            return
-        self._retired = True
-        leased = self._leased
-        generator = self._generator
-        completion_ref = self._completion_ref
-        self._source = None
-        self._leased = None
-        self._generator = None
-        self._completion_ref = None
+        _run_cleanup_operations(
+            "Ray failed stream retirement failed",
+            self.retire_failed_operations(),
+        )
+
+    def retire_failed_operations(self) -> tuple[RayStreamCleanupOperation, ...]:
+        return self._prepare_terminal_operations("failed")
+
+    def _prepare_terminal_operations(
+        self,
+        requested_kind: str,
+    ) -> tuple[RayStreamCleanupOperation, ...]:
+        if requested_kind not in {"retire", "failed", "cancel"}:
+            raise ValueError(f"invalid Ray stream terminal kind: {requested_kind}")
+        with self._lifecycle:
+            if not self._retired:
+                self._retired = True
+                self._terminal_kind = requested_kind
+                leased = self._leased
+                self._release_owner = leased
+                self._cleanup_generator = self._generator
+                self._cleanup_completion_ref = self._completion_ref
+                if requested_kind == "cancel" and leased is None:
+                    self._cancel_generator = self._generator
+                self._source = None
+                self._leased = None
+                self._generator = None
+                self._completion_ref = None
+            else:
+                leased = self._release_owner
+                # Never escalate normal completion into force-cancelling a Ray
+                # task whose terminal reply may already be in flight.
+                if self._terminal_kind == "retire" and requested_kind != "retire":
+                    self._terminal_kind = "failed"
+            terminal_kind = self._terminal_kind
+
+        leased_operations: list[RayStreamCleanupOperation] = []
         if leased is not None:
-            leased.retire_failed()
+            if terminal_kind == "cancel":
+                source_operations = leased.cancel_operations()
+            elif terminal_kind == "failed":
+                source_operations = leased.retire_failed_operations()
+            elif leased.cancellation_started:
+                source_operations = leased.cancel_operations()
+            else:
+                source_operations = leased.release_task_operations()
             leased.retire_local_state()
-        if generator is not None and completion_ref is not None:
-            self._delete_object_ref_stream(generator, completion_ref)
+            leased_operations = [
+                RayStreamCleanupOperation(
+                    operation.lane,
+                    partial(self._leased_operation, leased, operation.operation),
+                    retry_on_error=operation.retry_on_error,
+                    retry_on_incomplete=operation.retry_on_incomplete,
+                )
+                for operation in source_operations
+            ]
+
+        stream_operation = RayStreamCleanupOperation(
+            RAY_STREAM_CLEANUP_CORE,
+            self._run_pending_stream_cleanup,
+            retry_on_error=True,
+            retry_on_incomplete=True,
+        )
+        operations: list[RayStreamCleanupOperation] = [*leased_operations]
+        if terminal_kind == "cancel" and leased is None:
+            operations.append(
+                RayStreamCleanupOperation(
+                    RAY_STREAM_CLEANUP_CANCELLATION,
+                    self._run_unleased_generator_cancel,
+                    retry_on_error=True,
+                    retry_on_incomplete=True,
+                )
+            )
+        operations.append(stream_operation)
+        return tuple(operations)
+
+    @property
+    def terminal_cleanup_complete(self) -> bool:
+        with self._lifecycle:
+            stream_complete = self._cleanup_generator is None and not self._stream_cleanup_active
+            release_complete = self._release_owner is None
+            generator_complete = (
+                self._terminal_kind != "cancel"
+                or self._generator_cancelled
+                or (self._cancel_generator is None and not self._generator_cancel_active)
+            )
+            return self._retired and stream_complete and release_complete and generator_complete
 
 
 __all__ = [
+    "RAY_STREAM_CLEANUP_CANCELLATION",
+    "RAY_STREAM_CLEANUP_CONTROL",
+    "RAY_STREAM_CLEANUP_CORE",
+    "RAY_STREAM_CLEANUP_OUTPUT",
     "RayStreamAdapter",
+    "RayStreamCleanupOperation",
     "TaskLeaseObjectRefGenerator",
+    "resolve_ray_control_ack",
     "validate_ray_stream_contract",
 ]

--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import threading
-import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
@@ -219,6 +218,8 @@ class TaskLeaseObjectRefGenerator:
                 self._cancelled = True
                 if cancel_generator:
                     self._cancel_generator = self._generator
+                    if self._cancel_generator is None:
+                        self._generator_cancel_submitted = True
                 self._generator = None
 
     def _submit_generator_cancel(self) -> bool:
@@ -368,14 +369,13 @@ class RayStreamAdapter:
             active_ray_module = ray_module
 
         validate_ray_stream_contract(active_ray_module)
+        if not isinstance(source, TaskLeaseObjectRefGenerator):
+            raise TypeError(f"RayStreamAdapter requires a TaskLeaseObjectRefGenerator; got {type(source).__name__}")
         self._ray = active_ray_module
-        self._source = source
-        self._leased = source if isinstance(source, TaskLeaseObjectRefGenerator) else None
-        self._submission_scope = (
-            self._leased.submission_scope if self._leased is not None else f"stream:{uuid.uuid4().hex}"
-        )
-        self._task_request_identity = "" if self._leased is None else self._leased.request_id
-        self._generator = self._leased.generator if self._leased is not None else source
+        self._leased: TaskLeaseObjectRefGenerator | None = source
+        self._submission_scope = source.submission_scope
+        self._task_request_identity = source.request_id
+        self._generator = source.generator
         self._completion_ref: Any | None = None
         self._drained = False
         self._retired = False
@@ -384,8 +384,6 @@ class RayStreamAdapter:
         self._cleanup_completion_ref: Any | None = None
         self._stream_cleanup_active = False
         self._terminal_kind = ""
-        self._cancel_generator: Any | None = None
-        self._generator_cancelled = False
         self._lifecycle = threading.Condition()
         self._active_reads = 0
         self._active_core_calls = 0
@@ -393,7 +391,7 @@ class RayStreamAdapter:
 
     def _validate_generator_if_started(self) -> None:
         if self._generator is None:
-            return
+            raise TypeError("Ray UDF submission did not return an ObjectRefGenerator")
         version = str(getattr(self._ray, "__version__", "")).strip() or "unknown"
         missing = [name for name in _REQUIRED_GENERATOR_METHODS if not callable(getattr(self._generator, name, None))]
         if missing:
@@ -412,8 +410,8 @@ class RayStreamAdapter:
         completion_ref = self._generator.completed()
         if completion_ref is None:
             raise RuntimeError("Ray stream completion ObjectRef is unavailable")
-        if self._leased is not None:
-            self._leased._bind_completion_ref(completion_ref)
+        assert self._leased is not None
+        self._leased._bind_completion_ref(completion_ref)
         self._completion_ref = completion_ref
 
     @property
@@ -433,8 +431,8 @@ class RayStreamAdapter:
     @property
     def driver(self) -> Any | None:
         with self._lifecycle:
-            leased = self._leased
-        return None if leased is None else leased.driver
+            owner = self._leased if self._leased is not None else self._release_owner
+        return None if owner is None else owner.driver
 
     @property
     def waitable(self) -> Any:
@@ -520,13 +518,6 @@ class RayStreamAdapter:
             release_owner = self._release_owner
             if release_owner is not None and not release_owner.terminal_cleanup_complete:
                 return False
-            if (
-                self._terminal_kind == "cancel"
-                and release_owner is None
-                and not self._generator_cancelled
-                and self._cancel_generator is not None
-            ):
-                return False
             if self._active_reads or self._active_core_calls:
                 # The cleanup scheduler retries after the in-flight call exits;
                 # retirement prevents any new call from starting.
@@ -544,22 +535,6 @@ class RayStreamAdapter:
             if self._cleanup_generator is generator and self._cleanup_completion_ref is completion_ref:
                 self._cleanup_generator = None
                 self._cleanup_completion_ref = None
-            self._lifecycle.notify_all()
-        return True
-
-    def _run_unleased_generator_cancel(self) -> bool:
-        with self._lifecycle:
-            generator = self._cancel_generator
-            if generator is None:
-                return True
-        try:
-            self._ray.cancel(generator, force=True, recursive=True)
-        except BaseException:
-            raise
-        with self._lifecycle:
-            self._generator_cancelled = True
-            if self._cancel_generator is generator:
-                self._cancel_generator = None
             self._lifecycle.notify_all()
         return True
 
@@ -599,12 +574,11 @@ class RayStreamAdapter:
                 self._retired = True
                 self._terminal_kind = requested_kind
                 leased = self._leased
+                if leased is None:
+                    raise RuntimeError("Ray stream lost task-lease ownership before retirement")
                 self._release_owner = leased
                 self._cleanup_generator = self._generator
                 self._cleanup_completion_ref = self._completion_ref
-                if requested_kind == "cancel" and leased is None:
-                    self._cancel_generator = self._generator
-                self._source = None
                 self._leased = None
                 self._generator = None
                 self._completion_ref = None
@@ -645,15 +619,6 @@ class RayStreamAdapter:
             retry_on_incomplete=True,
         )
         operations: list[RayStreamCleanupOperation] = [*leased_operations]
-        if terminal_kind == "cancel" and leased is None:
-            operations.append(
-                RayStreamCleanupOperation(
-                    self._run_unleased_generator_cancel,
-                    submission_scope=self._submission_scope,
-                    retry_on_error=True,
-                    retry_on_incomplete=True,
-                )
-            )
         operations.append(stream_operation)
         return tuple(operations)
 
@@ -662,10 +627,7 @@ class RayStreamAdapter:
         with self._lifecycle:
             stream_complete = self._cleanup_generator is None and not self._stream_cleanup_active
             release_complete = self._release_owner is None
-            generator_complete = (
-                self._terminal_kind != "cancel" or self._generator_cancelled or self._cancel_generator is None
-            )
-            return self._retired and stream_complete and release_complete and generator_complete
+            return self._retired and stream_complete and release_complete
 
 
 __all__ = [

--- a/duckdb/execution/udf.py
+++ b/duckdb/execution/udf.py
@@ -24,6 +24,7 @@ _ALLOWED_OPTIONS = frozenset(
         "actor_dispatch_indices",
         "local_actor_pool",
         "query_driver_handle",
+        "query_generation_capability",
         "session_config",
     }
 )

--- a/duckdb/execution/udf_ray.py
+++ b/duckdb/execution/udf_ray.py
@@ -331,6 +331,7 @@ def ensure_actor_pools_for_plan(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     conn: Any = None,
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
@@ -339,6 +340,7 @@ def ensure_actor_pools_for_plan(
         conn=conn,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         actor_pool_cls=UDFActorPool,
         is_vane_worker_process=_is_vane_worker_process,
@@ -356,6 +358,7 @@ def ensure_actor_pools_for_nodes(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     set_handles: Any = None,
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
@@ -363,6 +366,7 @@ def ensure_actor_pools_for_nodes(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         set_handles=set_handles,
         actor_pool_cls=UDFActorPool,
@@ -381,6 +385,7 @@ def prepare_actor_pools_for_plan(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     conn: Any = None,
 ) -> tuple[list[_UDFActorPoolBase], dict[str, Any]]:
@@ -389,6 +394,7 @@ def prepare_actor_pools_for_plan(
         conn=conn,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         actor_pool_cls=UDFActorPool,
         is_vane_worker_process=_is_vane_worker_process,
@@ -420,12 +426,14 @@ class RemoteUDFExecutor(
         payload: dict[str, Any],
         *,
         query_driver_handle: Any,
+        query_generation_capability: str,
     ) -> None:
         self._actors_obj = actors
         self._payload = payload
         self._initialize_task_admission(
             payload,
             driver=query_driver_handle,
+            query_generation_capability=query_generation_capability,
         )
         self.actors = actors.actors
         # Actor readiness lifecycle:
@@ -492,6 +500,9 @@ def _build_ray_actor_executor(payload: dict[str, Any], options: dict[str, Any]) 
         query_driver_handle = options.get("query_driver_handle")
         if query_driver_handle is None:
             raise RuntimeError("Ray actor UDF executor requires an explicit query driver handle")
+        query_generation_capability = str(options.get("query_generation_capability") or "").strip()
+        if not query_generation_capability:
+            raise RuntimeError("Ray actor UDF executor requires a query generation capability")
         if "session_config" not in options:
             raise RuntimeError("Ray actor UDF executor requires explicit Vane session config")
         actors = UDFActorPool._from_handles(
@@ -504,6 +515,7 @@ def _build_ray_actor_executor(payload: dict[str, Any], options: dict[str, Any]) 
             actors,
             payload,
             query_driver_handle=query_driver_handle,
+            query_generation_capability=query_generation_capability,
         )
 
     raise RuntimeError(
@@ -519,6 +531,7 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
         run_ref_bundle_stream: Any,
         *,
         query_driver_handle: Any,
+        query_generation_capability: str,
     ) -> None:
         self.payload = payload
         self.run_bundle_stream = run_bundle_stream
@@ -527,6 +540,7 @@ class RayTaskUDFExecutor(TaskAdmissionExecutorMixin, UDFExecutor):
         self._initialize_task_admission(
             payload,
             driver=query_driver_handle,
+            query_generation_capability=query_generation_capability,
         )
         _ray_payload_requires_block_stream(payload)
         _ray_task_debug_log(
@@ -958,6 +972,9 @@ def _build_ray_task_executor(payload: dict[str, Any], options: dict[str, Any]) -
     query_driver_handle = options.get("query_driver_handle")
     if query_driver_handle is None:
         raise RuntimeError("Ray task UDF executor requires an explicit query driver handle")
+    query_generation_capability = str(options.get("query_generation_capability") or "").strip()
+    if not query_generation_capability:
+        raise RuntimeError("Ray task UDF executor requires a query generation capability")
     if "session_config" not in options:
         raise RuntimeError("Ray task UDF executor requires explicit Vane session config")
     ray_options = dict(options.get("ray_options") or {})
@@ -994,6 +1011,7 @@ def _build_ray_task_executor(payload: dict[str, Any], options: dict[str, Any]) -
             session_runtime_env_vars,
         ),
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
     )
 
 

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -488,7 +488,7 @@ def _create_actor_pools_for_nodes(
             if backend not in {"ray_task", "ray_actor", "subprocess_task", "subprocess_actor"}:
                 continue
             node_id = str(node["node_id"])
-            executor_options = {
+            executor_options: dict[str, Any] = {
                 "session_config": normalized_session_config,
             }
             actor_handles_map[node_id] = executor_options

--- a/duckdb/execution/udf_ray_actor_pool.py
+++ b/duckdb/execution/udf_ray_actor_pool.py
@@ -332,6 +332,7 @@ def ensure_actor_pools_for_plan(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
@@ -347,6 +348,7 @@ def ensure_actor_pools_for_plan(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         set_handles=lambda actor_handles_map: plan.set_udf_actor_handles(actor_handles_map, conn=conn),
         actor_pool_cls=actor_pool_cls,
@@ -366,6 +368,7 @@ def prepare_actor_pools_for_plan(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     actor_pool_cls: type[UDFActorPoolBase],
     is_vane_worker_process: Callable[[], bool],
@@ -388,6 +391,7 @@ def prepare_actor_pools_for_plan(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         set_handles=lambda actor_handles_map: plan.set_udf_actor_handles(actor_handles_map, conn=conn),
         actor_pool_cls=actor_pool_cls,
@@ -407,6 +411,7 @@ def ensure_actor_pools_for_nodes(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     set_handles: Callable[[dict[str, Any]], None] | None = None,
     actor_pool_cls: type[UDFActorPoolBase],
@@ -422,6 +427,7 @@ def ensure_actor_pools_for_nodes(
         udf_nodes,
         actor_node_ids_by_stage=actor_node_ids_by_stage,
         query_driver_handle=query_driver_handle,
+        query_generation_capability=query_generation_capability,
         session_config=session_config,
         set_handles=set_handles,
         actor_pool_cls=actor_pool_cls,
@@ -441,6 +447,7 @@ def _create_actor_pools_for_nodes(
     *,
     actor_node_ids_by_stage: dict[str, tuple[str, ...]],
     query_driver_handle: Any,
+    query_generation_capability: str,
     session_config: dict[str, str],
     set_handles: Callable[[dict[str, Any]], None] | None,
     actor_pool_cls: type[UDFActorPoolBase],
@@ -460,6 +467,9 @@ def _create_actor_pools_for_nodes(
         return [], {}
     if query_driver_handle is None:
         raise ValueError("Ray UDF executor preparation requires an explicit query driver handle")
+    generation_capability = str(query_generation_capability or "").strip()
+    if not generation_capability:
+        raise ValueError("Ray UDF executor preparation requires a query generation capability")
     normalized_session_config = {str(key): str(value) for key, value in session_config.items()}
     session_runtime_env_vars = build_session_runtime_env_vars(normalized_session_config)
 
@@ -485,6 +495,7 @@ def _create_actor_pools_for_nodes(
             if backend in {"subprocess_task", "subprocess_actor"}:
                 continue
             executor_options["query_driver_handle"] = query_driver_handle
+            executor_options["query_generation_capability"] = generation_capability
             if not requires_actor_pool_fn(raw_payload):
                 continue
             payload = normalize_actor_pool_payload(raw_payload)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -24,6 +24,9 @@ from duckdb.execution.udf_ray_stream_protocol import (
     validate_stream_error_metadata,
 )
 
+_GENERATOR_READINESS_POLL_INITIAL_DELAY_S = 0.001
+_GENERATOR_READINESS_POLL_MAX_DELAY_S = 0.01
+
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
     value = os.environ.get("DUCKDB_DISTRIBUTED_DEBUG", "")
@@ -107,6 +110,9 @@ class _StreamRecord:
     wait_future: Any | None = None
     completion_future: Any | None = None
     terminal_signal_observed: bool = False
+    next_ref_ready: bool = False
+    ready_sequence: int | None = None
+    cleanup_started: bool = False
 
 
 class AsyncResultCollector:
@@ -127,6 +133,7 @@ class AsyncResultCollector:
         self._cv = threading.Condition()
         self._shutdown = False
         self._started = False
+        self._thread_started = False
         self._thread_error: BaseException | None = None
         self._wakeup_fn: Any | None = None
         self._records: dict[tuple[int, int], _StreamRecord] = {}
@@ -135,8 +142,16 @@ class AsyncResultCollector:
         self._active_output_leases: dict[tuple[str, str], _OutputLeaseToken] = {}
         self._cancelled_slots: set[int] = set()
         self._next_sequence = 0
+        self._next_ready_sequence = 0
+        self._cleanup_threads: set[threading.Thread] = set()
+        self._cleanup_errors: list[BaseException] = []
+        self._cleanup_starting = 0
+        self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
+        self._readiness_timer: asyncio.TimerHandle | None = None
+        self._readiness_wakeup_pending = False
         self._loop = asyncio.new_event_loop()
         self._loop_ready = threading.Event()
+        self._start_lock = threading.Lock()
         self._thread = threading.Thread(
             target=self._run_event_loop,
             daemon=True,
@@ -173,14 +188,33 @@ class AsyncResultCollector:
             )
             self._next_sequence += 1
             self._records[key] = record
-            self._cv.notify_all()
+            self._signal_readiness_change_locked()
         _collector_debug_log("track", record)
-        self._ensure_started()
+        try:
+            self._ensure_started()
+            with self._cv:
+                if self._records.get(key) is not record:
+                    self._raise_if_stopped_locked()
+                    raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} was cancelled during startup")
+        except BaseException as exc:
+            with self._cv:
+                owned = self._records.pop(key, None) is record
+                record.terminal = True
+                self._cv.notify_all()
+            if owned:
+                try:
+                    record.adapter.cancel()
+                except BaseException as cleanup_exc:
+                    add_note = getattr(exc, "add_note", None)
+                    if callable(add_note):
+                        add_note(f"stream startup cleanup failed: {cleanup_exc}")
+            raise
         self._refresh_waiters()
 
     def drain_results(self, capacities: dict[Any, Any] | None = None) -> list[tuple[Any, ...]]:
         parsed = self._parse_capacities(capacities)
         results: list[tuple[Any, ...]] = []
+        readiness_changed = False
         with self._cv:
             self._raise_if_stopped_locked()
             for slot_id, capacity in parsed.items():
@@ -204,15 +238,23 @@ class AsyncResultCollector:
                         delivered_rows += 1
                         delivered_bytes += event.size_bytes
                     results.append(ready.popleft().as_tuple())
+                if delivered_rows:
+                    readiness_changed = True
                 if ready is not None and not ready:
                     self._ready_by_slot.pop(slot_id, None)
                 remaining_bytes = None if capacity.bytes is None else max(0, capacity.bytes - delivered_bytes)
-                self._capacity_by_slot[slot_id] = _DrainCapacity(
+                updated_capacity = _DrainCapacity(
                     rows=max(0, capacity.rows - delivered_rows),
                     bytes=remaining_bytes,
                     item_bytes=capacity.item_bytes,
                 )
-            self._cv.notify_all()
+                if self._capacity_by_slot.get(slot_id) != updated_capacity:
+                    readiness_changed = True
+                self._capacity_by_slot[slot_id] = updated_capacity
+            if readiness_changed:
+                self._signal_readiness_change_locked()
+            else:
+                self._cv.notify_all()
         self._refresh_waiters()
         return results
 
@@ -252,33 +294,68 @@ class AsyncResultCollector:
     def cancel_slot(self, slot_id: int) -> None:
         slot_key = int(slot_id)
         with self._cv:
+            if self._shutdown:
+                return
             records = [record for record in self._records.values() if record.slot_id == slot_key]
+            records_to_cancel = [record for record in records if not record.cleanup_started]
+            control_requests: list[tuple[Any, dict[str, Any]]] = []
             for record in records:
                 self._records.pop((record.slot_id, record.submit_id), None)
                 record.terminal = True
+                if not record.cleanup_started:
+                    record.cleanup_started = True
                 self._cancel_record_wait_locked(record)
+            for record in records_to_cancel:
+                request = record.output_request
+                driver = record.adapter.driver
+                if request is not None and driver is not None and not record.output_cancel_sent:
+                    record.output_cancel_sent = True
+                    control_requests.append((driver, request))
             ready = list(self._ready_by_slot.pop(slot_key, ()))
             tokens = [token for token in self._active_output_leases.values() if token.slot_id == slot_key]
             for token in tokens:
                 self._active_output_leases.pop((token.request_id, token.lease_id), None)
             self._capacity_by_slot.pop(slot_key, None)
             self._cancelled_slots.add(slot_key)
-            self._cv.notify_all()
+            self._cleanup_starting += 1
+            self._signal_readiness_change_locked()
 
-        for record in records:
-            self._cancel_record_control(record)
-            record.adapter.cancel()
         ready_tokens = [event.output_token for event in ready if event.output_token is not None]
         token_keys = {(token.request_id, token.lease_id) for token in tokens}
         for token in ready_tokens:
             if token is not None and (token.request_id, token.lease_id) not in token_keys:
                 tokens.append(token)
                 token_keys.add((token.request_id, token.lease_id))
-        for token in tokens:
-            token.driver.release_query_output_block_lease.remote(
-                token.request_id,
-                token.lease_id,
+
+        def cleanup_slot() -> None:
+            actions: list[Any] = [
+                lambda driver=driver, request=request: driver.cancel_query_output_block_lease_request.remote(request)
+                for driver, request in control_requests
+            ]
+            for record in records_to_cancel:
+                actions.append(record.adapter.cancel)
+            for token in tokens:
+                actions.append(
+                    lambda token=token: token.driver.release_query_output_block_lease.remote(
+                        token.request_id,
+                        token.lease_id,
+                    )
+                )
+            self._run_isolated_cleanup_actions(
+                actions,
+                name="udf-ray-stream-cancel-action",
             )
+
+        def cleanup_registered() -> None:
+            with self._cv:
+                self._cleanup_starting -= 1
+                self._cv.notify_all()
+
+        self._run_cleanup_after_scheduler_turn(
+            cleanup_slot,
+            timeout_message=f"Ray UDF slot {slot_key} cleanup did not terminate",
+            on_registered=cleanup_registered,
+        )
 
     def slot_has_pending(self, slot_id: int) -> bool:
         slot_key = int(slot_id)
@@ -294,64 +371,115 @@ class AsyncResultCollector:
             self._wakeup_fn = fn
 
     def shutdown(self) -> None:
-        with self._cv:
-            if self._shutdown:
-                return
-            self._shutdown = True
-            self._wakeup_fn = None
-            records = list(self._records.values())
-            for record in records:
-                self._cancel_record_wait_locked(record)
-            self._records.clear()
-            tokens = list(self._active_output_leases.values())
-            self._active_output_leases.clear()
-            self._ready_by_slot.clear()
-            self._capacity_by_slot.clear()
-            self._cv.notify_all()
-        if self._started:
-            self._loop.call_soon_threadsafe(self._loop.stop)
-        if self._started and self._thread is not threading.current_thread():
-            self._thread.join(timeout=self._shutdown_timeout_s)
-            if self._thread.is_alive():
-                raise RuntimeError("Ray UDF stream multiplexer did not terminate")
-
-        cleanup_errors: list[BaseException] = []
-
-        def cleanup_remote_state() -> None:
-            try:
+        deadline = time.monotonic() + self._shutdown_timeout_s
+        shutdown_from_scheduler = self._thread is threading.current_thread()
+        shutdown_errors: list[BaseException] = []
+        with self._start_lock:
+            with self._cv:
+                if self._shutdown:
+                    return
+                self._shutdown = True
+                self._wakeup_fn = None
+                records = list(self._records.values())
+                records_to_cancel = [record for record in records if not record.cleanup_started]
+                control_requests: list[tuple[Any, dict[str, Any]]] = []
                 for record in records:
-                    self._cancel_record_control(record)
-                    record.adapter.cancel()
-                for token in tokens:
-                    token.driver.release_query_output_block_lease.remote(
-                        token.request_id,
-                        token.lease_id,
-                    )
-            except BaseException as exc:
-                cleanup_errors.append(exc)
+                    self._cancel_record_wait_locked(record)
+                for record in records_to_cancel:
+                    request = record.output_request
+                    driver = record.adapter.driver
+                    if request is not None and driver is not None and not record.output_cancel_sent:
+                        record.output_cancel_sent = True
+                        control_requests.append((driver, request))
+                self._records.clear()
+                tokens = list(self._active_output_leases.values())
+                self._active_output_leases.clear()
+                self._ready_by_slot.clear()
+                self._capacity_by_slot.clear()
+                self._signal_readiness_change_locked()
+            if self._thread_started:
+                try:
+                    self._loop.call_soon_threadsafe(self._loop.stop)
+                except RuntimeError as exc:
+                    if self._thread.is_alive():
+                        shutdown_errors.append(exc)
+        for driver, request in control_requests:
+            self._start_tracked_cleanup(
+                name="udf-ray-stream-shutdown-control",
+                operation=lambda driver=driver, request=request: driver.cancel_query_output_block_lease_request.remote(
+                    request
+                ),
+            )
 
-        cleanup_thread = threading.Thread(
-            target=cleanup_remote_state,
-            daemon=True,
-            name="udf-ray-stream-shutdown",
-        )
-        cleanup_thread.start()
-        cleanup_thread.join(timeout=self._shutdown_timeout_s)
-        if cleanup_thread.is_alive():
-            raise RuntimeError("Ray UDF stream remote cleanup did not terminate")
-        if cleanup_errors:
-            raise RuntimeError(f"Ray UDF stream remote cleanup failed: {cleanup_errors[0]}") from cleanup_errors[0]
+        for record in records_to_cancel:
+
+            def cancel_adapter(record: _StreamRecord = record) -> None:
+                # A stalled zero-time Ray probe still owns the generator
+                # handle. Keep this daemon task as its durable cleanup owner.
+                if self._thread.is_alive() and not shutdown_from_scheduler:
+                    self._thread.join()
+                record.adapter.cancel()
+
+            self._start_tracked_cleanup(
+                name="udf-ray-stream-shutdown-adapter",
+                operation=cancel_adapter,
+            )
+        for token in tokens:
+            self._start_tracked_cleanup(
+                name="udf-ray-stream-shutdown-lease",
+                operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
+                    token.request_id,
+                    token.lease_id,
+                ),
+            )
+
+        if self._thread_started and self._thread is not threading.current_thread():
+            self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            if self._thread.is_alive():
+                shutdown_errors.append(RuntimeError("Ray UDF stream multiplexer did not terminate"))
+
+        with self._cv:
+            while self._cleanup_starting or self._cleanup_threads:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._cv.wait(timeout=remaining)
+            if self._cleanup_starting or self._cleanup_threads:
+                shutdown_errors.append(RuntimeError("Ray UDF stream remote cleanup did not terminate"))
+            shutdown_errors.extend(self._cleanup_errors)
+            self._cleanup_errors.clear()
+        if shutdown_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in shutdown_errors)
+            raise RuntimeError(f"Ray UDF stream shutdown failed: {details}") from shutdown_errors[0]
 
     # Multiplexer internals.
 
     def _ensure_started(self) -> None:
-        with self._cv:
-            if self._started:
-                return
-            self._started = True
-        self._thread.start()
-        if not self._loop_ready.wait(timeout=self._shutdown_timeout_s):
-            raise RuntimeError("Ray UDF stream event loop did not start")
+        with self._start_lock:
+            with self._cv:
+                if self._started:
+                    self._raise_if_stopped_locked()
+                    return
+                self._raise_if_stopped_locked()
+                self._started = True
+            thread_started = False
+            try:
+                self._thread.start()
+                thread_started = True
+                self._thread_started = True
+                if not self._loop_ready.wait(timeout=self._shutdown_timeout_s):
+                    raise RuntimeError("Ray UDF stream event loop did not start")
+                with self._cv:
+                    self._raise_if_stopped_locked()
+                    self._signal_readiness_change_locked()
+            except BaseException as exc:
+                with self._cv:
+                    if self._thread_error is None:
+                        self._thread_error = exc
+                    self._cv.notify_all()
+                if not thread_started:
+                    self._loop.close()
+                raise
 
     def _raise_if_stopped_locked(self) -> None:
         if self._thread_error is not None:
@@ -390,6 +518,8 @@ class AsyncResultCollector:
         return ready + in_progress
 
     def _may_read_block_locked(self, record: _StreamRecord) -> bool:
+        if not record.next_ref_ready:
+            return False
         capacity = self._capacity_by_slot.get(record.slot_id)
         if capacity is None or capacity.rows <= 0:
             return False
@@ -398,6 +528,276 @@ class AsyncResultCollector:
         if capacity.item_bytes is not None and capacity.item_bytes <= 0:
             return False
         return self._pending_data_count_locked(record.slot_id) < capacity.rows
+
+    def _signal_readiness_change_locked(self) -> None:
+        """Request an immediate scheduler pass without a remote wakeup RPC."""
+        self._cv.notify_all()
+        if (
+            self._shutdown
+            or self._thread_error is not None
+            or not self._started
+            or not self._loop_ready.is_set()
+            or self._readiness_wakeup_pending
+        ):
+            return
+        self._readiness_wakeup_pending = True
+        try:
+            self._loop.call_soon_threadsafe(self._wake_generator_readiness)
+        except RuntimeError as exc:
+            self._readiness_wakeup_pending = False
+            if not self._shutdown:
+                self._thread_error = exc
+                self._cv.notify_all()
+
+    def _readiness_waitables_locked(self) -> dict[Any, _StreamRecord]:
+        waitables: dict[Any, _StreamRecord] = {}
+        admissible_slots = {
+            slot_id
+            for slot_id, capacity in self._capacity_by_slot.items()
+            if capacity.rows > 0
+            and (capacity.bytes is None or capacity.bytes > 0)
+            and (capacity.item_bytes is None or capacity.item_bytes > 0)
+            and self._pending_data_count_locked(slot_id) < capacity.rows
+        }
+        for record in self._records.values():
+            if (
+                record.terminal
+                or record.slot_id not in admissible_slots
+                or record.phase != "block"
+                or record.next_ref_ready
+                or record.wait_future is not None
+                or record.terminal_ref is not None
+            ):
+                continue
+            waitable = record.adapter.waitable
+            if waitable in waitables:
+                raise RuntimeError("Ray UDF collector cannot observe one generator for multiple stream records")
+            waitables[waitable] = record
+        return waitables
+
+    def _scheduler_stopped_locked(self) -> bool:
+        return self._shutdown or self._thread_error is not None
+
+    def _wake_generator_readiness(self) -> None:
+        """Interrupt an idle backoff and run the central scheduler immediately."""
+        try:
+            with self._cv:
+                self._readiness_wakeup_pending = False
+                timer = self._readiness_timer
+                self._readiness_timer = None
+                if timer is not None:
+                    timer.cancel()
+                if self._shutdown or self._thread_error is not None:
+                    return
+                self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
+            self._poll_generator_readiness()
+        except BaseException as exc:
+            self._report_scheduler_error(exc)
+
+    def _poll_generator_readiness(self) -> None:
+        """Run one Ray Data-style non-consuming readiness scheduling pass.
+
+        The existing multiplexer event loop is the single owner of generator
+        probes, reads, and terminal retirement.  A zero-time public
+        ``ray.wait`` rebuilds the eligible set on every pass; local admission
+        changes cancel the current idle timer, while exponential backoff bounds
+        polling overhead for genuinely slow generators.
+        """
+        try:
+            self._poll_generator_readiness_once()
+        except BaseException as exc:
+            self._report_scheduler_error(exc)
+
+    def _poll_generator_readiness_once(self) -> None:
+        with self._cv:
+            self._readiness_timer = None
+            if self._scheduler_stopped_locked():
+                return
+            waitables = self._readiness_waitables_locked()
+        if not waitables:
+            with self._cv:
+                self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
+            return
+
+        ready, _ = self._ray.wait(
+            list(waitables),
+            num_returns=len(waitables),
+            fetch_local=False,
+            timeout=0,
+        )
+
+        ready_records: list[_StreamRecord] = []
+        with self._cv:
+            if self._scheduler_stopped_locked():
+                return
+            currently_waitable = self._readiness_waitables_locked()
+            for waitable in ready:
+                record = waitables.get(waitable)
+                if record is None:
+                    self._thread_error = RuntimeError("Ray returned an unknown generator readiness handle")
+                    self._cv.notify_all()
+                    break
+                if currently_waitable.get(waitable) is record:
+                    record.next_ref_ready = True
+                    record.ready_sequence = self._next_ready_sequence
+                    self._next_ready_sequence += 1
+                    ready_records.append(record)
+            if self._thread_error is not None:
+                notify_error = True
+            else:
+                notify_error = False
+                if ready_records:
+                    self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
+                    self._cv.notify_all()
+                elif not self._readiness_wakeup_pending:
+                    delay_s = self._readiness_delay_s
+                    self._readiness_delay_s = min(
+                        _GENERATOR_READINESS_POLL_MAX_DELAY_S,
+                        delay_s * 2,
+                    )
+                    self._readiness_timer = self._loop.call_later(
+                        delay_s,
+                        self._poll_generator_readiness,
+                    )
+
+        if notify_error:
+            self._notify_wakeup()
+            return
+        if ready_records:
+            for record in ready_records:
+                _collector_debug_log("generator_ready", record)
+            self._refresh_waiters()
+
+    def _report_scheduler_error(self, exc: BaseException) -> None:
+        with self._cv:
+            report = not self._shutdown and self._thread_error is None
+            if report:
+                self._thread_error = exc
+            self._cv.notify_all()
+        if report:
+            self._notify_wakeup()
+
+    def _start_tracked_cleanup(
+        self,
+        *,
+        name: str,
+        operation: Any,
+        on_done: Any | None = None,
+        store_error: bool = True,
+    ) -> tuple[threading.Thread | None, list[BaseException]]:
+        """Run a possibly blocking Ray cleanup without occupying the scheduler."""
+        errors: list[BaseException] = []
+        thread: threading.Thread
+
+        def cleanup() -> None:
+            operation_error: BaseException | None = None
+            try:
+                operation()
+            except BaseException as exc:
+                operation_error = exc
+                errors.append(exc)
+            try:
+                if on_done is not None:
+                    on_done(operation_error)
+                elif operation_error is not None and store_error:
+                    with self._cv:
+                        self._cleanup_errors.append(operation_error)
+                        self._cv.notify_all()
+            except BaseException as exc:
+                errors.append(exc)
+                if store_error:
+                    with self._cv:
+                        self._cleanup_errors.append(exc)
+                        self._cv.notify_all()
+            finally:
+                with self._cv:
+                    self._cleanup_threads.discard(thread)
+                    self._cv.notify_all()
+
+        thread = threading.Thread(
+            target=cleanup,
+            daemon=True,
+            name=name,
+        )
+        with self._cv:
+            self._cleanup_threads.add(thread)
+        try:
+            thread.start()
+        except BaseException:
+            with self._cv:
+                self._cleanup_threads.discard(thread)
+                self._cv.notify_all()
+            cleanup()
+            return None, errors
+        return thread, errors
+
+    def _run_isolated_cleanup_actions(
+        self,
+        actions: list[Any],
+        *,
+        name: str,
+    ) -> None:
+        """Attempt every independent cleanup even when one Ray call blocks."""
+        handles: list[threading.Thread] = []
+        action_errors: list[list[BaseException]] = []
+        for action in actions:
+            thread, errors = self._start_tracked_cleanup(
+                name=name,
+                operation=action,
+                store_error=False,
+            )
+            action_errors.append(errors)
+            if thread is not None:
+                handles.append(thread)
+        for thread in handles:
+            thread.join()
+        errors = [error for group in action_errors for error in group]
+        if errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+            raise RuntimeError(f"Ray UDF stream cleanup failed: {details}") from errors[0]
+
+    def _run_cleanup_after_scheduler_turn(
+        self,
+        operation: Any,
+        *,
+        timeout_message: str,
+        on_registered: Any | None = None,
+    ) -> None:
+        """Run terminal cleanup only after every earlier generator probe."""
+        scheduler_safe = threading.Event()
+        with self._cv:
+            needs_turn = self._started and self._thread.is_alive() and self._thread is not threading.current_thread()
+        if needs_turn:
+            try:
+                self._loop.call_soon_threadsafe(scheduler_safe.set)
+            except RuntimeError:
+                if not self._thread.is_alive():
+                    scheduler_safe.set()
+        else:
+            scheduler_safe.set()
+
+        def cleanup() -> None:
+            while not scheduler_safe.wait(timeout=0.1):
+                if not self._thread.is_alive():
+                    break
+            operation()
+
+        cleanup_thread, cleanup_errors = self._start_tracked_cleanup(
+            name="udf-ray-stream-cancel",
+            operation=cleanup,
+            store_error=False,
+        )
+        if on_registered is not None:
+            on_registered()
+        if cleanup_thread is None:
+            if cleanup_errors:
+                raise RuntimeError(f"{timeout_message}: {cleanup_errors[0]}") from cleanup_errors[0]
+            return
+        cleanup_thread.join(timeout=self._shutdown_timeout_s)
+        if cleanup_thread.is_alive():
+            raise RuntimeError(timeout_message)
+        if cleanup_errors:
+            raise RuntimeError(f"{timeout_message}: {cleanup_errors[0]}") from cleanup_errors[0]
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
@@ -410,6 +810,12 @@ class AsyncResultCollector:
                 self._cv.notify_all()
             self._notify_wakeup()
         finally:
+            with self._cv:
+                timer = self._readiness_timer
+                self._readiness_timer = None
+                self._readiness_wakeup_pending = False
+            if timer is not None:
+                timer.cancel()
             pending = asyncio.all_tasks(self._loop)
             for task in pending:
                 task.cancel()
@@ -463,6 +869,9 @@ class AsyncResultCollector:
                 # downstream capacity may legitimately fall to zero before the
                 # metadata ObjectRef becomes ready.
                 record.block_item_capacity_bytes = capacity.item_bytes
+                record.next_ref_ready = False
+                record.ready_sequence = None
+                self._signal_readiness_change_locked()
             future = asyncio.run_coroutine_threadsafe(
                 record.adapter.read_next_ref_async(),
                 self._loop,
@@ -517,9 +926,16 @@ class AsyncResultCollector:
 
     def _refresh_waiters(self) -> None:
         with self._cv:
-            if self._shutdown or not self._started or not self._loop_ready.is_set():
+            if self._shutdown or self._thread_error is not None or not self._started or not self._loop_ready.is_set():
                 return
-            for record in self._records.values():
+            records = sorted(
+                self._records.values(),
+                key=lambda record: (
+                    record.phase == "block" and record.next_ref_ready,
+                    record.ready_sequence if record.ready_sequence is not None else record.sequence,
+                ),
+            )
+            for record in records:
                 self._schedule_completion_wait_locked(record)
                 self._schedule_record_wait_locked(record)
 
@@ -609,6 +1025,7 @@ class AsyncResultCollector:
                 if record.wait_future is future:
                     record.wait_future = None
                     record.wait_kind = ""
+                    self._signal_readiness_change_locked()
             self._refresh_waiters()
 
     def _accept_stream_ref(self, record: _StreamRecord, next_ref: Any) -> None:
@@ -691,8 +1108,15 @@ class AsyncResultCollector:
             stale = self._shutdown or self._records.get(key) is not record or record.terminal
             if not stale:
                 record.output_lease_ref = output_lease_ref
+            cancel_stale_request = stale and not record.output_cancel_sent
+            if cancel_stale_request:
+                record.output_cancel_sent = True
         if stale:
-            self._cancel_record_control(record)
+            if cancel_stale_request:
+                self._start_tracked_cleanup(
+                    name="udf-ray-stream-stale-control",
+                    operation=lambda: driver.cancel_query_output_block_lease_request.remote(request),
+                )
             return
         _collector_debug_log("output_lease_requested", record)
 
@@ -771,11 +1195,14 @@ class AsyncResultCollector:
                 record.output_request = None
                 record.output_lease_ref = None
                 record.output_cancel_sent = False
-                self._cv.notify_all()
+                self._signal_readiness_change_locked()
         if stale:
-            driver.release_query_output_block_lease.remote(
-                token.request_id,
-                token.lease_id,
+            self._start_tracked_cleanup(
+                name="udf-ray-stream-stale-lease",
+                operation=lambda: driver.release_query_output_block_lease.remote(
+                    token.request_id,
+                    token.lease_id,
+                ),
             )
             return
         _collector_debug_log("output_lease_granted", record)
@@ -790,18 +1217,60 @@ class AsyncResultCollector:
             return
         record.adapter.mark_drained()
         key = (record.slot_id, record.submit_id)
+
+        def finish_retirement(error: BaseException | None) -> None:
+            dropped_tokens: list[_OutputLeaseToken] = []
+            with self._cv:
+                if self._records.pop(key, None) is not record:
+                    if error is not None:
+                        self._cleanup_errors.append(error)
+                        self._cv.notify_all()
+                    return
+                if error is None:
+                    event = _ReadyEvent(record.slot_id, record.submit_id, "complete", None)
+                else:
+                    ready = self._ready_by_slot.get(record.slot_id)
+                    if ready is not None:
+                        kept: deque[_ReadyEvent] = deque()
+                        for queued in ready:
+                            if queued.submit_id == record.submit_id and queued.kind == "data":
+                                if queued.output_token is not None:
+                                    dropped_tokens.append(queued.output_token)
+                                continue
+                            kept.append(queued)
+                        self._ready_by_slot[record.slot_id] = kept
+                    for token in dropped_tokens:
+                        self._active_output_leases.pop((token.request_id, token.lease_id), None)
+                    event = _ReadyEvent(
+                        record.slot_id,
+                        record.submit_id,
+                        "error",
+                        f"{type(error).__name__}: {error}",
+                    )
+                self._ready_by_slot[record.slot_id].append(event)
+                for token in dropped_tokens:
+                    self._start_tracked_cleanup(
+                        name="udf-ray-stream-retire-leases",
+                        operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
+                            token.request_id,
+                            token.lease_id,
+                        ),
+                    )
+                self._cv.notify_all()
+            _collector_debug_log("retired" if error is None else "retire_failed", record)
+            self._notify_wakeup()
+
         with self._cv:
             if self._records.get(key) is not record:
                 return
             record.terminal = True
-        record.adapter.retire()
-        with self._cv:
-            if self._records.pop(key, None) is not record:
-                return
-            self._ready_by_slot[record.slot_id].append(_ReadyEvent(record.slot_id, record.submit_id, "complete", None))
-            self._cv.notify_all()
-        _collector_debug_log("retired", record)
-        self._notify_wakeup()
+            record.cleanup_started = True
+            self._signal_readiness_change_locked()
+            self._start_tracked_cleanup(
+                name="udf-ray-stream-retire",
+                operation=record.adapter.retire,
+                on_done=finish_retirement,
+            )
 
     def _cancel_record_control(self, record: _StreamRecord) -> None:
         with self._cv:
@@ -819,6 +1288,7 @@ class AsyncResultCollector:
             if self._records.pop(key, None) is not record:
                 return
             record.terminal = True
+            record.cleanup_started = True
             ready = self._ready_by_slot.get(record.slot_id)
             dropped_tokens: list[_OutputLeaseToken] = []
             if ready is not None:
@@ -840,22 +1310,41 @@ class AsyncResultCollector:
                     f"{type(exc).__name__}: {exc}",
                 )
             )
-            self._cv.notify_all()
+            request = record.output_request
+            driver = record.adapter.driver
+            record.output_cancel_sent = request is not None and driver is not None
+            terminal_signal_observed = record.terminal_signal_observed
+            self._cleanup_starting += 1
+            self._signal_readiness_change_locked()
         # Publish the terminal event before any Ray cancellation/control work.
         # The C++ dispatcher is event-driven; delaying this callback until after
         # ray.cancel() can leave the slot asleep forever when cancellation is
         # slow or the failed generator is being reconstructed.
-        self._notify_wakeup()
-        self._cancel_record_control(record)
-        if record.terminal_signal_observed:
-            record.adapter.retire_failed()
-        else:
-            record.adapter.cancel()
-        for token in dropped_tokens:
-            token.driver.release_query_output_block_lease.remote(
-                token.request_id,
-                token.lease_id,
-            )
+        try:
+            self._notify_wakeup()
+        finally:
+            try:
+                for token in dropped_tokens:
+                    self._start_tracked_cleanup(
+                        name="udf-ray-stream-failed-lease",
+                        operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
+                            token.request_id,
+                            token.lease_id,
+                        ),
+                    )
+                if request is not None and driver is not None:
+                    self._start_tracked_cleanup(
+                        name="udf-ray-stream-failed-control",
+                        operation=lambda: driver.cancel_query_output_block_lease_request.remote(request),
+                    )
+                self._start_tracked_cleanup(
+                    name="udf-ray-stream-failed-adapter",
+                    operation=record.adapter.retire_failed if terminal_signal_observed else record.adapter.cancel,
+                )
+            finally:
+                with self._cv:
+                    self._cleanup_starting -= 1
+                    self._cv.notify_all()
 
     def _notify_wakeup(self) -> None:
         with self._cv:

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from duckdb.execution.ray_control_submission import submit_ray_control
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
     RayStreamCleanupOperation,
@@ -116,6 +117,7 @@ class _StreamRecord:
     block_item_capacity_bytes: int | None = None
     output_request_id: str = ""
     output_request: dict[str, Any] | None = None
+    output_submit_future: Any | None = None
     output_lease_ref: Any | None = None
     output_cancel_sent: bool = False
     producer_completed: bool = False
@@ -149,6 +151,7 @@ class _CleanupTicket:
         self.retry_on_incomplete = bool(retry_on_incomplete)
         self.abandon_wait = abandon_wait
         self.retry_count = 0
+        self.operation_future: Any | None = None
         self.wait_future: Any | None = None
         self.wait_timeout: asyncio.TimerHandle | None = None
         self._done = False
@@ -206,11 +209,13 @@ class AsyncResultCollector:
     A terminal record is removed only while ``_cleanup_handoff_lock`` prevents
     shutdown from observing an ownership gap.
 
-    The asyncio thread is the sole generator readiness, read, and cleanup
-    consumer. Driver RPCs are observed through public ObjectRef futures;
-    cancellation and CoreWorker stream deletion are non-waiting submissions.
-    Every terminal operation enters the ticket ledger before its source record
-    is removed, so shutdown can never observe an ownership gap.
+    The asyncio thread is the sole generator-readiness, read, and state
+    scheduler. Potentially blocking Ray control submissions and terminal
+    operations run on one fixed process-wide daemon executor and publish their
+    results back to that loop. Driver RPCs are observed through public
+    ObjectRef futures. Every terminal operation enters the ticket ledger before
+    its source record is removed, so shutdown can never observe an ownership
+    gap.
 
     The native dispatcher keeps this collector alive across empty slot
     intervals. ``shutdown`` is the process-owner fence and is called only after
@@ -1285,70 +1290,142 @@ class AsyncResultCollector:
 
     def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
-            if ticket not in self._cleanup_tickets or ticket.wait_future is not None:
+            if (
+                ticket not in self._cleanup_tickets
+                or ticket.operation_future is not None
+                or ticket.wait_future is not None
+            ):
                 return
-        error: BaseException | None = None
-        retry = False
         try:
-            result = ticket.operation()
-            if all(callable(getattr(result, name, None)) for name in ("add_done_callback", "done", "result")):
-                with self._cv:
-                    if ticket not in self._cleanup_tickets:
-                        return
-                    ticket.wait_future = result
-
-                collector_ref = weakref.ref(self)
-                ticket_ref = weakref.ref(ticket)
-
-                def ready(future: Any) -> None:
-                    collector = collector_ref()
-                    active_ticket = ticket_ref()
-                    if collector is None or active_ticket is None:
-                        return
-                    try:
-                        collector._loop.call_soon_threadsafe(
-                            collector._resume_cleanup_ticket,
-                            active_ticket,
-                            future,
-                        )
-                    except RuntimeError as exc:
-                        with collector._cv:
-                            if collector._thread_error is None:
-                                collector._thread_error = exc
-                            collector._cv.notify_all()
-
-                try:
-                    result.add_done_callback(ready)
-                except BaseException as exc:
-                    with self._cv:
-                        if ticket.wait_future is result:
-                            ticket.wait_future = None
-                    # Callback registration is part of the required public
-                    # Future contract, not a transient remote operation.
-                    error = exc
-                else:
-                    if ticket.abandon_wait is not None:
-                        with self._cv:
-                            if ticket in self._cleanup_tickets and ticket.wait_future is result:
-                                ticket.wait_timeout = self._loop.call_later(
-                                    self._cleanup_response_timeout(
-                                        ticket.retry_count,
-                                    ),
-                                    self._timeout_cleanup_ticket,
-                                    ticket,
-                                    result,
-                                )
-                    return
-            retry = result is False and ticket.retry_on_incomplete
+            operation_future = submit_ray_control(ticket.operation)
         except BaseException as exc:
+            self._finish_cleanup_operation(ticket, error=exc)
+            return
+        with self._cv:
+            if ticket not in self._cleanup_tickets:
+                operation_future.cancel()
+                return
+            ticket.operation_future = operation_future
+
+        collector_ref = weakref.ref(self)
+        ticket_ref = weakref.ref(ticket)
+
+        def ready(future: Any) -> None:
+            collector = collector_ref()
+            active_ticket = ticket_ref()
+            if collector is None or active_ticket is None:
+                return
+            try:
+                collector._loop.call_soon_threadsafe(
+                    collector._run_scheduler_callback,
+                    collector._complete_cleanup_operation,
+                    active_ticket,
+                    future,
+                )
+            except RuntimeError as exc:
+                with collector._cv:
+                    if collector._thread_error is None:
+                        collector._thread_error = exc
+                    collector._cv.notify_all()
+
+        try:
+            operation_future.add_done_callback(ready)
+        except BaseException as exc:
+            with self._cv:
+                if ticket.operation_future is operation_future:
+                    ticket.operation_future = None
+            operation_future.cancel()
+            self._finish_cleanup_operation(ticket, error=exc)
+
+    def _complete_cleanup_operation(
+        self,
+        ticket: _CleanupTicket,
+        operation_future: Any,
+    ) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.operation_future is not operation_future:
+                return
+            ticket.operation_future = None
+        assert operation_future is not None
+        try:
+            result = operation_future.result()
+        except BaseException as exc:
+            self._finish_cleanup_operation(ticket, error=exc)
+            return
+        self._finish_cleanup_operation(ticket, result=result)
+
+    def _finish_cleanup_operation(
+        self,
+        ticket: _CleanupTicket,
+        *,
+        result: Any = None,
+        error: BaseException | None = None,
+    ) -> None:
+        if error is not None:
             if ticket.retry_on_error:
-                retry = True
-            else:
-                error = exc
-        if retry:
+                self._retry_cleanup_ticket(ticket)
+                return
+            ticket.finish(error)
+            self._stop_loop_after_final_cleanup_ticket()
+            return
+
+        if all(callable(getattr(result, name, None)) for name in ("add_done_callback", "done", "result")):
+            with self._cv:
+                if ticket not in self._cleanup_tickets:
+                    return
+                ticket.wait_future = result
+
+            collector_ref = weakref.ref(self)
+            ticket_ref = weakref.ref(ticket)
+
+            def ready(future: Any) -> None:
+                collector = collector_ref()
+                active_ticket = ticket_ref()
+                if collector is None or active_ticket is None:
+                    return
+                try:
+                    collector._loop.call_soon_threadsafe(
+                        collector._resume_cleanup_ticket,
+                        active_ticket,
+                        future,
+                    )
+                except RuntimeError as exc:
+                    with collector._cv:
+                        if collector._thread_error is None:
+                            collector._thread_error = exc
+                        collector._cv.notify_all()
+
+            try:
+                result.add_done_callback(ready)
+            except BaseException as exc:
+                with self._cv:
+                    if ticket.wait_future is result:
+                        ticket.wait_future = None
+                # Callback registration is part of the required public Future
+                # contract, not a transient remote operation.
+                ticket.finish(exc)
+                self._stop_loop_after_final_cleanup_ticket()
+                return
+            if ticket.abandon_wait is not None:
+                with self._cv:
+                    if ticket in self._cleanup_tickets and ticket.wait_future is result:
+                        ticket.wait_timeout = self._loop.call_later(
+                            self._cleanup_response_timeout(
+                                ticket.retry_count,
+                            ),
+                            self._timeout_cleanup_ticket,
+                            ticket,
+                            result,
+                        )
+            return
+
+        if result is False and ticket.retry_on_incomplete:
             self._retry_cleanup_ticket(ticket)
             return
-        ticket.finish(error)
+        ticket.finish(None)
+        self._stop_loop_after_final_cleanup_ticket()
+
+    def _stop_loop_after_final_cleanup_ticket(self) -> None:
         with self._cv:
             stop = self._shutdown and not self._cleanup_tickets
         if stop:
@@ -1418,13 +1495,17 @@ class AsyncResultCollector:
     def _cancel_record_wait_locked(self, record: _StreamRecord) -> None:
         future = record.wait_future
         completion_future = record.completion_future
+        output_submit_future = record.output_submit_future
         record.wait_future = None
         record.completion_future = None
+        record.output_submit_future = None
         record.wait_kind = ""
         if future is not None:
             future.cancel()
         if completion_future is not None:
             completion_future.cancel()
+        if output_submit_future is not None:
+            output_submit_future.cancel()
 
     @staticmethod
     def _object_ref_future(ref: Any) -> Any:
@@ -1731,22 +1812,90 @@ class AsyncResultCollector:
             record.output_cancel_sent = False
             record.phase = "output_lease"
 
-        output_lease_ref = driver.acquire_query_output_block_lease.remote(request)
+        output_submit_future = submit_ray_control(
+            lambda: driver.acquire_query_output_block_lease.remote(
+                dict(request),
+            )
+        )
         with self._cv:
             stale = self._shutdown or self._records.get(key) is not record or record.terminal
             if not stale:
-                record.output_lease_ref = output_lease_ref
+                record.output_submit_future = output_submit_future
             cancel_stale_request = stale and not record.output_cancel_sent
             if cancel_stale_request:
                 record.output_cancel_sent = True
         if stale:
+            output_submit_future.cancel()
             if cancel_stale_request:
                 self._submit_cleanup_operations(
                     (self._output_request_cancel_operation(driver, request),),
                     slot_ids=(record.slot_id,),
                 )
             return
+
+        collector_ref = weakref.ref(self)
+        record_ref = weakref.ref(record)
+
+        def submitted(done: Any) -> None:
+            collector = collector_ref()
+            active_record = record_ref()
+            if collector is None or active_record is None:
+                return
+            with collector._cv:
+                if collector._shutdown:
+                    return
+            try:
+                collector._loop.call_soon_threadsafe(
+                    collector._run_scheduler_callback,
+                    collector._complete_output_lease_submission,
+                    active_record,
+                    done,
+                )
+            except RuntimeError as exc:
+                with collector._cv:
+                    shutting_down = collector._shutdown
+                if not shutting_down:
+                    collector._report_scheduler_error(exc)
+
+        try:
+            output_submit_future.add_done_callback(submitted)
+        except BaseException:
+            with self._cv:
+                if record.output_submit_future is output_submit_future:
+                    record.output_submit_future = None
+            output_submit_future.cancel()
+            raise
         _collector_debug_log("output_lease_requested", record)
+
+    def _complete_output_lease_submission(
+        self,
+        record: _StreamRecord,
+        output_submit_future: Any,
+    ) -> None:
+        key = (record.slot_id, record.submit_id)
+        failure: BaseException | None = None
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                if record.output_submit_future is not output_submit_future:
+                    return
+                record.output_submit_future = None
+                if self._shutdown or self._records.get(key) is not record or record.terminal:
+                    return
+            assert output_submit_future is not None
+            try:
+                output_lease_ref = output_submit_future.result()
+            except BaseException as exc:
+                failure = exc
+            else:
+                with self._cv:
+                    if self._shutdown or self._records.get(key) is not record or record.terminal:
+                        return
+                    record.output_lease_ref = output_lease_ref
+                    self._cv.notify_all()
+        if failure is not None:
+            self._fail_record(record, failure)
+            return
+        self._refresh_waiters()
 
     @staticmethod
     def _validate_task_identity(record: _StreamRecord, metadata: dict[str, Any]) -> None:

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -19,7 +19,10 @@ from duckdb.execution.ray_control_deadline import (
     RAY_CONTROL_DEADLINE_SCHEDULER,
     RayControlScheduledCall,
 )
-from duckdb.execution.ray_control_submission import submit_ray_control
+from duckdb.execution.ray_control_submission import (
+    create_ray_control_deadline,
+    submit_ray_control,
+)
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
     RayStreamCleanupOperation,
@@ -219,12 +222,12 @@ class AsyncResultCollector:
     The asyncio thread is the sole generator-readiness, read, and stream-state
     scheduler. Potentially blocking Ray control submissions and terminal
     operations run on admitted stream-owner daemon workers. Cleanup tickets use
-    the process-wide control deadline clock directly, so loop shutdown cannot
-    orphan a retry or response timeout. One blocked stream therefore cannot
-    consume a healthy peer's submission progress. Driver RPCs are observed
-    through public ObjectRef futures. Every terminal operation enters the ticket
-    ledger before its source record is removed, so shutdown can never observe an
-    ownership gap.
+    the process-wide control deadline clock, which hands owner callbacks to a
+    separate bounded/recoverable executor, so loop shutdown and one blocked
+    Future callback cannot orphan unrelated retries or response timeouts.
+    Driver RPCs are observed through public ObjectRef futures. Every terminal
+    operation enters the ticket ledger before its source record is removed, so
+    shutdown can never observe an ownership gap.
 
     The native dispatcher keeps this collector alive across empty slot
     intervals. ``shutdown`` is the process-owner fence and is called only after
@@ -1286,7 +1289,10 @@ class AsyncResultCollector:
             def retry() -> None:
                 self._run_cleanup_retry(ticket, retry_call)
 
-            retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(retry)
+            retry_call = create_ray_control_deadline(
+                f"{ticket.operation.submission_scope}:cleanup-retry",
+                retry,
+            )
             ticket.retry_call = retry_call
             retry_delay = self._cleanup_retry_delay(ticket.retry_count)
         try:
@@ -1338,14 +1344,16 @@ class AsyncResultCollector:
                 return
             ticket.wait_future = None
             ticket.wait_timeout = None
+        # Make the ticket self-driving before abandoning the old response.
+        # Future.cancel invokes completion callbacks inline and may block.
+        self._retry_cleanup_ticket(ticket)
         try:
             assert ticket.abandon_wait is not None
             ticket.abandon_wait(future)
-        except BaseException as exc:
-            if not ticket.retry_on_error:
-                ticket.finish(exc)
-                return
-        self._retry_cleanup_ticket(ticket)
+        except BaseException:
+            # Abandonment is best-effort; the newly published retry owns the
+            # idempotent remote terminal transition from this point onward.
+            pass
 
     def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
@@ -1477,7 +1485,10 @@ class AsyncResultCollector:
                         timeout_call,
                     )
 
-                timeout_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(response_timed_out)
+                timeout_call = create_ray_control_deadline(
+                    f"{ticket.operation.submission_scope}:cleanup-response-timeout",
+                    response_timed_out,
+                )
                 with self._cv:
                     if ticket in self._cleanup_tickets and ticket.wait_future is result:
                         ticket.wait_timeout = timeout_call

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -15,6 +15,10 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from duckdb.execution.ray_control_deadline import (
+    RAY_CONTROL_DEADLINE_SCHEDULER,
+    RayControlScheduledCall,
+)
 from duckdb.execution.ray_control_submission import submit_ray_control
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
@@ -136,7 +140,7 @@ class _StreamRecord:
 
 
 class _CleanupTicket:
-    """Durable owner for one event-loop-driven terminal operation."""
+    """Durable owner for one independently driven terminal operation."""
 
     def __init__(
         self,
@@ -152,9 +156,11 @@ class _CleanupTicket:
         self.retry_on_incomplete = bool(retry_on_incomplete)
         self.abandon_wait = abandon_wait
         self.retry_count = 0
+        self.submitting = False
         self.operation_future: Any | None = None
         self.wait_future: Any | None = None
-        self.wait_timeout: asyncio.TimerHandle | None = None
+        self.retry_call: RayControlScheduledCall | None = None
+        self.wait_timeout: RayControlScheduledCall | None = None
         self._done = False
         self._error: BaseException | None = None
         self._on_complete = on_complete
@@ -210,15 +216,15 @@ class AsyncResultCollector:
     A terminal record is removed only while ``_cleanup_handoff_lock`` prevents
     shutdown from observing an ownership gap.
 
-    The asyncio thread is the sole generator-readiness, read, and state
+    The asyncio thread is the sole generator-readiness, read, and stream-state
     scheduler. Potentially blocking Ray control submissions and terminal
-    operations run on admitted stream-owner daemon workers and publish their
-    results back to that loop. One blocked stream therefore cannot consume a
-    healthy peer's submission progress, and worker cardinality follows the
-    existing task-admission bound. Driver RPCs are observed through public
-    ObjectRef futures. Every terminal operation enters the ticket ledger before
-    its source record is removed, so shutdown can never observe an ownership
-    gap.
+    operations run on admitted stream-owner daemon workers. Cleanup tickets use
+    the process-wide control deadline clock directly, so loop shutdown cannot
+    orphan a retry or response timeout. One blocked stream therefore cannot
+    consume a healthy peer's submission progress. Driver RPCs are observed
+    through public ObjectRef futures. Every terminal operation enters the ticket
+    ledger before its source record is removed, so shutdown can never observe an
+    ownership gap.
 
     The native dispatcher keeps this collector alive across empty slot
     intervals. ``shutdown`` is the process-owner fence and is called only after
@@ -237,6 +243,9 @@ class AsyncResultCollector:
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
         if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
             raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
+        # Cleanup ownership can outlive the asyncio loop, so its process-wide
+        # deadline owner must exist before this collector accepts any stream.
+        RAY_CONTROL_DEADLINE_SCHEDULER.ensure_started()
         self._cv = threading.Condition()
         self._shutdown = False
         self._started = False
@@ -841,8 +850,8 @@ class AsyncResultCollector:
                         self._capacity_by_slot.clear()
                         stop_now = not self._cleanup_tickets
                         self._cv.notify_all()
-                    if stop_now and self._thread.is_alive():
-                        self._loop.call_soon_threadsafe(self._loop.stop)
+                    if stop_now:
+                        self._request_event_loop_stop()
 
         if self._thread is threading.current_thread():
             if shutdown_errors:
@@ -878,8 +887,8 @@ class AsyncResultCollector:
                     shutdown_errors.append(error)
             owns_stream_state = bool(self._records or self._active_output_leases or self._ready_by_slot)
 
-        if not pending and not owns_stream_state and self._thread.is_alive():
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        if not pending and not owns_stream_state:
+            self._request_event_loop_stop()
         if (
             self._thread_started
             and self._thread is not threading.current_thread()
@@ -919,10 +928,7 @@ class AsyncResultCollector:
                         self._thread_error = exc
                     self._cv.notify_all()
                 if thread_started:
-                    try:
-                        self._loop.call_soon_threadsafe(self._loop.stop)
-                    except RuntimeError:
-                        pass
+                    self._request_event_loop_stop()
                     if self._thread is not threading.current_thread():
                         # Construction has not transferred ownership to a
                         # caller, so returning while this thread is alive would
@@ -1166,7 +1172,7 @@ class AsyncResultCollector:
         callback: Callable[..., Any],
         *args: Any,
     ) -> None:
-        """Turn every event-loop callback failure into visible collector state."""
+        """Turn every asynchronous callback failure into visible collector state."""
         try:
             callback(*args)
         except BaseException as exc:
@@ -1180,7 +1186,7 @@ class AsyncResultCollector:
         store_error: bool = True,
         slot_ids: Sequence[int] = (),
     ) -> tuple[_CleanupTicket, ...]:
-        """Atomically transfer operations into the event-loop ticket ledger."""
+        """Atomically transfer operations into the durable cleanup ledger."""
         actions = tuple(operations)
         if not actions:
             if on_each_done is not None:
@@ -1223,6 +1229,7 @@ class AsyncResultCollector:
                                     )
                         self._cv.notify_all()
                     self._notify_wakeup()
+                    self._stop_loop_after_final_cleanup_ticket()
 
             ticket = _CleanupTicket(
                 operation=action,
@@ -1234,44 +1241,18 @@ class AsyncResultCollector:
             ticket_holder.append(ticket)
             tickets.append(ticket)
 
-        schedule_error: BaseException | None = None
         with self._cleanup_handoff_lock:
-            # Publish ledger ownership before scheduling. The callback also
-            # acquires _cleanup_handoff_lock, so it cannot drive or finish a
-            # ticket before the transfer is externally visible. If the loop
-            # becomes unavailable, the ledger deliberately retains ownership
-            # and the collector becomes failed instead of silently orphaning
-            # remote resources after a caller drops its source record.
+            # Publish durable ownership before any operation can run. Driving a
+            # ticket only queues bounded control work, so it does not need an
+            # asyncio handoff and remains viable after that loop has stopped.
             with self._cv:
                 self._cleanup_tickets.update(tickets)
                 for slot_id in owner_slots:
                     self._cleanup_tickets_by_slot[slot_id].update(tickets)
                 self._cv.notify_all()
-                loop_available = self._thread_started and self._thread.is_alive() and not self._loop.is_closed()
-            try:
-                if not loop_available:
-                    raise RuntimeError("Ray UDF cleanup event loop is not available")
-                if self._thread is threading.current_thread():
-                    self._loop.call_soon(self._start_cleanup_tickets, tuple(tickets))
-                else:
-                    self._loop.call_soon_threadsafe(self._start_cleanup_tickets, tuple(tickets))
-            except BaseException as exc:
-                schedule_error = exc
-                with self._cv:
-                    if not self._shutdown and self._thread_error is None:
-                        self._thread_error = exc
-                    self._cv.notify_all()
-        if schedule_error is not None and not self._shutdown:
-            self._notify_wakeup()
+            for ticket in tickets:
+                self._drive_cleanup_ticket(ticket)
         return tuple(tickets)
-
-    def _start_cleanup_tickets(self, tickets: tuple[_CleanupTicket, ...]) -> None:
-        """Start tickets only after their ledger handoff is visible."""
-        with self._cleanup_handoff_lock:
-            with self._cv:
-                active = tuple(ticket for ticket in tickets if ticket in self._cleanup_tickets)
-        for ticket in active:
-            self._drive_cleanup_ticket(ticket)
 
     @staticmethod
     def _cleanup_retry_delay(retry_count: int) -> float:
@@ -1291,14 +1272,45 @@ class AsyncResultCollector:
 
     def _retry_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
-            if ticket not in self._cleanup_tickets:
+            if (
+                ticket not in self._cleanup_tickets
+                or ticket.submitting
+                or ticket.operation_future is not None
+                or ticket.wait_future is not None
+                or ticket.retry_call is not None
+            ):
                 return
-        ticket.retry_count += 1
-        self._loop.call_later(
-            self._cleanup_retry_delay(ticket.retry_count),
-            self._drive_cleanup_ticket,
-            ticket,
-        )
+            ticket.retry_count += 1
+            retry_call: RayControlScheduledCall
+
+            def retry() -> None:
+                self._run_cleanup_retry(ticket, retry_call)
+
+            retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(retry)
+            ticket.retry_call = retry_call
+            retry_delay = self._cleanup_retry_delay(ticket.retry_count)
+        try:
+            RAY_CONTROL_DEADLINE_SCHEDULER.schedule(retry_call, retry_delay)
+        except BaseException as exc:
+            with self._cv:
+                if ticket.retry_call is retry_call:
+                    ticket.retry_call = None
+                    active = ticket in self._cleanup_tickets
+                else:
+                    active = False
+            if active:
+                ticket.finish(exc)
+
+    def _run_cleanup_retry(
+        self,
+        ticket: _CleanupTicket,
+        retry_call: RayControlScheduledCall,
+    ) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.retry_call is not retry_call:
+                return
+            ticket.retry_call = None
+        self._drive_cleanup_ticket(ticket)
 
     def _resume_cleanup_ticket(self, ticket: _CleanupTicket, future: Any) -> None:
         with self._cv:
@@ -1311,9 +1323,18 @@ class AsyncResultCollector:
             timeout.cancel()
         self._drive_cleanup_ticket(ticket)
 
-    def _timeout_cleanup_ticket(self, ticket: _CleanupTicket, future: Any) -> None:
+    def _timeout_cleanup_ticket(
+        self,
+        ticket: _CleanupTicket,
+        future: Any,
+        timeout_call: RayControlScheduledCall,
+    ) -> None:
         with self._cv:
-            if ticket not in self._cleanup_tickets or ticket.wait_future is not future:
+            if (
+                ticket not in self._cleanup_tickets
+                or ticket.wait_future is not future
+                or ticket.wait_timeout is not timeout_call
+            ):
                 return
             ticket.wait_future = None
             ticket.wait_timeout = None
@@ -1323,10 +1344,6 @@ class AsyncResultCollector:
         except BaseException as exc:
             if not ticket.retry_on_error:
                 ticket.finish(exc)
-                with self._cv:
-                    stop = self._shutdown and not self._cleanup_tickets
-                if stop:
-                    self._loop.stop()
                 return
         self._retry_cleanup_ticket(ticket)
 
@@ -1334,19 +1351,25 @@ class AsyncResultCollector:
         with self._cv:
             if (
                 ticket not in self._cleanup_tickets
+                or ticket.submitting
                 or ticket.operation_future is not None
                 or ticket.wait_future is not None
+                or ticket.retry_call is not None
             ):
                 return
+            ticket.submitting = True
         try:
             operation_future = submit_ray_control(
                 ticket.operation.submission_scope,
                 ticket.operation,
             )
         except BaseException as exc:
+            with self._cv:
+                ticket.submitting = False
             self._finish_cleanup_operation(ticket, error=exc)
             return
         with self._cv:
+            ticket.submitting = False
             if ticket not in self._cleanup_tickets:
                 operation_future.cancel()
                 return
@@ -1360,24 +1383,24 @@ class AsyncResultCollector:
             active_ticket = ticket_ref()
             if collector is None or active_ticket is None:
                 return
-            try:
-                collector._loop.call_soon_threadsafe(
-                    collector._run_scheduler_callback,
-                    collector._complete_cleanup_operation,
-                    active_ticket,
-                    future,
-                )
-            except RuntimeError as exc:
-                collector._report_scheduler_error(exc)
+            collector._run_scheduler_callback(
+                collector._complete_cleanup_operation,
+                active_ticket,
+                future,
+            )
 
         try:
             operation_future.add_done_callback(ready)
         except BaseException as exc:
             with self._cv:
-                if ticket.operation_future is operation_future:
+                if ticket in self._cleanup_tickets and ticket.operation_future is operation_future:
                     ticket.operation_future = None
-            operation_future.cancel()
-            self._finish_cleanup_operation(ticket, error=exc)
+                    active = True
+                else:
+                    active = False
+            if active:
+                operation_future.cancel()
+                self._finish_cleanup_operation(ticket, error=exc)
 
     def _complete_cleanup_operation(
         self,
@@ -1408,7 +1431,6 @@ class AsyncResultCollector:
                 self._retry_cleanup_ticket(ticket)
                 return
             ticket.finish(error)
-            self._stop_loop_after_final_cleanup_ticket()
             return
 
         if all(callable(getattr(result, name, None)) for name in ("add_done_callback", "done", "result")):
@@ -1425,50 +1447,89 @@ class AsyncResultCollector:
                 active_ticket = ticket_ref()
                 if collector is None or active_ticket is None:
                     return
-                try:
-                    collector._loop.call_soon_threadsafe(
-                        collector._resume_cleanup_ticket,
-                        active_ticket,
-                        future,
-                    )
-                except RuntimeError as exc:
-                    collector._report_scheduler_error(exc)
+                collector._run_scheduler_callback(
+                    collector._resume_cleanup_ticket,
+                    active_ticket,
+                    future,
+                )
 
             try:
                 result.add_done_callback(ready)
             except BaseException as exc:
                 with self._cv:
-                    if ticket.wait_future is result:
+                    if ticket in self._cleanup_tickets and ticket.wait_future is result:
                         ticket.wait_future = None
+                        active = True
+                    else:
+                        active = False
                 # Callback registration is part of the required public Future
                 # contract, not a transient remote operation.
-                ticket.finish(exc)
-                self._stop_loop_after_final_cleanup_ticket()
+                if active:
+                    ticket.finish(exc)
                 return
             if ticket.abandon_wait is not None:
+                timeout_call: RayControlScheduledCall
+
+                def response_timed_out() -> None:
+                    self._timeout_cleanup_ticket(
+                        ticket,
+                        result,
+                        timeout_call,
+                    )
+
+                timeout_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(response_timed_out)
                 with self._cv:
                     if ticket in self._cleanup_tickets and ticket.wait_future is result:
-                        ticket.wait_timeout = self._loop.call_later(
-                            self._cleanup_response_timeout(
-                                ticket.retry_count,
-                            ),
-                            self._timeout_cleanup_ticket,
-                            ticket,
-                            result,
+                        ticket.wait_timeout = timeout_call
+                        start_timeout = True
+                    else:
+                        start_timeout = False
+                if start_timeout:
+                    try:
+                        RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
+                            timeout_call,
+                            self._cleanup_response_timeout(ticket.retry_count),
                         )
+                    except BaseException as exc:
+                        with self._cv:
+                            if ticket.wait_timeout is timeout_call and ticket.wait_future is result:
+                                ticket.wait_timeout = None
+                                ticket.wait_future = None
+                                active = ticket in self._cleanup_tickets
+                            else:
+                                active = False
+                        if active:
+                            try:
+                                ticket.abandon_wait(result)
+                            except BaseException:
+                                pass
+                            ticket.finish(exc)
             return
 
         if result is False and ticket.retry_on_incomplete:
             self._retry_cleanup_ticket(ticket)
             return
         ticket.finish(None)
-        self._stop_loop_after_final_cleanup_ticket()
 
     def _stop_loop_after_final_cleanup_ticket(self) -> None:
         with self._cv:
             stop = self._shutdown and not self._cleanup_tickets
         if stop:
+            self._request_event_loop_stop()
+
+    def _request_event_loop_stop(self) -> None:
+        """Idempotently wake a live loop without racing its final close."""
+        if not self._thread.is_alive():
+            return
+        if self._thread is threading.current_thread():
             self._loop.stop()
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        except RuntimeError:
+            if not self._loop.is_closed() and self._thread.is_alive():
+                raise
+            # The loop completed between the liveness check and notification.
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -139,21 +139,20 @@ class _StreamRecord:
     next_ref_ready: bool = False
     ready_sequence: int | None = None
     cleanup_started: bool = False
-    registration_accepted: bool = True
-    registration_cancelled: bool = False
+    cleanup_remaining: int = 0
+    cleanup_error: BaseException | None = None
 
 
-class _CleanupGroup:
-    """Completion fence for one atomically accepted terminal cleanup plan."""
+class _CleanupTicket:
+    """Durable owner for one blocking terminal operation."""
 
     def __init__(
         self,
-        operation_count: int,
         *,
         on_complete: Callable[[BaseException | None], None],
     ) -> None:
-        self._remaining = int(operation_count)
-        self._errors: list[BaseException] = []
+        self._done = False
+        self._error: BaseException | None = None
         self._on_complete = on_complete
         self._callback_thread: threading.Thread | None = None
         self._callback_complete = False
@@ -161,23 +160,17 @@ class _CleanupGroup:
 
     def finish(self, error: BaseException | None) -> None:
         callback: Callable[[BaseException | None], None] | None = None
-        first_error: BaseException | None = None
         with self._cv:
-            if error is not None:
-                self._errors.append(error)
-            self._remaining -= 1
-            if self._remaining < 0:
-                raise RuntimeError("Ray UDF cleanup group count underflow")
-            if self._remaining == 0:
-                callback = self._on_complete
-                self._on_complete = lambda _error: None
-                first_error = self._errors[0] if self._errors else None
-                self._callback_thread = threading.current_thread()
-                self._cv.notify_all()
-        if callback is None:
-            return
+            if self._done:
+                raise RuntimeError("Ray UDF cleanup ticket completed twice")
+            self._done = True
+            self._error = error
+            callback = self._on_complete
+            self._on_complete = lambda _error: None
+            self._callback_thread = threading.current_thread()
+            self._cv.notify_all()
         try:
-            callback(first_error)
+            callback(error)
         finally:
             with self._cv:
                 self._callback_thread = None
@@ -188,7 +181,7 @@ class _CleanupGroup:
         deadline = time.monotonic() + max(0.0, float(timeout))
         current = threading.current_thread()
         with self._cv:
-            while self._remaining or (not self._callback_complete and self._callback_thread is not current):
+            while not self._done or (not self._callback_complete and self._callback_thread is not current):
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return False
@@ -197,18 +190,18 @@ class _CleanupGroup:
 
     def callback_owned_by_current_thread(self) -> bool:
         with self._cv:
-            return self._remaining == 0 and self._callback_thread is threading.current_thread()
+            return self._done and self._callback_thread is threading.current_thread()
 
     @property
     def errors(self) -> tuple[BaseException, ...]:
         with self._cv:
-            return tuple(self._errors)
+            return () if self._error is None else (self._error,)
 
 
 @dataclass
 class _CleanupWorkItem:
     operation: Callable[[], Any]
-    group: _CleanupGroup
+    ticket: _CleanupTicket
     retry_on_error: bool = False
     retry_on_incomplete: bool = False
     retry_count: int = 0
@@ -263,25 +256,11 @@ class _DaemonCleanupPool:
 
     def _enqueue_locked(
         self,
-        operations: Sequence[Callable[[], Any]],
-        group: _CleanupGroup,
+        items: Sequence[_CleanupWorkItem],
     ) -> None:
         if not self._started or self._stop_when_idle:
             raise RuntimeError(f"Ray UDF cleanup pool {self._name!r} is not accepting work")
         ready_at = time.monotonic()
-        items = [
-            _CleanupWorkItem(
-                operation,
-                group,
-                retry_on_error=(
-                    operation.retry_on_error if isinstance(operation, RayStreamCleanupOperation) else False
-                ),
-                retry_on_incomplete=(
-                    operation.retry_on_incomplete if isinstance(operation, RayStreamCleanupOperation) else False
-                ),
-            )
-            for operation in operations
-        ]
         for item in items:
             sequence = self._next_queue_sequence
             self._next_queue_sequence += 1
@@ -367,7 +346,7 @@ class _DaemonCleanupPool:
                 del error
                 del result
                 continue
-            item.group.finish(error)
+            item.ticket.finish(error)
             del item
             del error
             del result
@@ -376,9 +355,9 @@ class _DaemonCleanupPool:
 class AsyncResultCollector:
     """Capacity-aware scheduler for lease-owned Ray generator streams.
 
-    ``_cv`` owns every local stream transition. A registering record is not
-    schedulable until ``track_generator_ref`` commits its accepted bit, and a
-    terminal record is removed only while ``_cleanup_handoff_lock`` prevents
+    ``_cv`` owns every published stream transition. Registration first starts
+    the scheduler, then publishes a complete record in one critical section.
+    A terminal record is removed only while ``_cleanup_handoff_lock`` prevents
     shutdown from observing an ownership gap.
 
     The asyncio thread is the sole generator readiness/read consumer. Terminal
@@ -416,8 +395,8 @@ class AsyncResultCollector:
         self._next_sequence = 0
         self._next_ready_sequence = 0
         self._cleanup_handoff_lock = threading.RLock()
-        self._cleanup_groups: set[_CleanupGroup] = set()
-        self._cleanup_groups_by_slot: dict[int, set[_CleanupGroup]] = defaultdict(set)
+        self._cleanup_tickets: set[_CleanupTicket] = set()
+        self._cleanup_tickets_by_slot: dict[int, set[_CleanupTicket]] = defaultdict(set)
         self._terminal_cleanup_errors: list[BaseException] = []
         self._cleanup_pools_stopping = False
         self._cleanup_pools = {
@@ -489,83 +468,84 @@ class AsyncResultCollector:
         key = (int(slot_id), int(submit_id))
         adapter: RayStreamAdapter | None = None
         record: _StreamRecord | None = None
-        accepted = False
+        cleanup_tickets: tuple[_CleanupTicket, ...] = ()
         try:
-            # Serialize only registration/startup against shutdown. The record
-            # stays invisible to the scheduler until the final accepted bit is
-            # committed, so a ready stream cannot retire before C++ owns its
-            # corresponding submit_id.
             with self._start_lock:
-                adapter = RayStreamAdapter(source, ray_module=self._ray)
-                source = None
-                with self._cv:
-                    self._raise_if_stopped_locked()
-                    if key in self._records:
-                        raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
-                    if key[0] in self._cancelled_slots:
-                        raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
-                    record = _StreamRecord(
-                        slot_id=key[0],
-                        submit_id=key[1],
-                        adapter=adapter,
-                        sequence=self._next_sequence,
-                        error_context=dict(error_context) if error_context else None,
-                        registration_accepted=False,
-                    )
-                    self._next_sequence += 1
-                    self._records[key] = record
-                    self._cv.notify_all()
-                self._ensure_started()
-                with self._cv:
-                    if self._records.get(key) is record:
-                        record.registration_accepted = True
-                        accepted = True
-                        self._signal_readiness_change_locked()
-                    elif record.registration_cancelled:
-                        raise RuntimeError(
-                            f"Ray UDF stream slot={key[0]} submit={key[1]} was cancelled during registration"
+                try:
+                    adapter = RayStreamAdapter(source, ray_module=self._ray)
+                    source = None
+                    self._ensure_started()
+                    with self._cv:
+                        self._raise_if_stopped_locked()
+                        if key in self._records:
+                            raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
+                        if key[0] in self._cancelled_slots:
+                            raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
+                        record = _StreamRecord(
+                            slot_id=key[0],
+                            submit_id=key[1],
+                            adapter=adapter,
+                            sequence=self._next_sequence,
+                            error_context=dict(error_context) if error_context else None,
                         )
-                    else:
-                        raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} lost registration ownership")
+                        self._next_sequence += 1
+                        self._records[key] = record
+                        self._signal_readiness_change_locked()
+                except BaseException:
+                    with self._cleanup_handoff_lock:
+                        cleanup_operations: Sequence[Callable[[], Any]] = ()
+                        with self._cv:
+                            if record is not None and self._records.pop(key, None) is record:
+                                record.terminal = True
+                                record.cleanup_started = True
+                                cleanup_operations = record.adapter.cancel_operations()
+                                self._signal_readiness_change_locked()
+                            elif adapter is not None:
+                                cleanup_operations = adapter.cancel_operations()
+                            elif source is not None:
+                                cleanup_operations = source.cancel_operations()
+                                source.retire_local_state()
+                        if cleanup_operations:
+                            cleanup_tickets = self._submit_cleanup_operations(
+                                self._fence_cleanup_operations(cleanup_operations),
+                                store_error=False,
+                                slot_ids=(key[0],),
+                            )
+                    raise
             assert record is not None
             _collector_debug_log("track", record)
             self._refresh_waiters()
         except BaseException as registration_error:
-            cleanup_group: _CleanupGroup | None = None
-            with self._cleanup_handoff_lock:
-                cleanup_operations: Sequence[Callable[[], Any]] = ()
-                with self._cv:
-                    if record is not None and self._records.pop(key, None) is record:
-                        record.terminal = True
-                        record.cleanup_started = True
-                        cleanup_operations = record.adapter.cancel_operations()
-                        self._signal_readiness_change_locked()
-                    elif record is None and adapter is not None:
-                        cleanup_operations = adapter.cancel_operations()
-                    elif record is None and source is not None:
-                        cleanup_operations = source.cancel_operations()
-                        source.retire_local_state()
-                if cleanup_operations:
-                    cleanup_group = self._submit_cleanup_operations(
-                        self._fence_cleanup_operations(cleanup_operations),
-                        store_error=False,
-                        slot_ids=(key[0],),
+            if cleanup_tickets:
+                try:
+                    cleanup_errors = self._wait_cleanup_tickets(
+                        cleanup_tickets,
+                        timeout_message="submitted Ray stream cleanup did not terminate",
                     )
-            if cleanup_group is not None:
-                cleanup_complete = cleanup_group.wait(self._shutdown_timeout_s)
-                cleanup_errors = cleanup_group.errors
-                if not cleanup_complete or cleanup_errors:
-                    detail = (
-                        "cleanup did not terminate"
-                        if not cleanup_complete
-                        else "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
-                    )
+                    detail = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                except BaseException as cleanup_error:
+                    detail = f"{type(cleanup_error).__name__}: {cleanup_error}"
+                if detail:
                     add_note = getattr(registration_error, "add_note", None)
                     if callable(add_note):
                         add_note(f"submitted Ray stream cleanup failed: {detail}")
             raise
-        if not accepted:
-            raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} was not accepted")
+
+    def discard_generator_ref(self, source: Any) -> None:
+        """Cancel a submitted stream rejected by the C++ slot-generation fence."""
+        if not isinstance(source, TaskLeaseObjectRefGenerator):
+            raise TypeError(
+                f"distributed Ray UDF discard requires TaskLeaseObjectRefGenerator; got {type(source).__name__}"
+            )
+        with self._start_lock:
+            adapter = RayStreamAdapter(source, ray_module=self._ray)
+            with self._cv:
+                self._raise_if_stopped_locked()
+            with self._cleanup_handoff_lock:
+                self._submit_cleanup_operations(
+                    adapter.cancel_operations(),
+                    store_error=True,
+                )
 
     def drain_results(self, capacities: dict[Any, Any] | None = None) -> list[tuple[Any, ...]]:
         parsed = self._parse_capacities(capacities)
@@ -635,7 +615,7 @@ class AsyncResultCollector:
         try:
             self._submit_cleanup_operations(
                 (self._output_token_release_operation(token),),
-                on_done=finish_release,
+                on_each_done=finish_release,
                 slot_ids=(token.slot_id,),
             )
         except BaseException:
@@ -670,7 +650,7 @@ class AsyncResultCollector:
         try:
             self._submit_cleanup_operations(
                 (self._output_token_handoff_operation(token),),
-                on_done=finish_handoff,
+                on_each_done=finish_handoff,
                 slot_ids=(token.slot_id,),
             )
         except BaseException:
@@ -780,20 +760,18 @@ class AsyncResultCollector:
 
     def cancel_slot(self, slot_id: int) -> None:
         slot_key = int(slot_id)
-        cleanup_groups: set[_CleanupGroup] = set()
+        cleanup_tickets: set[_CleanupTicket] = set()
         with self._cleanup_handoff_lock:
             with self._cv:
                 if self._shutdown:
                     return
-                cleanup_groups.update(self._cleanup_groups_by_slot.get(slot_key, ()))
+                cleanup_tickets.update(self._cleanup_tickets_by_slot.get(slot_key, ()))
                 records = [record for record in self._records.values() if record.slot_id == slot_key]
                 records_to_cancel = [record for record in records if not record.cleanup_started]
                 cleanup_operations: list[Callable[[], Any]] = []
                 for record in records:
                     self._records.pop((record.slot_id, record.submit_id), None)
                     record.terminal = True
-                    if not record.registration_accepted:
-                        record.registration_cancelled = True
                     if not record.cleanup_started:
                         record.cleanup_started = True
                     self._cancel_record_wait_locked(record)
@@ -822,18 +800,18 @@ class AsyncResultCollector:
             for token in tokens:
                 token.release_pending = True
             cleanup_operations.extend(self._output_token_release_operation(token) for token in tokens)
-            cleanup_group = self._submit_cleanup_operations(
-                self._fence_cleanup_operations(cleanup_operations),
-                store_error=False,
-                slot_ids=(slot_key,),
+            cleanup_tickets.update(
+                self._submit_cleanup_operations(
+                    self._fence_cleanup_operations(cleanup_operations),
+                    store_error=False,
+                    slot_ids=(slot_key,),
+                )
             )
-            if cleanup_group is not None:
-                cleanup_groups.add(cleanup_group)
 
         cleanup_errors = self._wait_slot_cleanup(
             slot_key,
             timeout_message=f"Ray UDF slot {slot_key} cleanup did not terminate",
-            initial_groups=tuple(cleanup_groups),
+            initial_tickets=tuple(cleanup_tickets),
         )
         if cleanup_errors:
             details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
@@ -846,7 +824,7 @@ class AsyncResultCollector:
                 any(record.slot_id == slot_key for record in self._records.values())
                 or bool(self._ready_by_slot.get(slot_key))
                 or any(token.slot_id == slot_key for token in self._active_output_leases.values())
-                or bool(self._cleanup_groups_by_slot.get(slot_key))
+                or bool(self._cleanup_tickets_by_slot.get(slot_key))
             )
 
     def set_wakeup_callback(self, fn: Any) -> None:
@@ -869,8 +847,6 @@ class AsyncResultCollector:
                         for record in records:
                             cleanup_slot_ids.add(record.slot_id)
                             self._cancel_record_wait_locked(record)
-                            if not record.registration_accepted:
-                                record.registration_cancelled = True
                             if record.cleanup_started:
                                 continue
                             record.cleanup_started = True
@@ -923,14 +899,14 @@ class AsyncResultCollector:
 
         with self._cv:
             while True:
-                pending = [group for group in self._cleanup_groups if not group.callback_owned_by_current_thread()]
+                pending = [ticket for ticket in self._cleanup_tickets if not ticket.callback_owned_by_current_thread()]
                 if not pending:
                     break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 self._cv.wait(timeout=remaining)
-            pending = [group for group in self._cleanup_groups if not group.callback_owned_by_current_thread()]
+            pending = [ticket for ticket in self._cleanup_tickets if not ticket.callback_owned_by_current_thread()]
             if pending:
                 shutdown_errors.append(RuntimeError("Ray UDF stream remote cleanup did not terminate"))
             shutdown_errors.extend(self._terminal_cleanup_errors)
@@ -1056,7 +1032,6 @@ class AsyncResultCollector:
         for record in self._records.values():
             if (
                 record.terminal
-                or not record.registration_accepted
                 or record.slot_id not in admissible_slots
                 or record.phase != "block"
                 or record.next_ref_ready
@@ -1210,48 +1185,70 @@ class AsyncResultCollector:
         self,
         operations: Sequence[Callable[[], Any]],
         *,
-        on_done: Callable[[BaseException | None], None] | None = None,
+        on_each_done: Callable[[BaseException | None], None] | None = None,
         store_error: bool = True,
         slot_ids: Sequence[int] = (),
-    ) -> _CleanupGroup | None:
-        """Atomically hand one terminal plan to bounded, isolated worker lanes."""
+    ) -> tuple[_CleanupTicket, ...]:
+        """Atomically hand independent operations to bounded worker lanes."""
         actions = tuple(operations)
         if not actions:
-            if on_done is not None:
-                on_done(None)
-            return None
+            if on_each_done is not None:
+                on_each_done(None)
+            return ()
 
-        operations_by_pool: dict[_DaemonCleanupPool, list[Callable[[], Any]]] = defaultdict(list)
+        owner_slots = frozenset(int(slot_id) for slot_id in slot_ids)
+        items_by_pool: dict[_DaemonCleanupPool, list[_CleanupWorkItem]] = defaultdict(list)
+        tickets: list[_CleanupTicket] = []
+
         for action in actions:
             lane = action.lane if isinstance(action, RayStreamCleanupOperation) else RAY_STREAM_CLEANUP_CONTROL
-            operations_by_pool[self._cleanup_pools[lane]].append(action)
-        pools = tuple(pool for pool in self._cleanup_pools.values() if pool in operations_by_pool)
-        group_holder: list[_CleanupGroup] = []
-        owner_slots = frozenset(int(slot_id) for slot_id in slot_ids)
+            ticket_holder: list[_CleanupTicket] = []
 
-        def complete(first_error: BaseException | None) -> None:
-            callback_error: BaseException | None = None
-            try:
-                if on_done is not None:
-                    on_done(first_error)
-            except BaseException as exc:
-                callback_error = exc
-            finally:
-                with self._cv:
-                    if store_error:
-                        if first_error is not None:
-                            self._terminal_cleanup_errors.append(first_error)
-                    if callback_error is not None:
-                        self._terminal_cleanup_errors.append(callback_error)
-                    self._cleanup_groups.discard(group_holder[0])
-                    for slot_id in owner_slots:
-                        groups = self._cleanup_groups_by_slot.get(slot_id)
-                        if groups is not None:
-                            groups.discard(group_holder[0])
-                            if not groups:
-                                self._cleanup_groups_by_slot.pop(slot_id, None)
-                    self._cv.notify_all()
+            def complete(
+                error: BaseException | None,
+                *,
+                holder: list[_CleanupTicket] = ticket_holder,
+            ) -> None:
+                callback_error: BaseException | None = None
+                try:
+                    if on_each_done is not None:
+                        on_each_done(error)
+                except BaseException as exc:
+                    callback_error = exc
+                finally:
+                    ticket = holder[0]
+                    with self._cv:
+                        if store_error and error is not None:
+                            self._terminal_cleanup_errors.append(error)
+                        if callback_error is not None:
+                            self._terminal_cleanup_errors.append(callback_error)
+                        self._cleanup_tickets.discard(ticket)
+                        for slot_id in owner_slots:
+                            slot_tickets = self._cleanup_tickets_by_slot.get(slot_id)
+                            if slot_tickets is not None:
+                                slot_tickets.discard(ticket)
+                                if not slot_tickets:
+                                    self._cleanup_tickets_by_slot.pop(
+                                        slot_id,
+                                        None,
+                                    )
+                        self._cv.notify_all()
 
+            ticket = _CleanupTicket(on_complete=complete)
+            ticket_holder.append(ticket)
+            tickets.append(ticket)
+            items_by_pool[self._cleanup_pools[lane]].append(
+                _CleanupWorkItem(
+                    action,
+                    ticket,
+                    retry_on_error=(action.retry_on_error if isinstance(action, RayStreamCleanupOperation) else False),
+                    retry_on_incomplete=(
+                        action.retry_on_incomplete if isinstance(action, RayStreamCleanupOperation) else False
+                    ),
+                )
+            )
+
+        pools = tuple(pool for pool in self._cleanup_pools.values() if pool in items_by_pool)
         with self._cleanup_handoff_lock:
             for pool in pools:
                 pool._cv.acquire()
@@ -1260,19 +1257,17 @@ class AsyncResultCollector:
                     if not pool._started or pool._stop_when_idle:
                         raise RuntimeError(f"Ray UDF cleanup pool {pool._name!r} is not accepting work")
                     pool._ensure_worker_locked()
-                group = _CleanupGroup(len(actions), on_complete=complete)
-                group_holder.append(group)
                 with self._cv:
-                    self._cleanup_groups.add(group)
+                    self._cleanup_tickets.update(tickets)
                     for slot_id in owner_slots:
-                        self._cleanup_groups_by_slot[slot_id].add(group)
+                        self._cleanup_tickets_by_slot[slot_id].update(tickets)
                     self._cv.notify_all()
-                for pool, pool_operations in operations_by_pool.items():
-                    pool._enqueue_locked(pool_operations, group)
+                for pool, items in items_by_pool.items():
+                    pool._enqueue_locked(items)
             finally:
                 for pool in reversed(pools):
                     pool._cv.release()
-        return group
+        return tuple(tickets)
 
     def _fence_cleanup_operations(
         self,
@@ -1316,39 +1311,42 @@ class AsyncResultCollector:
             )
         return tuple(fenced)
 
-    def _wait_cleanup_group(
+    def _wait_cleanup_tickets(
         self,
-        group: _CleanupGroup | None,
+        tickets: Sequence[_CleanupTicket],
         *,
         timeout_message: str,
-    ) -> None:
-        if group is None:
-            return
-        if not group.wait(self._shutdown_timeout_s):
-            raise RuntimeError(timeout_message)
+    ) -> tuple[BaseException, ...]:
+        deadline = time.monotonic() + self._shutdown_timeout_s
+        for ticket in tickets:
+            if ticket.callback_owned_by_current_thread():
+                continue
+            if not ticket.wait(max(0.0, deadline - time.monotonic())):
+                raise RuntimeError(timeout_message)
+        return tuple(error for ticket in tickets for error in ticket.errors)
 
     def _wait_slot_cleanup(
         self,
         slot_id: int,
         *,
         timeout_message: str,
-        initial_groups: Sequence[_CleanupGroup] = (),
+        initial_tickets: Sequence[_CleanupTicket] = (),
     ) -> tuple[BaseException, ...]:
         deadline = time.monotonic() + self._shutdown_timeout_s
-        observed = set(initial_groups)
+        observed = set(initial_tickets)
         while True:
             with self._cv:
-                groups = tuple(self._cleanup_groups_by_slot.get(int(slot_id), ()))
-            observed.update(groups)
+                tickets = tuple(self._cleanup_tickets_by_slot.get(int(slot_id), ()))
+            observed.update(tickets)
             pending = [
-                group for group in observed if not group.wait(0) and not group.callback_owned_by_current_thread()
+                ticket for ticket in observed if not ticket.wait(0) and not ticket.callback_owned_by_current_thread()
             ]
             if not pending:
                 break
             remaining = deadline - time.monotonic()
             if remaining <= 0 or not pending[0].wait(remaining):
                 raise RuntimeError(timeout_message)
-        return tuple(error for group in observed for error in group.errors)
+        return tuple(error for ticket in observed for error in ticket.errors)
 
     def _stop_cleanup_pools_when_idle(self) -> None:
         with self._cleanup_handoff_lock:
@@ -1515,7 +1513,7 @@ class AsyncResultCollector:
             if self._shutdown or self._thread_error is not None or not self._started or not self._loop_ready.is_set():
                 return
             records = sorted(
-                (record for record in self._records.values() if record.registration_accepted),
+                self._records.values(),
                 key=lambda record: (
                     record.phase == "block" and record.next_ref_ready,
                     record.ready_sequence if record.ready_sequence is not None else record.sequence,
@@ -1849,6 +1847,18 @@ class AsyncResultCollector:
             _collector_debug_log("retired" if error is None else "retire_failed", record)
             self._notify_wakeup()
 
+        def finish_cleanup_operation(error: BaseException | None) -> None:
+            with self._cv:
+                if error is not None and record.cleanup_error is None:
+                    record.cleanup_error = error
+                record.cleanup_remaining -= 1
+                if record.cleanup_remaining < 0:
+                    raise RuntimeError("Ray UDF record cleanup count underflow")
+                if record.cleanup_remaining:
+                    return
+                cleanup_error = record.cleanup_error
+            finish_retirement(cleanup_error)
+
         with self._cleanup_handoff_lock:
             with self._cv:
                 if self._records.get(key) is not record:
@@ -1857,12 +1867,17 @@ class AsyncResultCollector:
                 record.cleanup_started = True
                 self._signal_readiness_change_locked()
                 cleanup_operations = record.adapter.retire_operations()
-            self._submit_cleanup_operations(
-                cleanup_operations,
-                on_done=finish_retirement,
-                store_error=False,
-                slot_ids=(record.slot_id,),
-            )
+                record.cleanup_remaining = len(cleanup_operations)
+                record.cleanup_error = None
+            if cleanup_operations:
+                self._submit_cleanup_operations(
+                    cleanup_operations,
+                    on_each_done=finish_cleanup_operation,
+                    store_error=False,
+                    slot_ids=(record.slot_id,),
+                )
+            else:
+                finish_retirement(None)
 
     def _fail_record(self, record: _StreamRecord, exc: BaseException) -> None:
         exc = format_stateful_actor_loss(record.error_context, exc)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -34,6 +34,7 @@ _GENERATOR_READINESS_POLL_MAX_DELAY_S = 0.01
 _CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _CLEANUP_RESPONSE_TIMEOUT_S = 1.0
+_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
 
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
@@ -1233,6 +1234,14 @@ class AsyncResultCollector:
             _CLEANUP_RETRY_MAX_DELAY_S,
         )
 
+    @staticmethod
+    def _cleanup_response_timeout(retry_count: int) -> float:
+        exponent = min(max(0, int(retry_count)), 30)
+        return min(
+            math.ldexp(_CLEANUP_RESPONSE_TIMEOUT_S, exponent),
+            _CLEANUP_RESPONSE_TIMEOUT_MAX_S,
+        )
+
     def _retry_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
             if ticket not in self._cleanup_tickets:
@@ -1322,7 +1331,9 @@ class AsyncResultCollector:
                         with self._cv:
                             if ticket in self._cleanup_tickets and ticket.wait_future is result:
                                 ticket.wait_timeout = self._loop.call_later(
-                                    _CLEANUP_RESPONSE_TIMEOUT_S,
+                                    self._cleanup_response_timeout(
+                                        ticket.retry_count,
+                                    ),
                                     self._timeout_cleanup_ticket,
                                     ticket,
                                     result,

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -68,6 +68,7 @@ class _OutputLeaseToken:
     lease_id: str
     query_id: str
     driver: Any
+    submission_scope: str
     slot_id: int
     submit_id: int
     size_bytes: int
@@ -140,7 +141,7 @@ class _CleanupTicket:
     def __init__(
         self,
         *,
-        operation: Callable[[], Any],
+        operation: RayStreamCleanupOperation,
         retry_on_error: bool,
         retry_on_incomplete: bool,
         abandon_wait: Callable[[Any], None] | None,
@@ -211,11 +212,13 @@ class AsyncResultCollector:
 
     The asyncio thread is the sole generator-readiness, read, and state
     scheduler. Potentially blocking Ray control submissions and terminal
-    operations run on one fixed process-wide daemon executor and publish their
-    results back to that loop. Driver RPCs are observed through public
-    ObjectRef futures. Every terminal operation enters the ticket ledger before
-    its source record is removed, so shutdown can never observe an ownership
-    gap.
+    operations run on admitted stream-owner daemon workers and publish their
+    results back to that loop. One blocked stream therefore cannot consume a
+    healthy peer's submission progress, and worker cardinality follows the
+    existing task-admission bound rather than an arbitrary lane count. Driver
+    RPCs are observed through public ObjectRef futures. Every terminal operation
+    enters the ticket ledger before its source record is removed, so shutdown
+    can never observe an ownership gap.
 
     The native dispatcher keeps this collector alive across empty slot
     intervals. ``shutdown`` is the process-owner fence and is called only after
@@ -595,6 +598,7 @@ class AsyncResultCollector:
     ) -> RayStreamCleanupOperation:
         return RayStreamCleanupOperation(
             lambda: self._run_output_token_handoff(token),
+            submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
             abandon_wait=lambda future: self._abandon_output_token_handoff(
@@ -609,6 +613,7 @@ class AsyncResultCollector:
     ) -> RayStreamCleanupOperation:
         return RayStreamCleanupOperation(
             lambda: self._run_output_token_release(token),
+            submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
             abandon_wait=lambda future: self._abandon_output_token_release(
@@ -621,6 +626,7 @@ class AsyncResultCollector:
     def _output_request_cancel_operation(
         driver: Any,
         request: dict[str, Any],
+        submission_scope: str,
     ) -> RayStreamCleanupOperation:
         response_future: Any | None = None
 
@@ -650,6 +656,7 @@ class AsyncResultCollector:
 
         return RayStreamCleanupOperation(
             cancel,
+            submission_scope=submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
             abandon_wait=abandon_wait,
@@ -678,7 +685,13 @@ class AsyncResultCollector:
                     if request is not None and driver is not None and not record.output_cancel_sent:
                         record.output_cancel_sent = True
                         output_cancel_records.append(record)
-                        cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                        cleanup_operations.append(
+                            self._output_request_cancel_operation(
+                                driver,
+                                request,
+                                record.adapter.submission_scope,
+                            )
+                        )
                     cleanup_operations.extend(record.adapter.cancel_operations())
                 ready = list(self._ready_by_slot.get(slot_key, ()))
                 tokens = [token for token in self._active_output_leases.values() if token.slot_id == slot_key]
@@ -780,7 +793,13 @@ class AsyncResultCollector:
                             driver = record.adapter.driver
                             if request is not None and driver is not None and not record.output_cancel_sent:
                                 record.output_cancel_sent = True
-                                cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                                cleanup_operations.append(
+                                    self._output_request_cancel_operation(
+                                        driver,
+                                        request,
+                                        record.adapter.submission_scope,
+                                    )
+                                )
                             cleanup_operations.extend(record.adapter.cancel_operations())
                         ready = [event for events in self._ready_by_slot.values() for event in events]
                         tokens = list(self._active_output_leases.values())
@@ -1293,7 +1312,10 @@ class AsyncResultCollector:
             ):
                 return
         try:
-            operation_future = submit_ray_control(ticket.operation)
+            operation_future = submit_ray_control(
+                ticket.operation.submission_scope,
+                ticket.operation,
+            )
         except BaseException as exc:
             self._finish_cleanup_operation(ticket, error=exc)
             return
@@ -1772,9 +1794,10 @@ class AsyncResultCollector:
             record.phase = "output_lease"
 
         output_submit_future = submit_ray_control(
+            record.adapter.submission_scope,
             lambda: driver.acquire_query_output_block_lease.remote(
                 dict(request),
-            )
+            ),
         )
         with self._cv:
             stale = self._shutdown or self._records.get(key) is not record or record.terminal
@@ -1787,7 +1810,13 @@ class AsyncResultCollector:
             output_submit_future.cancel()
             if cancel_stale_request:
                 self._submit_cleanup_operations(
-                    (self._output_request_cancel_operation(driver, request),),
+                    (
+                        self._output_request_cancel_operation(
+                            driver,
+                            request,
+                            record.adapter.submission_scope,
+                        ),
+                    ),
                     slot_ids=(record.slot_id,),
                 )
             return
@@ -1891,6 +1920,7 @@ class AsyncResultCollector:
             lease_id=str(lease["lease_id"]),
             query_id=str(metadata["query_id"]),
             driver=driver,
+            submission_scope=record.adapter.submission_scope,
             slot_id=record.slot_id,
             submit_id=record.submit_id,
             size_bytes=int(metadata["size_bytes"]),
@@ -2084,6 +2114,7 @@ class AsyncResultCollector:
                     output_cancel_operation = self._output_request_cancel_operation(
                         driver,
                         request,
+                        record.adapter.submission_scope,
                     )
                 terminal_signal_observed = record.terminal_signal_observed
                 cleanup_operations: list[RayStreamCleanupOperation] = [

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -250,6 +250,7 @@ class AsyncResultCollector:
         self._cleanup_handoff_lock = threading.RLock()
         self._cleanup_tickets: set[_CleanupTicket] = set()
         self._cleanup_tickets_by_slot: dict[int, set[_CleanupTicket]] = defaultdict(set)
+        self._slot_cancellation_tickets: dict[int, set[_CleanupTicket]] = defaultdict(set)
         self._terminal_cleanup_errors: list[BaseException] = []
         self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
         self._readiness_timer: asyncio.TimerHandle | None = None
@@ -669,13 +670,13 @@ class AsyncResultCollector:
         )
 
     def cancel_slot(self, slot_id: int) -> None:
+        """Fence a slot and atomically hand its remote cleanup to the event loop."""
         slot_key = int(slot_id)
-        cleanup_tickets: set[_CleanupTicket] = set()
         with self._cleanup_handoff_lock:
             with self._cv:
                 if self._shutdown:
                     return
-                cleanup_tickets.update(self._cleanup_tickets_by_slot.get(slot_key, ()))
+                self._slot_cancellation_tickets[slot_key].update(self._cleanup_tickets_by_slot.get(slot_key, ()))
                 records = [record for record in self._records.values() if record.slot_id == slot_key]
                 records_to_cancel = [record for record in records if not record.cleanup_started]
                 cleanup_operations: list[RayStreamCleanupOperation] = []
@@ -706,12 +707,10 @@ class AsyncResultCollector:
                 self._signal_readiness_change_locked()
 
             try:
-                cleanup_tickets.update(
-                    self._submit_cleanup_operations(
-                        cleanup_operations,
-                        store_error=False,
-                        slot_ids=(slot_key,),
-                    )
+                cleanup_tickets = self._submit_cleanup_operations(
+                    cleanup_operations,
+                    store_error=False,
+                    slot_ids=(slot_key,),
                 )
             except BaseException:
                 self._restore_output_token_release_claims(claimed_tokens)
@@ -725,6 +724,7 @@ class AsyncResultCollector:
                     self._cv.notify_all()
                 raise
             with self._cv:
+                self._slot_cancellation_tickets[slot_key].update(cleanup_tickets)
                 for record in records:
                     if self._records.get((record.slot_id, record.submit_id)) is record:
                         self._records.pop((record.slot_id, record.submit_id), None)
@@ -734,15 +734,6 @@ class AsyncResultCollector:
                 self._capacity_by_slot.pop(slot_key, None)
                 self._cancelled_slots.add(slot_key)
                 self._signal_readiness_change_locked()
-
-        cleanup_errors = self._wait_slot_cleanup(
-            slot_key,
-            timeout_message=f"Ray UDF slot {slot_key} cleanup did not terminate",
-            initial_tickets=tuple(cleanup_tickets),
-        )
-        if cleanup_errors:
-            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
-            raise RuntimeError(f"Ray UDF slot {slot_key} cleanup failed: {details}") from cleanup_errors[0]
 
     def slot_has_pending(self, slot_id: int) -> bool:
         slot_key = int(slot_id)
@@ -754,8 +745,8 @@ class AsyncResultCollector:
                 or bool(self._cleanup_tickets_by_slot.get(slot_key))
             )
 
-    def retire_slot(self, slot_id: int) -> None:
-        """Drop the cancellation fence after the native submitter is quiescent."""
+    def retire_slot(self, slot_id: int) -> str | None:
+        """Drop a quiescent slot fence and return any terminal cleanup failure."""
         slot_key = int(slot_id)
         with self._cv:
             if (
@@ -765,9 +756,14 @@ class AsyncResultCollector:
                 or bool(self._cleanup_tickets_by_slot.get(slot_key))
             ):
                 raise RuntimeError(f"Ray UDF slot {slot_key} still owns collector state")
+            cancellation_tickets = self._slot_cancellation_tickets.pop(slot_key, ())
             self._cancelled_slots.discard(slot_key)
             self._capacity_by_slot.pop(slot_key, None)
             self._cv.notify_all()
+        cleanup_errors = tuple(error for ticket in cancellation_tickets for error in ticket.errors)
+        if not cleanup_errors:
+            return None
+        return "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
 
     def set_wakeup_callback(self, fn: Any) -> None:
         with self._cv:
@@ -853,7 +849,20 @@ class AsyncResultCollector:
             pending = [ticket for ticket in self._cleanup_tickets if not ticket.callback_owned_by_current_thread()]
             if pending:
                 shutdown_errors.append(RuntimeError("Ray UDF stream remote cleanup did not terminate"))
-            shutdown_errors.extend(self._terminal_cleanup_errors)
+            recorded_errors = [
+                *self._terminal_cleanup_errors,
+                *(
+                    error
+                    for tickets in self._slot_cancellation_tickets.values()
+                    for ticket in tickets
+                    for error in ticket.errors
+                ),
+            ]
+            known_error_ids = {id(error) for error in shutdown_errors}
+            for error in recorded_errors:
+                if id(error) not in known_error_ids:
+                    known_error_ids.add(id(error))
+                    shutdown_errors.append(error)
 
         if not pending and self._thread.is_alive():
             self._loop.call_soon_threadsafe(self._loop.stop)
@@ -1194,6 +1203,7 @@ class AsyncResultCollector:
                                         None,
                                     )
                         self._cv.notify_all()
+                    self._notify_wakeup()
 
             ticket = _CleanupTicket(
                 operation=action,
@@ -1444,29 +1454,6 @@ class AsyncResultCollector:
             if not ticket.wait(max(0.0, deadline - time.monotonic())):
                 raise RuntimeError(timeout_message)
         return tuple(error for ticket in tickets for error in ticket.errors)
-
-    def _wait_slot_cleanup(
-        self,
-        slot_id: int,
-        *,
-        timeout_message: str,
-        initial_tickets: Sequence[_CleanupTicket] = (),
-    ) -> tuple[BaseException, ...]:
-        deadline = time.monotonic() + self._shutdown_timeout_s
-        observed = set(initial_tickets)
-        while True:
-            with self._cv:
-                tickets = tuple(self._cleanup_tickets_by_slot.get(int(slot_id), ()))
-            observed.update(tickets)
-            pending = [
-                ticket for ticket in observed if not ticket.wait(0) and not ticket.callback_owned_by_current_thread()
-            ]
-            if not pending:
-                break
-            remaining = deadline - time.monotonic()
-            if remaining <= 0 or not pending[0].wait(remaining):
-                raise RuntimeError(timeout_message)
-        return tuple(error for ticket in observed for error in ticket.errors)
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -9,6 +9,7 @@ import os
 import sys
 import threading
 import time
+import weakref
 from collections import defaultdict, deque
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -32,6 +33,7 @@ _GENERATOR_READINESS_POLL_INITIAL_DELAY_S = 0.001
 _GENERATOR_READINESS_POLL_MAX_DELAY_S = 0.01
 _CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _CLEANUP_RETRY_MAX_DELAY_S = 1.0
+_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
@@ -138,13 +140,16 @@ class _CleanupTicket:
         operation: Callable[[], Any],
         retry_on_error: bool,
         retry_on_incomplete: bool,
+        abandon_wait: Callable[[Any], None] | None,
         on_complete: Callable[[BaseException | None], None],
     ) -> None:
         self.operation = operation
         self.retry_on_error = bool(retry_on_error)
         self.retry_on_incomplete = bool(retry_on_incomplete)
+        self.abandon_wait = abandon_wait
         self.retry_count = 0
         self.wait_future: Any | None = None
+        self.wait_timeout: asyncio.TimerHandle | None = None
         self._done = False
         self._error: BaseException | None = None
         self._on_complete = on_complete
@@ -205,6 +210,10 @@ class AsyncResultCollector:
     cancellation and CoreWorker stream deletion are non-waiting submissions.
     Every terminal operation enters the ticket ledger before its source record
     is removed, so shutdown can never observe an ownership gap.
+
+    The native dispatcher keeps this collector alive across empty slot
+    intervals. ``shutdown`` is the process-owner fence and is called only after
+    that dispatcher thread has stopped accepting and executing submissions.
     """
 
     def __init__(self, *, ray_module: Any | None = None) -> None:
@@ -340,12 +349,13 @@ class AsyncResultCollector:
                         add_note(f"submitted Ray stream cleanup failed: {detail}")
             raise
 
-    def discard_generator_ref(self, source: Any) -> None:
+    def discard_generator_ref(self, slot_id: int, source: Any) -> None:
         """Cancel a submitted stream rejected by the C++ slot-generation fence."""
         if not isinstance(source, TaskLeaseObjectRefGenerator):
             raise TypeError(
                 f"distributed Ray UDF discard requires TaskLeaseObjectRefGenerator; got {type(source).__name__}"
             )
+        slot_key = int(slot_id)
         with self._start_lock:
             try:
                 adapter = RayStreamAdapter(source, ray_module=self._ray)
@@ -361,6 +371,7 @@ class AsyncResultCollector:
                 self._submit_cleanup_operations(
                     cleanup_operations,
                     store_error=True,
+                    slot_ids=(slot_key,),
                 )
 
     def drain_results(self, capacities: dict[Any, Any] | None = None) -> list[tuple[Any, ...]]:
@@ -507,6 +518,19 @@ class AsyncResultCollector:
             token.handoff_response_future = None
         return True
 
+    def _abandon_output_token_handoff(
+        self,
+        token: _OutputLeaseToken,
+        response_future: Any,
+    ) -> None:
+        with self._cv:
+            if token.handoff_response_future is response_future:
+                token.handoff_response_future = None
+        try:
+            response_future.cancel()
+        except BaseException:
+            pass
+
     def _run_output_token_release(self, token: _OutputLeaseToken) -> bool | Any:
         with self._cv:
             response_future = token.release_response_future
@@ -531,6 +555,19 @@ class AsyncResultCollector:
         with self._cv:
             token.release_response_future = None
         return True
+
+    def _abandon_output_token_release(
+        self,
+        token: _OutputLeaseToken,
+        response_future: Any,
+    ) -> None:
+        with self._cv:
+            if token.release_response_future is response_future:
+                token.release_response_future = None
+        try:
+            response_future.cancel()
+        except BaseException:
+            pass
 
     @staticmethod
     def _claim_output_token_releases_locked(
@@ -567,6 +604,10 @@ class AsyncResultCollector:
             lambda: self._run_output_token_handoff(token),
             retry_on_error=True,
             retry_on_incomplete=True,
+            abandon_wait=lambda future: self._abandon_output_token_handoff(
+                token,
+                future,
+            ),
         )
 
     def _output_token_release_operation(
@@ -577,6 +618,10 @@ class AsyncResultCollector:
             lambda: self._run_output_token_release(token),
             retry_on_error=True,
             retry_on_incomplete=True,
+            abandon_wait=lambda future: self._abandon_output_token_release(
+                token,
+                future,
+            ),
         )
 
     @staticmethod
@@ -601,10 +646,20 @@ class AsyncResultCollector:
             response_future = None
             return True
 
+        def abandon_wait(future: Any) -> None:
+            nonlocal response_future
+            if response_future is future:
+                response_future = None
+            try:
+                future.cancel()
+            except BaseException:
+                pass
+
         return RayStreamCleanupOperation(
             cancel,
             retry_on_error=True,
             retry_on_incomplete=True,
+            abandon_wait=abandon_wait,
         )
 
     def cancel_slot(self, slot_id: int) -> None:
@@ -693,11 +748,27 @@ class AsyncResultCollector:
                 or bool(self._cleanup_tickets_by_slot.get(slot_key))
             )
 
+    def retire_slot(self, slot_id: int) -> None:
+        """Drop the cancellation fence after the native submitter is quiescent."""
+        slot_key = int(slot_id)
+        with self._cv:
+            if (
+                any(record.slot_id == slot_key for record in self._records.values())
+                or bool(self._ready_by_slot.get(slot_key))
+                or any(token.slot_id == slot_key for token in self._active_output_leases.values())
+                or bool(self._cleanup_tickets_by_slot.get(slot_key))
+            ):
+                raise RuntimeError(f"Ray UDF slot {slot_key} still owns collector state")
+            self._cancelled_slots.discard(slot_key)
+            self._capacity_by_slot.pop(slot_key, None)
+            self._cv.notify_all()
+
     def set_wakeup_callback(self, fn: Any) -> None:
         with self._cv:
             self._wakeup_fn = fn
 
     def shutdown(self) -> None:
+        """Stop the process-owned loop after the native submitter is quiescent."""
         deadline = time.monotonic() + self._shutdown_timeout_s
         shutdown_errors: list[BaseException] = []
         with self._start_lock:
@@ -813,7 +884,18 @@ class AsyncResultCollector:
                     if self._thread_error is None:
                         self._thread_error = exc
                     self._cv.notify_all()
-                if not thread_started:
+                if thread_started:
+                    try:
+                        self._loop.call_soon_threadsafe(self._loop.stop)
+                    except RuntimeError:
+                        pass
+                    if self._thread is not threading.current_thread():
+                        self._thread.join(timeout=self._shutdown_timeout_s)
+                    if self._thread.is_alive():
+                        add_note = getattr(exc, "add_note", None)
+                        if callable(add_note):
+                            add_note("Ray UDF stream event loop did not terminate after start failure")
+                else:
                     self._loop.close()
                 raise
 
@@ -973,6 +1055,8 @@ class AsyncResultCollector:
             # A single dead generator must not poison unrelated query slots.
             # Ray does not identify the failed waitable in a batch exception,
             # so isolate only on this exceptional path with zero-time probes.
+            # Even when every current probe fails, keep the process-owned
+            # collector usable for future query slots.
             ready = []
             failed: list[tuple[_StreamRecord, BaseException]] = []
             for waitable, record in waitables.items():
@@ -987,8 +1071,6 @@ class AsyncResultCollector:
                     failed.append((record, exc))
                 else:
                     ready.extend(one_ready)
-            if not failed or len(failed) == len(waitables):
-                raise
             for failed_record, failure in failed:
                 self._fail_record(failed_record, failure)
 
@@ -1109,6 +1191,7 @@ class AsyncResultCollector:
                 operation=action,
                 retry_on_error=action.retry_on_error,
                 retry_on_incomplete=action.retry_on_incomplete,
+                abandon_wait=action.abandon_wait,
                 on_complete=complete,
             )
             ticket_holder.append(ticket)
@@ -1164,7 +1247,30 @@ class AsyncResultCollector:
             if ticket not in self._cleanup_tickets or ticket.wait_future is not future:
                 return
             ticket.wait_future = None
+            timeout = ticket.wait_timeout
+            ticket.wait_timeout = None
+        if timeout is not None:
+            timeout.cancel()
         self._drive_cleanup_ticket(ticket)
+
+    def _timeout_cleanup_ticket(self, ticket: _CleanupTicket, future: Any) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.wait_future is not future:
+                return
+            ticket.wait_future = None
+            ticket.wait_timeout = None
+        try:
+            assert ticket.abandon_wait is not None
+            ticket.abandon_wait(future)
+        except BaseException as exc:
+            if not ticket.retry_on_error:
+                ticket.finish(exc)
+                with self._cv:
+                    stop = self._shutdown and not self._cleanup_tickets
+                if stop:
+                    self._loop.stop()
+                return
+        self._retry_cleanup_ticket(ticket)
 
     def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
@@ -1180,18 +1286,25 @@ class AsyncResultCollector:
                         return
                     ticket.wait_future = result
 
+                collector_ref = weakref.ref(self)
+                ticket_ref = weakref.ref(ticket)
+
                 def ready(future: Any) -> None:
+                    collector = collector_ref()
+                    active_ticket = ticket_ref()
+                    if collector is None or active_ticket is None:
+                        return
                     try:
-                        self._loop.call_soon_threadsafe(
-                            self._resume_cleanup_ticket,
-                            ticket,
+                        collector._loop.call_soon_threadsafe(
+                            collector._resume_cleanup_ticket,
+                            active_ticket,
                             future,
                         )
                     except RuntimeError as exc:
-                        with self._cv:
-                            if self._thread_error is None:
-                                self._thread_error = exc
-                            self._cv.notify_all()
+                        with collector._cv:
+                            if collector._thread_error is None:
+                                collector._thread_error = exc
+                            collector._cv.notify_all()
 
                 try:
                     result.add_done_callback(ready)
@@ -1203,6 +1316,15 @@ class AsyncResultCollector:
                     # Future contract, not a transient remote operation.
                     error = exc
                 else:
+                    if ticket.abandon_wait is not None:
+                        with self._cv:
+                            if ticket in self._cleanup_tickets and ticket.wait_future is result:
+                                ticket.wait_timeout = self._loop.call_later(
+                                    _CLEANUP_RESPONSE_TIMEOUT_S,
+                                    self._timeout_cleanup_ticket,
+                                    ticket,
+                                    result,
+                                )
                     return
             retry = result is False and ticket.retry_on_incomplete
         except BaseException as exc:
@@ -1345,23 +1467,30 @@ class AsyncResultCollector:
         record.wait_kind = kind
         record.wait_future = future
 
+        collector_ref = weakref.ref(self)
+        record_ref = weakref.ref(record)
+
         def on_done(done: Any) -> None:
-            with self._cv:
-                if self._shutdown:
+            collector = collector_ref()
+            active_record = record_ref()
+            if collector is None or active_record is None:
+                return
+            with collector._cv:
+                if collector._shutdown:
                     return
             try:
-                self._loop.call_soon_threadsafe(
-                    self._run_scheduler_callback,
-                    self._complete_record_wait,
-                    record,
+                collector._loop.call_soon_threadsafe(
+                    collector._run_scheduler_callback,
+                    collector._complete_record_wait,
+                    active_record,
                     kind,
                     done,
                 )
             except RuntimeError as exc:
-                with self._cv:
-                    shutting_down = self._shutdown
+                with collector._cv:
+                    shutting_down = collector._shutdown
                 if not shutting_down:
-                    self._report_scheduler_error(exc)
+                    collector._report_scheduler_error(exc)
 
         future.add_done_callback(on_done)
         return block_admitted
@@ -1372,22 +1501,29 @@ class AsyncResultCollector:
         future = self._object_ref_future(record.adapter.completion_ref)
         record.completion_future = future
 
+        collector_ref = weakref.ref(self)
+        record_ref = weakref.ref(record)
+
         def on_done(done: Any) -> None:
-            with self._cv:
-                if self._shutdown:
+            collector = collector_ref()
+            active_record = record_ref()
+            if collector is None or active_record is None:
+                return
+            with collector._cv:
+                if collector._shutdown:
                     return
             try:
-                self._loop.call_soon_threadsafe(
-                    self._run_scheduler_callback,
-                    self._complete_producer_wait,
-                    record,
+                collector._loop.call_soon_threadsafe(
+                    collector._run_scheduler_callback,
+                    collector._complete_producer_wait,
+                    active_record,
                     done,
                 )
             except RuntimeError as exc:
-                with self._cv:
-                    shutting_down = self._shutdown
+                with collector._cv:
+                    shutting_down = collector._shutdown
                 if not shutting_down:
-                    self._report_scheduler_error(exc)
+                    collector._report_scheduler_error(exc)
 
         future.add_done_callback(on_done)
 
@@ -1783,12 +1919,21 @@ class AsyncResultCollector:
                 record.cleanup_remaining = len(cleanup_operations)
                 record.cleanup_error = None
             if cleanup_operations:
-                self._submit_cleanup_operations(
-                    cleanup_operations,
-                    on_each_done=finish_cleanup_operation,
-                    store_error=False,
-                    slot_ids=(record.slot_id,),
-                )
+                try:
+                    self._submit_cleanup_operations(
+                        cleanup_operations,
+                        on_each_done=finish_cleanup_operation,
+                        store_error=False,
+                        slot_ids=(record.slot_id,),
+                    )
+                except BaseException:
+                    with self._cv:
+                        if self._records.get(key) is record:
+                            record.cleanup_started = False
+                            record.cleanup_remaining = 0
+                            record.cleanup_error = None
+                            self._cv.notify_all()
+                    raise
             else:
                 finish_retirement(None)
 

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -27,6 +27,7 @@ from duckdb.execution.ray_control_submission import (
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
     RayStreamCleanupOperation,
+    RayStreamCleanupWait,
     TaskLeaseObjectRefGenerator,
     ray_object_ref_future,
     validate_ray_control_ack,
@@ -83,8 +84,6 @@ class _OutputLeaseToken:
     handed_off: bool = False
     handoff_pending: bool = False
     release_pending: bool = False
-    handoff_response_future: Any | None = None
-    release_response_future: Any | None = None
 
 
 @dataclass
@@ -153,17 +152,16 @@ class _CleanupTicket:
         operation: RayStreamCleanupOperation,
         retry_on_error: bool,
         retry_on_incomplete: bool,
-        release_wait: Callable[[Any], None] | None,
         on_complete: Callable[[BaseException | None], None],
     ) -> None:
         self.operation = operation
         self.retry_on_error = bool(retry_on_error)
         self.retry_on_incomplete = bool(retry_on_incomplete)
-        self.release_wait = release_wait
         self.retry_count = 0
         self.submitting = False
         self.operation_future: Any | None = None
         self.wait_future: Any | None = None
+        self.wait_response: RayStreamCleanupWait | None = None
         self.retry_call: RayControlScheduledCall | None = None
         self.wait_timeout: RayControlScheduledCall | None = None
         self._done = False
@@ -173,11 +171,11 @@ class _CleanupTicket:
         self._callback_complete = False
         self._cv = threading.Condition()
 
-    def finish(self, error: BaseException | None) -> None:
+    def finish(self, error: BaseException | None) -> bool:
         callback: Callable[[BaseException | None], None] | None = None
         with self._cv:
             if self._done:
-                raise RuntimeError("Ray UDF cleanup ticket completed twice")
+                return False
             self._done = True
             self._error = error
             callback = self._on_complete
@@ -191,6 +189,7 @@ class _CleanupTicket:
                 self._callback_thread = None
                 self._callback_complete = True
                 self._cv.notify_all()
+        return True
 
     def wait(self, timeout: float) -> bool:
         deadline = time.monotonic() + max(0.0, float(timeout))
@@ -507,77 +506,45 @@ class AsyncResultCollector:
                 raise
         return True
 
-    def _run_output_token_handoff(self, token: _OutputLeaseToken) -> bool | Any:
+    def _run_output_token_handoff(
+        self,
+        token: _OutputLeaseToken,
+    ) -> bool | RayStreamCleanupWait:
         key = (token.request_id, token.lease_id)
         with self._cv:
             if token.release_pending or self._active_output_leases.get(key) is not token:
-                token.handoff_response_future = None
                 return True
-            response_future = token.handoff_response_future
-        try:
-            if response_future is None:
-                response_ref = token.driver.handoff_query_output_block_lease.remote(
-                    token.request_id,
-                    token.lease_id,
-                    token.query_id,
-                )
-                response_future = ray_object_ref_future(response_ref)
-                with self._cv:
-                    token.handoff_response_future = response_future
-            if not response_future.done():
-                return response_future
-            validate_ray_control_ack(response_future.result(), field="handed_off")
-        except BaseException:
-            with self._cv:
-                if token.handoff_response_future is response_future:
-                    token.handoff_response_future = None
-            raise
-        with self._cv:
-            token.handoff_response_future = None
-        return True
+        response_ref = token.driver.handoff_query_output_block_lease.remote(
+            token.request_id,
+            token.lease_id,
+            token.query_id,
+        )
+        response_future = ray_object_ref_future(response_ref)
+        return RayStreamCleanupWait(
+            response_future,
+            lambda response: validate_ray_control_ack(
+                response,
+                field="handed_off",
+            ),
+        )
 
-    def _release_output_token_handoff_wait(
+    def _run_output_token_release(
         self,
         token: _OutputLeaseToken,
-        response_future: Any,
-    ) -> None:
-        with self._cv:
-            if token.handoff_response_future is response_future:
-                token.handoff_response_future = None
-
-    def _run_output_token_release(self, token: _OutputLeaseToken) -> bool | Any:
-        with self._cv:
-            response_future = token.release_response_future
-        try:
-            if response_future is None:
-                response_ref = token.driver.release_query_output_block_lease.remote(
-                    token.request_id,
-                    token.lease_id,
-                    token.query_id,
-                )
-                response_future = ray_object_ref_future(response_ref)
-                with self._cv:
-                    token.release_response_future = response_future
-            if not response_future.done():
-                return response_future
-            validate_ray_control_ack(response_future.result(), field="released")
-        except BaseException:
-            with self._cv:
-                if token.release_response_future is response_future:
-                    token.release_response_future = None
-            raise
-        with self._cv:
-            token.release_response_future = None
-        return True
-
-    def _release_output_token_release_wait(
-        self,
-        token: _OutputLeaseToken,
-        response_future: Any,
-    ) -> None:
-        with self._cv:
-            if token.release_response_future is response_future:
-                token.release_response_future = None
+    ) -> RayStreamCleanupWait:
+        response_ref = token.driver.release_query_output_block_lease.remote(
+            token.request_id,
+            token.lease_id,
+            token.query_id,
+        )
+        response_future = ray_object_ref_future(response_ref)
+        return RayStreamCleanupWait(
+            response_future,
+            lambda response: validate_ray_control_ack(
+                response,
+                field="released",
+            ),
+        )
 
     @staticmethod
     def _claim_output_token_releases_locked(
@@ -615,10 +582,6 @@ class AsyncResultCollector:
             submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            release_wait=lambda future: self._release_output_token_handoff_wait(
-                token,
-                future,
-            ),
         )
 
     def _output_token_release_operation(
@@ -630,10 +593,6 @@ class AsyncResultCollector:
             submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            release_wait=lambda future: self._release_output_token_release_wait(
-                token,
-                future,
-            ),
         )
 
     @staticmethod
@@ -642,34 +601,22 @@ class AsyncResultCollector:
         request: dict[str, Any],
         submission_scope: str,
     ) -> RayStreamCleanupOperation:
-        response_future: Any | None = None
-
-        def cancel() -> bool | Any:
-            nonlocal response_future
-            try:
-                if response_future is None:
-                    response_ref = driver.cancel_query_output_block_lease_request.remote(request)
-                    response_future = ray_object_ref_future(response_ref)
-                if not response_future.done():
-                    return response_future
-                validate_ray_control_ack(response_future.result(), field="cancelled")
-            except BaseException:
-                response_future = None
-                raise
-            response_future = None
-            return True
-
-        def release_wait(future: Any) -> None:
-            nonlocal response_future
-            if response_future is future:
-                response_future = None
+        def cancel() -> RayStreamCleanupWait:
+            response_ref = driver.cancel_query_output_block_lease_request.remote(request)
+            response_future = ray_object_ref_future(response_ref)
+            return RayStreamCleanupWait(
+                response_future,
+                lambda response: validate_ray_control_ack(
+                    response,
+                    field="cancelled",
+                ),
+            )
 
         return RayStreamCleanupOperation(
             cancel,
             submission_scope=submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            release_wait=release_wait,
         )
 
     def cancel_slot(self, slot_id: int) -> None:
@@ -1253,7 +1200,6 @@ class AsyncResultCollector:
                 operation=action,
                 retry_on_error=action.retry_on_error,
                 retry_on_incomplete=action.retry_on_incomplete,
-                release_wait=action.release_wait,
                 on_complete=complete,
             )
             ticket_holder.append(ticket)
@@ -1333,41 +1279,76 @@ class AsyncResultCollector:
             ticket.retry_call = None
         self._drive_cleanup_ticket(ticket)
 
-    def _resume_cleanup_ticket(self, ticket: _CleanupTicket, future: Any) -> None:
+    def _resume_cleanup_ticket(
+        self,
+        ticket: _CleanupTicket,
+        future: Any,
+        accept_response: Callable[[Any], Any] | None,
+    ) -> None:
         with self._cv:
-            if ticket not in self._cleanup_tickets or ticket.wait_future is not future:
+            if ticket not in self._cleanup_tickets:
                 return
-            ticket.wait_future = None
-            timeout = ticket.wait_timeout
-            ticket.wait_timeout = None
+            current = ticket.wait_future is future
+            if current:
+                ticket.wait_future = None
+                ticket.wait_response = None
+                timeout = ticket.wait_timeout
+                ticket.wait_timeout = None
+            else:
+                timeout = None
         if timeout is not None:
             timeout.cancel()
-        self._drive_cleanup_ticket(ticket)
+        if accept_response is None:
+            if current:
+                self._drive_cleanup_ticket(ticket)
+            return
+        try:
+            accept_response(future.result())
+        except BaseException as exc:
+            if current:
+                self._finish_cleanup_operation(ticket, error=exc)
+            return
+
+        # A valid acknowledgement from any timed-out attempt proves that the
+        # idempotent terminal transition completed. Retire a newer observer or
+        # pending retry before publishing ticket completion.
+        with self._cv:
+            if ticket not in self._cleanup_tickets:
+                return
+            wait_timeout = ticket.wait_timeout
+            retry_call = ticket.retry_call
+            ticket.wait_future = None
+            ticket.wait_response = None
+            ticket.wait_timeout = None
+            ticket.retry_call = None
+        if wait_timeout is not None:
+            wait_timeout.cancel()
+        if retry_call is not None:
+            retry_call.cancel()
+        ticket.finish(None)
 
     def _timeout_cleanup_ticket(
         self,
         ticket: _CleanupTicket,
         future: Any,
+        response: RayStreamCleanupWait,
         timeout_call: RayControlScheduledCall,
     ) -> None:
         with self._cv:
             if (
                 ticket not in self._cleanup_tickets
                 or ticket.wait_future is not future
+                or ticket.wait_response is not response
                 or ticket.wait_timeout is not timeout_call
             ):
                 return
             ticket.wait_future = None
+            ticket.wait_response = None
             ticket.wait_timeout = None
-        # Publish the retry owner before releasing attempt-local state. The
-        # release hook is not allowed to call Future.cancel(), but an
-        # unexpected hook failure must not drop durable cleanup ownership.
+        # The Future callback retains this response attempt, so a later valid
+        # acknowledgement can still complete the ticket while the retry owns
+        # forward progress.
         self._retry_cleanup_ticket(ticket)
-        try:
-            assert ticket.release_wait is not None
-            ticket.release_wait(future)
-        except BaseException:
-            pass
 
     def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
@@ -1453,16 +1434,21 @@ class AsyncResultCollector:
             ticket.finish(error)
             return
 
-        if all(callable(getattr(result, name, None)) for name in ("add_done_callback", "done", "result")):
+        response = result if isinstance(result, RayStreamCleanupWait) else None
+        future = response.future if response is not None else result
+        if all(callable(getattr(future, name, None)) for name in ("add_done_callback", "done", "result")):
             with self._cv:
                 if ticket not in self._cleanup_tickets:
                     return
-                ticket.wait_future = result
+                ticket.wait_future = future
+                ticket.wait_response = response
 
             collector_ref = weakref.ref(self)
             ticket_ref = weakref.ref(ticket)
+            response_holder = [None if response is None else response.accept]
 
-            def ready(future: Any) -> None:
+            def ready(done: Any) -> None:
+                accept_response = response_holder.pop() if response_holder else None
                 collector = collector_ref()
                 active_ticket = ticket_ref()
                 if collector is None or active_ticket is None:
@@ -1470,15 +1456,17 @@ class AsyncResultCollector:
                 collector._run_scheduler_callback(
                     collector._resume_cleanup_ticket,
                     active_ticket,
-                    future,
+                    done,
+                    accept_response,
                 )
 
             try:
-                result.add_done_callback(ready)
+                future.add_done_callback(ready)
             except BaseException as exc:
                 with self._cv:
-                    if ticket in self._cleanup_tickets and ticket.wait_future is result:
+                    if ticket in self._cleanup_tickets and ticket.wait_future is future:
                         ticket.wait_future = None
+                        ticket.wait_response = None
                         active = True
                     else:
                         active = False
@@ -1487,13 +1475,14 @@ class AsyncResultCollector:
                 if active:
                     ticket.finish(exc)
                 return
-            if ticket.release_wait is not None:
+            if response is not None:
                 timeout_call: RayControlScheduledCall
 
                 def response_timed_out() -> None:
                     self._timeout_cleanup_ticket(
                         ticket,
-                        result,
+                        future,
+                        response,
                         timeout_call,
                     )
 
@@ -1502,7 +1491,11 @@ class AsyncResultCollector:
                     response_timed_out,
                 )
                 with self._cv:
-                    if ticket in self._cleanup_tickets and ticket.wait_future is result:
+                    if (
+                        ticket in self._cleanup_tickets
+                        and ticket.wait_future is future
+                        and ticket.wait_response is response
+                    ):
                         ticket.wait_timeout = timeout_call
                         start_timeout = True
                     else:
@@ -1515,18 +1508,21 @@ class AsyncResultCollector:
                         )
                     except BaseException as exc:
                         with self._cv:
-                            if ticket.wait_timeout is timeout_call and ticket.wait_future is result:
+                            if (
+                                ticket.wait_timeout is timeout_call
+                                and ticket.wait_future is future
+                                and ticket.wait_response is response
+                            ):
                                 ticket.wait_timeout = None
                                 ticket.wait_future = None
+                                ticket.wait_response = None
                                 active = ticket in self._cleanup_tickets
                             else:
                                 active = False
                         if active:
-                            try:
-                                ticket.release_wait(result)
-                            except BaseException:
-                                pass
                             ticket.finish(exc)
+                else:
+                    timeout_call.cancel()
             return
 
         if result is False and ticket.retry_on_incomplete:

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -1554,8 +1554,8 @@ class AsyncResultCollector:
                         pending_data_counts[record.slot_id] = pending_data_counts.get(record.slot_id, 0) + 1
                 except BaseException as exc:
                     failures.append((record, exc))
-        for record, exc in failures:
-            self._fail_record(record, exc)
+        for record, failure in failures:
+            self._fail_record(record, failure)
 
     def _complete_producer_wait(self, record: _StreamRecord, future: Any) -> None:
         key = (record.slot_id, record.submit_id)
@@ -1959,15 +1959,19 @@ class AsyncResultCollector:
                 claimed_tokens = self._claim_output_token_releases_locked(dropped_tokens)
                 request = record.output_request
                 driver = record.adapter.driver
-                cancel_output_request = request is not None and driver is not None and not record.output_cancel_sent
-                if cancel_output_request:
+                output_cancel_operation: RayStreamCleanupOperation | None = None
+                if request is not None and driver is not None and not record.output_cancel_sent:
                     record.output_cancel_sent = True
+                    output_cancel_operation = self._output_request_cancel_operation(
+                        driver,
+                        request,
+                    )
                 terminal_signal_observed = record.terminal_signal_observed
                 cleanup_operations: list[RayStreamCleanupOperation] = [
                     self._output_token_release_operation(token) for token in claimed_tokens
                 ]
-                if cancel_output_request:
-                    cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                if output_cancel_operation is not None:
+                    cleanup_operations.append(output_cancel_operation)
                 if not cleanup_was_started:
                     if terminal_signal_observed:
                         cleanup_operations.extend(record.adapter.retire_failed_operations())
@@ -1985,7 +1989,7 @@ class AsyncResultCollector:
                     if self._records.get(key) is record:
                         if not cleanup_was_started:
                             record.cleanup_started = False
-                        if cancel_output_request:
+                        if output_cancel_operation is not None:
                             record.output_cancel_sent = False
                         self._cv.notify_all()
                 raise

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -4,18 +4,26 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
 import math
 import os
 import sys
 import threading
 import time
 from collections import defaultdict, deque
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 from duckdb.execution.ray_stream_adapter import (
+    RAY_STREAM_CLEANUP_CANCELLATION,
+    RAY_STREAM_CLEANUP_CONTROL,
+    RAY_STREAM_CLEANUP_CORE,
+    RAY_STREAM_CLEANUP_OUTPUT,
     RayStreamAdapter,
+    RayStreamCleanupOperation,
     TaskLeaseObjectRefGenerator,
+    resolve_ray_control_ack,
 )
 from duckdb.execution.udf_ray_actor_state import format_stateful_actor_loss
 from duckdb.execution.udf_ray_config import REF_BUNDLE_RESULT_MARKER
@@ -26,6 +34,19 @@ from duckdb.execution.udf_ray_stream_protocol import (
 
 _GENERATOR_READINESS_POLL_INITIAL_DELAY_S = 0.001
 _GENERATOR_READINESS_POLL_MAX_DELAY_S = 0.01
+_DEFAULT_CONTROL_CLEANUP_WORKERS = 4
+_DEFAULT_OUTPUT_CLEANUP_WORKERS = 4
+_DEFAULT_CANCELLATION_CLEANUP_WORKERS = 2
+_DEFAULT_CORE_CLEANUP_WORKERS = 2
+_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
+_CLEANUP_RETRY_MAX_DELAY_S = 1.0
+
+
+def _cleanup_worker_count(name: str, default: int) -> int:
+    value = int(os.environ.get(name, str(default)))
+    if value <= 0 or value > 256:
+        raise ValueError(f"{name} must be between 1 and 256")
+    return value
 
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
@@ -56,11 +77,16 @@ class _DrainCapacity:
 class _OutputLeaseToken:
     request_id: str
     lease_id: str
+    query_id: str
     driver: Any
     slot_id: int
     submit_id: int
     size_bytes: int
     handed_off: bool = False
+    handoff_pending: bool = False
+    release_pending: bool = False
+    handoff_response_ref: Any | None = None
+    release_response_ref: Any | None = None
 
 
 @dataclass
@@ -113,10 +139,256 @@ class _StreamRecord:
     next_ref_ready: bool = False
     ready_sequence: int | None = None
     cleanup_started: bool = False
+    registration_accepted: bool = True
+    registration_cancelled: bool = False
+
+
+class _CleanupGroup:
+    """Completion fence for one atomically accepted terminal cleanup plan."""
+
+    def __init__(
+        self,
+        operation_count: int,
+        *,
+        on_complete: Callable[[BaseException | None], None],
+    ) -> None:
+        self._remaining = int(operation_count)
+        self._errors: list[BaseException] = []
+        self._on_complete = on_complete
+        self._callback_thread: threading.Thread | None = None
+        self._callback_complete = False
+        self._cv = threading.Condition()
+
+    def finish(self, error: BaseException | None) -> None:
+        callback: Callable[[BaseException | None], None] | None = None
+        first_error: BaseException | None = None
+        with self._cv:
+            if error is not None:
+                self._errors.append(error)
+            self._remaining -= 1
+            if self._remaining < 0:
+                raise RuntimeError("Ray UDF cleanup group count underflow")
+            if self._remaining == 0:
+                callback = self._on_complete
+                self._on_complete = lambda _error: None
+                first_error = self._errors[0] if self._errors else None
+                self._callback_thread = threading.current_thread()
+                self._cv.notify_all()
+        if callback is None:
+            return
+        try:
+            callback(first_error)
+        finally:
+            with self._cv:
+                self._callback_thread = None
+                self._callback_complete = True
+                self._cv.notify_all()
+
+    def wait(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        current = threading.current_thread()
+        with self._cv:
+            while self._remaining or (not self._callback_complete and self._callback_thread is not current):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._cv.wait(timeout=remaining)
+            return True
+
+    def callback_owned_by_current_thread(self) -> bool:
+        with self._cv:
+            return self._remaining == 0 and self._callback_thread is threading.current_thread()
+
+    @property
+    def errors(self) -> tuple[BaseException, ...]:
+        with self._cv:
+            return tuple(self._errors)
+
+
+@dataclass
+class _CleanupWorkItem:
+    operation: Callable[[], Any]
+    group: _CleanupGroup
+    retry_on_error: bool = False
+    retry_on_incomplete: bool = False
+    retry_count: int = 0
+
+
+class _DaemonCleanupPool:
+    """Lazily scaled, fixed-size daemon bulkhead for blocking terminal calls."""
+
+    def __init__(self, worker_count: int, *, name: str) -> None:
+        self._worker_count = int(worker_count)
+        self._name = str(name)
+        self._cv = threading.Condition()
+        self._queue: list[tuple[float, int, _CleanupWorkItem]] = []
+        self._next_queue_sequence = 0
+        self._threads: list[threading.Thread] = []
+        self._started = False
+        self._stop_when_idle = False
+        self._idle_workers = 0
+
+    def start(self) -> None:
+        with self._cv:
+            if self._started:
+                return
+            self._started = True
+
+    def _ensure_worker_locked(self) -> None:
+        if self._threads:
+            return
+        try:
+            self._start_worker_locked()
+        except BaseException as exc:
+            raise RuntimeError(f"Ray UDF cleanup pool {self._name!r} did not start") from exc
+
+    def _start_worker_locked(self) -> None:
+        worker = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name=f"{self._name}-{len(self._threads)}",
+        )
+        worker.start()
+        self._threads.append(worker)
+
+    def _scale_workers_locked(self) -> None:
+        needed = max(0, len(self._queue) - self._idle_workers)
+        available = self._worker_count - len(self._threads)
+        for _index in range(min(needed, available)):
+            try:
+                self._start_worker_locked()
+            except BaseException:
+                # The already-running worker remains the durable queue owner.
+                break
+
+    def _enqueue_locked(
+        self,
+        operations: Sequence[Callable[[], Any]],
+        group: _CleanupGroup,
+    ) -> None:
+        if not self._started or self._stop_when_idle:
+            raise RuntimeError(f"Ray UDF cleanup pool {self._name!r} is not accepting work")
+        ready_at = time.monotonic()
+        items = [
+            _CleanupWorkItem(
+                operation,
+                group,
+                retry_on_error=(
+                    operation.retry_on_error if isinstance(operation, RayStreamCleanupOperation) else False
+                ),
+                retry_on_incomplete=(
+                    operation.retry_on_incomplete if isinstance(operation, RayStreamCleanupOperation) else False
+                ),
+            )
+            for operation in operations
+        ]
+        for item in items:
+            sequence = self._next_queue_sequence
+            self._next_queue_sequence += 1
+            heapq.heappush(self._queue, (ready_at, sequence, item))
+        self._scale_workers_locked()
+        self._cv.notify_all()
+
+    def stop_when_idle(self) -> None:
+        with self._cv:
+            self._stop_when_idle = True
+            self._cv.notify_all()
+
+    def join(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        with self._cv:
+            threads = tuple(self._threads)
+        current = threading.current_thread()
+        for worker in threads:
+            if worker is current:
+                continue
+            worker.join(timeout=max(0.0, deadline - time.monotonic()))
+        return not any(worker is not current and worker.is_alive() for worker in threads)
+
+    @property
+    def threads(self) -> tuple[threading.Thread, ...]:
+        with self._cv:
+            return tuple(self._threads)
+
+    def _take_ready_item_locked(self) -> tuple[_CleanupWorkItem | None, float | None]:
+        if not self._queue:
+            return None, None
+        now = time.monotonic()
+        ready_at, _sequence, item = self._queue[0]
+        if ready_at <= now:
+            heapq.heappop(self._queue)
+            return item, None
+        return None, max(0.0, ready_at - now)
+
+    @staticmethod
+    def _retry_delay(retry_count: int) -> float:
+        exponent = min(max(0, int(retry_count) - 1), 30)
+        return min(
+            math.ldexp(_CLEANUP_RETRY_INITIAL_DELAY_S, exponent),
+            _CLEANUP_RETRY_MAX_DELAY_S,
+        )
+
+    def _run(self) -> None:
+        while True:
+            with self._cv:
+                item: _CleanupWorkItem | None = None
+                while item is None:
+                    item, retry_wait = self._take_ready_item_locked()
+                    if item is not None:
+                        break
+                    if not self._queue and self._stop_when_idle:
+                        return
+                    self._idle_workers += 1
+                    try:
+                        self._cv.wait(timeout=retry_wait)
+                    finally:
+                        self._idle_workers -= 1
+            error: BaseException | None = None
+            retry = False
+            result: Any = None
+            try:
+                result = item.operation()
+            except BaseException as exc:
+                if item.retry_on_error:
+                    retry = True
+                else:
+                    error = exc
+            else:
+                retry = result is False and item.retry_on_incomplete
+            if retry:
+                item.retry_count += 1
+                ready_at = time.monotonic() + self._retry_delay(item.retry_count)
+                with self._cv:
+                    sequence = self._next_queue_sequence
+                    self._next_queue_sequence += 1
+                    heapq.heappush(self._queue, (ready_at, sequence, item))
+                    self._cv.notify_all()
+                del item
+                del error
+                del result
+                continue
+            item.group.finish(error)
+            del item
+            del error
+            del result
 
 
 class AsyncResultCollector:
-    """Event-driven multiplexer for lease-owned Ray generator streams."""
+    """Capacity-aware scheduler for lease-owned Ray generator streams.
+
+    ``_cv`` owns every local stream transition. A registering record is not
+    schedulable until ``track_generator_ref`` commits its accepted bit, and a
+    terminal record is removed only while ``_cleanup_handoff_lock`` prevents
+    shutdown from observing an ownership gap.
+
+    The asyncio thread is the sole generator readiness/read consumer. Terminal
+    Ray, driver, and CoreWorker calls run in fixed-size lane-specific daemon
+    pools; task admission bounds the queued plans, while lane isolation keeps a
+    blocked cancellation from withholding stream deletion or unrelated control
+    work. Cancellation acceptance intentionally precedes task-lease release so
+    running work remains budgeted. User wakeups are invoked only after the
+    complete terminal plan has an accepted cleanup owner.
+    """
 
     def __init__(self, *, ray_module: Any | None = None) -> None:
         if ray_module is None:
@@ -143,20 +415,63 @@ class AsyncResultCollector:
         self._cancelled_slots: set[int] = set()
         self._next_sequence = 0
         self._next_ready_sequence = 0
-        self._cleanup_threads: set[threading.Thread] = set()
-        self._cleanup_errors: list[BaseException] = []
-        self._cleanup_starting = 0
+        self._cleanup_handoff_lock = threading.RLock()
+        self._cleanup_groups: set[_CleanupGroup] = set()
+        self._cleanup_groups_by_slot: dict[int, set[_CleanupGroup]] = defaultdict(set)
+        self._terminal_cleanup_errors: list[BaseException] = []
+        self._cleanup_pools_stopping = False
+        self._cleanup_pools = {
+            RAY_STREAM_CLEANUP_CONTROL: _DaemonCleanupPool(
+                _cleanup_worker_count(
+                    "VANE_UDF_STREAM_CONTROL_CLEANUP_WORKERS",
+                    _DEFAULT_CONTROL_CLEANUP_WORKERS,
+                ),
+                name="udf-ray-stream-control-cleanup",
+            ),
+            RAY_STREAM_CLEANUP_OUTPUT: _DaemonCleanupPool(
+                _cleanup_worker_count(
+                    "VANE_UDF_STREAM_OUTPUT_CLEANUP_WORKERS",
+                    _DEFAULT_OUTPUT_CLEANUP_WORKERS,
+                ),
+                name="udf-ray-stream-output-cleanup",
+            ),
+            RAY_STREAM_CLEANUP_CANCELLATION: _DaemonCleanupPool(
+                _cleanup_worker_count(
+                    "VANE_UDF_STREAM_CANCELLATION_CLEANUP_WORKERS",
+                    _DEFAULT_CANCELLATION_CLEANUP_WORKERS,
+                ),
+                name="udf-ray-stream-cancellation-cleanup",
+            ),
+            RAY_STREAM_CLEANUP_CORE: _DaemonCleanupPool(
+                _cleanup_worker_count(
+                    "VANE_UDF_STREAM_CORE_CLEANUP_WORKERS",
+                    _DEFAULT_CORE_CLEANUP_WORKERS,
+                ),
+                name="udf-ray-stream-core-cleanup",
+            ),
+        }
         self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
         self._readiness_timer: asyncio.TimerHandle | None = None
         self._readiness_wakeup_pending = False
         self._loop = asyncio.new_event_loop()
         self._loop_ready = threading.Event()
-        self._start_lock = threading.Lock()
+        self._start_lock = threading.RLock()
         self._thread = threading.Thread(
             target=self._run_event_loop,
             daemon=True,
             name="udf-ray-stream-multiplexer",
         )
+        started_pools: list[_DaemonCleanupPool] = []
+        try:
+            for pool in self._cleanup_pools.values():
+                pool.start()
+                started_pools.append(pool)
+        except BaseException:
+            for pool in started_pools:
+                pool.stop_when_idle()
+            for pool in started_pools:
+                pool.join(self._shutdown_timeout_s)
+            raise
 
     # Public API called by the C++ dispatcher while it owns the GIL.
 
@@ -172,44 +487,85 @@ class AsyncResultCollector:
                 f"distributed Ray UDF submission must return TaskLeaseObjectRefGenerator; got {type(source).__name__}"
             )
         key = (int(slot_id), int(submit_id))
-        with self._cv:
-            self._raise_if_stopped_locked()
-            if key in self._records:
-                raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
-            if key[0] in self._cancelled_slots:
-                raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
-            adapter = RayStreamAdapter(source, ray_module=self._ray)
-            record = _StreamRecord(
-                slot_id=key[0],
-                submit_id=key[1],
-                adapter=adapter,
-                sequence=self._next_sequence,
-                error_context=dict(error_context) if error_context else None,
-            )
-            self._next_sequence += 1
-            self._records[key] = record
-            self._signal_readiness_change_locked()
-        _collector_debug_log("track", record)
+        adapter: RayStreamAdapter | None = None
+        record: _StreamRecord | None = None
+        accepted = False
         try:
-            self._ensure_started()
-            with self._cv:
-                if self._records.get(key) is not record:
+            # Serialize only registration/startup against shutdown. The record
+            # stays invisible to the scheduler until the final accepted bit is
+            # committed, so a ready stream cannot retire before C++ owns its
+            # corresponding submit_id.
+            with self._start_lock:
+                adapter = RayStreamAdapter(source, ray_module=self._ray)
+                source = None
+                with self._cv:
                     self._raise_if_stopped_locked()
-                    raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} was cancelled during startup")
-        except BaseException as exc:
-            with self._cv:
-                owned = self._records.pop(key, None) is record
-                record.terminal = True
-                self._cv.notify_all()
-            if owned:
-                try:
-                    record.adapter.cancel()
-                except BaseException as cleanup_exc:
-                    add_note = getattr(exc, "add_note", None)
+                    if key in self._records:
+                        raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
+                    if key[0] in self._cancelled_slots:
+                        raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
+                    record = _StreamRecord(
+                        slot_id=key[0],
+                        submit_id=key[1],
+                        adapter=adapter,
+                        sequence=self._next_sequence,
+                        error_context=dict(error_context) if error_context else None,
+                        registration_accepted=False,
+                    )
+                    self._next_sequence += 1
+                    self._records[key] = record
+                    self._cv.notify_all()
+                self._ensure_started()
+                with self._cv:
+                    if self._records.get(key) is record:
+                        record.registration_accepted = True
+                        accepted = True
+                        self._signal_readiness_change_locked()
+                    elif record.registration_cancelled:
+                        raise RuntimeError(
+                            f"Ray UDF stream slot={key[0]} submit={key[1]} was cancelled during registration"
+                        )
+                    else:
+                        raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} lost registration ownership")
+            assert record is not None
+            _collector_debug_log("track", record)
+            self._refresh_waiters()
+        except BaseException as registration_error:
+            cleanup_group: _CleanupGroup | None = None
+            with self._cleanup_handoff_lock:
+                cleanup_operations: Sequence[Callable[[], Any]] = ()
+                with self._cv:
+                    if record is not None and self._records.pop(key, None) is record:
+                        record.terminal = True
+                        record.cleanup_started = True
+                        cleanup_operations = record.adapter.cancel_operations()
+                        self._signal_readiness_change_locked()
+                    elif record is None and adapter is not None:
+                        cleanup_operations = adapter.cancel_operations()
+                    elif record is None and source is not None:
+                        cleanup_operations = source.cancel_operations()
+                        source.retire_local_state()
+                if cleanup_operations:
+                    cleanup_group = self._submit_cleanup_operations(
+                        self._fence_cleanup_operations(cleanup_operations),
+                        store_error=False,
+                        slot_ids=(key[0],),
+                    )
+            if cleanup_group is not None:
+                cleanup_complete = cleanup_group.wait(self._shutdown_timeout_s)
+                cleanup_errors = cleanup_group.errors
+                if not cleanup_complete or cleanup_errors:
+                    detail = (
+                        "cleanup did not terminate"
+                        if not cleanup_complete
+                        else "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+                    )
+                    add_note = getattr(registration_error, "add_note", None)
                     if callable(add_note):
-                        add_note(f"stream startup cleanup failed: {cleanup_exc}")
+                        add_note(f"submitted Ray stream cleanup failed: {detail}")
             raise
-        self._refresh_waiters()
+        if not accepted:
+            raise RuntimeError(f"Ray UDF stream slot={key[0]} submit={key[1]} was not accepted")
 
     def drain_results(self, capacities: dict[Any, Any] | None = None) -> list[tuple[Any, ...]]:
         parsed = self._parse_capacities(capacities)
@@ -261,14 +617,32 @@ class AsyncResultCollector:
     def release_output_block_lease(self, request_id: str, lease_id: str) -> bool:
         key = (str(request_id), str(lease_id))
         with self._cv:
-            token = self._active_output_leases.pop(key, None)
+            token = self._active_output_leases.get(key)
+            if token is None or token.release_pending:
+                return False
+            token.release_pending = True
             self._cv.notify_all()
-        if token is None:
-            return False
-        token.driver.release_query_output_block_lease.remote(
-            token.request_id,
-            token.lease_id,
-        )
+
+        def finish_release(error: BaseException | None) -> None:
+            with self._cv:
+                if error is None:
+                    if self._active_output_leases.get(key) is token:
+                        self._active_output_leases.pop(key, None)
+                else:
+                    token.release_pending = False
+                self._cv.notify_all()
+
+        try:
+            self._submit_cleanup_operations(
+                (self._output_token_release_operation(token),),
+                on_done=finish_release,
+                slot_ids=(token.slot_id,),
+            )
+        except BaseException:
+            with self._cv:
+                token.release_pending = False
+                self._cv.notify_all()
+            raise
         return True
 
     def handoff_output_block_lease(self, request_id: str, lease_id: str) -> bool:
@@ -281,81 +655,189 @@ class AsyncResultCollector:
         key = (str(request_id), str(lease_id))
         with self._cv:
             token = self._active_output_leases.get(key)
-            if token is None or token.handed_off:
+            if token is None or token.handed_off or token.handoff_pending:
                 return False
-            token.handed_off = True
+            token.handoff_pending = True
             self._cv.notify_all()
-        token.driver.handoff_query_output_block_lease.remote(
-            token.request_id,
-            token.lease_id,
-        )
+
+        def finish_handoff(error: BaseException | None) -> None:
+            with self._cv:
+                token.handoff_pending = False
+                if error is None and not token.release_pending and self._active_output_leases.get(key) is token:
+                    token.handed_off = True
+                self._cv.notify_all()
+
+        try:
+            self._submit_cleanup_operations(
+                (self._output_token_handoff_operation(token),),
+                on_done=finish_handoff,
+                slot_ids=(token.slot_id,),
+            )
+        except BaseException:
+            with self._cv:
+                token.handoff_pending = False
+                self._cv.notify_all()
+            raise
         return True
+
+    def _run_output_token_handoff(self, token: _OutputLeaseToken) -> bool:
+        key = (token.request_id, token.lease_id)
+        with self._cv:
+            if token.release_pending or self._active_output_leases.get(key) is not token:
+                return True
+            response_ref = token.handoff_response_ref
+        try:
+            if response_ref is None:
+                response_ref = token.driver.handoff_query_output_block_lease.remote(
+                    token.request_id,
+                    token.lease_id,
+                    token.query_id,
+                )
+                with self._cv:
+                    token.handoff_response_ref = response_ref
+            resolve_ray_control_ack(response_ref, field="handed_off")
+        except BaseException as exc:
+            if not isinstance(exc, TimeoutError):
+                with self._cv:
+                    if token.handoff_response_ref is response_ref:
+                        token.handoff_response_ref = None
+            raise
+        with self._cv:
+            token.handoff_response_ref = None
+        return True
+
+    def _run_output_token_release(self, token: _OutputLeaseToken) -> bool:
+        with self._cv:
+            response_ref = token.release_response_ref
+        try:
+            if response_ref is None:
+                response_ref = token.driver.release_query_output_block_lease.remote(
+                    token.request_id,
+                    token.lease_id,
+                    token.query_id,
+                )
+                with self._cv:
+                    token.release_response_ref = response_ref
+            resolve_ray_control_ack(response_ref, field="released")
+        except BaseException as exc:
+            if not isinstance(exc, TimeoutError):
+                with self._cv:
+                    if token.release_response_ref is response_ref:
+                        token.release_response_ref = None
+            raise
+        with self._cv:
+            token.release_response_ref = None
+        return True
+
+    def _output_token_handoff_operation(
+        self,
+        token: _OutputLeaseToken,
+    ) -> RayStreamCleanupOperation:
+        return RayStreamCleanupOperation(
+            RAY_STREAM_CLEANUP_OUTPUT,
+            lambda: self._run_output_token_handoff(token),
+            retry_on_error=True,
+            retry_on_incomplete=True,
+        )
+
+    def _output_token_release_operation(
+        self,
+        token: _OutputLeaseToken,
+    ) -> RayStreamCleanupOperation:
+        return RayStreamCleanupOperation(
+            RAY_STREAM_CLEANUP_OUTPUT,
+            lambda: self._run_output_token_release(token),
+            retry_on_error=True,
+            retry_on_incomplete=True,
+        )
+
+    @staticmethod
+    def _output_request_cancel_operation(
+        driver: Any,
+        request: dict[str, Any],
+    ) -> RayStreamCleanupOperation:
+        response_ref: Any | None = None
+
+        def cancel() -> bool:
+            nonlocal response_ref
+            try:
+                if response_ref is None:
+                    response_ref = driver.cancel_query_output_block_lease_request.remote(request)
+                resolve_ray_control_ack(response_ref, field="cancelled")
+            except BaseException as exc:
+                if not isinstance(exc, TimeoutError):
+                    response_ref = None
+                raise
+            response_ref = None
+            return True
+
+        return RayStreamCleanupOperation(
+            RAY_STREAM_CLEANUP_OUTPUT,
+            cancel,
+            retry_on_error=True,
+            retry_on_incomplete=True,
+        )
 
     def cancel_slot(self, slot_id: int) -> None:
         slot_key = int(slot_id)
-        with self._cv:
-            if self._shutdown:
-                return
-            records = [record for record in self._records.values() if record.slot_id == slot_key]
-            records_to_cancel = [record for record in records if not record.cleanup_started]
-            control_requests: list[tuple[Any, dict[str, Any]]] = []
-            for record in records:
-                self._records.pop((record.slot_id, record.submit_id), None)
-                record.terminal = True
-                if not record.cleanup_started:
-                    record.cleanup_started = True
-                self._cancel_record_wait_locked(record)
-            for record in records_to_cancel:
-                request = record.output_request
-                driver = record.adapter.driver
-                if request is not None and driver is not None and not record.output_cancel_sent:
-                    record.output_cancel_sent = True
-                    control_requests.append((driver, request))
-            ready = list(self._ready_by_slot.pop(slot_key, ()))
-            tokens = [token for token in self._active_output_leases.values() if token.slot_id == slot_key]
-            for token in tokens:
-                self._active_output_leases.pop((token.request_id, token.lease_id), None)
-            self._capacity_by_slot.pop(slot_key, None)
-            self._cancelled_slots.add(slot_key)
-            self._cleanup_starting += 1
-            self._signal_readiness_change_locked()
-
-        ready_tokens = [event.output_token for event in ready if event.output_token is not None]
-        token_keys = {(token.request_id, token.lease_id) for token in tokens}
-        for token in ready_tokens:
-            if token is not None and (token.request_id, token.lease_id) not in token_keys:
-                tokens.append(token)
-                token_keys.add((token.request_id, token.lease_id))
-
-        def cleanup_slot() -> None:
-            actions: list[Any] = [
-                lambda driver=driver, request=request: driver.cancel_query_output_block_lease_request.remote(request)
-                for driver, request in control_requests
-            ]
-            for record in records_to_cancel:
-                actions.append(record.adapter.cancel)
-            for token in tokens:
-                actions.append(
-                    lambda token=token: token.driver.release_query_output_block_lease.remote(
-                        token.request_id,
-                        token.lease_id,
-                    )
-                )
-            self._run_isolated_cleanup_actions(
-                actions,
-                name="udf-ray-stream-cancel-action",
-            )
-
-        def cleanup_registered() -> None:
+        cleanup_groups: set[_CleanupGroup] = set()
+        with self._cleanup_handoff_lock:
             with self._cv:
-                self._cleanup_starting -= 1
-                self._cv.notify_all()
+                if self._shutdown:
+                    return
+                cleanup_groups.update(self._cleanup_groups_by_slot.get(slot_key, ()))
+                records = [record for record in self._records.values() if record.slot_id == slot_key]
+                records_to_cancel = [record for record in records if not record.cleanup_started]
+                cleanup_operations: list[Callable[[], Any]] = []
+                for record in records:
+                    self._records.pop((record.slot_id, record.submit_id), None)
+                    record.terminal = True
+                    if not record.registration_accepted:
+                        record.registration_cancelled = True
+                    if not record.cleanup_started:
+                        record.cleanup_started = True
+                    self._cancel_record_wait_locked(record)
+                for record in records_to_cancel:
+                    request = record.output_request
+                    driver = record.adapter.driver
+                    if request is not None and driver is not None and not record.output_cancel_sent:
+                        record.output_cancel_sent = True
+                        cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                    cleanup_operations.extend(record.adapter.cancel_operations())
+                ready = list(self._ready_by_slot.pop(slot_key, ()))
+                tokens = [token for token in self._active_output_leases.values() if token.slot_id == slot_key]
+                for token in tokens:
+                    token.release_pending = True
+                    self._active_output_leases.pop((token.request_id, token.lease_id), None)
+                self._capacity_by_slot.pop(slot_key, None)
+                self._cancelled_slots.add(slot_key)
+                self._signal_readiness_change_locked()
 
-        self._run_cleanup_after_scheduler_turn(
-            cleanup_slot,
+            ready_tokens = [event.output_token for event in ready if event.output_token is not None]
+            token_keys = {(token.request_id, token.lease_id) for token in tokens}
+            for token in ready_tokens:
+                if token is not None and (token.request_id, token.lease_id) not in token_keys:
+                    tokens.append(token)
+                    token_keys.add((token.request_id, token.lease_id))
+            for token in tokens:
+                token.release_pending = True
+            cleanup_operations.extend(self._output_token_release_operation(token) for token in tokens)
+            cleanup_group = self._submit_cleanup_operations(
+                self._fence_cleanup_operations(cleanup_operations),
+                store_error=False,
+                slot_ids=(slot_key,),
+            )
+            if cleanup_group is not None:
+                cleanup_groups.add(cleanup_group)
+
+        cleanup_errors = self._wait_slot_cleanup(
+            slot_key,
             timeout_message=f"Ray UDF slot {slot_key} cleanup did not terminate",
-            on_registered=cleanup_registered,
+            initial_groups=tuple(cleanup_groups),
         )
+        if cleanup_errors:
+            details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
+            raise RuntimeError(f"Ray UDF slot {slot_key} cleanup failed: {details}") from cleanup_errors[0]
 
     def slot_has_pending(self, slot_id: int) -> bool:
         slot_key = int(slot_id)
@@ -364,6 +846,7 @@ class AsyncResultCollector:
                 any(record.slot_id == slot_key for record in self._records.values())
                 or bool(self._ready_by_slot.get(slot_key))
                 or any(token.slot_id == slot_key for token in self._active_output_leases.values())
+                or bool(self._cleanup_groups_by_slot.get(slot_key))
             )
 
     def set_wakeup_callback(self, fn: Any) -> None:
@@ -372,82 +855,87 @@ class AsyncResultCollector:
 
     def shutdown(self) -> None:
         deadline = time.monotonic() + self._shutdown_timeout_s
-        shutdown_from_scheduler = self._thread is threading.current_thread()
         shutdown_errors: list[BaseException] = []
         with self._start_lock:
-            with self._cv:
-                if self._shutdown:
-                    return
-                self._shutdown = True
-                self._wakeup_fn = None
-                records = list(self._records.values())
-                records_to_cancel = [record for record in records if not record.cleanup_started]
-                control_requests: list[tuple[Any, dict[str, Any]]] = []
-                for record in records:
-                    self._cancel_record_wait_locked(record)
-                for record in records_to_cancel:
-                    request = record.output_request
-                    driver = record.adapter.driver
-                    if request is not None and driver is not None and not record.output_cancel_sent:
-                        record.output_cancel_sent = True
-                        control_requests.append((driver, request))
-                self._records.clear()
-                tokens = list(self._active_output_leases.values())
-                self._active_output_leases.clear()
-                self._ready_by_slot.clear()
-                self._capacity_by_slot.clear()
-                self._signal_readiness_change_locked()
-            if self._thread_started:
-                try:
-                    self._loop.call_soon_threadsafe(self._loop.stop)
-                except RuntimeError as exc:
-                    if self._thread.is_alive():
+            with self._cleanup_handoff_lock:
+                with self._cv:
+                    first_shutdown = not self._shutdown
+                    cleanup_operations: list[Callable[[], Any]] = []
+                    cleanup_slot_ids: set[int] = set()
+                    if first_shutdown:
+                        self._shutdown = True
+                        self._wakeup_fn = None
+                        records = list(self._records.values())
+                        for record in records:
+                            cleanup_slot_ids.add(record.slot_id)
+                            self._cancel_record_wait_locked(record)
+                            if not record.registration_accepted:
+                                record.registration_cancelled = True
+                            if record.cleanup_started:
+                                continue
+                            record.cleanup_started = True
+                            request = record.output_request
+                            driver = record.adapter.driver
+                            if request is not None and driver is not None and not record.output_cancel_sent:
+                                record.output_cancel_sent = True
+                                cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                            cleanup_operations.extend(record.adapter.cancel_operations())
+                        self._records.clear()
+                        ready = [event for events in self._ready_by_slot.values() for event in events]
+                        tokens = list(self._active_output_leases.values())
+                        token_keys = {(token.request_id, token.lease_id) for token in tokens}
+                        for event in ready:
+                            cleanup_slot_ids.add(event.slot_id)
+                            token = event.output_token
+                            if token is not None and (token.request_id, token.lease_id) not in token_keys:
+                                tokens.append(token)
+                                token_keys.add((token.request_id, token.lease_id))
+                        self._active_output_leases.clear()
+                        self._ready_by_slot.clear()
+                        self._capacity_by_slot.clear()
+                        for token in tokens:
+                            token.release_pending = True
+                        cleanup_operations.extend(self._output_token_release_operation(token) for token in tokens)
+                        cleanup_slot_ids.update(token.slot_id for token in tokens)
+                        self._signal_readiness_change_locked()
+                    if self._thread_started and self._thread.is_alive():
+                        try:
+                            self._loop.call_soon_threadsafe(self._loop.stop)
+                        except RuntimeError as exc:
+                            if self._thread.is_alive():
+                                shutdown_errors.append(exc)
+                if first_shutdown and cleanup_operations:
+                    try:
+                        self._submit_cleanup_operations(
+                            self._fence_cleanup_operations(cleanup_operations),
+                            slot_ids=tuple(cleanup_slot_ids),
+                        )
+                    except BaseException as exc:
                         shutdown_errors.append(exc)
-        for driver, request in control_requests:
-            self._start_tracked_cleanup(
-                name="udf-ray-stream-shutdown-control",
-                operation=lambda driver=driver, request=request: driver.cancel_query_output_block_lease_request.remote(
-                    request
-                ),
-            )
-
-        for record in records_to_cancel:
-
-            def cancel_adapter(record: _StreamRecord = record) -> None:
-                # A stalled zero-time Ray probe still owns the generator
-                # handle. Keep this daemon task as its durable cleanup owner.
-                if self._thread.is_alive() and not shutdown_from_scheduler:
-                    self._thread.join()
-                record.adapter.cancel()
-
-            self._start_tracked_cleanup(
-                name="udf-ray-stream-shutdown-adapter",
-                operation=cancel_adapter,
-            )
-        for token in tokens:
-            self._start_tracked_cleanup(
-                name="udf-ray-stream-shutdown-lease",
-                operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
-                    token.request_id,
-                    token.lease_id,
-                ),
-            )
 
         if self._thread_started and self._thread is not threading.current_thread():
             self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
             if self._thread.is_alive():
                 shutdown_errors.append(RuntimeError("Ray UDF stream multiplexer did not terminate"))
 
+        if not self._thread.is_alive():
+            self._stop_cleanup_pools_when_idle()
+
         with self._cv:
-            while self._cleanup_starting or self._cleanup_threads:
+            while True:
+                pending = [group for group in self._cleanup_groups if not group.callback_owned_by_current_thread()]
+                if not pending:
+                    break
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 self._cv.wait(timeout=remaining)
-            if self._cleanup_starting or self._cleanup_threads:
+            pending = [group for group in self._cleanup_groups if not group.callback_owned_by_current_thread()]
+            if pending:
                 shutdown_errors.append(RuntimeError("Ray UDF stream remote cleanup did not terminate"))
-            shutdown_errors.extend(self._cleanup_errors)
-            self._cleanup_errors.clear()
+            shutdown_errors.extend(self._terminal_cleanup_errors)
+        if not self._thread.is_alive():
+            shutdown_errors.extend(self._join_cleanup_pools(deadline))
         if shutdown_errors:
             details = "; ".join(f"{type(error).__name__}: {error}" for error in shutdown_errors)
             raise RuntimeError(f"Ray UDF stream shutdown failed: {details}") from shutdown_errors[0]
@@ -507,17 +995,22 @@ class AsyncResultCollector:
             )
         return parsed
 
-    def _pending_data_count_locked(self, slot_id: int) -> int:
-        ready = sum(1 for event in self._ready_by_slot.get(slot_id, ()) if event.kind == "data")
-        in_progress = sum(
-            1
-            for record in self._records.values()
-            if record.slot_id == slot_id
-            and (record.phase != "block" or (record.wait_kind == "data" and record.wait_future is not None))
-        )
-        return ready + in_progress
+    def _pending_data_counts_locked(self) -> dict[int, int]:
+        """Count every admitted block once in a single linear ledger pass."""
+        counts: dict[int, int] = defaultdict(int)
+        for slot_id, ready in self._ready_by_slot.items():
+            counts[slot_id] += sum(1 for event in ready if event.kind == "data")
+        for record in self._records.values():
+            if record.phase != "block" or (record.wait_kind == "data" and record.wait_future is not None):
+                counts[record.slot_id] += 1
+        return counts
 
-    def _may_read_block_locked(self, record: _StreamRecord) -> bool:
+    def _may_read_block_locked(
+        self,
+        record: _StreamRecord,
+        *,
+        pending_data_count: int,
+    ) -> bool:
         if not record.next_ref_ready:
             return False
         capacity = self._capacity_by_slot.get(record.slot_id)
@@ -527,7 +1020,7 @@ class AsyncResultCollector:
             return False
         if capacity.item_bytes is not None and capacity.item_bytes <= 0:
             return False
-        return self._pending_data_count_locked(record.slot_id) < capacity.rows
+        return int(pending_data_count) < capacity.rows
 
     def _signal_readiness_change_locked(self) -> None:
         """Request an immediate scheduler pass without a remote wakeup RPC."""
@@ -551,17 +1044,19 @@ class AsyncResultCollector:
 
     def _readiness_waitables_locked(self) -> dict[Any, _StreamRecord]:
         waitables: dict[Any, _StreamRecord] = {}
+        pending_data_counts = self._pending_data_counts_locked()
         admissible_slots = {
             slot_id
             for slot_id, capacity in self._capacity_by_slot.items()
             if capacity.rows > 0
             and (capacity.bytes is None or capacity.bytes > 0)
             and (capacity.item_bytes is None or capacity.item_bytes > 0)
-            and self._pending_data_count_locked(slot_id) < capacity.rows
+            and pending_data_counts.get(slot_id, 0) < capacity.rows
         }
         for record in self._records.values():
             if (
                 record.terminal
+                or not record.registration_accepted
                 or record.slot_id not in admissible_slots
                 or record.phase != "block"
                 or record.next_ref_ready
@@ -598,7 +1093,7 @@ class AsyncResultCollector:
         """Run one Ray Data-style non-consuming readiness scheduling pass.
 
         The existing multiplexer event loop is the single owner of generator
-        probes, reads, and terminal retirement.  A zero-time public
+        probes, reads, and terminal-state transitions.  A zero-time public
         ``ray.wait`` rebuilds the eligible set on every pass; local admission
         changes cancel the current idle timer, while exponential backoff bounds
         polling overhead for genuinely slow generators.
@@ -619,12 +1114,35 @@ class AsyncResultCollector:
                 self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
             return
 
-        ready, _ = self._ray.wait(
-            list(waitables),
-            num_returns=len(waitables),
-            fetch_local=False,
-            timeout=0,
-        )
+        try:
+            ready, _ = self._ray.wait(
+                list(waitables),
+                num_returns=len(waitables),
+                fetch_local=False,
+                timeout=0,
+            )
+        except BaseException:
+            # A single dead generator must not poison unrelated query slots.
+            # Ray does not identify the failed waitable in a batch exception,
+            # so isolate only on this exceptional path with zero-time probes.
+            ready = []
+            failed: list[tuple[_StreamRecord, BaseException]] = []
+            for waitable, record in waitables.items():
+                try:
+                    one_ready, _ = self._ray.wait(
+                        [waitable],
+                        num_returns=1,
+                        fetch_local=False,
+                        timeout=0,
+                    )
+                except BaseException as exc:
+                    failed.append((record, exc))
+                else:
+                    ready.extend(one_ready)
+            if not failed or len(failed) == len(waitables):
+                raise
+            for failed_record, failure in failed:
+                self._fail_record(failed_record, failure)
 
         ready_records: list[_StreamRecord] = []
         with self._cv:
@@ -632,16 +1150,16 @@ class AsyncResultCollector:
                 return
             currently_waitable = self._readiness_waitables_locked()
             for waitable in ready:
-                record = waitables.get(waitable)
-                if record is None:
+                ready_record = waitables.get(waitable)
+                if ready_record is None:
                     self._thread_error = RuntimeError("Ray returned an unknown generator readiness handle")
                     self._cv.notify_all()
                     break
-                if currently_waitable.get(waitable) is record:
-                    record.next_ref_ready = True
-                    record.ready_sequence = self._next_ready_sequence
+                if currently_waitable.get(waitable) is ready_record:
+                    ready_record.next_ref_ready = True
+                    ready_record.ready_sequence = self._next_ready_sequence
                     self._next_ready_sequence += 1
-                    ready_records.append(record)
+                    ready_records.append(ready_record)
             if self._thread_error is not None:
                 notify_error = True
             else:
@@ -677,93 +1195,93 @@ class AsyncResultCollector:
         if report:
             self._notify_wakeup()
 
-    def _start_tracked_cleanup(
+    def _run_scheduler_callback(
         self,
-        *,
-        name: str,
-        operation: Any,
-        on_done: Any | None = None,
-        store_error: bool = True,
-    ) -> tuple[threading.Thread | None, list[BaseException]]:
-        """Run a possibly blocking Ray cleanup without occupying the scheduler."""
-        errors: list[BaseException] = []
-        thread: threading.Thread
+        callback: Callable[..., Any],
+        *args: Any,
+    ) -> None:
+        """Turn every event-loop callback failure into visible collector state."""
+        try:
+            callback(*args)
+        except BaseException as exc:
+            self._report_scheduler_error(exc)
 
-        def cleanup() -> None:
-            operation_error: BaseException | None = None
-            try:
-                operation()
-            except BaseException as exc:
-                operation_error = exc
-                errors.append(exc)
+    def _submit_cleanup_operations(
+        self,
+        operations: Sequence[Callable[[], Any]],
+        *,
+        on_done: Callable[[BaseException | None], None] | None = None,
+        store_error: bool = True,
+        slot_ids: Sequence[int] = (),
+    ) -> _CleanupGroup | None:
+        """Atomically hand one terminal plan to bounded, isolated worker lanes."""
+        actions = tuple(operations)
+        if not actions:
+            if on_done is not None:
+                on_done(None)
+            return None
+
+        operations_by_pool: dict[_DaemonCleanupPool, list[Callable[[], Any]]] = defaultdict(list)
+        for action in actions:
+            lane = action.lane if isinstance(action, RayStreamCleanupOperation) else RAY_STREAM_CLEANUP_CONTROL
+            operations_by_pool[self._cleanup_pools[lane]].append(action)
+        pools = tuple(pool for pool in self._cleanup_pools.values() if pool in operations_by_pool)
+        group_holder: list[_CleanupGroup] = []
+        owner_slots = frozenset(int(slot_id) for slot_id in slot_ids)
+
+        def complete(first_error: BaseException | None) -> None:
+            callback_error: BaseException | None = None
             try:
                 if on_done is not None:
-                    on_done(operation_error)
-                elif operation_error is not None and store_error:
-                    with self._cv:
-                        self._cleanup_errors.append(operation_error)
-                        self._cv.notify_all()
+                    on_done(first_error)
             except BaseException as exc:
-                errors.append(exc)
-                if store_error:
-                    with self._cv:
-                        self._cleanup_errors.append(exc)
-                        self._cv.notify_all()
+                callback_error = exc
             finally:
                 with self._cv:
-                    self._cleanup_threads.discard(thread)
+                    if store_error:
+                        if first_error is not None:
+                            self._terminal_cleanup_errors.append(first_error)
+                    if callback_error is not None:
+                        self._terminal_cleanup_errors.append(callback_error)
+                    self._cleanup_groups.discard(group_holder[0])
+                    for slot_id in owner_slots:
+                        groups = self._cleanup_groups_by_slot.get(slot_id)
+                        if groups is not None:
+                            groups.discard(group_holder[0])
+                            if not groups:
+                                self._cleanup_groups_by_slot.pop(slot_id, None)
                     self._cv.notify_all()
 
-        thread = threading.Thread(
-            target=cleanup,
-            daemon=True,
-            name=name,
-        )
-        with self._cv:
-            self._cleanup_threads.add(thread)
-        try:
-            thread.start()
-        except BaseException:
-            with self._cv:
-                self._cleanup_threads.discard(thread)
-                self._cv.notify_all()
-            cleanup()
-            return None, errors
-        return thread, errors
+        with self._cleanup_handoff_lock:
+            for pool in pools:
+                pool._cv.acquire()
+            try:
+                for pool in pools:
+                    if not pool._started or pool._stop_when_idle:
+                        raise RuntimeError(f"Ray UDF cleanup pool {pool._name!r} is not accepting work")
+                    pool._ensure_worker_locked()
+                group = _CleanupGroup(len(actions), on_complete=complete)
+                group_holder.append(group)
+                with self._cv:
+                    self._cleanup_groups.add(group)
+                    for slot_id in owner_slots:
+                        self._cleanup_groups_by_slot[slot_id].add(group)
+                    self._cv.notify_all()
+                for pool, pool_operations in operations_by_pool.items():
+                    pool._enqueue_locked(pool_operations, group)
+            finally:
+                for pool in reversed(pools):
+                    pool._cv.release()
+        return group
 
-    def _run_isolated_cleanup_actions(
+    def _fence_cleanup_operations(
         self,
-        actions: list[Any],
-        *,
-        name: str,
-    ) -> None:
-        """Attempt every independent cleanup even when one Ray call blocks."""
-        handles: list[threading.Thread] = []
-        action_errors: list[list[BaseException]] = []
-        for action in actions:
-            thread, errors = self._start_tracked_cleanup(
-                name=name,
-                operation=action,
-                store_error=False,
-            )
-            action_errors.append(errors)
-            if thread is not None:
-                handles.append(thread)
-        for thread in handles:
-            thread.join()
-        errors = [error for group in action_errors for error in group]
-        if errors:
-            details = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
-            raise RuntimeError(f"Ray UDF stream cleanup failed: {details}") from errors[0]
-
-    def _run_cleanup_after_scheduler_turn(
-        self,
-        operation: Any,
-        *,
-        timeout_message: str,
-        on_registered: Any | None = None,
-    ) -> None:
-        """Run terminal cleanup only after every earlier generator probe."""
+        operations: Sequence[Callable[[], Any]],
+    ) -> tuple[RayStreamCleanupOperation, ...]:
+        """Delay generator teardown until every earlier scheduler probe exits."""
+        actions = tuple(operations)
+        if not actions:
+            return ()
         scheduler_safe = threading.Event()
         with self._cv:
             needs_turn = self._started and self._thread.is_alive() and self._thread is not threading.current_thread()
@@ -776,28 +1294,76 @@ class AsyncResultCollector:
         else:
             scheduler_safe.set()
 
-        def cleanup() -> None:
-            while not scheduler_safe.wait(timeout=0.1):
-                if not self._thread.is_alive():
-                    break
-            operation()
+        fenced: list[RayStreamCleanupOperation] = []
+        for action in actions:
+            lane = action.lane if isinstance(action, RayStreamCleanupOperation) else RAY_STREAM_CLEANUP_CONTROL
+            retry_on_error = action.retry_on_error if isinstance(action, RayStreamCleanupOperation) else False
+            retry_on_incomplete = action.retry_on_incomplete if isinstance(action, RayStreamCleanupOperation) else False
 
-        cleanup_thread, cleanup_errors = self._start_tracked_cleanup(
-            name="udf-ray-stream-cancel",
-            operation=cleanup,
-            store_error=False,
-        )
-        if on_registered is not None:
-            on_registered()
-        if cleanup_thread is None:
-            if cleanup_errors:
-                raise RuntimeError(f"{timeout_message}: {cleanup_errors[0]}") from cleanup_errors[0]
+            def run(action: Callable[[], Any] = action) -> Any:
+                while not scheduler_safe.wait(timeout=0.1):
+                    if not self._thread.is_alive():
+                        break
+                return action()
+
+            fenced.append(
+                RayStreamCleanupOperation(
+                    lane,
+                    run,
+                    retry_on_error=retry_on_error,
+                    retry_on_incomplete=retry_on_incomplete,
+                )
+            )
+        return tuple(fenced)
+
+    def _wait_cleanup_group(
+        self,
+        group: _CleanupGroup | None,
+        *,
+        timeout_message: str,
+    ) -> None:
+        if group is None:
             return
-        cleanup_thread.join(timeout=self._shutdown_timeout_s)
-        if cleanup_thread.is_alive():
+        if not group.wait(self._shutdown_timeout_s):
             raise RuntimeError(timeout_message)
-        if cleanup_errors:
-            raise RuntimeError(f"{timeout_message}: {cleanup_errors[0]}") from cleanup_errors[0]
+
+    def _wait_slot_cleanup(
+        self,
+        slot_id: int,
+        *,
+        timeout_message: str,
+        initial_groups: Sequence[_CleanupGroup] = (),
+    ) -> tuple[BaseException, ...]:
+        deadline = time.monotonic() + self._shutdown_timeout_s
+        observed = set(initial_groups)
+        while True:
+            with self._cv:
+                groups = tuple(self._cleanup_groups_by_slot.get(int(slot_id), ()))
+            observed.update(groups)
+            pending = [
+                group for group in observed if not group.wait(0) and not group.callback_owned_by_current_thread()
+            ]
+            if not pending:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not pending[0].wait(remaining):
+                raise RuntimeError(timeout_message)
+        return tuple(error for group in observed for error in group.errors)
+
+    def _stop_cleanup_pools_when_idle(self) -> None:
+        with self._cleanup_handoff_lock:
+            if self._cleanup_pools_stopping:
+                return
+            self._cleanup_pools_stopping = True
+            for pool in self._cleanup_pools.values():
+                pool.stop_when_idle()
+
+    def _join_cleanup_pools(self, deadline: float) -> list[BaseException]:
+        errors: list[BaseException] = []
+        for lane, pool in self._cleanup_pools.items():
+            if not pool.join(max(0.0, deadline - time.monotonic())):
+                errors.append(RuntimeError(f"Ray UDF {lane} cleanup workers did not terminate"))
+        return errors
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
@@ -822,6 +1388,10 @@ class AsyncResultCollector:
             if pending:
                 self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             self._loop.close()
+            with self._cv:
+                shutting_down = self._shutdown
+            if shutting_down:
+                self._stop_cleanup_pools_when_idle()
 
     def _cancel_record_wait_locked(self, record: _StreamRecord) -> None:
         future = record.wait_future
@@ -844,11 +1414,17 @@ class AsyncResultCollector:
             raise TypeError("Ray UDF control ObjectRef future does not support callbacks")
         return future
 
-    def _schedule_record_wait_locked(self, record: _StreamRecord) -> None:
+    def _schedule_record_wait_locked(
+        self,
+        record: _StreamRecord,
+        *,
+        pending_data_count: int,
+    ) -> bool:
         if record.terminal or record.wait_future is not None:
-            return
+            return False
         kind = ""
         future = None
+        block_admitted = False
         if record.terminal_ref is not None:
             kind = "terminal"
             future = self._object_ref_future(record.terminal_ref)
@@ -858,7 +1434,13 @@ class AsyncResultCollector:
         elif record.metadata_ref is not None:
             kind = "metadata"
             future = self._object_ref_future(record.metadata_ref)
-        elif record.phase == "metadata" or (record.phase == "block" and self._may_read_block_locked(record)):
+        elif record.phase == "metadata" or (
+            record.phase == "block"
+            and self._may_read_block_locked(
+                record,
+                pending_data_count=pending_data_count,
+            )
+        ):
             kind = "data"
             if record.phase == "block":
                 capacity = self._capacity_by_slot.get(record.slot_id)
@@ -871,13 +1453,14 @@ class AsyncResultCollector:
                 record.block_item_capacity_bytes = capacity.item_bytes
                 record.next_ref_ready = False
                 record.ready_sequence = None
+                block_admitted = True
                 self._signal_readiness_change_locked()
             future = asyncio.run_coroutine_threadsafe(
                 record.adapter.read_next_ref_async(),
                 self._loop,
             )
         if future is None:
-            return
+            return False
         record.wait_kind = kind
         record.wait_future = future
 
@@ -887,6 +1470,7 @@ class AsyncResultCollector:
                     return
             try:
                 self._loop.call_soon_threadsafe(
+                    self._run_scheduler_callback,
                     self._complete_record_wait,
                     record,
                     kind,
@@ -894,11 +1478,12 @@ class AsyncResultCollector:
                 )
             except RuntimeError as exc:
                 with self._cv:
-                    if not self._shutdown:
-                        self._thread_error = exc
-                        self._cv.notify_all()
+                    shutting_down = self._shutdown
+                if not shutting_down:
+                    self._report_scheduler_error(exc)
 
         future.add_done_callback(on_done)
+        return block_admitted
 
     def _schedule_completion_wait_locked(self, record: _StreamRecord) -> None:
         if record.terminal or record.producer_completed or record.completion_future is not None:
@@ -912,15 +1497,16 @@ class AsyncResultCollector:
                     return
             try:
                 self._loop.call_soon_threadsafe(
+                    self._run_scheduler_callback,
                     self._complete_producer_wait,
                     record,
                     done,
                 )
             except RuntimeError as exc:
                 with self._cv:
-                    if not self._shutdown:
-                        self._thread_error = exc
-                        self._cv.notify_all()
+                    shutting_down = self._shutdown
+                if not shutting_down:
+                    self._report_scheduler_error(exc)
 
         future.add_done_callback(on_done)
 
@@ -929,15 +1515,20 @@ class AsyncResultCollector:
             if self._shutdown or self._thread_error is not None or not self._started or not self._loop_ready.is_set():
                 return
             records = sorted(
-                self._records.values(),
+                (record for record in self._records.values() if record.registration_accepted),
                 key=lambda record: (
                     record.phase == "block" and record.next_ref_ready,
                     record.ready_sequence if record.ready_sequence is not None else record.sequence,
                 ),
             )
+            pending_data_counts = self._pending_data_counts_locked()
             for record in records:
                 self._schedule_completion_wait_locked(record)
-                self._schedule_record_wait_locked(record)
+                if self._schedule_record_wait_locked(
+                    record,
+                    pending_data_count=pending_data_counts.get(record.slot_id, 0),
+                ):
+                    pending_data_counts[record.slot_id] = pending_data_counts.get(record.slot_id, 0) + 1
 
     def _complete_producer_wait(self, record: _StreamRecord, future: Any) -> None:
         key = (record.slot_id, record.submit_id)
@@ -1113,9 +1704,9 @@ class AsyncResultCollector:
                 record.output_cancel_sent = True
         if stale:
             if cancel_stale_request:
-                self._start_tracked_cleanup(
-                    name="udf-ray-stream-stale-control",
-                    operation=lambda: driver.cancel_query_output_block_lease_request.remote(request),
+                self._submit_cleanup_operations(
+                    (self._output_request_cancel_operation(driver, request),),
+                    slot_ids=(record.slot_id,),
                 )
             return
         _collector_debug_log("output_lease_requested", record)
@@ -1153,6 +1744,7 @@ class AsyncResultCollector:
         token = _OutputLeaseToken(
             request_id=record.output_request_id,
             lease_id=str(lease["lease_id"]),
+            query_id=str(metadata["query_id"]),
             driver=driver,
             slot_id=record.slot_id,
             submit_id=record.submit_id,
@@ -1197,12 +1789,10 @@ class AsyncResultCollector:
                 record.output_cancel_sent = False
                 self._signal_readiness_change_locked()
         if stale:
-            self._start_tracked_cleanup(
-                name="udf-ray-stream-stale-lease",
-                operation=lambda: driver.release_query_output_block_lease.remote(
-                    token.request_id,
-                    token.lease_id,
-                ),
+            token.release_pending = True
+            self._submit_cleanup_operations(
+                (self._output_token_release_operation(token),),
+                slot_ids=(record.slot_id,),
             )
             return
         _collector_debug_log("output_lease_granted", record)
@@ -1220,137 +1810,127 @@ class AsyncResultCollector:
 
         def finish_retirement(error: BaseException | None) -> None:
             dropped_tokens: list[_OutputLeaseToken] = []
-            with self._cv:
-                if self._records.pop(key, None) is not record:
-                    if error is not None:
-                        self._cleanup_errors.append(error)
-                        self._cv.notify_all()
-                    return
-                if error is None:
-                    event = _ReadyEvent(record.slot_id, record.submit_id, "complete", None)
-                else:
-                    ready = self._ready_by_slot.get(record.slot_id)
-                    if ready is not None:
-                        kept: deque[_ReadyEvent] = deque()
-                        for queued in ready:
-                            if queued.submit_id == record.submit_id and queued.kind == "data":
-                                if queued.output_token is not None:
-                                    dropped_tokens.append(queued.output_token)
-                                continue
-                            kept.append(queued)
-                        self._ready_by_slot[record.slot_id] = kept
-                    for token in dropped_tokens:
-                        self._active_output_leases.pop((token.request_id, token.lease_id), None)
-                    event = _ReadyEvent(
-                        record.slot_id,
-                        record.submit_id,
-                        "error",
-                        f"{type(error).__name__}: {error}",
+            with self._cleanup_handoff_lock:
+                with self._cv:
+                    if self._records.pop(key, None) is not record:
+                        if error is not None:
+                            self._terminal_cleanup_errors.append(error)
+                            self._cv.notify_all()
+                        return
+                    if error is None:
+                        event = _ReadyEvent(record.slot_id, record.submit_id, "complete", None)
+                    else:
+                        ready = self._ready_by_slot.get(record.slot_id)
+                        if ready is not None:
+                            kept: deque[_ReadyEvent] = deque()
+                            for queued in ready:
+                                if queued.submit_id == record.submit_id and queued.kind == "data":
+                                    if queued.output_token is not None:
+                                        dropped_tokens.append(queued.output_token)
+                                    continue
+                                kept.append(queued)
+                            self._ready_by_slot[record.slot_id] = kept
+                        for token in dropped_tokens:
+                            token.release_pending = True
+                            self._active_output_leases.pop((token.request_id, token.lease_id), None)
+                        event = _ReadyEvent(
+                            record.slot_id,
+                            record.submit_id,
+                            "error",
+                            f"{type(error).__name__}: {error}",
+                        )
+                    self._ready_by_slot[record.slot_id].append(event)
+                    self._cv.notify_all()
+                if dropped_tokens:
+                    self._submit_cleanup_operations(
+                        tuple(self._output_token_release_operation(token) for token in dropped_tokens),
+                        slot_ids=(record.slot_id,),
                     )
-                self._ready_by_slot[record.slot_id].append(event)
-                for token in dropped_tokens:
-                    self._start_tracked_cleanup(
-                        name="udf-ray-stream-retire-leases",
-                        operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
-                            token.request_id,
-                            token.lease_id,
-                        ),
-                    )
-                self._cv.notify_all()
             _collector_debug_log("retired" if error is None else "retire_failed", record)
             self._notify_wakeup()
 
-        with self._cv:
-            if self._records.get(key) is not record:
-                return
-            record.terminal = True
-            record.cleanup_started = True
-            self._signal_readiness_change_locked()
-            self._start_tracked_cleanup(
-                name="udf-ray-stream-retire",
-                operation=record.adapter.retire,
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                if self._records.get(key) is not record:
+                    return
+                record.terminal = True
+                record.cleanup_started = True
+                self._signal_readiness_change_locked()
+                cleanup_operations = record.adapter.retire_operations()
+            self._submit_cleanup_operations(
+                cleanup_operations,
                 on_done=finish_retirement,
+                store_error=False,
+                slot_ids=(record.slot_id,),
             )
-
-    def _cancel_record_control(self, record: _StreamRecord) -> None:
-        with self._cv:
-            request = record.output_request
-            driver = record.adapter.driver
-            if request is None or driver is None or record.output_cancel_sent:
-                return
-            record.output_cancel_sent = True
-        driver.cancel_query_output_block_lease_request.remote(request)
 
     def _fail_record(self, record: _StreamRecord, exc: BaseException) -> None:
         exc = format_stateful_actor_loss(record.error_context, exc)
         key = (record.slot_id, record.submit_id)
-        with self._cv:
-            if self._records.pop(key, None) is not record:
-                return
-            record.terminal = True
-            record.cleanup_started = True
-            ready = self._ready_by_slot.get(record.slot_id)
-            dropped_tokens: list[_OutputLeaseToken] = []
-            if ready is not None:
-                kept: deque[_ReadyEvent] = deque()
-                for event in ready:
-                    if event.submit_id == record.submit_id and event.kind == "data":
-                        if event.output_token is not None:
-                            dropped_tokens.append(event.output_token)
-                        continue
-                    kept.append(event)
-                self._ready_by_slot[record.slot_id] = kept
-            for token in dropped_tokens:
-                self._active_output_leases.pop((token.request_id, token.lease_id), None)
-            self._ready_by_slot[record.slot_id].append(
-                _ReadyEvent(
-                    record.slot_id,
-                    record.submit_id,
-                    "error",
-                    f"{type(exc).__name__}: {exc}",
-                )
-            )
-            request = record.output_request
-            driver = record.adapter.driver
-            record.output_cancel_sent = request is not None and driver is not None
-            terminal_signal_observed = record.terminal_signal_observed
-            self._cleanup_starting += 1
-            self._signal_readiness_change_locked()
-        # Publish the terminal event before any Ray cancellation/control work.
-        # The C++ dispatcher is event-driven; delaying this callback until after
-        # ray.cancel() can leave the slot asleep forever when cancellation is
-        # slow or the failed generator is being reconstructed.
-        try:
-            self._notify_wakeup()
-        finally:
-            try:
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                if self._records.pop(key, None) is not record:
+                    return
+                record.terminal = True
+                record.cleanup_started = True
+                ready = self._ready_by_slot.get(record.slot_id)
+                dropped_tokens: list[_OutputLeaseToken] = []
+                if ready is not None:
+                    kept: deque[_ReadyEvent] = deque()
+                    for event in ready:
+                        if event.submit_id == record.submit_id and event.kind == "data":
+                            if event.output_token is not None:
+                                dropped_tokens.append(event.output_token)
+                            continue
+                        kept.append(event)
+                    self._ready_by_slot[record.slot_id] = kept
                 for token in dropped_tokens:
-                    self._start_tracked_cleanup(
-                        name="udf-ray-stream-failed-lease",
-                        operation=lambda token=token: token.driver.release_query_output_block_lease.remote(
-                            token.request_id,
-                            token.lease_id,
-                        ),
+                    token.release_pending = True
+                    self._active_output_leases.pop((token.request_id, token.lease_id), None)
+                self._ready_by_slot[record.slot_id].append(
+                    _ReadyEvent(
+                        record.slot_id,
+                        record.submit_id,
+                        "error",
+                        f"{type(exc).__name__}: {exc}",
                     )
-                if request is not None and driver is not None:
-                    self._start_tracked_cleanup(
-                        name="udf-ray-stream-failed-control",
-                        operation=lambda: driver.cancel_query_output_block_lease_request.remote(request),
-                    )
-                self._start_tracked_cleanup(
-                    name="udf-ray-stream-failed-adapter",
-                    operation=record.adapter.retire_failed if terminal_signal_observed else record.adapter.cancel,
                 )
-            finally:
-                with self._cv:
-                    self._cleanup_starting -= 1
-                    self._cv.notify_all()
+                request = record.output_request
+                driver = record.adapter.driver
+                record.output_cancel_sent = request is not None and driver is not None
+                terminal_signal_observed = record.terminal_signal_observed
+                cleanup_operations: list[Callable[[], Any]] = [
+                    self._output_token_release_operation(token) for token in dropped_tokens
+                ]
+                if request is not None and driver is not None:
+                    cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                if terminal_signal_observed:
+                    cleanup_operations.extend(record.adapter.retire_failed_operations())
+                else:
+                    cleanup_operations.extend(record.adapter.cancel_operations())
+                self._signal_readiness_change_locked()
+            self._submit_cleanup_operations(
+                cleanup_operations,
+                slot_ids=(record.slot_id,),
+            )
+
+        # The entire terminal plan has a durable bounded-lane owner before an
+        # arbitrary dispatcher callback can reenter shutdown.
+        self._notify_wakeup()
 
     def _notify_wakeup(self) -> None:
         with self._cv:
             callback = self._wakeup_fn
         if callback is not None:
-            callback()
+            try:
+                callback()
+            except BaseException as exc:
+                with self._cv:
+                    if not self._shutdown and self._thread_error is None:
+                        self._thread_error = RuntimeError(
+                            f"Ray UDF stream wakeup callback failed: {type(exc).__name__}: {exc}"
+                        )
+                    self._cv.notify_all()
 
 
 __all__ = ["AsyncResultCollector"]

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -890,11 +890,13 @@ class AsyncResultCollector:
                     except RuntimeError:
                         pass
                     if self._thread is not threading.current_thread():
-                        self._thread.join(timeout=self._shutdown_timeout_s)
-                    if self._thread.is_alive():
-                        add_note = getattr(exc, "add_note", None)
-                        if callable(add_note):
-                            add_note("Ray UDF stream event loop did not terminate after start failure")
+                        # Construction has not transferred ownership to a
+                        # caller, so returning while this thread is alive would
+                        # orphan its loop and Ray references.  The production
+                        # thread target publishes ``_loop_ready`` before doing
+                        # any blocking work; once ``loop.stop`` is queued it
+                        # therefore has a finite path to termination.
+                        self._thread.join()
                 else:
                     self._loop.close()
                 raise

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -284,77 +284,63 @@ class AsyncResultCollector:
         key = (int(slot_id), int(submit_id))
         adapter: RayStreamAdapter | None = None
         record: _StreamRecord | None = None
-        cleanup_tickets: tuple[_CleanupTicket, ...] = ()
-        try:
-            with self._start_lock:
-                try:
-                    adapter = RayStreamAdapter(source, ray_module=self._ray)
-                    source = None
-                    self._ensure_started()
-                    with self._cv:
-                        self._raise_if_stopped_locked()
-                        if key in self._records:
-                            raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
-                        if key[0] in self._cancelled_slots:
-                            raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
-                        record = _StreamRecord(
-                            slot_id=key[0],
-                            submit_id=key[1],
-                            adapter=adapter,
-                            sequence=self._next_sequence,
-                            error_context=dict(error_context) if error_context else None,
-                        )
-                        self._next_sequence += 1
-                        self._records[key] = record
-                        # Publish and install the first terminal observer under
-                        # one lock. Readiness skips unregistered records, so a
-                        # failing Future factory can never expose a half-owned
-                        # stream to the scheduler.
-                        self._schedule_completion_wait_locked(record)
-                        record.registered = True
-                        self._signal_readiness_change_locked()
-                    _collector_debug_log("track", record)
-                except BaseException:
-                    with self._cleanup_handoff_lock:
-                        cleanup_operations: Sequence[RayStreamCleanupOperation] = ()
-                        with self._cv:
-                            if record is not None and self._records.get(key) is record:
-                                record.terminal = True
-                                record.cleanup_started = True
-                                self._cancel_record_wait_locked(record)
-                                cleanup_operations = record.adapter.cancel_operations()
-                                self._signal_readiness_change_locked()
-                            elif adapter is not None:
-                                cleanup_operations = adapter.cancel_operations()
-                            elif source is not None:
-                                cleanup_operations = source.cancel_operations()
-                                source.retire_local_state()
-                        if cleanup_operations:
-                            cleanup_tickets = self._submit_cleanup_operations(
-                                cleanup_operations,
-                                store_error=False,
-                                slot_ids=(key[0],),
-                            )
-                        with self._cv:
-                            if record is not None and self._records.get(key) is record:
-                                self._records.pop(key, None)
-                                self._signal_readiness_change_locked()
-                    raise
-        except BaseException as registration_error:
-            if cleanup_tickets:
-                try:
-                    cleanup_errors = self._wait_cleanup_tickets(
-                        cleanup_tickets,
-                        timeout_message="submitted Ray stream cleanup did not terminate",
+        with self._start_lock:
+            try:
+                adapter = RayStreamAdapter(source, ray_module=self._ray)
+                source = None
+                self._ensure_started()
+                with self._cv:
+                    self._raise_if_stopped_locked()
+                    if key in self._records:
+                        raise ValueError(f"duplicate Ray UDF stream identity slot={key[0]} submit={key[1]}")
+                    if key[0] in self._cancelled_slots:
+                        raise RuntimeError(f"Ray UDF slot {key[0]} is cancelled")
+                    record = _StreamRecord(
+                        slot_id=key[0],
+                        submit_id=key[1],
+                        adapter=adapter,
+                        sequence=self._next_sequence,
+                        error_context=dict(error_context) if error_context else None,
                     )
-                    detail = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
-                except BaseException as cleanup_error:
-                    detail = f"{type(cleanup_error).__name__}: {cleanup_error}"
-                if detail:
-                    add_note = getattr(registration_error, "add_note", None)
-                    if callable(add_note):
-                        add_note(f"submitted Ray stream cleanup failed: {detail}")
-            raise
+                    self._next_sequence += 1
+                    self._records[key] = record
+                    # Publish and install the first terminal observer under
+                    # one lock. Readiness skips unregistered records, so a
+                    # failing Future factory can never expose a half-owned
+                    # stream to the scheduler.
+                    self._schedule_completion_wait_locked(record)
+                    record.registered = True
+                    self._signal_readiness_change_locked()
+                _collector_debug_log("track", record)
+            except BaseException:
+                with self._cleanup_handoff_lock:
+                    cleanup_operations: Sequence[RayStreamCleanupOperation] = ()
+                    with self._cv:
+                        if record is not None and self._records.get(key) is record:
+                            record.terminal = True
+                            record.cleanup_started = True
+                            self._cancel_record_wait_locked(record)
+                            cleanup_operations = record.adapter.cancel_operations()
+                            self._signal_readiness_change_locked()
+                        elif adapter is not None:
+                            cleanup_operations = adapter.cancel_operations()
+                        elif source is not None:
+                            cleanup_operations = source.cancel_operations()
+                            source.retire_local_state()
+                    if cleanup_operations:
+                        # Registration runs on the one native dispatcher. The
+                        # durable ticket ledger owns remote cleanup from this
+                        # point; waiting for its ACK here would stall every
+                        # otherwise healthy slot.
+                        self._submit_cleanup_operations(
+                            cleanup_operations,
+                            slot_ids=(key[0],),
+                        )
+                    with self._cv:
+                        if record is not None and self._records.get(key) is record:
+                            self._records.pop(key, None)
+                            self._signal_readiness_change_locked()
+                raise
 
     def discard_generator_ref(self, slot_id: int, source: Any) -> None:
         """Cancel a submitted stream rejected by the C++ slot-generation fence."""
@@ -1440,20 +1426,6 @@ class AsyncResultCollector:
             stop = self._shutdown and not self._cleanup_tickets
         if stop:
             self._loop.stop()
-
-    def _wait_cleanup_tickets(
-        self,
-        tickets: Sequence[_CleanupTicket],
-        *,
-        timeout_message: str,
-    ) -> tuple[BaseException, ...]:
-        deadline = time.monotonic() + self._shutdown_timeout_s
-        for ticket in tickets:
-            if ticket.callback_owned_by_current_thread():
-                continue
-            if not ticket.wait(max(0.0, deadline - time.monotonic())):
-                raise RuntimeError(timeout_message)
-        return tuple(error for ticket in tickets for error in ticket.errors)
 
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -21,6 +21,7 @@ from duckdb.execution.ray_control_deadline import (
 )
 from duckdb.execution.ray_control_submission import (
     create_ray_control_deadline,
+    dispatch_ray_control_abandonment,
     submit_ray_control,
 )
 from duckdb.execution.ray_stream_adapter import (
@@ -134,6 +135,7 @@ class _StreamRecord:
     wait_kind: str = ""
     wait_future: Any | None = None
     completion_future: Any | None = None
+    detached_waits: tuple[Any, ...] = ()
     terminal_signal_observed: bool = False
     next_ref_ready: bool = False
     ready_sequence: int | None = None
@@ -151,13 +153,13 @@ class _CleanupTicket:
         operation: RayStreamCleanupOperation,
         retry_on_error: bool,
         retry_on_incomplete: bool,
-        abandon_wait: Callable[[Any], None] | None,
+        release_wait: Callable[[Any], None] | None,
         on_complete: Callable[[BaseException | None], None],
     ) -> None:
         self.operation = operation
         self.retry_on_error = bool(retry_on_error)
         self.retry_on_incomplete = bool(retry_on_incomplete)
-        self.abandon_wait = abandon_wait
+        self.release_wait = release_wait
         self.retry_count = 0
         self.submitting = False
         self.operation_future: Any | None = None
@@ -222,9 +224,10 @@ class AsyncResultCollector:
     The asyncio thread is the sole generator-readiness, read, and stream-state
     scheduler. Potentially blocking Ray control submissions and terminal
     operations run on admitted stream-owner daemon workers. Cleanup tickets use
-    the process-wide control deadline clock, which hands owner callbacks to a
-    separate bounded/recoverable executor, so loop shutdown and one blocked
-    Future callback cannot orphan unrelated retries or response timeouts.
+    the process-wide control deadline clock, which hands state transitions and
+    potentially blocking completion/abandonment work to separate bounded,
+    recoverable domains. Loop shutdown and one blocked Future callback therefore
+    cannot orphan unrelated retries or response timeouts.
     Driver RPCs are observed through public ObjectRef futures. Every terminal
     operation enters the ticket ledger before its source record is removed, so
     shutdown can never observe an ownership gap.
@@ -299,6 +302,7 @@ class AsyncResultCollector:
         key = (int(slot_id), int(submit_id))
         adapter: RayStreamAdapter | None = None
         record: _StreamRecord | None = None
+        detached_waits: tuple[Any, ...] = ()
         with self._start_lock:
             try:
                 adapter = RayStreamAdapter(source, ray_module=self._ray)
@@ -334,7 +338,7 @@ class AsyncResultCollector:
                         if record is not None and self._records.get(key) is record:
                             record.terminal = True
                             record.cleanup_started = True
-                            self._cancel_record_wait_locked(record)
+                            self._detach_record_waits_locked(record)
                             cleanup_operations = record.adapter.cancel_operations()
                             self._signal_readiness_change_locked()
                         elif adapter is not None:
@@ -353,8 +357,14 @@ class AsyncResultCollector:
                         )
                     with self._cv:
                         if record is not None and self._records.get(key) is record:
+                            detached_waits = record.detached_waits
+                            record.detached_waits = ()
                             self._records.pop(key, None)
                             self._signal_readiness_change_locked()
+                self._abandon_record_waits(
+                    detached_waits,
+                    owner_scope=f"collector:{id(self):x}:track:{key[0]}:{key[1]}",
+                )
                 raise
 
     def discard_generator_ref(self, slot_id: int, source: Any) -> None:
@@ -526,7 +536,7 @@ class AsyncResultCollector:
             token.handoff_response_future = None
         return True
 
-    def _abandon_output_token_handoff(
+    def _release_output_token_handoff_wait(
         self,
         token: _OutputLeaseToken,
         response_future: Any,
@@ -534,10 +544,6 @@ class AsyncResultCollector:
         with self._cv:
             if token.handoff_response_future is response_future:
                 token.handoff_response_future = None
-        try:
-            response_future.cancel()
-        except BaseException:
-            pass
 
     def _run_output_token_release(self, token: _OutputLeaseToken) -> bool | Any:
         with self._cv:
@@ -564,7 +570,7 @@ class AsyncResultCollector:
             token.release_response_future = None
         return True
 
-    def _abandon_output_token_release(
+    def _release_output_token_release_wait(
         self,
         token: _OutputLeaseToken,
         response_future: Any,
@@ -572,10 +578,6 @@ class AsyncResultCollector:
         with self._cv:
             if token.release_response_future is response_future:
                 token.release_response_future = None
-        try:
-            response_future.cancel()
-        except BaseException:
-            pass
 
     @staticmethod
     def _claim_output_token_releases_locked(
@@ -613,7 +615,7 @@ class AsyncResultCollector:
             submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            abandon_wait=lambda future: self._abandon_output_token_handoff(
+            release_wait=lambda future: self._release_output_token_handoff_wait(
                 token,
                 future,
             ),
@@ -628,7 +630,7 @@ class AsyncResultCollector:
             submission_scope=token.submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            abandon_wait=lambda future: self._abandon_output_token_release(
+            release_wait=lambda future: self._release_output_token_release_wait(
                 token,
                 future,
             ),
@@ -657,26 +659,23 @@ class AsyncResultCollector:
             response_future = None
             return True
 
-        def abandon_wait(future: Any) -> None:
+        def release_wait(future: Any) -> None:
             nonlocal response_future
             if response_future is future:
                 response_future = None
-            try:
-                future.cancel()
-            except BaseException:
-                pass
 
         return RayStreamCleanupOperation(
             cancel,
             submission_scope=submission_scope,
             retry_on_error=True,
             retry_on_incomplete=True,
-            abandon_wait=abandon_wait,
+            release_wait=release_wait,
         )
 
     def cancel_slot(self, slot_id: int) -> None:
         """Fence a slot and atomically hand its remote cleanup to the event loop."""
         slot_key = int(slot_id)
+        detached_waits: list[Any] = []
         with self._cleanup_handoff_lock:
             with self._cv:
                 if self._shutdown:
@@ -690,7 +689,7 @@ class AsyncResultCollector:
                     record.terminal = True
                     if not record.cleanup_started:
                         record.cleanup_started = True
-                    self._cancel_record_wait_locked(record)
+                    self._detach_record_waits_locked(record)
                 for record in records_to_cancel:
                     request = record.output_request
                     driver = record.adapter.driver
@@ -738,6 +737,8 @@ class AsyncResultCollector:
                 self._slot_cancellation_tickets[slot_key].update(cleanup_tickets)
                 for record in records:
                     if self._records.get((record.slot_id, record.submit_id)) is record:
+                        detached_waits.extend(record.detached_waits)
+                        record.detached_waits = ()
                         self._records.pop((record.slot_id, record.submit_id), None)
                 self._ready_by_slot.pop(slot_key, None)
                 for token in tokens:
@@ -745,6 +746,10 @@ class AsyncResultCollector:
                 self._capacity_by_slot.pop(slot_key, None)
                 self._cancelled_slots.add(slot_key)
                 self._signal_readiness_change_locked()
+        self._abandon_record_waits(
+            detached_waits,
+            owner_scope=f"collector:{id(self):x}:cancel-slot:{slot_key}",
+        )
 
     def slot_has_pending(self, slot_id: int) -> bool:
         slot_key = int(slot_id)
@@ -784,6 +789,7 @@ class AsyncResultCollector:
         """Stop the process-owned loop after the native submitter is quiescent."""
         deadline = time.monotonic() + self._shutdown_timeout_s
         shutdown_errors: list[BaseException] = []
+        detached_waits: list[Any] = []
         with self._start_lock:
             with self._cleanup_handoff_lock:
                 with self._cv:
@@ -797,7 +803,7 @@ class AsyncResultCollector:
                     for record in records:
                         cleanup_slot_ids.add(record.slot_id)
                         record.terminal = True
-                        self._cancel_record_wait_locked(record)
+                        self._detach_record_waits_locked(record)
                         if record.cleanup_started:
                             continue
                         record.cleanup_started = True
@@ -847,6 +853,9 @@ class AsyncResultCollector:
                         shutdown_errors.append(exc)
                 if not shutdown_errors:
                     with self._cv:
+                        for record in records:
+                            detached_waits.extend(record.detached_waits)
+                            record.detached_waits = ()
                         self._records.clear()
                         self._active_output_leases.clear()
                         self._ready_by_slot.clear()
@@ -855,6 +864,12 @@ class AsyncResultCollector:
                         self._cv.notify_all()
                     if stop_now:
                         self._request_event_loop_stop()
+
+        if not shutdown_errors:
+            self._abandon_record_waits(
+                detached_waits,
+                owner_scope=f"collector:{id(self):x}:shutdown",
+            )
 
         if self._thread is threading.current_thread():
             if shutdown_errors:
@@ -1238,7 +1253,7 @@ class AsyncResultCollector:
                 operation=action,
                 retry_on_error=action.retry_on_error,
                 retry_on_incomplete=action.retry_on_incomplete,
-                abandon_wait=action.abandon_wait,
+                release_wait=action.release_wait,
                 on_complete=complete,
             )
             ticket_holder.append(ticket)
@@ -1344,15 +1359,14 @@ class AsyncResultCollector:
                 return
             ticket.wait_future = None
             ticket.wait_timeout = None
-        # Make the ticket self-driving before abandoning the old response.
-        # Future.cancel invokes completion callbacks inline and may block.
+        # Publish the retry owner before releasing attempt-local state. The
+        # release hook is not allowed to call Future.cancel(), but an
+        # unexpected hook failure must not drop durable cleanup ownership.
         self._retry_cleanup_ticket(ticket)
         try:
-            assert ticket.abandon_wait is not None
-            ticket.abandon_wait(future)
+            assert ticket.release_wait is not None
+            ticket.release_wait(future)
         except BaseException:
-            # Abandonment is best-effort; the newly published retry owns the
-            # idempotent remote terminal transition from this point onward.
             pass
 
     def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
@@ -1379,7 +1393,6 @@ class AsyncResultCollector:
         with self._cv:
             ticket.submitting = False
             if ticket not in self._cleanup_tickets:
-                operation_future.cancel()
                 return
             ticket.operation_future = operation_future
 
@@ -1407,7 +1420,6 @@ class AsyncResultCollector:
                 else:
                     active = False
             if active:
-                operation_future.cancel()
                 self._finish_cleanup_operation(ticket, error=exc)
 
     def _complete_cleanup_operation(
@@ -1475,7 +1487,7 @@ class AsyncResultCollector:
                 if active:
                     ticket.finish(exc)
                 return
-            if ticket.abandon_wait is not None:
+            if ticket.release_wait is not None:
                 timeout_call: RayControlScheduledCall
 
                 def response_timed_out() -> None:
@@ -1511,7 +1523,7 @@ class AsyncResultCollector:
                                 active = False
                         if active:
                             try:
-                                ticket.abandon_wait(result)
+                                ticket.release_wait(result)
                             except BaseException:
                                 pass
                             ticket.finish(exc)
@@ -1566,20 +1578,48 @@ class AsyncResultCollector:
                 self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             self._loop.close()
 
-    def _cancel_record_wait_locked(self, record: _StreamRecord) -> None:
-        future = record.wait_future
-        completion_future = record.completion_future
-        output_submit_future = record.output_submit_future
+    @staticmethod
+    def _detach_record_waits_locked(record: _StreamRecord) -> None:
+        """Detach local observers while retaining handles until cleanup handoff."""
+        futures = (
+            *record.detached_waits,
+            record.wait_future,
+            record.completion_future,
+            record.output_submit_future,
+        )
         record.wait_future = None
         record.completion_future = None
         record.output_submit_future = None
         record.wait_kind = ""
-        if future is not None:
-            future.cancel()
-        if completion_future is not None:
-            completion_future.cancel()
-        if output_submit_future is not None:
-            output_submit_future.cancel()
+        unique: list[Any] = []
+        seen: set[int] = set()
+        for future in futures:
+            if future is None or id(future) in seen:
+                continue
+            seen.add(id(future))
+            unique.append(future)
+        record.detached_waits = tuple(unique)
+
+    @staticmethod
+    def _abandon_record_waits(
+        futures: Sequence[Any],
+        *,
+        owner_scope: str,
+    ) -> None:
+        """Cancel detached observers only after durable cleanup owns the record."""
+        for future in futures:
+            cancel = getattr(future, "cancel", None)
+            if not callable(cancel):
+                continue
+            try:
+                dispatch_ray_control_abandonment(
+                    f"{owner_scope}:future:{id(future):x}",
+                    cancel,
+                )
+            except BaseException:
+                # Remote ownership is already durable. Event-loop shutdown is
+                # the final fallback for local observers if dispatch fails.
+                pass
 
     @staticmethod
     def _object_ref_future(ref: Any) -> Any:
@@ -1900,7 +1940,6 @@ class AsyncResultCollector:
             if cancel_stale_request:
                 record.output_cancel_sent = True
         if stale:
-            output_submit_future.cancel()
             if cancel_stale_request:
                 self._submit_cleanup_operations(
                     (
@@ -1944,7 +1983,6 @@ class AsyncResultCollector:
             with self._cv:
                 if record.output_submit_future is output_submit_future:
                     record.output_submit_future = None
-            output_submit_future.cancel()
             raise
         _collector_debug_log("output_lease_requested", record)
 

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -215,10 +215,10 @@ class AsyncResultCollector:
     operations run on admitted stream-owner daemon workers and publish their
     results back to that loop. One blocked stream therefore cannot consume a
     healthy peer's submission progress, and worker cardinality follows the
-    existing task-admission bound rather than an arbitrary lane count. Driver
-    RPCs are observed through public ObjectRef futures. Every terminal operation
-    enters the ticket ledger before its source record is removed, so shutdown
-    can never observe an ownership gap.
+    existing task-admission bound. Driver RPCs are observed through public
+    ObjectRef futures. Every terminal operation enters the ticket ledger before
+    its source record is removed, so shutdown can never observe an ownership
+    gap.
 
     The native dispatcher keeps this collector alive across empty slot
     intervals. ``shutdown`` is the process-owner fence and is called only after
@@ -775,48 +775,48 @@ class AsyncResultCollector:
         with self._start_lock:
             with self._cleanup_handoff_lock:
                 with self._cv:
-                    first_shutdown = not self._shutdown
+                    self._shutdown = True
+                    self._wakeup_fn = None
                     cleanup_operations: list[RayStreamCleanupOperation] = []
                     cleanup_slot_ids: set[int] = set()
-                    if first_shutdown:
-                        self._shutdown = True
-                        self._wakeup_fn = None
-                        records = list(self._records.values())
-                        for record in records:
-                            cleanup_slot_ids.add(record.slot_id)
-                            record.terminal = True
-                            self._cancel_record_wait_locked(record)
-                            if record.cleanup_started:
-                                continue
-                            record.cleanup_started = True
-                            request = record.output_request
-                            driver = record.adapter.driver
-                            if request is not None and driver is not None and not record.output_cancel_sent:
-                                record.output_cancel_sent = True
-                                cleanup_operations.append(
-                                    self._output_request_cancel_operation(
-                                        driver,
-                                        request,
-                                        record.adapter.submission_scope,
-                                    )
+                    claimed_records: list[_StreamRecord] = []
+                    output_cancel_records: list[_StreamRecord] = []
+                    records = list(self._records.values())
+                    for record in records:
+                        cleanup_slot_ids.add(record.slot_id)
+                        record.terminal = True
+                        self._cancel_record_wait_locked(record)
+                        if record.cleanup_started:
+                            continue
+                        record.cleanup_started = True
+                        claimed_records.append(record)
+                        request = record.output_request
+                        driver = record.adapter.driver
+                        if request is not None and driver is not None and not record.output_cancel_sent:
+                            record.output_cancel_sent = True
+                            output_cancel_records.append(record)
+                            cleanup_operations.append(
+                                self._output_request_cancel_operation(
+                                    driver,
+                                    request,
+                                    record.adapter.submission_scope,
                                 )
-                            cleanup_operations.extend(record.adapter.cancel_operations())
-                        ready = [event for events in self._ready_by_slot.values() for event in events]
-                        tokens = list(self._active_output_leases.values())
-                        token_keys = {(token.request_id, token.lease_id) for token in tokens}
-                        for event in ready:
-                            cleanup_slot_ids.add(event.slot_id)
-                            token = event.output_token
-                            if token is not None and (token.request_id, token.lease_id) not in token_keys:
-                                tokens.append(token)
-                                token_keys.add((token.request_id, token.lease_id))
-                        claimed_tokens = self._claim_output_token_releases_locked(tokens)
-                        cleanup_operations.extend(
-                            self._output_token_release_operation(token) for token in claimed_tokens
-                        )
-                        cleanup_slot_ids.update(token.slot_id for token in tokens)
-                        self._signal_readiness_change_locked()
-                if first_shutdown and cleanup_operations:
+                            )
+                        cleanup_operations.extend(record.adapter.cancel_operations())
+                    ready = [event for events in self._ready_by_slot.values() for event in events]
+                    tokens = list(self._active_output_leases.values())
+                    token_keys = {(token.request_id, token.lease_id) for token in tokens}
+                    for event in ready:
+                        cleanup_slot_ids.add(event.slot_id)
+                        token = event.output_token
+                        if token is not None and (token.request_id, token.lease_id) not in token_keys:
+                            tokens.append(token)
+                            token_keys.add((token.request_id, token.lease_id))
+                    claimed_tokens = self._claim_output_token_releases_locked(tokens)
+                    cleanup_operations.extend(self._output_token_release_operation(token) for token in claimed_tokens)
+                    cleanup_slot_ids.update(token.slot_id for token in tokens)
+                    self._signal_readiness_change_locked()
+                if cleanup_operations:
                     try:
                         self._submit_cleanup_operations(
                             cleanup_operations,
@@ -824,8 +824,16 @@ class AsyncResultCollector:
                         )
                     except BaseException as exc:
                         self._restore_output_token_release_claims(claimed_tokens)
+                        with self._cv:
+                            for record in claimed_records:
+                                if self._records.get((record.slot_id, record.submit_id)) is record:
+                                    record.cleanup_started = False
+                            for record in output_cancel_records:
+                                if self._records.get((record.slot_id, record.submit_id)) is record:
+                                    record.output_cancel_sent = False
+                            self._cv.notify_all()
                         shutdown_errors.append(exc)
-                if first_shutdown and not shutdown_errors:
+                if not shutdown_errors:
                     with self._cv:
                         self._records.clear()
                         self._active_output_leases.clear()
@@ -868,10 +876,16 @@ class AsyncResultCollector:
                 if id(error) not in known_error_ids:
                     known_error_ids.add(id(error))
                     shutdown_errors.append(error)
+            owns_stream_state = bool(self._records or self._active_output_leases or self._ready_by_slot)
 
-        if not pending and self._thread.is_alive():
+        if not pending and not owns_stream_state and self._thread.is_alive():
             self._loop.call_soon_threadsafe(self._loop.stop)
-        if self._thread_started and self._thread is not threading.current_thread() and not pending:
+        if (
+            self._thread_started
+            and self._thread is not threading.current_thread()
+            and not pending
+            and not owns_stream_state
+        ):
             self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
             if self._thread.is_alive():
                 shutdown_errors.append(RuntimeError("Ray UDF stream multiplexer did not terminate"))
@@ -1220,22 +1234,35 @@ class AsyncResultCollector:
             ticket_holder.append(ticket)
             tickets.append(ticket)
 
+        schedule_error: BaseException | None = None
         with self._cleanup_handoff_lock:
-            with self._cv:
-                if not self._thread_started or not self._thread.is_alive() or self._loop.is_closed():
-                    raise RuntimeError("Ray UDF cleanup event loop is not available")
-            if self._thread is threading.current_thread():
-                self._loop.call_soon(self._start_cleanup_tickets, tuple(tickets))
-            else:
-                self._loop.call_soon_threadsafe(self._start_cleanup_tickets, tuple(tickets))
-            # The scheduled callback first acquires _cleanup_handoff_lock.  Add
-            # ledger ownership before releasing that lock, so it cannot drive
-            # or finish a ticket before the transfer is externally visible.
+            # Publish ledger ownership before scheduling. The callback also
+            # acquires _cleanup_handoff_lock, so it cannot drive or finish a
+            # ticket before the transfer is externally visible. If the loop
+            # becomes unavailable, the ledger deliberately retains ownership
+            # and the collector becomes failed instead of silently orphaning
+            # remote resources after a caller drops its source record.
             with self._cv:
                 self._cleanup_tickets.update(tickets)
                 for slot_id in owner_slots:
                     self._cleanup_tickets_by_slot[slot_id].update(tickets)
                 self._cv.notify_all()
+                loop_available = self._thread_started and self._thread.is_alive() and not self._loop.is_closed()
+            try:
+                if not loop_available:
+                    raise RuntimeError("Ray UDF cleanup event loop is not available")
+                if self._thread is threading.current_thread():
+                    self._loop.call_soon(self._start_cleanup_tickets, tuple(tickets))
+                else:
+                    self._loop.call_soon_threadsafe(self._start_cleanup_tickets, tuple(tickets))
+            except BaseException as exc:
+                schedule_error = exc
+                with self._cv:
+                    if not self._shutdown and self._thread_error is None:
+                        self._thread_error = exc
+                    self._cv.notify_all()
+        if schedule_error is not None and not self._shutdown:
+            self._notify_wakeup()
         return tuple(tickets)
 
     def _start_cleanup_tickets(self, tickets: tuple[_CleanupTicket, ...]) -> None:
@@ -1341,10 +1368,7 @@ class AsyncResultCollector:
                     future,
                 )
             except RuntimeError as exc:
-                with collector._cv:
-                    if collector._thread_error is None:
-                        collector._thread_error = exc
-                    collector._cv.notify_all()
+                collector._report_scheduler_error(exc)
 
         try:
             operation_future.add_done_callback(ready)
@@ -1408,10 +1432,7 @@ class AsyncResultCollector:
                         future,
                     )
                 except RuntimeError as exc:
-                    with collector._cv:
-                        if collector._thread_error is None:
-                            collector._thread_error = exc
-                        collector._cv.notify_all()
+                    collector._report_scheduler_error(exc)
 
             try:
                 result.add_done_callback(ready)

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-import heapq
 import math
 import os
 import sys
@@ -16,14 +15,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from duckdb.execution.ray_stream_adapter import (
-    RAY_STREAM_CLEANUP_CANCELLATION,
-    RAY_STREAM_CLEANUP_CONTROL,
-    RAY_STREAM_CLEANUP_CORE,
-    RAY_STREAM_CLEANUP_OUTPUT,
     RayStreamAdapter,
     RayStreamCleanupOperation,
     TaskLeaseObjectRefGenerator,
-    resolve_ray_control_ack,
+    ray_object_ref_future,
+    validate_ray_control_ack,
 )
 from duckdb.execution.udf_ray_actor_state import format_stateful_actor_loss
 from duckdb.execution.udf_ray_config import REF_BUNDLE_RESULT_MARKER
@@ -34,19 +30,8 @@ from duckdb.execution.udf_ray_stream_protocol import (
 
 _GENERATOR_READINESS_POLL_INITIAL_DELAY_S = 0.001
 _GENERATOR_READINESS_POLL_MAX_DELAY_S = 0.01
-_DEFAULT_CONTROL_CLEANUP_WORKERS = 4
-_DEFAULT_OUTPUT_CLEANUP_WORKERS = 4
-_DEFAULT_CANCELLATION_CLEANUP_WORKERS = 2
-_DEFAULT_CORE_CLEANUP_WORKERS = 2
 _CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _CLEANUP_RETRY_MAX_DELAY_S = 1.0
-
-
-def _cleanup_worker_count(name: str, default: int) -> int:
-    value = int(os.environ.get(name, str(default)))
-    if value <= 0 or value > 256:
-        raise ValueError(f"{name} must be between 1 and 256")
-    return value
 
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
@@ -85,8 +70,8 @@ class _OutputLeaseToken:
     handed_off: bool = False
     handoff_pending: bool = False
     release_pending: bool = False
-    handoff_response_ref: Any | None = None
-    release_response_ref: Any | None = None
+    handoff_response_future: Any | None = None
+    release_response_future: Any | None = None
 
 
 @dataclass
@@ -119,6 +104,7 @@ class _StreamRecord:
     submit_id: int
     adapter: RayStreamAdapter
     sequence: int
+    registered: bool = False
     phase: str = "block"
     block_ref: Any | None = None
     metadata_ref: Any | None = None
@@ -144,13 +130,21 @@ class _StreamRecord:
 
 
 class _CleanupTicket:
-    """Durable owner for one blocking terminal operation."""
+    """Durable owner for one event-loop-driven terminal operation."""
 
     def __init__(
         self,
         *,
+        operation: Callable[[], Any],
+        retry_on_error: bool,
+        retry_on_incomplete: bool,
         on_complete: Callable[[BaseException | None], None],
     ) -> None:
+        self.operation = operation
+        self.retry_on_error = bool(retry_on_error)
+        self.retry_on_incomplete = bool(retry_on_incomplete)
+        self.retry_count = 0
+        self.wait_future: Any | None = None
         self._done = False
         self._error: BaseException | None = None
         self._on_complete = on_complete
@@ -198,160 +192,6 @@ class _CleanupTicket:
             return () if self._error is None else (self._error,)
 
 
-@dataclass
-class _CleanupWorkItem:
-    operation: Callable[[], Any]
-    ticket: _CleanupTicket
-    retry_on_error: bool = False
-    retry_on_incomplete: bool = False
-    retry_count: int = 0
-
-
-class _DaemonCleanupPool:
-    """Lazily scaled, fixed-size daemon bulkhead for blocking terminal calls."""
-
-    def __init__(self, worker_count: int, *, name: str) -> None:
-        self._worker_count = int(worker_count)
-        self._name = str(name)
-        self._cv = threading.Condition()
-        self._queue: list[tuple[float, int, _CleanupWorkItem]] = []
-        self._next_queue_sequence = 0
-        self._threads: list[threading.Thread] = []
-        self._started = False
-        self._stop_when_idle = False
-        self._idle_workers = 0
-
-    def start(self) -> None:
-        with self._cv:
-            if self._started:
-                return
-            self._started = True
-
-    def _ensure_worker_locked(self) -> None:
-        if self._threads:
-            return
-        try:
-            self._start_worker_locked()
-        except BaseException as exc:
-            raise RuntimeError(f"Ray UDF cleanup pool {self._name!r} did not start") from exc
-
-    def _start_worker_locked(self) -> None:
-        worker = threading.Thread(
-            target=self._run,
-            daemon=True,
-            name=f"{self._name}-{len(self._threads)}",
-        )
-        worker.start()
-        self._threads.append(worker)
-
-    def _scale_workers_locked(self) -> None:
-        needed = max(0, len(self._queue) - self._idle_workers)
-        available = self._worker_count - len(self._threads)
-        for _index in range(min(needed, available)):
-            try:
-                self._start_worker_locked()
-            except BaseException:
-                # The already-running worker remains the durable queue owner.
-                break
-
-    def _enqueue_locked(
-        self,
-        items: Sequence[_CleanupWorkItem],
-    ) -> None:
-        if not self._started or self._stop_when_idle:
-            raise RuntimeError(f"Ray UDF cleanup pool {self._name!r} is not accepting work")
-        ready_at = time.monotonic()
-        for item in items:
-            sequence = self._next_queue_sequence
-            self._next_queue_sequence += 1
-            heapq.heappush(self._queue, (ready_at, sequence, item))
-        self._scale_workers_locked()
-        self._cv.notify_all()
-
-    def stop_when_idle(self) -> None:
-        with self._cv:
-            self._stop_when_idle = True
-            self._cv.notify_all()
-
-    def join(self, timeout: float) -> bool:
-        deadline = time.monotonic() + max(0.0, float(timeout))
-        with self._cv:
-            threads = tuple(self._threads)
-        current = threading.current_thread()
-        for worker in threads:
-            if worker is current:
-                continue
-            worker.join(timeout=max(0.0, deadline - time.monotonic()))
-        return not any(worker is not current and worker.is_alive() for worker in threads)
-
-    @property
-    def threads(self) -> tuple[threading.Thread, ...]:
-        with self._cv:
-            return tuple(self._threads)
-
-    def _take_ready_item_locked(self) -> tuple[_CleanupWorkItem | None, float | None]:
-        if not self._queue:
-            return None, None
-        now = time.monotonic()
-        ready_at, _sequence, item = self._queue[0]
-        if ready_at <= now:
-            heapq.heappop(self._queue)
-            return item, None
-        return None, max(0.0, ready_at - now)
-
-    @staticmethod
-    def _retry_delay(retry_count: int) -> float:
-        exponent = min(max(0, int(retry_count) - 1), 30)
-        return min(
-            math.ldexp(_CLEANUP_RETRY_INITIAL_DELAY_S, exponent),
-            _CLEANUP_RETRY_MAX_DELAY_S,
-        )
-
-    def _run(self) -> None:
-        while True:
-            with self._cv:
-                item: _CleanupWorkItem | None = None
-                while item is None:
-                    item, retry_wait = self._take_ready_item_locked()
-                    if item is not None:
-                        break
-                    if not self._queue and self._stop_when_idle:
-                        return
-                    self._idle_workers += 1
-                    try:
-                        self._cv.wait(timeout=retry_wait)
-                    finally:
-                        self._idle_workers -= 1
-            error: BaseException | None = None
-            retry = False
-            result: Any = None
-            try:
-                result = item.operation()
-            except BaseException as exc:
-                if item.retry_on_error:
-                    retry = True
-                else:
-                    error = exc
-            else:
-                retry = result is False and item.retry_on_incomplete
-            if retry:
-                item.retry_count += 1
-                ready_at = time.monotonic() + self._retry_delay(item.retry_count)
-                with self._cv:
-                    sequence = self._next_queue_sequence
-                    self._next_queue_sequence += 1
-                    heapq.heappush(self._queue, (ready_at, sequence, item))
-                    self._cv.notify_all()
-                del item
-                del error
-                del result
-                continue
-            item.ticket.finish(error)
-            del item
-            del error
-            del result
-
-
 class AsyncResultCollector:
     """Capacity-aware scheduler for lease-owned Ray generator streams.
 
@@ -360,13 +200,11 @@ class AsyncResultCollector:
     A terminal record is removed only while ``_cleanup_handoff_lock`` prevents
     shutdown from observing an ownership gap.
 
-    The asyncio thread is the sole generator readiness/read consumer. Terminal
-    Ray, driver, and CoreWorker calls run in fixed-size lane-specific daemon
-    pools; task admission bounds the queued plans, while lane isolation keeps a
-    blocked cancellation from withholding stream deletion or unrelated control
-    work. Cancellation acceptance intentionally precedes task-lease release so
-    running work remains budgeted. User wakeups are invoked only after the
-    complete terminal plan has an accepted cleanup owner.
+    The asyncio thread is the sole generator readiness, read, and cleanup
+    consumer. Driver RPCs are observed through public ObjectRef futures;
+    cancellation and CoreWorker stream deletion are non-waiting submissions.
+    Every terminal operation enters the ticket ledger before its source record
+    is removed, so shutdown can never observe an ownership gap.
     """
 
     def __init__(self, *, ray_module: Any | None = None) -> None:
@@ -398,37 +236,6 @@ class AsyncResultCollector:
         self._cleanup_tickets: set[_CleanupTicket] = set()
         self._cleanup_tickets_by_slot: dict[int, set[_CleanupTicket]] = defaultdict(set)
         self._terminal_cleanup_errors: list[BaseException] = []
-        self._cleanup_pools_stopping = False
-        self._cleanup_pools = {
-            RAY_STREAM_CLEANUP_CONTROL: _DaemonCleanupPool(
-                _cleanup_worker_count(
-                    "VANE_UDF_STREAM_CONTROL_CLEANUP_WORKERS",
-                    _DEFAULT_CONTROL_CLEANUP_WORKERS,
-                ),
-                name="udf-ray-stream-control-cleanup",
-            ),
-            RAY_STREAM_CLEANUP_OUTPUT: _DaemonCleanupPool(
-                _cleanup_worker_count(
-                    "VANE_UDF_STREAM_OUTPUT_CLEANUP_WORKERS",
-                    _DEFAULT_OUTPUT_CLEANUP_WORKERS,
-                ),
-                name="udf-ray-stream-output-cleanup",
-            ),
-            RAY_STREAM_CLEANUP_CANCELLATION: _DaemonCleanupPool(
-                _cleanup_worker_count(
-                    "VANE_UDF_STREAM_CANCELLATION_CLEANUP_WORKERS",
-                    _DEFAULT_CANCELLATION_CLEANUP_WORKERS,
-                ),
-                name="udf-ray-stream-cancellation-cleanup",
-            ),
-            RAY_STREAM_CLEANUP_CORE: _DaemonCleanupPool(
-                _cleanup_worker_count(
-                    "VANE_UDF_STREAM_CORE_CLEANUP_WORKERS",
-                    _DEFAULT_CORE_CLEANUP_WORKERS,
-                ),
-                name="udf-ray-stream-core-cleanup",
-            ),
-        }
         self._readiness_delay_s = _GENERATOR_READINESS_POLL_INITIAL_DELAY_S
         self._readiness_timer: asyncio.TimerHandle | None = None
         self._readiness_wakeup_pending = False
@@ -440,17 +247,10 @@ class AsyncResultCollector:
             daemon=True,
             name="udf-ray-stream-multiplexer",
         )
-        started_pools: list[_DaemonCleanupPool] = []
-        try:
-            for pool in self._cleanup_pools.values():
-                pool.start()
-                started_pools.append(pool)
-        except BaseException:
-            for pool in started_pools:
-                pool.stop_when_idle()
-            for pool in started_pools:
-                pool.join(self._shutdown_timeout_s)
-            raise
+        # Start before any submitted generator can be transferred into this
+        # collector.  A collector that cannot own its event loop therefore
+        # fails construction instead of creating a post-submit cleanup gap.
+        self._ensure_started()
 
     # Public API called by the C++ dispatcher while it owns the GIL.
 
@@ -490,14 +290,22 @@ class AsyncResultCollector:
                         )
                         self._next_sequence += 1
                         self._records[key] = record
+                        # Publish and install the first terminal observer under
+                        # one lock. Readiness skips unregistered records, so a
+                        # failing Future factory can never expose a half-owned
+                        # stream to the scheduler.
+                        self._schedule_completion_wait_locked(record)
+                        record.registered = True
                         self._signal_readiness_change_locked()
+                    _collector_debug_log("track", record)
                 except BaseException:
                     with self._cleanup_handoff_lock:
-                        cleanup_operations: Sequence[Callable[[], Any]] = ()
+                        cleanup_operations: Sequence[RayStreamCleanupOperation] = ()
                         with self._cv:
-                            if record is not None and self._records.pop(key, None) is record:
+                            if record is not None and self._records.get(key) is record:
                                 record.terminal = True
                                 record.cleanup_started = True
+                                self._cancel_record_wait_locked(record)
                                 cleanup_operations = record.adapter.cancel_operations()
                                 self._signal_readiness_change_locked()
                             elif adapter is not None:
@@ -507,14 +315,15 @@ class AsyncResultCollector:
                                 source.retire_local_state()
                         if cleanup_operations:
                             cleanup_tickets = self._submit_cleanup_operations(
-                                self._fence_cleanup_operations(cleanup_operations),
+                                cleanup_operations,
                                 store_error=False,
                                 slot_ids=(key[0],),
                             )
+                        with self._cv:
+                            if record is not None and self._records.get(key) is record:
+                                self._records.pop(key, None)
+                                self._signal_readiness_change_locked()
                     raise
-            assert record is not None
-            _collector_debug_log("track", record)
-            self._refresh_waiters()
         except BaseException as registration_error:
             if cleanup_tickets:
                 try:
@@ -538,12 +347,19 @@ class AsyncResultCollector:
                 f"distributed Ray UDF discard requires TaskLeaseObjectRefGenerator; got {type(source).__name__}"
             )
         with self._start_lock:
-            adapter = RayStreamAdapter(source, ray_module=self._ray)
+            try:
+                adapter = RayStreamAdapter(source, ray_module=self._ray)
+            except BaseException:
+                cleanup_operations = source.cancel_operations()
+                source.retire_local_state()
+            else:
+                cleanup_operations = adapter.cancel_operations()
             with self._cv:
-                self._raise_if_stopped_locked()
+                if self._shutdown:
+                    raise RuntimeError("Ray UDF stream collector is shut down")
             with self._cleanup_handoff_lock:
                 self._submit_cleanup_operations(
-                    adapter.cancel_operations(),
+                    cleanup_operations,
                     store_error=True,
                 )
 
@@ -596,33 +412,34 @@ class AsyncResultCollector:
 
     def release_output_block_lease(self, request_id: str, lease_id: str) -> bool:
         key = (str(request_id), str(lease_id))
-        with self._cv:
-            token = self._active_output_leases.get(key)
-            if token is None or token.release_pending:
-                return False
-            token.release_pending = True
-            self._cv.notify_all()
-
-        def finish_release(error: BaseException | None) -> None:
+        with self._cleanup_handoff_lock:
             with self._cv:
-                if error is None:
-                    if self._active_output_leases.get(key) is token:
-                        self._active_output_leases.pop(key, None)
-                else:
+                token = self._active_output_leases.get(key)
+                if token is None or token.release_pending:
+                    return False
+                token.release_pending = True
+                self._cv.notify_all()
+
+            def finish_release(error: BaseException | None) -> None:
+                with self._cv:
+                    if error is None:
+                        if self._active_output_leases.get(key) is token:
+                            self._active_output_leases.pop(key, None)
+                    else:
+                        token.release_pending = False
+                    self._cv.notify_all()
+
+            try:
+                self._submit_cleanup_operations(
+                    (self._output_token_release_operation(token),),
+                    on_each_done=finish_release,
+                    slot_ids=(token.slot_id,),
+                )
+            except BaseException:
+                with self._cv:
                     token.release_pending = False
-                self._cv.notify_all()
-
-        try:
-            self._submit_cleanup_operations(
-                (self._output_token_release_operation(token),),
-                on_each_done=finish_release,
-                slot_ids=(token.slot_id,),
-            )
-        except BaseException:
-            with self._cv:
-                token.release_pending = False
-                self._cv.notify_all()
-            raise
+                    self._cv.notify_all()
+                raise
         return True
 
     def handoff_output_block_lease(self, request_id: str, lease_id: str) -> bool:
@@ -633,88 +450,120 @@ class AsyncResultCollector:
         idempotent transition: it must never drop the physical ObjectRef lease.
         """
         key = (str(request_id), str(lease_id))
-        with self._cv:
-            token = self._active_output_leases.get(key)
-            if token is None or token.handed_off or token.handoff_pending:
-                return False
-            token.handoff_pending = True
-            self._cv.notify_all()
-
-        def finish_handoff(error: BaseException | None) -> None:
+        with self._cleanup_handoff_lock:
             with self._cv:
-                token.handoff_pending = False
-                if error is None and not token.release_pending and self._active_output_leases.get(key) is token:
-                    token.handed_off = True
+                token = self._active_output_leases.get(key)
+                if token is None or token.handed_off or token.handoff_pending:
+                    return False
+                token.handoff_pending = True
                 self._cv.notify_all()
 
-        try:
-            self._submit_cleanup_operations(
-                (self._output_token_handoff_operation(token),),
-                on_each_done=finish_handoff,
-                slot_ids=(token.slot_id,),
-            )
-        except BaseException:
-            with self._cv:
-                token.handoff_pending = False
-                self._cv.notify_all()
-            raise
+            def finish_handoff(error: BaseException | None) -> None:
+                with self._cv:
+                    token.handoff_pending = False
+                    if error is None and not token.release_pending and self._active_output_leases.get(key) is token:
+                        token.handed_off = True
+                    self._cv.notify_all()
+
+            try:
+                self._submit_cleanup_operations(
+                    (self._output_token_handoff_operation(token),),
+                    on_each_done=finish_handoff,
+                    slot_ids=(token.slot_id,),
+                )
+            except BaseException:
+                with self._cv:
+                    token.handoff_pending = False
+                    self._cv.notify_all()
+                raise
         return True
 
-    def _run_output_token_handoff(self, token: _OutputLeaseToken) -> bool:
+    def _run_output_token_handoff(self, token: _OutputLeaseToken) -> bool | Any:
         key = (token.request_id, token.lease_id)
         with self._cv:
             if token.release_pending or self._active_output_leases.get(key) is not token:
+                token.handoff_response_future = None
                 return True
-            response_ref = token.handoff_response_ref
+            response_future = token.handoff_response_future
         try:
-            if response_ref is None:
+            if response_future is None:
                 response_ref = token.driver.handoff_query_output_block_lease.remote(
                     token.request_id,
                     token.lease_id,
                     token.query_id,
                 )
+                response_future = ray_object_ref_future(response_ref)
                 with self._cv:
-                    token.handoff_response_ref = response_ref
-            resolve_ray_control_ack(response_ref, field="handed_off")
-        except BaseException as exc:
-            if not isinstance(exc, TimeoutError):
-                with self._cv:
-                    if token.handoff_response_ref is response_ref:
-                        token.handoff_response_ref = None
+                    token.handoff_response_future = response_future
+            if not response_future.done():
+                return response_future
+            validate_ray_control_ack(response_future.result(), field="handed_off")
+        except BaseException:
+            with self._cv:
+                if token.handoff_response_future is response_future:
+                    token.handoff_response_future = None
             raise
         with self._cv:
-            token.handoff_response_ref = None
+            token.handoff_response_future = None
         return True
 
-    def _run_output_token_release(self, token: _OutputLeaseToken) -> bool:
+    def _run_output_token_release(self, token: _OutputLeaseToken) -> bool | Any:
         with self._cv:
-            response_ref = token.release_response_ref
+            response_future = token.release_response_future
         try:
-            if response_ref is None:
+            if response_future is None:
                 response_ref = token.driver.release_query_output_block_lease.remote(
                     token.request_id,
                     token.lease_id,
                     token.query_id,
                 )
+                response_future = ray_object_ref_future(response_ref)
                 with self._cv:
-                    token.release_response_ref = response_ref
-            resolve_ray_control_ack(response_ref, field="released")
-        except BaseException as exc:
-            if not isinstance(exc, TimeoutError):
-                with self._cv:
-                    if token.release_response_ref is response_ref:
-                        token.release_response_ref = None
+                    token.release_response_future = response_future
+            if not response_future.done():
+                return response_future
+            validate_ray_control_ack(response_future.result(), field="released")
+        except BaseException:
+            with self._cv:
+                if token.release_response_future is response_future:
+                    token.release_response_future = None
             raise
         with self._cv:
-            token.release_response_ref = None
+            token.release_response_future = None
         return True
+
+    @staticmethod
+    def _claim_output_token_releases_locked(
+        tokens: Sequence[_OutputLeaseToken],
+    ) -> tuple[_OutputLeaseToken, ...]:
+        """Claim each physical output lease once before its ticket handoff."""
+        claimed: list[_OutputLeaseToken] = []
+        seen: set[tuple[str, str]] = set()
+        for token in tokens:
+            key = (token.request_id, token.lease_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            if token.release_pending:
+                continue
+            token.release_pending = True
+            claimed.append(token)
+        return tuple(claimed)
+
+    def _restore_output_token_release_claims(
+        self,
+        tokens: Sequence[_OutputLeaseToken],
+    ) -> None:
+        with self._cv:
+            for token in tokens:
+                token.release_pending = False
+            self._cv.notify_all()
 
     def _output_token_handoff_operation(
         self,
         token: _OutputLeaseToken,
     ) -> RayStreamCleanupOperation:
         return RayStreamCleanupOperation(
-            RAY_STREAM_CLEANUP_OUTPUT,
             lambda: self._run_output_token_handoff(token),
             retry_on_error=True,
             retry_on_incomplete=True,
@@ -725,7 +574,6 @@ class AsyncResultCollector:
         token: _OutputLeaseToken,
     ) -> RayStreamCleanupOperation:
         return RayStreamCleanupOperation(
-            RAY_STREAM_CLEANUP_OUTPUT,
             lambda: self._run_output_token_release(token),
             retry_on_error=True,
             retry_on_incomplete=True,
@@ -736,23 +584,24 @@ class AsyncResultCollector:
         driver: Any,
         request: dict[str, Any],
     ) -> RayStreamCleanupOperation:
-        response_ref: Any | None = None
+        response_future: Any | None = None
 
-        def cancel() -> bool:
-            nonlocal response_ref
+        def cancel() -> bool | Any:
+            nonlocal response_future
             try:
-                if response_ref is None:
+                if response_future is None:
                     response_ref = driver.cancel_query_output_block_lease_request.remote(request)
-                resolve_ray_control_ack(response_ref, field="cancelled")
-            except BaseException as exc:
-                if not isinstance(exc, TimeoutError):
-                    response_ref = None
+                    response_future = ray_object_ref_future(response_ref)
+                if not response_future.done():
+                    return response_future
+                validate_ray_control_ack(response_future.result(), field="cancelled")
+            except BaseException:
+                response_future = None
                 raise
-            response_ref = None
+            response_future = None
             return True
 
         return RayStreamCleanupOperation(
-            RAY_STREAM_CLEANUP_OUTPUT,
             cancel,
             retry_on_error=True,
             retry_on_incomplete=True,
@@ -768,9 +617,9 @@ class AsyncResultCollector:
                 cleanup_tickets.update(self._cleanup_tickets_by_slot.get(slot_key, ()))
                 records = [record for record in self._records.values() if record.slot_id == slot_key]
                 records_to_cancel = [record for record in records if not record.cleanup_started]
-                cleanup_operations: list[Callable[[], Any]] = []
+                cleanup_operations: list[RayStreamCleanupOperation] = []
+                output_cancel_records: list[_StreamRecord] = []
                 for record in records:
-                    self._records.pop((record.slot_id, record.submit_id), None)
                     record.terminal = True
                     if not record.cleanup_started:
                         record.cleanup_started = True
@@ -780,33 +629,50 @@ class AsyncResultCollector:
                     driver = record.adapter.driver
                     if request is not None and driver is not None and not record.output_cancel_sent:
                         record.output_cancel_sent = True
+                        output_cancel_records.append(record)
                         cleanup_operations.append(self._output_request_cancel_operation(driver, request))
                     cleanup_operations.extend(record.adapter.cancel_operations())
-                ready = list(self._ready_by_slot.pop(slot_key, ()))
+                ready = list(self._ready_by_slot.get(slot_key, ()))
                 tokens = [token for token in self._active_output_leases.values() if token.slot_id == slot_key]
+                token_keys = {(token.request_id, token.lease_id) for token in tokens}
+                for event in ready:
+                    token = event.output_token
+                    if token is not None and (token.request_id, token.lease_id) not in token_keys:
+                        tokens.append(token)
+                        token_keys.add((token.request_id, token.lease_id))
+                claimed_tokens = self._claim_output_token_releases_locked(tokens)
+                cleanup_operations.extend(self._output_token_release_operation(token) for token in claimed_tokens)
+                self._signal_readiness_change_locked()
+
+            try:
+                cleanup_tickets.update(
+                    self._submit_cleanup_operations(
+                        cleanup_operations,
+                        store_error=False,
+                        slot_ids=(slot_key,),
+                    )
+                )
+            except BaseException:
+                self._restore_output_token_release_claims(claimed_tokens)
+                with self._cv:
+                    for record in records_to_cancel:
+                        if self._records.get((record.slot_id, record.submit_id)) is record:
+                            record.cleanup_started = False
+                    for record in output_cancel_records:
+                        if self._records.get((record.slot_id, record.submit_id)) is record:
+                            record.output_cancel_sent = False
+                    self._cv.notify_all()
+                raise
+            with self._cv:
+                for record in records:
+                    if self._records.get((record.slot_id, record.submit_id)) is record:
+                        self._records.pop((record.slot_id, record.submit_id), None)
+                self._ready_by_slot.pop(slot_key, None)
                 for token in tokens:
-                    token.release_pending = True
                     self._active_output_leases.pop((token.request_id, token.lease_id), None)
                 self._capacity_by_slot.pop(slot_key, None)
                 self._cancelled_slots.add(slot_key)
                 self._signal_readiness_change_locked()
-
-            ready_tokens = [event.output_token for event in ready if event.output_token is not None]
-            token_keys = {(token.request_id, token.lease_id) for token in tokens}
-            for token in ready_tokens:
-                if token is not None and (token.request_id, token.lease_id) not in token_keys:
-                    tokens.append(token)
-                    token_keys.add((token.request_id, token.lease_id))
-            for token in tokens:
-                token.release_pending = True
-            cleanup_operations.extend(self._output_token_release_operation(token) for token in tokens)
-            cleanup_tickets.update(
-                self._submit_cleanup_operations(
-                    self._fence_cleanup_operations(cleanup_operations),
-                    store_error=False,
-                    slot_ids=(slot_key,),
-                )
-            )
 
         cleanup_errors = self._wait_slot_cleanup(
             slot_key,
@@ -838,7 +704,7 @@ class AsyncResultCollector:
             with self._cleanup_handoff_lock:
                 with self._cv:
                     first_shutdown = not self._shutdown
-                    cleanup_operations: list[Callable[[], Any]] = []
+                    cleanup_operations: list[RayStreamCleanupOperation] = []
                     cleanup_slot_ids: set[int] = set()
                     if first_shutdown:
                         self._shutdown = True
@@ -846,6 +712,7 @@ class AsyncResultCollector:
                         records = list(self._records.values())
                         for record in records:
                             cleanup_slot_ids.add(record.slot_id)
+                            record.terminal = True
                             self._cancel_record_wait_locked(record)
                             if record.cleanup_started:
                                 continue
@@ -856,7 +723,6 @@ class AsyncResultCollector:
                                 record.output_cancel_sent = True
                                 cleanup_operations.append(self._output_request_cancel_operation(driver, request))
                             cleanup_operations.extend(record.adapter.cancel_operations())
-                        self._records.clear()
                         ready = [event for events in self._ready_by_slot.values() for event in events]
                         tokens = list(self._active_output_leases.values())
                         token_keys = {(token.request_id, token.lease_id) for token in tokens}
@@ -866,36 +732,37 @@ class AsyncResultCollector:
                             if token is not None and (token.request_id, token.lease_id) not in token_keys:
                                 tokens.append(token)
                                 token_keys.add((token.request_id, token.lease_id))
-                        self._active_output_leases.clear()
-                        self._ready_by_slot.clear()
-                        self._capacity_by_slot.clear()
-                        for token in tokens:
-                            token.release_pending = True
-                        cleanup_operations.extend(self._output_token_release_operation(token) for token in tokens)
+                        claimed_tokens = self._claim_output_token_releases_locked(tokens)
+                        cleanup_operations.extend(
+                            self._output_token_release_operation(token) for token in claimed_tokens
+                        )
                         cleanup_slot_ids.update(token.slot_id for token in tokens)
                         self._signal_readiness_change_locked()
-                    if self._thread_started and self._thread.is_alive():
-                        try:
-                            self._loop.call_soon_threadsafe(self._loop.stop)
-                        except RuntimeError as exc:
-                            if self._thread.is_alive():
-                                shutdown_errors.append(exc)
                 if first_shutdown and cleanup_operations:
                     try:
                         self._submit_cleanup_operations(
-                            self._fence_cleanup_operations(cleanup_operations),
+                            cleanup_operations,
                             slot_ids=tuple(cleanup_slot_ids),
                         )
                     except BaseException as exc:
+                        self._restore_output_token_release_claims(claimed_tokens)
                         shutdown_errors.append(exc)
+                if first_shutdown and not shutdown_errors:
+                    with self._cv:
+                        self._records.clear()
+                        self._active_output_leases.clear()
+                        self._ready_by_slot.clear()
+                        self._capacity_by_slot.clear()
+                        stop_now = not self._cleanup_tickets
+                        self._cv.notify_all()
+                    if stop_now and self._thread.is_alive():
+                        self._loop.call_soon_threadsafe(self._loop.stop)
 
-        if self._thread_started and self._thread is not threading.current_thread():
-            self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
-            if self._thread.is_alive():
-                shutdown_errors.append(RuntimeError("Ray UDF stream multiplexer did not terminate"))
-
-        if not self._thread.is_alive():
-            self._stop_cleanup_pools_when_idle()
+        if self._thread is threading.current_thread():
+            if shutdown_errors:
+                details = "; ".join(f"{type(error).__name__}: {error}" for error in shutdown_errors)
+                raise RuntimeError(f"Ray UDF stream shutdown failed: {details}") from shutdown_errors[0]
+            return
 
         with self._cv:
             while True:
@@ -910,8 +777,13 @@ class AsyncResultCollector:
             if pending:
                 shutdown_errors.append(RuntimeError("Ray UDF stream remote cleanup did not terminate"))
             shutdown_errors.extend(self._terminal_cleanup_errors)
-        if not self._thread.is_alive():
-            shutdown_errors.extend(self._join_cleanup_pools(deadline))
+
+        if not pending and self._thread.is_alive():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread_started and self._thread is not threading.current_thread() and not pending:
+            self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            if self._thread.is_alive():
+                shutdown_errors.append(RuntimeError("Ray UDF stream multiplexer did not terminate"))
         if shutdown_errors:
             details = "; ".join(f"{type(error).__name__}: {error}" for error in shutdown_errors)
             raise RuntimeError(f"Ray UDF stream shutdown failed: {details}") from shutdown_errors[0]
@@ -1032,6 +904,7 @@ class AsyncResultCollector:
         for record in self._records.values():
             if (
                 record.terminal
+                or not record.registered
                 or record.slot_id not in admissible_slots
                 or record.phase != "block"
                 or record.next_ref_ready
@@ -1183,13 +1056,13 @@ class AsyncResultCollector:
 
     def _submit_cleanup_operations(
         self,
-        operations: Sequence[Callable[[], Any]],
+        operations: Sequence[RayStreamCleanupOperation],
         *,
         on_each_done: Callable[[BaseException | None], None] | None = None,
         store_error: bool = True,
         slot_ids: Sequence[int] = (),
     ) -> tuple[_CleanupTicket, ...]:
-        """Atomically hand independent operations to bounded worker lanes."""
+        """Atomically transfer operations into the event-loop ticket ledger."""
         actions = tuple(operations)
         if not actions:
             if on_each_done is not None:
@@ -1197,11 +1070,9 @@ class AsyncResultCollector:
             return ()
 
         owner_slots = frozenset(int(slot_id) for slot_id in slot_ids)
-        items_by_pool: dict[_DaemonCleanupPool, list[_CleanupWorkItem]] = defaultdict(list)
         tickets: list[_CleanupTicket] = []
 
         for action in actions:
-            lane = action.lane if isinstance(action, RayStreamCleanupOperation) else RAY_STREAM_CLEANUP_CONTROL
             ticket_holder: list[_CleanupTicket] = []
 
             def complete(
@@ -1234,82 +1105,119 @@ class AsyncResultCollector:
                                     )
                         self._cv.notify_all()
 
-            ticket = _CleanupTicket(on_complete=complete)
+            ticket = _CleanupTicket(
+                operation=action,
+                retry_on_error=action.retry_on_error,
+                retry_on_incomplete=action.retry_on_incomplete,
+                on_complete=complete,
+            )
             ticket_holder.append(ticket)
             tickets.append(ticket)
-            items_by_pool[self._cleanup_pools[lane]].append(
-                _CleanupWorkItem(
-                    action,
-                    ticket,
-                    retry_on_error=(action.retry_on_error if isinstance(action, RayStreamCleanupOperation) else False),
-                    retry_on_incomplete=(
-                        action.retry_on_incomplete if isinstance(action, RayStreamCleanupOperation) else False
-                    ),
-                )
-            )
 
-        pools = tuple(pool for pool in self._cleanup_pools.values() if pool in items_by_pool)
         with self._cleanup_handoff_lock:
-            for pool in pools:
-                pool._cv.acquire()
-            try:
-                for pool in pools:
-                    if not pool._started or pool._stop_when_idle:
-                        raise RuntimeError(f"Ray UDF cleanup pool {pool._name!r} is not accepting work")
-                    pool._ensure_worker_locked()
-                with self._cv:
-                    self._cleanup_tickets.update(tickets)
-                    for slot_id in owner_slots:
-                        self._cleanup_tickets_by_slot[slot_id].update(tickets)
-                    self._cv.notify_all()
-                for pool, items in items_by_pool.items():
-                    pool._enqueue_locked(items)
-            finally:
-                for pool in reversed(pools):
-                    pool._cv.release()
+            with self._cv:
+                if not self._thread_started or not self._thread.is_alive() or self._loop.is_closed():
+                    raise RuntimeError("Ray UDF cleanup event loop is not available")
+            if self._thread is threading.current_thread():
+                self._loop.call_soon(self._start_cleanup_tickets, tuple(tickets))
+            else:
+                self._loop.call_soon_threadsafe(self._start_cleanup_tickets, tuple(tickets))
+            # The scheduled callback first acquires _cleanup_handoff_lock.  Add
+            # ledger ownership before releasing that lock, so it cannot drive
+            # or finish a ticket before the transfer is externally visible.
+            with self._cv:
+                self._cleanup_tickets.update(tickets)
+                for slot_id in owner_slots:
+                    self._cleanup_tickets_by_slot[slot_id].update(tickets)
+                self._cv.notify_all()
         return tuple(tickets)
 
-    def _fence_cleanup_operations(
-        self,
-        operations: Sequence[Callable[[], Any]],
-    ) -> tuple[RayStreamCleanupOperation, ...]:
-        """Delay generator teardown until every earlier scheduler probe exits."""
-        actions = tuple(operations)
-        if not actions:
-            return ()
-        scheduler_safe = threading.Event()
+    def _start_cleanup_tickets(self, tickets: tuple[_CleanupTicket, ...]) -> None:
+        """Start tickets only after their ledger handoff is visible."""
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                active = tuple(ticket for ticket in tickets if ticket in self._cleanup_tickets)
+        for ticket in active:
+            self._drive_cleanup_ticket(ticket)
+
+    @staticmethod
+    def _cleanup_retry_delay(retry_count: int) -> float:
+        exponent = min(max(0, int(retry_count) - 1), 30)
+        return min(
+            math.ldexp(_CLEANUP_RETRY_INITIAL_DELAY_S, exponent),
+            _CLEANUP_RETRY_MAX_DELAY_S,
+        )
+
+    def _retry_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
         with self._cv:
-            needs_turn = self._started and self._thread.is_alive() and self._thread is not threading.current_thread()
-        if needs_turn:
-            try:
-                self._loop.call_soon_threadsafe(scheduler_safe.set)
-            except RuntimeError:
-                if not self._thread.is_alive():
-                    scheduler_safe.set()
-        else:
-            scheduler_safe.set()
+            if ticket not in self._cleanup_tickets:
+                return
+        ticket.retry_count += 1
+        self._loop.call_later(
+            self._cleanup_retry_delay(ticket.retry_count),
+            self._drive_cleanup_ticket,
+            ticket,
+        )
 
-        fenced: list[RayStreamCleanupOperation] = []
-        for action in actions:
-            lane = action.lane if isinstance(action, RayStreamCleanupOperation) else RAY_STREAM_CLEANUP_CONTROL
-            retry_on_error = action.retry_on_error if isinstance(action, RayStreamCleanupOperation) else False
-            retry_on_incomplete = action.retry_on_incomplete if isinstance(action, RayStreamCleanupOperation) else False
+    def _resume_cleanup_ticket(self, ticket: _CleanupTicket, future: Any) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.wait_future is not future:
+                return
+            ticket.wait_future = None
+        self._drive_cleanup_ticket(ticket)
 
-            def run(action: Callable[[], Any] = action) -> Any:
-                while not scheduler_safe.wait(timeout=0.1):
-                    if not self._thread.is_alive():
-                        break
-                return action()
+    def _drive_cleanup_ticket(self, ticket: _CleanupTicket) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.wait_future is not None:
+                return
+        error: BaseException | None = None
+        retry = False
+        try:
+            result = ticket.operation()
+            if all(callable(getattr(result, name, None)) for name in ("add_done_callback", "done", "result")):
+                with self._cv:
+                    if ticket not in self._cleanup_tickets:
+                        return
+                    ticket.wait_future = result
 
-            fenced.append(
-                RayStreamCleanupOperation(
-                    lane,
-                    run,
-                    retry_on_error=retry_on_error,
-                    retry_on_incomplete=retry_on_incomplete,
-                )
-            )
-        return tuple(fenced)
+                def ready(future: Any) -> None:
+                    try:
+                        self._loop.call_soon_threadsafe(
+                            self._resume_cleanup_ticket,
+                            ticket,
+                            future,
+                        )
+                    except RuntimeError as exc:
+                        with self._cv:
+                            if self._thread_error is None:
+                                self._thread_error = exc
+                            self._cv.notify_all()
+
+                try:
+                    result.add_done_callback(ready)
+                except BaseException as exc:
+                    with self._cv:
+                        if ticket.wait_future is result:
+                            ticket.wait_future = None
+                    # Callback registration is part of the required public
+                    # Future contract, not a transient remote operation.
+                    error = exc
+                else:
+                    return
+            retry = result is False and ticket.retry_on_incomplete
+        except BaseException as exc:
+            if ticket.retry_on_error:
+                retry = True
+            else:
+                error = exc
+        if retry:
+            self._retry_cleanup_ticket(ticket)
+            return
+        ticket.finish(error)
+        with self._cv:
+            stop = self._shutdown and not self._cleanup_tickets
+        if stop:
+            self._loop.stop()
 
     def _wait_cleanup_tickets(
         self,
@@ -1348,21 +1256,6 @@ class AsyncResultCollector:
                 raise RuntimeError(timeout_message)
         return tuple(error for ticket in observed for error in ticket.errors)
 
-    def _stop_cleanup_pools_when_idle(self) -> None:
-        with self._cleanup_handoff_lock:
-            if self._cleanup_pools_stopping:
-                return
-            self._cleanup_pools_stopping = True
-            for pool in self._cleanup_pools.values():
-                pool.stop_when_idle()
-
-    def _join_cleanup_pools(self, deadline: float) -> list[BaseException]:
-        errors: list[BaseException] = []
-        for lane, pool in self._cleanup_pools.items():
-            if not pool.join(max(0.0, deadline - time.monotonic())):
-                errors.append(RuntimeError(f"Ray UDF {lane} cleanup workers did not terminate"))
-        return errors
-
     def _run_event_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
         self._loop_ready.set()
@@ -1386,10 +1279,6 @@ class AsyncResultCollector:
             if pending:
                 self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             self._loop.close()
-            with self._cv:
-                shutting_down = self._shutdown
-            if shutting_down:
-                self._stop_cleanup_pools_when_idle()
 
     def _cancel_record_wait_locked(self, record: _StreamRecord) -> None:
         future = record.wait_future
@@ -1404,13 +1293,7 @@ class AsyncResultCollector:
 
     @staticmethod
     def _object_ref_future(ref: Any) -> Any:
-        future_factory = getattr(ref, "future", None)
-        if not callable(future_factory):
-            raise TypeError("Ray UDF control ObjectRef does not expose future()")
-        future = future_factory()
-        if not callable(getattr(future, "add_done_callback", None)):
-            raise TypeError("Ray UDF control ObjectRef future does not support callbacks")
-        return future
+        return ray_object_ref_future(ref)
 
     def _schedule_record_wait_locked(
         self,
@@ -1509,6 +1392,7 @@ class AsyncResultCollector:
         future.add_done_callback(on_done)
 
     def _refresh_waiters(self) -> None:
+        failures: list[tuple[_StreamRecord, BaseException]] = []
         with self._cv:
             if self._shutdown or self._thread_error is not None or not self._started or not self._loop_ready.is_set():
                 return
@@ -1521,101 +1405,107 @@ class AsyncResultCollector:
             )
             pending_data_counts = self._pending_data_counts_locked()
             for record in records:
-                self._schedule_completion_wait_locked(record)
-                if self._schedule_record_wait_locked(
-                    record,
-                    pending_data_count=pending_data_counts.get(record.slot_id, 0),
-                ):
-                    pending_data_counts[record.slot_id] = pending_data_counts.get(record.slot_id, 0) + 1
+                if not record.registered:
+                    continue
+                try:
+                    self._schedule_completion_wait_locked(record)
+                    if self._schedule_record_wait_locked(
+                        record,
+                        pending_data_count=pending_data_counts.get(record.slot_id, 0),
+                    ):
+                        pending_data_counts[record.slot_id] = pending_data_counts.get(record.slot_id, 0) + 1
+                except BaseException as exc:
+                    failures.append((record, exc))
+        for record, exc in failures:
+            self._fail_record(record, exc)
 
     def _complete_producer_wait(self, record: _StreamRecord, future: Any) -> None:
         key = (record.slot_id, record.submit_id)
-        with self._cv:
-            if (
-                self._shutdown
-                or self._records.get(key) is not record
-                or record.terminal
-                or record.completion_future is not future
-            ):
-                return
-            if future is None:
-                return
-        try:
-            future.result()
-            record.producer_completed = True
-            if record.adapter.stream_finished():
-                record.adapter.mark_drained()
-            self._maybe_complete_record(record)
-        except BaseException as exc:
-            # A failed completion ObjectRef means Ray has already made the task
-            # terminal.  Force-cancelling that task can race its normal reply.
-            record.terminal_signal_observed = True
+        with self._cleanup_handoff_lock:
             with self._cv:
-                shutting_down = self._shutdown
-            if not shutting_down:
-                self._fail_record(record, exc)
-        finally:
-            # Keep the completed future installed until its state transition is
-            # fully applied. A concurrent dispatcher capacity refresh calls
-            # _refresh_waiters(); exposing an empty slot earlier can register a
-            # duplicate callback for the same completion ObjectRef.
-            with self._cv:
-                if record.completion_future is future:
-                    record.completion_future = None
-            self._refresh_waiters()
+                if (
+                    self._shutdown
+                    or self._records.get(key) is not record
+                    or record.terminal
+                    or record.completion_future is not future
+                ):
+                    return
+                if future is None:
+                    return
+            try:
+                future.result()
+                record.producer_completed = True
+                if record.adapter.stream_finished():
+                    record.adapter.mark_drained()
+                self._maybe_complete_record(record)
+            except BaseException as exc:
+                # A failed completion ObjectRef means Ray has already made the
+                # task terminal. Force-cancelling it can race its normal reply.
+                record.terminal_signal_observed = True
+                with self._cv:
+                    shutting_down = self._shutdown
+                if not shutting_down:
+                    self._fail_record(record, exc)
+            finally:
+                # Keep the completed future installed until its state transition
+                # is fully applied. A concurrent capacity refresh must not
+                # register a duplicate callback for the completion ObjectRef.
+                with self._cv:
+                    if record.completion_future is future:
+                        record.completion_future = None
+        self._refresh_waiters()
 
     def _complete_record_wait(self, record: _StreamRecord, kind: str, future: Any) -> None:
         key = (record.slot_id, record.submit_id)
-        with self._cv:
-            if (
-                self._shutdown
-                or self._records.get(key) is not record
-                or record.terminal
-                or record.wait_future is not future
-            ):
-                return
-            if future is None:
-                return
-        try:
-            value = future.result()
-            _collector_debug_log(f"ready_{kind}", record)
-            if kind == "data":
-                self._accept_stream_ref(record, value)
-            elif kind == "metadata":
-                record.metadata_ref = None
-                self._accept_metadata(record, value)
-            elif kind == "output_lease":
-                self._finish_output_lease(record, value)
-                self._maybe_complete_record(record)
-            elif kind == "terminal":
-                record.terminal_ref = None
-                self._finish_stream(record)
-            else:
-                raise RuntimeError(f"unknown Ray stream readiness kind {kind!r}")
-        except StopAsyncIteration:
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                if (
+                    self._shutdown
+                    or self._records.get(key) is not record
+                    or record.terminal
+                    or record.wait_future is not future
+                ):
+                    return
+                if future is None:
+                    return
             try:
-                self._finish_stream(record)
+                value = future.result()
+                _collector_debug_log(f"ready_{kind}", record)
+                if kind == "data":
+                    self._accept_stream_ref(record, value)
+                elif kind == "metadata":
+                    record.metadata_ref = None
+                    self._accept_metadata(record, value)
+                elif kind == "output_lease":
+                    self._finish_output_lease(record, value)
+                    self._maybe_complete_record(record)
+                elif kind == "terminal":
+                    record.terminal_ref = None
+                    self._finish_stream(record)
+                else:
+                    raise RuntimeError(f"unknown Ray stream readiness kind {kind!r}")
+            except StopAsyncIteration:
+                try:
+                    self._finish_stream(record)
+                except BaseException as exc:
+                    self._fail_record(record, exc)
             except BaseException as exc:
-                self._fail_record(record, exc)
-        except BaseException as exc:
-            if kind == "terminal":
-                record.terminal_signal_observed = True
-            with self._cv:
-                shutting_down = self._shutdown
-            if not shutting_down:
-                self._fail_record(record, exc)
-        finally:
-            # wait_future is also the transition-in-progress fence. Clearing
-            # it before block/metadata/output state is updated lets a capacity
-            # refresh schedule a second waiter for the same ObjectRef. That
-            # duplicate callback observes the next phase and corrupts the
-            # strict block/metadata pairing.
-            with self._cv:
-                if record.wait_future is future:
-                    record.wait_future = None
-                    record.wait_kind = ""
-                    self._signal_readiness_change_locked()
-            self._refresh_waiters()
+                if kind == "terminal":
+                    record.terminal_signal_observed = True
+                with self._cv:
+                    shutting_down = self._shutdown
+                if not shutting_down:
+                    self._fail_record(record, exc)
+            finally:
+                # wait_future is also the transition-in-progress fence. Clearing
+                # it before block/metadata/output state is updated lets a
+                # capacity refresh corrupt the strict block/metadata pairing.
+                with self._cv:
+                    if record.wait_future is future:
+                        record.wait_future = None
+                        record.wait_kind = ""
+                        self._signal_readiness_change_locked()
+        self._refresh_waiters()
 
     def _accept_stream_ref(self, record: _StreamRecord, next_ref: Any) -> None:
         if record.adapter.is_terminal_ref(next_ref):
@@ -1772,27 +1662,37 @@ class AsyncResultCollector:
             size_bytes=token.size_bytes,
             output_token=token,
         )
-        with self._cv:
-            stale = self._records.get((record.slot_id, record.submit_id)) is not record
-            if not stale:
-                self._active_output_leases[(token.request_id, token.lease_id)] = token
-                self._ready_by_slot[record.slot_id].append(event)
-                record.phase = "block"
-                record.block_ref = None
-                record.metadata = None
-                record.block_item_capacity_bytes = None
-                record.output_request_id = ""
-                record.output_request = None
-                record.output_lease_ref = None
-                record.output_cancel_sent = False
-                self._signal_readiness_change_locked()
-        if stale:
-            token.release_pending = True
-            self._submit_cleanup_operations(
-                (self._output_token_release_operation(token),),
-                slot_ids=(record.slot_id,),
-            )
-            return
+        with self._cleanup_handoff_lock:
+            with self._cv:
+                stale = (
+                    self._shutdown
+                    or record.terminal
+                    or self._records.get((record.slot_id, record.submit_id)) is not record
+                )
+                if not stale:
+                    self._active_output_leases[(token.request_id, token.lease_id)] = token
+                    self._ready_by_slot[record.slot_id].append(event)
+                    record.phase = "block"
+                    record.block_ref = None
+                    record.metadata = None
+                    record.block_item_capacity_bytes = None
+                    record.output_request_id = ""
+                    record.output_request = None
+                    record.output_lease_ref = None
+                    record.output_cancel_sent = False
+                    self._signal_readiness_change_locked()
+                else:
+                    claimed_tokens = self._claim_output_token_releases_locked((token,))
+            if stale:
+                try:
+                    self._submit_cleanup_operations(
+                        tuple(self._output_token_release_operation(item) for item in claimed_tokens),
+                        slot_ids=(record.slot_id,),
+                    )
+                except BaseException:
+                    self._restore_output_token_release_claims(claimed_tokens)
+                    raise
+                return
         _collector_debug_log("output_lease_granted", record)
         self._notify_wakeup()
 
@@ -1807,8 +1707,30 @@ class AsyncResultCollector:
         key = (record.slot_id, record.submit_id)
 
         def finish_retirement(error: BaseException | None) -> None:
-            dropped_tokens: list[_OutputLeaseToken] = []
             with self._cleanup_handoff_lock:
+                with self._cv:
+                    if self._records.get(key) is not record:
+                        if error is not None:
+                            self._terminal_cleanup_errors.append(error)
+                            self._cv.notify_all()
+                        return
+                    dropped_tokens: list[_OutputLeaseToken] = []
+                    if error is not None:
+                        ready = self._ready_by_slot.get(record.slot_id)
+                        if ready is not None:
+                            for queued in ready:
+                                if queued.submit_id == record.submit_id and queued.kind == "data":
+                                    if queued.output_token is not None:
+                                        dropped_tokens.append(queued.output_token)
+                    claimed_tokens = self._claim_output_token_releases_locked(dropped_tokens)
+                try:
+                    self._submit_cleanup_operations(
+                        tuple(self._output_token_release_operation(token) for token in claimed_tokens),
+                        slot_ids=(record.slot_id,),
+                    )
+                except BaseException:
+                    self._restore_output_token_release_claims(claimed_tokens)
+                    raise
                 with self._cv:
                     if self._records.pop(key, None) is not record:
                         if error is not None:
@@ -1820,16 +1742,12 @@ class AsyncResultCollector:
                     else:
                         ready = self._ready_by_slot.get(record.slot_id)
                         if ready is not None:
-                            kept: deque[_ReadyEvent] = deque()
-                            for queued in ready:
-                                if queued.submit_id == record.submit_id and queued.kind == "data":
-                                    if queued.output_token is not None:
-                                        dropped_tokens.append(queued.output_token)
-                                    continue
-                                kept.append(queued)
-                            self._ready_by_slot[record.slot_id] = kept
+                            self._ready_by_slot[record.slot_id] = deque(
+                                queued
+                                for queued in ready
+                                if not (queued.submit_id == record.submit_id and queued.kind == "data")
+                            )
                         for token in dropped_tokens:
-                            token.release_pending = True
                             self._active_output_leases.pop((token.request_id, token.lease_id), None)
                         event = _ReadyEvent(
                             record.slot_id,
@@ -1839,11 +1757,6 @@ class AsyncResultCollector:
                         )
                     self._ready_by_slot[record.slot_id].append(event)
                     self._cv.notify_all()
-                if dropped_tokens:
-                    self._submit_cleanup_operations(
-                        tuple(self._output_token_release_operation(token) for token in dropped_tokens),
-                        slot_ids=(record.slot_id,),
-                    )
             _collector_debug_log("retired" if error is None else "retire_failed", record)
             self._notify_wakeup()
 
@@ -1884,23 +1797,61 @@ class AsyncResultCollector:
         key = (record.slot_id, record.submit_id)
         with self._cleanup_handoff_lock:
             with self._cv:
-                if self._records.pop(key, None) is not record:
+                if self._records.get(key) is not record:
                     return
                 record.terminal = True
+                cleanup_was_started = record.cleanup_started
                 record.cleanup_started = True
                 ready = self._ready_by_slot.get(record.slot_id)
                 dropped_tokens: list[_OutputLeaseToken] = []
                 if ready is not None:
-                    kept: deque[_ReadyEvent] = deque()
                     for event in ready:
                         if event.submit_id == record.submit_id and event.kind == "data":
                             if event.output_token is not None:
                                 dropped_tokens.append(event.output_token)
-                            continue
-                        kept.append(event)
-                    self._ready_by_slot[record.slot_id] = kept
+                claimed_tokens = self._claim_output_token_releases_locked(dropped_tokens)
+                request = record.output_request
+                driver = record.adapter.driver
+                cancel_output_request = request is not None and driver is not None and not record.output_cancel_sent
+                if cancel_output_request:
+                    record.output_cancel_sent = True
+                terminal_signal_observed = record.terminal_signal_observed
+                cleanup_operations: list[RayStreamCleanupOperation] = [
+                    self._output_token_release_operation(token) for token in claimed_tokens
+                ]
+                if cancel_output_request:
+                    cleanup_operations.append(self._output_request_cancel_operation(driver, request))
+                if not cleanup_was_started:
+                    if terminal_signal_observed:
+                        cleanup_operations.extend(record.adapter.retire_failed_operations())
+                    else:
+                        cleanup_operations.extend(record.adapter.cancel_operations())
+                self._signal_readiness_change_locked()
+            try:
+                self._submit_cleanup_operations(
+                    cleanup_operations,
+                    slot_ids=(record.slot_id,),
+                )
+            except BaseException:
+                self._restore_output_token_release_claims(claimed_tokens)
+                with self._cv:
+                    if self._records.get(key) is record:
+                        if not cleanup_was_started:
+                            record.cleanup_started = False
+                        if cancel_output_request:
+                            record.output_cancel_sent = False
+                        self._cv.notify_all()
+                raise
+            with self._cv:
+                if self._records.get(key) is not record:
+                    return
+                self._records.pop(key, None)
+                ready = self._ready_by_slot.get(record.slot_id)
+                if ready is not None:
+                    self._ready_by_slot[record.slot_id] = deque(
+                        event for event in ready if not (event.submit_id == record.submit_id and event.kind == "data")
+                    )
                 for token in dropped_tokens:
-                    token.release_pending = True
                     self._active_output_leases.pop((token.request_id, token.lease_id), None)
                 self._ready_by_slot[record.slot_id].append(
                     _ReadyEvent(
@@ -1910,26 +1861,9 @@ class AsyncResultCollector:
                         f"{type(exc).__name__}: {exc}",
                     )
                 )
-                request = record.output_request
-                driver = record.adapter.driver
-                record.output_cancel_sent = request is not None and driver is not None
-                terminal_signal_observed = record.terminal_signal_observed
-                cleanup_operations: list[Callable[[], Any]] = [
-                    self._output_token_release_operation(token) for token in dropped_tokens
-                ]
-                if request is not None and driver is not None:
-                    cleanup_operations.append(self._output_request_cancel_operation(driver, request))
-                if terminal_signal_observed:
-                    cleanup_operations.extend(record.adapter.retire_failed_operations())
-                else:
-                    cleanup_operations.extend(record.adapter.cancel_operations())
                 self._signal_readiness_change_locked()
-            self._submit_cleanup_operations(
-                cleanup_operations,
-                slot_ids=(record.slot_id,),
-            )
 
-        # The entire terminal plan has a durable bounded-lane owner before an
+        # The complete terminal plan has a durable ticket owner before an
         # arbitrary dispatcher callback can reenter shutdown.
         self._notify_wakeup()
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import heapq
 import os
-import queue
 import threading
 import time
 import uuid
@@ -13,6 +12,7 @@ import weakref
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
+from duckdb.execution.ray_control_submission import submit_ray_control
 from duckdb.execution.ray_stream_adapter import (
     ray_object_ref_future,
     validate_ray_control_ack,
@@ -28,7 +28,6 @@ _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
-_TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS = 4
 
 
 class _ScheduledCall:
@@ -48,33 +47,16 @@ class _ScheduledCall:
 
 
 class _TaskAdmissionCancellationScheduler:
-    """Process-wide deadlines plus bounded Ray control submission workers."""
+    """Process-wide deadline scheduler for every admission cancellation."""
 
     def __init__(self) -> None:
         self._cv = threading.Condition()
         self._queue: list[tuple[float, int, _ScheduledCall]] = []
         self._next_sequence = 0
         self._thread: threading.Thread | None = None
-        self._submission_lock = threading.Lock()
-        self._submission_queue: queue.SimpleQueue[Callable[[], None]] = queue.SimpleQueue()
-        self._submission_threads: list[threading.Thread] = []
 
     def create(self, callback: Callable[[], None]) -> _ScheduledCall:
         return _ScheduledCall(self, callback)
-
-    def submit(self, callback: Callable[[], None]) -> None:
-        """Run a potentially blocking Ray submission on the bounded worker set."""
-        with self._submission_lock:
-            while len(self._submission_threads) < _TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS:
-                index = len(self._submission_threads)
-                thread = threading.Thread(
-                    target=self._run_submission_worker,
-                    daemon=True,
-                    name=f"vane-task-admission-submit-{index}",
-                )
-                thread.start()
-                self._submission_threads.append(thread)
-        self._submission_queue.put(callback)
 
     def schedule(self, call: _ScheduledCall, delay_s: float) -> None:
         with self._cv:
@@ -135,16 +117,6 @@ class _TaskAdmissionCancellationScheduler:
                     # Cancellation methods own their retry/error policy. One
                     # malformed callback must not terminate the shared clock.
                     pass
-
-    def _run_submission_worker(self) -> None:
-        while True:
-            callback = self._submission_queue.get()
-            try:
-                callback()
-            except BaseException:
-                # Cancellation submissions own their retry/error policy. Keep
-                # one malformed callback from reducing the fixed worker set.
-                pass
 
 
 _TASK_ADMISSION_CANCELLATION_SCHEDULER = _TaskAdmissionCancellationScheduler()
@@ -230,7 +202,7 @@ class _TaskAdmissionCancellation:
                 return
             self._submitting = True
         try:
-            _TASK_ADMISSION_CANCELLATION_SCHEDULER.submit(self._submit)
+            submit_ray_control(self._submit)
         except BaseException:
             with self._lock:
                 self._submitting = False
@@ -384,7 +356,7 @@ class _TaskAdmissionCancellation:
 
 
 class TaskAdmissionController:
-    """One-lookahead, non-blocking query task-lease admission."""
+    """One-lookahead query task admission that never blocks its dispatcher."""
 
     def __init__(self, payload: dict[str, Any], *, driver: Any) -> None:
         self._payload = dict(payload)
@@ -402,6 +374,7 @@ class TaskAdmissionController:
         self._state = "idle"
         self._request_id = ""
         self._retained_input_bytes = 0
+        self._request_submit_future: Any | None = None
         self._request_ref: Any | None = None
         self._ready_lease: dict[str, Any] | None = None
         self._cancellation: _TaskAdmissionCancellation | None = None
@@ -449,35 +422,144 @@ class TaskAdmissionController:
             )
             self._cancellation = cancellation
         request_id = str(request["request_id"])
+        driver = self._driver_actor()
+        submitted_request = {
+            **request,
+            "resources": dict(request["resources"]),
+        }
         try:
-            request_ref = self._driver_actor().acquire_query_task_lease.remote(request)
-            future = ray_object_ref_future(request_ref)
-            with self._lock:
-                if self._state == "requested" and self._request_id == request_id:
-                    self._request_ref = request_ref
-            controller_ref = weakref.ref(self)
-
-            def finish(done: Any) -> None:
-                controller = controller_ref()
-                if controller is None:
-                    cancellation.start()
-                    return
-                controller._finish_request(
-                    request_id,
-                    cancellation,
-                    done,
-                )
-
-            future.add_done_callback(finish)
+            submission = submit_ray_control(
+                lambda: driver.acquire_query_task_lease.remote(submitted_request),
+            )
         except BaseException as exc:
             with self._lock:
                 if self._state == "requested" and self._request_id == request_id:
+                    self._state = "failed"
+                    self._error = exc
+                    wakeup = self._wakeup
+                else:
+                    wakeup = None
+            cancellation.start()
+            if wakeup is not None:
+                wakeup()
+            raise
+        with self._lock:
+            publish = self._state == "requested" and self._request_id == request_id
+            if publish:
+                self._request_submit_future = submission
+        if not publish:
+            submission.cancel()
+            cancellation.start()
+            return True
+
+        controller_ref = weakref.ref(self)
+
+        def finish_submission(done: Any) -> None:
+            controller = controller_ref()
+            if controller is None:
+                cancellation.start()
+                return
+            controller._finish_request_submission(
+                request_id,
+                cancellation,
+                done,
+            )
+
+        try:
+            submission.add_done_callback(finish_submission)
+        except BaseException as exc:
+            submission.cancel()
+            with self._lock:
+                if (
+                    self._state == "requested"
+                    and self._request_id == request_id
+                    and self._request_submit_future is submission
+                ):
+                    self._request_submit_future = None
+                    self._state = "failed"
+                    self._error = exc
+                    wakeup = self._wakeup
+                else:
+                    wakeup = None
+            cancellation.start()
+            if wakeup is not None:
+                wakeup()
+            raise
+        return True
+
+    def _finish_request_submission(
+        self,
+        request_id: str,
+        cancellation: _TaskAdmissionCancellation,
+        submission: Any,
+    ) -> None:
+        try:
+            request_ref = submission.result()
+            future = ray_object_ref_future(request_ref)
+        except BaseException as exc:
+            with self._lock:
+                active = (
+                    self._state == "requested"
+                    and self._request_id == request_id
+                    and self._request_submit_future is submission
+                )
+                if self._request_submit_future is submission:
+                    self._request_submit_future = None
+                if active:
+                    self._state = "failed"
+                    self._error = exc
+                    wakeup = self._wakeup
+                else:
+                    wakeup = None
+            cancellation.start()
+            if wakeup is not None:
+                wakeup()
+            return
+
+        with self._lock:
+            active = (
+                self._state == "requested"
+                and self._request_id == request_id
+                and self._request_submit_future is submission
+            )
+            if self._request_submit_future is submission:
+                self._request_submit_future = None
+            if active:
+                self._request_ref = request_ref
+        if not active:
+            cancellation.start()
+            return
+
+        controller_ref = weakref.ref(self)
+
+        def finish(done: Any) -> None:
+            controller = controller_ref()
+            if controller is None:
+                cancellation.start()
+                return
+            controller._finish_request(
+                request_id,
+                cancellation,
+                done,
+            )
+
+        try:
+            future.add_done_callback(finish)
+        except BaseException as exc:
+            with self._lock:
+                active = (
+                    self._state == "requested" and self._request_id == request_id and self._request_ref is request_ref
+                )
+                if active:
                     self._request_ref = None
                     self._state = "failed"
                     self._error = exc
+                    wakeup = self._wakeup
+                else:
+                    wakeup = None
             cancellation.start()
-            raise
-        return True
+            if wakeup is not None:
+                wakeup()
 
     def _finish_request(
         self,
@@ -569,17 +651,22 @@ class TaskAdmissionController:
 
     def close(self) -> None:
         cancellation: _TaskAdmissionCancellation | None = None
+        submission: Any | None = None
         with self._lock:
             if self._state == "closed" and self._cancellation is None:
                 return
             cancellation = self._cancellation
+            submission = self._request_submit_future
             self._state = "closed"
             self._request_id = ""
             self._retained_input_bytes = 0
+            self._request_submit_future = None
             self._request_ref = None
             self._ready_lease = None
             self._cancellation = None
             self._wakeup = None
+        if submission is not None:
+            submission.cancel()
         if cancellation is not None:
             cancellation.start()
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -6,9 +6,14 @@ from __future__ import annotations
 import os
 import threading
 import uuid
+import weakref
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
+from duckdb.execution.ray_stream_adapter import (
+    ray_object_ref_future,
+    validate_ray_control_ack,
+)
 from duckdb.execution.udf_admission import (
     AdmissionExecutorMixin,
     AdmissionLease,
@@ -16,6 +21,9 @@ from duckdb.execution.udf_admission import (
 
 _DEFAULT_RAY_TASK_HEAP_BYTES = 2 * 1024**3
 _DEFAULT_RAY_ACTOR_HEAP_BYTES = 4 * 1024**3
+_TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
+_TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
+_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 
 
 def _positive_int(value: Any, name: str) -> int:
@@ -58,6 +66,161 @@ def ray_udf_task_resource_spec(payload: dict[str, Any]) -> dict[str, Any]:
 TaskAdmission: TypeAlias = AdmissionLease
 
 
+class _TaskAdmissionCancellation:
+    """Durably drive one pre-submission lease cancellation to acknowledgement."""
+
+    def __init__(self, *, driver: Any, request: dict[str, Any]) -> None:
+        self._driver = driver
+        self._request = {
+            **request,
+            "resources": dict(request["resources"]),
+        }
+        self._lock = threading.Lock()
+        self._response_future: Any | None = None
+        self._response_watchdog: threading.Timer | None = None
+        self._retry_timer: threading.Timer | None = None
+        self._submitting = False
+        self._retry_count = 0
+        self._done = False
+
+    @staticmethod
+    def _retry_delay(retry_count: int) -> float:
+        exponent = min(max(0, int(retry_count) - 1), 30)
+        return min(
+            _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S * (2**exponent),
+            _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S,
+        )
+
+    def start(self) -> None:
+        """Start once; callbacks and bounded timers retain cancellation ownership."""
+        with self._lock:
+            if self._done or self._submitting or self._response_future is not None or self._retry_timer is not None:
+                return
+            self._submitting = True
+        try:
+            response_ref = self._driver.cancel_query_task_lease_request.remote(
+                dict(self._request),
+            )
+            response_future = ray_object_ref_future(response_ref)
+        except BaseException:
+            with self._lock:
+                self._submitting = False
+            self._schedule_retry()
+            return
+        watchdog = threading.Timer(
+            _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S,
+            self._response_timed_out,
+            args=(response_future,),
+        )
+        watchdog.daemon = True
+        discard_response = False
+        with self._lock:
+            self._submitting = False
+            if self._done:
+                discard_response = True
+            else:
+                self._response_future = response_future
+                self._response_watchdog = watchdog
+        if discard_response:
+            try:
+                response_future.cancel()
+            except BaseException:
+                pass
+            return
+        owner_ref = weakref.ref(self)
+
+        def finish(done: Any) -> None:
+            owner = owner_ref()
+            if owner is not None:
+                owner._finish(done)
+
+        try:
+            response_future.add_done_callback(finish)
+        except BaseException:
+            with self._lock:
+                if self._response_future is response_future:
+                    self._response_future = None
+                    self._response_watchdog = None
+            watchdog.cancel()
+            self._schedule_retry()
+            return
+        with self._lock:
+            start_watchdog = (
+                not self._done and self._response_future is response_future and self._response_watchdog is watchdog
+            )
+        if start_watchdog:
+            watchdog.start()
+
+    def _finish(self, response_future: Any) -> None:
+        try:
+            validate_ray_control_ack(
+                response_future.result(),
+                field="cancelled",
+            )
+        except BaseException:
+            with self._lock:
+                if self._done or self._response_future is not response_future:
+                    return
+                self._response_future = None
+                watchdog = self._response_watchdog
+                self._response_watchdog = None
+            if watchdog is not None:
+                watchdog.cancel()
+            self._schedule_retry()
+            return
+        with self._lock:
+            if self._done:
+                return
+            # A late acknowledgement from a timed-out attempt is still a valid
+            # proof for this idempotent cancellation request.
+            self._done = True
+            current_response = self._response_future
+            self._response_future = None
+            watchdog = self._response_watchdog
+            self._response_watchdog = None
+            retry_timer = self._retry_timer
+            self._retry_timer = None
+        if current_response is not None and current_response is not response_future:
+            try:
+                current_response.cancel()
+            except BaseException:
+                pass
+        if watchdog is not None:
+            watchdog.cancel()
+        if retry_timer is not None:
+            retry_timer.cancel()
+
+    def _response_timed_out(self, response_future: Any) -> None:
+        with self._lock:
+            if self._done or self._response_future is not response_future:
+                return
+            self._response_future = None
+            self._response_watchdog = None
+        try:
+            response_future.cancel()
+        except BaseException:
+            pass
+        self._schedule_retry()
+
+    def _schedule_retry(self) -> None:
+        with self._lock:
+            if self._done or self._submitting or self._response_future is not None or self._retry_timer is not None:
+                return
+            self._retry_count += 1
+            timer = threading.Timer(
+                self._retry_delay(self._retry_count),
+                self._retry,
+            )
+            timer.daemon = True
+            self._retry_timer = timer
+        timer.start()
+
+    def _retry(self) -> None:
+        with self._lock:
+            self._retry_timer = None
+        self.start()
+
+
 class TaskAdmissionController:
     """One-lookahead, non-blocking query task-lease admission."""
 
@@ -79,6 +242,7 @@ class TaskAdmissionController:
         self._retained_input_bytes = 0
         self._request_ref: Any | None = None
         self._ready_lease: dict[str, Any] | None = None
+        self._cancellation: _TaskAdmissionCancellation | None = None
         self._error: BaseException | None = None
         self._wakeup: Callable[[], None] | None = None
 
@@ -117,37 +281,51 @@ class TaskAdmissionController:
             self._state = "requested"
             self._request_id = str(request["request_id"])
             self._retained_input_bytes = retained
+            cancellation = _TaskAdmissionCancellation(
+                driver=self._driver_actor(),
+                request=request,
+            )
+            self._cancellation = cancellation
         request_id = str(request["request_id"])
         try:
             request_ref = self._driver_actor().acquire_query_task_lease.remote(request)
-            future = request_ref.future()
+            future = ray_object_ref_future(request_ref)
             with self._lock:
                 if self._state == "requested" and self._request_id == request_id:
                     self._request_ref = request_ref
-            future.add_done_callback(
-                lambda done, request_id=request_id: self._finish_request(
+            controller_ref = weakref.ref(self)
+
+            def finish(done: Any) -> None:
+                controller = controller_ref()
+                if controller is None:
+                    cancellation.start()
+                    return
+                controller._finish_request(
                     request_id,
+                    cancellation,
                     done,
                 )
-            )
+
+            future.add_done_callback(finish)
         except BaseException as exc:
             with self._lock:
                 if self._state == "requested" and self._request_id == request_id:
                     self._request_ref = None
                     self._state = "failed"
                     self._error = exc
-            try:
-                self._driver_actor().cancel_query_task_lease_request.remote(request_id)
-            except BaseException as cleanup_error:
-                add_note = getattr(exc, "add_note", None)
-                if callable(add_note):
-                    add_note(f"task admission setup cleanup failed: {type(cleanup_error).__name__}: {cleanup_error}")
+            cancellation.start()
             raise
         return True
 
-    def _finish_request(self, request_id: str, future: Any) -> None:
+    def _finish_request(
+        self,
+        request_id: str,
+        cancellation: _TaskAdmissionCancellation,
+        future: Any,
+    ) -> None:
         wakeup: Callable[[], None] | None = None
         abandon = False
+        cancel = False
         try:
             grant = future.result()
             if not isinstance(grant, dict) or not grant.get("granted"):
@@ -172,9 +350,11 @@ class TaskAdmissionController:
                 self._state = "failed"
                 self._error = exc
                 wakeup = self._wakeup
+                cancel = True
         if abandon:
-            self._driver_actor().cancel_query_task_lease_request.remote(request_id)
-            return
+            cancellation.start()
+        elif cancel:
+            cancellation.start()
         if wakeup is not None:
             wakeup()
 
@@ -191,17 +371,21 @@ class TaskAdmissionController:
                 )
             driver = self._driver_actor()
             request_id = self._request_id
+            cancellation = self._cancellation
+            if cancellation is None:
+                raise RuntimeError("task admission is missing cancellation ownership")
             admission = TaskAdmission(
                 driver=driver,
                 request_id=request_id,
                 retained_input_bytes=self._retained_input_bytes,
                 lease=dict(self._ready_lease),
-                _release_callback=lambda: driver.cancel_query_task_lease_request.remote(request_id),
+                _release_callback=cancellation.start,
             )
             self._state = "idle"
             self._request_id = ""
             self._retained_input_bytes = 0
             self._ready_lease = None
+            self._cancellation = None
             return admission
 
     def state(self) -> dict[str, Any]:
@@ -222,20 +406,20 @@ class TaskAdmissionController:
         raise RuntimeError(f"task admission failed: {self._error}") from self._error
 
     def close(self) -> None:
-        request_id = ""
+        cancellation: _TaskAdmissionCancellation | None = None
         with self._lock:
-            if self._state == "closed":
+            if self._state == "closed" and self._cancellation is None:
                 return
-            if self._state in {"requested", "ready"}:
-                request_id = self._request_id
+            cancellation = self._cancellation
             self._state = "closed"
             self._request_id = ""
             self._retained_input_bytes = 0
             self._request_ref = None
             self._ready_lease = None
+            self._cancellation = None
             self._wakeup = None
-        if request_id:
-            self._driver_actor().cancel_query_task_lease_request.remote(request_id)
+        if cancellation is not None:
+            cancellation.start()
 
 
 class TaskAdmissionExecutorMixin(AdmissionExecutorMixin):

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -411,7 +411,6 @@ class TaskAdmissionController:
         self._resources = ray_udf_task_resource_spec(self._payload)
         self._driver = driver
         self._executor_id = uuid.uuid4().hex
-        self._submission_scope = f"udf-executor:{self._executor_id}"
         self._sequence = 0
         self._lock = threading.Lock()
         self._state = "idle"
@@ -446,6 +445,13 @@ class TaskAdmissionController:
             "query_generation_capability": self._query_generation_capability,
         }
 
+    @staticmethod
+    def _submission_scope_for_request(request_id: str) -> str:
+        request_key = str(request_id or "").strip()
+        if not request_key:
+            raise ValueError("Ray task admission submission scope requires a request identity")
+        return f"udf-stream:{request_key}"
+
     def request(self, retained_input_bytes: int) -> bool:
         retained = int(retained_input_bytes)
         if retained < 0:
@@ -460,10 +466,11 @@ class TaskAdmissionController:
             self._state = "requested"
             self._request_id = str(request["request_id"])
             self._retained_input_bytes = retained
+            submission_scope = self._submission_scope_for_request(self._request_id)
             cancellation = _TaskAdmissionCancellation(
                 driver=self._driver_actor(),
                 request=request,
-                submission_scope=self._submission_scope,
+                submission_scope=submission_scope,
             )
             self._cancellation = cancellation
         request_id = str(request["request_id"])
@@ -474,7 +481,7 @@ class TaskAdmissionController:
         }
         try:
             submission = submit_ray_control(
-                self._submission_scope,
+                submission_scope,
                 lambda: driver.acquire_query_task_lease.remote(submitted_request),
             )
         except BaseException as exc:
@@ -671,7 +678,7 @@ class TaskAdmissionController:
                 request_id=request_id,
                 retained_input_bytes=self._retained_input_bytes,
                 lease=dict(self._ready_lease),
-                submission_scope=self._submission_scope,
+                submission_scope=self._submission_scope_for_request(request_id),
                 _release_callback=cancellation.start,
             )
             self._state = "idle"

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -113,14 +113,10 @@ class _TaskAdmissionCancellation:
             args=(response_future,),
         )
         watchdog.daemon = True
-        discard_response = False
-        with self._lock:
-            self._submitting = False
-            if self._done:
-                discard_response = True
-            else:
-                self._response_future = response_future
-                self._response_watchdog = watchdog
+        discard_response = self._publish_response_future(
+            response_future,
+            watchdog,
+        )
         if discard_response:
             try:
                 response_future.cancel()
@@ -150,6 +146,20 @@ class _TaskAdmissionCancellation:
             )
         if start_watchdog:
             watchdog.start()
+
+    def _publish_response_future(
+        self,
+        response_future: Any,
+        watchdog: threading.Timer,
+    ) -> bool:
+        """Publish a response unless a concurrent acknowledgement finished."""
+        with self._lock:
+            self._submitting = False
+            if self._done:
+                return True
+            self._response_future = response_future
+            self._response_watchdog = watchdog
+            return False
 
     def _finish(self, response_future: Any) -> None:
         try:
@@ -197,7 +207,9 @@ class _TaskAdmissionCancellation:
             self._response_future = None
             self._response_watchdog = None
         try:
-            response_future.cancel()
+            cancel = getattr(response_future, "cancel", None)
+            if callable(cancel):
+                cancel()
         except BaseException:
             pass
         self._schedule_retry()

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -231,9 +231,31 @@ class _TaskAdmissionCancellation:
                 return
             self._submitting = True
         try:
-            submit_ray_control(self._submission_scope, self._submit)
+            submission_future = submit_ray_control(
+                self._submission_scope,
+                self._submit,
+            )
         except BaseException:
             with self._lock:
+                self._submitting = False
+            self._schedule_retry()
+            return
+        try:
+            submission_future.add_done_callback(self._finish_submission)
+        except BaseException:
+            submission_future.cancel()
+            with self._lock:
+                self._submitting = False
+            self._schedule_retry()
+
+    def _finish_submission(self, submission_future: Any) -> None:
+        """Retry if admitted control work is rejected before invocation."""
+        try:
+            submission_future.result()
+        except BaseException:
+            with self._lock:
+                if self._done or not self._submitting:
+                    return
                 self._submitting = False
             self._schedule_retry()
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -15,7 +15,10 @@ from duckdb.execution.ray_control_deadline import (
     RAY_CONTROL_DEADLINE_SCHEDULER,
     RayControlScheduledCall,
 )
-from duckdb.execution.ray_control_submission import submit_ray_control
+from duckdb.execution.ray_control_submission import (
+    create_ray_control_deadline,
+    submit_ray_control,
+)
 from duckdb.execution.ray_stream_adapter import (
     ray_object_ref_future,
     validate_ray_control_ack,
@@ -171,7 +174,8 @@ class _TaskAdmissionCancellation:
                 self._submitting = False
             self._schedule_retry()
             return
-        response_deadline = RAY_CONTROL_DEADLINE_SCHEDULER.create(
+        response_deadline = create_ray_control_deadline(
+            f"{self._submission_scope}:response-timeout",
             lambda: self._response_timed_out(response_future),
         )
         discard_response = self._publish_response_future(
@@ -272,13 +276,15 @@ class _TaskAdmissionCancellation:
                 return
             self._response_future = None
             self._response_deadline = None
+        # Publish the next owner before best-effort cancellation. Future.cancel
+        # invokes completion callbacks inline and may never return.
+        self._schedule_retry()
         try:
             cancel = getattr(response_future, "cancel", None)
             if callable(cancel):
                 cancel()
         except BaseException:
             pass
-        self._schedule_retry()
 
     def _schedule_retry(self) -> None:
         with self._lock:
@@ -290,7 +296,10 @@ class _TaskAdmissionCancellation:
             def retry() -> None:
                 self._retry(retry_call)
 
-            retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(retry)
+            retry_call = create_ray_control_deadline(
+                f"{self._submission_scope}:retry",
+                retry,
+            )
             self._retry_call = retry_call
             retry_delay = self._retry_delay(self._retry_count)
         RAY_CONTROL_DEADLINE_SCHEDULER.schedule(

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -387,7 +387,13 @@ class _TaskAdmissionCancellation:
 class TaskAdmissionController:
     """One-lookahead query task admission that never blocks its dispatcher."""
 
-    def __init__(self, payload: dict[str, Any], *, driver: Any) -> None:
+    def __init__(
+        self,
+        payload: dict[str, Any],
+        *,
+        driver: Any,
+        query_generation_capability: str,
+    ) -> None:
         self._payload = dict(payload)
         self._query_id = str(self._payload.get("query_id") or "").strip()
         self._stage_id = str(self._payload.get("stage_id") or "").strip()
@@ -395,6 +401,9 @@ class TaskAdmissionController:
             raise ValueError("distributed Ray UDF task admission requires query_id and stage_id")
         if driver is None:
             raise ValueError("distributed Ray UDF task admission requires an explicit query driver handle")
+        self._query_generation_capability = str(query_generation_capability or "").strip()
+        if not self._query_generation_capability:
+            raise ValueError("distributed Ray UDF task admission requires a query generation capability")
         # The cancellation deadline owner must exist before this controller can
         # submit any remote lease request.  Startup failure is therefore a
         # pre-submit construction error, never a post-submit ownership gap.
@@ -434,6 +443,7 @@ class TaskAdmissionController:
             "node_id": None,
             "retained_input_bytes": retained_input_bytes,
             "resources": dict(self._resources),
+            "query_generation_capability": self._query_generation_capability,
         }
 
     def request(self, retained_input_bytes: int) -> bool:
@@ -472,10 +482,12 @@ class TaskAdmissionController:
                 if self._state == "requested" and self._request_id == request_id:
                     self._state = "failed"
                     self._error = exc
+                    self._cancellation = None
                     wakeup = self._wakeup
                 else:
                     wakeup = None
-            cancellation.start()
+            # submit_ray_control rejects atomically, so this request never
+            # crossed the remote boundary and owns nothing to cancel.
             if wakeup is not None:
                 wakeup()
             raise
@@ -716,8 +728,13 @@ class TaskAdmissionExecutorMixin(AdmissionExecutorMixin):
         payload: dict[str, Any],
         *,
         driver: Any,
+        query_generation_capability: str,
     ) -> None:
-        authority = TaskAdmissionController(payload, driver=driver)
+        authority = TaskAdmissionController(
+            payload,
+            driver=driver,
+            query_generation_capability=query_generation_capability,
+        )
         self._task_admission = authority
         self._initialize_admission(authority)
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -146,7 +146,6 @@ class _TaskAdmissionCancellation:
         try:
             submission_future.add_done_callback(self._finish_submission)
         except BaseException:
-            submission_future.cancel()
             with self._lock:
                 self._submitting = False
             self._schedule_retry()
@@ -183,10 +182,6 @@ class _TaskAdmissionCancellation:
             response_deadline,
         )
         if discard_response:
-            try:
-                response_future.cancel()
-            except BaseException:
-                pass
             return
         owner_ref = weakref.ref(self)
 
@@ -254,17 +249,11 @@ class _TaskAdmissionCancellation:
             # A late acknowledgement from a timed-out attempt is still a valid
             # proof for this idempotent cancellation request.
             self._done = True
-            current_response = self._response_future
             self._response_future = None
             response_deadline = self._response_deadline
             self._response_deadline = None
             retry_call = self._retry_call
             self._retry_call = None
-        if current_response is not None and current_response is not response_future:
-            try:
-                current_response.cancel()
-            except BaseException:
-                pass
         if response_deadline is not None:
             response_deadline.cancel()
         if retry_call is not None:
@@ -276,15 +265,9 @@ class _TaskAdmissionCancellation:
                 return
             self._response_future = None
             self._response_deadline = None
-        # Publish the next owner before best-effort cancellation. Future.cancel
-        # invokes completion callbacks inline and may never return.
+        # The idempotent retry supersedes this local response observer. Do not
+        # call Future.cancel(): arbitrary completion callbacks execute inline.
         self._schedule_retry()
-        try:
-            cancel = getattr(response_future, "cancel", None)
-            if callable(cancel):
-                cancel()
-        except BaseException:
-            pass
 
     def _schedule_retry(self) -> None:
         with self._lock:
@@ -434,7 +417,6 @@ class TaskAdmissionController:
             if publish:
                 self._request_submit_future = submission
         if not publish:
-            submission.cancel()
             cancellation.start()
             return True
 
@@ -454,7 +436,6 @@ class TaskAdmissionController:
         try:
             submission.add_done_callback(finish_submission)
         except BaseException as exc:
-            submission.cancel()
             with self._lock:
                 if (
                     self._state == "requested"
@@ -638,12 +619,10 @@ class TaskAdmissionController:
 
     def close(self) -> None:
         cancellation: _TaskAdmissionCancellation | None = None
-        submission: Any | None = None
         with self._lock:
             if self._state == "closed" and self._cancellation is None:
                 return
             cancellation = self._cancellation
-            submission = self._request_submit_future
             self._state = "closed"
             self._request_id = ""
             self._retained_input_bytes = 0
@@ -652,8 +631,6 @@ class TaskAdmissionController:
             self._ready_lease = None
             self._cancellation = None
             self._wakeup = None
-        if submission is not None:
-            submission.cancel()
         if cancellation is not None:
             cancellation.start()
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import heapq
 import os
 import threading
+import time
 import uuid
 import weakref
 from collections.abc import Callable
@@ -25,6 +27,98 @@ _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
+
+
+class _ScheduledCall:
+    """One cancellable deadline owned by the shared cleanup scheduler."""
+
+    def __init__(
+        self,
+        scheduler: _TaskAdmissionCancellationScheduler,
+        callback: Callable[[], None],
+    ) -> None:
+        self._scheduler = scheduler
+        self._callback: Callable[[], None] | None = callback
+        self._scheduled = False
+
+    def cancel(self) -> None:
+        self._scheduler.cancel(self)
+
+
+class _TaskAdmissionCancellationScheduler:
+    """Process-wide deadline scheduler for every admission cancellation."""
+
+    def __init__(self) -> None:
+        self._cv = threading.Condition()
+        self._queue: list[tuple[float, int, _ScheduledCall]] = []
+        self._next_sequence = 0
+        self._thread: threading.Thread | None = None
+
+    def create(self, callback: Callable[[], None]) -> _ScheduledCall:
+        return _ScheduledCall(self, callback)
+
+    def schedule(self, call: _ScheduledCall, delay_s: float) -> None:
+        with self._cv:
+            if call._scheduler is not self:
+                raise RuntimeError("scheduled call belongs to a different scheduler")
+            if call._callback is None:
+                return
+            if call._scheduled:
+                raise RuntimeError("scheduled call is already armed")
+            call._scheduled = True
+            self._next_sequence += 1
+            heapq.heappush(
+                self._queue,
+                (
+                    time.monotonic() + max(0.0, float(delay_s)),
+                    self._next_sequence,
+                    call,
+                ),
+            )
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run,
+                    daemon=True,
+                    name="vane-task-admission-cleanup",
+                )
+                self._thread.start()
+            self._cv.notify()
+
+    def cancel(self, call: _ScheduledCall) -> None:
+        with self._cv:
+            if call._scheduler is not self:
+                raise RuntimeError("scheduled call belongs to a different scheduler")
+            call._callback = None
+            self._cv.notify()
+
+    def _run(self) -> None:
+        while True:
+            callback: Callable[[], None] | None = None
+            with self._cv:
+                while callback is None:
+                    while self._queue and self._queue[0][2]._callback is None:
+                        heapq.heappop(self._queue)
+                    if not self._queue:
+                        self._cv.wait()
+                        continue
+                    deadline, _sequence, call = self._queue[0]
+                    remaining = deadline - time.monotonic()
+                    if remaining > 0:
+                        self._cv.wait(timeout=remaining)
+                        continue
+                    heapq.heappop(self._queue)
+                    callback = call._callback
+                    call._callback = None
+            if callback is not None:
+                try:
+                    callback()
+                except BaseException:
+                    # Cancellation methods own their retry/error policy. One
+                    # malformed callback must not terminate the shared clock.
+                    pass
+
+
+_TASK_ADMISSION_CANCELLATION_SCHEDULER = _TaskAdmissionCancellationScheduler()
 
 
 def _positive_int(value: Any, name: str) -> int:
@@ -78,8 +172,8 @@ class _TaskAdmissionCancellation:
         }
         self._lock = threading.Lock()
         self._response_future: Any | None = None
-        self._response_watchdog: threading.Timer | None = None
-        self._retry_timer: threading.Timer | None = None
+        self._response_deadline: _ScheduledCall | None = None
+        self._retry_call: _ScheduledCall | None = None
         self._submitting = False
         self._retry_count = 0
         self._done = False
@@ -101,9 +195,9 @@ class _TaskAdmissionCancellation:
         )
 
     def start(self) -> None:
-        """Start once; callbacks and bounded timers retain cancellation ownership."""
+        """Start once; callbacks and shared deadlines retain cleanup ownership."""
         with self._lock:
-            if self._done or self._submitting or self._response_future is not None or self._retry_timer is not None:
+            if self._done or self._submitting or self._response_future is not None or self._retry_call is not None:
                 return
             self._submitting = True
         try:
@@ -116,15 +210,12 @@ class _TaskAdmissionCancellation:
                 self._submitting = False
             self._schedule_retry()
             return
-        watchdog = threading.Timer(
-            self._response_timeout(self._retry_count),
-            self._response_timed_out,
-            args=(response_future,),
+        response_deadline = _TASK_ADMISSION_CANCELLATION_SCHEDULER.create(
+            lambda: self._response_timed_out(response_future),
         )
-        watchdog.daemon = True
         discard_response = self._publish_response_future(
             response_future,
-            watchdog,
+            response_deadline,
         )
         if discard_response:
             try:
@@ -145,21 +236,26 @@ class _TaskAdmissionCancellation:
             with self._lock:
                 if self._response_future is response_future:
                     self._response_future = None
-                    self._response_watchdog = None
-            watchdog.cancel()
+                    self._response_deadline = None
+            response_deadline.cancel()
             self._schedule_retry()
             return
         with self._lock:
-            start_watchdog = (
-                not self._done and self._response_future is response_future and self._response_watchdog is watchdog
+            start_deadline = (
+                not self._done
+                and self._response_future is response_future
+                and self._response_deadline is response_deadline
             )
-        if start_watchdog:
-            watchdog.start()
+        if start_deadline:
+            _TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
+                response_deadline,
+                self._response_timeout(self._retry_count),
+            )
 
     def _publish_response_future(
         self,
         response_future: Any,
-        watchdog: threading.Timer,
+        response_deadline: _ScheduledCall,
     ) -> bool:
         """Publish a response unless a concurrent acknowledgement finished."""
         with self._lock:
@@ -167,7 +263,7 @@ class _TaskAdmissionCancellation:
             if self._done:
                 return True
             self._response_future = response_future
-            self._response_watchdog = watchdog
+            self._response_deadline = response_deadline
             return False
 
     def _finish(self, response_future: Any) -> None:
@@ -181,10 +277,10 @@ class _TaskAdmissionCancellation:
                 if self._done or self._response_future is not response_future:
                     return
                 self._response_future = None
-                watchdog = self._response_watchdog
-                self._response_watchdog = None
-            if watchdog is not None:
-                watchdog.cancel()
+                response_deadline = self._response_deadline
+                self._response_deadline = None
+            if response_deadline is not None:
+                response_deadline.cancel()
             self._schedule_retry()
             return
         with self._lock:
@@ -195,26 +291,26 @@ class _TaskAdmissionCancellation:
             self._done = True
             current_response = self._response_future
             self._response_future = None
-            watchdog = self._response_watchdog
-            self._response_watchdog = None
-            retry_timer = self._retry_timer
-            self._retry_timer = None
+            response_deadline = self._response_deadline
+            self._response_deadline = None
+            retry_call = self._retry_call
+            self._retry_call = None
         if current_response is not None and current_response is not response_future:
             try:
                 current_response.cancel()
             except BaseException:
                 pass
-        if watchdog is not None:
-            watchdog.cancel()
-        if retry_timer is not None:
-            retry_timer.cancel()
+        if response_deadline is not None:
+            response_deadline.cancel()
+        if retry_call is not None:
+            retry_call.cancel()
 
     def _response_timed_out(self, response_future: Any) -> None:
         with self._lock:
             if self._done or self._response_future is not response_future:
                 return
             self._response_future = None
-            self._response_watchdog = None
+            self._response_deadline = None
         try:
             cancel = getattr(response_future, "cancel", None)
             if callable(cancel):
@@ -225,20 +321,27 @@ class _TaskAdmissionCancellation:
 
     def _schedule_retry(self) -> None:
         with self._lock:
-            if self._done or self._submitting or self._response_future is not None or self._retry_timer is not None:
+            if self._done or self._submitting or self._response_future is not None or self._retry_call is not None:
                 return
             self._retry_count += 1
-            timer = threading.Timer(
-                self._retry_delay(self._retry_count),
-                self._retry,
-            )
-            timer.daemon = True
-            self._retry_timer = timer
-        timer.start()
+            retry_call: _ScheduledCall
 
-    def _retry(self) -> None:
+            def retry() -> None:
+                self._retry(retry_call)
+
+            retry_call = _TASK_ADMISSION_CANCELLATION_SCHEDULER.create(retry)
+            self._retry_call = retry_call
+            retry_delay = self._retry_delay(self._retry_count)
+        _TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
+            retry_call,
+            retry_delay,
+        )
+
+    def _retry(self, retry_call: _ScheduledCall) -> None:
         with self._lock:
-            self._retry_timer = None
+            if self._retry_call is not retry_call:
+                return
+            self._retry_call = None
         self.start()
 
 

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -59,7 +59,24 @@ class _TaskAdmissionCancellationScheduler:
     def create(self, callback: Callable[[], None]) -> _ScheduledCall:
         return _ScheduledCall(self, callback)
 
+    def ensure_started(self) -> None:
+        """Start before remote work can transfer cleanup ownership to this clock."""
+        with self._cv:
+            if self._thread is not None:
+                return
+            thread = threading.Thread(
+                target=self._run,
+                daemon=True,
+                name="vane-task-admission-cleanup",
+            )
+            # Publish only a successfully started thread.  If start() raises,
+            # a later controller can retry instead of inheriting a permanently
+            # poisoned scheduler with no worker.
+            thread.start()
+            self._thread = thread
+
     def schedule(self, call: _ScheduledCall, delay_s: float) -> None:
+        self.ensure_started()
         with self._cv:
             if call._scheduler is not self:
                 raise RuntimeError("scheduled call belongs to a different scheduler")
@@ -77,13 +94,6 @@ class _TaskAdmissionCancellationScheduler:
                     call,
                 ),
             )
-            if self._thread is None:
-                self._thread = threading.Thread(
-                    target=self._run,
-                    daemon=True,
-                    name="vane-task-admission-cleanup",
-                )
-                self._thread.start()
             self._cv.notify()
 
     def cancel(self, call: _ScheduledCall) -> None:
@@ -385,6 +395,10 @@ class TaskAdmissionController:
             raise ValueError("distributed Ray UDF task admission requires query_id and stage_id")
         if driver is None:
             raise ValueError("distributed Ray UDF task admission requires an explicit query driver handle")
+        # The cancellation deadline owner must exist before this controller can
+        # submit any remote lease request.  Startup failure is therefore a
+        # pre-submit construction error, never a post-submit ownership gap.
+        _TASK_ADMISSION_CANCELLATION_SCHEDULER.ensure_started()
         self._resources = ray_udf_task_resource_spec(self._payload)
         self._driver = driver
         self._executor_id = uuid.uuid4().hex

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -163,7 +163,7 @@ TaskAdmission: TypeAlias = AdmissionLease
 
 
 class _TaskAdmissionCancellation:
-    """Durably drive one pre-submission lease cancellation to acknowledgement."""
+    """Durably drive one task-admission cancellation to acknowledgement."""
 
     def __init__(self, *, driver: Any, request: dict[str, Any]) -> None:
         self._driver = driver

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import heapq
 import os
+import queue
 import threading
 import time
 import uuid
@@ -27,6 +28,7 @@ _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
+_TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS = 4
 
 
 class _ScheduledCall:
@@ -46,16 +48,33 @@ class _ScheduledCall:
 
 
 class _TaskAdmissionCancellationScheduler:
-    """Process-wide deadline scheduler for every admission cancellation."""
+    """Process-wide deadlines plus bounded Ray control submission workers."""
 
     def __init__(self) -> None:
         self._cv = threading.Condition()
         self._queue: list[tuple[float, int, _ScheduledCall]] = []
         self._next_sequence = 0
         self._thread: threading.Thread | None = None
+        self._submission_lock = threading.Lock()
+        self._submission_queue: queue.SimpleQueue[Callable[[], None]] = queue.SimpleQueue()
+        self._submission_threads: list[threading.Thread] = []
 
     def create(self, callback: Callable[[], None]) -> _ScheduledCall:
         return _ScheduledCall(self, callback)
+
+    def submit(self, callback: Callable[[], None]) -> None:
+        """Run a potentially blocking Ray submission on the bounded worker set."""
+        with self._submission_lock:
+            while len(self._submission_threads) < _TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS:
+                index = len(self._submission_threads)
+                thread = threading.Thread(
+                    target=self._run_submission_worker,
+                    daemon=True,
+                    name=f"vane-task-admission-submit-{index}",
+                )
+                thread.start()
+                self._submission_threads.append(thread)
+        self._submission_queue.put(callback)
 
     def schedule(self, call: _ScheduledCall, delay_s: float) -> None:
         with self._cv:
@@ -116,6 +135,16 @@ class _TaskAdmissionCancellationScheduler:
                     # Cancellation methods own their retry/error policy. One
                     # malformed callback must not terminate the shared clock.
                     pass
+
+    def _run_submission_worker(self) -> None:
+        while True:
+            callback = self._submission_queue.get()
+            try:
+                callback()
+            except BaseException:
+                # Cancellation submissions own their retry/error policy. Keep
+                # one malformed callback from reducing the fixed worker set.
+                pass
 
 
 _TASK_ADMISSION_CANCELLATION_SCHEDULER = _TaskAdmissionCancellationScheduler()
@@ -200,6 +229,15 @@ class _TaskAdmissionCancellation:
             if self._done or self._submitting or self._response_future is not None or self._retry_call is not None:
                 return
             self._submitting = True
+        try:
+            _TASK_ADMISSION_CANCELLATION_SCHEDULER.submit(self._submit)
+        except BaseException:
+            with self._lock:
+                self._submitting = False
+            self._schedule_retry()
+
+    def _submit(self) -> None:
+        """Submit one driver RPC without occupying its caller or deadline thread."""
         try:
             response_ref = self._driver.cancel_query_task_lease_request.remote(
                 dict(self._request),

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -117,23 +117,32 @@ class TaskAdmissionController:
             self._state = "requested"
             self._request_id = str(request["request_id"])
             self._retained_input_bytes = retained
+        request_id = str(request["request_id"])
         try:
             request_ref = self._driver_actor().acquire_query_task_lease.remote(request)
             future = request_ref.future()
+            with self._lock:
+                if self._state == "requested" and self._request_id == request_id:
+                    self._request_ref = request_ref
+            future.add_done_callback(
+                lambda done, request_id=request_id: self._finish_request(
+                    request_id,
+                    done,
+                )
+            )
         except BaseException as exc:
             with self._lock:
-                self._state = "failed"
-                self._error = exc
+                if self._state == "requested" and self._request_id == request_id:
+                    self._request_ref = None
+                    self._state = "failed"
+                    self._error = exc
+            try:
+                self._driver_actor().cancel_query_task_lease_request.remote(request_id)
+            except BaseException as cleanup_error:
+                add_note = getattr(exc, "add_note", None)
+                if callable(add_note):
+                    add_note(f"task admission setup cleanup failed: {type(cleanup_error).__name__}: {cleanup_error}")
             raise
-        with self._lock:
-            if self._state == "requested" and self._request_id == request["request_id"]:
-                self._request_ref = request_ref
-        future.add_done_callback(
-            lambda done, request_id=str(request["request_id"]): self._finish_request(
-                request_id,
-                done,
-            )
-        )
         return True
 
     def _finish_request(self, request_id: str, future: Any) -> None:
@@ -164,10 +173,7 @@ class TaskAdmissionController:
                 self._error = exc
                 wakeup = self._wakeup
         if abandon:
-            self._driver_actor().cancel_query_task_lease_request.remote(
-                request_id,
-                submitted=False,
-            )
+            self._driver_actor().cancel_query_task_lease_request.remote(request_id)
             return
         if wakeup is not None:
             wakeup()
@@ -190,10 +196,7 @@ class TaskAdmissionController:
                 request_id=request_id,
                 retained_input_bytes=self._retained_input_bytes,
                 lease=dict(self._ready_lease),
-                _release_callback=lambda: driver.cancel_query_task_lease_request.remote(
-                    request_id,
-                    submitted=False,
-                ),
+                _release_callback=lambda: driver.cancel_query_task_lease_request.remote(request_id),
             )
             self._state = "idle"
             self._request_id = ""
@@ -232,10 +235,7 @@ class TaskAdmissionController:
             self._ready_lease = None
             self._wakeup = None
         if request_id:
-            self._driver_actor().cancel_query_task_lease_request.remote(
-                request_id,
-                submitted=False,
-            )
+            self._driver_actor().cancel_query_task_lease_request.remote(request_id)
 
 
 class TaskAdmissionExecutorMixin(AdmissionExecutorMixin):

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -3,16 +3,18 @@
 
 from __future__ import annotations
 
-import heapq
 import os
 import threading
-import time
 import uuid
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from duckdb.execution.ray_control_deadline import (
+    RAY_CONTROL_DEADLINE_SCHEDULER,
+    RayControlScheduledCall,
+)
 from duckdb.execution.ray_control_submission import submit_ray_control
 from duckdb.execution.ray_stream_adapter import (
     ray_object_ref_future,
@@ -29,108 +31,6 @@ _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
-
-
-class _ScheduledCall:
-    """One cancellable deadline owned by the shared cleanup scheduler."""
-
-    def __init__(
-        self,
-        scheduler: _TaskAdmissionCancellationScheduler,
-        callback: Callable[[], None],
-    ) -> None:
-        self._scheduler = scheduler
-        self._callback: Callable[[], None] | None = callback
-        self._scheduled = False
-
-    def cancel(self) -> None:
-        self._scheduler.cancel(self)
-
-
-class _TaskAdmissionCancellationScheduler:
-    """Process-wide deadline scheduler for every admission cancellation."""
-
-    def __init__(self) -> None:
-        self._cv = threading.Condition()
-        self._queue: list[tuple[float, int, _ScheduledCall]] = []
-        self._next_sequence = 0
-        self._thread: threading.Thread | None = None
-
-    def create(self, callback: Callable[[], None]) -> _ScheduledCall:
-        return _ScheduledCall(self, callback)
-
-    def ensure_started(self) -> None:
-        """Start before remote work can transfer cleanup ownership to this clock."""
-        with self._cv:
-            if self._thread is not None:
-                return
-            thread = threading.Thread(
-                target=self._run,
-                daemon=True,
-                name="vane-task-admission-cleanup",
-            )
-            # Publish only a successfully started thread.  If start() raises,
-            # a later controller can retry instead of inheriting a permanently
-            # poisoned scheduler with no worker.
-            thread.start()
-            self._thread = thread
-
-    def schedule(self, call: _ScheduledCall, delay_s: float) -> None:
-        self.ensure_started()
-        with self._cv:
-            if call._scheduler is not self:
-                raise RuntimeError("scheduled call belongs to a different scheduler")
-            if call._callback is None:
-                return
-            if call._scheduled:
-                raise RuntimeError("scheduled call is already armed")
-            call._scheduled = True
-            self._next_sequence += 1
-            heapq.heappush(
-                self._queue,
-                (
-                    time.monotonic() + max(0.0, float(delay_s)),
-                    self._next_sequence,
-                    call,
-                ),
-            )
-            self._cv.notify()
-
-    def cancel(self, call: _ScheduledCall) -> None:
-        with self._cv:
-            if call._scheduler is not self:
-                raise RuntimeError("scheduled call belongs to a different scheduler")
-            call._callback = None
-            self._cv.notify()
-
-    def _run(self) -> None:
-        while True:
-            callback: Callable[[], None] | None = None
-            with self._cv:
-                while callback is None:
-                    while self._queue and self._queue[0][2]._callback is None:
-                        heapq.heappop(self._queue)
-                    if not self._queue:
-                        self._cv.wait()
-                        continue
-                    deadline, _sequence, call = self._queue[0]
-                    remaining = deadline - time.monotonic()
-                    if remaining > 0:
-                        self._cv.wait(timeout=remaining)
-                        continue
-                    heapq.heappop(self._queue)
-                    callback = call._callback
-                    call._callback = None
-            if callback is not None:
-                try:
-                    callback()
-                except BaseException:
-                    # Cancellation methods own their retry/error policy. One
-                    # malformed callback must not terminate the shared clock.
-                    pass
-
-
-_TASK_ADMISSION_CANCELLATION_SCHEDULER = _TaskAdmissionCancellationScheduler()
 
 
 def _positive_int(value: Any, name: str) -> int:
@@ -202,8 +102,8 @@ class _TaskAdmissionCancellation:
             raise ValueError("Ray task admission cancellation requires an explicit submission scope")
         self._lock = threading.Lock()
         self._response_future: Any | None = None
-        self._response_deadline: _ScheduledCall | None = None
-        self._retry_call: _ScheduledCall | None = None
+        self._response_deadline: RayControlScheduledCall | None = None
+        self._retry_call: RayControlScheduledCall | None = None
         self._submitting = False
         self._retry_count = 0
         self._done = False
@@ -271,7 +171,7 @@ class _TaskAdmissionCancellation:
                 self._submitting = False
             self._schedule_retry()
             return
-        response_deadline = _TASK_ADMISSION_CANCELLATION_SCHEDULER.create(
+        response_deadline = RAY_CONTROL_DEADLINE_SCHEDULER.create(
             lambda: self._response_timed_out(response_future),
         )
         discard_response = self._publish_response_future(
@@ -308,7 +208,7 @@ class _TaskAdmissionCancellation:
                 and self._response_deadline is response_deadline
             )
         if start_deadline:
-            _TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
+            RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
                 response_deadline,
                 self._response_timeout(self._retry_count),
             )
@@ -316,7 +216,7 @@ class _TaskAdmissionCancellation:
     def _publish_response_future(
         self,
         response_future: Any,
-        response_deadline: _ScheduledCall,
+        response_deadline: RayControlScheduledCall,
     ) -> bool:
         """Publish a response unless a concurrent acknowledgement finished."""
         with self._lock:
@@ -385,20 +285,20 @@ class _TaskAdmissionCancellation:
             if self._done or self._submitting or self._response_future is not None or self._retry_call is not None:
                 return
             self._retry_count += 1
-            retry_call: _ScheduledCall
+            retry_call: RayControlScheduledCall
 
             def retry() -> None:
                 self._retry(retry_call)
 
-            retry_call = _TASK_ADMISSION_CANCELLATION_SCHEDULER.create(retry)
+            retry_call = RAY_CONTROL_DEADLINE_SCHEDULER.create(retry)
             self._retry_call = retry_call
             retry_delay = self._retry_delay(self._retry_count)
-        _TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
+        RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
             retry_call,
             retry_delay,
         )
 
-    def _retry(self, retry_call: _ScheduledCall) -> None:
+    def _retry(self, retry_call: RayControlScheduledCall) -> None:
         with self._lock:
             if self._retry_call is not retry_call:
                 return
@@ -429,7 +329,7 @@ class TaskAdmissionController:
         # The cancellation deadline owner must exist before this controller can
         # submit any remote lease request.  Startup failure is therefore a
         # pre-submit construction error, never a post-submit ownership gap.
-        _TASK_ADMISSION_CANCELLATION_SCHEDULER.ensure_started()
+        RAY_CONTROL_DEADLINE_SCHEDULER.ensure_started()
         self._resources = ray_udf_task_resource_spec(self._payload)
         self._driver = driver
         self._executor_id = uuid.uuid4().hex

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -10,7 +10,8 @@ import time
 import uuid
 import weakref
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from dataclasses import dataclass
+from typing import Any
 
 from duckdb.execution.ray_control_submission import submit_ray_control
 from duckdb.execution.ray_stream_adapter import (
@@ -159,18 +160,36 @@ def ray_udf_task_resource_spec(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-TaskAdmission: TypeAlias = AdmissionLease
+@dataclass(kw_only=True)
+class TaskAdmission(AdmissionLease):
+    """Ray task admission plus its long-lived local control owner."""
+
+    submission_scope: str
+
+    def __post_init__(self) -> None:
+        self.submission_scope = str(self.submission_scope or "").strip()
+        if not self.submission_scope:
+            raise ValueError("Ray task admission requires an explicit submission scope")
 
 
 class _TaskAdmissionCancellation:
     """Durably drive one task-admission cancellation to acknowledgement."""
 
-    def __init__(self, *, driver: Any, request: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        *,
+        driver: Any,
+        request: dict[str, Any],
+        submission_scope: str,
+    ) -> None:
         self._driver = driver
         self._request = {
             **request,
             "resources": dict(request["resources"]),
         }
+        self._submission_scope = str(submission_scope or "").strip()
+        if not self._submission_scope:
+            raise ValueError("Ray task admission cancellation requires an explicit submission scope")
         self._lock = threading.Lock()
         self._response_future: Any | None = None
         self._response_deadline: _ScheduledCall | None = None
@@ -202,7 +221,7 @@ class _TaskAdmissionCancellation:
                 return
             self._submitting = True
         try:
-            submit_ray_control(self._submit)
+            submit_ray_control(self._submission_scope, self._submit)
         except BaseException:
             with self._lock:
                 self._submitting = False
@@ -369,6 +388,7 @@ class TaskAdmissionController:
         self._resources = ray_udf_task_resource_spec(self._payload)
         self._driver = driver
         self._executor_id = uuid.uuid4().hex
+        self._submission_scope = f"udf-executor:{self._executor_id}"
         self._sequence = 0
         self._lock = threading.Lock()
         self._state = "idle"
@@ -419,6 +439,7 @@ class TaskAdmissionController:
             cancellation = _TaskAdmissionCancellation(
                 driver=self._driver_actor(),
                 request=request,
+                submission_scope=self._submission_scope,
             )
             self._cancellation = cancellation
         request_id = str(request["request_id"])
@@ -429,6 +450,7 @@ class TaskAdmissionController:
         }
         try:
             submission = submit_ray_control(
+                self._submission_scope,
                 lambda: driver.acquire_query_task_lease.remote(submitted_request),
             )
         except BaseException as exc:
@@ -623,6 +645,7 @@ class TaskAdmissionController:
                 request_id=request_id,
                 retained_input_bytes=self._retained_input_bytes,
                 lease=dict(self._ready_lease),
+                submission_scope=self._submission_scope,
                 _release_callback=cancellation.start,
             )
             self._state = "idle"

--- a/duckdb/execution/udf_task_admission.py
+++ b/duckdb/execution/udf_task_admission.py
@@ -24,6 +24,7 @@ _DEFAULT_RAY_ACTOR_HEAP_BYTES = 4 * 1024**3
 _TASK_ADMISSION_CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S = 1.0
+_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
 
 
 def _positive_int(value: Any, name: str) -> int:
@@ -91,6 +92,14 @@ class _TaskAdmissionCancellation:
             _TASK_ADMISSION_CLEANUP_RETRY_MAX_DELAY_S,
         )
 
+    @staticmethod
+    def _response_timeout(retry_count: int) -> float:
+        exponent = min(max(0, int(retry_count)), 30)
+        return min(
+            _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S * (2**exponent),
+            _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S,
+        )
+
     def start(self) -> None:
         """Start once; callbacks and bounded timers retain cancellation ownership."""
         with self._lock:
@@ -108,7 +117,7 @@ class _TaskAdmissionCancellation:
             self._schedule_retry()
             return
         watchdog = threading.Timer(
-            _TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S,
+            self._response_timeout(self._retry_count),
             self._response_timed_out,
             args=(response_future,),
         )

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -3025,6 +3025,34 @@ class RayQueryDriverActor:
             return None
         return fields
 
+    def _issue_query_task_admission_capability(self, query_id: str) -> str:
+        query_key = str(query_id)
+        return self._issue_lease_capability(
+            kind="task-admission",
+            fields=(
+                query_key,
+                self._query_lease_generation_id(query_key),
+            ),
+        )
+
+    def _verify_query_task_admission_capability(
+        self,
+        *,
+        capability: str,
+        query_id: str,
+    ) -> str | None:
+        fields = self._decode_lease_capability(
+            capability,
+            kind="task-admission",
+            field_count=2,
+        )
+        if fields is None:
+            return None
+        capability_query_id, capability_generation_id = fields
+        if capability_query_id != str(query_id):
+            return None
+        return capability_generation_id
+
     def _issue_task_lease_capability(
         self,
         *,
@@ -3590,11 +3618,13 @@ class RayQueryDriverActor:
     def _parse_task_lease_request(
         self,
         payload: dict[str, Any],
-    ) -> tuple[str, Any, dict[str, Any]]:
+    ) -> tuple[str, Any, dict[str, Any], str]:
         from duckdb.runners.ray.query_resource_manager import TaskRequest
 
+        raw_values = dict(payload)
+        generation_capability = str(raw_values.pop("query_generation_capability", "") or "").strip()
         values = self._strict_lease_request(
-            payload,
+            raw_values,
             fields={
                 "request_id",
                 "query_id",
@@ -3611,16 +3641,39 @@ class RayQueryDriverActor:
         raw_resources = values.pop("resources")
         request = TaskRequest(**values)
         identity = {**asdict(request), "resources": dict(raw_resources)}
-        return request_id, request, identity
+        return request_id, request, identity, generation_capability
 
     async def acquire_query_task_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Resolve one task lease through the query's serialized admission pump."""
         from duckdb.runners.ray.query_resource_manager import TaskGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        request_id, request, identity = self._parse_task_lease_request(payload)
+        request_id, request, identity, generation_capability = self._parse_task_lease_request(payload)
         raw_resources = identity["resources"]
         self._ensure_query_resource_admission_state()
+        generation_id = self._verify_query_task_admission_capability(
+            capability=generation_capability,
+            query_id=request.query_id,
+        )
+        if generation_id is None:
+            return self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="invalid_query_generation_capability",
+                    fatal=True,
+                )
+            )
+        if self._capability_targets_inactive_query_generation(
+            request.query_id,
+            generation_id,
+        ):
+            return self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="query_generation_inactive",
+                    fatal=True,
+                )
+            )
         terminal_control = self._task_terminal_control_for_identity(
             request_id,
             identity,
@@ -4089,8 +4142,20 @@ class RayQueryDriverActor:
         from duckdb.runners.ray.query_resource_manager import TaskGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        request_id, request, identity = self._parse_task_lease_request(payload)
+        request_id, request, identity, generation_capability = self._parse_task_lease_request(payload)
         self._ensure_query_resource_admission_state()
+        generation_id = self._verify_query_task_admission_capability(
+            capability=generation_capability,
+            query_id=request.query_id,
+        )
+        if generation_id is None or self._capability_targets_inactive_query_generation(
+            request.query_id,
+            generation_id,
+        ):
+            # A stale or unsigned cleanup request owns no state in the active
+            # generation. Acknowledge the no-op so its durable retry owner can
+            # retire without touching a reopened query with the same ID.
+            return {"cancelled": True, "released": False}
         request_key = str(request_id)
         with self._query_task_lease_condition:
             terminal_control = self._task_terminal_control_for_identity(
@@ -4990,6 +5055,9 @@ class RayQueryDriverActor:
                 plan,
                 actor_node_ids_by_stage=actor_node_ids_by_stage,
                 query_driver_handle=self._driver_handle,
+                query_generation_capability=self._issue_query_task_admission_capability(
+                    graph.query_id,
+                ),
                 session_config=session_config,
                 conn=query_connection,
             )

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -63,6 +63,8 @@ _RUNTIME_ATTACH_CLEANUP_ATTEMPTS = 3
 _RUNTIME_ATTACH_CLEANUP_TIMEOUT_S = 300.0
 _DEFAULT_CLIENT_LEASE_TIMEOUT_S = 60.0
 _DEFAULT_CLIENT_HEARTBEAT_INTERVAL_S = 10.0
+_TASK_COMPLETION_CLEANUP_RETRY_MIN_S = 0.01
+_TASK_COMPLETION_CLEANUP_RETRY_MAX_S = 1.0
 RAY_QUERY_RUNTIME_ACTOR_NAMESPACE = "vane"
 RAY_QUERY_RUNTIME_ACTOR_NAME_PREFIX = "vane-query-runtime-"
 
@@ -1282,11 +1284,11 @@ class RayQueryDriverActor:
         self._query_task_request_owner_by_identity: dict[tuple[str, str, str], str] = {}
         self._query_output_request_owner_by_identity: dict[tuple[str, str], str] = {}
         self._query_resource_closing_queries: set[str] = set()
+        self._query_execution_quiesced_queries: set[str] = set()
         self._query_pending_execution_teardowns: dict[str, set[str]] = {}
         self._query_task_admission_pumps: set[str] = set()
         self._query_task_lease_condition = threading.Condition()
         self._query_task_completion_waiters: dict[str, tuple[str, asyncio.Task[None]]] = {}
-        self._query_execution_quiesced_queries: set[str] = set()
         self._query_output_admission_pumps: set[str] = set()
         self._query_fte_admission_pumps: dict[str, asyncio.Task[Any]] = {}
         self._query_fte_admission_dirty_queries: set[str] = set()
@@ -2463,14 +2465,14 @@ class RayQueryDriverActor:
             self._query_output_request_owner_by_identity = {}
         if not hasattr(self, "_query_resource_closing_queries"):
             self._query_resource_closing_queries = set()
+        if not hasattr(self, "_query_execution_quiesced_queries"):
+            self._query_execution_quiesced_queries = set()
         if not hasattr(self, "_query_task_admission_pumps"):
             self._query_task_admission_pumps = set()
         if not hasattr(self, "_query_task_lease_condition"):
             self._query_task_lease_condition = threading.Condition()
         if not hasattr(self, "_query_task_completion_waiters"):
             self._query_task_completion_waiters = {}
-        if not hasattr(self, "_query_execution_quiesced_queries"):
-            self._query_execution_quiesced_queries = set()
         if not hasattr(self, "_query_terminal_errors"):
             self._query_terminal_errors = {}
         if not hasattr(self, "_query_output_admission_pumps"):
@@ -2594,7 +2596,9 @@ class RayQueryDriverActor:
         self._query_resource_closing_queries.add(query_key)
         self._fail_query_admission_requests(query_key)
         # Granted task records are the execution ledger. Keep them until their
-        # terminal RPC (or structural teardown) releases the physical lease.
+        # terminal RPC releases the physical lease. Native query teardown cannot
+        # prove that a dispatcher call which crossed its bounded unregister
+        # deadline did not submit remote work afterward.
         self._query_output_lease_requests = {
             request_id: state
             for request_id, state in self._query_output_lease_requests.items()
@@ -2642,7 +2646,8 @@ class RayQueryDriverActor:
             old_completion_waiter_exists = any(
                 owner_query_id == query_key for owner_query_id, _task in self._query_task_completion_waiters.values()
             )
-        if old_state_exists or old_owner_exists or old_completion_waiter_exists:
+            old_execution_quiesced = query_key in self._query_execution_quiesced_queries
+        if old_state_exists or old_owner_exists or old_completion_waiter_exists or old_execution_quiesced:
             raise RuntimeError(f"cannot reopen query admission with old generation state: {query_key}")
         fte_pump = self._query_fte_admission_pumps.get(query_key)
         if fte_pump is not None and not fte_pump.done():
@@ -2652,8 +2657,6 @@ class RayQueryDriverActor:
         self._query_fte_admission_dirty_queries.discard(query_key)
         open_fte_registry_for_query(query_key)
         self._query_resource_closing_queries.discard(query_key)
-        with self._query_task_lease_condition:
-            self._query_execution_quiesced_queries.discard(query_key)
 
     def _signal_query_resource_change(self, query_id: str) -> None:
         """Coalesce a resource mutation into one task and output pump run.
@@ -3203,7 +3206,7 @@ class RayQueryDriverActor:
             raise ValueError(f"task lease request_id reused with different identity: {request_id}")
         if existing is not None:
             status = existing["status"]
-            if status in {"granted", "submitted"}:
+            if status in {"granted", "completion_wait", "teardown_wait"}:
                 return {
                     "granted": True,
                     "lease": dict(existing["lease"]),
@@ -3211,6 +3214,8 @@ class RayQueryDriverActor:
                     "fatal": False,
                     "liveness": bool(existing["lease"]["liveness"]),
                 }
+            if status != "pending":
+                raise RuntimeError(f"invalid task lease request state: {status}")
             return await asyncio.shield(existing["future"])
 
         resource_identity = (
@@ -3322,30 +3327,30 @@ class RayQueryDriverActor:
             return True
 
     def _mark_query_execution_quiesced(self, query_id: str) -> None:
-        """Use structural teardown as terminal proof for fallback-owned tasks."""
+        """Retire only task leases explicitly transferred to query teardown."""
         from duckdb.runners.ray.query_resource_manager import TaskGrant
 
+        self._ensure_query_resource_admission_state()
         query_key = str(query_id)
-        denial = self._grant_payload(
-            TaskGrant(
-                False,
-                blocked_reason="task_lease_owned_by_query_teardown",
-                fatal=True,
-            )
-        )
         with self._query_task_lease_condition:
             self._query_execution_quiesced_queries.add(query_key)
-            teardown_owned = [
+            teardown_waiters = [
                 (request_id, state)
                 for request_id, state in self._query_task_lease_requests.items()
-                if state.get("identity", {}).get("query_id") == query_key and state.get("status") == "teardown_owned"
+                if state.get("identity", {}).get("query_id") == query_key and state.get("status") == "teardown_wait"
             ]
-            for request_id, state in teardown_owned:
+            for request_id, state in teardown_waiters:
                 self._retire_query_lease_request(
                     request_id=request_id,
                     state=state,
-                    result=denial,
-                    status="teardown_owned",
+                    result=self._grant_payload(
+                        TaskGrant(
+                            False,
+                            blocked_reason="task_lease_owned_by_query_teardown",
+                            fatal=True,
+                        )
+                    ),
+                    status="released_by_teardown",
                     active=self._query_task_lease_requests,
                     tombstones=self._query_task_lease_request_tombstones,
                 )
@@ -3413,7 +3418,6 @@ class RayQueryDriverActor:
         request_id: str,
         lease_id: str,
         attempt_id: str,
-        query_id: str,
         completion_future: ConcurrentFuture[Any],
     ) -> None:
         """Observe terminal work without occupying a Ray actor RPC slot."""
@@ -3427,19 +3431,28 @@ class RayQueryDriverActor:
             except BaseException:
                 # A failed completion ObjectRef is still terminal proof.
                 pass
-            self._finish_query_task_completion_wait(
-                request_key,
-                lease_id,
-                attempt_id,
-            )
-        except asyncio.CancelledError:
-            # Query teardown remains the conservative execution owner.
-            pass
-        except BaseException as exc:
-            self._query_terminal_errors.setdefault(
-                str(query_id),
-                f"task completion ownership transfer failed for {request_key}: {type(exc).__name__}: {exc}",
-            )
+            retry_delay_s = _TASK_COMPLETION_CLEANUP_RETRY_MIN_S
+            while True:
+                try:
+                    self._finish_query_task_completion_wait(
+                        request_key,
+                        lease_id,
+                        attempt_id,
+                    )
+                    return
+                except BaseException as exc:
+                    with self._query_task_lease_condition:
+                        state = self._query_task_lease_requests.get(request_key)
+                        if state is None or state.get("status") != "completion_wait":
+                            return
+                        state["completion_cleanup_attempts"] = int(state.get("completion_cleanup_attempts", 0)) + 1
+                        state["completion_cleanup_error"] = f"{type(exc).__name__}: {exc}"
+                        self._query_task_lease_condition.notify_all()
+                    await asyncio.sleep(retry_delay_s)
+                    retry_delay_s = min(
+                        _TASK_COMPLETION_CLEANUP_RETRY_MAX_S,
+                        retry_delay_s * 2.0,
+                    )
         finally:
             with self._query_task_lease_condition:
                 record = self._query_task_completion_waiters.get(request_key)
@@ -3481,9 +3494,10 @@ class RayQueryDriverActor:
                 attempt_id,
             ):
                 return {"scheduled": False}
-            if state.get("status") == "teardown_owned":
+            if state.get("status") == "teardown_wait":
                 return {"scheduled": False}
-            if state.get("status") == "completion_wait" or request_key in self._query_task_completion_waiters:
+            waiter = self._query_task_completion_waiters.get(request_key)
+            if waiter is not None and not waiter[1].done():
                 return {"scheduled": True}
             query_id = str(state["identity"]["query_id"])
 
@@ -3493,20 +3507,85 @@ class RayQueryDriverActor:
         with self._query_task_lease_condition:
             if self._query_task_lease_requests.get(request_key) is not state:
                 return {"scheduled": False}
+            if state.get("status") == "teardown_wait":
+                return {"scheduled": False}
+            waiter = self._query_task_completion_waiters.get(request_key)
+            if waiter is not None and not waiter[1].done():
+                return {"scheduled": True}
             task = asyncio.create_task(
                 self._wait_for_query_task_completion(
                     request_key,
                     str(lease_id),
                     str(attempt_id),
-                    query_id,
                     completion_future,
                 ),
                 name=f"vane-query-task-completion:{request_key}",
             )
             state["status"] = "completion_wait"
+            state.pop("completion_cleanup_attempts", None)
+            state.pop("completion_cleanup_error", None)
             self._query_task_completion_waiters[request_key] = (query_id, task)
             self._query_task_lease_condition.notify_all()
         return {"scheduled": True}
+
+    async def handoff_query_task_lease_to_teardown(
+        self,
+        request_id: str,
+        lease_id: str,
+        attempt_id: str,
+    ) -> dict[str, Any]:
+        """Transfer a cancelled task without a completion ref to query teardown."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+        self._ensure_query_resource_admission_state()
+        request_key = str(request_id)
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
+            if state is None:
+                tombstone = self._query_task_lease_request_tombstones.get(request_key)
+                return {
+                    "handed_off": bool(
+                        tombstone is not None
+                        and tombstone.get("status") == "released_by_teardown"
+                        and self._query_task_lease_replay_matches(
+                            tombstone,
+                            lease_id=lease_id,
+                            attempt_id=attempt_id,
+                        )
+                    )
+                }
+            if not self._query_task_lease_matches(
+                state,
+                lease_id,
+                attempt_id,
+            ):
+                return {"handed_off": False}
+            status = str(state.get("status") or "")
+            if status == "completion_wait":
+                return {"handed_off": False}
+            if status == "teardown_wait":
+                return {"handed_off": True}
+            if status != "granted":
+                return {"handed_off": False}
+            state["status"] = "teardown_wait"
+            query_id = str(state["identity"]["query_id"])
+            if query_id in self._query_execution_quiesced_queries:
+                self._retire_query_lease_request(
+                    request_id=request_key,
+                    state=state,
+                    result=self._grant_payload(
+                        TaskGrant(
+                            False,
+                            blocked_reason="task_lease_owned_by_query_teardown",
+                            fatal=True,
+                        )
+                    ),
+                    status="released_by_teardown",
+                    active=self._query_task_lease_requests,
+                    tombstones=self._query_task_lease_request_tombstones,
+                )
+            self._query_task_lease_condition.notify_all()
+        return {"handed_off": True}
 
     def _wait_for_query_task_leases(
         self,
@@ -3535,63 +3614,9 @@ class RayQueryDriverActor:
                     )
                 self._query_task_lease_condition.wait(remaining)
 
-    async def handoff_query_task_lease_to_teardown(
-        self,
-        request_id: str,
-        lease_id: str,
-        attempt_id: str,
-    ) -> dict[str, Any]:
-        """Retain a submitted lease until structural query teardown."""
-        self._ensure_query_resource_admission_state()
-        request_key = str(request_id)
-        with self._query_task_lease_condition:
-            state = self._query_task_lease_requests.get(request_key)
-            if state is None:
-                tombstone = self._query_task_lease_request_tombstones.get(request_key)
-                return {
-                    "handed_off": self._query_task_lease_replay_matches(
-                        tombstone,
-                        lease_id=lease_id,
-                        attempt_id=attempt_id,
-                    )
-                }
-            if not self._query_task_lease_matches(
-                state,
-                lease_id,
-                attempt_id,
-            ):
-                return {"handed_off": False}
-            if state.get("status") == "completion_wait":
-                return {"handed_off": False}
-            if state.get("status") == "teardown_owned":
-                return {"handed_off": True}
-            state["status"] = "teardown_owned"
-            query_id = str(state["identity"]["query_id"])
-            if query_id in self._query_execution_quiesced_queries:
-                from duckdb.runners.ray.query_resource_manager import TaskGrant
-
-                self._retire_query_lease_request(
-                    request_id=request_key,
-                    state=state,
-                    result=self._grant_payload(
-                        TaskGrant(
-                            False,
-                            blocked_reason="task_lease_owned_by_query_teardown",
-                            fatal=True,
-                        )
-                    ),
-                    status="teardown_owned",
-                    active=self._query_task_lease_requests,
-                    tombstones=self._query_task_lease_request_tombstones,
-                )
-            self._query_task_lease_condition.notify_all()
-        return {"handed_off": True}
-
     async def cancel_query_task_lease_request(
         self,
         request_id: str,
-        *,
-        submitted: bool,
     ) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import TaskGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
@@ -3606,9 +3631,9 @@ class RayQueryDriverActor:
                     "released": False,
                 }
             status = str(state.get("status") or "")
-            if submitted or status in {"completion_wait", "teardown_owned"}:
-                # Cancellation submission is not terminal proof. Submitted work
-                # must use the completion-gated handoff above.
+            if status in {"completion_wait", "teardown_wait"}:
+                # A submitted task can only retire through its selected
+                # completion or query-teardown owner.
                 return {"cancelled": False, "released": False}
             identity = dict(state["identity"])
             lease = state.get("lease")
@@ -3674,7 +3699,7 @@ class RayQueryDriverActor:
                         attempt_id=attempt_id,
                     )
                 }
-            if state.get("status") in {"completion_wait", "teardown_owned"}:
+            if state.get("status") in {"completion_wait", "teardown_wait"}:
                 return {"released": False}
             if not self._query_task_lease_matches(
                 state,
@@ -4211,13 +4236,13 @@ class RayQueryDriverActor:
                     f"failed to fence query resource release for {query_key}: {type(exc).__name__}: {exc}"
                 ) from exc
         if execution_quiesced:
-            # Structural query teardown is the fallback proof for the rare
-            # submitted object that could not expose a completion ObjectRef.
-            # Completion-owned Ray calls still require their own terminal ref.
+            # Successful execution teardown is terminal evidence only for a
+            # cancelled task that explicitly selected teardown ownership.
+            # Ordinary grants and completion waiters remain fenced.
             self._mark_query_execution_quiesced(query_key)
         # A granted request remains in the same admission ledger until its
-        # terminal transition, including completion handoffs that arrive while
-        # query teardown is already fenced.
+        # explicit terminal transition, including completion handoffs that
+        # arrive after query teardown is already fenced.
         self._wait_for_query_task_leases(query_key)
         cleanup_errors: list[BaseException] = []
         deferred_teardowns: tuple[_DeferredQueryAllocationTeardown, ...] = ()

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import math
 import os
 import sys
@@ -125,6 +127,16 @@ class QueryExecutionCleanupError(RuntimeError):
             primary_error=primary_error,
             cleanup_errors=cleanup,
         )
+
+
+@dataclass(frozen=True)
+class _TaskTerminalControl:
+    """Compact driver-lifetime proof for one terminal task request."""
+
+    identity_fingerprint: bytes
+    lease_fingerprint: bytes | None
+    status: str
+    blocked_reason: str
 
 
 def _client_owner_lease_settings() -> tuple[float, float]:
@@ -1278,6 +1290,11 @@ class RayQueryDriverActor:
         self._query_task_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
             capacity=_LEASE_REQUEST_REPLAY_CAPACITY
         )
+        # Full replay payloads are bounded, but terminal control identity must
+        # remain exact for the actor lifetime. Otherwise a lost response can
+        # become unacknowledgeable after tombstone eviction.
+        self._query_task_terminal_controls: dict[bytes, _TaskTerminalControl] = {}
+        self._query_task_terminal_attempts: set[bytes] = set()
         self._query_output_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
             capacity=_LEASE_REQUEST_REPLAY_CAPACITY
         )
@@ -2453,6 +2470,10 @@ class RayQueryDriverActor:
                 getattr(task_tombstones, "items", lambda: ())(),
                 capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
             )
+        if not hasattr(self, "_query_task_terminal_controls"):
+            self._query_task_terminal_controls = {}
+        if not hasattr(self, "_query_task_terminal_attempts"):
+            self._query_task_terminal_attempts = set()
         output_tombstones = getattr(self, "_query_output_lease_request_tombstones", ())
         if not isinstance(output_tombstones, BoundedReplayMap):
             self._query_output_lease_request_tombstones = BoundedReplayMap(
@@ -2816,6 +2837,112 @@ class RayQueryDriverActor:
         elif not target_loop.is_closed():
             target_loop.call_soon_threadsafe(_complete)
 
+    @staticmethod
+    def _task_identity_fingerprint(identity: dict[str, Any]) -> bytes:
+        encoded = json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).digest()
+
+    @staticmethod
+    def _task_lease_fingerprint(lease_id: str, attempt_id: str) -> bytes:
+        encoded = json.dumps(
+            [str(lease_id), str(attempt_id)],
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).digest()
+
+    @staticmethod
+    def _task_request_fingerprint(request_id: str) -> bytes:
+        return hashlib.sha256(str(request_id).encode("utf-8")).digest()
+
+    @classmethod
+    def _task_attempt_fingerprint(cls, identity: dict[str, Any]) -> bytes:
+        return cls._task_identity_fingerprint(
+            {
+                "query_id": str(identity["query_id"]),
+                "task_id": str(identity["task_id"]),
+                "attempt_id": str(identity["attempt_id"]),
+            }
+        )
+
+    @staticmethod
+    def _task_resource_identity(identity: dict[str, Any]) -> tuple[str, str, str]:
+        return (
+            str(identity["query_id"]),
+            str(identity["task_id"]),
+            str(identity["attempt_id"]),
+        )
+
+    def _store_task_terminal_control(
+        self,
+        *,
+        request_id: str,
+        identity: dict[str, Any],
+        lease: dict[str, Any] | None,
+        status: str,
+        result: dict[str, Any],
+    ) -> None:
+        request_key = str(request_id)
+        request_fingerprint = self._task_request_fingerprint(request_key)
+        control = _TaskTerminalControl(
+            identity_fingerprint=self._task_identity_fingerprint(identity),
+            lease_fingerprint=(
+                None
+                if lease is None
+                else self._task_lease_fingerprint(
+                    str(lease["lease_id"]),
+                    str(lease["attempt_id"]),
+                )
+            ),
+            status=str(status),
+            blocked_reason=str(result.get("blocked_reason") or "task_request_terminal"),
+        )
+        existing = self._query_task_terminal_controls.get(request_fingerprint)
+        if existing is not None and existing != control:
+            raise RuntimeError(f"task terminal control identity changed: {request_key}")
+        self._query_task_terminal_controls[request_fingerprint] = control
+        if str(status) != "failed":
+            self._query_task_terminal_attempts.add(
+                self._task_attempt_fingerprint(identity),
+            )
+
+    def _task_terminal_control_for_identity(
+        self,
+        request_id: str,
+        identity: dict[str, Any],
+    ) -> _TaskTerminalControl | None:
+        control = self._query_task_terminal_controls.get(self._task_request_fingerprint(request_id))
+        if control is None:
+            return None
+        if control.identity_fingerprint != self._task_identity_fingerprint(identity):
+            raise ValueError(f"task lease request_id reused with different identity: {request_id}")
+        return control
+
+    def _task_terminal_lease_matches(
+        self,
+        request_id: str,
+        *,
+        lease_id: str,
+        attempt_id: str,
+        status: str | None = None,
+    ) -> bool:
+        control = self._query_task_terminal_controls.get(self._task_request_fingerprint(request_id))
+        return bool(
+            control is not None
+            and control.lease_fingerprint
+            == self._task_lease_fingerprint(
+                lease_id,
+                attempt_id,
+            )
+            and (status is None or control.status == status)
+        )
+
     def _retire_query_lease_request(
         self,
         *,
@@ -2847,6 +2974,13 @@ class RayQueryDriverActor:
             if output_owners.get(output_owner_key) == str(request_id):
                 output_owners.pop(output_owner_key, None)
         else:
+            self._store_task_terminal_control(
+                request_id=str(request_id),
+                identity=dict(identity),
+                lease=dict(lease) if isinstance(lease, dict) else None,
+                status=str(status),
+                result=terminal_result,
+            )
             task_owner_key = (
                 str(identity["query_id"]),
                 str(identity["task_id"]),
@@ -3164,10 +3298,11 @@ class RayQueryDriverActor:
         request = OutputBlockRequest(**values)
         return request_id, request, asdict(request)
 
-    async def acquire_query_task_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Resolve one task lease through the query's serialized admission pump."""
-        from duckdb.runners.ray.query_resource_manager import TaskGrant, TaskRequest
-        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+    def _parse_task_lease_request(
+        self,
+        payload: dict[str, Any],
+    ) -> tuple[str, Any, dict[str, Any]]:
+        from duckdb.runners.ray.query_resource_manager import TaskRequest
 
         values = self._strict_lease_request(
             payload,
@@ -3187,7 +3322,36 @@ class RayQueryDriverActor:
         raw_resources = values.pop("resources")
         request = TaskRequest(**values)
         identity = {**asdict(request), "resources": dict(raw_resources)}
+        return request_id, request, identity
+
+    async def acquire_query_task_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Resolve one task lease through the query's serialized admission pump."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        request_id, request, identity = self._parse_task_lease_request(payload)
+        raw_resources = identity["resources"]
         self._ensure_query_resource_admission_state()
+        terminal_control = self._task_terminal_control_for_identity(
+            request_id,
+            identity,
+        )
+        if terminal_control is not None:
+            return self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason=terminal_control.blocked_reason,
+                    fatal=True,
+                )
+            )
+        if self._task_attempt_fingerprint(identity) in self._query_task_terminal_attempts:
+            return self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="attempt_terminal",
+                    fatal=True,
+                )
+            )
         tombstone = self._query_task_lease_request_tombstones.get(request_id)
         if tombstone is not None and tombstone["identity"] != identity:
             raise ValueError(f"task lease request_id reused with different identity: {request_id}")
@@ -3218,11 +3382,7 @@ class RayQueryDriverActor:
                 raise RuntimeError(f"invalid task lease request state: {status}")
             return await asyncio.shield(existing["future"])
 
-        resource_identity = (
-            str(identity["query_id"]),
-            str(identity["task_id"]),
-            str(identity["attempt_id"]),
-        )
+        resource_identity = self._task_resource_identity(identity)
         conflicting_owner = self._query_task_request_owner_by_identity.get(resource_identity)
         if conflicting_owner is not None:
             raise ValueError(
@@ -3243,6 +3403,13 @@ class RayQueryDriverActor:
                 "status": "failed",
                 "result": denial,
             }
+            self._store_task_terminal_control(
+                request_id=request_id,
+                identity=identity,
+                lease=None,
+                status="failed",
+                result=denial,
+            )
             return dict(denial)
 
         future = asyncio.get_running_loop().create_future()
@@ -3284,23 +3451,6 @@ class RayQueryDriverActor:
         lease = state.get("lease") or {}
         return str(lease.get("lease_id") or "") == str(lease_id) and str(lease.get("attempt_id") or "") == str(
             attempt_id
-        )
-
-    @classmethod
-    def _query_task_lease_replay_matches(
-        cls,
-        tombstone: dict[str, Any] | None,
-        *,
-        lease_id: str,
-        attempt_id: str,
-    ) -> bool:
-        return bool(
-            tombstone is not None
-            and cls._query_task_lease_matches(
-                tombstone,
-                lease_id,
-                attempt_id,
-            )
         )
 
     def _retire_query_task_lease_record(
@@ -3480,10 +3630,9 @@ class RayQueryDriverActor:
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                tombstone = self._query_task_lease_request_tombstones.get(request_key)
                 return {
-                    "scheduled": self._query_task_lease_replay_matches(
-                        tombstone,
+                    "scheduled": self._task_terminal_lease_matches(
+                        request_key,
                         lease_id=lease_id,
                         attempt_id=attempt_id,
                     )
@@ -3542,16 +3691,12 @@ class RayQueryDriverActor:
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                tombstone = self._query_task_lease_request_tombstones.get(request_key)
                 return {
-                    "handed_off": bool(
-                        tombstone is not None
-                        and tombstone.get("status") == "released_by_teardown"
-                        and self._query_task_lease_replay_matches(
-                            tombstone,
-                            lease_id=lease_id,
-                            attempt_id=attempt_id,
-                        )
+                    "handed_off": self._task_terminal_lease_matches(
+                        request_key,
+                        lease_id=lease_id,
+                        attempt_id=attempt_id,
+                        status="released_by_teardown",
                     )
                 }
             if not self._query_task_lease_matches(
@@ -3616,20 +3761,73 @@ class RayQueryDriverActor:
 
     async def cancel_query_task_lease_request(
         self,
-        request_id: str,
+        payload: dict[str, Any],
     ) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import TaskGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
+        request_id, request, identity = self._parse_task_lease_request(payload)
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
         with self._query_task_lease_condition:
+            terminal_control = self._task_terminal_control_for_identity(
+                request_key,
+                identity,
+            )
+            if terminal_control is not None:
+                return {"cancelled": True, "released": False}
+            if self._task_attempt_fingerprint(identity) in self._query_task_terminal_attempts:
+                raise ValueError(
+                    "task attempt is already terminal under another request_id: "
+                    f"query_id={request.query_id} task_id={request.task_id} "
+                    f"attempt_id={request.attempt_id}"
+                )
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                return {
-                    "cancelled": request_key in self._query_task_lease_request_tombstones,
-                    "released": False,
+                resource_identity = self._task_resource_identity(identity)
+                conflicting_owner = self._query_task_request_owner_by_identity.get(resource_identity)
+                if conflicting_owner is not None:
+                    raise ValueError(
+                        "task attempt is already owned by request_id "
+                        f"{conflicting_owner}: query_id={request.query_id} "
+                        f"task_id={request.task_id} attempt_id={request.attempt_id}"
+                    )
+                denial = self._grant_payload(
+                    TaskGrant(
+                        False,
+                        blocked_reason="task_lease_request_cancelled",
+                        fatal=True,
+                    )
+                )
+                try:
+                    manager = get_query_resource_manager(request.query_id)
+                    manager.remove_task_waiter(
+                        str(request.task_id),
+                        str(request.attempt_id),
+                    )
+                    manager.mark_task_attempt_terminal(
+                        str(request.task_id),
+                        str(request.attempt_id),
+                    )
+                except KeyError:
+                    pass
+                self._query_task_lease_request_tombstones[request_key] = {
+                    "identity": identity,
+                    "status": "cancelled",
+                    "result": denial,
                 }
+                self._store_task_terminal_control(
+                    request_id=request_key,
+                    identity=identity,
+                    lease=None,
+                    status="cancelled",
+                    result=denial,
+                )
+                if str(request.query_id) not in self._query_resource_closing_queries:
+                    self._run_query_resource_admission_pumps(request.query_id)
+                return {"cancelled": True, "released": False}
+            if state["identity"] != identity:
+                raise ValueError(f"task lease request_id reused with different identity: {request_key}")
             status = str(state.get("status") or "")
             if status in {"completion_wait", "teardown_wait"}:
                 # A submitted task can only retire through its selected
@@ -3691,10 +3889,9 @@ class RayQueryDriverActor:
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                tombstone = self._query_task_lease_request_tombstones.get(request_key)
                 return {
-                    "released": self._query_task_lease_replay_matches(
-                        tombstone,
+                    "released": self._task_terminal_lease_matches(
+                        request_key,
                         lease_id=lease_id,
                         attempt_id=attempt_id,
                     )

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -2966,6 +2966,14 @@ class RayQueryDriverActor:
             self._query_lease_generation_ids[query_key] = generation_id
         return generation_id
 
+    def _capability_targets_inactive_query_generation(
+        self,
+        query_id: str,
+        generation_id: str,
+    ) -> bool:
+        active_generation_id = self._query_lease_generation_ids.get(str(query_id))
+        return active_generation_id != str(generation_id)
+
     def _issue_lease_capability(
         self,
         *,
@@ -3099,12 +3107,14 @@ class RayQueryDriverActor:
         manager_lease_id: str,
         query_id: str,
     ) -> str:
+        query_key = str(query_id)
         return self._issue_lease_capability(
             kind="output",
             fields=(
                 str(request_id),
                 str(manager_lease_id),
-                str(query_id),
+                query_key,
+                self._query_lease_generation_id(query_key),
             ),
         )
 
@@ -3114,18 +3124,23 @@ class RayQueryDriverActor:
         request_id: str,
         lease_id: str,
         query_id: str = "",
-    ) -> tuple[str, str] | None:
+    ) -> tuple[str, str, str] | None:
         fields = self._decode_lease_capability(
             lease_id,
             kind="output",
-            field_count=3,
+            field_count=4,
         )
         if fields is None:
             return None
-        capability_request_id, manager_lease_id, capability_query_id = fields
+        (
+            capability_request_id,
+            manager_lease_id,
+            capability_query_id,
+            capability_generation_id,
+        ) = fields
         if capability_request_id != str(request_id) or (query_id and capability_query_id != str(query_id)):
             return None
-        return manager_lease_id, capability_query_id
+        return manager_lease_id, capability_query_id, capability_generation_id
 
     def _store_output_terminal_control(
         self,
@@ -3526,7 +3541,9 @@ class RayQueryDriverActor:
     def _parse_output_block_lease_request(
         self,
         payload: dict[str, Any],
-    ) -> tuple[str, Any, dict[str, Any]]:
+        *,
+        allow_inactive_generation: bool = False,
+    ) -> tuple[str, Any, dict[str, Any], bool]:
         from duckdb.runners.ray.query_resource_manager import OutputBlockRequest
 
         values = self._strict_lease_request(
@@ -3558,14 +3575,17 @@ class RayQueryDriverActor:
             _task_request_id,
             capability_generation_id,
         ) = capability
-        active_generation_id = self._query_lease_generation_ids.get(capability_query_id)
-        if active_generation_id is not None and active_generation_id != capability_generation_id:
+        generation_is_active = not self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        )
+        if not generation_is_active and not allow_inactive_generation:
             raise ValueError("output block request belongs to an inactive query generation")
         values["task_lease_id"] = manager_task_lease_id
         request = OutputBlockRequest(**values)
         identity = asdict(request)
         identity["task_lease_id"] = task_lease_id
-        return request_id, request, identity
+        return request_id, request, identity, generation_is_active
 
     def _parse_task_lease_request(
         self,
@@ -3901,8 +3921,13 @@ class RayQueryDriverActor:
             _capability_attempt_id,
             capability_query_id,
             _capability_request_id,
-            _capability_generation_id,
+            capability_generation_id,
         ) = capability
+        if self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        ):
+            return {"scheduled": True}
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
@@ -3981,8 +4006,13 @@ class RayQueryDriverActor:
             _capability_attempt_id,
             capability_query_id,
             _capability_request_id,
-            _capability_generation_id,
+            capability_generation_id,
         ) = capability
+        if self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        ):
+            return {"handed_off": True}
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
@@ -4190,8 +4220,13 @@ class RayQueryDriverActor:
             _capability_attempt_id,
             capability_query_id,
             _capability_request_id,
-            _capability_generation_id,
+            capability_generation_id,
         ) = capability
+        if self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        ):
+            return {"released": True}
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
@@ -4263,7 +4298,7 @@ class RayQueryDriverActor:
         from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        request_id, request, identity = self._parse_output_block_lease_request(payload)
+        request_id, request, identity, _generation_is_active = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
         terminal_control = self._output_terminal_control_for_identity(
             request_id,
@@ -4375,7 +4410,12 @@ class RayQueryDriverActor:
         )
         if capability is None:
             return {"handed_off": False}
-        manager_lease_id, capability_query_id = capability
+        manager_lease_id, capability_query_id, capability_generation_id = capability
+        if self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        ):
+            return {"handed_off": True}
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
             return {"handed_off": True}
@@ -4421,9 +4461,25 @@ class RayQueryDriverActor:
         )
         if capability is None:
             return {"released": False}
-        manager_lease_id, capability_query_id = capability
+        manager_lease_id, capability_query_id, capability_generation_id = capability
+        if self._capability_targets_inactive_query_generation(
+            capability_query_id,
+            capability_generation_id,
+        ):
+            return {"released": True}
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
+            # Query close drops request payload state before the QRM itself can
+            # be released. The signed capability still authorizes this exact
+            # internal lease in the current generation, so reclaim it
+            # idempotently instead of retaining object-store accounting behind
+            # an unrelated task-teardown fence.
+            try:
+                get_query_resource_manager(capability_query_id).release_output_block(
+                    manager_lease_id,
+                )
+            except KeyError:
+                pass
             return {"released": True}
         lease = state.get("lease") or {}
         if str(lease.get("lease_id") or "") != str(lease_id):
@@ -4455,8 +4511,17 @@ class RayQueryDriverActor:
         from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
-        request_id, request, identity = self._parse_output_block_lease_request(payload)
+        request_id, request, identity, generation_is_active = self._parse_output_block_lease_request(
+            payload,
+            allow_inactive_generation=True,
+        )
         self._ensure_query_resource_admission_state()
+        # A valid task capability from an older query generation proves that
+        # this cancellation cannot own anything in the current manager.  ACK it
+        # without publishing a tombstone or terminal block into the reopened
+        # generation; the remote cleanup owner can then retire durably.
+        if not generation_is_active:
+            return {"cancelled": True, "released": False}
         request_key = request_id
         terminal_control = self._output_terminal_control_for_identity(
             request_key,

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -354,42 +354,6 @@ class _AdmissionLoopFence:
     error: BaseException | None = None
 
 
-@dataclass
-class _QueryTaskExecutionOwner:
-    """Durable ownership of one granted task across admission-table cleanup."""
-
-    query_id: str
-    allocation_generation: int
-    request_id: str
-    task_id: str
-    attempt_id: str
-    lease_id: str
-    phase: Literal[
-        "granted",
-        "submitted",
-        "completion_wait",
-        "teardown_owned",
-    ] = "granted"
-
-
-@dataclass(frozen=True)
-class _QueryTaskExecutionReplay:
-    """Bounded acknowledgement for a terminal execution-owner transition."""
-
-    query_id: str
-    allocation_generation: int
-    request_id: str
-    task_id: str
-    attempt_id: str
-    lease_id: str
-    terminal_action: Literal[
-        "cancelled",
-        "released",
-        "completion",
-        "teardown",
-    ]
-
-
 def _normalize_session_config(config: Mapping[str, Any]) -> dict[str, str]:
     if not isinstance(config, Mapping):
         raise TypeError("Vane session config must be a mapping")
@@ -1320,13 +1284,8 @@ class RayQueryDriverActor:
         self._query_resource_closing_queries: set[str] = set()
         self._query_pending_execution_teardowns: dict[str, set[str]] = {}
         self._query_task_admission_pumps: set[str] = set()
-        self._query_task_execution_condition = threading.Condition()
+        self._query_task_lease_condition = threading.Condition()
         self._query_task_completion_waiters: dict[str, tuple[str, asyncio.Task[None]]] = {}
-        self._query_task_execution_owners: dict[str, _QueryTaskExecutionOwner] = {}
-        self._query_task_execution_replays = BoundedReplayMap[
-            str,
-            _QueryTaskExecutionReplay,
-        ](capacity=_LEASE_REQUEST_REPLAY_CAPACITY)
         self._query_execution_quiesced_queries: set[str] = set()
         self._query_output_admission_pumps: set[str] = set()
         self._query_fte_admission_pumps: dict[str, asyncio.Task[Any]] = {}
@@ -2506,18 +2465,10 @@ class RayQueryDriverActor:
             self._query_resource_closing_queries = set()
         if not hasattr(self, "_query_task_admission_pumps"):
             self._query_task_admission_pumps = set()
-        if not hasattr(self, "_query_task_execution_condition"):
-            self._query_task_execution_condition = threading.Condition()
+        if not hasattr(self, "_query_task_lease_condition"):
+            self._query_task_lease_condition = threading.Condition()
         if not hasattr(self, "_query_task_completion_waiters"):
             self._query_task_completion_waiters = {}
-        if not hasattr(self, "_query_task_execution_owners"):
-            self._query_task_execution_owners = {}
-        execution_replays = getattr(self, "_query_task_execution_replays", None)
-        if not isinstance(execution_replays, BoundedReplayMap):
-            self._query_task_execution_replays = BoundedReplayMap[
-                str,
-                _QueryTaskExecutionReplay,
-            ](capacity=_LEASE_REQUEST_REPLAY_CAPACITY)
         if not hasattr(self, "_query_execution_quiesced_queries"):
             self._query_execution_quiesced_queries = set()
         if not hasattr(self, "_query_terminal_errors"):
@@ -2642,27 +2593,16 @@ class RayQueryDriverActor:
             pass
         self._query_resource_closing_queries.add(query_key)
         self._fail_query_admission_requests(query_key)
-        self._query_task_lease_requests = {
-            request_id: state
-            for request_id, state in self._query_task_lease_requests.items()
-            if state.get("identity", {}).get("query_id") != query_key
-        }
+        # Granted task records are the execution ledger. Keep them until their
+        # terminal RPC (or structural teardown) releases the physical lease.
         self._query_output_lease_requests = {
             request_id: state
             for request_id, state in self._query_output_lease_requests.items()
             if state.get("identity", {}).get("query_id") != query_key
         }
-        self._query_task_lease_request_tombstones.discard_where(
-            lambda _request_id, state: state.get("identity", {}).get("query_id") == query_key
-        )
         self._query_output_lease_request_tombstones.discard_where(
             lambda _request_id, state: state.get("identity", {}).get("query_id") == query_key
         )
-        self._query_task_request_owner_by_identity = {
-            identity: request_id
-            for identity, request_id in self._query_task_request_owner_by_identity.items()
-            if identity[0] != query_key
-        }
         self._query_output_request_owner_by_identity = {
             identity: request_id
             for identity, request_id in self._query_output_request_owner_by_identity.items()
@@ -2686,7 +2626,6 @@ class RayQueryDriverActor:
             for table in (
                 self._query_task_lease_requests,
                 self._query_output_lease_requests,
-                self._query_task_lease_request_tombstones,
                 self._query_output_lease_request_tombstones,
             )
             for state in table.values()
@@ -2699,14 +2638,11 @@ class RayQueryDriverActor:
             )
             for identity in owners
         )
-        with self._query_task_execution_condition:
+        with self._query_task_lease_condition:
             old_completion_waiter_exists = any(
                 owner_query_id == query_key for owner_query_id, _task in self._query_task_completion_waiters.values()
             )
-            old_execution_owner_exists = any(
-                owner.query_id == query_key for owner in self._query_task_execution_owners.values()
-            )
-        if old_state_exists or old_owner_exists or old_completion_waiter_exists or old_execution_owner_exists:
+        if old_state_exists or old_owner_exists or old_completion_waiter_exists:
             raise RuntimeError(f"cannot reopen query admission with old generation state: {query_key}")
         fte_pump = self._query_fte_admission_pumps.get(query_key)
         if fte_pump is not None and not fte_pump.done():
@@ -2716,7 +2652,7 @@ class RayQueryDriverActor:
         self._query_fte_admission_dirty_queries.discard(query_key)
         open_fte_registry_for_query(query_key)
         self._query_resource_closing_queries.discard(query_key)
-        with self._query_task_execution_condition:
+        with self._query_task_lease_condition:
             self._query_execution_quiesced_queries.discard(query_key)
 
     def _signal_query_resource_change(self, query_id: str) -> None:
@@ -3024,21 +2960,13 @@ class RayQueryDriverActor:
             request_id, state = owned_request
             if grant.granted:
                 lease_payload = asdict(grant.lease)
-                state["lease"] = lease_payload
-                try:
-                    self._register_query_task_execution_owner(
-                        request_id=request_id,
-                        state=state,
-                    )
-                except BaseException as registration_error:
-                    self._fail_unpublished_query_task_grant(
-                        manager=manager,
-                        request_id=request_id,
-                        state=state,
-                        registration_error=registration_error,
-                    )
-                    return
-                state["status"] = "granted"
+                # This request record is both the admission result and the
+                # durable execution owner. Publish it before completing the
+                # caller's Future so teardown can never miss a visible grant.
+                with self._query_task_lease_condition:
+                    state["lease"] = lease_payload
+                    state["status"] = "granted"
+                    self._query_task_lease_condition.notify_all()
                 _log_resource_debug(
                     "task_granted",
                     query_id=request.query_id,
@@ -3342,237 +3270,86 @@ class RayQueryDriverActor:
             raise
         return await asyncio.shield(future)
 
-    async def mark_query_task_lease_submitted(self, request_id: str, lease_id: str) -> dict[str, Any]:
-        self._ensure_query_resource_admission_state()
-        request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            if owner is None or owner.lease_id != str(lease_id):
-                return {"submitted": False}
-            if owner.phase not in {"completion_wait", "teardown_owned"}:
-                owner.phase = "submitted"
-            self._query_task_execution_condition.notify_all()
-        if state is not None and state.get("status") in {"granted", "submitted"}:
-            state["status"] = "submitted"
-        return {"submitted": True}
-
-    def _register_query_task_execution_owner(
-        self,
-        *,
-        request_id: str,
-        state: dict[str, Any],
-    ) -> None:
-        """Publish execution ownership before exposing a granted task lease."""
-        identity = state["identity"]
-        lease = state["lease"]
-        owner = _QueryTaskExecutionOwner(
-            query_id=str(identity["query_id"]),
-            allocation_generation=int(lease["allocation_generation"]),
-            request_id=str(request_id),
-            task_id=str(identity["task_id"]),
-            attempt_id=str(lease["attempt_id"]),
-            lease_id=str(lease["lease_id"]),
-        )
-        with self._query_task_execution_condition:
-            if self._query_task_execution_replays.get(owner.request_id) is not None:
-                raise RuntimeError(f"task execution request is already terminal: {owner.request_id}")
-            existing = self._query_task_execution_owners.get(owner.request_id)
-            if existing is not None and existing != owner:
-                raise RuntimeError(f"task execution owner identity changed for request {owner.request_id}")
-            self._query_task_execution_owners[owner.request_id] = owner
-            self._query_task_execution_condition.notify_all()
-
-    def _fail_unpublished_query_task_grant(
-        self,
-        *,
-        manager: Any,
-        request_id: str,
-        state: dict[str, Any],
-        registration_error: BaseException,
-    ) -> None:
-        """Fence a grant that could not publish its durable execution owner."""
-        from duckdb.runners.ray.query_resource_manager import TaskGrant
-
-        identity = state["identity"]
-        lease = state["lease"]
-        request_key = str(request_id)
-        rollback_errors: list[BaseException] = []
-        try:
-            abandoned = bool(
-                manager.abandon_task_lease(
-                    lease["lease_id"],
-                    attempt_id=lease["attempt_id"],
-                )
-            )
-        except BaseException as exc:
-            abandoned = False
-            rollback_errors.append(exc)
-
-        with self._query_task_execution_condition:
-            current_owner = self._query_task_execution_owners.get(request_key)
-            owner_matches = bool(
-                current_owner is not None
-                and self._query_task_execution_owner_matches(
-                    current_owner,
-                    lease["lease_id"],
-                    lease["attempt_id"],
-                )
-            )
-            if abandoned:
-                if owner_matches:
-                    self._query_task_execution_owners.pop(request_key, None)
-            else:
-                if current_owner is None:
-                    current_owner = _QueryTaskExecutionOwner(
-                        query_id=str(identity["query_id"]),
-                        allocation_generation=int(lease["allocation_generation"]),
-                        request_id=request_key,
-                        task_id=str(identity["task_id"]),
-                        attempt_id=str(lease["attempt_id"]),
-                        lease_id=str(lease["lease_id"]),
-                        phase="teardown_owned",
-                    )
-                    self._query_task_execution_owners[request_key] = current_owner
-                elif owner_matches:
-                    current_owner.phase = "teardown_owned"
-                else:
-                    recovery_key = f"{request_key}:unpublished:{lease['lease_id']}"
-                    self._query_task_execution_owners[recovery_key] = _QueryTaskExecutionOwner(
-                        query_id=str(identity["query_id"]),
-                        allocation_generation=int(lease["allocation_generation"]),
-                        request_id=recovery_key,
-                        task_id=str(identity["task_id"]),
-                        attempt_id=str(lease["attempt_id"]),
-                        lease_id=str(lease["lease_id"]),
-                        phase="teardown_owned",
-                    )
-            self._query_task_execution_condition.notify_all()
-
-        if abandoned:
-            try:
-                manager.mark_task_attempt_terminal(
-                    identity["task_id"],
-                    lease["attempt_id"],
-                )
-            except BaseException as exc:
-                rollback_errors.append(exc)
-
-        query_id = str(identity["query_id"])
-        try:
-            manager.close_admission()
-        except BaseException as exc:
-            rollback_errors.append(exc)
-        details = [
-            f"{type(registration_error).__name__}: {registration_error}",
-            *(f"rollback {type(exc).__name__}: {exc}" for exc in rollback_errors),
-        ]
-        self._query_terminal_errors.setdefault(
-            query_id,
-            f"task execution owner registration failed for {request_key}: " + "; ".join(details),
-        )
-        self._query_resource_closing_queries.add(query_id)
-        self._retire_query_lease_request(
-            request_id=request_key,
-            state=state,
-            result=self._grant_payload(
-                TaskGrant(
-                    False,
-                    blocked_reason="task_execution_owner_registration_failed",
-                    fatal=True,
-                )
-            ),
-            status="failed",
-            active=self._query_task_lease_requests,
-            tombstones=self._query_task_lease_request_tombstones,
-        )
-        self._fail_query_admission_requests(query_id)
-
     @staticmethod
-    def _query_task_execution_owner_matches(
-        owner: _QueryTaskExecutionOwner,
+    def _query_task_lease_matches(
+        state: dict[str, Any],
         lease_id: str,
         attempt_id: str,
     ) -> bool:
-        return owner.lease_id == str(lease_id) and owner.attempt_id == str(attempt_id)
-
-    @staticmethod
-    def _query_task_execution_replay_matches(
-        replay: _QueryTaskExecutionReplay | None,
-        *,
-        lease_id: str,
-        attempt_id: str,
-    ) -> bool:
-        return bool(replay is not None and replay.lease_id == str(lease_id) and replay.attempt_id == str(attempt_id))
-
-    def _record_query_task_execution_replay_locked(
-        self,
-        owner: _QueryTaskExecutionOwner,
-        *,
-        terminal_action: Literal[
-            "cancelled",
-            "released",
-            "completion",
-            "teardown",
-        ],
-    ) -> None:
-        self._query_task_execution_replays[owner.request_id] = _QueryTaskExecutionReplay(
-            query_id=owner.query_id,
-            allocation_generation=owner.allocation_generation,
-            request_id=owner.request_id,
-            task_id=owner.task_id,
-            attempt_id=owner.attempt_id,
-            lease_id=owner.lease_id,
-            terminal_action=terminal_action,
+        lease = state.get("lease") or {}
+        return str(lease.get("lease_id") or "") == str(lease_id) and str(lease.get("attempt_id") or "") == str(
+            attempt_id
         )
 
-    def _retire_query_task_execution_owner(
-        self,
-        request_id: str,
+    @classmethod
+    def _query_task_lease_replay_matches(
+        cls,
+        tombstone: dict[str, Any] | None,
         *,
         lease_id: str,
         attempt_id: str,
-        terminal_action: Literal[
-            "cancelled",
-            "released",
-            "completion",
-            "teardown",
-        ],
     ) -> bool:
-        request_key = str(request_id)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            if owner is None or not self._query_task_execution_owner_matches(
-                owner,
+        return bool(
+            tombstone is not None
+            and cls._query_task_lease_matches(
+                tombstone,
                 lease_id,
                 attempt_id,
-            ):
-                return False
-            self._record_query_task_execution_replay_locked(
-                owner,
-                terminal_action=terminal_action,
             )
-            self._query_task_execution_owners.pop(request_key, None)
-            self._query_task_execution_condition.notify_all()
+        )
+
+    def _retire_query_task_lease_record(
+        self,
+        request_id: str,
+        state: dict[str, Any],
+        *,
+        result: dict[str, Any],
+        status: str,
+    ) -> bool:
+        request_key = str(request_id)
+        with self._query_task_lease_condition:
+            if self._query_task_lease_requests.get(request_key) is not state:
+                return False
+            self._retire_query_lease_request(
+                request_id=request_key,
+                state=state,
+                result=result,
+                status=status,
+                active=self._query_task_lease_requests,
+                tombstones=self._query_task_lease_request_tombstones,
+            )
+            self._query_task_lease_condition.notify_all()
             return True
 
     def _mark_query_execution_quiesced(self, query_id: str) -> None:
-        """Publish structural teardown and retire its explicit fallback owners."""
+        """Use structural teardown as terminal proof for fallback-owned tasks."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+
         query_key = str(query_id)
-        with self._query_task_execution_condition:
+        denial = self._grant_payload(
+            TaskGrant(
+                False,
+                blocked_reason="task_lease_owned_by_query_teardown",
+                fatal=True,
+            )
+        )
+        with self._query_task_lease_condition:
             self._query_execution_quiesced_queries.add(query_key)
             teardown_owned = [
-                (request_id, owner)
-                for request_id, owner in self._query_task_execution_owners.items()
-                if owner.query_id == query_key and owner.phase == "teardown_owned"
+                (request_id, state)
+                for request_id, state in self._query_task_lease_requests.items()
+                if state.get("identity", {}).get("query_id") == query_key and state.get("status") == "teardown_owned"
             ]
-            for request_id, owner in teardown_owned:
-                self._record_query_task_execution_replay_locked(
-                    owner,
-                    terminal_action="teardown",
+            for request_id, state in teardown_owned:
+                self._retire_query_lease_request(
+                    request_id=request_id,
+                    state=state,
+                    result=denial,
+                    status="teardown_owned",
+                    active=self._query_task_lease_requests,
+                    tombstones=self._query_task_lease_request_tombstones,
                 )
-                self._query_task_execution_owners.pop(request_id, None)
-            self._query_task_execution_condition.notify_all()
+            self._query_task_lease_condition.notify_all()
 
     def _finish_query_task_completion_wait(
         self,
@@ -3585,57 +3362,50 @@ class RayQueryDriverActor:
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
             if (
-                owner is None
-                or owner.phase != "completion_wait"
-                or not self._query_task_execution_owner_matches(
-                    owner,
+                state is None
+                or state.get("status") != "completion_wait"
+                or not self._query_task_lease_matches(
+                    state,
                     lease_id,
                     attempt_id,
                 )
             ):
                 return {"released": False}
+            identity = dict(state["identity"])
+        query_id = str(identity["query_id"])
         try:
-            released = get_query_resource_manager(owner.query_id).release_task_lease(
+            released = get_query_resource_manager(query_id).release_task_lease(
                 str(lease_id),
                 attempt_id=str(attempt_id),
             )
         except KeyError:
             released = False
         try:
-            get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
-                owner.task_id,
-                owner.attempt_id,
+            get_query_resource_manager(query_id).mark_task_attempt_terminal(
+                str(identity["task_id"]),
+                str(identity["attempt_id"]),
             )
         except KeyError:
             pass
-        if state is not None:
-            self._retire_query_lease_request(
-                request_id=request_key,
-                state=state,
-                result=self._grant_payload(
-                    TaskGrant(
-                        False,
-                        blocked_reason="task_lease_remote_work_completed",
-                        fatal=True,
-                    )
-                ),
-                status="released_after_completion",
-                active=self._query_task_lease_requests,
-                tombstones=self._query_task_lease_request_tombstones,
-            )
-        if not self._retire_query_task_execution_owner(
+        retired = self._retire_query_task_lease_record(
             request_key,
-            lease_id=lease_id,
-            attempt_id=attempt_id,
-            terminal_action="completion",
-        ):
-            raise RuntimeError(f"task completion owner changed while finishing request {request_key}")
-        if owner.query_id not in self._query_resource_closing_queries:
-            self._run_query_resource_admission_pumps(owner.query_id)
+            state,
+            result=self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="task_lease_remote_work_completed",
+                    fatal=True,
+                )
+            ),
+            status="released_after_completion",
+        )
+        if not retired:
+            raise RuntimeError(f"task completion lease changed while finishing request {request_key}")
+        if query_id not in self._query_resource_closing_queries:
+            self._run_query_resource_admission_pumps(query_id)
         return {"released": bool(released)}
 
     async def _wait_for_query_task_completion(
@@ -3671,11 +3441,11 @@ class RayQueryDriverActor:
                 f"task completion ownership transfer failed for {request_key}: {type(exc).__name__}: {exc}",
             )
         finally:
-            with self._query_task_execution_condition:
+            with self._query_task_lease_condition:
                 record = self._query_task_completion_waiters.get(request_key)
                 if record is not None and record[1] is current:
                     self._query_task_completion_waiters.pop(request_key, None)
-                    self._query_task_execution_condition.notify_all()
+                    self._query_task_lease_condition.notify_all()
 
     async def release_query_task_lease_after_completion(
         self,
@@ -3694,40 +3464,35 @@ class RayQueryDriverActor:
             raise TypeError("task completion handoff requires an ObjectRef with future()")
 
         request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            if owner is None:
-                replay = self._query_task_execution_replays.get(request_key)
-                if self._query_task_execution_replay_matches(
-                    replay,
-                    lease_id=lease_id,
-                    attempt_id=attempt_id,
-                ):
-                    return {"scheduled": True}
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
+            if state is None:
                 tombstone = self._query_task_lease_request_tombstones.get(request_key)
-                return {"scheduled": bool(tombstone and tombstone.get("status") == "released_after_completion")}
-            if not self._query_task_execution_owner_matches(
-                owner,
+                return {
+                    "scheduled": self._query_task_lease_replay_matches(
+                        tombstone,
+                        lease_id=lease_id,
+                        attempt_id=attempt_id,
+                    )
+                }
+            if not self._query_task_lease_matches(
+                state,
                 lease_id,
                 attempt_id,
             ):
                 return {"scheduled": False}
-            if owner.phase == "teardown_owned":
+            if state.get("status") == "teardown_owned":
                 return {"scheduled": False}
-            if request_key in self._query_task_completion_waiters:
+            if state.get("status") == "completion_wait" or request_key in self._query_task_completion_waiters:
                 return {"scheduled": True}
+            query_id = str(state["identity"]["query_id"])
 
         completion_future = future_method()
         if not isinstance(completion_future, ConcurrentFuture):
             raise TypeError("task completion ObjectRef.future() must return a concurrent Future")
-        query_id = owner.query_id
-        with self._query_task_execution_condition:
-            current_owner = self._query_task_execution_owners.get(request_key)
-            if current_owner is not owner:
+        with self._query_task_lease_condition:
+            if self._query_task_lease_requests.get(request_key) is not state:
                 return {"scheduled": False}
-            if state is not None:
-                state["status"] = "completion_wait"
             task = asyncio.create_task(
                 self._wait_for_query_task_completion(
                     request_key,
@@ -3738,37 +3503,37 @@ class RayQueryDriverActor:
                 ),
                 name=f"vane-query-task-completion:{request_key}",
             )
-            owner.phase = "completion_wait"
+            state["status"] = "completion_wait"
             self._query_task_completion_waiters[request_key] = (query_id, task)
-            self._query_task_execution_condition.notify_all()
+            self._query_task_lease_condition.notify_all()
         return {"scheduled": True}
 
-    def _wait_for_query_task_execution_owners(
+    def _wait_for_query_task_leases(
         self,
         query_id: str,
         *,
         timeout_s: float = 30.0,
     ) -> None:
-        """Fence QRM release behind every granted execution owner."""
+        """Fence QRM release behind every granted task record."""
         self._ensure_query_resource_admission_state()
         query_key = str(query_id)
         deadline = time.monotonic() + max(0.001, float(timeout_s))
-        with self._query_task_execution_condition:
+        with self._query_task_lease_condition:
             while True:
                 owners = sorted(
-                    (request_id, owner.phase)
-                    for request_id, owner in self._query_task_execution_owners.items()
-                    if owner.query_id == query_key
+                    (request_id, str(state.get("status") or "unknown"))
+                    for request_id, state in self._query_task_lease_requests.items()
+                    if state.get("identity", {}).get("query_id") == query_key
                 )
                 if not owners:
                     return
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise QueryTeardownOwnershipError(
-                        f"query task execution owners did not quiesce for {query_key}: "
-                        + ", ".join(f"{request_id}[{phase}]" for request_id, phase in owners)
+                        f"query task leases did not quiesce for {query_key}: "
+                        + ", ".join(f"{request_id}[{status}]" for request_id, status in owners)
                     )
-                self._query_task_execution_condition.wait(remaining)
+                self._query_task_lease_condition.wait(remaining)
 
     async def handoff_query_task_lease_to_teardown(
         self,
@@ -3776,144 +3541,113 @@ class RayQueryDriverActor:
         lease_id: str,
         attempt_id: str,
     ) -> dict[str, Any]:
-        """Retain a submitted lease when no completion contract is available."""
-        from duckdb.runners.ray.query_resource_manager import TaskGrant
-
+        """Retain a submitted lease until structural query teardown."""
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            if owner is None:
-                replay = self._query_task_execution_replays.get(request_key)
-                if self._query_task_execution_replay_matches(
-                    replay,
-                    lease_id=lease_id,
-                    attempt_id=attempt_id,
-                ):
-                    return {"handed_off": True}
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
+            if state is None:
                 tombstone = self._query_task_lease_request_tombstones.get(request_key)
-                return {"handed_off": bool(tombstone and tombstone.get("status") == "teardown_owned")}
-            if not self._query_task_execution_owner_matches(
-                owner,
+                return {
+                    "handed_off": self._query_task_lease_replay_matches(
+                        tombstone,
+                        lease_id=lease_id,
+                        attempt_id=attempt_id,
+                    )
+                }
+            if not self._query_task_lease_matches(
+                state,
                 lease_id,
                 attempt_id,
             ):
                 return {"handed_off": False}
-            if owner.phase == "completion_wait":
+            if state.get("status") == "completion_wait":
                 return {"handed_off": False}
-            if owner.phase == "teardown_owned":
+            if state.get("status") == "teardown_owned":
                 return {"handed_off": True}
-        if state is not None:
-            self._retire_query_lease_request(
-                request_id=request_key,
-                state=state,
-                result=self._grant_payload(
-                    TaskGrant(
-                        False,
-                        blocked_reason="task_lease_owned_by_query_teardown",
-                        fatal=True,
-                    )
-                ),
-                status="teardown_owned",
-                active=self._query_task_lease_requests,
-                tombstones=self._query_task_lease_request_tombstones,
-            )
-        with self._query_task_execution_condition:
-            current_owner = self._query_task_execution_owners.get(request_key)
-            if current_owner is not owner:
-                return {"handed_off": False}
-            if owner.query_id in self._query_execution_quiesced_queries:
-                self._record_query_task_execution_replay_locked(
-                    owner,
-                    terminal_action="teardown",
+            state["status"] = "teardown_owned"
+            query_id = str(state["identity"]["query_id"])
+            if query_id in self._query_execution_quiesced_queries:
+                from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+                self._retire_query_lease_request(
+                    request_id=request_key,
+                    state=state,
+                    result=self._grant_payload(
+                        TaskGrant(
+                            False,
+                            blocked_reason="task_lease_owned_by_query_teardown",
+                            fatal=True,
+                        )
+                    ),
+                    status="teardown_owned",
+                    active=self._query_task_lease_requests,
+                    tombstones=self._query_task_lease_request_tombstones,
                 )
-                self._query_task_execution_owners.pop(request_key, None)
-            else:
-                owner.phase = "teardown_owned"
-            self._query_task_execution_condition.notify_all()
+            self._query_task_lease_condition.notify_all()
         return {"handed_off": True}
 
-    async def cancel_query_task_lease_request(self, request_id: str, *, submitted: bool) -> dict[str, Any]:
+    async def cancel_query_task_lease_request(
+        self,
+        request_id: str,
+        *,
+        submitted: bool,
+    ) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import TaskGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            replay = self._query_task_execution_replays.get(request_key)
-        if state is None and owner is None:
-            if replay is not None:
-                return {"cancelled": True, "released": False}
-            if request_key in self._query_task_lease_request_tombstones:
-                return {"cancelled": True, "released": False}
-            return {"cancelled": False, "released": False}
-        if submitted or (owner is not None and owner.phase in {"submitted", "completion_wait", "teardown_owned"}):
-            # Cancellation submission is not terminal proof. Submitted work must
-            # use the completion-gated handoff above.
-            return {"cancelled": False, "released": False}
-        denial = self._grant_payload(
-            TaskGrant(
-                False,
-                blocked_reason="task_lease_request_cancelled",
-                fatal=True,
-            )
-        )
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
+            if state is None:
+                return {
+                    "cancelled": request_key in self._query_task_lease_request_tombstones,
+                    "released": False,
+                }
+            status = str(state.get("status") or "")
+            if submitted or status in {"completion_wait", "teardown_owned"}:
+                # Cancellation submission is not terminal proof. Submitted work
+                # must use the completion-gated handoff above.
+                return {"cancelled": False, "released": False}
+            identity = dict(state["identity"])
+            lease = state.get("lease")
+
+        query_id = str(identity["query_id"])
         released = False
-        if owner is not None:
-            try:
-                released = get_query_resource_manager(owner.query_id).abandon_task_lease(
-                    owner.lease_id,
-                    attempt_id=owner.attempt_id,
+        try:
+            manager = get_query_resource_manager(query_id)
+            if isinstance(lease, dict):
+                released = manager.abandon_task_lease(
+                    str(lease["lease_id"]),
+                    attempt_id=str(lease["attempt_id"]),
                 )
-            except KeyError:
-                released = False
-        identity = None if state is None else state["identity"]
-        if owner is None:
-            assert identity is not None
-            try:
-                manager = get_query_resource_manager(identity["query_id"])
+            else:
                 manager.remove_task_waiter(
-                    identity["task_id"],
-                    identity["attempt_id"],
+                    str(identity["task_id"]),
+                    str(identity["attempt_id"]),
                 )
-                manager.mark_task_attempt_terminal(
-                    identity["task_id"],
-                    identity["attempt_id"],
-                )
-            except KeyError:
-                pass
-        else:
-            try:
-                get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
-                    owner.task_id,
-                    owner.attempt_id,
-                )
-            except KeyError:
-                pass
-        if state is not None:
-            self._retire_query_lease_request(
-                request_id=request_key,
-                state=state,
-                result=denial,
-                status="cancelled",
-                active=self._query_task_lease_requests,
-                tombstones=self._query_task_lease_request_tombstones,
+            manager.mark_task_attempt_terminal(
+                str(identity["task_id"]),
+                str(identity["attempt_id"]),
             )
-        if owner is not None and not self._retire_query_task_execution_owner(
+        except KeyError:
+            pass
+
+        retired = self._retire_query_task_lease_record(
             request_key,
-            lease_id=owner.lease_id,
-            attempt_id=owner.attempt_id,
-            terminal_action="cancelled",
-        ):
-            raise RuntimeError(f"task execution owner changed while cancelling request {request_key}")
-        if owner is not None:
-            query_id = owner.query_id
-        else:
-            assert identity is not None
-            query_id = str(identity["query_id"])
+            state,
+            result=self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="task_lease_request_cancelled",
+                    fatal=True,
+                )
+            ),
+            status="cancelled",
+        )
+        if not retired:
+            return {"cancelled": True, "released": False}
         if query_id not in self._query_resource_closing_queries:
             self._run_query_resource_admission_pumps(query_id)
         return {"cancelled": True, "released": bool(released)}
@@ -3929,79 +3663,72 @@ class RayQueryDriverActor:
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
-        state = self._query_task_lease_requests.get(request_key)
-        with self._query_task_execution_condition:
-            owner = self._query_task_execution_owners.get(request_key)
-            if owner is None:
-                replay = self._query_task_execution_replays.get(request_key)
-                if self._query_task_execution_replay_matches(
-                    replay,
-                    lease_id=lease_id,
-                    attempt_id=attempt_id,
-                ):
-                    return {"released": True}
+        with self._query_task_lease_condition:
+            state = self._query_task_lease_requests.get(request_key)
+            if state is None:
                 tombstone = self._query_task_lease_request_tombstones.get(request_key)
-                return {"released": bool(tombstone and tombstone.get("status") == "released")}
-            if owner.phase in {"completion_wait", "teardown_owned"}:
+                return {
+                    "released": self._query_task_lease_replay_matches(
+                        tombstone,
+                        lease_id=lease_id,
+                        attempt_id=attempt_id,
+                    )
+                }
+            if state.get("status") in {"completion_wait", "teardown_owned"}:
                 return {"released": False}
-            if not self._query_task_execution_owner_matches(
-                owner,
+            if not self._query_task_lease_matches(
+                state,
                 lease_id,
                 attempt_id,
             ):
                 return {"released": False}
+            identity = dict(state["identity"])
+        query_id = str(identity["query_id"])
         try:
             _log_resource_debug(
                 "task_release_start",
-                query_id=owner.query_id,
-                stage_id=(state or {}).get("identity", {}).get("stage_id", ""),
+                query_id=query_id,
+                stage_id=identity.get("stage_id", ""),
                 request_id=request_key,
                 lease_id=lease_id,
             )
-            released = get_query_resource_manager(owner.query_id).release_task_lease(
-                str(lease_id), attempt_id=str(attempt_id)
+            released = get_query_resource_manager(query_id).release_task_lease(
+                str(lease_id),
+                attempt_id=str(attempt_id),
             )
         except KeyError:
             released = False
         try:
-            get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
-                owner.task_id,
-                owner.attempt_id,
+            get_query_resource_manager(query_id).mark_task_attempt_terminal(
+                str(identity["task_id"]),
+                str(identity["attempt_id"]),
             )
         except KeyError:
             pass
-        if state is not None:
-            self._retire_query_lease_request(
-                request_id=request_key,
-                state=state,
-                result=self._grant_payload(
-                    TaskGrant(
-                        False,
-                        blocked_reason="task_lease_request_released",
-                        fatal=True,
-                    )
-                ),
-                status="released",
-                active=self._query_task_lease_requests,
-                tombstones=self._query_task_lease_request_tombstones,
-            )
-        if not self._retire_query_task_execution_owner(
+        retired = self._retire_query_task_lease_record(
             request_key,
-            lease_id=lease_id,
-            attempt_id=attempt_id,
-            terminal_action="released",
-        ):
-            raise RuntimeError(f"task execution owner changed while releasing request {request_key}")
+            state,
+            result=self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="task_lease_request_released",
+                    fatal=True,
+                )
+            ),
+            status="released",
+        )
+        if not retired:
+            return {"released": False}
         _log_resource_debug(
             "task_release_done",
-            query_id=owner.query_id,
-            stage_id=(state or {}).get("identity", {}).get("stage_id", ""),
+            query_id=query_id,
+            stage_id=identity.get("stage_id", ""),
             request_id=request_key,
             lease_id=lease_id,
             released=bool(released),
         )
-        if owner.query_id not in self._query_resource_closing_queries:
-            self._run_query_resource_admission_pumps(owner.query_id)
+        if query_id not in self._query_resource_closing_queries:
+            self._run_query_resource_admission_pumps(query_id)
         return {"released": True}
 
     async def acquire_query_output_block_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -4488,11 +4215,10 @@ class RayQueryDriverActor:
             # submitted object that could not expose a completion ObjectRef.
             # Completion-owned Ray calls still require their own terminal ref.
             self._mark_query_execution_quiesced(query_key)
-        # Admission close may delete request/replay state, but every grant has
-        # an independent execution owner published before the grant Future.
-        # This fence therefore also covers terminal handoff RPCs that have been
-        # submitted by a collector but have not reached this actor yet.
-        self._wait_for_query_task_execution_owners(query_key)
+        # A granted request remains in the same admission ledger until its
+        # terminal transition, including completion handoffs that arrive while
+        # query teardown is already fenced.
+        self._wait_for_query_task_leases(query_key)
         cleanup_errors: list[BaseException] = []
         deferred_teardowns: tuple[_DeferredQueryAllocationTeardown, ...] = ()
         try:
@@ -4534,7 +4260,7 @@ class RayQueryDriverActor:
                 f"{len(cleanup_errors)} error(s): "
                 + "; ".join(f"{type(exc).__name__}: {exc}" for exc in cleanup_errors)
             ) from cleanup_errors[0]
-        with self._query_task_execution_condition:
+        with self._query_task_lease_condition:
             self._query_execution_quiesced_queries.discard(query_key)
 
     def query_resource_snapshot(

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -12,6 +12,7 @@ import time
 import uuid
 import weakref
 from collections.abc import Callable, Mapping
+from concurrent.futures import Future as ConcurrentFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import asdict, dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal, NoReturn
@@ -351,6 +352,42 @@ class _ClientOwnerLease:
 class _AdmissionLoopFence:
     completed: threading.Event = field(default_factory=threading.Event)
     error: BaseException | None = None
+
+
+@dataclass
+class _QueryTaskExecutionOwner:
+    """Durable ownership of one granted task across admission-table cleanup."""
+
+    query_id: str
+    allocation_generation: int
+    request_id: str
+    task_id: str
+    attempt_id: str
+    lease_id: str
+    phase: Literal[
+        "granted",
+        "submitted",
+        "completion_wait",
+        "teardown_owned",
+    ] = "granted"
+
+
+@dataclass(frozen=True)
+class _QueryTaskExecutionReplay:
+    """Bounded acknowledgement for a terminal execution-owner transition."""
+
+    query_id: str
+    allocation_generation: int
+    request_id: str
+    task_id: str
+    attempt_id: str
+    lease_id: str
+    terminal_action: Literal[
+        "cancelled",
+        "released",
+        "completion",
+        "teardown",
+    ]
 
 
 def _normalize_session_config(config: Mapping[str, Any]) -> dict[str, str]:
@@ -1283,6 +1320,14 @@ class RayQueryDriverActor:
         self._query_resource_closing_queries: set[str] = set()
         self._query_pending_execution_teardowns: dict[str, set[str]] = {}
         self._query_task_admission_pumps: set[str] = set()
+        self._query_task_execution_condition = threading.Condition()
+        self._query_task_completion_waiters: dict[str, tuple[str, asyncio.Task[None]]] = {}
+        self._query_task_execution_owners: dict[str, _QueryTaskExecutionOwner] = {}
+        self._query_task_execution_replays = BoundedReplayMap[
+            str,
+            _QueryTaskExecutionReplay,
+        ](capacity=_LEASE_REQUEST_REPLAY_CAPACITY)
+        self._query_execution_quiesced_queries: set[str] = set()
         self._query_output_admission_pumps: set[str] = set()
         self._query_fte_admission_pumps: dict[str, asyncio.Task[Any]] = {}
         self._query_fte_admission_dirty_queries: set[str] = set()
@@ -1454,6 +1499,7 @@ class RayQueryDriverActor:
                     query_id,
                     reason="query_fragments_dropped",
                     admission_fenced=True,
+                    execution_quiesced=True,
                 )
             except BaseException as exc:
                 errors.append(exc)
@@ -2460,6 +2506,22 @@ class RayQueryDriverActor:
             self._query_resource_closing_queries = set()
         if not hasattr(self, "_query_task_admission_pumps"):
             self._query_task_admission_pumps = set()
+        if not hasattr(self, "_query_task_execution_condition"):
+            self._query_task_execution_condition = threading.Condition()
+        if not hasattr(self, "_query_task_completion_waiters"):
+            self._query_task_completion_waiters = {}
+        if not hasattr(self, "_query_task_execution_owners"):
+            self._query_task_execution_owners = {}
+        execution_replays = getattr(self, "_query_task_execution_replays", None)
+        if not isinstance(execution_replays, BoundedReplayMap):
+            self._query_task_execution_replays = BoundedReplayMap[
+                str,
+                _QueryTaskExecutionReplay,
+            ](capacity=_LEASE_REQUEST_REPLAY_CAPACITY)
+        if not hasattr(self, "_query_execution_quiesced_queries"):
+            self._query_execution_quiesced_queries = set()
+        if not hasattr(self, "_query_terminal_errors"):
+            self._query_terminal_errors = {}
         if not hasattr(self, "_query_output_admission_pumps"):
             self._query_output_admission_pumps = set()
         if not hasattr(self, "_query_fte_admission_pumps"):
@@ -2637,7 +2699,14 @@ class RayQueryDriverActor:
             )
             for identity in owners
         )
-        if old_state_exists or old_owner_exists:
+        with self._query_task_execution_condition:
+            old_completion_waiter_exists = any(
+                owner_query_id == query_key for owner_query_id, _task in self._query_task_completion_waiters.values()
+            )
+            old_execution_owner_exists = any(
+                owner.query_id == query_key for owner in self._query_task_execution_owners.values()
+            )
+        if old_state_exists or old_owner_exists or old_completion_waiter_exists or old_execution_owner_exists:
             raise RuntimeError(f"cannot reopen query admission with old generation state: {query_key}")
         fte_pump = self._query_fte_admission_pumps.get(query_key)
         if fte_pump is not None and not fte_pump.done():
@@ -2647,6 +2716,8 @@ class RayQueryDriverActor:
         self._query_fte_admission_dirty_queries.discard(query_key)
         open_fte_registry_for_query(query_key)
         self._query_resource_closing_queries.discard(query_key)
+        with self._query_task_execution_condition:
+            self._query_execution_quiesced_queries.discard(query_key)
 
     def _signal_query_resource_change(self, query_id: str) -> None:
         """Coalesce a resource mutation into one task and output pump run.
@@ -2821,11 +2892,15 @@ class RayQueryDriverActor:
         state["status"] = str(status)
         self._complete_lease_request(state, terminal_result)
         active.pop(str(request_id), None)
-        tombstones[str(request_id)] = {
+        tombstone = {
             "identity": dict(state["identity"]),
             "status": str(status),
             "result": terminal_result,
         }
+        lease = state.get("lease")
+        if isinstance(lease, dict):
+            tombstone["lease"] = dict(lease)
+        tombstones[str(request_id)] = tombstone
         identity = state["identity"]
         if "block_id" in identity:
             output_owner_key = (str(identity["query_id"]), str(identity["block_id"]))
@@ -2949,8 +3024,21 @@ class RayQueryDriverActor:
             request_id, state = owned_request
             if grant.granted:
                 lease_payload = asdict(grant.lease)
-                state["status"] = "granted"
                 state["lease"] = lease_payload
+                try:
+                    self._register_query_task_execution_owner(
+                        request_id=request_id,
+                        state=state,
+                    )
+                except BaseException as registration_error:
+                    self._fail_unpublished_query_task_grant(
+                        manager=manager,
+                        request_id=request_id,
+                        state=state,
+                        registration_error=registration_error,
+                    )
+                    return
+                state["status"] = "granted"
                 _log_resource_debug(
                     "task_granted",
                     query_id=request.query_id,
@@ -3169,6 +3257,11 @@ class RayQueryDriverActor:
         request = TaskRequest(**values)
         identity = {**asdict(request), "resources": dict(raw_resources)}
         self._ensure_query_resource_admission_state()
+        tombstone = self._query_task_lease_request_tombstones.get(request_id)
+        if tombstone is not None and tombstone["identity"] != identity:
+            raise ValueError(f"task lease request_id reused with different identity: {request_id}")
+        if tombstone is not None:
+            return dict(tombstone["result"])
         if str(request.query_id) in self._query_resource_closing_queries:
             return self._grant_payload(
                 TaskGrant(
@@ -3177,11 +3270,6 @@ class RayQueryDriverActor:
                     fatal=True,
                 )
             )
-        tombstone = self._query_task_lease_request_tombstones.get(request_id)
-        if tombstone is not None and tombstone["identity"] != identity:
-            raise ValueError(f"task lease request_id reused with different identity: {request_id}")
-        if tombstone is not None:
-            return dict(tombstone["result"])
         existing = self._query_task_lease_requests.get(request_id)
         if existing is not None and existing["identity"] != identity:
             raise ValueError(f"task lease request_id reused with different identity: {request_id}")
@@ -3256,14 +3344,495 @@ class RayQueryDriverActor:
 
     async def mark_query_task_lease_submitted(self, request_id: str, lease_id: str) -> dict[str, Any]:
         self._ensure_query_resource_admission_state()
-        state = self._query_task_lease_requests.get(str(request_id))
-        if state is None or state.get("status") not in {"granted", "submitted"}:
-            return {"submitted": False}
-        lease = state.get("lease") or {}
-        if str(lease.get("lease_id") or "") != str(lease_id):
-            return {"submitted": False}
-        state["status"] = "submitted"
+        request_key = str(request_id)
+        state = self._query_task_lease_requests.get(request_key)
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if owner is None or owner.lease_id != str(lease_id):
+                return {"submitted": False}
+            if owner.phase not in {"completion_wait", "teardown_owned"}:
+                owner.phase = "submitted"
+            self._query_task_execution_condition.notify_all()
+        if state is not None and state.get("status") in {"granted", "submitted"}:
+            state["status"] = "submitted"
         return {"submitted": True}
+
+    def _register_query_task_execution_owner(
+        self,
+        *,
+        request_id: str,
+        state: dict[str, Any],
+    ) -> None:
+        """Publish execution ownership before exposing a granted task lease."""
+        identity = state["identity"]
+        lease = state["lease"]
+        owner = _QueryTaskExecutionOwner(
+            query_id=str(identity["query_id"]),
+            allocation_generation=int(lease["allocation_generation"]),
+            request_id=str(request_id),
+            task_id=str(identity["task_id"]),
+            attempt_id=str(lease["attempt_id"]),
+            lease_id=str(lease["lease_id"]),
+        )
+        with self._query_task_execution_condition:
+            if self._query_task_execution_replays.get(owner.request_id) is not None:
+                raise RuntimeError(f"task execution request is already terminal: {owner.request_id}")
+            existing = self._query_task_execution_owners.get(owner.request_id)
+            if existing is not None and existing != owner:
+                raise RuntimeError(f"task execution owner identity changed for request {owner.request_id}")
+            self._query_task_execution_owners[owner.request_id] = owner
+            self._query_task_execution_condition.notify_all()
+
+    def _fail_unpublished_query_task_grant(
+        self,
+        *,
+        manager: Any,
+        request_id: str,
+        state: dict[str, Any],
+        registration_error: BaseException,
+    ) -> None:
+        """Fence a grant that could not publish its durable execution owner."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+        identity = state["identity"]
+        lease = state["lease"]
+        request_key = str(request_id)
+        rollback_errors: list[BaseException] = []
+        try:
+            abandoned = bool(
+                manager.abandon_task_lease(
+                    lease["lease_id"],
+                    attempt_id=lease["attempt_id"],
+                )
+            )
+        except BaseException as exc:
+            abandoned = False
+            rollback_errors.append(exc)
+
+        with self._query_task_execution_condition:
+            current_owner = self._query_task_execution_owners.get(request_key)
+            owner_matches = bool(
+                current_owner is not None
+                and self._query_task_execution_owner_matches(
+                    current_owner,
+                    lease["lease_id"],
+                    lease["attempt_id"],
+                )
+            )
+            if abandoned:
+                if owner_matches:
+                    self._query_task_execution_owners.pop(request_key, None)
+            else:
+                if current_owner is None:
+                    current_owner = _QueryTaskExecutionOwner(
+                        query_id=str(identity["query_id"]),
+                        allocation_generation=int(lease["allocation_generation"]),
+                        request_id=request_key,
+                        task_id=str(identity["task_id"]),
+                        attempt_id=str(lease["attempt_id"]),
+                        lease_id=str(lease["lease_id"]),
+                        phase="teardown_owned",
+                    )
+                    self._query_task_execution_owners[request_key] = current_owner
+                elif owner_matches:
+                    current_owner.phase = "teardown_owned"
+                else:
+                    recovery_key = f"{request_key}:unpublished:{lease['lease_id']}"
+                    self._query_task_execution_owners[recovery_key] = _QueryTaskExecutionOwner(
+                        query_id=str(identity["query_id"]),
+                        allocation_generation=int(lease["allocation_generation"]),
+                        request_id=recovery_key,
+                        task_id=str(identity["task_id"]),
+                        attempt_id=str(lease["attempt_id"]),
+                        lease_id=str(lease["lease_id"]),
+                        phase="teardown_owned",
+                    )
+            self._query_task_execution_condition.notify_all()
+
+        if abandoned:
+            try:
+                manager.mark_task_attempt_terminal(
+                    identity["task_id"],
+                    lease["attempt_id"],
+                )
+            except BaseException as exc:
+                rollback_errors.append(exc)
+
+        query_id = str(identity["query_id"])
+        try:
+            manager.close_admission()
+        except BaseException as exc:
+            rollback_errors.append(exc)
+        details = [
+            f"{type(registration_error).__name__}: {registration_error}",
+            *(f"rollback {type(exc).__name__}: {exc}" for exc in rollback_errors),
+        ]
+        self._query_terminal_errors.setdefault(
+            query_id,
+            f"task execution owner registration failed for {request_key}: " + "; ".join(details),
+        )
+        self._query_resource_closing_queries.add(query_id)
+        self._retire_query_lease_request(
+            request_id=request_key,
+            state=state,
+            result=self._grant_payload(
+                TaskGrant(
+                    False,
+                    blocked_reason="task_execution_owner_registration_failed",
+                    fatal=True,
+                )
+            ),
+            status="failed",
+            active=self._query_task_lease_requests,
+            tombstones=self._query_task_lease_request_tombstones,
+        )
+        self._fail_query_admission_requests(query_id)
+
+    @staticmethod
+    def _query_task_execution_owner_matches(
+        owner: _QueryTaskExecutionOwner,
+        lease_id: str,
+        attempt_id: str,
+    ) -> bool:
+        return owner.lease_id == str(lease_id) and owner.attempt_id == str(attempt_id)
+
+    @staticmethod
+    def _query_task_execution_replay_matches(
+        replay: _QueryTaskExecutionReplay | None,
+        *,
+        lease_id: str,
+        attempt_id: str,
+    ) -> bool:
+        return bool(replay is not None and replay.lease_id == str(lease_id) and replay.attempt_id == str(attempt_id))
+
+    def _record_query_task_execution_replay_locked(
+        self,
+        owner: _QueryTaskExecutionOwner,
+        *,
+        terminal_action: Literal[
+            "cancelled",
+            "released",
+            "completion",
+            "teardown",
+        ],
+    ) -> None:
+        self._query_task_execution_replays[owner.request_id] = _QueryTaskExecutionReplay(
+            query_id=owner.query_id,
+            allocation_generation=owner.allocation_generation,
+            request_id=owner.request_id,
+            task_id=owner.task_id,
+            attempt_id=owner.attempt_id,
+            lease_id=owner.lease_id,
+            terminal_action=terminal_action,
+        )
+
+    def _retire_query_task_execution_owner(
+        self,
+        request_id: str,
+        *,
+        lease_id: str,
+        attempt_id: str,
+        terminal_action: Literal[
+            "cancelled",
+            "released",
+            "completion",
+            "teardown",
+        ],
+    ) -> bool:
+        request_key = str(request_id)
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if owner is None or not self._query_task_execution_owner_matches(
+                owner,
+                lease_id,
+                attempt_id,
+            ):
+                return False
+            self._record_query_task_execution_replay_locked(
+                owner,
+                terminal_action=terminal_action,
+            )
+            self._query_task_execution_owners.pop(request_key, None)
+            self._query_task_execution_condition.notify_all()
+            return True
+
+    def _mark_query_execution_quiesced(self, query_id: str) -> None:
+        """Publish structural teardown and retire its explicit fallback owners."""
+        query_key = str(query_id)
+        with self._query_task_execution_condition:
+            self._query_execution_quiesced_queries.add(query_key)
+            teardown_owned = [
+                (request_id, owner)
+                for request_id, owner in self._query_task_execution_owners.items()
+                if owner.query_id == query_key and owner.phase == "teardown_owned"
+            ]
+            for request_id, owner in teardown_owned:
+                self._record_query_task_execution_replay_locked(
+                    owner,
+                    terminal_action="teardown",
+                )
+                self._query_task_execution_owners.pop(request_id, None)
+            self._query_task_execution_condition.notify_all()
+
+    def _finish_query_task_completion_wait(
+        self,
+        request_id: str,
+        lease_id: str,
+        attempt_id: str,
+    ) -> dict[str, Any]:
+        """Release one lease only after its submitted Ray call is terminal."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+        from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
+
+        request_key = str(request_id)
+        state = self._query_task_lease_requests.get(request_key)
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if (
+                owner is None
+                or owner.phase != "completion_wait"
+                or not self._query_task_execution_owner_matches(
+                    owner,
+                    lease_id,
+                    attempt_id,
+                )
+            ):
+                return {"released": False}
+        try:
+            released = get_query_resource_manager(owner.query_id).release_task_lease(
+                str(lease_id),
+                attempt_id=str(attempt_id),
+            )
+        except KeyError:
+            released = False
+        try:
+            get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
+                owner.task_id,
+                owner.attempt_id,
+            )
+        except KeyError:
+            pass
+        if state is not None:
+            self._retire_query_lease_request(
+                request_id=request_key,
+                state=state,
+                result=self._grant_payload(
+                    TaskGrant(
+                        False,
+                        blocked_reason="task_lease_remote_work_completed",
+                        fatal=True,
+                    )
+                ),
+                status="released_after_completion",
+                active=self._query_task_lease_requests,
+                tombstones=self._query_task_lease_request_tombstones,
+            )
+        if not self._retire_query_task_execution_owner(
+            request_key,
+            lease_id=lease_id,
+            attempt_id=attempt_id,
+            terminal_action="completion",
+        ):
+            raise RuntimeError(f"task completion owner changed while finishing request {request_key}")
+        if owner.query_id not in self._query_resource_closing_queries:
+            self._run_query_resource_admission_pumps(owner.query_id)
+        return {"released": bool(released)}
+
+    async def _wait_for_query_task_completion(
+        self,
+        request_id: str,
+        lease_id: str,
+        attempt_id: str,
+        query_id: str,
+        completion_future: ConcurrentFuture[Any],
+    ) -> None:
+        """Observe terminal work without occupying a Ray actor RPC slot."""
+        request_key = str(request_id)
+        current = asyncio.current_task()
+        try:
+            try:
+                await asyncio.wrap_future(completion_future)
+            except asyncio.CancelledError:
+                raise
+            except BaseException:
+                # A failed completion ObjectRef is still terminal proof.
+                pass
+            self._finish_query_task_completion_wait(
+                request_key,
+                lease_id,
+                attempt_id,
+            )
+        except asyncio.CancelledError:
+            # Query teardown remains the conservative execution owner.
+            pass
+        except BaseException as exc:
+            self._query_terminal_errors.setdefault(
+                str(query_id),
+                f"task completion ownership transfer failed for {request_key}: {type(exc).__name__}: {exc}",
+            )
+        finally:
+            with self._query_task_execution_condition:
+                record = self._query_task_completion_waiters.get(request_key)
+                if record is not None and record[1] is current:
+                    self._query_task_completion_waiters.pop(request_key, None)
+                    self._query_task_execution_condition.notify_all()
+
+    async def release_query_task_lease_after_completion(
+        self,
+        request_id: str,
+        lease_id: str,
+        attempt_id: str,
+        completion_refs: list[Any],
+    ) -> dict[str, Any]:
+        """Transfer task accounting to a driver-owned completion waiter."""
+        self._ensure_query_resource_admission_state()
+        if not isinstance(completion_refs, list) or len(completion_refs) != 1:
+            raise ValueError("task completion handoff requires exactly one nested ObjectRef")
+        completion_ref = completion_refs[0]
+        future_method = getattr(completion_ref, "future", None)
+        if not callable(future_method):
+            raise TypeError("task completion handoff requires an ObjectRef with future()")
+
+        request_key = str(request_id)
+        state = self._query_task_lease_requests.get(request_key)
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if owner is None:
+                replay = self._query_task_execution_replays.get(request_key)
+                if self._query_task_execution_replay_matches(
+                    replay,
+                    lease_id=lease_id,
+                    attempt_id=attempt_id,
+                ):
+                    return {"scheduled": True}
+                tombstone = self._query_task_lease_request_tombstones.get(request_key)
+                return {"scheduled": bool(tombstone and tombstone.get("status") == "released_after_completion")}
+            if not self._query_task_execution_owner_matches(
+                owner,
+                lease_id,
+                attempt_id,
+            ):
+                return {"scheduled": False}
+            if owner.phase == "teardown_owned":
+                return {"scheduled": False}
+            if request_key in self._query_task_completion_waiters:
+                return {"scheduled": True}
+
+        completion_future = future_method()
+        if not isinstance(completion_future, ConcurrentFuture):
+            raise TypeError("task completion ObjectRef.future() must return a concurrent Future")
+        query_id = owner.query_id
+        with self._query_task_execution_condition:
+            current_owner = self._query_task_execution_owners.get(request_key)
+            if current_owner is not owner:
+                return {"scheduled": False}
+            if state is not None:
+                state["status"] = "completion_wait"
+            task = asyncio.create_task(
+                self._wait_for_query_task_completion(
+                    request_key,
+                    str(lease_id),
+                    str(attempt_id),
+                    query_id,
+                    completion_future,
+                ),
+                name=f"vane-query-task-completion:{request_key}",
+            )
+            owner.phase = "completion_wait"
+            self._query_task_completion_waiters[request_key] = (query_id, task)
+            self._query_task_execution_condition.notify_all()
+        return {"scheduled": True}
+
+    def _wait_for_query_task_execution_owners(
+        self,
+        query_id: str,
+        *,
+        timeout_s: float = 30.0,
+    ) -> None:
+        """Fence QRM release behind every granted execution owner."""
+        self._ensure_query_resource_admission_state()
+        query_key = str(query_id)
+        deadline = time.monotonic() + max(0.001, float(timeout_s))
+        with self._query_task_execution_condition:
+            while True:
+                owners = sorted(
+                    (request_id, owner.phase)
+                    for request_id, owner in self._query_task_execution_owners.items()
+                    if owner.query_id == query_key
+                )
+                if not owners:
+                    return
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise QueryTeardownOwnershipError(
+                        f"query task execution owners did not quiesce for {query_key}: "
+                        + ", ".join(f"{request_id}[{phase}]" for request_id, phase in owners)
+                    )
+                self._query_task_execution_condition.wait(remaining)
+
+    async def handoff_query_task_lease_to_teardown(
+        self,
+        request_id: str,
+        lease_id: str,
+        attempt_id: str,
+    ) -> dict[str, Any]:
+        """Retain a submitted lease when no completion contract is available."""
+        from duckdb.runners.ray.query_resource_manager import TaskGrant
+
+        self._ensure_query_resource_admission_state()
+        request_key = str(request_id)
+        state = self._query_task_lease_requests.get(request_key)
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if owner is None:
+                replay = self._query_task_execution_replays.get(request_key)
+                if self._query_task_execution_replay_matches(
+                    replay,
+                    lease_id=lease_id,
+                    attempt_id=attempt_id,
+                ):
+                    return {"handed_off": True}
+                tombstone = self._query_task_lease_request_tombstones.get(request_key)
+                return {"handed_off": bool(tombstone and tombstone.get("status") == "teardown_owned")}
+            if not self._query_task_execution_owner_matches(
+                owner,
+                lease_id,
+                attempt_id,
+            ):
+                return {"handed_off": False}
+            if owner.phase == "completion_wait":
+                return {"handed_off": False}
+            if owner.phase == "teardown_owned":
+                return {"handed_off": True}
+        if state is not None:
+            self._retire_query_lease_request(
+                request_id=request_key,
+                state=state,
+                result=self._grant_payload(
+                    TaskGrant(
+                        False,
+                        blocked_reason="task_lease_owned_by_query_teardown",
+                        fatal=True,
+                    )
+                ),
+                status="teardown_owned",
+                active=self._query_task_lease_requests,
+                tombstones=self._query_task_lease_request_tombstones,
+            )
+        with self._query_task_execution_condition:
+            current_owner = self._query_task_execution_owners.get(request_key)
+            if current_owner is not owner:
+                return {"handed_off": False}
+            if owner.query_id in self._query_execution_quiesced_queries:
+                self._record_query_task_execution_replay_locked(
+                    owner,
+                    terminal_action="teardown",
+                )
+                self._query_task_execution_owners.pop(request_key, None)
+            else:
+                owner.phase = "teardown_owned"
+            self._query_task_execution_condition.notify_all()
+        return {"handed_off": True}
 
     async def cancel_query_task_lease_request(self, request_id: str, *, submitted: bool) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import TaskGrant
@@ -3272,9 +3841,18 @@ class RayQueryDriverActor:
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
         state = self._query_task_lease_requests.get(request_key)
-        if state is None:
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            replay = self._query_task_execution_replays.get(request_key)
+        if state is None and owner is None:
+            if replay is not None:
+                return {"cancelled": True, "released": False}
             if request_key in self._query_task_lease_request_tombstones:
                 return {"cancelled": True, "released": False}
+            return {"cancelled": False, "released": False}
+        if submitted or (owner is not None and owner.phase in {"submitted", "completion_wait", "teardown_owned"}):
+            # Cancellation submission is not terminal proof. Submitted work must
+            # use the completion-gated handoff above.
             return {"cancelled": False, "released": False}
         denial = self._grant_payload(
             TaskGrant(
@@ -3283,19 +3861,18 @@ class RayQueryDriverActor:
                 fatal=True,
             )
         )
-        lease = state.get("lease")
         released = False
-        if lease is not None:
+        if owner is not None:
             try:
-                manager = get_query_resource_manager(lease["query_id"])
-                if submitted:
-                    released = manager.release_task_lease(lease["lease_id"], attempt_id=lease["attempt_id"])
-                else:
-                    released = manager.abandon_task_lease(lease["lease_id"], attempt_id=lease["attempt_id"])
+                released = get_query_resource_manager(owner.query_id).abandon_task_lease(
+                    owner.lease_id,
+                    attempt_id=owner.attempt_id,
+                )
             except KeyError:
                 released = False
-        identity = state["identity"]
-        if lease is None:
+        identity = None if state is None else state["identity"]
+        if owner is None:
+            assert identity is not None
             try:
                 manager = get_query_resource_manager(identity["query_id"])
                 manager.remove_task_waiter(
@@ -3310,21 +3887,35 @@ class RayQueryDriverActor:
                 pass
         else:
             try:
-                get_query_resource_manager(identity["query_id"]).mark_task_attempt_terminal(
-                    identity["task_id"],
-                    identity["attempt_id"],
+                get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
+                    owner.task_id,
+                    owner.attempt_id,
                 )
             except KeyError:
                 pass
-        self._retire_query_lease_request(
-            request_id=request_key,
-            state=state,
-            result=denial,
-            status="cancelled",
-            active=self._query_task_lease_requests,
-            tombstones=self._query_task_lease_request_tombstones,
-        )
-        self._run_query_resource_admission_pumps(identity["query_id"])
+        if state is not None:
+            self._retire_query_lease_request(
+                request_id=request_key,
+                state=state,
+                result=denial,
+                status="cancelled",
+                active=self._query_task_lease_requests,
+                tombstones=self._query_task_lease_request_tombstones,
+            )
+        if owner is not None and not self._retire_query_task_execution_owner(
+            request_key,
+            lease_id=owner.lease_id,
+            attempt_id=owner.attempt_id,
+            terminal_action="cancelled",
+        ):
+            raise RuntimeError(f"task execution owner changed while cancelling request {request_key}")
+        if owner is not None:
+            query_id = owner.query_id
+        else:
+            assert identity is not None
+            query_id = str(identity["query_id"])
+        if query_id not in self._query_resource_closing_queries:
+            self._run_query_resource_admission_pumps(query_id)
         return {"cancelled": True, "released": bool(released)}
 
     async def release_query_task_lease(
@@ -3339,48 +3930,79 @@ class RayQueryDriverActor:
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
         state = self._query_task_lease_requests.get(request_key)
-        if state is None:
-            return {"released": False}
-        lease = state.get("lease") or {}
-        if str(lease.get("lease_id") or "") != str(lease_id) or str(lease.get("attempt_id") or "") != str(attempt_id):
-            return {"released": False}
+        with self._query_task_execution_condition:
+            owner = self._query_task_execution_owners.get(request_key)
+            if owner is None:
+                replay = self._query_task_execution_replays.get(request_key)
+                if self._query_task_execution_replay_matches(
+                    replay,
+                    lease_id=lease_id,
+                    attempt_id=attempt_id,
+                ):
+                    return {"released": True}
+                tombstone = self._query_task_lease_request_tombstones.get(request_key)
+                return {"released": bool(tombstone and tombstone.get("status") == "released")}
+            if owner.phase in {"completion_wait", "teardown_owned"}:
+                return {"released": False}
+            if not self._query_task_execution_owner_matches(
+                owner,
+                lease_id,
+                attempt_id,
+            ):
+                return {"released": False}
         try:
             _log_resource_debug(
                 "task_release_start",
-                query_id=lease.get("query_id", ""),
-                stage_id=lease.get("stage_id", ""),
+                query_id=owner.query_id,
+                stage_id=(state or {}).get("identity", {}).get("stage_id", ""),
                 request_id=request_key,
                 lease_id=lease_id,
             )
-            released = get_query_resource_manager(lease["query_id"]).release_task_lease(
+            released = get_query_resource_manager(owner.query_id).release_task_lease(
                 str(lease_id), attempt_id=str(attempt_id)
             )
         except KeyError:
             released = False
-        self._retire_query_lease_request(
-            request_id=request_key,
-            state=state,
-            result=self._grant_payload(
-                TaskGrant(
-                    False,
-                    blocked_reason="task_lease_request_released",
-                    fatal=True,
-                )
-            ),
-            status="released",
-            active=self._query_task_lease_requests,
-            tombstones=self._query_task_lease_request_tombstones,
-        )
+        try:
+            get_query_resource_manager(owner.query_id).mark_task_attempt_terminal(
+                owner.task_id,
+                owner.attempt_id,
+            )
+        except KeyError:
+            pass
+        if state is not None:
+            self._retire_query_lease_request(
+                request_id=request_key,
+                state=state,
+                result=self._grant_payload(
+                    TaskGrant(
+                        False,
+                        blocked_reason="task_lease_request_released",
+                        fatal=True,
+                    )
+                ),
+                status="released",
+                active=self._query_task_lease_requests,
+                tombstones=self._query_task_lease_request_tombstones,
+            )
+        if not self._retire_query_task_execution_owner(
+            request_key,
+            lease_id=lease_id,
+            attempt_id=attempt_id,
+            terminal_action="released",
+        ):
+            raise RuntimeError(f"task execution owner changed while releasing request {request_key}")
         _log_resource_debug(
             "task_release_done",
-            query_id=lease.get("query_id", ""),
-            stage_id=lease.get("stage_id", ""),
+            query_id=owner.query_id,
+            stage_id=(state or {}).get("identity", {}).get("stage_id", ""),
             request_id=request_key,
             lease_id=lease_id,
             released=bool(released),
         )
-        self._run_query_resource_admission_pumps(lease["query_id"])
-        return {"released": bool(released)}
+        if owner.query_id not in self._query_resource_closing_queries:
+            self._run_query_resource_admission_pumps(owner.query_id)
+        return {"released": True}
 
     async def acquire_query_output_block_lease(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Resolve one produced block through the query's admission pump."""
@@ -3389,6 +4011,11 @@ class RayQueryDriverActor:
 
         request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
+        tombstone = self._query_output_lease_request_tombstones.get(request_id)
+        if tombstone is not None and tombstone["identity"] != identity:
+            raise ValueError(f"output lease request_id reused with different identity: {request_id}")
+        if tombstone is not None:
+            return dict(tombstone["result"])
         if str(request.query_id) in self._query_resource_closing_queries:
             return self._grant_payload(
                 OutputBlockGrant(
@@ -3397,11 +4024,6 @@ class RayQueryDriverActor:
                     fatal=True,
                 )
             )
-        tombstone = self._query_output_lease_request_tombstones.get(request_id)
-        if tombstone is not None and tombstone["identity"] != identity:
-            raise ValueError(f"output lease request_id reused with different identity: {request_id}")
-        if tombstone is not None:
-            return dict(tombstone["result"])
         existing = self._query_output_lease_requests.get(request_id)
         if existing is not None and existing["identity"] != identity:
             raise ValueError(f"output lease request_id reused with different identity: {request_id}")
@@ -3467,6 +4089,7 @@ class RayQueryDriverActor:
         self,
         request_id: str,
         lease_id: str,
+        query_id: str = "",
     ) -> dict[str, Any]:
         """Transfer a live output from the producer queue to downstream input.
 
@@ -3480,14 +4103,26 @@ class RayQueryDriverActor:
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
         state = self._query_output_lease_requests.get(request_key)
-        if state is None or state.get("status") in {"released", "cancelled", "failed"}:
+        if state is None:
+            tombstone = self._query_output_lease_request_tombstones.get(request_key)
+            replay_lease = {} if tombstone is None else tombstone.get("lease") or {}
+            if (
+                tombstone is not None
+                and str(replay_lease.get("lease_id") or "") == str(lease_id)
+                and tombstone.get("status") in {"released", "cancelled"}
+            ):
+                return {"handed_off": True}
+            if str(query_id) in self._query_resource_closing_queries:
+                return {"handed_off": True}
             return {"handed_off": False}
         lease = state.get("lease") or {}
         if str(lease.get("lease_id") or "") != str(lease_id):
             return {"handed_off": False}
+        if query_id and str(lease.get("query_id") or "") != str(query_id):
+            return {"handed_off": False}
         current_state = str(lease.get("state") or "")
         if current_state == "downstream_input":
-            return {"handed_off": False}
+            return {"handed_off": True}
         if current_state != "stage_queue":
             raise RuntimeError(f"output lease handoff requires stage_queue state, got {current_state!r}")
         try:
@@ -3500,12 +4135,15 @@ class RayQueryDriverActor:
         if handed_off:
             lease["state"] = "downstream_input"
             self._run_query_resource_admission_pumps(lease["query_id"])
-        return {"handed_off": bool(handed_off)}
+        return {
+            "handed_off": bool(handed_off or str(lease.get("query_id") or "") in self._query_resource_closing_queries)
+        }
 
     async def release_query_output_block_lease(
         self,
         request_id: str,
         lease_id: str,
+        query_id: str = "",
     ) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
         from duckdb.runners.ray.query_resource_runtime import get_query_resource_manager
@@ -3514,14 +4152,26 @@ class RayQueryDriverActor:
         request_key = str(request_id)
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
+            tombstone = self._query_output_lease_request_tombstones.get(request_key)
+            replay_lease = {} if tombstone is None else tombstone.get("lease") or {}
+            if (
+                tombstone is not None
+                and str(replay_lease.get("lease_id") or "") == str(lease_id)
+                and tombstone.get("status") in {"released", "cancelled"}
+            ):
+                return {"released": True}
+            if str(query_id) in self._query_resource_closing_queries:
+                return {"released": True}
             return {"released": False}
         lease = state.get("lease") or {}
         if str(lease.get("lease_id") or "") != str(lease_id):
             return {"released": False}
+        if query_id and str(lease.get("query_id") or "") != str(query_id):
+            return {"released": False}
         try:
-            released = get_query_resource_manager(lease["query_id"]).release_output_block(str(lease_id))
+            get_query_resource_manager(lease["query_id"]).release_output_block(str(lease_id))
         except KeyError:
-            released = False
+            pass
         self._retire_query_lease_request(
             request_id=request_key,
             state=state,
@@ -3537,7 +4187,7 @@ class RayQueryDriverActor:
             tombstones=self._query_output_lease_request_tombstones,
         )
         self._run_query_resource_admission_pumps(lease["query_id"])
-        return {"released": bool(released)}
+        return {"released": True}
 
     async def cancel_query_output_block_lease_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         from duckdb.runners.ray.query_resource_manager import OutputBlockGrant
@@ -3545,13 +4195,13 @@ class RayQueryDriverActor:
 
         request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
-        if str(request.query_id) in self._query_resource_closing_queries:
-            return {"cancelled": True, "released": False}
         request_key = request_id
         tombstone = self._query_output_lease_request_tombstones.get(request_key)
         if tombstone is not None and tombstone["identity"] != identity:
             raise ValueError(f"output lease request_id reused with different identity: {request_key}")
         if tombstone is not None:
+            return {"cancelled": True, "released": False}
+        if str(request.query_id) in self._query_resource_closing_queries:
             return {"cancelled": True, "released": False}
         state = self._query_output_lease_requests.get(request_key)
         if state is not None and state["identity"] != identity:
@@ -3816,6 +4466,7 @@ class RayQueryDriverActor:
         *,
         reason: str,
         admission_fenced: bool = False,
+        execution_quiesced: bool = False,
     ) -> None:
         from duckdb.runners.ray.query_resource_runtime import release_query_resource_manager
 
@@ -3832,6 +4483,16 @@ class RayQueryDriverActor:
                 raise QueryTeardownOwnershipError(
                     f"failed to fence query resource release for {query_key}: {type(exc).__name__}: {exc}"
                 ) from exc
+        if execution_quiesced:
+            # Structural query teardown is the fallback proof for the rare
+            # submitted object that could not expose a completion ObjectRef.
+            # Completion-owned Ray calls still require their own terminal ref.
+            self._mark_query_execution_quiesced(query_key)
+        # Admission close may delete request/replay state, but every grant has
+        # an independent execution owner published before the grant Future.
+        # This fence therefore also covers terminal handoff RPCs that have been
+        # submitted by a collector but have not reached this actor yet.
+        self._wait_for_query_task_execution_owners(query_key)
         cleanup_errors: list[BaseException] = []
         deferred_teardowns: tuple[_DeferredQueryAllocationTeardown, ...] = ()
         try:
@@ -3873,6 +4534,8 @@ class RayQueryDriverActor:
                 f"{len(cleanup_errors)} error(s): "
                 + "; ".join(f"{type(exc).__name__}: {exc}" for exc in cleanup_errors)
             ) from cleanup_errors[0]
+        with self._query_task_execution_condition:
+            self._query_execution_quiesced_queries.discard(query_key)
 
     def query_resource_snapshot(
         self,
@@ -4134,6 +4797,7 @@ class RayQueryDriverActor:
         drop_fragments: bool,
     ) -> None:
         errors: list[BaseException] = []
+        execution_owner_errors: list[BaseException] = []
         self.curr_plans.pop(plan_id, None)
         self.curr_streams.pop(plan_id, None)
         with self._plan_teardown_condition:
@@ -4146,6 +4810,7 @@ class RayQueryDriverActor:
                     output_lease_owner.release()
                 except BaseException as exc:
                     errors.append(exc)
+                    execution_owner_errors.append(exc)
                 else:
                     with self._plan_teardown_condition:
                         current_refs = self._leased_result_partition_refs.get(str(plan_id))
@@ -4164,19 +4829,31 @@ class RayQueryDriverActor:
             self._cleanup_udf_actor_pools(str(plan_id))
         except BaseException as exc:
             errors.append(exc)
+            execution_owner_errors.append(exc)
         try:
             self._cleanup_vllm_actor_pools(str(plan_id))
         except BaseException as exc:
             errors.append(exc)
+            execution_owner_errors.append(exc)
         query_key = str(query_id or "").strip()
         if query_key:
             try:
                 if drop_fragments:
-                    self._drop_query_fragments_sync(query_key)
-                else:
+                    if execution_owner_errors:
+                        # Quiesce independently owned fragments, but keep the
+                        # QRM/coordinator allocation intact while an output or
+                        # actor owner failed to terminate.
+                        self._drop_query_fragments_after_admission_fence_sync(
+                            query_key,
+                            release_resources=False,
+                        )
+                    else:
+                        self._drop_query_fragments_sync(query_key)
+                elif not execution_owner_errors:
                     self._release_query_resources(
                         query_key,
                         reason="query_ended_before_fragment_start",
+                        execution_quiesced=True,
                     )
             except BaseException as exc:
                 errors.append(exc)

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -129,12 +129,23 @@ class QueryExecutionCleanupError(RuntimeError):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _TaskTerminalControl:
     """Compact driver-lifetime proof for one terminal task request."""
 
     identity_fingerprint: bytes
     lease_fingerprint: bytes | None
+    status: str
+    blocked_reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class _OutputTerminalControl:
+    """Compact driver-lifetime proof for one terminal output request."""
+
+    identity_fingerprint: bytes
+    lease_fingerprint: bytes | None
+    query_fingerprint: bytes
     status: str
     blocked_reason: str
 
@@ -1298,6 +1309,9 @@ class RayQueryDriverActor:
         self._query_output_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
             capacity=_LEASE_REQUEST_REPLAY_CAPACITY
         )
+        # Output payload replay is bounded, but a delayed release ACK must stay
+        # provable after that cache entry is evicted.
+        self._query_output_terminal_controls: dict[bytes, _OutputTerminalControl] = {}
         self._query_task_request_owner_by_identity: dict[tuple[str, str, str], str] = {}
         self._query_output_request_owner_by_identity: dict[tuple[str, str], str] = {}
         self._query_resource_closing_queries: set[str] = set()
@@ -2480,6 +2494,8 @@ class RayQueryDriverActor:
                 getattr(output_tombstones, "items", lambda: ())(),
                 capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
             )
+        if not hasattr(self, "_query_output_terminal_controls"):
+            self._query_output_terminal_controls = {}
         if not hasattr(self, "_query_task_request_owner_by_identity"):
             self._query_task_request_owner_by_identity = {}
         if not hasattr(self, "_query_output_request_owner_by_identity"):
@@ -2943,6 +2959,93 @@ class RayQueryDriverActor:
             and (status is None or control.status == status)
         )
 
+    @staticmethod
+    def _output_identity_fingerprint(identity: dict[str, Any]) -> bytes:
+        encoded = json.dumps(
+            identity,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).digest()
+
+    @staticmethod
+    def _output_request_fingerprint(request_id: str) -> bytes:
+        return hashlib.sha256(str(request_id).encode("utf-8")).digest()
+
+    @staticmethod
+    def _output_lease_fingerprint(lease_id: str) -> bytes:
+        return hashlib.sha256(str(lease_id).encode("utf-8")).digest()
+
+    @staticmethod
+    def _output_query_fingerprint(query_id: str) -> bytes:
+        return hashlib.sha256(str(query_id).encode("utf-8")).digest()
+
+    def _store_output_terminal_control(
+        self,
+        *,
+        request_id: str,
+        identity: dict[str, Any],
+        lease: dict[str, Any] | None,
+        status: str,
+        result: dict[str, Any],
+    ) -> None:
+        request_key = str(request_id)
+        request_fingerprint = self._output_request_fingerprint(request_key)
+        control = _OutputTerminalControl(
+            identity_fingerprint=self._output_identity_fingerprint(identity),
+            lease_fingerprint=(
+                None
+                if lease is None
+                else self._output_lease_fingerprint(
+                    str(lease["lease_id"]),
+                )
+            ),
+            query_fingerprint=self._output_query_fingerprint(
+                str(identity["query_id"]),
+            ),
+            status=str(status),
+            blocked_reason=str(result.get("blocked_reason") or "output_request_terminal"),
+        )
+        existing = self._query_output_terminal_controls.get(request_fingerprint)
+        if existing is not None and existing != control:
+            raise RuntimeError(f"output terminal control identity changed: {request_key}")
+        self._query_output_terminal_controls[request_fingerprint] = control
+
+    def _output_terminal_control_for_identity(
+        self,
+        request_id: str,
+        identity: dict[str, Any],
+    ) -> _OutputTerminalControl | None:
+        control = self._query_output_terminal_controls.get(self._output_request_fingerprint(request_id))
+        if control is None:
+            return None
+        if control.identity_fingerprint != self._output_identity_fingerprint(identity):
+            raise ValueError(f"output lease request_id reused with different identity: {request_id}")
+        return control
+
+    def _output_terminal_lease_matches(
+        self,
+        request_id: str,
+        *,
+        lease_id: str,
+        query_id: str = "",
+    ) -> bool:
+        control = self._query_output_terminal_controls.get(self._output_request_fingerprint(request_id))
+        return bool(
+            control is not None
+            and control.lease_fingerprint == self._output_lease_fingerprint(lease_id)
+            and (
+                not query_id
+                or control.query_fingerprint
+                == self._output_query_fingerprint(
+                    query_id,
+                )
+            )
+            and control.status in {"released", "cancelled"}
+        )
+
     def _retire_query_lease_request(
         self,
         *,
@@ -2969,6 +3072,13 @@ class RayQueryDriverActor:
         tombstones[str(request_id)] = tombstone
         identity = state["identity"]
         if "block_id" in identity:
+            self._store_output_terminal_control(
+                request_id=str(request_id),
+                identity=dict(identity),
+                lease=dict(lease) if isinstance(lease, dict) else None,
+                status=str(status),
+                result=terminal_result,
+            )
             output_owner_key = (str(identity["query_id"]), str(identity["block_id"]))
             output_owners = self._query_output_request_owner_by_identity
             if output_owners.get(output_owner_key) == str(request_id):
@@ -3960,6 +4070,18 @@ class RayQueryDriverActor:
 
         request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
+        terminal_control = self._output_terminal_control_for_identity(
+            request_id,
+            identity,
+        )
+        if terminal_control is not None:
+            return self._grant_payload(
+                OutputBlockGrant(
+                    False,
+                    blocked_reason=terminal_control.blocked_reason,
+                    fatal=True,
+                )
+            )
         tombstone = self._query_output_lease_request_tombstones.get(request_id)
         if tombstone is not None and tombstone["identity"] != identity:
             raise ValueError(f"output lease request_id reused with different identity: {request_id}")
@@ -4053,12 +4175,10 @@ class RayQueryDriverActor:
         request_key = str(request_id)
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
-            tombstone = self._query_output_lease_request_tombstones.get(request_key)
-            replay_lease = {} if tombstone is None else tombstone.get("lease") or {}
-            if (
-                tombstone is not None
-                and str(replay_lease.get("lease_id") or "") == str(lease_id)
-                and tombstone.get("status") in {"released", "cancelled"}
+            if self._output_terminal_lease_matches(
+                request_key,
+                lease_id=str(lease_id),
+                query_id=str(query_id),
             ):
                 return {"handed_off": True}
             if str(query_id) in self._query_resource_closing_queries:
@@ -4101,12 +4221,10 @@ class RayQueryDriverActor:
         request_key = str(request_id)
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
-            tombstone = self._query_output_lease_request_tombstones.get(request_key)
-            replay_lease = {} if tombstone is None else tombstone.get("lease") or {}
-            if (
-                tombstone is not None
-                and str(replay_lease.get("lease_id") or "") == str(lease_id)
-                and tombstone.get("status") in {"released", "cancelled"}
+            if self._output_terminal_lease_matches(
+                request_key,
+                lease_id=str(lease_id),
+                query_id=str(query_id),
             ):
                 return {"released": True}
             if str(query_id) in self._query_resource_closing_queries:
@@ -4145,16 +4263,12 @@ class RayQueryDriverActor:
         request_id, request, identity = self._parse_output_block_lease_request(payload)
         self._ensure_query_resource_admission_state()
         request_key = request_id
-        tombstone = self._query_output_lease_request_tombstones.get(request_key)
-        if tombstone is not None and tombstone["identity"] != identity:
-            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
-        if tombstone is not None:
+        terminal_control = self._output_terminal_control_for_identity(
+            request_key,
+            identity,
+        )
+        if terminal_control is not None:
             return {"cancelled": True, "released": False}
-        if str(request.query_id) in self._query_resource_closing_queries:
-            return {"cancelled": True, "released": False}
-        state = self._query_output_lease_requests.get(request_key)
-        if state is not None and state["identity"] != identity:
-            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
         denial = self._grant_payload(
             OutputBlockGrant(
                 False,
@@ -4162,6 +4276,23 @@ class RayQueryDriverActor:
                 fatal=True,
             )
         )
+        tombstone = self._query_output_lease_request_tombstones.get(request_key)
+        if tombstone is not None and tombstone["identity"] != identity:
+            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
+        if tombstone is not None:
+            return {"cancelled": True, "released": False}
+        if str(request.query_id) in self._query_resource_closing_queries:
+            self._store_output_terminal_control(
+                request_id=request_key,
+                identity=identity,
+                lease=None,
+                status="cancelled",
+                result=denial,
+            )
+            return {"cancelled": True, "released": False}
+        state = self._query_output_lease_requests.get(request_key)
+        if state is not None and state["identity"] != identity:
+            raise ValueError(f"output lease request_id reused with different identity: {request_key}")
         if state is None:
             resource_identity = (
                 str(identity["query_id"]),
@@ -4183,6 +4314,13 @@ class RayQueryDriverActor:
                 "status": "cancelled",
                 "result": denial,
             }
+            self._store_output_terminal_control(
+                request_id=request_key,
+                identity=identity,
+                lease=None,
+                status="cancelled",
+                result=denial,
+            )
             self._run_query_resource_admission_pumps(request.query_id)
             return {"cancelled": True, "released": False}
         lease = state.get("lease")

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import hashlib
+import hmac
 import json
 import math
 import os
@@ -131,20 +134,19 @@ class QueryExecutionCleanupError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class _TaskTerminalControl:
-    """Compact driver-lifetime proof for one terminal task request."""
+    """Bounded payload-replay identity for one terminal task request."""
 
     identity_fingerprint: bytes
-    lease_fingerprint: bytes | None
+    query_fingerprint: bytes
     status: str
     blocked_reason: str
 
 
 @dataclass(frozen=True, slots=True)
 class _OutputTerminalControl:
-    """Compact driver-lifetime proof for one terminal output request."""
+    """Bounded payload-replay identity for one terminal output request."""
 
     identity_fingerprint: bytes
-    lease_fingerprint: bytes | None
     query_fingerprint: bytes
     status: str
     blocked_reason: str
@@ -1301,17 +1303,24 @@ class RayQueryDriverActor:
         self._query_task_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
             capacity=_LEASE_REQUEST_REPLAY_CAPACITY
         )
-        # Full replay payloads are bounded, but terminal control identity must
-        # remain exact for the actor lifetime. Otherwise a lost response can
-        # become unacknowledgeable after tombstone eviction.
-        self._query_task_terminal_controls: dict[bytes, _TaskTerminalControl] = {}
-        self._query_task_terminal_attempts: set[bytes] = set()
+        # Request payload replay is bounded and query-scoped. Granted task
+        # lease IDs are signed capabilities, so cleanup ACK replay does not
+        # depend on retaining an entry in either compact denial ledger.
+        self._query_task_terminal_controls = BoundedReplayMap[bytes, _TaskTerminalControl](
+            capacity=_LEASE_REQUEST_REPLAY_CAPACITY
+        )
+        self._query_task_terminal_attempts = BoundedReplayMap[bytes, bytes](capacity=_LEASE_REQUEST_REPLAY_CAPACITY)
         self._query_output_lease_request_tombstones = BoundedReplayMap[str, dict[str, Any]](
             capacity=_LEASE_REQUEST_REPLAY_CAPACITY
         )
-        # Output payload replay is bounded, but a delayed release ACK must stay
-        # provable after that cache entry is evicted.
-        self._query_output_terminal_controls: dict[bytes, _OutputTerminalControl] = {}
+        # Request payload replay is bounded and query-scoped. Granted output
+        # lease IDs are signed capabilities, so cleanup ACK replay does not
+        # depend on retaining an entry in this map.
+        self._query_output_terminal_controls = BoundedReplayMap[bytes, _OutputTerminalControl](
+            capacity=_LEASE_REQUEST_REPLAY_CAPACITY
+        )
+        self._query_lease_control_key = os.urandom(32)
+        self._query_lease_generation_ids: dict[str, str] = {}
         self._query_task_request_owner_by_identity: dict[tuple[str, str, str], str] = {}
         self._query_output_request_owner_by_identity: dict[tuple[str, str], str] = {}
         self._query_resource_closing_queries: set[str] = set()
@@ -2478,24 +2487,30 @@ class RayQueryDriverActor:
             self._query_task_lease_requests = {}
         if not hasattr(self, "_query_output_lease_requests"):
             self._query_output_lease_requests = {}
-        task_tombstones = getattr(self, "_query_task_lease_request_tombstones", ())
-        if not isinstance(task_tombstones, BoundedReplayMap):
+        if not hasattr(self, "_query_task_lease_request_tombstones"):
             self._query_task_lease_request_tombstones = BoundedReplayMap(
-                getattr(task_tombstones, "items", lambda: ())(),
                 capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
             )
         if not hasattr(self, "_query_task_terminal_controls"):
-            self._query_task_terminal_controls = {}
+            self._query_task_terminal_controls = BoundedReplayMap(
+                capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
+            )
         if not hasattr(self, "_query_task_terminal_attempts"):
-            self._query_task_terminal_attempts = set()
-        output_tombstones = getattr(self, "_query_output_lease_request_tombstones", ())
-        if not isinstance(output_tombstones, BoundedReplayMap):
+            self._query_task_terminal_attempts = BoundedReplayMap(
+                capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
+            )
+        if not hasattr(self, "_query_output_lease_request_tombstones"):
             self._query_output_lease_request_tombstones = BoundedReplayMap(
-                getattr(output_tombstones, "items", lambda: ())(),
                 capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
             )
         if not hasattr(self, "_query_output_terminal_controls"):
-            self._query_output_terminal_controls = {}
+            self._query_output_terminal_controls = BoundedReplayMap(
+                capacity=_LEASE_REQUEST_REPLAY_CAPACITY,
+            )
+        if not hasattr(self, "_query_lease_control_key"):
+            self._query_lease_control_key = os.urandom(32)
+        if not hasattr(self, "_query_lease_generation_ids"):
+            self._query_lease_generation_ids = {}
         if not hasattr(self, "_query_task_request_owner_by_identity"):
             self._query_task_request_owner_by_identity = {}
         if not hasattr(self, "_query_output_request_owner_by_identity"):
@@ -2618,6 +2633,26 @@ class RayQueryDriverActor:
         if fence.error is not None:
             raise fence.error
 
+    def _discard_query_admission_replay(self, query_id: str) -> None:
+        """Drop bounded replay caches that must never cross a query generation."""
+        query_key = str(query_id)
+        query_fingerprint = self._query_fingerprint(query_key)
+        self._query_task_lease_request_tombstones.discard_where(
+            lambda _request_id, state: state.get("identity", {}).get("query_id") == query_key
+        )
+        self._query_output_lease_request_tombstones.discard_where(
+            lambda _request_id, state: state.get("identity", {}).get("query_id") == query_key
+        )
+        self._query_task_terminal_controls.discard_where(
+            lambda _request_fingerprint, control: control.query_fingerprint == query_fingerprint
+        )
+        self._query_task_terminal_attempts.discard_where(
+            lambda _attempt_fingerprint, owner_query_fingerprint: owner_query_fingerprint == query_fingerprint
+        )
+        self._query_output_terminal_controls.discard_where(
+            lambda _request_fingerprint, control: control.query_fingerprint == query_fingerprint
+        )
+
     def _close_query_resource_admission(self, query_id: str) -> None:
         """Fence new requests and resolve all old requests on the owner loop."""
         from duckdb.runners.ray.fte_fragment_scheduler import close_fte_registry_for_query
@@ -2641,9 +2676,7 @@ class RayQueryDriverActor:
             for request_id, state in self._query_output_lease_requests.items()
             if state.get("identity", {}).get("query_id") != query_key
         }
-        self._query_output_lease_request_tombstones.discard_where(
-            lambda _request_id, state: state.get("identity", {}).get("query_id") == query_key
-        )
+        self._discard_query_admission_replay(query_key)
         self._query_output_request_owner_by_identity = {
             identity: request_id
             for identity, request_id in self._query_output_request_owner_by_identity.items()
@@ -2667,7 +2700,6 @@ class RayQueryDriverActor:
             for table in (
                 self._query_task_lease_requests,
                 self._query_output_lease_requests,
-                self._query_output_lease_request_tombstones,
             )
             for state in table.values()
         )
@@ -2692,7 +2724,9 @@ class RayQueryDriverActor:
         self._query_fte_admission_pumps.pop(query_key, None)
         self._query_fte_admission_done_events.pop(query_key, None)
         self._query_fte_admission_dirty_queries.discard(query_key)
+        self._discard_query_admission_replay(query_key)
         open_fte_registry_for_query(query_key)
+        self._query_lease_generation_ids[query_key] = uuid.uuid4().hex
         self._query_resource_closing_queries.discard(query_key)
 
     def _signal_query_resource_change(self, query_id: str) -> None:
@@ -2865,15 +2899,6 @@ class RayQueryDriverActor:
         return hashlib.sha256(encoded).digest()
 
     @staticmethod
-    def _task_lease_fingerprint(lease_id: str, attempt_id: str) -> bytes:
-        encoded = json.dumps(
-            [str(lease_id), str(attempt_id)],
-            separators=(",", ":"),
-            ensure_ascii=False,
-        ).encode("utf-8")
-        return hashlib.sha256(encoded).digest()
-
-    @staticmethod
     def _task_request_fingerprint(request_id: str) -> bytes:
         return hashlib.sha256(str(request_id).encode("utf-8")).digest()
 
@@ -2900,7 +2925,6 @@ class RayQueryDriverActor:
         *,
         request_id: str,
         identity: dict[str, Any],
-        lease: dict[str, Any] | None,
         status: str,
         result: dict[str, Any],
     ) -> None:
@@ -2908,13 +2932,8 @@ class RayQueryDriverActor:
         request_fingerprint = self._task_request_fingerprint(request_key)
         control = _TaskTerminalControl(
             identity_fingerprint=self._task_identity_fingerprint(identity),
-            lease_fingerprint=(
-                None
-                if lease is None
-                else self._task_lease_fingerprint(
-                    str(lease["lease_id"]),
-                    str(lease["attempt_id"]),
-                )
+            query_fingerprint=self._query_fingerprint(
+                str(identity["query_id"]),
             ),
             status=str(status),
             blocked_reason=str(result.get("blocked_reason") or "task_request_terminal"),
@@ -2924,9 +2943,7 @@ class RayQueryDriverActor:
             raise RuntimeError(f"task terminal control identity changed: {request_key}")
         self._query_task_terminal_controls[request_fingerprint] = control
         if str(status) != "failed":
-            self._query_task_terminal_attempts.add(
-                self._task_attempt_fingerprint(identity),
-            )
+            self._query_task_terminal_attempts[self._task_attempt_fingerprint(identity)] = control.query_fingerprint
 
     def _task_terminal_control_for_identity(
         self,
@@ -2940,23 +2957,120 @@ class RayQueryDriverActor:
             raise ValueError(f"task lease request_id reused with different identity: {request_id}")
         return control
 
-    def _task_terminal_lease_matches(
+    def _query_lease_generation_id(self, query_id: str) -> str:
+        self._ensure_query_resource_admission_state()
+        query_key = str(query_id)
+        generation_id = self._query_lease_generation_ids.get(query_key)
+        if generation_id is None:
+            generation_id = uuid.uuid4().hex
+            self._query_lease_generation_ids[query_key] = generation_id
+        return generation_id
+
+    def _issue_lease_capability(
         self,
+        *,
+        kind: str,
+        fields: tuple[str, ...],
+    ) -> str:
+        self._ensure_query_resource_admission_state()
+        payload = json.dumps(
+            [f"vane-{kind}-lease-v1", *fields],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        encoded = base64.urlsafe_b64encode(payload).rstrip(b"=")
+        signature = hmac.new(
+            self._query_lease_control_key,
+            encoded,
+            hashlib.sha256,
+        ).hexdigest()
+        return f"v1.{encoded.decode('ascii')}.{signature}"
+
+    def _decode_lease_capability(
+        self,
+        lease_id: str,
+        *,
+        kind: str,
+        field_count: int,
+    ) -> tuple[str, ...] | None:
+        self._ensure_query_resource_admission_state()
+        try:
+            version, encoded_text, supplied_signature = str(lease_id).split(".", 2)
+            if version != "v1":
+                return None
+            encoded = encoded_text.encode("ascii")
+            expected_signature = hmac.new(
+                self._query_lease_control_key,
+                encoded,
+                hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(supplied_signature, expected_signature):
+                return None
+            padding = b"=" * (-len(encoded) % 4)
+            values = json.loads(base64.urlsafe_b64decode(encoded + padding).decode("utf-8"))
+        except (UnicodeError, ValueError, TypeError, binascii.Error):
+            return None
+        if not isinstance(values, list) or len(values) != field_count + 1 or values[0] != f"vane-{kind}-lease-v1":
+            return None
+        fields = tuple(str(value) for value in values[1:])
+        if any(not value for value in fields):
+            return None
+        return fields
+
+    def _issue_task_lease_capability(
+        self,
+        *,
         request_id: str,
+        manager_lease_id: str,
+        attempt_id: str,
+        query_id: str,
+    ) -> str:
+        query_key = str(query_id)
+        return self._issue_lease_capability(
+            kind="task",
+            fields=(
+                str(request_id),
+                str(manager_lease_id),
+                str(attempt_id),
+                query_key,
+                self._query_lease_generation_id(query_key),
+            ),
+        )
+
+    def _verify_task_lease_capability(
+        self,
         *,
         lease_id: str,
-        attempt_id: str,
-        status: str | None = None,
-    ) -> bool:
-        control = self._query_task_terminal_controls.get(self._task_request_fingerprint(request_id))
-        return bool(
-            control is not None
-            and control.lease_fingerprint
-            == self._task_lease_fingerprint(
-                lease_id,
-                attempt_id,
-            )
-            and (status is None or control.status == status)
+        request_id: str = "",
+        attempt_id: str = "",
+        query_id: str = "",
+    ) -> tuple[str, str, str, str, str] | None:
+        fields = self._decode_lease_capability(
+            lease_id,
+            kind="task",
+            field_count=5,
+        )
+        if fields is None:
+            return None
+        (
+            capability_request_id,
+            manager_lease_id,
+            capability_attempt_id,
+            capability_query_id,
+            capability_generation_id,
+        ) = fields
+        if (
+            (request_id and capability_request_id != str(request_id))
+            or (attempt_id and capability_attempt_id != str(attempt_id))
+            or (query_id and capability_query_id != str(query_id))
+        ):
+            return None
+        return (
+            manager_lease_id,
+            capability_attempt_id,
+            capability_query_id,
+            capability_request_id,
+            capability_generation_id,
         )
 
     @staticmethod
@@ -2975,19 +3089,49 @@ class RayQueryDriverActor:
         return hashlib.sha256(str(request_id).encode("utf-8")).digest()
 
     @staticmethod
-    def _output_lease_fingerprint(lease_id: str) -> bytes:
-        return hashlib.sha256(str(lease_id).encode("utf-8")).digest()
-
-    @staticmethod
-    def _output_query_fingerprint(query_id: str) -> bytes:
+    def _query_fingerprint(query_id: str) -> bytes:
         return hashlib.sha256(str(query_id).encode("utf-8")).digest()
+
+    def _issue_output_lease_capability(
+        self,
+        *,
+        request_id: str,
+        manager_lease_id: str,
+        query_id: str,
+    ) -> str:
+        return self._issue_lease_capability(
+            kind="output",
+            fields=(
+                str(request_id),
+                str(manager_lease_id),
+                str(query_id),
+            ),
+        )
+
+    def _verify_output_lease_capability(
+        self,
+        *,
+        request_id: str,
+        lease_id: str,
+        query_id: str = "",
+    ) -> tuple[str, str] | None:
+        fields = self._decode_lease_capability(
+            lease_id,
+            kind="output",
+            field_count=3,
+        )
+        if fields is None:
+            return None
+        capability_request_id, manager_lease_id, capability_query_id = fields
+        if capability_request_id != str(request_id) or (query_id and capability_query_id != str(query_id)):
+            return None
+        return manager_lease_id, capability_query_id
 
     def _store_output_terminal_control(
         self,
         *,
         request_id: str,
         identity: dict[str, Any],
-        lease: dict[str, Any] | None,
         status: str,
         result: dict[str, Any],
     ) -> None:
@@ -2995,14 +3139,7 @@ class RayQueryDriverActor:
         request_fingerprint = self._output_request_fingerprint(request_key)
         control = _OutputTerminalControl(
             identity_fingerprint=self._output_identity_fingerprint(identity),
-            lease_fingerprint=(
-                None
-                if lease is None
-                else self._output_lease_fingerprint(
-                    str(lease["lease_id"]),
-                )
-            ),
-            query_fingerprint=self._output_query_fingerprint(
+            query_fingerprint=self._query_fingerprint(
                 str(identity["query_id"]),
             ),
             status=str(status),
@@ -3024,27 +3161,6 @@ class RayQueryDriverActor:
         if control.identity_fingerprint != self._output_identity_fingerprint(identity):
             raise ValueError(f"output lease request_id reused with different identity: {request_id}")
         return control
-
-    def _output_terminal_lease_matches(
-        self,
-        request_id: str,
-        *,
-        lease_id: str,
-        query_id: str = "",
-    ) -> bool:
-        control = self._query_output_terminal_controls.get(self._output_request_fingerprint(request_id))
-        return bool(
-            control is not None
-            and control.lease_fingerprint == self._output_lease_fingerprint(lease_id)
-            and (
-                not query_id
-                or control.query_fingerprint
-                == self._output_query_fingerprint(
-                    query_id,
-                )
-            )
-            and control.status in {"released", "cancelled"}
-        )
 
     def _retire_query_lease_request(
         self,
@@ -3075,7 +3191,6 @@ class RayQueryDriverActor:
             self._store_output_terminal_control(
                 request_id=str(request_id),
                 identity=dict(identity),
-                lease=dict(lease) if isinstance(lease, dict) else None,
                 status=str(status),
                 result=terminal_result,
             )
@@ -3087,7 +3202,6 @@ class RayQueryDriverActor:
             self._store_task_terminal_control(
                 request_id=str(request_id),
                 identity=dict(identity),
-                lease=dict(lease) if isinstance(lease, dict) else None,
                 status=str(status),
                 result=terminal_result,
             )
@@ -3207,10 +3321,25 @@ class RayQueryDriverActor:
             request_id, state = owned_request
             if grant.granted:
                 lease_payload = asdict(grant.lease)
+                manager_lease_id = str(lease_payload["lease_id"])
+                public_lease_id = self._issue_task_lease_capability(
+                    request_id=request_id,
+                    manager_lease_id=manager_lease_id,
+                    attempt_id=lease_payload["attempt_id"],
+                    query_id=lease_payload["query_id"],
+                )
+                lease_payload["lease_id"] = public_lease_id
+                if lease_payload.get("actor_index") is None:
+                    # A task execution slot is a public per-lease identity.
+                    # Keep the QRM's raw lease ID from being used as an
+                    # authoritative external control token and bind the
+                    # worker-visible slot to the signed capability.
+                    lease_payload["execution_slot_id"] = f"ray_task:{lease_payload['stage_id']}:{public_lease_id}"
                 # This request record is both the admission result and the
                 # durable execution owner. Publish it before completing the
                 # caller's Future so teardown can never miss a visible grant.
                 with self._query_task_lease_condition:
+                    state["manager_lease_id"] = manager_lease_id
                     state["lease"] = lease_payload
                     state["status"] = "granted"
                     self._query_task_lease_condition.notify_all()
@@ -3221,9 +3350,11 @@ class RayQueryDriverActor:
                     request_id=request_id,
                     lease_id=lease_payload["lease_id"],
                 )
+                result = self._grant_payload(grant)
+                result["lease"] = lease_payload
                 self._complete_lease_request(
                     state,
-                    self._grant_payload(grant),
+                    result,
                 )
                 return
             if grant.fatal:
@@ -3311,6 +3442,13 @@ class RayQueryDriverActor:
                 if lease.state != "stage_queue":
                     raise RuntimeError("queued output admission must atomically grant stage_queue ownership")
                 lease_payload = asdict(lease)
+                manager_lease_id = str(lease_payload["lease_id"])
+                lease_payload["lease_id"] = self._issue_output_lease_capability(
+                    request_id=request_id,
+                    manager_lease_id=manager_lease_id,
+                    query_id=lease_payload["query_id"],
+                )
+                state["manager_lease_id"] = manager_lease_id
                 state["status"] = "granted"
                 state["lease"] = lease_payload
                 _log_resource_debug(
@@ -3405,8 +3543,29 @@ class RayQueryDriverActor:
             kind="output block",
         )
         request_id = values.pop("request_id")
+        task_lease_id = str(values["task_lease_id"])
+        capability = self._verify_task_lease_capability(
+            lease_id=task_lease_id,
+            attempt_id=str(values["attempt_id"]),
+            query_id=str(values["query_id"]),
+        )
+        if capability is None:
+            raise ValueError("output block request has an invalid task lease capability")
+        (
+            manager_task_lease_id,
+            _attempt_id,
+            capability_query_id,
+            _task_request_id,
+            capability_generation_id,
+        ) = capability
+        active_generation_id = self._query_lease_generation_ids.get(capability_query_id)
+        if active_generation_id is not None and active_generation_id != capability_generation_id:
+            raise ValueError("output block request belongs to an inactive query generation")
+        values["task_lease_id"] = manager_task_lease_id
         request = OutputBlockRequest(**values)
-        return request_id, request, asdict(request)
+        identity = asdict(request)
+        identity["task_lease_id"] = task_lease_id
+        return request_id, request, identity
 
     def _parse_task_lease_request(
         self,
@@ -3516,7 +3675,6 @@ class RayQueryDriverActor:
             self._store_task_terminal_control(
                 request_id=request_id,
                 identity=identity,
-                lease=None,
                 status="failed",
                 result=denial,
             )
@@ -3640,10 +3798,11 @@ class RayQueryDriverActor:
             ):
                 return {"released": False}
             identity = dict(state["identity"])
+            manager_lease_id = str(state["manager_lease_id"])
         query_id = str(identity["query_id"])
         try:
             released = get_query_resource_manager(query_id).release_task_lease(
-                str(lease_id),
+                manager_lease_id,
                 attempt_id=str(attempt_id),
             )
         except KeyError:
@@ -3729,29 +3888,35 @@ class RayQueryDriverActor:
     ) -> dict[str, Any]:
         """Transfer task accounting to a driver-owned completion waiter."""
         self._ensure_query_resource_admission_state()
-        if not isinstance(completion_refs, list) or len(completion_refs) != 1:
-            raise ValueError("task completion handoff requires exactly one nested ObjectRef")
-        completion_ref = completion_refs[0]
-        future_method = getattr(completion_ref, "future", None)
-        if not callable(future_method):
-            raise TypeError("task completion handoff requires an ObjectRef with future()")
-
         request_key = str(request_id)
+        capability = self._verify_task_lease_capability(
+            request_id=request_key,
+            lease_id=str(lease_id),
+            attempt_id=str(attempt_id),
+        )
+        if capability is None:
+            return {"scheduled": False}
+        (
+            manager_lease_id,
+            _capability_attempt_id,
+            capability_query_id,
+            _capability_request_id,
+            _capability_generation_id,
+        ) = capability
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                return {
-                    "scheduled": self._task_terminal_lease_matches(
-                        request_key,
-                        lease_id=lease_id,
-                        attempt_id=attempt_id,
-                    )
-                }
-            if not self._query_task_lease_matches(
-                state,
-                lease_id,
-                attempt_id,
+                return {"scheduled": True}
+            if (
+                not self._query_task_lease_matches(
+                    state,
+                    lease_id,
+                    attempt_id,
+                )
+                or str(state.get("manager_lease_id") or "") != manager_lease_id
             ):
+                return {"scheduled": False}
+            if str(state["identity"]["query_id"]) != capability_query_id:
                 return {"scheduled": False}
             if state.get("status") == "teardown_wait":
                 return {"scheduled": False}
@@ -3760,6 +3925,12 @@ class RayQueryDriverActor:
                 return {"scheduled": True}
             query_id = str(state["identity"]["query_id"])
 
+        if not isinstance(completion_refs, list) or len(completion_refs) != 1:
+            raise ValueError("task completion handoff requires exactly one nested ObjectRef")
+        completion_ref = completion_refs[0]
+        future_method = getattr(completion_ref, "future", None)
+        if not callable(future_method):
+            raise TypeError("task completion handoff requires an ObjectRef with future()")
         completion_future = future_method()
         if not isinstance(completion_future, ConcurrentFuture):
             raise TypeError("task completion ObjectRef.future() must return a concurrent Future")
@@ -3798,22 +3969,34 @@ class RayQueryDriverActor:
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
+        capability = self._verify_task_lease_capability(
+            request_id=request_key,
+            lease_id=str(lease_id),
+            attempt_id=str(attempt_id),
+        )
+        if capability is None:
+            return {"handed_off": False}
+        (
+            manager_lease_id,
+            _capability_attempt_id,
+            capability_query_id,
+            _capability_request_id,
+            _capability_generation_id,
+        ) = capability
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                return {
-                    "handed_off": self._task_terminal_lease_matches(
-                        request_key,
-                        lease_id=lease_id,
-                        attempt_id=attempt_id,
-                        status="released_by_teardown",
-                    )
-                }
-            if not self._query_task_lease_matches(
-                state,
-                lease_id,
-                attempt_id,
+                return {"handed_off": True}
+            if (
+                not self._query_task_lease_matches(
+                    state,
+                    lease_id,
+                    attempt_id,
+                )
+                or str(state.get("manager_lease_id") or "") != manager_lease_id
             ):
+                return {"handed_off": False}
+            if str(state["identity"]["query_id"]) != capability_query_id:
                 return {"handed_off": False}
             status = str(state.get("status") or "")
             if status == "completion_wait":
@@ -3929,7 +4112,6 @@ class RayQueryDriverActor:
                 self._store_task_terminal_control(
                     request_id=request_key,
                     identity=identity,
-                    lease=None,
                     status="cancelled",
                     result=denial,
                 )
@@ -3952,7 +4134,7 @@ class RayQueryDriverActor:
             manager = get_query_resource_manager(query_id)
             if isinstance(lease, dict):
                 released = manager.abandon_task_lease(
-                    str(lease["lease_id"]),
+                    str(state["manager_lease_id"]),
                     attempt_id=str(lease["attempt_id"]),
                 )
             else:
@@ -3996,23 +4178,36 @@ class RayQueryDriverActor:
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
+        capability = self._verify_task_lease_capability(
+            request_id=request_key,
+            lease_id=str(lease_id),
+            attempt_id=str(attempt_id),
+        )
+        if capability is None:
+            return {"released": False}
+        (
+            manager_lease_id,
+            _capability_attempt_id,
+            capability_query_id,
+            _capability_request_id,
+            _capability_generation_id,
+        ) = capability
         with self._query_task_lease_condition:
             state = self._query_task_lease_requests.get(request_key)
             if state is None:
-                return {
-                    "released": self._task_terminal_lease_matches(
-                        request_key,
-                        lease_id=lease_id,
-                        attempt_id=attempt_id,
-                    )
-                }
+                return {"released": True}
             if state.get("status") in {"completion_wait", "teardown_wait"}:
                 return {"released": False}
-            if not self._query_task_lease_matches(
-                state,
-                lease_id,
-                attempt_id,
+            if (
+                not self._query_task_lease_matches(
+                    state,
+                    lease_id,
+                    attempt_id,
+                )
+                or str(state.get("manager_lease_id") or "") != manager_lease_id
             ):
+                return {"released": False}
+            if str(state["identity"]["query_id"]) != capability_query_id:
                 return {"released": False}
             identity = dict(state["identity"])
         query_id = str(identity["query_id"])
@@ -4025,7 +4220,7 @@ class RayQueryDriverActor:
                 lease_id=lease_id,
             )
             released = get_query_resource_manager(query_id).release_task_lease(
-                str(lease_id),
+                manager_lease_id,
                 attempt_id=str(attempt_id),
             )
         except KeyError:
@@ -4173,21 +4368,21 @@ class RayQueryDriverActor:
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
+        capability = self._verify_output_lease_capability(
+            request_id=request_key,
+            lease_id=str(lease_id),
+            query_id=str(query_id),
+        )
+        if capability is None:
+            return {"handed_off": False}
+        manager_lease_id, capability_query_id = capability
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
-            if self._output_terminal_lease_matches(
-                request_key,
-                lease_id=str(lease_id),
-                query_id=str(query_id),
-            ):
-                return {"handed_off": True}
-            if str(query_id) in self._query_resource_closing_queries:
-                return {"handed_off": True}
-            return {"handed_off": False}
+            return {"handed_off": True}
         lease = state.get("lease") or {}
         if str(lease.get("lease_id") or "") != str(lease_id):
             return {"handed_off": False}
-        if query_id and str(lease.get("query_id") or "") != str(query_id):
+        if str(lease.get("query_id") or "") != capability_query_id:
             return {"handed_off": False}
         current_state = str(lease.get("state") or "")
         if current_state == "downstream_input":
@@ -4195,8 +4390,8 @@ class RayQueryDriverActor:
         if current_state != "stage_queue":
             raise RuntimeError(f"output lease handoff requires stage_queue state, got {current_state!r}")
         try:
-            handed_off = get_query_resource_manager(lease["query_id"]).transition_output_block(
-                str(lease_id),
+            handed_off = get_query_resource_manager(capability_query_id).transition_output_block(
+                manager_lease_id,
                 "downstream_input",
             )
         except KeyError:
@@ -4219,24 +4414,24 @@ class RayQueryDriverActor:
 
         self._ensure_query_resource_admission_state()
         request_key = str(request_id)
+        capability = self._verify_output_lease_capability(
+            request_id=request_key,
+            lease_id=str(lease_id),
+            query_id=str(query_id),
+        )
+        if capability is None:
+            return {"released": False}
+        manager_lease_id, capability_query_id = capability
         state = self._query_output_lease_requests.get(request_key)
         if state is None:
-            if self._output_terminal_lease_matches(
-                request_key,
-                lease_id=str(lease_id),
-                query_id=str(query_id),
-            ):
-                return {"released": True}
-            if str(query_id) in self._query_resource_closing_queries:
-                return {"released": True}
-            return {"released": False}
+            return {"released": True}
         lease = state.get("lease") or {}
         if str(lease.get("lease_id") or "") != str(lease_id):
             return {"released": False}
-        if query_id and str(lease.get("query_id") or "") != str(query_id):
+        if str(lease.get("query_id") or "") != capability_query_id:
             return {"released": False}
         try:
-            get_query_resource_manager(lease["query_id"]).release_output_block(str(lease_id))
+            get_query_resource_manager(capability_query_id).release_output_block(manager_lease_id)
         except KeyError:
             pass
         self._retire_query_lease_request(
@@ -4285,7 +4480,6 @@ class RayQueryDriverActor:
             self._store_output_terminal_control(
                 request_id=request_key,
                 identity=identity,
-                lease=None,
                 status="cancelled",
                 result=denial,
             )
@@ -4317,7 +4511,6 @@ class RayQueryDriverActor:
             self._store_output_terminal_control(
                 request_id=request_key,
                 identity=identity,
-                lease=None,
                 status="cancelled",
                 result=denial,
             )
@@ -4327,7 +4520,9 @@ class RayQueryDriverActor:
         released = False
         if lease is not None:
             try:
-                released = get_query_resource_manager(lease["query_id"]).release_output_block(lease["lease_id"])
+                released = get_query_resource_manager(lease["query_id"]).release_output_block(
+                    str(state["manager_lease_id"])
+                )
             except KeyError:
                 released = False
         else:
@@ -4622,6 +4817,7 @@ class RayQueryDriverActor:
             ) from cleanup_errors[0]
         with self._query_task_lease_condition:
             self._query_execution_quiesced_queries.discard(query_key)
+        self._query_lease_generation_ids.pop(query_key, None)
 
     def query_resource_snapshot(
         self,

--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -75,6 +75,21 @@ static bool StreamingUDFDebugEnabled() {
 	return cached == 1;
 }
 
+static bool DuplicateStreamingWakeupsForTesting() {
+	static const bool enabled =
+	    DebugEnvFlagEnabled("VANE_ENABLE_UDF_TEST_HOOKS") && DebugEnvFlagEnabled("VANE_TEST_DUPLICATE_UDF_WAKEUPS");
+	return enabled;
+}
+
+static bool InjectEarlyStreamingWakeupForTesting() {
+	if (!DuplicateStreamingWakeupsForTesting()) {
+		return false;
+	}
+	static atomic<bool> injected {false};
+	bool expected = false;
+	return injected.compare_exchange_strong(expected, true);
+}
+
 static void StreamingUDFDebugLog(const string &message) {
 	if (!StreamingUDFDebugEnabled()) {
 		return;
@@ -1422,53 +1437,20 @@ static bool RunStreamingWakeCallbacksUnlocked(StreamingUDFState &state, vector<I
 	}
 	auto shared_state = state.self.lock();
 	if (!shared_state) {
-		throw InternalException("streaming UDF deferred wakeup queue is not initialized");
-	}
-	if (!state.op || !state.op->executor) {
-		// A zero-input UDF can reach its terminal state without ever creating an
-		// executor. Its blocked source tasks are already descheduled, so wake them
-		// directly outside the state lock. Every non-terminal path still requires
-		// the joined executor dispatcher for deferred wakeup ordering.
-		if (!StreamingTerminalReady(state)) {
-			throw InternalException("streaming UDF deferred wakeup queue is not initialized");
-		}
-		guard.unlock();
-		for (auto &entry : callbacks) {
-			try {
-				entry.Callback();
-			} catch (const std::exception &ex) {
-				SetStreamingError(*shared_state,
-				                  StringUtil::Format("streaming UDF terminal wakeup callback failed: %s", ex.what()));
-			} catch (...) {
-				SetStreamingError(*shared_state,
-				                  "streaming UDF terminal wakeup callback failed with an unknown exception");
-			}
-		}
-		guard.lock();
-		return true;
+		throw InternalException("streaming UDF wakeup state is not initialized");
 	}
 	guard.unlock();
-	try {
-		// Every queued function owns at least one blocked task callback, so queue
-		// growth is bounded by the query's pipeline task count. The joined UDF
-		// dispatcher executes it on its next event-loop turn, after the target task
-		// has had a chance to finish descheduling.
-		state.op->executor->EnqueueDeferredWakeup([shared_state = std::move(shared_state),
-		                                           callbacks = std::move(callbacks)]() mutable {
-			for (auto &entry : callbacks) {
-				try {
-					entry.Callback();
-				} catch (const std::exception &ex) {
-					SetStreamingError(*shared_state,
-					                  StringUtil::Format("streaming UDF wakeup callback failed: %s", ex.what()));
-				} catch (...) {
-					SetStreamingError(*shared_state, "streaming UDF wakeup callback failed with an unknown exception");
-				}
+	for (auto &entry : callbacks) {
+		try {
+			entry.Callback();
+			if (DuplicateStreamingWakeupsForTesting()) {
+				entry.Callback();
 			}
-		});
-	} catch (...) {
-		guard.lock();
-		throw;
+		} catch (const std::exception &ex) {
+			SetStreamingError(*shared_state, StringUtil::Format("streaming UDF wakeup callback failed: %s", ex.what()));
+		} catch (...) {
+			SetStreamingError(*shared_state, "streaming UDF wakeup callback failed with an unknown exception");
+		}
 	}
 	guard.lock();
 	return true;
@@ -1484,6 +1466,9 @@ static bool BlockStreamingTask(StreamingUDFState &state, const unique_lock<mutex
 		state.blocked_source_tasks.push_back(interrupt_state);
 	} else {
 		state.blocked_control_tasks.push_back(interrupt_state);
+	}
+	if (InjectEarlyStreamingWakeupForTesting()) {
+		interrupt_state.Callback();
 	}
 	return true;
 }

--- a/external/duckdb/src/include/duckdb/execution/udf_executor.hpp
+++ b/external/duckdb/src/include/duckdb/execution/udf_executor.hpp
@@ -86,7 +86,6 @@ public:
 	virtual bool SupportsAsyncWakeup() = 0;
 	virtual UDFWakeupRegistrationResult RegisterWakeup(InterruptState &interrupt_state) = 0;
 	virtual void RegisterWakeupCallback(std::function<void()> callback) = 0;
-	virtual void EnqueueDeferredWakeup(std::function<void()> callback) = 0;
 	// Register exactly once, before the first submission.
 	virtual void RegisterOutputConsumer(UDFOutputConsumer consumer) = 0;
 	virtual void NotifyOutputConsumerSpaceAvailable() = 0;

--- a/external/duckdb/src/include/duckdb/parallel/executor_task.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/executor_task.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/parallel/task.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 
 namespace duckdb {
@@ -26,7 +27,8 @@ public:
 
 public:
 	void Deschedule() override;
-	void Reschedule() override;
+	uint64_t CurrentInterruptEpoch() const override;
+	void Reschedule(uint64_t interrupt_epoch) override;
 
 public:
 	Executor &executor;
@@ -35,6 +37,23 @@ public:
 	optional_ptr<const PhysicalOperator> op;
 
 private:
+	enum class InterruptExecutionState : uint8_t {
+		IDLE,
+		RUNNING,
+		BLOCKING,
+		DESCHEDULING,
+		DESCHEDULED,
+		RESCHEDULED,
+		FINISHED
+	};
+
+	void BeginInterruptExecution();
+	void FinishInterruptExecution(TaskExecutionResult result);
+
+	mutable mutex interrupt_lock;
+	uint64_t interrupt_epoch = 0;
+	InterruptExecutionState interrupt_execution_state = InterruptExecutionState::IDLE;
+	bool interrupt_reschedule_requested = false;
 	ClientContext &context;
 
 public:

--- a/external/duckdb/src/include/duckdb/parallel/interrupt.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/interrupt.hpp
@@ -64,6 +64,8 @@ protected:
 	InterruptMode mode;
 	//! Task ptr for InterruptMode::TASK
 	weak_ptr<Task> current_task;
+	//! Execution epoch that owns this one-shot task callback
+	uint64_t task_interrupt_epoch = 0;
 	//! Signal state for InterruptMode::BLOCKING
 	weak_ptr<InterruptDoneSignalState> signal_state;
 };

--- a/external/duckdb/src/include/duckdb/parallel/task.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/task.hpp
@@ -43,8 +43,14 @@ public:
 		throw InternalException("Cannot deschedule task of base Task class");
 	};
 
-	//! Ensures a task is rescheduled to the correct queue
-	virtual void Reschedule() {
+	//! Return the execution epoch captured by a task interrupt callback.
+	virtual uint64_t CurrentInterruptEpoch() const {
+		throw InternalException("Cannot read interrupt epoch of base Task class");
+	}
+
+	//! Ensures a task is rescheduled to the correct queue for the captured execution epoch.
+	virtual void Reschedule(uint64_t interrupt_epoch) {
+		(void)interrupt_epoch;
 		throw InternalException("Cannot reschedule task of base Task class");
 	}
 

--- a/external/duckdb/src/parallel/executor.cpp
+++ b/external/duckdb/src/parallel/executor.cpp
@@ -591,21 +591,21 @@ void Executor::WaitForTask() {
 }
 
 void Executor::RescheduleTask(shared_ptr<Task> &task_p) {
-	// This function will spin lock until the task provided is added to the to_be_rescheduled_tasks
-	while (true) {
-		lock_guard<mutex> l(executor_lock);
-		if (cancelled) {
-			return;
-		}
-		auto entry = to_be_rescheduled_tasks.find(task_p.get());
-		if (entry != to_be_rescheduled_tasks.end()) {
-			auto &scheduler = TaskScheduler::GetScheduler(context);
-			to_be_rescheduled_tasks.erase(task_p.get());
-			scheduler.ScheduleTask(GetToken(), task_p);
-			SignalTaskRescheduled(l);
-			break;
-		}
+	lock_guard<mutex> l(executor_lock);
+	if (cancelled) {
+		return;
 	}
+	auto entry = to_be_rescheduled_tasks.find(task_p.get());
+	if (entry == to_be_rescheduled_tasks.end()) {
+		// Cancellation/reset can remove the executor's final strong reference
+		// after a callback has already locked its weak task reference. The
+		// callback is terminally stale and must not affect the next execution.
+		return;
+	}
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+	to_be_rescheduled_tasks.erase(task_p.get());
+	scheduler.ScheduleTask(GetToken(), task_p);
+	SignalTaskRescheduled(l);
 }
 
 bool Executor::ResultCollectorIsBlocked() {

--- a/external/duckdb/src/parallel/executor_task.cpp
+++ b/external/duckdb/src/parallel/executor_task.cpp
@@ -26,18 +26,93 @@ ExecutorTask::~ExecutorTask() {
 
 void ExecutorTask::Deschedule() {
 	auto this_ptr = shared_from_this();
+	{
+		lock_guard<mutex> guard(interrupt_lock);
+		D_ASSERT(interrupt_execution_state == InterruptExecutionState::BLOCKING);
+		interrupt_execution_state = InterruptExecutionState::DESCHEDULING;
+	}
 	executor.AddToBeRescheduled(this_ptr);
+	bool reschedule = false;
+	{
+		lock_guard<mutex> guard(interrupt_lock);
+		D_ASSERT(interrupt_execution_state == InterruptExecutionState::DESCHEDULING);
+		if (interrupt_reschedule_requested) {
+			interrupt_execution_state = InterruptExecutionState::RESCHEDULED;
+			reschedule = true;
+		} else {
+			interrupt_execution_state = InterruptExecutionState::DESCHEDULED;
+		}
+	}
+	if (reschedule) {
+		auto reschedule_task = shared_from_this();
+		executor.RescheduleTask(reschedule_task);
+	}
 }
 
-void ExecutorTask::Reschedule() {
-	auto this_ptr = shared_from_this();
-	executor.RescheduleTask(this_ptr);
+uint64_t ExecutorTask::CurrentInterruptEpoch() const {
+	lock_guard<mutex> guard(interrupt_lock);
+	D_ASSERT(interrupt_execution_state == InterruptExecutionState::RUNNING);
+	return interrupt_epoch;
+}
+
+void ExecutorTask::Reschedule(uint64_t callback_epoch) {
+	bool reschedule = false;
+	{
+		lock_guard<mutex> guard(interrupt_lock);
+		if (callback_epoch != interrupt_epoch) {
+			return;
+		}
+		switch (interrupt_execution_state) {
+		case InterruptExecutionState::RUNNING:
+		case InterruptExecutionState::BLOCKING:
+		case InterruptExecutionState::DESCHEDULING:
+			interrupt_reschedule_requested = true;
+			return;
+		case InterruptExecutionState::DESCHEDULED:
+			interrupt_execution_state = InterruptExecutionState::RESCHEDULED;
+			reschedule = true;
+			break;
+		case InterruptExecutionState::IDLE:
+		case InterruptExecutionState::RESCHEDULED:
+		case InterruptExecutionState::FINISHED:
+			return;
+		}
+	}
+	if (reschedule) {
+		auto this_ptr = shared_from_this();
+		executor.RescheduleTask(this_ptr);
+	}
+}
+
+void ExecutorTask::BeginInterruptExecution() {
+	lock_guard<mutex> guard(interrupt_lock);
+	D_ASSERT(interrupt_execution_state == InterruptExecutionState::IDLE ||
+	         interrupt_execution_state == InterruptExecutionState::RESCHEDULED ||
+	         interrupt_execution_state == InterruptExecutionState::FINISHED);
+	interrupt_epoch++;
+	if (interrupt_epoch == 0) {
+		interrupt_epoch++;
+	}
+	interrupt_execution_state = InterruptExecutionState::RUNNING;
+	interrupt_reschedule_requested = false;
+}
+
+void ExecutorTask::FinishInterruptExecution(TaskExecutionResult result) {
+	lock_guard<mutex> guard(interrupt_lock);
+	D_ASSERT(interrupt_execution_state == InterruptExecutionState::RUNNING);
+	if (result == TaskExecutionResult::TASK_BLOCKED) {
+		interrupt_execution_state = InterruptExecutionState::BLOCKING;
+		return;
+	}
+	interrupt_execution_state = InterruptExecutionState::FINISHED;
+	interrupt_reschedule_requested = false;
 }
 
 TaskExecutionResult ExecutorTask::Execute(TaskExecutionMode mode) {
+	BeginInterruptExecution();
+	TaskExecutionResult result = TaskExecutionResult::TASK_ERROR;
 	try {
 		if (thread_context) {
-			TaskExecutionResult result;
 			do {
 				TaskNotifier task_notifier {context};
 				thread_context->profiler.StartOperator(op);
@@ -46,18 +121,17 @@ TaskExecutionResult ExecutorTask::Execute(TaskExecutionMode mode) {
 				thread_context->profiler.EndOperator(nullptr);
 				executor.Flush(*thread_context);
 			} while (mode == TaskExecutionMode::PROCESS_ALL && result == TaskExecutionResult::TASK_NOT_FINISHED);
-			return result;
 		} else {
 			TaskNotifier task_notifier {context};
-			auto result = ExecuteTask(mode);
-			return result;
+			result = ExecuteTask(mode);
 		}
 	} catch (std::exception &ex) {
 		executor.PushError(ErrorData(ex));
 	} catch (...) { // LCOV_EXCL_START
 		executor.PushError(ErrorData("Unknown exception in ExecutorTask::Execute"));
 	} // LCOV_EXCL_STOP
-	return TaskExecutionResult::TASK_ERROR;
+	FinishInterruptExecution(result);
+	return result;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/parallel/interrupt.cpp
+++ b/external/duckdb/src/parallel/interrupt.cpp
@@ -10,6 +10,10 @@ namespace duckdb {
 InterruptState::InterruptState() : mode(InterruptMode::NO_INTERRUPTS) {
 }
 InterruptState::InterruptState(weak_ptr<Task> task) : mode(InterruptMode::TASK), current_task(std::move(task)) {
+	auto task_ref = current_task.lock();
+	if (task_ref) {
+		task_interrupt_epoch = task_ref->CurrentInterruptEpoch();
+	}
 }
 InterruptState::InterruptState(weak_ptr<InterruptDoneSignalState> signal_state_p)
     : mode(InterruptMode::BLOCKING), signal_state(std::move(signal_state_p)) {
@@ -23,7 +27,7 @@ void InterruptState::Callback() const {
 			return;
 		}
 
-		task->Reschedule();
+		task->Reschedule(task_interrupt_epoch);
 	} else if (mode == InterruptMode::BLOCKING) {
 		auto signal_state_l = signal_state.lock();
 

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -519,8 +519,14 @@ struct CollectorOutputLeaseCallbacks {
 	std::function<void()> release;
 };
 
-static CollectorOutputLeaseCallbacks
-MakeCollectorOutputLeaseCallbacks(const py::object &collector, const string &request_id, const string &lease_id);
+struct PendingCollectorOutputLeaseCallback {
+	uint64_t slot_id;
+	std::function<void()> callback;
+};
+
+static CollectorOutputLeaseCallbacks MakeCollectorOutputLeaseCallbacks(const py::object &collector, uint64_t slot_id,
+                                                                       const string &request_id,
+                                                                       const string &lease_id);
 
 static bool PyDictContains(const py::dict &dict, const char *key) {
 	return dict.contains(py::str(key));
@@ -777,6 +783,11 @@ static bool PayloadUsesTaskAdmission(const Value &payload) {
 	auto backend = GetStructStringField(payload, "execution_backend");
 	return backend.first && (backend.second == "ray_task" || backend.second == "ray_actor" ||
 	                         backend.second == "subprocess_task" || backend.second == "subprocess_actor");
+}
+
+static bool PayloadUsesRayStreamCollector(const Value &payload) {
+	auto backend = GetStructStringField(payload, "execution_backend");
+	return backend.first && (backend.second == "ray_task" || backend.second == "ray_actor");
 }
 
 static string GetStructStringOrDefault(const Value &payload, const string &name, const string &default_value = "") {
@@ -1083,7 +1094,7 @@ struct ExecutorSlot {
 	atomic<bool> finished_submitting_acked {false};
 	atomic<bool> all_tasks_finished {false};
 	atomic<bool> cleanup_cancel_requested {false};
-	atomic<bool> collector_cancel_requested {false};
+	atomic<bool> collector_retired {false};
 
 	// Error propagation
 	mutex error_lock;
@@ -1178,20 +1189,16 @@ public:
 		return instance;
 	}
 
-	// Register a new executor slot. Returns the slot ID, raw pointer (valid
-	// until Unregister), and the generation captured by queued commands.
+	// Register a new executor slot. The executor and dispatcher retain shared
+	// ownership so terminal shutdown can publish an error and remove the slot
+	// from the dispatcher without invalidating an in-flight pipeline callback.
 	uint64_t Register(Value payload, vector<LogicalType> output_types, vector<LogicalType> ref_output_types,
 	                  ClientContext *ctx, shared_ptr<void> actor_handles, UDFOutputConsumer output_consumer,
-	                  ExecutorSlot **out_slot, uint64_t *out_generation) {
+	                  shared_ptr<ExecutorSlot> *out_slot, uint64_t *out_generation) {
 		ThrowIfDispatcherError();
 		lock_guard<mutex> g(global_lock);
-		slot_generation++;
-		if (pending_async_shutdown.exchange(false)) {
-			{
-				lock_guard<mutex> shutdown_lock(async_shutdown_lock);
-				async_shutdown_complete = true;
-			}
-			async_shutdown_cv.notify_all();
+		if (lifecycle_state != DispatcherLifecycleState::ACCEPTING) {
+			throw InvalidInputException("udf dispatcher has been shut down");
 		}
 		auto id = next_slot_id.fetch_add(1);
 		auto slot = make_shared_ptr<ExecutorSlot>();
@@ -1207,13 +1214,17 @@ public:
 		slot->output_consumer = std::move(output_consumer);
 		slot->has_output_consumer = true;
 		slot->is_table_udf = ClassifyUDFMode(slot->payload) == UDFMode::RESULT_ONLY_BATCH;
-		auto *raw = slot.get();
-		slots[id] = std::move(slot);
-		*out_slot = raw;
-		*out_generation = raw->generation.load();
+		slots[id] = slot;
+		try {
+			StartThreadLocked();
+		} catch (...) {
+			slots.erase(id);
+			throw;
+		}
+		*out_generation = slot->generation.load();
+		*out_slot = std::move(slot);
 		UDFDebugLog(StringUtil::Format("register slot=%llu total_slots=%llu", static_cast<unsigned long long>(id),
 		                               static_cast<unsigned long long>(slots.size())));
-		StartThreadLocked();
 		return id;
 	}
 
@@ -1267,17 +1278,9 @@ public:
 			}
 		}
 		// CleanupSlot erases the map entry. This local shared_ptr keeps the slot
-		// alive through the condition-variable wait and lock destruction.
-		{
-			std::unique_lock<mutex> shutdown_lk(async_shutdown_lock);
-			ScopedGILReleaseIfHeld release_gil;
-			if (!async_shutdown_complete && !async_shutdown_cv.wait_for(shutdown_lk, unregister_timeout,
-			                                                            [this] { return async_shutdown_complete; })) {
-				UDFDebugLog(StringUtil::Format("unregister_async_shutdown_timeout deadline_ms=%llu",
-				                               static_cast<unsigned long long>(unregister_timeout.count())));
-				return;
-			}
-		}
+		// alive through the condition-variable wait and lock destruction. The
+		// process-wide collector remains alive until StopThread has quiesced
+		// every submitter, so unregister does not race a per-slot loop shutdown.
 	}
 
 	void NotifyWork() {
@@ -1285,13 +1288,17 @@ public:
 		work_cv.notify_one();
 	}
 
-	void EnqueueOutputLeaseRelease(std::function<void()> release) {
+	void EnqueueOutputLeaseRelease(uint64_t slot_id, std::function<void()> release) {
 		if (!release) {
 			return;
 		}
 		{
+			lock_guard<mutex> lifecycle_guard(global_lock);
+			if (lifecycle_state != DispatcherLifecycleState::ACCEPTING) {
+				return;
+			}
 			lock_guard<mutex> lock(output_lease_release_lock);
-			output_lease_releases.push_back(std::move(release));
+			output_lease_releases.push_back({slot_id, std::move(release)});
 		}
 		NotifyWork();
 	}
@@ -1301,6 +1308,10 @@ public:
 			return;
 		}
 		{
+			lock_guard<mutex> lifecycle_guard(global_lock);
+			if (!accept_deferred_wakeups) {
+				return;
+			}
 			lock_guard<mutex> lock(deferred_wakeup_lock);
 			deferred_wakeups.push_back(std::move(callback));
 		}
@@ -1315,6 +1326,8 @@ public:
 		// Python atexit callbacks still own a valid interpreter and normally hold
 		// the GIL.  Release it while joining so the dispatcher can acquire the GIL
 		// for its final Python-object cleanup before module/static destruction.
+		// Shutdown is terminal: accepting work again would cross the process-wide
+		// collector cleanup fence.
 		ScopedGILReleaseIfHeld release_gil;
 		StopThread();
 	}
@@ -1346,6 +1359,7 @@ private:
 	GlobalPythonDispatcher &operator=(const GlobalPythonDispatcher &) = delete;
 
 	void StartThreadLocked() {
+		D_ASSERT(lifecycle_state == DispatcherLifecycleState::ACCEPTING);
 		if (thread_running) {
 			return;
 		}
@@ -1355,16 +1369,33 @@ private:
 	}
 
 	void StopThread() {
-		if (!thread_running) {
-			return;
+		if (g_on_udf_dispatcher_thread) {
+			throw InvalidInputException("cannot shut down the UDF dispatcher from its own callback thread");
 		}
-		stop.store(true);
-		work_pending.store(true);
+		lock_guard<mutex> shutdown_guard(dispatcher_shutdown_lock);
+		{
+			lock_guard<mutex> lifecycle_lock(global_lock);
+			if (lifecycle_state == DispatcherLifecycleState::STOPPED) {
+				return;
+			}
+			D_ASSERT(lifecycle_state == DispatcherLifecycleState::ACCEPTING);
+			lifecycle_state = DispatcherLifecycleState::STOPPING;
+			if (!thread_running) {
+				lifecycle_state = DispatcherLifecycleState::STOPPED;
+				return;
+			}
+			shutdown_requested.store(true);
+			work_pending.store(true);
+		}
 		work_cv.notify_one();
 		if (dispatcher_thread.joinable()) {
 			dispatcher_thread.join();
 		}
-		thread_running = false;
+		{
+			lock_guard<mutex> lifecycle_lock(global_lock);
+			thread_running = false;
+			lifecycle_state = DispatcherLifecycleState::STOPPED;
+		}
 	}
 
 	void RecordDispatcherError(const string &msg) {
@@ -1414,14 +1445,41 @@ private:
 	}
 
 	bool DrainOutputLeaseReleases_WithGIL() {
-		std::deque<std::function<void()>> releases;
+		std::deque<PendingCollectorOutputLeaseCallback> releases;
 		{
 			lock_guard<mutex> lock(output_lease_release_lock);
 			releases.swap(output_lease_releases);
 		}
+		std::unordered_map<uint64_t, string> failures;
 		for (auto &release : releases) {
-			if (release) {
-				release();
+			if (!release.callback) {
+				continue;
+			}
+			try {
+				release.callback();
+			} catch (const py::error_already_set &ex) {
+				failures.emplace(release.slot_id, StringUtil::Format("udf output lease release failed: %s", ex.what()));
+			} catch (const std::exception &ex) {
+				failures.emplace(release.slot_id, StringUtil::Format("udf output lease release failed: %s", ex.what()));
+			} catch (...) {
+				failures.emplace(release.slot_id, "udf output lease release failed with an unknown exception");
+			}
+		}
+		for (auto &failure : failures) {
+			shared_ptr<ExecutorSlot> slot;
+			{
+				lock_guard<mutex> guard(global_lock);
+				auto entry = slots.find(failure.first);
+				if (entry != slots.end()) {
+					slot = entry->second;
+				}
+			}
+			if (slot && PayloadUsesRayStreamCollector(slot->payload)) {
+				SetSlotError(*slot, failure.second);
+			} else {
+				// A retired slot has already fenced collector ownership. Its
+				// stale descriptor callback cannot affect a later query.
+				UDFDebugLog(failure.second);
 			}
 		}
 		if (!releases.empty()) {
@@ -1431,11 +1489,45 @@ private:
 		return !releases.empty();
 	}
 
+	bool FinishTerminalShutdownIfRequested() {
+		if (!shutdown_requested.load()) {
+			return false;
+		}
+		vector<shared_ptr<ExecutorSlot>> shutdown_slots;
+		{
+			lock_guard<mutex> guard(global_lock);
+			shutdown_slots.reserve(slots.size());
+			for (auto &entry : slots) {
+				shutdown_slots.push_back(entry.second);
+			}
+		}
+		for (auto &slot : shutdown_slots) {
+			if (!slot || !IsSlotActive(*slot)) {
+				continue;
+			}
+			PublishSlotError(*slot, "udf dispatcher shutdown interrupted active execution");
+		}
+		for (auto &slot : shutdown_slots) {
+			if (!slot || !IsSlotActive(*slot)) {
+				continue;
+			}
+			AbortSlotForError(*slot);
+		}
+		// StopThread fences Register under global_lock before setting
+		// shutdown_requested. The fresh snapshot above therefore covers every
+		// slot that could have linearized before terminal shutdown.
+		stop.store(true);
+		return true;
+	}
+
 	// ── Dispatcher main loop (runs on the single dispatcher thread) ──────
 
 	void DispatcherLoop() {
 		g_on_udf_dispatcher_thread = true;
 		while (!stop.load()) {
+			if (FinishTerminalShutdownIfRequested()) {
+				continue;
+			}
 			// Consume event flags at the start of the loop. Producers set these
 			// flags before notifying work_cv; clearing them later in the loop can
 			// clobber a wakeup that races with async result draining and put the
@@ -1528,17 +1620,15 @@ private:
 				if (!sc || !sc->slot) {
 					continue;
 				}
-				auto execution_backend = GetStructStringField(sc->slot->payload, "execution_backend");
-				if (execution_backend.first &&
-				    (execution_backend.second == "ray_task" || execution_backend.second == "ray_actor")) {
+				if (PayloadUsesRayStreamCollector(sc->slot->payload)) {
 					pending_commands_need_async_collector = true;
 					break;
 				}
 			}
 			bool drain_async = (bool)async_collector || has_async_inflight;
 
-			bool needs_gil = !pending_commands.empty() || has_pending_cleanup_cancel || drain_async ||
-			                 has_output_lease_releases || pending_async_shutdown.load();
+			bool needs_gil =
+			    !pending_commands.empty() || has_pending_cleanup_cancel || drain_async || has_output_lease_releases;
 			needs_gil = needs_gil || python_wakeup_fired;
 			auto debug_loop_tick = g_udf_debug_dispatcher_tick.fetch_add(1, std::memory_order_relaxed) + 1;
 			idx_t debug_active_slots = 0;
@@ -1565,9 +1655,8 @@ private:
 					debug_command_count += static_cast<idx_t>(sc->commands.size());
 				}
 			}
-			if (UDFDebugEnabled() &&
-			    (!pending_commands.empty() || has_pending_cleanup_cancel || has_output_lease_releases ||
-			     pending_async_shutdown.load() || debug_loop_tick % 200 == 0)) {
+			if (UDFDebugEnabled() && (!pending_commands.empty() || has_pending_cleanup_cancel ||
+			                          has_output_lease_releases || debug_loop_tick % 200 == 0)) {
 				UDFDebugLog(StringUtil::Format(
 				    "dispatcher_loop tick=%llu active_slots=%llu inflight_slots=%llu inflight_total=%llu "
 				    "pending_shutdown_slots=%llu command_slots=%llu command_count=%llu async_collector=%s "
@@ -1592,25 +1681,20 @@ private:
 						EnsureAsyncCollector();
 					} catch (const std::exception &ex) {
 						auto msg = StringUtil::Format("udf async collector initialization failed: %s", ex.what());
-						bool marked_slot = false;
 						for (auto &sc : pending_commands) {
-							if (sc && sc->slot && !sc->slot->abort_requested.load()) {
+							if (sc && sc->slot && PayloadUsesRayStreamCollector(sc->slot->payload) &&
+							    !sc->slot->abort_requested.load()) {
 								SetSlotError(*sc->slot, msg);
-								marked_slot = true;
 							}
 						}
 						for (auto *slot : active) {
-							if (!slot || slot->abort_requested.load() || slot->inflight_count.load() <= 0) {
+							if (!slot || !PayloadUsesRayStreamCollector(slot->payload) ||
+							    slot->abort_requested.load() || slot->inflight_count.load() <= 0) {
 								continue;
 							}
 							SetSlotError(*slot, msg);
-							marked_slot = true;
-						}
-						if (!marked_slot) {
-							RecordDispatcherError(msg);
 						}
 						did_work = true;
-						continue;
 					}
 				}
 
@@ -1619,16 +1703,12 @@ private:
 						did_work |= DrainOutputLeaseReleases_WithGIL();
 					} catch (const std::exception &ex) {
 						auto msg = StringUtil::Format("udf output lease release failed: %s", ex.what());
-						bool marked_slot = false;
 						for (auto *slot : active) {
-							if (!slot || slot->abort_requested.load()) {
+							if (!slot || !PayloadUsesRayStreamCollector(slot->payload) ||
+							    slot->abort_requested.load()) {
 								continue;
 							}
 							SetSlotError(*slot, msg);
-							marked_slot = true;
-						}
-						if (!marked_slot) {
-							RecordDispatcherError(msg);
 						}
 						did_work = true;
 					}
@@ -1710,36 +1790,10 @@ private:
 						did_work = true;
 					}
 				}
-				// A last-slot shutdown is generation-fenced against concurrent Register.
-				// Hold global_lock through collector shutdown so a new slot either cancels
-				// the pending generation first or registers after a fully joined shutdown.
-				if (pending_async_shutdown.load()) {
-					std::unique_lock<mutex> slots_lock(global_lock);
-					const bool should_shutdown = pending_async_shutdown.load() && slots.empty() &&
-					                             pending_async_shutdown_generation == slot_generation;
-					if (should_shutdown && async_collector) {
-						try {
-							async_collector->obj.attr("shutdown")();
-							async_collector.reset();
-						} catch (const py::error_already_set &ex) {
-							RecordDispatcherError(
-							    StringUtil::Format("udf async collector shutdown failed: %s", ex.what()));
-							async_collector.reset();
-						} catch (const std::exception &ex) {
-							RecordDispatcherError(
-							    StringUtil::Format("udf async collector shutdown failed: %s", ex.what()));
-							async_collector.reset();
-						}
-					}
-					pending_async_shutdown.store(false);
-					slots_lock.unlock();
-					{
-						lock_guard<mutex> shutdown_lock(async_shutdown_lock);
-						async_shutdown_complete = true;
-					}
-					async_shutdown_cv.notify_all();
-					did_work = true;
-				}
+			}
+
+			if (FinishTerminalShutdownIfRequested()) {
+				continue;
 			}
 
 			if (!did_work) {
@@ -1765,8 +1819,13 @@ private:
 		}
 
 		// Drain every owned wakeup before destroying query/executor state. A
-		// callback may enqueue another callback while resolving an error, so run
-		// to a fixed point.
+		// callback may enqueue another callback while resolving an error. Close
+		// the producer fence first, then run the accepted callbacks to a fixed
+		// point.
+		{
+			lock_guard<mutex> guard(global_lock);
+			accept_deferred_wakeups = false;
+		}
 		while (DrainDeferredWakeups()) {
 		}
 
@@ -1797,28 +1856,31 @@ private:
 			}
 			return;
 		}
-		try {
-			PythonGILWrapper gil;
-			for (auto &kv : cleanup_slots) {
-				if (kv.second->py_executor) {
-					kv.second->py_executor.reset();
-				}
-				kv.second->actor_handles.reset();
+		PythonGILWrapper gil;
+		for (auto &kv : cleanup_slots) {
+			CancelSlotForCleanup_WithGIL(*kv.second);
+			if (kv.second->py_executor) {
+				kv.second->py_executor.reset();
 			}
-			if (cleanup_async_collector) {
-				cleanup_async_collector->obj.attr("shutdown")();
-				cleanup_async_collector.reset();
+			kv.second->actor_handles.reset();
+		}
+		try {
+			while (DrainOutputLeaseReleases_WithGIL()) {
 			}
 		} catch (const py::error_already_set &ex) {
-			RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
-			if (cleanup_async_collector) {
-				cleanup_async_collector.reset();
-			}
+			RecordDispatcherError(StringUtil::Format("udf output lease final release failed: %s", ex.what()));
 		} catch (const std::exception &ex) {
-			RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
-			if (cleanup_async_collector) {
-				cleanup_async_collector.reset();
+			RecordDispatcherError(StringUtil::Format("udf output lease final release failed: %s", ex.what()));
+		}
+		if (cleanup_async_collector) {
+			try {
+				cleanup_async_collector->obj.attr("shutdown")();
+			} catch (const py::error_already_set &ex) {
+				RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
+			} catch (const std::exception &ex) {
+				RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
 			}
+			cleanup_async_collector.reset();
 		}
 		for (auto &kv : cleanup_slots) {
 			MarkSlotCleanupComplete(*kv.second);
@@ -1858,7 +1920,10 @@ private:
 		// crashes in PyList_AsTuple/PyType_FromModuleAndSpec without GIL.
 		{
 			PythonGILWrapper gil;
-			CancelAsyncCollectorSlot_WithGIL(*slot_ptr);
+			if (!CancelAsyncCollectorSlot_WithGIL(*slot_ptr)) {
+				NotifyWork();
+				return;
+			}
 			if (slot_ptr->py_executor) {
 				try {
 					slot_ptr->py_executor->obj.attr("close")();
@@ -1879,14 +1944,6 @@ private:
 			auto it = slots.find(id);
 			if (it != slots.end() && it->second.get() == slot_ptr) {
 				slots.erase(it);
-				if (slots.empty() && (bool)async_collector) {
-					{
-						lock_guard<mutex> shutdown_lock(async_shutdown_lock);
-						async_shutdown_complete = false;
-					}
-					pending_async_shutdown.store(true);
-					pending_async_shutdown_generation = slot_generation;
-				}
 			}
 		}
 		// External unregister callers retain a shared_ptr while waiting. A
@@ -2022,32 +2079,47 @@ private:
 		WakeupPipelineThread(slot);
 	}
 
-	void CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
-		if (!async_collector) {
-			return;
-		}
-		if (slot.collector_cancel_requested.exchange(true)) {
-			return;
+	bool CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
+		if (!PayloadUsesRayStreamCollector(slot.payload) || !async_collector || slot.collector_retired.load()) {
+			return true;
 		}
 		try {
 			async_collector->obj.attr("cancel_slot")(py::int_(slot.id));
 		} catch (const py::error_already_set &ex) {
-			SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return;
+			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
+			return false;
 		} catch (const std::exception &ex) {
-			SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return;
+			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
+			return false;
+		}
+		bool collector_pending;
+		try {
+			collector_pending = async_collector->obj.attr("slot_has_pending")(py::int_(slot.id)).cast<bool>();
+		} catch (const py::error_already_set &ex) {
+			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
+			return false;
+		} catch (const std::exception &ex) {
+			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
+			return false;
+		}
+		if (collector_pending) {
+			PublishSlotError(slot, "udf async collector still has pending records after slot cancel");
+			return false;
 		}
 		try {
-			auto collector_pending = async_collector->obj.attr("slot_has_pending")(py::int_(slot.id)).cast<bool>();
-			if (collector_pending) {
-				SetSlotError(slot, "udf async collector still has pending records after slot cancel");
-			}
+			// cancel_slot is synchronous. Once it reports no ownership, this
+			// dispatcher generation is the last possible submitter for the slot,
+			// so its process-lifetime cancellation fence can go.
+			async_collector->obj.attr("retire_slot")(py::int_(slot.id));
+			slot.collector_retired.store(true);
 		} catch (const py::error_already_set &ex) {
-			SetSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
+			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
+			return false;
 		} catch (const std::exception &ex) {
-			SetSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
+			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
+			return false;
 		}
+		return true;
 	}
 
 	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot) {
@@ -2466,7 +2538,7 @@ private:
 			// preserving the C++ submit_id -> input rows association.
 			py::object ref = slot.py_executor->obj.attr("submit_with_id")(py::int_(task.submit_id), py_args);
 			if (!IsActiveSlotGeneration(slot, generation)) {
-				DiscardSubmittedPythonRef_WithGIL(ref);
+				DiscardSubmittedPythonRef_WithGIL(slot, ref);
 				return;
 			}
 			ConsumeTaskAdmissionReservation(slot);
@@ -2516,21 +2588,21 @@ private:
 		return py::make_tuple(std::move(refs), std::move(slices), std::move(metadata), std::move(names));
 	}
 
-	void DiscardSubmittedPythonRef_WithGIL(py::object &ref) {
+	void DiscardSubmittedPythonRef_WithGIL(ExecutorSlot &slot, py::object &ref) {
 		if (ref.is_none()) {
 			return;
 		}
 		if (!async_collector) {
 			throw InvalidInputException("udf async collector is unavailable for stale submitted work");
 		}
-		async_collector->obj.attr("discard_generator_ref")(ref);
+		async_collector->obj.attr("discard_generator_ref")(py::int_(slot.id), ref);
 	}
 
 	void TrackSubmittedPythonRef_WithGIL(ExecutorSlot &slot, idx_t submit_id, py::object &ref,
 	                                     unique_ptr<DataChunk> rows, uint64_t generation,
 	                                     bool require_generator_ref = false) {
 		if (!IsActiveSlotGeneration(slot, generation)) {
-			DiscardSubmittedPythonRef_WithGIL(ref);
+			DiscardSubmittedPythonRef_WithGIL(slot, ref);
 			return;
 		}
 		if (ref.is_none()) {
@@ -2552,7 +2624,7 @@ private:
 			error_context = slot.py_executor->obj.attr("error_context")();
 		}
 		if (!IsActiveSlotGeneration(slot, generation)) {
-			DiscardSubmittedPythonRef_WithGIL(ref);
+			DiscardSubmittedPythonRef_WithGIL(slot, ref);
 			return;
 		}
 		async_collector->obj.attr("track_generator_ref")(py::int_(slot.id), py::int_(submit_id), ref, error_context);
@@ -2583,7 +2655,7 @@ private:
 			py::object ref = slot.py_executor->obj.attr("submit_ref_bundle_with_id")(py::int_(task.submit_id), refs,
 			                                                                         slices, metadata, names);
 			if (!IsActiveSlotGeneration(slot, generation)) {
-				DiscardSubmittedPythonRef_WithGIL(ref);
+				DiscardSubmittedPythonRef_WithGIL(slot, ref);
 				return;
 			}
 			ConsumeTaskAdmissionReservation(slot);
@@ -2600,16 +2672,20 @@ private:
 
 	bool DrainAsyncResults_WithGIL(vector<ExecutorSlot *> &active) {
 		bool did_work = false;
+		bool has_ray_collector_slot = false;
 		std::unordered_map<uint64_t, std::pair<ExecutorSlot *, uint64_t>> slots_by_id;
 		slots_by_id.reserve(active.size());
 		for (auto *slot : active) {
-			if (slot) {
+			if (slot && PayloadUsesRayStreamCollector(slot->payload)) {
 				slots_by_id.emplace(slot->id, std::make_pair(slot, slot->generation.load()));
+				has_ray_collector_slot |=
+				    IsSlotActive(*slot) && !slot->abort_requested.load() && slot->inflight_count.load() > 0;
 			}
 		}
 		auto fail_active_slots = [&](const string &msg) {
 			for (auto *slot : active) {
-				if (!slot || !slot->py_executor || slot->abort_requested.load() || !IsSlotActive(*slot)) {
+				if (!slot || !PayloadUsesRayStreamCollector(slot->payload) || !slot->py_executor ||
+				    slot->abort_requested.load() || !IsSlotActive(*slot)) {
 					continue;
 				}
 				SetSlotError(*slot, msg);
@@ -2745,7 +2821,7 @@ private:
 			return true;
 		};
 
-		if (async_collector) {
+		if (async_collector && has_ray_collector_slot) {
 			try {
 				py::dict capacities;
 				idx_t debug_capacity_total = 0;
@@ -2755,7 +2831,8 @@ private:
 				auto debug_probe_tick = g_udf_debug_drain_tick.load(std::memory_order_relaxed);
 				bool debug_probe_slots = UDFDebugEnabled() && (debug_probe_tick >= 650 || debug_probe_tick % 200 == 0);
 				for (auto *slot : active) {
-					if (!slot || slot->abort_requested.load() || !IsSlotActive(*slot)) {
+					if (!slot || !PayloadUsesRayStreamCollector(slot->payload) || slot->abort_requested.load() ||
+					    !IsSlotActive(*slot)) {
 						continue;
 					}
 					auto generation = slot->generation.load();
@@ -2857,8 +2934,8 @@ private:
 								throw InvalidInputException(
 								    "udf async collector data event is missing output lease identity");
 							}
-							auto callbacks = MakeCollectorOutputLeaseCallbacks(async_collector->obj, output_request_id,
-							                                                   output_lease_id);
+							auto callbacks = MakeCollectorOutputLeaseCallbacks(async_collector->obj, slot_id,
+							                                                   output_request_id, output_lease_id);
 							handoff_output_lease = std::move(callbacks.handoff);
 							release_output_lease = std::move(callbacks.release);
 						}
@@ -2943,19 +3020,6 @@ private:
 					}
 				}
 
-				for (auto *slot : active) {
-					if (!slot || slot->abort_requested.load() || !IsSlotActive(*slot) || !slot->py_executor ||
-					    slot->inflight_count.load() <= 0) {
-						continue;
-					}
-					auto generation = slot->generation.load();
-					if (!ShouldDrainSyncResults(*slot, generation)) {
-						continue;
-					}
-					if (DrainSyncSlotSafely(*slot, generation)) {
-						did_work = true;
-					}
-				}
 			} catch (const py::error_already_set &ex) {
 				fail_active_slots(StringUtil::Format("udf async collector failed: %s", ex.what()));
 			} catch (const std::exception &ex) {
@@ -2963,19 +3027,17 @@ private:
 			}
 		}
 
-		if (!async_collector) {
-			for (auto *slot : active) {
-				if (!slot || slot->abort_requested.load() || !IsSlotActive(*slot) || !slot->py_executor ||
-				    slot->inflight_count.load() <= 0) {
-					continue;
-				}
-				auto generation = slot->generation.load();
-				if (!ShouldDrainSyncResults(*slot, generation)) {
-					continue;
-				}
-				if (DrainSyncSlotSafely(*slot, generation)) {
-					did_work = true;
-				}
+		for (auto *slot : active) {
+			if (!slot || slot->abort_requested.load() || !IsSlotActive(*slot) || !slot->py_executor ||
+			    slot->inflight_count.load() <= 0) {
+				continue;
+			}
+			auto generation = slot->generation.load();
+			if (!ShouldDrainSyncResults(*slot, generation)) {
+				continue;
+			}
+			if (DrainSyncSlotSafely(*slot, generation)) {
+				did_work = true;
 			}
 		}
 
@@ -2996,7 +3058,7 @@ private:
 		}
 	}
 
-	void SetSlotError(ExecutorSlot &slot, const string &msg, bool notify_output_consumer = true) {
+	bool PublishSlotError(ExecutorSlot &slot, const string &msg, bool notify_output_consumer = true) {
 		bool should_notify = false;
 		{
 			lock_guard<mutex> eg(slot.error_lock);
@@ -3006,13 +3068,12 @@ private:
 				should_notify = true;
 			}
 		}
-		AbortSlotForError(slot);
 		if (!should_notify) {
-			return;
+			return false;
 		}
 		WakeupPipelineThread(slot);
 		if (!notify_output_consumer) {
-			return;
+			return true;
 		}
 		UDFOutputConsumer output_consumer;
 		if (GetOutputConsumer(slot, output_consumer) && output_consumer.accept_error) {
@@ -3024,6 +3085,12 @@ private:
 				slot.error += StringUtil::Format("; udf output consumer accept_error failed: %s", ex.what());
 			}
 		}
+		return true;
+	}
+
+	void SetSlotError(ExecutorSlot &slot, const string &msg, bool notify_output_consumer = true) {
+		PublishSlotError(slot, msg, notify_output_consumer);
+		AbortSlotForError(slot);
 	}
 
 	void NotifySlotFinished(ExecutorSlot &slot) {
@@ -3194,27 +3261,27 @@ private:
 	}
 
 	// ── Members ──────────────────────────────────────────────────────────
+	enum class DispatcherLifecycleState : uint8_t { ACCEPTING, STOPPING, STOPPED };
+
 	mutex global_lock;
+	mutex dispatcher_shutdown_lock;
 	std::condition_variable work_cv;
 	std::unordered_map<uint64_t, shared_ptr<ExecutorSlot>> slots;
 	atomic<uint64_t> next_slot_id {1};
 	std::thread dispatcher_thread;
 	atomic<bool> stop {false};
-	atomic<bool> wakeup_fired {false};           // set by async collector wakeup callback
-	atomic<bool> work_pending {false};           // set by all notify paths before signaling work_cv
-	atomic<bool> pending_async_shutdown {false}; // deferred async_collector shutdown
-	uint64_t slot_generation = 0;
-	uint64_t pending_async_shutdown_generation = 0;
-	mutex async_shutdown_lock;
-	std::condition_variable async_shutdown_cv;
-	bool async_shutdown_complete {true};
+	atomic<bool> shutdown_requested {false};
+	atomic<bool> wakeup_fired {false}; // set by async collector wakeup callback
+	atomic<bool> work_pending {false}; // set by all notify paths before signaling work_cv
 	mutex dispatcher_error_lock;
 	atomic<bool> has_dispatcher_error {false};
 	string dispatcher_error;
+	DispatcherLifecycleState lifecycle_state = DispatcherLifecycleState::ACCEPTING;
 	bool thread_running = false;
 	mutex output_lease_release_lock;
-	std::deque<std::function<void()>> output_lease_releases;
+	std::deque<PendingCollectorOutputLeaseCallback> output_lease_releases;
 	mutex deferred_wakeup_lock;
+	bool accept_deferred_wakeups = true;
 	std::deque<std::function<void()>> deferred_wakeups;
 	unique_ptr<RegisteredObject> async_collector; // Python AsyncResultCollector
 };
@@ -3225,12 +3292,13 @@ struct CollectorOutputLeaseCallbackState {
 	bool released = false;
 };
 
-static CollectorOutputLeaseCallbacks
-MakeCollectorOutputLeaseCallbacks(const py::object &collector, const string &request_id, const string &lease_id) {
+static CollectorOutputLeaseCallbacks MakeCollectorOutputLeaseCallbacks(const py::object &collector, uint64_t slot_id,
+                                                                       const string &request_id,
+                                                                       const string &lease_id) {
 	auto collector_holder = MakePythonObjectHolder(py::reinterpret_borrow<py::object>(collector));
 	auto state = std::make_shared<CollectorOutputLeaseCallbackState>();
 	CollectorOutputLeaseCallbacks callbacks;
-	callbacks.handoff = [collector_holder, state, request_id, lease_id]() {
+	callbacks.handoff = [collector_holder, state, slot_id, request_id, lease_id]() {
 		{
 			lock_guard<mutex> guard(state->lock);
 			if (state->released || state->handed_off) {
@@ -3241,15 +3309,16 @@ MakeCollectorOutputLeaseCallbacks(const py::object &collector, const string &req
 		if (!PythonRuntimeUsableForUDFTeardown()) {
 			return;
 		}
-		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease([collector_holder, request_id, lease_id]() {
-			auto collector_obj = BorrowPythonObjectHolder(collector_holder);
-			if (collector_obj.is_none()) {
-				return;
-			}
-			collector_obj.attr("handoff_output_block_lease")(py::str(request_id), py::str(lease_id));
-		});
+		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease(
+		    slot_id, [collector_holder, request_id, lease_id]() {
+			    auto collector_obj = BorrowPythonObjectHolder(collector_holder);
+			    if (collector_obj.is_none()) {
+				    return;
+			    }
+			    collector_obj.attr("handoff_output_block_lease")(py::str(request_id), py::str(lease_id));
+		    });
 	};
-	callbacks.release = [collector_holder, state, request_id, lease_id]() {
+	callbacks.release = [collector_holder, state, slot_id, request_id, lease_id]() {
 		{
 			lock_guard<mutex> guard(state->lock);
 			if (state->released) {
@@ -3260,13 +3329,14 @@ MakeCollectorOutputLeaseCallbacks(const py::object &collector, const string &req
 		if (!PythonRuntimeUsableForUDFTeardown()) {
 			return;
 		}
-		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease([collector_holder, request_id, lease_id]() {
-			auto collector_obj = BorrowPythonObjectHolder(collector_holder);
-			if (collector_obj.is_none()) {
-				return;
-			}
-			collector_obj.attr("release_output_block_lease")(py::str(request_id), py::str(lease_id));
-		});
+		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease(
+		    slot_id, [collector_holder, request_id, lease_id]() {
+			    auto collector_obj = BorrowPythonObjectHolder(collector_holder);
+			    if (collector_obj.is_none()) {
+				    return;
+			    }
+			    collector_obj.attr("release_output_block_lease")(py::str(request_id), py::str(lease_id));
+		    });
 	};
 	return callbacks;
 }
@@ -3408,18 +3478,11 @@ public:
 	                                         idx_t retained_input_bytes, idx_t &submit_id) override {
 		lock_guard<mutex> submit_guard(submit_lock_);
 		EnsureRegistered(context);
+		ThrowIfSlotError();
 
 		if (!TryReserveTaskAdmission(retained_input_bytes)) {
 			submit_id = 0;
 			return false;
-		}
-
-		{
-			lock_guard<mutex> eg(slot_->error_lock);
-			if (slot_->has_error.load()) {
-				auto msg = slot_->error;
-				throw InvalidInputException("udf async error: %s", msg);
-			}
 		}
 
 		{
@@ -3685,7 +3748,7 @@ private:
 	shared_ptr<void> actor_handles_;
 	uint64_t slot_id_ = 0;
 	uint64_t slot_generation_ = 0;
-	ExecutorSlot *slot_ = nullptr; // raw pointer, valid from Register to Unregister
+	shared_ptr<ExecutorSlot> slot_;
 	bool registered_ = false;
 	mutex submit_lock_;
 	idx_t next_submit_id_ = 1;

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -2152,14 +2152,15 @@ private:
 	}
 
 	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot, bool cancel_collector = true) {
-		if (slot.cleanup_cancel_requested.exchange(true)) {
-			return;
-		}
-		if (cancel_collector) {
+		const bool first_cancel = !slot.cleanup_cancel_requested.exchange(true);
+		if (first_cancel && cancel_collector) {
 			if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
 				ScheduleCollectorCleanupRetry(slot);
 			}
 		}
+		// Local executor close is independently idempotent and must not be
+		// skipped when process shutdown takes over a slot whose collector
+		// cancellation was already pending.
 		if (slot.py_executor) {
 			try {
 				slot.py_executor->obj.attr("close")();

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1094,8 +1094,10 @@ struct ExecutorSlot {
 	atomic<bool> finished_submitting_acked {false};
 	atomic<bool> all_tasks_finished {false};
 	atomic<bool> cleanup_cancel_requested {false};
-	atomic<bool> collector_cleanup_retry_consumed {false};
 	atomic<bool> collector_retired {false};
+	idx_t collector_cleanup_retry_count = 0;
+	bool collector_cleanup_retry_scheduled = false;
+	std::chrono::steady_clock::time_point collector_cleanup_retry_deadline;
 
 	// Error propagation
 	mutex error_lock;
@@ -1304,21 +1306,6 @@ public:
 		NotifyWork();
 	}
 
-	void EnqueueDeferredWakeup(std::function<void()> callback) {
-		if (!callback) {
-			return;
-		}
-		{
-			lock_guard<mutex> lifecycle_guard(global_lock);
-			if (!accept_deferred_wakeups) {
-				return;
-			}
-			lock_guard<mutex> lock(deferred_wakeup_lock);
-			deferred_wakeups.push_back(std::move(callback));
-		}
-		NotifyWork();
-	}
-
 	~GlobalPythonDispatcher() {
 		StopThread();
 	}
@@ -1347,11 +1334,6 @@ public:
 				WakeupPipelineThread(*slot);
 			}
 		}
-		// Strict streaming operators defer task callbacks onto the dispatcher
-		// after their executor wakeup callback runs. The test hook must also
-		// flush that second hop so it can wake teardown while the dispatcher is
-		// deliberately blocked inside a Python conversion callback.
-		DrainDeferredWakeups();
 	}
 
 private:
@@ -1426,27 +1408,6 @@ private:
 	bool HasPendingOutputLeaseReleases() {
 		lock_guard<mutex> lock(output_lease_release_lock);
 		return !output_lease_releases.empty();
-	}
-
-	bool DrainDeferredWakeups() {
-		std::deque<std::function<void()>> callbacks;
-		{
-			lock_guard<mutex> lock(deferred_wakeup_lock);
-			callbacks.swap(deferred_wakeups);
-		}
-		for (auto &callback : callbacks) {
-			if (!callback) {
-				continue;
-			}
-			try {
-				callback();
-			} catch (const std::exception &ex) {
-				RecordDispatcherError(StringUtil::Format("deferred UDF wakeup failed: %s", ex.what()));
-			} catch (...) {
-				RecordDispatcherError("deferred UDF wakeup failed with an unknown exception");
-			}
-		}
-		return !callbacks.empty();
 	}
 
 	bool DrainOutputLeaseReleases_WithGIL() {
@@ -1555,7 +1516,18 @@ private:
 			// enqueues its last submit. Since inflight_count is only incremented
 			// once the dispatcher runs the Python submit, cleanup must not run
 			// before already-queued commands are dispatched.
-			bool did_work = DrainDeferredWakeups();
+			bool did_work = false;
+			bool has_collector_cleanup_retry_deadline = false;
+			auto next_collector_cleanup_retry_deadline = std::chrono::steady_clock::time_point::max();
+			auto note_collector_cleanup_retry = [&](const ExecutorSlot &slot) {
+				if (!slot.collector_cleanup_retry_scheduled) {
+					return;
+				}
+				has_collector_cleanup_retry_deadline = true;
+				if (slot.collector_cleanup_retry_deadline < next_collector_cleanup_retry_deadline) {
+					next_collector_cleanup_retry_deadline = slot.collector_cleanup_retry_deadline;
+				}
+			};
 			struct SlotCommands {
 				ExecutorSlot *slot;
 				std::deque<DispatcherCommand> commands;
@@ -1590,7 +1562,17 @@ private:
 							has_pending_cleanup_cancel = true;
 							continue;
 						}
-						did_work |= CleanupSlot(slot->id);
+						if (slot->collector_cleanup_retry_scheduled &&
+						    std::chrono::steady_clock::now() < slot->collector_cleanup_retry_deadline) {
+							note_collector_cleanup_retry(*slot);
+							continue;
+						}
+						slot->collector_cleanup_retry_scheduled = false;
+						const auto cleanup_complete = CleanupSlot(slot->id);
+						did_work |= cleanup_complete;
+						if (!cleanup_complete) {
+							note_collector_cleanup_retry(*slot);
+						}
 					}
 					slot = nullptr; // prevent dangling pointer in subsequent loops
 					continue;
@@ -1827,22 +1809,15 @@ private:
 					    static_cast<unsigned long long>(debug_inflight_total), work_pending.load() ? "true" : "false",
 					    wakeup_fired.load() ? "true" : "false"));
 				}
-				// Pure event-driven wait: only wake on actual events. All producers
-				// (NotifyWork, Unregister, StopThread, Python executor wakeup, async
-				// collector wakeup) set work_pending/wakeup_fired before signaling.
-				work_cv.wait(lk, predicate);
+				// Normal progress is event-driven. A synchronous collector
+				// ownership-handoff failure is the sole timed path because it
+				// has no Future callback capable of waking this dispatcher.
+				if (has_collector_cleanup_retry_deadline) {
+					work_cv.wait_until(lk, next_collector_cleanup_retry_deadline, predicate);
+				} else {
+					work_cv.wait(lk, predicate);
+				}
 			}
-		}
-
-		// Drain every owned wakeup before destroying query/executor state. A
-		// callback may enqueue another callback while resolving an error. Close
-		// the producer fence first, then run the accepted callbacks to a fixed
-		// point.
-		{
-			lock_guard<mutex> guard(global_lock);
-			accept_deferred_wakeups = false;
-		}
-		while (DrainDeferredWakeups()) {
 		}
 
 		// Final cleanup: only touch Python while the interpreter is still alive.
@@ -1916,6 +1891,23 @@ private:
 
 	enum class AsyncCollectorSlotCancelStatus : uint8_t { COMPLETE, PENDING, RETRY };
 
+	static std::chrono::milliseconds CollectorCleanupRetryDelay(idx_t retry_count) {
+		const auto exponent = MinValue<idx_t>(retry_count > 0 ? retry_count - 1 : 0, 7);
+		return std::chrono::milliseconds(MinValue<idx_t>(idx_t(10) << exponent, 1000));
+	}
+
+	static void ResetCollectorCleanupRetry(ExecutorSlot &slot) {
+		slot.collector_cleanup_retry_count = 0;
+		slot.collector_cleanup_retry_scheduled = false;
+	}
+
+	static void ScheduleCollectorCleanupRetry(ExecutorSlot &slot) {
+		slot.collector_cleanup_retry_count++;
+		slot.collector_cleanup_retry_deadline =
+		    std::chrono::steady_clock::now() + CollectorCleanupRetryDelay(slot.collector_cleanup_retry_count);
+		slot.collector_cleanup_retry_scheduled = true;
+	}
+
 	bool CleanupSlot(uint64_t id) {
 		shared_ptr<ExecutorSlot> slot;
 		{
@@ -1943,15 +1935,17 @@ private:
 			slot_ptr->cleanup_cancel_requested.store(true);
 			auto cancel_status = CancelAsyncCollectorSlot_WithGIL(*slot_ptr);
 			if (cancel_status != AsyncCollectorSlotCancelStatus::COMPLETE) {
-				// A pending ticket owns its eventual wakeup. Give a synchronous
-				// handoff failure one immediate retry, then wait for external work
-				// instead of spinning the process-wide dispatcher.
-				if (cancel_status == AsyncCollectorSlotCancelStatus::RETRY &&
-				    !slot_ptr->collector_cleanup_retry_consumed.exchange(true)) {
-					NotifyWork();
+				// A pending ticket owns its eventual wakeup. A synchronous
+				// ownership-handoff failure has no such event, so retain the
+				// slot and retry it on the dispatcher's bounded backoff clock.
+				if (cancel_status == AsyncCollectorSlotCancelStatus::RETRY) {
+					ScheduleCollectorCleanupRetry(*slot_ptr);
+				} else {
+					ResetCollectorCleanupRetry(*slot_ptr);
 				}
 				return false;
 			}
+			ResetCollectorCleanupRetry(*slot_ptr);
 			if (slot_ptr->py_executor) {
 				try {
 					slot_ptr->py_executor->obj.attr("close")();
@@ -2163,8 +2157,7 @@ private:
 		}
 		if (cancel_collector) {
 			if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
-				// The current dispatcher pass is already the bounded retry wake.
-				slot.collector_cleanup_retry_consumed.store(true);
+				ScheduleCollectorCleanupRetry(slot);
 			}
 		}
 		if (slot.py_executor) {
@@ -2203,7 +2196,7 @@ private:
 			try {
 				PythonGILWrapper gil;
 				if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
-					slot.collector_cleanup_retry_consumed.store(true);
+					ScheduleCollectorCleanupRetry(slot);
 				}
 			} catch (const py::error_already_set &ex) {
 				SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
@@ -3332,9 +3325,6 @@ private:
 	bool thread_running = false;
 	mutex output_lease_release_lock;
 	std::deque<PendingCollectorOutputLeaseCallback> output_lease_releases;
-	mutex deferred_wakeup_lock;
-	bool accept_deferred_wakeups = true;
-	std::deque<std::function<void()>> deferred_wakeups;
 	unique_ptr<RegisteredObject> async_collector; // Python AsyncResultCollector
 };
 
@@ -3658,13 +3648,6 @@ public:
 		}
 		lock_guard<mutex> wg(slot_->wakeup_lock);
 		slot_->wakeup_callback = wakeup_callback_;
-	}
-
-	void EnqueueDeferredWakeup(std::function<void()> callback) override {
-		if (!registered_ || !slot_) {
-			throw InvalidInputException("cannot enqueue a deferred wakeup for an unregistered UDF executor");
-		}
-		GlobalPythonDispatcher::Instance().EnqueueDeferredWakeup(std::move(callback));
 	}
 
 private:

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1094,6 +1094,7 @@ struct ExecutorSlot {
 	atomic<bool> finished_submitting_acked {false};
 	atomic<bool> all_tasks_finished {false};
 	atomic<bool> cleanup_cancel_requested {false};
+	atomic<bool> collector_cleanup_retry_consumed {false};
 	atomic<bool> collector_retired {false};
 
 	// Error propagation
@@ -1121,7 +1122,7 @@ struct ExecutorSlot {
 	atomic<idx_t> udf_output_budget_limit_bytes {0};
 	atomic<idx_t> udf_output_budget_usage_bytes {0};
 
-	// Synchronous cleanup: signaled by CleanupSlot, waited on by Unregister
+	// Cleanup completion fence: signaled by CleanupSlot, waited on by Unregister.
 	mutex cleanup_lock;
 	std::condition_variable cleanup_cv;
 	bool cleanup_complete {false};
@@ -1589,8 +1590,7 @@ private:
 							has_pending_cleanup_cancel = true;
 							continue;
 						}
-						CleanupSlot(slot->id);
-						did_work = true;
+						did_work |= CleanupSlot(slot->id);
 					}
 					slot = nullptr; // prevent dangling pointer in subsequent loops
 					continue;
@@ -1902,13 +1902,15 @@ private:
 		slot.cleanup_cv.notify_all();
 	}
 
-	void CleanupSlot(uint64_t id) {
+	enum class AsyncCollectorSlotCancelStatus : uint8_t { COMPLETE, PENDING, RETRY };
+
+	bool CleanupSlot(uint64_t id) {
 		shared_ptr<ExecutorSlot> slot;
 		{
 			lock_guard<mutex> g(global_lock);
 			auto it = slots.find(id);
 			if (it == slots.end()) {
-				return;
+				return true;
 			}
 			slot = it->second;
 		}
@@ -1926,9 +1928,17 @@ private:
 		// crashes in PyList_AsTuple/PyType_FromModuleAndSpec without GIL.
 		{
 			PythonGILWrapper gil;
-			if (!CancelAsyncCollectorSlot_WithGIL(*slot_ptr)) {
-				NotifyWork();
-				return;
+			slot_ptr->cleanup_cancel_requested.store(true);
+			auto cancel_status = CancelAsyncCollectorSlot_WithGIL(*slot_ptr);
+			if (cancel_status != AsyncCollectorSlotCancelStatus::COMPLETE) {
+				// A pending ticket owns its eventual wakeup. Give a synchronous
+				// handoff failure one immediate retry, then wait for external work
+				// instead of spinning the process-wide dispatcher.
+				if (cancel_status == AsyncCollectorSlotCancelStatus::RETRY &&
+				    !slot_ptr->collector_cleanup_retry_consumed.exchange(true)) {
+					NotifyWork();
+				}
+				return false;
 			}
 			if (slot_ptr->py_executor) {
 				try {
@@ -1957,6 +1967,7 @@ private:
 		// the final owner after the map entry is erased.
 		MarkSlotCleanupComplete(*slot_ptr);
 		UDFDebugLog(StringUtil::Format("cleanup_done slot=%llu", static_cast<unsigned long long>(id)));
+		return true;
 	}
 
 	// ── Submit/ready-result helpers (caller must hold GIL) ──────────────────────
@@ -2085,50 +2096,53 @@ private:
 		WakeupPipelineThread(slot);
 	}
 
-	bool CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
+	AsyncCollectorSlotCancelStatus CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
 		if (terminal_collector_shutdown_owned.load()) {
-			return true;
+			return AsyncCollectorSlotCancelStatus::COMPLETE;
 		}
 		if (!PayloadUsesRayStreamCollector(slot.payload) || !async_collector || slot.collector_retired.load()) {
-			return true;
+			return AsyncCollectorSlotCancelStatus::COMPLETE;
 		}
 		try {
 			async_collector->obj.attr("cancel_slot")(py::int_(slot.id));
 		} catch (const py::error_already_set &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		}
 		bool collector_pending;
 		try {
 			collector_pending = async_collector->obj.attr("slot_has_pending")(py::int_(slot.id)).cast<bool>();
 		} catch (const py::error_already_set &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		}
 		if (collector_pending) {
-			PublishSlotError(slot, "udf async collector still has pending records after slot cancel");
-			return false;
+			return AsyncCollectorSlotCancelStatus::PENDING;
 		}
 		try {
-			// cancel_slot is synchronous. Once it reports no ownership, this
-			// dispatcher generation is the last possible submitter for the slot,
-			// so its process-lifetime cancellation fence can go.
-			async_collector->obj.attr("retire_slot")(py::int_(slot.id));
+			// Once the collector reports no ownership, this dispatcher generation
+			// is the last possible submitter, so its process-lifetime cancellation
+			// fence can go.
+			auto cleanup_error = async_collector->obj.attr("retire_slot")(py::int_(slot.id));
 			slot.collector_retired.store(true);
+			if (!cleanup_error.is_none()) {
+				PublishSlotError(slot, StringUtil::Format("udf async collector slot cleanup failed: %s",
+				                                          py::str(cleanup_error).cast<string>()));
+			}
 		} catch (const py::error_already_set &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
 			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
-			return false;
+			return AsyncCollectorSlotCancelStatus::RETRY;
 		}
-		return true;
+		return AsyncCollectorSlotCancelStatus::COMPLETE;
 	}
 
 	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot, bool cancel_collector = true) {
@@ -2136,7 +2150,10 @@ private:
 			return;
 		}
 		if (cancel_collector) {
-			CancelAsyncCollectorSlot_WithGIL(slot);
+			if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
+				// The current dispatcher pass is already the bounded retry wake.
+				slot.collector_cleanup_retry_consumed.store(true);
+			}
 		}
 		if (slot.py_executor) {
 			try {
@@ -2173,7 +2190,9 @@ private:
 		if (first_abort && PythonRuntimeUsableForUDFTeardown()) {
 			try {
 				PythonGILWrapper gil;
-				CancelAsyncCollectorSlot_WithGIL(slot);
+				if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
+					slot.collector_cleanup_retry_consumed.store(true);
+				}
 			} catch (const py::error_already_set &ex) {
 				SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
 			} catch (const std::exception &ex) {

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1787,11 +1787,23 @@ private:
 						continue;
 					}
 					auto generation = slot->generation.load();
-					auto wake_submitter = RefreshTaskAdmission_WithGIL(*slot, generation);
-					wake_submitter |= UpdateSlotUDFStats_WithGIL(*slot, generation);
-					if (wake_submitter && IsActiveSlotGeneration(*slot, generation)) {
-						WakeupPipelineThread(*slot);
-						did_work = true;
+					try {
+						auto wake_submitter = RefreshTaskAdmission_WithGIL(*slot, generation);
+						wake_submitter |= UpdateSlotUDFStats_WithGIL(*slot, generation);
+						if (wake_submitter && IsActiveSlotGeneration(*slot, generation)) {
+							WakeupPipelineThread(*slot);
+							did_work = true;
+						}
+					} catch (const py::error_already_set &ex) {
+						if (IsActiveSlotGeneration(*slot, generation)) {
+							SetSlotError(*slot, StringUtil::Format("udf task admission refresh failed: %s", ex.what()));
+							did_work = true;
+						}
+					} catch (const std::exception &ex) {
+						if (IsActiveSlotGeneration(*slot, generation)) {
+							SetSlotError(*slot, StringUtil::Format("udf task admission refresh failed: %s", ex.what()));
+							did_work = true;
+						}
 					}
 				}
 			}

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1380,6 +1380,10 @@ private:
 			}
 			D_ASSERT(lifecycle_state == DispatcherLifecycleState::ACCEPTING);
 			lifecycle_state = DispatcherLifecycleState::STOPPING;
+			// From this point, every collector record belongs to the one
+			// aggregate shutdown below. A racing unregister must not start a
+			// fresh per-slot deadline after the terminal fence linearizes.
+			terminal_collector_shutdown_owned.store(true);
 			if (!thread_running) {
 				lifecycle_state = DispatcherLifecycleState::STOPPED;
 				return;
@@ -1511,7 +1515,7 @@ private:
 			if (!slot || !IsSlotActive(*slot)) {
 				continue;
 			}
-			AbortSlotForError(*slot);
+			AbortSlotForTerminalShutdown(*slot);
 		}
 		// StopThread fences Register under global_lock before setting
 		// shutdown_requested. The fresh snapshot above therefore covers every
@@ -1858,7 +1862,9 @@ private:
 		}
 		PythonGILWrapper gil;
 		for (auto &kv : cleanup_slots) {
-			CancelSlotForCleanup_WithGIL(*kv.second);
+			// Terminal shutdown owns the process-wide collector as one unit.
+			// Per-slot cancellation would apply its full timeout once per slot.
+			CancelSlotForCleanup_WithGIL(*kv.second, false);
 			if (kv.second->py_executor) {
 				kv.second->py_executor.reset();
 			}
@@ -2080,6 +2086,9 @@ private:
 	}
 
 	bool CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
+		if (terminal_collector_shutdown_owned.load()) {
+			return true;
+		}
 		if (!PayloadUsesRayStreamCollector(slot.payload) || !async_collector || slot.collector_retired.load()) {
 			return true;
 		}
@@ -2122,11 +2131,13 @@ private:
 		return true;
 	}
 
-	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot) {
+	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot, bool cancel_collector = true) {
 		if (slot.cleanup_cancel_requested.exchange(true)) {
 			return;
 		}
-		CancelAsyncCollectorSlot_WithGIL(slot);
+		if (cancel_collector) {
+			CancelAsyncCollectorSlot_WithGIL(slot);
+		}
 		if (slot.py_executor) {
 			try {
 				slot.py_executor->obj.attr("close")();
@@ -2143,13 +2154,22 @@ private:
 		slot.all_tasks_finished.store(true);
 	}
 
-	void AbortSlotForError(ExecutorSlot &slot) {
+	bool MarkSlotAborted(ExecutorSlot &slot) {
 		const bool first_abort = !slot.abort_requested.exchange(true);
 		slot.inflight_count.store(0);
 		slot.finished_submitting_acked.store(true);
 		slot.all_tasks_finished.store(true);
 		slot.rows_by_submit_id.clear();
 		slot.ref_inputs_by_submit_id.clear();
+		return first_abort;
+	}
+
+	void AbortSlotForTerminalShutdown(ExecutorSlot &slot) {
+		MarkSlotAborted(slot);
+	}
+
+	void AbortSlotForError(ExecutorSlot &slot) {
+		const bool first_abort = MarkSlotAborted(slot);
 		if (first_abort && PythonRuntimeUsableForUDFTeardown()) {
 			try {
 				PythonGILWrapper gil;
@@ -3271,6 +3291,7 @@ private:
 	std::thread dispatcher_thread;
 	atomic<bool> stop {false};
 	atomic<bool> shutdown_requested {false};
+	atomic<bool> terminal_collector_shutdown_owned {false};
 	atomic<bool> wakeup_fired {false}; // set by async collector wakeup callback
 	atomic<bool> work_pending {false}; // set by all notify paths before signaling work_cv
 	mutex dispatcher_error_lock;

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -2466,6 +2466,7 @@ private:
 			// preserving the C++ submit_id -> input rows association.
 			py::object ref = slot.py_executor->obj.attr("submit_with_id")(py::int_(task.submit_id), py_args);
 			if (!IsActiveSlotGeneration(slot, generation)) {
+				DiscardSubmittedPythonRef_WithGIL(ref);
 				return;
 			}
 			ConsumeTaskAdmissionReservation(slot);
@@ -2515,10 +2516,21 @@ private:
 		return py::make_tuple(std::move(refs), std::move(slices), std::move(metadata), std::move(names));
 	}
 
+	void DiscardSubmittedPythonRef_WithGIL(py::object &ref) {
+		if (ref.is_none()) {
+			return;
+		}
+		if (!async_collector) {
+			throw InvalidInputException("udf async collector is unavailable for stale submitted work");
+		}
+		async_collector->obj.attr("discard_generator_ref")(ref);
+	}
+
 	void TrackSubmittedPythonRef_WithGIL(ExecutorSlot &slot, idx_t submit_id, py::object &ref,
 	                                     unique_ptr<DataChunk> rows, uint64_t generation,
 	                                     bool require_generator_ref = false) {
 		if (!IsActiveSlotGeneration(slot, generation)) {
+			DiscardSubmittedPythonRef_WithGIL(ref);
 			return;
 		}
 		if (ref.is_none()) {
@@ -2540,6 +2552,7 @@ private:
 			error_context = slot.py_executor->obj.attr("error_context")();
 		}
 		if (!IsActiveSlotGeneration(slot, generation)) {
+			DiscardSubmittedPythonRef_WithGIL(ref);
 			return;
 		}
 		async_collector->obj.attr("track_generator_ref")(py::int_(slot.id), py::int_(submit_id), ref, error_context);
@@ -2570,6 +2583,7 @@ private:
 			py::object ref = slot.py_executor->obj.attr("submit_ref_bundle_with_id")(py::int_(task.submit_id), refs,
 			                                                                         slices, metadata, names);
 			if (!IsActiveSlotGeneration(slot, generation)) {
+				DiscardSubmittedPythonRef_WithGIL(ref);
 				return;
 			}
 			ConsumeTaskAdmissionReservation(slot);

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -906,7 +906,6 @@ def test_driver_exposes_query_task_and_output_lease_api():
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     required = {
         "acquire_query_task_lease",
-        "mark_query_task_lease_submitted",
         "release_query_task_lease",
         "acquire_query_output_block_lease",
         "handoff_query_output_block_lease",

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -658,6 +658,10 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
             "heap_bytes": 128,
             "object_store_bytes": 0,
         },
+        "query_generation_capability": runner_cls._issue_query_task_admission_capability(
+            runner,
+            streaming_query_id,
+        ),
     }
 
     async def _run_concurrently():

--- a/tests/fast/test_driver_query_graph_registration.py
+++ b/tests/fast/test_driver_query_graph_registration.py
@@ -907,6 +907,7 @@ def test_driver_exposes_query_task_and_output_lease_api():
     required = {
         "acquire_query_task_lease",
         "release_query_task_lease",
+        "handoff_query_task_lease_to_teardown",
         "acquire_query_output_block_lease",
         "handoff_query_output_block_lease",
         "release_query_output_block_lease",

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -87,7 +87,7 @@ def _manager_task_lease_id(runner_cls, runner, lease: dict) -> str:
     return capability[0]
 
 
-def _task_request(query_id: str, request_id: str, task_id: str) -> dict:
+def _task_request(runner, query_id: str, request_id: str, task_id: str) -> dict:
     return {
         "request_id": request_id,
         "query_id": query_id,
@@ -102,6 +102,9 @@ def _task_request(query_id: str, request_id: str, task_id: str) -> dict:
             "heap_bytes": 100,
             "object_store_bytes": 0,
         },
+        "query_generation_capability": runner._issue_query_task_admission_capability(
+            query_id,
+        ),
     }
 
 
@@ -144,12 +147,12 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
         )
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
-        first_request = _task_request(query_id, "request:first", "task:first")
+        first_request = _task_request(runner, query_id, "request:first", "task:first")
         first = await runner_cls.acquire_query_task_lease(runner, first_request)
         assert first["granted"]
         first_lease = first["lease"]
 
-        second_request = _task_request(query_id, "request:second", "task:second")
+        second_request = _task_request(runner, query_id, "request:second", "task:second")
         second_waiter = asyncio.create_task(runner_cls.acquire_query_task_lease(runner, second_request))
         for _ in range(3):
             await asyncio.sleep(0)
@@ -225,6 +228,59 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
     asyncio.run(scenario())
 
 
+def test_task_admission_rejects_unsigned_or_tampered_generation_capabilities():
+    async def scenario():
+        query_id = "query-admission-capability"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        valid_request = _task_request(
+            runner,
+            query_id,
+            "request:admission-capability",
+            "task:admission-capability",
+        )
+        unsigned_request = dict(valid_request)
+        unsigned_request.pop("query_generation_capability")
+        unsigned_denial = await runner_cls.acquire_query_task_lease(
+            runner,
+            unsigned_request,
+        )
+        assert unsigned_denial["granted"] is False
+        assert unsigned_denial["blocked_reason"] == "invalid_query_generation_capability"
+        assert await runner_cls.cancel_query_task_lease_request(
+            runner,
+            unsigned_request,
+        ) == {"cancelled": True, "released": False}
+
+        tampered_request = dict(valid_request)
+        tampered_request["query_generation_capability"] += "tampered"
+        tampered_denial = await runner_cls.acquire_query_task_lease(
+            runner,
+            tampered_request,
+        )
+        assert tampered_denial["granted"] is False
+        assert tampered_denial["blocked_reason"] == "invalid_query_generation_capability"
+        assert manager.snapshot()["task_leases"] == {}
+        assert runner._query_task_lease_requests == {}
+
+        grant = await runner_cls.acquire_query_task_lease(
+            runner,
+            valid_request,
+        )
+        assert grant["granted"] is True
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            valid_request["request_id"],
+            grant["lease"]["lease_id"],
+            grant["lease"]["attempt_id"],
+        ) == {"released": True}
+
+    asyncio.run(scenario())
+
+
 def test_late_output_controls_transfer_to_fenced_query_teardown():
     async def scenario():
         query_id = "query-late-output-control"
@@ -233,6 +289,7 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
         manager = register_query_graph(graph, _allocation())
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         task_request = _task_request(
+            runner,
             query_id,
             "request:late-output-task",
             "task:late-output-task",
@@ -309,11 +366,11 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
         )
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
-        active_request = _task_request(query_id, "request:active", "task:active")
+        active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
 
         pending_requests = [
-            _task_request(query_id, f"request:pending:{index}", f"task:pending:{index}") for index in range(6)
+            _task_request(runner, query_id, f"request:pending:{index}", f"task:pending:{index}") for index in range(6)
         ]
         pending_tasks = [
             asyncio.create_task(runner_cls.acquire_query_task_lease(runner, request)) for request in pending_requests
@@ -419,9 +476,9 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         )
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
-        active_request = _task_request(query_id, "request:active", "task:active")
+        active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
-        pending_request = _task_request(query_id, "request:pending", "task:pending")
+        pending_request = _task_request(runner, query_id, "request:pending", "task:pending")
         pending = asyncio.create_task(runner_cls.acquire_query_task_lease(runner, pending_request))
         for _ in range(3):
             await asyncio.sleep(0)
@@ -469,6 +526,7 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         active_request = _task_request(
+            runner,
             query_id,
             "request:completion-gated",
             "task:completion-gated",
@@ -477,6 +535,7 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         lease = active["lease"]
 
         pending_request = _task_request(
+            runner,
             query_id,
             "request:completion-gated-pending",
             "task:completion-gated-pending",
@@ -547,6 +606,7 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         request = _task_request(
+            runner,
             query_id,
             "request:query-close-retains",
             "task:query-close-retains",
@@ -601,6 +661,7 @@ def test_completed_task_cleanup_retries_without_losing_its_ledger_owner(monkeypa
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         request = _task_request(
+            runner,
             query_id,
             "request:completion-cleanup-retry",
             "task:completion-cleanup-retry",
@@ -651,6 +712,7 @@ def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         request = _task_request(
+            runner,
             query_id,
             "request:close-before-handoff",
             "task:close-before-handoff",
@@ -720,6 +782,7 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         request = _task_request(
+            runner,
             query_id,
             f"request:teardown-wait:{quiesce_first}",
             f"task:teardown-wait:{quiesce_first}",
@@ -814,6 +877,7 @@ def test_task_grant_is_published_in_the_admission_ledger_before_future_completio
         manager = register_query_graph(graph, _allocation())
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         request = _task_request(
+            runner,
             query_id,
             "request:single-ledger",
             "task:single-ledger",
@@ -879,6 +943,7 @@ def test_query_resource_release_waits_for_late_submission_completion_handoff():
         runner._synchronize_query_allocations = lambda: ()
 
         request = _task_request(
+            runner,
             query_id,
             "request:unresolved-grant",
             "task:unresolved-grant",
@@ -949,7 +1014,7 @@ def test_driver_rejects_runtime_resources_that_diverge_from_registered_stage():
             on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
         )
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
-        request = _task_request(query_id, "request:mismatch", "task:mismatch")
+        request = _task_request(runner, query_id, "request:mismatch", "task:mismatch")
         request["resources"]["heap_bytes"] = 99
 
         denial = await runner_cls.acquire_query_task_lease(runner, request)
@@ -964,6 +1029,7 @@ def test_driver_rejects_runtime_resources_that_diverge_from_registered_stage():
         assert owner_identity not in runner._query_task_request_owner_by_identity
 
         corrected = _task_request(
+            runner,
             query_id,
             "request:mismatch-corrected",
             "task:mismatch",
@@ -987,7 +1053,7 @@ def test_driver_pending_output_waiter_is_live_and_cancel_cleanup_is_complete():
         )
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
-        task_request = _task_request(query_id, "request:task", "task:output")
+        task_request = _task_request(runner, query_id, "request:task", "task:output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         owned = await _fill_task_output_window(
             runner_cls,
@@ -1049,7 +1115,7 @@ def test_driver_output_cancel_before_acquire_is_durable_and_restores_budget():
         )
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
-        task_request = _task_request(query_id, "request:task", "task:pre-cancel-output")
+        task_request = _task_request(runner, query_id, "request:task", "task:pre-cancel-output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         output_request = {
             "request_id": "request:pre-cancel-output",
@@ -1105,7 +1171,7 @@ def test_driver_output_cancel_after_grant_releases_late_lease_and_restores_budge
         )
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
-        task_request = _task_request(query_id, "request:task", "task:late-grant-output")
+        task_request = _task_request(runner, query_id, "request:task", "task:late-grant-output")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         output_request = {
             "request_id": "request:late-grant-output",
@@ -1167,7 +1233,7 @@ def test_driver_output_pump_evaluates_each_waiter_once_per_state_transition():
         )
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
-        task_request = _task_request(query_id, "request:task", "task:output-pump")
+        task_request = _task_request(runner, query_id, "request:task", "task:output-pump")
         task = await runner_cls.acquire_query_task_lease(runner, task_request)
         owned = await _fill_task_output_window(
             runner_cls,
@@ -1272,12 +1338,14 @@ def test_task_attempt_rejects_a_second_request_id_instead_of_orphaning_future():
         )
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         active_request = _task_request(
+            runner,
             query_id,
             "request:active",
             "task:active",
         )
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         first_request = _task_request(
+            runner,
             query_id,
             "request:first-owner",
             "task:duplicate",
@@ -1327,6 +1395,7 @@ def test_output_block_rejects_a_second_request_id_instead_of_orphaning_future():
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
         task_request = _task_request(
+            runner,
             query_id,
             "request:task",
             "task:output-owner",
@@ -1398,6 +1467,7 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         task_request = _task_request(
+            runner,
             query_id,
             "request:terminal-task",
             "task:terminal",
@@ -1487,6 +1557,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         task_request = _task_request(
+            runner,
             query_id,
             "request:terminal-task-after-eviction",
             "task:terminal-after-eviction",
@@ -1509,6 +1580,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
                 conflicting_terminal_cancel,
             )
         unseen_request = _task_request(
+            runner,
             query_id,
             "request:never-admitted",
             "task:never-admitted",
@@ -1573,6 +1645,7 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
             task["lease"],
         )
         closing_request = _task_request(
+            runner,
             query_id,
             "request:released-after-close",
             "task:released-after-close",
@@ -1603,6 +1676,12 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
         assert len(runner._query_task_lease_request_tombstones) == 0
         assert len(runner._query_task_terminal_controls) == 0
         assert len(runner._query_task_terminal_attempts) == 0
+        task_request = _task_request(
+            runner,
+            query_id,
+            task_request["request_id"],
+            task_request["task_id"],
+        )
         replacement = await runner_cls.acquire_query_task_lease(
             runner,
             task_request,
@@ -1698,6 +1777,7 @@ def test_output_terminal_control_ack_survives_bounded_replay_payload_eviction():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         task_request = _task_request(
+            runner,
             query_id,
             "request:output-terminal-task",
             "task:output-terminal",
@@ -1786,12 +1866,14 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         active_request = _task_request(
+            runner,
             query_id,
             "request:active-for-cancel",
             "task:active-for-cancel",
         )
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         cancelled_request = _task_request(
+            runner,
             query_id,
             "request:cancelled",
             "task:cancelled",
@@ -1865,7 +1947,7 @@ def test_query_teardown_resolves_all_pending_admission_futures():
         runner._query_graphs = {query_id: graph}
         runner._query_allocations = {query_id: allocation}
 
-        active_request = _task_request(query_id, "request:active", "task:active")
+        active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         await _fill_task_output_window(
             runner_cls,
@@ -1876,6 +1958,7 @@ def test_query_teardown_resolves_all_pending_admission_futures():
             prefix="teardown",
         )
         pending_task_request = _task_request(
+            runner,
             query_id,
             "request:pending",
             "task:pending",
@@ -2586,6 +2669,7 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
         runner._query_allocations = {query_id: allocation}
 
         active_request = _task_request(
+            runner,
             query_id,
             "request:active",
             "task:active",
@@ -2638,6 +2722,7 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
         ) == {"scheduled": True}
 
         late_request = _task_request(
+            runner,
             query_id,
             "request:late",
             "task:late",
@@ -2669,9 +2754,10 @@ def test_task_admission_pump_resolves_waiter_when_stage_becomes_terminal():
         )
         stage_id = graph.stages[0].stage_id
         manager.update_stage_state(stage_id, runnable=True)
-        active_request = _task_request(query_id, "request:active", "task:active")
+        active_request = _task_request(runner, query_id, "request:active", "task:active")
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         pending_request = _task_request(
+            runner,
             query_id,
             "request:pending",
             "task:pending",
@@ -2733,6 +2819,12 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
         register_query_graph(graph, _allocation())
+        delayed_old_request = _task_request(
+            runner,
+            query_id,
+            "request:reused-generation",
+            "task:reused-generation",
+        )
 
         runner_cls._close_query_resource_admission(runner, query_id)
         assert query_id in runner._query_resource_closing_queries
@@ -2796,13 +2888,44 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         manager = register_query_graph(graph, _allocation())
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
+
+        stale_grant = await runner_cls.acquire_query_task_lease(
+            runner,
+            delayed_old_request,
+        )
+        assert stale_grant["granted"] is False
+        assert stale_grant["blocked_reason"] == "query_generation_inactive"
+        assert stale_grant["fatal"] is True
+        assert manager.snapshot()["task_leases"] == {}
+        assert runner._query_task_lease_requests == {}
+
+        current_request = _task_request(
+            runner,
+            query_id,
+            delayed_old_request["request_id"],
+            delayed_old_request["task_id"],
+        )
         grant = await runner_cls.acquire_query_task_lease(
             runner,
-            _task_request(query_id, "request:new-generation", "task:new-generation"),
+            current_request,
         )
 
         assert grant["granted"] is True
+        manager_lease_id = _manager_task_lease_id(runner_cls, runner, grant["lease"])
+        assert await runner_cls.cancel_query_task_lease_request(
+            runner,
+            delayed_old_request,
+        ) == {"cancelled": True, "released": False}
+        assert manager_lease_id in manager.snapshot()["task_leases"]
+        assert runner._query_task_lease_requests[current_request["request_id"]]["status"] == "granted"
         assert query_id not in runner._query_resource_closing_queries
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            current_request["request_id"],
+            grant["lease"]["lease_id"],
+            grant["lease"]["attempt_id"],
+        ) == {"released": True}
 
     asyncio.run(scenario())
 
@@ -2817,6 +2940,7 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
 
         task_request = _task_request(
+            runner,
             query_id,
             "request:signed-output-task",
             "task:signed-output-task",
@@ -2899,6 +3023,12 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
 
+        task_request = _task_request(
+            runner,
+            query_id,
+            task_request["request_id"],
+            task_request["task_id"],
+        )
         replacement_task = await runner_cls.acquire_query_task_lease(
             runner,
             task_request,

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -135,9 +135,6 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
         first = await runner_cls.acquire_query_task_lease(runner, first_request)
         assert first["granted"]
         first_lease = first["lease"]
-        assert await runner_cls.mark_query_task_lease_submitted(
-            runner, first_request["request_id"], first_lease["lease_id"]
-        ) == {"submitted": True}
 
         second_request = _task_request(query_id, "request:second", "task:second")
         second_waiter = asyncio.create_task(runner_cls.acquire_query_task_lease(runner, second_request))
@@ -457,11 +454,6 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         )
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         lease = active["lease"]
-        assert await runner_cls.mark_query_task_lease_submitted(
-            runner,
-            active_request["request_id"],
-            lease["lease_id"],
-        ) == {"submitted": True}
 
         pending_request = _task_request(
             query_id,
@@ -553,12 +545,12 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
         await asyncio.sleep(0)
 
         assert request["request_id"] in runner._query_task_completion_waiters
-        assert runner._query_task_lease_requests == {}
+        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "completion_wait"
         assert lease["lease_id"] in manager.snapshot()["task_leases"]
 
         teardown_fence = asyncio.create_task(
             asyncio.to_thread(
-                runner_cls._wait_for_query_task_execution_owners,
+                runner_cls._wait_for_query_task_leases,
                 runner,
                 query_id,
                 timeout_s=1,
@@ -572,7 +564,7 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
         await asyncio.wait_for(teardown_fence, timeout=1)
 
         assert runner._query_task_completion_waiters == {}
-        assert runner._query_task_execution_owners == {}
+        assert runner._query_task_lease_requests == {}
         assert lease["lease_id"] not in manager.snapshot()["task_leases"]
 
     asyncio.run(scenario())
@@ -593,19 +585,13 @@ def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
         )
         grant = await runner_cls.acquire_query_task_lease(runner, request)
         lease = grant["lease"]
-        assert await runner_cls.mark_query_task_lease_submitted(
-            runner,
-            request["request_id"],
-            lease["lease_id"],
-        ) == {"submitted": True}
 
         runner_cls._close_query_resource_admission(runner, query_id)
-        assert runner._query_task_lease_requests == {}
-        assert runner._query_task_execution_owners[request["request_id"]].phase == "submitted"
+        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "granted"
 
         teardown_fence = asyncio.create_task(
             asyncio.to_thread(
-                runner_cls._wait_for_query_task_execution_owners,
+                runner_cls._wait_for_query_task_leases,
                 runner,
                 query_id,
                 timeout_s=1,
@@ -623,13 +609,13 @@ def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
             lease["attempt_id"],
             [SimpleNamespace(future=lambda: completion)],
         ) == {"scheduled": True}
-        assert runner._query_task_execution_owners[request["request_id"]].phase == "completion_wait"
+        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "completion_wait"
         assert not teardown_fence.done()
 
         completion.set_result(None)
         await asyncio.wait_for(teardown_fence, timeout=1)
 
-        assert runner._query_task_execution_owners == {}
+        assert runner._query_task_lease_requests == {}
         assert runner._query_task_completion_waiters == {}
         assert manager.snapshot()["task_leases"] == {}
         assert await runner_cls.release_query_task_lease_after_completion(
@@ -661,115 +647,60 @@ def test_query_task_completion_owner_fence_is_bounded():
 
     runner_cls, runner = _runner(None)
     runner_cls._ensure_query_resource_admission_state(runner)
-    runner._query_task_execution_owners["request:still-running"] = SimpleNamespace(
-        query_id="query:still-running",
-        phase="submitted",
-    )
+    runner._query_task_lease_requests["request:still-running"] = {
+        "identity": {"query_id": "query:still-running"},
+        "status": "granted",
+    }
 
     with pytest.raises(
         QueryTeardownOwnershipError,
         match="request:still-running",
     ):
-        runner_cls._wait_for_query_task_execution_owners(
+        runner_cls._wait_for_query_task_leases(
             runner,
             "query:still-running",
             timeout_s=0.01,
         )
 
 
-def test_task_grant_owner_registration_failure_is_fatal_and_atomic():
+def test_task_grant_is_published_in_the_admission_ledger_before_future_completion():
     async def scenario():
-        query_id = "query-owner-registration-failure"
+        query_id = "query-single-task-ledger"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
         manager = register_query_graph(graph, _allocation())
         manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         request = _task_request(
             query_id,
-            "request:owner-registration-failure",
-            "task:owner-registration-failure",
+            "request:single-ledger",
+            "task:single-ledger",
         )
+        observed = []
+        complete_request = runner_cls._complete_lease_request
 
-        def fail_registration(*, request_id, state):
-            del request_id, state
-            raise RuntimeError("planned owner registration failure")
-
-        runner._register_query_task_execution_owner = fail_registration
-        denial = await runner_cls.acquire_query_task_lease(runner, request)
-
-        assert denial["granted"] is False
-        assert denial["fatal"] is True
-        assert denial["blocked_reason"] == "task_execution_owner_registration_failed"
-        assert manager.snapshot()["task_leases"] == {}
-        assert runner._query_task_execution_owners == {}
-        assert request["request_id"] not in runner._query_task_lease_requests
-        assert runner._query_task_lease_request_tombstones[request["request_id"]]["result"] == denial
-        assert "planned owner registration failure" in runner._query_terminal_errors[query_id]
-
-        replay = await runner_cls.acquire_query_task_lease(runner, request)
-        assert replay == denial
-        late = await runner_cls.acquire_query_task_lease(
-            runner,
-            _task_request(
-                query_id,
-                "request:after-owner-registration-failure",
-                "task:after-owner-registration-failure",
-            ),
-        )
-        assert late["granted"] is False
-        assert late["fatal"] is True
-        assert late["blocked_reason"] == "query_not_registered"
-
-    asyncio.run(scenario())
-
-
-@pytest.mark.parametrize("rollback_raises", [False, True])
-def test_task_grant_owner_registration_rollback_retains_uncertain_lease_for_teardown(
-    rollback_raises,
-):
-    from duckdb.runners.ray.driver import QueryTeardownOwnershipError
-
-    async def scenario():
-        query_id = f"query-owner-registration-rollback-{rollback_raises}"
-        graph = _graph(query_id)
-        runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
-        request = _task_request(
-            query_id,
-            "request:owner-registration-rollback",
-            "task:owner-registration-rollback",
-        )
-
-        def fail_registration(*, request_id, state):
-            del request_id, state
-            raise RuntimeError("planned owner registration failure")
-
-        def fail_rollback(lease_id, *, attempt_id):
-            del lease_id, attempt_id
-            if rollback_raises:
-                raise RuntimeError("planned grant rollback failure")
-            return False
-
-        runner._register_query_task_execution_owner = fail_registration
-        manager.abandon_task_lease = fail_rollback
-        denial = await runner_cls.acquire_query_task_lease(runner, request)
-
-        assert denial["granted"] is False
-        assert denial["fatal"] is True
-        owner = runner._query_task_execution_owners[request["request_id"]]
-        assert owner.query_id == query_id
-        assert owner.phase == "teardown_owned"
-        assert owner.lease_id in manager.snapshot()["task_leases"]
-        with pytest.raises(QueryTeardownOwnershipError):
-            runner_cls._wait_for_query_task_execution_owners(
-                runner,
-                query_id,
-                timeout_s=0.01,
+        def inspect_grant(state, result):
+            observed.append(
+                (
+                    runner._query_task_lease_requests.get(request["request_id"]) is state,
+                    state["status"],
+                    dict(state["lease"]),
+                )
             )
+            complete_request(state, result)
 
-        runner_cls._mark_query_execution_quiesced(runner, query_id)
-        assert runner._query_task_execution_owners == {}
+        runner._complete_lease_request = inspect_grant
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+
+        assert grant["granted"] is True
+        assert observed == [(True, "granted", grant["lease"])]
+        assert not hasattr(runner, "_query_task_execution_owners")
+        assert not hasattr(runner, "_query_task_execution_replays")
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            request["request_id"],
+            grant["lease"]["lease_id"],
+            grant["lease"]["attempt_id"],
+        ) == {"released": True}
 
     asyncio.run(scenario())
 
@@ -811,11 +742,11 @@ def test_query_resource_release_stops_before_qrm_when_grant_owner_is_unresolved(
         )
         grant = await runner_cls.acquire_query_task_lease(runner, request)
         lease = grant["lease"]
-        original_wait = runner_cls._wait_for_query_task_execution_owners.__get__(
+        original_wait = runner_cls._wait_for_query_task_leases.__get__(
             runner,
             runner_cls,
         )
-        runner._wait_for_query_task_execution_owners = lambda owner_query_id: original_wait(
+        runner._wait_for_query_task_leases = lambda owner_query_id: original_wait(
             owner_query_id,
             timeout_s=0.01,
         )
@@ -879,9 +810,8 @@ def test_missing_completion_contract_hands_live_lease_to_query_teardown():
         ) == {"handed_off": True}
 
         assert lease["lease_id"] in manager.snapshot()["task_leases"]
-        assert request["request_id"] not in runner._query_task_lease_requests
-        assert runner._query_task_lease_request_tombstones[request["request_id"]]["status"] == "teardown_owned"
-        assert runner._query_task_execution_owners[request["request_id"]].phase == "teardown_owned"
+        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "teardown_owned"
+        assert request["request_id"] not in runner._query_task_lease_request_tombstones
         completion = Future()
         assert await runner_cls.release_query_task_lease_after_completion(
             runner,
@@ -893,7 +823,8 @@ def test_missing_completion_contract_hands_live_lease_to_query_teardown():
         assert runner._query_task_completion_waiters == {}
 
         runner_cls._mark_query_execution_quiesced(runner, query_id)
-        assert runner._query_task_execution_owners == {}
+        assert runner._query_task_lease_requests == {}
+        assert runner._query_task_lease_request_tombstones[request["request_id"]]["status"] == "teardown_owned"
         assert await runner_cls.handoff_query_task_lease_to_teardown(
             runner,
             request["request_id"],

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -331,7 +331,7 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
                 continue
             await runner_cls.cancel_query_task_lease_request(
                 runner,
-                request["request_id"],
+                request,
             )
         await asyncio.gather(*pending_tasks)
         granted_request = pending_requests[pending_tasks.index(granted_task)]
@@ -410,7 +410,7 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
 
         cancelled = await runner_cls.cancel_query_task_lease_request(
             runner,
-            pending_request["request_id"],
+            pending_request,
         )
         assert cancelled == {"cancelled": True, "released": False}
         denial = await asyncio.wait_for(pending, timeout=1)
@@ -490,7 +490,7 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         ) == {"released": False}
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
-            active_request["request_id"],
+            active_request,
         ) == {"cancelled": False, "released": False}
 
         if completion_error is None:
@@ -725,7 +725,7 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
             ) == {"released": False}
             assert await runner_cls.cancel_query_task_lease_request(
                 runner,
-                request["request_id"],
+                request,
             ) == {"cancelled": False, "released": False}
             completion = Future()
             assert await runner_cls.release_query_task_lease_after_completion(
@@ -742,6 +742,7 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
         assert lease["lease_id"] in manager.snapshot()["task_leases"]
         tombstone = runner._query_task_lease_request_tombstones[request["request_id"]]
         assert tombstone["status"] == "released_by_teardown"
+        runner._query_task_lease_request_tombstones.clear()
         assert await runner_cls.handoff_query_task_lease_to_teardown(
             runner,
             request["request_id"],
@@ -1272,7 +1273,7 @@ def test_task_attempt_rejects_a_second_request_id_instead_of_orphaning_future():
 
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
-            first_request["request_id"],
+            first_request,
         ) == {"cancelled": True, "released": False}
         denial = await first_waiter
         assert denial["blocked_reason"] == "task_lease_request_cancelled"
@@ -1444,6 +1445,95 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
     asyncio.run(scenario())
 
 
+def test_terminal_control_ack_survives_bounded_replay_payload_eviction():
+    async def scenario():
+        query_id = "query-terminal-control-after-eviction"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(
+            graph,
+            _allocation(),
+            on_change=lambda: runner_cls._signal_query_resource_change(
+                runner,
+                query_id,
+            ),
+        )
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        task_request = _task_request(
+            query_id,
+            "request:terminal-task-after-eviction",
+            "task:terminal-after-eviction",
+        )
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+
+        runner._query_task_lease_request_tombstones.clear()
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            "wrong-lease",
+            task["lease"]["attempt_id"],
+        ) == {"released": False}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+            [SimpleNamespace(future=lambda: Future())],
+        ) == {"scheduled": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"handed_off": False}
+        conflicting_terminal_cancel = dict(task_request)
+        conflicting_terminal_cancel["request_id"] = "request:conflicting-terminal-cancel"
+        with pytest.raises(ValueError, match="already terminal under another request_id"):
+            await runner_cls.cancel_query_task_lease_request(
+                runner,
+                conflicting_terminal_cancel,
+            )
+        unseen_request = _task_request(
+            query_id,
+            "request:never-admitted",
+            "task:never-admitted",
+        )
+        assert await runner_cls.cancel_query_task_lease_request(
+            runner,
+            unseen_request,
+        ) == {"cancelled": True, "released": False}
+        unseen_denial = await runner_cls.acquire_query_task_lease(
+            runner,
+            unseen_request,
+        )
+        assert unseen_denial["granted"] is False
+        assert unseen_denial["blocked_reason"] == "task_lease_request_cancelled"
+        mismatched_unseen = dict(unseen_request)
+        mismatched_unseen["task_id"] = "task:mismatched-never-admitted"
+        with pytest.raises(ValueError, match="reused with different identity"):
+            await runner_cls.cancel_query_task_lease_request(
+                runner,
+                mismatched_unseen,
+            )
+
+    asyncio.run(scenario())
+
+
 def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
     async def scenario():
         query_id = "query-cancelled-request-replay"
@@ -1475,9 +1565,19 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
             await asyncio.sleep(0)
         assert not original_waiter.done()
 
+        conflicting_cancel = dict(cancelled_request)
+        conflicting_cancel["request_id"] = "request:conflicting-cancel"
+        with pytest.raises(ValueError, match="already owned by request_id request:cancelled"):
+            await runner_cls.cancel_query_task_lease_request(
+                runner,
+                conflicting_cancel,
+            )
+        assert not original_waiter.done()
+        assert manager.snapshot()["stages"][graph.stages[0].stage_id]["pending_task_count"] == 1
+
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
-            cancelled_request["request_id"],
+            cancelled_request,
         ) == {"cancelled": True, "released": False}
         original_denial = await original_waiter
         replay_denial = await runner_cls.acquire_query_task_lease(

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from concurrent.futures import Future
 from types import SimpleNamespace
 
 import pytest
@@ -182,12 +183,22 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
             runner,
             "output-request:block-1",
             output["lease"]["lease_id"],
-        ) == {"handed_off": False}
+        ) == {"handed_off": True}
         assert await runner_cls.release_query_output_block_lease(
             runner,
             "output-request:block-1",
             output["lease"]["lease_id"],
         ) == {"released": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            "output-request:block-1",
+            output["lease"]["lease_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            "output-request:block-1",
+            "wrong-output-lease",
+        ) == {"released": False}
         assert await runner_cls.release_query_task_lease(
             runner,
             second_request["request_id"],
@@ -199,6 +210,69 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
         assert snapshot["output_leases"] == {}
         assert runner._query_task_lease_requests == {}
         assert runner._query_output_lease_requests == {}
+
+    asyncio.run(scenario())
+
+
+def test_late_output_controls_transfer_to_fenced_query_teardown():
+    async def scenario():
+        query_id = "query-late-output-control"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        task_request = _task_request(
+            query_id,
+            "request:late-output-task",
+            "task:late-output-task",
+        )
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+        output_request = {
+            "request_id": "request:late-output",
+            "query_id": query_id,
+            "producer_stage_id": graph.stages[0].stage_id,
+            "task_lease_id": task["lease"]["lease_id"],
+            "attempt_id": task["lease"]["attempt_id"],
+            "block_id": "block:late-output",
+            "size_bytes": 10,
+        }
+        output = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+
+        runner_cls._close_query_resource_admission(runner, query_id)
+
+        assert runner._query_output_lease_requests == {}
+        assert output["lease"]["lease_id"] in manager.snapshot()["output_leases"]
+        assert await runner_cls.handoff_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            output["lease"]["lease_id"],
+            query_id,
+        ) == {"handed_off": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            output["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            output["lease"]["lease_id"],
+            "different-query",
+        ) == {"released": False}
+        # The ACK transfers ownership to structural teardown; it does not
+        # pretend that the still-live QRM block has already disappeared.
+        assert output["lease"]["lease_id"] in manager.snapshot()["output_leases"]
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
 
     asyncio.run(scenario())
 
@@ -359,6 +433,473 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         )
         assert manager.snapshot()["task_leases"] == {}
         assert runner._query_task_lease_requests == {}
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("completion_error", [None, RuntimeError("planned remote failure")])
+def test_submitted_task_lease_is_released_only_after_remote_completion(completion_error):
+    async def scenario():
+        query_id = "query-completion-gated-cancel"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(
+            graph,
+            _allocation(),
+            on_change=lambda: runner_cls._signal_query_resource_change(runner, query_id),
+        )
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        active_request = _task_request(
+            query_id,
+            "request:completion-gated",
+            "task:completion-gated",
+        )
+        active = await runner_cls.acquire_query_task_lease(runner, active_request)
+        lease = active["lease"]
+        assert await runner_cls.mark_query_task_lease_submitted(
+            runner,
+            active_request["request_id"],
+            lease["lease_id"],
+        ) == {"submitted": True}
+
+        pending_request = _task_request(
+            query_id,
+            "request:completion-gated-pending",
+            "task:completion-gated-pending",
+        )
+        pending = asyncio.create_task(runner_cls.acquire_query_task_lease(runner, pending_request))
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not pending.done()
+
+        completion = Future()
+        completion_ref = SimpleNamespace(future=lambda: completion)
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            active_request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [completion_ref],
+        ) == {"scheduled": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            active_request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"handed_off": False}
+
+        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        assert not pending.done()
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            active_request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"released": False}
+        assert await runner_cls.cancel_query_task_lease_request(
+            runner,
+            active_request["request_id"],
+            submitted=True,
+        ) == {"cancelled": False, "released": False}
+
+        if completion_error is None:
+            completion.set_result(None)
+        else:
+            completion.set_exception(completion_error)
+        granted = await asyncio.wait_for(pending, timeout=1)
+
+        assert granted["granted"] is True
+        assert lease["lease_id"] not in manager.snapshot()["task_leases"]
+        assert runner._query_task_completion_waiters == {}
+        tombstone = runner._query_task_lease_request_tombstones[active_request["request_id"]]
+        assert tombstone["status"] == "released_after_completion"
+
+        await runner_cls.release_query_task_lease(
+            runner,
+            pending_request["request_id"],
+            granted["lease"]["lease_id"],
+            granted["lease"]["attempt_id"],
+        )
+
+    asyncio.run(scenario())
+
+
+def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
+    async def scenario():
+        query_id = "query-close-retains-live-task"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        request = _task_request(
+            query_id,
+            "request:query-close-retains",
+            "task:query-close-retains",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+        completion = Future()
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
+
+        runner_cls._close_query_resource_admission(runner, query_id)
+        await asyncio.sleep(0)
+
+        assert request["request_id"] in runner._query_task_completion_waiters
+        assert runner._query_task_lease_requests == {}
+        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+
+        teardown_fence = asyncio.create_task(
+            asyncio.to_thread(
+                runner_cls._wait_for_query_task_execution_owners,
+                runner,
+                query_id,
+                timeout_s=1,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not teardown_fence.done()
+
+        completion.set_result(None)
+        await asyncio.wait_for(teardown_fence, timeout=1)
+
+        assert runner._query_task_completion_waiters == {}
+        assert runner._query_task_execution_owners == {}
+        assert lease["lease_id"] not in manager.snapshot()["task_leases"]
+
+    asyncio.run(scenario())
+
+
+def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
+    async def scenario():
+        query_id = "query-close-before-completion-handoff"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        request = _task_request(
+            query_id,
+            "request:close-before-handoff",
+            "task:close-before-handoff",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+        assert await runner_cls.mark_query_task_lease_submitted(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+        ) == {"submitted": True}
+
+        runner_cls._close_query_resource_admission(runner, query_id)
+        assert runner._query_task_lease_requests == {}
+        assert runner._query_task_execution_owners[request["request_id"]].phase == "submitted"
+
+        teardown_fence = asyncio.create_task(
+            asyncio.to_thread(
+                runner_cls._wait_for_query_task_execution_owners,
+                runner,
+                query_id,
+                timeout_s=1,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert not teardown_fence.done()
+
+        completion = Future()
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
+        assert runner._query_task_execution_owners[request["request_id"]].phase == "completion_wait"
+        assert not teardown_fence.done()
+
+        completion.set_result(None)
+        await asyncio.wait_for(teardown_fence, timeout=1)
+
+        assert runner._query_task_execution_owners == {}
+        assert runner._query_task_completion_waiters == {}
+        assert manager.snapshot()["task_leases"] == {}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
+        assert runner._query_task_completion_waiters == {}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"handed_off": True}
+
+    asyncio.run(scenario())
+
+
+def test_query_task_completion_owner_fence_is_bounded():
+    from duckdb.runners.ray.driver import QueryTeardownOwnershipError
+
+    runner_cls, runner = _runner(None)
+    runner_cls._ensure_query_resource_admission_state(runner)
+    runner._query_task_execution_owners["request:still-running"] = SimpleNamespace(
+        query_id="query:still-running",
+        phase="submitted",
+    )
+
+    with pytest.raises(
+        QueryTeardownOwnershipError,
+        match="request:still-running",
+    ):
+        runner_cls._wait_for_query_task_execution_owners(
+            runner,
+            "query:still-running",
+            timeout_s=0.01,
+        )
+
+
+def test_task_grant_owner_registration_failure_is_fatal_and_atomic():
+    async def scenario():
+        query_id = "query-owner-registration-failure"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        request = _task_request(
+            query_id,
+            "request:owner-registration-failure",
+            "task:owner-registration-failure",
+        )
+
+        def fail_registration(*, request_id, state):
+            del request_id, state
+            raise RuntimeError("planned owner registration failure")
+
+        runner._register_query_task_execution_owner = fail_registration
+        denial = await runner_cls.acquire_query_task_lease(runner, request)
+
+        assert denial["granted"] is False
+        assert denial["fatal"] is True
+        assert denial["blocked_reason"] == "task_execution_owner_registration_failed"
+        assert manager.snapshot()["task_leases"] == {}
+        assert runner._query_task_execution_owners == {}
+        assert request["request_id"] not in runner._query_task_lease_requests
+        assert runner._query_task_lease_request_tombstones[request["request_id"]]["result"] == denial
+        assert "planned owner registration failure" in runner._query_terminal_errors[query_id]
+
+        replay = await runner_cls.acquire_query_task_lease(runner, request)
+        assert replay == denial
+        late = await runner_cls.acquire_query_task_lease(
+            runner,
+            _task_request(
+                query_id,
+                "request:after-owner-registration-failure",
+                "task:after-owner-registration-failure",
+            ),
+        )
+        assert late["granted"] is False
+        assert late["fatal"] is True
+        assert late["blocked_reason"] == "query_not_registered"
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("rollback_raises", [False, True])
+def test_task_grant_owner_registration_rollback_retains_uncertain_lease_for_teardown(
+    rollback_raises,
+):
+    from duckdb.runners.ray.driver import QueryTeardownOwnershipError
+
+    async def scenario():
+        query_id = f"query-owner-registration-rollback-{rollback_raises}"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        request = _task_request(
+            query_id,
+            "request:owner-registration-rollback",
+            "task:owner-registration-rollback",
+        )
+
+        def fail_registration(*, request_id, state):
+            del request_id, state
+            raise RuntimeError("planned owner registration failure")
+
+        def fail_rollback(lease_id, *, attempt_id):
+            del lease_id, attempt_id
+            if rollback_raises:
+                raise RuntimeError("planned grant rollback failure")
+            return False
+
+        runner._register_query_task_execution_owner = fail_registration
+        manager.abandon_task_lease = fail_rollback
+        denial = await runner_cls.acquire_query_task_lease(runner, request)
+
+        assert denial["granted"] is False
+        assert denial["fatal"] is True
+        owner = runner._query_task_execution_owners[request["request_id"]]
+        assert owner.query_id == query_id
+        assert owner.phase == "teardown_owned"
+        assert owner.lease_id in manager.snapshot()["task_leases"]
+        with pytest.raises(QueryTeardownOwnershipError):
+            runner_cls._wait_for_query_task_execution_owners(
+                runner,
+                query_id,
+                timeout_s=0.01,
+            )
+
+        runner_cls._mark_query_execution_quiesced(runner, query_id)
+        assert runner._query_task_execution_owners == {}
+
+    asyncio.run(scenario())
+
+
+def test_query_resource_release_stops_before_qrm_when_grant_owner_is_unresolved():
+    from duckdb.runners.ray.driver import QueryTeardownOwnershipError
+    from duckdb.runners.ray.query_resource_runtime import (
+        get_query_resource_manager,
+    )
+
+    class _Coordinator:
+        def __init__(self):
+            self.release_calls = []
+
+        def release_query(self, query_id, generation):
+            self.release_calls.append((query_id, generation))
+            return True
+
+        def snapshot(self):
+            return {"queries": {}}
+
+    async def scenario():
+        query_id = "query-unresolved-grant-owner"
+        graph = _graph(query_id)
+        allocation = _allocation()
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, allocation)
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        runner._query_resource_lock = threading.RLock()
+        runner._query_resource_coordinator = _Coordinator()
+        runner._query_graphs = {query_id: graph}
+        runner._query_allocations = {query_id: allocation}
+        runner._synchronize_query_allocations = lambda: ()
+
+        request = _task_request(
+            query_id,
+            "request:unresolved-grant",
+            "task:unresolved-grant",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+        original_wait = runner_cls._wait_for_query_task_execution_owners.__get__(
+            runner,
+            runner_cls,
+        )
+        runner._wait_for_query_task_execution_owners = lambda owner_query_id: original_wait(
+            owner_query_id,
+            timeout_s=0.01,
+        )
+
+        with pytest.raises(
+            QueryTeardownOwnershipError,
+            match=r"request:unresolved-grant\[granted\]",
+        ):
+            runner_cls._release_query_resources(
+                runner,
+                query_id,
+                reason="unresolved_owner",
+            )
+
+        assert runner._query_resource_coordinator.release_calls == []
+        assert get_query_resource_manager(query_id) is manager
+        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"released": True}
+        runner_cls._release_query_resources(
+            runner,
+            query_id,
+            reason="owner_resolved",
+            admission_fenced=True,
+        )
+
+        assert runner._query_resource_coordinator.release_calls == [
+            (query_id, allocation.generation),
+        ]
+        with pytest.raises(KeyError):
+            get_query_resource_manager(query_id)
+
+    asyncio.run(scenario())
+
+
+def test_missing_completion_contract_hands_live_lease_to_query_teardown():
+    async def scenario():
+        query_id = "query-missing-completion-contract"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        request = _task_request(
+            query_id,
+            "request:teardown-owned",
+            "task:teardown-owned",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"handed_off": True}
+
+        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        assert request["request_id"] not in runner._query_task_lease_requests
+        assert runner._query_task_lease_request_tombstones[request["request_id"]]["status"] == "teardown_owned"
+        assert runner._query_task_execution_owners[request["request_id"]].phase == "teardown_owned"
+        completion = Future()
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": False}
+        assert runner._query_task_completion_waiters == {}
+
+        runner_cls._mark_query_execution_quiesced(runner, query_id)
+        assert runner._query_task_execution_owners == {}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"handed_off": True}
 
     asyncio.run(scenario())
 
@@ -1016,10 +1557,21 @@ def test_query_teardown_resolves_all_pending_admission_futures():
         assert not pending_task.done()
         assert not pending_output.done()
 
+        # This resource-layer test has no fragment/collector to perform the
+        # terminal task handoff. Model that owner explicitly before releasing
+        # the whole query.
+        runner_cls._close_query_resource_admission(runner, query_id)
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            active_request["request_id"],
+            active["lease"]["lease_id"],
+            active["lease"]["attempt_id"],
+        ) == {"released": True}
         runner_cls._release_query_resources(
             runner,
             query_id,
             reason="test_teardown",
+            admission_fenced=True,
         )
         task_denial, output_denial = await asyncio.wait_for(
             asyncio.gather(pending_task, pending_output),
@@ -1722,6 +2274,25 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
             )
         )
         await asyncio.to_thread(failed_pending.wait, 1)
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            active_request["request_id"],
+            active["lease"]["lease_id"],
+            active["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            active_request["request_id"],
+            active["lease"]["lease_id"],
+            active["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            active_request["request_id"],
+            active["lease"]["lease_id"],
+            active["lease"]["attempt_id"],
+            [SimpleNamespace(future=Future)],
+        ) == {"scheduled": True}
 
         late_request = _task_request(
             query_id,

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -275,9 +275,17 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
             output["lease"]["lease_id"],
             "different-query",
         ) == {"released": False}
-        # The ACK transfers ownership to structural teardown; it does not
-        # pretend that the still-live QRM block has already disappeared.
-        assert output_manager_lease_id in manager.snapshot()["output_leases"]
+        # Query close has discarded only the public request record. The signed
+        # capability still identifies the exact current-generation manager
+        # lease, so release must reclaim its object-store accounting. Replays
+        # remain successful and cannot affect another lease.
+        assert output_manager_lease_id not in manager.snapshot()["output_leases"]
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            output["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
 
         assert await runner_cls.release_query_task_lease(
             runner,
@@ -1612,7 +1620,20 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
             task_request["request_id"],
             old_capability,
             task["lease"]["attempt_id"],
-        ) == {"released": False}
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            task_request["request_id"],
+            old_capability,
+            task["lease"]["attempt_id"],
+            [SimpleNamespace(future=lambda: Future())],
+        ) == {"scheduled": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            task_request["request_id"],
+            old_capability,
+            task["lease"]["attempt_id"],
+        ) == {"handed_off": True}
         assert replacement_manager_lease_id in next_manager.snapshot()["task_leases"]
         assert old_manager_lease_id not in next_manager.snapshot()["task_leases"]
 
@@ -1625,11 +1646,10 @@ def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
             "block_id": "block:generation-fence",
             "size_bytes": 10,
         }
-        with pytest.raises(ValueError, match="inactive query generation"):
-            await runner_cls.cancel_query_output_block_lease_request(
-                runner,
-                stale_output_request,
-            )
+        assert await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            stale_output_request,
+        ) == {"cancelled": True, "released": False}
 
         current_output_request = dict(stale_output_request)
         current_output_request["request_id"] = "request:current-generation-output"
@@ -2737,6 +2757,40 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
         )
         assert late_cancel == {"cancelled": True, "released": False}
         assert len(runner._query_output_lease_request_tombstones) == 0
+        runner._query_lease_generation_ids.pop(query_id)
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            "request:retired-old-generation-task",
+            retired_task_lease_id,
+            "attempt:retired-old-generation-task",
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            "request:retired-old-generation-task",
+            retired_task_lease_id,
+            "attempt:retired-old-generation-task",
+            [],
+        ) == {"scheduled": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            "request:retired-old-generation-task",
+            retired_task_lease_id,
+            "attempt:retired-old-generation-task",
+        ) == {"handed_off": True}
+        closed_generation_cancel = dict(
+            request_id="request:closed-generation-output",
+            query_id=query_id,
+            producer_stage_id=graph.stages[0].stage_id,
+            task_lease_id=retired_task_lease_id,
+            attempt_id="attempt:retired-old-generation-task",
+            block_id="block:closed-generation-output",
+            size_bytes=10,
+        )
+        assert await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            closed_generation_cancel,
+        ) == {"cancelled": True, "released": False}
+        assert len(runner._query_output_lease_request_tombstones) == 0
         clear_query_resource_managers()
 
         manager = register_query_graph(graph, _allocation())
@@ -2825,6 +2879,14 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         runner_cls._close_query_resource_admission(runner, query_id)
         assert runner._query_output_lease_requests == {}
         assert len(runner._query_output_terminal_controls) == 0
+        assert len(manager.snapshot()["output_leases"]) == 1
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            active_request["request_id"],
+            active_capability,
+            query_id,
+        ) == {"released": True}
+        assert manager.snapshot()["output_leases"] == {}
         assert await runner_cls.release_query_task_lease(
             runner,
             task_request["request_id"],
@@ -2837,18 +2899,35 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
         next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
         runner_cls._open_query_resource_admission(runner, query_id)
 
+        replacement_task = await runner_cls.acquire_query_task_lease(
+            runner,
+            task_request,
+        )
+        replacement_request = {
+            **active_request,
+            "task_lease_id": replacement_task["lease"]["lease_id"],
+            "attempt_id": replacement_task["lease"]["attempt_id"],
+        }
+        replacement_output = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            replacement_request,
+        )
+        assert replacement_output["lease"]["lease_id"] != active_capability
+
         assert await runner_cls.handoff_query_output_block_lease(
             runner,
             active_request["request_id"],
             active_capability,
             query_id,
         ) == {"handed_off": True}
+        assert len(next_manager.snapshot()["output_leases"]) == 1
         assert await runner_cls.release_query_output_block_lease(
             runner,
             active_request["request_id"],
             active_capability,
             query_id,
         ) == {"released": True}
+        assert len(next_manager.snapshot()["output_leases"]) == 1
         assert await runner_cls.release_query_output_block_lease(
             runner,
             active_request["request_id"],
@@ -2861,6 +2940,18 @@ def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
             "forged-output-capability",
             query_id,
         ) == {"released": False}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            replacement_request["request_id"],
+            replacement_output["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            replacement_task["lease"]["lease_id"],
+            replacement_task["lease"]["attempt_id"],
+        ) == {"released": True}
         assert next_manager.snapshot()["output_leases"] == {}
 
     asyncio.run(scenario())

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -1534,6 +1534,94 @@ def test_terminal_control_ack_survives_bounded_replay_payload_eviction():
     asyncio.run(scenario())
 
 
+def test_output_terminal_control_ack_survives_bounded_replay_payload_eviction():
+    async def scenario():
+        query_id = "query-output-terminal-after-eviction"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(
+            graph,
+            _allocation(),
+            on_change=lambda: runner_cls._signal_query_resource_change(
+                runner,
+                query_id,
+            ),
+        )
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        task_request = _task_request(
+            query_id,
+            "request:output-terminal-task",
+            "task:output-terminal",
+        )
+        task = await runner_cls.acquire_query_task_lease(runner, task_request)
+        output_request = {
+            "request_id": "request:output-terminal-after-eviction",
+            "query_id": query_id,
+            "producer_stage_id": graph.stages[0].stage_id,
+            "task_lease_id": task["lease"]["lease_id"],
+            "attempt_id": task["lease"]["attempt_id"],
+            "block_id": "block:output-terminal-after-eviction",
+            "size_bytes": 10,
+        }
+        output = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+        lease_id = output["lease"]["lease_id"]
+
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            lease_id,
+        ) == {"released": True}
+
+        runner._query_output_lease_request_tombstones.clear()
+
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            lease_id,
+        ) == {"released": True}
+        assert await runner_cls.handoff_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            lease_id,
+        ) == {"handed_off": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            output_request["request_id"],
+            "wrong-output-lease",
+        ) == {"released": False}
+        replay = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            output_request,
+        )
+        assert replay["granted"] is False
+        assert replay["fatal"] is True
+        assert replay["blocked_reason"] == "output_lease_request_released"
+        assert await runner_cls.cancel_query_output_block_lease_request(
+            runner,
+            output_request,
+        ) == {"cancelled": True, "released": False}
+        mismatched = dict(output_request)
+        mismatched["size_bytes"] = 11
+        with pytest.raises(ValueError, match="reused with different identity"):
+            await runner_cls.cancel_query_output_block_lease_request(
+                runner,
+                mismatched,
+            )
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+
+    asyncio.run(scenario())
+
+
 def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
     async def scenario():
         query_id = "query-cancelled-request-replay"

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from concurrent.futures import Future
 from types import SimpleNamespace
 
@@ -331,7 +332,6 @@ def test_driver_resource_change_evaluates_only_the_selected_task_waiter():
             await runner_cls.cancel_query_task_lease_request(
                 runner,
                 request["request_id"],
-                submitted=False,
             )
         await asyncio.gather(*pending_tasks)
         granted_request = pending_requests[pending_tasks.index(granted_task)]
@@ -411,7 +411,6 @@ def test_driver_pending_task_lease_can_be_cancelled_without_a_polling_wakeup():
         cancelled = await runner_cls.cancel_query_task_lease_request(
             runner,
             pending_request["request_id"],
-            submitted=False,
         )
         assert cancelled == {"cancelled": True, "released": False}
         denial = await asyncio.wait_for(pending, timeout=1)
@@ -474,12 +473,12 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
             lease["attempt_id"],
             [completion_ref],
         ) == {"scheduled": True}
-        assert await runner_cls.handoff_query_task_lease_to_teardown(
+        replay = await runner_cls.acquire_query_task_lease(
             runner,
-            active_request["request_id"],
-            lease["lease_id"],
-            lease["attempt_id"],
-        ) == {"handed_off": False}
+            active_request,
+        )
+        assert replay["granted"] is True
+        assert replay["lease"] == lease
 
         assert lease["lease_id"] in manager.snapshot()["task_leases"]
         assert not pending.done()
@@ -492,7 +491,6 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
             active_request["request_id"],
-            submitted=True,
         ) == {"cancelled": False, "released": False}
 
         if completion_error is None:
@@ -570,6 +568,56 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
     asyncio.run(scenario())
 
 
+def test_completed_task_cleanup_retries_without_losing_its_ledger_owner(monkeypatch):
+    async def scenario():
+        query_id = "query-completion-cleanup-retry"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        request = _task_request(
+            query_id,
+            "request:completion-cleanup-retry",
+            "task:completion-cleanup-retry",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+        completion = Future()
+        release_attempts = 0
+        original_release = manager.release_task_lease
+
+        def fail_once(lease_id, *, attempt_id):
+            nonlocal release_attempts
+            release_attempts += 1
+            if release_attempts == 1:
+                raise RuntimeError("planned completion cleanup failure")
+            return original_release(lease_id, attempt_id=attempt_id)
+
+        monkeypatch.setattr(manager, "release_task_lease", fail_once)
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
+
+        completion.set_result(None)
+        deadline = time.monotonic() + 1
+        while request["request_id"] in runner._query_task_lease_requests and time.monotonic() < deadline:
+            await asyncio.sleep(0.001)
+
+        assert release_attempts == 2
+        assert runner._query_task_lease_requests == {}
+        assert runner._query_task_completion_waiters == {}
+        assert manager.snapshot()["task_leases"] == {}
+        tombstone = runner._query_task_lease_request_tombstones[request["request_id"]]
+        assert tombstone["status"] == "released_after_completion"
+
+    asyncio.run(scenario())
+
+
 def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
     async def scenario():
         query_id = "query-close-before-completion-handoff"
@@ -632,12 +680,82 @@ def test_query_close_before_completion_handoff_cannot_erase_execution_owner():
             lease["lease_id"],
             lease["attempt_id"],
         ) == {"released": True}
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("quiesce_first", [False, True])
+def test_missing_completion_contract_requires_explicit_teardown_ownership(
+    quiesce_first,
+):
+    async def scenario():
+        query_id = f"query-missing-completion:{quiesce_first}"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        request = _task_request(
+            query_id,
+            f"request:teardown-wait:{quiesce_first}",
+            f"task:teardown-wait:{quiesce_first}",
+        )
+        grant = await runner_cls.acquire_query_task_lease(runner, request)
+        lease = grant["lease"]
+
+        if quiesce_first:
+            runner_cls._mark_query_execution_quiesced(runner, query_id)
+            assert runner._query_task_lease_requests[request["request_id"]]["status"] == "granted"
+            assert lease["lease_id"] in manager.snapshot()["task_leases"]
+
         assert await runner_cls.handoff_query_task_lease_to_teardown(
             runner,
             request["request_id"],
             lease["lease_id"],
             lease["attempt_id"],
         ) == {"handed_off": True}
+
+        if not quiesce_first:
+            assert runner._query_task_lease_requests[request["request_id"]]["status"] == "teardown_wait"
+            assert await runner_cls.release_query_task_lease(
+                runner,
+                request["request_id"],
+                lease["lease_id"],
+                lease["attempt_id"],
+            ) == {"released": False}
+            assert await runner_cls.cancel_query_task_lease_request(
+                runner,
+                request["request_id"],
+            ) == {"cancelled": False, "released": False}
+            completion = Future()
+            assert await runner_cls.release_query_task_lease_after_completion(
+                runner,
+                request["request_id"],
+                lease["lease_id"],
+                lease["attempt_id"],
+                [SimpleNamespace(future=lambda: completion)],
+            ) == {"scheduled": False}
+            assert runner._query_task_completion_waiters == {}
+            runner_cls._mark_query_execution_quiesced(runner, query_id)
+
+        assert runner._query_task_lease_requests == {}
+        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        tombstone = runner._query_task_lease_request_tombstones[request["request_id"]]
+        assert tombstone["status"] == "released_by_teardown"
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+        ) == {"handed_off": True}
+        completion = Future()
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            request["request_id"],
+            lease["lease_id"],
+            lease["attempt_id"],
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
 
     asyncio.run(scenario())
 
@@ -705,7 +823,7 @@ def test_task_grant_is_published_in_the_admission_ledger_before_future_completio
     asyncio.run(scenario())
 
 
-def test_query_resource_release_stops_before_qrm_when_grant_owner_is_unresolved():
+def test_query_resource_release_waits_for_late_submission_completion_handoff():
     from duckdb.runners.ray.driver import QueryTeardownOwnershipError
     from duckdb.runners.ray.query_resource_runtime import (
         get_query_resource_manager,
@@ -765,12 +883,20 @@ def test_query_resource_release_stops_before_qrm_when_grant_owner_is_unresolved(
         assert get_query_resource_manager(query_id) is manager
         assert lease["lease_id"] in manager.snapshot()["task_leases"]
 
-        assert await runner_cls.release_query_task_lease(
+        completion = Future()
+        assert await runner_cls.release_query_task_lease_after_completion(
             runner,
             request["request_id"],
             lease["lease_id"],
             lease["attempt_id"],
-        ) == {"released": True}
+            [SimpleNamespace(future=lambda: completion)],
+        ) == {"scheduled": True}
+        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "completion_wait"
+        completion.set_result(None)
+        deadline = time.monotonic() + 1
+        while runner._query_task_lease_requests and time.monotonic() < deadline:
+            await asyncio.sleep(0.001)
+        assert runner._query_task_lease_requests == {}
         runner_cls._release_query_resources(
             runner,
             query_id,
@@ -783,54 +909,6 @@ def test_query_resource_release_stops_before_qrm_when_grant_owner_is_unresolved(
         ]
         with pytest.raises(KeyError):
             get_query_resource_manager(query_id)
-
-    asyncio.run(scenario())
-
-
-def test_missing_completion_contract_hands_live_lease_to_query_teardown():
-    async def scenario():
-        query_id = "query-missing-completion-contract"
-        graph = _graph(query_id)
-        runner_cls, runner = _runner(asyncio.get_running_loop())
-        manager = register_query_graph(graph, _allocation())
-        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
-
-        request = _task_request(
-            query_id,
-            "request:teardown-owned",
-            "task:teardown-owned",
-        )
-        grant = await runner_cls.acquire_query_task_lease(runner, request)
-        lease = grant["lease"]
-        assert await runner_cls.handoff_query_task_lease_to_teardown(
-            runner,
-            request["request_id"],
-            lease["lease_id"],
-            lease["attempt_id"],
-        ) == {"handed_off": True}
-
-        assert lease["lease_id"] in manager.snapshot()["task_leases"]
-        assert runner._query_task_lease_requests[request["request_id"]]["status"] == "teardown_owned"
-        assert request["request_id"] not in runner._query_task_lease_request_tombstones
-        completion = Future()
-        assert await runner_cls.release_query_task_lease_after_completion(
-            runner,
-            request["request_id"],
-            lease["lease_id"],
-            lease["attempt_id"],
-            [SimpleNamespace(future=lambda: completion)],
-        ) == {"scheduled": False}
-        assert runner._query_task_completion_waiters == {}
-
-        runner_cls._mark_query_execution_quiesced(runner, query_id)
-        assert runner._query_task_lease_requests == {}
-        assert runner._query_task_lease_request_tombstones[request["request_id"]]["status"] == "teardown_owned"
-        assert await runner_cls.handoff_query_task_lease_to_teardown(
-            runner,
-            request["request_id"],
-            lease["lease_id"],
-            lease["attempt_id"],
-        ) == {"handed_off": True}
 
     asyncio.run(scenario())
 
@@ -1195,7 +1273,6 @@ def test_task_attempt_rejects_a_second_request_id_instead_of_orphaning_future():
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
             first_request["request_id"],
-            submitted=False,
         ) == {"cancelled": True, "released": False}
         denial = await first_waiter
         assert denial["blocked_reason"] == "task_lease_request_cancelled"
@@ -1401,7 +1478,6 @@ def test_cancelled_admission_request_replay_returns_the_same_terminal_denial():
         assert await runner_cls.cancel_query_task_lease_request(
             runner,
             cancelled_request["request_id"],
-            submitted=False,
         ) == {"cancelled": True, "released": False}
         original_denial = await original_waiter
         replay_denial = await runner_cls.acquire_query_task_lease(

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.query_execution_graph import (
     NodeResourceAllocation,
     QueryAllocation,
@@ -73,6 +74,17 @@ def _runner(loop: asyncio.AbstractEventLoop):
     runner._query_output_admission_pumps = set()
     runner._query_resource_admission_loop = loop
     return runner_cls, runner
+
+
+def _manager_task_lease_id(runner_cls, runner, lease: dict) -> str:
+    capability = runner_cls._verify_task_lease_capability(
+        runner,
+        lease_id=lease["lease_id"],
+        attempt_id=lease["attempt_id"],
+        query_id=lease["query_id"],
+    )
+    assert capability is not None
+    return capability[0]
 
 
 def _task_request(query_id: str, request_id: str, task_id: str) -> dict:
@@ -169,6 +181,7 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
                 "size_bytes": 10,
             },
         )
+        output_manager_lease_id = runner._query_output_lease_requests["output-request:block-1"]["manager_lease_id"]
         assert output["granted"]
         assert output["lease"]["state"] == "stage_queue"
         assert await runner_cls.handoff_query_output_block_lease(
@@ -176,7 +189,7 @@ def test_driver_task_lease_wait_is_event_driven_and_release_wakes_next_request()
             "output-request:block-1",
             output["lease"]["lease_id"],
         ) == {"handed_off": True}
-        assert manager.snapshot()["output_leases"][output["lease"]["lease_id"]]["state"] == "downstream_input"
+        assert manager.snapshot()["output_leases"][output_manager_lease_id]["state"] == "downstream_input"
         assert await runner_cls.handoff_query_output_block_lease(
             runner,
             "output-request:block-1",
@@ -238,11 +251,12 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
             runner,
             output_request,
         )
+        output_manager_lease_id = runner._query_output_lease_requests[output_request["request_id"]]["manager_lease_id"]
 
         runner_cls._close_query_resource_admission(runner, query_id)
 
         assert runner._query_output_lease_requests == {}
-        assert output["lease"]["lease_id"] in manager.snapshot()["output_leases"]
+        assert output_manager_lease_id in manager.snapshot()["output_leases"]
         assert await runner_cls.handoff_query_output_block_lease(
             runner,
             output_request["request_id"],
@@ -263,7 +277,7 @@ def test_late_output_controls_transfer_to_fenced_query_teardown():
         ) == {"released": False}
         # The ACK transfers ownership to structural teardown; it does not
         # pretend that the still-live QRM block has already disappeared.
-        assert output["lease"]["lease_id"] in manager.snapshot()["output_leases"]
+        assert output_manager_lease_id in manager.snapshot()["output_leases"]
 
         assert await runner_cls.release_query_task_lease(
             runner,
@@ -480,7 +494,8 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         assert replay["granted"] is True
         assert replay["lease"] == lease
 
-        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        manager_lease_id = _manager_task_lease_id(runner_cls, runner, lease)
+        assert manager_lease_id in manager.snapshot()["task_leases"]
         assert not pending.done()
         assert await runner_cls.release_query_task_lease(
             runner,
@@ -500,7 +515,7 @@ def test_submitted_task_lease_is_released_only_after_remote_completion(completio
         granted = await asyncio.wait_for(pending, timeout=1)
 
         assert granted["granted"] is True
-        assert lease["lease_id"] not in manager.snapshot()["task_leases"]
+        assert manager_lease_id not in manager.snapshot()["task_leases"]
         assert runner._query_task_completion_waiters == {}
         tombstone = runner._query_task_lease_request_tombstones[active_request["request_id"]]
         assert tombstone["status"] == "released_after_completion"
@@ -544,7 +559,8 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
 
         assert request["request_id"] in runner._query_task_completion_waiters
         assert runner._query_task_lease_requests[request["request_id"]]["status"] == "completion_wait"
-        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        manager_lease_id = _manager_task_lease_id(runner_cls, runner, lease)
+        assert manager_lease_id in manager.snapshot()["task_leases"]
 
         teardown_fence = asyncio.create_task(
             asyncio.to_thread(
@@ -563,7 +579,7 @@ def test_query_close_retains_completion_owner_until_remote_task_is_terminal():
 
         assert runner._query_task_completion_waiters == {}
         assert runner._query_task_lease_requests == {}
-        assert lease["lease_id"] not in manager.snapshot()["task_leases"]
+        assert manager_lease_id not in manager.snapshot()["task_leases"]
 
     asyncio.run(scenario())
 
@@ -706,7 +722,7 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
         if quiesce_first:
             runner_cls._mark_query_execution_quiesced(runner, query_id)
             assert runner._query_task_lease_requests[request["request_id"]]["status"] == "granted"
-            assert lease["lease_id"] in manager.snapshot()["task_leases"]
+            assert _manager_task_lease_id(runner_cls, runner, lease) in manager.snapshot()["task_leases"]
 
         assert await runner_cls.handoff_query_task_lease_to_teardown(
             runner,
@@ -739,7 +755,7 @@ def test_missing_completion_contract_requires_explicit_teardown_ownership(
             runner_cls._mark_query_execution_quiesced(runner, query_id)
 
         assert runner._query_task_lease_requests == {}
-        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        assert _manager_task_lease_id(runner_cls, runner, lease) in manager.snapshot()["task_leases"]
         tombstone = runner._query_task_lease_request_tombstones[request["request_id"]]
         assert tombstone["status"] == "released_by_teardown"
         runner._query_task_lease_request_tombstones.clear()
@@ -882,7 +898,7 @@ def test_query_resource_release_waits_for_late_submission_completion_handoff():
 
         assert runner._query_resource_coordinator.release_calls == []
         assert get_query_resource_manager(query_id) is manager
-        assert lease["lease_id"] in manager.snapshot()["task_leases"]
+        assert _manager_task_lease_id(runner_cls, runner, lease) in manager.snapshot()["task_leases"]
 
         completion = Future()
         assert await runner_cls.release_query_task_lease_after_completion(
@@ -1445,11 +1461,13 @@ def test_terminal_task_and_output_requests_are_idempotent_for_query_lifetime():
     asyncio.run(scenario())
 
 
-def test_terminal_control_ack_survives_bounded_replay_payload_eviction():
+def test_signed_task_lease_ack_survives_eviction_and_query_id_reuse():
     async def scenario():
         query_id = "query-terminal-control-after-eviction"
         graph = _graph(query_id)
         runner_cls, runner = _runner(asyncio.get_running_loop())
+        runner._query_task_terminal_controls = BoundedReplayMap(capacity=1)
+        runner._query_task_terminal_attempts = BoundedReplayMap(capacity=1)
         manager = register_query_graph(
             graph,
             _allocation(),
@@ -1475,32 +1493,6 @@ def test_terminal_control_ack_survives_bounded_replay_payload_eviction():
         ) == {"released": True}
 
         runner._query_task_lease_request_tombstones.clear()
-
-        assert await runner_cls.release_query_task_lease(
-            runner,
-            task_request["request_id"],
-            "wrong-lease",
-            task["lease"]["attempt_id"],
-        ) == {"released": False}
-        assert await runner_cls.release_query_task_lease(
-            runner,
-            task_request["request_id"],
-            task["lease"]["lease_id"],
-            task["lease"]["attempt_id"],
-        ) == {"released": True}
-        assert await runner_cls.release_query_task_lease_after_completion(
-            runner,
-            task_request["request_id"],
-            task["lease"]["lease_id"],
-            task["lease"]["attempt_id"],
-            [SimpleNamespace(future=lambda: Future())],
-        ) == {"scheduled": True}
-        assert await runner_cls.handoff_query_task_lease_to_teardown(
-            runner,
-            task_request["request_id"],
-            task["lease"]["lease_id"],
-            task["lease"]["attempt_id"],
-        ) == {"handed_off": False}
         conflicting_terminal_cancel = dict(task_request)
         conflicting_terminal_cancel["request_id"] = "request:conflicting-terminal-cancel"
         with pytest.raises(ValueError, match="already terminal under another request_id"):
@@ -1530,6 +1522,142 @@ def test_terminal_control_ack_survives_bounded_replay_payload_eviction():
                 runner,
                 mismatched_unseen,
             )
+
+        assert len(runner._query_task_terminal_controls) == 1
+        assert len(runner._query_task_terminal_attempts) == 1
+        assert (
+            runner_cls._task_request_fingerprint(
+                task_request["request_id"],
+            )
+            not in runner._query_task_terminal_controls
+        )
+        assert runner_cls._task_attempt_fingerprint(task_request) not in runner._query_task_terminal_attempts
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            "wrong-lease",
+            task["lease"]["attempt_id"],
+        ) == {"released": False}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease_after_completion(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+            [SimpleNamespace(future=lambda: Future())],
+        ) == {"scheduled": True}
+        assert await runner_cls.handoff_query_task_lease_to_teardown(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"handed_off": True}
+
+        old_capability = task["lease"]["lease_id"]
+        old_manager_lease_id = _manager_task_lease_id(
+            runner_cls,
+            runner,
+            task["lease"],
+        )
+        closing_request = _task_request(
+            query_id,
+            "request:released-after-close",
+            "task:released-after-close",
+        )
+        closing_task = await runner_cls.acquire_query_task_lease(
+            runner,
+            closing_request,
+        )
+        assert closing_task["granted"] is True
+        runner_cls._close_query_resource_admission(runner, query_id)
+        assert len(runner._query_task_lease_request_tombstones) == 0
+        assert len(runner._query_task_terminal_controls) == 0
+        assert len(runner._query_task_terminal_attempts) == 0
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            closing_request["request_id"],
+            closing_task["lease"]["lease_id"],
+            closing_task["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert len(runner._query_task_lease_request_tombstones) == 1
+        assert len(runner._query_task_terminal_controls) == 1
+        assert len(runner._query_task_terminal_attempts) == 1
+
+        clear_query_resource_managers()
+        next_manager = register_query_graph(graph, _allocation())
+        next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        runner_cls._open_query_resource_admission(runner, query_id)
+        assert len(runner._query_task_lease_request_tombstones) == 0
+        assert len(runner._query_task_terminal_controls) == 0
+        assert len(runner._query_task_terminal_attempts) == 0
+        replacement = await runner_cls.acquire_query_task_lease(
+            runner,
+            task_request,
+        )
+        assert replacement["granted"] is True
+        assert replacement["lease"]["lease_id"] != old_capability
+        replacement_manager_lease_id = _manager_task_lease_id(
+            runner_cls,
+            runner,
+            replacement["lease"],
+        )
+
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            old_capability,
+            task["lease"]["attempt_id"],
+        ) == {"released": False}
+        assert replacement_manager_lease_id in next_manager.snapshot()["task_leases"]
+        assert old_manager_lease_id not in next_manager.snapshot()["task_leases"]
+
+        stale_output_request = {
+            "request_id": "request:stale-generation-output",
+            "query_id": query_id,
+            "producer_stage_id": graph.stages[0].stage_id,
+            "task_lease_id": old_capability,
+            "attempt_id": task["lease"]["attempt_id"],
+            "block_id": "block:generation-fence",
+            "size_bytes": 10,
+        }
+        with pytest.raises(ValueError, match="inactive query generation"):
+            await runner_cls.cancel_query_output_block_lease_request(
+                runner,
+                stale_output_request,
+            )
+
+        current_output_request = dict(stale_output_request)
+        current_output_request["request_id"] = "request:current-generation-output"
+        current_output_request["task_lease_id"] = replacement["lease"]["lease_id"]
+        current_output = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            current_output_request,
+        )
+        assert current_output["granted"] is True
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            current_output_request["request_id"],
+            current_output["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            replacement["lease"]["lease_id"],
+            replacement["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            old_capability,
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+        assert next_manager.snapshot()["task_leases"] == {}
 
     asyncio.run(scenario())
 
@@ -2588,13 +2716,20 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
 
         runner_cls._close_query_resource_admission(runner, query_id)
         assert query_id in runner._query_resource_closing_queries
+        retired_task_lease_id = runner_cls._issue_task_lease_capability(
+            runner,
+            request_id="request:retired-old-generation-task",
+            manager_lease_id="lease:retired-old-generation-task",
+            attempt_id="attempt:retired-old-generation-task",
+            query_id=query_id,
+        )
         late_cancel = await runner_cls.cancel_query_output_block_lease_request(
             runner,
             {
                 "request_id": "request:late-old-generation-output",
                 "query_id": query_id,
                 "producer_stage_id": graph.stages[0].stage_id,
-                "task_lease_id": "lease:retired-old-generation-task",
+                "task_lease_id": retired_task_lease_id,
                 "attempt_id": "attempt:retired-old-generation-task",
                 "block_id": "block:late-old-generation-output",
                 "size_bytes": 10,
@@ -2614,5 +2749,118 @@ def test_new_query_generation_reopens_admission_after_old_state_is_purged():
 
         assert grant["granted"] is True
         assert query_id not in runner._query_resource_closing_queries
+
+    asyncio.run(scenario())
+
+
+def test_signed_output_lease_ack_survives_teardown_and_query_id_reuse():
+    async def scenario():
+        query_id = "query-signed-output-reopen"
+        graph = _graph(query_id)
+        runner_cls, runner = _runner(asyncio.get_running_loop())
+        runner._query_output_terminal_controls = BoundedReplayMap(capacity=1)
+        manager = register_query_graph(graph, _allocation())
+        manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+
+        task_request = _task_request(
+            query_id,
+            "request:signed-output-task",
+            "task:signed-output-task",
+        )
+        task = await runner_cls.acquire_query_task_lease(
+            runner,
+            task_request,
+        )
+
+        def output_request(index):
+            return {
+                "request_id": f"request:signed-output:{index}",
+                "query_id": query_id,
+                "producer_stage_id": graph.stages[0].stage_id,
+                "task_lease_id": task["lease"]["lease_id"],
+                "attempt_id": task["lease"]["attempt_id"],
+                "block_id": f"block:signed-output:{index}",
+                "size_bytes": 10,
+            }
+
+        released_request = output_request(0)
+        released = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            released_request,
+        )
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            released_request["request_id"],
+            released["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+        assert len(runner._query_output_terminal_controls) == 1
+
+        evicting_request = output_request(1)
+        evicting = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            evicting_request,
+        )
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            evicting_request["request_id"],
+            evicting["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+        assert len(runner._query_output_terminal_controls) == 1
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            released_request["request_id"],
+            released["lease"]["lease_id"],
+            query_id,
+        ) == {"released": True}
+
+        active_request = output_request(2)
+        active = await runner_cls.acquire_query_output_block_lease(
+            runner,
+            active_request,
+        )
+        active_capability = active["lease"]["lease_id"]
+
+        runner_cls._close_query_resource_admission(runner, query_id)
+        assert runner._query_output_lease_requests == {}
+        assert len(runner._query_output_terminal_controls) == 0
+        assert await runner_cls.release_query_task_lease(
+            runner,
+            task_request["request_id"],
+            task["lease"]["lease_id"],
+            task["lease"]["attempt_id"],
+        ) == {"released": True}
+
+        clear_query_resource_managers()
+        next_manager = register_query_graph(graph, _allocation())
+        next_manager.update_stage_state(graph.stages[0].stage_id, runnable=True)
+        runner_cls._open_query_resource_admission(runner, query_id)
+
+        assert await runner_cls.handoff_query_output_block_lease(
+            runner,
+            active_request["request_id"],
+            active_capability,
+            query_id,
+        ) == {"handed_off": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            active_request["request_id"],
+            active_capability,
+            query_id,
+        ) == {"released": True}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            active_request["request_id"],
+            active_capability,
+            "different-query",
+        ) == {"released": False}
+        assert await runner_cls.release_query_output_block_lease(
+            runner,
+            active_request["request_id"],
+            "forged-output-capability",
+            query_id,
+        ) == {"released": False}
+        assert next_manager.snapshot()["output_leases"] == {}
 
     asyncio.run(scenario())

--- a/tests/fast/test_driver_udf_precreate.py
+++ b/tests/fast/test_driver_udf_precreate.py
@@ -16,6 +16,8 @@ from types import SimpleNamespace
 
 import pytest
 
+_QUERY_GENERATION_CAPABILITY = "test-query-generation-capability"
+
 
 class _FakePlan:
     def __init__(self, nodes):
@@ -301,11 +303,13 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
         *,
         actor_node_ids_by_stage,
         query_driver_handle,
+        query_generation_capability,
         session_config,
         conn=None,
     ):
         assert actor_node_ids_by_stage == {}
         assert query_driver_handle is driver_handle
+        assert query_generation_capability == _QUERY_GENERATION_CAPABILITY
         assert session_config == {"AWS_ACCESS_KEY_ID": "session-access-key"}
         assert conn is query_connection
         created = []
@@ -315,6 +319,7 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
             if payload.get("execution_backend") in {"ray_task", "ray_actor"}:
                 handles_map[str(node["node_id"])] = {
                     "query_driver_handle": query_driver_handle,
+                    "query_generation_capability": query_generation_capability,
                     "session_config": dict(session_config),
                 }
         if handles_map:
@@ -329,6 +334,7 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     runner = SimpleNamespace(
         _driver_handle=driver_handle,
         _active_udf_actors=[],
+        _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
     )
     query_connection = object()
 
@@ -350,7 +356,7 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
     created = runner_cls._precreate_udf_actors(
         runner,
         plan,
-        SimpleNamespace(stages=()),
+        SimpleNamespace(query_id="test-plan", stages=()),
         SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
         query_connection=query_connection,
         session_config={"AWS_ACCESS_KEY_ID": "session-access-key"},
@@ -362,6 +368,7 @@ def test_precreate_udf_actors_injects_driver_handle_for_ray_task(monkeypatch):
             "handles_map": {
                 "7": {
                     "query_driver_handle": driver_handle,
+                    "query_generation_capability": _QUERY_GENERATION_CAPABILITY,
                     "session_config": {
                         "AWS_ACCESS_KEY_ID": "session-access-key",
                     },
@@ -387,6 +394,7 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
         _driver_handle=object(),
         _duckdb_conn=object(),
         _active_udf_actors=[],
+        _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
     )
 
     plan = _FakePlan(
@@ -404,7 +412,7 @@ def test_precreate_udf_actors_skips_non_ray_nodes(monkeypatch):
     created = runner_cls._precreate_udf_actors(
         runner,
         plan,
-        SimpleNamespace(stages=()),
+        SimpleNamespace(query_id="test-plan", stages=()),
         SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
         query_connection=object(),
         session_config={},
@@ -457,6 +465,7 @@ def test_precreate_retains_partially_created_actor_pool_for_teardown(
     runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
     runner = SimpleNamespace(
         _driver_handle=object(),
+        _issue_query_task_admission_capability=lambda _query_id: _QUERY_GENERATION_CAPABILITY,
         **{
             active_attr: [],
             by_plan_attr: {},
@@ -470,7 +479,7 @@ def test_precreate_retains_partially_created_actor_pool_for_teardown(
             method(
                 runner,
                 plan,
-                SimpleNamespace(stages=()),
+                SimpleNamespace(query_id="test-plan", stages=()),
                 SimpleNamespace(actor_node_ids_for_stage=lambda _stage_id: ()),
                 query_connection=object(),
                 session_config={},
@@ -691,6 +700,7 @@ def test_precreate_udf_actors_enable_generic_async_for_distributed_pool(
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -762,6 +772,7 @@ def test_ensure_actor_pools_for_plan_creates_anonymous_handles_without_pool_name
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=query_driver_handle,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -848,6 +859,7 @@ def test_ensure_actor_pools_for_plan_disables_restarts_and_retries_for_stateful_
         plan,
         actor_node_ids_by_stage={"stage:test:stateful": ("node-a",)},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -922,6 +934,7 @@ def test_ensure_actor_pools_for_plan_disables_retries_for_side_effecting_udf(mon
         plan,
         actor_node_ids_by_stage={"stage:test:side-effects": ("node-a",)},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -993,6 +1006,7 @@ def test_ensure_actor_pools_for_plan_keeps_default_retry_policy_for_non_stateful
         plan,
         actor_node_ids_by_stage={"stage:test:retry-policy": ("node-a",)},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -1118,6 +1132,7 @@ def test_ensure_actor_pools_for_nodes_injects_with_callback(monkeypatch):
         nodes,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         set_handles=inject,
     )
@@ -1172,6 +1187,7 @@ def test_ray_plan_injects_session_context_for_explicit_subprocess_backends(monke
         nodes,
         actor_node_ids_by_stage={},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config=session_config,
         set_handles=injected.append,
     )
@@ -1247,6 +1263,7 @@ def test_prepare_actor_pools_publishes_handles_before_waiting_for_init(monkeypat
             "stage:test:deferred-ready": ("node-a", "node-b"),
         },
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
     )
 
@@ -1468,6 +1485,7 @@ def test_ensure_actor_pools_for_plan_does_not_fail_fast_on_cluster_resource_snap
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -1524,6 +1542,7 @@ def test_ensure_actor_pools_for_plan_publishes_driver_handle_for_ray_task(monkey
         plan,
         actor_node_ids_by_stage={},
         query_driver_handle=query_driver_handle,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
         conn=object(),
     )
@@ -1532,6 +1551,7 @@ def test_ensure_actor_pools_for_plan_publishes_driver_handle_for_ray_task(monkey
     assert handles_map == {
         "9": {
             "query_driver_handle": query_driver_handle,
+            "query_generation_capability": _QUERY_GENERATION_CAPABILITY,
             "session_config": {},
         }
     }
@@ -1553,6 +1573,7 @@ def test_ensure_actor_pools_for_plan_propagates_collect_errors(monkeypatch):
             _BadPlan(),
             actor_node_ids_by_stage={},
             query_driver_handle=object(),
+            query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
             conn=object(),
         )
@@ -1598,6 +1619,7 @@ def test_ensure_actor_pools_for_plan_propagates_actor_creation_errors(monkeypatc
             plan,
             actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
             query_driver_handle=object(),
+            query_generation_capability=_QUERY_GENERATION_CAPABILITY,
             session_config={},
             conn=object(),
         )
@@ -1726,6 +1748,7 @@ def test_physical_plan_structured_executor_options_reach_udf_builder(monkeypatch
                     "actor_handles": ["actor-0"],
                     "actor_node_ids": ["node-a"],
                     "query_driver_handle": query_driver_handle,
+                    "query_generation_capability": _QUERY_GENERATION_CAPABILITY,
                     "session_config": {},
                 }
             },
@@ -1742,6 +1765,7 @@ def test_physical_plan_structured_executor_options_reach_udf_builder(monkeypatch
     assert build_calls[0]["options"]["actor_handles"] == ["actor-0"]
     assert build_calls[0]["options"]["actor_node_ids"] == ["node-a"]
     assert build_calls[0]["options"]["query_driver_handle"] is query_driver_handle
+    assert build_calls[0]["options"]["query_generation_capability"] == _QUERY_GENERATION_CAPABILITY
     assert build_calls[0]["options"]["session_config"] == {}
     assert sorted(table.column(0).to_pylist()) == [2, 3]
 
@@ -1849,6 +1873,7 @@ def test_execute_native_udf_cleanup_does_not_deadlock_with_gil_held():
                     "actor_handles": ["actor-0"],
                     "actor_node_ids": ["node-a"],
                     "query_driver_handle": object(),
+                    "query_generation_capability": "test-query-generation-capability",
                 }
             },
             conn=con,
@@ -1959,6 +1984,7 @@ def test_ensure_actor_pools_for_plan_uses_coordinator_actor_nodes(monkeypatch):
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
     )
 
@@ -2038,6 +2064,7 @@ def test_ensure_actor_pools_waits_for_init_refs_before_ready_lookup(monkeypatch)
         plan,
         actor_node_ids_by_stage={"stage:test:actor": ("node-a", "node-b")},
         query_driver_handle=object(),
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
         session_config={},
     )
 

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -352,6 +352,7 @@ def test_actor_gpu_reservation_follows_resolved_backend(
             nodes,
             actor_node_ids_by_stage={stage_id: ("node-a",)},
             query_driver_handle=object(),
+            query_generation_capability="test-query-generation-capability",
             session_config={},
         )
 
@@ -463,6 +464,7 @@ def test_stateless_ray_actor_pool_size_and_gpu_options_follow_physical_payload(m
         nodes,
         actor_node_ids_by_stage={stage_id: ("node-a", "node-a", "node-a")},
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
         session_config={},
     )
 

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -232,6 +232,7 @@ def test_task_executor_consumes_pregranted_admission_with_exact_resources(monkey
         run_bundle_stream=object(),
         run_ref_bundle_stream=object(),
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
     )
     admission = SimpleNamespace(
         driver=object(),
@@ -277,6 +278,7 @@ def test_task_submission_starts_immediately_from_pregranted_lease(monkeypatch):
         run_bundle_stream=_Remote(),
         run_ref_bundle_stream=_Remote(),
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
     )
     lease = {
         "query_id": "q1",

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -2814,8 +2814,8 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
         calls.append(("actors", plan_id))
         raise RuntimeError("actor cleanup failed")
 
-    def _drop_fragments(_self, query_id):
-        calls.append(("fragments", query_id))
+    def _drop_fragments(_self, query_id, *, release_resources):
+        calls.append(("fragments", query_id, release_resources))
         raise RuntimeError("fragment cleanup failed")
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
@@ -2828,7 +2828,11 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
     )
     monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_udf_actors)
-    monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
+    monkeypatch.setattr(
+        cls,
+        "_drop_query_fragments_after_admission_fence_sync",
+        _drop_fragments,
+    )
 
     with pytest.raises(RuntimeError, match="failed to start and teardown also failed") as exc_info:
         asyncio.run(_run_actor_stream_plan(runner, logical_plan))
@@ -2839,7 +2843,7 @@ def test_query_driver_run_plan_start_failure_runs_complete_teardown(monkeypatch)
     assert "fragment cleanup failed" in message
     assert calls == [
         ("actors", "failed-plan"),
-        ("fragments", "failed-query"),
+        ("fragments", "failed-query", False),
     ]
     assert "failed-plan" not in runner.curr_plans
     assert "failed-plan" not in runner.curr_streams
@@ -2890,8 +2894,8 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
         if attempts["vllm"] == 1:
             raise RuntimeError("vllm actor release failed")
 
-    def _drop_fragments(_self, query_id):
-        calls.append(f"fragments:{query_id}")
+    def _drop_fragments(_self, query_id, *, release_resources=True):
+        calls.append(f"fragments:{query_id}:release={release_resources}")
         attempts["fragments"] += 1
         if attempts["fragments"] == 1:
             raise RuntimeError("fragment release failed")
@@ -2899,6 +2903,11 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
     monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", _cleanup_actors)
     monkeypatch.setattr(cls, "_cleanup_vllm_actor_pools", _cleanup_vllm_actors)
     monkeypatch.setattr(cls, "_drop_query_fragments_sync", _drop_fragments)
+    monkeypatch.setattr(
+        cls,
+        "_drop_query_fragments_after_admission_fence_sync",
+        _drop_fragments,
+    )
 
     with pytest.raises(RuntimeError, match="teardown failed") as exc_info:
         cls._teardown_plan_resources(
@@ -2916,7 +2925,7 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
         "output",
         "actors:teardown-plan",
         "vllm:teardown-plan",
-        "fragments:teardown-query",
+        "fragments:teardown-query:release=False",
     ]
     assert plan_id not in runner.curr_plans
     assert plan_id not in runner.curr_streams
@@ -2936,11 +2945,11 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
         "output",
         "actors:teardown-plan",
         "vllm:teardown-plan",
-        "fragments:teardown-query",
+        "fragments:teardown-query:release=False",
         "output",
         "actors:teardown-plan",
         "vllm:teardown-plan",
-        "fragments:teardown-query",
+        "fragments:teardown-query:release=True",
     ]
     assert plan_id not in runner._plan_query_ids
     assert plan_id not in runner._plan_session_ids
@@ -2982,6 +2991,50 @@ def test_query_actor_pool_cleanup_retains_failed_pool_for_retry(cleanup_method, 
 
     assert getattr(runner, active_attr) == []
     assert getattr(runner, by_plan_attr) == {}
+
+
+def test_failed_execution_owner_cleanup_blocks_query_resource_release(monkeypatch):
+    from duckdb.runners.ray.query_resource_runtime import (
+        get_query_resource_manager,
+        release_query_resource_manager,
+    )
+
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "execution-owner-release-gate"
+    query_id = "execution-owner-release-gate-query"
+    manager = _bind_test_query_resource_owner(runner, plan_id, query_id=query_id)
+    runner.curr_plans[plan_id] = object()
+    runner.curr_streams[plan_id] = _DummyStream([])
+    fragment_calls = []
+
+    def fail_actor_cleanup(_self, actual_plan_id):
+        assert actual_plan_id == plan_id
+        raise RuntimeError("planned live actor owner")
+
+    def quiesce_without_release(_self, actual_query_id, *, release_resources):
+        fragment_calls.append((actual_query_id, release_resources))
+
+    monkeypatch.setattr(cls, "_cleanup_udf_actor_pools", fail_actor_cleanup)
+    monkeypatch.setattr(
+        cls,
+        "_drop_query_fragments_after_admission_fence_sync",
+        quiesce_without_release,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="planned live actor owner"):
+            cls._teardown_plan_resources(
+                runner,
+                plan_id,
+                query_id,
+                drop_fragments=True,
+            )
+
+        assert fragment_calls == [(query_id, False)]
+        assert get_query_resource_manager(query_id) is manager
+        assert runner._plan_query_ids[plan_id] == query_id
+    finally:
+        release_query_resource_manager(query_id, reason="test_complete")
 
 
 def test_teardown_fence_failure_retains_retryable_query_ownership(monkeypatch):

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -297,6 +297,7 @@ def test_task_lease_stream_submits_immediately_from_pregranted_admission():
     adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     assert submitted == [lease]
+    assert adapter.task_lease == lease
 
     _finish_cleanup_operations(source.release_task_operations())
     _finish_cleanup_operations(source.release_task_operations())

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -109,6 +109,8 @@ def _driver(grant):
         acquire_query_task_lease=_RemoteMethod(lambda _request: _Ref(grant)),
         mark_query_task_lease_submitted=_RemoteMethod(lambda *_args: _Ref({"submitted": True})),
         release_query_task_lease=_RemoteMethod(lambda *_args: _Ref({"released": True})),
+        release_query_task_lease_after_completion=_RemoteMethod(lambda *_args: _Ref({"scheduled": True})),
+        handoff_query_task_lease_to_teardown=_RemoteMethod(lambda *_args: _Ref({"handed_off": True})),
         cancel_query_task_lease_request=_RemoteMethod(lambda *_args, **_kwargs: _Ref({"cancelled": True})),
     )
 
@@ -120,6 +122,7 @@ def _lease():
         "stage_id": "stage:q1:node:1:udf",
         "task_id": "task-1",
         "attempt_id": "attempt-1",
+        "actor_index": None,
         "resources": {"cpu": 1.0, "gpu": 0.0, "heap_bytes": 1, "object_store_bytes": 0},
         "output_window_bytes": 256,
         "liveness": False,
@@ -222,12 +225,46 @@ def test_adapter_uses_public_completion_ref_for_stream_lifecycle():
     assert generator.deleted_streams == [generator.completion]
 
 
-def _admission(driver, request_id="request-1"):
+def test_stream_cleanup_retries_without_blocking_a_cleanup_lane_on_active_read():
+    async def scenario():
+        read_started = asyncio.Event()
+        finish_read = asyncio.Event()
+
+        class _BlockedGenerator(_Generator):
+            async def __anext__(self):
+                read_started.set()
+                await finish_read.wait()
+                return _Ref("block")
+
+        fake_ray = _FakeRay()
+        generator = _BlockedGenerator([])
+        adapter = RayStreamAdapter(generator, ray_module=fake_ray)
+        read = asyncio.create_task(adapter.read_next_ref_async())
+        await read_started.wait()
+
+        first_cancel = asyncio.create_task(asyncio.to_thread(adapter.cancel))
+        try:
+            with pytest.raises(RuntimeError, match="remained incomplete"):
+                await asyncio.wait_for(asyncio.shield(first_cancel), timeout=0.2)
+        finally:
+            finish_read.set()
+        assert (await read).value == "block"
+        if not first_cancel.done():
+            with pytest.raises(RuntimeError, match="remained incomplete"):
+                await first_cancel
+
+        adapter.cancel()
+        assert generator.deleted_streams == [generator.completion]
+
+    asyncio.run(scenario())
+
+
+def _admission(driver, request_id="request-1", *, lease=None):
     return TaskAdmission(
         driver=driver,
         request_id=request_id,
         retained_input_bytes=0,
-        lease=_lease(),
+        lease=_lease() if lease is None else lease,
     )
 
 
@@ -303,12 +340,22 @@ def test_successful_submission_releases_captured_input_ownership_immediately():
     assert large_input_ref() is None
 
 
-def test_cancelling_started_stream_cancels_remote_work_and_releases_lease():
+@pytest.mark.parametrize(
+    ("execution_backend", "force"),
+    [("ray_task", True), ("ray_actor", False)],
+)
+def test_cancelling_started_stream_uses_backend_safe_ray_cancel(
+    execution_backend,
+    force,
+):
     fake_ray = _FakeRay()
-    driver = _driver({"granted": True, "lease": _lease()})
+    lease = _lease()
+    if execution_backend == "ray_actor":
+        lease["actor_index"] = 0
+    driver = _driver({"granted": True, "lease": lease})
     generator = _Generator([])
     source = TaskLeaseObjectRefGenerator(
-        admission=_admission(driver, "request-cancel"),
+        admission=_admission(driver, "request-cancel", lease=lease),
         submitter=lambda _lease: generator,
         ray_module=fake_ray,
     )
@@ -317,9 +364,54 @@ def test_cancelling_started_stream_cancels_remote_work_and_releases_lease():
     adapter.cancel()
     adapter.cancel()
 
-    assert fake_ray.cancel_calls == [(generator, {"force": True, "recursive": True})]
-    assert len(driver.cancel_query_task_lease_request.calls) == 1
-    assert driver.cancel_query_task_lease_request.calls[0][1] == {"submitted": True}
+    assert fake_ray.cancel_calls == [(generator, {"force": force, "recursive": True})]
+    assert driver.release_query_task_lease_after_completion.calls == [
+        (
+            (
+                "request-cancel",
+                "lease-1",
+                "attempt-1",
+                [generator.completion],
+            ),
+            {},
+        )
+    ]
+    assert driver.cancel_query_task_lease_request.calls == []
+
+
+def test_stream_delete_waits_for_generator_cancel_submission():
+    class _FailingCancelRay(_FakeRay):
+        def __init__(self):
+            super().__init__()
+            self.fail_cancel = True
+
+        def cancel(self, ref, **kwargs):
+            self.cancel_calls.append((ref, kwargs))
+            if self.fail_cancel:
+                raise RuntimeError("planned cancellation submission failure")
+
+    fake_ray = _FailingCancelRay()
+    driver = _driver({"granted": True, "lease": _lease()})
+    generator = _Generator([])
+    source = TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, "request-cancel-failure"),
+        submitter=lambda _lease: generator,
+        ray_module=fake_ray,
+    )
+    adapter = RayStreamAdapter(source, ray_module=fake_ray)
+
+    with pytest.raises(RuntimeError, match="planned cancellation submission failure"):
+        adapter.cancel()
+
+    assert len(driver.release_query_task_lease_after_completion.calls) == 1
+    assert generator.deleted_streams == []
+    assert generator.worker is not None
+
+    fake_ray.fail_cancel = False
+    adapter.cancel()
+
+    assert generator.deleted_streams == [generator.completion]
+    assert generator.worker is None
 
 
 def test_retiring_terminal_failure_does_not_cancel_already_ending_remote_work():
@@ -338,7 +430,8 @@ def test_retiring_terminal_failure_does_not_cancel_already_ending_remote_work():
 
     assert fake_ray.cancel_calls == []
     assert driver.release_query_task_lease.calls == []
-    assert driver.cancel_query_task_lease_request.calls == [(("request-failed",), {"submitted": True})]
+    assert len(driver.release_query_task_lease_after_completion.calls) == 1
+    assert driver.cancel_query_task_lease_request.calls == []
     assert generator.deleted_streams == [generator.completion]
     assert generator.worker is None
 

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -214,7 +214,12 @@ def test_adapter_advances_generator_asynchronously_and_never_gets_data_ref():
     metadata_ref = _Ref({"size_bytes": 10})
     generator = _Generator([])
     generator.refs = [block_ref, metadata_ref]
-    adapter = RayStreamAdapter(generator, ray_module=fake_ray)
+    source = _leased_source(
+        fake_ray,
+        generator,
+        request_id="request-async-read",
+    )
+    adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     assert adapter.waitable is generator
     assert generator.read_calls == []
@@ -233,8 +238,14 @@ def test_adapter_advances_generator_asynchronously_and_never_gets_data_ref():
 
 
 def test_adapter_uses_public_completion_ref_for_stream_lifecycle():
+    fake_ray = _FakeRay()
     generator = _Generator([])
-    adapter = RayStreamAdapter(generator, ray_module=_FakeRay())
+    source = _leased_source(
+        fake_ray,
+        generator,
+        request_id="request-public-completion",
+    )
+    adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     assert adapter.completion_ref is generator.completion
     assert adapter.stream_finished() is True
@@ -258,7 +269,12 @@ def test_stream_cleanup_retries_without_blocking_on_an_active_read():
 
         fake_ray = _FakeRay()
         generator = _BlockedGenerator([])
-        adapter = RayStreamAdapter(generator, ray_module=fake_ray)
+        source = _leased_source(
+            fake_ray,
+            generator,
+            request_id="request-active-read",
+        )
+        adapter = RayStreamAdapter(source, ray_module=fake_ray)
         read = asyncio.create_task(adapter.read_next_ref_async())
         await read_started.wait()
 
@@ -282,6 +298,21 @@ def _admission(driver, request_id="request-1", *, lease=None):
         lease=_lease() if lease is None else lease,
         submission_scope=f"test-stream:{request_id}",
     )
+
+
+def _leased_source(fake_ray, generator, *, request_id):
+    driver = _driver({"granted": True, "lease": _lease()})
+    return TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, request_id),
+        submitter=lambda _lease: generator,
+        ray_module=fake_ray,
+    )
+
+
+def test_adapter_rejects_raw_generator_without_task_lease():
+    fake_ray = _FakeRay()
+    with pytest.raises(TypeError, match="requires a TaskLeaseObjectRefGenerator"):
+        RayStreamAdapter(_Generator([]), ray_module=fake_ray)
 
 
 def test_task_lease_stream_submits_immediately_from_pregranted_admission():
@@ -349,6 +380,27 @@ def test_invalid_submitted_stream_hands_cancelled_lease_to_query_teardown():
         (("request-invalid-stream", "lease-1", "attempt-1"), {}),
     ]
     assert driver.release_query_task_lease_after_completion.calls == []
+
+
+def test_missing_submitted_stream_hands_lease_to_query_teardown_without_cancel():
+    fake_ray = _FakeRay()
+    driver = _driver({"granted": True, "lease": _lease()})
+    source = TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, "request-missing-stream"),
+        submitter=lambda _lease: None,
+        ray_module=fake_ray,
+    )
+
+    with pytest.raises(TypeError, match="did not return an ObjectRefGenerator"):
+        RayStreamAdapter(source, ray_module=fake_ray)
+
+    cancel, handoff = source.cancel_operations()
+    assert cancel() is True
+    assert handoff() is True
+    assert fake_ray.cancel_calls == []
+    assert driver.handoff_query_task_lease_to_teardown.calls == [
+        (("request-missing-stream", "lease-1", "attempt-1"), {}),
+    ]
 
 
 def test_missing_completion_ref_cannot_handoff_before_cancel_submission():
@@ -508,7 +560,12 @@ def test_retiring_terminal_failure_does_not_cancel_already_ending_remote_work():
 def test_terminal_stream_cleanup_disarms_ray_generator_destructor(terminal_action):
     fake_ray = _FakeRay()
     generator = _Generator([])
-    adapter = RayStreamAdapter(generator, ray_module=fake_ray)
+    source = _leased_source(
+        fake_ray,
+        generator,
+        request_id=f"request-terminal-{terminal_action}",
+    )
+    adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     _finish_cleanup_operations(getattr(adapter, f"{terminal_action}_operations")())
     _finish_cleanup_operations(getattr(adapter, f"{terminal_action}_operations")())

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -280,6 +280,7 @@ def _admission(driver, request_id="request-1", *, lease=None):
         request_id=request_id,
         retained_input_bytes=0,
         lease=_lease() if lease is None else lease,
+        submission_scope=f"test-stream:{request_id}",
     )
 
 
@@ -313,6 +314,7 @@ def test_task_lease_stream_abandons_pregranted_lease_when_submitter_fails():
         request_id=request_id,
         retained_input_bytes=0,
         lease=_lease(),
+        submission_scope=f"test-stream:{request_id}",
         _release_callback=lambda: driver.cancel_query_task_lease_request.remote(request_id),
     )
 

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -107,7 +107,6 @@ class _FakeRay:
 def _driver(grant):
     return SimpleNamespace(
         acquire_query_task_lease=_RemoteMethod(lambda _request: _Ref(grant)),
-        mark_query_task_lease_submitted=_RemoteMethod(lambda *_args: _Ref({"submitted": True})),
         release_query_task_lease=_RemoteMethod(lambda *_args: _Ref({"released": True})),
         release_query_task_lease_after_completion=_RemoteMethod(lambda *_args: _Ref({"scheduled": True})),
         handoff_query_task_lease_to_teardown=_RemoteMethod(lambda *_args: _Ref({"handed_off": True})),
@@ -282,7 +281,6 @@ def test_task_lease_stream_submits_immediately_from_pregranted_admission():
     adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     assert submitted == [lease]
-    assert driver.mark_query_task_lease_submitted.calls[0][0] == ("request-1", "lease-1")
 
     adapter.release_task()
     adapter.release_task()

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -13,6 +13,7 @@ import pytest
 
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
+    RayStreamCleanupWait,
     TaskLeaseObjectRefGenerator,
     validate_ray_stream_contract,
 )
@@ -135,6 +136,12 @@ def _finish_cleanup_operations(operations):
         for operation in pending:
             try:
                 result = operation()
+                if isinstance(result, RayStreamCleanupWait):
+                    if not result.future.done():
+                        remaining.append(operation)
+                        continue
+                    result.complete()
+                    continue
                 if all(callable(getattr(result, name, None)) for name in ("done", "result")):
                     if not result.done():
                         remaining.append(operation)
@@ -374,7 +381,7 @@ def test_invalid_submitted_stream_hands_cancelled_lease_to_query_teardown():
 
     cancel, handoff = source.cancel_operations()
     assert cancel() is True
-    assert handoff() is True
+    _finish_cleanup_operations((handoff,))
     assert fake_ray.cancel_calls == [(invalid_stream, {"force": True, "recursive": True})]
     assert driver.handoff_query_task_lease_to_teardown.calls == [
         (("request-invalid-stream", "lease-1", "attempt-1"), {}),
@@ -396,7 +403,7 @@ def test_missing_submitted_stream_hands_lease_to_query_teardown_without_cancel()
 
     cancel, handoff = source.cancel_operations()
     assert cancel() is True
-    assert handoff() is True
+    _finish_cleanup_operations((handoff,))
     assert fake_ray.cancel_calls == []
     assert driver.handoff_query_task_lease_to_teardown.calls == [
         (("request-missing-stream", "lease-1", "attempt-1"), {}),

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -96,6 +96,10 @@ class _FakeRay:
         self.get_calls.append(ref)
         return ref.value
 
+    @staticmethod
+    def wait(waitables, **_kwargs):
+        return list(waitables), []
+
     def cancel(self, ref, **kwargs):
         self.cancel_calls.append((ref, kwargs))
 
@@ -124,9 +128,23 @@ def _lease():
 
 
 def test_contract_accepts_unlisted_ray_version_when_capabilities_are_present():
-    ray_module = SimpleNamespace(__version__="9.0.0", ObjectRefGenerator=_Generator)
+    ray_module = SimpleNamespace(
+        __version__="9.0.0",
+        ObjectRefGenerator=_Generator,
+        wait=lambda *_args, **_kwargs: ([], []),
+    )
 
     validate_ray_stream_contract(ray_module)
+
+
+def test_contract_rejects_missing_non_consuming_wait_capability():
+    ray_module = SimpleNamespace(
+        __version__="2.56.0",
+        ObjectRefGenerator=_Generator,
+    )
+
+    with pytest.raises(RuntimeError, match="Ray '2.56.0' runtime contract is missing: wait"):
+        validate_ray_stream_contract(ray_module)
 
 
 def test_contract_rejects_missing_generator_capability_with_version_context():
@@ -134,7 +152,11 @@ def test_contract_rejects_missing_generator_capability_with_version_context():
         async def __anext__(self):
             raise StopAsyncIteration
 
-    ray_module = SimpleNamespace(__version__="2.56.0", ObjectRefGenerator=_IncompleteGenerator)
+    ray_module = SimpleNamespace(
+        __version__="2.56.0",
+        ObjectRefGenerator=_IncompleteGenerator,
+        wait=lambda *_args, **_kwargs: ([], []),
+    )
 
     with pytest.raises(RuntimeError, match="Ray '2.56.0' ObjectRefGenerator contract is missing: completed"):
         validate_ray_stream_contract(ray_module)
@@ -170,6 +192,9 @@ def test_adapter_advances_generator_asynchronously_and_never_gets_data_ref():
     generator = _Generator([])
     generator.refs = [block_ref, metadata_ref]
     adapter = RayStreamAdapter(generator, ray_module=fake_ray)
+
+    assert adapter.waitable is generator
+    assert generator.read_calls == []
 
     async def read_pair():
         return await adapter.read_next_ref_async(), await adapter.read_next_ref_async()

--- a/tests/fast/test_ray_stream_adapter.py
+++ b/tests/fast/test_ray_stream_adapter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import weakref
+from concurrent.futures import Future
 from types import SimpleNamespace
 
 import pytest
@@ -23,19 +24,14 @@ class _Ref:
         self.value = value
         self._nil = nil
         self.future_result_calls = []
+        self._future = Future()
+        self._future.set_result(value)
 
     def is_nil(self):
         return self._nil
 
     def future(self):
-        ref = self
-
-        class _Future:
-            def result(self, timeout=None):
-                ref.future_result_calls.append(timeout)
-                return ref.value
-
-        return _Future()
+        return self._future
 
 
 class _Generator:
@@ -129,6 +125,31 @@ def _lease():
     }
 
 
+def _finish_cleanup_operations(operations):
+    pending = list(operations)
+    errors = []
+    for _attempt in range(20):
+        if not pending:
+            break
+        remaining = []
+        for operation in pending:
+            try:
+                result = operation()
+                if all(callable(getattr(result, name, None)) for name in ("done", "result")):
+                    if not result.done():
+                        remaining.append(operation)
+                        continue
+                    result = operation()
+                if result is False:
+                    remaining.append(operation)
+            except BaseException as exc:
+                errors.append(exc)
+        pending = remaining
+    if errors:
+        raise RuntimeError("; ".join(str(error) for error in errors)) from errors[0]
+    assert pending == []
+
+
 def test_contract_accepts_unlisted_ray_version_when_capabilities_are_present():
     ray_module = SimpleNamespace(
         __version__="9.0.0",
@@ -219,12 +240,12 @@ def test_adapter_uses_public_completion_ref_for_stream_lifecycle():
     assert adapter.stream_finished() is True
     assert adapter.is_terminal_ref(generator.completion) is True
 
-    adapter.retire()
+    _finish_cleanup_operations(adapter.retire_operations())
 
     assert generator.deleted_streams == [generator.completion]
 
 
-def test_stream_cleanup_retries_without_blocking_a_cleanup_lane_on_active_read():
+def test_stream_cleanup_retries_without_blocking_on_an_active_read():
     async def scenario():
         read_started = asyncio.Event()
         finish_read = asyncio.Event()
@@ -241,18 +262,13 @@ def test_stream_cleanup_retries_without_blocking_a_cleanup_lane_on_active_read()
         read = asyncio.create_task(adapter.read_next_ref_async())
         await read_started.wait()
 
-        first_cancel = asyncio.create_task(asyncio.to_thread(adapter.cancel))
-        try:
-            with pytest.raises(RuntimeError, match="remained incomplete"):
-                await asyncio.wait_for(asyncio.shield(first_cancel), timeout=0.2)
-        finally:
-            finish_read.set()
+        operations = adapter.cancel_operations()
+        with pytest.raises(AssertionError):
+            _finish_cleanup_operations(operations)
+        finish_read.set()
         assert (await read).value == "block"
-        if not first_cancel.done():
-            with pytest.raises(RuntimeError, match="remained incomplete"):
-                await first_cancel
 
-        adapter.cancel()
+        _finish_cleanup_operations(adapter.cancel_operations())
         assert generator.deleted_streams == [generator.completion]
 
     asyncio.run(scenario())
@@ -282,8 +298,8 @@ def test_task_lease_stream_submits_immediately_from_pregranted_admission():
 
     assert submitted == [lease]
 
-    adapter.release_task()
-    adapter.release_task()
+    _finish_cleanup_operations(source.release_task_operations())
+    _finish_cleanup_operations(source.release_task_operations())
     assert len(driver.release_query_task_lease.calls) == 1
 
 
@@ -296,10 +312,7 @@ def test_task_lease_stream_abandons_pregranted_lease_when_submitter_fails():
         request_id=request_id,
         retained_input_bytes=0,
         lease=_lease(),
-        _release_callback=lambda: driver.cancel_query_task_lease_request.remote(
-            request_id,
-            submitted=False,
-        ),
+        _release_callback=lambda: driver.cancel_query_task_lease_request.remote(request_id),
     )
 
     with pytest.raises(RuntimeError, match="submit failed"):
@@ -309,7 +322,61 @@ def test_task_lease_stream_abandons_pregranted_lease_when_submitter_fails():
             ray_module=fake_ray,
         )
 
-    assert driver.cancel_query_task_lease_request.calls == [((request_id,), {"submitted": False})]
+    assert driver.cancel_query_task_lease_request.calls == [((request_id,), {})]
+
+
+def test_invalid_submitted_stream_hands_cancelled_lease_to_query_teardown():
+    fake_ray = _FakeRay()
+    driver = _driver({"granted": True, "lease": _lease()})
+    invalid_stream = SimpleNamespace()
+    source = TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, "request-invalid-stream"),
+        submitter=lambda _lease: invalid_stream,
+        ray_module=fake_ray,
+    )
+
+    with pytest.raises(TypeError, match="not an ObjectRefGenerator"):
+        RayStreamAdapter(source, ray_module=fake_ray)
+
+    cancel, handoff = source.cancel_operations()
+    assert cancel() is True
+    assert handoff() is True
+    assert fake_ray.cancel_calls == [(invalid_stream, {"force": True, "recursive": True})]
+    assert driver.handoff_query_task_lease_to_teardown.calls == [
+        (("request-invalid-stream", "lease-1", "attempt-1"), {}),
+    ]
+    assert driver.release_query_task_lease_after_completion.calls == []
+
+
+def test_missing_completion_ref_cannot_handoff_before_cancel_submission():
+    class _FailingCancelRay(_FakeRay):
+        def cancel(self, ref, **kwargs):
+            self.cancel_calls.append((ref, kwargs))
+            raise RuntimeError("planned cancellation submission failure")
+
+    class _MissingCompletionGenerator(_Generator):
+        def completed(self):
+            return None
+
+    fake_ray = _FailingCancelRay()
+    driver = _driver({"granted": True, "lease": _lease()})
+    generator = _MissingCompletionGenerator([])
+    source = TaskLeaseObjectRefGenerator(
+        admission=_admission(driver, "request-missing-completion"),
+        submitter=lambda _lease: generator,
+        ray_module=fake_ray,
+    )
+
+    with pytest.raises(RuntimeError, match="completion ObjectRef is unavailable"):
+        RayStreamAdapter(source, ray_module=fake_ray)
+
+    cancel, handoff = source.cancel_operations()
+    with pytest.raises(RuntimeError, match="before generator cancellation is submitted"):
+        handoff()
+    with pytest.raises(RuntimeError, match="planned cancellation submission failure"):
+        cancel()
+    assert fake_ray.cancel_calls == [(generator, {"force": True, "recursive": True})]
+    assert driver.handoff_query_task_lease_to_teardown.calls == []
 
 
 def test_successful_submission_releases_captured_input_ownership_immediately():
@@ -359,8 +426,8 @@ def test_cancelling_started_stream_uses_backend_safe_ray_cancel(
     )
     adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
-    adapter.cancel()
-    adapter.cancel()
+    _finish_cleanup_operations(adapter.cancel_operations())
+    _finish_cleanup_operations(adapter.cancel_operations())
 
     assert fake_ray.cancel_calls == [(generator, {"force": force, "recursive": True})]
     assert driver.release_query_task_lease_after_completion.calls == [
@@ -399,14 +466,14 @@ def test_stream_delete_waits_for_generator_cancel_submission():
     adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
     with pytest.raises(RuntimeError, match="planned cancellation submission failure"):
-        adapter.cancel()
+        _finish_cleanup_operations(adapter.cancel_operations())
 
     assert len(driver.release_query_task_lease_after_completion.calls) == 1
     assert generator.deleted_streams == []
     assert generator.worker is not None
 
     fake_ray.fail_cancel = False
-    adapter.cancel()
+    _finish_cleanup_operations(adapter.cancel_operations())
 
     assert generator.deleted_streams == [generator.completion]
     assert generator.worker is None
@@ -423,8 +490,8 @@ def test_retiring_terminal_failure_does_not_cancel_already_ending_remote_work():
     )
     adapter = RayStreamAdapter(source, ray_module=fake_ray)
 
-    adapter.retire_failed()
-    adapter.retire_failed()
+    _finish_cleanup_operations(adapter.retire_failed_operations())
+    _finish_cleanup_operations(adapter.retire_failed_operations())
 
     assert fake_ray.cancel_calls == []
     assert driver.release_query_task_lease.calls == []
@@ -440,8 +507,8 @@ def test_terminal_stream_cleanup_disarms_ray_generator_destructor(terminal_actio
     generator = _Generator([])
     adapter = RayStreamAdapter(generator, ray_module=fake_ray)
 
-    getattr(adapter, terminal_action)()
-    getattr(adapter, terminal_action)()
+    _finish_cleanup_operations(getattr(adapter, f"{terminal_action}_operations")())
+    _finish_cleanup_operations(getattr(adapter, f"{terminal_action}_operations")())
 
     assert generator.deleted_streams == [generator.completion]
     assert generator.worker is None

--- a/tests/fast/test_ray_udf_plan_replay.py
+++ b/tests/fast/test_ray_udf_plan_replay.py
@@ -311,14 +311,6 @@ def _assert_no_udf_direct_output_conversion():
     return counters
 
 
-@pytest.fixture(autouse=True)
-def _stop_native_udf_dispatcher_after_test():
-    yield
-    import _duckdb
-
-    _duckdb._shutdown_udf_executor_dispatcher()
-
-
 def test_execute_native_rejects_ray_scalar_without_registered_query_graph(tmp_path, monkeypatch):
     pytest.importorskip("pyarrow")
     pytest.importorskip("ray")

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -6564,6 +6564,7 @@ def _ray_task_executor(*, stream_result="stream-ref", ref_stream_result="ref-str
         run_stream,
         run_ref_stream,
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
     )
     return executor, run_stream, run_ref_stream
 

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -10,6 +10,255 @@ import pyarrow as pa
 import duckdb
 
 
+def test_native_dispatcher_shutdown_is_terminal():
+    """Process-owner shutdown must reject every later slot registration."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import _duckdb
+        import duckdb
+        import pyarrow as pa
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        _duckdb._shutdown_udf_executor_dispatcher()
+        _duckdb._shutdown_udf_executor_dispatcher()
+
+        connection = duckdb.connect()
+        try:
+            relation = connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
+                passthrough,
+                schema={"y": duckdb.sqltypes.BIGINT},
+                execution_backend="subprocess_task",
+            )
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                assert "udf dispatcher has been shut down" in str(exc), str(exc)
+            else:
+                raise AssertionError("dispatcher accepted work after terminal shutdown")
+        finally:
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={**os.environ},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_native_dispatcher_concurrent_shutdown_never_reopens():
+    """Register either linearizes before shutdown or observes its terminal fence."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import threading
+
+        import _duckdb
+        import duckdb
+        import pyarrow as pa
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        connection = duckdb.connect()
+        relation = connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="subprocess_task",
+        )
+        barrier = threading.Barrier(3)
+        query_errors = []
+        shutdown_errors = []
+
+
+        def run_query():
+            barrier.wait()
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                query_errors.append(exc)
+
+
+        def run_shutdown():
+            barrier.wait()
+            try:
+                _duckdb._shutdown_udf_executor_dispatcher()
+            except BaseException as exc:
+                shutdown_errors.append(exc)
+
+
+        query_thread = threading.Thread(target=run_query)
+        shutdown_thread = threading.Thread(target=run_shutdown)
+        query_thread.start()
+        shutdown_thread.start()
+        barrier.wait()
+        query_thread.join(timeout=10)
+        shutdown_thread.join(timeout=10)
+        assert not query_thread.is_alive(), "query raced shutdown without terminating"
+        assert not shutdown_thread.is_alive(), "dispatcher shutdown deadlocked with Register"
+        assert not shutdown_errors, shutdown_errors
+        connection.close()
+
+        final_connection = duckdb.connect()
+        try:
+            final_relation = final_connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
+                passthrough,
+                schema={"y": duckdb.sqltypes.BIGINT},
+                execution_backend="subprocess_task",
+            )
+            try:
+                final_relation.fetchall()
+            except BaseException as exc:
+                assert "udf dispatcher has been shut down" in str(exc), str(exc)
+            else:
+                raise AssertionError("concurrent Register reopened the dispatcher after shutdown")
+        finally:
+            final_connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_native_dispatcher_shutdown_closes_active_executor():
+    """Terminal shutdown must close Python ownership before it returns."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import threading
+
+        import _duckdb
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import pyarrow as pa
+
+        submitted = threading.Event()
+        closed = threading.Event()
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._retained_input_bytes = 0
+                self._admission_state = "idle"
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, _table):
+                self._admission_state = "idle"
+                submitted.set()
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                closed.set()
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        connection = duckdb.connect()
+        relation = connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="subprocess_task",
+        )
+        query_errors = []
+
+
+        def run_query():
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                query_errors.append(exc)
+
+
+        query_thread = threading.Thread(target=run_query)
+        query_thread.start()
+        try:
+            assert submitted.wait(timeout=5), "query never submitted to the fake executor"
+            _duckdb._shutdown_udf_executor_dispatcher()
+            assert closed.is_set(), "shutdown returned before closing the active executor"
+            query_thread.join(timeout=5)
+            assert not query_thread.is_alive(), "active query did not observe terminal shutdown"
+            assert query_errors, "active query unexpectedly succeeded during terminal shutdown"
+            assert "shutdown interrupted active execution" in str(query_errors[0]), query_errors[0]
+        finally:
+            query_thread.join(timeout=5)
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={**os.environ},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_unregister_timeout_detaches_stale_dispatcher_work():
     """A timed-out slot must not retain its context or poison later UDFs."""
     import os
@@ -174,7 +423,8 @@ def test_unregister_timeout_detaches_stale_dispatcher_work():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
-def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
+@pytest.mark.parametrize("failure_phase", ["cancel", "pending", "retire"])
+def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_phase):
     """A Ray stream returned after slot retirement must reach collector cleanup."""
     import os
     import subprocess
@@ -185,6 +435,7 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
         """
         from __future__ import annotations
 
+        import os
         import threading
         import time
 
@@ -198,7 +449,12 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
         release_submit = threading.Event()
         discarded = threading.Event()
         executor_closed = threading.Event()
+        collector_retired = threading.Event()
         submitted_ref = object()
+        failure_phase = os.environ["VANE_TEST_COLLECTOR_FAILURE_PHASE"]
+        cancel_calls = 0
+        pending_checks = 0
+        retire_calls = 0
 
 
         class FakeCollector:
@@ -208,15 +464,28 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
 
-            def discard_generator_ref(self, ref):
+            def discard_generator_ref(self, _slot_id, ref):
                 assert ref is submitted_ref
                 discarded.set()
 
             def cancel_slot(self, _slot_id):
+                global cancel_calls
+                cancel_calls += 1
+                if failure_phase == "cancel" and cancel_calls == 1:
+                    raise RuntimeError("planned transient collector cancellation failure")
                 return None
 
             def slot_has_pending(self, _slot_id):
-                return False
+                global pending_checks
+                pending_checks += 1
+                return failure_phase == "pending" and pending_checks == 1
+
+            def retire_slot(self, _slot_id):
+                global retire_calls
+                retire_calls += 1
+                if failure_phase == "retire" and retire_calls == 1:
+                    raise RuntimeError("planned transient collector retirement failure")
+                collector_retired.set()
 
             def drain_results(self, _capacities):
                 return []
@@ -305,6 +574,10 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
             release_submit.set()
             assert discarded.wait(timeout=5), "stale Ray stream was dropped without collector cleanup"
             assert executor_closed.wait(timeout=5), "retired executor was not eventually closed"
+            assert collector_retired.wait(timeout=5), "collector cancellation was not retried through retirement"
+            assert cancel_calls == 2
+            assert pending_checks == (1 if failure_phase == "cancel" else 2)
+            assert retire_calls == (2 if failure_phase == "retire" else 1)
         finally:
             release_submit.set()
             query_thread.join(timeout=5)
@@ -321,8 +594,235 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
         env={
             **os.environ,
             "VANE_ENABLE_UDF_TEST_HOOKS": "1",
+            "VANE_TEST_COLLECTOR_FAILURE_PHASE": failure_phase,
             "VANE_UDF_UNREGISTER_TIMEOUT_MS": "50",
         },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
+    """One descriptor callback must not drop or fail another slot's callback."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import threading
+
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import make_local_shm_ref_bundle_result
+
+        both_tracked = threading.Event()
+        good_handoff = threading.Event()
+
+
+        class FakeSource:
+            def __init__(self, value):
+                self.value = int(value)
+
+
+        class FakeCollector:
+            def __init__(self):
+                self._lock = threading.Lock()
+                self._wakeup = None
+                self._events = {}
+                self._tracked = set()
+                self._cancelled = set()
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def track_generator_ref(self, slot_id, submit_id, source, _error_context):
+                slot_id = int(slot_id)
+                submit_id = int(submit_id)
+                value = int(source.value)
+                request_id = "output-request:bad" if value == 1 else "output-request:good"
+                payload = make_local_shm_ref_bundle_result(pa.table({"y": [value]}))
+                with self._lock:
+                    self._tracked.add(slot_id)
+                    self._events[slot_id] = [
+                        (
+                            slot_id,
+                            submit_id,
+                            "data",
+                            payload,
+                            request_id,
+                            f"output-lease:{value}",
+                        ),
+                        (slot_id, submit_id, "complete", None),
+                    ]
+                    if len(self._tracked) == 2:
+                        both_tracked.set()
+                if self._wakeup is not None:
+                    self._wakeup()
+
+            def discard_generator_ref(self, _slot_id, _source):
+                return None
+
+            def drain_results(self, capacities):
+                if not both_tracked.is_set():
+                    return []
+                results = []
+                with self._lock:
+                    # Force the failing callback ahead of the healthy callback
+                    # in the dispatcher's same release batch.
+                    ordered = sorted(
+                        self._events,
+                        key=lambda slot_id: self._events[slot_id][0][4] != "output-request:bad",
+                    )
+                    for slot_id in ordered:
+                        if slot_id in self._cancelled:
+                            self._events.pop(slot_id, None)
+                            continue
+                        capacity = capacities.get(slot_id, {})
+                        if int(capacity.get("rows", 0)) <= 0:
+                            continue
+                        results.extend(self._events.pop(slot_id, ()))
+                return results
+
+            def handoff_output_block_lease(self, request_id, _lease_id):
+                if str(request_id) == "output-request:bad":
+                    raise RuntimeError("planned output lease handoff failure")
+                good_handoff.set()
+                return True
+
+            def release_output_block_lease(self, _request_id, _lease_id):
+                return True
+
+            def cancel_slot(self, slot_id):
+                with self._lock:
+                    self._cancelled.add(int(slot_id))
+                    self._events.pop(int(slot_id), None)
+
+            def slot_has_pending(self, _slot_id):
+                return False
+
+            def retire_slot(self, _slot_id):
+                return None
+
+            def shutdown(self):
+                return None
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._admission_state = "idle"
+                self._retained_input_bytes = 0
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, table):
+                self._admission_state = "idle"
+                return FakeSource(table.column(0).to_pylist()[0])
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                return None
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.AsyncResultCollector = FakeCollector
+        bad_connection = duckdb.connect()
+        good_connection = duckdb.connect()
+        bad_relation = bad_connection.sql("select 1::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        good_relation = good_connection.sql("select 2::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        barrier = threading.Barrier(3)
+        bad_errors = []
+        good_results = []
+        good_errors = []
+
+
+        def run_bad():
+            barrier.wait()
+            try:
+                bad_relation.fetchall()
+            except BaseException as exc:
+                bad_errors.append(exc)
+
+
+        def run_good():
+            barrier.wait()
+            try:
+                good_results.extend(good_relation.fetchall())
+            except BaseException as exc:
+                good_errors.append(exc)
+
+
+        bad_thread = threading.Thread(target=run_bad)
+        good_thread = threading.Thread(target=run_good)
+        bad_thread.start()
+        good_thread.start()
+        barrier.wait()
+        bad_thread.join(timeout=10)
+        good_thread.join(timeout=10)
+        try:
+            assert not bad_thread.is_alive(), "failing Ray slot did not terminate"
+            assert not good_thread.is_alive(), "healthy Ray slot did not terminate"
+            assert bad_errors, (bad_errors, good_errors, good_results)
+            assert "planned output lease handoff failure" in str(bad_errors[0]), bad_errors[0]
+            assert good_errors == [], (bad_errors, good_errors, good_results)
+            assert good_results == [(2,)], (bad_errors, good_errors, good_results)
+            assert good_handoff.is_set(), "healthy output lease callback was dropped"
+        finally:
+            bad_connection.close()
+            good_connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ},
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
 

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -656,7 +656,10 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             def slot_has_pending(self, _slot_id):
                 global pending_checks
                 pending_checks += 1
-                return failure_phase == "pending" and pending_checks == 1
+                pending = failure_phase == "pending" and pending_checks == 1
+                if pending and self._wakeup is not None:
+                    self._wakeup()
+                return pending
 
             def retire_slot(self, _slot_id):
                 global retire_calls
@@ -774,6 +777,260 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             "VANE_ENABLE_UDF_TEST_HOOKS": "1",
             "VANE_TEST_COLLECTOR_FAILURE_PHASE": failure_phase,
             "VANE_UDF_UNREGISTER_TIMEOUT_MS": "50",
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_pending_ray_slot_cleanup_does_not_spin_or_block_healthy_slot():
+    """A remote cleanup ACK may delay its slot, never the process dispatcher."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import threading
+        import time
+
+        import _duckdb
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import make_local_shm_ref_bundle_result
+
+        state_lock = threading.Lock()
+        slow_tracked = threading.Event()
+        slow_cancel_started = threading.Event()
+        slow_retired = threading.Event()
+        collector_instance = None
+
+
+        class FakeSource:
+            def __init__(self, value):
+                self.value = int(value)
+
+
+        class FakeCollector:
+            def __init__(self):
+                global collector_instance
+                self._wakeup = None
+                self._slow_slot = None
+                self._pending = set()
+                self._cancelled = set()
+                self._events = {}
+                self.pending_checks = 0
+                collector_instance = self
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def track_generator_ref(self, slot_id, submit_id, source, _error_context):
+                slot_id = int(slot_id)
+                submit_id = int(submit_id)
+                if source.value == 1:
+                    with state_lock:
+                        self._slow_slot = slot_id
+                    slow_tracked.set()
+                    return
+                payload = make_local_shm_ref_bundle_result(pa.table({"y": [source.value]}))
+                with state_lock:
+                    self._events[slot_id] = [
+                        (
+                            slot_id,
+                            submit_id,
+                            "data",
+                            payload,
+                            "output-request:healthy",
+                            "output-lease:healthy",
+                        ),
+                        (slot_id, submit_id, "complete", None),
+                    ]
+                if self._wakeup is not None:
+                    self._wakeup()
+
+            def discard_generator_ref(self, _slot_id, _source):
+                return None
+
+            def drain_results(self, capacities):
+                results = []
+                with state_lock:
+                    for slot_id in list(self._events):
+                        if int(capacities.get(slot_id, {}).get("rows", 0)) <= 0:
+                            continue
+                        results.extend(self._events.pop(slot_id))
+                return results
+
+            def handoff_output_block_lease(self, _request_id, _lease_id):
+                return True
+
+            def release_output_block_lease(self, _request_id, _lease_id):
+                return True
+
+            def cancel_slot(self, slot_id):
+                slot_id = int(slot_id)
+                with state_lock:
+                    self._events.pop(slot_id, None)
+                    if slot_id == self._slow_slot and slot_id not in self._cancelled:
+                        self._cancelled.add(slot_id)
+                        self._pending.add(slot_id)
+                        slow_cancel_started.set()
+
+            def slot_has_pending(self, slot_id):
+                with state_lock:
+                    self.pending_checks += 1
+                    return int(slot_id) in self._pending
+
+            def retire_slot(self, slot_id):
+                if int(slot_id) == self._slow_slot:
+                    slow_retired.set()
+                return None
+
+            def release_slow_cleanup(self):
+                with state_lock:
+                    self._pending.discard(self._slow_slot)
+                    wakeup = self._wakeup
+                if wakeup is not None:
+                    wakeup()
+
+            def shutdown(self):
+                return None
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._admission_state = "idle"
+                self._retained_input_bytes = 0
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, table):
+                self._admission_state = "idle"
+                return FakeSource(table.column(0).to_pylist()[0])
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                return None
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.AsyncResultCollector = FakeCollector
+        slow_connection = duckdb.connect()
+        healthy_connection = duckdb.connect()
+        slow_relation = slow_connection.sql("select 1::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        healthy_relation = healthy_connection.sql("select 2::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        slow_errors = []
+
+
+        def run_slow():
+            try:
+                slow_relation.fetchall()
+            except BaseException as exc:
+                slow_errors.append(exc)
+
+
+        slow_thread = threading.Thread(target=run_slow)
+        slow_thread.start()
+        try:
+            assert slow_tracked.wait(timeout=5), "slow Ray slot was not tracked"
+            slow_connection.interrupt()
+            deadline = time.monotonic() + 5
+            while not slow_cancel_started.is_set() and time.monotonic() < deadline:
+                _duckdb._wake_udf_executor_slots_for_testing()
+                time.sleep(0.01)
+            assert slow_cancel_started.is_set(), "slow Ray slot never entered cleanup"
+
+            with state_lock:
+                checks_before_idle = collector_instance.pending_checks
+            time.sleep(0.1)
+            with state_lock:
+                idle_checks = collector_instance.pending_checks - checks_before_idle
+            assert idle_checks <= 1, f"pending cleanup busy-spun dispatcher: {idle_checks} checks"
+
+            healthy_result = []
+            healthy_errors = []
+
+            def run_healthy():
+                try:
+                    healthy_result.extend(healthy_relation.fetchall())
+                except BaseException as exc:
+                    healthy_errors.append(exc)
+
+            healthy_thread = threading.Thread(target=run_healthy)
+            healthy_thread.start()
+            healthy_thread.join(timeout=5)
+            assert not healthy_thread.is_alive(), "pending cleanup blocked the healthy Ray slot"
+            assert healthy_errors == [], healthy_errors
+            assert healthy_result == [(2,)], healthy_result
+            assert not slow_retired.is_set(), "slow slot retired before its cleanup ACK"
+
+            collector_instance.release_slow_cleanup()
+            assert slow_retired.wait(timeout=5), "cleanup ACK did not wake slot retirement"
+            slow_thread.join(timeout=5)
+            assert not slow_thread.is_alive(), "slow query did not finish after cleanup ACK"
+            assert slow_errors, "interrupted slow query unexpectedly succeeded"
+        finally:
+            if collector_instance is not None:
+                collector_instance.release_slow_cleanup()
+            slow_thread.join(timeout=5)
+            slow_connection.close()
+            healthy_connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={
+            **os.environ,
+            "VANE_ENABLE_UDF_TEST_HOOKS": "1",
+            "VANE_UDF_UNREGISTER_TIMEOUT_MS": "5000",
         },
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -259,6 +259,184 @@ def test_native_dispatcher_shutdown_closes_active_executor():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_native_dispatcher_terminal_shutdown_uses_one_aggregate_collector_deadline():
+    """Terminal Ray cleanup must not apply one collector timeout per slot."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import threading
+        import time
+
+        import _duckdb
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+
+        slot_count = 4
+        state_lock = threading.Lock()
+        all_tracked = threading.Event()
+        aggregate_shutdown = threading.Event()
+        tracked_count = 0
+        cancel_calls = 0
+        shutdown_calls = 0
+
+
+        class FakeCollector:
+            def __init__(self):
+                self._wakeup = None
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def track_generator_ref(self, _slot_id, _submit_id, _source, _error_context):
+                global tracked_count
+                with state_lock:
+                    tracked_count += 1
+                    if tracked_count == slot_count:
+                        all_tracked.set()
+
+            def discard_generator_ref(self, _slot_id, _source):
+                return None
+
+            def drain_results(self, _capacities):
+                return []
+
+            def cancel_slot(self, _slot_id):
+                global cancel_calls
+                with state_lock:
+                    cancel_calls += 1
+                time.sleep(0.1)
+
+            def slot_has_pending(self, _slot_id):
+                return False
+
+            def retire_slot(self, _slot_id):
+                return None
+
+            def shutdown(self):
+                global shutdown_calls
+                with state_lock:
+                    shutdown_calls += 1
+                time.sleep(0.1)
+                aggregate_shutdown.set()
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._retained_input_bytes = 0
+                self._admission_state = "idle"
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, _table):
+                self._admission_state = "idle"
+                return object()
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                return None
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.AsyncResultCollector = FakeCollector
+        connections = [duckdb.connect() for _ in range(slot_count)]
+        relations = [
+            connection.sql("select 1::BIGINT as x").map_batches(
+                passthrough,
+                schema={"y": duckdb.sqltypes.BIGINT},
+                execution_backend="ray_task",
+            )
+            for connection in connections
+        ]
+        query_errors = []
+
+
+        def run_query(relation):
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                query_errors.append(exc)
+
+
+        query_threads = [
+            threading.Thread(target=run_query, args=(relation,))
+            for relation in relations
+        ]
+        for thread in query_threads:
+            thread.start()
+        try:
+            assert all_tracked.wait(timeout=5), "not every Ray slot reached the collector"
+            assert cancel_calls == 0, cancel_calls
+            started_at = time.monotonic()
+            _duckdb._shutdown_udf_executor_dispatcher()
+            elapsed = time.monotonic() - started_at
+            assert aggregate_shutdown.is_set(), "aggregate collector shutdown was not called"
+            assert shutdown_calls == 1, shutdown_calls
+            assert cancel_calls == 0, cancel_calls
+            assert elapsed < 1.0, elapsed
+            for thread in query_threads:
+                thread.join(timeout=5)
+            assert not any(thread.is_alive() for thread in query_threads)
+            assert len(query_errors) == slot_count, query_errors
+            assert all(
+                "shutdown interrupted active execution" in str(error)
+                for error in query_errors
+            ), query_errors
+        finally:
+            for thread in query_threads:
+                thread.join(timeout=5)
+            for connection in connections:
+                connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={**os.environ},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_unregister_timeout_detaches_stale_dispatcher_work():
     """A timed-out slot must not retain its context or poison later UDFs."""
     import os

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -274,6 +274,59 @@ def test_native_dispatcher_isolates_async_task_admission_failure():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_streaming_task_wakeup_epoch_handles_early_and_duplicate_callbacks():
+    """Early and duplicate callbacks must each schedule a blocked task at most once."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import vane
+
+
+        @vane.func(return_dtype="INTEGER")
+        def add_one(value):
+            return value + 1
+
+
+        @vane.func(return_dtype="INTEGER")
+        def times_two(value):
+            return value * 2
+
+
+        connection = vane.connect()
+        try:
+            relation = connection.sql("select i::INTEGER as x from range(3) t(i)")
+            result = relation.select(
+                add_one(vane.col("x")).alias("a"),
+                times_two(vane.col("x")).alias("b"),
+                times_two(add_one(vane.col("x"))).alias("nested"),
+            )
+            assert result.fetchall() == [(1, 0, 2), (2, 2, 4), (3, 4, 6)]
+            assert connection.sql("select 42").fetchall() == [(42,)]
+        finally:
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={
+            **os.environ,
+            "VANE_ENABLE_UDF_TEST_HOOKS": "1",
+            "VANE_TEST_DUPLICATE_UDF_WAKEUPS": "1",
+            "VANE_RUNNER": "local-fast",
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_native_dispatcher_shutdown_closes_active_executor():
     """Terminal shutdown must close Python ownership before it returns."""
     import os
@@ -775,7 +828,7 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             def cancel_slot(self, _slot_id):
                 global cancel_calls
                 cancel_calls += 1
-                if failure_phase == "cancel" and cancel_calls == 1:
+                if failure_phase == "cancel" and cancel_calls <= 3:
                     raise RuntimeError("planned transient collector cancellation failure")
                 return None
 
@@ -790,7 +843,7 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             def retire_slot(self, _slot_id):
                 global retire_calls
                 retire_calls += 1
-                if failure_phase == "retire" and retire_calls == 1:
+                if failure_phase == "retire" and retire_calls <= 3:
                     raise RuntimeError("planned transient collector retirement failure")
                 collector_retired.set()
 
@@ -882,9 +935,9 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             assert discarded.wait(timeout=5), "stale Ray stream was dropped without collector cleanup"
             assert executor_closed.wait(timeout=5), "retired executor was not eventually closed"
             assert collector_retired.wait(timeout=5), "collector cancellation was not retried through retirement"
-            assert cancel_calls == 2
-            assert pending_checks == (1 if failure_phase == "cancel" else 2)
-            assert retire_calls == (2 if failure_phase == "retire" else 1)
+            assert cancel_calls == (4 if failure_phase in {"cancel", "retire"} else 2)
+            assert pending_checks == (1 if failure_phase == "cancel" else 4 if failure_phase == "retire" else 2)
+            assert retire_calls == (4 if failure_phase == "retire" else 1)
         finally:
             release_submit.set()
             query_thread.join(timeout=5)

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -1992,6 +1992,7 @@ def test_mixed_streaming_inputs_preserve_task_admission_owner():
                 "actor_handles": [f"actor-{node['node_id']}"],
                 "actor_node_ids": ["node-a"],
                 "query_driver_handle": object(),
+                "query_generation_capability": "test-query-generation-capability",
                 "session_config": {},
             }
             for node in plan.collect_udf_nodes(conn=connection)

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -616,6 +616,161 @@ def test_native_dispatcher_terminal_shutdown_uses_one_aggregate_collector_deadli
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_collector_handoff():
+    """Aggregate shutdown must close local ownership after per-slot cleanup stalls."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import threading
+
+        import _duckdb
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+
+        tracked = threading.Event()
+        cancel_started = threading.Event()
+        executor_closed = threading.Event()
+
+
+        class FakeCollector:
+            def __init__(self):
+                self._wakeup = None
+                self._events = []
+                self._pending_slots = set()
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def track_generator_ref(self, slot_id, submit_id, _source, _error_context):
+                self._events.append((int(slot_id), int(submit_id), "complete", None))
+                tracked.set()
+                if self._wakeup is not None:
+                    self._wakeup()
+
+            def discard_generator_ref(self, _slot_id, _source):
+                return None
+
+            def drain_results(self, _capacities):
+                events, self._events = self._events, []
+                return events
+
+            def cancel_slot(self, slot_id):
+                self._pending_slots.add(int(slot_id))
+                cancel_started.set()
+
+            def slot_has_pending(self, slot_id):
+                return int(slot_id) in self._pending_slots
+
+            def retire_slot(self, _slot_id):
+                raise AssertionError("pending slot must not retire before terminal shutdown")
+
+            def shutdown(self):
+                return None
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._retained_input_bytes = 0
+                self._admission_state = "idle"
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, _table):
+                self._admission_state = "idle"
+                return object()
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                executor_closed.set()
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.AsyncResultCollector = FakeCollector
+        connection = duckdb.connect()
+        relation = connection.sql("select 1::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        query_errors = []
+
+
+        def run_query():
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                query_errors.append(exc)
+
+
+        query_thread = threading.Thread(target=run_query)
+        query_thread.start()
+        try:
+            assert tracked.wait(timeout=5), "Ray stream was not tracked"
+            query_thread.join(timeout=5)
+            assert not query_thread.is_alive(), "completed query did not reach unregister"
+            assert query_errors == [], query_errors
+            assert cancel_started.is_set(), "slot cleanup never transferred to the collector"
+            assert not executor_closed.is_set(), "pending per-slot cleanup unexpectedly closed the executor"
+
+            _duckdb._shutdown_udf_executor_dispatcher()
+            assert executor_closed.is_set(), "terminal shutdown skipped the pending slot's executor close"
+        finally:
+            query_thread.join(timeout=5)
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={
+            **os.environ,
+            "VANE_UDF_UNREGISTER_TIMEOUT_MS": "50",
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_unregister_timeout_detaches_stale_dispatcher_work():
     """A timed-out slot must not retain its context or poison later UDFs."""
     import os

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -174,6 +174,159 @@ def test_unregister_timeout_detaches_stale_dispatcher_work():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped():
+    """A Ray stream returned after slot retirement must reach collector cleanup."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import threading
+        import time
+
+        import _duckdb
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+
+        submit_entered = threading.Event()
+        release_submit = threading.Event()
+        discarded = threading.Event()
+        executor_closed = threading.Event()
+        submitted_ref = object()
+
+
+        class FakeCollector:
+            def __init__(self):
+                self._wakeup = None
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def discard_generator_ref(self, ref):
+                assert ref is submitted_ref
+                discarded.set()
+
+            def cancel_slot(self, _slot_id):
+                return None
+
+            def slot_has_pending(self, _slot_id):
+                return False
+
+            def drain_results(self, _capacities):
+                return []
+
+            def shutdown(self):
+                return None
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._admission_state = "idle"
+                self._retained_input_bytes = 0
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, _table):
+                self._admission_state = "idle"
+                submit_entered.set()
+                if not release_submit.wait(timeout=10):
+                    raise RuntimeError("test did not release blocked Ray submit")
+                return submitted_ref
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                executor_closed.set()
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.AsyncResultCollector = FakeCollector
+        connection = duckdb.connect()
+        relation = connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        query_errors = []
+
+
+        def run_query():
+            try:
+                relation.fetchall()
+            except BaseException as exc:
+                query_errors.append(exc)
+
+
+        query_thread = threading.Thread(target=run_query)
+        query_thread.start()
+        try:
+            assert submit_entered.wait(timeout=5), "dispatcher never entered the Ray submit"
+            connection.interrupt()
+            teardown_deadline = time.monotonic() + 5
+            while query_thread.is_alive() and time.monotonic() < teardown_deadline:
+                _duckdb._wake_udf_executor_slots_for_testing()
+                query_thread.join(timeout=0.01)
+            assert not query_thread.is_alive(), "query teardown did not honor the unregister deadline"
+            assert query_errors, "the interrupted query unexpectedly succeeded"
+
+            release_submit.set()
+            assert discarded.wait(timeout=5), "stale Ray stream was dropped without collector cleanup"
+            assert executor_closed.wait(timeout=5), "retired executor was not eventually closed"
+        finally:
+            release_submit.set()
+            query_thread.join(timeout=5)
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={
+            **os.environ,
+            "VANE_ENABLE_UDF_TEST_HOOKS": "1",
+            "VANE_UDF_UNREGISTER_TIMEOUT_MS": "50",
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_unregister_timeout_keeps_context_alive_during_input_conversion():
     """Input Arrow conversion must not outlive its ClientContext lease."""
     import os

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -148,6 +148,132 @@ def test_native_dispatcher_concurrent_shutdown_never_reopens():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_native_dispatcher_isolates_async_task_admission_failure():
+    """An asynchronous admission failure must fail one slot, not the process."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import make_local_shm_ref_bundle_result
+
+        build_count = 0
+
+
+        class FakeExecutor:
+            def __init__(self, *, fail_admission):
+                self._fail_admission = fail_admission
+                self._wakeup = None
+                self._state = "idle"
+                self._retained_input_bytes = 0
+                self._output = None
+                self._finished = False
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._state = "failed" if self._fail_admission else "ready"
+                if self._wakeup is not None:
+                    self._wakeup()
+                return True
+
+            def task_admission_state(self):
+                state = {
+                    "state": self._state,
+                    "available": self._state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+                if self._state == "failed":
+                    state["error"] = "injected asynchronous admission failure"
+                return state
+
+            def submit_with_id(self, submit_id, table):
+                if self._fail_admission:
+                    raise AssertionError("failed admission must not submit")
+                self._state = "idle"
+                values = table.column(0).to_pylist()
+                self._output = (
+                    "__vane_submit_result__",
+                    int(submit_id),
+                    make_local_shm_ref_bundle_result(
+                        pa.table({"y": [value + 1 for value in values]})
+                    ),
+                )
+                if self._wakeup is not None:
+                    self._wakeup()
+
+            def take_ready_result(self):
+                result = self._output
+                self._output = None
+                return result
+
+            def finished_submitting(self):
+                self._finished = True
+
+            def all_tasks_finished(self):
+                return self._finished and self._output is None
+
+            def close(self):
+                self._state = "closed"
+
+
+        def build_executor(_payload, options=None):
+            del options
+            global build_count
+            build_count += 1
+            return FakeExecutor(fail_admission=build_count == 1)
+
+
+        def add_one(table):
+            return pa.table({"y": [value + 1 for value in table.column(0).to_pylist()]})
+
+
+        def make_relation(connection):
+            return connection.sql("select 1::BIGINT as x").map_batches(
+                add_one,
+                schema={"y": duckdb.sqltypes.BIGINT},
+                execution_backend="subprocess_task",
+            )
+
+
+        udf_exec.build_executor = build_executor
+        failed_connection = duckdb.connect()
+        try:
+            try:
+                make_relation(failed_connection).fetchall()
+            except BaseException as exc:
+                assert "injected asynchronous admission failure" in str(exc), exc
+            else:
+                raise AssertionError("failed task admission unexpectedly succeeded")
+        finally:
+            failed_connection.close()
+
+        healthy_connection = duckdb.connect()
+        try:
+            assert make_relation(healthy_connection).fetchall() == [(2,)]
+        finally:
+            healthy_connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+        env={**os.environ, "VANE_RUNNER": "local-fast"},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_native_dispatcher_shutdown_closes_active_executor():
     """Terminal shutdown must close Python ownership before it returns."""
     import os

--- a/tests/fast/test_udf_ray_ready.py
+++ b/tests/fast/test_udf_ray_ready.py
@@ -66,6 +66,7 @@ def _executor(actors, *, dispatch_indices=None, payload=None, node_ids=None):
         pool,
         payload or _payload(),
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
     )
 
 
@@ -215,6 +216,7 @@ def test_existing_actor_handles_require_explicit_dispatch_eligibility():
         pool,
         _payload(),
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
     )
     assert executor._ready_actor_indices == []
     assert executor._actor_init_errors[0] == "ray actor does not expose __ray_ready__ readiness probe"
@@ -234,7 +236,7 @@ def test_actor_executor_uses_explicit_query_driver_handle():
     with pytest.raises(RuntimeError, match="explicit query driver handle"):
         _build_ray_actor_executor(_payload(), options)
 
-    with pytest.raises(RuntimeError, match="explicit Vane session config"):
+    with pytest.raises(RuntimeError, match="query generation capability"):
         _build_ray_actor_executor(
             _payload(),
             {
@@ -243,11 +245,22 @@ def test_actor_executor_uses_explicit_query_driver_handle():
             },
         )
 
+    with pytest.raises(RuntimeError, match="explicit Vane session config"):
+        _build_ray_actor_executor(
+            _payload(),
+            {
+                **options,
+                "query_driver_handle": query_driver_handle,
+                "query_generation_capability": "test-query-generation-capability",
+            },
+        )
+
     executor = _build_ray_actor_executor(
         _payload(),
         {
             **options,
             "query_driver_handle": query_driver_handle,
+            "query_generation_capability": "test-query-generation-capability",
             "session_config": {},
         },
     )

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+import weakref
 from concurrent.futures import Future
 from types import SimpleNamespace
 
@@ -181,9 +182,19 @@ class _FakeRay:
 
 
 class _FailingWaitRay(_FakeRay):
+    def __init__(self):
+        super().__init__()
+        self.fail_waits = True
+
     def wait(self, waitables, *, num_returns, timeout, fetch_local):
-        del waitables, num_returns, timeout, fetch_local
-        raise RuntimeError("planned generator readiness failure")
+        if self.fail_waits:
+            raise RuntimeError("planned generator readiness failure")
+        return super().wait(
+            waitables,
+            num_returns=num_returns,
+            timeout=timeout,
+            fetch_local=fetch_local,
+        )
 
 
 class _SelectiveFailingWaitRay(_FakeRay):
@@ -380,7 +391,22 @@ def test_event_loop_start_failure_prevents_submitted_stream_ownership(monkeypatc
     assert fake_ray.cancel_calls == []
 
 
-def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
+def test_event_loop_start_timeout_rolls_back_started_thread(monkeypatch):
+    fake_ray = _FakeRay()
+    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
+
+    class SlowStartCollector(AsyncResultCollector):
+        def _run_event_loop(self):
+            time.sleep(0.06)
+            super()._run_event_loop()
+
+    with pytest.raises(RuntimeError, match="event loop did not start"):
+        SlowStartCollector(ray_module=fake_ray)
+
+    assert not any(thread.name == "udf-ray-stream-multiplexer" for thread in threading.enumerate())
+
+
+def test_scheduler_failure_isolated_to_stream_does_not_poison_future_slots():
     fake_ray = _FailingWaitRay()
     driver = _Driver()
     collector = AsyncResultCollector(ray_module=fake_ray)
@@ -397,49 +423,41 @@ def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
             ),
         ),
     )
-    collector.drain_results({1: {"rows": 1, "bytes": 128, "item_bytes": 128}})
-    deadline = time.monotonic() + 1
-    while time.monotonic() < deadline:
+    try:
+        failed_events = _drain_until(
+            collector,
+            {1: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(event[2] == "error" for event in values),
+        )
+        assert [event[2] for event in failed_events] == ["error"]
+        assert "planned generator readiness failure" in failed_events[0][3]
         with collector._cv:
-            if collector._thread_error is not None:
-                break
-        time.sleep(0.005)
-    else:
-        pytest.fail("readiness scheduler failure was not published")
+            assert collector._thread_error is None
 
-    rejected_generators = []
-
-    def submit_rejected(_lease):
-        generator = _Generator([], completed=False)
-        rejected_generators.append(generator)
-        return generator
-
-    with pytest.raises(RuntimeError, match="planned generator readiness failure"):
+        fake_ray.fail_waits = False
         collector.track_generator_ref(
-            1,
+            2,
             2,
             _source(
                 fake_ray,
                 driver,
-                request_id="rejected-after-readiness-failure",
-                submitter=submit_rejected,
+                request_id="healthy-after-readiness-failure",
+                submitter=lambda lease: _Generator(
+                    [
+                        _Ref("healthy", is_block=True),
+                        _Ref(_metadata(lease)),
+                    ]
+                ),
             ),
         )
-
-    rejected = rejected_generators[0]
-    assert any(ref is rejected for ref, _kwargs in fake_ray.cancel_calls)
-    assert rejected.deleted_streams == [rejected.completion_ref]
-    assert any(
-        args[:3]
-        == (
-            "rejected-after-readiness-failure",
-            "task-lease-2",
-            "attempt:rejected-after-readiness-failure",
+        healthy_events = _drain_until(
+            collector,
+            {2: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(event[2] == "complete" for event in values),
         )
-        and kwargs == {}
-        for args, kwargs in driver.release_query_task_lease_after_completion.calls
-    )
-    collector.shutdown()
+        assert [event[2] for event in healthy_events] == ["data", "complete"]
+    finally:
+        collector.shutdown()
 
 
 def test_initial_waiter_registration_failure_unpublishes_and_cleans_stream():
@@ -663,12 +681,13 @@ def test_discarded_submitted_stream_enters_terminal_cleanup_ledger():
     collector = AsyncResultCollector(ray_module=fake_ray)
     try:
         collector.discard_generator_ref(
+            9,
             _source(
                 fake_ray,
                 driver,
                 request_id="stale-submission-discard",
                 submitter=lambda _lease: generator,
-            )
+            ),
         )
 
         deadline = time.monotonic() + 2
@@ -685,6 +704,51 @@ def test_discarded_submitted_stream_enters_terminal_cleanup_ledger():
         assert generator.deleted_streams == [generator.completion_ref]
         assert generator.worker is None
     finally:
+        collector.shutdown()
+
+
+def test_slot_retirement_waits_for_discarded_stream_cleanup():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    cleanup_response = _Ref({"scheduled": True}, ready=False)
+    driver.release_query_task_lease_after_completion = _DelayedAckRemoteMethod(
+        cleanup_response,
+    )
+    generator = _Generator([], completed=False)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.discard_generator_ref(
+        9,
+        _source(
+            fake_ray,
+            driver,
+            request_id="stale-submission-slot-owner",
+            submitter=lambda _lease: generator,
+        ),
+    )
+    cancel_errors = []
+    cancel_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            cancel_errors,
+            collector.cancel_slot,
+            9,
+        )
+    )
+    try:
+        assert collector.slot_has_pending(9)
+        cancel_thread.start()
+        time.sleep(0.05)
+        assert cancel_thread.is_alive()
+
+        cleanup_response.ready = True
+        cancel_thread.join(timeout=2)
+
+        assert not cancel_thread.is_alive()
+        assert cancel_errors == []
+        assert not collector.slot_has_pending(9)
+        collector.retire_slot(9)
+    finally:
+        cleanup_response.ready = True
+        cancel_thread.join(timeout=2)
         collector.shutdown()
 
 
@@ -818,6 +882,58 @@ def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
         assert "planned cleanup callback registration failure" in str(errors[0])
         with collector._cv:
             assert collector._cleanup_tickets == set()
+    finally:
+        collector.shutdown()
+
+
+def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = []
+    response_future = None
+
+    def transfer_owner():
+        nonlocal response_future
+        if response_future is None:
+            response_future = Future()
+            attempts.append(response_future)
+            if len(attempts) == 2:
+                response_future.set_result(True)
+        if not response_future.done():
+            return response_future
+        response_future.result()
+        response_future = None
+        return True
+
+    def abandon_wait(future):
+        nonlocal response_future
+        if response_future is future:
+            response_future = None
+        future.cancel()
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                transfer_owner,
+                retry_on_error=True,
+                abandon_wait=abandon_wait,
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        assert (
+            collector._wait_cleanup_tickets(
+                tickets,
+                timeout_message="hung cleanup response was not retried",
+            )
+            == ()
+        )
+        assert len(attempts) == 2
+        assert attempts[0].cancelled()
     finally:
         collector.shutdown()
 
@@ -1343,24 +1459,29 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
 
     monkeypatch.setattr(RayStreamAdapter, "retire_operations", blocking_retire_operations)
 
-    def submitter(lease):
-        generator = _Generator(
-            [
-                _Ref("large-block", is_block=True),
-                _Ref(_metadata(lease, size_bytes=64)),
-            ]
-        )
-        generator_holder["generator"] = generator
-        return generator
+    def make_source():
+        def submitter(lease):
+            generator = _Generator(
+                [
+                    _Ref("large-block", is_block=True),
+                    _Ref(_metadata(lease, size_bytes=64)),
+                ]
+            )
+            generator_holder["generator"] = generator
+            return generator
 
-    source = _source(
-        fake_ray,
-        driver,
-        request_id="deterministic-retirement",
-        submitter=submitter,
-    )
+        source = _source(
+            fake_ray,
+            driver,
+            request_id="deterministic-retirement",
+            submitter=submitter,
+        )
+        return source, weakref.ref(source)
+
+    source, source_ref = make_source()
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(2, 22, source)
+    del source
     capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
     try:
         events = []
@@ -1395,12 +1516,68 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
 
         assert [item[2] for item in events] == ["complete"]
         assert collector._records == {}
-        assert source.generator is None
-        assert source.lease is None
+        assert source_ref() is None
         assert generator.deleted_streams == [generator.completion_ref]
     finally:
         if not retirement.done():
             retirement.set_result(None)
+        collector.shutdown()
+
+
+def test_terminal_cleanup_handoff_failure_replans_owned_stream(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generator = _Generator([])
+
+    def submitter(lease):
+        generator.refs.extend(
+            [
+                _Ref("large-block", is_block=True),
+                _Ref(_metadata(lease, size_bytes=64)),
+            ]
+        )
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        22,
+        _source(
+            fake_ray,
+            driver,
+            request_id="retirement-handoff-failure",
+            submitter=submitter,
+        ),
+    )
+    original_submit = collector._submit_cleanup_operations
+    fail_next_handoff = True
+
+    def fail_one_cleanup_handoff(*args, **kwargs):
+        nonlocal fail_next_handoff
+        if fail_next_handoff:
+            fail_next_handoff = False
+            raise RuntimeError("planned terminal cleanup handoff failure")
+        return original_submit(*args, **kwargs)
+
+    monkeypatch.setattr(
+        collector,
+        "_submit_cleanup_operations",
+        fail_one_cleanup_handoff,
+    )
+    capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
+    try:
+        events = _drain_until(
+            collector,
+            capacity,
+            predicate=lambda values: any(item[2] == "error" for item in values),
+        )
+
+        assert [item[2] for item in events] == ["error"]
+        assert "planned terminal cleanup handoff failure" in events[0][3]
+        _wait_until(lambda: generator.deleted_streams == [generator.completion_ref])
+        assert driver.release_query_task_lease_after_completion.calls
+        assert collector._records == {}
+    finally:
         collector.shutdown()
 
 
@@ -2047,17 +2224,16 @@ def test_readiness_probe_failure_is_reported_without_dequeuing():
         ),
     )
     try:
-        collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}})
-        deadline = time.monotonic() + 1
-        while time.monotonic() < deadline:
-            with collector._cv:
-                if collector._thread_error is not None:
-                    break
-            time.sleep(0.005)
-
-        with pytest.raises(RuntimeError, match="planned generator readiness failure"):
-            collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+        events = _drain_until(
+            collector,
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(event[2] == "error" for event in values),
+        )
+        assert [event[2] for event in events] == ["error"]
+        assert "planned generator readiness failure" in events[0][3]
         assert generators[0].read_count == 0
+        with collector._cv:
+            assert collector._thread_error is None
     finally:
         collector.shutdown()
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -859,6 +859,58 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
         collector.shutdown()
 
 
+def test_cleanup_ticket_ledger_retains_ownership_when_loop_notification_fails(
+    monkeypatch,
+):
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    operation_calls = []
+    original_call_soon_threadsafe = collector._loop.call_soon_threadsafe
+
+    def fail_notification(*_args, **_kwargs):
+        raise RuntimeError("planned cleanup loop notification failure")
+
+    monkeypatch.setattr(
+        collector._loop,
+        "call_soon_threadsafe",
+        fail_notification,
+    )
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                lambda: operation_calls.append("cleaned"),
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+            ),
+        ),
+        store_error=False,
+        slot_ids=(17,),
+    )
+
+    with collector._cv:
+        assert set(tickets) <= collector._cleanup_tickets
+        assert set(tickets) <= collector._cleanup_tickets_by_slot[17]
+        assert "planned cleanup loop notification failure" in str(collector._thread_error)
+    assert operation_calls == []
+
+    monkeypatch.setattr(
+        collector._loop,
+        "call_soon_threadsafe",
+        original_call_soon_threadsafe,
+    )
+    original_call_soon_threadsafe(
+        collector._start_cleanup_tickets,
+        tickets,
+    )
+    assert (
+        _wait_cleanup_tickets(
+            tickets,
+            timeout_message="retained cleanup ticket did not finish",
+        )
+        == ()
+    )
+    assert operation_calls == ["cleaned"]
+    collector.shutdown()
+
+
 def test_cleanup_ticket_preserves_incomplete_ownership_retry():
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = 0
@@ -3014,3 +3066,58 @@ def test_shutdown_clears_callback_and_fully_joins_owned_thread():
     assert collector._wakeup_fn is None
     assert collector._thread.is_alive() is False
     assert collector._cleanup_tickets == set()
+
+
+def test_shutdown_cleanup_handoff_failure_is_retryable(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generator = _Generator([], completed=False)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        8,
+        81,
+        _source(
+            fake_ray,
+            driver,
+            request_id="shutdown-handoff-retry",
+            submitter=lambda _lease: generator,
+        ),
+    )
+    output_request = {
+        "request_id": "output-request:shutdown-handoff-retry",
+    }
+    with collector._cv:
+        collector._records[(8, 81)].output_request = output_request
+    original_submit = collector._submit_cleanup_operations
+    fail_next_handoff = True
+
+    def fail_one_cleanup_handoff(*args, **kwargs):
+        nonlocal fail_next_handoff
+        if fail_next_handoff:
+            fail_next_handoff = False
+            raise RuntimeError("planned shutdown cleanup handoff failure")
+        return original_submit(*args, **kwargs)
+
+    monkeypatch.setattr(
+        collector,
+        "_submit_cleanup_operations",
+        fail_one_cleanup_handoff,
+    )
+
+    with pytest.raises(RuntimeError, match="planned shutdown cleanup handoff failure"):
+        collector.shutdown()
+
+    assert collector._records
+    assert collector._thread.is_alive()
+
+    collector.shutdown()
+
+    assert collector._records == {}
+    assert collector._cleanup_tickets == set()
+    assert collector._thread.is_alive() is False
+    assert fake_ray.cancel_calls == [
+        (generator, {"force": True, "recursive": True}),
+    ]
+    assert driver.cancel_query_output_block_lease_request.calls == [
+        ((output_request,), {}),
+    ]

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -11,8 +11,14 @@ from types import SimpleNamespace
 
 import pytest
 
+import duckdb.execution.ray_stream_adapter as stream_adapter_module
 import duckdb.execution.udf_stream_result_collector as collector_module
-from duckdb.execution.ray_stream_adapter import RayStreamAdapter, TaskLeaseObjectRefGenerator
+from duckdb.execution.ray_stream_adapter import (
+    RAY_STREAM_CLEANUP_CONTROL,
+    RayStreamAdapter,
+    RayStreamCleanupOperation,
+    TaskLeaseObjectRefGenerator,
+)
 from duckdb.execution.udf_stream_result_collector import (
     AsyncResultCollector,
     _OutputLeaseToken,
@@ -176,8 +182,12 @@ class _BlockingCancelRay(_FakeRay):
         super().__init__()
         self.cancel_started = threading.Event()
         self.allow_cancel = threading.Event()
+        self.cancel_started_count = 0
+        self.cancel_started_lock = threading.Lock()
 
     def cancel(self, ref, **kwargs):
+        with self.cancel_started_lock:
+            self.cancel_started_count += 1
         self.cancel_started.set()
         self.allow_cancel.wait(timeout=2.0)
         super().cancel(ref, **kwargs)
@@ -206,6 +216,24 @@ class _FailingWaitRay(_FakeRay):
         raise RuntimeError("planned generator readiness failure")
 
 
+class _SelectiveFailingWaitRay(_FakeRay):
+    def __init__(self):
+        super().__init__()
+        self.failed_waitable = None
+
+    def wait(self, waitables, *, num_returns, timeout, fetch_local):
+        if len(waitables) > 1:
+            raise RuntimeError("planned batch readiness failure")
+        if waitables and waitables[0] is self.failed_waitable:
+            raise RuntimeError("planned isolated generator readiness failure")
+        return super().wait(
+            waitables,
+            num_returns=num_returns,
+            timeout=timeout,
+            fetch_local=fetch_local,
+        )
+
+
 class _RemoteMethod:
     def __init__(self, fn):
         self.fn = fn
@@ -230,6 +258,16 @@ class _BlockingRemoteMethod(_RemoteMethod):
         return _Ref(self.fn(*args, **kwargs))
 
 
+class _DelayedAckRemoteMethod:
+    def __init__(self, response_ref):
+        self.response_ref = response_ref
+        self.calls = []
+
+    def remote(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.response_ref
+
+
 class _Driver:
     def __init__(self):
         self.next_task = 0
@@ -237,6 +275,8 @@ class _Driver:
         self.acquire_query_task_lease = _RemoteMethod(self._acquire_task)
         self.mark_query_task_lease_submitted = _RemoteMethod(lambda *_args: {"submitted": True})
         self.release_query_task_lease = _RemoteMethod(lambda *_args: {"released": True})
+        self.release_query_task_lease_after_completion = _RemoteMethod(lambda *_args: {"scheduled": True})
+        self.handoff_query_task_lease_to_teardown = _RemoteMethod(lambda *_args: {"handed_off": True})
         self.cancel_query_task_lease_request = _RemoteMethod(lambda *_args, **_kwargs: {"cancelled": True})
         self.acquire_query_output_block_lease = _RemoteMethod(self._acquire_output)
         self.handoff_query_output_block_lease = _RemoteMethod(lambda *_args: {"handed_off": True})
@@ -337,6 +377,15 @@ def _drain_until(collector, capacities, predicate=lambda values: bool(values), t
     return collected
 
 
+def _wait_until(predicate, *, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("timed out waiting for collector state transition")
+
+
 def _capture_thread_error(errors, operation, *args):
     try:
         operation(*args)
@@ -388,6 +437,235 @@ def test_event_loop_start_failure_releases_the_registered_stream(monkeypatch):
     with pytest.raises(RuntimeError, match="planned thread start failure"):
         collector.drain_results({})
     collector.shutdown()
+
+
+def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
+    fake_ray = _FailingWaitRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        1,
+        1,
+        _source(
+            fake_ray,
+            driver,
+            request_id="readiness-failure-owner",
+            submitter=lambda _lease: _Generator(
+                [_Ref("never-consumed", ready=False, is_block=True)],
+                completed=False,
+            ),
+        ),
+    )
+    collector.drain_results({1: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        with collector._cv:
+            if collector._thread_error is not None:
+                break
+        time.sleep(0.005)
+    else:
+        pytest.fail("readiness scheduler failure was not published")
+
+    rejected_generators = []
+
+    def submit_rejected(_lease):
+        generator = _Generator([], completed=False)
+        rejected_generators.append(generator)
+        return generator
+
+    with pytest.raises(RuntimeError, match="planned generator readiness failure"):
+        collector.track_generator_ref(
+            1,
+            2,
+            _source(
+                fake_ray,
+                driver,
+                request_id="rejected-after-readiness-failure",
+                submitter=submit_rejected,
+            ),
+        )
+
+    rejected = rejected_generators[0]
+    assert any(ref is rejected for ref, _kwargs in fake_ray.cancel_calls)
+    assert rejected.deleted_streams == [rejected.completion_ref]
+    assert any(
+        args[:3]
+        == (
+            "rejected-after-readiness-failure",
+            "task-lease-2",
+            "attempt:rejected-after-readiness-failure",
+        )
+        and kwargs == {}
+        for args, kwargs in driver.release_query_task_lease_after_completion.calls
+    )
+    collector.shutdown()
+
+
+def test_registration_is_not_schedulable_until_track_accepts_it(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector._ensure_started()
+    collector.drain_results({1: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+    registration_paused = threading.Event()
+    allow_registration = threading.Event()
+    original_ensure_started = collector._ensure_started
+
+    def pause_after_start():
+        original_ensure_started()
+        registration_paused.set()
+        assert allow_registration.wait(timeout=2)
+
+    monkeypatch.setattr(collector, "_ensure_started", pause_after_start)
+    generators = []
+
+    def submitter(lease):
+        generator = _Generator(
+            [
+                _Ref("ready-during-registration", is_block=True),
+                _Ref(_metadata(lease)),
+            ]
+        )
+        generators.append(generator)
+        return generator
+
+    errors = []
+    registration = threading.Thread(
+        target=lambda: _capture_thread_error(
+            errors,
+            collector.track_generator_ref,
+            1,
+            2,
+            _source(
+                fake_ray,
+                driver,
+                request_id="registration-fence",
+                submitter=submitter,
+            ),
+        )
+    )
+    try:
+        registration.start()
+        assert registration_paused.wait(timeout=1)
+        time.sleep(0.05)
+        with collector._cv:
+            record = collector._records[(1, 2)]
+            assert record.registration_accepted is False
+        assert generators[0].read_count == 0
+        assert collector._ready_by_slot.get(1) is None
+
+        allow_registration.set()
+        registration.join(timeout=2)
+        assert registration.is_alive() is False
+        assert errors == []
+        events = _drain_until(
+            collector,
+            {1: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(item[2] == "complete" for item in values),
+        )
+        assert [item[2] for item in events] == ["data", "complete"]
+    finally:
+        allow_registration.set()
+        registration.join(timeout=2)
+        collector.shutdown()
+
+
+def test_failure_wakeup_can_reenter_shutdown_after_cleanup_handoff():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        1,
+        1,
+        _source(
+            fake_ray,
+            driver,
+            request_id="reentrant-failure-shutdown",
+            submitter=lambda _lease: _Generator([], completed=False),
+        ),
+    )
+    with collector._cv:
+        record = collector._records[(1, 1)]
+    shutdown_errors = []
+    collector.set_wakeup_callback(
+        lambda: _capture_thread_error(
+            shutdown_errors,
+            collector.shutdown,
+        )
+    )
+
+    collector._fail_record(record, RuntimeError("planned terminal failure"))
+
+    assert shutdown_errors == []
+    assert collector._shutdown is True
+    assert collector._records == {}
+    collector.shutdown()
+
+
+def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
+    monkeypatch,
+):
+    monkeypatch.setenv("VANE_UDF_STREAM_CONTROL_CLEANUP_WORKERS", "1")
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = 0
+    order = []
+
+    def fail_transiently():
+        nonlocal attempts
+        attempts += 1
+        order.append(f"retry-{attempts}")
+        if attempts < 6:
+            raise RuntimeError("planned transient cleanup failure")
+
+    group = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                fail_transiently,
+                retry_on_error=True,
+            ),
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                lambda: order.append("peer"),
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        assert group is not None
+        assert group.wait(timeout=1)
+        assert group.errors == ()
+        assert order == ["retry-1", "peer", "retry-2", "retry-3", "retry-4", "retry-5", "retry-6"]
+    finally:
+        collector.shutdown()
+
+
+def test_scheduler_fence_preserves_incomplete_ownership_retry():
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = 0
+
+    def transfer_owner():
+        nonlocal attempts
+        attempts += 1
+        return attempts >= 2
+
+    operations = collector._fence_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                transfer_owner,
+                retry_on_incomplete=True,
+            ),
+        )
+    )
+    group = collector._submit_cleanup_operations(operations, store_error=False)
+    try:
+        assert group is not None
+        assert group.wait(timeout=1)
+        assert group.errors == ()
+        assert attempts == 2
+    finally:
+        collector.shutdown()
 
 
 def test_zero_capacity_does_not_consume_block_or_metadata_objects():
@@ -494,6 +772,7 @@ def test_data_capacity_does_not_count_interleaved_control_events():
     token = _OutputLeaseToken(
         request_id="strict-consumer-request",
         lease_id="strict-consumer-lease",
+        query_id="q1",
         driver=object(),
         slot_id=1,
         submit_id=11,
@@ -548,14 +827,105 @@ def test_direct_block_pair_is_leased_and_large_block_is_never_fetched():
 
         assert collector.handoff_output_block_lease(data[4], data[5]) is True
         assert collector.handoff_output_block_lease(data[4], data[5]) is False
+        _wait_until(lambda: len(driver.handoff_query_output_block_lease.calls) == 1)
         assert len(driver.handoff_query_output_block_lease.calls) == 1
         assert driver.release_query_output_block_lease.calls == []
 
         assert collector.release_output_block_lease(data[4], data[5]) is True
         assert collector.release_output_block_lease(data[4], data[5]) is False
+        _wait_until(lambda: len(driver.release_query_output_block_lease.calls) == 1)
         assert len(driver.release_query_output_block_lease.calls) == 1
         assert len(driver.release_query_task_lease.calls) == 1
     finally:
+        collector.shutdown()
+
+
+@pytest.mark.parametrize("operation", ["handoff", "release"])
+def test_output_lease_control_retries_until_driver_acknowledges_ownership(operation):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    attempts = 0
+
+    def transient_failure(*_args):
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 5:
+            raise RuntimeError(f"planned {operation} submission failure")
+        if operation == "handoff":
+            return {"handed_off": True}
+        return {"released": True}
+
+    if operation == "handoff":
+        driver.handoff_query_output_block_lease = _RemoteMethod(transient_failure)
+    else:
+        driver.release_query_output_block_lease = _RemoteMethod(transient_failure)
+    token = _OutputLeaseToken(
+        request_id="output-request:retry",
+        lease_id="output-lease-retry",
+        query_id="q1",
+        driver=driver,
+        slot_id=2,
+        submit_id=20,
+        size_bytes=64,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    key = (token.request_id, token.lease_id)
+    with collector._cv:
+        collector._active_output_leases[key] = token
+    try:
+        callback = (
+            collector.handoff_output_block_lease if operation == "handoff" else collector.release_output_block_lease
+        )
+        assert callback(*key) is True
+        if operation == "handoff":
+            _wait_until(lambda: token.handed_off)
+            assert attempts == 6
+            assert collector.release_output_block_lease(*key) is True
+        else:
+            _wait_until(lambda: key not in collector._active_output_leases)
+            assert attempts == 6
+    finally:
+        collector.shutdown()
+
+
+def test_output_control_timeout_reuses_the_inflight_driver_response(monkeypatch):
+    monkeypatch.setattr(
+        stream_adapter_module,
+        "_TASK_LEASE_CONTROL_ACK_TIMEOUT_S",
+        0.01,
+    )
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    response_ref = _Ref({"released": True}, ready=False)
+    driver.release_query_output_block_lease = _DelayedAckRemoteMethod(response_ref)
+    token = _OutputLeaseToken(
+        request_id="output-request:delayed-ack",
+        lease_id="output-lease-delayed-ack",
+        query_id="q1",
+        driver=driver,
+        slot_id=2,
+        submit_id=21,
+        size_bytes=64,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    key = (token.request_id, token.lease_id)
+    with collector._cv:
+        collector._active_output_leases[key] = token
+    try:
+        assert collector.release_output_block_lease(*key) is True
+        _wait_until(lambda: bool(driver.release_query_output_block_lease.calls))
+        time.sleep(0.08)
+
+        assert len(driver.release_query_output_block_lease.calls) == 1
+        with collector._cv:
+            assert collector._active_output_leases[key] is token
+            assert token.release_pending is True
+
+        response_ref.ready = True
+        _wait_until(lambda: key not in collector._active_output_leases)
+        assert len(driver.release_query_output_block_lease.calls) == 1
+    finally:
+        response_ref.ready = True
         collector.shutdown()
 
 
@@ -730,14 +1100,24 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
     generator_holder = {}
     retire_started = threading.Event()
     allow_retire = threading.Event()
-    original_retire = RayStreamAdapter.retire
+    original_retire_operations = RayStreamAdapter.retire_operations
 
-    def blocking_retire(adapter):
-        retire_started.set()
-        allow_retire.wait()
-        original_retire(adapter)
+    def blocking_retire_operations(adapter):
+        operations = original_retire_operations(adapter)
 
-    monkeypatch.setattr(RayStreamAdapter, "retire", blocking_retire)
+        def block_retirement():
+            retire_started.set()
+            allow_retire.wait()
+
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                block_retirement,
+            ),
+            *operations,
+        )
+
+    monkeypatch.setattr(RayStreamAdapter, "retire_operations", blocking_retire_operations)
 
     def submitter(lease):
         generator = _Generator(
@@ -767,15 +1147,15 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         assert retire_started.is_set()
         events.extend(collector.drain_results(capacity))
 
-        # Completion is the observable retirement boundary. Keep the record
-        # pending, and do not publish completion, until local stream cleanup
-        # has dropped the source and deleted the Ray ObjectRef stream.
+        # Completion is the observable retirement boundary. Independent lanes
+        # may already delete the local stream while task-accounting cleanup is
+        # blocked, but the record cannot complete until the whole plan settles.
         assert [item[2] for item in events] == ["data"]
         assert collector._records
+        assert collector._cleanup_groups
         generator = generator_holder["generator"]
-        assert source.generator is generator
-        assert source.lease is not None
-        assert generator.deleted_streams == []
+        assert source_ref() is None
+        assert generator.deleted_streams == [generator.completion_ref]
 
         data = next(item for item in events if item[2] == "data")
         assert collector.release_output_block_lease(data[4], data[5]) is True
@@ -805,15 +1185,31 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
     retire_started = threading.Event()
     allow_retire = threading.Event()
     healthy_block = _Ref("healthy-after-retire", ready=False, is_block=True)
-    original_retire = RayStreamAdapter.retire
+    original_retire_operations = RayStreamAdapter.retire_operations
 
-    def selectively_blocking_retire(adapter):
-        if adapter.task_request_id == "blocked-retire":
+    def selectively_blocking_retire_operations(adapter):
+        should_block = adapter.task_request_id == "blocked-retire"
+        operations = original_retire_operations(adapter)
+        if not should_block:
+            return operations
+
+        def block_retirement():
             retire_started.set()
             allow_retire.wait()
-        original_retire(adapter)
 
-    monkeypatch.setattr(RayStreamAdapter, "retire", selectively_blocking_retire)
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                block_retirement,
+            ),
+            *operations,
+        )
+
+    monkeypatch.setattr(
+        RayStreamAdapter,
+        "retire_operations",
+        selectively_blocking_retire_operations,
+    )
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
@@ -859,6 +1255,61 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
     finally:
         allow_retire.set()
         collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    retire_started = threading.Event()
+    allow_retire = threading.Event()
+    original_retire_operations = RayStreamAdapter.retire_operations
+
+    def blocking_retire_operations(adapter):
+        operations = original_retire_operations(adapter)
+
+        def block_retirement():
+            retire_started.set()
+            assert allow_retire.wait(timeout=2)
+
+        return (
+            RayStreamCleanupOperation(
+                RAY_STREAM_CLEANUP_CONTROL,
+                block_retirement,
+            ),
+            *operations,
+        )
+
+    monkeypatch.setattr(RayStreamAdapter, "retire_operations", blocking_retire_operations)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        4,
+        41,
+        _source(
+            fake_ray,
+            driver,
+            request_id="cancel-claimed-retirement",
+            submitter=lambda _lease: _Generator([]),
+        ),
+    )
+    collector.drain_results({4: {"rows": 0, "bytes": 0, "item_bytes": 0}})
+    assert retire_started.wait(timeout=1)
+
+    cancel_errors = []
+    cancel_thread = threading.Thread(target=lambda: _capture_thread_error(cancel_errors, collector.cancel_slot, 4))
+    try:
+        cancel_thread.start()
+        time.sleep(0.05)
+        assert cancel_thread.is_alive()
+
+        allow_retire.set()
+        cancel_thread.join(timeout=2)
+        assert cancel_thread.is_alive() is False
+        assert cancel_errors == []
+        assert collector.slot_has_pending(4) is False
+    finally:
+        allow_retire.set()
+        cancel_thread.join(timeout=2)
         collector.shutdown()
 
 
@@ -969,8 +1420,11 @@ def test_stale_record_releases_completed_output_lease_with_exact_rpc_contract():
     try:
         collector._finish_output_lease(record, record.output_lease_ref.value)
 
+        deadline = time.monotonic() + 1
+        while not driver.release_query_output_block_lease.calls and time.monotonic() < deadline:
+            time.sleep(0.005)
         assert driver.release_query_output_block_lease.calls == [
-            ((record.output_request_id, "output-lease-1"), {}),
+            ((record.output_request_id, "output-lease-1", metadata["query_id"]), {}),
         ]
     finally:
         collector.shutdown()
@@ -1311,7 +1765,7 @@ def test_shutdown_retains_cleanup_after_a_stuck_readiness_probe(monkeypatch):
 
     fake_ray.allow_wait.set()
     deadline = time.monotonic() + 1
-    while time.monotonic() < deadline and not fake_ray.cancel_calls:
+    while time.monotonic() < deadline and (not fake_ray.cancel_calls or not generators[0].deleted_streams):
         time.sleep(0.005)
 
     assert len(fake_ray.cancel_calls) == 1
@@ -1356,6 +1810,77 @@ def test_readiness_probe_failure_is_reported_without_dequeuing():
         with pytest.raises(RuntimeError, match="planned generator readiness failure"):
             collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}})
         assert generators[0].read_count == 0
+    finally:
+        collector.shutdown()
+
+
+def test_batch_wait_failure_isolates_one_bad_generator_from_healthy_slots():
+    fake_ray = _SelectiveFailingWaitRay()
+    driver = _Driver()
+    failed_generator = _Generator(
+        [_Ref("failed-block", is_block=True)],
+        completed=False,
+    )
+    healthy_holder = {}
+
+    def healthy_submitter(lease):
+        generator = _Generator(
+            [
+                _Ref("healthy-block", is_block=True),
+                _Ref(_metadata(lease)),
+            ]
+        )
+        healthy_holder["generator"] = generator
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        31,
+        310,
+        _source(
+            fake_ray,
+            driver,
+            request_id="isolated-readiness-failure",
+            submitter=lambda _lease: failed_generator,
+        ),
+    )
+    collector.track_generator_ref(
+        32,
+        320,
+        _source(
+            fake_ray,
+            driver,
+            request_id="healthy-readiness-neighbor",
+            submitter=healthy_submitter,
+        ),
+    )
+    fake_ray.failed_waitable = failed_generator
+    capacities = {
+        31: {"rows": 1, "bytes": 128, "item_bytes": 128},
+        32: {"rows": 1, "bytes": 128, "item_bytes": 128},
+    }
+    events = []
+    try:
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            events.extend(collector.drain_results(capacities))
+            kinds_by_slot = {(event[0], event[2]) for event in events}
+            if (31, "error") in kinds_by_slot and (32, "complete") in kinds_by_slot:
+                break
+            time.sleep(0.005)
+
+        assert any(
+            event[0] == 31 and event[2] == "error" and "planned isolated generator readiness failure" in event[3]
+            for event in events
+        )
+        assert [event[2] for event in events if event[0] == 32] == [
+            "data",
+            "complete",
+        ]
+        assert failed_generator.read_count == 0
+        assert healthy_holder["generator"].read_count == 2
+        with collector._cv:
+            assert collector._thread_error is None
     finally:
         collector.shutdown()
 
@@ -1504,7 +2029,10 @@ def test_failed_completion_retires_without_cancelling_terminal_remote_work():
             )
         ]
         assert fake_ray.cancel_calls == []
-        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        deadline = time.monotonic() + 1
+        while not driver.release_query_task_lease_after_completion.calls and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
         assert generator.deleted_streams == [generator.completion_ref]
     finally:
         collector.shutdown()
@@ -1551,7 +2079,7 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
         assert driver.acquire_query_output_block_lease.calls == []
         assert holder["block_ref"].future_result_calls == []
         assert fake_ray.cancel_calls == []
-        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
         assert holder["generator"].deleted_streams == [holder["generator"].completion_ref]
     finally:
         collector.shutdown()
@@ -1580,7 +2108,7 @@ def test_malformed_metadata_fails_only_its_stream_without_output_admission():
         assert events[0][2] == "error"
         assert "invalid Ray UDF stream metadata" in events[0][3]
         assert driver.acquire_query_output_block_lease.calls == []
-        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
         assert fake_ray.cancel_calls[-1][1] == {"force": True, "recursive": True}
     finally:
         collector.shutdown()
@@ -1647,6 +2175,112 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         collector.shutdown()
 
 
+def test_blocked_cancellations_use_bounded_workers_and_preserve_delete_ordering(
+    monkeypatch,
+):
+    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("VANE_UDF_STREAM_CANCELLATION_CLEANUP_WORKERS", "2")
+    fake_ray = _BlockingCancelRay()
+    driver = _Driver()
+    generators = []
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    for index in range(12):
+        generator = _Generator([], completed=False)
+        generators.append(generator)
+        collector.track_generator_ref(
+            18,
+            index,
+            _source(
+                fake_ray,
+                driver,
+                request_id=f"bounded-cancel-{index}",
+                submitter=lambda _lease, generator=generator: generator,
+            ),
+        )
+
+    try:
+        with pytest.raises(RuntimeError, match="cleanup did not terminate"):
+            collector.cancel_slot(18)
+
+        assert fake_ray.cancel_started_count == 2
+        cancellation_pool = collector._cleanup_pools["cancellation"]
+        assert len(cancellation_pool.threads) == 2
+        assert driver.cancel_query_task_lease_request.calls == []
+        assert len(driver.release_query_task_lease_after_completion.calls) == len(generators)
+        assert all(generator.deleted_streams == [] for generator in generators)
+
+        fake_ray.allow_cancel.set()
+        deadline = time.monotonic() + 3
+        while (
+            len(fake_ray.cancel_calls) < len(generators)
+            or not all(generator.deleted_streams for generator in generators)
+        ) and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert len(fake_ray.cancel_calls) == len(generators)
+        assert all(generator.deleted_streams == [generator.completion_ref] for generator in generators)
+    finally:
+        fake_ray.allow_cancel.set()
+        collector.shutdown()
+
+
+def test_blocked_output_controls_do_not_withhold_task_or_stream_cleanup(
+    monkeypatch,
+):
+    monkeypatch.setenv("VANE_UDF_STREAM_OUTPUT_CLEANUP_WORKERS", "2")
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    blocked_release = _BlockingRemoteMethod(lambda *_args: {"released": True})
+    driver.release_query_output_block_lease = blocked_release
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    output_tokens = [
+        _OutputLeaseToken(
+            request_id=f"output-request:blocked:{index}",
+            lease_id=f"output-lease-blocked-{index}",
+            query_id="q1",
+            driver=driver,
+            slot_id=71,
+            submit_id=index,
+            size_bytes=64,
+        )
+        for index in range(2)
+    ]
+    with collector._cv:
+        for token in output_tokens:
+            collector._active_output_leases[(token.request_id, token.lease_id)] = token
+    for token in output_tokens:
+        assert collector.release_output_block_lease(token.request_id, token.lease_id)
+    _wait_until(lambda: len(blocked_release.calls) == 2)
+
+    generator = _Generator([], completed=False)
+    collector.track_generator_ref(
+        72,
+        720,
+        _source(
+            fake_ray,
+            driver,
+            request_id="cleanup-beside-blocked-output",
+            submitter=lambda _lease: generator,
+        ),
+    )
+    try:
+        collector.cancel_slot(72)
+
+        assert fake_ray.cancel_calls == [
+            (generator, {"force": True, "recursive": True}),
+        ]
+        assert generator.deleted_streams == [generator.completion_ref]
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
+        assert all(token.release_pending for token in output_tokens)
+    finally:
+        blocked_release.release.set()
+        _wait_until(
+            lambda: all(
+                (token.request_id, token.lease_id) not in collector._active_output_leases for token in output_tokens
+            )
+        )
+        collector.shutdown()
+
+
 def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queue():
     fake_ray = _FakeRay()
     driver = _Driver()
@@ -1675,7 +2309,7 @@ def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queu
         assert events[0][2] == "error"
         assert "exceeds downstream item capacity" in events[0][3]
         assert driver.acquire_query_output_block_lease.calls == []
-        assert len(driver.cancel_query_task_lease_request.calls) == 1
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
     finally:
         collector.shutdown()
 
@@ -1732,3 +2366,4 @@ def test_shutdown_clears_callback_and_fully_joins_owned_thread():
 
     assert collector._wakeup_fn is None
     assert collector._thread.is_alive() is False
+    assert all(not thread.is_alive() for pool in collector._cleanup_pools.values() for thread in pool.threads)

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -859,7 +859,7 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
         collector.shutdown()
 
 
-def test_cleanup_ticket_ledger_retains_ownership_when_loop_notification_fails(
+def test_cleanup_tickets_progress_when_loop_notification_fails(
     monkeypatch,
 ):
     collector = AsyncResultCollector(ray_module=_FakeRay())
@@ -874,6 +874,47 @@ def test_cleanup_ticket_ledger_retains_ownership_when_loop_notification_fails(
         "call_soon_threadsafe",
         fail_notification,
     )
+    try:
+        tickets = collector._submit_cleanup_operations(
+            (
+                RayStreamCleanupOperation(
+                    lambda: operation_calls.append("cleaned"),
+                    submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                ),
+            ),
+            store_error=False,
+            slot_ids=(17,),
+        )
+
+        assert (
+            _wait_cleanup_tickets(
+                tickets,
+                timeout_message="self-driven cleanup ticket did not finish",
+            )
+            == ()
+        )
+        assert operation_calls == ["cleaned"]
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
+            assert collector._cleanup_tickets_by_slot.get(17) is None
+            assert collector._thread_error is None
+    finally:
+        monkeypatch.setattr(
+            collector._loop,
+            "call_soon_threadsafe",
+            original_call_soon_threadsafe,
+        )
+        collector.shutdown()
+
+
+def test_cleanup_tickets_progress_after_event_loop_exits():
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    operation_calls = []
+    collector._request_event_loop_stop()
+    collector._thread.join(timeout=1.0)
+    assert collector._thread.is_alive() is False
+    assert collector._loop.is_closed()
+
     tickets = collector._submit_cleanup_operations(
         (
             RayStreamCleanupOperation(
@@ -882,33 +923,20 @@ def test_cleanup_ticket_ledger_retains_ownership_when_loop_notification_fails(
             ),
         ),
         store_error=False,
-        slot_ids=(17,),
     )
-
-    with collector._cv:
-        assert set(tickets) <= collector._cleanup_tickets
-        assert set(tickets) <= collector._cleanup_tickets_by_slot[17]
-        assert "planned cleanup loop notification failure" in str(collector._thread_error)
-    assert operation_calls == []
-
-    monkeypatch.setattr(
-        collector._loop,
-        "call_soon_threadsafe",
-        original_call_soon_threadsafe,
-    )
-    original_call_soon_threadsafe(
-        collector._start_cleanup_tickets,
-        tickets,
-    )
-    assert (
-        _wait_cleanup_tickets(
-            tickets,
-            timeout_message="retained cleanup ticket did not finish",
+    try:
+        assert (
+            _wait_cleanup_tickets(
+                tickets,
+                timeout_message="cleanup ticket did not survive loop exit",
+            )
+            == ()
         )
-        == ()
-    )
-    assert operation_calls == ["cleaned"]
-    collector.shutdown()
+        assert operation_calls == ["cleaned"]
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
+    finally:
+        collector.shutdown()
 
 
 def test_cleanup_ticket_preserves_incomplete_ownership_retry():

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -712,7 +712,7 @@ def test_discarded_submitted_stream_enters_terminal_cleanup_ledger():
         collector.shutdown()
 
 
-def test_slot_retirement_waits_for_discarded_stream_cleanup():
+def test_slot_cancel_is_nonblocking_and_cleanup_completion_wakes_dispatcher():
     fake_ray = _FakeRay()
     driver = _Driver()
     cleanup_response = _Ref({"scheduled": True}, ready=False)
@@ -721,6 +721,8 @@ def test_slot_retirement_waits_for_discarded_stream_cleanup():
     )
     generator = _Generator([], completed=False)
     collector = AsyncResultCollector(ray_module=fake_ray)
+    cleanup_wakeup = threading.Event()
+    collector.set_wakeup_callback(cleanup_wakeup.set)
     collector.discard_generator_ref(
         9,
         _source(
@@ -730,30 +732,20 @@ def test_slot_retirement_waits_for_discarded_stream_cleanup():
             submitter=lambda _lease: generator,
         ),
     )
-    cancel_errors = []
-    cancel_thread = threading.Thread(
-        target=lambda: _capture_thread_error(
-            cancel_errors,
-            collector.cancel_slot,
-            9,
-        )
-    )
     try:
         assert collector.slot_has_pending(9)
-        cancel_thread.start()
-        time.sleep(0.05)
-        assert cancel_thread.is_alive()
+        started_at = time.monotonic()
+        collector.cancel_slot(9)
+        assert time.monotonic() - started_at < 0.1
+        assert collector.slot_has_pending(9)
 
+        cleanup_wakeup.clear()
         cleanup_response.ready = True
-        cancel_thread.join(timeout=2)
-
-        assert not cancel_thread.is_alive()
-        assert cancel_errors == []
-        assert not collector.slot_has_pending(9)
+        assert cleanup_wakeup.wait(timeout=2)
+        _wait_until(lambda: not collector.slot_has_pending(9))
         collector.retire_slot(9)
     finally:
         cleanup_response.ready = True
-        cancel_thread.join(timeout=2)
         collector.shutdown()
 
 
@@ -888,6 +880,47 @@ def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
         with collector._cv:
             assert collector._cleanup_tickets == set()
     finally:
+        collector.shutdown()
+
+
+def test_slot_retirement_reports_async_cancellation_ticket_failure():
+    operation_started = threading.Event()
+    allow_operation = threading.Event()
+
+    class _BrokenFuture:
+        def add_done_callback(self, _callback):
+            raise RuntimeError("planned slot cleanup callback registration failure")
+
+        def done(self):
+            return False
+
+        def result(self):
+            raise AssertionError("broken Future must never be resolved")
+
+    def broken_cleanup():
+        operation_started.set()
+        assert allow_operation.wait(timeout=2)
+        return _BrokenFuture()
+
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector._submit_cleanup_operations(
+        (RayStreamCleanupOperation(broken_cleanup, retry_on_error=True),),
+        store_error=False,
+        slot_ids=(7,),
+    )
+    try:
+        assert operation_started.wait(timeout=1)
+        collector.cancel_slot(7)
+        assert collector.slot_has_pending(7)
+
+        allow_operation.set()
+        _wait_until(lambda: not collector.slot_has_pending(7))
+        cleanup_error = collector.retire_slot(7)
+
+        assert cleanup_error is not None
+        assert "planned slot cleanup callback registration failure" in cleanup_error
+    finally:
+        allow_operation.set()
         collector.shutdown()
 
 
@@ -1363,17 +1396,17 @@ def test_slot_cancel_reuses_an_already_claimed_output_release_ticket():
         _wait_until(lambda: len(driver.release_query_output_block_lease.calls) == 1)
 
         cancel_thread.start()
-        time.sleep(0.05)
-        assert cancel_thread.is_alive()
+        cancel_thread.join(timeout=0.5)
+        assert cancel_thread.is_alive() is False
+        assert cancel_errors == []
+        assert collector.slot_has_pending(token.slot_id)
         assert len(driver.release_query_output_block_lease.calls) == 1
 
         release_response.ready = True
-        cancel_thread.join(timeout=2)
+        _wait_until(lambda: not collector.slot_has_pending(token.slot_id))
 
-        assert cancel_thread.is_alive() is False
-        assert cancel_errors == []
         assert len(driver.release_query_output_block_lease.calls) == 1
-        assert collector.slot_has_pending(token.slot_id) is False
+        collector.retire_slot(token.slot_id)
     finally:
         release_response.ready = True
         cancel_thread.join(timeout=2)
@@ -1807,7 +1840,7 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         collector.shutdown()
 
 
-def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
+def test_slot_cancel_observes_claimed_terminal_retirement_without_waiting(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     retire_started = threading.Event()
@@ -1846,22 +1879,18 @@ def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
     collector.drain_results({4: {"rows": 0, "bytes": 0, "item_bytes": 0}})
     assert retire_started.wait(timeout=1)
 
-    cancel_errors = []
-    cancel_thread = threading.Thread(target=lambda: _capture_thread_error(cancel_errors, collector.cancel_slot, 4))
     try:
-        cancel_thread.start()
-        time.sleep(0.05)
-        assert cancel_thread.is_alive()
+        started_at = time.monotonic()
+        collector.cancel_slot(4)
+        assert time.monotonic() - started_at < 0.1
+        assert collector.slot_has_pending(4)
 
         retirement.set_result(None)
-        cancel_thread.join(timeout=2)
-        assert cancel_thread.is_alive() is False
-        assert cancel_errors == []
-        assert collector.slot_has_pending(4) is False
+        _wait_until(lambda: not collector.slot_has_pending(4))
+        collector.retire_slot(4)
     finally:
         if not retirement.done():
             retirement.set_result(None)
-        cancel_thread.join(timeout=2)
         collector.shutdown()
 
 
@@ -2004,8 +2033,9 @@ def test_output_grant_transition_is_atomic_with_slot_cancellation():
         assert cancel_thread.is_alive() is False
         assert transition_errors == []
         assert cancel_errors == []
+        _wait_until(lambda: not collector.slot_has_pending(record.slot_id))
         assert len(driver.release_query_output_block_lease.calls) == 1
-        assert collector.slot_has_pending(record.slot_id) is False
+        collector.retire_slot(record.slot_id)
     finally:
         allow_result.set()
         transition_thread.join(timeout=2)
@@ -2768,6 +2798,7 @@ def test_many_cancellations_complete_on_the_cleanup_event_loop():
 
     try:
         collector.cancel_slot(18)
+        _wait_until(lambda: not collector.slot_has_pending(18))
 
         assert driver.cancel_query_task_lease_request.calls == []
         assert len(driver.release_query_task_lease_after_completion.calls) == len(generators)
@@ -2816,6 +2847,7 @@ def test_pending_output_control_futures_do_not_withhold_task_or_stream_cleanup()
     )
     try:
         collector.cancel_slot(72)
+        _wait_until(lambda: not collector.slot_has_pending(72))
 
         assert fake_ray.cancel_calls == [
             (generator, {"force": True, "recursive": True}),
@@ -2890,6 +2922,7 @@ def test_slot_cancellation_recursively_cancels_stream_and_releases_output_lease(
         )
         assert events[0][2] == "data"
         collector.cancel_slot(6)
+        _wait_until(lambda: not collector.slot_has_pending(6))
         assert fake_ray.cancel_calls
         assert fake_ray.cancel_calls[-1][1] == {"force": True, "recursive": True}
         assert len(driver.release_query_output_block_lease.calls) == 1

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -1652,11 +1652,86 @@ def test_terminal_cleanup_handoff_failure_replans_owned_stream(monkeypatch):
         collector.shutdown()
 
 
+def test_blocked_output_admission_submission_does_not_stall_healthy_stream():
+    fake_ray = _FakeRay()
+    blocked_driver = _Driver()
+    healthy_driver = _Driver()
+    output_submission_started = threading.Event()
+    release_output_submission = threading.Event()
+    healthy_block = _Ref("healthy-beside-output-admission", ready=False, is_block=True)
+    original_acquire_output = blocked_driver._acquire_output
+
+    def blocking_acquire_output(request):
+        output_submission_started.set()
+        if not release_output_submission.wait(timeout=5):
+            raise RuntimeError("test did not release blocked output admission")
+        return original_acquire_output(request)
+
+    blocked_driver.acquire_query_output_block_lease = _RemoteMethod(
+        blocking_acquire_output,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        24,
+        _source(
+            fake_ray,
+            blocked_driver,
+            request_id="blocked-output-admission",
+            submitter=lambda lease: _Generator(
+                [
+                    _Ref("blocked-output-block", is_block=True),
+                    _Ref(_metadata(lease)),
+                ],
+                completed=False,
+            ),
+        ),
+    )
+    collector.track_generator_ref(
+        3,
+        34,
+        _source(
+            fake_ray,
+            healthy_driver,
+            request_id="healthy-beside-output-admission",
+            submitter=lambda lease: _Generator(
+                [
+                    healthy_block,
+                    _Ref(_metadata(lease)),
+                ],
+                completed=False,
+            ),
+        ),
+    )
+    capacity = {
+        2: {"rows": 1, "bytes": 128, "item_bytes": 128},
+        3: {"rows": 1, "bytes": 128, "item_bytes": 128},
+    }
+    try:
+        collector.drain_results(capacity)
+        assert output_submission_started.wait(timeout=2)
+
+        fake_ray.make_ready(healthy_block)
+        healthy_events = _drain_until(
+            collector,
+            capacity,
+            predicate=lambda values: any(item[0] == 3 and item[2] == "data" for item in values),
+        )
+
+        assert [item[2] for item in healthy_events if item[0] == 3] == ["data"]
+        assert release_output_submission.is_set() is False
+    finally:
+        release_output_submission.set()
+        collector.cancel_slot(2)
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
 def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     retire_started = threading.Event()
-    retirement = Future()
+    release_retirement = threading.Event()
     healthy_block = _Ref("healthy-after-retire", ready=False, is_block=True)
     original_retire_operations = RayStreamAdapter.retire_operations
 
@@ -1668,9 +1743,8 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
 
         def block_retirement():
             retire_started.set()
-            if not retirement.done():
-                return retirement
-            retirement.result()
+            if not release_retirement.wait(timeout=5):
+                raise RuntimeError("test did not release blocked terminal retirement")
             return True
 
         return (
@@ -1726,10 +1800,9 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         )
 
         assert [item[2] for item in healthy_events] == ["data"]
-        assert retirement.done() is False
+        assert release_retirement.is_set() is False
     finally:
-        if not retirement.done():
-            retirement.set_result(None)
+        release_retirement.set()
         collector.cancel_slot(3)
         collector.shutdown()
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -358,6 +358,16 @@ def _wait_until(predicate, *, timeout=3.0):
     raise AssertionError("timed out waiting for collector state transition")
 
 
+def _wait_cleanup_tickets(tickets, *, timeout_message, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    for ticket in tickets:
+        if ticket.callback_owned_by_current_thread():
+            continue
+        if not ticket.wait(max(0.0, deadline - time.monotonic())):
+            raise AssertionError(timeout_message)
+    return tuple(error for ticket in tickets for error in ticket.errors)
+
+
 def _capture_thread_error(errors, operation, *args):
     try:
         operation(*args)
@@ -484,6 +494,7 @@ def test_initial_waiter_registration_failure_unpublishes_and_cleans_stream():
                 ),
             )
 
+        _wait_until(lambda: not collector.slot_has_pending(1))
         with collector._cv:
             assert collector._records == {}
             assert collector._cleanup_tickets == set()
@@ -496,7 +507,7 @@ def test_initial_waiter_registration_failure_unpublishes_and_cleans_stream():
         collector.shutdown()
 
 
-def test_invalid_submitted_stream_handoff_remains_owned_until_driver_ack():
+def test_invalid_submitted_stream_cleanup_does_not_block_healthy_stream():
     fake_ray = _FakeRay()
     driver = _Driver()
     handoff_ack = _Ref({"handed_off": True}, ready=False)
@@ -516,26 +527,50 @@ def test_invalid_submitted_stream_handoff_remains_owned_until_driver_ack():
     )
     try:
         track.start()
-        _wait_until(
-            lambda: bool(driver.handoff_query_task_lease_to_teardown.calls),
-        )
-
-        assert track.is_alive()
-        with collector._cv:
-            assert len(collector._cleanup_tickets) == 1
-
-        handoff_ack.ready = True
         track.join(timeout=1)
-
-        assert not track.is_alive()
+        assert track.is_alive() is False
         assert len(errors) == 1
         assert isinstance(errors[0], TypeError)
         assert "not an ObjectRefGenerator" in str(errors[0])
+
+        _wait_until(
+            lambda: bool(driver.handoff_query_task_lease_to_teardown.calls),
+        )
         with collector._cv:
-            assert collector._cleanup_tickets == set()
+            assert collector._cleanup_tickets
+        assert collector.slot_has_pending(1)
+
+        healthy_driver = _Driver()
+        collector.track_generator_ref(
+            2,
+            2,
+            _source(
+                fake_ray,
+                healthy_driver,
+                request_id="healthy-after-invalid-stream",
+                submitter=lambda lease: _Generator(
+                    [
+                        _Ref("healthy", is_block=True),
+                        _Ref(_metadata(lease)),
+                    ]
+                ),
+            ),
+        )
+        healthy_events = _drain_until(
+            collector,
+            {2: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(event[2] == "complete" for event in values),
+        )
+        assert [event[2] for event in healthy_events] == ["data", "complete"]
+        assert collector.slot_has_pending(1)
+
+        handoff_ack.ready = True
+        _wait_until(lambda: not collector.slot_has_pending(1))
         assert fake_ray.cancel_calls == [
             (invalid_stream, {"force": True, "recursive": True}),
         ]
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
     finally:
         handoff_ack.ready = True
         track.join(timeout=1)
@@ -808,7 +843,7 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
     try:
         assert len(tickets) == 2
         assert (
-            collector._wait_cleanup_tickets(
+            _wait_cleanup_tickets(
                 tickets,
                 timeout_message="cleanup tickets did not finish",
             )
@@ -838,7 +873,7 @@ def test_cleanup_ticket_preserves_incomplete_ownership_retry():
     try:
         assert len(tickets) == 1
         assert (
-            collector._wait_cleanup_tickets(
+            _wait_cleanup_tickets(
                 tickets,
                 timeout_message="cleanup ticket did not finish",
             )
@@ -871,7 +906,7 @@ def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
         store_error=False,
     )
     try:
-        errors = collector._wait_cleanup_tickets(
+        errors = _wait_cleanup_tickets(
             tickets,
             timeout_message="broken cleanup Future did not terminate",
         )
@@ -964,7 +999,7 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
     )
     try:
         assert (
-            collector._wait_cleanup_tickets(
+            _wait_cleanup_tickets(
                 tickets,
                 timeout_message="hung cleanup response was not retried",
             )
@@ -1028,7 +1063,7 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
     )
     try:
         assert (
-            collector._wait_cleanup_tickets(
+            _wait_cleanup_tickets(
                 tickets,
                 timeout_message="slow cleanup response was not acknowledged",
             )
@@ -2108,7 +2143,7 @@ def test_terminal_record_releases_completed_output_lease_with_exact_rpc_contract
             adapter.cancel_operations(),
             store_error=False,
         )
-        collector._wait_cleanup_tickets(
+        _wait_cleanup_tickets(
             tickets,
             timeout_message="adapter cleanup did not finish",
         )

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -26,6 +26,8 @@ from duckdb.execution.udf_stream_result_collector import (
 )
 from duckdb.execution.udf_task_admission import TaskAdmission
 
+_CLEANUP_SUBMISSION_SCOPE = "query:test-cleanup"
+
 
 class _Ref:
     def __init__(self, value=None, *, ready=True, is_block=False):
@@ -332,6 +334,7 @@ def _source(fake_ray, driver, *, request_id, submitter):
             request_id=request_id,
             retained_input_bytes=0,
             lease=lease,
+            submission_scope=f"test-stream:{request_id}",
         ),
         submitter=submitter,
         ray_module=fake_ray,
@@ -832,10 +835,12 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
         (
             RayStreamCleanupOperation(
                 fail_transiently,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
             ),
             RayStreamCleanupOperation(
                 lambda: order.append("peer"),
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
             ),
         ),
         store_error=False,
@@ -866,6 +871,7 @@ def test_cleanup_ticket_preserves_incomplete_ownership_retry():
     operations = (
         RayStreamCleanupOperation(
             transfer_owner,
+            submission_scope=_CLEANUP_SUBMISSION_SCOPE,
             retry_on_incomplete=True,
         ),
     )
@@ -900,6 +906,7 @@ def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
         (
             RayStreamCleanupOperation(
                 _BrokenFuture,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
             ),
         ),
@@ -939,7 +946,13 @@ def test_slot_retirement_reports_async_cancellation_ticket_failure():
 
     collector = AsyncResultCollector(ray_module=_FakeRay())
     collector._submit_cleanup_operations(
-        (RayStreamCleanupOperation(broken_cleanup, retry_on_error=True),),
+        (
+            RayStreamCleanupOperation(
+                broken_cleanup,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
         store_error=False,
         slot_ids=(7,),
     )
@@ -991,6 +1004,7 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         (
             RayStreamCleanupOperation(
                 transfer_owner,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
                 abandon_wait=abandon_wait,
             ),
@@ -1055,6 +1069,7 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
         (
             RayStreamCleanupOperation(
                 transfer_owner,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
                 abandon_wait=abandon_wait,
             ),
@@ -1183,6 +1198,7 @@ def test_data_capacity_does_not_count_interleaved_control_events():
         lease_id="strict-consumer-lease",
         query_id="q1",
         driver=object(),
+        submission_scope="test-output:strict-consumer",
         slot_id=1,
         submit_id=11,
         size_bytes=64,
@@ -1273,6 +1289,7 @@ def test_output_lease_control_retries_until_driver_acknowledges_ownership(operat
         lease_id="output-lease-retry",
         query_id="q1",
         driver=driver,
+        submission_scope="test-output:retry",
         slot_id=2,
         submit_id=20,
         size_bytes=64,
@@ -1307,6 +1324,7 @@ def test_output_control_waits_on_one_inflight_driver_response():
         lease_id="output-lease-delayed-ack",
         query_id="q1",
         driver=driver,
+        submission_scope="test-output:delayed-ack",
         slot_id=2,
         submit_id=21,
         size_bytes=64,
@@ -1341,6 +1359,7 @@ def test_output_release_ticket_handoff_is_atomic_with_shutdown(monkeypatch):
         lease_id="output-lease-shutdown-race",
         query_id="q1",
         driver=driver,
+        submission_scope="test-output:shutdown-race",
         slot_id=2,
         submit_id=22,
         size_bytes=64,
@@ -1409,6 +1428,7 @@ def test_slot_cancel_reuses_an_already_claimed_output_release_ticket():
         lease_id="output-lease-cancel-release-race",
         query_id="q1",
         driver=driver,
+        submission_scope="test-output:cancel-release-race",
         slot_id=2,
         submit_id=23,
         size_bytes=64,
@@ -1592,6 +1612,7 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         return (
             RayStreamCleanupOperation(
                 block_retirement,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
             ),
             *operations,
         )
@@ -1722,20 +1743,23 @@ def test_terminal_cleanup_handoff_failure_replans_owned_stream(monkeypatch):
 
 def test_blocked_output_admission_submission_does_not_stall_healthy_stream():
     fake_ray = _FakeRay()
-    blocked_driver = _Driver()
-    healthy_driver = _Driver()
+    driver = _Driver()
     output_submission_started = threading.Event()
     release_output_submission = threading.Event()
     healthy_block = _Ref("healthy-beside-output-admission", ready=False, is_block=True)
-    original_acquire_output = blocked_driver._acquire_output
+    original_acquire_output = driver._acquire_output
+    first_submission = True
 
     def blocking_acquire_output(request):
-        output_submission_started.set()
-        if not release_output_submission.wait(timeout=5):
-            raise RuntimeError("test did not release blocked output admission")
+        nonlocal first_submission
+        if first_submission:
+            first_submission = False
+            output_submission_started.set()
+            if not release_output_submission.wait(timeout=5):
+                raise RuntimeError("test did not release blocked output admission")
         return original_acquire_output(request)
 
-    blocked_driver.acquire_query_output_block_lease = _RemoteMethod(
+    driver.acquire_query_output_block_lease = _RemoteMethod(
         blocking_acquire_output,
     )
     collector = AsyncResultCollector(ray_module=fake_ray)
@@ -1744,7 +1768,7 @@ def test_blocked_output_admission_submission_does_not_stall_healthy_stream():
         24,
         _source(
             fake_ray,
-            blocked_driver,
+            driver,
             request_id="blocked-output-admission",
             submitter=lambda lease: _Generator(
                 [
@@ -1760,7 +1784,7 @@ def test_blocked_output_admission_submission_does_not_stall_healthy_stream():
         34,
         _source(
             fake_ray,
-            healthy_driver,
+            driver,
             request_id="healthy-beside-output-admission",
             submitter=lambda lease: _Generator(
                 [
@@ -1818,6 +1842,7 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         return (
             RayStreamCleanupOperation(
                 block_retirement,
+                submission_scope=adapter.submission_scope,
             ),
             *operations,
         )
@@ -1895,6 +1920,7 @@ def test_slot_cancel_observes_claimed_terminal_retirement_without_waiting(monkey
         return (
             RayStreamCleanupOperation(
                 block_retirement,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
             ),
             *operations,
         )
@@ -2856,6 +2882,7 @@ def test_pending_output_control_futures_do_not_withhold_task_or_stream_cleanup()
             lease_id=f"output-lease-blocked-{index}",
             query_id="q1",
             driver=driver,
+            submission_scope=f"test-output:blocked:{index}",
             slot_id=71,
             submit_id=index,
             size_bytes=64,

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -273,7 +273,6 @@ class _Driver:
         self.next_task = 0
         self.next_output = 0
         self.acquire_query_task_lease = _RemoteMethod(self._acquire_task)
-        self.mark_query_task_lease_submitted = _RemoteMethod(lambda *_args: {"submitted": True})
         self.release_query_task_lease = _RemoteMethod(lambda *_args: {"released": True})
         self.release_query_task_lease_after_completion = _RemoteMethod(lambda *_args: {"scheduled": True})
         self.handoff_query_task_lease_to_teardown = _RemoteMethod(lambda *_args: {"handed_off": True})
@@ -501,7 +500,7 @@ def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
     collector.shutdown()
 
 
-def test_registration_is_not_schedulable_until_track_accepts_it(monkeypatch):
+def test_registration_is_not_visible_until_track_commits_it(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     collector = AsyncResultCollector(ray_module=fake_ray)
@@ -549,8 +548,7 @@ def test_registration_is_not_schedulable_until_track_accepts_it(monkeypatch):
         assert registration_paused.wait(timeout=1)
         time.sleep(0.05)
         with collector._cv:
-            record = collector._records[(1, 2)]
-            assert record.registration_accepted is False
+            assert (1, 2) not in collector._records
         assert generators[0].read_count == 0
         assert collector._ready_by_slot.get(1) is None
 
@@ -567,6 +565,38 @@ def test_registration_is_not_schedulable_until_track_accepts_it(monkeypatch):
     finally:
         allow_registration.set()
         registration.join(timeout=2)
+        collector.shutdown()
+
+
+def test_discarded_submitted_stream_enters_terminal_cleanup_ledger():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generator = _Generator([], completed=False)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    try:
+        collector.discard_generator_ref(
+            _source(
+                fake_ray,
+                driver,
+                request_id="stale-submission-discard",
+                submitter=lambda _lease: generator,
+            )
+        )
+
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and generator.worker is not None:
+            time.sleep(0.005)
+
+        with collector._cv:
+            assert collector._records == {}
+            assert collector._cleanup_tickets == set()
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
+        assert fake_ray.cancel_calls == [
+            (generator, {"force": True, "recursive": True}),
+        ]
+        assert generator.deleted_streams == [generator.completion_ref]
+        assert generator.worker is None
+    finally:
         collector.shutdown()
 
 
@@ -617,7 +647,7 @@ def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
         if attempts < 6:
             raise RuntimeError("planned transient cleanup failure")
 
-    group = collector._submit_cleanup_operations(
+    tickets = collector._submit_cleanup_operations(
         (
             RayStreamCleanupOperation(
                 RAY_STREAM_CLEANUP_CONTROL,
@@ -632,9 +662,14 @@ def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
         store_error=False,
     )
     try:
-        assert group is not None
-        assert group.wait(timeout=1)
-        assert group.errors == ()
+        assert len(tickets) == 2
+        assert (
+            collector._wait_cleanup_tickets(
+                tickets,
+                timeout_message="cleanup tickets did not finish",
+            )
+            == ()
+        )
         assert order == ["retry-1", "peer", "retry-2", "retry-3", "retry-4", "retry-5", "retry-6"]
     finally:
         collector.shutdown()
@@ -658,11 +693,16 @@ def test_scheduler_fence_preserves_incomplete_ownership_retry():
             ),
         )
     )
-    group = collector._submit_cleanup_operations(operations, store_error=False)
+    tickets = collector._submit_cleanup_operations(operations, store_error=False)
     try:
-        assert group is not None
-        assert group.wait(timeout=1)
-        assert group.errors == ()
+        assert len(tickets) == 1
+        assert (
+            collector._wait_cleanup_tickets(
+                tickets,
+                timeout_message="cleanup ticket did not finish",
+            )
+            == ()
+        )
         assert attempts == 2
     finally:
         collector.shutdown()
@@ -1152,7 +1192,7 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         # blocked, but the record cannot complete until the whole plan settles.
         assert [item[2] for item in events] == ["data"]
         assert collector._records
-        assert collector._cleanup_groups
+        assert collector._cleanup_tickets
         generator = generator_holder["generator"]
         assert source_ref() is None
         assert generator.deleted_streams == [generator.completion_ref]
@@ -2144,10 +2184,8 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         ),
     )
     try:
-        deadline = time.monotonic() + 2.0
-        while not driver.mark_query_task_lease_submitted.calls and time.monotonic() < deadline:
-            time.sleep(0.005)
-        assert driver.mark_query_task_lease_submitted.calls
+        with collector._cv:
+            assert len(collector._records) == 2
         wakeup.clear()
 
         collector.drain_results({8: {"rows": 1, "bytes": 128, "item_bytes": 128}})

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -11,10 +11,8 @@ from types import SimpleNamespace
 
 import pytest
 
-import duckdb.execution.ray_stream_adapter as stream_adapter_module
 import duckdb.execution.udf_stream_result_collector as collector_module
 from duckdb.execution.ray_stream_adapter import (
-    RAY_STREAM_CLEANUP_CONTROL,
     RayStreamAdapter,
     RayStreamCleanupOperation,
     TaskLeaseObjectRefGenerator,
@@ -75,6 +73,11 @@ class _Ref:
 
         future.result = tracked_result
         return future
+
+
+class _FailingFutureRef(_Ref):
+    def future(self):
+        raise RuntimeError("planned Future registration failure")
 
 
 class _Generator:
@@ -177,39 +180,6 @@ class _FakeRay:
             self._cv.notify_all()
 
 
-class _BlockingCancelRay(_FakeRay):
-    def __init__(self):
-        super().__init__()
-        self.cancel_started = threading.Event()
-        self.allow_cancel = threading.Event()
-        self.cancel_started_count = 0
-        self.cancel_started_lock = threading.Lock()
-
-    def cancel(self, ref, **kwargs):
-        with self.cancel_started_lock:
-            self.cancel_started_count += 1
-        self.cancel_started.set()
-        self.allow_cancel.wait(timeout=2.0)
-        super().cancel(ref, **kwargs)
-
-
-class _BlockingWaitRay(_FakeRay):
-    def __init__(self):
-        super().__init__()
-        self.wait_started = threading.Event()
-        self.allow_wait = threading.Event()
-
-    def wait(self, waitables, *, num_returns, timeout, fetch_local):
-        self.wait_started.set()
-        assert self.allow_wait.wait(timeout=2)
-        return super().wait(
-            waitables,
-            num_returns=num_returns,
-            timeout=timeout,
-            fetch_local=fetch_local,
-        )
-
-
 class _FailingWaitRay(_FakeRay):
     def wait(self, waitables, *, num_returns, timeout, fetch_local):
         del waitables, num_returns, timeout, fetch_local
@@ -244,20 +214,6 @@ class _RemoteMethod:
         return _Ref(self.fn(*args, **kwargs))
 
 
-class _BlockingRemoteMethod(_RemoteMethod):
-    def __init__(self, fn):
-        super().__init__(fn)
-        self.started = threading.Event()
-        self.release = threading.Event()
-
-    def remote(self, *args, **kwargs):
-        self.calls.append((args, kwargs))
-        self.started.set()
-        if not self.release.wait(timeout=2.0):
-            raise TimeoutError("timed out waiting to release blocked remote call")
-        return _Ref(self.fn(*args, **kwargs))
-
-
 class _DelayedAckRemoteMethod:
     def __init__(self, response_ref):
         self.response_ref = response_ref
@@ -266,6 +222,12 @@ class _DelayedAckRemoteMethod:
     def remote(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return self.response_ref
+
+
+class _FailingFutureRemoteMethod(_RemoteMethod):
+    def remote(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return _FailingFutureRef(self.fn(*args, **kwargs))
 
 
 class _Driver:
@@ -402,40 +364,20 @@ def test_collector_requires_task_lease_stream_and_has_no_raw_generator_fallback(
         collector.shutdown()
 
 
-def test_event_loop_start_failure_releases_the_registered_stream(monkeypatch):
+def test_event_loop_start_failure_prevents_submitted_stream_ownership(monkeypatch):
     fake_ray = _FakeRay()
-    driver = _Driver()
-    generators = []
+    original_start = threading.Thread.start
 
-    def submitter(_lease):
-        generator = _Generator([], completed=False)
-        generators.append(generator)
-        return generator
+    def fail_start(thread):
+        if thread.name == "udf-ray-stream-multiplexer":
+            raise RuntimeError("planned thread start failure")
+        return original_start(thread)
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
-
-    def fail_start():
-        raise RuntimeError("planned thread start failure")
-
-    monkeypatch.setattr(collector._thread, "start", fail_start)
+    monkeypatch.setattr(threading.Thread, "start", fail_start)
     with pytest.raises(RuntimeError, match="planned thread start failure"):
-        collector.track_generator_ref(
-            1,
-            2,
-            _source(
-                fake_ray,
-                driver,
-                request_id="start-failure",
-                submitter=submitter,
-            ),
-        )
+        AsyncResultCollector(ray_module=fake_ray)
 
-    assert collector._records == {}
-    assert len(fake_ray.cancel_calls) == 1
-    assert generators[0].deleted_streams == [generators[0].completion_ref]
-    with pytest.raises(RuntimeError, match="planned thread start failure"):
-        collector.drain_results({})
-    collector.shutdown()
+    assert fake_ray.cancel_calls == []
 
 
 def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
@@ -498,6 +440,152 @@ def test_scheduler_failure_rejection_cancels_the_unpublished_submitted_stream():
         for args, kwargs in driver.release_query_task_lease_after_completion.calls
     )
     collector.shutdown()
+
+
+def test_initial_waiter_registration_failure_unpublishes_and_cleans_stream():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generator = _Generator([], completed=False)
+    generator.completion_ref = _FailingFutureRef(None, ready=False)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    try:
+        with pytest.raises(RuntimeError, match="planned Future registration failure"):
+            collector.track_generator_ref(
+                1,
+                1,
+                _source(
+                    fake_ray,
+                    driver,
+                    request_id="initial-waiter-failure",
+                    submitter=lambda _lease: generator,
+                ),
+            )
+
+        with collector._cv:
+            assert collector._records == {}
+            assert collector._cleanup_tickets == set()
+        assert fake_ray.cancel_calls == [
+            (generator, {"force": True, "recursive": True}),
+        ]
+        assert generator.deleted_streams == [generator.completion_ref]
+        assert len(driver.release_query_task_lease_after_completion.calls) == 1
+    finally:
+        collector.shutdown()
+
+
+def test_invalid_submitted_stream_handoff_remains_owned_until_driver_ack():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    handoff_ack = _Ref({"handed_off": True}, ready=False)
+    driver.handoff_query_task_lease_to_teardown = _DelayedAckRemoteMethod(handoff_ack)
+    invalid_stream = SimpleNamespace()
+    source = _source(
+        fake_ray,
+        driver,
+        request_id="invalid-stream-delayed-handoff",
+        submitter=lambda _lease: invalid_stream,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    errors = []
+    track = threading.Thread(
+        target=_capture_thread_error,
+        args=(errors, collector.track_generator_ref, 1, 1, source),
+    )
+    try:
+        track.start()
+        _wait_until(
+            lambda: bool(driver.handoff_query_task_lease_to_teardown.calls),
+        )
+
+        assert track.is_alive()
+        with collector._cv:
+            assert len(collector._cleanup_tickets) == 1
+
+        handoff_ack.ready = True
+        track.join(timeout=1)
+
+        assert not track.is_alive()
+        assert len(errors) == 1
+        assert isinstance(errors[0], TypeError)
+        assert "not an ObjectRefGenerator" in str(errors[0])
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
+        assert fake_ray.cancel_calls == [
+            (invalid_stream, {"force": True, "recursive": True}),
+        ]
+    finally:
+        handoff_ack.ready = True
+        track.join(timeout=1)
+        collector.shutdown()
+
+
+def test_midstream_waiter_registration_failure_is_isolated_to_its_stream():
+    fake_ray = _FakeRay()
+    failed_driver = _Driver()
+    failed_driver.acquire_query_output_block_lease = _FailingFutureRemoteMethod(
+        failed_driver._acquire_output,
+    )
+    healthy_driver = _Driver()
+    failed_generator = None
+
+    def submit_failed(lease):
+        nonlocal failed_generator
+        failed_generator = _Generator(
+            [_Ref("failed-block", is_block=True), _Ref(_metadata(lease))],
+        )
+        return failed_generator
+
+    def submit_healthy(lease):
+        return _Generator(
+            [_Ref("healthy-block", is_block=True), _Ref(_metadata(lease))],
+        )
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        1,
+        1,
+        _source(
+            fake_ray,
+            failed_driver,
+            request_id="midstream-waiter-failure",
+            submitter=submit_failed,
+        ),
+    )
+    collector.track_generator_ref(
+        2,
+        2,
+        _source(
+            fake_ray,
+            healthy_driver,
+            request_id="healthy-beside-waiter-failure",
+            submitter=submit_healthy,
+        ),
+    )
+    try:
+        events = _drain_until(
+            collector,
+            {
+                1: {"rows": 1, "bytes": 128, "item_bytes": 128},
+                2: {"rows": 1, "bytes": 128, "item_bytes": 128},
+            },
+            predicate=lambda values: (
+                any(item[0] == 1 and item[2] == "error" for item in values)
+                and any(item[0] == 2 and item[2] == "complete" for item in values)
+            ),
+        )
+
+        assert any(
+            item[0] == 1 and item[2] == "error" and "planned Future registration failure" in item[3] for item in events
+        )
+        assert [item[2] for item in events if item[0] == 2] == ["data", "complete"]
+        assert failed_generator is not None
+        assert failed_generator.deleted_streams == [failed_generator.completion_ref]
+        with collector._cv:
+            assert collector._thread_error is None
+    finally:
+        collector.cancel_slot(1)
+        collector.cancel_slot(2)
+        collector.shutdown()
 
 
 def test_registration_is_not_visible_until_track_commits_it(monkeypatch):
@@ -632,10 +720,7 @@ def test_failure_wakeup_can_reenter_shutdown_after_cleanup_handoff():
     collector.shutdown()
 
 
-def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
-    monkeypatch,
-):
-    monkeypatch.setenv("VANE_UDF_STREAM_CONTROL_CLEANUP_WORKERS", "1")
+def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = 0
     order = []
@@ -650,12 +735,10 @@ def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
     tickets = collector._submit_cleanup_operations(
         (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 fail_transiently,
                 retry_on_error=True,
             ),
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 lambda: order.append("peer"),
             ),
         ),
@@ -675,7 +758,7 @@ def test_bounded_cleanup_lane_retries_transient_failure_without_starving_peer(
         collector.shutdown()
 
 
-def test_scheduler_fence_preserves_incomplete_ownership_retry():
+def test_cleanup_ticket_preserves_incomplete_ownership_retry():
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = 0
 
@@ -684,14 +767,11 @@ def test_scheduler_fence_preserves_incomplete_ownership_retry():
         attempts += 1
         return attempts >= 2
 
-    operations = collector._fence_cleanup_operations(
-        (
-            RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
-                transfer_owner,
-                retry_on_incomplete=True,
-            ),
-        )
+    operations = (
+        RayStreamCleanupOperation(
+            transfer_owner,
+            retry_on_incomplete=True,
+        ),
     )
     tickets = collector._submit_cleanup_operations(operations, store_error=False)
     try:
@@ -704,6 +784,40 @@ def test_scheduler_fence_preserves_incomplete_ownership_retry():
             == ()
         )
         assert attempts == 2
+    finally:
+        collector.shutdown()
+
+
+def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
+    class _BrokenFuture:
+        def add_done_callback(self, _callback):
+            raise RuntimeError("planned cleanup callback registration failure")
+
+        def done(self):
+            return False
+
+        def result(self):
+            raise AssertionError("broken Future must never be resolved")
+
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                _BrokenFuture,
+                retry_on_error=True,
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        errors = collector._wait_cleanup_tickets(
+            tickets,
+            timeout_message="broken cleanup Future did not terminate",
+        )
+        assert len(errors) == 1
+        assert "planned cleanup callback registration failure" in str(errors[0])
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
     finally:
         collector.shutdown()
 
@@ -928,12 +1042,7 @@ def test_output_lease_control_retries_until_driver_acknowledges_ownership(operat
         collector.shutdown()
 
 
-def test_output_control_timeout_reuses_the_inflight_driver_response(monkeypatch):
-    monkeypatch.setattr(
-        stream_adapter_module,
-        "_TASK_LEASE_CONTROL_ACK_TIMEOUT_S",
-        0.01,
-    )
+def test_output_control_waits_on_one_inflight_driver_response():
     fake_ray = _FakeRay()
     driver = _Driver()
     response_ref = _Ref({"released": True}, ready=False)
@@ -954,7 +1063,7 @@ def test_output_control_timeout_reuses_the_inflight_driver_response(monkeypatch)
     try:
         assert collector.release_output_block_lease(*key) is True
         _wait_until(lambda: bool(driver.release_query_output_block_lease.calls))
-        time.sleep(0.08)
+        time.sleep(0.05)
 
         assert len(driver.release_query_output_block_lease.calls) == 1
         with collector._cv:
@@ -966,6 +1075,121 @@ def test_output_control_timeout_reuses_the_inflight_driver_response(monkeypatch)
         assert len(driver.release_query_output_block_lease.calls) == 1
     finally:
         response_ref.ready = True
+        collector.shutdown()
+
+
+def test_output_release_ticket_handoff_is_atomic_with_shutdown(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    token = _OutputLeaseToken(
+        request_id="output-request:shutdown-race",
+        lease_id="output-lease-shutdown-race",
+        query_id="q1",
+        driver=driver,
+        slot_id=2,
+        submit_id=22,
+        size_bytes=64,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    key = (token.request_id, token.lease_id)
+    with collector._cv:
+        collector._active_output_leases[key] = token
+
+    handoff_started = threading.Event()
+    allow_handoff = threading.Event()
+    original_submit = collector._submit_cleanup_operations
+
+    def blocking_submit(*args, **kwargs):
+        handoff_started.set()
+        assert allow_handoff.wait(timeout=2)
+        return original_submit(*args, **kwargs)
+
+    monkeypatch.setattr(collector, "_submit_cleanup_operations", blocking_submit)
+    release_errors = []
+    shutdown_errors = []
+    release_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            release_errors,
+            collector.release_output_block_lease,
+            *key,
+        )
+    )
+    shutdown_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            shutdown_errors,
+            collector.shutdown,
+        )
+    )
+    try:
+        release_thread.start()
+        assert handoff_started.wait(timeout=1)
+        shutdown_thread.start()
+        time.sleep(0.05)
+        assert shutdown_thread.is_alive()
+
+        allow_handoff.set()
+        release_thread.join(timeout=2)
+        shutdown_thread.join(timeout=2)
+
+        assert release_thread.is_alive() is False
+        assert shutdown_thread.is_alive() is False
+        assert release_errors == []
+        assert shutdown_errors == []
+        assert len(driver.release_query_output_block_lease.calls) == 1
+        assert collector._thread.is_alive() is False
+    finally:
+        allow_handoff.set()
+        release_thread.join(timeout=2)
+        shutdown_thread.join(timeout=2)
+        collector.shutdown()
+
+
+def test_slot_cancel_reuses_an_already_claimed_output_release_ticket():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    release_response = _Ref({"released": True}, ready=False)
+    driver.release_query_output_block_lease = _DelayedAckRemoteMethod(release_response)
+    token = _OutputLeaseToken(
+        request_id="output-request:cancel-release-race",
+        lease_id="output-lease-cancel-release-race",
+        query_id="q1",
+        driver=driver,
+        slot_id=2,
+        submit_id=23,
+        size_bytes=64,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    key = (token.request_id, token.lease_id)
+    with collector._cv:
+        collector._active_output_leases[key] = token
+
+    cancel_errors = []
+    cancel_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            cancel_errors,
+            collector.cancel_slot,
+            token.slot_id,
+        )
+    )
+    try:
+        assert collector.release_output_block_lease(*key) is True
+        _wait_until(lambda: len(driver.release_query_output_block_lease.calls) == 1)
+
+        cancel_thread.start()
+        time.sleep(0.05)
+        assert cancel_thread.is_alive()
+        assert len(driver.release_query_output_block_lease.calls) == 1
+
+        release_response.ready = True
+        cancel_thread.join(timeout=2)
+
+        assert cancel_thread.is_alive() is False
+        assert cancel_errors == []
+        assert len(driver.release_query_output_block_lease.calls) == 1
+        assert collector.slot_has_pending(token.slot_id) is False
+    finally:
+        release_response.ready = True
+        cancel_thread.join(timeout=2)
         collector.shutdown()
 
 
@@ -1027,48 +1251,6 @@ def test_metadata_transition_is_atomic_with_concurrent_capacity_refresh(
         assert [item[2] for item in events] == ["data", "complete"]
     finally:
         allow_transition.set()
-        collector.shutdown()
-
-
-def test_slot_cancel_fences_output_lease_acquire_before_ref_publication():
-    fake_ray = _FakeRay()
-    driver = _Driver()
-    acquire = _BlockingRemoteMethod(driver._acquire_output)
-    driver.acquire_query_output_block_lease = acquire
-
-    def submitter(lease):
-        return _Generator(
-            [_Ref("block", is_block=True), _Ref(_metadata(lease))],
-            completed=False,
-        )
-
-    collector = AsyncResultCollector(ray_module=fake_ray)
-    collector.track_generator_ref(
-        2,
-        24,
-        _source(
-            fake_ray,
-            driver,
-            request_id="cancel-during-output-acquire",
-            submitter=submitter,
-        ),
-    )
-    try:
-        collector.drain_results({2: {"rows": 1, "bytes": 128, "item_bytes": 128}})
-        assert acquire.started.wait(timeout=2.0)
-
-        collector.cancel_slot(2)
-        acquire.release.set()
-
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and not driver.cancel_query_output_block_lease_request.calls:
-            time.sleep(0.005)
-
-        assert len(driver.cancel_query_output_block_lease_request.calls) == 1
-        assert driver.cancel_query_output_block_lease_request.calls[0] == acquire.calls[0]
-        assert collector.slot_has_pending(2) is False
-    finally:
-        acquire.release.set()
         collector.shutdown()
 
 
@@ -1139,7 +1321,7 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
     driver = _Driver()
     generator_holder = {}
     retire_started = threading.Event()
-    allow_retire = threading.Event()
+    retirement = Future()
     original_retire_operations = RayStreamAdapter.retire_operations
 
     def blocking_retire_operations(adapter):
@@ -1147,11 +1329,13 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
 
         def block_retirement():
             retire_started.set()
-            allow_retire.wait()
+            if not retirement.done():
+                return retirement
+            retirement.result()
+            return True
 
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 block_retirement,
             ),
             *operations,
@@ -1187,9 +1371,9 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         assert retire_started.is_set()
         events.extend(collector.drain_results(capacity))
 
-        # Completion is the observable retirement boundary. Independent lanes
-        # may already delete the local stream while task-accounting cleanup is
-        # blocked, but the record cannot complete until the whole plan settles.
+        # Completion is the observable retirement boundary. Independent
+        # tickets may finish while one control Future remains pending, but the
+        # record cannot complete until the whole plan settles.
         assert [item[2] for item in events] == ["data"]
         assert collector._records
         assert collector._cleanup_tickets
@@ -1202,7 +1386,7 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         del data
         del events
 
-        allow_retire.set()
+        retirement.set_result(None)
         events = _drain_until(
             collector,
             capacity,
@@ -1215,7 +1399,8 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         assert source.lease is None
         assert generator.deleted_streams == [generator.completion_ref]
     finally:
-        allow_retire.set()
+        if not retirement.done():
+            retirement.set_result(None)
         collector.shutdown()
 
 
@@ -1223,7 +1408,7 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     retire_started = threading.Event()
-    allow_retire = threading.Event()
+    retirement = Future()
     healthy_block = _Ref("healthy-after-retire", ready=False, is_block=True)
     original_retire_operations = RayStreamAdapter.retire_operations
 
@@ -1235,11 +1420,13 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
 
         def block_retirement():
             retire_started.set()
-            allow_retire.wait()
+            if not retirement.done():
+                return retirement
+            retirement.result()
+            return True
 
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 block_retirement,
             ),
             *operations,
@@ -1291,9 +1478,10 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         )
 
         assert [item[2] for item in healthy_events] == ["data"]
-        assert allow_retire.is_set() is False
+        assert retirement.done() is False
     finally:
-        allow_retire.set()
+        if not retirement.done():
+            retirement.set_result(None)
         collector.cancel_slot(3)
         collector.shutdown()
 
@@ -1302,7 +1490,7 @@ def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     retire_started = threading.Event()
-    allow_retire = threading.Event()
+    retirement = Future()
     original_retire_operations = RayStreamAdapter.retire_operations
 
     def blocking_retire_operations(adapter):
@@ -1310,11 +1498,13 @@ def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
 
         def block_retirement():
             retire_started.set()
-            assert allow_retire.wait(timeout=2)
+            if not retirement.done():
+                return retirement
+            retirement.result()
+            return True
 
         return (
             RayStreamCleanupOperation(
-                RAY_STREAM_CLEANUP_CONTROL,
                 block_retirement,
             ),
             *operations,
@@ -1342,13 +1532,14 @@ def test_slot_cancel_waits_for_already_claimed_terminal_retirement(monkeypatch):
         time.sleep(0.05)
         assert cancel_thread.is_alive()
 
-        allow_retire.set()
+        retirement.set_result(None)
         cancel_thread.join(timeout=2)
         assert cancel_thread.is_alive() is False
         assert cancel_errors == []
         assert collector.slot_has_pending(4) is False
     finally:
-        allow_retire.set()
+        if not retirement.done():
+            retirement.set_result(None)
         cancel_thread.join(timeout=2)
         collector.shutdown()
 
@@ -1412,7 +1603,96 @@ def test_completion_ready_before_final_metadata_does_not_fail_valid_pair():
         collector.shutdown()
 
 
-def test_stale_record_releases_completed_output_lease_with_exact_rpc_contract():
+def test_output_grant_transition_is_atomic_with_slot_cancellation():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        19,
+        _source(
+            fake_ray,
+            driver,
+            request_id="output-grant-cancel-race",
+            submitter=lambda _lease: _Generator([], completed=False),
+        ),
+    )
+    with collector._cv:
+        record = collector._records[(2, 19)]
+        metadata = _metadata(record.adapter.task_lease)
+        request = {
+            "request_id": f"output-request:{metadata['block_id']}",
+            "query_id": metadata["query_id"],
+            "producer_stage_id": metadata["producer_stage_id"],
+            "task_lease_id": metadata["task_lease_id"],
+            "attempt_id": metadata["attempt_id"],
+            "block_id": metadata["block_id"],
+            "size_bytes": metadata["size_bytes"],
+        }
+        record.phase = "output_lease"
+        record.block_ref = _Ref("large-block", is_block=True)
+        record.metadata = metadata
+        record.output_request_id = request["request_id"]
+        record.output_request = request
+
+    grant = driver._acquire_output(request)
+    result_started = threading.Event()
+    allow_result = threading.Event()
+
+    class _BlockingGrantFuture:
+        def result(self):
+            result_started.set()
+            assert allow_result.wait(timeout=2)
+            return grant
+
+    grant_future = _BlockingGrantFuture()
+    with collector._cv:
+        record.wait_kind = "output_lease"
+        record.wait_future = grant_future
+
+    transition_errors = []
+    cancel_errors = []
+    transition_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            transition_errors,
+            collector._complete_record_wait,
+            record,
+            "output_lease",
+            grant_future,
+        )
+    )
+    cancel_thread = threading.Thread(
+        target=lambda: _capture_thread_error(
+            cancel_errors,
+            collector.cancel_slot,
+            record.slot_id,
+        )
+    )
+    try:
+        transition_thread.start()
+        assert result_started.wait(timeout=1)
+        cancel_thread.start()
+        time.sleep(0.05)
+        assert cancel_thread.is_alive()
+
+        allow_result.set()
+        transition_thread.join(timeout=2)
+        cancel_thread.join(timeout=2)
+
+        assert transition_thread.is_alive() is False
+        assert cancel_thread.is_alive() is False
+        assert transition_errors == []
+        assert cancel_errors == []
+        assert len(driver.release_query_output_block_lease.calls) == 1
+        assert collector.slot_has_pending(record.slot_id) is False
+    finally:
+        allow_result.set()
+        transition_thread.join(timeout=2)
+        cancel_thread.join(timeout=2)
+        collector.shutdown()
+
+
+def test_terminal_record_releases_completed_output_lease_with_exact_rpc_contract():
     fake_ray = _FakeRay()
     driver = _Driver()
     source = _source(
@@ -1445,6 +1725,10 @@ def test_stale_record_releases_completed_output_lease_with_exact_rpc_contract():
         output_lease_ref=_Ref(driver._acquire_output(output_request)),
     )
     collector = AsyncResultCollector(ray_module=fake_ray)
+    record.registered = True
+    record.terminal = True
+    with collector._cv:
+        collector._records[(record.slot_id, record.submit_id)] = record
     original_release = driver.release_query_output_block_lease
 
     class _LockCheckingRelease:
@@ -1467,8 +1751,17 @@ def test_stale_record_releases_completed_output_lease_with_exact_rpc_contract():
             ((record.output_request_id, "output-lease-1", metadata["query_id"]), {}),
         ]
     finally:
+        with collector._cv:
+            collector._records.pop((record.slot_id, record.submit_id), None)
+        tickets = collector._submit_cleanup_operations(
+            adapter.cancel_operations(),
+            store_error=False,
+        )
+        collector._wait_cleanup_tickets(
+            tickets,
+            timeout_message="adapter cleanup did not finish",
+        )
         collector.shutdown()
-        adapter.cancel()
 
 
 def test_one_slow_stream_cannot_block_a_ready_stream():
@@ -1727,91 +2020,6 @@ def test_local_eligibility_change_interrupts_idle_readiness_backoff():
     finally:
         collector.cancel_slot(3)
         collector.shutdown()
-
-
-def test_slot_cancel_fences_the_active_zero_time_readiness_probe():
-    fake_ray = _BlockingWaitRay()
-    driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
-    collector.track_generator_ref(
-        3,
-        40,
-        _source(
-            fake_ray,
-            driver,
-            request_id="cancel-readiness-probe",
-            submitter=lambda lease: _Generator(
-                [_Ref("slow", ready=False, is_block=True), _Ref(_metadata(lease))],
-                completed=False,
-            ),
-        ),
-    )
-    assert collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}}) == []
-    assert fake_ray.wait_started.wait(timeout=1)
-    errors = []
-    cancel_thread = threading.Thread(
-        target=lambda: _capture_thread_error(errors, collector.cancel_slot, 3),
-    )
-    cancel_thread.start()
-    try:
-        time.sleep(0.05)
-        assert cancel_thread.is_alive()
-        assert fake_ray.cancel_calls == []
-
-        fake_ray.allow_wait.set()
-        cancel_thread.join(timeout=1)
-        assert cancel_thread.is_alive() is False
-        assert errors == []
-        assert len(fake_ray.cancel_calls) == 1
-    finally:
-        fake_ray.allow_wait.set()
-        cancel_thread.join(timeout=1)
-        collector.shutdown()
-
-
-def test_shutdown_retains_cleanup_after_a_stuck_readiness_probe(monkeypatch):
-    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
-    fake_ray = _BlockingWaitRay()
-    driver = _Driver()
-    generators = []
-
-    def submitter(lease):
-        generator = _Generator(
-            [_Ref("slow", ready=False, is_block=True), _Ref(_metadata(lease))],
-            completed=False,
-        )
-        generators.append(generator)
-        return generator
-
-    collector = AsyncResultCollector(ray_module=fake_ray)
-    collector.track_generator_ref(
-        3,
-        41,
-        _source(
-            fake_ray,
-            driver,
-            request_id="shutdown-readiness-probe",
-            submitter=submitter,
-        ),
-    )
-    assert collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}}) == []
-    assert fake_ray.wait_started.wait(timeout=1)
-
-    started_at = time.monotonic()
-    with pytest.raises(RuntimeError, match="multiplexer did not terminate"):
-        collector.shutdown()
-    assert time.monotonic() - started_at < 0.5
-    assert fake_ray.cancel_calls == []
-
-    fake_ray.allow_wait.set()
-    deadline = time.monotonic() + 1
-    while time.monotonic() < deadline and (not fake_ray.cancel_calls or not generators[0].deleted_streams):
-        time.sleep(0.005)
-
-    assert len(fake_ray.cancel_calls) == 1
-    assert generators[0].deleted_streams == [generators[0].completion_ref]
-    collector._thread.join(timeout=1)
-    assert collector._thread.is_alive() is False
 
 
 def test_readiness_probe_failure_is_reported_without_dequeuing():
@@ -2155,16 +2363,22 @@ def test_malformed_metadata_fails_only_its_stream_without_output_admission():
 
 
 def test_stream_error_wakes_dispatcher_before_generator_cancellation():
-    fake_ray = _BlockingCancelRay()
+    fake_ray = _FakeRay()
     driver = _Driver()
     wakeup = threading.Event()
+    cancel_counts_at_wakeup = []
     healthy_block = _Ref("healthy-block", ready=False, is_block=True)
 
     def submitter(_lease):
         return _Generator([_Ref("block", is_block=True), _Ref({"size_bytes": 1})])
 
     collector = AsyncResultCollector(ray_module=fake_ray)
-    collector.set_wakeup_callback(wakeup.set)
+
+    def notify():
+        cancel_counts_at_wakeup.append(len(fake_ray.cancel_calls))
+        wakeup.set()
+
+    collector.set_wakeup_callback(notify)
     collector.track_generator_ref(
         8,
         80,
@@ -2187,11 +2401,12 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         with collector._cv:
             assert len(collector._records) == 2
         wakeup.clear()
+        cancel_counts_at_wakeup.clear()
 
         collector.drain_results({8: {"rows": 1, "bytes": 128, "item_bytes": 128}})
 
-        assert fake_ray.cancel_started.wait(timeout=2.0)
-        assert wakeup.is_set(), "terminal error was not published before ray.cancel"
+        assert wakeup.wait(timeout=2.0)
+        assert cancel_counts_at_wakeup[0] == 0
         fake_ray.make_ready(healthy_block)
         healthy_events = _drain_until(
             collector,
@@ -2200,25 +2415,20 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         )
         assert [item[2] for item in healthy_events] == ["data"]
 
-        fake_ray.allow_cancel.set()
         events = _drain_until(
             collector,
             {8: {"rows": 1, "bytes": 128, "item_bytes": 128}},
             predicate=lambda values: any(item[2] == "error" for item in values),
         )
         assert [item[2] for item in events] == ["error"]
+        assert len(fake_ray.cancel_calls) == 1
     finally:
-        fake_ray.allow_cancel.set()
         collector.cancel_slot(9)
         collector.shutdown()
 
 
-def test_blocked_cancellations_use_bounded_workers_and_preserve_delete_ordering(
-    monkeypatch,
-):
-    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
-    monkeypatch.setenv("VANE_UDF_STREAM_CANCELLATION_CLEANUP_WORKERS", "2")
-    fake_ray = _BlockingCancelRay()
+def test_many_cancellations_complete_on_the_cleanup_event_loop():
+    fake_ray = _FakeRay()
     driver = _Driver()
     generators = []
     collector = AsyncResultCollector(ray_module=fake_ray)
@@ -2237,37 +2447,21 @@ def test_blocked_cancellations_use_bounded_workers_and_preserve_delete_ordering(
         )
 
     try:
-        with pytest.raises(RuntimeError, match="cleanup did not terminate"):
-            collector.cancel_slot(18)
+        collector.cancel_slot(18)
 
-        assert fake_ray.cancel_started_count == 2
-        cancellation_pool = collector._cleanup_pools["cancellation"]
-        assert len(cancellation_pool.threads) == 2
         assert driver.cancel_query_task_lease_request.calls == []
         assert len(driver.release_query_task_lease_after_completion.calls) == len(generators)
-        assert all(generator.deleted_streams == [] for generator in generators)
-
-        fake_ray.allow_cancel.set()
-        deadline = time.monotonic() + 3
-        while (
-            len(fake_ray.cancel_calls) < len(generators)
-            or not all(generator.deleted_streams for generator in generators)
-        ) and time.monotonic() < deadline:
-            time.sleep(0.005)
         assert len(fake_ray.cancel_calls) == len(generators)
         assert all(generator.deleted_streams == [generator.completion_ref] for generator in generators)
     finally:
-        fake_ray.allow_cancel.set()
         collector.shutdown()
 
 
-def test_blocked_output_controls_do_not_withhold_task_or_stream_cleanup(
-    monkeypatch,
-):
-    monkeypatch.setenv("VANE_UDF_STREAM_OUTPUT_CLEANUP_WORKERS", "2")
+def test_pending_output_control_futures_do_not_withhold_task_or_stream_cleanup():
     fake_ray = _FakeRay()
     driver = _Driver()
-    blocked_release = _BlockingRemoteMethod(lambda *_args: {"released": True})
+    release_response = _Ref({"released": True}, ready=False)
+    blocked_release = _DelayedAckRemoteMethod(release_response)
     driver.release_query_output_block_lease = blocked_release
     collector = AsyncResultCollector(ray_module=fake_ray)
     output_tokens = [
@@ -2310,7 +2504,7 @@ def test_blocked_output_controls_do_not_withhold_task_or_stream_cleanup(
         assert len(driver.release_query_task_lease_after_completion.calls) == 1
         assert all(token.release_pending for token in output_tokens)
     finally:
-        blocked_release.release.set()
+        release_response.ready = True
         _wait_until(
             lambda: all(
                 (token.request_id, token.lease_id) not in collector._active_output_leases for token in output_tokens
@@ -2404,4 +2598,4 @@ def test_shutdown_clears_callback_and_fully_joins_owned_thread():
 
     assert collector._wakeup_fn is None
     assert collector._thread.is_alive() is False
-    assert all(not thread.is_alive() for pool in collector._cleanup_pools.values() for thread in pool.threads)
+    assert collector._cleanup_tickets == set()

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -16,6 +16,7 @@ import duckdb.execution.udf_stream_result_collector as collector_module
 from duckdb.execution.ray_stream_adapter import (
     RayStreamAdapter,
     RayStreamCleanupOperation,
+    RayStreamCleanupWait,
     TaskLeaseObjectRefGenerator,
 )
 from duckdb.execution.udf_stream_result_collector import (
@@ -369,6 +370,10 @@ def _wait_cleanup_tickets(tickets, *, timeout_message, timeout=3.0):
         if not ticket.wait(max(0.0, deadline - time.monotonic())):
             raise AssertionError(timeout_message)
     return tuple(error for ticket in tickets for error in ticket.errors)
+
+
+def _accept_true_cleanup_response(response):
+    assert response is True
 
 
 def _capture_thread_error(errors, operation, *args):
@@ -1126,25 +1131,16 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
     )
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = []
-    response_future = None
 
     def transfer_owner():
-        nonlocal response_future
-        if response_future is None:
-            response_future = Future()
-            attempts.append(response_future)
-            if len(attempts) > 1:
-                response_future.set_result(True)
-        if not response_future.done():
-            return response_future
-        response_future.result()
-        response_future = None
-        return True
-
-    def release_wait(future):
-        nonlocal response_future
-        if response_future is future:
-            response_future = None
+        response_future = Future()
+        attempts.append(response_future)
+        if len(attempts) > 1:
+            response_future.set_result(True)
+        return RayStreamCleanupWait(
+            response_future,
+            _accept_true_cleanup_response,
+        )
 
     tickets = collector._submit_cleanup_operations(
         (
@@ -1152,7 +1148,6 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
                 transfer_owner,
                 submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
-                release_wait=release_wait,
             ),
         ),
         store_error=False,
@@ -1171,6 +1166,163 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         collector.shutdown()
 
 
+def test_cleanup_ticket_accepts_late_ack_from_timed_out_attempt(monkeypatch):
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = []
+    second_attempt_started = threading.Event()
+
+    def transfer_owner():
+        response_future = Future()
+        attempts.append(response_future)
+        if len(attempts) == 2:
+            second_attempt_started.set()
+        return RayStreamCleanupWait(
+            response_future,
+            _accept_true_cleanup_response,
+        )
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                transfer_owner,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        assert second_attempt_started.wait(timeout=1.0)
+        attempts[0].set_result(True)
+        assert (
+            _wait_cleanup_tickets(
+                tickets,
+                timeout_message="late cleanup acknowledgement was discarded",
+            )
+            == ()
+        )
+        assert len(attempts) == 2
+        assert not attempts[1].done()
+    finally:
+        collector.shutdown()
+
+
+def test_cleanup_ticket_ignores_invalid_late_ack(monkeypatch):
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = []
+    second_attempt_started = threading.Event()
+
+    def transfer_owner():
+        response_future = Future()
+        attempts.append(response_future)
+        if len(attempts) == 2:
+            second_attempt_started.set()
+        return RayStreamCleanupWait(
+            response_future,
+            _accept_true_cleanup_response,
+        )
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                transfer_owner,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        assert second_attempt_started.wait(timeout=1.0)
+        attempts[0].set_result(False)
+        assert tickets[0].wait(0.0) is False
+
+        attempts[1].set_result(True)
+        assert (
+            _wait_cleanup_tickets(
+                tickets,
+                timeout_message="valid current cleanup acknowledgement was lost",
+            )
+            == ()
+        )
+        assert len(attempts) == 2
+    finally:
+        collector.shutdown()
+
+
+def test_cleanup_ticket_finishes_once_when_retried_acks_race(monkeypatch):
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = []
+    second_attempt_started = threading.Event()
+    completions = []
+
+    def transfer_owner():
+        response_future = Future()
+        attempts.append(response_future)
+        if len(attempts) == 2:
+            second_attempt_started.set()
+        return RayStreamCleanupWait(
+            response_future,
+            _accept_true_cleanup_response,
+        )
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                transfer_owner,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
+        on_each_done=completions.append,
+        store_error=False,
+    )
+    release_acknowledgements = threading.Barrier(3)
+
+    def acknowledge(future):
+        release_acknowledgements.wait()
+        future.set_result(True)
+
+    acknowledgement_threads = []
+    try:
+        assert second_attempt_started.wait(timeout=1.0)
+        acknowledgement_threads = [
+            threading.Thread(
+                target=acknowledge,
+                args=(future,),
+            )
+            for future in attempts
+        ]
+        for thread in acknowledgement_threads:
+            thread.start()
+        release_acknowledgements.wait(timeout=1.0)
+        for thread in acknowledgement_threads:
+            thread.join(timeout=1.0)
+            assert thread.is_alive() is False
+        assert (
+            _wait_cleanup_tickets(
+                tickets,
+                timeout_message="racing cleanup acknowledgements did not finish",
+            )
+            == ()
+        )
+        assert completions == [None]
+    finally:
+        collector.shutdown()
+
+
 def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
     monkeypatch.setattr(
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
@@ -1183,32 +1335,23 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = []
     response_timers = []
-    response_future = None
 
     def transfer_owner():
-        nonlocal response_future
-        if response_future is None:
-            response_future = Future()
-            attempts.append(response_future)
+        response_future = Future()
+        attempts.append(response_future)
+        if len(attempts) > 1:
 
             def acknowledge(future=response_future):
-                if not future.cancelled():
-                    future.set_result(True)
+                future.set_result(True)
 
             timer = threading.Timer(0.015, acknowledge)
             timer.daemon = True
             timer.start()
             response_timers.append(timer)
-        if not response_future.done():
-            return response_future
-        response_future.result()
-        response_future = None
-        return True
-
-    def release_wait(future):
-        nonlocal response_future
-        if response_future is future:
-            response_future = None
+        return RayStreamCleanupWait(
+            response_future,
+            _accept_true_cleanup_response,
+        )
 
     tickets = collector._submit_cleanup_operations(
         (
@@ -1216,7 +1359,6 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
                 transfer_owner,
                 submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
-                release_wait=release_wait,
             ),
         ),
         store_error=False,

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -393,17 +393,22 @@ def test_event_loop_start_failure_prevents_submitted_stream_ownership(monkeypatc
 
 def test_event_loop_start_timeout_rolls_back_started_thread(monkeypatch):
     fake_ray = _FakeRay()
-    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.02")
+    existing_threads = set(threading.enumerate())
 
     class SlowStartCollector(AsyncResultCollector):
         def _run_event_loop(self):
-            time.sleep(0.06)
+            # Stay blocked beyond both the startup deadline and the old
+            # second bounded join. Construction must still reclaim this
+            # thread before propagating its startup failure.
+            time.sleep(0.08)
             super()._run_event_loop()
 
     with pytest.raises(RuntimeError, match="event loop did not start"):
         SlowStartCollector(ray_module=fake_ray)
 
-    assert not any(thread.name == "udf-ray-stream-multiplexer" for thread in threading.enumerate())
+    new_threads = set(threading.enumerate()) - existing_threads
+    assert not any(thread.name == "udf-ray-stream-multiplexer" for thread in new_threads)
 
 
 def test_scheduler_failure_isolated_to_stream_does_not_poison_future_slots():

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -1060,13 +1060,22 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = []
     response_future = None
+    cancel_callback_entered = threading.Event()
+    release_cancel_callback = threading.Event()
+
+    def block_cancel_callback(_future):
+        assert threading.current_thread().name != "vane-ray-control-deadlines"
+        cancel_callback_entered.set()
+        assert release_cancel_callback.wait(timeout=5.0)
 
     def transfer_owner():
         nonlocal response_future
         if response_future is None:
             response_future = Future()
             attempts.append(response_future)
-            if len(attempts) == 2:
+            if len(attempts) == 1:
+                response_future.add_done_callback(block_cancel_callback)
+            else:
                 response_future.set_result(True)
         if not response_future.done():
             return response_future
@@ -1092,16 +1101,18 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         store_error=False,
     )
     try:
+        assert cancel_callback_entered.wait(timeout=1.0)
         assert (
             _wait_cleanup_tickets(
                 tickets,
-                timeout_message="hung cleanup response was not retried",
+                timeout_message="blocking cancellation callback orphaned cleanup retry",
             )
             == ()
         )
         assert len(attempts) == 2
         assert attempts[0].cancelled()
     finally:
+        release_cancel_callback.set()
         collector.shutdown()
 
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -133,6 +133,7 @@ class _FakeRay:
     def __init__(self):
         self.get_calls = []
         self.cancel_calls = []
+        self.wait_calls = []
         self._cv = threading.Condition()
 
     def get(self, ref, timeout=None):
@@ -146,6 +147,7 @@ class _FakeRay:
 
     def wait(self, waitables, *, num_returns, timeout, fetch_local):
         assert fetch_local is False
+        self.wait_calls.append((list(waitables), num_returns, timeout, time.monotonic()))
 
         def _ready(value):
             if isinstance(value, _Generator):
@@ -179,6 +181,29 @@ class _BlockingCancelRay(_FakeRay):
         self.cancel_started.set()
         self.allow_cancel.wait(timeout=2.0)
         super().cancel(ref, **kwargs)
+
+
+class _BlockingWaitRay(_FakeRay):
+    def __init__(self):
+        super().__init__()
+        self.wait_started = threading.Event()
+        self.allow_wait = threading.Event()
+
+    def wait(self, waitables, *, num_returns, timeout, fetch_local):
+        self.wait_started.set()
+        assert self.allow_wait.wait(timeout=2)
+        return super().wait(
+            waitables,
+            num_returns=num_returns,
+            timeout=timeout,
+            fetch_local=fetch_local,
+        )
+
+
+class _FailingWaitRay(_FakeRay):
+    def wait(self, waitables, *, num_returns, timeout, fetch_local):
+        del waitables, num_returns, timeout, fetch_local
+        raise RuntimeError("planned generator readiness failure")
 
 
 class _RemoteMethod:
@@ -312,6 +337,13 @@ def _drain_until(collector, capacities, predicate=lambda values: bool(values), t
     return collected
 
 
+def _capture_thread_error(errors, operation, *args):
+    try:
+        operation(*args)
+    except BaseException as exc:
+        errors.append(exc)
+
+
 def test_collector_requires_task_lease_stream_and_has_no_raw_generator_fallback():
     fake_ray = _FakeRay()
     collector = AsyncResultCollector(ray_module=fake_ray)
@@ -320,6 +352,42 @@ def test_collector_requires_task_lease_stream_and_has_no_raw_generator_fallback(
             collector.track_generator_ref(1, 1, _Generator([]))
     finally:
         collector.shutdown()
+
+
+def test_event_loop_start_failure_releases_the_registered_stream(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    generators = []
+
+    def submitter(_lease):
+        generator = _Generator([], completed=False)
+        generators.append(generator)
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+
+    def fail_start():
+        raise RuntimeError("planned thread start failure")
+
+    monkeypatch.setattr(collector._thread, "start", fail_start)
+    with pytest.raises(RuntimeError, match="planned thread start failure"):
+        collector.track_generator_ref(
+            1,
+            2,
+            _source(
+                fake_ray,
+                driver,
+                request_id="start-failure",
+                submitter=submitter,
+            ),
+        )
+
+    assert collector._records == {}
+    assert len(fake_ray.cancel_calls) == 1
+    assert generators[0].deleted_streams == [generators[0].completion_ref]
+    with pytest.raises(RuntimeError, match="planned thread start failure"):
+        collector.drain_results({})
+    collector.shutdown()
 
 
 def test_zero_capacity_does_not_consume_block_or_metadata_objects():
@@ -353,18 +421,21 @@ def test_zero_capacity_does_not_consume_block_or_metadata_objects():
         collector.shutdown()
 
 
-def test_scheduled_block_read_reserves_data_capacity_across_streams():
+def test_ready_block_read_reserves_data_capacity_across_streams():
     fake_ray = _FakeRay()
     driver = _Driver()
+    generators = []
 
     def submitter(lease):
-        return _Generator(
+        generator = _Generator(
             [
                 _Ref(f"block-{lease['lease_id']}", ready=False, is_block=True),
-                _Ref(_metadata(lease)),
+                _Ref(_metadata(lease), ready=False),
             ],
             completed=False,
         )
+        generators.append(generator)
+        return generator
 
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
@@ -386,6 +457,20 @@ def test_scheduled_block_read_reserves_data_capacity_across_streams():
                 for record in collector._records.values()
                 if record.wait_kind == "data" and record.wait_future is not None
             ]
+        assert scheduled == []
+
+        fake_ray.make_ready(generators[0].refs[0])
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            with collector._cv:
+                scheduled = [
+                    record.submit_id
+                    for record in collector._records.values()
+                    if record.wait_kind == "data" and record.wait_future is not None
+                ]
+            if scheduled:
+                break
+            time.sleep(0.005)
         assert scheduled == [10]
 
         # A dispatcher capacity refresh must not grant the same downstream
@@ -714,6 +799,69 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         collector.shutdown()
 
 
+def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    retire_started = threading.Event()
+    allow_retire = threading.Event()
+    healthy_block = _Ref("healthy-after-retire", ready=False, is_block=True)
+    original_retire = RayStreamAdapter.retire
+
+    def selectively_blocking_retire(adapter):
+        if adapter.task_request_id == "blocked-retire":
+            retire_started.set()
+            allow_retire.wait()
+        original_retire(adapter)
+
+    monkeypatch.setattr(RayStreamAdapter, "retire", selectively_blocking_retire)
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        25,
+        _source(
+            fake_ray,
+            driver,
+            request_id="blocked-retire",
+            submitter=lambda _lease: _Generator([]),
+        ),
+    )
+    collector.track_generator_ref(
+        3,
+        35,
+        _source(
+            fake_ray,
+            driver,
+            request_id="healthy-after-retire",
+            submitter=lambda lease: _Generator(
+                [healthy_block, _Ref(_metadata(lease))],
+                completed=False,
+            ),
+        ),
+    )
+    try:
+        collector.drain_results(
+            {
+                2: {"rows": 0, "bytes": 0, "item_bytes": 0},
+                3: {"rows": 1, "bytes": 128, "item_bytes": 128},
+            }
+        )
+        assert retire_started.wait(timeout=2)
+
+        fake_ray.make_ready(healthy_block)
+        healthy_events = _drain_until(
+            collector,
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(item[2] == "data" for item in values),
+        )
+
+        assert [item[2] for item in healthy_events] == ["data"]
+        assert allow_retire.is_set() is False
+    finally:
+        allow_retire.set()
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
 def test_completion_ready_before_final_metadata_does_not_fail_valid_pair():
     fake_ray = _FakeRay()
     driver = _Driver()
@@ -864,6 +1012,402 @@ def test_one_slow_stream_cannot_block_a_ready_stream():
         assert all(not (item[1] == 30 and item[2] == "data") for item in events)
     finally:
         collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_capacity_one_selects_ready_stream_without_prefetching_slow_stream():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    slow_block = _Ref("slow", ready=False, is_block=True)
+    generators = {}
+
+    def slow_submitter(lease):
+        generator = _Generator(
+            [slow_block, _Ref(_metadata(lease))],
+            completed=False,
+        )
+        generators["slow"] = generator
+        return generator
+
+    fast_block = _Ref("fast", is_block=True)
+
+    def fast_submitter(lease):
+        generator = _Generator([fast_block, _Ref(_metadata(lease))])
+        generators["fast"] = generator
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        32,
+        _source(fake_ray, driver, request_id="capacity-one-slow", submitter=slow_submitter),
+    )
+    collector.track_generator_ref(
+        3,
+        33,
+        _source(fake_ray, driver, request_id="capacity-one-fast", submitter=fast_submitter),
+    )
+    try:
+        events = _drain_until(
+            collector,
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(item[1] == 33 and item[2] == "data" for item in values),
+        )
+
+        fast_data = next(item for item in events if item[1] == 33 and item[2] == "data")
+        assert fast_data[3][1] == [fast_block]
+        assert generators["slow"].read_count == 0
+        assert generators["fast"].read_count == 2
+        assert all(call[2] == 0 for call in fake_ray.wait_calls)
+    finally:
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_capacity_one_schedules_ready_streams_in_round_robin_order():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+
+    def submitter(lease):
+        return _Generator(
+            [
+                _Ref(f"{lease['task_id']}-0", is_block=True),
+                _Ref(_metadata(lease, index=0)),
+                _Ref(f"{lease['task_id']}-1", is_block=True),
+                _Ref(_metadata(lease, index=1)),
+            ]
+        )
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    for submit_id in (37, 38):
+        collector.track_generator_ref(
+            3,
+            submit_id,
+            _source(
+                fake_ray,
+                driver,
+                request_id=f"round-robin-{submit_id}",
+                submitter=submitter,
+            ),
+        )
+    try:
+        events = _drain_until(
+            collector,
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: sum(item[2] == "data" for item in values) == 4,
+        )
+        data_submit_ids = [item[1] for item in events if item[2] == "data"]
+
+        assert data_submit_ids == [37, 38, 37, 38]
+    finally:
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_ready_generator_without_capacity_is_not_dequeued_or_polled():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    holder = {}
+
+    def submitter(lease):
+        generator = _Generator(
+            [_Ref("ready-without-capacity", is_block=True), _Ref(_metadata(lease))],
+            completed=False,
+        )
+        holder["generator"] = generator
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        34,
+        _source(fake_ray, driver, request_id="ready-without-capacity", submitter=submitter),
+    )
+    try:
+        assert collector.drain_results({3: {"rows": 0, "bytes": 0, "item_bytes": 0}}) == []
+        time.sleep(0.05)
+
+        assert holder["generator"].read_count == 0
+        assert fake_ray.wait_calls == []
+    finally:
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_unready_generator_polling_uses_bounded_idle_backoff():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        39,
+        _source(
+            fake_ray,
+            driver,
+            request_id="idle-poll-backoff",
+            submitter=lambda lease: _Generator(
+                [_Ref("slow", ready=False, is_block=True), _Ref(_metadata(lease))],
+                completed=False,
+            ),
+        ),
+    )
+    try:
+        assert collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}}) == []
+        time.sleep(0.1)
+        wait_count = len(fake_ray.wait_calls)
+
+        assert 5 <= wait_count <= 20
+        assert all(call[2] == 0 for call in fake_ray.wait_calls)
+    finally:
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_local_eligibility_change_interrupts_idle_readiness_backoff():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    pending_first_output = _Ref(ready=False)
+    output_calls = []
+
+    class _OutputAdmission:
+        def remote(self, request):
+            output_calls.append(request)
+            grant = driver._acquire_output(request)
+            if len(output_calls) == 1:
+                pending_first_output.value = grant
+                return pending_first_output
+            return _Ref(grant)
+
+    driver.acquire_query_output_block_lease = _OutputAdmission()
+    fast_generators = []
+
+    def slow_submitter(lease):
+        return _Generator(
+            [_Ref("persistently-slow", ready=False, is_block=True), _Ref(_metadata(lease))],
+            completed=False,
+        )
+
+    def fast_submitter(lease):
+        generator = _Generator(
+            [
+                _Ref("fast-0", is_block=True),
+                _Ref(_metadata(lease, index=0)),
+                _Ref("fast-1", is_block=True),
+                _Ref(_metadata(lease, index=1)),
+            ]
+        )
+        fast_generators.append(generator)
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        35,
+        _source(fake_ray, driver, request_id="idle-backoff-slow", submitter=slow_submitter),
+    )
+    collector.track_generator_ref(
+        3,
+        36,
+        _source(fake_ray, driver, request_id="idle-backoff-fast", submitter=fast_submitter),
+    )
+    try:
+        assert collector.drain_results({3: {"rows": 2, "bytes": 256, "item_bytes": 128}}) == []
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline and (not output_calls or fast_generators[0].read_count < 2):
+            time.sleep(0.005)
+        assert len(output_calls) == 1
+        assert fast_generators[0].read_count == 2
+
+        # Let the slow-only poll reach its 10 ms idle ceiling. Completing the
+        # local output-admission future must wake that sleep immediately.
+        time.sleep(0.15)
+        started_at = time.monotonic()
+        pending_first_output.ready = True
+        deadline = started_at + 0.08
+        while time.monotonic() < deadline and fast_generators[0].read_count < 4:
+            time.sleep(0.002)
+
+        assert fast_generators[0].read_count == 4
+        assert time.monotonic() - started_at < 0.08
+        assert all(call[2] == 0 for call in fake_ray.wait_calls)
+    finally:
+        collector.cancel_slot(3)
+        collector.shutdown()
+
+
+def test_slot_cancel_fences_the_active_zero_time_readiness_probe():
+    fake_ray = _BlockingWaitRay()
+    driver = _Driver()
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        40,
+        _source(
+            fake_ray,
+            driver,
+            request_id="cancel-readiness-probe",
+            submitter=lambda lease: _Generator(
+                [_Ref("slow", ready=False, is_block=True), _Ref(_metadata(lease))],
+                completed=False,
+            ),
+        ),
+    )
+    assert collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}}) == []
+    assert fake_ray.wait_started.wait(timeout=1)
+    errors = []
+    cancel_thread = threading.Thread(
+        target=lambda: _capture_thread_error(errors, collector.cancel_slot, 3),
+    )
+    cancel_thread.start()
+    try:
+        time.sleep(0.05)
+        assert cancel_thread.is_alive()
+        assert fake_ray.cancel_calls == []
+
+        fake_ray.allow_wait.set()
+        cancel_thread.join(timeout=1)
+        assert cancel_thread.is_alive() is False
+        assert errors == []
+        assert len(fake_ray.cancel_calls) == 1
+    finally:
+        fake_ray.allow_wait.set()
+        cancel_thread.join(timeout=1)
+        collector.shutdown()
+
+
+def test_shutdown_retains_cleanup_after_a_stuck_readiness_probe(monkeypatch):
+    monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.05")
+    fake_ray = _BlockingWaitRay()
+    driver = _Driver()
+    generators = []
+
+    def submitter(lease):
+        generator = _Generator(
+            [_Ref("slow", ready=False, is_block=True), _Ref(_metadata(lease))],
+            completed=False,
+        )
+        generators.append(generator)
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        41,
+        _source(
+            fake_ray,
+            driver,
+            request_id="shutdown-readiness-probe",
+            submitter=submitter,
+        ),
+    )
+    assert collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}}) == []
+    assert fake_ray.wait_started.wait(timeout=1)
+
+    started_at = time.monotonic()
+    with pytest.raises(RuntimeError, match="multiplexer did not terminate"):
+        collector.shutdown()
+    assert time.monotonic() - started_at < 0.5
+    assert fake_ray.cancel_calls == []
+
+    fake_ray.allow_wait.set()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline and not fake_ray.cancel_calls:
+        time.sleep(0.005)
+
+    assert len(fake_ray.cancel_calls) == 1
+    assert generators[0].deleted_streams == [generators[0].completion_ref]
+    collector._thread.join(timeout=1)
+    assert collector._thread.is_alive() is False
+
+
+def test_readiness_probe_failure_is_reported_without_dequeuing():
+    fake_ray = _FailingWaitRay()
+    driver = _Driver()
+    generators = []
+
+    def submitter(lease):
+        generator = _Generator(
+            [_Ref("ready", is_block=True), _Ref(_metadata(lease))],
+            completed=False,
+        )
+        generators.append(generator)
+        return generator
+
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        3,
+        42,
+        _source(
+            fake_ray,
+            driver,
+            request_id="readiness-probe-failure",
+            submitter=submitter,
+        ),
+    )
+    try:
+        collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            with collector._cv:
+                if collector._thread_error is not None:
+                    break
+            time.sleep(0.005)
+
+        with pytest.raises(RuntimeError, match="planned generator readiness failure"):
+            collector.drain_results({3: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+        assert generators[0].read_count == 0
+    finally:
+        collector.shutdown()
+
+
+@pytest.mark.usefixtures("ray_local")
+def test_real_ray_generator_wait_is_non_consuming_and_preserves_pair_order():
+    import ray
+
+    @ray.remote(num_returns="streaming")
+    def yield_pair(metadata):
+        yield "real-ray-block"
+        yield metadata
+
+    driver = _Driver()
+
+    def submitter(lease):
+        metadata = {
+            "protocol_version": 1,
+            "query_id": lease["query_id"],
+            "producer_stage_id": lease["stage_id"],
+            "task_lease_id": lease["lease_id"],
+            "attempt_id": lease["attempt_id"],
+            "block_id": "real-ray:block:0",
+            "size_bytes": 64,
+            "num_rows": 1,
+            "names": ["value"],
+        }
+        return yield_pair.remote(metadata)
+
+    collector = AsyncResultCollector(ray_module=ray)
+    collector.track_generator_ref(
+        3,
+        43,
+        _source(
+            ray,
+            driver,
+            request_id="real-ray-readiness",
+            submitter=submitter,
+        ),
+    )
+    try:
+        events = _drain_until(
+            collector,
+            {3: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(item[2] == "complete" for item in values),
+            timeout=10,
+        )
+
+        assert [item[2] for item in events] == ["data", "complete"]
+        block_ref = events[0][3][1][0]
+        assert ray.get(block_ref) == "real-ray-block"
+    finally:
         collector.shutdown()
 
 
@@ -1046,6 +1590,7 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
     fake_ray = _BlockingCancelRay()
     driver = _Driver()
     wakeup = threading.Event()
+    healthy_block = _Ref("healthy-block", ready=False, is_block=True)
 
     def submitter(_lease):
         return _Generator([_Ref("block", is_block=True), _Ref({"size_bytes": 1})])
@@ -1056,6 +1601,19 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         8,
         80,
         _source(fake_ray, driver, request_id="blocking-cancel", submitter=submitter),
+    )
+    collector.track_generator_ref(
+        9,
+        90,
+        _source(
+            fake_ray,
+            driver,
+            request_id="healthy-beside-blocking-cancel",
+            submitter=lambda lease: _Generator(
+                [healthy_block, _Ref(_metadata(lease))],
+                completed=False,
+            ),
+        ),
     )
     try:
         deadline = time.monotonic() + 2.0
@@ -1068,6 +1626,14 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
 
         assert fake_ray.cancel_started.wait(timeout=2.0)
         assert wakeup.is_set(), "terminal error was not published before ray.cancel"
+        fake_ray.make_ready(healthy_block)
+        healthy_events = _drain_until(
+            collector,
+            {9: {"rows": 1, "bytes": 128, "item_bytes": 128}},
+            predicate=lambda values: any(item[2] == "data" for item in values),
+        )
+        assert [item[2] for item in healthy_events] == ["data"]
+
         fake_ray.allow_cancel.set()
         events = _drain_until(
             collector,
@@ -1077,6 +1643,7 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
         assert [item[2] for item in events] == ["error"]
     finally:
         fake_ray.allow_cancel.set()
+        collector.cancel_slot(9)
         collector.shutdown()
 
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -943,6 +943,72 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         collector.shutdown()
 
 
+def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_MAX_S",
+        0.04,
+    )
+    collector = AsyncResultCollector(ray_module=_FakeRay())
+    attempts = []
+    response_timers = []
+    response_future = None
+
+    def transfer_owner():
+        nonlocal response_future
+        if response_future is None:
+            response_future = Future()
+            attempts.append(response_future)
+
+            def acknowledge(future=response_future):
+                if not future.cancelled():
+                    future.set_result(True)
+
+            timer = threading.Timer(0.015, acknowledge)
+            timer.daemon = True
+            timer.start()
+            response_timers.append(timer)
+        if not response_future.done():
+            return response_future
+        response_future.result()
+        response_future = None
+        return True
+
+    def abandon_wait(future):
+        nonlocal response_future
+        if response_future is future:
+            response_future = None
+        future.cancel()
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                transfer_owner,
+                retry_on_error=True,
+                abandon_wait=abandon_wait,
+            ),
+        ),
+        store_error=False,
+    )
+    try:
+        assert (
+            collector._wait_cleanup_tickets(
+                tickets,
+                timeout_message="slow cleanup response was not acknowledged",
+            )
+            == ()
+        )
+        assert len(attempts) == 2
+        for timer in response_timers:
+            timer.join(timeout=1.0)
+            assert timer.is_alive() is False
+    finally:
+        collector.shutdown()
+
+
 def test_zero_capacity_does_not_consume_block_or_metadata_objects():
     fake_ray = _FakeRay()
     driver = _Driver()

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -787,6 +787,73 @@ def test_slot_cancel_is_nonblocking_and_cleanup_completion_wakes_dispatcher():
         collector.shutdown()
 
 
+def test_slot_cancel_hands_off_cleanup_before_blocking_record_future_cancel():
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    read_started = threading.Event()
+    cancel_callback_entered = threading.Event()
+    release_cancel_callback = threading.Event()
+    cleanup_owned_at_cancel = []
+
+    class _BlockingReadGenerator(_Generator):
+        async def __anext__(self):
+            read_started.set()
+            await asyncio.sleep(3600)
+
+    generator = _BlockingReadGenerator(
+        [
+            _Ref("blocked-local-read", is_block=True),
+            _Ref({"unused": True}),
+        ],
+        completed=False,
+    )
+    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        19,
+        1,
+        _source(
+            fake_ray,
+            driver,
+            request_id="blocking-record-future-cancel",
+            submitter=lambda _lease: generator,
+        ),
+    )
+    collector.drain_results({19: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+    assert read_started.wait(timeout=1.0)
+    with collector._cv:
+        record_future = collector._records[(19, 1)].wait_future
+    assert record_future is not None
+
+    def block_cancel_callback(_future):
+        with collector._cv:
+            cleanup_owned_at_cancel.append(bool(collector._slot_cancellation_tickets.get(19)))
+        cancel_callback_entered.set()
+        assert release_cancel_callback.wait(timeout=5.0)
+
+    record_future.add_done_callback(block_cancel_callback)
+    cancel_errors = []
+    cancellation = threading.Thread(
+        target=_capture_thread_error,
+        args=(cancel_errors, collector.cancel_slot, 19),
+    )
+    try:
+        cancellation.start()
+        assert cancel_callback_entered.wait(timeout=1.0)
+        cancellation.join(timeout=0.2)
+        assert cancellation.is_alive() is False
+        assert cancel_errors == []
+        assert cleanup_owned_at_cancel == [True]
+
+        _wait_until(lambda: not collector.slot_has_pending(19))
+        collector.shutdown()
+        assert collector._thread.is_alive() is False
+    finally:
+        release_cancel_callback.set()
+        cancellation.join(timeout=1.0)
+        if collector._thread.is_alive():
+            collector.shutdown()
+
+
 def test_failure_wakeup_can_reenter_shutdown_after_cleanup_handoff():
     fake_ray = _FakeRay()
     driver = _Driver()
@@ -1060,22 +1127,13 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
     collector = AsyncResultCollector(ray_module=_FakeRay())
     attempts = []
     response_future = None
-    cancel_callback_entered = threading.Event()
-    release_cancel_callback = threading.Event()
-
-    def block_cancel_callback(_future):
-        assert threading.current_thread().name != "vane-ray-control-deadlines"
-        cancel_callback_entered.set()
-        assert release_cancel_callback.wait(timeout=5.0)
 
     def transfer_owner():
         nonlocal response_future
         if response_future is None:
             response_future = Future()
             attempts.append(response_future)
-            if len(attempts) == 1:
-                response_future.add_done_callback(block_cancel_callback)
-            else:
+            if len(attempts) > 1:
                 response_future.set_result(True)
         if not response_future.done():
             return response_future
@@ -1083,11 +1141,10 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         response_future = None
         return True
 
-    def abandon_wait(future):
+    def release_wait(future):
         nonlocal response_future
         if response_future is future:
             response_future = None
-        future.cancel()
 
     tickets = collector._submit_cleanup_operations(
         (
@@ -1095,24 +1152,22 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
                 transfer_owner,
                 submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
-                abandon_wait=abandon_wait,
+                release_wait=release_wait,
             ),
         ),
         store_error=False,
     )
     try:
-        assert cancel_callback_entered.wait(timeout=1.0)
         assert (
             _wait_cleanup_tickets(
                 tickets,
-                timeout_message="blocking cancellation callback orphaned cleanup retry",
+                timeout_message="hung cleanup response was not retried",
             )
             == ()
         )
         assert len(attempts) == 2
-        assert attempts[0].cancelled()
+        assert not attempts[0].cancelled()
     finally:
-        release_cancel_callback.set()
         collector.shutdown()
 
 
@@ -1150,11 +1205,10 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
         response_future = None
         return True
 
-    def abandon_wait(future):
+    def release_wait(future):
         nonlocal response_future
         if response_future is future:
             response_future = None
-        future.cancel()
 
     tickets = collector._submit_cleanup_operations(
         (
@@ -1162,7 +1216,7 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
                 transfer_owner,
                 submission_scope=_CLEANUP_SUBMISSION_SCOPE,
                 retry_on_error=True,
-                abandon_wait=abandon_wait,
+                release_wait=release_wait,
             ),
         ),
         store_error=False,
@@ -3110,7 +3164,20 @@ def test_shutdown_clears_callback_and_fully_joins_owned_thread():
 def test_shutdown_cleanup_handoff_failure_is_retryable(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
-    generator = _Generator([], completed=False)
+    read_started = threading.Event()
+
+    class _BlockingReadGenerator(_Generator):
+        async def __anext__(self):
+            read_started.set()
+            await asyncio.sleep(3600)
+
+    generator = _BlockingReadGenerator(
+        [
+            _Ref("shutdown-retry-blocked-read", is_block=True),
+            _Ref({"unused": True}),
+        ],
+        completed=False,
+    )
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         8,
@@ -3127,6 +3194,8 @@ def test_shutdown_cleanup_handoff_failure_is_retryable(monkeypatch):
     }
     with collector._cv:
         collector._records[(8, 81)].output_request = output_request
+    collector.drain_results({8: {"rows": 1, "bytes": 128, "item_bytes": 128}})
+    assert read_started.wait(timeout=1.0)
     original_submit = collector._submit_cleanup_operations
     fail_next_handoff = True
 
@@ -3148,6 +3217,8 @@ def test_shutdown_cleanup_handoff_failure_is_retryable(monkeypatch):
 
     assert collector._records
     assert collector._thread.is_alive()
+    with collector._cv:
+        assert collector._records[(8, 81)].detached_waits
 
     collector.shutdown()
 

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -19,6 +19,8 @@ from duckdb.execution.udf_admission import (
 )
 from duckdb.execution.udf_task_admission import TaskAdmissionController
 
+_QUERY_GENERATION_CAPABILITY = "test-query-generation-capability"
+
 
 class _RemoteMethod:
     def __init__(self, fn):
@@ -115,7 +117,39 @@ def _payload():
 
 def test_task_admission_requires_explicit_query_driver_handle():
     with pytest.raises(ValueError, match="query driver handle"):
-        TaskAdmissionController(_payload(), driver=None)
+        TaskAdmissionController(
+            _payload(),
+            driver=None,
+            query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+        )
+
+
+def test_task_admission_submission_rejection_does_not_schedule_cancellation(
+    monkeypatch,
+):
+    driver = _Driver()
+    submissions = []
+
+    def reject_submission(owner_scope, callback):
+        submissions.append((owner_scope, callback))
+        raise RuntimeError("control submission capacity exhausted")
+
+    monkeypatch.setattr(task_admission, "submit_ray_control", reject_submission)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
+
+    with pytest.raises(RuntimeError, match="capacity exhausted"):
+        controller.request(64)
+
+    assert len(submissions) == 1
+    assert driver.acquire_query_task_lease.calls == []
+    assert driver.cancel_query_task_lease_request.calls == []
+    assert controller._cancellation is None
+    controller.close()
+    assert len(submissions) == 1
 
 
 @pytest.mark.parametrize("callback", [False, True])
@@ -124,7 +158,11 @@ def test_task_admission_setup_failure_cancels_the_remote_request(callback):
     driver.acquire_query_task_lease = _RemoteMethod(
         lambda _request: _FailingObjectRef(callback=callback),
     )
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     failed = threading.Event()
     controller.register_wakeup(failed.set)
 
@@ -172,7 +210,11 @@ def _grant(request):
 def test_task_admission_has_one_unresolved_request_and_publishes_ready_lease():
     driver = _Driver()
     wakeups = []
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     controller.register_wakeup(lambda: wakeups.append("ready"))
 
     assert controller.request(64)
@@ -181,6 +223,7 @@ def test_task_admission_has_one_unresolved_request_and_publishes_ready_lease():
     _wait_for_request_refs(driver, 1)
     assert len(driver.acquire_query_task_lease.calls) == 1
     request = driver.acquire_query_task_lease.calls[0][0][0]
+    assert request["query_generation_capability"] == _QUERY_GENERATION_CAPABILITY
     assert request["retained_input_bytes"] == 64
     assert request["resources"]["object_store_bytes"] == 128
     assert controller.state() == {
@@ -211,7 +254,11 @@ def test_task_admission_has_one_unresolved_request_and_publishes_ready_lease():
 
 def test_task_admission_does_not_consume_a_lease_for_different_input_bytes():
     driver = _Driver()
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(64)
     _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
     _wait_for_request_refs(driver, 1)
@@ -230,7 +277,11 @@ def test_task_admission_does_not_consume_a_lease_for_different_input_bytes():
 
 def test_task_admission_preserves_async_denial_reason():
     driver = _Driver()
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(16)
 
     _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
@@ -252,7 +303,11 @@ def test_task_admission_preserves_async_denial_reason():
 
 def test_task_admission_close_cancels_pending_and_ready_leases():
     pending_driver = _Driver()
-    pending = TaskAdmissionController(_payload(), driver=pending_driver)
+    pending = TaskAdmissionController(
+        _payload(),
+        driver=pending_driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert pending.request(32)
     _wait_for_remote_calls(pending_driver.acquire_query_task_lease, 1)
     _wait_for_request_refs(pending_driver, 1)
@@ -270,7 +325,11 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     ]
 
     ready_driver = _Driver()
-    ready = TaskAdmissionController(_payload(), driver=ready_driver)
+    ready = TaskAdmissionController(
+        _payload(),
+        driver=ready_driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert ready.request(48)
     _wait_for_remote_calls(ready_driver.acquire_query_task_lease, 1)
     _wait_for_request_refs(ready_driver, 1)
@@ -287,7 +346,11 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
 
 def test_pending_admission_future_does_not_retain_closed_controller():
     driver = _Driver()
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(32)
     _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
     _wait_for_request_refs(driver, 1)
@@ -306,7 +369,11 @@ def test_pending_admission_future_does_not_retain_closed_controller():
 
 def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
     driver = _Driver()
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(24)
     _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
     _wait_for_request_refs(driver, 1)
@@ -337,8 +404,16 @@ def test_blocked_task_admission_submission_does_not_stall_other_controller():
         return original_acquire(request)
 
     driver.acquire_query_task_lease = _RemoteMethod(selectively_blocking_acquire)
-    blocked = TaskAdmissionController(_payload(), driver=driver)
-    healthy = TaskAdmissionController(_payload(), driver=driver)
+    blocked = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
+    healthy = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     healthy_ready = threading.Event()
     healthy.register_wakeup(healthy_ready.set)
 
@@ -380,7 +455,11 @@ def test_blocked_task_admission_submission_does_not_retain_closed_controller():
         return _resolved_ref(_grant(request))
 
     driver.acquire_query_task_lease = _RemoteMethod(blocked_acquire)
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(29)
     assert submission_entered.wait(timeout=1.0)
     controller_ref = weakref.ref(controller)
@@ -413,7 +492,11 @@ def test_task_admission_cancellation_retries_until_driver_acknowledges():
         return response
 
     driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(24)
 
     controller.close()
@@ -441,7 +524,11 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
         return _resolved_ref({"cancelled": True})
 
     driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
-    controller = TaskAdmissionController(_payload(), driver=driver)
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
     assert controller.request(24)
 
     controller.close()
@@ -619,6 +706,109 @@ def test_ray_control_submissions_isolate_blocked_owner_and_retire_idle_workers()
     assert executor._workers == {}
 
 
+def test_ray_control_submissions_bound_stalled_workers_and_queued_owners():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        max_workers=3,
+        max_pending_submissions=5,
+        max_pending_per_owner=2,
+    )
+    release_submissions = threading.Event()
+    all_workers_blocked = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    def blocked_submission():
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == 3:
+                all_workers_blocked.set()
+        if not release_submissions.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release bounded control worker")
+        return "released"
+
+    futures = [executor.submit(f"owner:blocked:{index}", blocked_submission) for index in range(5)]
+    assert all_workers_blocked.wait(timeout=1.0)
+    with pytest.raises(RuntimeError, match="queue is full"):
+        executor.submit("owner:overflow", blocked_submission)
+
+    with executor._condition:
+        assert len(executor._workers) == 3
+        assert executor._pending_submissions == 5
+        assert len(executor._owners) == 5
+
+    release_submissions.set()
+    assert [future.result(timeout=1.0) for future in futures] == ["released"] * 5
+    completion_deadline = time.monotonic() + 1.0
+    while executor._workers and time.monotonic() < completion_deadline:
+        time.sleep(0.005)
+    assert executor._workers == {}
+    assert executor._owners == {}
+    assert executor._pending_submissions == 0
+
+
+def test_ray_control_submissions_bound_one_owner_queue():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        max_workers=1,
+        max_pending_submissions=3,
+        max_pending_per_owner=2,
+    )
+    release_submission = threading.Event()
+    submission_entered = threading.Event()
+
+    def blocked_submission():
+        submission_entered.set()
+        if not release_submission.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release owner queue")
+        return "released"
+
+    first = executor.submit("owner:bounded", blocked_submission)
+    assert submission_entered.wait(timeout=1.0)
+    second = executor.submit("owner:bounded", lambda: "second")
+    with pytest.raises(RuntimeError, match="owner queue is full"):
+        executor.submit("owner:bounded", lambda: "overflow")
+
+    release_submission.set()
+    assert first.result(timeout=1.0) == "released"
+    assert second.result(timeout=1.0) == "second"
+
+
+def test_cancelled_queued_control_submissions_release_capacity_while_worker_is_blocked():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        max_workers=1,
+        max_pending_submissions=3,
+        max_pending_per_owner=1,
+    )
+    release_submission = threading.Event()
+    submission_entered = threading.Event()
+
+    def blocked_submission():
+        submission_entered.set()
+        if not release_submission.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release control worker")
+        return "released"
+
+    running = executor.submit("owner:blocked", blocked_submission)
+    assert submission_entered.wait(timeout=1.0)
+    cancelled = [
+        executor.submit("owner:cancelled:1", lambda: "unexpected"),
+        executor.submit("owner:cancelled:2", lambda: "unexpected"),
+    ]
+
+    assert all(future.cancel() for future in cancelled)
+    with executor._condition:
+        assert executor._pending_submissions == 1
+        assert set(executor._owners) == {"owner:blocked"}
+
+    replacement = executor.submit("owner:replacement", lambda: "replacement")
+    release_submission.set()
+    assert running.result(timeout=1.0) == "released"
+    assert replacement.result(timeout=1.0) == "replacement"
+
+
 def test_ray_control_submission_does_not_retain_worker_when_thread_start_fails(
     monkeypatch,
 ):
@@ -636,6 +826,8 @@ def test_ray_control_submission_does_not_retain_worker_when_thread_start_fails(
         executor.submit("owner:start-failure", lambda: None)
 
     assert executor._workers == {}
+    assert executor._owners == {}
+    assert executor._pending_submissions == 0
 
 
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -559,6 +559,43 @@ def test_task_admission_cancellation_retries_until_driver_acknowledges():
     assert len(driver.cancel_query_task_lease_request.calls) == 2
 
 
+def test_task_admission_cancellation_retries_async_submission_rejection(
+    monkeypatch,
+):
+    driver = _Driver()
+    submissions = []
+
+    def submit_control(_owner_scope, callback):
+        future = Future()
+        submissions.append((future, callback))
+        if len(submissions) > 1:
+            callback()
+            future.set_result(None)
+        return future
+
+    monkeypatch.setattr(task_admission, "submit_ray_control", submit_control)
+    cancellation = task_admission._TaskAdmissionCancellation(
+        driver=driver,
+        request={
+            "request_id": "async-submission-rejection",
+            "query_id": "query:async-submission-rejection",
+            "resources": {},
+        },
+        submission_scope="test-admission:async-submission-rejection",
+    )
+
+    cancellation.start()
+    assert cancellation._submitting
+    submissions[0][0].set_exception(RuntimeError("planned async queue rejection"))
+
+    deadline = time.monotonic() + 1.0
+    while not cancellation._done and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert cancellation._done
+    assert len(submissions) == 2
+    assert len(driver.cancel_query_task_lease_request.calls) == 1
+
+
 def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
     monkeypatch.setattr(
         task_admission,
@@ -760,6 +797,18 @@ def test_ray_control_submissions_isolate_blocked_owner_and_retire_idle_workers()
     assert executor._workers == {}
 
 
+def test_ray_control_submissions_require_one_recovery_capacity_slot():
+    with pytest.raises(
+        ValueError,
+        match="pending capacity must exceed max_stalled_workers",
+    ):
+        ray_control_submission._RayControlSubmissionExecutor(
+            max_workers=2,
+            max_stalled_workers=2,
+            max_pending_submissions=2,
+        )
+
+
 def test_ray_control_submissions_bound_stalled_workers_and_queued_owners():
     executor = ray_control_submission._RayControlSubmissionExecutor(
         idle_timeout_s=0.01,
@@ -800,6 +849,164 @@ def test_ray_control_submissions_bound_stalled_workers_and_queued_owners():
     assert executor._workers == {}
     assert executor._owners == {}
     assert executor._pending_submissions == 0
+
+
+def test_stalled_control_owners_do_not_consume_the_schedulable_pool():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.02,
+        max_workers=32,
+        max_stalled_workers=32,
+        max_pending_submissions=64,
+        max_pending_per_owner=1,
+    )
+    release_submissions = threading.Event()
+    all_workers_blocked = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    def blocked_submission():
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == 32:
+                all_workers_blocked.set()
+        if not release_submissions.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release stalled control owner")
+        return "released"
+
+    blocked = [executor.submit(f"owner:stalled:{index}", blocked_submission) for index in range(32)]
+    assert all_workers_blocked.wait(timeout=1.0)
+    stall_deadline = time.monotonic() + 1.0
+    while time.monotonic() < stall_deadline:
+        with executor._condition:
+            stalled_workers = sum(worker.stalled for worker in executor._workers.values())
+        if stalled_workers == 32:
+            break
+        time.sleep(0.005)
+
+    healthy = executor.submit("owner:healthy-after-stalls", lambda: "healthy")
+    assert healthy.result(timeout=1.0) == "healthy"
+    with executor._condition:
+        assert sum(worker.stalled for worker in executor._workers.values()) == 32
+        assert len(executor._workers) <= 64
+        assert executor._pending_submissions == 32
+
+    release_submissions.set()
+    assert [future.result(timeout=1.0) for future in blocked] == ["released"] * 32
+    completion_deadline = time.monotonic() + 1.0
+    while executor._workers and time.monotonic() < completion_deadline:
+        time.sleep(0.005)
+    assert executor._workers == {}
+    assert executor._owners == {}
+    assert executor._pending_submissions == 0
+
+
+def test_stalled_control_owner_retains_fifo_while_healthy_owner_progresses():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.02,
+        max_workers=1,
+        max_stalled_workers=1,
+        max_pending_submissions=3,
+        max_pending_per_owner=2,
+    )
+    release_submission = threading.Event()
+    blocked_submission_entered = threading.Event()
+    same_owner_followup_entered = threading.Event()
+
+    def blocked_submission():
+        blocked_submission_entered.set()
+        if not release_submission.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release FIFO control owner")
+        return "first"
+
+    first = executor.submit("owner:stalled-fifo", blocked_submission)
+    assert blocked_submission_entered.wait(timeout=1.0)
+    second = executor.submit(
+        "owner:stalled-fifo",
+        lambda: same_owner_followup_entered.set() or "second",
+    )
+    healthy = executor.submit("owner:healthy-beside-stall", lambda: "healthy")
+
+    assert healthy.result(timeout=1.0) == "healthy"
+    assert same_owner_followup_entered.is_set() is False
+    assert second.done() is False
+
+    release_submission.set()
+    assert first.result(timeout=1.0) == "first"
+    assert second.result(timeout=1.0) == "second"
+    assert same_owner_followup_entered.is_set()
+
+
+def test_control_submissions_fail_fast_at_stalled_worker_bound_and_recover():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.02,
+        max_workers=2,
+        max_stalled_workers=1,
+        max_pending_submissions=4,
+        max_pending_per_owner=2,
+    )
+    release_submissions = threading.Event()
+    all_workers_blocked = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    def blocked_submission():
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == 2:
+                all_workers_blocked.set()
+        if not release_submissions.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release bounded stalled worker")
+        return "released"
+
+    blocked = [executor.submit(f"owner:bounded-stall:{index}", blocked_submission) for index in range(2)]
+    assert all_workers_blocked.wait(timeout=1.0)
+    queued = executor.submit("owner:bounded-stall:0", lambda: "unexpected")
+
+    with pytest.raises(RuntimeError, match="stalled callback capacity is exhausted"):
+        queued.result(timeout=1.0)
+    with pytest.raises(RuntimeError, match="stalled callback capacity is exhausted"):
+        executor.submit("owner:rejected-while-exhausted", lambda: "unexpected")
+    with executor._condition:
+        assert len(executor._workers) == 2
+        assert executor._pending_submissions == 2
+
+    release_submissions.set()
+    assert [future.result(timeout=1.0) for future in blocked] == ["released"] * 2
+    recovery = executor.submit("owner:recovered", lambda: "recovered")
+    assert recovery.result(timeout=1.0) == "recovered"
+
+
+def test_ray_control_submission_watchdog_start_failure_is_retryable(monkeypatch):
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+    )
+    original_start = threading.Thread.start
+    starts = 0
+
+    def fail_first_watchdog_start(thread):
+        nonlocal starts
+        if thread.name.startswith("vane-ray-control-submit-watchdog-"):
+            starts += 1
+            if starts == 1:
+                raise RuntimeError("control watchdog unavailable")
+        return original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_first_watchdog_start)
+    with pytest.raises(RuntimeError, match="control watchdog unavailable"):
+        executor.submit("owner:watchdog-start-failure", lambda: "unexpected")
+
+    assert executor._watchdog_thread is None
+    assert executor._workers == {}
+    assert executor._owners == {}
+    assert executor._pending_submissions == 0
+
+    retry = executor.submit("owner:watchdog-start-retry", lambda: "recovered")
+    assert retry.result(timeout=1.0) == "recovered"
 
 
 def test_ray_control_submissions_bound_one_owner_queue():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -551,6 +551,32 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
     assert all(cancellation._done for cancellation in cancellations)
 
 
+def test_task_admission_deadline_scheduler_start_failure_is_retryable(
+    monkeypatch,
+):
+    scheduler = task_admission._TaskAdmissionCancellationScheduler()
+    original_start = threading.Thread.start
+    starts = 0
+
+    def fail_first_start(thread):
+        nonlocal starts
+        if thread.name == "vane-task-admission-cleanup":
+            starts += 1
+            if starts == 1:
+                raise RuntimeError("deadline thread unavailable")
+        return original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_first_start)
+    with pytest.raises(RuntimeError, match="deadline thread unavailable"):
+        scheduler.ensure_started()
+
+    assert scheduler._thread is None
+
+    scheduler.ensure_started()
+    assert scheduler._thread is not None
+    assert scheduler._thread.is_alive()
+
+
 def test_ray_control_submissions_isolate_blocked_owner_and_retire_idle_workers():
     executor = ray_control_submission._RayControlSubmissionExecutor(
         idle_timeout_s=0.01,

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -606,6 +606,15 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
     driver = _Driver()
     acknowledged = threading.Event()
     first_response = _ObjectRef()
+    cancel_callback_entered = threading.Event()
+    release_cancel_callback = threading.Event()
+
+    def block_cancel_callback(_future):
+        assert threading.current_thread().name != "vane-ray-control-deadlines"
+        cancel_callback_entered.set()
+        assert release_cancel_callback.wait(timeout=5.0)
+
+    first_response._future.add_done_callback(block_cancel_callback)
 
     def cancel(_request):
         if not driver.cancel_query_task_lease_request.calls:
@@ -625,9 +634,15 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
 
     controller.close()
 
-    assert acknowledged.wait(timeout=1.0)
-    assert len(driver.cancel_query_task_lease_request.calls) == 2
-    assert first_response._future.cancelled()
+    try:
+        assert cancel_callback_entered.wait(timeout=1.0)
+        # The next attempt is published before Future.cancel can invoke a
+        # blocking completion callback inline.
+        assert acknowledged.wait(timeout=1.0)
+        assert len(driver.cancel_query_task_lease_request.calls) == 2
+        assert first_response._future.cancelled()
+    finally:
+        release_cancel_callback.set()
 
 
 def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch):
@@ -980,6 +995,7 @@ def test_control_deadline_uses_lock_free_completion_timestamps():
     first = executor.submit("owner:lock-contention:first", submission)
     assert submission_entered.wait(timeout=1.0)
     healthy = executor.submit("owner:lock-contention:healthy", lambda: "healthy")
+    unrelated_deadline_ran = threading.Event()
 
     with executor._condition:
         original_worker = next(iter(executor._workers.values()))
@@ -990,8 +1006,18 @@ def test_control_deadline_uses_lock_free_completion_timestamps():
         assert original_worker.callback_finished_at is not None
         assert original_worker.completion_finished_at is not None
         # Hold the bookkeeping lock beyond both phase deadlines. The worker's
-        # already-published timestamps must prevent a false stall classification.
-        time.sleep(0.25)
+        # already-published timestamps must prevent a false stall classification
+        # without delaying an unrelated deadline behind this lock.
+        time.sleep(0.12)
+        unrelated_call = ray_control_submission.create_ray_control_deadline(
+            "owner:unrelated-lock-contention",
+            unrelated_deadline_ran.set,
+        )
+        ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
+            unrelated_call,
+            0,
+        )
+        assert unrelated_deadline_ran.wait(timeout=0.2)
 
     assert first.result(timeout=1.0) == "first"
     assert healthy.result(timeout=1.0) == "healthy"
@@ -1075,6 +1101,105 @@ def test_control_submissions_fail_fast_at_stalled_worker_bound_and_recover():
     assert [future.result(timeout=1.0) for future in blocked] == ["released"] * 2
     recovery = executor.submit("owner:recovered", lambda: "recovered")
     assert recovery.result(timeout=1.0) == "recovered"
+
+
+def test_stalled_capacity_failures_do_not_run_future_callbacks_on_the_clock():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.02,
+        max_workers=2,
+        max_stalled_workers=1,
+        max_pending_submissions=6,
+        max_pending_per_owner=2,
+    )
+    release_submissions = threading.Event()
+    all_workers_blocked = threading.Event()
+    failure_callback_entered = threading.Event()
+    release_failure_callback = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    def blocked_submission():
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == 2:
+                all_workers_blocked.set()
+        assert release_submissions.wait(timeout=5.0)
+        return "released"
+
+    def block_failure_callback(_future):
+        assert threading.current_thread().name != "vane-ray-control-deadlines"
+        failure_callback_entered.set()
+        assert release_failure_callback.wait(timeout=5.0)
+
+    running = [
+        executor.submit("owner:isolated-failure:0", blocked_submission),
+        executor.submit("owner:isolated-failure:1", blocked_submission),
+    ]
+    assert all_workers_blocked.wait(timeout=1.0)
+    first_rejected = executor.submit("owner:isolated-failure:0", lambda: "unexpected")
+    second_rejected = executor.submit("owner:isolated-failure:1", lambda: "unexpected")
+    first_rejected.add_done_callback(block_failure_callback)
+
+    try:
+        assert failure_callback_entered.wait(timeout=1.0)
+        # A callback blocked by the first set_exception must not prevent the
+        # second rejected Future from becoming terminal.
+        with pytest.raises(RuntimeError, match="stalled callback capacity is exhausted"):
+            second_rejected.result(timeout=1.0)
+    finally:
+        release_failure_callback.set()
+        release_submissions.set()
+
+    with pytest.raises(RuntimeError, match="stalled callback capacity is exhausted"):
+        first_rejected.result(timeout=1.0)
+    assert [future.result(timeout=1.0) for future in running] == ["released"] * 2
+
+
+def test_deadline_callback_dispatch_replaces_a_blocked_worker(monkeypatch):
+    callback_executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.02,
+        max_workers=1,
+        max_stalled_workers=1,
+        max_pending_submissions=3,
+        max_pending_per_owner=1,
+        thread_name_prefix="test-ray-control-deadline-callback",
+    )
+    monkeypatch.setattr(
+        ray_control_submission,
+        "_RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR",
+        callback_executor,
+    )
+    blocked_callback_entered = threading.Event()
+    release_blocked_callback = threading.Event()
+    healthy_callback_ran = threading.Event()
+
+    def blocked_callback():
+        assert threading.current_thread().name != "vane-ray-control-deadlines"
+        blocked_callback_entered.set()
+        assert release_blocked_callback.wait(timeout=5.0)
+
+    blocked_call = ray_control_submission.create_ray_control_deadline(
+        "owner:blocked-deadline-callback",
+        blocked_callback,
+    )
+    ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(blocked_call, 0)
+    assert blocked_callback_entered.wait(timeout=1.0)
+
+    healthy_call = ray_control_submission.create_ray_control_deadline(
+        "owner:healthy-deadline-callback",
+        healthy_callback_ran.set,
+    )
+    ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(healthy_call, 0)
+    try:
+        assert healthy_callback_ran.wait(timeout=1.0)
+        with callback_executor._condition:
+            assert any(worker.stalled for worker in callback_executor._workers.values())
+            assert len(callback_executor._workers) <= 2
+    finally:
+        release_blocked_callback.set()
 
 
 def test_ray_control_submission_deadline_start_failure_does_not_admit_work(monkeypatch):

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -1166,9 +1166,9 @@ def test_exhausted_completion_callbacks_do_not_block_control_state(monkeypatch):
         callback_executor,
     )
     all_callback_workers_blocked = threading.Event()
-    all_callbacks_ran = threading.Event()
     release_callbacks = threading.Event()
     state_callback_ran = threading.Event()
+    dropped_abandonment_ran = threading.Event()
     entered_lock = threading.Lock()
     entered = 0
 
@@ -1178,16 +1178,36 @@ def test_exhausted_completion_callbacks_do_not_block_control_state(monkeypatch):
             entered += 1
             if entered == 2:
                 all_callback_workers_blocked.set()
-            if entered == 3:
-                all_callbacks_ran.set()
         assert release_callbacks.wait(timeout=5.0)
 
-    for index in range(3):
+    for index in range(2):
         ray_control_submission.dispatch_ray_control_abandonment(
             f"owner:blocked-abandonment:{index}",
             blocked_callback,
         )
     assert all_callback_workers_blocked.wait(timeout=1.0)
+    stalled_deadline = time.monotonic() + 1.0
+    while time.monotonic() < stalled_deadline:
+        with callback_executor._condition:
+            if callback_executor._stalled_worker_count_locked() > 1:
+                break
+        time.sleep(0.005)
+    else:
+        raise AssertionError("completion callback capacity was not exhausted")
+
+    class _DroppedAbandonment:
+        def cancel(self):
+            dropped_abandonment_ran.set()
+
+    dropped_abandonment = _DroppedAbandonment()
+    dropped_ref = weakref.ref(dropped_abandonment)
+    ray_control_submission.dispatch_ray_control_abandonment(
+        "owner:dropped-abandonment",
+        dropped_abandonment.cancel,
+    )
+    del dropped_abandonment
+    gc.collect()
+    assert dropped_ref() is None
 
     state_call = ray_control_submission.create_ray_control_deadline(
         "owner:state-beside-exhausted-completions",
@@ -1201,7 +1221,7 @@ def test_exhausted_completion_callbacks_do_not_block_control_state(monkeypatch):
             assert len(callback_executor._workers) <= 2
     finally:
         release_callbacks.set()
-    assert all_callbacks_ran.wait(timeout=1.0)
+    assert dropped_abandonment_ran.is_set() is False
     completion_deadline = time.monotonic() + 1.0
     while callback_executor._workers and time.monotonic() < completion_deadline:
         time.sleep(0.005)

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -323,20 +323,22 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
 
 
 def test_blocked_task_admission_submission_does_not_stall_other_controller():
-    blocked_driver = _Driver()
+    driver = _Driver()
     blocked_submission_entered = threading.Event()
     release_blocked_submission = threading.Event()
+    original_acquire = driver._acquire
 
-    def blocked_acquire(request):
-        blocked_submission_entered.set()
-        if not release_blocked_submission.wait(timeout=5.0):
-            raise RuntimeError("timed out waiting to release blocked task admission")
-        return _resolved_ref(_grant(request))
+    def selectively_blocking_acquire(request):
+        if request["retained_input_bytes"] == 31:
+            blocked_submission_entered.set()
+            if not release_blocked_submission.wait(timeout=5.0):
+                raise RuntimeError("timed out waiting to release blocked task admission")
+            return _resolved_ref(_grant(request))
+        return original_acquire(request)
 
-    blocked_driver.acquire_query_task_lease = _RemoteMethod(blocked_acquire)
-    blocked = TaskAdmissionController(_payload(), driver=blocked_driver)
-    healthy_driver = _Driver()
-    healthy = TaskAdmissionController(_payload(), driver=healthy_driver)
+    driver.acquire_query_task_lease = _RemoteMethod(selectively_blocking_acquire)
+    blocked = TaskAdmissionController(_payload(), driver=driver)
+    healthy = TaskAdmissionController(_payload(), driver=driver)
     healthy_ready = threading.Event()
     healthy.register_wakeup(healthy_ready.set)
 
@@ -349,10 +351,12 @@ def test_blocked_task_admission_submission_does_not_stall_other_controller():
         assert blocked_submission_entered.wait(timeout=1.0)
 
         assert healthy.request(47)
-        _wait_for_remote_calls(healthy_driver.acquire_query_task_lease, 1)
-        _wait_for_request_refs(healthy_driver, 1)
-        healthy_request = healthy_driver.acquire_query_task_lease.calls[0][0][0]
-        healthy_driver.requests[0].resolve(_grant(healthy_request))
+        _wait_for_remote_calls(driver.acquire_query_task_lease, 2)
+        _wait_for_request_refs(driver, 1)
+        healthy_request = next(
+            call[0][0] for call in driver.acquire_query_task_lease.calls if call[0][0]["retained_input_bytes"] == 47
+        )
+        driver.requests[0].resolve(_grant(healthy_request))
 
         assert healthy_ready.wait(timeout=1.0)
         assert healthy.state()["state"] == "ready"
@@ -361,8 +365,7 @@ def test_blocked_task_admission_submission_does_not_stall_other_controller():
         blocked.close()
         healthy.close()
 
-    _wait_for_remote_calls(blocked_driver.cancel_query_task_lease_request, 1)
-    _wait_for_remote_calls(healthy_driver.cancel_query_task_lease_request, 1)
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 2)
 
 
 def test_blocked_task_admission_submission_does_not_retain_closed_controller():
@@ -383,7 +386,6 @@ def test_blocked_task_admission_submission_does_not_retain_closed_controller():
     controller_ref = weakref.ref(controller)
 
     controller.close()
-    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     del controller
     gc.collect()
 
@@ -391,6 +393,7 @@ def test_blocked_task_admission_submission_does_not_retain_closed_controller():
         assert controller_ref() is None
     finally:
         release_submission.set()
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
 
 
 def test_task_admission_cancellation_retries_until_driver_acknowledges():
@@ -478,7 +481,12 @@ def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch)
     driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
     cancellation = task_admission._TaskAdmissionCancellation(
         driver=driver,
-        request={"request_id": "slow-cancel", "resources": {}},
+        request={
+            "request_id": "slow-cancel",
+            "query_id": "query:slow-cancel",
+            "resources": {},
+        },
+        submission_scope="test-admission:slow-cancel",
     )
 
     cancellation.start()
@@ -513,8 +521,10 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
             driver=driver,
             request={
                 "request_id": f"shared-cancel:{index}",
+                "query_id": "query:shared-cancel",
                 "resources": {},
             },
+            submission_scope="test-admission:shared-cancel",
         )
         for index in range(256)
     ]
@@ -541,70 +551,65 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
     assert all(cancellation._done for cancellation in cancellations)
 
 
-def test_task_admission_blocked_rpc_submissions_use_bounded_workers_without_blocking_deadlines():
-    driver = _Driver()
+def test_ray_control_submissions_isolate_blocked_owner_and_retire_idle_workers():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+    )
+    blocked_owner = "owner:blocked"
+    healthy_owner = "owner:healthy"
     release_submissions = threading.Event()
-    all_workers_blocked = threading.Event()
-    entered_lock = threading.Lock()
+    blocked_submission_entered = threading.Event()
     entered = 0
 
-    def cancel(_request):
+    def blocked_submission():
         nonlocal entered
-        with entered_lock:
-            entered += 1
-            if entered == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS:
-                all_workers_blocked.set()
-        release_submissions.wait(timeout=5.0)
-        return _resolved_ref({"cancelled": True})
+        entered += 1
+        blocked_submission_entered.set()
+        if not release_submissions.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release blocked driver")
+        return "released"
 
-    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
-    cancellation_count = ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS + 64
-    cancellations = [
-        task_admission._TaskAdmissionCancellation(
-            driver=driver,
-            request={
-                "request_id": f"blocked-submit:{index}",
-                "resources": {},
-            },
+    blocked_futures = [
+        executor.submit(
+            blocked_owner,
+            blocked_submission,
         )
-        for index in range(cancellation_count)
+        for _ in range(65)
     ]
 
-    started_at = time.monotonic()
-    for cancellation in cancellations:
-        cancellation.start()
-    start_elapsed = time.monotonic() - started_at
-
-    deadline_fired = threading.Event()
-    deadline = task_admission._TASK_ADMISSION_CANCELLATION_SCHEDULER.create(
-        deadline_fired.set,
-    )
-    task_admission._TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
-        deadline,
-        0.01,
-    )
     try:
-        assert start_elapsed < 1.0
-        assert all_workers_blocked.wait(timeout=2.0)
-        assert deadline_fired.wait(timeout=1.0)
-        assert (
-            len(driver.cancel_query_task_lease_request.calls) == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS
-        )
-        submission_threads = [
-            thread for thread in threading.enumerate() if thread.name.startswith("vane-ray-control-submit-")
-        ]
-        assert len(submission_threads) == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS
+        assert blocked_submission_entered.wait(timeout=1.0)
+        assert entered == 1
+        healthy = executor.submit(healthy_owner, lambda: "healthy")
+        assert healthy.result(timeout=1.0) == "healthy"
+        assert entered == 1
     finally:
         release_submissions.set()
 
-    _wait_for_remote_calls(
-        driver.cancel_query_task_lease_request,
-        cancellation_count,
-    )
+    assert [future.result(timeout=1.0) for future in blocked_futures] == ["released"] * len(blocked_futures)
     completion_deadline = time.monotonic() + 1.0
-    while not all(cancellation._done for cancellation in cancellations) and time.monotonic() < completion_deadline:
+    while executor._workers and time.monotonic() < completion_deadline:
         time.sleep(0.005)
-    assert all(cancellation._done for cancellation in cancellations)
+    assert executor._workers == {}
+
+
+def test_ray_control_submission_does_not_retain_worker_when_thread_start_fails(
+    monkeypatch,
+):
+    executor = ray_control_submission._RayControlSubmissionExecutor()
+
+    def fail_start(_worker):
+        raise RuntimeError("thread unavailable")
+
+    monkeypatch.setattr(
+        ray_control_submission._RayControlSubmissionWorker,
+        "start",
+        fail_start,
+    )
+    with pytest.raises(RuntimeError, match="thread unavailable"):
+        executor.submit("owner:start-failure", lambda: None)
+
+    assert executor._workers == {}
 
 
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -35,6 +35,22 @@ class _ObjectRef:
         self._future.set_result(value)
 
 
+class _FailingObjectRef:
+    def __init__(self, *, callback=False):
+        self._callback = callback
+
+    def future(self):
+        if not self._callback:
+            raise RuntimeError("planned admission Future factory failure")
+
+        class _FailingCallbackFuture(Future):
+            def add_done_callback(self, fn, *, context=None):
+                del fn, context
+                raise RuntimeError("planned admission callback registration failure")
+
+        return _FailingCallbackFuture()
+
+
 class _Driver:
     def __init__(self):
         self.requests: list[_ObjectRef] = []
@@ -62,6 +78,25 @@ def _payload():
 def test_task_admission_requires_explicit_query_driver_handle():
     with pytest.raises(ValueError, match="query driver handle"):
         TaskAdmissionController(_payload(), driver=None)
+
+
+@pytest.mark.parametrize("callback", [False, True])
+def test_task_admission_setup_failure_cancels_the_remote_request(callback):
+    driver = _Driver()
+    driver.acquire_query_task_lease = _RemoteMethod(
+        lambda _request: _FailingObjectRef(callback=callback),
+    )
+    controller = TaskAdmissionController(_payload(), driver=driver)
+
+    expected = "callback registration" if callback else "Future factory"
+    with pytest.raises(RuntimeError, match=expected):
+        controller.request(64)
+
+    request = driver.acquire_query_task_lease.calls[0][0][0]
+    assert controller.state()["state"] == "failed"
+    assert driver.cancel_query_task_lease_request.calls == [
+        ((request["request_id"],), {}),
+    ]
 
 
 def _grant(request):
@@ -172,14 +207,12 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     pending.close()
 
     assert pending.state()["state"] == "closed"
-    assert pending_driver.cancel_query_task_lease_request.calls == [
-        ((pending_request["request_id"],), {"submitted": False})
-    ]
+    assert pending_driver.cancel_query_task_lease_request.calls == [((pending_request["request_id"],), {})]
 
     pending_driver.requests[0].resolve(_grant(pending_request))
     assert pending_driver.cancel_query_task_lease_request.calls == [
-        ((pending_request["request_id"],), {"submitted": False}),
-        ((pending_request["request_id"],), {"submitted": False}),
+        ((pending_request["request_id"],), {}),
+        ((pending_request["request_id"],), {}),
     ]
 
     ready_driver = _Driver()
@@ -191,9 +224,7 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     ready.close()
 
     assert ready.state()["state"] == "closed"
-    assert ready_driver.cancel_query_task_lease_request.calls == [
-        ((ready_request["request_id"],), {"submitted": False})
-    ]
+    assert ready_driver.cancel_query_task_lease_request.calls == [((ready_request["request_id"],), {})]
 
 
 def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
@@ -207,7 +238,7 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
     admission.release()
     admission.release()
 
-    assert driver.cancel_query_task_lease_request.calls == [((request["request_id"],), {"submitted": False})]
+    assert driver.cancel_query_task_lease_request.calls == [((request["request_id"],), {})]
 
 
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -11,6 +11,7 @@ from concurrent.futures import Future
 
 import pytest
 
+import duckdb.execution.ray_control_deadline as ray_control_deadline
 import duckdb.execution.ray_control_submission as ray_control_submission
 import duckdb.execution.udf_task_admission as task_admission
 from duckdb.execution.udf_admission import (
@@ -718,7 +719,7 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
     while len(responses) < len(cancellations) and time.monotonic() < response_deadline:
         time.sleep(0.005)
     assert len(responses) == len(cancellations)
-    scheduler_threads = [thread for thread in threading.enumerate() if thread.name == "vane-task-admission-cleanup"]
+    scheduler_threads = [thread for thread in threading.enumerate() if thread.name == "vane-ray-control-deadlines"]
     assert len(scheduler_threads) == 1
 
     for response in responses:
@@ -732,13 +733,13 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
 def test_task_admission_deadline_scheduler_start_failure_is_retryable(
     monkeypatch,
 ):
-    scheduler = task_admission._TaskAdmissionCancellationScheduler()
+    scheduler = ray_control_deadline.RayControlDeadlineScheduler()
     original_start = threading.Thread.start
     starts = 0
 
     def fail_first_start(thread):
         nonlocal starts
-        if thread.name == "vane-task-admission-cleanup":
+        if thread.name == "vane-ray-control-deadlines":
             starts += 1
             if starts == 1:
                 raise RuntimeError("deadline thread unavailable")
@@ -902,6 +903,101 @@ def test_stalled_control_owners_do_not_consume_the_schedulable_pool():
     assert executor._pending_submissions == 0
 
 
+def test_blocked_future_callbacks_do_not_consume_the_schedulable_pool():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.01,
+        stall_timeout_s=0.2,
+        max_workers=2,
+        max_stalled_workers=2,
+        max_pending_submissions=8,
+        max_pending_per_owner=1,
+    )
+    callbacks_may_return = threading.Event()
+    release_completion_callbacks = threading.Event()
+    submissions_entered = threading.Event()
+    completion_callbacks_entered = threading.Event()
+    counter_lock = threading.Lock()
+    entered_submissions = 0
+    entered_callbacks = 0
+
+    def submission():
+        nonlocal entered_submissions
+        with counter_lock:
+            entered_submissions += 1
+            if entered_submissions == 2:
+                submissions_entered.set()
+        assert callbacks_may_return.wait(timeout=5.0)
+        return "completed"
+
+    def block_completion(_future):
+        nonlocal entered_callbacks
+        with counter_lock:
+            entered_callbacks += 1
+            if entered_callbacks == 2:
+                completion_callbacks_entered.set()
+        assert release_completion_callbacks.wait(timeout=5.0)
+
+    blocked = [executor.submit(f"owner:blocked-completion:{index}", submission) for index in range(2)]
+    assert submissions_entered.wait(timeout=1.0)
+    for future in blocked:
+        future.add_done_callback(block_completion)
+    callbacks_may_return.set()
+    assert completion_callbacks_entered.wait(timeout=1.0)
+
+    healthy = executor.submit("owner:healthy-after-completion-stalls", lambda: "healthy")
+    assert healthy.result(timeout=1.0) == "healthy"
+    with executor._condition:
+        assert sum(worker.stalled for worker in executor._workers.values()) >= 1
+        assert len(executor._workers) <= 4
+
+    release_completion_callbacks.set()
+    assert [future.result(timeout=1.0) for future in blocked] == ["completed"] * 2
+    completion_deadline = time.monotonic() + 1.0
+    while executor._workers and time.monotonic() < completion_deadline:
+        time.sleep(0.005)
+    assert executor._workers == {}
+    assert executor._owners == {}
+    assert executor._pending_submissions == 0
+
+
+def test_control_deadline_uses_lock_free_completion_timestamps():
+    executor = ray_control_submission._RayControlSubmissionExecutor(
+        idle_timeout_s=0.5,
+        stall_timeout_s=0.1,
+        max_workers=1,
+        max_stalled_workers=1,
+        max_pending_submissions=3,
+        max_pending_per_owner=1,
+    )
+    submission_entered = threading.Event()
+    callback_may_return = threading.Event()
+
+    def submission():
+        submission_entered.set()
+        assert callback_may_return.wait(timeout=5.0)
+        return "first"
+
+    first = executor.submit("owner:lock-contention:first", submission)
+    assert submission_entered.wait(timeout=1.0)
+    healthy = executor.submit("owner:lock-contention:healthy", lambda: "healthy")
+
+    with executor._condition:
+        original_worker = next(iter(executor._workers.values()))
+        callback_may_return.set()
+        timestamp_deadline = time.monotonic() + 1.0
+        while original_worker.completion_finished_at is None and time.monotonic() < timestamp_deadline:
+            time.sleep(0.001)
+        assert original_worker.callback_finished_at is not None
+        assert original_worker.completion_finished_at is not None
+        # Hold the bookkeeping lock beyond both phase deadlines. The worker's
+        # already-published timestamps must prevent a false stall classification.
+        time.sleep(0.25)
+
+    assert first.result(timeout=1.0) == "first"
+    assert healthy.result(timeout=1.0) == "healthy"
+    assert original_worker.stalled is False
+
+
 def test_stalled_control_owner_retains_fifo_while_healthy_owner_progresses():
     executor = ray_control_submission._RayControlSubmissionExecutor(
         idle_timeout_s=0.01,
@@ -981,31 +1077,33 @@ def test_control_submissions_fail_fast_at_stalled_worker_bound_and_recover():
     assert recovery.result(timeout=1.0) == "recovered"
 
 
-def test_ray_control_submission_watchdog_start_failure_is_retryable(monkeypatch):
+def test_ray_control_submission_deadline_start_failure_does_not_admit_work(monkeypatch):
+    scheduler = ray_control_deadline.RayControlDeadlineScheduler()
     executor = ray_control_submission._RayControlSubmissionExecutor(
         idle_timeout_s=0.01,
+        deadline_scheduler=scheduler,
     )
     original_start = threading.Thread.start
     starts = 0
 
-    def fail_first_watchdog_start(thread):
+    def fail_first_deadline_start(thread):
         nonlocal starts
-        if thread.name.startswith("vane-ray-control-submit-watchdog-"):
+        if thread.name == "vane-ray-control-deadlines":
             starts += 1
             if starts == 1:
-                raise RuntimeError("control watchdog unavailable")
+                raise RuntimeError("control deadline clock unavailable")
         return original_start(thread)
 
-    monkeypatch.setattr(threading.Thread, "start", fail_first_watchdog_start)
-    with pytest.raises(RuntimeError, match="control watchdog unavailable"):
-        executor.submit("owner:watchdog-start-failure", lambda: "unexpected")
+    monkeypatch.setattr(threading.Thread, "start", fail_first_deadline_start)
+    with pytest.raises(RuntimeError, match="control deadline clock unavailable"):
+        executor.submit("owner:deadline-start-failure", lambda: "unexpected")
 
-    assert executor._watchdog_thread is None
+    assert scheduler._thread is None
     assert executor._workers == {}
     assert executor._owners == {}
     assert executor._pending_submissions == 0
 
-    retry = executor.submit("owner:watchdog-start-retry", lambda: "recovered")
+    retry = executor.submit("owner:deadline-start-retry", lambda: "recovered")
     assert retry.result(timeout=1.0) == "recovered"
 
 

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -443,6 +443,60 @@ def test_blocked_task_admission_submission_does_not_stall_other_controller():
     _wait_for_remote_calls(driver.cancel_query_task_lease_request, 2)
 
 
+def test_blocked_stream_control_does_not_stall_next_admission_from_same_controller():
+    driver = _Driver()
+    blocked_cancel_entered = threading.Event()
+    release_blocked_cancel = threading.Event()
+    first_request_id = ""
+
+    def selectively_blocking_cancel(request):
+        if request["request_id"] == first_request_id:
+            blocked_cancel_entered.set()
+            if not release_blocked_cancel.wait(timeout=5.0):
+                raise RuntimeError("timed out waiting to release blocked stream control")
+        return _resolved_ref({"cancelled": True})
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(
+        selectively_blocking_cancel,
+    )
+    controller = TaskAdmissionController(
+        _payload(),
+        driver=driver,
+        query_generation_capability=_QUERY_GENERATION_CAPABILITY,
+    )
+
+    try:
+        assert controller.request(31)
+        _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+        _wait_for_request_refs(driver, 1)
+        first_request = driver.acquire_query_task_lease.calls[0][0][0]
+        first_request_id = first_request["request_id"]
+        driver.requests[0].resolve(_grant(first_request))
+        _wait_for_state(controller, "ready")
+
+        first_admission = controller.take(31)
+        assert first_admission.submission_scope == f"udf-stream:{first_request_id}"
+        first_admission.release()
+        assert blocked_cancel_entered.wait(timeout=1.0)
+
+        assert controller.request(47)
+        _wait_for_remote_calls(driver.acquire_query_task_lease, 2)
+        _wait_for_request_refs(driver, 2)
+        second_request = driver.acquire_query_task_lease.calls[1][0][0]
+        driver.requests[1].resolve(_grant(second_request))
+        _wait_for_state(controller, "ready")
+
+        second_admission = controller.take(47)
+        assert second_admission.submission_scope == f"udf-stream:{second_request['request_id']}"
+        assert second_admission.submission_scope != first_admission.submission_scope
+        second_admission.release()
+        _wait_for_remote_calls(driver.cancel_query_task_lease_request, 2)
+        assert release_blocked_cancel.is_set() is False
+    finally:
+        release_blocked_cancel.set()
+        controller.close()
+
+
 def test_blocked_task_admission_submission_does_not_retain_closed_controller():
     driver = _Driver()
     submission_entered = threading.Event()

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import gc
 import threading
+import time
 import weakref
 from concurrent.futures import Future
 
@@ -321,6 +322,51 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
     assert acknowledged.wait(timeout=1.0)
     assert len(driver.cancel_query_task_lease_request.calls) == 2
     assert first_response._future.cancelled()
+
+
+def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch):
+    monkeypatch.setattr(
+        task_admission,
+        "_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        task_admission,
+        "_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_MAX_S",
+        0.04,
+    )
+    driver = _Driver()
+    response_timers = []
+
+    def cancel(_request):
+        response = _ObjectRef()
+
+        def acknowledge():
+            if not response._future.cancelled():
+                response.resolve({"cancelled": True})
+
+        timer = threading.Timer(0.015, acknowledge)
+        timer.daemon = True
+        timer.start()
+        response_timers.append(timer)
+        return response
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
+    cancellation = task_admission._TaskAdmissionCancellation(
+        driver=driver,
+        request={"request_id": "slow-cancel", "resources": {}},
+    )
+
+    cancellation.start()
+
+    deadline = time.monotonic() + 1.0
+    while not cancellation._done and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert cancellation._done
+    assert len(driver.cancel_query_task_lease_request.calls) == 2
+    for timer in response_timers:
+        timer.join(timeout=1.0)
+        assert timer.is_alive() is False
 
 
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -606,15 +606,6 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
     driver = _Driver()
     acknowledged = threading.Event()
     first_response = _ObjectRef()
-    cancel_callback_entered = threading.Event()
-    release_cancel_callback = threading.Event()
-
-    def block_cancel_callback(_future):
-        assert threading.current_thread().name != "vane-ray-control-deadlines"
-        cancel_callback_entered.set()
-        assert release_cancel_callback.wait(timeout=5.0)
-
-    first_response._future.add_done_callback(block_cancel_callback)
 
     def cancel(_request):
         if not driver.cancel_query_task_lease_request.calls:
@@ -634,15 +625,11 @@ def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
 
     controller.close()
 
-    try:
-        assert cancel_callback_entered.wait(timeout=1.0)
-        # The next attempt is published before Future.cancel can invoke a
-        # blocking completion callback inline.
-        assert acknowledged.wait(timeout=1.0)
-        assert len(driver.cancel_query_task_lease_request.calls) == 2
-        assert first_response._future.cancelled()
-    finally:
-        release_cancel_callback.set()
+    assert acknowledged.wait(timeout=1.0)
+    assert len(driver.cancel_query_task_lease_request.calls) == 2
+    # The idempotent retry supersedes the observer without invoking arbitrary
+    # callbacks through Future.cancel().
+    assert not first_response._future.cancelled()
 
 
 def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch):
@@ -658,13 +645,17 @@ def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch)
     )
     driver = _Driver()
     response_timers = []
+    first_response = None
 
     def cancel(_request):
+        nonlocal first_response
         response = _ObjectRef()
+        if len(driver.cancel_query_task_lease_request.calls) == 1:
+            first_response = response
+            return response
 
         def acknowledge():
-            if not response._future.cancelled():
-                response.resolve({"cancelled": True})
+            response.resolve({"cancelled": True})
 
         timer = threading.Timer(0.015, acknowledge)
         timer.daemon = True
@@ -690,6 +681,8 @@ def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch)
         time.sleep(0.005)
     assert cancellation._done
     assert len(driver.cancel_query_task_lease_request.calls) == 2
+    assert first_response is not None
+    assert not first_response._future.cancelled()
     for timer in response_timers:
         timer.join(timeout=1.0)
         assert timer.is_alive() is False
@@ -1129,7 +1122,7 @@ def test_stalled_capacity_failures_do_not_run_future_callbacks_on_the_clock():
         return "released"
 
     def block_failure_callback(_future):
-        assert threading.current_thread().name != "vane-ray-control-deadlines"
+        assert threading.current_thread().name.startswith("vane-ray-control-completion")
         failure_callback_entered.set()
         assert release_failure_callback.wait(timeout=5.0)
 
@@ -1157,7 +1150,7 @@ def test_stalled_capacity_failures_do_not_run_future_callbacks_on_the_clock():
     assert [future.result(timeout=1.0) for future in running] == ["released"] * 2
 
 
-def test_deadline_callback_dispatch_replaces_a_blocked_worker(monkeypatch):
+def test_exhausted_completion_callbacks_do_not_block_control_state(monkeypatch):
     callback_executor = ray_control_submission._RayControlSubmissionExecutor(
         idle_timeout_s=0.01,
         stall_timeout_s=0.02,
@@ -1165,41 +1158,55 @@ def test_deadline_callback_dispatch_replaces_a_blocked_worker(monkeypatch):
         max_stalled_workers=1,
         max_pending_submissions=3,
         max_pending_per_owner=1,
-        thread_name_prefix="test-ray-control-deadline-callback",
+        thread_name_prefix="test-ray-control-completion",
     )
     monkeypatch.setattr(
         ray_control_submission,
-        "_RAY_CONTROL_DEADLINE_CALLBACK_EXECUTOR",
+        "_RAY_CONTROL_COMPLETION_CALLBACK_EXECUTOR",
         callback_executor,
     )
-    blocked_callback_entered = threading.Event()
-    release_blocked_callback = threading.Event()
-    healthy_callback_ran = threading.Event()
+    all_callback_workers_blocked = threading.Event()
+    all_callbacks_ran = threading.Event()
+    release_callbacks = threading.Event()
+    state_callback_ran = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
 
     def blocked_callback():
-        assert threading.current_thread().name != "vane-ray-control-deadlines"
-        blocked_callback_entered.set()
-        assert release_blocked_callback.wait(timeout=5.0)
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == 2:
+                all_callback_workers_blocked.set()
+            if entered == 3:
+                all_callbacks_ran.set()
+        assert release_callbacks.wait(timeout=5.0)
 
-    blocked_call = ray_control_submission.create_ray_control_deadline(
-        "owner:blocked-deadline-callback",
-        blocked_callback,
-    )
-    ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(blocked_call, 0)
-    assert blocked_callback_entered.wait(timeout=1.0)
+    for index in range(3):
+        ray_control_submission.dispatch_ray_control_abandonment(
+            f"owner:blocked-abandonment:{index}",
+            blocked_callback,
+        )
+    assert all_callback_workers_blocked.wait(timeout=1.0)
 
-    healthy_call = ray_control_submission.create_ray_control_deadline(
-        "owner:healthy-deadline-callback",
-        healthy_callback_ran.set,
+    state_call = ray_control_submission.create_ray_control_deadline(
+        "owner:state-beside-exhausted-completions",
+        state_callback_ran.set,
     )
-    ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(healthy_call, 0)
+    ray_control_deadline.RAY_CONTROL_DEADLINE_SCHEDULER.schedule(state_call, 0)
     try:
-        assert healthy_callback_ran.wait(timeout=1.0)
+        assert state_callback_ran.wait(timeout=1.0)
         with callback_executor._condition:
             assert any(worker.stalled for worker in callback_executor._workers.values())
             assert len(callback_executor._workers) <= 2
     finally:
-        release_blocked_callback.set()
+        release_callbacks.set()
+    assert all_callbacks_ran.wait(timeout=1.0)
+    completion_deadline = time.monotonic() + 1.0
+    while callback_executor._workers and time.monotonic() < completion_deadline:
+        time.sleep(0.005)
+    assert callback_executor._workers == {}
+    assert callback_executor._owners == {}
 
 
 def test_ray_control_submission_deadline_start_failure_does_not_admit_work(monkeypatch):

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -46,6 +46,13 @@ def _resolved_ref(value):
     return ref
 
 
+def _wait_for_remote_calls(method, count, *, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while len(method.calls) < count and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert len(method.calls) == count
+
+
 class _FailingObjectRef:
     def __init__(self, *, callback=False):
         self._callback = callback
@@ -107,6 +114,7 @@ def test_task_admission_setup_failure_cancels_the_remote_request(callback):
 
     request = driver.acquire_query_task_lease.calls[0][0][0]
     assert controller.state()["state"] == "failed"
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     assert driver.cancel_query_task_lease_request.calls == [
         ((request,), {}),
     ]
@@ -220,6 +228,7 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     pending.close()
 
     assert pending.state()["state"] == "closed"
+    _wait_for_remote_calls(pending_driver.cancel_query_task_lease_request, 1)
     assert pending_driver.cancel_query_task_lease_request.calls == [((pending_request,), {})]
 
     pending_driver.requests[0].resolve(_grant(pending_request))
@@ -236,6 +245,7 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     ready.close()
 
     assert ready.state()["state"] == "closed"
+    _wait_for_remote_calls(ready_driver.cancel_query_task_lease_request, 1)
     assert ready_driver.cancel_query_task_lease_request.calls == [((ready_request,), {})]
 
 
@@ -252,6 +262,7 @@ def test_pending_admission_future_does_not_retain_closed_controller():
 
     assert controller_ref() is None
     driver.requests[0].resolve(_grant(request))
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     assert driver.cancel_query_task_lease_request.calls == [((request,), {})]
 
 
@@ -266,6 +277,7 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
     admission.release()
     admission.release()
 
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     assert driver.cancel_query_task_lease_request.calls == [((request,), {})]
 
 
@@ -398,7 +410,14 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
     for cancellation in cancellations:
         cancellation.start()
 
-    assert len(driver.cancel_query_task_lease_request.calls) == len(cancellations)
+    _wait_for_remote_calls(
+        driver.cancel_query_task_lease_request,
+        len(cancellations),
+    )
+    response_deadline = time.monotonic() + 1.0
+    while len(responses) < len(cancellations) and time.monotonic() < response_deadline:
+        time.sleep(0.005)
+    assert len(responses) == len(cancellations)
     scheduler_threads = [thread for thread in threading.enumerate() if thread.name == "vane-task-admission-cleanup"]
     assert len(scheduler_threads) == 1
 
@@ -406,6 +425,73 @@ def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
         response.resolve({"cancelled": True})
     deadline = time.monotonic() + 1.0
     while not all(cancellation._done for cancellation in cancellations) and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert all(cancellation._done for cancellation in cancellations)
+
+
+def test_task_admission_blocked_rpc_submissions_use_bounded_workers_without_blocking_deadlines():
+    driver = _Driver()
+    release_submissions = threading.Event()
+    all_workers_blocked = threading.Event()
+    entered_lock = threading.Lock()
+    entered = 0
+
+    def cancel(_request):
+        nonlocal entered
+        with entered_lock:
+            entered += 1
+            if entered == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS:
+                all_workers_blocked.set()
+        release_submissions.wait(timeout=5.0)
+        return _resolved_ref({"cancelled": True})
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
+    cancellation_count = task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS + 64
+    cancellations = [
+        task_admission._TaskAdmissionCancellation(
+            driver=driver,
+            request={
+                "request_id": f"blocked-submit:{index}",
+                "resources": {},
+            },
+        )
+        for index in range(cancellation_count)
+    ]
+
+    started_at = time.monotonic()
+    for cancellation in cancellations:
+        cancellation.start()
+    start_elapsed = time.monotonic() - started_at
+
+    deadline_fired = threading.Event()
+    deadline = task_admission._TASK_ADMISSION_CANCELLATION_SCHEDULER.create(
+        deadline_fired.set,
+    )
+    task_admission._TASK_ADMISSION_CANCELLATION_SCHEDULER.schedule(
+        deadline,
+        0.01,
+    )
+    try:
+        assert start_elapsed < 1.0
+        assert all_workers_blocked.wait(timeout=2.0)
+        assert deadline_fired.wait(timeout=1.0)
+        assert (
+            len(driver.cancel_query_task_lease_request.calls)
+            == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS
+        )
+        submission_threads = [
+            thread for thread in threading.enumerate() if thread.name.startswith("vane-task-admission-submit-")
+        ]
+        assert len(submission_threads) == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS
+    finally:
+        release_submissions.set()
+
+    _wait_for_remote_calls(
+        driver.cancel_query_task_lease_request,
+        cancellation_count,
+    )
+    completion_deadline = time.monotonic() + 1.0
+    while not all(cancellation._done for cancellation in cancellations) and time.monotonic() < completion_deadline:
         time.sleep(0.005)
     assert all(cancellation._done for cancellation in cancellations)
 

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -369,6 +369,47 @@ def test_task_admission_cancellation_expands_slow_response_deadline(monkeypatch)
         assert timer.is_alive() is False
 
 
+def test_task_admission_cancellations_share_one_deadline_thread(monkeypatch):
+    monkeypatch.setattr(
+        task_admission,
+        "_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S",
+        30.0,
+    )
+    driver = _Driver()
+    responses = []
+
+    def cancel(_request):
+        response = _ObjectRef()
+        responses.append(response)
+        return response
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
+    cancellations = [
+        task_admission._TaskAdmissionCancellation(
+            driver=driver,
+            request={
+                "request_id": f"shared-cancel:{index}",
+                "resources": {},
+            },
+        )
+        for index in range(256)
+    ]
+
+    for cancellation in cancellations:
+        cancellation.start()
+
+    assert len(driver.cancel_query_task_lease_request.calls) == len(cancellations)
+    scheduler_threads = [thread for thread in threading.enumerate() if thread.name == "vane-task-admission-cleanup"]
+    assert len(scheduler_threads) == 1
+
+    for response in responses:
+        response.resolve({"cancelled": True})
+    deadline = time.monotonic() + 1.0
+    while not all(cancellation._done for cancellation in cancellations) and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert all(cancellation._done for cancellation in cancellations)
+
+
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():
     authority = LocalSlotAdmissionAuthority(
         max_slots=2,

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -3,10 +3,14 @@
 
 from __future__ import annotations
 
+import gc
+import threading
+import weakref
 from concurrent.futures import Future
 
 import pytest
 
+import duckdb.execution.udf_task_admission as task_admission
 from duckdb.execution.udf_admission import (
     LocalExecutionSlotPool,
     LocalSlotAdmissionAuthority,
@@ -35,6 +39,12 @@ class _ObjectRef:
         self._future.set_result(value)
 
 
+def _resolved_ref(value):
+    ref = _ObjectRef()
+    ref.resolve(value)
+    return ref
+
+
 class _FailingObjectRef:
     def __init__(self, *, callback=False):
         self._callback = callback
@@ -55,7 +65,9 @@ class _Driver:
     def __init__(self):
         self.requests: list[_ObjectRef] = []
         self.acquire_query_task_lease = _RemoteMethod(self._acquire)
-        self.cancel_query_task_lease_request = _RemoteMethod(lambda *_args, **_kwargs: None)
+        self.cancel_query_task_lease_request = _RemoteMethod(
+            lambda *_args, **_kwargs: _resolved_ref({"cancelled": True})
+        )
 
     def _acquire(self, _request):
         ref = _ObjectRef()
@@ -95,7 +107,7 @@ def test_task_admission_setup_failure_cancels_the_remote_request(callback):
     request = driver.acquire_query_task_lease.calls[0][0][0]
     assert controller.state()["state"] == "failed"
     assert driver.cancel_query_task_lease_request.calls == [
-        ((request["request_id"],), {}),
+        ((request,), {}),
     ]
 
 
@@ -207,12 +219,11 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     pending.close()
 
     assert pending.state()["state"] == "closed"
-    assert pending_driver.cancel_query_task_lease_request.calls == [((pending_request["request_id"],), {})]
+    assert pending_driver.cancel_query_task_lease_request.calls == [((pending_request,), {})]
 
     pending_driver.requests[0].resolve(_grant(pending_request))
     assert pending_driver.cancel_query_task_lease_request.calls == [
-        ((pending_request["request_id"],), {}),
-        ((pending_request["request_id"],), {}),
+        ((pending_request,), {}),
     ]
 
     ready_driver = _Driver()
@@ -224,7 +235,23 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     ready.close()
 
     assert ready.state()["state"] == "closed"
-    assert ready_driver.cancel_query_task_lease_request.calls == [((ready_request["request_id"],), {})]
+    assert ready_driver.cancel_query_task_lease_request.calls == [((ready_request,), {})]
+
+
+def test_pending_admission_future_does_not_retain_closed_controller():
+    driver = _Driver()
+    controller = TaskAdmissionController(_payload(), driver=driver)
+    assert controller.request(32)
+    request = driver.acquire_query_task_lease.calls[0][0][0]
+    controller_ref = weakref.ref(controller)
+
+    controller.close()
+    del controller
+    gc.collect()
+
+    assert controller_ref() is None
+    driver.requests[0].resolve(_grant(request))
+    assert driver.cancel_query_task_lease_request.calls == [((request,), {})]
 
 
 def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
@@ -238,7 +265,62 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
     admission.release()
     admission.release()
 
-    assert driver.cancel_query_task_lease_request.calls == [((request["request_id"],), {})]
+    assert driver.cancel_query_task_lease_request.calls == [((request,), {})]
+
+
+def test_task_admission_cancellation_retries_until_driver_acknowledges():
+    driver = _Driver()
+    acknowledged = threading.Event()
+    attempts = 0
+
+    def cancel(_request_id):
+        nonlocal attempts
+        attempts += 1
+        response = _ObjectRef()
+        if attempts == 1:
+            response._future.set_exception(RuntimeError("planned transient cancellation failure"))
+        else:
+            response.resolve({"cancelled": True})
+            acknowledged.set()
+        return response
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
+    controller = TaskAdmissionController(_payload(), driver=driver)
+    assert controller.request(24)
+
+    controller.close()
+
+    assert acknowledged.wait(timeout=1.0)
+    assert len(driver.cancel_query_task_lease_request.calls) == 2
+
+
+def test_task_admission_cancellation_retries_a_hung_response(monkeypatch):
+    monkeypatch.setattr(
+        task_admission,
+        "_TASK_ADMISSION_CLEANUP_RESPONSE_TIMEOUT_S",
+        0.01,
+    )
+    driver = _Driver()
+    acknowledged = threading.Event()
+    first_response = _ObjectRef()
+
+    def cancel(_request):
+        if not driver.cancel_query_task_lease_request.calls:
+            raise AssertionError("remote call must be recorded before dispatch")
+        if len(driver.cancel_query_task_lease_request.calls) == 1:
+            return first_response
+        acknowledged.set()
+        return _resolved_ref({"cancelled": True})
+
+    driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
+    controller = TaskAdmissionController(_payload(), driver=driver)
+    assert controller.request(24)
+
+    controller.close()
+
+    assert acknowledged.wait(timeout=1.0)
+    assert len(driver.cancel_query_task_lease_request.calls) == 2
+    assert first_response._future.cancelled()
 
 
 def test_local_slot_admission_owns_concrete_slots_and_wakes_one_waiter():

--- a/tests/fast/test_udf_task_admission.py
+++ b/tests/fast/test_udf_task_admission.py
@@ -11,6 +11,7 @@ from concurrent.futures import Future
 
 import pytest
 
+import duckdb.execution.ray_control_submission as ray_control_submission
 import duckdb.execution.udf_task_admission as task_admission
 from duckdb.execution.udf_admission import (
     LocalExecutionSlotPool,
@@ -51,6 +52,23 @@ def _wait_for_remote_calls(method, count, *, timeout=1.0):
     while len(method.calls) < count and time.monotonic() < deadline:
         time.sleep(0.005)
     assert len(method.calls) == count
+
+
+def _wait_for_state(controller, expected, *, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    state = controller.state()
+    while state["state"] != expected and time.monotonic() < deadline:
+        time.sleep(0.005)
+        state = controller.state()
+    assert state["state"] == expected
+    return state
+
+
+def _wait_for_request_refs(driver, count, *, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while len(driver.requests) < count and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert len(driver.requests) == count
 
 
 class _FailingObjectRef:
@@ -107,13 +125,18 @@ def test_task_admission_setup_failure_cancels_the_remote_request(callback):
         lambda _request: _FailingObjectRef(callback=callback),
     )
     controller = TaskAdmissionController(_payload(), driver=driver)
+    failed = threading.Event()
+    controller.register_wakeup(failed.set)
 
     expected = "callback registration" if callback else "Future factory"
-    with pytest.raises(RuntimeError, match=expected):
-        controller.request(64)
+    assert controller.request(64)
 
+    assert failed.wait(timeout=1.0)
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
     request = driver.acquire_query_task_lease.calls[0][0][0]
     assert controller.state()["state"] == "failed"
+    with pytest.raises(RuntimeError, match=expected):
+        controller.request(64)
     _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     assert driver.cancel_query_task_lease_request.calls == [
         ((request,), {}),
@@ -154,6 +177,8 @@ def test_task_admission_has_one_unresolved_request_and_publishes_ready_lease():
 
     assert controller.request(64)
     assert not controller.request(64)
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(driver, 1)
     assert len(driver.acquire_query_task_lease.calls) == 1
     request = driver.acquire_query_task_lease.calls[0][0][0]
     assert request["retained_input_bytes"] == 64
@@ -166,6 +191,7 @@ def test_task_admission_has_one_unresolved_request_and_publishes_ready_lease():
 
     driver.requests[0].resolve(_grant(request))
 
+    _wait_for_state(controller, "ready")
     assert wakeups == ["ready"]
     assert controller.state() == {
         "state": "ready",
@@ -187,8 +213,11 @@ def test_task_admission_does_not_consume_a_lease_for_different_input_bytes():
     driver = _Driver()
     controller = TaskAdmissionController(_payload(), driver=driver)
     assert controller.request(64)
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(driver, 1)
     request = driver.acquire_query_task_lease.calls[0][0][0]
     driver.requests[0].resolve(_grant(request))
+    _wait_for_state(controller, "ready")
 
     with pytest.raises(RuntimeError, match="retained input bytes"):
         controller.take(32)
@@ -204,6 +233,8 @@ def test_task_admission_preserves_async_denial_reason():
     controller = TaskAdmissionController(_payload(), driver=driver)
     assert controller.request(16)
 
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(driver, 1)
     driver.requests[0].resolve(
         {
             "granted": False,
@@ -212,7 +243,7 @@ def test_task_admission_preserves_async_denial_reason():
         }
     )
 
-    state = controller.state()
+    state = _wait_for_state(controller, "failed")
     assert state["state"] == "failed"
     assert "query_not_registered" in state["error"]
     with pytest.raises(RuntimeError, match="query_not_registered"):
@@ -223,6 +254,8 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     pending_driver = _Driver()
     pending = TaskAdmissionController(_payload(), driver=pending_driver)
     assert pending.request(32)
+    _wait_for_remote_calls(pending_driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(pending_driver, 1)
     pending_request = pending_driver.acquire_query_task_lease.calls[0][0][0]
 
     pending.close()
@@ -239,8 +272,11 @@ def test_task_admission_close_cancels_pending_and_ready_leases():
     ready_driver = _Driver()
     ready = TaskAdmissionController(_payload(), driver=ready_driver)
     assert ready.request(48)
+    _wait_for_remote_calls(ready_driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(ready_driver, 1)
     ready_request = ready_driver.acquire_query_task_lease.calls[0][0][0]
     ready_driver.requests[0].resolve(_grant(ready_request))
+    _wait_for_state(ready, "ready")
 
     ready.close()
 
@@ -253,6 +289,8 @@ def test_pending_admission_future_does_not_retain_closed_controller():
     driver = _Driver()
     controller = TaskAdmissionController(_payload(), driver=driver)
     assert controller.request(32)
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(driver, 1)
     request = driver.acquire_query_task_lease.calls[0][0][0]
     controller_ref = weakref.ref(controller)
 
@@ -270,8 +308,11 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
     driver = _Driver()
     controller = TaskAdmissionController(_payload(), driver=driver)
     assert controller.request(24)
+    _wait_for_remote_calls(driver.acquire_query_task_lease, 1)
+    _wait_for_request_refs(driver, 1)
     request = driver.acquire_query_task_lease.calls[0][0][0]
     driver.requests[0].resolve(_grant(request))
+    _wait_for_state(controller, "ready")
 
     admission = controller.take(24)
     admission.release()
@@ -279,6 +320,77 @@ def test_taken_task_admission_abandons_if_submission_never_takes_ownership():
 
     _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
     assert driver.cancel_query_task_lease_request.calls == [((request,), {})]
+
+
+def test_blocked_task_admission_submission_does_not_stall_other_controller():
+    blocked_driver = _Driver()
+    blocked_submission_entered = threading.Event()
+    release_blocked_submission = threading.Event()
+
+    def blocked_acquire(request):
+        blocked_submission_entered.set()
+        if not release_blocked_submission.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release blocked task admission")
+        return _resolved_ref(_grant(request))
+
+    blocked_driver.acquire_query_task_lease = _RemoteMethod(blocked_acquire)
+    blocked = TaskAdmissionController(_payload(), driver=blocked_driver)
+    healthy_driver = _Driver()
+    healthy = TaskAdmissionController(_payload(), driver=healthy_driver)
+    healthy_ready = threading.Event()
+    healthy.register_wakeup(healthy_ready.set)
+
+    try:
+        started_at = time.monotonic()
+        assert blocked.request(31)
+        request_elapsed = time.monotonic() - started_at
+
+        assert request_elapsed < 1.0
+        assert blocked_submission_entered.wait(timeout=1.0)
+
+        assert healthy.request(47)
+        _wait_for_remote_calls(healthy_driver.acquire_query_task_lease, 1)
+        _wait_for_request_refs(healthy_driver, 1)
+        healthy_request = healthy_driver.acquire_query_task_lease.calls[0][0][0]
+        healthy_driver.requests[0].resolve(_grant(healthy_request))
+
+        assert healthy_ready.wait(timeout=1.0)
+        assert healthy.state()["state"] == "ready"
+    finally:
+        release_blocked_submission.set()
+        blocked.close()
+        healthy.close()
+
+    _wait_for_remote_calls(blocked_driver.cancel_query_task_lease_request, 1)
+    _wait_for_remote_calls(healthy_driver.cancel_query_task_lease_request, 1)
+
+
+def test_blocked_task_admission_submission_does_not_retain_closed_controller():
+    driver = _Driver()
+    submission_entered = threading.Event()
+    release_submission = threading.Event()
+
+    def blocked_acquire(request):
+        submission_entered.set()
+        if not release_submission.wait(timeout=5.0):
+            raise RuntimeError("timed out waiting to release blocked task admission")
+        return _resolved_ref(_grant(request))
+
+    driver.acquire_query_task_lease = _RemoteMethod(blocked_acquire)
+    controller = TaskAdmissionController(_payload(), driver=driver)
+    assert controller.request(29)
+    assert submission_entered.wait(timeout=1.0)
+    controller_ref = weakref.ref(controller)
+
+    controller.close()
+    _wait_for_remote_calls(driver.cancel_query_task_lease_request, 1)
+    del controller
+    gc.collect()
+
+    try:
+        assert controller_ref() is None
+    finally:
+        release_submission.set()
 
 
 def test_task_admission_cancellation_retries_until_driver_acknowledges():
@@ -440,13 +552,13 @@ def test_task_admission_blocked_rpc_submissions_use_bounded_workers_without_bloc
         nonlocal entered
         with entered_lock:
             entered += 1
-            if entered == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS:
+            if entered == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS:
                 all_workers_blocked.set()
         release_submissions.wait(timeout=5.0)
         return _resolved_ref({"cancelled": True})
 
     driver.cancel_query_task_lease_request = _RemoteMethod(cancel)
-    cancellation_count = task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS + 64
+    cancellation_count = ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS + 64
     cancellations = [
         task_admission._TaskAdmissionCancellation(
             driver=driver,
@@ -476,13 +588,12 @@ def test_task_admission_blocked_rpc_submissions_use_bounded_workers_without_bloc
         assert all_workers_blocked.wait(timeout=2.0)
         assert deadline_fired.wait(timeout=1.0)
         assert (
-            len(driver.cancel_query_task_lease_request.calls)
-            == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS
+            len(driver.cancel_query_task_lease_request.calls) == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS
         )
         submission_threads = [
-            thread for thread in threading.enumerate() if thread.name.startswith("vane-task-admission-submit-")
+            thread for thread in threading.enumerate() if thread.name.startswith("vane-ray-control-submit-")
         ]
-        assert len(submission_threads) == task_admission._TASK_ADMISSION_CLEANUP_SUBMISSION_WORKERS
+        assert len(submission_threads) == ray_control_submission._RAY_CONTROL_SUBMISSION_WORKERS
     finally:
         release_submissions.set()
 

--- a/tests/slow/test_expression_udf_side_effect_fault.py
+++ b/tests/slow/test_expression_udf_side_effect_fault.py
@@ -122,6 +122,7 @@ try:
         FakePlan(),
         actor_node_ids_by_stage={"stage:side-effect-fault": (node_id,)},
         query_driver_handle=object(),
+        query_generation_capability="test-query-generation-capability",
         session_config={},
     )
     assert len(created) == 1


### PR DESCRIPTION
## Summary

- observe every eligible Ray `ObjectRefGenerator` from one process-lifetime collector with public, non-consuming `ray.wait(..., fetch_local=False, timeout=0)` probes
- rebuild eligibility from current downstream row, aggregate-byte, and per-item byte capacity on every scheduler pass; local capacity/lifecycle changes interrupt the bounded idle backoff immediately
- dequeue a block only after admission, then keep block -> metadata -> output-lease ownership under one collector; task admission uses one lookahead, actual retained input bytes, and serialized query-driver task/output soft budgets
- retain task, generator, and output-lease ownership in durable cleanup tickets until the driver positively acknowledges the terminal transition
- bind task admission and terminal controls to the current query generation, with bounded replay/proof ledgers preserving exact idempotence without process-lifetime growth
- isolate Ray control calls, state transitions, completion callbacks, and local abandonment in bounded process-wide execution domains so one blocked stream cannot starve unrelated owners
- keep one collector alive for the native dispatcher lifetime and drain all collector-owned streams and leases under one aggregate shutdown deadline

## Why

#264 restored the image workload by consuming one ObjectRef from every active generator as client-side prefetch. That recovered concurrency, but it moved physical blocks into Vane before downstream capacity admitted them.

This PR implements the scheduling boundary requested by #269: readiness observation does not consume generator output, while generator reads and task admission remain controlled by the downstream soft budgets. Ray Core still owns spilling and the streaming-generator buffer; one complete block remains the bounded unit of progress.

## Architecture

The final implementation has three explicit ownership domains:

1. **Data plane** - one collector owns readiness probes, generator reads, metadata validation, output admission, and stream state transitions. It never holds a long-lived eligibility snapshot.
2. **Control plane** - one process-wide deadline clock and bounded, per-owner FIFO executors isolate Ray RPC submission from state and completion callbacks. Each domain caps schedulable and stalled workers; the main submission queue is also bounded globally and per owner.
3. **Terminal cleanup** - cleanup tickets are independent of the collector's asyncio-loop lifetime. `RayStreamCleanupWait` is only a response Future plus a bounded acceptor, so a valid late ACK can finish the ticket exactly once after an earlier attempt timed out, while invalid or stale ACKs cannot release current ownership.

The earlier readiness observer, eligibility-epoch RPCs, actor concurrency groups, wait/control lanes, operation-local cleanup response state, and compatibility fallback paths are removed.

## Key invariants

- zero downstream capacity never consumes a block or metadata ObjectRef
- a slow generator cannot occupy the only downstream DATA credit before it is ready
- terminal cleanup ownership is published before stream-record removal or local Future cancellation
- local Future cancellation and generator abandonment never block the collector; best-effort abandonment is one-shot only after durable remote cleanup owns the resource
- same-owner control calls stay FIFO, while a stalled owner is replaced for unrelated owners within fixed active/stalled/thread and queue bounds
- Future callback invocation and inline completion callbacks are both watchdog-covered, using lock-free completion timestamps so executor-lock contention is not misclassified as a stalled Ray call
- query-generation capabilities prevent delayed admission/cancellation requests from mutating a reopened query with the same query ID
- slot cancellation keeps its fence until all slot-owned tickets finish; process shutdown fences native submission first and then drains the aggregate cleanup ledger

## Validation

Current head: `4b4ce4bbf5`.

- exact-head GitHub CI is green across Python 3.10-3.14 native/release jobs, Python 3.12 native distributed tests, all non-Ray and Ray fast-test shards, lint/type/format, dependency review, and source packages
- full Vane image-classification benchmark at default `batch_size=100`, one RTX 2080 Ti: 803,580/803,580 rows, 840.53s query time, 14:06.32 wall time, 956.04 images/s, exit status 0
- benchmark performance is 0.46% faster than the latest 844.39s reference and 0.51% slower than the historical 836.26s best, i.e. no measurable regression; all paths are unique, null/empty counts are zero, all 1,000 labels are present, and the complete `(image_url, label)` multiset matches the previous valid full output in both directions
- Python 3.14 compilation of the complete `duckdb`, `vane`, and benchmark trees: passed
- focused collector, adapter, and task-admission suite: `119 passed`
- release base suite: `468 passed, 1 skipped`
- the three directly affected stalled-worker, blocked-Future-callback, and same-owner-FIFO race tests passed `90/90` across 30 fresh pytest processes on this exact head; broader cleanup-ACK, shutdown, and abandonment race groups also passed their prior `30/30` repetitions
- root format hooks, Ruff, mypy, changed-file pre-commit hooks, and `git diff --check`: passed
- two consecutive independent GitHub Codex reviews found no major issues on this exact head: [round 1](https://github.com/AstroVela/vane/pull/271#issuecomment-5156934243), [round 2](https://github.com/AstroVela/vane/pull/271#issuecomment-5156964294); unresolved review threads: 0

The benchmark started on `56d0da2e83`; the only later code change moves a stalled-worker exit out of `finally` for Python 3.14 syntax compatibility and does not touch the benchmark's normal data path.

Closes #269
Closes #260

Supersedes #264

Related: #245, #38, #221, #80
