### PR TITLE
[fix](distributed) Drain hash join source updates independently

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 
 #include <algorithm>
+#include <functional>
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
@@ -14,6 +15,218 @@
 
 namespace duckdb {
 namespace distributed {
+
+namespace {
+
+using HashJoinSubmittableTask = SubmittableTask<WorkerTask>;
+using HashJoinTaskPoll = std::pair<bool, HashJoinSubmittableTask>;
+using HashJoinInitialTaskBuilder =
+    std::function<HashJoinSubmittableTask(HashJoinSubmittableTask, HashJoinSubmittableTask)>;
+
+HashJoinTaskPoll EndOfHashJoinTaskStream() {
+	return std::make_pair(false, HashJoinSubmittableTask());
+}
+
+void MoveTaskInputsOrThrow(TaskInputs &target, TaskInputs &source) {
+	for (auto &entry : source) {
+		auto inserted = target.emplace(entry.first, std::move(entry.second));
+		if (!inserted.second) {
+			throw InvalidInputException("HashJoinNode received duplicate source node id %llu",
+			                            static_cast<unsigned long long>(entry.first));
+		}
+	}
+	source.clear();
+}
+
+class HashJoinTaskFanInStream {
+public:
+	HashJoinTaskFanInStream(SubmittableTaskStream<WorkerTask> left, SubmittableTaskStream<WorkerTask> right,
+	                        HashJoinInitialTaskBuilder build_initial_task,
+	                        std::shared_ptr<TaskIDCounter> task_id_counter, uint16_t query_idx, NodeID node_id)
+	    : left_(std::move(left)), right_(std::move(right)), build_initial_task_(std::move(build_initial_task)),
+	      task_id_counter_(std::move(task_id_counter)), query_idx_(query_idx), node_id_(node_id) {
+	}
+
+	HashJoinTaskPoll poll_next() {
+		if (finished_) {
+			return EndOfHashJoinTaskStream();
+		}
+		if (!initialized_) {
+			return PollInitialTask();
+		}
+
+		while (true) {
+			PollReadyInputs();
+			auto ready = EmitContinuationTask();
+			if (ready.first) {
+				return ready;
+			}
+			if (left_exhausted_ && right_exhausted_) {
+				finished_ = true;
+				return EndOfHashJoinTaskStream();
+			}
+
+			if (ShouldBlockOnLeft()) {
+				PollLeft(true);
+			} else {
+				PollRight(true);
+			}
+		}
+	}
+
+	HashJoinTaskPoll try_poll_next() {
+		if (finished_) {
+			return EndOfHashJoinTaskStream();
+		}
+		if (!initialized_) {
+			PollReadyInputs();
+			return TryEmitInitialTask();
+		}
+
+		PollReadyInputs();
+		auto ready = EmitContinuationTask();
+		if (ready.first) {
+			return ready;
+		}
+		if (left_exhausted_ && right_exhausted_) {
+			finished_ = true;
+		}
+		return EndOfHashJoinTaskStream();
+	}
+
+	bool is_exhausted() const {
+		return finished_;
+	}
+
+private:
+	HashJoinTaskPoll PollInitialTask() {
+		while (true) {
+			PollReadyInputs();
+			auto ready = TryEmitInitialTask();
+			if (ready.first || finished_) {
+				return ready;
+			}
+
+			if (!pending_left_ && !left_exhausted_) {
+				PollLeft(true);
+				continue;
+			}
+			if (!pending_right_ && !right_exhausted_) {
+				PollRight(true);
+				continue;
+			}
+		}
+	}
+
+	HashJoinTaskPoll TryEmitInitialTask() {
+		if (pending_left_ && pending_right_) {
+			auto left_task = std::move(*pending_left_);
+			auto right_task = std::move(*pending_right_);
+			pending_left_.reset();
+			pending_right_.reset();
+
+			auto joined_task = build_initial_task_(std::move(left_task), std::move(right_task));
+			continuation_template_ = joined_task.task()->clone();
+			continuation_template_->mutable_inputs().clear();
+			initialized_ = true;
+			return std::make_pair(true, std::move(joined_task));
+		}
+		if (pending_left_ && right_exhausted_) {
+			throw InvalidInputException("HashJoinNode received an empty right task stream");
+		}
+		if (pending_right_ && left_exhausted_) {
+			throw InvalidInputException("HashJoinNode received an empty left task stream");
+		}
+		if (left_exhausted_ && right_exhausted_) {
+			finished_ = true;
+		}
+		return EndOfHashJoinTaskStream();
+	}
+
+	HashJoinTaskPoll EmitContinuationTask() {
+		if (!pending_left_ && !pending_right_) {
+			return EndOfHashJoinTaskStream();
+		}
+
+		TaskInputs inputs;
+		if (pending_left_) {
+			MoveTaskInputsOrThrow(inputs, pending_left_->task()->mutable_inputs());
+			pending_left_.reset();
+		}
+		if (pending_right_) {
+			MoveTaskInputsOrThrow(inputs, pending_right_->task()->mutable_inputs());
+			pending_right_.reset();
+		}
+
+		TaskContext task_context = TaskContext::from_node_context(query_idx_, node_id_, task_id_counter_->next());
+		WorkerTask continuation_task(task_context, continuation_template_->plan(), continuation_template_->config(),
+		                             continuation_template_->context(), continuation_template_->name(),
+		                             std::move(inputs));
+		return std::make_pair(true, HashJoinSubmittableTask(std::move(continuation_task)));
+	}
+
+	void PollReadyInputs() {
+		PollLeft(false);
+		PollRight(false);
+	}
+
+	void PollLeft(bool blocking) {
+		PollSide(left_, pending_left_, left_exhausted_, blocking);
+	}
+
+	void PollRight(bool blocking) {
+		PollSide(right_, pending_right_, right_exhausted_, blocking);
+	}
+
+	static void PollSide(SubmittableTaskStream<WorkerTask> &stream, std::unique_ptr<HashJoinSubmittableTask> &pending,
+	                     bool &exhausted, bool blocking) {
+		if (pending || exhausted) {
+			return;
+		}
+
+		auto next = blocking ? stream.poll_next() : stream.try_poll_next();
+		if (next.first) {
+			pending.reset(new HashJoinSubmittableTask(std::move(next.second)));
+			if (stream.is_exhausted()) {
+				exhausted = true;
+			}
+			return;
+		}
+		if (blocking || stream.is_exhausted()) {
+			exhausted = true;
+		}
+	}
+
+	bool ShouldBlockOnLeft() {
+		if (left_exhausted_) {
+			return false;
+		}
+		if (right_exhausted_) {
+			return true;
+		}
+		const bool block_on_left = prefer_left_;
+		prefer_left_ = !prefer_left_;
+		return block_on_left;
+	}
+
+private:
+	SubmittableTaskStream<WorkerTask> left_;
+	SubmittableTaskStream<WorkerTask> right_;
+	HashJoinInitialTaskBuilder build_initial_task_;
+	std::shared_ptr<TaskIDCounter> task_id_counter_;
+	uint16_t query_idx_;
+	NodeID node_id_;
+	std::unique_ptr<HashJoinSubmittableTask> pending_left_;
+	std::unique_ptr<HashJoinSubmittableTask> pending_right_;
+	std::unique_ptr<WorkerTask> continuation_template_;
+	bool left_exhausted_ = false;
+	bool right_exhausted_ = false;
+	bool initialized_ = false;
+	bool finished_ = false;
+	bool prefer_left_ = true;
+};
+
+} // namespace
 
 HashJoinNode::HashJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<JoinCondition> conditions,
                            JoinType join_type, duckdb::vector<LogicalType> output_types,
@@ -119,11 +332,6 @@ HashJoinNode::CopyJoinStats(const duckdb::vector<unique_ptr<BaseStatistics>> &st
 	return copy;
 }
 
-std::pair<bool, SubmittableTask<WorkerTask>> HashJoinNode::PollNextWithWait(SubmittableTaskStream<WorkerTask> &stream) {
-	// poll_next() is blocking (ChannelStream uses recv()), so no retry needed.
-	return stream.poll_next();
-}
-
 SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<WorkerTask> left_task,
                                                             SubmittableTask<WorkerTask> right_task,
                                                             TaskIDCounter &task_id_counter,
@@ -215,10 +423,8 @@ SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<Work
 	merged_ctx = MergeTaskContext(merged_ctx, context_.to_hashmap());
 	WorkerTask new_task(task_context, left_plan, left_task.task()->config(), std::move(merged_ctx), "WorkerTask");
 	auto &inputs = new_task.mutable_inputs();
-	inputs = left_task.task()->inputs();
-	for (const auto &entry : right_task.task()->inputs()) {
-		inputs[entry.first] = entry.second;
-	}
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs());
 	return std::move(left_task).with_new_task(std::move(new_task));
 }
 
