### PR TITLE
[fix](distributed) Keep broadcast joins on semantic-safe sides

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/broadcast_join.cpp
@@ -8,6 +8,7 @@
 #include <unordered_set>
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/plan/exchange_source_task.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
@@ -23,6 +24,37 @@
 
 namespace duckdb {
 namespace distributed {
+
+bool IsBroadcastJoinSideSemanticallySafe(JoinType join_type, BroadcastJoinSide broadcast_side) {
+	switch (join_type) {
+	case JoinType::INNER:
+		return true;
+	case JoinType::LEFT:
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+	case JoinType::SINGLE:
+		return broadcast_side == BroadcastJoinSide::RIGHT;
+	case JoinType::RIGHT:
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		return broadcast_side == BroadcastJoinSide::LEFT;
+	case JoinType::OUTER:
+	case JoinType::INVALID:
+		return false;
+	}
+	return false;
+}
+
+void ValidateBroadcastJoinSide(JoinType join_type, BroadcastJoinSide broadcast_side) {
+	if (IsBroadcastJoinSideSemanticallySafe(join_type, broadcast_side)) {
+		return;
+	}
+	const auto *side_name = broadcast_side == BroadcastJoinSide::LEFT ? "left" : "right";
+	throw InvalidInputException("Cannot broadcast the %s side of a %s join because that side is semantically "
+	                            "preserved",
+	                            side_name, EnumUtil::ToString(join_type));
+}
 
 namespace {
 std::string MakeBroadcastShuffleStageId(const PipelineNodeContext &context) {
@@ -49,17 +81,18 @@ BroadcastJoinNode::BroadcastJoinNode(
     duckdb::vector<LogicalType> condition_types, PhysicalHashJoin::JoinProjectionColumns payload_columns,
     PhysicalHashJoin::JoinProjectionColumns lhs_output_columns,
     PhysicalHashJoin::JoinProjectionColumns rhs_output_columns, duckdb::vector<unique_ptr<BaseStatistics>> join_stats,
-    unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality, bool is_swapped,
+    unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality, BroadcastJoinSide broadcast_side,
     std::shared_ptr<DistributedPipelineNode> broadcaster, std::shared_ptr<DistributedPipelineNode> receiver,
     SchemaRef schema, std::shared_ptr<ExchangeManager> exchange_mgr)
     : context_(plan_config.query_idx, plan_config.query_id, node_id, "BroadcastJoin"),
-      broadcaster_(std::move(broadcaster)), receiver_(std::move(receiver)), is_swapped_(is_swapped),
+      broadcaster_(std::move(broadcaster)), receiver_(std::move(receiver)), broadcast_side_(broadcast_side),
       conditions_(std::move(conditions)), join_type_(join_type), output_types_(std::move(output_types)),
       delim_types_(std::move(delim_types)), condition_types_(std::move(condition_types)),
       payload_columns_(std::move(payload_columns)), lhs_output_columns_(std::move(lhs_output_columns)),
       rhs_output_columns_(std::move(rhs_output_columns)), join_stats_(std::move(join_stats)),
       filter_pushdown_(std::move(filter_pushdown)), estimated_cardinality_(estimated_cardinality),
       exchange_mgr_(std::move(exchange_mgr)) {
+	ValidateBroadcastJoinSide(join_type_, broadcast_side_);
 	ClusteringSpecRef clustering = ClusteringSpec::unknown_with_num_partitions(1);
 	if (receiver_) {
 		clustering = receiver_->config().clustering_spec();
@@ -85,7 +118,7 @@ std::vector<std::string> BroadcastJoinNode::multiline_display(bool /*verbose*/) 
 	res.push_back("Broadcast Join");
 	res.push_back("Join type: " + std::to_string(static_cast<int>(join_type_)));
 	res.push_back("Conditions: " + std::to_string(conditions_.size()));
-	res.push_back("Swapped: " + std::string(is_swapped_ ? "true" : "false"));
+	res.push_back("Broadcast side: " + std::string(broadcast_side_ == BroadcastJoinSide::LEFT ? "left" : "right"));
 	return res;
 }
 
@@ -196,8 +229,9 @@ SubmittableTask<WorkerTask> BroadcastJoinNode::BuildBroadcastHashJoinTask(Submit
 	auto &broadcast_root = *broadcast_root_ptr;
 
 	auto conditions = CopyConditions(conditions_);
-	auto &left_child = is_swapped_ ? input_root : broadcast_root;
-	auto &right_child = is_swapped_ ? broadcast_root : input_root;
+	auto broadcast_right = broadcast_side_ == BroadcastJoinSide::RIGHT;
+	auto &left_child = broadcast_right ? input_root : broadcast_root;
+	auto &right_child = broadcast_right ? broadcast_root : input_root;
 	FixHashJoinConditionTypes(conditions, left_child.GetTypes(), right_child.GetTypes());
 
 	LogicalComparisonJoin dummy_join(join_type_);

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <cstdlib>
 
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
@@ -247,16 +248,31 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	}
 
 	auto join_override = GetJoinStrategyOverride();
-	bool force_hash_join = (join_override == DistributedJoinStrategyOverride::kHash);
-	bool force_broadcast_join = (join_override == DistributedJoinStrategyOverride::kBroadcast ||
-	                             join_override == DistributedJoinStrategyOverride::kBroadcastLeft ||
-	                             join_override == DistributedJoinStrategyOverride::kBroadcastRight);
+	Optional<BroadcastJoinSide> broadcast_side;
 
-	if (force_broadcast_join && hj.join_type == JoinType::OUTER) {
-		force_broadcast_join = false;
-	}
-
-	if (!force_hash_join && !force_broadcast_join && left_node && right_node && hj.join_type != JoinType::OUTER) {
+	if (join_override == DistributedJoinStrategyOverride::kBroadcastLeft ||
+	    join_override == DistributedJoinStrategyOverride::kBroadcastRight) {
+		auto requested_side = join_override == DistributedJoinStrategyOverride::kBroadcastLeft
+		                          ? BroadcastJoinSide::LEFT
+		                          : BroadcastJoinSide::RIGHT;
+		ValidateBroadcastJoinSide(hj.join_type, requested_side);
+		broadcast_side = requested_side;
+	} else if (join_override == DistributedJoinStrategyOverride::kBroadcast && left_node && right_node) {
+		bool left_safe = IsBroadcastJoinSideSemanticallySafe(hj.join_type, BroadcastJoinSide::LEFT);
+		bool right_safe = IsBroadcastJoinSideSemanticallySafe(hj.join_type, BroadcastJoinSide::RIGHT);
+		if (!left_safe && !right_safe) {
+			throw InvalidInputException("Cannot use broadcast strategy for a %s join because neither side can be "
+			                            "broadcast without changing its semantics",
+			                            EnumUtil::ToString(hj.join_type));
+		}
+		if (left_safe && right_safe) {
+			size_t left_parts = left_node->config().clustering_spec()->num_partitions();
+			size_t right_parts = right_node->config().clustering_spec()->num_partitions();
+			broadcast_side = left_parts > right_parts ? BroadcastJoinSide::RIGHT : BroadcastJoinSide::LEFT;
+		} else {
+			broadcast_side = left_safe ? BroadcastJoinSide::LEFT : BroadcastJoinSide::RIGHT;
+		}
+	} else if (join_override == DistributedJoinStrategyOverride::kDefault && left_node && right_node) {
 		auto threshold_bytes = GetAutoBroadcastThresholdBytes();
 		if (threshold_bytes > 0) {
 			idx_t left_card = hj.children.size() > 0 ? hj.children[0].get().estimated_cardinality : 0;
@@ -265,55 +281,30 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 			auto &right_types = hj.children.size() > 1 ? hj.children[1].get().GetTypes() : hj.GetTypes();
 			idx_t left_bytes = EstimateDataSizeBytes(left_card, left_types);
 			idx_t right_bytes = EstimateDataSizeBytes(right_card, right_types);
-			bool left_small = left_card > 0 && left_bytes <= threshold_bytes;
-			bool right_small = right_card > 0 && right_bytes <= threshold_bytes;
+			bool left_small = left_card > 0 && left_bytes <= threshold_bytes &&
+			                  IsBroadcastJoinSideSemanticallySafe(hj.join_type, BroadcastJoinSide::LEFT);
+			bool right_small = right_card > 0 && right_bytes <= threshold_bytes &&
+			                   IsBroadcastJoinSideSemanticallySafe(hj.join_type, BroadcastJoinSide::RIGHT);
 			if (left_small || right_small) {
-				force_broadcast_join = true;
 				if (left_small && right_small) {
-					join_override = (left_bytes <= right_bytes) ? DistributedJoinStrategyOverride::kBroadcastLeft
-					                                            : DistributedJoinStrategyOverride::kBroadcastRight;
+					broadcast_side = left_bytes <= right_bytes ? BroadcastJoinSide::LEFT : BroadcastJoinSide::RIGHT;
 				} else if (left_small) {
-					join_override = DistributedJoinStrategyOverride::kBroadcastLeft;
+					broadcast_side = BroadcastJoinSide::LEFT;
 				} else {
-					join_override = DistributedJoinStrategyOverride::kBroadcastRight;
+					broadcast_side = BroadcastJoinSide::RIGHT;
 				}
 			}
 		}
 	}
 
-	if (force_broadcast_join && left_node && right_node) {
-		bool is_swapped = false;
-		if (join_override == DistributedJoinStrategyOverride::kBroadcastLeft) {
-			is_swapped = false;
-		} else if (join_override == DistributedJoinStrategyOverride::kBroadcastRight) {
-			is_swapped = true;
-		} else {
-			size_t left_parts = left_node->config().clustering_spec()->num_partitions();
-			size_t right_parts = right_node->config().clustering_spec()->num_partitions();
-			bool left_is_larger = left_parts > right_parts;
-			switch (hj.join_type) {
-			case JoinType::INNER:
-				is_swapped = left_is_larger;
-				break;
-			case JoinType::LEFT:
-			case JoinType::SEMI:
-			case JoinType::ANTI:
-				is_swapped = true;
-				break;
-			case JoinType::RIGHT:
-				is_swapped = false;
-				break;
-			default:
-				is_swapped = left_is_larger;
-				break;
-			}
-		}
-		auto broadcaster = is_swapped ? right_node : left_node;
-		auto receiver = is_swapped ? left_node : right_node;
+	if (broadcast_side && left_node && right_node) {
+		bool broadcast_right = *broadcast_side == BroadcastJoinSide::RIGHT;
+		auto broadcaster = broadcast_right ? right_node : left_node;
+		auto receiver = broadcast_right ? left_node : right_node;
 
 		bool repartition_receiver = BroadcastReceiverRepartitionOverride().value_or(false);
 		if (repartition_receiver && plan_config_.num_partitions > 1) {
-			const auto &receiver_keys = is_swapped ? left_partition_by : right_partition_by;
+			const auto &receiver_keys = broadcast_right ? left_partition_by : right_partition_by;
 			if (!receiver_keys.empty()) {
 				size_t target_partitions = plan_config_.num_partitions;
 				auto receiver_spec = RepartitionSpec::create_hash(target_partitions, receiver_keys);
@@ -327,7 +318,7 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 		return std::make_shared<BroadcastJoinNode>(
 		    get_next_pipeline_node_id(), plan_config_, std::move(conditions), hj.join_type, hj.GetTypes(),
 		    hj.delim_types, hj.condition_types, hj.payload_columns, hj.lhs_output_columns, hj.rhs_output_columns,
-		    std::move(join_stats), std::move(filter_pushdown), hj.estimated_cardinality, is_swapped, broadcaster,
+		    std::move(join_stats), std::move(filter_pushdown), hj.estimated_cardinality, *broadcast_side, broadcaster,
 		    receiver, schema, exchange_mgr_);
 	}
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp
@@ -21,6 +21,11 @@
 namespace duckdb {
 namespace distributed {
 
+enum class BroadcastJoinSide : uint8_t { LEFT, RIGHT };
+
+bool IsBroadcastJoinSideSemanticallySafe(JoinType join_type, BroadcastJoinSide broadcast_side);
+void ValidateBroadcastJoinSide(JoinType join_type, BroadcastJoinSide broadcast_side);
+
 class BroadcastJoinNode : public PipelineNodeImpl, public std::enable_shared_from_this<BroadcastJoinNode> {
 public:
 	BroadcastJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<JoinCondition> conditions,
@@ -30,8 +35,8 @@ public:
 	                  PhysicalHashJoin::JoinProjectionColumns lhs_output_columns,
 	                  PhysicalHashJoin::JoinProjectionColumns rhs_output_columns,
 	                  duckdb::vector<unique_ptr<BaseStatistics>> join_stats,
-	                  unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality, bool is_swapped,
-	                  std::shared_ptr<DistributedPipelineNode> broadcaster,
+	                  unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality,
+	                  BroadcastJoinSide broadcast_side, std::shared_ptr<DistributedPipelineNode> broadcaster,
 	                  std::shared_ptr<DistributedPipelineNode> receiver, SchemaRef schema,
 	                  std::shared_ptr<ExchangeManager> exchange_mgr = nullptr);
 
@@ -63,7 +68,7 @@ private:
 	PipelineNodeContext context_;
 	std::shared_ptr<DistributedPipelineNode> broadcaster_;
 	std::shared_ptr<DistributedPipelineNode> receiver_;
-	bool is_swapped_ = false;
+	BroadcastJoinSide broadcast_side_;
 
 	duckdb::vector<JoinCondition> conditions_;
 	JoinType join_type_;

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -212,6 +212,91 @@ static std::string SQLStringLiteral(const std::string &value) {
 	return "'" + StringUtil::Replace(value, "'", "''") + "'";
 }
 
+class ScopedTranslatorEnvironment {
+public:
+	ScopedTranslatorEnvironment(std::string name, const char *value) : name_(std::move(name)) {
+		const auto *existing = std::getenv(name_.c_str());
+		if (existing) {
+			had_value_ = true;
+			old_value_ = existing;
+		}
+		Set(value);
+	}
+
+	~ScopedTranslatorEnvironment() {
+		if (had_value_) {
+			Set(old_value_.c_str());
+		} else {
+			Set(nullptr);
+		}
+	}
+
+private:
+	void Set(const char *value) {
+#if defined(_WIN32)
+		_putenv_s(name_.c_str(), value ? value : "");
+#else
+		if (value) {
+			setenv(name_.c_str(), value, 1);
+		} else {
+			unsetenv(name_.c_str());
+		}
+#endif
+	}
+
+	std::string name_;
+	std::string old_value_;
+	bool had_value_ = false;
+};
+
+static DuckPhysicalPlanRef MakeHashJoinPlan(JoinType join_type, idx_t left_cardinality, idx_t right_cardinality) {
+	auto plan = std::make_shared<PhysicalPlan>(Allocator::DefaultAllocator());
+	vector<LogicalType> input_types = {LogicalType::INTEGER};
+	auto left_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), input_types);
+	auto &left_scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                     left_cardinality, std::move(left_collection));
+	auto right_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), input_types);
+	auto &right_scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                      right_cardinality, std::move(right_collection));
+
+	vector<JoinCondition> conditions;
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.comparison = ExpressionType::COMPARE_EQUAL;
+	conditions.push_back(std::move(condition));
+
+	LogicalComparisonJoin logical_join(join_type);
+	switch (join_type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::RIGHT_SEMI:
+	case JoinType::RIGHT_ANTI:
+		logical_join.types = input_types;
+		break;
+	case JoinType::MARK:
+		logical_join.types = {LogicalType::INTEGER, LogicalType::BOOLEAN};
+		break;
+	default:
+		logical_join.types = {LogicalType::INTEGER, LogicalType::INTEGER};
+		break;
+	}
+
+	auto &hash_join = plan->Make<PhysicalHashJoin>(logical_join, left_scan, right_scan, std::move(conditions),
+	                                               join_type, left_cardinality);
+	plan->SetRoot(hash_join);
+	return plan;
+}
+
+static bool NodeDisplayContains(const DistributedPipelineNodeRef &node, const std::string &needle) {
+	for (const auto &line : node->inner()->multiline_display(false)) {
+		if (line.find(needle) != std::string::npos) {
+			return true;
+		}
+	}
+	return false;
+}
+
 TEST_CASE("Streaming UDF passthrough schema preserves all output columns", "[distributed][udf]") {
 	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::VARCHAR};
 	StreamingUDFPassthroughNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {}, vector<column_t> {},
@@ -327,6 +412,87 @@ TEST_CASE("PhysicalPlanTranslator: plan without root returns error", "[distribut
 	REQUIRE(res.is_err());
 	auto msg = std::string(res.error().what());
 	REQUIRE(msg.find("physical plan has no root") != std::string::npos);
+}
+
+TEST_CASE("PhysicalPlanTranslator: auto broadcast only considers semantically safe sides", "[distributed][join]") {
+	ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", nullptr);
+	ScopedTranslatorEnvironment threshold("VANE_DISTRIBUTED_AUTO_BROADCAST_THRESHOLD_BYTES", "64");
+	PlanConfig config;
+	config.num_partitions = 4;
+
+	SECTION("hash join is selected when only the small side is preserved") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::LEFT, 2, 400));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "HashJoin");
+	}
+
+	SECTION("optimizer-swapped plan selects hash join when only the small side is preserved") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::RIGHT, 400, 2));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "HashJoin");
+	}
+
+	SECTION("small non-preserved side is broadcast") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::LEFT, 400, 2));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "BroadcastJoin");
+		REQUIRE(NodeDisplayContains(res.value(), "Broadcast side: right"));
+	}
+
+	SECTION("optimizer-swapped small non-preserved side is broadcast") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::RIGHT, 2, 400));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "BroadcastJoin");
+		REQUIRE(NodeDisplayContains(res.value(), "Broadcast side: left"));
+	}
+
+	SECTION("inner join broadcasts the smaller side") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::INNER, 2, 400));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "BroadcastJoin");
+		REQUIRE(NodeDisplayContains(res.value(), "Broadcast side: left"));
+	}
+
+	SECTION("full outer join selects hash join") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::OUTER, 2, 2));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "HashJoin");
+	}
+}
+
+TEST_CASE("PhysicalPlanTranslator: forced broadcast validates the selected side", "[distributed][join]") {
+	ScopedTranslatorEnvironment threshold("VANE_DISTRIBUTED_AUTO_BROADCAST_THRESHOLD_BYTES", "0");
+	PlanConfig config;
+	config.num_partitions = 4;
+
+	SECTION("generic strategy chooses the non-preserved side") {
+		ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast");
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::LEFT, 2, 400));
+		REQUIRE(res.is_ok());
+		REQUIRE(res.value()->name() == "BroadcastJoin");
+		REQUIRE(NodeDisplayContains(res.value(), "Broadcast side: right"));
+	}
+
+	SECTION("unsafe directional strategy fails clearly") {
+		ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast_left");
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::LEFT, 2, 400));
+		REQUIRE(res.is_err());
+		REQUIRE(std::string(res.error().what()).find("semantically preserved") != std::string::npos);
+	}
+
+	SECTION("generic full outer join fails clearly") {
+		ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast");
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::OUTER, 2, 2));
+		REQUIRE(res.is_err());
+		REQUIRE(std::string(res.error().what()).find("neither side") != std::string::npos);
+	}
+
+	SECTION("directional full outer join fails clearly") {
+		ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast_left");
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::OUTER, 2, 2));
+		REQUIRE(res.is_err());
+		REQUIRE(std::string(res.error().what()).find("semantically preserved") != std::string::npos);
+	}
 }
 
 TEST_CASE("PhysicalFilter: empty select list handled as true", "[distributed]") {

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -505,7 +505,8 @@ TEST_CASE("BroadcastJoinNode: replacement task preserves receiver inputs", "[dis
 
 	BroadcastJoinNode node(301, plan_cfg, {}, JoinType::INNER, output_types, {}, {},
 	                       PhysicalHashJoin::JoinProjectionColumns(), PhysicalHashJoin::JoinProjectionColumns(),
-	                       PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1, false, nullptr, nullptr, schema);
+	                       PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1, BroadcastJoinSide::LEFT, nullptr,
+	                       nullptr, schema);
 
 	auto receiver_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(30, "receiver", 30, "receiver_scan"));
 	auto broadcast_plan = MakeScanPlanWithRoot();
