### PR TITLE
[fix](distributed) Preserve streaming UDF output schema

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/streaming_udf_passthrough.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/streaming_udf_passthrough.hpp
@@ -21,7 +21,7 @@ public:
 	                            vector<column_t> projected_input, optional_idx ordinality_idx,
 	                            vector<LogicalType> output_types, idx_t estimated_cardinality)
 	    : ctx_(InheritPipelineNodeContext(child, node_id, "StreamingUDF")),
-	      config_(BuildSchema(output_types), child ? child->config().execution_config() : DuckDBExecutionConfigRef(),
+	      config_(MakeSchemaRef(output_types), child ? child->config().execution_config() : DuckDBExecutionConfigRef(),
 	              child ? child->config().clustering_spec() : ClusteringSpec::unknown_with_num_partitions(1)),
 	      child_(std::move(child)), function_(std::move(function)), bind_data_(std::move(bind_data)),
 	      column_ids_(std::move(column_ids)), projected_input_(std::move(projected_input)),
@@ -87,13 +87,6 @@ public:
 	}
 
 private:
-	static SchemaRef BuildSchema(const vector<LogicalType> &output_types) {
-		if (output_types.empty()) {
-			return nullptr;
-		}
-		return std::make_shared<duckdb::LogicalType>(output_types[0]);
-	}
-
 	PipelineNodeContext ctx_;
 	PipelineNodeConfig config_;
 	PipelineNodeRef child_;

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -59,6 +59,7 @@
 #include "duckdb/execution/distributed/pipeline_node/expression_scan.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/pipeline_node/sort.hpp"
+#include "duckdb/execution/distributed/pipeline_node/streaming_udf_passthrough.hpp"
 #include "duckdb/execution/distributed/pipeline_node/window.hpp"
 #include "duckdb/planner/expression/bound_window_expression.hpp"
 
@@ -209,6 +210,20 @@ static idx_t SchemaColumnCount(const SchemaRef &schema) {
 
 static std::string SQLStringLiteral(const std::string &value) {
 	return "'" + StringUtil::Replace(value, "'", "''") + "'";
+}
+
+TEST_CASE("Streaming UDF passthrough schema preserves all output columns", "[distributed][udf]") {
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::VARCHAR};
+	StreamingUDFPassthroughNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {}, vector<column_t> {},
+	                                 optional_idx(), output_types, 0);
+
+	auto schema = node.config().schema();
+	REQUIRE(schema);
+	REQUIRE(schema->id() == LogicalTypeId::STRUCT);
+	const auto &columns = StructType::GetChildTypes(*schema);
+	REQUIRE(columns.size() == output_types.size());
+	REQUIRE(columns[0].second == output_types[0]);
+	REQUIRE(columns[1].second == output_types[1]);
 }
 
 TEST_CASE("PhysicalPlanTranslator: simple projection", "[distributed]") {

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -2762,6 +2762,68 @@ def test_ray_map_batches_udf(ray_runner, duckdb_conn, parquet_path):
     _assert_results_match(duckdb_conn, sql, parts, label)
 
 
+def test_ray_row_preserving_batch_udf_limit_preserves_output_schema(
+    ray_runner,
+    duckdb_conn,
+    tmp_path,
+    monkeypatch,
+):
+    pa = pytest.importorskip("pyarrow")
+    import vane
+
+    if ray is None:
+        pytest.skip("ray not installed")
+
+    label = "test_ray_e2e: row-preserving batch UDF across streaming limit"
+    input_path = tmp_path / "row_preserving_udf_limit"
+    shuffle_dir = tmp_path / "row_preserving_udf_limit_shuffle"
+    monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", str(shuffle_dir))
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                i::INTEGER AS x,
+                floor(i / 4)::INTEGER AS file_id
+            FROM range(0, 16) AS t(i)
+        ) TO '{input_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+
+    def add_one(table):
+        values = table.column("x").to_pylist()
+        return pa.table({"y": [value + 1 for value in values]})
+
+    base = duckdb_conn.sql(f"SELECT x FROM read_parquet('{input_path}/**/*.parquet')")
+    expression = vane.func.batch(
+        add_one,
+        inputs={"x": vane.col("x")},
+        schema={"y": "INTEGER"},
+        row_preserving=True,
+    )
+    relation = base.select(vane.col("x"), expression.alias("y")).limit(5)
+
+    ray_cxx = getattr(duckdb, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("duckdb.ray_cxx.PyLogicalPlan not available in this environment")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"{label}-plan")
+    distributed_plan = logical_plan.to_physical_plan(duckdb_conn)
+    descriptor_counts = [len(descriptors) for descriptors in distributed_plan.scan_task_descriptor_map().values()]
+    assert descriptor_counts == [4], f"{label}: expected four scan tasks, got {descriptor_counts}"
+    assert distributed_plan.num_partitions() == 4
+    plan_text = distributed_plan.repr_ascii(False).upper()
+    assert "STREAMINGUDF" in plan_text
+    assert "STREAMINGLIMIT" in plan_text
+
+    parts = _run_iter_tables(ray_runner, relation, label, timeout_s=60.0)
+    rows = _collect_result_rows(parts)
+
+    assert len(rows) == 5
+    assert all(len(row) == 2 for row in rows)
+    assert all(int(y) == int(x) + 1 for x, y in rows)
+
+
 def test_ray_python_stream_table_udf(ray_runner, duckdb_conn, parquet_path):
     pytest.importorskip("pyarrow")
     if ray is None:


### PR DESCRIPTION
## Summary

- build the distributed `StreamingUDF` node schema from every physical output type instead of only `output_types[0]`
- add a native regression test for multi-column streaming UDF schemas
- add a four-scan-task Ray regression covering a row-preserving batch UDF followed by a distributed `LIMIT` coordinator

## Root cause

The row-preserving streaming UDF emits passthrough columns together with its UDF result columns, but its pipeline-node configuration advertised only the first type. `StreamingLimit` copied that incomplete schema into the materialized coordinator, so the Flight exchange source expected one column while the exchange partitions contained multiple columns.

Using the shared `MakeSchemaRef` helper preserves the existing empty- and single-column behavior and represents multi-column output as a struct schema that the coordinator expands back into the complete physical type list.

## Testing

- `VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed scripts/run_native_tests.sh "Streaming UDF passthrough schema preserves all output columns"`
- `VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed scripts/run_native_tests.sh "[distributed]"` (140 cases, 4273 assertions)
- `python -m pytest tests/fast/test_ray_e2e.py::test_ray_row_preserving_batch_udf_limit_preserves_output_schema`
- `scripts/run_release_tests.sh` (459 non-Ray passed, 1 skipped; 10 real-Ray passed)
- `VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh non-ray` (5943 passed)
- `VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh shared-ray` (91 passed)
- `VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh owner-ray` (7 independent owner tests passed)

Fixes #283
