### PR TITLE
[fix](udf) Preserve mixed-input task admission ownership

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -935,6 +935,120 @@ struct StreamingPendingMaterializedEnvelope {
 	idx_t bytes = 0;
 };
 
+enum class StreamingPlannedSubmitKind : uint8_t { NONE, MATERIALIZED, LAZY };
+
+// Task admission belongs to one concrete submit, not to an input channel. Keep
+// exactly one cross-channel head-of-line candidate until it is submitted or
+// cancelled so another input kind cannot consume its grant.
+struct StreamingPlannedSubmit {
+	bool HasValue() const {
+		return kind != StreamingPlannedSubmitKind::NONE;
+	}
+
+	bool IsMaterialized() const {
+		return kind == StreamingPlannedSubmitKind::MATERIALIZED;
+	}
+
+	bool IsLazy() const {
+		return kind == StreamingPlannedSubmitKind::LAZY;
+	}
+
+	const char *KindName() const {
+		switch (kind) {
+		case StreamingPlannedSubmitKind::MATERIALIZED:
+			return "materialized";
+		case StreamingPlannedSubmitKind::LAZY:
+			return "lazy";
+		case StreamingPlannedSubmitKind::NONE:
+			return "none";
+		}
+		return "unknown";
+	}
+
+	idx_t Sequence() const {
+		return sequence;
+	}
+
+	idx_t Rows() const {
+		if (IsMaterialized()) {
+			return materialized.rows;
+		}
+		if (IsLazy()) {
+			return lazy.rows;
+		}
+		return 0;
+	}
+
+	idx_t InputBytes() const {
+		if (IsMaterialized()) {
+			return materialized.bytes;
+		}
+		if (IsLazy()) {
+			return lazy.bytes;
+		}
+		return 0;
+	}
+
+	idx_t RetainedInputBytes() const {
+		return retained_input_bytes;
+	}
+
+	StreamingPendingMaterializedEnvelope &Materialized() {
+		if (!IsMaterialized()) {
+			throw InternalException("streaming UDF planned submit is not materialized");
+		}
+		return materialized;
+	}
+
+	StreamingPendingLazyInput &Lazy() {
+		if (!IsLazy()) {
+			throw InternalException("streaming UDF planned submit is not lazy");
+		}
+		return lazy;
+	}
+
+	void SetMaterialized(StreamingPendingMaterializedEnvelope &&submit, idx_t sequence_p) {
+		if (HasValue()) {
+			throw InternalException("streaming UDF cannot replace an active planned submit");
+		}
+		if (submit.chunks.empty() || submit.rows == 0) {
+			throw InternalException("streaming UDF cannot plan an empty materialized submit");
+		}
+		materialized = std::move(submit);
+		retained_input_bytes = materialized.bytes;
+		sequence = sequence_p;
+		kind = StreamingPlannedSubmitKind::MATERIALIZED;
+	}
+
+	void SetLazy(StreamingPendingLazyInput &&submit, idx_t sequence_p) {
+		if (HasValue()) {
+			throw InternalException("streaming UDF cannot replace an active planned submit");
+		}
+		if (!submit.bundle || submit.rows == 0) {
+			throw InternalException("streaming UDF cannot plan an empty lazy submit");
+		}
+		lazy = std::move(submit);
+		retained_input_bytes = 0;
+		sequence = sequence_p;
+		kind = StreamingPlannedSubmitKind::LAZY;
+	}
+
+	void Clear() {
+		materialized = StreamingPendingMaterializedEnvelope();
+		lazy = StreamingPendingLazyInput();
+		retained_input_bytes = 0;
+		sequence = 0;
+		kind = StreamingPlannedSubmitKind::NONE;
+	}
+
+private:
+	StreamingPlannedSubmitKind kind = StreamingPlannedSubmitKind::NONE;
+	idx_t sequence = 0;
+	idx_t retained_input_bytes = 0;
+	StreamingPendingMaterializedEnvelope materialized;
+	StreamingPendingLazyInput lazy;
+};
+
 struct StreamingInflightBatch {
 	idx_t submit_id = 0;
 	idx_t total_rows = 0;
@@ -1047,10 +1161,8 @@ struct StreamingUDFState : public StateWithBlockableTasks {
 	string error;
 	std::deque<StreamingPendingInputPiece> pending_inputs;
 	std::deque<StreamingPendingLazyInput> pending_lazy_inputs;
-	// Once task admission has registered a waiter, its input identity and byte
-	// commitment are immutable until that exact submit is granted or cancelled.
-	StreamingPendingMaterializedEnvelope planned_materialized_submit;
-	StreamingPendingLazyInput planned_lazy_submit;
+	StreamingPlannedSubmit planned_submit;
+	idx_t next_planned_submit_sequence = 1;
 	idx_t pending_rows = 0;
 	idx_t reserved_rows = 0;
 	idx_t reserved_bytes = 0;
@@ -1153,7 +1265,8 @@ static void StreamingUDFDebugState(StreamingUDFState &state, const char *where, 
 	StreamingUDFDebugLog(StringUtil::Format(
 	    "state tick=%llu udf_name=%s where=%s%s pending_rows=%llu pending_bytes=%llu reserved_rows=%llu "
 	    "reserved_bytes=%llu pending_lazy=%llu inflight_batches=%llu inflight_rows=%llu inflight_bytes=%llu "
-	    "planned_materialized_rows=%llu planned_lazy_rows=%llu "
+	    "planned_submit_kind=%s planned_submit_sequence=%llu planned_submit_rows=%llu "
+	    "planned_submit_input_bytes=%llu planned_submit_retained_input_bytes=%llu "
 	    "ready_outputs=%llu ready_rows=%llu ready_bytes=%llu handoff_outputs=%llu handoff_rows=%llu "
 	    "handoff_bytes=%llu deferred_outputs=%llu deferred_rows=%llu "
 	    "deferred_bytes=%llu queued_events=%llu sink_finished=%s "
@@ -1171,8 +1284,10 @@ static void StreamingUDFDebugState(StreamingUDFState &state, const char *where, 
 	    static_cast<unsigned long long>(state.pending_lazy_inputs.size()),
 	    static_cast<unsigned long long>(state.inflight_batches.size()),
 	    static_cast<unsigned long long>(state.inflight_rows), static_cast<unsigned long long>(state.inflight_bytes),
-	    static_cast<unsigned long long>(state.planned_materialized_submit.rows),
-	    static_cast<unsigned long long>(state.planned_lazy_submit.rows),
+	    state.planned_submit.KindName(), static_cast<unsigned long long>(state.planned_submit.Sequence()),
+	    static_cast<unsigned long long>(state.planned_submit.Rows()),
+	    static_cast<unsigned long long>(state.planned_submit.InputBytes()),
+	    static_cast<unsigned long long>(state.planned_submit.RetainedInputBytes()),
 	    static_cast<unsigned long long>(state.ready_outputs.size()), static_cast<unsigned long long>(state.ready_rows),
 	    static_cast<unsigned long long>(state.ready_bytes),
 	    static_cast<unsigned long long>(state.handoff_counters->outputs.load(std::memory_order_relaxed)),
@@ -1851,7 +1966,15 @@ static idx_t RowsWithinByteLimit(idx_t candidate_rows, idx_t candidate_bytes, id
 }
 
 static bool StreamingHasLazyInput(const StreamingUDFState &state) {
-	return state.planned_lazy_submit.bundle || !state.pending_lazy_inputs.empty();
+	return state.planned_submit.IsLazy() || !state.pending_lazy_inputs.empty();
+}
+
+static idx_t NextStreamingPlannedSubmitSequence(StreamingUDFState &state) {
+	auto sequence = state.next_planned_submit_sequence++;
+	if (state.next_planned_submit_sequence == 0) {
+		state.next_planned_submit_sequence = 1;
+	}
+	return sequence;
 }
 
 static StreamingSubmitPlan StreamingIncompleteSubmitPlan(const StreamingUDFState &state, bool flush_tail) {
@@ -2228,7 +2351,10 @@ static bool CompleteStreamingSubmitLocked(StreamingUDFState &state, unique_lock<
 static bool TrySubmitStreamingLazyInput(ExecutionContext &context, StreamingUDFState &state,
                                         const unique_lock<mutex> &guard, bool flush_tail) {
 	state.VerifyLock(guard);
-	const bool retrying_planned_submit = state.planned_lazy_submit.bundle != nullptr;
+	if (state.planned_submit.HasValue() && !state.planned_submit.IsLazy()) {
+		throw InternalException("streaming UDF lazy submit attempted while a materialized submit owns admission");
+	}
+	const bool retrying_planned_submit = state.planned_submit.IsLazy();
 	if (!retrying_planned_submit && state.pending_lazy_inputs.empty()) {
 		return false;
 	}
@@ -2239,7 +2365,7 @@ static bool TrySubmitStreamingLazyInput(ExecutionContext &context, StreamingUDFS
 	StreamingPendingLazyInput candidate;
 	StreamingPendingLazyInput *pending = nullptr;
 	if (retrying_planned_submit) {
-		pending = &state.planned_lazy_submit;
+		pending = &state.planned_submit.Lazy();
 	} else {
 		auto plan = PlanStreamingLazySubmit(state, flush_tail);
 		if (!plan) {
@@ -2255,17 +2381,17 @@ static bool TrySubmitStreamingLazyInput(ExecutionContext &context, StreamingUDFS
 	idx_t submit_id = 0;
 	// Lazy refs remain charged to their upstream output leases through handoff;
 	// charging the same physical objects as retained task input would double count.
-	if (!TrySubmitRefBundleRaw(context, *state.op, *pending->bundle, submit_id, 0)) {
+	const auto retained_input_bytes = retrying_planned_submit ? state.planned_submit.RetainedInputBytes() : idx_t(0);
+	if (!TrySubmitRefBundleRaw(context, *state.op, *pending->bundle, submit_id, retained_input_bytes)) {
 		if (!retrying_planned_submit) {
-			// Preserve the exact ref bundle associated with the admission waiter.
-			state.planned_lazy_submit = std::move(candidate);
+			state.planned_submit.SetLazy(std::move(candidate), NextStreamingPlannedSubmitSequence(state));
 		}
 		return false;
 	}
 	const auto submitted_rows = pending->rows;
 	const auto submitted_bytes = pending->bytes;
 	if (retrying_planned_submit) {
-		state.planned_lazy_submit = StreamingPendingLazyInput();
+		state.planned_submit.Clear();
 	}
 	StreamingInflightBatch inflight;
 	inflight.submit_id = submit_id;
@@ -2559,71 +2685,101 @@ static bool DrainStreamingOutputEventsLocked(StreamingUDFState &state, unique_lo
 	return did_work;
 }
 
+static bool TrySubmitStreamingMaterializedInput(ExecutionContext &context, StreamingUDFState &state,
+                                                const unique_lock<mutex> &guard, bool flush_tail) {
+	state.VerifyLock(guard);
+	if (state.planned_submit.HasValue() && !state.planned_submit.IsMaterialized()) {
+		throw InternalException("streaming UDF materialized submit attempted while a lazy submit owns admission");
+	}
+	const bool retrying_planned_submit = state.planned_submit.IsMaterialized();
+	if (!retrying_planned_submit && state.pending_inputs.empty()) {
+		return false;
+	}
+	EnsureStreamingExecutor(context, state, guard);
+	StreamingPendingMaterializedEnvelope candidate;
+	StreamingPendingMaterializedEnvelope *envelope = nullptr;
+	if (retrying_planned_submit) {
+		envelope = &state.planned_submit.Materialized();
+	} else {
+		auto plan = PlanStreamingMaterializedSubmit(state, flush_tail);
+		if (!plan) {
+			return false;
+		}
+		candidate = TakeStreamingMaterializedEnvelope(context, state, plan, state.config.compute_batch_rows,
+		                                              state.config.task_input_max_bytes);
+		envelope = &candidate;
+	}
+	if (envelope->chunks.empty() || envelope->rows == 0) {
+		return false;
+	}
+	const auto rows = envelope->rows;
+	const auto bytes = envelope->bytes;
+	const auto retained_input_bytes =
+	    retrying_planned_submit ? state.planned_submit.RetainedInputBytes() : envelope->bytes;
+	idx_t submit_id = 0;
+	if (!TrySubmitMaterializedEnvelopeRaw(context, *state.op, envelope->chunks, retained_input_bytes, submit_id)) {
+		if (!retrying_planned_submit) {
+			// Keep this exact envelope at the cross-channel head of line. Its
+			// rows remain part of the shared pending byte window while admission
+			// is unavailable.
+			state.pending_rows += rows;
+			state.pending_bytes += bytes;
+			state.planned_submit.SetMaterialized(std::move(candidate), NextStreamingPlannedSubmitSequence(state));
+		}
+		return false;
+	}
+	if (retrying_planned_submit) {
+		state.pending_rows = state.pending_rows >= rows ? state.pending_rows - rows : 0;
+		state.pending_bytes = state.pending_bytes >= bytes ? state.pending_bytes - bytes : 0;
+		state.planned_submit.Clear();
+	}
+	StreamingInflightBatch inflight;
+	inflight.submit_id = submit_id;
+	inflight.total_rows = rows;
+	inflight.bytes = bytes;
+	auto inserted = state.inflight_batches.emplace(submit_id, inflight);
+	if (!inserted.second) {
+		throw InternalException("streaming UDF duplicate submit_id %llu", static_cast<unsigned long long>(submit_id));
+	}
+	AtomicAddStreamingCounter(state.submitted_input_rows, rows);
+	AtomicAddStreamingCounter(state.submitted_input_bytes, bytes);
+	state.inflight_rows += rows;
+	state.inflight_bytes += bytes;
+	state.max_active_batches =
+	    MaxValue<idx_t>(state.max_active_batches, static_cast<idx_t>(state.inflight_batches.size()));
+	state.max_outstanding_rows = MaxValue<idx_t>(state.max_outstanding_rows, state.inflight_rows);
+	state.submitted_batches.fetch_add(1);
+	StreamingUDFDebugState(state, "submit_materialized_envelope", true);
+	return true;
+}
+
+static void DriveStreamingMaterializedSubmits(ExecutionContext &context, StreamingUDFState &state,
+                                              const unique_lock<mutex> &guard, bool flush_tail) {
+	state.VerifyLock(guard);
+	while (state.pending_rows > 0 && !StreamingOutputBackpressured(state)) {
+		if (!TrySubmitStreamingMaterializedInput(context, state, guard, flush_tail)) {
+			break;
+		}
+	}
+}
+
 static void DriveStreamingSubmits(ExecutionContext &context, StreamingUDFState &state, const unique_lock<mutex> &guard,
                                   bool flush_tail) {
 	state.VerifyLock(guard);
 	ThrowIfStreamingError(state);
+	if (state.planned_submit.HasValue()) {
+		const bool submitted = state.planned_submit.IsLazy()
+		                           ? TrySubmitStreamingLazyInput(context, state, guard, flush_tail)
+		                           : TrySubmitStreamingMaterializedInput(context, state, guard, flush_tail);
+		if (!submitted) {
+			return;
+		}
+	}
 	DriveStreamingLazySubmits(context, state, guard, flush_tail);
 	if (StreamingHasLazyInput(state)) {
 		return;
 	}
-	while (state.pending_rows > 0 && !StreamingOutputBackpressured(state)) {
-		EnsureStreamingExecutor(context, state, guard);
-		const bool retrying_planned_submit = !state.planned_materialized_submit.chunks.empty();
-		StreamingPendingMaterializedEnvelope candidate;
-		StreamingPendingMaterializedEnvelope *envelope = nullptr;
-		if (retrying_planned_submit) {
-			envelope = &state.planned_materialized_submit;
-		} else {
-			auto plan = PlanStreamingMaterializedSubmit(state, flush_tail);
-			if (!plan) {
-				break;
-			}
-			candidate = TakeStreamingMaterializedEnvelope(context, state, plan, state.config.compute_batch_rows,
-			                                              state.config.task_input_max_bytes);
-			envelope = &candidate;
-		}
-		if (envelope->chunks.empty() || envelope->rows == 0) {
-			break;
-		}
-		const auto rows = envelope->rows;
-		const auto bytes = envelope->bytes;
-		idx_t submit_id = 0;
-		if (!TrySubmitMaterializedEnvelopeRaw(context, *state.op, envelope->chunks, bytes, submit_id)) {
-			if (!retrying_planned_submit) {
-				// The executor has registered admission for this exact byte
-				// commitment. Keep the envelope intact instead of restoring and
-				// repartitioning it while the waiter sleeps.
-				state.pending_rows += rows;
-				state.pending_bytes += bytes;
-				state.planned_materialized_submit = std::move(candidate);
-			}
-			break;
-		}
-		if (retrying_planned_submit) {
-			state.pending_rows = state.pending_rows >= rows ? state.pending_rows - rows : 0;
-			state.pending_bytes = state.pending_bytes >= bytes ? state.pending_bytes - bytes : 0;
-			state.planned_materialized_submit = StreamingPendingMaterializedEnvelope();
-		}
-		StreamingInflightBatch inflight;
-		inflight.submit_id = submit_id;
-		inflight.total_rows = rows;
-		inflight.bytes = bytes;
-		auto inserted = state.inflight_batches.emplace(submit_id, inflight);
-		if (!inserted.second) {
-			throw InternalException("streaming UDF duplicate submit_id %llu",
-			                        static_cast<unsigned long long>(submit_id));
-		}
-		AtomicAddStreamingCounter(state.submitted_input_rows, rows);
-		AtomicAddStreamingCounter(state.submitted_input_bytes, bytes);
-		state.inflight_rows += rows;
-		state.inflight_bytes += bytes;
-		state.max_active_batches =
-		    MaxValue<idx_t>(state.max_active_batches, static_cast<idx_t>(state.inflight_batches.size()));
-		state.max_outstanding_rows = MaxValue<idx_t>(state.max_outstanding_rows, state.inflight_rows);
-		state.submitted_batches.fetch_add(1);
-		StreamingUDFDebugState(state, "submit_materialized_envelope", true);
-	}
+	DriveStreamingMaterializedSubmits(context, state, guard, flush_tail);
 }
 
 static void DrainStreamingPendingBeforeInputBlock(ExecutionContext &context, StreamingUDFState &state,

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -357,6 +357,265 @@ def test_unregister_timeout_keeps_context_alive_during_input_conversion():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_mixed_streaming_inputs_preserve_task_admission_owner():
+    """A lazy input must not consume a materialized input's ready grant."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import threading
+        import time
+        import uuid
+
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import (
+            make_local_shm_ref_bundle_result,
+            materialize_ref_bundle,
+        )
+
+        materialized_request_started = threading.Event()
+        lazy_output_taken = threading.Event()
+        async_errors = []
+        admission_requests = []
+        downstream_submits = []
+
+
+        class Stage1:
+            def __call__(self, table):
+                return pa.table({"y": table.column(0).to_pylist()})
+
+
+        class Stage2:
+            def __call__(self, table):
+                return pa.table({"z": table.column(0).to_pylist()})
+
+
+        class FakeExecutor:
+            def __init__(self, name):
+                self._name = name
+                self._output = []
+                self._finished = False
+                self._wakeup = None
+                self._admission_state = "idle"
+                self._retained_input_bytes = 0
+                self._pending_outputs = 0
+                self._error = ""
+                self._lock = threading.Lock()
+
+            def _notify(self):
+                wakeup = self._wakeup
+                if wakeup is not None:
+                    wakeup()
+
+            def _set_ready(self):
+                with self._lock:
+                    if self._admission_state != "requested":
+                        return
+                    self._admission_state = "ready"
+                self._notify()
+
+            def _set_failed(self, error):
+                with self._lock:
+                    self._error = str(error)
+                    self._admission_state = "failed"
+                    self._pending_outputs = 0
+                async_errors.append(str(error))
+                self._notify()
+
+            def supports_async_wakeup(self):
+                return True
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                retained = int(retained_input_bytes)
+                with self._lock:
+                    if self._admission_state != "idle":
+                        return False
+                    self._retained_input_bytes = retained
+                    self._admission_state = "requested"
+                admission_requests.append((self._name, retained))
+                if self._name != "Stage2" or retained == 0:
+                    self._set_ready()
+                    return True
+
+                materialized_request_started.set()
+
+                def grant_after_lazy_arrives():
+                    if not lazy_output_taken.wait(timeout=10):
+                        self._set_failed("lazy output never reached the dispatcher")
+                        return
+                    # The dispatcher has converted the upstream lazy result.
+                    # Leave the materialized grant parked while the awakened
+                    # UNION pipeline moves that result into the downstream sink.
+                    time.sleep(1)
+                    self._set_ready()
+
+                threading.Thread(target=grant_after_lazy_arrives, daemon=True).start()
+                return True
+
+            def task_admission_state(self):
+                with self._lock:
+                    state = {
+                        "state": self._admission_state,
+                        "available": self._admission_state == "ready",
+                        "retained_input_bytes": self._retained_input_bytes,
+                    }
+                    if self._error:
+                        state["error"] = self._error
+                    return state
+
+            def _consume_admission(self):
+                with self._lock:
+                    self._admission_state = "idle"
+                    self._retained_input_bytes = 0
+                    self._pending_outputs += 1
+
+            def _publish(self, submit_id, table):
+                result_name = "y" if self._name == "Stage1" else "z"
+                result = pa.table({result_name: table.column(0).to_pylist()})
+                output = (
+                    "__vane_submit_result__",
+                    int(submit_id),
+                    make_local_shm_ref_bundle_result(result),
+                )
+                with self._lock:
+                    self._output.append(output)
+                    self._pending_outputs -= 1
+                self._notify()
+
+            def submit_with_id(self, submit_id, table):
+                self._consume_admission()
+                if self._name == "Stage2":
+                    downstream_submits.append("materialized")
+                    self._publish(submit_id, table)
+                    return None
+
+                def publish_after_materialized_request():
+                    if not materialized_request_started.wait(timeout=10):
+                        self._set_failed("materialized request was not registered first")
+                        return
+                    self._publish(submit_id, table)
+
+                threading.Thread(target=publish_after_materialized_request, daemon=True).start()
+                return None
+
+            def submit_ref_bundle_with_id(self, submit_id, refs, slices, metadata, names):
+                self._consume_admission()
+                if self._name != "Stage2":
+                    raise RuntimeError("only the downstream UDF accepts lazy input")
+                downstream_submits.append("lazy")
+                table = materialize_ref_bundle(refs, slices, metadata, names)
+                self._publish(submit_id, table)
+                return None
+
+            def take_ready_result(self):
+                with self._lock:
+                    if not self._output:
+                        return None
+                    result = self._output.pop(0)
+                if self._name == "Stage1":
+                    lazy_output_taken.set()
+                return result
+
+            def finished_submitting(self):
+                self._finished = True
+
+            def all_tasks_finished(self):
+                with self._lock:
+                    return self._finished and self._pending_outputs == 0 and not self._output
+
+
+        def build_executor(payload, options=None):
+            del options
+            return FakeExecutor(str(payload["udf_name"]))
+
+
+        udf_exec.build_executor = build_executor
+        connection = duckdb.connect()
+        cursor = connection.cursor()
+        lazy = connection.sql("SELECT i::BIGINT AS x FROM range(4) t(i)").map_batches(
+            Stage1,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_actor",
+            actor_number=1,
+            gpus=0.0,
+            batch_size=4,
+            task_input_max_bytes=1024 * 1024,
+        )
+        materialized = connection.sql("SELECT (100 + i)::BIGINT AS y FROM range(4) t(i)")
+        relation = materialized.union(lazy).map_batches(
+            Stage2,
+            schema={"z": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_actor",
+            actor_number=1,
+            gpus=0.0,
+            batch_size=4,
+            task_input_max_bytes=1024 * 1024,
+        )
+        plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            f"mixed-task-admission-{uuid.uuid4().hex[:8]}",
+        ).to_physical_plan(connection)
+        handles = {
+            str(node["node_id"]): {
+                "actor_handles": [f"actor-{node['node_id']}"],
+                "actor_node_ids": ["node-a"],
+                "query_driver_handle": object(),
+                "session_config": {},
+            }
+            for node in plan.collect_udf_nodes(conn=connection)
+        }
+        plan.set_udf_actor_handles(handles, conn=connection)
+
+        try:
+            result = duckdb.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+                cursor,
+                plan,
+                None,
+                None,
+            )
+            values = sorted(
+                value
+                for partition in result.partition_payloads
+                for value in partition.column(0).to_pylist()
+            )
+            assert values == [0, 1, 2, 3, 100, 101, 102, 103], values
+            assert not async_errors, async_errors
+            downstream_requests = [
+                retained
+                for name, retained in admission_requests
+                if name == "Stage2"
+            ]
+            assert len(downstream_requests) == 2, downstream_requests
+            assert downstream_requests[0] > 0, downstream_requests
+            assert downstream_requests[1] == 0, downstream_requests
+            assert downstream_submits == ["materialized", "lazy"], downstream_submits
+        finally:
+            cursor.close()
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env=os.environ.copy(),
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_create_function_rejects_removed_process_and_ray_args():
     con = duckdb.connect()
 


### PR DESCRIPTION
## Summary

- replace the separate lazy and materialized planned-submit slots with one
  tagged cross-channel owner per streaming UDF executor
- retry that exact owner, including its immutable retained-input byte
  commitment, before selecting any new lazy or materialized work
- preserve the existing lazy-first policy after the current admission owner
  clears, while preventing one input kind from consuming the other kind's grant
- add a native mixed-input `UNION` regression that parks a materialized grant,
  introduces a lazy ref bundle, and verifies both commitments and submit order

This fixes the timing-sensitive query failure without changing the public API or
the lazy-ref memory-accounting contract.

## Related issue

close: #273

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change is internal task-admission state management and restores valid mixed
streaming input execution.

## Validation

- incremental non-editable Release package rebuild with
  `uv pip install . --no-build-isolation`
- `scripts/format workspace --changed`
- `python -m pytest tests/fast/test_udf_process.py` — 7 passed
- mixed-input regression repeated 10 times and also passed with
  `DUCKDB_DISTRIBUTED_DEBUG=1`
- `scripts/run_release_tests.sh` — 455 passed and 1 skipped in the non-Ray
  shard; 10 passed in the real-Ray shard
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. The change adds no new trust
      boundary.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
