### PR TITLE
[fix](distributed) Quiesce COPY losers before commit

### DIFF
--- a/duckdb/runners/fte/backends/native/backend.py
+++ b/duckdb/runners/fte/backends/native/backend.py
@@ -50,6 +50,26 @@ _FRAGMENT_STAT_KEYS = (
 )
 
 
+async def _to_thread_with_owned_side_effects(
+    callback: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Do not expose cancellation until a synchronous task mutation has finished."""
+    thread_task = asyncio.create_task(asyncio.to_thread(callback, *args, **kwargs))
+    cancellation: asyncio.CancelledError | None = None
+    while not thread_task.done():
+        try:
+            await asyncio.shield(thread_task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+    result = thread_task.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
 def _native_submit_debug_enabled() -> bool:
     for name in ("VANE_FTE_ADMISSION_DEBUG", "DUCKDB_DISTRIBUTED_DEBUG"):
         value = os.getenv(name, "")
@@ -346,6 +366,10 @@ class _BackgroundEventLoop:
                 return future.result()
             future.cancel()
             raise TimeoutError(f"native FTE event-loop operation timed out after {timeout_s:.3f}s") from exc
+
+    def run_owned_side_effects(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        """Wait without a fixed timeout until owned side effects are terminal."""
+        return self.submit(coro).result()
 
     def request_shutdown(self) -> None:
         """Fence new work and ask the loop thread to begin teardown."""
@@ -1181,7 +1205,7 @@ class NativeWorkerHandle:
         request_payload = dict(request)
         if inspect.iscoroutinefunction(self._execute_fn):
             return await self._execute_fn(request_payload)
-        return await asyncio.to_thread(self._execute_fn, request_payload)
+        return await _to_thread_with_owned_side_effects(self._execute_fn, request_payload)
 
     def fte_create_task(self, request: Mapping[str, Any]) -> dict[str, Any]:
         return _as_status("fte_create_task", self._loop.run(self._manager.create_task(dict(request))))
@@ -1267,10 +1291,17 @@ class NativeWorkerHandle:
         return _as_status("fte_get_task_info", self._loop.run(self._manager.get_task_info(task_id)))
 
     def fte_cancel_task(self, task_id: str | Mapping[str, Any]) -> dict[str, Any]:
-        return _as_status("fte_cancel_task", self._loop.run(self._manager.cancel_task(task_id)))
+        # A successful cancellation is a barrier for task-owned writes. The
+        # normal operation timeout must not expose a still-running writer.
+        return _as_status(
+            "fte_cancel_task",
+            self._loop.run_owned_side_effects(self._manager.cancel_task(task_id)),
+        )
 
     def fte_drop_query(self, query_id: str) -> dict[str, int]:
-        result = self._loop.run(self._manager.drop_query(str(query_id)))
+        # Query drop is also a barrier for task-owned writes and must not
+        # return while a canceled synchronous execution can still mutate data.
+        result = self._loop.run_owned_side_effects(self._manager.drop_query(str(query_id)))
         if not isinstance(result, Mapping):
             raise TypeError("fte_drop_query must return a mapping")
         return {str(key): int(value) for key, value in result.items()}

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -342,6 +342,7 @@ class FteTaskExecution:
         self._result_release_count = 0
         self._status_lock = threading.RLock()
         self._future: asyncio.Task[Any] | None = None
+        self._cancel_requested = False
         self._split_update_event = asyncio.Event()
         self._status_condition = asyncio.Condition()
         self._execution_started = False
@@ -690,10 +691,18 @@ class FteTaskExecution:
                     self.release_result(reason="task_failed")
                 except Exception:
                     pass
-            self._transition(
-                FteTaskState.FAILED,
-                failure=_failure_payload_from_exception(exc),
-            )
+            with self._status_lock:
+                cancel_requested = self._cancel_requested
+            if cancel_requested:
+                self._transition(
+                    FteTaskState.CANCELED,
+                    failure=_task_canceled_failure_payload(self.task_id),
+                )
+            else:
+                self._transition(
+                    FteTaskState.FAILED,
+                    failure=_failure_payload_from_exception(exc),
+                )
 
     def _complete_dynamic_source_splits(self) -> None:
         queues = [
@@ -1010,13 +1019,40 @@ class FteTaskExecution:
             queue.cancel()
         for queue in self.dynamic_scan_source_queues.values():
             queue.cancel()
-        if self._future is not None and not self._future.done():
-            self._future.cancel()
+        with self._status_lock:
+            self._cancel_requested = True
+            future = self._future
+        if future is not None and not future.done():
+            future.cancel()
+            self._split_update_event.set()
+            return self.status
         self._split_update_event.set()
         self._transition(
             FteTaskState.CANCELED,
             failure=_task_canceled_failure_payload(self.task_id),
         )
+        return self.status
+
+    async def wait_for_cancellation_barrier(self) -> TaskStatus:
+        future = self._future
+        if future is not None:
+            while not future.done():
+                try:
+                    await asyncio.shield(future)
+                except asyncio.CancelledError:
+                    if not future.done():
+                        raise
+            try:
+                future.result()
+            except asyncio.CancelledError:
+                pass
+        with self._status_lock:
+            needs_transition = self._cancel_requested and self.status.state not in _TERMINAL_STATES
+        if needs_transition:
+            self._transition(
+                FteTaskState.CANCELED,
+                failure=_task_canceled_failure_payload(self.task_id),
+            )
         return self.status
 
     def _log_result_lifecycle(self, event: str, *, result: Any = None, **fields: Any) -> None:
@@ -1476,6 +1512,7 @@ class FteWorkerTaskManager:
         except ValueError:
             pass
         execution.cancel()
+        await execution.wait_for_cancellation_barrier()
         execution.release_result(reason="cancel_task")
         self.running_tasks.discard(key)
         self._sync_udf_active_fte_fragment_tasks()
@@ -1487,9 +1524,26 @@ class FteWorkerTaskManager:
     async def drop_query(self, query_id: str) -> dict[str, int]:
         query_id = str(query_id)
         task_keys = list(self.query_tasks.get(query_id, ()))
+        canceled_task_keys: set[str] = set()
+        cancellation_errors: dict[str, BaseException] = {}
+        for key in task_keys:
+            execution = self.tasks.get(key)
+            if execution is None:
+                continue
+            try:
+                self.queued_tasks.remove(key)
+            except ValueError:
+                pass
+            try:
+                if execution.status.state not in _TERMINAL_STATES:
+                    execution.cancel()
+                    canceled_task_keys.add(key)
+            except BaseException as exc:
+                cancellation_errors[key] = exc
+
         removed = 0
         canceled = 0
-        errors: list[tuple[str, BaseException]] = []
+        errors = list(cancellation_errors.items())
         for key in task_keys:
             execution = self.tasks.get(key)
             if execution is None:
@@ -1497,15 +1551,12 @@ class FteWorkerTaskManager:
                 if query_tasks is not None:
                     query_tasks.discard(key)
                 continue
+            if key in cancellation_errors:
+                continue
+            canceled_task = key in canceled_task_keys
             try:
-                self.queued_tasks.remove(key)
-            except ValueError:
-                pass
-            canceled_task = False
-            try:
-                if execution.status.state not in _TERMINAL_STATES:
-                    execution.cancel()
-                    canceled_task = True
+                if canceled_task:
+                    await execution.wait_for_cancellation_barrier()
                 execution.release_result(reason="drop_query")
                 dropped_status = self._publish_status(execution)
                 dropped_status.pop("result", None)

--- a/duckdb/runners/ray/fragment_worker_task_control.py
+++ b/duckdb/runners/ray/fragment_worker_task_control.py
@@ -158,7 +158,17 @@ class FteWorkerTaskControlMixin:
         cancel_event: Any = None,
         honor_query_deadline: bool = True,
         on_cancel: Callable[[], None] | None = None,
+        wait_for_owned_side_effects: bool = False,
     ) -> Any:
+        if wait_for_owned_side_effects:
+            # A successful cancellation may gate a COPY commit. No local
+            # control, query, or ObjectRef timeout may outlive its writer.
+            return resolve_object_refs_blocking(
+                ref,
+                timeout=None,
+                honor_query_deadline=False,
+                honor_object_get_timeout=False,
+            )
         resolved_timeout_s = _fte_control_rpc_timeout_s() if timeout_s is None else max(0.0, float(timeout_s))
         if cancel_event is not None:
             try:
@@ -216,6 +226,7 @@ class FteWorkerTaskControlMixin:
         *args: Any,
         timeout_s: float | None = None,
         cancel_event: Any = None,
+        wait_for_owned_side_effects: bool = False,
     ) -> Any:
         tracked_query_id: str | None = None
         owns_registry_operation = False
@@ -243,6 +254,7 @@ class FteWorkerTaskControlMixin:
                 timeout_s=timeout_s,
                 cancel_event=cancel_event,
                 on_cancel=on_cancel,
+                wait_for_owned_side_effects=wait_for_owned_side_effects,
             )
         finally:
             if owns_registry_operation:
@@ -780,7 +792,11 @@ class FteWorkerTaskControlMixin:
             )
 
     def fte_cancel_task(self, task_id: str | dict[str, Any]) -> dict[str, Any]:
-        raw_status = self._enqueue_ordered_fte_control_rpc("fte_cancel_task", task_id)
+        raw_status = self._enqueue_ordered_fte_control_rpc(
+            "fte_cancel_task",
+            task_id,
+            wait_for_owned_side_effects=True,
+        )
         if not isinstance(raw_status, dict):
             raise TypeError("worker actor fte_cancel_task must return a dict")
         return dict(raw_status)

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -78,6 +78,20 @@ _CONNECTION_SNAPSHOT_SECURITY_SETTINGS = frozenset(
 )
 
 
+async def _await_future_with_owned_side_effects(future: asyncio.Future[Any]) -> Any:
+    """Do not expose cancellation until a future-owned mutation has finished."""
+    cancellation: asyncio.CancelledError | None = None
+    while not future.done():
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError as error:
+            cancellation = error
+    result = future.result()
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
 async def _to_thread_with_owned_side_effects(
     callback: Callable[..., Any],
     /,
@@ -86,16 +100,7 @@ async def _to_thread_with_owned_side_effects(
 ) -> Any:
     """Do not expose cancellation until a thread-owned mutation has finished."""
     thread_task = asyncio.create_task(asyncio.to_thread(callback, *args, **kwargs))
-    cancellation: asyncio.CancelledError | None = None
-    while not thread_task.done():
-        try:
-            await asyncio.shield(thread_task)
-        except asyncio.CancelledError as error:
-            cancellation = error
-    result = thread_task.result()
-    if cancellation is not None:
-        raise cancellation
-    return result
+    return await _await_future_with_owned_side_effects(thread_task)
 
 
 def _fte_applied_control_status(
@@ -2019,7 +2024,7 @@ class RayWorkerActor:
             finally:
                 self._end_worker_native_execution(query_id)
             raise
-        result_list = await asyncio.shield(native_future)
+        result_list = await _await_future_with_owned_side_effects(native_future)
         (
             payloads,
             partition_metadatas,

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -1033,113 +1033,6 @@ inline DuckDBResult<void> WriteDistributedCopyFinalizeCommittedMarker(FileSystem
 	return WriteDistributedCopyTextFileAtomically(fs, paths.committed_marker_path, "committed\n");
 }
 
-inline void
-CleanupDistributedCopyDirectWriteUnselectedFiles(FileSystem &fs, const std::string &direct_write_run_dir,
-                                                 const std::vector<DistributedCopyFileInfo> &selected_files) {
-	if (direct_write_run_dir.empty()) {
-		return;
-	}
-
-	std::unordered_set<std::string> selected_paths;
-	for (const auto &info : selected_files) {
-		if (!info.final_path.empty()) {
-			selected_paths.insert(info.final_path);
-		}
-	}
-
-	std::vector<std::string> all_files;
-	try {
-		ListDistributedCopyFilesRecursive(fs, direct_write_run_dir, all_files);
-	} catch (const std::exception &ex) {
-		return;
-	} catch (...) {
-		return;
-	}
-
-	for (const auto &path : all_files) {
-		if (selected_paths.find(path) != selected_paths.end()) {
-			continue;
-		}
-		try {
-			fs.RemoveFile(path);
-		} catch (...) {
-		}
-	}
-}
-
-inline void
-CleanupDistributedCopyDirectTargetUnselectedFiles(FileSystem &fs, const std::string &base_path,
-                                                  const std::string &run_id,
-                                                  const std::vector<DistributedCopyFileInfo> &selected_files) {
-	if (base_path.empty() || run_id.empty()) {
-		return;
-	}
-
-	std::unordered_set<std::string> selected_paths;
-	std::unordered_set<std::string> scan_dirs;
-	scan_dirs.insert(base_path);
-	for (const auto &info : selected_files) {
-		if (!info.final_path.empty()) {
-			selected_paths.insert(info.final_path);
-			auto parent = StringUtil::GetFilePath(info.final_path);
-			if (!parent.empty()) {
-				scan_dirs.insert(parent);
-			}
-		}
-	}
-
-	for (const auto &dir : scan_dirs) {
-		std::vector<std::string> all_files;
-		try {
-			ListDistributedCopyFilesRecursive(fs, dir, all_files);
-		} catch (...) {
-			continue;
-		}
-
-		for (const auto &path : all_files) {
-			if (selected_paths.find(path) != selected_paths.end()) {
-				continue;
-			}
-			if (!CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(path), run_id)) {
-				continue;
-			}
-			try {
-				fs.RemoveFile(path);
-			} catch (...) {
-			}
-		}
-	}
-}
-
-inline bool DistributedCopyUsesDirectTargetLayout(FileSystem &fs, const std::string &base_path,
-                                                  const std::vector<DistributedCopyFileInfo> &files,
-                                                  const std::string &run_id) {
-	if (base_path.empty() || run_id.empty()) {
-		return false;
-	}
-	auto separator = fs.PathSeparator(base_path);
-	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(base_path, run_id, separator);
-	auto is_direct_target_path = [&](const std::string &path) {
-		if (!CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(path), run_id)) {
-			return false;
-		}
-		if (!DistributedCopyPathIsInDirectory(path, base_path, separator)) {
-			return false;
-		}
-		return !DistributedCopyPathIsInDirectory(path, direct_write_run_dir, separator);
-	};
-
-	for (const auto &info : files) {
-		if (!info.final_path.empty() && is_direct_target_path(info.final_path)) {
-			return true;
-		}
-		if (!info.staging_path.empty() && is_direct_target_path(info.staging_path)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 struct DistributedCopyPrefixCleanupResult {
 	bool existed = false;
 	bool removed = false;
@@ -1168,6 +1061,135 @@ inline DuckDBResult<void> RemoveDistributedCopyFiles(FileSystem &fs, const std::
 		}
 	}
 	return DuckDBResult<void>::ok();
+}
+
+inline DuckDBResult<void>
+CleanupDistributedCopyDirectWriteUnselectedFiles(FileSystem &fs, const std::string &direct_write_run_dir,
+                                                 const std::vector<DistributedCopyFileInfo> &selected_files) {
+	if (direct_write_run_dir.empty()) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::value_error("distributed COPY direct-write cleanup requires a run directory"));
+	}
+
+	std::unordered_set<std::string> selected_paths;
+	for (const auto &info : selected_files) {
+		if (!info.final_path.empty()) {
+			selected_paths.insert(info.final_path);
+		}
+	}
+
+	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, direct_write_run_dir);
+	if (files_res.is_err()) {
+		return DuckDBResult<void>::err(files_res.error());
+	}
+	std::vector<std::string> unselected_files;
+	for (const auto &path : files_res.value()) {
+		if (selected_paths.find(path) == selected_paths.end()) {
+			unselected_files.push_back(path);
+		}
+	}
+	auto remove_res = RemoveDistributedCopyFiles(fs, unselected_files);
+	if (remove_res.is_err()) {
+		return remove_res;
+	}
+
+	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, direct_write_run_dir);
+	if (remaining_res.is_err()) {
+		return DuckDBResult<void>::err(remaining_res.error());
+	}
+	for (const auto &path : remaining_res.value()) {
+		if (selected_paths.find(path) == selected_paths.end()) {
+			return DuckDBResult<void>::err(DuckDBError::io_error(
+			    "distributed COPY unselected direct-write object still exists after cleanup: " + path));
+		}
+	}
+	return DuckDBResult<void>::ok();
+}
+
+inline DuckDBResult<void>
+CleanupDistributedCopyDirectTargetUnselectedFiles(FileSystem &fs, const std::string &base_path,
+                                                  const std::string &run_id,
+                                                  const std::vector<DistributedCopyFileInfo> &selected_files) {
+	if (base_path.empty() || run_id.empty()) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::value_error("distributed COPY direct-target cleanup requires base_path and run_id"));
+	}
+
+	std::unordered_set<std::string> selected_paths;
+	for (const auto &info : selected_files) {
+		if (!info.final_path.empty()) {
+			selected_paths.insert(info.final_path);
+		}
+	}
+
+	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
+	if (files_res.is_err()) {
+		return DuckDBResult<void>::err(files_res.error());
+	}
+	std::vector<std::string> unselected_files;
+	for (const auto &path : files_res.value()) {
+		if (selected_paths.find(path) != selected_paths.end()) {
+			continue;
+		}
+		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(path), run_id)) {
+			unselected_files.push_back(path);
+		}
+	}
+	auto remove_res = RemoveDistributedCopyFiles(fs, unselected_files);
+	if (remove_res.is_err()) {
+		return remove_res;
+	}
+
+	auto remaining_res = ListDistributedCopyFilesUnderPrefix(fs, base_path);
+	if (remaining_res.is_err()) {
+		return DuckDBResult<void>::err(remaining_res.error());
+	}
+	for (const auto &path : remaining_res.value()) {
+		if (selected_paths.find(path) != selected_paths.end()) {
+			continue;
+		}
+		if (CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(path), run_id)) {
+			return DuckDBResult<void>::err(DuckDBError::io_error(
+			    "distributed COPY unselected direct-target object still exists after cleanup: " + path));
+		}
+	}
+	return DuckDBResult<void>::ok();
+}
+
+inline bool DistributedCopyMayUseDirectTargetLayout(FileSystem &fs, const std::string &base_path,
+                                                    const std::vector<DistributedCopyFileInfo> &files,
+                                                    const std::string &run_id) {
+	if (base_path.empty() || run_id.empty()) {
+		return false;
+	}
+	// With no selected output, the layout cannot be inferred. Scan the direct
+	// target conservatively so loser files from an empty winning attempt are
+	// still removed.
+	if (files.empty()) {
+		return true;
+	}
+
+	auto separator = fs.PathSeparator(base_path);
+	auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(base_path, run_id, separator);
+	auto is_direct_target_path = [&](const std::string &path) {
+		if (!CopyDirectTargetFileNameMatchesRun(StringUtil::GetFileName(path), run_id)) {
+			return false;
+		}
+		if (!DistributedCopyPathIsInDirectory(path, base_path, separator)) {
+			return false;
+		}
+		return !DistributedCopyPathIsInDirectory(path, direct_write_run_dir, separator);
+	};
+
+	for (const auto &info : files) {
+		if (!info.final_path.empty() && is_direct_target_path(info.final_path)) {
+			return true;
+		}
+		if (!info.staging_path.empty() && is_direct_target_path(info.staging_path)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 inline DuckDBResult<DistributedCopyPrefixCleanupResult>
@@ -1586,6 +1608,7 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
                                                              std::string direct_write_run_id = std::string()) {
 	auto finalize_started = std::chrono::steady_clock::now();
 	const bool skip_move = staging_root.empty();
+	idx_t direct_write_cleanup_ms = 0;
 
 	DistributedCopyResult result;
 	result.files = std::move(files);
@@ -1613,7 +1636,6 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 	bool replaying_direct_write_manifest = false;
 	const bool direct_write_commit_enabled = skip_move && !direct_write_run_id.empty();
 	std::string direct_write_manifest_root;
-	std::string direct_write_cleanup_run_dir;
 	if (!skip_move) {
 		commit_paths = BuildDistributedCopyFinalizeCommitPathsFromStagingRoot(fs, base_path, staging_root);
 
@@ -1696,11 +1718,14 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 			auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(worker_base_path, direct_write_run_id,
 			                                                             fs.PathSeparator(worker_base_path));
 			auto cleanup_started = std::chrono::steady_clock::now();
-			CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_run_dir, committed_result.files);
-			if (DistributedCopyUsesDirectTargetLayout(fs, worker_base_path, committed_result.files,
-			                                          direct_write_run_id)) {
-				CleanupDistributedCopyDirectTargetUnselectedFiles(fs, worker_base_path, direct_write_run_id,
-				                                                  committed_result.files);
+			// A marker written by an older Vane version may predate loser cleanup.
+			// Preserve the committed outcome while repairing any files that are
+			// currently visible; new commits cannot reach this state.
+			(void)CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_run_dir, committed_result.files);
+			if (DistributedCopyMayUseDirectTargetLayout(fs, worker_base_path, committed_result.files,
+			                                            direct_write_run_id)) {
+				(void)CleanupDistributedCopyDirectTargetUnselectedFiles(fs, worker_base_path, direct_write_run_id,
+				                                                        committed_result.files);
 			}
 			committed_result.cleanup_ms = DistributedCopyElapsedMillis(cleanup_started);
 			return DuckDBResult<DistributedCopyResult>::ok(std::move(committed_result));
@@ -1830,13 +1855,28 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 					return DuckDBResult<DistributedCopyResult>::err(manifest_res.error());
 				}
 			}
+			auto direct_write_run_dir = BuildCopyDirectWriteRunDirectory(worker_base_path, direct_write_run_id,
+			                                                             fs.PathSeparator(worker_base_path));
+			auto cleanup_started = std::chrono::steady_clock::now();
+			auto run_cleanup_res =
+			    CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_run_dir, result.files);
+			if (run_cleanup_res.is_err()) {
+				return DuckDBResult<DistributedCopyResult>::err(run_cleanup_res.error());
+			}
+			if (DistributedCopyMayUseDirectTargetLayout(fs, worker_base_path, result.files, direct_write_run_id)) {
+				auto target_cleanup_res = CleanupDistributedCopyDirectTargetUnselectedFiles(
+				    fs, worker_base_path, direct_write_run_id, result.files);
+				if (target_cleanup_res.is_err()) {
+					return DuckDBResult<DistributedCopyResult>::err(target_cleanup_res.error());
+				}
+			}
+			direct_write_cleanup_ms = DistributedCopyElapsedMillis(cleanup_started);
+			result.cleanup_ms += direct_write_cleanup_ms;
 			auto marker_res = WriteDistributedCopyFinalizeCommittedMarker(fs, commit_paths);
 			if (marker_res.is_err()) {
 				return DuckDBResult<DistributedCopyResult>::err(marker_res.error());
 			}
 			AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, true);
-			direct_write_cleanup_run_dir = BuildCopyDirectWriteRunDirectory(worker_base_path, direct_write_run_id,
-			                                                                fs.PathSeparator(worker_base_path));
 		}
 	} else {
 		std::unordered_set<std::string> planned_final_paths;
@@ -1936,15 +1976,8 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 		                                DistributedCopyFinalizeRunIdFromStagingRoot(fs, staging_root), false, true);
 	}
 
-	result.finalize_ms = DistributedCopyElapsedMillis(finalize_started);
-	if (!direct_write_cleanup_run_dir.empty()) {
-		auto cleanup_started = std::chrono::steady_clock::now();
-		CleanupDistributedCopyDirectWriteUnselectedFiles(fs, direct_write_cleanup_run_dir, result.files);
-		if (DistributedCopyUsesDirectTargetLayout(fs, worker_base_path, result.files, direct_write_run_id)) {
-			CleanupDistributedCopyDirectTargetUnselectedFiles(fs, worker_base_path, direct_write_run_id, result.files);
-		}
-		result.cleanup_ms += DistributedCopyElapsedMillis(cleanup_started);
-	}
+	auto total_finalize_ms = DistributedCopyElapsedMillis(finalize_started);
+	result.finalize_ms = total_finalize_ms >= direct_write_cleanup_ms ? total_finalize_ms - direct_write_cleanup_ms : 0;
 	if (!staging_root.empty()) {
 		auto cleanup_started = std::chrono::steady_clock::now();
 		RemoveDistributedCopyDirectoryTree(fs, staging_root);

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -5,7 +5,11 @@
 #include "test_helpers.hpp"
 
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/virtual_file_system.hpp"
 #include "duckdb/execution/distributed/copy_finalize.hpp"
+
+#include <chrono>
+#include <thread>
 
 using namespace duckdb;
 using namespace duckdb::distributed;
@@ -187,14 +191,37 @@ public:
 	}
 
 	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
-		if (path == failed_path) {
+		if (fail_removal && path == failed_path) {
 			throw IOException("injected object removal failure");
 		}
 		LocalFileSystem::RemoveFile(path, opener);
 	}
 
+	void AllowRemoval() {
+		fail_removal = false;
+	}
+
 private:
 	string failed_path;
+	bool fail_removal = true;
+};
+
+class DelayedFileRemovalFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	DelayedFileRemovalFileSystem(string delayed_path, std::chrono::milliseconds delay)
+	    : delayed_path(std::move(delayed_path)), delay(delay) {
+	}
+
+	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == delayed_path) {
+			std::this_thread::sleep_for(delay);
+		}
+		LocalFileSystem::RemoveFile(path, opener);
+	}
+
+private:
+	string delayed_path;
+	std::chrono::milliseconds delay;
 };
 
 class DirectoryRemovalFailureFileSystem : public LocalFileSystem {
@@ -411,6 +438,127 @@ TEST_CASE("Distributed COPY temporary direct output preserves the canonical targ
 	REQUIRE(fs.FileExists(worker_file));
 	REQUIRE(fs.FileExists(output_path));
 	REQUIRE(ReadDistributedCopyTextFile(fs, output_path).value() == "old");
+}
+
+TEST_CASE("Distributed COPY direct-target empty result removes loser files before commit",
+          "[distributed][copy][lifecycle]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_empty_direct_target");
+	auto &fs = test_dir.fs;
+	auto base_path = fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-empty";
+	auto loser_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_loser", "part.parquet");
+	WriteTestFile(fs, loser_file, "loser");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id).is_ok());
+
+	DuckDB db(nullptr);
+	Connection connection(db);
+	DistributedCopySpec spec;
+	spec.file_path = base_path;
+	spec.file_extension = "parquet";
+	spec.per_thread_output = true;
+
+	auto finalize_res = FinalizeCopyFiles(spec, "", {}, *connection.context, run_id);
+
+	REQUIRE(finalize_res.is_ok());
+	REQUIRE(finalize_res.value().output_committed);
+	REQUIRE(finalize_res.value().files.empty());
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+	REQUIRE(fs.FileExists(commit_paths.committed_marker_path));
+	REQUIRE_FALSE(fs.FileExists(loser_file));
+}
+
+TEST_CASE("Distributed COPY direct-target cleanup failure prevents commit",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_cleanup_before_commit");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-cleanup-failure";
+	auto selected_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	auto loser_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_loser", "part.parquet");
+	const string selected_contents = "selected";
+	WriteTestFile(local_fs, selected_file, selected_contents);
+	WriteTestFile(local_fs, loser_file, "loser");
+
+	DBConfig config;
+	auto failure_fs = make_uniq<FileRemovalFailureFileSystem>(loser_file);
+	auto failure_fs_ptr = failure_fs.get();
+	config.file_system = make_uniq<VirtualFileSystem>(std::move(failure_fs));
+	DuckDB db(nullptr, &config);
+	Connection connection(db);
+	auto &fs = FileSystem::GetFileSystem(*connection.context);
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id).is_ok());
+
+	DistributedCopySpec spec;
+	spec.file_path = base_path;
+	spec.file_extension = "parquet";
+	spec.per_thread_output = true;
+	DistributedCopyFileInfo selected_info;
+	selected_info.staging_path = selected_file;
+	selected_info.row_count = 1;
+	selected_info.file_size_bytes = selected_contents.size();
+	vector<DistributedCopyFileInfo> selected_files;
+	selected_files.push_back(std::move(selected_info));
+
+	auto finalize_res = FinalizeCopyFiles(spec, "", std::move(selected_files), *connection.context, run_id);
+
+	REQUIRE(finalize_res.is_err());
+	REQUIRE(StringUtil::Contains(finalize_res.error().what(), "injected object removal failure"));
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+	REQUIRE(fs.FileExists(commit_paths.manifest_path));
+	REQUIRE_FALSE(fs.FileExists(commit_paths.committed_marker_path));
+	REQUIRE(fs.FileExists(selected_file));
+	REQUIRE(fs.FileExists(loser_file));
+
+	failure_fs_ptr->AllowRemoval();
+	auto retry_res = FinalizeCopyFiles(spec, "", {}, *connection.context, run_id);
+	REQUIRE(retry_res.is_ok());
+	REQUIRE(retry_res.value().output_committed);
+	REQUIRE(retry_res.value().files.size() == 1);
+	REQUIRE(fs.FileExists(commit_paths.committed_marker_path));
+	REQUIRE(fs.FileExists(selected_file));
+	REQUIRE_FALSE(fs.FileExists(loser_file));
+}
+
+TEST_CASE("Distributed COPY direct-target cleanup time is excluded from finalize time",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_exclusive_timing");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-exclusive-timing";
+	auto selected_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	auto loser_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_loser", "part.parquet");
+	const string selected_contents = "selected";
+	WriteTestFile(local_fs, selected_file, selected_contents);
+	WriteTestFile(local_fs, loser_file, "loser");
+
+	DBConfig config;
+	auto delayed_fs = make_uniq<DelayedFileRemovalFileSystem>(loser_file, std::chrono::milliseconds(150));
+	config.file_system = make_uniq<VirtualFileSystem>(std::move(delayed_fs));
+	DuckDB db(nullptr, &config);
+	Connection connection(db);
+	auto &fs = FileSystem::GetFileSystem(*connection.context);
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id).is_ok());
+
+	DistributedCopySpec spec;
+	spec.file_path = base_path;
+	spec.file_extension = "parquet";
+	spec.per_thread_output = true;
+	DistributedCopyFileInfo selected_info;
+	selected_info.staging_path = selected_file;
+	selected_info.row_count = 1;
+	selected_info.file_size_bytes = selected_contents.size();
+	vector<DistributedCopyFileInfo> selected_files;
+	selected_files.push_back(std::move(selected_info));
+
+	auto wall_started = std::chrono::steady_clock::now();
+	auto finalize_res = FinalizeCopyFiles(spec, "", std::move(selected_files), *connection.context, run_id);
+	auto wall_ms = DistributedCopyElapsedMillis(wall_started);
+
+	REQUIRE(finalize_res.is_ok());
+	const auto &result = finalize_res.value();
+	REQUIRE(result.cleanup_ms >= 100);
+	REQUIRE(result.finalize_ms + result.cleanup_ms <= wall_ms + 10);
+	REQUIRE_FALSE(fs.FileExists(loser_file));
 }
 
 TEST_CASE("Distributed COPY resolves relative and qualified list paths",

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -585,6 +585,7 @@ def test_native_worker_snapshots_report_resource_capacity():
 def test_native_worker_manager_drop_query_cancels_running_and_queued_tasks():
     started = threading.Event()
     release = threading.Event()
+    drop_errors: list[BaseException] = []
 
     def execute_fn(_request):
         started.set()
@@ -614,7 +615,23 @@ def test_native_worker_manager_drop_query_cancels_running_and_queued_tasks():
         assert snapshot["executor_running_task_count"] == 1
         assert snapshot["executor_queued_task_count"] == 1
 
-        backend.drop_query("query-drop")
+        def drop_query():
+            try:
+                backend.drop_query("query-drop")
+            except BaseException as exc:  # pragma: no cover - asserted below
+                drop_errors.append(exc)
+
+        drop_thread = threading.Thread(target=drop_query)
+        drop_thread.start()
+        time.sleep(0.05)
+
+        assert drop_thread.is_alive()
+        assert worker.fte_get_task_status_cached(task0)["state"] == FteTaskState.RUNNING.value
+
+        release.set()
+        drop_thread.join(timeout=2.0)
+        assert not drop_thread.is_alive()
+        assert drop_errors == []
 
         assert backend.pop_fte_result_handles("query-drop") == []
         query_status = backend.fte_query_status("query-drop")
@@ -628,6 +645,129 @@ def test_native_worker_manager_drop_query_cancels_running_and_queued_tasks():
     finally:
         release.set()
         backend.shutdown()
+
+
+def test_native_worker_cancel_barrier_outlives_operation_timeout():
+    started = threading.Event()
+    release = threading.Event()
+    background = _BackgroundEventLoop(
+        "native-fte-cancel-barrier-timeout",
+        operation_timeout_s=0.05,
+    )
+
+    def execute_fn(_request):
+        started.set()
+        assert release.wait(timeout=2.0)
+        return {"ok": True}
+
+    worker = NativeWorkerHandle(
+        "worker-cancel-barrier-timeout",
+        execute_fn,
+        loop=background,
+    )
+    task_id = _task_id(0, query_id="query-cancel-barrier-timeout")
+    cancel_results: list[dict[str, Any]] = []
+    cancel_errors: list[BaseException] = []
+    cancel_thread: threading.Thread | None = None
+    cancel_started = threading.Event()
+
+    try:
+        worker.fte_create_task(
+            {
+                "task_id": task_id,
+                "fragment_id": "query-cancel-barrier-timeout:copy",
+            }
+        )
+        assert started.wait(timeout=1.0)
+
+        def cancel_task():
+            cancel_started.set()
+            try:
+                cancel_results.append(worker.fte_cancel_task(task_id))
+            except BaseException as exc:  # pragma: no cover - asserted below
+                cancel_errors.append(exc)
+
+        cancel_thread = threading.Thread(target=cancel_task)
+        cancel_thread.start()
+        assert cancel_started.wait(timeout=1.0)
+        time.sleep(0.15)
+        outlived_operation_timeout = cancel_thread.is_alive()
+    finally:
+        release.set()
+        if cancel_thread is not None:
+            cancel_thread.join(timeout=2.0)
+        try:
+            worker.fte_drop_query("query-cancel-barrier-timeout")
+        finally:
+            background.shutdown()
+
+    assert outlived_operation_timeout
+    assert cancel_thread is not None
+    assert not cancel_thread.is_alive()
+    assert cancel_errors == []
+    assert cancel_results[0]["state"] == FteTaskState.CANCELED.value
+
+
+def test_native_worker_drop_query_barrier_outlives_operation_timeout():
+    started = threading.Event()
+    release = threading.Event()
+    background = _BackgroundEventLoop(
+        "native-fte-drop-barrier-timeout",
+        operation_timeout_s=0.05,
+    )
+
+    def execute_fn(_request):
+        started.set()
+        assert release.wait(timeout=2.0)
+        return {"ok": True}
+
+    worker = NativeWorkerHandle(
+        "worker-drop-barrier-timeout",
+        execute_fn,
+        loop=background,
+    )
+    query_id = "query-drop-barrier-timeout"
+    task_id = _task_id(0, query_id=query_id)
+    drop_results: list[dict[str, int]] = []
+    drop_errors: list[BaseException] = []
+    drop_thread: threading.Thread | None = None
+    drop_started = threading.Event()
+
+    try:
+        worker.fte_create_task(
+            {
+                "task_id": task_id,
+                "fragment_id": f"{query_id}:copy",
+            }
+        )
+        assert started.wait(timeout=1.0)
+
+        def drop_query():
+            drop_started.set()
+            try:
+                drop_results.append(worker.fte_drop_query(query_id))
+            except BaseException as exc:  # pragma: no cover - asserted below
+                drop_errors.append(exc)
+
+        drop_thread = threading.Thread(target=drop_query)
+        drop_thread.start()
+        assert drop_started.wait(timeout=1.0)
+        time.sleep(0.15)
+        outlived_operation_timeout = drop_thread.is_alive()
+    finally:
+        release.set()
+        if drop_thread is not None:
+            drop_thread.join(timeout=2.0)
+        try:
+            background.run_owned_side_effects(worker._manager.drop_query(query_id))
+        finally:
+            background.shutdown()
+
+    assert outlived_operation_timeout
+    assert drop_thread is not None
+    assert not drop_thread.is_alive()
+    assert drop_errors == []
+    assert drop_results == [{"removed": 1, "canceled": 1}]
 
 
 def test_native_worker_manager_drop_query_fans_out_after_worker_failure():

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -1385,6 +1385,61 @@ def test_fte_control_ref_preserves_query_deadline_when_wait_expires(monkeypatch)
         pending.cancel()
 
 
+def test_fte_cancel_barrier_outlives_configured_control_timeouts(monkeypatch):
+    query_id = "query-cancel-barrier-timeout"
+    task_id = {
+        "query_id": query_id,
+        "fragment_execution_id": 0,
+        "partition_id": 0,
+        "attempt_id": 1,
+    }
+    pending = Future()
+
+    class _DeferredCancel:
+        def options(self, **_kwargs):
+            return self
+
+        def remote(self, *_args):
+            return SimpleNamespace(future=lambda: pending)
+
+    actor = _FakeActor()
+    actor.fte_cancel_task = _DeferredCancel()
+    handle = RayWorkerActorHandle(actor, memory_capacity_bytes=1 << 60)
+    monkeypatch.setenv("VANE_FTE_CONTROL_RPC_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("VANE_RAY_OBJECT_GET_TIMEOUT_S", "0.05")
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", str(time.time() - 1.0))
+    cancel_results = []
+    cancel_errors = []
+    cancel_started = threading.Event()
+
+    def cancel_task():
+        cancel_started.set()
+        try:
+            cancel_results.append(handle.fte_cancel_task(task_id))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            cancel_errors.append(exc)
+
+    cancel_thread = threading.Thread(target=cancel_task)
+    cancel_thread.start()
+    assert cancel_started.wait(timeout=1.0)
+    time.sleep(0.15)
+    outlived_control_timeout = cancel_thread.is_alive()
+    pending.set_result(
+        {
+            "state": FteTaskState.CANCELED.value,
+            "task_id": task_id,
+            "_fte_control_operation": "fte_cancel_task",
+            "_fte_control_applied": True,
+        }
+    )
+    cancel_thread.join(timeout=2.0)
+
+    assert outlived_control_timeout
+    assert not cancel_thread.is_alive()
+    assert cancel_errors == []
+    assert cancel_results[0]["state"] == FteTaskState.CANCELED.value
+
+
 def test_ordered_add_ref_is_canceled_and_unowned_after_query_close(monkeypatch):
     query_id = "query-cancel-ordered-add"
     task_id = {

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -5386,6 +5386,41 @@ def test_fte_worker_task_manager_cancel_running_task():
     asyncio.run(run())
 
 
+def test_fte_worker_task_manager_cancel_waits_for_owned_execution_to_quiesce():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute_fn(_request):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+            raise
+
+    async def run():
+        manager = _fte_worker_task_manager(execute_fn)
+        task_id = "q.0.10.1"
+        await manager.create_task({"task_id": task_id, "fragment_id": "q:node:copy"})
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+        cancel_task = asyncio.create_task(manager.cancel_task(task_id))
+        await asyncio.sleep(0)
+
+        assert cancel_task.done() is False
+        status_while_writing = await manager.get_task_status(task_id)
+        assert status_while_writing["state"] == FteTaskState.RUNNING.value
+
+        release.set()
+        canceled = await asyncio.wait_for(cancel_task, timeout=1.0)
+
+        assert canceled["state"] == FteTaskState.CANCELED.value
+        assert manager.tasks[task_id]._future is not None
+        assert manager.tasks[task_id]._future.done() is True
+
+    asyncio.run(run())
+
+
 def test_fte_worker_task_manager_cancel_finished_loser_releases_result_immediately():
     result_payload = {"partition_refs": ["loser-object-ref"]}
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -4049,6 +4049,101 @@ def test_run_plan_return_uses_native_completed_sink_descriptor(monkeypatch):
     ]
 
 
+def test_run_plan_return_cancellation_waits_for_native_execution(monkeypatch):
+    from duckdb.runners.ray import worker as worker_module
+
+    events: list[tuple[str, str]] = []
+    native_started = threading.Event()
+    release_native = threading.Event()
+
+    def fake_require(name, hint=None):
+        assert hint
+        if name == "begin_flight_shuffle_query_execution":
+            return lambda query_id: events.append(("begin", query_id))
+        if name == "end_flight_shuffle_query_execution":
+            return lambda query_id: events.append(("end", query_id))
+        raise AssertionError(f"unexpected C++ binding lookup: {name}")
+
+    native_result = duckdb.ray_cxx.NativeDistributedTaskResult(
+        [],
+        [],
+        None,
+        [],
+        "ok",
+        31338,
+        None,
+        {},
+    )
+
+    class DummyWorker:
+        _env_overrides: dict[str, str] = {}
+
+        @staticmethod
+        def _begin_worker_native_execution(query_id):
+            events.append(("worker_begin", query_id))
+
+        @staticmethod
+        def _end_worker_native_execution(query_id):
+            events.append(("worker_end", query_id))
+
+        @staticmethod
+        def _worker_native_query_is_closing(_query_id):
+            return False
+
+        @staticmethod
+        def _execute_native_task(*args, **kwargs):
+            events.append(("execute", "query-native-cancel"))
+            native_started.set()
+            assert release_native.wait(timeout=2.0)
+            events.append(("write_complete", "query-native-cancel"))
+            return native_result
+
+    monkeypatch.setattr(worker_module, "require_ray_cxx_attr", fake_require)
+    actor_class = worker_module.RayWorkerActor.__ray_metadata__.modified_class
+    query_lease = {
+        "lease_id": "lease-native-cancel",
+        "query_id": "resource-query-native-cancel",
+        "execution_query_id": "query-native-cancel",
+        "stage_id": "stage-native-cancel",
+        "attempt_id": "query-native-cancel.0.0.1",
+        "target_output_block_bytes": 1,
+        "output_window_bytes": 1,
+    }
+
+    async def run():
+        task = asyncio.create_task(
+            actor_class.run_plan_return(
+                DummyWorker(),
+                object(),
+                None,
+                query_lease,
+            )
+        )
+        assert await asyncio.to_thread(native_started.wait, 1.0)
+
+        task.cancel()
+        await asyncio.sleep(0.05)
+
+        assert task.done() is False
+        assert ("end", "query-native-cancel") not in events
+        assert ("worker_end", "query-native-cancel") not in events
+
+        release_native.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1.0)
+
+    asyncio.run(run())
+
+    assert events == [
+        ("worker_begin", "query-native-cancel"),
+        ("begin", "query-native-cancel"),
+        ("execute", "query-native-cancel"),
+        ("write_complete", "query-native-cancel"),
+        ("end", "query-native-cancel"),
+        ("worker_end", "query-native-cancel"),
+    ]
+
+
 def test_normalize_native_task_result_rejects_legacy_shapes():
     with pytest.raises(TypeError, match="execute_native must return NativeDistributedTaskResult"):
         _normalize_native_task_result(([], [], None))


### PR DESCRIPTION
## Summary

- make successful FTE cancellation a quiescence barrier for synchronous/native task-owned side effects in both Ray and native backends
- make direct-write loser cleanup strict and publish the committed marker only after cleanup succeeds
- clean empty direct-target winners conservatively, retain manifest-based retry, and preserve already-committed replay semantics

## Correctness invariants

- a successful loser cancellation cannot be followed by a late native object-store write
- a new direct-write commit cannot become visible while an unselected run file is known to remain
- cleanup failure leaves the manifest replayable and the committed marker absent

## Tests

- `scripts/run_fast_tests.sh`
  - non-Ray: 6098 passed, 30 skipped, 9 xfailed
  - shared Ray cluster: 93 passed, 9 skipped
  - test-owned Ray clusters: 7 passed, 1 expected optional-dependency skip
- `scripts/run_release_tests.sh`: 460 passed, 1 skipped; real-Ray shard 10 passed
- affected Python/C++ binding suites: 455 passed
- native COPY lifecycle suite: 208 assertions across 16 cases
- `pre-commit` on all changed files

Closes #256