@@ -229,44 +435,23 @@ SubmittableTaskStream<WorkerTask> HashJoinNode::produce_tasks(PlanExecutionConte
 	auto left_input = left_->produce_tasks(plan_context);
 	auto right_input = right_->produce_tasks(plan_context);
 
-	auto channel_pair_ = create_channel<SubmittableTask<WorkerTask>>(1);
-	auto result_tx = std::move(channel_pair_.first);
-	auto result_rx = std::move(channel_pair_.second);
-	auto result_tx_ptr = std::make_shared<Sender<SubmittableTask<WorkerTask>>>(std::move(result_tx));
-
 	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
 	auto *client_context = plan_context.client_context();
 	auto self_shared = shared_from_this();
-	auto left_input_ptr = std::make_shared<SubmittableTaskStream<WorkerTask>>(std::move(left_input));
-	auto right_input_ptr = std::make_shared<SubmittableTaskStream<WorkerTask>>(std::move(right_input));
+	HashJoinInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                                 client_context](HashJoinSubmittableTask left_task,
+	                                                                 HashJoinSubmittableTask right_task) mutable {
+		return self_shared->BuildHashJoinTask(std::move(left_task), std::move(right_task), *task_id_counter,
+		                                      client_context);
+	};
 
-	plan_context.spawn([self_shared, left_input_ptr, right_input_ptr, task_id_counter, client_context,
-	                    result_tx_ptr]() mutable -> DuckDBResult<void> {
-		while (true) {
-			auto left_task = HashJoinNode::PollNextWithWait(*left_input_ptr);
-			if (!left_task.first) {
-				result_tx_ptr->close();
-				return DuckDBResult<void>::ok();
-			}
-			auto right_task = HashJoinNode::PollNextWithWait(*right_input_ptr);
-			if (!right_task.first) {
-				result_tx_ptr->close();
-				return DuckDBResult<void>::ok();
-			}
-			auto joined_task = self_shared->BuildHashJoinTask(std::move(left_task.second), std::move(right_task.second),
-			                                                  *task_id_counter, client_context);
-			auto send_res = result_tx_ptr->send(std::move(joined_task));
-			// Receiver drop is a normal cancellation signal (e.g. downstream
-			// finished processing before upstream exhausted).
-			if (send_res.is_err()) {
-				result_tx_ptr->close();
-				return DuckDBResult<void>::ok();
-			}
-		}
-		return DuckDBResult<void>::ok();
-	});
-
-	return SubmittableTaskStream<WorkerTask>::from_receiver(std::move(result_rx));
+	// The first event registers a physical join fragment containing both
+	// exchange sources. Later events are dynamic-input updates for that same
+	// fragment: their TaskInputs are keyed by source_node_id, so either side can
+	// advance independently without a positional left/right zip.
+	HashJoinTaskFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                               task_id_counter, context_.query_idx(), node_id());
+	return SubmittableTaskStream<WorkerTask>(boxed<HashJoinSubmittableTask>(std::move(stream)));
 }
 
 } // namespace distributed

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join.hpp
@@ -52,7 +52,6 @@ private:
 	static unique_ptr<JoinFilterPushdownInfo> CopyFilterPushdownInfo(const JoinFilterPushdownInfo &info);
 	static duckdb::vector<unique_ptr<BaseStatistics>>
 	CopyJoinStats(const duckdb::vector<unique_ptr<BaseStatistics>> &stats);
