### PR TITLE
[fix](distributed) Rebuild object shuffle storage during cleanup

### DIFF
--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -178,12 +178,21 @@ def _plan_resource_query_id(plan: Any) -> str:
     return query_id
 
 
-def _query_cleanup_connection_settings(
+class CleanupConnectionSnapshotIdentity(NamedTuple):
+    """Connection state that determines the cleanup filesystem."""
+
+    bootstrap_database: str
+    bootstrap_read_only: bool
+    bootstrap_config: tuple[tuple[str, str], ...]
+    settings: tuple[tuple[str, str, str], ...]
+
+
+def _query_cleanup_connection_identity(
     connection_snapshot_query_id: str,
     *,
     apply_snapshot_s3_credentials: bool,
-) -> tuple[tuple[str, str, str], ...]:
-    """Return the settings that cleanup snapshot replay will actually apply."""
+) -> CleanupConnectionSnapshotIdentity:
+    """Return the bootstrap and settings that cleanup replay will apply."""
     lookup = require_ray_cxx_attr(
         "_lookup_query_connection_snapshot",
         hint="Ensure the C++ ray extension is built with query replay lifecycle support.",
@@ -196,11 +205,23 @@ def _query_cleanup_connection_settings(
         )
     if not isinstance(snapshot, Mapping):
         raise TypeError("query connection snapshot must be a mapping")
+
+    bootstrap_database = ":memory:"
+    bootstrap_read_only = False
+    bootstrap_config: tuple[tuple[str, str], ...] = ()
+    raw_bootstrap = snapshot.get("bootstrap")
+    if isinstance(raw_bootstrap, Mapping):
+        bootstrap_database = str(raw_bootstrap.get("database") or ":memory:")
+        bootstrap_read_only = bool(raw_bootstrap.get("read_only", False))
+        raw_bootstrap_config = raw_bootstrap.get("config")
+        if isinstance(raw_bootstrap_config, Mapping):
+            bootstrap_config = tuple(sorted((str(key), str(value)) for key, value in raw_bootstrap_config.items()))
+
     raw_settings = snapshot.get("settings", [])
     if raw_settings is None:
-        return ()
+        raw_settings = []
     if not isinstance(raw_settings, list):
-        return ()
+        raw_settings = []
 
     settings: list[tuple[str, str, str]] = []
     for raw_setting in raw_settings:
@@ -221,7 +242,12 @@ def _query_cleanup_connection_settings(
                 str(raw_setting.get("input_type", "VARCHAR")).upper(),
             )
         )
-    return tuple(settings)
+    return CleanupConnectionSnapshotIdentity(
+        bootstrap_database=bootstrap_database,
+        bootstrap_read_only=bootstrap_read_only,
+        bootstrap_config=bootstrap_config,
+        settings=tuple(settings),
+    )
 
 
 def _cleanup_query_python_replay_state(query_id: str) -> None:
@@ -238,6 +264,7 @@ def _cleanup_flight_shuffle_for_query(
     connection_snapshot_query_id: str = "",
     *,
     apply_snapshot_s3_credentials: bool = True,
+    effective_session_config: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     query_id = str(query_id or "").strip()
     if not query_id:
@@ -262,6 +289,9 @@ def _cleanup_flight_shuffle_for_query(
             cleanup_connection,
             str(connection_snapshot_query_id or ""),
             bool(apply_snapshot_s3_credentials),
+            None
+            if effective_session_config is None
+            else {str(key): str(value) for key, value in effective_session_config.items()},
         )
     if not isinstance(raw, dict):
         raise TypeError("Flight shuffle cleanup binding must return a dict")
@@ -727,7 +757,7 @@ class NativeQueryCleanupContext(NamedTuple):
     session_config: tuple[tuple[str, str], ...]
     use_session_credentials: bool
     connection_snapshot_query_id: str
-    connection_snapshot_settings: tuple[tuple[str, str, str], ...]
+    connection_snapshot_identity: CleanupConnectionSnapshotIdentity
 
 
 @ray.remote(concurrency_groups={"execute": 128, "control": 512})
@@ -1435,7 +1465,7 @@ class RayWorkerActor:
             session_config=tuple(sorted((str(key), str(value)) for key, value in session_config.items())),
             use_session_credentials=use_session_credentials,
             connection_snapshot_query_id=connection_snapshot_query_id,
-            connection_snapshot_settings=_query_cleanup_connection_settings(
+            connection_snapshot_identity=_query_cleanup_connection_identity(
                 connection_snapshot_query_id,
                 apply_snapshot_s3_credentials=not use_session_credentials,
             ),
@@ -1455,7 +1485,7 @@ class RayWorkerActor:
                     existing.session_id != cleanup_context.session_id
                     or existing.session_config != cleanup_context.session_config
                     or existing.use_session_credentials != cleanup_context.use_session_credentials
-                    or existing.connection_snapshot_settings != cleanup_context.connection_snapshot_settings
+                    or existing.connection_snapshot_identity != cleanup_context.connection_snapshot_identity
                 ):
                     raise RuntimeError(f"native query cleanup context changed: {query_key}")
                 return
@@ -1513,6 +1543,7 @@ class RayWorkerActor:
                 # connection credentials still replay when session credentials
                 # are intentionally disabled.
                 apply_snapshot_s3_credentials=not cleanup_context.use_session_credentials,
+                effective_session_config=effective_s3_config,
             )
             cleanup["registry_entries_removed"] += probe["registry_entries_removed"]
             cleanup["storage_entries_removed"] += probe["storage_entries_removed"]

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -172,7 +172,11 @@ def _cleanup_query_python_replay_state(query_id: str) -> None:
     cleanup(str(query_id))
 
 
-def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, Any]:
+def _cleanup_flight_shuffle_for_query(
+    query_id: str,
+    cleanup_connection: Any | None = None,
+    connection_snapshot_query_id: str = "",
+) -> dict[str, Any]:
     query_id = str(query_id or "").strip()
     if not query_id:
         return {
@@ -187,7 +191,14 @@ def _cleanup_flight_shuffle_for_query(query_id: str) -> dict[str, Any]:
         "cleanup_flight_shuffle_for_query",
         hint="Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
     )
