### PR TITLE
[fix](relation) Preserve explode column order

### DIFF
--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -280,6 +280,8 @@ protected:
 	static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child, unique_ptr<SelectNode> select_node);
 	static unique_ptr<SelectNode> WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
 	                                            const vector<ColumnDefinition> &columns);
+	static unique_ptr<QueryNode> RestoreDuplicateColumnAliases(unique_ptr<QueryNode> query_node, const string &alias,
+	                                                           const vector<ColumnDefinition> &columns);
 	static unique_ptr<LogicalOperator> PlanRelationFilter(Binder &binder, unique_ptr<Expression> condition,
 	                                                      unique_ptr<LogicalOperator> child);
 	static void ExpandRelationFilter(Binder &binder, unique_ptr<ParsedExpression> &condition);

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -294,7 +294,20 @@ unique_ptr<QueryNode> Relation::TryGetSerializableQueryNode(Binder &binder) {
 	if (!CanSerializeToQueryNodeInternal(binder)) {
 		return nullptr;
 	}
-	return GetQueryNode();
+	return RestoreDuplicateColumnAliases(GetQueryNode(), GetAlias(), Columns());
+}
+
+unique_ptr<QueryNode> Relation::RestoreDuplicateColumnAliases(unique_ptr<QueryNode> query_node, const string &alias,
+                                                              const vector<ColumnDefinition> &columns) {
+	case_insensitive_set_t output_names;
+	for (auto &column : columns) {
+		if (!output_names.insert(column.Name()).second) {
+			// SQL table scopes deduplicate names so expressions can address every
+			// column. Restore duplicate public aliases at this query boundary.
+			return WrapQueryNode(std::move(query_node), alias, columns);
+		}
+	}
+	return query_node;
 }
 
 unique_ptr<QueryResult> Relation::Execute() {

--- a/external/duckdb/src/main/relation/unnest_relation.cpp
+++ b/external/duckdb/src/main/relation/unnest_relation.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
@@ -25,19 +26,16 @@ UnnestRelation::UnnestRelation(shared_ptr<Relation> child_p, string column_name_
 
 unique_ptr<QueryNode> UnnestRelation::GetQueryNode() {
 	// Fallback AST path (used by default Relation::Bind if custom Bind not called).
-	// Builds: SELECT * EXCLUDE(col), unnest(col) AS col FROM (child)
+	// Builds: SELECT * REPLACE (unnest(col) AS col) FROM (child)
 	auto result = make_uniq<SelectNode>();
 	result->from_table = GetTableRefForSerialization(*child);
 
 	auto star = make_uniq<StarExpression>();
-	star->exclude_list.insert(QualifiedColumnName(column_name));
-	result->select_list.push_back(std::move(star));
-
 	vector<unique_ptr<ParsedExpression>> unnest_args;
 	unnest_args.push_back(make_uniq<ColumnRefExpression>(column_name));
 	auto unnest_func = make_uniq<FunctionExpression>("unnest", std::move(unnest_args));
-	unnest_func->SetAlias(column_name);
-	result->select_list.push_back(std::move(unnest_func));
+	star->replace_list.emplace(column_name, std::move(unnest_func));
+	result->select_list.push_back(std::move(star));
 
 	return std::move(result);
 }
@@ -53,14 +51,22 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 
 	// 2. Find the column to unnest
 	idx_t unnest_col_idx = DConstants::INVALID_INDEX;
+	idx_t case_insensitive_match_count = 0;
 	for (idx_t i = 0; i < child_bound.names.size(); i++) {
-		if (child_bound.names[i] == column_name) {
-			unnest_col_idx = i;
-			break;
+		if (StringUtil::CIEquals(child_bound.names[i], column_name)) {
+			case_insensitive_match_count++;
 		}
+		if (child_bound.names[i] != column_name) {
+			continue;
+		}
+		unnest_col_idx = i;
 	}
 	if (unnest_col_idx == DConstants::INVALID_INDEX) {
 		throw BinderException("Column \"%s\" not found in child relation for unnest/explode", column_name);
+	}
+	// REPLACE follows SQL's case-insensitive identifier matching, so duplicate matches cannot be serialized faithfully.
+	if (case_insensitive_match_count > 1) {
+		throw BinderException("Ambiguous reference to column name \"%s\"", column_name);
 	}
 
 	// 3. Determine element type from the list/array column

--- a/external/duckdb/src/main/relation/unnest_relation.cpp
+++ b/external/duckdb/src/main/relation/unnest_relation.cpp
@@ -12,10 +12,19 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/common/string_util.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
+
+static idx_t FindUnnestColumnIndex(const vector<string> &names, const string &column_name) {
+	for (idx_t i = 0; i < names.size(); i++) {
+		if (names[i] == column_name) {
+			return i;
+		}
+	}
+	throw BinderException("Column \"%s\" not found in child relation for unnest/explode", column_name);
+}
 
 UnnestRelation::UnnestRelation(shared_ptr<Relation> child_p, string column_name_p)
     : Relation(child_p->context, RelationType::UNNEST_RELATION), column_name(std::move(column_name_p)),
@@ -25,19 +34,34 @@ UnnestRelation::UnnestRelation(shared_ptr<Relation> child_p, string column_name_
 }
 
 unique_ptr<QueryNode> UnnestRelation::GetQueryNode() {
-	// Fallback AST path (used by default Relation::Bind if custom Bind not called).
-	// Builds: SELECT * REPLACE (unnest(col) AS col) FROM (child)
+	// SQL serialization path: build an inner
+	// SELECT * REPLACE (unnest(col) AS col) FROM (child).
 	auto result = make_uniq<SelectNode>();
 	result->from_table = GetTableRefForSerialization(*child);
 
+	auto &child_columns = child->Columns();
+	vector<string> child_names;
+	child_names.reserve(child_columns.size());
+	for (auto &column : child_columns) {
+		child_names.push_back(column.Name());
+	}
+	auto unnest_col_idx = FindUnnestColumnIndex(child_names, column_name);
+	// A subquery gives duplicate names unique binding aliases. Address the
+	// target through its positional input alias so an earlier duplicate cannot
+	// shadow names such as x_1.
+	auto input_names = BindContext::AliasColumnNames(child->GetAlias(), child_names, {});
+	auto &input_column_name = input_names[unnest_col_idx];
+
 	auto star = make_uniq<StarExpression>();
 	vector<unique_ptr<ParsedExpression>> unnest_args;
-	unnest_args.push_back(make_uniq<ColumnRefExpression>(column_name));
+	unnest_args.push_back(make_uniq<ColumnRefExpression>(input_column_name));
 	auto unnest_func = make_uniq<FunctionExpression>("unnest", std::move(unnest_args));
-	star->replace_list.emplace(column_name, std::move(unnest_func));
+	star->replace_list.emplace(input_column_name, std::move(unnest_func));
 	result->select_list.push_back(std::move(star));
 
-	return std::move(result);
+	// Subquery binding deduplicates input names. Restore duplicate public aliases
+	// explicitly while keeping the common unique-name query free of another layer.
+	return RestoreDuplicateColumnAliases(std::move(result), GetAlias(), Columns());
 }
 
 BoundStatement UnnestRelation::Bind(Binder &binder) {
@@ -50,24 +74,7 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 	D_ASSERT(child_bindings.size() == child_bound.names.size());
 
 	// 2. Find the column to unnest
-	idx_t unnest_col_idx = DConstants::INVALID_INDEX;
-	idx_t case_insensitive_match_count = 0;
-	for (idx_t i = 0; i < child_bound.names.size(); i++) {
-		if (StringUtil::CIEquals(child_bound.names[i], column_name)) {
-			case_insensitive_match_count++;
-		}
-		if (child_bound.names[i] != column_name) {
-			continue;
-		}
-		unnest_col_idx = i;
-	}
-	if (unnest_col_idx == DConstants::INVALID_INDEX) {
-		throw BinderException("Column \"%s\" not found in child relation for unnest/explode", column_name);
-	}
-	// REPLACE follows SQL's case-insensitive identifier matching, so duplicate matches cannot be serialized faithfully.
-	if (case_insensitive_match_count > 1) {
-		throw BinderException("Ambiguous reference to column name \"%s\"", column_name);
-	}
+	auto unnest_col_idx = FindUnnestColumnIndex(child_bound.names, column_name);
 
 	// 3. Determine element type from the list/array column
 	auto &list_type = child_bound.types[unnest_col_idx];
@@ -82,9 +89,13 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 	}
 
 	// 4. Create BoundUnnestExpression: unnest(col_ref) → element_type
-	auto col_ref = make_uniq<BoundColumnRefExpression>(column_name, list_type, child_bindings[unnest_col_idx]);
+	unique_ptr<Expression> unnest_child =
+	    make_uniq<BoundColumnRefExpression>(column_name, list_type, child_bindings[unnest_col_idx]);
+	// PhysicalUnnest consumes LIST vectors. Match the SQL UNNEST binder by
+	// casting ARRAY inputs to LIST while preserving their element type.
+	unnest_child = BoundCastExpression::AddArrayCastToList(binder.context, std::move(unnest_child));
 	auto unnest_expr = make_uniq<BoundUnnestExpression>(element_type);
-	unnest_expr->child = std::move(col_ref);
+	unnest_expr->child = std::move(unnest_child);
 
 	// 5. Create LogicalUnnest node
 	idx_t unnest_index = binder.GenerateTableIndex();

--- a/tests/fast/relational_api/test_explode.py
+++ b/tests/fast/relational_api/test_explode.py
@@ -3,28 +3,82 @@
 
 import pytest
 
-import duckdb
-
 EXPECTED_COLUMNS = ["x", "a", "y"]
 EXPECTED_ROWS = [(10, 20, 30), (10, 21, 30)]
 
 
-def middle_list_relation(connection):
-    return connection.sql("SELECT 10::INTEGER AS x, [20, 21]::INTEGER[] AS a, 30::INTEGER AS y")
+def middle_collection_relation(connection, collection_type="INTEGER[]"):
+    return connection.sql(f"SELECT 10::INTEGER AS x, [20, 21]::{collection_type} AS a, 30::INTEGER AS y")
 
 
-def test_explode_serialized_query_matches_direct_binding(duckdb_cursor):
-    exploded = middle_list_relation(duckdb_cursor).explode("a")
+def duplicate_non_target_relation(connection, duplicate_name="x"):
+    return connection.sql(
+        f'SELECT [20, 21]::INTEGER[] AS a, 10::INTEGER AS x, 30::INTEGER AS "{duplicate_name}"'
+    ).explode("a")
+
+
+@pytest.mark.parametrize("collection_type", ["INTEGER[]", "INTEGER[2]"])
+def test_explode_serialized_query_matches_direct_binding(duckdb_cursor, collection_type):
+    exploded = middle_collection_relation(duckdb_cursor, collection_type).explode("a")
     serialized = duckdb_cursor.sql(exploded.sql_query())
 
     assert exploded.columns == EXPECTED_COLUMNS
     assert exploded.fetchall() == EXPECTED_ROWS
     assert serialized.columns == EXPECTED_COLUMNS
+    assert serialized.types == exploded.types
     assert serialized.fetchall() == EXPECTED_ROWS
 
 
+@pytest.mark.parametrize("duplicate_name", ["x", "X"])
+def test_explode_serialized_query_preserves_duplicate_non_target_names(duckdb_cursor, duplicate_name):
+    exploded = duplicate_non_target_relation(duckdb_cursor, duplicate_name)
+    serialized = duckdb_cursor.sql(exploded.sql_query())
+    expected_rows = [(20, 10, 30), (21, 10, 30)]
+
+    assert exploded.columns == ["a", "x", duplicate_name]
+    assert serialized.types == exploded.types
+    assert exploded.fetchall() == expected_rows
+    assert serialized.columns == ["a", "x", duplicate_name]
+    assert serialized.fetchall() == expected_rows
+
+
+def test_explode_duplicate_non_target_names_survive_filter_serialization(duckdb_cursor):
+    filtered = duplicate_non_target_relation(duckdb_cursor).filter("a > 20")
+    serialized = duckdb_cursor.sql(filtered.sql_query())
+
+    assert filtered.columns == ["a", "x", "x"]
+    assert serialized.columns == filtered.columns
+    assert serialized.types == filtered.types
+    assert serialized.fetchall() == filtered.fetchall() == [(21, 10, 30)]
+
+
+def test_explode_duplicate_non_target_names_survive_union_serialization(duckdb_cursor):
+    exploded = duplicate_non_target_relation(duckdb_cursor)
+    other = duckdb_cursor.sql("SELECT 22::INTEGER AS a, 11::INTEGER AS x, 31::INTEGER AS x")
+    unioned = exploded.union(other)
+    serialized = duckdb_cursor.sql(unioned.sql_query())
+
+    assert unioned.columns == ["a", "x", "x"]
+    assert serialized.columns == unioned.columns
+    assert serialized.types == unioned.types
+    assert serialized.fetchall() == unioned.fetchall() == [(20, 10, 30), (21, 10, 30), (22, 11, 31)]
+
+
+@pytest.mark.parametrize("duplicate_name", ["x", "X"])
+def test_explode_serialization_uses_deduplicated_target_binding(duckdb_cursor, duplicate_name):
+    exploded = duckdb_cursor.sql(
+        f'SELECT 10::INTEGER AS x, 20::INTEGER AS "{duplicate_name}", [30, 31]::INTEGER[] AS x_1'
+    ).explode("x_1")
+    serialized = duckdb_cursor.sql(exploded.sql_query())
+
+    assert exploded.columns == ["x", duplicate_name, "x_1"]
+    assert serialized.columns == exploded.columns
+    assert serialized.types == exploded.types
+    assert serialized.fetchall() == exploded.fetchall() == [(10, 20, 30), (10, 20, 31)]
+
+
 def test_explode_preserves_column_order_through_limit(duckdb_cursor):
-    limited = middle_list_relation(duckdb_cursor).explode("a").limit(10)
+    limited = middle_collection_relation(duckdb_cursor).explode("a").limit(10)
 
     assert limited.columns == EXPECTED_COLUMNS
     assert limited.fetchall() == EXPECTED_ROWS
@@ -33,14 +87,26 @@ def test_explode_preserves_column_order_through_limit(duckdb_cursor):
 def test_explode_preserves_positional_insert_values(duckdb_cursor):
     duckdb_cursor.execute("CREATE TABLE sink(x INTEGER, a INTEGER, y INTEGER)")
 
-    middle_list_relation(duckdb_cursor).explode("a").insert_into("sink")
+    middle_collection_relation(duckdb_cursor).explode("a").insert_into("sink")
 
     assert duckdb_cursor.sql("SELECT * FROM sink ORDER BY x, a, y").fetchall() == EXPECTED_ROWS
 
 
-@pytest.mark.parametrize("duplicate_name", ["a", "A"])
-def test_explode_rejects_ambiguous_column_names(duckdb_cursor, duplicate_name):
+@pytest.mark.parametrize(
+    ("duplicate_name", "target", "expected_rows"),
+    [
+        ("a", "a", [(20, [30, 31]), (21, [30, 31])]),
+        ("A", "a", [(20, [30, 31]), (21, [30, 31])]),
+        ("A", "A", [([20, 21], 30), ([20, 21], 31)]),
+    ],
+)
+def test_explode_serialization_preserves_duplicate_target_resolution(
+    duckdb_cursor, duplicate_name, target, expected_rows
+):
     relation = duckdb_cursor.sql(f'SELECT [20, 21]::INTEGER[] AS a, [30, 31]::INTEGER[] AS "{duplicate_name}"')
+    exploded = relation.explode(target)
+    serialized = duckdb_cursor.sql(exploded.sql_query())
 
-    with pytest.raises(duckdb.BinderException, match='Ambiguous reference to column name "a"'):
-        relation.explode("a")
+    assert serialized.columns == exploded.columns == ["a", duplicate_name]
+    assert serialized.types == exploded.types
+    assert serialized.fetchall() == exploded.fetchall() == expected_rows

--- a/tests/fast/relational_api/test_explode.py
+++ b/tests/fast/relational_api/test_explode.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import duckdb
+
+EXPECTED_COLUMNS = ["x", "a", "y"]
+EXPECTED_ROWS = [(10, 20, 30), (10, 21, 30)]
+
+
+def middle_list_relation(connection):
+    return connection.sql("SELECT 10::INTEGER AS x, [20, 21]::INTEGER[] AS a, 30::INTEGER AS y")
+
+
+def test_explode_serialized_query_matches_direct_binding(duckdb_cursor):
+    exploded = middle_list_relation(duckdb_cursor).explode("a")
+    serialized = duckdb_cursor.sql(exploded.sql_query())
+
+    assert exploded.columns == EXPECTED_COLUMNS
+    assert exploded.fetchall() == EXPECTED_ROWS
+    assert serialized.columns == EXPECTED_COLUMNS
+    assert serialized.fetchall() == EXPECTED_ROWS
+
+
+def test_explode_preserves_column_order_through_limit(duckdb_cursor):
+    limited = middle_list_relation(duckdb_cursor).explode("a").limit(10)
+
+    assert limited.columns == EXPECTED_COLUMNS
+    assert limited.fetchall() == EXPECTED_ROWS
+
+
+def test_explode_preserves_positional_insert_values(duckdb_cursor):
+    duckdb_cursor.execute("CREATE TABLE sink(x INTEGER, a INTEGER, y INTEGER)")
+
+    middle_list_relation(duckdb_cursor).explode("a").insert_into("sink")
+
+    assert duckdb_cursor.sql("SELECT * FROM sink ORDER BY x, a, y").fetchall() == EXPECTED_ROWS
+
+
+@pytest.mark.parametrize("duplicate_name", ["a", "A"])
+def test_explode_rejects_ambiguous_column_names(duckdb_cursor, duplicate_name):
+    relation = duckdb_cursor.sql(f'SELECT [20, 21]::INTEGER[] AS a, [30, 31]::INTEGER[] AS "{duplicate_name}"')
+
+    with pytest.raises(duckdb.BinderException, match='Ambiguous reference to column name "a"'):
+        relation.explode("a")


### PR DESCRIPTION
## Summary

- serialize `UnnestRelation` with `SELECT * REPLACE (unnest(column) AS column)` so SQL rebinding preserves the exploded column's original position
- resolve the explode target by its direct-binding position, then address the SQL subquery's deduplicated input alias; this preserves the pre-existing exact first-match behavior for duplicate and case-only names without binding the wrong suffix-collision column
- restore duplicate public aliases explicitly at relation serialization boundaries, including composed filter/set-operation trees, while leaving the common unique-name path unwrapped
- mirror DuckDB's SQL UNNEST binder by casting ARRAY inputs to LIST before direct `PhysicalUnnest` execution
- add regressions for LIST/ARRAY parity, duplicate non-target and target names, case variants, suffix collisions, filter/union composition, limit, and positional insert

The public API is unchanged: users still call `relation.explode("a")`. The implementation builds a structured AST; it does not construct SQL from user-provided identifiers.

## Related issue

Closes #276

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This fixes internal Relation binding and serialization without changing the documented API.

## Validation

- incremental Release package install with `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- focused explode and SQL-query regressions: 35 passed
- complete relational API suite: 406 passed, 1 skipped
- generated LIST/ARRAY serialization matrix: 1,524 direct-versus-serialized cases passed across positions, aliases, suffix collisions, filters, limits, and distinct
- manual composition matrix: nested explode, filter/order/project/distinct/union, replacement scan, insert/create, non-SQL child binding, special identifiers, NULL/empty inputs, and unchanged error paths
- `scripts/run_native_tests.sh "[relation_api]"`: 35 test cases and 651 assertions passed
- `scripts/run_release_tests.sh`: 455 passed, 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `scripts/run_fast_tests.sh`: 6,118 passed, 28 skipped, 8 xfailed, 1 xpassed in the non-Ray shard; 92 passed and 6 skipped in the shared-Ray shard; all 7 runnable isolated owner-Ray tests passed and the optional vLLM test skipped
- `scripts/format workspace --changed`
- pre-commit hooks for all four changed files
- `git diff --check`
- two consecutive clean code-review passes after the final implementation and test run

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. The change builds an internal AST and adds no trust boundary.
- [x] Native changes were compiled; Python, native, release, formatting, and static checks passed.
