### PR TITLE
[fix](distributed) Partition window inputs by semantics

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_misc_unary.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_misc_unary.cpp
@@ -3,19 +3,25 @@
 
 #include "duckdb/execution/distributed/pipeline_node/translator.hpp"
 
+#include <algorithm>
+
+#include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/expression_scan.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pivot.hpp"
+#include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/pipeline_node/streaming_udf_passthrough.hpp"
 #include "duckdb/execution/distributed/pipeline_node/table_inout.hpp"
 #include "duckdb/execution/distributed/pipeline_node/unnest.hpp"
 #include "duckdb/execution/distributed/pipeline_node/window.hpp"
 #include "duckdb/execution/operator/aggregate/physical_streaming_window.hpp"
 #include "duckdb/execution/operator/aggregate/physical_window.hpp"
+#include "duckdb/execution/operator/exchange/repartition.hpp"
 #include "duckdb/execution/operator/projection/physical_pivot.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
 #include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
 #include "duckdb/execution/operator/projection/physical_unnest.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -69,6 +75,77 @@ std::vector<std::vector<ExpressionRef>> CopyExpressionMatrixForMiscTranslator(co
 	return expressions;
 }
 
+template <class ExpressionList>
+const BoundWindowExpression *GetCommonWindowDefinition(const ExpressionList &select_list, const char *node_name) {
+	const BoundWindowExpression *first = nullptr;
+	for (const auto &expr : select_list) {
+		if (!expr || expr->GetExpressionClass() != ExpressionClass::BOUND_WINDOW) {
+			throw InvalidInputException("%s requires bound window expressions", node_name);
+		}
+		const auto &window = expr->template Cast<BoundWindowExpression>();
+		if (!first) {
+			first = &window;
+			continue;
+		}
+		if (!first->PartitionsAreEquivalent(window)) {
+			throw InvalidInputException("%s received incompatible partition definitions", node_name);
+		}
+	}
+	return first;
+}
+
+bool WindowPartitionKeysMatch(const std::shared_ptr<DistributedPipelineNode> &input_node,
+                              const vector<unique_ptr<Expression>> &required_partitions, size_t target_partitions) {
+	if (!input_node) {
+		return false;
+	}
+	auto input = input_node->inner();
+	// Some schema-changing nodes preserve stale clustering expressions. Reuse
+	// hash metadata only when this node established or validated the mapping.
+	if (!std::dynamic_pointer_cast<RepartitionNode>(input) && !std::dynamic_pointer_cast<WindowNode>(input)) {
+		return false;
+	}
+	auto clustering = input_node->config().clustering_spec();
+	if (!clustering || clustering->type() != ClusteringSpec::Type::Hash ||
+	    clustering->num_partitions() != target_partitions) {
+		return false;
+	}
+
+	auto actual_partitions = clustering->partition_by();
+	if (actual_partitions.size() != required_partitions.size()) {
+		return false;
+	}
+	std::vector<bool> matched(actual_partitions.size(), false);
+	for (const auto &required : required_partitions) {
+		bool found = false;
+		for (idx_t index = 0; index < actual_partitions.size(); index++) {
+			if (!matched[index] && required && actual_partitions[index] &&
+			    Expression::Equals(*required, *actual_partitions[index])) {
+				matched[index] = true;
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+std::vector<ExprRef> CopyWindowPartitionKeys(const BoundWindowExpression &window) {
+	std::vector<ExprRef> result;
+	result.reserve(window.partitions.size());
+	for (const auto &partition : window.partitions) {
+		if (!partition) {
+			throw InvalidInputException("Window contains a null partition expression");
+		}
+		auto copy = partition->Copy();
+		result.emplace_back(ExpressionRef(copy.release()));
+	}
+	return result;
+}
+
 } // namespace
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslatePivot(
@@ -117,20 +194,66 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateWindow(
     const PhysicalWindow &op, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
-	auto child_impl = FirstMiscUnaryChildImpl(children);
+	if (children.empty() || !children[0]) {
+		throw InvalidInputException("Window requires a child node");
+	}
+	auto input_node = children[0];
+	auto window_definition = GetCommonWindowDefinition(op.select_list, "Window");
+	if (window_definition) {
+		auto clustering = input_node->config().clustering_spec();
+		if (!clustering) {
+			throw InvalidInputException("Window child is missing clustering metadata");
+		}
+		const auto input_partitions = clustering->num_partitions();
+		if (window_definition->partitions.empty()) {
+			if (input_partitions > 1) {
+				input_node = gen_gather_node(input_node);
+			}
+		} else {
+			const auto target_partitions = std::max<size_t>(1, std::max(input_partitions, plan_config_.num_partitions));
+			if (target_partitions > 1 &&
+			    !WindowPartitionKeysMatch(input_node, window_definition->partitions, target_partitions)) {
+				auto spec =
+				    RepartitionSpec::create_hash(target_partitions, CopyWindowPartitionKeys(*window_definition));
+				auto shuffle = gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
+				if (!shuffle) {
+					throw InvalidInputException("Failed to repartition Window input: %s", shuffle.error().what());
+				}
+				input_node = shuffle.value();
+			}
+		}
+	}
 	auto select_list = CopyExpressionListForMiscTranslator(op.select_list);
 	std::vector<LogicalType> output_types = op.GetTypes();
-	return std::make_shared<WindowNode>(get_next_pipeline_node_id(), child_impl, std::move(select_list),
+	return std::make_shared<WindowNode>(get_next_pipeline_node_id(), input_node->inner(), std::move(select_list),
 	                                    std::move(output_types));
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateStreamingWindow(
     const PhysicalStreamingWindow &op, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
-	auto child_impl = FirstMiscUnaryChildImpl(children);
+	if (children.empty() || !children[0]) {
+		throw InvalidInputException("StreamingWindow requires a child node");
+	}
+	auto input_node = children[0];
+	auto window_definition = GetCommonWindowDefinition(op.select_list, "StreamingWindow");
+	if (window_definition &&
+	    (!window_definition->partitions.empty() || !window_definition->orders.empty() ||
+	     !window_definition->arg_orders.empty() || window_definition->exclude_clause != WindowExcludeMode::NO_OTHER)) {
+		throw InvalidInputException("StreamingWindow requires an empty OVER clause");
+	}
+	if (window_definition) {
+		auto clustering = input_node->config().clustering_spec();
+		if (!clustering) {
+			throw InvalidInputException("StreamingWindow child is missing clustering metadata");
+		}
+		if (clustering->num_partitions() > 1) {
+			input_node = gen_gather_node(input_node);
+		}
+	}
 	auto select_list = CopyExpressionListForMiscTranslator(op.select_list);
 	std::vector<LogicalType> output_types = op.GetTypes();
-	return std::make_shared<StreamingWindowNode>(get_next_pipeline_node_id(), child_impl, std::move(select_list),
-	                                             std::move(output_types));
+	return std::make_shared<StreamingWindowNode>(get_next_pipeline_node_id(), input_node->inner(),
+	                                             std::move(select_list), std::move(output_types));
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateExpressionScan(

--- a/external/duckdb/src/execution/distributed/pipeline_node/window.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/window.cpp
@@ -3,9 +3,11 @@
 
 #include "duckdb/execution/distributed/pipeline_node/window.hpp"
 
+#include "duckdb/common/exception.hpp"
 #include "duckdb/execution/operator/aggregate/physical_streaming_window.hpp"
 #include "duckdb/execution/operator/aggregate/physical_window.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -24,11 +26,126 @@ CopyWindowSelectList(const std::vector<ExpressionRef> &select_list) {
 	return copies;
 }
 
+static const BoundWindowExpression *GetCommonWindowDefinition(const std::vector<ExpressionRef> &select_list,
+                                                              const char *node_name) {
+	const BoundWindowExpression *first = nullptr;
+	for (const auto &expr : select_list) {
+		if (!expr || expr->GetExpressionClass() != ExpressionClass::BOUND_WINDOW) {
+			throw InvalidInputException("%s requires bound window expressions", node_name);
+		}
+		const auto &window = expr->Cast<BoundWindowExpression>();
+		if (!first) {
+			first = &window;
+			continue;
+		}
+		if (!first->PartitionsAreEquivalent(window)) {
+			throw InvalidInputException("%s received incompatible partition definitions", node_name);
+		}
+	}
+	return first;
+}
+
+static bool WindowPartitionKeysMatch(const ClusteringSpecRef &clustering,
+                                     const vector<unique_ptr<Expression>> &required_partitions) {
+	if (!clustering || clustering->type() != ClusteringSpec::Type::Hash) {
+		return false;
+	}
+	auto actual_partitions = clustering->partition_by();
+	if (actual_partitions.size() != required_partitions.size()) {
+		return false;
+	}
+
+	std::vector<bool> matched(actual_partitions.size(), false);
+	for (const auto &required : required_partitions) {
+		bool found = false;
+		for (idx_t index = 0; index < actual_partitions.size(); index++) {
+			if (!matched[index] && required && actual_partitions[index] &&
+			    Expression::Equals(*required, *actual_partitions[index])) {
+				matched[index] = true;
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static void ValidateWindowDistribution(const PipelineNodeRef &child, const std::vector<ExpressionRef> &select_list) {
+	auto window = GetCommonWindowDefinition(select_list, "Window");
+	if (!window) {
+		return;
+	}
+	if (!child || !child->config().clustering_spec()) {
+		throw InvalidInputException("Window child is missing clustering metadata");
+	}
+	auto clustering = child->config().clustering_spec();
+	if (clustering->num_partitions() <= 1) {
+		return;
+	}
+	if (window->partitions.empty()) {
+		throw InvalidInputException("Global Window requires single-partition input");
+	}
+	if (!WindowPartitionKeysMatch(clustering, window->partitions)) {
+		throw InvalidInputException("Partitioned Window requires matching hash-partitioned input");
+	}
+}
+
+static void ValidateStreamingWindowDistribution(const PipelineNodeRef &child,
+                                                const std::vector<ExpressionRef> &select_list) {
+	auto window = GetCommonWindowDefinition(select_list, "StreamingWindow");
+	if (!window) {
+		return;
+	}
+	if (!window->partitions.empty() || !window->orders.empty() || !window->arg_orders.empty() ||
+	    window->exclude_clause != WindowExcludeMode::NO_OTHER) {
+		throw InvalidInputException("StreamingWindow requires an empty OVER clause");
+	}
+	if (!child || !child->config().clustering_spec()) {
+		throw InvalidInputException("StreamingWindow child is missing clustering metadata");
+	}
+	if (child->config().clustering_spec()->num_partitions() > 1) {
+		throw InvalidInputException("StreamingWindow requires single-partition input");
+	}
+}
+
+static PipelineNodeConfig BuildWindowConfig(const PipelineNodeRef &child, const std::vector<ExpressionRef> &select_list,
+                                            const std::vector<LogicalType> &output_types) {
+	auto execution_config = child ? child->config().execution_config() : DuckDBExecutionConfigRef();
+	auto clustering = child ? child->config().clustering_spec() : ClusteringSpec::unknown_with_num_partitions(1);
+	if (output_types.empty()) {
+		return PipelineNodeConfig(nullptr, std::move(execution_config), std::move(clustering));
+	}
+	if (output_types.size() < select_list.size()) {
+		return PipelineNodeConfig(MakeSchemaRef(output_types), std::move(execution_config), std::move(clustering));
+	}
+
+	const auto input_column_count = output_types.size() - select_list.size();
+	auto output_names = child ? GetSchemaNames(child->config().schema()) : vector<string> {};
+	if (output_names.size() != input_column_count) {
+		output_names.clear();
+		output_names.reserve(output_types.size());
+		for (idx_t index = 0; index < input_column_count; index++) {
+			output_names.push_back("c" + std::to_string(index));
+		}
+	} else {
+		output_names.reserve(output_types.size());
+	}
+	for (idx_t index = input_column_count; index < output_types.size(); index++) {
+		output_names.push_back("c" + std::to_string(index));
+	}
+	return PipelineNodeConfig(MakeSchemaRef(output_types, output_names), std::move(execution_config),
+	                          std::move(clustering));
+}
+
 WindowNode::WindowNode(NodeID node_id, PipelineNodeRef child, std::vector<ExpressionRef> select_list,
                        std::vector<LogicalType> output_types)
     : ctx_(InheritPipelineNodeContext(child, node_id, "Window")),
-      config_(child ? child->config() : PipelineNodeConfig()), child_(std::move(child)),
+      config_(BuildWindowConfig(child, select_list, output_types)), child_(std::move(child)),
       select_list_(std::move(select_list)), output_types_(std::move(output_types)) {
+	ValidateWindowDistribution(child_, select_list_);
 }
 
 std::vector<PipelineNodeRef> WindowNode::children() const {
@@ -73,8 +190,9 @@ std::vector<std::string> WindowNode::multiline_display(bool /*verbose*/) const {
 StreamingWindowNode::StreamingWindowNode(NodeID node_id, PipelineNodeRef child, std::vector<ExpressionRef> select_list,
                                          std::vector<LogicalType> output_types)
     : ctx_(InheritPipelineNodeContext(child, node_id, "StreamingWindow")),
-      config_(child ? child->config() : PipelineNodeConfig()), child_(std::move(child)),
+      config_(BuildWindowConfig(child, select_list, output_types)), child_(std::move(child)),
       select_list_(std::move(select_list)), output_types_(std::move(output_types)) {
+	ValidateStreamingWindowDistribution(child_, select_list_);
 }
 
 std::vector<PipelineNodeRef> StreamingWindowNode::children() const {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -43,6 +43,9 @@
 #include "duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_partitioned_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
+#include "duckdb/execution/operator/aggregate/physical_streaming_window.hpp"
+#include "duckdb/execution/operator/aggregate/physical_window.hpp"
+#include "duckdb/execution/operator/exchange/physical_repartition.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_left_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_right_delim_join.hpp"
@@ -54,7 +57,10 @@
 #include "duckdb/execution/distributed/pipeline_node/limit.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/expression_scan.hpp"
+#include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/pipeline_node/sort.hpp"
+#include "duckdb/execution/distributed/pipeline_node/window.hpp"
+#include "duckdb/planner/expression/bound_window_expression.hpp"
 
 // Include distributed pipeline translator headers (lightweight declarations)
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
@@ -109,6 +115,73 @@ static UnaryPlan MakeUnaryScanPlan() {
 	auto &scan =
 	    plan->Make<PhysicalColumnDataScan>(types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0, std::move(collection));
 	return {plan, types, &scan};
+}
+
+static DuckPhysicalPlanRef MakeWindowPlan(bool streaming, idx_t input_partitions, bool input_hash_partitioned,
+                                          const vector<idx_t> &partition_columns,
+                                          const vector<idx_t> &second_partition_columns = {},
+                                          bool swap_columns_after_repartition = false) {
+	Allocator &alloc = Allocator::DefaultAllocator();
+	auto plan = std::make_shared<PhysicalPlan>(alloc);
+	vector<LogicalType> input_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto collection = make_uniq<ColumnDataCollection>(alloc, input_types);
+	auto &scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0,
+	                                                std::move(collection));
+	PhysicalOperator *input = &scan;
+
+	if (input_partitions > 1) {
+		std::shared_ptr<RepartitionSpec> spec;
+		if (input_hash_partitioned) {
+			vector<ExprRef> by;
+			by.emplace_back(std::make_shared<BoundReferenceExpression>(LogicalType::BIGINT, 0));
+			spec = RepartitionSpec::create_hash(input_partitions, std::move(by));
+		} else {
+			spec = RepartitionSpec::create_random(input_partitions);
+		}
+		auto &repartition = plan->Make<PhysicalRepartition>(input_types, std::move(spec), 0);
+		repartition.children.push_back(scan);
+		input = &repartition;
+	}
+
+	if (swap_columns_after_repartition) {
+		vector<unique_ptr<Expression>> projections;
+		projections.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1));
+		projections.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0));
+		auto &projection = plan->Make<PhysicalProjection>(input_types, std::move(projections), 0);
+		projection.children.push_back(*input);
+		input = &projection;
+	}
+
+	auto make_window_expression = [streaming](const vector<idx_t> &partitions) {
+		auto expression =
+		    make_uniq<BoundWindowExpression>(ExpressionType::WINDOW_ROW_NUMBER, LogicalType::BIGINT, nullptr, nullptr);
+		for (auto column : partitions) {
+			expression->partitions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, column));
+		}
+		if (!streaming) {
+			expression->orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+			                                make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1));
+		}
+		return expression;
+	};
+
+	vector<unique_ptr<Expression>> select_list;
+	select_list.push_back(make_window_expression(partition_columns));
+	if (!second_partition_columns.empty()) {
+		select_list.push_back(make_window_expression(second_partition_columns));
+	}
+	auto output_types = input_types;
+	output_types.resize(input_types.size() + select_list.size(), LogicalType::BIGINT);
+	if (streaming) {
+		auto &window = plan->Make<PhysicalStreamingWindow>(output_types, std::move(select_list), 0);
+		window.children.push_back(*input);
+		plan->SetRoot(window);
+	} else {
+		auto &window = plan->Make<PhysicalWindow>(output_types, std::move(select_list), 0);
+		window.children.push_back(*input);
+		plan->SetRoot(window);
+	}
+	return plan;
 }
 
 static unique_ptr<ColumnDataCollection> MakeSingleValueCollection(const vector<LogicalType> &types,
@@ -762,6 +835,119 @@ TEST_CASE("PhysicalPlanTranslator: top n -> TopNNode", "[distributed]") {
 	REQUIRE(res.value() != nullptr);
 	auto inner = res.value()->inner();
 	REQUIRE(std::dynamic_pointer_cast<duckdb::distributed::TopNNode>(inner) != nullptr);
+}
+
+TEST_CASE("PhysicalPlanTranslator: global window gathers multi-partition input", "[distributed][window]") {
+	auto plan = MakeWindowPlan(false, 4, false, {});
+	auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+	REQUIRE(res.is_ok());
+	auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+	REQUIRE(window != nullptr);
+	REQUIRE(SchemaColumnCount(window->config().schema()) == 3);
+	auto children = window->children();
+	REQUIRE(children.size() == 1);
+	REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) != nullptr);
+	REQUIRE(children[0]->config().clustering_spec()->num_partitions() == 1);
+}
+
+TEST_CASE("PhysicalPlanTranslator: partitioned window hash-shuffles by partition keys", "[distributed][window]") {
+	auto plan = MakeWindowPlan(false, 4, false, {0});
+	auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+	REQUIRE(res.is_ok());
+	auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+	REQUIRE(window != nullptr);
+	auto children = window->children();
+	REQUIRE(children.size() == 1);
+	REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) != nullptr);
+	auto clustering = children[0]->config().clustering_spec();
+	REQUIRE(clustering->type() == ClusteringSpec::Type::Hash);
+	REQUIRE(clustering->num_partitions() == 4);
+	auto partition_by = clustering->partition_by();
+	REQUIRE(partition_by.size() == 1);
+	REQUIRE(partition_by[0]->GetExpressionClass() == ExpressionClass::BOUND_REF);
+	REQUIRE(partition_by[0]->Cast<BoundReferenceExpression>().index == 0);
+}
+
+TEST_CASE("PhysicalPlanTranslator: streaming window gathers multi-partition input", "[distributed][window]") {
+	auto plan = MakeWindowPlan(true, 4, false, {});
+	auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+	REQUIRE(res.is_ok());
+	auto window = std::dynamic_pointer_cast<StreamingWindowNode>(res.value()->inner());
+	REQUIRE(window != nullptr);
+	REQUIRE(SchemaColumnCount(window->config().schema()) == 3);
+	auto children = window->children();
+	REQUIRE(children.size() == 1);
+	REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) != nullptr);
+	REQUIRE(children[0]->config().clustering_spec()->num_partitions() == 1);
+}
+
+TEST_CASE("PhysicalPlanTranslator: window reuses only verified partitioning", "[distributed][window]") {
+	SECTION("single-partition global window") {
+		auto plan = MakeWindowPlan(false, 1, false, {});
+		auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+		REQUIRE(res.is_ok());
+		auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+		REQUIRE(window != nullptr);
+		auto children = window->children();
+		REQUIRE(children.size() == 1);
+		REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) == nullptr);
+	}
+
+	SECTION("single-partition partitioned window") {
+		auto plan = MakeWindowPlan(false, 1, false, {0});
+		auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+		REQUIRE(res.is_ok());
+		auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+		REQUIRE(window != nullptr);
+		auto children = window->children();
+		REQUIRE(children.size() == 1);
+		REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) == nullptr);
+	}
+
+	SECTION("matching hash-partitioned input") {
+		auto plan = MakeWindowPlan(false, 4, true, {0});
+		auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+		REQUIRE(res.is_ok());
+		auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+		REQUIRE(window != nullptr);
+		auto children = window->children();
+		REQUIRE(children.size() == 1);
+		auto repartition = std::dynamic_pointer_cast<RepartitionNode>(children[0]);
+		REQUIRE(repartition != nullptr);
+		auto repartition_children = repartition->children();
+		REQUIRE(repartition_children.size() == 1);
+		REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(repartition_children[0]) == nullptr);
+	}
+
+	SECTION("stale hash metadata after projection") {
+		auto plan = MakeWindowPlan(false, 4, true, {0}, {}, true);
+		auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+		REQUIRE(res.is_ok());
+		auto window = std::dynamic_pointer_cast<WindowNode>(res.value()->inner());
+		REQUIRE(window != nullptr);
+		auto children = window->children();
+		REQUIRE(children.size() == 1);
+		auto repartition = std::dynamic_pointer_cast<RepartitionNode>(children[0]);
+		REQUIRE(repartition != nullptr);
+		auto repartition_children = repartition->children();
+		REQUIRE(repartition_children.size() == 1);
+		REQUIRE(repartition_children[0]->name() == "Projection");
+	}
+}
+
+TEST_CASE("PhysicalPlanTranslator: window rejects incompatible partition definitions", "[distributed][window]") {
+	auto plan = MakeWindowPlan(false, 4, false, {0}, {1});
+	auto res = physical_plan_to_pipeline_node(PlanConfig {}, std::move(plan));
+
+	REQUIRE(res.is_err());
+	REQUIRE_THAT(res.error().what(), Catch::Matchers::Contains("incompatible partition definitions"));
 }
 
 TEST_CASE("PhysicalPlanTranslator: left delim join -> placeholder node", "[distributed]") {

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3628,6 +3628,118 @@ def test_ray_window(ray_runner, duckdb_conn, parquet_path):
     )
 
 
