### PR TITLE
[fix](relation) Normalize ARRAY inputs for explode

### DIFF
--- a/external/duckdb/src/main/relation/unnest_relation.cpp
+++ b/external/duckdb/src/main/relation/unnest_relation.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/operator/logical_unnest.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/common/types.hpp"
@@ -76,7 +77,8 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 	}
 
 	// 4. Create BoundUnnestExpression: unnest(col_ref) → element_type
-	auto col_ref = make_uniq<BoundColumnRefExpression>(column_name, list_type, child_bindings[unnest_col_idx]);
+	auto col_ref = BoundCastExpression::AddArrayCastToList(
+	    binder.context, make_uniq<BoundColumnRefExpression>(column_name, list_type, child_bindings[unnest_col_idx]));
 	auto unnest_expr = make_uniq<BoundUnnestExpression>(element_type);
 	unnest_expr->child = std::move(col_ref);
 

--- a/tests/fast/relational_api/test_explode_array.py
+++ b/tests/fast/relational_api/test_explode_array.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import duckdb
+
+
+def test_explode_fixed_array(duckdb_cursor):
+    relation = duckdb_cursor.sql(
+        """
+        SELECT *
+        FROM (
+            VALUES
+                (10, [20, 21]::INTEGER[2], 30),
+                (11, NULL::INTEGER[2], 31),
+                (12, [22, NULL]::INTEGER[2], 32)
+        ) data(x, a, y)
+        """
+    )
+
+    exploded = relation.explode("a")
+
+    assert exploded.columns == ["x", "a", "y"]
+    assert exploded.types == [duckdb.sqltypes.INTEGER] * 3
+    assert exploded.fetchall() == [
+        (10, 20, 30),
+        (10, 21, 30),
+        (12, 22, 32),
+        (12, None, 32),
+    ]
+    assert duckdb_cursor.sql("SELECT 1").fetchall() == [(1,)]


### PR DESCRIPTION
## Summary

- normalize fixed-size `ARRAY` children to `LIST` before constructing the directly bound `BoundUnnestExpression`
- reuse the same `BoundCastExpression::AddArrayCastToList` path as SQL `UNNEST`, while preserving Relation direct binding and output column order
- add a multi-row Relation API regression covering fixed arrays, NULL arrays, NULL elements, scalar output types, and continued connection usability

## Root cause

`UnnestRelation::Bind` accepted both `LIST` and `ARRAY`, but attached the original `ARRAY`-typed column reference directly to `BoundUnnestExpression`. `PhysicalUnnest` consumes LIST vector storage, so direct Relation execution raised an internal LIST/ARRAY format mismatch and invalidated the database. The normal SQL binder already normalizes ARRAY children before reaching that operator.

## Validation

- confirmed the new regression fails before the implementation with `Expected unified vector format of type LIST, but found type ARRAY`
- `VANE_RUNNER=local .venv/bin/python -m pytest -q tests/fast/relational_api/test_explode_array.py` — 1 passed
- `VANE_RUNNER=local .venv/bin/python -m pytest -q tests/fast/relational_api` — 394 passed, 1 skipped
- `scripts/run_release_tests.sh` — 455 passed, 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed
- manual matrix: LIST, ARRAY, nested ARRAY, and NULL ARRAY all execute successfully and leave the connection usable
- three-way merge simulation with #298/#276 completed without conflicts

Closes #299