-    raw = cleanup_fn(query_id)
+    if cleanup_connection is None:
+        raw = cleanup_fn(query_id)
+    else:
+        raw = cleanup_fn(
+            query_id,
+            cleanup_connection,
+            str(connection_snapshot_query_id or ""),
+        )
     if not isinstance(raw, dict):
         raise TypeError("Flight shuffle cleanup binding must return a dict")
     return {
@@ -252,6 +263,7 @@ async def _drain_flight_shuffle_for_query(
     query_id: str,
     *,
     timeout_s: float | None = None,
+    cleanup_callback: Callable[[str], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if timeout_s is None:
         timeout_s = _fte_control_rpc_timeout_s() * 0.8
@@ -259,8 +271,9 @@ async def _drain_flight_shuffle_for_query(
     total_registry_removed = 0
     total_storage_removed = 0
     backoff_s = 0.01
+    cleanup_once = cleanup_callback or _cleanup_flight_shuffle_for_query
     while True:
-        cleanup = await asyncio.to_thread(_cleanup_flight_shuffle_for_query, query_id)
+        cleanup = await asyncio.to_thread(cleanup_once, query_id)
         total_registry_removed += cleanup["registry_entries_removed"]
         total_storage_removed += cleanup["storage_entries_removed"]
         if cleanup["active_executions"] == 0 and cleanup["cleanup_pending"] == 0 and cleanup["cleanup_errors"] == 0:
@@ -642,6 +655,15 @@ class WorkerTaskMetadata(NamedTuple):
     exchange_sink_instance: Any = None
 
 
+class NativeQueryCleanupContext(NamedTuple):
+    """Serializable inputs for rebuilding a query-scoped cleanup cursor."""
+
+    session_id: str
+    session_config: tuple[tuple[str, str], ...]
+    use_session_credentials: bool
+    connection_snapshot_query_id: str
+
+
 @ray.remote(concurrency_groups={"execute": 128, "control": 512})
 class RayWorkerActor:
     """RayWorkerActor is a ray actor that runs local physical plans on worker.
@@ -725,6 +747,7 @@ class RayWorkerActor:
         self._native_execution_condition = threading.Condition()
         self._native_execution_count = 0
         self._native_execution_counts_by_query: dict[str, int] = {}
+        self._native_query_cleanup_contexts: dict[str, NativeQueryCleanupContext] = {}
         self._active_native_cursors: set[Any] = set()
         self._native_cursor_query_ids: dict[Any, str] = {}
         self._closing_native_queries: set[str] = set()
@@ -1097,7 +1120,14 @@ class RayWorkerActor:
 
     @ray.method(concurrency_group="control")
     async def fte_cleanup_query(self, query_id: str) -> dict[str, int]:
-        flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
+        cleanup_with_context = getattr(self, "_cleanup_flight_shuffle_for_query_with_context", None)
+        if callable(cleanup_with_context):
+            flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(
+                query_id,
+                cleanup_callback=cleanup_with_context,
+            )
+        else:
+            flight_shuffle_cleanup = await _drain_flight_shuffle_for_query(query_id)
         _retire_flight_shuffle_query(query_id)
         self._retire_worker_native_query(query_id)
         _cleanup_query_python_replay_state(query_id)
@@ -1320,6 +1350,83 @@ class RayWorkerActor:
                 self._session_s3_configs[session_id] = effective_s3_config
             return effective_s3_config
 
+    def _register_native_query_cleanup_context(
+        self,
+        query_id: str,
+        plan: Any,
+        session_id: str,
+        session_config: Mapping[str, str],
+        *,
+        use_session_credentials: bool,
+    ) -> None:
+        query_key = str(query_id or "").strip()
+        if not query_key:
+            return
+        cleanup_context = NativeQueryCleanupContext(
+            session_id=str(session_id),
+            session_config=tuple(sorted((str(key), str(value)) for key, value in session_config.items())),
+            use_session_credentials=bool(use_session_credentials),
+            connection_snapshot_query_id=_plan_resource_query_id(plan),
+        )
+        with self._native_execution_condition:
+            contexts = getattr(self, "_native_query_cleanup_contexts", None)
+            if contexts is None:
+                contexts = {}
+                self._native_query_cleanup_contexts = contexts
+            existing = contexts.get(query_key)
+            if existing is not None and existing != cleanup_context:
+                raise RuntimeError(f"native query cleanup context changed: {query_key}")
+            contexts[query_key] = cleanup_context
+
+    def _cleanup_flight_shuffle_for_query_with_context(self, query_id: str) -> dict[str, Any]:
+        query_key = str(query_id or "").strip()
+        with self._native_execution_condition:
+            cleanup_context = getattr(self, "_native_query_cleanup_contexts", {}).get(query_key)
+        if cleanup_context is None:
+            return _cleanup_flight_shuffle_for_query(query_key)
+
+        session_config = dict(cleanup_context.session_config)
+        operation_lock = self._get_session_operation_lock(
+            cleanup_context.session_id,
+            allow_closed=True,
+        )
+        with operation_lock:
+            with self._session_connections_lock:
+                cached_s3_config = dict(
+                    getattr(self, "_session_s3_configs", {}).get(
+                        cleanup_context.session_id,
+                        session_config,
+                    )
+                )
+            effective_s3_config = _refresh_effective_duckdb_s3_config(
+                session_config,
+                cached_s3_config,
+                use_session_credentials=cleanup_context.use_session_credentials,
+            )
+            with self._session_connections_lock:
+                if cleanup_context.session_id in getattr(self, "_session_connections", {}):
+                    self._session_s3_configs[cleanup_context.session_id] = effective_s3_config
+
+        cleanup_cursor = self._get_shared_conn().cursor()
+        try:
+            _configure_duckdb_s3(
+                cleanup_cursor,
+                effective_s3_config,
+                use_session_credentials=cleanup_context.use_session_credentials,
+            )
+            return _cleanup_flight_shuffle_for_query(
+                query_key,
+                cleanup_cursor,
+                cleanup_context.connection_snapshot_query_id,
+            )
+        finally:
+            try:
+                cleanup_cursor.close()
+            except Exception:
+                # The cursor is no longer reachable after this callback. Keep
+                # the storage/configuration error as the retry diagnostic.
+                pass
+
     @ray.method(concurrency_group="control")
     async def close_session(self, session_id: str) -> None:
         session_key = str(session_id).strip()
@@ -1445,6 +1552,7 @@ class RayWorkerActor:
                     f"{query_id} active_executions={active_executions}"
                 )
             self._closing_native_queries.discard(query_id)
+            getattr(self, "_native_query_cleanup_contexts", {}).pop(query_id, None)
 
     def _prepare_worker_runtime_shutdown(self) -> None:
         shutdown_lock = getattr(self, "_shutdown_lock", None)
@@ -1638,6 +1746,13 @@ class RayWorkerActor:
             effective_s3_config = _configure_duckdb_s3(
                 cursor,
                 effective_s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            self._register_native_query_cleanup_context(
+                native_query_id,
+                plan,
+                session_id,
+                session_config,
                 use_session_credentials=use_session_credentials,
             )
             _ray_worker_memory_log(

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -62,6 +62,20 @@ _DUCKDB_S3_SESSION_KEYS = (
     "AWS_SECRET_ACCESS_KEY",
     "AWS_SESSION_TOKEN",
 )
+_CONNECTION_SNAPSHOT_S3_CREDENTIAL_SETTINGS = frozenset(
+    {
+        "s3_access_key_id",
+        "s3_secret_access_key",
+        "s3_session_token",
+    }
+)
+_CONNECTION_SNAPSHOT_SECURITY_SETTINGS = frozenset(
+    {
+        "allow_unsigned_extensions",
+        "autoinstall_known_extensions",
+        "autoload_known_extensions",
+    }
+)
 
 
 async def _to_thread_with_owned_side_effects(
@@ -162,6 +176,52 @@ def _plan_resource_query_id(plan: Any) -> str:
     if not query_id:
         raise ValueError("distributed physical plan resource_query_id must not be empty")
     return query_id
+
+
+def _query_cleanup_connection_settings(
+    connection_snapshot_query_id: str,
+    *,
+    apply_snapshot_s3_credentials: bool,
+) -> tuple[tuple[str, str, str], ...]:
+    """Return the settings that cleanup snapshot replay will actually apply."""
+    lookup = require_ray_cxx_attr(
+        "_lookup_query_connection_snapshot",
+        hint="Ensure the C++ ray extension is built with query replay lifecycle support.",
+    )
+    snapshot = lookup(str(connection_snapshot_query_id))
+    if snapshot is None:
+        raise RuntimeError(
+            "query connection snapshot is unavailable during cleanup context registration: "
+            f"{connection_snapshot_query_id}"
+        )
+    if not isinstance(snapshot, Mapping):
+        raise TypeError("query connection snapshot must be a mapping")
+    raw_settings = snapshot.get("settings", [])
+    if raw_settings is None:
+        return ()
+    if not isinstance(raw_settings, list):
+        return ()
+
+    settings: list[tuple[str, str, str]] = []
+    for raw_setting in raw_settings:
+        if not isinstance(raw_setting, Mapping) or "name" not in raw_setting or "value" not in raw_setting:
+            continue
+        name = str(raw_setting["name"])
+        lower_name = name.lower()
+        if (
+            not name
+            or lower_name in _CONNECTION_SNAPSHOT_SECURITY_SETTINGS
+            or (not apply_snapshot_s3_credentials and lower_name in _CONNECTION_SNAPSHOT_S3_CREDENTIAL_SETTINGS)
+        ):
+            continue
+        settings.append(
+            (
+                lower_name,
+                str(raw_setting["value"]),
+                str(raw_setting.get("input_type", "VARCHAR")).upper(),
+            )
+        )
+    return tuple(settings)
 
 
 def _cleanup_query_python_replay_state(query_id: str) -> None:
@@ -667,6 +727,7 @@ class NativeQueryCleanupContext(NamedTuple):
     session_config: tuple[tuple[str, str], ...]
     use_session_credentials: bool
     connection_snapshot_query_id: str
+    connection_snapshot_settings: tuple[tuple[str, str, str], ...]
 
 
 @ray.remote(concurrency_groups={"execute": 128, "control": 512})
@@ -1367,11 +1428,17 @@ class RayWorkerActor:
         query_key = str(query_id or "").strip()
         if not query_key:
             return
+        connection_snapshot_query_id = _plan_resource_query_id(plan)
+        use_session_credentials = bool(use_session_credentials)
         cleanup_context = NativeQueryCleanupContext(
             session_id=str(session_id),
             session_config=tuple(sorted((str(key), str(value)) for key, value in session_config.items())),
-            use_session_credentials=bool(use_session_credentials),
-            connection_snapshot_query_id=_plan_resource_query_id(plan),
+            use_session_credentials=use_session_credentials,
+            connection_snapshot_query_id=connection_snapshot_query_id,
+            connection_snapshot_settings=_query_cleanup_connection_settings(
+                connection_snapshot_query_id,
+                apply_snapshot_s3_credentials=not use_session_credentials,
+            ),
         )
         with self._native_execution_condition:
             contexts = getattr(self, "_native_query_cleanup_contexts", None)
@@ -1382,13 +1449,13 @@ class RayWorkerActor:
             if existing is not None:
                 # One execution query can contain independently materialized
                 # fragment plans with different replay-registry keys. Their
-                # cleanup storage configuration must agree, but retaining the
-                # first live snapshot is sufficient for the query-scoped
-                # storage context.
+                # effective cleanup settings must agree, but retaining the first
+                # live snapshot is sufficient for the query-scoped storage context.
                 if (
                     existing.session_id != cleanup_context.session_id
                     or existing.session_config != cleanup_context.session_config
                     or existing.use_session_credentials != cleanup_context.use_session_credentials
+                    or existing.connection_snapshot_settings != cleanup_context.connection_snapshot_settings
                 ):
                     raise RuntimeError(f"native query cleanup context changed: {query_key}")
                 return

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -183,6 +183,7 @@ def _cleanup_flight_shuffle_for_query(
             "registry_entries_removed": 0,
             "storage_entries_removed": 0,
             "cleanup_errors": 0,
+            "cleanup_storage_required": 0,
             "cleanup_pending": 0,
             "active_executions": 0,
             "last_error": "",
@@ -205,6 +206,7 @@ def _cleanup_flight_shuffle_for_query(
         "registry_entries_removed": int(raw.get("registry_entries_removed", 0)),
         "storage_entries_removed": int(raw.get("storage_entries_removed", 0)),
         "cleanup_errors": int(raw.get("cleanup_errors", 0)),
+        "cleanup_storage_required": int(raw.get("cleanup_storage_required", 0)),
         "cleanup_pending": int(raw.get("cleanup_pending", 0)),
         "active_executions": int(raw.get("active_executions", 0)),
         "last_error": str(raw.get("last_error", "")),
@@ -1385,6 +1387,13 @@ class RayWorkerActor:
         if cleanup_context is None:
             return _cleanup_flight_shuffle_for_query(query_key)
 
+        # Retained local caches need no connection context. Probe first so
+        # unrelated AWS credential failures cannot block local-only teardown.
+        probe = _cleanup_flight_shuffle_for_query(query_key)
+        cleanup_storage_required = int(probe["cleanup_storage_required"])
+        if cleanup_storage_required == 0:
+            return probe
+
         session_config = dict(cleanup_context.session_config)
         operation_lock = self._get_session_operation_lock(
             cleanup_context.session_id,
@@ -1414,11 +1423,20 @@ class RayWorkerActor:
                 effective_s3_config,
                 use_session_credentials=cleanup_context.use_session_credentials,
             )
-            return _cleanup_flight_shuffle_for_query(
+            cleanup = _cleanup_flight_shuffle_for_query(
                 query_key,
                 cleanup_cursor,
                 cleanup_context.connection_snapshot_query_id,
             )
+            cleanup["registry_entries_removed"] += probe["registry_entries_removed"]
+            cleanup["storage_entries_removed"] += probe["storage_entries_removed"]
+            # The retry satisfies only the probe errors caused by missing
+            # caller-owned storage; preserve any independent cleanup failures.
+            unresolved_probe_errors = max(0, probe["cleanup_errors"] - cleanup_storage_required)
+            cleanup["cleanup_errors"] += unresolved_probe_errors
+            if unresolved_probe_errors and not cleanup["last_error"]:
+                cleanup["last_error"] = probe["last_error"]
+            return cleanup
         finally:
             try:
                 cleanup_cursor.close()

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -1379,8 +1379,19 @@ class RayWorkerActor:
                 contexts = {}
                 self._native_query_cleanup_contexts = contexts
             existing = contexts.get(query_key)
-            if existing is not None and existing != cleanup_context:
-                raise RuntimeError(f"native query cleanup context changed: {query_key}")
+            if existing is not None:
+                # One execution query can contain independently materialized
+                # fragment plans with different replay-registry keys. Their
+                # cleanup storage configuration must agree, but retaining the
+                # first live snapshot is sufficient for the query-scoped
+                # storage context.
+                if (
+                    existing.session_id != cleanup_context.session_id
+                    or existing.session_config != cleanup_context.session_config
+                    or existing.use_session_credentials != cleanup_context.use_session_credentials
+                ):
+                    raise RuntimeError(f"native query cleanup context changed: {query_key}")
+                return
             contexts[query_key] = cleanup_context
 
     def _cleanup_flight_shuffle_for_query_with_context(self, query_id: str) -> dict[str, Any]:

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -176,6 +176,8 @@ def _cleanup_flight_shuffle_for_query(
     query_id: str,
     cleanup_connection: Any | None = None,
     connection_snapshot_query_id: str = "",
+    *,
+    apply_snapshot_s3_credentials: bool = True,
 ) -> dict[str, Any]:
     query_id = str(query_id or "").strip()
     if not query_id:
@@ -199,6 +201,7 @@ def _cleanup_flight_shuffle_for_query(
             query_id,
             cleanup_connection,
             str(connection_snapshot_query_id or ""),
+            bool(apply_snapshot_s3_credentials),
         )
     if not isinstance(raw, dict):
         raise TypeError("Flight shuffle cleanup binding must return a dict")
@@ -1427,6 +1430,11 @@ class RayWorkerActor:
                 query_key,
                 cleanup_cursor,
                 cleanup_context.connection_snapshot_query_id,
+                # Refreshed profile/role credentials must remain newer than
+                # plan-time local settings captured in the snapshot. Explicit
+                # connection credentials still replay when session credentials
+                # are intentionally disabled.
+                apply_snapshot_s3_credentials=not cleanup_context.use_session_credentials,
             )
             cleanup["registry_entries_removed"] += probe["registry_entries_removed"]
             cleanup["storage_entries_removed"] += probe["storage_entries_removed"]

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -828,10 +828,14 @@ void FlightExchange::Close() {
 // ─── FlightExchangeSink ─────────────────────────────────
 
 FlightExchangeSink::FlightExchangeSink(std::shared_ptr<ShuffleCache> shuffle_cache,
-                                       const ExchangeSinkInstanceHandle &handle, ClientContext *context)
+                                       const ExchangeSinkInstanceHandle &handle, ClientContext *context,
+                                       bool descriptor_only_cleanup)
     : shuffle_cache_(std::move(shuffle_cache)), handle_(handle), context_(context) {
-	auto track_result = ShuffleCacheRegistry::Instance().TrackPending(
-	    handle_.output_location, shuffle_cache_, handle_.query_id, handle_.flight_server_epoch, handle_.attempt_id);
+	auto retention = descriptor_only_cleanup ? ShuffleCacheRegistry::CacheRetention::DESCRIPTOR_ONLY
+	                                         : ShuffleCacheRegistry::CacheRetention::RETAIN;
+	auto track_result =
+	    ShuffleCacheRegistry::Instance().TrackPending(handle_.output_location, shuffle_cache_, handle_.query_id,
+	                                                  handle_.flight_server_epoch, handle_.attempt_id, retention);
 	if (track_result.is_err()) {
 		throw InvalidInputException("Failed to track Flight exchange sink attempt: %s", track_result.error().what());
 	}
@@ -1314,7 +1318,8 @@ std::unique_ptr<ExchangeSink> FlightExchangeManager::CreateSink(const ExchangeSi
 	auto sink_handle = handle;
 	sink_handle.flight_server_epoch = GetPublishedFlightServerEpoch();
 	auto shuffle_cache = MakeFlightExchangeShuffleCache(cache_config, config_, context_);
-	return std::unique_ptr<ExchangeSink>(new FlightExchangeSink(shuffle_cache, sink_handle, context_));
+	return std::unique_ptr<ExchangeSink>(
+	    new FlightExchangeSink(shuffle_cache, sink_handle, context_, FlightExchangeUsesObjectStorage(config_)));
 }
 
 std::unique_ptr<ExchangeSource> FlightExchangeManager::CreateSource() {

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -1048,21 +1048,25 @@ DuckDBResult<ShufflePartitionFiles> ShuffleCache::GetPartitionFilesFromManifest(
 }
 
 DuckDBResult<idx_t> ShuffleCache::RemoveAttemptStorage() const {
-	if (config_.shuffle_stage_id.empty()) {
+	return RemoveShuffleAttemptStorage(config_, *storage_);
+}
+
+DuckDBResult<idx_t> RemoveShuffleAttemptStorage(const ShuffleCacheConfig &config, const ShuffleStorage &storage) {
+	if (config.shuffle_stage_id.empty()) {
 		return DuckDBResult<idx_t>::err(DuckDBError::value_error("shuffle cache stage id is empty"));
 	}
-	if (config_.node_id.empty()) {
+	if (config.node_id.empty()) {
 		return DuckDBResult<idx_t>::err(DuckDBError::value_error("shuffle cache node id is empty"));
 	}
-	if (config_.local_dirs.empty()) {
+	if (config.local_dirs.empty()) {
 		return DuckDBResult<idx_t>::ok(0);
 	}
 
-	auto stage = ShuffleCacheSanitizePathComponent(config_.shuffle_stage_id);
-	auto node = ShuffleCacheSanitizePathComponent(config_.node_id);
+	auto stage = ShuffleCacheSanitizePathComponent(config.shuffle_stage_id);
+	auto node = ShuffleCacheSanitizePathComponent(config.node_id);
 	std::unordered_set<std::string> seen_attempt_dirs;
 	idx_t removed_total = 0;
-	for (const auto &base_dir : config_.local_dirs) {
+	for (const auto &base_dir : config.local_dirs) {
 		if (base_dir.empty()) {
 			continue;
 		}
@@ -1072,7 +1076,7 @@ DuckDBResult<idx_t> ShuffleCache::RemoveAttemptStorage() const {
 		if (!seen_attempt_dirs.insert(attempt_dir).second) {
 			continue;
 		}
-		auto removed_res = storage_->RemoveAll(attempt_dir);
+		auto removed_res = storage.RemoveAll(attempt_dir);
 		if (removed_res.is_err()) {
 			return DuckDBResult<idx_t>::err(removed_res.error());
 		}

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -239,7 +239,7 @@ private:
 class FlightExchangeSink : public ExchangeSink {
 public:
 	FlightExchangeSink(std::shared_ptr<ShuffleCache> shuffle_cache, const ExchangeSinkInstanceHandle &handle,
-	                   ClientContext *context);
+	                   ClientContext *context, bool descriptor_only_cleanup = false);
 	~FlightExchangeSink() override;
 
 	DuckDBResult<void> AddChunk(idx_t partition_id, DataChunk &chunk) override;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
@@ -81,6 +81,7 @@ public:
 
 std::shared_ptr<ShuffleStorage> MakeDuckDBFileSystemShuffleStorage(FileSystem &fs);
 std::shared_ptr<ShuffleStorage> MakeDuckDBFileSystemShuffleStorage(FileSystem &fs, FileOpener *opener);
+DuckDBResult<idx_t> RemoveShuffleAttemptStorage(const ShuffleCacheConfig &config, const ShuffleStorage &storage);
 
 class ShuffleCache {
 public:

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -91,6 +91,10 @@ private:
 			return cleanup_complete;
 		}
 
+		bool RequiresCleanupStorage() const {
+			return !retained_cache;
+		}
+
 		ShuffleCacheConfig config;
 		std::weak_ptr<ShuffleCache> cache_identity;
 		std::shared_ptr<ShuffleCache> retained_cache;
@@ -160,6 +164,7 @@ public:
 		idx_t registry_entries_removed = 0;
 		idx_t storage_entries_removed = 0;
 		idx_t cleanup_errors = 0;
+		idx_t cleanup_storage_required = 0;
 		idx_t cleanup_pending = 0;
 		idx_t active_executions = 0;
 		std::string last_error;
@@ -577,6 +582,9 @@ private:
 				auto cleanup_result = state->CleanupIfReady(cleanup_storage);
 				if (cleanup_result.is_err()) {
 					result.cleanup_errors++;
+					if (!cleanup_storage && state->RequiresCleanupStorage()) {
+						result.cleanup_storage_required++;
+					}
 					result.last_error = cleanup_result.error().what();
 					continue;
 				}

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache_registry.hpp
@@ -3,12 +3,13 @@
 
 /**
  * @file shuffle_cache_registry.hpp
- * @brief Process-local catalog of published ShuffleCache instances.
+ * @brief Process-local catalog of published shuffle attempts.
  *
- * Sinks publish committed attempts after FlushAll. Sources and the Flight
- * service borrow catalog entries by opaque exchange-attempt ID. Query close
- * fences late publishers and keeps cleanup work visible until all readers and
- * native executions have drained.
+ * Local-disk entries retain their ShuffleCache so the Flight service can
+ * borrow it. Object-storage entries retain only an immutable cleanup
+ * descriptor; teardown must supply storage backed by a live cleanup context.
+ * Query close fences late publishers and keeps cleanup work visible until all
+ * readers and native executions have drained.
  */
 
 #pragma once
@@ -30,7 +31,8 @@ namespace distributed {
 class ShuffleCacheRegistry {
 private:
 	struct CacheLeaseState {
-		explicit CacheLeaseState(std::shared_ptr<ShuffleCache> cache_p) : cache(std::move(cache_p)) {
+		CacheLeaseState(const std::shared_ptr<ShuffleCache> &cache_p, bool retain_cache)
+		    : config(cache_p->config()), cache_identity(cache_p), retained_cache(retain_cache ? cache_p : nullptr) {
 		}
 
 		void AcquireWriter() {
@@ -64,12 +66,20 @@ private:
 			cleanup_requested = true;
 		}
 
-		DuckDBResult<idx_t> CleanupIfReady() {
+		DuckDBResult<idx_t> CleanupIfReady(const std::shared_ptr<ShuffleStorage> &cleanup_storage) {
 			std::lock_guard<std::mutex> lock(cleanup_mutex);
 			if (!cleanup_requested || cleanup_complete || active_writers > 0 || active_readers > 0) {
 				return DuckDBResult<idx_t>::ok(0);
 			}
-			auto result = cache->RemoveAttemptStorage();
+			DuckDBResult<idx_t> result;
+			if (retained_cache) {
+				result = retained_cache->RemoveAttemptStorage();
+			} else if (cleanup_storage) {
+				result = RemoveShuffleAttemptStorage(config, *cleanup_storage);
+			} else {
+				result = DuckDBResult<idx_t>::err(DuckDBError::invalid_state_error(
+				    "shuffle cleanup requires a live filesystem context for " + config.shuffle_stage_id));
+			}
 			if (result.is_ok()) {
 				cleanup_complete = true;
 			}
@@ -81,7 +91,9 @@ private:
 			return cleanup_complete;
 		}
 
-		std::shared_ptr<ShuffleCache> cache;
+		ShuffleCacheConfig config;
+		std::weak_ptr<ShuffleCache> cache_identity;
+		std::shared_ptr<ShuffleCache> retained_cache;
 
 	private:
 		mutable std::mutex cleanup_mutex;
@@ -137,6 +149,13 @@ private:
 	using RegistryMap = std::unordered_map<std::string, Entry>;
 
 public:
+	enum class CacheRetention : uint8_t {
+		//! Keep the cache available to process-local Flight readers and cleanup.
+		RETAIN,
+		//! Keep only path metadata; cleanup must reconstruct context-bound storage.
+		DESCRIPTOR_ONLY,
+	};
+
 	struct CleanupResult {
 		idx_t registry_entries_removed = 0;
 		idx_t storage_entries_removed = 0;
@@ -213,9 +232,10 @@ public:
 
 	/// Track a sink attempt before it can write any storage. The returned lease
 	/// prevents query cleanup from deleting files while the sink is still writing.
+	/// DESCRIPTOR_ONLY avoids retaining context-bound storage beyond the task.
 	DuckDBResult<WriteLease> TrackPending(const std::string &exchange_id, std::shared_ptr<ShuffleCache> cache,
 	                                      const std::string &query_id, std::string server_epoch = std::string(),
-	                                      idx_t attempt_id = 0) {
+	                                      idx_t attempt_id = 0, CacheRetention retention = CacheRetention::RETAIN) {
 		if (exchange_id.empty() || query_id.empty() || !cache) {
 			return DuckDBResult<WriteLease>::err(
 			    DuckDBError::value_error("pending shuffle cache requires an exchange id, query id, and cache"));
@@ -225,7 +245,7 @@ public:
 			    "pending shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
 		}
 
-		auto state = std::make_shared<CacheLeaseState>(std::move(cache));
+		auto state = std::make_shared<CacheLeaseState>(cache, retention == CacheRetention::RETAIN);
 		WriteLease writer_lease = std::make_shared<CacheWriteLease>(state);
 		{
 			std::lock_guard<std::mutex> lock(mutex_);
@@ -280,7 +300,7 @@ public:
 			    "shuffle cache exchange id does not match its storage descriptor: " + exchange_id));
 		}
 
-		auto state = std::make_shared<CacheLeaseState>(std::move(cache));
+		auto state = std::make_shared<CacheLeaseState>(cache, true);
 		bool query_closing = false;
 		bool owns_cleanup = false;
 		{
@@ -291,7 +311,7 @@ public:
 				auto existing = registry_.find(exchange_id);
 				if (existing != registry_.end()) {
 					if (!existing->second.published ||
-					    !DescriptorsMatch(existing->second, state->cache, query_id, server_epoch, attempt_id)) {
+					    !DescriptorsMatch(existing->second, cache, query_id, server_epoch, attempt_id)) {
 						return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
 						    "conflicting shuffle cache registration for exchange " + exchange_id));
 					}
@@ -322,7 +342,7 @@ public:
 			    DuckDBError::invalid_state_error("query closed before shuffle cache publication: " + query_id));
 		}
 		state->RequestCleanup();
-		auto cleanup_result = state->CleanupIfReady();
+		auto cleanup_result = state->CleanupIfReady(nullptr);
 		RemoveCompletedDeferred();
 		if (cleanup_result.is_err()) {
 			return DuckDBResult<void>::err(cleanup_result.error());
@@ -346,12 +366,12 @@ public:
 	                                                    const std::string &node_id, idx_t attempt_id) const {
 		std::lock_guard<std::mutex> lock(mutex_);
 		auto it = registry_.find(exchange_id);
-		if (it == registry_.end() || !it->second.published || !it->second.state || !it->second.state->cache) {
+		if (it == registry_.end() || !it->second.published || !it->second.state || !it->second.state->retained_cache) {
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight exchange attempt is not published: " + exchange_id));
 		}
 		const auto &entry = it->second;
-		const auto &config = entry.state->cache->config();
+		const auto &config = entry.state->config;
 		if (entry.server_epoch != server_epoch) {
 			return DuckDBResult<std::shared_ptr<ShuffleCache>>::err(
 			    DuckDBError::invalid_state_error("flight ticket server epoch is stale"));
@@ -396,8 +416,10 @@ public:
 		}
 	}
 
-	/// Retry all cleanup owned by one exact query.
-	CleanupResult RemoveAndCleanupByQuery(const std::string &query_id) {
+	/// Retry all cleanup owned by one exact query. cleanup_storage is borrowed
+	/// for this call only and is never retained by the registry.
+	CleanupResult RemoveAndCleanupByQuery(const std::string &query_id,
+	                                      std::shared_ptr<ShuffleStorage> cleanup_storage = nullptr) {
 		if (query_id.empty()) {
 			return {};
 		}
@@ -408,7 +430,8 @@ public:
 			result.last_error = close_result.error().what();
 			return result;
 		}
-		auto result = CleanupMatching([&](const Entry &entry) { return entry.query_id == query_id; }, &query_id);
+		auto result =
+		    CleanupMatching([&](const Entry &entry) { return entry.query_id == query_id; }, &query_id, cleanup_storage);
 		result.registry_entries_removed += close_result.value();
 		return result;
 	}
@@ -483,29 +506,32 @@ public:
 			return {};
 		}
 		return CleanupMatching([&](const Entry &entry) { return entry.exchange_id.rfind(exchange_id_prefix, 0) == 0; },
-		                       nullptr);
+		                       nullptr, nullptr);
 	}
 
 private:
 	ShuffleCacheRegistry() = default;
 
 	static std::shared_ptr<ShuffleCache> Borrow(const std::shared_ptr<CacheLeaseState> &state) {
-		if (!state || !state->cache || !state->TryAcquireReader()) {
+		if (!state || !state->retained_cache || !state->TryAcquireReader()) {
 			return nullptr;
 		}
 		auto lease = std::make_shared<CacheBorrowLease>(state);
-		return std::shared_ptr<ShuffleCache>(lease, state->cache.get());
+		return std::shared_ptr<ShuffleCache>(lease, state->retained_cache.get());
 	}
 
 	static bool DescriptorsMatch(const Entry &left, const std::shared_ptr<ShuffleCache> &right_cache,
 	                             const std::string &right_query_id, const std::string &right_server_epoch,
 	                             idx_t right_attempt_id) {
-		if (!left.state || !left.state->cache || !right_cache || left.state->cache.get() != right_cache.get() ||
-		    left.query_id != right_query_id || left.server_epoch != right_server_epoch ||
+		if (!left.state || !right_cache || left.query_id != right_query_id || left.server_epoch != right_server_epoch ||
 		    left.attempt_id != right_attempt_id) {
 			return false;
 		}
-		const auto &left_config = left.state->cache->config();
+		auto left_cache = left.state->cache_identity.lock();
+		if (!left_cache || left_cache.get() != right_cache.get()) {
+			return false;
+		}
+		const auto &left_config = left.state->config;
 		const auto &right_config = right_cache->config();
 		return left_config.shuffle_stage_id == right_config.shuffle_stage_id &&
 		       left_config.node_id == right_config.node_id &&
@@ -514,7 +540,8 @@ private:
 	}
 
 	template <class MATCH>
-	CleanupResult CleanupMatching(MATCH &&matches, const std::string *query_id) {
+	CleanupResult CleanupMatching(MATCH &&matches, const std::string *query_id,
+	                              const std::shared_ptr<ShuffleStorage> &cleanup_storage) {
 		CleanupResult result;
 		std::vector<std::shared_ptr<CacheLeaseState>> candidates;
 		bool query_has_active_executions = false;
@@ -547,7 +574,7 @@ private:
 		if (!query_has_active_executions) {
 			for (const auto &state : candidates) {
 				state->RequestCleanup();
-				auto cleanup_result = state->CleanupIfReady();
+				auto cleanup_result = state->CleanupIfReady(cleanup_storage);
 				if (cleanup_result.is_err()) {
 					result.cleanup_errors++;
 					result.last_error = cleanup_result.error().what();

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -555,12 +555,14 @@ TEST_CASE("Exchange: object shuffle cleanup reconstructs storage without retaini
 
 	auto without_context = registry.RemoveAndCleanupByQuery(query_id);
 	REQUIRE(without_context.cleanup_errors == 1);
+	REQUIRE(without_context.cleanup_storage_required == 1);
 	REQUIRE(without_context.cleanup_pending == 1);
 	REQUIRE(without_context.last_error.find("requires a live filesystem context") != std::string::npos);
 
 	auto cleanup_storage = std::make_shared<MockObjectShuffleStorage>(storage_root);
 	auto with_context = registry.RemoveAndCleanupByQuery(query_id, cleanup_storage);
 	REQUIRE(with_context.cleanup_errors == 0);
+	REQUIRE(with_context.cleanup_storage_required == 0);
 	REQUIRE(with_context.cleanup_pending == 0);
 	REQUIRE(with_context.storage_entries_removed > 0);
 	ShuffleCache cleanup_probe(config, std::move(cleanup_storage));

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -520,6 +520,54 @@ TEST_CASE("Exchange: ShuffleCacheRegistry retains and retries failed cleanup", "
 	REQUIRE(registry.RetireQuery(query_id).is_ok());
 }
 
+TEST_CASE("Exchange: object shuffle cleanup reconstructs storage without retaining task cache",
+          "[distributed][exchange]") {
+	auto &registry = ShuffleCacheRegistry::Instance();
+	const std::string query_id = "registry-object-cleanup-context-query";
+	const std::string exchange_id = "registry_object_cleanup_context__sink_0__attempt_0";
+	auto storage_root = TestCreatePath("registry_object_cleanup_context");
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = exchange_id;
+	config.node_id = "node-a";
+	config.num_partitions = 1;
+	config.local_dirs = {"mock://shuffle"};
+	auto task_storage = std::make_shared<MockObjectShuffleStorage>(storage_root);
+	auto cache = std::make_shared<ShuffleCache>(config, task_storage);
+	REQUIRE(cache->WriteAttemptManifest(0, 0).is_ok());
+	REQUIRE(cache->HasCommittedManifest());
+
+	std::weak_ptr<ShuffleStorage> task_storage_lifetime = task_storage;
+	std::weak_ptr<ShuffleCache> task_cache_lifetime = cache;
+	auto lease_result = registry.TrackPending(exchange_id, cache, query_id, "epoch-a", 0,
+	                                          ShuffleCacheRegistry::CacheRetention::DESCRIPTOR_ONLY);
+	REQUIRE(lease_result.is_ok());
+	auto writer_lease = std::move(lease_result.value());
+	REQUIRE(registry.Publish(exchange_id, cache, query_id, "epoch-a", 0).is_ok());
+	REQUIRE(registry.Get(exchange_id) == nullptr);
+	REQUIRE(registry.Resolve(exchange_id, "epoch-a", "node-a", 0).is_err());
+
+	writer_lease.reset();
+	cache.reset();
+	task_storage.reset();
+	REQUIRE(task_cache_lifetime.expired());
+	REQUIRE(task_storage_lifetime.expired());
+
+	auto without_context = registry.RemoveAndCleanupByQuery(query_id);
+	REQUIRE(without_context.cleanup_errors == 1);
+	REQUIRE(without_context.cleanup_pending == 1);
+	REQUIRE(without_context.last_error.find("requires a live filesystem context") != std::string::npos);
+
+	auto cleanup_storage = std::make_shared<MockObjectShuffleStorage>(storage_root);
+	auto with_context = registry.RemoveAndCleanupByQuery(query_id, cleanup_storage);
+	REQUIRE(with_context.cleanup_errors == 0);
+	REQUIRE(with_context.cleanup_pending == 0);
+	REQUIRE(with_context.storage_entries_removed > 0);
+	ShuffleCache cleanup_probe(config, std::move(cleanup_storage));
+	REQUIRE_FALSE(cleanup_probe.HasCommittedManifest());
+	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
 TEST_CASE("Exchange: deferred cleanup retains exclusive attempt identity", "[distributed][exchange]") {
 	auto &registry = ShuffleCacheRegistry::Instance();
 	const std::string exchange_id = "registry_deferred_identity__sink_0__attempt_0";

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -419,6 +419,15 @@ static bool IsVaneSessionBaselineConnectionSetting(const string &name) {
 	return names.find(duckdb::StringUtil::Lower(name)) != names.end();
 }
 
+static bool IsS3CredentialConnectionSetting(const string &name) {
+	static const std::unordered_set<string> names {
+	    "s3_access_key_id",
+	    "s3_secret_access_key",
+	    "s3_session_token",
+	};
+	return names.find(duckdb::StringUtil::Lower(name)) != names.end();
+}
+
 static string QuoteSQLStringLiteral(const string &value) {
 	return "'" + duckdb::StringUtil::Replace(value, "'", "''") + "'";
 }
@@ -669,7 +678,8 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 }
 
 static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snapshot_obj,
-                                    bool apply_session_config = true, bool enforce_extension_security = true) {
+                                    bool apply_session_config = true, bool enforce_extension_security = true,
+                                    bool apply_s3_credentials = true) {
 	if (snapshot_obj.is_none()) {
 		return;
 	}
@@ -725,7 +735,9 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		auto input_type = setting_obj.contains(py::str("input_type"))
 		                      ? py::str(setting_obj[py::str("input_type")]).cast<string>()
 		                      : string("VARCHAR");
-		if (setting_name.empty() || IsExtensionSecuritySetting(duckdb::StringUtil::Lower(setting_name))) {
+		auto lower_setting_name = duckdb::StringUtil::Lower(setting_name);
+		if (setting_name.empty() || IsExtensionSecuritySetting(lower_setting_name) ||
+		    (!apply_s3_credentials && IsS3CredentialConnectionSetting(lower_setting_name))) {
 			continue;
 		}
 		string sql_value;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -64,6 +64,7 @@ static inline int DuckdbGetEnvIntMs(const char *name) {
 #include <duckdb/common/serializer/binary_serializer.hpp>
 #include <duckdb/common/serializer/binary_deserializer.hpp>
 #include <duckdb/main/client_context.hpp>
+#include <duckdb/main/client_data.hpp>
 #include <duckdb/main/config.hpp>
 #include <duckdb/main/database.hpp>
 #include <duckdb/common/types/data_chunk.hpp>
@@ -541,7 +542,7 @@ void register_ray_bindings(py::module_ &mod) {
 
 	m.def(
 	    "cleanup_flight_shuffle_for_query",
-	    [](const string &query_id) {
+	    [](const string &query_id, py::object cleanup_connection, const string &connection_snapshot_query_id) {
 		    py::dict out;
 		    if (query_id.empty()) {
 			    out["registry_entries_removed"] = 0;
@@ -552,9 +553,33 @@ void register_ray_bindings(py::module_ &mod) {
 			    out["last_error"] = "";
 			    return out;
 		    }
+		    std::shared_ptr<duckdb::distributed::ShuffleStorage> cleanup_storage;
+		    if (!cleanup_connection.is_none()) {
+			    auto &conn_wrapper = ExtractPyConnectionWrapper(cleanup_connection);
+			    if (conn_wrapper.con.ConnectionIsClosed()) {
+				    throw std::runtime_error("shuffle cleanup connection is closed");
+			    }
+			    if (!connection_snapshot_query_id.empty()) {
+				    auto snapshot = LookupQueryConnectionSnapshot(connection_snapshot_query_id);
+				    if (!snapshot.is_none()) {
+					    ApplyConnectionSnapshot(cleanup_connection, snapshot, false);
+				    }
+				    // Concurrent idempotent teardown can retire replay state after
+				    // this cleanup cursor was configured. Continue with its
+				    // sanitized session baseline: remaining storage failures stay
+				    // visible and retryable in the registry.
+			    }
+			    auto &context = *conn_wrapper.con.GetConnection().context;
+			    auto &fs = *duckdb::DBConfig::GetConfig(context).file_system;
+			    auto *opener = duckdb::ClientData::Get(context).file_opener.get();
+			    cleanup_storage = duckdb::distributed::MakeDuckDBFileSystemShuffleStorage(fs, opener);
+		    } else if (!connection_snapshot_query_id.empty()) {
+			    throw std::runtime_error("query connection snapshot requires a shuffle cleanup connection");
+		    }
 		    auto cleanup_result = [&]() {
 			    py::gil_scoped_release release;
-			    return duckdb::distributed::ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(query_id);
+			    return duckdb::distributed::ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(query_id,
+			                                                                                         cleanup_storage);
 		    }();
 		    out["registry_entries_removed"] = cleanup_result.registry_entries_removed;
 		    out["storage_entries_removed"] = cleanup_result.storage_entries_removed;
@@ -564,7 +589,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["last_error"] = cleanup_result.last_error;
 		    return out;
 	    },
-	    py::arg("query_id"));
+	    py::arg("query_id"), py::arg("cleanup_connection") = py::none(), py::arg("connection_snapshot_query_id") = "");
 
 	m.def(
 	    "retire_flight_shuffle_query",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -155,6 +155,32 @@ public:
 	shared_ptr<std::atomic<idx_t>> calls;
 };
 
+static py::object ResolveFlightShuffleCleanupConnection(py::object cleanup_connection,
+                                                        const py::object &connection_snapshot,
+                                                        const py::object &effective_session_config,
+                                                        bool apply_snapshot_s3_credentials) {
+	auto resolved_connection = connection_snapshot.is_none()
+	                               ? cleanup_connection
+	                               : ResolveConnectionForSnapshot(cleanup_connection, connection_snapshot);
+	auto &resolved_wrapper = ExtractPyConnectionWrapper(resolved_connection);
+	if (resolved_wrapper.con.ConnectionIsClosed()) {
+		throw std::runtime_error("resolved shuffle cleanup connection is closed");
+	}
+	ApplyEffectiveVaneSessionConfig(resolved_wrapper.con.GetConnection(), effective_session_config);
+	ApplyConnectionSnapshot(resolved_connection, connection_snapshot, false, true, apply_snapshot_s3_credentials);
+	return resolved_connection;
+}
+
+static string QueryConnectionSettingForTest(DuckDBPyConnection &connection, const string &name) {
+	auto result = ExecuteSnapshotQuery(connection.con.GetConnection(),
+	                                   "SELECT current_setting(" + QuoteSQLStringLiteral(name) + ")");
+	for (auto &row : result->Collection().Rows()) {
+		auto value = row.GetValue(0);
+		return value.IsNull() ? string() : value.ToString();
+	}
+	throw std::runtime_error("connection setting query returned no rows: " + name);
+}
+
 void register_ray_bindings(py::module_ &mod) {
 	auto m = mod.def_submodule("ray_cxx");
 	m.doc() = "C++ Ray execution bindings (experimental)";
@@ -543,7 +569,7 @@ void register_ray_bindings(py::module_ &mod) {
 	m.def(
 	    "cleanup_flight_shuffle_for_query",
 	    [](const string &query_id, py::object cleanup_connection, const string &connection_snapshot_query_id,
-	       bool apply_snapshot_s3_credentials) {
+	       bool apply_snapshot_s3_credentials, py::object effective_session_config) {
 		    py::dict out;
 		    if (query_id.empty()) {
 			    out["registry_entries_removed"] = 0;
@@ -555,24 +581,33 @@ void register_ray_bindings(py::module_ &mod) {
 			    out["last_error"] = "";
 			    return out;
 		    }
+		    py::object resolved_cleanup_connection = cleanup_connection;
+		    // Keep the resolved DatabaseInstance alive until after storage drops
+		    // its FileSystem and FileOpener references.
 		    std::shared_ptr<duckdb::distributed::ShuffleStorage> cleanup_storage;
 		    if (!cleanup_connection.is_none()) {
 			    auto &conn_wrapper = ExtractPyConnectionWrapper(cleanup_connection);
 			    if (conn_wrapper.con.ConnectionIsClosed()) {
 				    throw std::runtime_error("shuffle cleanup connection is closed");
 			    }
+			    py::object snapshot = py::none();
 			    if (!connection_snapshot_query_id.empty()) {
-				    auto snapshot = LookupQueryConnectionSnapshot(connection_snapshot_query_id);
+				    snapshot = LookupQueryConnectionSnapshot(connection_snapshot_query_id);
 				    if (!snapshot.is_none()) {
-					    ApplyConnectionSnapshot(cleanup_connection, snapshot, false, true,
-					                            apply_snapshot_s3_credentials);
+					    resolved_cleanup_connection = ResolveFlightShuffleCleanupConnection(
+					        cleanup_connection, snapshot, effective_session_config, apply_snapshot_s3_credentials);
+				    } else {
+					    ApplyEffectiveVaneSessionConfig(conn_wrapper.con.GetConnection(), effective_session_config);
 				    }
 				    // Concurrent idempotent teardown can retire replay state after
 				    // this cleanup cursor was configured. Continue with its
 				    // sanitized session baseline: remaining storage failures stay
 				    // visible and retryable in the registry.
+			    } else {
+				    ApplyEffectiveVaneSessionConfig(conn_wrapper.con.GetConnection(), effective_session_config);
 			    }
-			    auto &context = *conn_wrapper.con.GetConnection().context;
+			    auto &resolved_wrapper = ExtractPyConnectionWrapper(resolved_cleanup_connection);
+			    auto &context = *resolved_wrapper.con.GetConnection().context;
 			    auto &fs = *duckdb::DBConfig::GetConfig(context).file_system;
 			    auto *opener = duckdb::ClientData::Get(context).file_opener.get();
 			    cleanup_storage = duckdb::distributed::MakeDuckDBFileSystemShuffleStorage(fs, opener);
@@ -594,7 +629,29 @@ void register_ray_bindings(py::module_ &mod) {
 		    return out;
 	    },
 	    py::arg("query_id"), py::arg("cleanup_connection") = py::none(), py::arg("connection_snapshot_query_id") = "",
-	    py::arg("apply_snapshot_s3_credentials") = true);
+	    py::arg("apply_snapshot_s3_credentials") = true, py::arg("effective_session_config") = py::none());
+
+	m.def(
+	    "_resolve_flight_shuffle_cleanup_connection_for_test",
+	    [](py::object cleanup_connection, const string &connection_snapshot_query_id,
+	       py::object effective_session_config, bool apply_snapshot_s3_credentials) {
+		    auto snapshot = LookupQueryConnectionSnapshot(connection_snapshot_query_id);
+		    if (snapshot.is_none()) {
+			    throw std::runtime_error("query connection snapshot is unavailable");
+		    }
+		    auto resolved_connection = ResolveFlightShuffleCleanupConnection(
+		        cleanup_connection, snapshot, effective_session_config, apply_snapshot_s3_credentials);
+		    auto &resolved_wrapper = ExtractPyConnectionWrapper(resolved_connection);
+		    py::dict settings;
+		    for (const auto &name :
+		         {"s3_endpoint", "s3_region", "s3_access_key_id", "s3_secret_access_key", "s3_session_token"}) {
+			    settings[py::str(name)] = py::str(QueryConnectionSettingForTest(resolved_wrapper, name));
+		    }
+		    settings[py::str("reused_input")] = py::bool_(resolved_connection.ptr() == cleanup_connection.ptr());
+		    return settings;
+	    },
+	    py::arg("cleanup_connection"), py::arg("connection_snapshot_query_id"),
+	    py::arg("effective_session_config") = py::none(), py::arg("apply_snapshot_s3_credentials") = true);
 
 	m.def(
 	    "retire_flight_shuffle_query",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -542,7 +542,8 @@ void register_ray_bindings(py::module_ &mod) {
 
 	m.def(
 	    "cleanup_flight_shuffle_for_query",
-	    [](const string &query_id, py::object cleanup_connection, const string &connection_snapshot_query_id) {
+	    [](const string &query_id, py::object cleanup_connection, const string &connection_snapshot_query_id,
+	       bool apply_snapshot_s3_credentials) {
 		    py::dict out;
 		    if (query_id.empty()) {
 			    out["registry_entries_removed"] = 0;
@@ -563,7 +564,8 @@ void register_ray_bindings(py::module_ &mod) {
 			    if (!connection_snapshot_query_id.empty()) {
 				    auto snapshot = LookupQueryConnectionSnapshot(connection_snapshot_query_id);
 				    if (!snapshot.is_none()) {
-					    ApplyConnectionSnapshot(cleanup_connection, snapshot, false);
+					    ApplyConnectionSnapshot(cleanup_connection, snapshot, false, true,
+					                            apply_snapshot_s3_credentials);
 				    }
 				    // Concurrent idempotent teardown can retire replay state after
 				    // this cleanup cursor was configured. Continue with its
@@ -591,7 +593,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["last_error"] = cleanup_result.last_error;
 		    return out;
 	    },
-	    py::arg("query_id"), py::arg("cleanup_connection") = py::none(), py::arg("connection_snapshot_query_id") = "");
+	    py::arg("query_id"), py::arg("cleanup_connection") = py::none(), py::arg("connection_snapshot_query_id") = "",
+	    py::arg("apply_snapshot_s3_credentials") = true);
 
 	m.def(
 	    "retire_flight_shuffle_query",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -548,6 +548,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    out["registry_entries_removed"] = 0;
 			    out["storage_entries_removed"] = 0;
 			    out["cleanup_errors"] = 0;
+			    out["cleanup_storage_required"] = 0;
 			    out["cleanup_pending"] = 0;
 			    out["active_executions"] = 0;
 			    out["last_error"] = "";
@@ -584,6 +585,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["registry_entries_removed"] = cleanup_result.registry_entries_removed;
 		    out["storage_entries_removed"] = cleanup_result.storage_entries_removed;
 		    out["cleanup_errors"] = cleanup_result.cleanup_errors;
+		    out["cleanup_storage_required"] = cleanup_result.cleanup_storage_required;
 		    out["cleanup_pending"] = cleanup_result.cleanup_pending;
 		    out["active_executions"] = cleanup_result.active_executions;
 		    out["last_error"] = cleanup_result.last_error;
@@ -2859,7 +2861,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    selected_config.num_partitions = 1;
 		    selected_config.local_dirs = {base_uri};
 		    auto &fs = FileSystem::GetFileSystem(context);
-		    auto storage = MakeDuckDBFileSystemShuffleStorage(fs);
+		    auto *opener = ClientData::Get(context).file_opener.get();
+		    auto storage = MakeDuckDBFileSystemShuffleStorage(fs, opener);
 		    ShuffleCache selected_cache(selected_config, storage);
 		    auto selected_cleanup_res = selected_cache.RemoveAttemptStorage();
 		    if (selected_cleanup_res.is_err()) {
@@ -2887,7 +2890,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    out["selected_values_after_loser_cleanup"] = selected_values_after_cleanup;
 		    out["lost_manifest_after_cleanup_error"] = lost_manifest_after_cleanup_error;
 		    out["selected_cleanup_removed"] = selected_cleanup_res.value();
-		    auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(exchange_context.query_id);
+		    auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(exchange_context.query_id, storage);
 		    if (cleanup.cleanup_errors != 0 || cleanup.cleanup_pending != 0) {
 			    throw std::runtime_error("failed to clean MinIO selected-attempt test query");
 		    }

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -124,6 +124,64 @@ def test_flight_shuffle_cleanup_snapshot_s3_credential_precedence(
         source_con.close()
 
 
+def test_flight_shuffle_cleanup_resolves_bootstrap_storage_config():
+    snapshot_query_id = f"query-snapshot-{uuid.uuid4()}"
+    source_con = duckdb.connect(
+        config={
+            "s3_endpoint": "bootstrap.example.test",
+            "s3_region": "bootstrap-region",
+            "s3_access_key_id": "bootstrap-key",
+            "s3_secret_access_key": "bootstrap-secret",
+            "s3_session_token": "bootstrap-token",
+        }
+    )
+    plan = _make_test_physical_plan(source_con)
+    snapshot = plan.__getstate__()[6]
+    snapshot_setting_names = {setting["name"].lower() for setting in snapshot["settings"]}
+    assert snapshot_setting_names.isdisjoint(
+        {
+            "s3_endpoint",
+            "s3_region",
+            "s3_access_key_id",
+            "s3_secret_access_key",
+            "s3_session_token",
+        }
+    )
+    assert snapshot["bootstrap"]["config"]["s3_endpoint"] == "bootstrap.example.test"
+    duckdb.ray_cxx._register_query_python_replay_state(snapshot_query_id, plan)
+
+    cleanup_con = duckdb.connect()
+    cleanup_cursor = cleanup_con.cursor()
+    cleanup_cursor.execute("LOAD httpfs")
+    cleanup_cursor.execute("SET s3_endpoint='fallback.example.test'")
+
+    try:
+        settings = duckdb.ray_cxx._resolve_flight_shuffle_cleanup_connection_for_test(
+            cleanup_cursor,
+            snapshot_query_id,
+            {
+                "AWS_ACCESS_KEY_ID": "fresh-key",
+                "AWS_SECRET_ACCESS_KEY": "fresh-secret",
+                "AWS_SESSION_TOKEN": "fresh-token",
+            },
+            False,
+        )
+
+        assert settings == {
+            "s3_endpoint": "bootstrap.example.test",
+            "s3_region": "bootstrap-region",
+            "s3_access_key_id": "fresh-key",
+            "s3_secret_access_key": "fresh-secret",
+            "s3_session_token": "fresh-token",
+            "reused_input": False,
+        }
+    finally:
+        duckdb.ray_cxx._cleanup_query_python_replay_state(snapshot_query_id)
+        cleanup_cursor.close()
+        cleanup_con.close()
+        source_con.close()
+
+
 def test_execute_native_keeps_result_collector_query_local():
     con = duckdb.connect()
     cursor = con.cursor()

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -33,6 +33,37 @@ def _make_test_physical_plan(con=None):
     ).to_physical_plan(con)
 
 
+def test_flight_shuffle_cleanup_is_idempotent_after_snapshot_retirement():
+    query_id = f"query-cleanup-{uuid.uuid4()}"
+    snapshot_query_id = f"query-snapshot-{uuid.uuid4()}"
+    con = duckdb.connect()
+    cleanup_cursor = con.cursor()
+    plan = _make_test_physical_plan(con)
+    duckdb.ray_cxx._register_query_python_replay_state(snapshot_query_id, plan)
+    assert duckdb.ray_cxx._lookup_query_connection_snapshot(snapshot_query_id) is not None
+    duckdb.ray_cxx._cleanup_query_python_replay_state(snapshot_query_id)
+    assert duckdb.ray_cxx._lookup_query_connection_snapshot(snapshot_query_id) is None
+
+    try:
+        result = duckdb.ray_cxx.cleanup_flight_shuffle_for_query(
+            query_id,
+            cleanup_cursor,
+            snapshot_query_id,
+        )
+        assert result == {
+            "registry_entries_removed": 0,
+            "storage_entries_removed": 0,
+            "cleanup_errors": 0,
+            "cleanup_pending": 0,
+            "active_executions": 0,
+            "last_error": "",
+        }
+    finally:
+        duckdb.ray_cxx.retire_flight_shuffle_query(query_id)
+        cleanup_cursor.close()
+        con.close()
+
+
 def test_execute_native_keeps_result_collector_query_local():
     con = duckdb.connect()
     cursor = con.cursor()

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -54,6 +54,7 @@ def test_flight_shuffle_cleanup_is_idempotent_after_snapshot_retirement():
             "registry_entries_removed": 0,
             "storage_entries_removed": 0,
             "cleanup_errors": 0,
+            "cleanup_storage_required": 0,
             "cleanup_pending": 0,
             "active_executions": 0,
             "last_error": "",

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -65,6 +65,65 @@ def test_flight_shuffle_cleanup_is_idempotent_after_snapshot_retirement():
         con.close()
 
 
+@pytest.mark.parametrize(
+    ("apply_snapshot_s3_credentials", "expected_credential_prefix"),
+    [
+        (False, "fresh"),
+        (True, "stale"),
+    ],
+)
+def test_flight_shuffle_cleanup_snapshot_s3_credential_precedence(
+    apply_snapshot_s3_credentials,
+    expected_credential_prefix,
+):
+    query_id = f"query-cleanup-{uuid.uuid4()}"
+    snapshot_query_id = f"query-snapshot-{uuid.uuid4()}"
+    source_con = duckdb.connect()
+    source_con.execute("LOAD httpfs")
+    source_con.execute("SET s3_access_key_id='stale-key'")
+    source_con.execute("SET s3_secret_access_key='stale-secret'")
+    source_con.execute("SET s3_session_token='stale-token'")
+    source_con.execute("SET http_retries=7")
+    plan = _make_test_physical_plan(source_con)
+    duckdb.ray_cxx._register_query_python_replay_state(snapshot_query_id, plan)
+
+    cleanup_con = duckdb.connect()
+    cleanup_cursor = cleanup_con.cursor()
+    cleanup_cursor.execute("LOAD httpfs")
+    cleanup_cursor.execute("SET s3_access_key_id='fresh-key'")
+    cleanup_cursor.execute("SET s3_secret_access_key='fresh-secret'")
+    cleanup_cursor.execute("SET s3_session_token='fresh-token'")
+    cleanup_cursor.execute("SET http_retries=3")
+
+    try:
+        duckdb.ray_cxx.cleanup_flight_shuffle_for_query(
+            query_id,
+            cleanup_cursor,
+            snapshot_query_id,
+            apply_snapshot_s3_credentials,
+        )
+
+        assert (
+            cleanup_cursor.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0]
+            == f"{expected_credential_prefix}-key"
+        )
+        assert (
+            cleanup_cursor.execute("SELECT current_setting('s3_secret_access_key')").fetchone()[0]
+            == f"{expected_credential_prefix}-secret"
+        )
+        assert (
+            cleanup_cursor.execute("SELECT current_setting('s3_session_token')").fetchone()[0]
+            == f"{expected_credential_prefix}-token"
+        )
+        assert cleanup_cursor.execute("SELECT current_setting('http_retries')").fetchone()[0] == 7
+    finally:
+        duckdb.ray_cxx.retire_flight_shuffle_query(query_id)
+        duckdb.ray_cxx._cleanup_query_python_replay_state(snapshot_query_id)
+        cleanup_cursor.close()
+        cleanup_con.close()
+        source_con.close()
+
+
 def test_execute_native_keeps_result_collector_query_local():
     con = duckdb.connect()
     cursor = con.cursor()

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -3302,6 +3302,47 @@ def test_worker_cleanup_context_replays_snapshot_with_session_credentials():
     }
 
 
+def test_worker_cleanup_context_reuses_first_snapshot_across_query_fragments():
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+
+    class _Plan:
+        def __init__(self, resource_query_id):
+            self._resource_query_id = resource_query_id
+
+        def resource_query_id(self):
+            return self._resource_query_id
+
+    actor_class._register_native_query_cleanup_context(
+        actor,
+        "execution-query",
+        _Plan("resource-query-a"),
+        "session-a",
+        {"AWS_PROFILE": "profile-a"},
+        use_session_credentials=True,
+    )
+    actor_class._register_native_query_cleanup_context(
+        actor,
+        "execution-query",
+        _Plan("resource-query-b"),
+        "session-a",
+        {"AWS_PROFILE": "profile-a"},
+        use_session_credentials=True,
+    )
+
+    assert actor._native_query_cleanup_contexts["execution-query"].connection_snapshot_query_id == "resource-query-a"
+    with pytest.raises(RuntimeError, match="native query cleanup context changed"):
+        actor_class._register_native_query_cleanup_context(
+            actor,
+            "execution-query",
+            _Plan("resource-query-c"),
+            "session-a",
+            {"AWS_PROFILE": "profile-b"},
+            use_session_credentials=True,
+        )
+
+
 def test_worker_flight_shuffle_cleanup_drain_retries_pending_work(monkeypatch):
     cleanups = iter(
         [

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2942,8 +2942,23 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
     def _fake_require(name, hint=None):
         assert name == "cleanup_flight_shuffle_for_query"
 
-        def _cleanup(query_id, connection, snapshot_query_id, apply_snapshot_s3_credentials):
-            calls.append((query_id, connection, snapshot_query_id, apply_snapshot_s3_credentials, hint))
+        def _cleanup(
+            query_id,
+            connection,
+            snapshot_query_id,
+            apply_snapshot_s3_credentials,
+            effective_session_config,
+        ):
+            calls.append(
+                (
+                    query_id,
+                    connection,
+                    snapshot_query_id,
+                    apply_snapshot_s3_credentials,
+                    effective_session_config,
+                    hint,
+                )
+            )
             return {
                 "registry_entries_removed": 1,
                 "storage_entries_removed": 2,
@@ -2962,6 +2977,7 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
         cleanup_connection,
         "resource-query",
         apply_snapshot_s3_credentials=False,
+        effective_session_config={"AWS_REGION": "region-a"},
     )
 
     assert result["storage_entries_removed"] == 2
@@ -2971,6 +2987,7 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
             cleanup_connection,
             "resource-query",
             False,
+            {"AWS_REGION": "region-a"},
             "Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
         )
     ]
@@ -2986,7 +3003,7 @@ def test_worker_local_shuffle_cleanup_skips_object_storage_rebuild(monkeypatch):
             session_config=(("AWS_PROFILE", "unavailable-profile"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
-            connection_snapshot_settings=(),
+            connection_snapshot_identity=worker_mod.CleanupConnectionSnapshotIdentity(":memory:", False, (), ()),
         )
     }
     cleanup = {
@@ -3033,7 +3050,7 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
             session_config=(("AWS_PROFILE", "profile-a"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
-            connection_snapshot_settings=(),
+            connection_snapshot_identity=worker_mod.CleanupConnectionSnapshotIdentity(":memory:", False, (), ()),
         )
     }
     events = []
@@ -3063,6 +3080,7 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
         connection_snapshot_query_id="",
         *,
         apply_snapshot_s3_credentials=True,
+        effective_session_config=None,
     ):
         if connection is None:
             events.append(("probe", query_id))
@@ -3082,6 +3100,7 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
                 connection,
                 connection_snapshot_query_id,
                 apply_snapshot_s3_credentials,
+                effective_session_config,
             )
         )
         return {
@@ -3132,7 +3151,18 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
             },
             True,
         ),
-        ("cleanup", "query-drop", cleanup_cursor, "resource-query", False),
+        (
+            "cleanup",
+            "query-drop",
+            cleanup_cursor,
+            "resource-query",
+            False,
+            {
+                "AWS_ACCESS_KEY_ID": "fresh-key",
+                "AWS_SECRET_ACCESS_KEY": "fresh-secret",
+                worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "9999999999",
+            },
+        ),
         ("close",),
     ]
 
@@ -3150,7 +3180,7 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
             session_config=(("AWS_ENDPOINT_URL", "https://s3.example.test"),),
             use_session_credentials=False,
             connection_snapshot_query_id="resource-query",
-            connection_snapshot_settings=(),
+            connection_snapshot_identity=worker_mod.CleanupConnectionSnapshotIdentity(":memory:", False, (), ()),
         )
     }
     cleanup_cursor = SimpleNamespace(close=lambda: None)
@@ -3163,6 +3193,7 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
         connection_snapshot_query_id="",
         *,
         apply_snapshot_s3_credentials=True,
+        effective_session_config=None,
     ):
         cleanup_calls.append(
             (
@@ -3170,6 +3201,7 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
                 connection,
                 connection_snapshot_query_id,
                 apply_snapshot_s3_credentials,
+                effective_session_config,
             )
         )
         if connection is None:
@@ -3220,8 +3252,14 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
         "last_error": "",
     }
     assert cleanup_calls == [
-        ("query-drop", None, "", True),
-        ("query-drop", cleanup_cursor, "resource-query", True),
+        ("query-drop", None, "", True, None),
+        (
+            "query-drop",
+            cleanup_cursor,
+            "resource-query",
+            True,
+            {"AWS_ENDPOINT_URL": "https://s3.example.test"},
+        ),
     ]
 
 
@@ -3238,7 +3276,7 @@ def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close
             session_config=(),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
-            connection_snapshot_settings=(),
+            connection_snapshot_identity=worker_mod.CleanupConnectionSnapshotIdentity(":memory:", False, (), ()),
         )
     }
 
@@ -3281,7 +3319,8 @@ def test_worker_cleanup_context_replays_snapshot_with_session_credentials(monkey
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_class)
     actor._native_execution_condition = threading.Condition()
-    monkeypatch.setattr(worker_mod, "_query_cleanup_connection_settings", lambda *args, **kwargs: ())
+    default_identity = worker_mod.CleanupConnectionSnapshotIdentity(":memory:", False, (), ())
+    monkeypatch.setattr(worker_mod, "_query_cleanup_connection_identity", lambda *args, **kwargs: default_identity)
 
     class _Plan:
         @staticmethod
@@ -3303,20 +3342,28 @@ def test_worker_cleanup_context_replays_snapshot_with_session_credentials(monkey
             session_config=(("AWS_PROFILE", "profile-a"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
-            connection_snapshot_settings=(),
+            connection_snapshot_identity=default_identity,
         )
     }
 
 
-def test_worker_cleanup_connection_settings_match_snapshot_replay(monkeypatch):
+def test_worker_cleanup_connection_identity_matches_snapshot_replay(monkeypatch):
     snapshot = {
+        "bootstrap": {
+            "database": ":memory:",
+            "read_only": False,
+            "config": {
+                "s3_endpoint": "bootstrap.example.test",
+                "s3_region": "bootstrap-region",
+            },
+        },
         "settings": [
             {"name": "s3_endpoint", "value": "s3.example.test", "input_type": "VARCHAR"},
             {"name": "s3_access_key_id", "value": "plan-key", "input_type": "VARCHAR"},
             {"name": "s3_secret_access_key", "value": "plan-secret", "input_type": "VARCHAR"},
             {"name": "http_timeout", "value": "30", "input_type": "BIGINT"},
             {"name": "allow_unsigned_extensions", "value": "true", "input_type": "BOOLEAN"},
-        ]
+        ],
     }
 
     def require(name, *, hint):
@@ -3326,21 +3373,37 @@ def test_worker_cleanup_connection_settings_match_snapshot_replay(monkeypatch):
 
     monkeypatch.setattr(worker_mod, "require_ray_cxx_attr", require)
 
-    assert worker_mod._query_cleanup_connection_settings(
+    assert worker_mod._query_cleanup_connection_identity(
         "resource-query",
         apply_snapshot_s3_credentials=False,
-    ) == (
-        ("s3_endpoint", "s3.example.test", "VARCHAR"),
-        ("http_timeout", "30", "BIGINT"),
+    ) == worker_mod.CleanupConnectionSnapshotIdentity(
+        bootstrap_database=":memory:",
+        bootstrap_read_only=False,
+        bootstrap_config=(
+            ("s3_endpoint", "bootstrap.example.test"),
+            ("s3_region", "bootstrap-region"),
+        ),
+        settings=(
+            ("s3_endpoint", "s3.example.test", "VARCHAR"),
+            ("http_timeout", "30", "BIGINT"),
+        ),
     )
-    assert worker_mod._query_cleanup_connection_settings(
+    assert worker_mod._query_cleanup_connection_identity(
         "resource-query",
         apply_snapshot_s3_credentials=True,
-    ) == (
-        ("s3_endpoint", "s3.example.test", "VARCHAR"),
-        ("s3_access_key_id", "plan-key", "VARCHAR"),
-        ("s3_secret_access_key", "plan-secret", "VARCHAR"),
-        ("http_timeout", "30", "BIGINT"),
+    ) == worker_mod.CleanupConnectionSnapshotIdentity(
+        bootstrap_database=":memory:",
+        bootstrap_read_only=False,
+        bootstrap_config=(
+            ("s3_endpoint", "bootstrap.example.test"),
+            ("s3_region", "bootstrap-region"),
+        ),
+        settings=(
+            ("s3_endpoint", "s3.example.test", "VARCHAR"),
+            ("s3_access_key_id", "plan-key", "VARCHAR"),
+            ("s3_secret_access_key", "plan-secret", "VARCHAR"),
+            ("http_timeout", "30", "BIGINT"),
+        ),
     )
 
 
@@ -3348,16 +3411,27 @@ def test_worker_cleanup_context_reuses_first_equivalent_snapshot_across_query_fr
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_class)
     actor._native_execution_condition = threading.Condition()
-    snapshot_settings = {
-        "resource-query-a": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
-        "resource-query-b": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
-        "resource-query-c": (("s3_endpoint", "other.example.test", "VARCHAR"),),
-        "resource-query-d": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
+    default_identity = worker_mod.CleanupConnectionSnapshotIdentity(
+        ":memory:",
+        False,
+        (("s3_endpoint", "s3.example.test"),),
+        (),
+    )
+    snapshot_identities = {
+        "resource-query-a": default_identity,
+        "resource-query-b": default_identity,
+        "resource-query-c": worker_mod.CleanupConnectionSnapshotIdentity(
+            ":memory:",
+            False,
+            (("s3_endpoint", "other.example.test"),),
+            (),
+        ),
+        "resource-query-d": default_identity,
     }
     monkeypatch.setattr(
         worker_mod,
-        "_query_cleanup_connection_settings",
-        lambda query_id, **kwargs: snapshot_settings[query_id],
+        "_query_cleanup_connection_identity",
+        lambda query_id, **kwargs: snapshot_identities[query_id],
     )
 
     class _Plan:

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2934,6 +2934,249 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
     assert calls == [("query-drop", "Ensure the C++ ray extension is built with Flight shuffle cleanup support.")]
 
 
+def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snapshot(monkeypatch):
+    calls = []
+    cleanup_connection = object()
+
+    def _fake_require(name, hint=None):
+        assert name == "cleanup_flight_shuffle_for_query"
+
+        def _cleanup(query_id, connection, snapshot_query_id):
+            calls.append((query_id, connection, snapshot_query_id, hint))
+            return {
+                "registry_entries_removed": 1,
+                "storage_entries_removed": 2,
+                "cleanup_errors": 0,
+                "cleanup_pending": 0,
+                "active_executions": 0,
+                "last_error": "",
+            }
+
+        return _cleanup
+
+    monkeypatch.setattr(worker_mod, "require_ray_cxx_attr", _fake_require)
+
+    result = worker_mod._cleanup_flight_shuffle_for_query(
+        "query-drop",
+        cleanup_connection,
+        "resource-query",
+    )
+
+    assert result["storage_entries_removed"] == 2
+    assert calls == [
+        (
+            "query-drop",
+            cleanup_connection,
+            "resource-query",
+            "Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
+        )
+    ]
+
+
+def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypatch):
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+    actor._session_connections_lock = threading.RLock()
+    actor._session_connections = {"session-a": ({}, object())}
+    actor._session_s3_configs = {
+        "session-a": {
+            "AWS_ACCESS_KEY_ID": "stale-key",
+            "AWS_SECRET_ACCESS_KEY": "stale-secret",
+            worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "0",
+        }
+    }
+    actor._native_query_cleanup_contexts = {
+        "query-drop": worker_mod.NativeQueryCleanupContext(
+            session_id="session-a",
+            session_config=(("AWS_PROFILE", "profile-a"),),
+            use_session_credentials=True,
+            connection_snapshot_query_id="resource-query",
+        )
+    }
+    events = []
+
+    class _CleanupCursor:
+        def close(self):
+            events.append(("close",))
+
+    cleanup_cursor = _CleanupCursor()
+    actor._get_shared_conn = lambda: SimpleNamespace(cursor=lambda: cleanup_cursor)
+
+    def refresh(config, cached, *, use_session_credentials):
+        events.append(("refresh", dict(config), dict(cached), use_session_credentials))
+        return {
+            "AWS_ACCESS_KEY_ID": "fresh-key",
+            "AWS_SECRET_ACCESS_KEY": "fresh-secret",
+            worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "9999999999",
+        }
+
+    def configure(connection, config, *, use_session_credentials):
+        events.append(("configure", connection, dict(config), use_session_credentials))
+        return dict(config)
+
+    def cleanup(query_id, connection=None, connection_snapshot_query_id=""):
+        events.append(("cleanup", query_id, connection, connection_snapshot_query_id))
+        return {
+            "registry_entries_removed": 1,
+            "storage_entries_removed": 2,
+            "cleanup_errors": 0,
+            "cleanup_pending": 0,
+            "active_executions": 0,
+            "last_error": "",
+        }
+
+    monkeypatch.setattr(worker_mod, "_refresh_effective_duckdb_s3_config", refresh)
+    monkeypatch.setattr(worker_mod, "_configure_duckdb_s3", configure)
+    monkeypatch.setattr(worker_mod, "_cleanup_flight_shuffle_for_query", cleanup)
+
+    result = actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
+
+    assert result["storage_entries_removed"] == 2
+    assert actor._session_s3_configs["session-a"]["AWS_ACCESS_KEY_ID"] == "fresh-key"
+    assert events == [
+        (
+            "refresh",
+            {"AWS_PROFILE": "profile-a"},
+            {
+                "AWS_ACCESS_KEY_ID": "stale-key",
+                "AWS_SECRET_ACCESS_KEY": "stale-secret",
+                worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "0",
+            },
+            True,
+        ),
+        (
+            "configure",
+            cleanup_cursor,
+            {
+                "AWS_ACCESS_KEY_ID": "fresh-key",
+                "AWS_SECRET_ACCESS_KEY": "fresh-secret",
+                worker_mod._AWS_CREDENTIAL_REFRESH_AT_KEY: "9999999999",
+            },
+            True,
+        ),
+        ("cleanup", "query-drop", cleanup_cursor, "resource-query"),
+        ("close",),
+    ]
+
+
+def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monkeypatch):
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+    actor._session_connections_lock = threading.RLock()
+    actor._session_connections = {}
+    actor._session_s3_configs = {}
+    actor._native_query_cleanup_contexts = {
+        "query-drop": worker_mod.NativeQueryCleanupContext(
+            session_id="session-a",
+            session_config=(("AWS_ENDPOINT_URL", "https://s3.example.test"),),
+            use_session_credentials=False,
+            connection_snapshot_query_id="resource-query",
+        )
+    }
+    cleanup_cursor = SimpleNamespace(close=lambda: None)
+    actor._get_shared_conn = lambda: SimpleNamespace(cursor=lambda: cleanup_cursor)
+    cleanup_calls = []
+
+    monkeypatch.setattr(
+        worker_mod,
+        "_refresh_effective_duckdb_s3_config",
+        lambda config, cached, *, use_session_credentials: dict(config),
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_configure_duckdb_s3",
+        lambda connection, config, *, use_session_credentials: dict(config),
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_cleanup_flight_shuffle_for_query",
+        lambda query_id, connection=None, connection_snapshot_query_id="": (
+            cleanup_calls.append((query_id, connection, connection_snapshot_query_id))
+            or {
+                "registry_entries_removed": 1,
+                "storage_entries_removed": 2,
+                "cleanup_errors": 0,
+                "cleanup_pending": 0,
+                "active_executions": 0,
+                "last_error": "",
+            }
+        ),
+    )
+
+    actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
+
+    assert cleanup_calls == [("query-drop", cleanup_cursor, "resource-query")]
+
+
+def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close_fails(monkeypatch):
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+    actor._session_connections_lock = threading.RLock()
+    actor._session_connections = {}
+    actor._session_s3_configs = {}
+    actor._native_query_cleanup_contexts = {
+        "query-drop": worker_mod.NativeQueryCleanupContext(
+            session_id="session-a",
+            session_config=(),
+            use_session_credentials=True,
+            connection_snapshot_query_id="resource-query",
+        )
+    }
+
+    class _CleanupCursor:
+        def close(self):
+            raise RuntimeError("cursor close failed")
+
+    actor._get_shared_conn = lambda: SimpleNamespace(cursor=_CleanupCursor)
+    monkeypatch.setattr(
+        worker_mod,
+        "_refresh_effective_duckdb_s3_config",
+        lambda config, cached, *, use_session_credentials: {},
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_configure_duckdb_s3",
+        lambda connection, config, *, use_session_credentials: (_ for _ in ()).throw(
+            RuntimeError("cleanup configuration failed")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup configuration failed"):
+        actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
+
+
+def test_worker_cleanup_context_replays_snapshot_with_session_credentials():
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+
+    class _Plan:
+        @staticmethod
+        def resource_query_id():
+            return "resource-query"
+
+    actor_class._register_native_query_cleanup_context(
+        actor,
+        "execution-query",
+        _Plan(),
+        "session-a",
+        {"AWS_PROFILE": "profile-a"},
+        use_session_credentials=True,
+    )
+
+    assert actor._native_query_cleanup_contexts == {
+        "execution-query": worker_mod.NativeQueryCleanupContext(
+            session_id="session-a",
+            session_config=(("AWS_PROFILE", "profile-a"),),
+            use_session_credentials=True,
+            connection_snapshot_query_id="resource-query",
+        )
+    }
+
+
 def test_worker_flight_shuffle_cleanup_drain_retries_pending_work(monkeypatch):
     cleanups = iter(
         [
@@ -10685,6 +10928,7 @@ def test_execute_native_task_configuration_failure_closes_unregistered_cursor(mo
     assert closed == ["cursor"]
     assert actor._active_native_cursors == set()
     assert actor._native_cursor_query_ids == {}
+    assert getattr(actor, "_native_query_cleanup_contexts", {}) == {}
 
 
 def test_execute_native_task_passes_exchange_and_sink_inputs(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2942,8 +2942,8 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
     def _fake_require(name, hint=None):
         assert name == "cleanup_flight_shuffle_for_query"
 
-        def _cleanup(query_id, connection, snapshot_query_id):
-            calls.append((query_id, connection, snapshot_query_id, hint))
+        def _cleanup(query_id, connection, snapshot_query_id, apply_snapshot_s3_credentials):
+            calls.append((query_id, connection, snapshot_query_id, apply_snapshot_s3_credentials, hint))
             return {
                 "registry_entries_removed": 1,
                 "storage_entries_removed": 2,
@@ -2961,6 +2961,7 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
         "query-drop",
         cleanup_connection,
         "resource-query",
+        apply_snapshot_s3_credentials=False,
     )
 
     assert result["storage_entries_removed"] == 2
@@ -2969,6 +2970,7 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
             "query-drop",
             cleanup_connection,
             "resource-query",
+            False,
             "Ensure the C++ ray extension is built with Flight shuffle cleanup support.",
         )
     ]
@@ -3053,7 +3055,13 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
         events.append(("configure", connection, dict(config), use_session_credentials))
         return dict(config)
 
-    def cleanup(query_id, connection=None, connection_snapshot_query_id=""):
+    def cleanup(
+        query_id,
+        connection=None,
+        connection_snapshot_query_id="",
+        *,
+        apply_snapshot_s3_credentials=True,
+    ):
         if connection is None:
             events.append(("probe", query_id))
             return {
@@ -3065,7 +3073,15 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
                 "active_executions": 0,
                 "last_error": "shuffle cleanup requires a live filesystem context",
             }
-        events.append(("cleanup", query_id, connection, connection_snapshot_query_id))
+        events.append(
+            (
+                "cleanup",
+                query_id,
+                connection,
+                connection_snapshot_query_id,
+                apply_snapshot_s3_credentials,
+            )
+        )
         return {
             "registry_entries_removed": 0,
             "storage_entries_removed": 2,
@@ -3114,7 +3130,7 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
             },
             True,
         ),
-        ("cleanup", "query-drop", cleanup_cursor, "resource-query"),
+        ("cleanup", "query-drop", cleanup_cursor, "resource-query", False),
         ("close",),
     ]
 
@@ -3138,8 +3154,21 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
     actor._get_shared_conn = lambda: SimpleNamespace(cursor=lambda: cleanup_cursor)
     cleanup_calls = []
 
-    def cleanup(query_id, connection=None, connection_snapshot_query_id=""):
-        cleanup_calls.append((query_id, connection, connection_snapshot_query_id))
+    def cleanup(
+        query_id,
+        connection=None,
+        connection_snapshot_query_id="",
+        *,
+        apply_snapshot_s3_credentials=True,
+    ):
+        cleanup_calls.append(
+            (
+                query_id,
+                connection,
+                connection_snapshot_query_id,
+                apply_snapshot_s3_credentials,
+            )
+        )
         if connection is None:
             return {
                 "registry_entries_removed": 1,
@@ -3188,8 +3217,8 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
         "last_error": "",
     }
     assert cleanup_calls == [
-        ("query-drop", None, ""),
-        ("query-drop", cleanup_cursor, "resource-query"),
+        ("query-drop", None, "", True),
+        ("query-drop", cleanup_cursor, "resource-query", True),
     ]
 
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2986,6 +2986,7 @@ def test_worker_local_shuffle_cleanup_skips_object_storage_rebuild(monkeypatch):
             session_config=(("AWS_PROFILE", "unavailable-profile"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
+            connection_snapshot_settings=(),
         )
     }
     cleanup = {
@@ -3032,6 +3033,7 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
             session_config=(("AWS_PROFILE", "profile-a"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
+            connection_snapshot_settings=(),
         )
     }
     events = []
@@ -3148,6 +3150,7 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
             session_config=(("AWS_ENDPOINT_URL", "https://s3.example.test"),),
             use_session_credentials=False,
             connection_snapshot_query_id="resource-query",
+            connection_snapshot_settings=(),
         )
     }
     cleanup_cursor = SimpleNamespace(close=lambda: None)
@@ -3235,6 +3238,7 @@ def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close
             session_config=(),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
+            connection_snapshot_settings=(),
         )
     }
 
@@ -3273,10 +3277,11 @@ def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close
         actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
 
 
-def test_worker_cleanup_context_replays_snapshot_with_session_credentials():
+def test_worker_cleanup_context_replays_snapshot_with_session_credentials(monkeypatch):
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_class)
     actor._native_execution_condition = threading.Condition()
+    monkeypatch.setattr(worker_mod, "_query_cleanup_connection_settings", lambda *args, **kwargs: ())
 
     class _Plan:
         @staticmethod
@@ -3298,14 +3303,62 @@ def test_worker_cleanup_context_replays_snapshot_with_session_credentials():
             session_config=(("AWS_PROFILE", "profile-a"),),
             use_session_credentials=True,
             connection_snapshot_query_id="resource-query",
+            connection_snapshot_settings=(),
         )
     }
 
 
-def test_worker_cleanup_context_reuses_first_snapshot_across_query_fragments():
+def test_worker_cleanup_connection_settings_match_snapshot_replay(monkeypatch):
+    snapshot = {
+        "settings": [
+            {"name": "s3_endpoint", "value": "s3.example.test", "input_type": "VARCHAR"},
+            {"name": "s3_access_key_id", "value": "plan-key", "input_type": "VARCHAR"},
+            {"name": "s3_secret_access_key", "value": "plan-secret", "input_type": "VARCHAR"},
+            {"name": "http_timeout", "value": "30", "input_type": "BIGINT"},
+            {"name": "allow_unsigned_extensions", "value": "true", "input_type": "BOOLEAN"},
+        ]
+    }
+
+    def require(name, *, hint):
+        assert name == "_lookup_query_connection_snapshot"
+        assert hint == "Ensure the C++ ray extension is built with query replay lifecycle support."
+        return lambda query_id: snapshot if query_id == "resource-query" else None
+
+    monkeypatch.setattr(worker_mod, "require_ray_cxx_attr", require)
+
+    assert worker_mod._query_cleanup_connection_settings(
+        "resource-query",
+        apply_snapshot_s3_credentials=False,
+    ) == (
+        ("s3_endpoint", "s3.example.test", "VARCHAR"),
+        ("http_timeout", "30", "BIGINT"),
+    )
+    assert worker_mod._query_cleanup_connection_settings(
+        "resource-query",
+        apply_snapshot_s3_credentials=True,
+    ) == (
+        ("s3_endpoint", "s3.example.test", "VARCHAR"),
+        ("s3_access_key_id", "plan-key", "VARCHAR"),
+        ("s3_secret_access_key", "plan-secret", "VARCHAR"),
+        ("http_timeout", "30", "BIGINT"),
+    )
+
+
+def test_worker_cleanup_context_reuses_first_equivalent_snapshot_across_query_fragments(monkeypatch):
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_class)
     actor._native_execution_condition = threading.Condition()
+    snapshot_settings = {
+        "resource-query-a": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
+        "resource-query-b": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
+        "resource-query-c": (("s3_endpoint", "other.example.test", "VARCHAR"),),
+        "resource-query-d": (("s3_endpoint", "s3.example.test", "VARCHAR"),),
+    }
+    monkeypatch.setattr(
+        worker_mod,
+        "_query_cleanup_connection_settings",
+        lambda query_id, **kwargs: snapshot_settings[query_id],
+    )
 
     class _Plan:
         def __init__(self, resource_query_id):
@@ -3337,6 +3390,15 @@ def test_worker_cleanup_context_reuses_first_snapshot_across_query_fragments():
             actor,
             "execution-query",
             _Plan("resource-query-c"),
+            "session-a",
+            {"AWS_PROFILE": "profile-a"},
+            use_session_credentials=True,
+        )
+    with pytest.raises(RuntimeError, match="native query cleanup context changed"):
+        actor_class._register_native_query_cleanup_context(
+            actor,
+            "execution-query",
+            _Plan("resource-query-d"),
             "session-a",
             {"AWS_PROFILE": "profile-b"},
             use_session_credentials=True,

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -2927,6 +2927,7 @@ def test_worker_flight_shuffle_cleanup_helper_uses_cxx_binding(monkeypatch):
         "registry_entries_removed": 2,
         "storage_entries_removed": 7,
         "cleanup_errors": 0,
+        "cleanup_storage_required": 0,
         "cleanup_pending": 0,
         "active_executions": 0,
         "last_error": "",
@@ -2973,6 +2974,43 @@ def test_worker_flight_shuffle_cleanup_helper_passes_cleanup_connection_and_snap
     ]
 
 
+def test_worker_local_shuffle_cleanup_skips_object_storage_rebuild(monkeypatch):
+    actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    actor = object.__new__(actor_class)
+    actor._native_execution_condition = threading.Condition()
+    actor._native_query_cleanup_contexts = {
+        "query-drop": worker_mod.NativeQueryCleanupContext(
+            session_id="session-a",
+            session_config=(("AWS_PROFILE", "unavailable-profile"),),
+            use_session_credentials=True,
+            connection_snapshot_query_id="resource-query",
+        )
+    }
+    cleanup = {
+        "registry_entries_removed": 1,
+        "storage_entries_removed": 2,
+        "cleanup_errors": 0,
+        "cleanup_storage_required": 0,
+        "cleanup_pending": 0,
+        "active_executions": 0,
+        "last_error": "",
+    }
+    monkeypatch.setattr(
+        worker_mod,
+        "_cleanup_flight_shuffle_for_query",
+        lambda query_id, connection=None, connection_snapshot_query_id="": cleanup,
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_refresh_effective_duckdb_s3_config",
+        lambda *args, **kwargs: pytest.fail("local cleanup must not refresh AWS credentials"),
+    )
+
+    result = actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
+
+    assert result == cleanup
+
+
 def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypatch):
     actor_class = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_class)
@@ -3016,11 +3054,23 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
         return dict(config)
 
     def cleanup(query_id, connection=None, connection_snapshot_query_id=""):
+        if connection is None:
+            events.append(("probe", query_id))
+            return {
+                "registry_entries_removed": 1,
+                "storage_entries_removed": 0,
+                "cleanup_errors": 1,
+                "cleanup_storage_required": 1,
+                "cleanup_pending": 1,
+                "active_executions": 0,
+                "last_error": "shuffle cleanup requires a live filesystem context",
+            }
         events.append(("cleanup", query_id, connection, connection_snapshot_query_id))
         return {
-            "registry_entries_removed": 1,
+            "registry_entries_removed": 0,
             "storage_entries_removed": 2,
             "cleanup_errors": 0,
+            "cleanup_storage_required": 0,
             "cleanup_pending": 0,
             "active_executions": 0,
             "last_error": "",
@@ -3032,9 +3082,18 @@ def test_worker_object_shuffle_cleanup_uses_refreshed_dedicated_cursor(monkeypat
 
     result = actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
 
-    assert result["storage_entries_removed"] == 2
+    assert result == {
+        "registry_entries_removed": 1,
+        "storage_entries_removed": 2,
+        "cleanup_errors": 0,
+        "cleanup_storage_required": 0,
+        "cleanup_pending": 0,
+        "active_executions": 0,
+        "last_error": "",
+    }
     assert actor._session_s3_configs["session-a"]["AWS_ACCESS_KEY_ID"] == "fresh-key"
     assert events == [
+        ("probe", "query-drop"),
         (
             "refresh",
             {"AWS_PROFILE": "profile-a"},
@@ -3079,6 +3138,28 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
     actor._get_shared_conn = lambda: SimpleNamespace(cursor=lambda: cleanup_cursor)
     cleanup_calls = []
 
+    def cleanup(query_id, connection=None, connection_snapshot_query_id=""):
+        cleanup_calls.append((query_id, connection, connection_snapshot_query_id))
+        if connection is None:
+            return {
+                "registry_entries_removed": 1,
+                "storage_entries_removed": 0,
+                "cleanup_errors": 1,
+                "cleanup_storage_required": 1,
+                "cleanup_pending": 1,
+                "active_executions": 0,
+                "last_error": "shuffle cleanup requires a live filesystem context",
+            }
+        return {
+            "registry_entries_removed": 0,
+            "storage_entries_removed": 2,
+            "cleanup_errors": 0,
+            "cleanup_storage_required": 0,
+            "cleanup_pending": 0,
+            "active_executions": 0,
+            "last_error": "",
+        }
+
     monkeypatch.setattr(
         worker_mod,
         "_refresh_effective_duckdb_s3_config",
@@ -3092,22 +3173,24 @@ def test_worker_object_shuffle_cleanup_replays_explicit_connection_snapshot(monk
     monkeypatch.setattr(
         worker_mod,
         "_cleanup_flight_shuffle_for_query",
-        lambda query_id, connection=None, connection_snapshot_query_id="": (
-            cleanup_calls.append((query_id, connection, connection_snapshot_query_id))
-            or {
-                "registry_entries_removed": 1,
-                "storage_entries_removed": 2,
-                "cleanup_errors": 0,
-                "cleanup_pending": 0,
-                "active_executions": 0,
-                "last_error": "",
-            }
-        ),
+        cleanup,
     )
 
-    actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
+    result = actor_class._cleanup_flight_shuffle_for_query_with_context(actor, "query-drop")
 
-    assert cleanup_calls == [("query-drop", cleanup_cursor, "resource-query")]
+    assert result == {
+        "registry_entries_removed": 1,
+        "storage_entries_removed": 2,
+        "cleanup_errors": 0,
+        "cleanup_storage_required": 0,
+        "cleanup_pending": 0,
+        "active_executions": 0,
+        "last_error": "",
+    }
+    assert cleanup_calls == [
+        ("query-drop", None, ""),
+        ("query-drop", cleanup_cursor, "resource-query"),
+    ]
 
 
 def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close_fails(monkeypatch):
@@ -3131,6 +3214,19 @@ def test_worker_object_shuffle_cleanup_preserves_primary_error_when_cursor_close
             raise RuntimeError("cursor close failed")
 
     actor._get_shared_conn = lambda: SimpleNamespace(cursor=_CleanupCursor)
+    monkeypatch.setattr(
+        worker_mod,
+        "_cleanup_flight_shuffle_for_query",
+        lambda query_id, connection=None, connection_snapshot_query_id="": {
+            "registry_entries_removed": 1,
+            "storage_entries_removed": 0,
+            "cleanup_errors": 1,
+            "cleanup_storage_required": 1,
+            "cleanup_pending": 1,
+            "active_executions": 0,
+            "last_error": "shuffle cleanup requires a live filesystem context",
+        },
+    )
     monkeypatch.setattr(
         worker_mod,
         "_refresh_effective_duckdb_s3_config",

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -840,7 +840,7 @@ def test_real_ray_host_loss_replays_all_owned_full_query_outputs(monkeypatch, tm
                 break
             time.sleep(0.05)
         else:
-            raise AssertionError("host-loss native scans did not enter blocked RUNNING state")
+            raise AssertionError(f"host-loss native scans did not enter blocked RUNNING state: {infos!r}")
 
         actor1 = worker_mod.RayWorkerActor.options(num_cpus=0).remote(2, 0, 1 << 30, 1 << 60)
         handle1 = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="worker-host-b")


### PR DESCRIPTION
## Summary

- retain only immutable cleanup descriptors for object-storage Flight shuffle attempts, so the registry cannot extend a task `ClientContext` or `FileOpener` lifetime
- rebuild an ephemeral shuffle storage adapter from a dedicated cleanup cursor with refreshed session credentials and source connection snapshot replay
- keep local-disk cache borrowing unchanged and preserve pending cleanup across active writers, active executions, and retryable storage errors
- make duplicate teardown tolerant of replay state already retired by a concurrent successful cleanup

## Why this is the long-term fix

The registry now owns query-lifetime metadata only. Context-bound filesystem state is acquired at the cleanup boundary and borrowed for that synchronous attempt, which makes the lifetime contract explicit instead of depending on cursor destruction order.

## Tests

- `scripts/run_native_tests.sh "Exchange: object shuffle cleanup reconstructs storage without retaining task cache" -s`
- `build/native-cxx20/test/unittest "[distributed][exchange]"`
- `python -m pytest tests/fast/test_ray_cpp_bindings.py -q`
- `python -m pytest tests/fast/test_ray_fragment_submission.py -q`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/run_release_tests.sh`

Closes #253