### PR TITLE
[fix](datasource) Preserve Arrow scan state across batches

### DIFF
--- a/external/duckdb/src/function/table/datasource_scan.cpp
+++ b/external/duckdb/src/function/table/datasource_scan.cpp
@@ -164,27 +164,35 @@ static unique_ptr<GlobalTableFunctionState> DataSourceScanInitGlobal(ClientConte
 // ── Init Local ─────────────────────────────────────────────────────
 // Each pipeline thread gets its own local state. On init, grab first task.
 
+static void DataSourceScanStartNextTask(const DataSourceScanBindData &bind_data, DataSourceScanGlobalState &gstate,
+                                        DataSourceScanLocalState &lstate) {
+	D_ASSERT(lstate.state == DataSourceScanLocalState::ScanState::NEED_TASK);
+	D_ASSERT(!lstate.stream);
+
+	auto idx = gstate.next_task_idx.fetch_add(1);
+	if (idx >= gstate.total_tasks) {
+		lstate.state = DataSourceScanLocalState::ScanState::EXHAUSTED;
+		return;
+	}
+
+	auto &pickled = bind_data.pickled_tasks[idx];
+	auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
+	RequireProduceStream(bind_data.produce_stream)(pickled.c_str(), pickled.size(),
+	                                               &stream_wrapper->arrow_array_stream);
+	lstate.stream = std::move(stream_wrapper);
+	lstate.state = DataSourceScanLocalState::ScanState::NEED_BATCH;
+}
+
 static unique_ptr<LocalTableFunctionState> DataSourceScanInitLocal(ExecutionContext &context,
                                                                    TableFunctionInitInput &input,
                                                                    GlobalTableFunctionState *global_state) {
 	auto &bind_data = input.bind_data->Cast<DataSourceScanBindData>();
 	auto &gstate = global_state->Cast<DataSourceScanGlobalState>();
-	auto result = make_uniq<DataSourceScanLocalState>();
-
-	// Grab first task for this thread
-	auto idx = gstate.next_task_idx.fetch_add(1);
-	if (idx >= gstate.total_tasks) {
-		result->exhausted = true;
-		return std::move(result);
+	auto result = make_uniq<DataSourceScanLocalState>(context.client);
+	for (idx_t i = 0; i < bind_data.arrow_table.GetColumns().size(); i++) {
+		result->scan_state.column_ids.push_back(i);
 	}
-
-	// Produce stream for this task
-	auto &pickled = bind_data.pickled_tasks[idx];
-	auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
-	RequireProduceStream(bind_data.produce_stream)(pickled.c_str(), pickled.size(),
-	                                               &stream_wrapper->arrow_array_stream);
-	result->stream = std::move(stream_wrapper);
-
+	DataSourceScanStartNextTask(bind_data, gstate, *result);
 	return std::move(result);
 }
 
@@ -192,58 +200,54 @@ static unique_ptr<LocalTableFunctionState> DataSourceScanInitLocal(ExecutionCont
 // Each pipeline thread pulls chunks from its current ArrowArrayStream.
 // When exhausted, grabs the next task.
 
-static void DataSourceScanGetData(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+static void DataSourceScanGetData(ClientContext &, TableFunctionInput &data, DataChunk &output) {
 	auto &bind_data = data.bind_data->Cast<DataSourceScanBindData>();
 	auto &gstate = data.global_state->Cast<DataSourceScanGlobalState>();
 	auto &lstate = data.local_state->Cast<DataSourceScanLocalState>();
 
-	while (!lstate.exhausted) {
-		if (lstate.stream) {
-			// Try to get next chunk from current stream
+	while (true) {
+		switch (lstate.state) {
+		case DataSourceScanLocalState::ScanState::NEED_TASK:
+			DataSourceScanStartNextTask(bind_data, gstate, lstate);
+			break;
+		case DataSourceScanLocalState::ScanState::NEED_BATCH: {
+			D_ASSERT(lstate.stream);
+			auto &scan_state = lstate.scan_state;
+			scan_state.Reset();
 			auto chunk = lstate.stream->GetNextChunk();
-			if (chunk->arrow_array.release && chunk->arrow_array.length > 0) {
-				// Convert Arrow → DataChunk using ArrowScanLocalState
-				auto output_size = MinValue<idx_t>(STANDARD_VECTOR_SIZE, NumericCast<idx_t>(chunk->arrow_array.length));
-
-				// ArrowScanLocalState needs unique_ptr, but GetNextChunk returns shared_ptr
-				// Move the ArrowArray into a new unique_ptr wrapper
-				auto owned_chunk = make_uniq<ArrowArrayWrapper>();
-				owned_chunk->arrow_array = chunk->arrow_array;
-				chunk->arrow_array.release = nullptr; // prevent double-free
-
-				ArrowScanLocalState arrow_lstate(std::move(owned_chunk), context);
-				// Set column_ids to identity mapping (no projection pushdown)
-				for (idx_t i = 0; i < bind_data.arrow_table.GetColumns().size(); i++) {
-					arrow_lstate.column_ids.push_back(i);
-				}
-
-				output.SetCardinality(output_size);
-				ArrowTableFunction::ArrowToDuckDB(arrow_lstate, bind_data.arrow_table.GetColumns(), output,
-				                                  false /* arrow_scan_is_projected */);
-				output.Verify();
-				return;
+			while (chunk->arrow_array.release && chunk->arrow_array.length == 0) {
+				chunk = lstate.stream->GetNextChunk();
 			}
-			// Stream exhausted
-			lstate.stream.reset();
+			scan_state.chunk = std::move(chunk);
+			if (scan_state.chunk->arrow_array.release) {
+				lstate.state = DataSourceScanLocalState::ScanState::SCANNING;
+			} else {
+				lstate.stream.reset();
+				lstate.state = DataSourceScanLocalState::ScanState::NEED_TASK;
+			}
+			break;
 		}
-
-		// Grab next task
-		auto idx = gstate.next_task_idx.fetch_add(1);
-		if (idx >= gstate.total_tasks) {
-			lstate.exhausted = true;
+		case DataSourceScanLocalState::ScanState::SCANNING: {
+			auto &scan_state = lstate.scan_state;
+			D_ASSERT(scan_state.chunk->arrow_array.release);
+			auto chunk_size = NumericCast<idx_t>(scan_state.chunk->arrow_array.length);
+			D_ASSERT(scan_state.chunk_offset < chunk_size);
+			auto output_size = MinValue<idx_t>(STANDARD_VECTOR_SIZE, chunk_size - scan_state.chunk_offset);
+			output.SetCardinality(output_size);
+			ArrowTableFunction::ArrowToDuckDB(scan_state, bind_data.arrow_table.GetColumns(), output,
+			                                  false /* arrow_scan_is_projected */);
+			output.Verify();
+			scan_state.chunk_offset += output.size();
+			if (scan_state.chunk_offset == chunk_size) {
+				lstate.state = DataSourceScanLocalState::ScanState::NEED_BATCH;
+			}
+			return;
+		}
+		case DataSourceScanLocalState::ScanState::EXHAUSTED:
 			output.SetCardinality(0);
 			return;
 		}
-
-		// Produce new stream
-		auto &pickled = bind_data.pickled_tasks[idx];
-		auto stream_wrapper = make_uniq<ArrowArrayStreamWrapper>();
-		RequireProduceStream(bind_data.produce_stream)(pickled.c_str(), pickled.size(),
-		                                               &stream_wrapper->arrow_array_stream);
-		lstate.stream = std::move(stream_wrapper);
 	}
-
-	output.SetCardinality(0);
 }
 
 // ── Serialize/Deserialize ──────────────────────────────────────────

--- a/external/duckdb/src/include/duckdb/function/table/datasource_scan.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/datasource_scan.hpp
@@ -13,9 +13,9 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
-#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 #include "duckdb/function/built_in_functions.hpp"
 #include "duckdb/function/extension_file_list_provider.hpp"
+#include "duckdb/function/table/arrow.hpp"
 
 namespace duckdb {
 
@@ -85,10 +85,22 @@ struct DataSourceScanGlobalState : public GlobalTableFunctionState {
 };
 
 struct DataSourceScanLocalState : public LocalTableFunctionState {
+	enum class ScanState {
+		NEED_TASK,
+		NEED_BATCH,
+		SCANNING,
+		EXHAUSTED,
+	};
+
+	explicit DataSourceScanLocalState(ClientContext &context) : scan_state(make_uniq<ArrowArrayWrapper>(), context) {
+	}
+
 	//! Per-thread arrow stream (one per task)
 	unique_ptr<ArrowArrayStreamWrapper> stream;
-	//! Whether this thread is done
-	bool exhausted = false;
+	//! Current Arrow batch and conversion offset, retained across output vectors
+	ArrowScanLocalState scan_state;
+	//! Explicit scan state for task, batch, and output-vector transitions
+	ScanState state = ScanState::NEED_TASK;
 };
 
 struct DataSourceScanFunction {

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -129,6 +129,28 @@ class StreamingSource(DataSource):
         yield StreamingTask()
 
 
+class BatchSequenceTask(DataSourceTask):
+    def __init__(self, batches: list[list[int]]) -> None:
+        self.batches = [list(batch) for batch in batches]
+
+    def execute(self) -> Iterator[pa.RecordBatch]:
+        for batch in self.batches:
+            yield pa.record_batch({"value": pa.array(batch, type=pa.int64())})
+
+
+class BatchSequenceSource(DataSource):
+    def __init__(self, tasks: list[list[list[int]]]) -> None:
+        self.tasks = [[list(batch) for batch in task] for task in tasks]
+
+    @property
+    def schema(self) -> dict[str, str]:
+        return {"value": "BIGINT"}
+
+    def get_tasks(self) -> Iterator[DataSourceTask]:
+        for task in self.tasks:
+            yield BatchSequenceTask(task)
+
+
 class SchemaCallTrackingSource(StreamingSource):
     schema_calls = 0
 
@@ -274,6 +296,20 @@ def test_datasource_factory_owner_released_when_stream_finishes(duckdb_conn):
     assert finished["registry_size"] == baseline["registry_size"]
     assert finished["factory_count"] == baseline["factory_count"]
     assert finished["owner_count"] == baseline["owner_count"]
+
+
+def test_datasource_scan_reads_entire_large_record_batch(duckdb_conn):
+    values = list(range(5000))
+
+    result = read_datasource(BatchSequenceSource([[values]]), con=duckdb_conn).fetchall()
+
+    assert result == [(value,) for value in values]
+
+
+def test_datasource_scan_continues_after_empty_record_batches(duckdb_conn):
+    source = BatchSequenceSource([[[], [10, 20], [], [], [30], []]])
+
+    assert read_datasource(source, con=duckdb_conn).fetchall() == [(10,), (20,), (30,)]
 
 
 def test_datasource_schema_is_evaluated_once(duckdb_conn):
@@ -544,3 +580,27 @@ def test_ray_runner_executes_python_datasource_task_on_worker(ray_runner, duckdb
     shared_worker_pids = creation_counts_by_run[0].keys() & creation_counts_by_run[1].keys()
     for pid in shared_worker_pids:
         assert creation_counts_by_run[1][pid] == creation_counts_by_run[0][pid] + 1
+
+
+def test_ray_runner_preserves_large_and_post_empty_datasource_batches(ray_runner, duckdb_conn):
+    class RayBatchSequenceTask(DataSourceTask):
+        def __init__(self, batches: list[list[int]]) -> None:
+            self.batches = [list(batch) for batch in batches]
+
+        def execute(self) -> Iterator[pa.RecordBatch]:
+            for batch in self.batches:
+                yield pa.record_batch({"value": pa.array(batch, type=pa.int64())})
+
+    class RayBatchSequenceSource(DataSource):
+        @property
+        def schema(self) -> dict[str, str]:
+            return {"value": "BIGINT"}
+
+        def get_tasks(self) -> Iterator[DataSourceTask]:
+            yield RayBatchSequenceTask([[], list(range(5000)), [], [5000, 5001]])
+            yield RayBatchSequenceTask([[], [6000], []])
+
+    expected = list(range(5002)) + [6000]
+    table = _collect_tables(ray_runner, read_datasource(RayBatchSequenceSource(), con=duckdb_conn))
+
+    assert sorted(table.column(0).to_pylist()) == expected


### PR DESCRIPTION
## Summary

- replace the implicit datasource scan flow with explicit `NEED_TASK`, `NEED_BATCH`, `SCANNING`, and `EXHAUSTED` states
- retain `ArrowScanLocalState` across table-function calls so every DuckDB vector in a large Arrow RecordBatch is emitted
- treat only an Arrow array with `release == nullptr` as end-of-stream and skip valid zero-row batches without abandoning the task
- cover connection-local and Ray worker execution with regressions for batches larger than 2,048 rows and for leading, middle, consecutive, and trailing empty batches

## Related issue

close: #272
close: #275

## Documentation impact

- [x] No user-facing documentation update is required. The change restores the existing `DataSourceTask.execute()` contract.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format workspace --changed`
- incremental non-editable Release package rebuild with `uv pip install . --no-build-isolation`
- `python -m pytest -v tests/fast/test_datasource_distributed_scan.py` — 12 passed
- `scripts/run_release_tests.sh` — 455 passed and 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh` — 6,100 passed, 28 skipped, 8 xfailed, and 1 xpassed in the non-Ray shard; 88 passed and 2 skipped in the shared-Ray shard; all isolated real-Ray shards passed
- `scripts/run_native_tests.sh "[distributed]"` — 130 test cases and 4,156 assertions passed
- manual four-thread boundary matrix — 10,241 exact rows across 2,047/2,048/2,049/4,097-row batches, leading/middle/trailing empty batches, an empty-only task, multiple tasks, and `BIGINT` plus `VARCHAR` columns

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. The change adds no new trust boundary.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.