### PR TITLE
[fix](executor) Preserve finalization state across flush re-entry

### DIFF
--- a/external/duckdb/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -145,10 +145,19 @@ private:
 	//! source_chunk should be sent through the pipeline
 	bool next_batch_blocked = false;
 
+	enum class OperatorFlushState : uint8_t {
+		//! The current operator's FinalExecute callback should be invoked
+		NEEDS_FINALIZE,
+		//! The current output must be drained before invoking FinalExecute again
+		DRAINING_MORE_OUTPUT,
+		//! The current output must be drained before advancing to the next operator
+		DRAINING_FINAL_OUTPUT
+	};
+
 	//! Current operator being flushed
 	idx_t flushing_idx;
-	//! Whether the current flushing_idx should be flushed: this needs to be stored to make flushing code re-entrant
-	bool should_flush_current_idx = true;
+	//! Persist the current operator's finalization result while downstream operators drain its output
+	OperatorFlushState operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
 	//! Whether this executor should route source/operator/sink calls through ExecutionBatch callbacks
 	bool use_execution_batches = false;
 

--- a/external/duckdb/src/parallel/pipeline_executor.cpp
+++ b/external/duckdb/src/parallel/pipeline_executor.cpp
@@ -172,46 +172,53 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 			continue;
 		}
 
