### PR TITLE
[fix](enum) Correct physical operator enum table bounds

### DIFF
--- a/external/duckdb/src/common/enum_util.cpp
+++ b/external/duckdb/src/common/enum_util.cpp
@@ -3822,12 +3822,12 @@ const StringUtil::EnumStringLiteral *GetPhysicalOperatorTypeValues() {
 
 template<>
 const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value) {
-	return StringUtil::EnumToString(GetPhysicalOperatorTypeValues(), 90, "PhysicalOperatorType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetPhysicalOperatorTypeValues(), 88, "PhysicalOperatorType", static_cast<uint32_t>(value));
 }
 
 template<>
 PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value) {
-	return static_cast<PhysicalOperatorType>(StringUtil::StringToEnum(GetPhysicalOperatorTypeValues(), 91, "PhysicalOperatorType", value));
+	return static_cast<PhysicalOperatorType>(StringUtil::StringToEnum(GetPhysicalOperatorTypeValues(), 88, "PhysicalOperatorType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetPhysicalTableScanExecutionStrategyValues() {

--- a/external/duckdb/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/external/duckdb/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -21,6 +21,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Physical Operator Types
 //===--------------------------------------------------------------------===//
+// After changing this enum, regenerate enum_util.hpp and enum_util.cpp with scripts/generate_enum_util.py.
 enum class PhysicalOperatorType : uint8_t {
 	INVALID,
 	ORDER_BY,


### PR DESCRIPTION
## Summary

- Correct both `PhysicalOperatorType` EnumUtil entry counts from 90/91 to the actual 88 generated entries.
- Add a source-level reminder to keep the generated mapping synchronized when the enum changes.
- Ensure unknown physical operator values and names stop at the mapping boundary instead of reading past the static table.

A full enum-generator run currently also emits unrelated stale mappings and misclassifies the nested `duckdb::distributed::DistributedCopyType`. This focused PR does not include those unrelated outputs.

## Related issue

close: #289

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format duckdb --changed`
- `git diff --check`
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- No new test was added for this generated metadata correction; the Release native build compiled and installed successfully.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.