-	static std::pair<bool, SubmittableTask<WorkerTask>> PollNextWithWait(SubmittableTaskStream<WorkerTask> &stream);
 
 	SubmittableTask<WorkerTask> BuildHashJoinTask(SubmittableTask<WorkerTask> left_task,
 	                                              SubmittableTask<WorkerTask> right_task,

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -29,6 +29,9 @@
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
@@ -85,6 +88,140 @@ static WorkerTask MakeWorkerTaskWithoutRoot(NodeID node_id, const std::string &n
 	return WorkerTask(TaskContext::from_node_context(1, node_id, static_cast<TaskID>(node_id)), plan,
 	                  DuckDBExecutionConfigRef(),
 	                  PipelineNodeContext(1, "join-query", node_id, node_name).to_hashmap());
+}
+
+class StaticTaskNode : public PipelineNodeImpl {
+public:
+	StaticTaskNode(NodeID node_id, SourceNodeId source_node_id, const std::string &node_name,
+	               const std::vector<std::string> &input_bytes)
+	    : config_(MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT}),
+	              std::make_shared<DuckDBExecutionConfig>(), ClusteringSpec::unknown_with_num_partitions(1)),
+	      context_(1, "join-query", node_id, node_name) {
+		for (const auto &input : input_bytes) {
+			tasks_.push_back(MakeWorkerTaskWithInput(node_id, node_name, source_node_id, input));
+		}
+	}
+
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override {
+		return {};
+	}
+
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext & /*plan_context*/) override {
+		struct VectorTaskStream {
+			explicit VectorTaskStream(std::vector<WorkerTask> tasks_p) : tasks(std::move(tasks_p)) {
+			}
+
+			std::pair<bool, SubmittableTask<WorkerTask>> poll_next() {
+				if (index >= tasks.size()) {
+					return std::make_pair(false, SubmittableTask<WorkerTask>());
+				}
+				return std::make_pair(true, SubmittableTask<WorkerTask>(std::move(tasks[index++])));
+			}
+
+			std::pair<bool, SubmittableTask<WorkerTask>> try_poll_next() {
+				return poll_next();
+			}
+
+			bool is_exhausted() const {
+				return index >= tasks.size();
+			}
+
+			std::vector<WorkerTask> tasks;
+			idx_t index = 0;
+		};
+
+		auto stream = VectorTaskStream(std::move(tasks_));
+		return SubmittableTaskStream<WorkerTask>(boxed<SubmittableTask<WorkerTask>>(std::move(stream)));
+	}
+
+	std::vector<std::string> multiline_display(bool /*verbose*/) const override {
+		return {context_.node_name()};
+	}
+
+private:
+	PipelineNodeConfig config_;
+	PipelineNodeContext context_;
+	std::vector<WorkerTask> tasks_;
+};
+
+static std::shared_ptr<HashJoinNode> MakeHashJoinNode(const std::vector<std::string> &left_inputs,
+                                                      const std::vector<std::string> &right_inputs) {
+	PlanConfig plan_cfg(1, "join-query", std::make_shared<DuckDBExecutionConfig>());
+	auto left_impl = std::make_shared<StaticTaskNode>(10, 10, "left", left_inputs);
+	auto right_impl = std::make_shared<StaticTaskNode>(20, 20, "right", right_inputs);
+	auto left = std::make_shared<DistributedPipelineNode>(left_impl);
+	auto right = std::make_shared<DistributedPipelineNode>(right_impl);
+	auto schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT, LogicalType::BIGINT});
+
+	return std::make_shared<HashJoinNode>(
+	    300, plan_cfg, vector<JoinCondition> {}, JoinType::INNER,
+	    vector<LogicalType> {LogicalType::BIGINT, LogicalType::BIGINT}, vector<LogicalType> {}, vector<LogicalType> {},
+	    PhysicalHashJoin::JoinProjectionColumns(), PhysicalHashJoin::JoinProjectionColumns(),
+	    PhysicalHashJoin::JoinProjectionColumns(), vector<unique_ptr<BaseStatistics>> {}, nullptr, 1, std::move(left),
+	    std::move(right), std::move(schema));
+}
+
+static std::vector<std::string> MakeInputNames(const std::string &prefix, idx_t count) {
+	std::vector<std::string> result;
+	for (idx_t index = 0; index < count; index++) {
+		result.push_back(prefix + std::to_string(index));
+	}
+	return result;
+}
+
+static void RequireHashJoinFanInPreservesInputs(idx_t left_count, idx_t right_count) {
+	auto left_inputs = MakeInputNames("left-", left_count);
+	auto right_inputs = MakeInputNames("right-", right_count);
+	auto node = MakeHashJoinNode(left_inputs, right_inputs);
+
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto task_executor = std::make_shared<TaskExecutor>(*connection.context);
+	PlanExecutionContext plan_context(task_executor, connection.context);
+	auto stream = node->produce_tasks(plan_context);
+
+	std::vector<std::string> actual_left_inputs;
+	std::vector<std::string> actual_right_inputs;
+	std::string fragment_node_id;
+	while (true) {
+		auto next = stream.poll_next();
+		if (!next.first) {
+			break;
+		}
+		const auto &context = next.second.task()->context();
+		auto node_id_entry = context.find("node_id");
+		REQUIRE(node_id_entry != context.end());
+		REQUIRE_FALSE(node_id_entry->second.empty());
+		if (fragment_node_id.empty()) {
+			fragment_node_id = node_id_entry->second;
+		} else {
+			REQUIRE(node_id_entry->second == fragment_node_id);
+		}
+
+		const auto &inputs = next.second.task()->inputs();
+		REQUIRE_FALSE(inputs.empty());
+		REQUIRE(inputs.size() <= 2);
+		auto left_entry = inputs.find(10);
+		if (left_entry != inputs.end()) {
+			actual_left_inputs.push_back(left_entry->second.scan_task_bytes);
+		}
+		auto right_entry = inputs.find(20);
+		if (right_entry != inputs.end()) {
+			actual_right_inputs.push_back(right_entry->second.scan_task_bytes);
+		}
+	}
+	task_executor->WorkOnTasks();
+
+	REQUIRE(actual_left_inputs == left_inputs);
+	REQUIRE(actual_right_inputs == right_inputs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -310,6 +447,55 @@ TEST_CASE("HashJoinNode: replacement task preserves both side inputs", "[distrib
 	    ClonePhysicalPlanOrThrow(joined_task.task()->plan(), "hash_join_owned_children_test", nullptr);
 	REQUIRE(joined_plan_clone->HasRoot());
 	REQUIRE(joined_plan_clone->Root().children.size() == 2);
+}
+
+TEST_CASE("HashJoinNode: fan-in preserves child task streams", "[distributed][source_id][join]") {
+	SECTION("streams have equal length") {
+		RequireHashJoinFanInPreservesInputs(3, 3);
+	}
+	SECTION("left stream is longer") {
+		RequireHashJoinFanInPreservesInputs(3, 1);
+	}
+	SECTION("right stream is longer") {
+		RequireHashJoinFanInPreservesInputs(1, 3);
+	}
+}
+
+TEST_CASE("HashJoinNode: asymmetric empty child stream fails loudly", "[distributed][source_id][join]") {
+	SECTION("right stream is empty") {
+		auto node = MakeHashJoinNode(MakeInputNames("left-", 1), {});
+		DuckDB db(nullptr);
+		Connection connection(db);
+		auto task_executor = std::make_shared<TaskExecutor>(*connection.context);
+		PlanExecutionContext plan_context(task_executor, connection.context);
+		auto stream = node->produce_tasks(plan_context);
+
+		REQUIRE_THROWS_WITH(stream.poll_next(), Catch::Matchers::Contains("empty right task stream"));
+		task_executor->WorkOnTasks();
+	}
+	SECTION("left stream is empty") {
+		auto node = MakeHashJoinNode({}, MakeInputNames("right-", 1));
+		DuckDB db(nullptr);
+		Connection connection(db);
+		auto task_executor = std::make_shared<TaskExecutor>(*connection.context);
+		PlanExecutionContext plan_context(task_executor, connection.context);
+		auto stream = node->produce_tasks(plan_context);
+
+		REQUIRE_THROWS_WITH(stream.poll_next(), Catch::Matchers::Contains("empty left task stream"));
+		task_executor->WorkOnTasks();
+	}
+}
+
+TEST_CASE("HashJoinNode: two empty child streams produce no task", "[distributed][source_id][join]") {
+	auto node = MakeHashJoinNode({}, {});
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto task_executor = std::make_shared<TaskExecutor>(*connection.context);
+	PlanExecutionContext plan_context(task_executor, connection.context);
+	auto stream = node->produce_tasks(plan_context);
+
+	REQUIRE_FALSE(stream.poll_next().first);
+	task_executor->WorkOnTasks();
 }
 
 TEST_CASE("BroadcastJoinNode: replacement task preserves receiver inputs", "[distributed][source_id][join]") {

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3380,6 +3380,65 @@ def test_ray_join_flight_shuffle_exchange(ray_runner, duckdb_conn, parquet_path,
     )
 
 
+def test_ray_hash_join_drains_unequal_repartition_event_streams(ray_runner, duckdb_conn, tmp_path, monkeypatch):
+    label = "test_ray_e2e: hash join unequal repartition event streams"
+    left_path = tmp_path / "hash_join_unequal_left"
+    right_path = tmp_path / "hash_join_unequal_right"
+    shuffle_dir = tmp_path / "hash_join_unequal_shuffle"
+
+    monkeypatch.setenv("VANE_SHUFFLE_ALGORITHM", "flight_shuffle")
+    monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", str(shuffle_dir))
+    monkeypatch.setenv("VANE_DISTRIBUTED_JOIN_STRATEGY", "hash")
+    monkeypatch.setenv("VANE_DISTRIBUTED_AUTO_BROADCAST_THRESHOLD_BYTES", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "8")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                i::INTEGER AS id,
+                i::INTEGER AS file_id
+            FROM range(0, 8) AS t(i)
+        ) TO '{left_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                i::INTEGER AS id,
+                (i % 2)::INTEGER AS file_id
+            FROM range(0, 8) AS t(i)
+        ) TO '{right_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+
+    sql = f"""
+        SELECT l.id
+        FROM read_parquet('{left_path}/**/*.parquet') AS l
+        JOIN read_parquet('{right_path}/**/*.parquet') AS r
+          ON l.id = r.id
+    """
+    relation = duckdb_conn.sql(sql)
+    ray_cxx = getattr(duckdb, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("duckdb.ray_cxx.PyLogicalPlan not available in this environment")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"{label}-plan")
+    distributed_plan = logical_plan.to_physical_plan(duckdb_conn)
+    descriptor_counts = sorted(len(descriptors) for descriptors in distributed_plan.scan_task_descriptor_map().values())
+    assert descriptor_counts == [2, 8], f"{label}: expected unequal scan task streams, got {descriptor_counts}"
+    plan_text = distributed_plan.repr_ascii(False)
+    assert "REPARTITION" in plan_text.upper(), f"{label}: expected repartitioned hash join, got:\n{plan_text}"
+    assert "HASH JOIN" in plan_text.upper(), f"{label}: expected hash join, got:\n{plan_text}"
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["HASH_JOIN"],
+        timeout_s=60.0,
+    )
+
+
 @pytest.mark.external_service
 def test_ray_group_by_flight_shuffle_exchange_minio_durable(ray_runner, duckdb_conn, tmp_path, monkeypatch):
     label = "test_ray_e2e: group by flight shuffle exchange minio durable"

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -7622,6 +7622,79 @@ def test_fte_exchange_source_stream_exhaustion_sends_no_more_to_running_task(mon
     assert no_more_call[2] == "3"
 
 
+def test_fte_hash_fragment_accepts_one_sided_exchange_updates(monkeypatch):
+    monkeypatch.setattr(
+        RayWorkerActorHandle,
+        "_fte_task_handle_cls",
+        staticmethod(lambda: _FakeFteTaskHandle),
+    )
+    actor = _FakeActor()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    first_task = _FakeTask(
+        name="hash-join-exchange-initial",
+        context={"query_id": "query-fte-hash-join-fan-in", "node_id": "8"},
+        inputs={
+            "3": {
+                "kind": "exchange_source_task",
+                "data": {
+                    "partition_indices": [0],
+                    "source_partition_count": 1,
+                    "source_task_count": 1,
+                    "source_handles": [{"partition_id": 0, "path": "left-sink-a"}],
+                },
+            },
+            "4": {
+                "kind": "exchange_source_task",
+                "data": {
+                    "partition_indices": [0],
+                    "source_partition_count": 1,
+                    "source_task_count": 1,
+                    "source_handles": [{"partition_id": 0, "path": "right-sink-a"}],
+                },
+            },
+        },
+        plan={"plan": "hash-join-template"},
+    )
+    left_update = _FakeTask(
+        name="hash-join-exchange-left-update",
+        context={"query_id": "query-fte-hash-join-fan-in", "node_id": "8"},
+        inputs={
+            "3": {
+                "kind": "exchange_source_task",
+                "data": {
+                    "partition_indices": [0],
+                    "source_partition_count": 1,
+                    "source_task_count": 1,
+                    "source_handles": [{"partition_id": 0, "path": "left-sink-b"}],
+                },
+            }
+        },
+        plan={"plan": "hash-join-template"},
+    )
+
+    first_handles = handle.submit_tasks([first_task])
+    actor.fte_calls.clear()
+    update_handles = handle.submit_tasks([left_update])
+
+    assert len(first_handles) == 1
+    assert update_handles == []
+    assert [call[0] for call in actor.fte_calls] == [
+        "wait_split_queue",
+        "add_splits",
+    ]
+    add_call = actor.fte_calls[1]
+    assert add_call[2] == "3"
+    assert add_call[3][0]["data"]["source_handles"][0]["path"] == "left-sink-b"
+
+    actor.fte_calls.clear()
+    exhausted_handles = handle.task_input_stream_exhausted(["3", "4"])
+
+    assert exhausted_handles == []
+    no_more_calls = [call for call in actor.fte_calls if call[0] == "no_more_splits"]
+    assert len(no_more_calls) == 2
+    assert {call[2] for call in no_more_calls} == {"3", "4"}
+
+
 def test_fte_exchange_selector_event_updates_running_consumer(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,


### PR DESCRIPTION
## Summary

- replace the positional left/right task-stream zip with a source-keyed fan-in
- register the physical hash-join fragment once, then send one-sided or two-sided dynamic exchange-source updates to that stable fragment
- drain both child streams to exhaustion with bounded pending state and reject duplicate source IDs
- add native stream-shape coverage, FTE one-sided update coverage, and a real unequal-repartition Ray regression

## Validation

- scripts/format workspace --changed
- native distributed suite: 119 tests, 4021 assertions
- release suite: 453 non-Ray passed, 1 skipped; 8 Ray passed
- FTE fragment submission suite: 227 passed
- unequal repartition hash-join e2e: passed

Closes #280