@@ -548,7 +549,8 @@ TEST_CASE("BroadcastJoinNode: invalid receiver plan throws instead of passing th
 
 	BroadcastJoinNode node(303, plan_cfg, {}, JoinType::INNER, output_types, {}, {},
 	                       PhysicalHashJoin::JoinProjectionColumns(), PhysicalHashJoin::JoinProjectionColumns(),
-	                       PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1, false, nullptr, nullptr, schema);
+	                       PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1, BroadcastJoinSide::LEFT, nullptr,
+	                       nullptr, schema);
 
 	auto receiver_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithoutRoot(30, "receiver"));
 	auto broadcast_plan = MakeScanPlanWithRoot();
@@ -561,4 +563,35 @@ TEST_CASE("BroadcastJoinNode: invalid receiver plan throws instead of passing th
 		REQUIRE(std::string(ex.what()).find("BroadcastJoinNode cannot build join task") != std::string::npos);
 	}
 	REQUIRE(saw_error);
+}
+
+TEST_CASE("BroadcastJoinNode: broadcast side must not be semantically preserved", "[distributed][source_id][join]") {
+	struct SafetyCase {
+		JoinType join_type;
+		bool left_safe;
+		bool right_safe;
+	};
+	const std::vector<SafetyCase> cases = {
+	    {JoinType::INNER, true, true},       {JoinType::LEFT, false, true},     {JoinType::RIGHT, true, false},
+	    {JoinType::OUTER, false, false},     {JoinType::SEMI, false, true},     {JoinType::ANTI, false, true},
+	    {JoinType::MARK, false, true},       {JoinType::SINGLE, false, true},   {JoinType::RIGHT_SEMI, true, false},
+	    {JoinType::RIGHT_ANTI, true, false}, {JoinType::INVALID, false, false},
+	};
+
+	for (const auto &entry : cases) {
+		INFO("join type: " << static_cast<int>(entry.join_type));
+		REQUIRE(IsBroadcastJoinSideSemanticallySafe(entry.join_type, BroadcastJoinSide::LEFT) == entry.left_safe);
+		REQUIRE(IsBroadcastJoinSideSemanticallySafe(entry.join_type, BroadcastJoinSide::RIGHT) == entry.right_safe);
+	}
+
+	PlanConfig plan_cfg(1, "join-query", std::make_shared<DuckDBExecutionConfig>());
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT, LogicalType::BIGINT});
+
+	REQUIRE_THROWS_WITH(BroadcastJoinNode(304, plan_cfg, {}, JoinType::LEFT, output_types, {}, {},
+	                                      PhysicalHashJoin::JoinProjectionColumns(),
+	                                      PhysicalHashJoin::JoinProjectionColumns(),
+	                                      PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1,
+	                                      BroadcastJoinSide::LEFT, nullptr, nullptr, schema),
+	                    Catch::Matchers::Contains("semantically preserved"));
 }