-		// This slightly awkward way of increasing the flushing idx is to make the code re-entrant: We need to call this
-		// method again in the case of a Sink returning BLOCKED.
-		if (!should_flush_current_idx && in_process_operators.empty()) {
-			should_flush_current_idx = true;
+		// Resolve the persisted FinalExecute result only after downstream operators (and any blocked sink retry)
+		// have drained the current output.
+		if (in_process_operators.empty()) {
+			switch (operator_flush_state) {
+			case OperatorFlushState::NEEDS_FINALIZE:
+				break;
+			case OperatorFlushState::DRAINING_MORE_OUTPUT:
+				operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
+				break;
+			case OperatorFlushState::DRAINING_FINAL_OUTPUT:
+				operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
+				flushing_idx++;
+				continue;
+			}
 		}
 
 		auto &curr_chunk =
 		    flushing_idx + 1 >= intermediate_chunks.size() ? final_chunk : *intermediate_chunks[flushing_idx + 1];
 		auto &current_operator = pipeline.operators[flushing_idx].get();
 
-		OperatorFinalizeResultType finalize_result;
-
 		if (in_process_operators.empty()) {
+			D_ASSERT(operator_flush_state == OperatorFlushState::NEEDS_FINALIZE);
 			curr_chunk.Reset();
 			if (&curr_chunk == &final_chunk) {
 				sink_input_counted = false;
 			}
 			StartOperator(current_operator);
-			finalize_result = current_operator.FinalExecute(context, curr_chunk, *current_operator.op_state,
-			                                                *intermediate_states[flushing_idx]);
+			auto finalize_result = current_operator.FinalExecute(context, curr_chunk, *current_operator.op_state,
+			                                                     *intermediate_states[flushing_idx]);
 			EndOperator(current_operator, &curr_chunk, current_operator.op_state.get(),
 			            intermediate_states[flushing_idx].get());
-			if (finalize_result == OperatorFinalizeResultType::BLOCKED) {
+			switch (finalize_result) {
+			case OperatorFinalizeResultType::HAVE_MORE_OUTPUT:
+				operator_flush_state = OperatorFlushState::DRAINING_MORE_OUTPUT;
+				break;
+			case OperatorFinalizeResultType::FINISHED:
+				operator_flush_state = OperatorFlushState::DRAINING_FINAL_OUTPUT;
+				break;
+			case OperatorFinalizeResultType::BLOCKED:
 				D_ASSERT(curr_chunk.size() == 0);
-				should_flush_current_idx = true;
 				blocked_on_finalize = true;
 				return false;
 			}
-		} else {
-			// Reset flag and reflush the last chunk we were flushing.
-			finalize_result = OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 		}
 
+		D_ASSERT(operator_flush_state != OperatorFlushState::NEEDS_FINALIZE);
 		auto push_result = ExecutePushInternal(curr_chunk, chunk_budget, flushing_idx + 1);
-
-		if (finalize_result == OperatorFinalizeResultType::HAVE_MORE_OUTPUT) {
-			should_flush_current_idx = true;
-		} else {
-			should_flush_current_idx = false;
-		}
 
 		switch (push_result) {
 		case OperatorResultType::BLOCKED: {
@@ -227,10 +234,6 @@ bool PipelineExecutor::TryFlushCachingOperators(ExecutionBudget &chunk_budget) {
 			return false;
 		}
 		case OperatorResultType::NEED_MORE_INPUT:
-			if (!should_flush_current_idx) {
-				// FinalExecute returned FINISHED for this operator — advance past it
-				flushing_idx++;
-			}
 			continue;
 		case OperatorResultType::FINISHED:
 			break;
@@ -256,43 +259,53 @@ bool PipelineExecutor::TryFlushCachingOperatorsBatch(ExecutionBudget &chunk_budg
 			continue;
 		}
 
-		if (!should_flush_current_idx && in_process_operators.empty()) {
-			should_flush_current_idx = true;
+		// Resolve the persisted FinalExecute result only after downstream operators (and any blocked sink retry)
+		// have drained the current output.
+		if (in_process_operators.empty()) {
+			switch (operator_flush_state) {
+			case OperatorFlushState::NEEDS_FINALIZE:
+				break;
+			case OperatorFlushState::DRAINING_MORE_OUTPUT:
+				operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
+				break;
+			case OperatorFlushState::DRAINING_FINAL_OUTPUT:
+				operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
+				flushing_idx++;
+				continue;
+			}
 		}
 
 		auto &curr_batch =
 		    flushing_idx + 1 >= intermediate_batches.size() ? final_batch : *intermediate_batches[flushing_idx + 1];
 		auto &current_operator = pipeline.operators[flushing_idx].get();
 
-		OperatorFinalizeResultType finalize_result;
-
 		if (in_process_operators.empty()) {
+			D_ASSERT(operator_flush_state == OperatorFlushState::NEEDS_FINALIZE);
 			curr_batch = ExecutionBatch();
 			if (&curr_batch == &final_batch) {
 				sink_input_counted = false;
 			}
 			StartOperator(current_operator);
-			finalize_result = current_operator.FinalExecuteBatch(context, curr_batch, *current_operator.op_state,
-			                                                     *intermediate_states[flushing_idx]);
+			auto finalize_result = current_operator.FinalExecuteBatch(context, curr_batch, *current_operator.op_state,
+			                                                          *intermediate_states[flushing_idx]);
 			EndOperator(current_operator, ExecutionBatchMaterializedChunk(curr_batch), current_operator.op_state.get(),
 			            intermediate_states[flushing_idx].get());
-			if (finalize_result == OperatorFinalizeResultType::BLOCKED) {
+			switch (finalize_result) {
+			case OperatorFinalizeResultType::HAVE_MORE_OUTPUT:
+				operator_flush_state = OperatorFlushState::DRAINING_MORE_OUTPUT;
+				break;
+			case OperatorFinalizeResultType::FINISHED:
+				operator_flush_state = OperatorFlushState::DRAINING_FINAL_OUTPUT;
+				break;
+			case OperatorFinalizeResultType::BLOCKED:
 				D_ASSERT(ExecutionBatchSize(curr_batch) == 0);
-				should_flush_current_idx = true;
 				blocked_on_finalize = true;
 				return false;
 			}
-		} else {
-			finalize_result = OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 		}
 
+		D_ASSERT(operator_flush_state != OperatorFlushState::NEEDS_FINALIZE);
 		auto push_result = ExecutePushInternalBatch(curr_batch, chunk_budget, flushing_idx + 1);
-
-		if (finalize_result == OperatorFinalizeResultType::HAVE_MORE_OUTPUT) {
-			should_flush_current_idx = true;
-		} else {
-			should_flush_current_idx = false;
-		}
 
 		switch (push_result) {
 		case OperatorResultType::BLOCKED: {
@@ -306,9 +319,6 @@ bool PipelineExecutor::TryFlushCachingOperatorsBatch(ExecutionBudget &chunk_budg
 			return false;
 		}
 		case OperatorResultType::NEED_MORE_INPUT:
-			if (!should_flush_current_idx) {
-				flushing_idx++;
-			}
 			continue;
 		case OperatorResultType::FINISHED:
 			break;

--- a/external/duckdb/test/api/test_api.cpp
+++ b/external/duckdb/test/api/test_api.cpp
@@ -479,6 +479,27 @@ TEST_CASE("Test TryFlushCachingOperators interrupted ExecutePushInternal", "[api
 	}
 }
 
+TEST_CASE("Test completed FinalExecute output is not finalized again", "[api]") {
+	DuckDB db;
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("SET scheduler_process_partial = true"));
+	REQUIRE_NO_FAIL(con.Query("PRAGMA threads=1"));
+	// The streaming LEAD emits its delayed row together with FINISHED. UNNEST depletes the execution budget while
+	// pushing that row downstream, forcing the flush state machine to resume before the output is fully drained.
+	auto result = con.Query(R"(
+		SELECT count(*), sum(x)
+		FROM (
+			SELECT unnest(range(200000)) AS u, x
+			FROM (SELECT lead(i, 1, 7) OVER () AS x FROM range(1) t(i))
+			LIMIT 200001
+		)
+	)");
+	REQUIRE(!result->HasError());
+	REQUIRE(CHECK_COLUMN(result, 0, {Value::BIGINT(200000)}));
+	REQUIRE(CHECK_COLUMN(result, 1, {Value::BIGINT(1400000)}));
+}
+
 TEST_CASE("Test streaming query during stack unwinding", "[api]") {
 	DuckDB db;
 	Connection con(db);


### PR DESCRIPTION
## Summary

- persist whether a finalizing operator has more output or has already finished while downstream output drains
- advance after final output without invoking `FinalExecute`/`FinalExecuteBatch` again, while preserving `HAVE_MORE_OUTPUT` and `BLOCKED` retry behavior
- add a default-running partial-scheduler regression using streaming `LEAD` followed by `UNNEST`

## Root cause

`FinalExecute`/`FinalExecuteBatch` could return `FINISHED` with output, but a downstream `HAVE_MORE_OUTPUT` or `BLOCKED` re-entry lost that completed result and invoked the same finalizer again. The boolean state could not distinguish “drain before calling again” from “drain before advancing.”

The fix replaces that boolean with an explicit three-state transition:

- `NEEDS_FINALIZE`
- `DRAINING_MORE_OUTPUT`
- `DRAINING_FINAL_OUTPUT`

The saved state is resolved only after downstream operators and any blocked sink retry have fully drained the current output.

## Testing

- clean `upstream/main` (`c0735b8b70b8978b86102d7de48e52dbe0cffba7`) red proof: the new regression returned `(200001, 1400007)` instead of `(200000, 1400000)`
- patched regression: passed 10 consecutive runs and is discoverable in the default `[api]` suite
- batch and non-batch flush paths: regression passed in both modes
- related caching/flush tests: 3 test cases and 400,009 assertions passed in both modes
- multi-finalizer and multi-batch `HAVE_MORE_OUTPUT` diagnostics passed
- required incremental native install succeeded; installed extension returned `(200000, 1400000)`
- `scripts/run_release_tests.sh`: 455 non-Ray tests passed (1 skipped), then 10 real-Ray tests passed
- full native suite: 4,551 passed and 19 failed; the same 19 failures reproduce on the clean base commit (including the same empty-vector, ordering, and unavailable test-extension failures), so no new full-suite failure was introduced
- `scripts/format duckdb --changed` and `git diff --check` passed

Closes #292
