### PR TITLE
[fix](distributed) Expand grouping sets before shuffle

### DIFF
--- a/external/duckdb/src/common/enum_util.cpp
+++ b/external/duckdb/src/common/enum_util.cpp
@@ -3815,19 +3815,20 @@ const StringUtil::EnumStringLiteral *GetPhysicalOperatorTypeValues() {
 		{ static_cast<uint32_t>(PhysicalOperatorType::VLLM_PROJECT), "VLLM_PROJECT" },
 		{ static_cast<uint32_t>(PhysicalOperatorType::REPARTITION), "REPARTITION" },
 		{ static_cast<uint32_t>(PhysicalOperatorType::LOCAL_EXCHANGE), "LOCAL_EXCHANGE" },
-		{ static_cast<uint32_t>(PhysicalOperatorType::STREAMING_UDF), "STREAMING_UDF" }
+		{ static_cast<uint32_t>(PhysicalOperatorType::STREAMING_UDF), "STREAMING_UDF" },
+		{ static_cast<uint32_t>(PhysicalOperatorType::GROUPING_SET_EXPAND), "GROUPING_SET_EXPAND" }
 	};
 	return values;
 }
 
 template<>
 const char* EnumUtil::ToChars<PhysicalOperatorType>(PhysicalOperatorType value) {
-	return StringUtil::EnumToString(GetPhysicalOperatorTypeValues(), 88, "PhysicalOperatorType", static_cast<uint32_t>(value));
+	return StringUtil::EnumToString(GetPhysicalOperatorTypeValues(), 89, "PhysicalOperatorType", static_cast<uint32_t>(value));
 }
 
 template<>
 PhysicalOperatorType EnumUtil::FromString<PhysicalOperatorType>(const char *value) {
-	return static_cast<PhysicalOperatorType>(StringUtil::StringToEnum(GetPhysicalOperatorTypeValues(), 88, "PhysicalOperatorType", value));
+	return static_cast<PhysicalOperatorType>(StringUtil::StringToEnum(GetPhysicalOperatorTypeValues(), 89, "PhysicalOperatorType", value));
 }
 
 const StringUtil::EnumStringLiteral *GetPhysicalTableScanExecutionStrategyValues() {

--- a/external/duckdb/src/common/enums/physical_operator_type.cpp
+++ b/external/duckdb/src/common/enums/physical_operator_type.cpp
@@ -163,6 +163,8 @@ string PhysicalOperatorToString(PhysicalOperatorType type) {
 		return "INOUT_FUNCTION";
 	case PhysicalOperatorType::STREAMING_UDF:
 		return "STREAMING_UDF";
+	case PhysicalOperatorType::GROUPING_SET_EXPAND:
+		return "GROUPING_SET_EXPAND";
 	case PhysicalOperatorType::CREATE_TYPE:
 		return "CREATE_TYPE";
 	case PhysicalOperatorType::ATTACH:

--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -41,6 +41,7 @@ set(DISTRIBUTED_SOURCES_COMMON
 set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/aggregate.cpp
     pipeline_node/expression_scan.cpp
+    pipeline_node/grouping_set_expand.cpp
     pipeline_node/join/broadcast_join.cpp
     pipeline_node/join/delim_join.cpp
     pipeline_node/join/hash_join.cpp

--- a/external/duckdb/src/execution/distributed/pipeline_node/aggregate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/aggregate.cpp
@@ -246,9 +246,18 @@ SchemaRef MakeSchemaFromTypes(const std::vector<LogicalType> &types, const Schem
 AggregateNode::AggregateNode(NodeID node_id, const PlanConfig &plan_config, std::vector<BoundExprRef> group_by,
                              std::vector<BoundAggExprRef> aggs, SchemaRef output_schema,
                              DistributedPipelineNodeRef child)
+    : AggregateNode(node_id, plan_config, std::move(group_by), std::move(aggs), std::move(output_schema),
+                    std::move(child), {}, {}) {
+}
+
+AggregateNode::AggregateNode(NodeID node_id, const PlanConfig &plan_config, std::vector<BoundExprRef> group_by,
+                             std::vector<BoundAggExprRef> aggs, SchemaRef output_schema,
+                             DistributedPipelineNodeRef child, std::vector<GroupingSet> grouping_sets,
+                             std::vector<std::vector<idx_t>> grouping_functions)
     : config_(output_schema, plan_config.config, child ? child->config().clustering_spec() : ClusteringSpecRef()),
       context_(plan_config.query_idx, plan_config.query_id, node_id, AggregateNode::node_name(group_by)),
-      node_id_(node_id), group_by_(std::move(group_by)), aggs_(std::move(aggs)), child_(std::move(child)) {
+      node_id_(node_id), group_by_(std::move(group_by)), aggs_(std::move(aggs)), child_(std::move(child)),
+      grouping_sets_(std::move(grouping_sets)), grouping_functions_(std::move(grouping_functions)) {
 }
 
 NodeName AggregateNode::node_name(const std::vector<BoundExprRef> &group_by) {
@@ -286,7 +295,9 @@ SubmittableTaskStream<WorkerTask> AggregateNode::produce_tasks(PlanExecutionCont
 		    auto plan = input; // base scan plan
 		    Allocator &alloc = Allocator::DefaultAllocator();
 
-		    if (self->group_by_.empty()) {
+		    const bool use_hash_aggregate =
+		        !self->group_by_.empty() || !self->grouping_sets_.empty() || !self->grouping_functions_.empty();
+		    if (!use_hash_aggregate) {
 			    // Un-grouped aggregate
 			    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> agg_exprs;
 			    duckdb::vector<duckdb::LogicalType> out_types;
@@ -329,6 +340,18 @@ SubmittableTaskStream<WorkerTask> AggregateNode::produce_tasks(PlanExecutionCont
 				    types.push_back(g->return_type);
 			    for (auto &a : agg_exprs)
 				    types.push_back(a->return_type);
+			    types.resize(types.size() + self->grouping_functions_.size(), LogicalType::BIGINT);
+
+			    duckdb::vector<GroupingSet> grouping_sets;
+			    grouping_sets.reserve(self->grouping_sets_.size());
+			    for (const auto &grouping_set : self->grouping_sets_) {
+				    grouping_sets.push_back(grouping_set);
+			    }
+			    duckdb::vector<unsafe_vector<idx_t>> grouping_functions;
+			    grouping_functions.reserve(self->grouping_functions_.size());
+			    for (const auto &grouping_function : self->grouping_functions_) {
+				    grouping_functions.emplace_back(grouping_function.begin(), grouping_function.end());
+			    }
 
 			    idx_t estimated_cardinality = 0;
 			    // `plan` is a dependent type, so use `template` to disambiguate the
@@ -336,7 +359,9 @@ SubmittableTaskStream<WorkerTask> AggregateNode::produce_tasks(PlanExecutionCont
 			    // type `duckdb::PhysicalHashAggregate` is visible.
 			    auto &old_root = plan->Root();
 			    auto &hash_agg = plan->template Make<duckdb::PhysicalHashAggregate>(
-			        *client, types, std::move(agg_exprs), std::move(group_exprs), estimated_cardinality);
+			        *client, types, std::move(agg_exprs), std::move(group_exprs), std::move(grouping_sets),
+			        std::move(grouping_functions), estimated_cardinality, TupleDataValidityType::CAN_HAVE_NULL_VALUES,
+			        TupleDataValidityType::CAN_HAVE_NULL_VALUES);
 			    hash_agg.children.push_back(old_root);
 			    plan->SetRoot(hash_agg);
 			    return plan;

--- a/external/duckdb/src/execution/distributed/pipeline_node/grouping_set_expand.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/grouping_set_expand.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp"
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+GroupingSetExpandNode::GroupingSetExpandNode(NodeID node_id, PipelineNodeRef child, std::vector<BoundExpr> groups,
+                                             std::vector<GroupingSet> grouping_sets,
+                                             std::vector<std::vector<idx_t>> grouping_functions,
+                                             std::vector<idx_t> aggregate_filter_indexes,
+                                             std::vector<LogicalType> output_types)
+    : ctx_(InheritPipelineNodeContext(child, node_id, "GroupingSetExpand")),
+      config_(
+          MakeSchemaRef(output_types), child ? child->config().execution_config() : DuckDBExecutionConfigRef(),
+          ClusteringSpec::unknown_with_num_partitions(child ? child->config().clustering_spec()->num_partitions() : 1)),
+      child_(std::move(child)), groups_(std::move(groups)), grouping_sets_(std::move(grouping_sets)),
+      grouping_functions_(std::move(grouping_functions)),
+      aggregate_filter_indexes_(std::move(aggregate_filter_indexes)), output_types_(std::move(output_types)),
+      has_empty_grouping_set_(false) {
+	for (const auto &grouping_set : grouping_sets_) {
+		if (grouping_set.empty()) {
+			has_empty_grouping_set_ = true;
+			break;
+		}
+	}
+}
+
+std::vector<PipelineNodeRef> GroupingSetExpandNode::children() const {
+	return {child_};
+}
+
+SubmittableTaskStream<WorkerTask> GroupingSetExpandNode::produce_tasks(PlanExecutionContext &plan_context) {
+	auto input_stream = child_->produce_tasks(plan_context);
+	auto self = shared_from_this();
+	auto seed_plan_assigned = std::make_shared<atomic<bool>>(false);
+	return input_stream.pipeline_instruction(
+	    self,
+	    [self, seed_plan_assigned](DuckPhysicalPlanRef input_plan) -> DuckPhysicalPlanRef {
+		    vector<unique_ptr<Expression>> groups;
+		    groups.reserve(self->groups_.size());
+		    for (const auto &group : self->groups_) {
+			    groups.push_back(group->Copy());
+		    }
+
+		    vector<GroupingSet> grouping_sets(self->grouping_sets_.begin(), self->grouping_sets_.end());
+		    vector<vector<idx_t>> grouping_functions;
+		    grouping_functions.reserve(self->grouping_functions_.size());
+		    for (const auto &grouping_function : self->grouping_functions_) {
+			    grouping_functions.emplace_back(grouping_function.begin(), grouping_function.end());
+		    }
+		    vector<idx_t> filter_indexes(self->aggregate_filter_indexes_.begin(),
+		                                 self->aggregate_filter_indexes_.end());
+		    vector<LogicalType> output_types(self->output_types_.begin(), self->output_types_.end());
+		    const auto input_column_count = input_plan->Root().GetTypes().size();
+		    // One task is sufficient: seed rows hash to the same keys as real
+		    // empty-set rows, and retries preserve this flag in the task plan.
+		    const bool emit_empty_grouping_sets = self->has_empty_grouping_set_ && !seed_plan_assigned->exchange(true);
+		    const auto estimated_cardinality = input_plan->Root().estimated_cardinality * self->grouping_sets_.size();
+
+		    auto &old_root = input_plan->Root();
+		    auto &expand = input_plan->Make<PhysicalGroupingSetExpand>(
+		        std::move(output_types), std::move(groups), std::move(grouping_sets), std::move(grouping_functions),
+		        std::move(filter_indexes), input_column_count, emit_empty_grouping_sets, estimated_cardinality);
+		    expand.children.push_back(old_root);
+		    input_plan->SetRoot(expand);
+		    return input_plan;
+	    },
+	    plan_context.client_context());
+}
+
+std::vector<std::string> GroupingSetExpandNode::multiline_display(bool /*verbose*/) const {
+	return {"GroupingSetExpand: " + std::to_string(grouping_sets_.size()) + " sets"};
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_aggregate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_aggregate.cpp
@@ -8,12 +8,14 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/aggregate.hpp"
+#include "duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp"
 #include "duckdb/execution/distributed/pipeline_node/projection.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_partitioned_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_perfecthash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
+#include "duckdb/function/function_binder.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -123,6 +125,169 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::g
 	return gen_with_pre_agg(input_node, split, output_schema);
 }
 
+std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::gen_grouping_sets_agg(
+    std::shared_ptr<DistributedPipelineNode> input_node, const std::vector<BoundExpr> &group_by,
+    const std::vector<BoundAggExpr> &aggregations, const std::vector<GroupingSet> &grouping_sets,
+    const std::vector<std::vector<idx_t>> &grouping_functions, const std::vector<LogicalType> &input_types,
+    SchemaRef output_schema) {
+	auto make_single_stage = [&](std::shared_ptr<DistributedPipelineNode> child) {
+		return std::make_shared<AggregateNode>(get_next_pipeline_node_id(), plan_config_, group_by, aggregations,
+		                                       output_schema, std::move(child), grouping_sets, grouping_functions)
+		    ->into_node();
+	};
+
+	if (!input_node) {
+		return make_single_stage(nullptr);
+	}
+	const auto input_partitions = input_node->config().clustering_spec()->num_partitions();
+	if (input_partitions <= 1) {
+		return make_single_stage(input_node);
+	}
+
+	std::vector<idx_t> aggregate_filter_indexes;
+	aggregate_filter_indexes.reserve(aggregations.size());
+	for (const auto &aggregation : aggregations) {
+		auto &aggregate = aggregation->Cast<BoundAggregateExpression>();
+		if (!aggregate.filter) {
+			aggregate_filter_indexes.push_back(DConstants::INVALID_INDEX);
+			continue;
+		}
+		if (aggregate.filter->GetExpressionType() != ExpressionType::BOUND_REF) {
+			throw InternalException("Grouping-set aggregate filter is not a bound reference");
+		}
+		aggregate_filter_indexes.push_back(aggregate.filter->Cast<BoundReferenceExpression>().index);
+	}
+
+	std::vector<LogicalType> expanded_types(input_types.begin(), input_types.end());
+	expanded_types.reserve(input_types.size() + group_by.size() + grouping_functions.size() + 1 + aggregations.size());
+	for (const auto &group : group_by) {
+		expanded_types.push_back(group->return_type);
+	}
+	expanded_types.resize(expanded_types.size() + grouping_functions.size(), LogicalType::BIGINT);
+	expanded_types.push_back(LogicalType::UBIGINT);
+	// Every aggregate gets an effective filter. Real rows use TRUE or the
+	// original filter; synthetic empty-set rows use FALSE for every aggregate.
+	expanded_types.resize(expanded_types.size() + aggregations.size(), LogicalType::BOOLEAN);
+	auto expanded_schema = MakeSchemaRef(expanded_types);
+
+	auto expand_impl = std::make_shared<GroupingSetExpandNode>(get_next_pipeline_node_id(), input_node->inner(),
+	                                                           group_by, grouping_sets, grouping_functions,
+	                                                           aggregate_filter_indexes, expanded_types);
+	auto expanded = std::make_shared<DistributedPipelineNode>(std::move(expand_impl));
+
+	const idx_t expanded_group_offset = input_types.size();
+	const idx_t expanded_grouping_function_offset = expanded_group_offset + group_by.size();
+	const idx_t grouping_set_id_offset = expanded_grouping_function_offset + grouping_functions.size();
+	const idx_t effective_filter_offset = grouping_set_id_offset + 1;
+
+	std::vector<ExprRef> partition_by;
+	partition_by.reserve(group_by.size() + 1);
+	for (idx_t group_idx = 0; group_idx < group_by.size(); group_idx++) {
+		partition_by.emplace_back(std::make_shared<BoundReferenceExpression>(group_by[group_idx]->return_type,
+		                                                                     expanded_group_offset + group_idx));
+	}
+	partition_by.emplace_back(std::make_shared<BoundReferenceExpression>(LogicalType::UBIGINT, grouping_set_id_offset));
+
+	const auto raw_partitions = expanded->config().clustering_spec()->num_partitions();
+	const auto configured_partitions =
+	    plan_config_.num_partitions > 0 ? std::min(raw_partitions, plan_config_.num_partitions) : raw_partitions;
+	const auto target_partitions = std::max<size_t>(1, configured_partitions);
+	auto repartition_spec = RepartitionSpec::create_hash(target_partitions, std::move(partition_by));
+	auto shuffle_res = gen_shuffle_node(repartition_spec, expanded_schema, expanded);
+	if (shuffle_res.is_err()) {
+		throw std::runtime_error(std::string("gen_shuffle_node failed in grouping sets translation: ") +
+		                         shuffle_res.error().what());
+	}
+
+	std::vector<BoundExpr> final_group_by;
+	final_group_by.reserve(group_by.size() + grouping_functions.size() + 1);
+	for (idx_t group_idx = 0; group_idx < group_by.size(); group_idx++) {
+		auto ref =
+		    make_uniq<BoundReferenceExpression>(group_by[group_idx]->return_type, expanded_group_offset + group_idx);
+		final_group_by.emplace_back(ExpressionRef(ref.release()));
+	}
+	for (idx_t function_idx = 0; function_idx < grouping_functions.size(); function_idx++) {
+		auto ref =
+		    make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, expanded_grouping_function_offset + function_idx);
+		final_group_by.emplace_back(ExpressionRef(ref.release()));
+	}
+	auto grouping_set_ref = make_uniq<BoundReferenceExpression>(LogicalType::UBIGINT, grouping_set_id_offset);
+	final_group_by.emplace_back(ExpressionRef(grouping_set_ref.release()));
+
+	std::vector<BoundAggExpr> final_aggregations;
+	final_aggregations.reserve(aggregations.size());
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggregations.size(); aggregate_idx++) {
+		auto copy =
+		    FunctionBinder::UnbindSortedAggregate(aggregations[aggregate_idx]->Cast<BoundAggregateExpression>());
+		auto &aggregate = *copy;
+		aggregate.filter =
+		    make_uniq<BoundReferenceExpression>(LogicalType::BOOLEAN, effective_filter_offset + aggregate_idx);
+		final_aggregations.emplace_back(ExpressionRef(copy.release()));
+	}
+
+	std::vector<LogicalType> final_aggregate_types;
+	final_aggregate_types.reserve(final_group_by.size() + final_aggregations.size());
+	for (const auto &group : final_group_by) {
+		final_aggregate_types.push_back(group->return_type);
+	}
+	for (const auto &aggregate : final_aggregations) {
+		final_aggregate_types.push_back(aggregate->return_type);
+	}
+	auto final_aggregate_schema = MakeSchemaRef(final_aggregate_types);
+	auto final_aggregation =
+	    std::make_shared<AggregateNode>(get_next_pipeline_node_id(), plan_config_, final_group_by, final_aggregations,
+	                                    final_aggregate_schema, shuffle_res.value())
+	        ->into_node();
+
+	std::vector<BoundExpr> final_expressions;
+	final_expressions.reserve(group_by.size() + aggregations.size() + grouping_functions.size());
+	for (idx_t group_idx = 0; group_idx < group_by.size(); group_idx++) {
+		auto ref = make_uniq<BoundReferenceExpression>(group_by[group_idx]->return_type, group_idx);
+		final_expressions.emplace_back(ExpressionRef(ref.release()));
+	}
+	const idx_t final_aggregate_offset = final_group_by.size();
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggregations.size(); aggregate_idx++) {
+		auto ref = make_uniq<BoundReferenceExpression>(aggregations[aggregate_idx]->return_type,
+		                                               final_aggregate_offset + aggregate_idx);
+		final_expressions.emplace_back(ExpressionRef(ref.release()));
+	}
+	const idx_t final_grouping_function_offset = group_by.size();
+	for (idx_t function_idx = 0; function_idx < grouping_functions.size(); function_idx++) {
+		auto ref =
+		    make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, final_grouping_function_offset + function_idx);
+		final_expressions.emplace_back(ExpressionRef(ref.release()));
+	}
+
+	std::vector<std::string> projection_names;
+	projection_names.reserve(final_expressions.size());
+	for (const auto &expression : final_expressions) {
+		projection_names.push_back(expression->GetName());
+	}
+	auto projection = std::make_shared<ProjectionNode>(
+	    get_next_pipeline_node_id(), final_aggregation->inner(), std::move(final_expressions),
+	    std::move(projection_names), output_schema, ClusteringSpec::unknown_with_num_partitions(target_partitions));
+	return std::make_shared<DistributedPipelineNode>(std::move(projection));
+}
+
+static bool RequiresGroupingSetsPlan(const PhysicalHashAggregate &aggregate) {
+	if (!aggregate.grouped_aggregate_data.grouping_functions.empty() || aggregate.grouping_sets.size() != 1) {
+		return true;
+	}
+	if (aggregate.grouping_sets.empty()) {
+		return false;
+	}
+	const auto &grouping_set = aggregate.grouping_sets[0];
+	if (grouping_set.size() != aggregate.grouped_aggregate_data.groups.size()) {
+		return true;
+	}
+	for (idx_t group_idx = 0; group_idx < aggregate.grouped_aggregate_data.groups.size(); group_idx++) {
+		if (grouping_set.find(group_idx) == grouping_set.end()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::TranslateHashGroupBy(
     const PhysicalHashAggregate &ha, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
 	DistributedPipelineNodeRef child_node = nullptr;
@@ -144,13 +309,46 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::T
 		if (!a) {
 			continue;
 		}
-		auto copy = a->Copy();
+		auto &aggregate = a->Cast<BoundAggregateExpression>();
+		auto copy = FunctionBinder::UnbindSortedAggregate(aggregate);
+		if (aggregate.filter) {
+			auto filter_index = ha.filter_indexes.find(aggregate.filter.get());
+			if (filter_index == ha.filter_indexes.end()) {
+				throw InternalException("hash aggregate filter is missing its input index");
+			}
+			auto &copied_filter = copy->filter->Cast<BoundReferenceExpression>();
+			copied_filter.index = filter_index->second;
+		}
 		aggs.emplace_back(ExpressionRef(copy.release()));
 	}
 
 	SchemaRef schema = nullptr;
 	if (!ha.GetTypes().empty()) {
 		schema = MakeSchemaRef(ha.GetTypes());
+	}
+
+	if (RequiresGroupingSetsPlan(ha)) {
+		std::vector<GroupingSet> grouping_sets;
+		grouping_sets.reserve(ha.grouping_sets.size());
+		for (const auto &grouping_set : ha.grouping_sets) {
+			grouping_sets.push_back(grouping_set);
+		}
+		std::vector<std::vector<idx_t>> grouping_functions;
+		grouping_functions.reserve(ha.grouped_aggregate_data.grouping_functions.size());
+		for (const auto &grouping_function : ha.grouped_aggregate_data.grouping_functions) {
+			grouping_functions.emplace_back(grouping_function.begin(), grouping_function.end());
+		}
+		std::vector<LogicalType> input_types;
+		if (!ha.children.empty()) {
+			const auto &child_types = ha.children[0].get().GetTypes();
+			input_types.assign(child_types.begin(), child_types.end());
+		}
+		auto agg_node =
+		    gen_grouping_sets_agg(child_node, group_by, aggs, grouping_sets, grouping_functions, input_types, schema);
+		if (!agg_node) {
+			throw InternalException("distributed grouping sets translation produced null node");
+		}
+		return agg_node;
 	}
 
 	auto agg_node = gen_agg_nodes(child_node, group_by, aggs, schema, group_by);

--- a/external/duckdb/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/external/duckdb/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/aggregate_hashtable.hpp"
 #include "duckdb/execution/operator/aggregate/distinct_aggregate_data.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/base_pipeline_event.hpp"
 #include "duckdb/parallel/interrupt.hpp"
@@ -949,7 +950,24 @@ InsertionOrderPreservingMap<string> PhysicalHashAggregate::ParamsToString() cons
 
 void PhysicalHashAggregate::SerializeOperatorData(Serializer &serializer) const {
 	serializer.WriteProperty(103, "groups", grouped_aggregate_data.groups);
-	serializer.WriteProperty(104, "aggregates", grouped_aggregate_data.aggregates);
+	vector<unique_ptr<Expression>> aggregates;
+	aggregates.reserve(grouped_aggregate_data.aggregates.size());
+	for (const auto &expression : grouped_aggregate_data.aggregates) {
+		auto &aggregate = expression->Cast<BoundAggregateExpression>();
+		unique_ptr<Expression> copy = FunctionBinder::UnbindSortedAggregate(aggregate);
+		if (aggregate.filter) {
+			auto filter_index = filter_indexes.find(aggregate.filter.get());
+			if (filter_index == filter_indexes.end()) {
+				throw InternalException("hash aggregate filter is missing its input index");
+			}
+			auto &copied_filter = copy->Cast<BoundAggregateExpression>().filter->Cast<BoundReferenceExpression>();
+			copied_filter.index = filter_index->second;
+		}
+		aggregates.push_back(std::move(copy));
+	}
+	serializer.WriteProperty(104, "aggregates", aggregates);
+	serializer.WriteProperty(105, "grouping_sets", grouping_sets);
+	serializer.WriteProperty(106, "grouping_functions", grouped_aggregate_data.grouping_functions);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/projection/CMakeLists.txt
+++ b/external/duckdb/src/execution/operator/projection/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   duckdb_operator_projection
   OBJECT
   physical_projection.cpp
+  physical_grouping_set_expand.cpp
   physical_tableinout_function.cpp
   physical_pivot.cpp
   physical_unnest.cpp

--- a/external/duckdb/src/execution/operator/projection/physical_grouping_set_expand.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_grouping_set_expand.cpp
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+
+namespace duckdb {
+
+namespace {
+
+class GroupingSetExpandGlobalState : public GlobalOperatorState {
+public:
+	atomic<bool> seed_owner_claimed {false};
+};
+
+class GroupingSetExpandOperatorState : public OperatorState {
+public:
+	GroupingSetExpandOperatorState(ExecutionContext &context, const vector<unique_ptr<Expression>> &groups)
+	    : executor(context.client, groups) {
+		vector<LogicalType> group_types;
+		group_types.reserve(groups.size());
+		for (const auto &group : groups) {
+			group_types.push_back(group->return_type);
+		}
+		group_chunk.Initialize(Allocator::Get(context.client), group_types);
+	}
+
+	ExpressionExecutor executor;
+	DataChunk group_chunk;
+	idx_t next_grouping_set = 0;
+	bool input_prepared = false;
+	bool owns_seed_output = false;
+	idx_t next_seed = 0;
+};
+
+int64_t GetGroupingValue(const vector<idx_t> &grouping_function, const GroupingSet &grouping_set) {
+	uint64_t value = 0;
+	for (const auto group_idx : grouping_function) {
+		value <<= 1;
+		if (grouping_set.find(group_idx) == grouping_set.end()) {
+			value++;
+		}
+	}
+	return UnsafeNumericCast<int64_t>(value);
+}
+
+} // namespace
+
+PhysicalGroupingSetExpand::PhysicalGroupingSetExpand(PhysicalPlan &physical_plan, vector<LogicalType> types,
+                                                     vector<unique_ptr<Expression>> groups_p,
+                                                     vector<GroupingSet> grouping_sets_p,
+                                                     vector<vector<idx_t>> grouping_functions_p,
+                                                     vector<idx_t> filter_indexes_p, idx_t input_column_count_p,
+                                                     bool emit_empty_grouping_sets_p, idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::GROUPING_SET_EXPAND, std::move(types),
+                       estimated_cardinality),
+      groups(std::move(groups_p)), grouping_sets(std::move(grouping_sets_p)),
+      grouping_functions(std::move(grouping_functions_p)), filter_indexes(std::move(filter_indexes_p)),
+      input_column_count(input_column_count_p), emit_empty_grouping_sets(emit_empty_grouping_sets_p) {
+	const auto expected_column_count =
+	    input_column_count + groups.size() + grouping_functions.size() + 1 + filter_indexes.size();
+	if (this->types.size() != expected_column_count) {
+		throw InternalException("Grouping-set expand expected %llu output columns, got %llu", expected_column_count,
+		                        this->types.size());
+	}
+	for (const auto &grouping_set : grouping_sets) {
+		for (const auto group_idx : grouping_set) {
+			if (group_idx >= groups.size()) {
+				throw InternalException("Grouping-set expand group index %llu is out of range", group_idx);
+			}
+		}
+	}
+	for (const auto &grouping_function : grouping_functions) {
+		for (const auto group_idx : grouping_function) {
+			if (group_idx >= groups.size()) {
+				throw InternalException("Grouping-set expand GROUPING argument %llu is out of range", group_idx);
+			}
+		}
+	}
+	for (const auto filter_idx : filter_indexes) {
+		if (filter_idx != DConstants::INVALID_INDEX && filter_idx >= input_column_count) {
+			throw InternalException("Grouping-set expand filter index %llu is out of range", filter_idx);
+		}
+	}
+}
+
+unique_ptr<OperatorState> PhysicalGroupingSetExpand::GetOperatorState(ExecutionContext &context) const {
+	return make_uniq<GroupingSetExpandOperatorState>(context, groups);
+}
+
+unique_ptr<GlobalOperatorState> PhysicalGroupingSetExpand::GetGlobalOperatorState(ClientContext &context) const {
+	return make_uniq<GroupingSetExpandGlobalState>();
+}
+
+OperatorResultType PhysicalGroupingSetExpand::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                      GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = state_p.Cast<GroupingSetExpandOperatorState>();
+	if (grouping_sets.empty()) {
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	if (!state.input_prepared) {
+		state.group_chunk.Reset();
+		if (!groups.empty()) {
+			state.executor.Execute(input, state.group_chunk);
+		}
+		state.input_prepared = true;
+	}
+
+	const auto grouping_set_idx = state.next_grouping_set++;
+	const auto &grouping_set = grouping_sets[grouping_set_idx];
+
+	for (idx_t column_idx = 0; column_idx < input_column_count; column_idx++) {
+		chunk.data[column_idx].Reference(input.data[column_idx]);
+	}
+
+	const auto group_offset = input_column_count;
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		auto &result = chunk.data[group_offset + group_idx];
+		if (grouping_set.find(group_idx) != grouping_set.end()) {
+			result.Reference(state.group_chunk.data[group_idx]);
+		} else {
+			result.Reference(Value(groups[group_idx]->return_type));
+		}
+	}
+
+	const auto grouping_function_offset = group_offset + groups.size();
+	for (idx_t function_idx = 0; function_idx < grouping_functions.size(); function_idx++) {
+		chunk.data[grouping_function_offset + function_idx].Reference(
+		    Value::BIGINT(GetGroupingValue(grouping_functions[function_idx], grouping_set)));
+	}
+
+	const auto grouping_set_id_offset = grouping_function_offset + grouping_functions.size();
+	chunk.data[grouping_set_id_offset].Reference(Value::UBIGINT(grouping_set_idx));
+
+	const auto filter_offset = grouping_set_id_offset + 1;
+	for (idx_t filter_idx = 0; filter_idx < filter_indexes.size(); filter_idx++) {
+		const auto input_idx = filter_indexes[filter_idx];
+		if (input_idx == DConstants::INVALID_INDEX) {
+			chunk.data[filter_offset + filter_idx].Reference(Value::BOOLEAN(true));
+		} else {
+			chunk.data[filter_offset + filter_idx].Reference(input.data[input_idx]);
+		}
+	}
+
+	chunk.SetCardinality(input.size());
+	if (state.next_grouping_set < grouping_sets.size()) {
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
+	state.next_grouping_set = 0;
+	state.input_prepared = false;
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+OperatorFinalizeResultType PhysicalGroupingSetExpand::FinalExecute(ExecutionContext &context, DataChunk &chunk,
+                                                                   GlobalOperatorState &gstate_p,
+                                                                   OperatorState &state_p) const {
+	if (!emit_empty_grouping_sets) {
+		return OperatorFinalizeResultType::FINISHED;
+	}
+
+	// FinalExecute runs once per local operator state. Elect one state so this
+	// physical plan contributes only one seed per empty-set occurrence.
+	auto &gstate = gstate_p.Cast<GroupingSetExpandGlobalState>();
+	auto &state = state_p.Cast<GroupingSetExpandOperatorState>();
+	if (!state.owns_seed_output) {
+		bool expected = false;
+		if (!gstate.seed_owner_claimed.compare_exchange_strong(expected, true)) {
+			return OperatorFinalizeResultType::FINISHED;
+		}
+		state.owns_seed_output = true;
+	}
+
+	vector<idx_t> empty_grouping_set_ids;
+	for (idx_t grouping_set_idx = state.next_seed; grouping_set_idx < grouping_sets.size(); grouping_set_idx++) {
+		if (grouping_sets[grouping_set_idx].empty()) {
+			empty_grouping_set_ids.push_back(grouping_set_idx);
+		}
+	}
+	if (empty_grouping_set_ids.empty()) {
+		return OperatorFinalizeResultType::FINISHED;
+	}
+
+	const auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, empty_grouping_set_ids.size());
+	const auto group_offset = input_column_count;
+	const auto grouping_function_offset = group_offset + groups.size();
+	const auto grouping_set_id_offset = grouping_function_offset + grouping_functions.size();
+	const auto filter_offset = grouping_set_id_offset + 1;
+
+	for (idx_t column_idx = 0; column_idx < input_column_count; column_idx++) {
+		chunk.data[column_idx].Reference(Value(types[column_idx]));
+	}
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		chunk.data[group_offset + group_idx].Reference(Value(groups[group_idx]->return_type));
+	}
+	for (idx_t function_idx = 0; function_idx < grouping_functions.size(); function_idx++) {
+		chunk.data[grouping_function_offset + function_idx].SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	chunk.data[grouping_set_id_offset].SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t filter_idx = 0; filter_idx < filter_indexes.size(); filter_idx++) {
+		chunk.data[filter_offset + filter_idx].Reference(Value::BOOLEAN(false));
+	}
+
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		const auto grouping_set_idx = empty_grouping_set_ids[row_idx];
+		const auto &grouping_set = grouping_sets[grouping_set_idx];
+		for (idx_t function_idx = 0; function_idx < grouping_functions.size(); function_idx++) {
+			chunk.SetValue(grouping_function_offset + function_idx, row_idx,
+			               Value::BIGINT(GetGroupingValue(grouping_functions[function_idx], grouping_set)));
+		}
+		chunk.SetValue(grouping_set_id_offset, row_idx, Value::UBIGINT(grouping_set_idx));
+	}
+	state.next_seed = empty_grouping_set_ids[count - 1] + 1;
+	chunk.SetCardinality(count);
+	return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
+}
+
+InsertionOrderPreservingMap<string> PhysicalGroupingSetExpand::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Grouping Sets"] = std::to_string(grouping_sets.size());
+	result["Groups"] = std::to_string(groups.size());
+	SetEstimatedCardinality(result, estimated_cardinality);
+	return result;
+}
+
+void PhysicalGroupingSetExpand::SerializeOperatorData(Serializer &serializer) const {
+	serializer.WriteProperty(103, "groups", groups);
+	serializer.WriteProperty(104, "grouping_sets", grouping_sets);
+	serializer.WriteProperty(105, "grouping_functions", grouping_functions);
+	serializer.WriteProperty(106, "filter_indexes", filter_indexes);
+	serializer.WriteProperty(107, "input_column_count", input_column_count);
+	serializer.WriteProperty(108, "emit_empty_grouping_sets", emit_empty_grouping_sets);
+}
+
+} // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -20,7 +20,9 @@
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_window.hpp"
 #include "duckdb/execution/operator/aggregate/physical_streaming_window.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
+#include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
 #include "duckdb/execution/operator/projection/physical_vllm.hpp"
 
 #include "duckdb/execution/operator/projection/physical_pivot.hpp"
@@ -796,6 +798,17 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		return make_uniq<PhysicalUnnest>(physical_plan, std::move(types), std::move(select_list),
 		                                 estimated_cardinality);
 	}
+	case PhysicalOperatorType::GROUPING_SET_EXPAND: {
+		auto groups = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(103, "groups");
+		auto grouping_sets = deserializer.ReadProperty<vector<GroupingSet>>(104, "grouping_sets");
+		auto grouping_functions = deserializer.ReadProperty<vector<vector<idx_t>>>(105, "grouping_functions");
+		auto filter_indexes = deserializer.ReadProperty<vector<idx_t>>(106, "filter_indexes");
+		auto input_column_count = deserializer.ReadProperty<idx_t>(107, "input_column_count");
+		auto emit_empty_grouping_sets = deserializer.ReadProperty<bool>(108, "emit_empty_grouping_sets");
+		return make_uniq<PhysicalGroupingSetExpand>(
+		    physical_plan, std::move(types), std::move(groups), std::move(grouping_sets), std::move(grouping_functions),
+		    std::move(filter_indexes), input_column_count, emit_empty_grouping_sets, estimated_cardinality);
+	}
 	case PhysicalOperatorType::RESERVOIR_SAMPLE: {
 		auto options = deserializer.ReadProperty<unique_ptr<SampleOptions>>(103, "sample_options");
 		return make_uniq<PhysicalReservoirSample>(physical_plan, std::move(types), std::move(options),
@@ -1093,9 +1106,19 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 	case PhysicalOperatorType::HASH_GROUP_BY: {
 		auto groups = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(103, "groups");
 		auto aggregates = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(104, "aggregates");
+		auto grouping_sets = deserializer.ReadProperty<vector<GroupingSet>>(105, "grouping_sets");
+		auto grouping_functions = deserializer.ReadProperty<vector<unsafe_vector<idx_t>>>(106, "grouping_functions");
 		auto &context = deserializer.Get<ClientContext &>();
-		return make_uniq<PhysicalHashAggregate>(physical_plan, context, std::move(types), std::move(aggregates),
-		                                        std::move(groups), estimated_cardinality);
+		for (auto &aggregate : aggregates) {
+			auto &bound_aggregate = aggregate->Cast<BoundAggregateExpression>();
+			if (bound_aggregate.order_bys) {
+				FunctionBinder::BindSortedAggregate(context, bound_aggregate, groups, grouping_sets);
+			}
+		}
+		return make_uniq<PhysicalHashAggregate>(
+		    physical_plan, context, std::move(types), std::move(aggregates), std::move(groups),
+		    std::move(grouping_sets), std::move(grouping_functions), estimated_cardinality,
+		    TupleDataValidityType::CAN_HAVE_NULL_VALUES, TupleDataValidityType::CAN_HAVE_NULL_VALUES);
 	}
 	case PhysicalOperatorType::PERFECT_HASH_GROUP_BY: {
 		auto groups = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(103, "groups");

--- a/external/duckdb/src/execution/physical_operator_visitor.cpp
+++ b/external/duckdb/src/execution/physical_operator_visitor.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/execution/operator/filter/physical_filter.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
+#include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/order/physical_order.hpp"
 #include "duckdb/execution/operator/helper/physical_limit.hpp"
@@ -175,6 +176,13 @@ void PhysicalOperatorVisitor::EnumerateExpressions(PhysicalOperator &op,
 	case PhysicalOperatorType::PROJECTION: {
 		auto &proj = op.Cast<PhysicalProjection>();
 		for (auto &expr : proj.select_list) {
+			callback(&expr);
+		}
+		break;
+	}
+	case PhysicalOperatorType::GROUPING_SET_EXPAND: {
+		auto &expand = op.Cast<PhysicalGroupingSetExpand>();
+		for (auto &expr : expand.groups) {
 			callback(&expr);
 		}
 		break;

--- a/external/duckdb/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/external/duckdb/src/function/aggregate/sorted_aggregate_function.cpp
@@ -675,6 +675,53 @@ struct SortedAggregateFunction {
 
 } // namespace
 
+unique_ptr<BoundAggregateExpression> FunctionBinder::UnbindSortedAggregate(const BoundAggregateExpression &expr) {
+	if (expr.function.update != SortedAggregateFunction::ScatterUpdate) {
+		return unique_ptr_cast<Expression, BoundAggregateExpression>(expr.Copy());
+	}
+	if (!expr.bind_info) {
+		throw InternalException("Sorted aggregate is missing bind data");
+	}
+
+	auto &sorted_bind = expr.bind_info->Cast<SortedAggregateBindData>();
+	const auto child_count = sorted_bind.scan_cols.size();
+	if (child_count > expr.children.size() || sorted_bind.orders.empty()) {
+		throw InternalException("Sorted aggregate has invalid bind data");
+	}
+
+	vector<unique_ptr<Expression>> children;
+	children.reserve(child_count);
+	for (idx_t child_idx = 0; child_idx < child_count; child_idx++) {
+		children.push_back(expr.children[child_idx]->Copy());
+	}
+
+	auto filter = expr.filter ? expr.filter->Copy() : nullptr;
+	auto bind_info = sorted_bind.bind_info ? sorted_bind.bind_info->Copy() : nullptr;
+	auto result = make_uniq<BoundAggregateExpression>(sorted_bind.function, std::move(children), std::move(filter),
+	                                                  std::move(bind_info), expr.aggr_type);
+	result->return_type = expr.return_type;
+	result->SetAlias(expr.GetAlias());
+	result->SetQueryLocation(expr.GetQueryLocation());
+	result->order_bys = make_uniq<BoundOrderModifier>();
+	result->order_bys->orders.reserve(sorted_bind.orders.size() - 1);
+	for (idx_t order_idx = 1; order_idx < sorted_bind.orders.size(); order_idx++) {
+		const auto &order = sorted_bind.orders[order_idx];
+		if (order.expression->GetExpressionType() != ExpressionType::BOUND_REF) {
+			throw InternalException("Sorted aggregate order key is not a bound reference");
+		}
+		const auto input_index = order.expression->Cast<BoundReferenceExpression>().index;
+		if (input_index == 0 || input_index > sorted_bind.buffered_cols.size()) {
+			throw InternalException("Sorted aggregate order key index is out of range");
+		}
+		const auto child_index = sorted_bind.buffered_cols[input_index - 1];
+		if (child_index >= expr.children.size()) {
+			throw InternalException("Sorted aggregate buffered column index is out of range");
+		}
+		result->order_bys->orders.emplace_back(order.type, order.null_order, expr.children[child_index]->Copy());
+	}
+	return result;
+}
+
 void FunctionBinder::BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
                                          const vector<unique_ptr<Expression>> &groups,
                                          optional_ptr<vector<GroupingSet>> grouping_sets) {

--- a/external/duckdb/src/include/duckdb/common/enums/physical_operator_type.hpp
+++ b/external/duckdb/src/include/duckdb/common/enums/physical_operator_type.hpp
@@ -141,6 +141,7 @@ enum class PhysicalOperatorType : uint8_t {
 	VLLM_PROJECT,
 	REPARTITION,
 	STREAMING_UDF,
+	GROUPING_SET_EXPAND,
 };
 
 string PhysicalOperatorToString(PhysicalOperatorType type);

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/aggregate.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/aggregate.hpp
@@ -13,6 +13,7 @@
 
 #include "duckdb/execution/distributed/common_types.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/parser/group_by_node.hpp"
 
 #include "duckdb/execution/distributed/plan/distributed_physical_plan.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
@@ -29,6 +30,9 @@ class AggregateNode : public PipelineNodeImpl, public std::enable_shared_from_th
 public:
 	AggregateNode(NodeID node_id, const PlanConfig &plan_config, std::vector<BoundExprRef> group_by,
 	              std::vector<BoundAggExprRef> aggs, SchemaRef output_schema, DistributedPipelineNodeRef child);
+	AggregateNode(NodeID node_id, const PlanConfig &plan_config, std::vector<BoundExprRef> group_by,
+	              std::vector<BoundAggExprRef> aggs, SchemaRef output_schema, DistributedPipelineNodeRef child,
+	              std::vector<GroupingSet> grouping_sets, std::vector<std::vector<idx_t>> grouping_functions);
 
 	static NodeName node_name(const std::vector<BoundExprRef> &group_by);
 
@@ -64,6 +68,8 @@ private:
 	std::vector<BoundExprRef> group_by_;
 	std::vector<BoundAggExprRef> aggs_;
 	DistributedPipelineNodeRef child_;
+	std::vector<GroupingSet> grouping_sets_;
+	std::vector<std::vector<idx_t>> grouping_functions_;
 };
 
 class PerfectHashAggregateNode : public PipelineNodeImpl,

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/parser/group_by_node.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class GroupingSetExpandNode : public PipelineNodeImpl, public std::enable_shared_from_this<GroupingSetExpandNode> {
+public:
+	GroupingSetExpandNode(NodeID node_id, PipelineNodeRef child, std::vector<BoundExpr> groups,
+	                      std::vector<GroupingSet> grouping_sets, std::vector<std::vector<idx_t>> grouping_functions,
+	                      std::vector<idx_t> aggregate_filter_indexes, std::vector<LogicalType> output_types);
+
+	std::string name() const override {
+		return "GroupingSetExpand";
+	}
+	NodeID node_id() const override {
+		return ctx_.node_id();
+	}
+	const PipelineNodeContext &context() const override {
+		return ctx_;
+	}
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override;
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	PipelineNodeContext ctx_;
+	PipelineNodeConfig config_;
+	PipelineNodeRef child_;
+	std::vector<BoundExpr> groups_;
+	std::vector<GroupingSet> grouping_sets_;
+	std::vector<std::vector<idx_t>> grouping_functions_;
+	std::vector<idx_t> aggregate_filter_indexes_;
+	std::vector<LogicalType> output_types_;
+	bool has_empty_grouping_set_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/projection.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/projection.hpp
@@ -18,10 +18,13 @@ namespace distributed {
 class ProjectionNode : public PipelineNodeImpl, public std::enable_shared_from_this<ProjectionNode> {
 public:
 	ProjectionNode(NodeID node_id, PipelineNodeRef child, std::vector<ExpressionRef> projection,
-	               std::vector<std::string> projection_names, SchemaRef schema)
+	               std::vector<std::string> projection_names, SchemaRef schema,
+	               ClusteringSpecRef clustering_override = nullptr)
 	    : ctx_(InheritPipelineNodeContext(child, node_id, "Projection")),
 	      config_(std::move(schema), child ? child->config().execution_config() : DuckDBExecutionConfigRef(),
-	              child ? child->config().clustering_spec() : ClusteringSpec::unknown_with_num_partitions(1)),
+	              clustering_override
+	                  ? std::move(clustering_override)
+	                  : (child ? child->config().clustering_spec() : ClusteringSpec::unknown_with_num_partitions(1))),
 	      child_(std::move(child)), projection_(std::move(projection)), projection_names_(std::move(projection_names)) {
 	}
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -109,6 +109,12 @@ private:
 	                                                       SchemaRef output_schema,
 	                                                       const std::vector<BoundExpr> &partition_by);
 
+	std::shared_ptr<DistributedPipelineNode>
+	gen_grouping_sets_agg(std::shared_ptr<DistributedPipelineNode> input_node, const std::vector<BoundExpr> &group_by,
+	                      const std::vector<BoundAggExpr> &aggregations, const std::vector<GroupingSet> &grouping_sets,
+	                      const std::vector<std::vector<idx_t>> &grouping_functions,
+	                      const std::vector<LogicalType> &input_types, SchemaRef output_schema);
+
 	// 生成 gather 节点（使用 RepartitionNode with num_partitions=1）
 	std::shared_ptr<DistributedPipelineNode> gen_gather_node(std::shared_ptr<DistributedPipelineNode> input_node);
 

--- a/external/duckdb/src/include/duckdb/execution/operator/projection/physical_grouping_set_expand.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/projection/physical_grouping_set_expand.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/parser/group_by_node.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+//! Expands every input row once per grouping-set occurrence.
+//!
+//! The output layout is:
+//!   input columns, expanded group columns, GROUPING() values,
+//!   grouping-set occurrence id, aggregate filter columns.
+class PhysicalGroupingSetExpand : public PhysicalOperator {
+public:
+	static constexpr const PhysicalOperatorType TYPE = PhysicalOperatorType::GROUPING_SET_EXPAND;
+
+public:
+	PhysicalGroupingSetExpand(PhysicalPlan &physical_plan, vector<LogicalType> types,
+	                          vector<unique_ptr<Expression>> groups, vector<GroupingSet> grouping_sets,
+	                          vector<vector<idx_t>> grouping_functions, vector<idx_t> filter_indexes,
+	                          idx_t input_column_count, bool emit_empty_grouping_sets, idx_t estimated_cardinality);
+
+	vector<unique_ptr<Expression>> groups;
+	vector<GroupingSet> grouping_sets;
+	vector<vector<idx_t>> grouping_functions;
+	vector<idx_t> filter_indexes;
+	idx_t input_column_count;
+	bool emit_empty_grouping_sets;
+
+public:
+	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
+	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
+
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
+	                                        OperatorState &state) const override;
+
+	bool RequiresFinalExecute() const override {
+		return true;
+	}
+
+	bool ParallelOperator() const override {
+		return true;
+	}
+
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+protected:
+	void SerializeOperatorData(Serializer &serializer) const override;
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/function_binder.hpp
+++ b/external/duckdb/src/include/duckdb/function/function_binder.hpp
@@ -72,6 +72,10 @@ public:
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundAggregateExpression &expr,
 	                                           const vector<unique_ptr<Expression>> &groups,
 	                                           optional_ptr<vector<GroupingSet>> grouping_sets);
+	//! Reconstruct the portable, pre-bind representation of a sorted aggregate.
+	//! Physical plans use this before copying or serializing an aggregate because
+	//! the bound sorted-aggregate state owns query-context-specific sort objects.
+	DUCKDB_API static unique_ptr<BoundAggregateExpression> UnbindSortedAggregate(const BoundAggregateExpression &expr);
 	DUCKDB_API static void BindSortedAggregate(ClientContext &context, BoundWindowExpression &expr);
 
 	//! Cast a set of expressions to the arguments of this function

--- a/external/duckdb/src/main/query_profiler.cpp
+++ b/external/duckdb/src/main/query_profiler.cpp
@@ -153,6 +153,7 @@ bool QueryProfiler::OperatorRequiresProfiling(const PhysicalOperatorType op_type
 	case PhysicalOperatorType::TOP_N:
 	case PhysicalOperatorType::WINDOW:
 	case PhysicalOperatorType::UNNEST:
+	case PhysicalOperatorType::GROUPING_SET_EXPAND:
 	case PhysicalOperatorType::UNGROUPED_AGGREGATE:
 	case PhysicalOperatorType::HASH_GROUP_BY:
 	case PhysicalOperatorType::FILTER:

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/execution/physical_plan.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
+#include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
 #include "duckdb/execution/operator/filter/physical_filter.hpp"
 #include "duckdb/execution/operator/helper/physical_limit.hpp"
 #include "duckdb/execution/operator/helper/physical_streaming_limit.hpp"
@@ -1002,6 +1003,171 @@ TEST_CASE("PhysicalHashAggregate serialization roundtrip", "[serialization][phys
 
 	std::cerr << "[test] PhysicalHashAggregate serialization roundtrip PASSED" << std::endl;
 	conn.Rollback();
+}
+
+TEST_CASE("PhysicalHashAggregate grouping sets serialization roundtrip",
+          "[serialization][physical_plan][grouping_sets]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	conn.BeginTransaction();
+	auto &context = *conn.context;
+
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+
+	vector<unique_ptr<Expression>> groups;
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+
+	vector<unique_ptr<Expression>> aggregates;
+	auto count = MakeCountAggregate(context, 2, LogicalType::INTEGER);
+	count->Cast<BoundAggregateExpression>().filter = make_uniq<BoundReferenceExpression>(LogicalType::BOOLEAN, 3);
+	aggregates.push_back(std::move(count));
+
+	vector<GroupingSet> grouping_sets;
+	grouping_sets.push_back({0, 1});
+	grouping_sets.push_back({0});
+	grouping_sets.push_back({0}); // Duplicate grouping sets have duplicate-row semantics.
+	grouping_sets.push_back({});
+
+	vector<unsafe_vector<idx_t>> grouping_functions;
+	grouping_functions.push_back({0, 1});
+
+	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT, LogicalType::BIGINT};
+	auto &hash_agg = plan.Make<PhysicalHashAggregate>(
+	    context, types, std::move(aggregates), std::move(groups), grouping_sets, grouping_functions, 42,
+	    TupleDataValidityType::CAN_HAVE_NULL_VALUES, TupleDataValidityType::CAN_HAVE_NULL_VALUES);
+
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	hash_agg.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Set<ClientContext &>(context);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	REQUIRE(deserialized_op != nullptr);
+	auto *hash_ptr = dynamic_cast<PhysicalHashAggregate *>(deserialized_op.get());
+	REQUIRE(hash_ptr != nullptr);
+	REQUIRE(hash_ptr->grouping_sets == grouping_sets);
+	REQUIRE(hash_ptr->grouped_aggregate_data.grouping_functions.size() == grouping_functions.size());
+	REQUIRE(hash_ptr->grouped_aggregate_data.grouping_functions[0] == grouping_functions[0]);
+	auto &aggregate = hash_ptr->grouped_aggregate_data.aggregates[0]->Cast<BoundAggregateExpression>();
+	auto &filter = aggregate.filter->Cast<BoundReferenceExpression>();
+	REQUIRE(filter.index == 1);
+	auto filter_index = hash_ptr->filter_indexes.find(aggregate.filter.get());
+	REQUIRE(filter_index != hash_ptr->filter_indexes.end());
+	REQUIRE(filter_index->second == 3);
+
+	conn.Rollback();
+}
+
+TEST_CASE("PhysicalHashAggregate sorted aggregate serialization roundtrip",
+          "[serialization][physical_plan][grouping_sets]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	conn.BeginTransaction();
+	auto &context = *conn.context;
+
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+
+	vector<unique_ptr<Expression>> groups;
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+
+	auto aggregate = MakeCountAggregate(context, 1, LogicalType::INTEGER);
+	aggregate->order_bys = make_uniq<BoundOrderModifier>();
+	aggregate->order_bys->orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_FIRST,
+	                                          make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 2));
+	FunctionBinder::BindSortedAggregate(context, *aggregate, groups, nullptr);
+	REQUIRE(aggregate->order_bys == nullptr);
+
+	vector<unique_ptr<Expression>> aggregates;
+	aggregates.push_back(std::move(aggregate));
+	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::BIGINT};
+	auto &hash_agg = plan.Make<PhysicalHashAggregate>(context, types, std::move(aggregates), std::move(groups), 42);
+
+	// Reproduce distributed stage construction: the query transaction that
+	// created the sorted aggregate has ended before the task plan is serialized.
+	conn.Rollback();
+
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	hash_agg.Serialize(serializer);
+	serializer.End();
+
+	conn.BeginTransaction();
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Set<ClientContext &>(context);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	REQUIRE(deserialized_op != nullptr);
+	auto *hash_ptr = dynamic_cast<PhysicalHashAggregate *>(deserialized_op.get());
+	REQUIRE(hash_ptr != nullptr);
+	auto &roundtrip = hash_ptr->grouped_aggregate_data.aggregates[0]->Cast<BoundAggregateExpression>();
+	REQUIRE(roundtrip.order_bys == nullptr);
+	REQUIRE(roundtrip.children.size() == 2);
+
+	auto portable = FunctionBinder::UnbindSortedAggregate(roundtrip);
+	REQUIRE(portable->children.size() == 1);
+	REQUIRE(portable->order_bys != nullptr);
+	REQUIRE(portable->order_bys->orders.size() == 1);
+	auto &order = portable->order_bys->orders[0];
+	REQUIRE(order.type == OrderType::DESCENDING);
+	REQUIRE(order.null_order == OrderByNullType::NULLS_FIRST);
+	REQUIRE(order.expression->Cast<BoundReferenceExpression>().index == 2);
+
+	conn.Rollback();
+}
+
+TEST_CASE("PhysicalGroupingSetExpand serialization roundtrip", "[serialization][physical_plan][grouping_sets]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+
+	vector<unique_ptr<Expression>> groups;
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+	vector<GroupingSet> grouping_sets = {{0, 1}, {0}, {0}, {}};
+	vector<vector<idx_t>> grouping_functions = {{0, 1}};
+	vector<idx_t> filter_indexes = {DConstants::INVALID_INDEX, 2};
+	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BOOLEAN,
+	                             LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT,
+	                             LogicalType::UBIGINT, LogicalType::BOOLEAN, LogicalType::BOOLEAN};
+	auto &expand = plan.Make<PhysicalGroupingSetExpand>(types, std::move(groups), grouping_sets, grouping_functions,
+	                                                    filter_indexes, 3, true, 42);
+
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	expand.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	REQUIRE(deserialized_op != nullptr);
+	auto *expand_ptr = dynamic_cast<PhysicalGroupingSetExpand *>(deserialized_op.get());
+	REQUIRE(expand_ptr != nullptr);
+	REQUIRE(expand_ptr->grouping_sets == grouping_sets);
+	REQUIRE(expand_ptr->grouping_functions == grouping_functions);
+	REQUIRE(expand_ptr->filter_indexes == filter_indexes);
+	REQUIRE(expand_ptr->input_column_count == 3);
+	REQUIRE(expand_ptr->emit_empty_grouping_sets);
 }
 
 TEST_CASE("PhysicalPlan with chain: Projection -> Filter", "[serialization][physical_plan]") {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -54,7 +54,9 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/execution/distributed/pipeline_node/translator.hpp"
 #include "duckdb/execution/distributed/pipeline_node/aggregate.hpp"
+#include "duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp"
 #include "duckdb/execution/distributed/pipeline_node/limit.hpp"
+#include "duckdb/execution/distributed/pipeline_node/projection.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/expression_scan.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
@@ -397,6 +399,180 @@ TEST_CASE("PhysicalPlanTranslator: grouped hash aggregate -> AggregateNode", "[d
 	auto dist = res.value();
 	auto inner = dist->inner();
 	REQUIRE(std::dynamic_pointer_cast<duckdb::distributed::AggregateNode>(inner) != nullptr);
+}
+
+TEST_CASE("PhysicalPlanTranslator: grouping sets use expand-shuffle-aggregate", "[distributed][grouping_sets]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types = {LogicalType::INTEGER, LogicalType::INTEGER};
+	auto collection = make_uniq<ColumnDataCollection>(allocator, input_types);
+	auto &scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0,
+	                                                std::move(collection));
+	auto repartition_spec = RepartitionSpec::create_random(4);
+	auto &input = plan->Make<PhysicalRepartition>(input_types, std::move(repartition_spec), 0);
+	input.children.push_back(scan);
+
+	vector<unique_ptr<Expression>> groups;
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+	vector<unique_ptr<Expression>> aggregates;
+	vector<GroupingSet> grouping_sets = {{0, 1}, {0}, {0}, {}};
+	vector<unsafe_vector<idx_t>> grouping_functions = {{0, 1}};
+	vector<LogicalType> output_types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT};
+
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &aggregate = plan->Make<PhysicalHashAggregate>(
+	    *conn.context, output_types, std::move(aggregates), std::move(groups), grouping_sets, grouping_functions, 0,
+	    TupleDataValidityType::CAN_HAVE_NULL_VALUES, TupleDataValidityType::CAN_HAVE_NULL_VALUES);
+	aggregate.children.push_back(input);
+	plan->SetRoot(aggregate);
+
+	PlanConfig config;
+	config.num_partitions = 4;
+	auto result = physical_plan_to_pipeline_node(config, std::move(plan));
+
+	REQUIRE(result.is_ok());
+	auto projection = std::dynamic_pointer_cast<ProjectionNode>(result.value()->inner());
+	REQUIRE(projection != nullptr);
+	REQUIRE(SchemaColumnCount(projection->config().schema()) == output_types.size());
+	REQUIRE(projection->config().clustering_spec()->type() == ClusteringSpec::Type::Unknown);
+	REQUIRE(projection->config().clustering_spec()->num_partitions() == 4);
+
+	auto projection_children = projection->children();
+	REQUIRE(projection_children.size() == 1);
+	auto final_aggregate = std::dynamic_pointer_cast<AggregateNode>(projection_children[0]);
+	REQUIRE(final_aggregate != nullptr);
+
+	auto final_children = final_aggregate->children();
+	REQUIRE(final_children.size() == 1);
+	auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(final_children[0]);
+	REQUIRE(shuffle != nullptr);
+	REQUIRE(shuffle->config().clustering_spec()->type() == ClusteringSpec::Type::Hash);
+	REQUIRE(shuffle->config().clustering_spec()->partition_by().size() == 3);
+
+	auto shuffle_children = shuffle->children();
+	REQUIRE(shuffle_children.size() == 1);
+	REQUIRE(std::dynamic_pointer_cast<GroupingSetExpandNode>(shuffle_children[0]) != nullptr);
+}
+
+TEST_CASE("PhysicalPlanTranslator: grouping-set expansion accepts exact aggregate semantics",
+          "[distributed][grouping_sets]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	AggregateType aggregate_type = AggregateType::NON_DISTINCT;
+	bool with_filter = false;
+	bool with_order = false;
+	SECTION("DISTINCT") {
+		aggregate_type = AggregateType::DISTINCT;
+	}
+	SECTION("FILTER") {
+		with_filter = true;
+	}
+	SECTION("ordered aggregate") {
+		with_order = true;
+	}
+
+	auto &allocator = Allocator::DefaultAllocator();
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types = {LogicalType::BIGINT, LogicalType::BOOLEAN};
+	auto collection = make_uniq<ColumnDataCollection>(allocator, input_types);
+	auto &scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0,
+	                                                std::move(collection));
+	auto repartition_spec = RepartitionSpec::create_random(4);
+	auto &input = plan->Make<PhysicalRepartition>(input_types, std::move(repartition_spec), 0);
+	input.children.push_back(scan);
+
+	auto aggregate_function =
+	    AggregateFunction::NullaryAggregate<int64_t, int64_t, TestNullaryAggOp>(LogicalType::BIGINT);
+	aggregate_function.name = "test_nullary";
+	unique_ptr<Expression> filter;
+	if (with_filter) {
+		filter = make_uniq<BoundReferenceExpression>(LogicalType::BOOLEAN, 1);
+	}
+	auto aggregate_expression = make_uniq<BoundAggregateExpression>(
+	    std::move(aggregate_function), vector<unique_ptr<Expression>> {}, std::move(filter), nullptr, aggregate_type);
+	if (with_order) {
+		aggregate_expression->order_bys = make_uniq<BoundOrderModifier>();
+		aggregate_expression->order_bys->orders.emplace_back(
+		    OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		    make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0));
+	}
+
+	vector<unique_ptr<Expression>> aggregates;
+	aggregates.push_back(std::move(aggregate_expression));
+	vector<unique_ptr<Expression>> groups;
+	groups.push_back(make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0));
+	vector<GroupingSet> grouping_sets = {{0}, {}};
+	vector<unsafe_vector<idx_t>> grouping_functions;
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto &aggregate = plan->Make<PhysicalHashAggregate>(
+	    *conn.context, output_types, std::move(aggregates), std::move(groups), std::move(grouping_sets),
+	    std::move(grouping_functions), 0, TupleDataValidityType::CAN_HAVE_NULL_VALUES,
+	    TupleDataValidityType::CAN_HAVE_NULL_VALUES);
+	aggregate.children.push_back(input);
+	plan->SetRoot(aggregate);
+
+	PlanConfig config;
+	config.num_partitions = 4;
+	auto result = physical_plan_to_pipeline_node(config, std::move(plan));
+
+	REQUIRE(result.is_ok());
+	auto projection = std::dynamic_pointer_cast<ProjectionNode>(result.value()->inner());
+	REQUIRE(projection != nullptr);
+	auto final_aggregate = std::dynamic_pointer_cast<AggregateNode>(projection->children()[0]);
+	REQUIRE(final_aggregate != nullptr);
+	auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(final_aggregate->children()[0]);
+	REQUIRE(shuffle != nullptr);
+	REQUIRE(std::dynamic_pointer_cast<GroupingSetExpandNode>(shuffle->children()[0]) != nullptr);
+}
+
+TEST_CASE("PhysicalPlanTranslator: grouping-set expansion accepts zero-column input", "[distributed][grouping_sets]") {
+	auto &allocator = Allocator::DefaultAllocator();
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types;
+	auto collection = make_uniq<ColumnDataCollection>(allocator, input_types);
+	auto &scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0,
+	                                                std::move(collection));
+	auto repartition_spec = RepartitionSpec::create_random(4);
+	auto &input = plan->Make<PhysicalRepartition>(input_types, std::move(repartition_spec), 0);
+	input.children.push_back(scan);
+
+	auto aggregate_function =
+	    AggregateFunction::NullaryAggregate<int64_t, int64_t, TestNullaryAggOp>(LogicalType::BIGINT);
+	aggregate_function.name = "test_nullary";
+	vector<unique_ptr<Expression>> aggregates;
+	aggregates.push_back(make_uniq<BoundAggregateExpression>(std::move(aggregate_function),
+	                                                         vector<unique_ptr<Expression>> {}, nullptr, nullptr,
+	                                                         AggregateType::NON_DISTINCT));
+	vector<unique_ptr<Expression>> groups;
+	vector<GroupingSet> grouping_sets = {{}, {}};
+	vector<unsafe_vector<idx_t>> grouping_functions;
+	vector<LogicalType> output_types = {LogicalType::BIGINT};
+
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &aggregate = plan->Make<PhysicalHashAggregate>(
+	    *conn.context, output_types, std::move(aggregates), std::move(groups), std::move(grouping_sets),
+	    std::move(grouping_functions), 0, TupleDataValidityType::CAN_HAVE_NULL_VALUES,
+	    TupleDataValidityType::CAN_HAVE_NULL_VALUES);
+	aggregate.children.push_back(input);
+	plan->SetRoot(aggregate);
+
+	PlanConfig config;
+	config.num_partitions = 4;
+	auto result = physical_plan_to_pipeline_node(config, std::move(plan));
+
+	REQUIRE(result.is_ok());
+	auto projection = std::dynamic_pointer_cast<ProjectionNode>(result.value()->inner());
+	REQUIRE(projection != nullptr);
+	auto final_aggregate = std::dynamic_pointer_cast<AggregateNode>(projection->children()[0]);
+	REQUIRE(final_aggregate != nullptr);
+	auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(final_aggregate->children()[0]);
+	REQUIRE(shuffle != nullptr);
+	REQUIRE(shuffle->config().clustering_spec()->partition_by().size() == 1);
+	REQUIRE(std::dynamic_pointer_cast<GroupingSetExpandNode>(shuffle->children()[0]) != nullptr);
 }
 
 TEST_CASE("PhysicalPlanTranslator: distributed distinct aggregate throws", "[distributed]") {

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3075,6 +3075,161 @@ def test_ray_group_by_multi_partition_plan(ray_runner, duckdb_conn, parquet_path
     )
 
 
+def test_ray_grouping_sets_span_multiple_scan_tasks(ray_runner, duckdb_conn, tmp_path, monkeypatch):
+    label = "test_ray_e2e: grouping sets span multiple scan tasks"
+    input_path = tmp_path / "grouping_sets_multi_task"
+    shuffle_dir = tmp_path / "grouping_sets_multi_task_shuffle"
+
+    monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", str(shuffle_dir))
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+    duckdb_conn.execute("SET perfect_ht_threshold=0")
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                CASE WHEN i % 7 = 0 THEN NULL ELSE (i % 3)::INTEGER END AS a,
+                CASE WHEN i % 5 = 0 THEN NULL ELSE (i % 2)::INTEGER END AS b,
+                (i + 1)::INTEGER AS value,
+                (i % 4)::INTEGER AS file_id
+            FROM range(0, 24) AS t(i)
+        ) TO '{input_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+    source = f"read_parquet('{input_path}/**/*.parquet')"
+
+    rollup_sql = f"""
+        SELECT a, b, COUNT(*) AS cnt, SUM(value) AS total, GROUPING(a, b) AS grouping_id
+        FROM {source}
+        GROUP BY ROLLUP(a, b)
+    """
+    relation = duckdb_conn.sql(rollup_sql)
+    ray_cxx = getattr(duckdb, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("duckdb.ray_cxx.PyLogicalPlan not available in this environment")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"{label}-plan")
+    distributed_plan = logical_plan.to_physical_plan(duckdb_conn)
+    descriptor_counts = [len(descriptors) for descriptors in distributed_plan.scan_task_descriptor_map().values()]
+    assert descriptor_counts == [4], f"{label}: expected four scan tasks, got {descriptor_counts}"
+    plan_text = distributed_plan.repr_ascii(False)
+    normalized_plan = plan_text.upper()
+    assert plan_text and "GROUPINGSETEXPAND" in normalized_plan and "REPARTITION" in normalized_plan, (
+        f"{label}: expected expand and repartition for distributed grouping sets, got:\n{plan_text}"
+    )
+
+    cases = {
+        "rollup with real nulls": rollup_sql,
+        "cube": f"""
+            SELECT a, b, COUNT(*) AS cnt, SUM(value) AS total, GROUPING(a, b) AS grouping_id
+            FROM {source}
+            GROUP BY CUBE(a, b)
+        """,
+        "duplicate explicit sets": f"""
+            SELECT a, b, COUNT(*) AS cnt, GROUPING(a, b) AS grouping_id
+            FROM {source}
+            GROUP BY GROUPING SETS ((a, b), (a), (a), ())
+        """,
+        "duplicate sets without grouping function": f"""
+            SELECT a, b, COUNT(*) AS cnt
+            FROM {source}
+            GROUP BY GROUPING SETS ((a, b), (a), (a), ())
+        """,
+        "multiple grouping functions": f"""
+            SELECT a, b, COUNT(*) AS cnt, GROUPING(a) AS grouping_a, GROUPING(b) AS grouping_b
+            FROM {source}
+            GROUP BY CUBE(a, b)
+        """,
+        "no aggregates or grouping functions": f"""
+            SELECT a, b
+            FROM {source}
+            GROUP BY GROUPING SETS ((a, b), (a), (a), ())
+        """,
+        "distinct aggregate": f"""
+            SELECT a, COUNT(DISTINCT value % 5) AS cnt, GROUPING(a) AS grouping_id
+            FROM {source}
+            GROUP BY ROLLUP(a)
+        """,
+        "filtered aggregate": f"""
+            SELECT a, COUNT(*) FILTER (WHERE value % 2 = 0) AS cnt, GROUPING(a) AS grouping_id
+            FROM {source}
+            GROUP BY ROLLUP(a)
+        """,
+        "ordered aggregate": f"""
+            SELECT a, LIST(value ORDER BY b, value) AS values, GROUPING(a) AS grouping_id
+            FROM {source}
+            GROUP BY ROLLUP(a)
+        """,
+        "distinct filtered aggregate": f"""
+            SELECT
+                a,
+                COUNT(DISTINCT value % 5) FILTER (WHERE b = 1) AS cnt,
+                GROUPING(a) AS grouping_id
+            FROM {source}
+            GROUP BY ROLLUP(a)
+        """,
+        "distinct filtered ordered aggregate": f"""
+            SELECT
+                a,
+                STRING_AGG(
+                    DISTINCT (value % 5)::VARCHAR,
+                    ',' ORDER BY (value % 5)::VARCHAR
+                ) FILTER (WHERE b = 1) AS values,
+                GROUPING(a) AS grouping_id
+            FROM {source}
+            GROUP BY ROLLUP(a)
+        """,
+        "empty input": f"""
+            SELECT a, b, COUNT(*) AS cnt, SUM(value) AS total, GROUPING(a, b) AS grouping_id
+            FROM {source}
+            WHERE value < 0
+            GROUP BY ROLLUP(a, b)
+        """,
+        "filtered aggregate on empty input": f"""
+            SELECT
+                a,
+                COUNT(*) FILTER (WHERE b = 1) AS cnt,
+                LIST(value ORDER BY b, value) AS values,
+                GROUPING(a) AS grouping_id
+            FROM {source}
+            WHERE value < 0
+            GROUP BY ROLLUP(a)
+        """,
+        "duplicate empty sets on empty input": f"""
+            SELECT COUNT(*) AS cnt
+            FROM {source}
+            WHERE value < 0
+            GROUP BY GROUPING SETS ((), ())
+        """,
+        "duplicate empty sets without input columns": f"""
+            SELECT COUNT(*) AS cnt
+            FROM {source}
+            GROUP BY GROUPING SETS ((), ())
+        """,
+    }
+    for case_name, sql in cases.items():
+        _run_query_case(
+            duckdb_conn,
+            ray_runner,
+            sql,
+            f"{label}: {case_name}",
+            require_all=["HASH_GROUP_BY"],
+            timeout_s=60.0,
+        )
+
+    single_partition_filter_sql = """
+        SELECT a, COUNT(*) FILTER (WHERE keep) AS cnt, GROUPING(a) AS grouping_id
+        FROM (VALUES (1, TRUE), (1, FALSE), (2, FALSE)) AS t(a, keep)
+        GROUP BY ROLLUP(a)
+    """
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        single_partition_filter_sql,
+        f"{label}: single-partition FILTER",
+        require_all=["HASH_GROUP_BY"],
+        timeout_s=60.0,
+    )
+
+
 def test_ray_perfect_hash_group_by(ray_runner, duckdb_conn, parquet_path):
     label = "test_ray_e2e: perfect hash group by"
     duckdb_conn.execute("SET perfect_ht_threshold=32")