+def test_ray_windows_span_multiple_scan_tasks(ray_runner, duckdb_conn, tmp_path, monkeypatch):
+    label = "test_ray_e2e: windows span multiple scan tasks"
+    window_path = tmp_path / "window_multi_task"
+    shuffle_dir = tmp_path / "window_multi_task_shuffle"
+
+    monkeypatch.setenv("VANE_SHUFFLE_ALGORITHM", "flight_shuffle")
+    monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", str(shuffle_dir))
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                i::INTEGER AS x,
+                (i % 2)::INTEGER AS k,
+                floor(i / 3)::INTEGER AS file_id
+            FROM range(0, 12) AS t(i)
+        ) TO '{window_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+
+    global_sql = f"""
+        SELECT x, ROW_NUMBER() OVER (ORDER BY x) AS rn
+        FROM read_parquet('{window_path}/**/*.parquet')
+    """
+    ray_cxx = getattr(duckdb, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("duckdb.ray_cxx.PyLogicalPlan not available in this environment")
+
+    def distributed_plan(sql, suffix):
+        relation = duckdb_conn.sql(sql)
+        logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"{label}-{suffix}-plan")
+        return logical_plan.to_physical_plan(duckdb_conn)
+
+    global_plan = distributed_plan(global_sql, "global")
+    descriptor_counts = [len(descriptors) for descriptors in global_plan.scan_task_descriptor_map().values()]
+    assert descriptor_counts == [4], f"{label}: expected four scan tasks, got {descriptor_counts}"
+    assert global_plan.num_partitions() == 1
+    assert "REPARTITION" in global_plan.repr_ascii(False).upper()
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        global_sql,
+        f"{label}: global ordered window",
+        require_all=["WINDOW"],
+        timeout_s=60.0,
+    )
+
+    partitioned_sql = f"""
+        SELECT
+            x,
+            k,
+            ROW_NUMBER() OVER (PARTITION BY k ORDER BY x) AS rn,
+            SUM(x) OVER (
+                PARTITION BY k
+                ORDER BY x
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS running_sum,
+            LAG(x) OVER (PARTITION BY k ORDER BY x) AS previous_x
+        FROM read_parquet('{window_path}/**/*.parquet')
+    """
+    partitioned_plan = distributed_plan(partitioned_sql, "partitioned")
+    assert partitioned_plan.num_partitions() == 4
+    assert "REPARTITION" in partitioned_plan.repr_ascii(False).upper()
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        partitioned_sql,
+        f"{label}: partitioned ordered windows",
+        require_all=["WINDOW"],
+        timeout_s=60.0,
+    )
+
+    stacked_sql = f"""
+        SELECT
+            x,
+            k,
+            ROW_NUMBER() OVER (ORDER BY x) AS global_rn,
+            ROW_NUMBER() OVER (PARTITION BY k ORDER BY x) AS partition_rn
+        FROM read_parquet('{window_path}/**/*.parquet')
+    """
+    stacked_plan = distributed_plan(stacked_sql, "stacked")
+    stacked_plan_text = stacked_plan.repr_ascii(False).upper()
+    assert stacked_plan_text.count("WINDOW") >= 2
+    assert "REPARTITION" in stacked_plan_text
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        stacked_sql,
+        f"{label}: stacked windows with different distributions",
+        require_all=["WINDOW"],
+        timeout_s=60.0,
+    )
+
+    streaming_sql = f"""
+        SELECT ROW_NUMBER() OVER () AS rn
+        FROM read_parquet('{window_path}/**/*.parquet')
+    """
+    streaming_plan = distributed_plan(streaming_sql, "streaming")
+    assert streaming_plan.num_partitions() == 1
+    assert "REPARTITION" in streaming_plan.repr_ascii(False).upper()
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        streaming_sql,
+        f"{label}: streaming window",
+        require_all=["STREAMING_WINDOW"],
+        timeout_s=60.0,
+    )
+
+
 def test_ray_streaming_window(ray_runner, duckdb_conn, parquet_path):
     label = "test_ray_e2e: streaming window"
     sql = f"""


### PR DESCRIPTION
## Summary

- gather global and streaming windows before evaluation so they observe the complete input
- hash-partition `PARTITION BY` windows on the complete partition-key set while retaining distributed parallelism
- reuse only directly verified compatible partitioning and preserve accurate window schema/clustering metadata
- add constructor guardrails plus native topology and forced multi-scan-task Ray regressions

## Validation

- `VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh '[distributed]'` (138 cases, 4250 assertions)
- `python -m pytest tests/fast/test_ray_e2e.py -k 'windows_span_multiple_scan_tasks or test_ray_window or test_ray_streaming_window' -vv` (3 passed)
- `scripts/run_release_tests.sh` (455 passed + 10 real-Ray passed)
- `scripts/run_fast_tests.sh non-ray` (6083 passed)
- `scripts/run_fast_tests.sh shared-ray` (93 passed)
- `scripts/run_fast_tests.sh owner-ray` (7 passed, 1 optional-dependency skip)

Closes #281
