### PR TITLE
[fix](vllm) Retire producers after downstream LIMIT

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -341,6 +341,24 @@ struct VLLMOperatorState : public OperatorState {
 	VLLMOperatorState(ClientContext &context, const Expression &prompt_expr) : prompt_executor(context, prompt_expr) {
 	}
 
+	void FinishSubmitting(ClientContext &context, VLLMGlobalOperatorState &gstate) {
+		if (finished_submitting) {
+			return;
+		}
+		finished_submitting = true;
+		gstate.ThreadFinishedSubmitting(context);
+	}
+
+	void Finalize(const PhysicalOperator &op, ExecutionContext &context) override {
+		if (!op.op_state) {
+			throw InternalException("vllm operator state is missing during local finalization");
+		}
+		// A downstream operator can finish the pipeline before this operator's
+		// FinalExecute runs. Retire this producer without submitting buffered
+		// work so the global producer barrier can still complete.
+		FinishSubmitting(context.client, op.op_state->Cast<VLLMGlobalOperatorState>());
+	}
+
 	ExpressionExecutor prompt_executor;
 
 	vector<BufferedVLLMInput> buffer;
@@ -660,8 +678,7 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 			gstate.EnsureExecutor(context);
 			PopAndSubmitTasks(context, gstate, state, 0);
 		}
-		state.finished_submitting = true;
-		gstate.ThreadFinishedSubmitting(context.client);
+		state.FinishSubmitting(context.client, gstate);
 	}
 
 	if (!gstate.HasExecutor()) {

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -99,7 +99,7 @@ class _DeferredWakeupExecutor(_RecordingExecutor):
             callback()
 
 
-def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=1):
+def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=1, query_suffix=""):
     import duckdb
     import duckdb.execution.vllm as vllm
 
@@ -119,7 +119,10 @@ def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=
         )
         encoded = json.dumps(options, separators=(",", ":"))
         rows = con.execute(
-            "SELECT id, prompt, vllm(prompt, 'recording-model', '" + encoded + "') AS generated FROM vllm_input"
+            "SELECT id, prompt, vllm(prompt, 'recording-model', '"
+            + encoded
+            + "') AS generated FROM vllm_input"
+            + query_suffix
         ).fetchall()
         return executor, rows
     finally:
@@ -379,6 +382,25 @@ def test_native_finalizer_blocks_and_resumes_through_a_one_shot_callback(monkeyp
     assert executor.finished_count == 1
     assert not executor.pending
     assert not executor.invalid_wait
+
+
+def test_native_downstream_limit_retires_producer_when_final_execute_is_skipped(monkeypatch):
+    prompts = [f"prompt-{index}" for index in range(5000)]
+    executor, rows = _run_recording_sql(
+        monkeypatch,
+        prompts,
+        {
+            "do_prefix_routing": False,
+            "batch_size": None,
+            "inflight_limit": 0,
+        },
+        threads=1,
+        query_suffix=" LIMIT 1",
+    )
+
+    assert rows == [(0, "prompt-0", "generated:prompt-0")]
+    assert sum(len(submitted) for _, submitted in executor.submissions) < len(prompts)
+    assert executor.finished_count == 1
 
 
 def test_distributed_collection_keeps_explicit_pool_names_query_scoped():


### PR DESCRIPTION
## Summary

Downstream operators such as LIMIT can finish a pipeline before the vLLM operator reaches FinalExecute. The skipped completion notification leaves the global producer-finalization barrier waiting for a producer that will never arrive.

VLLMOperatorState now shares an idempotent FinishSubmitting transition between the normal FinalExecute path and local state finalization. Early downstream completion retires the producer without submitting its buffered work, so the barrier completes while LIMIT retains its short-circuit behavior.

A native regression covers the downstream LIMIT path and verifies both the exact-once producer notification and early input cutoff.

## Related issue

close: #274

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in AstroVela/vane-website.

This is an internal native lifecycle correction with no public API or configuration change.

## Validation

- PATH="$PWD/.venv/bin:$PATH" scripts/format workspace --changed — passed.
- Incremental Release reinstall with SKBUILD_BUILD_DIR="$PWD/build/python-release", SKBUILD_CMAKE_BUILD_TYPE=Release, and extension autoload/autoinstall disabled — passed.
- python -m pytest tests/fast/test_vllm_native_regressions.py — 26 passed.
- python -m pytest tests/fast/test_vllm_runtime_fixes.py tests/fast/test_vllm_sampling_param_fold.py — 82 passed.
- scripts/run_release_tests.sh — non-Ray: 455 passed, 1 skipped, 14 deselected; real-Ray: 10 passed, 460 deselected.
- Final focused LIMIT regression rerun — 1 passed.
- Runtime DuckDB SourceID 27b0637cd4 matched the source tree 27b0637cd4d5980fa24e16cfc9cfd7abd65c1ef0.
- git diff --check — passed.

No real-model or GPU-backed vLLM inference was run; native execution used the recording executor test double.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. None were added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. The change only adjusts native operator lifecycle bookkeeping and adds no new input or execution surface.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.