--- a/tests/fast/test_query_graph_registration.py
+++ b/tests/fast/test_query_graph_registration.py
@@ -198,7 +198,7 @@ def test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity(monkeyp
 
         metadata = plan.collect_execution_stages(conn=con)
         assert metadata == plan.collect_execution_stages(conn=con)
-        assert "Swapped: true" in plan.repr_ascii(False)
+        assert "Broadcast side: right" in plan.repr_ascii(False)
 
         udf_nodes = [node for node in metadata["nodes"] if node["udf_payload"] is not None]
         by_name = {node["udf_payload"]["udf_name"].rsplit(".", 1)[-1]: node for node in udf_nodes}

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3307,6 +3307,69 @@ def test_ray_join_broadcast_multi_partition_plan(ray_runner, duckdb_conn, parque
     )
 
 
+def test_ray_join_auto_broadcast_keeps_preserved_side_as_receiver(ray_runner, duckdb_conn, tmp_path, monkeypatch):
+    label = "test_ray_e2e: auto broadcast keeps preserved side as receiver"
+    big_path = tmp_path / "auto_broadcast_preserved_side"
+
+    monkeypatch.delenv("VANE_DISTRIBUTED_JOIN_STRATEGY", raising=False)
+    monkeypatch.delenv("VANE_DISTRIBUTED_AUTO_BROADCAST_THRESHOLD_BYTES", raising=False)
+    monkeypatch.setenv("VANE_DISTRIBUTED_BROADCAST_JOIN_RECEIVER_REPARTITION", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                CASE WHEN i < 4 THEN 1 ELSE 1000 + i END::INTEGER AS k,
+                (i % 4)::INTEGER AS file_id
+            FROM range(0, 400) AS t(i)
+        ) TO '{big_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+
+    left_join_sql = f"""
+        SELECT small.k, big.k
+        FROM (VALUES (1), (999)) AS small(k)
+        LEFT JOIN read_parquet('{big_path}/**/*.parquet') AS big
+          ON small.k = big.k
+    """
+    relation = duckdb_conn.sql(left_join_sql)
+    plan_text, _ = _get_distributed_plan_info(relation, label)
+    assert plan_text and "BROADCAST JOIN" in plan_text.upper(), f"{label}: expected automatic broadcast:\n{plan_text}"
+    assert "BROADCAST SIDE: LEFT" in plan_text.upper(), (
+        f"{label}: expected the physical left (non-preserved) side to be broadcast:\n{plan_text}"
+    )
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        left_join_sql,
+        label,
+        require_all=["HASH_JOIN"],
+    )
+
+    semi_join_sql = f"""
+        SELECT k
+        FROM (VALUES (1)) AS small(k)
+        WHERE k IN (
+            SELECT k
+            FROM read_parquet('{big_path}/**/*.parquet')
+        )
+    """
+    semi_label = f"{label} (semi join)"
+    semi_plan_text, _ = _get_distributed_plan_info(duckdb_conn.sql(semi_join_sql), semi_label)
+    assert semi_plan_text and "BROADCAST JOIN" in semi_plan_text.upper(), (
+        f"{semi_label}: expected automatic broadcast:\n{semi_plan_text}"
+    )
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        semi_join_sql,
+        semi_label,
+        require_all=["HASH_JOIN"],
+    )
+
+
 def test_ray_chained_broadcast_joins_keep_materialize_outputs_scoped(
     ray_runner, duckdb_conn, parquet_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- replace the implicit `is_swapped` flag with a typed physical `BroadcastJoinSide`
- centralize the join-type safety invariant and validate it again in `BroadcastJoinNode`
- let automatic planning consider only semantically safe broadcast candidates
- reject explicitly forced unsafe/FULL broadcast strategies instead of silently selecting another strategy
- replace the legacy `Swapped: true/false` plan display with `Broadcast side: left/right`
- cover optimizer-swapped LEFT/RIGHT plans, every supported join type, forced strategies, and multi-task LEFT/SEMI execution

## Related issue

close: #278

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The affected strategy overrides and physical-plan display are internal diagnostics. The compatibility impact is explicit here: unsafe forced broadcast configurations now fail clearly, and the old `Swapped` display field is removed.

## Validation

- `scripts/format workspace --changed`
- `VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh "[distributed][join]"` — 10 cases, 112 assertions passed
- `VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh "[distributed]"` — 141 cases, 4297 assertions passed
- incremental Release Python extension rebuild per `AGENTS.md`
- `test_duckdb_source_id_matches_recorded_source_tree` — passed against the rebuilt extension
- broadcast-plan, multi-partition broadcast, automatic preserved-side LEFT/SEMI, and chained-broadcast Ray tests — passed individually against the rebuilt extension
- `test_stage_collection_pairs_reordered_branch_udfs_by_stable_identity` — passed
- `scripts/run_release_tests.sh` — 455 passed / 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard

A combined local run of the four Ray E2E tests was not counted as a pass because the local Ray control plane terminated between tests (`raylet` marked dead / GCS unavailable). Each affected test passed in a fresh process, the native suites passed, and the prescribed Release Ray shard passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (No new dependencies or copied assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (No security surface changes.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