### PR DESCRIPTION
## Summary

- add a distributed grouping-set Expand operator that emits one row per grouping-set occurrence before repartitioning
- hash-shuffle expanded group keys plus a hidden occurrence ID, run an ordinary exact hash aggregate, then project away internal columns
- preserve duplicate grouping sets, rolled-up versus real NULLs, `GROUPING()` values, and empty-input semantics
- execute `DISTINCT`, `FILTER`, and ordered aggregates exactly after the shuffle; there is no gather fallback or compatibility path
- preserve grouping metadata and raw FILTER references across physical-plan serialization, and rebuild ordered aggregates in each worker context
- retain DuckDB's native grouping-set operator for single-partition plans

## Design

For multi-partition input the plan is:

`GroupingSetExpand -> hash Repartition -> HashAggregate -> Projection`

Expand evaluates the group expressions once per input chunk and emits:

`raw input columns + expanded group columns + GROUPING values + grouping-set occurrence ID + effective aggregate filters`

The occurrence ID is part of the shuffle/final-aggregate key. It preserves duplicate entries in `GROUPING SETS` and distinguishes grouping-set occurrences even when their public key and `GROUPING()` value are identical.

Each aggregate receives an effective filter. Real rows use `TRUE` or the query's original filter. One elected task also emits a synthetic, all-filters-false row for every empty grouping-set occurrence. Those rows create the required empty groups without changing any aggregate state, including on empty input.

Ordered aggregate bind data owns query-context-specific sort state, so task-plan construction first restores its portable pre-bind form; deserialization binds it again in the worker's active context.

## Tests

- native `[grouping_sets]`: 14 cases, 1559 assertions
- native `[distributed]`: 142 cases, 4302 assertions
- native `[serialization][physical_plan]`: 35 cases, 343 assertions
- targeted Ray grouping-set E2E matrix: passed
- `scripts/run_release_tests.sh`: passed, including the real-Ray shard

The E2E matrix covers ROLLUP, CUBE, real NULL keys, duplicate ordinary and empty grouping sets, zero/one/multiple `GROUPING()` functions, no aggregates, `DISTINCT`, `FILTER`, true ordered aggregates, combined modifiers, empty input, and single-partition execution.

Closes #279
