### PR TITLE
[fix](distributed) Fail closed on ambiguous COPY commits

### DIFF
--- a/duckdb/runners/__init__.py
+++ b/duckdb/runners/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import duckdb as _duckdb_pkg
+from duckdb.runners.copy_outcome import CopyOutcomeUnknownError
 
 if TYPE_CHECKING:
     from duckdb.runners.runner import Runner
@@ -18,6 +19,7 @@ from duckdb.runners.local import set_runner_local
 from duckdb.runners.ray import set_runner_ray
 
 __all__ = [
+    "CopyOutcomeUnknownError",
     "get_or_create_runner",
     "get_or_infer_runner_type",
     "set_runner_local",

--- a/duckdb/runners/copy_outcome.py
+++ b/duckdb/runners/copy_outcome.py
@@ -28,6 +28,9 @@ class CopyOutcomeUnknownError(RuntimeError):
         self.detail = str(detail)
         self.cleanup_warnings = tuple(str(warning) for warning in cleanup_warnings)
         self.safe_to_retry = False
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
         message = (
             f"COPY outcome is unknown for operation {self.operation_id}; "
             "refusing to resubmit a potentially committed write"
@@ -37,8 +40,17 @@ class CopyOutcomeUnknownError(RuntimeError):
         if self.detail:
             message += f"; {self.detail}"
         if self.base_path and self.run_id:
-            message += "; inspect or explicitly abort this run before deciding whether to retry"
-        super().__init__(message)
+            message += "; inspect and explicitly resolve this run before deciding whether to retry"
+        if self.cleanup_warnings:
+            message += "; cleanup also failed: " + "; ".join(self.cleanup_warnings)
+        return message
+
+    def add_cleanup_warnings(self, *warnings: str) -> None:
+        additions = tuple(str(warning) for warning in warnings if str(warning))
+        if not additions:
+            return
+        self.cleanup_warnings += additions
+        self.args = (self._build_message(),)
 
     @classmethod
     def from_native_result(

--- a/duckdb/runners/copy_outcome.py
+++ b/duckdb/runners/copy_outcome.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class CopyOutcomeUnknownError(RuntimeError):
+    """The runner cannot prove whether a COPY operation committed."""
+
+    def __init__(
+        self,
+        operation_id: str,
+        base_path: str = "",
+        run_id: str = "",
+        manifest_path: str = "",
+        committed_marker_path: str = "",
+        detail: str = "",
+        cleanup_warnings: tuple[str, ...] = (),
+    ) -> None:
+        self.operation_id = str(operation_id)
+        self.base_path = str(base_path)
+        self.run_id = str(run_id)
+        self.manifest_path = str(manifest_path)
+        self.committed_marker_path = str(committed_marker_path)
+        self.detail = str(detail)
+        self.cleanup_warnings = tuple(str(warning) for warning in cleanup_warnings)
+        self.safe_to_retry = False
+        message = (
+            f"COPY outcome is unknown for operation {self.operation_id}; "
+            "refusing to resubmit a potentially committed write"
+        )
+        if self.base_path or self.run_id:
+            message += f"; base_path={self.base_path!r}, run_id={self.run_id!r}"
+        if self.detail:
+            message += f"; {self.detail}"
+        if self.base_path and self.run_id:
+            message += "; inspect or explicitly abort this run before deciding whether to retry"
+        super().__init__(message)
+
+    @classmethod
+    def from_native_result(
+        cls,
+        operation_id: str,
+        result: Mapping[str, Any],
+    ) -> CopyOutcomeUnknownError:
+        raw_warnings = result.get("copy_runner_cleanup_warnings", ())
+        cleanup_warnings: tuple[str, ...]
+        if isinstance(raw_warnings, str):
+            cleanup_warnings = (raw_warnings,) if raw_warnings else ()
+        elif isinstance(raw_warnings, (list, tuple)):
+            cleanup_warnings = tuple(str(warning) for warning in raw_warnings if str(warning))
+        else:
+            cleanup_warnings = ()
+        return cls(
+            operation_id,
+            str(result.get("copy_output_base_path") or ""),
+            str(result.get("copy_output_run_id") or ""),
+            str(result.get("copy_output_manifest_path") or ""),
+            str(result.get("copy_output_committed_marker_path") or ""),
+            str(result.get("copy_output_outcome_error") or ""),
+            cleanup_warnings,
+        )
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        type[CopyOutcomeUnknownError],
+        tuple[str, str, str, str, str, str, tuple[str, ...]],
+    ]:
+        return CopyOutcomeUnknownError, (
+            self.operation_id,
+            self.base_path,
+            self.run_id,
+            self.manifest_path,
+            self.committed_marker_path,
+            self.detail,
+            self.cleanup_warnings,
+        )

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from duckdb._ray_cxx import require_ray_cxx_attr
 from duckdb._vane_session import ensure_vane_session_dir
+from duckdb.runners.copy_outcome import CopyOutcomeUnknownError
 from duckdb.runners.fte.backends.native import NativeFteWorkerManagerBackend
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
 from duckdb.runners.progress import ProgressRenderer, build_progress_snapshot, progress_enabled
@@ -91,6 +92,12 @@ def _copy_output_info_from_context(context: dict[str, Any] | None) -> dict[str, 
         "run_id": str(run_id or ""),
         "remote_base": str(remote_base or ""),
     }
+
+
+def _require_known_copy_outcome(operation_id: str, result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("copy_output_outcome_unknown") is True:
+        raise CopyOutcomeUnknownError.from_native_result(operation_id, result)
+    return result
 
 
 def _shutdown_udf_actor_pools(actor_pools: list[Any], *, kill: bool) -> list[BaseException]:
@@ -445,12 +452,15 @@ class LocalRunner(Runner):
             try:
                 future = write_executor.submit(execute_write)
                 if renderer is None:
-                    result = future.result()
+                    result = _require_known_copy_outcome(query_id, future.result())
                     write_succeeded = True
                     return result
                 while True:
                     try:
-                        result = future.result(timeout=renderer.interval_s)
+                        result = _require_known_copy_outcome(
+                            query_id,
+                            future.result(timeout=renderer.interval_s),
+                        )
                         write_succeeded = True
                         break
                     except TimeoutError:
@@ -459,12 +469,32 @@ class LocalRunner(Runner):
                 return result
             except Exception:
                 if renderer is not None:
-                    renderer.update(force=True)
+                    try:
+                        renderer.update(force=True)
+                    except Exception:
+                        # Progress is diagnostic and must not replace the
+                        # write's terminal error, especially UNKNOWN.
+                        pass
                 raise
             finally:
+                primary_error_active = sys.exc_info()[0] is not None
+                progress_error: Exception | None = None
                 if renderer is not None:
-                    renderer.finish(final_state="FINISHED" if write_succeeded else None)
-                write_executor.shutdown(wait=True)
+                    try:
+                        renderer.finish(final_state="FINISHED" if write_succeeded else None)
+                    except Exception as error:
+                        if not primary_error_active:
+                            progress_error = error
+                shutdown_error: Exception | None = None
+                try:
+                    write_executor.shutdown(wait=True)
+                except Exception as error:
+                    if not primary_error_active:
+                        shutdown_error = error
+                if shutdown_error is not None:
+                    raise shutdown_error
+                if progress_error is not None:
+                    raise progress_error
         finally:
             primary_error_active = sys.exc_info()[0] is not None
             cleanup_errors = _shutdown_local_write_resources(

--- a/duckdb/runners/local/runner.py
+++ b/duckdb/runners/local/runner.py
@@ -100,6 +100,24 @@ def _require_known_copy_outcome(operation_id: str, result: dict[str, Any]) -> di
     return result
 
 
+def _record_unknown_copy_cleanup_errors(
+    primary_error: BaseException | None,
+    stage: str,
+    cleanup_errors: list[BaseException],
+) -> bool:
+    if not isinstance(primary_error, CopyOutcomeUnknownError) or not cleanup_errors:
+        return False
+    warnings: list[str] = []
+    for error in cleanup_errors:
+        try:
+            message = str(error)
+        except BaseException:
+            message = "<error message unavailable>"
+        warnings.append(f"{stage} failed: {type(error).__name__}: {message}")
+    primary_error.add_cleanup_warnings(*warnings)
+    return True
+
+
 def _shutdown_udf_actor_pools(actor_pools: list[Any], *, kill: bool) -> list[BaseException]:
     errors: list[BaseException] = []
     for pool in reversed(actor_pools):
@@ -477,26 +495,40 @@ class LocalRunner(Runner):
                         pass
                 raise
             finally:
-                primary_error_active = sys.exc_info()[0] is not None
+                primary_error = sys.exc_info()[1]
                 progress_error: Exception | None = None
                 if renderer is not None:
                     try:
                         renderer.finish(final_state="FINISHED" if write_succeeded else None)
                     except Exception as error:
-                        if not primary_error_active:
+                        if (
+                            not _record_unknown_copy_cleanup_errors(
+                                primary_error,
+                                "progress finalization",
+                                [error],
+                            )
+                            and primary_error is None
+                        ):
                             progress_error = error
                 shutdown_error: Exception | None = None
                 try:
                     write_executor.shutdown(wait=True)
                 except Exception as error:
-                    if not primary_error_active:
+                    if (
+                        not _record_unknown_copy_cleanup_errors(
+                            primary_error,
+                            "write executor shutdown",
+                            [error],
+                        )
+                        and primary_error is None
+                    ):
                         shutdown_error = error
                 if shutdown_error is not None:
                     raise shutdown_error
                 if progress_error is not None:
                     raise progress_error
         finally:
-            primary_error_active = sys.exc_info()[0] is not None
+            primary_error = sys.exc_info()[1]
             cleanup_errors = _shutdown_local_write_resources(
                 backend,
                 fragment_executor,
@@ -505,6 +537,11 @@ class LocalRunner(Runner):
                 kill_actor_pools=not write_succeeded,
                 timeout_s=fragment_executor.close_timeout_s,
             )
-            if write_succeeded and not primary_error_active and cleanup_errors:
+            _record_unknown_copy_cleanup_errors(
+                primary_error,
+                "local write resource shutdown",
+                cleanup_errors,
+            )
+            if write_succeeded and primary_error is None and cleanup_errors:
                 details = "; ".join(f"{type(error).__name__}: {error}" for error in cleanup_errors)
                 raise RuntimeError(f"failed to shut down local write resources: {details}") from cleanup_errors[0]

--- a/duckdb/runners/ray/__init__.py
+++ b/duckdb/runners/ray/__init__.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from duckdb.runners.ray.committed_copy import read_committed_copy_direct_write_parquet
-from duckdb.runners.ray.driver import CopyOutcomeUnknownError
+from duckdb.runners.copy_outcome import CopyOutcomeUnknownError
+from duckdb.runners.ray.committed_copy import (
+    force_abort_copy_direct_write_run,
+    inspect_copy_direct_write_run,
+    read_committed_copy_direct_write_parquet,
+)
 from duckdb.runners.ray.lifecycle import (
     cleanup_copy_direct_write_lifecycle_once,
     run_copy_direct_write_lifecycle_cleanup_loop,
@@ -24,6 +28,8 @@ __all__ = [
     "CopyOutcomeUnknownError",
     "RayRunner",
     "cleanup_copy_direct_write_lifecycle_once",
+    "force_abort_copy_direct_write_run",
+    "inspect_copy_direct_write_run",
     "read_committed_copy_direct_write_parquet",
     "run_copy_direct_write_lifecycle_cleanup_loop",
     "set_runner_ray",

--- a/duckdb/runners/ray/committed_copy.py
+++ b/duckdb/runners/ray/committed_copy.py
@@ -27,10 +27,46 @@ def read_committed_copy_direct_write_parquet(
     if conn is None:
         conn = duckdb.connect()
 
-    result = duckdb.ray_cxx.read_committed_copy_direct_write_result(str(base_path), run_id)
+    result = duckdb.ray_cxx.read_committed_copy_direct_write_result(str(base_path), run_id, conn)
     files = [entry["final_path"] for entry in result["files"]]
     if not files:
         raise ValueError(
             "committed direct-write COPY result contains no parquet files; cannot infer a schema for read_parquet"
         )
     return conn.read_parquet(files, **read_parquet_kwargs)
+
+
+def inspect_copy_direct_write_run(
+    base_path: str | PathLike[str],
+    run_id: str,
+    *,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    """Inspect a direct-write COPY run without changing its storage state.
+
+    ``UNCOMMITTED`` is an observation, not proof that a prior marker write
+    failed. Only ``force_abort_copy_direct_write_run`` can return
+    ``safe_to_retry=True``.
+    """
+    import duckdb
+
+    return duckdb.ray_cxx.inspect_copy_direct_write_run(str(base_path), run_id, conn)
+
+
+def force_abort_copy_direct_write_run(
+    base_path: str | PathLike[str],
+    run_id: str,
+    *,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    """Discard one direct-write COPY run after an operator chooses data loss.
+
+    The native operation removes the committed marker first, deletes only
+    output owned by ``run_id``, removes its metadata, and verifies the marker
+    remains absent. A raised exception means the run is not safe to retry.
+    This is operator-driven recovery, not an exactly-once fence: call it only
+    after the originating COPY has terminated and do not race another writer.
+    """
+    import duckdb
+
+    return duckdb.ray_cxx.force_abort_copy_direct_write_run(str(base_path), run_id, conn)

--- a/duckdb/runners/ray/committed_copy.py
+++ b/duckdb/runners/ray/committed_copy.py
@@ -45,8 +45,8 @@ def inspect_copy_direct_write_run(
     """Inspect a direct-write COPY run without changing its storage state.
 
     ``UNCOMMITTED`` is an observation, not proof that a prior marker write
-    failed. Only ``force_abort_copy_direct_write_run`` can return
-    ``safe_to_retry=True``.
+    failed. A successful shared-storage
+    ``force_abort_copy_direct_write_run`` can return ``safe_to_retry=True``.
     """
     import duckdb
 
@@ -61,11 +61,14 @@ def force_abort_copy_direct_write_run(
 ) -> dict[str, Any]:
     """Discard one direct-write COPY run after an operator chooses data loss.
 
-    The native operation removes the committed marker first, deletes only
-    output owned by ``run_id``, removes its metadata, and verifies the marker
-    remains absent. A raised exception means the run is not safe to retry.
-    This is operator-driven recovery, not an exactly-once fence: call it only
-    after the originating COPY has terminated and do not race another writer.
+    The native operation is available only when worker output is on shared
+    remote storage. It removes the committed marker first, deletes only output
+    owned by ``run_id``, removes its metadata, and verifies the marker remains
+    absent. Node-local output requires cleanup on every worker and is rejected
+    without changing its marker or lifecycle record. A raised exception means
+    the run is not safe to retry. This is operator-driven recovery, not an
+    exactly-once fence: call it only after the originating COPY has terminated
+    and do not race another writer.
     """
     import duckdb
 

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -14,7 +14,7 @@ import weakref
 from collections.abc import Callable, Mapping
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import asdict, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 from duckdb._ray_cxx import require_ray_cxx_attr
 from duckdb._ray_errors import restore_remote_ray_exception
@@ -181,6 +181,23 @@ def _runtime_error_candidates(error: BaseException) -> list[BaseException]:
                 candidate_ids.add(id(cause))
                 candidates.append(cause)
     return candidates
+
+
+def _raise_copy_outcome_unknown(
+    operation_id: str,
+    operation_error: BaseException,
+) -> NoReturn:
+    unknown_error = next(
+        (
+            candidate
+            for candidate in _runtime_error_candidates(operation_error)
+            if isinstance(candidate, CopyOutcomeUnknownError)
+        ),
+        None,
+    )
+    if unknown_error is not None:
+        raise unknown_error
+    raise CopyOutcomeUnknownError(operation_id) from operation_error
 
 
 def _runtime_error_contains(error: BaseException, error_type: type[BaseException]) -> bool:
@@ -6061,7 +6078,7 @@ class RayQueryDriverClient:
                 operation_id,
             )
         except BaseException:
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
         try:
             recovery = resolve_object_refs_blocking(
                 recovery_future,
@@ -6080,16 +6097,16 @@ class RayQueryDriverClient:
             )
             if unknown_error is not None:
                 raise unknown_error
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
         if not isinstance(recovery, CopyPlanRecovery):
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
         if recovery.operation_id != operation_id:
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
         if (recovery.outcome is None) == (recovery.error is None):
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
         if recovery.error is not None:
             if not isinstance(recovery.error, BaseException):
-                raise CopyOutcomeUnknownError(operation_id) from operation_error
+                _raise_copy_outcome_unknown(operation_id, operation_error)
             restored_error = restore_remote_ray_exception(recovery.error)
             raise recovery.error if restored_error is None else restored_error
         try:
@@ -6098,7 +6115,7 @@ class RayQueryDriverClient:
                 operation_id,
             )
         except BaseException:
-            raise CopyOutcomeUnknownError(operation_id) from operation_error
+            _raise_copy_outcome_unknown(operation_id, operation_error)
 
     @staticmethod
     def _validate_copy_outcome(

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -32,6 +32,7 @@ RayTaskResult = require_ray_cxx_attr(
 configure_ray_progress_logging_defaults()
 
 from duckdb.event_loop import set_event_loop
+from duckdb.runners.copy_outcome import CopyOutcomeUnknownError
 from duckdb.runners.fte import (
     FteTaskAttemptId,
     FteTaskState,
@@ -121,20 +122,6 @@ class QueryExecutionCleanupError(RuntimeError):
             primary_error=primary_error,
             cleanup_errors=cleanup,
         )
-
-
-class CopyOutcomeUnknownError(RuntimeError):
-    """The actor cannot prove whether a COPY operation committed."""
-
-    def __init__(self, operation_id: str) -> None:
-        self.operation_id = str(operation_id)
-        super().__init__(
-            f"COPY outcome is unknown for operation {self.operation_id}; "
-            "refusing to resubmit a potentially committed write"
-        )
-
-    def __reduce__(self) -> tuple[type[CopyOutcomeUnknownError], tuple[str]]:
-        return CopyOutcomeUnknownError, (self.operation_id,)
 
 
 def _client_owner_lease_settings() -> tuple[float, float]:
@@ -5132,6 +5119,8 @@ class RayQueryDriverActor:
             result = await asyncio.shield(plan_execution)
             if not isinstance(result, Mapping):
                 raise TypeError(f"native COPY returned {type(result).__name__}, expected a mapping")
+            if result.get("copy_output_outcome_unknown") is True:
+                raise CopyOutcomeUnknownError.from_native_result(plan_id, result)
             if result.get("copy_output_committed") is not True:
                 raise RuntimeError(f"native COPY plan {plan_id} returned without a committed output marker")
         except BaseException as execution_error:
@@ -5153,6 +5142,7 @@ class RayQueryDriverActor:
             # terminal result so a concurrent failure cannot escape as an
             # unobserved asyncio task exception.
             committed_result: Mapping[str, Any] | None = None
+            unknown_outcome_error = execution_error if isinstance(execution_error, CopyOutcomeUnknownError) else None
             if plan_execution is not None:
                 try:
                     await self._await_copy_operation(plan_execution)
@@ -5163,8 +5153,15 @@ class RayQueryDriverActor:
                 except BaseException:
                     pass
                 else:
-                    if isinstance(observed_result, Mapping) and observed_result.get("copy_output_committed") is True:
-                        committed_result = observed_result
+                    if isinstance(observed_result, Mapping):
+                        if observed_result.get("copy_output_outcome_unknown") is True:
+                            if unknown_outcome_error is None:
+                                unknown_outcome_error = CopyOutcomeUnknownError.from_native_result(
+                                    plan_id,
+                                    observed_result,
+                                )
+                        elif observed_result.get("copy_output_committed") is True:
+                            committed_result = observed_result
             await self._drain_copy_startup_tasks(startup_tasks)
             if committed_result is not None:
                 cleanup_warnings = self._copy_native_cleanup_warnings(committed_result) + (
@@ -5198,6 +5195,21 @@ class RayQueryDriverActor:
                     cleanup_state=cleanup_state,
                     cleanup_warnings=cleanup_warnings,
                 )
+            if unknown_outcome_error is not None:
+                if unknown_outcome_error is not execution_error:
+                    unknown_outcome_error.cleanup_warnings += (
+                        self._copy_cleanup_warning(
+                            "COPY outcome-unknown execution finalization",
+                            execution_error,
+                        ),
+                    )
+                if teardown_error is not None:
+                    unknown_outcome_error.cleanup_warnings += (
+                        self._copy_cleanup_warning("COPY outcome-unknown teardown", teardown_error),
+                    )
+                if unknown_outcome_error is execution_error:
+                    raise
+                raise unknown_outcome_error from execution_error
             if teardown_error is not None:
                 aggregate_error = QueryExecutionCleanupError.from_errors(
                     f"COPY query plan {plan_id} failed and teardown also failed",

--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -5197,15 +5197,15 @@ class RayQueryDriverActor:
                 )
             if unknown_outcome_error is not None:
                 if unknown_outcome_error is not execution_error:
-                    unknown_outcome_error.cleanup_warnings += (
+                    unknown_outcome_error.add_cleanup_warnings(
                         self._copy_cleanup_warning(
                             "COPY outcome-unknown execution finalization",
                             execution_error,
-                        ),
+                        )
                     )
                 if teardown_error is not None:
-                    unknown_outcome_error.cleanup_warnings += (
-                        self._copy_cleanup_warning("COPY outcome-unknown teardown", teardown_error),
+                    unknown_outcome_error.add_cleanup_warnings(
+                        self._copy_cleanup_warning("COPY outcome-unknown teardown", teardown_error)
                     )
                 if unknown_outcome_error is execution_error:
                     raise

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -997,6 +997,52 @@ ReadCommittedDistributedCopyDirectWriteResult(FileSystem &fs, const std::string 
 	return DuckDBResult<DistributedCopyResult>::ok(std::move(result));
 }
 
+enum class DistributedCopyDirectWriteRunState : uint8_t { COMMITTED, UNCOMMITTED, UNKNOWN };
+
+struct DistributedCopyDirectWriteRunInspection {
+	DistributedCopyDirectWriteRunState state = DistributedCopyDirectWriteRunState::UNKNOWN;
+	DistributedCopyFinalizeCommitPaths paths;
+	std::string base_path;
+	std::string run_id;
+	std::string error;
+	DistributedCopyResult committed_result;
+};
+
+inline DuckDBResult<DistributedCopyDirectWriteRunInspection>
+InspectDistributedCopyDirectWriteRun(FileSystem &fs, const std::string &base_path, const std::string &run_id) {
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunInspection>::err(canonical_res.error());
+	}
+	if (run_id.empty()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunInspection>::err(
+		    DuckDBError::value_error("direct-write inspection requires non-empty run_id"));
+	}
+
+	DistributedCopyDirectWriteRunInspection inspection;
+	inspection.base_path = std::move(canonical_res).value();
+	inspection.run_id = run_id;
+	inspection.paths = BuildDistributedCopyFinalizeCommitPaths(fs, inspection.base_path, run_id);
+	auto marker_res = CheckDistributedCopyFileExists(fs, inspection.paths.committed_marker_path);
+	if (marker_res.is_err()) {
+		inspection.error = marker_res.error().what();
+		return DuckDBResult<DistributedCopyDirectWriteRunInspection>::ok(std::move(inspection));
+	}
+	if (!marker_res.value()) {
+		inspection.state = DistributedCopyDirectWriteRunState::UNCOMMITTED;
+		return DuckDBResult<DistributedCopyDirectWriteRunInspection>::ok(std::move(inspection));
+	}
+
+	auto committed_res = ReadCommittedDistributedCopyDirectWriteResult(fs, inspection.base_path, run_id);
+	if (committed_res.is_err()) {
+		inspection.error = committed_res.error().what();
+		return DuckDBResult<DistributedCopyDirectWriteRunInspection>::ok(std::move(inspection));
+	}
+	inspection.state = DistributedCopyDirectWriteRunState::COMMITTED;
+	inspection.committed_result = std::move(committed_res).value();
+	return DuckDBResult<DistributedCopyDirectWriteRunInspection>::ok(std::move(inspection));
+}
+
 inline DuckDBResult<void> MoveDistributedCopyFileOrReplay(FileSystem &fs, const DistributedCopyFileInfo &info) {
 	auto parent_dir = StringUtil::GetFilePath(info.final_path);
 	try {
@@ -1425,6 +1471,70 @@ CleanupDistributedCopyUncommittedDirectWriteRun(FileSystem &fs, const std::strin
 	auto worker_base_path = std::move(lifecycle_res).value().worker_base_path;
 	return CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(fs, canonical_base_path, worker_base_path,
 	                                                                     run_id);
+}
+
+inline DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>
+ForceAbortDistributedCopyDirectWriteRun(FileSystem &fs, const std::string &base_path, const std::string &run_id) {
+	auto canonical_res = CanonicalDistributedCopyBasePath(fs, base_path);
+	if (canonical_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(canonical_res.error());
+	}
+	if (run_id.empty()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
+		    DuckDBError::value_error("direct-write force abort requires non-empty run_id"));
+	}
+	auto canonical_base_path = std::move(canonical_res).value();
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(fs, canonical_base_path, run_id);
+	auto lifecycle_exists_res = CheckDistributedCopyFileExists(fs, commit_paths.lifecycle_path);
+	if (lifecycle_exists_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_exists_res.error());
+	}
+	if (!lifecycle_exists_res.value()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::io_error(
+		    "direct-write force abort requires lifecycle registration: " + commit_paths.lifecycle_path));
+	}
+	auto lifecycle_res = ReadDistributedCopyDirectWriteLifecycle(fs, commit_paths, canonical_base_path, run_id);
+	if (lifecycle_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_res.error());
+	}
+	auto worker_base_path = std::move(lifecycle_res).value().worker_base_path;
+
+	try {
+		fs.RemoveFile(commit_paths.committed_marker_path);
+	} catch (const std::exception &ex) {
+		if (!DistributedCopyExceptionIsNotFound(ex)) {
+			return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::io_error(
+			    StringUtil::Format("failed to remove distributed COPY committed marker \"%s\": %s",
+			                       commit_paths.committed_marker_path, ex.what())));
+		}
+	}
+	auto marker_res = CheckDistributedCopyFileExists(fs, commit_paths.committed_marker_path);
+	if (marker_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(marker_res.error());
+	}
+	if (marker_res.value()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::io_error(
+		    "distributed COPY committed marker still exists after force abort: " + commit_paths.committed_marker_path));
+	}
+
+	auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRunWithWorkerBase(fs, canonical_base_path,
+	                                                                                 worker_base_path, run_id);
+	if (cleanup_res.is_err()) {
+		return cleanup_res;
+	}
+	if (cleanup_res.value().skipped_committed) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(
+		    DuckDBError::invalid_state_error("distributed COPY committed marker reappeared during force abort"));
+	}
+	auto final_marker_res = CheckDistributedCopyFileExists(fs, commit_paths.committed_marker_path);
+	if (final_marker_res.is_err()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(final_marker_res.error());
+	}
+	if (final_marker_res.value()) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::io_error(
+		    "distributed COPY committed marker reappeared after force abort: " + commit_paths.committed_marker_path));
+	}
+	return cleanup_res;
 }
 
 struct DistributedCopyDirectWriteCleanupScanResult {
@@ -1874,9 +1984,22 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 			result.cleanup_ms += direct_write_cleanup_ms;
 			auto marker_res = WriteDistributedCopyFinalizeCommittedMarker(fs, commit_paths);
 			if (marker_res.is_err()) {
-				return DuckDBResult<DistributedCopyResult>::err(marker_res.error());
+				auto marker_error = std::string(marker_res.error().what());
+				auto committed_res = ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, direct_write_run_id);
+				if (committed_res.is_ok()) {
+					auto cleanup_ms = result.cleanup_ms;
+					result = std::move(committed_res).value();
+					result.cleanup_ms = cleanup_ms;
+				} else {
+					AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, false);
+					result.output_outcome_unknown = true;
+					result.output_outcome_error =
+					    StringUtil::Format("%s; committed-marker readback was inconclusive: %s", marker_error,
+					                       committed_res.error().what());
+				}
+			} else {
+				AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, true);
 			}
-			AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, true);
 		}
 	} else {
 		std::unordered_set<std::string> planned_final_paths;

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -989,7 +989,7 @@ ReadCommittedDistributedCopyDirectWriteResult(FileSystem &fs, const std::string 
 			    "distributed COPY direct-write committed manifest file is outside run output: \"%s\"",
 			    info.final_path)));
 		}
-		auto validate_res = ValidateDistributedCopyFinalFile(fs, info);
+		auto validate_res = ValidateDistributedCopyDirectWriteFinalFile(fs, info);
 		if (validate_res.is_err()) {
 			return DuckDBResult<DistributedCopyResult>::err(validate_res.error());
 		}
@@ -1498,6 +1498,11 @@ ForceAbortDistributedCopyDirectWriteRun(FileSystem &fs, const std::string &base_
 		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(lifecycle_res.error());
 	}
 	auto worker_base_path = std::move(lifecycle_res).value().worker_base_path;
+	if (!FileSystem::IsRemoteFile(worker_base_path)) {
+		return DuckDBResult<DistributedCopyDirectWriteRunCleanupResult>::err(DuckDBError::invalid_state_error(
+		    "direct-write force abort cannot prove node-local worker output was removed; "
+		    "clean the run on every worker before retrying"));
+	}
 
 	try {
 		fs.RemoveFile(commit_paths.committed_marker_path);
@@ -1987,9 +1992,10 @@ inline DuckDBResult<DistributedCopyResult> FinalizeCopyFiles(const DistributedCo
 				auto marker_error = std::string(marker_res.error().what());
 				auto committed_res = ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, direct_write_run_id);
 				if (committed_res.is_ok()) {
-					auto cleanup_ms = result.cleanup_ms;
-					result = std::move(committed_res).value();
-					result.cleanup_ms = cleanup_ms;
+					// Readback proves the marker and persisted manifest. Keep the
+					// in-memory result because the manifest intentionally omits
+					// format-specific file metadata.
+					AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, true);
 				} else {
 					AttachDistributedCopyCommitInfo(result, commit_paths, base_path, direct_write_run_id, true, false);
 					result.output_outcome_unknown = true;

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_to_file.hpp
@@ -97,8 +97,10 @@ struct DistributedCopyResult {
 	std::string output_manifest_path;
 	std::string output_committed_marker_path;
 	std::string output_lifecycle_path;
+	std::string output_outcome_error;
 	bool output_direct_write = false;
 	bool output_committed = false;
+	bool output_outcome_unknown = false;
 };
 
 // ── Shared path utilities (used by scheduler + worker) ──────────────────────

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -206,6 +206,22 @@ private:
 	bool fail_removal = true;
 };
 
+class MissingFileRemovalFileSystem : public FileOnlyRecursiveListFileSystem {
+public:
+	explicit MissingFileRemovalFileSystem(string missing_path) : missing_path(std::move(missing_path)) {
+	}
+
+	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == missing_path) {
+			throw Exception({{"status_code", "404"}}, ExceptionType::HTTP, "injected missing object");
+		}
+		LocalFileSystem::RemoveFile(path, opener);
+	}
+
+private:
+	string missing_path;
+};
+
 class DelayedFileRemovalFileSystem : public FileOnlyRecursiveListFileSystem {
 public:
 	DelayedFileRemovalFileSystem(string delayed_path, std::chrono::milliseconds delay)
@@ -243,6 +259,42 @@ public:
 private:
 	string failed_path;
 	bool fail_removal = true;
+};
+
+enum class MarkerReadbackMode : uint8_t { VISIBLE, MISSING, ERROR };
+
+class PersistThenFailMarkerFileSystem : public LocalFileSystem {
+public:
+	PersistThenFailMarkerFileSystem(string marker_path, MarkerReadbackMode readback_mode)
+	    : marker_path(std::move(marker_path)), readback_mode(readback_mode) {
+	}
+
+	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override {
+		LocalFileSystem::MoveFile(source, target, opener);
+		if (target == marker_path) {
+			marker_write_failed = true;
+			throw IOException("injected lost committed-marker response");
+		}
+	}
+
+	bool FileExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (marker_write_failed && path == marker_path) {
+			switch (readback_mode) {
+			case MarkerReadbackMode::VISIBLE:
+				break;
+			case MarkerReadbackMode::MISSING:
+				return false;
+			case MarkerReadbackMode::ERROR:
+				throw IOException("injected committed-marker readback failure");
+			}
+		}
+		return LocalFileSystem::FileExists(path, opener);
+	}
+
+private:
+	string marker_path;
+	MarkerReadbackMode readback_mode;
+	bool marker_write_failed = false;
 };
 
 class CopyFinalizeTestDirectory {
@@ -561,6 +613,93 @@ TEST_CASE("Distributed COPY direct-target cleanup time is excluded from finalize
 	REQUIRE_FALSE(fs.FileExists(loser_file));
 }
 
+TEST_CASE("Distributed COPY accepts a committed marker after its write response is lost",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_marker_response_lost");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-marker-response-lost";
+	auto selected_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	const string selected_contents = "selected";
+	WriteTestFile(local_fs, selected_file, selected_contents);
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id).is_ok());
+	auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+
+	DBConfig config;
+	config.file_system = make_uniq<VirtualFileSystem>(
+	    make_uniq<PersistThenFailMarkerFileSystem>(commit_paths.committed_marker_path, MarkerReadbackMode::VISIBLE));
+	DuckDB db(nullptr, &config);
+	Connection connection(db);
+
+	DistributedCopySpec spec;
+	spec.file_path = base_path;
+	spec.file_extension = "parquet";
+	spec.per_thread_output = true;
+	DistributedCopyFileInfo selected_info;
+	selected_info.staging_path = selected_file;
+	selected_info.row_count = 3;
+	selected_info.file_size_bytes = selected_contents.size();
+	vector<DistributedCopyFileInfo> selected_files;
+	selected_files.push_back(std::move(selected_info));
+
+	auto finalize_res = FinalizeCopyFiles(spec, "", std::move(selected_files), *connection.context, run_id);
+
+	REQUIRE(finalize_res.is_ok());
+	REQUIRE(finalize_res.value().output_committed);
+	REQUIRE_FALSE(finalize_res.value().output_outcome_unknown);
+	REQUIRE(finalize_res.value().rows_copied == 3);
+	REQUIRE(local_fs.FileExists(commit_paths.committed_marker_path));
+}
+
+TEST_CASE("Distributed COPY reports an unknown outcome when committed marker readback is inconclusive",
+          "[distributed][copy][lifecycle][object-storage]") {
+	for (auto readback_mode : {MarkerReadbackMode::MISSING, MarkerReadbackMode::ERROR}) {
+		CopyFinalizeTestDirectory test_dir(readback_mode == MarkerReadbackMode::MISSING
+		                                       ? "copy_finalize_marker_readback_missing"
+		                                       : "copy_finalize_marker_readback_error");
+		auto &local_fs = test_dir.fs;
+		auto base_path = local_fs.JoinPath(test_dir.path, "out");
+		const string run_id = "run-marker-readback-unknown";
+		auto selected_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+		const string selected_contents = "selected";
+		WriteTestFile(local_fs, selected_file, selected_contents);
+		REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id).is_ok());
+		auto commit_paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+
+		DBConfig config;
+		config.file_system = make_uniq<VirtualFileSystem>(
+		    make_uniq<PersistThenFailMarkerFileSystem>(commit_paths.committed_marker_path, readback_mode));
+		DuckDB db(nullptr, &config);
+		Connection connection(db);
+
+		DistributedCopySpec spec;
+		spec.file_path = base_path;
+		spec.file_extension = "parquet";
+		spec.per_thread_output = true;
+		DistributedCopyFileInfo selected_info;
+		selected_info.staging_path = selected_file;
+		selected_info.row_count = 3;
+		selected_info.file_size_bytes = selected_contents.size();
+		vector<DistributedCopyFileInfo> selected_files;
+		selected_files.push_back(std::move(selected_info));
+
+		auto finalize_res = FinalizeCopyFiles(spec, "", std::move(selected_files), *connection.context, run_id);
+
+		REQUIRE(finalize_res.is_ok());
+		const auto &result = finalize_res.value();
+		REQUIRE_FALSE(result.output_committed);
+		REQUIRE(result.output_outcome_unknown);
+		REQUIRE(result.output_base_path == base_path);
+		REQUIRE(result.output_run_id == run_id);
+		REQUIRE(result.output_manifest_path == commit_paths.manifest_path);
+		REQUIRE(result.output_committed_marker_path == commit_paths.committed_marker_path);
+		REQUIRE(StringUtil::Contains(result.output_outcome_error, "injected lost committed-marker response"));
+		REQUIRE_FALSE(result.output_outcome_error.empty());
+		REQUIRE(local_fs.FileExists(selected_file));
+		REQUIRE(local_fs.FileExists(commit_paths.committed_marker_path));
+	}
+}
+
 TEST_CASE("Distributed COPY resolves relative and qualified list paths",
           "[distributed][copy][lifecycle][object-storage][path]") {
 	LocalFileSystem fs;
@@ -831,6 +970,62 @@ TEST_CASE("Direct-write cleanup requires lifecycle registration", "[distributed]
 	REQUIRE(cleanup_res.is_err());
 	REQUIRE(StringUtil::Contains(cleanup_res.error().what(), "requires lifecycle registration"));
 	REQUIRE(fs.FileExists(data_file));
+}
+
+TEST_CASE("Direct-write force abort removes the commit marker before run data",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-force-abort";
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	WriteTestFile(local_fs, data_file, "discard me");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	WriteTestFile(local_fs, paths.manifest_path, "manifest");
+	REQUIRE(WriteDistributedCopyFinalizeCommittedMarker(local_fs, paths).is_ok());
+
+	FileRemovalFailureFileSystem failing_fs(paths.committed_marker_path);
+	auto failed_abort = ForceAbortDistributedCopyDirectWriteRun(failing_fs, base_path, run_id);
+
+	REQUIRE(failed_abort.is_err());
+	REQUIRE(StringUtil::Contains(failed_abort.error().what(), "injected object removal failure"));
+	REQUIRE(local_fs.FileExists(paths.committed_marker_path));
+	REQUIRE(local_fs.FileExists(data_file));
+	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+
+	failing_fs.AllowRemoval();
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(failing_fs, base_path, run_id);
+
+	REQUIRE(abort_res.is_ok());
+	REQUIRE_FALSE(abort_res.value().skipped_committed);
+	REQUIRE_FALSE(local_fs.FileExists(paths.committed_marker_path));
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(local_fs.DirectoryExists(paths.commit_dir));
+}
+
+TEST_CASE("Direct-write force abort accepts an already absent commit marker",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort_missing_marker");
+	auto &local_fs = test_dir.fs;
+	auto base_path = local_fs.JoinPath(test_dir.path, "out");
+	const string run_id = "run-force-abort-missing-marker";
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	WriteTestFile(local_fs, data_file, "discard me");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
+	WriteTestFile(local_fs, paths.manifest_path, "manifest");
+	REQUIRE_FALSE(local_fs.FileExists(paths.committed_marker_path));
+
+	MissingFileRemovalFileSystem missing_fs(paths.committed_marker_path);
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(missing_fs, base_path, run_id);
+
+	REQUIRE(abort_res.is_ok());
+	REQUIRE_FALSE(abort_res.value().skipped_committed);
+	REQUIRE_FALSE(local_fs.FileExists(data_file));
+	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(local_fs.DirectoryExists(paths.commit_dir));
 }
 
 TEST_CASE("Direct-write cleanup restores lifecycle when directory removal fails", "[distributed][copy][lifecycle]") {

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -157,6 +157,100 @@ private:
 	string marker_path;
 };
 
+class CoordinatorHiddenWorkerFileSystem : public LocalFileSystem {
+public:
+	explicit CoordinatorHiddenWorkerFileSystem(string hidden_path) : hidden_path(std::move(hidden_path)) {
+	}
+
+	bool FileExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == hidden_path) {
+			return false;
+		}
+		return LocalFileSystem::FileExists(path, opener);
+	}
+
+private:
+	string hidden_path;
+};
+
+class MappedRemoteFileSystem : public LocalFileSystem {
+public:
+	explicit MappedRemoteFileSystem(string local_root) : local_root(std::move(local_root)) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		return backing_fs.OpenFile(MapPath(path), flags, opener);
+	}
+
+	bool DirectoryExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		return backing_fs.DirectoryExists(MapPath(path), opener);
+	}
+
+	void CreateDirectory(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		backing_fs.CreateDirectory(MapPath(path), opener);
+	}
+
+	void CreateDirectoriesRecursive(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		backing_fs.CreateDirectoriesRecursive(MapPath(path), opener);
+	}
+
+	void RemoveDirectory(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		backing_fs.RemoveDirectory(MapPath(path), opener);
+	}
+
+	bool ListFiles(const string &path, const std::function<void(const string &, bool)> &callback,
+	               FileOpener *opener = nullptr) override {
+		return backing_fs.ListFiles(MapPath(path), callback, opener);
+	}
+
+	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override {
+		backing_fs.MoveFile(MapPath(source), MapPath(target), opener);
+	}
+
+	bool FileExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		return backing_fs.FileExists(MapPath(path), opener);
+	}
+
+	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (fail_removal && path == failed_removal_path) {
+			throw IOException("injected remote object removal failure");
+		}
+		backing_fs.RemoveFile(MapPath(path), opener);
+	}
+
+	bool TryRemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		return backing_fs.TryRemoveFile(MapPath(path), opener);
+	}
+
+	void FailRemovalOf(string path) {
+		failed_removal_path = std::move(path);
+		fail_removal = true;
+	}
+
+	void AllowRemoval() {
+		fail_removal = false;
+	}
+
+	string GetName() const override {
+		return "MappedRemoteFileSystem";
+	}
+
+private:
+	string MapPath(const string &path) const {
+		const string remote_prefix = "s3://bucket";
+		if (!StringUtil::StartsWith(path, remote_prefix)) {
+			throw InternalException("unexpected mapped remote path: " + path);
+		}
+		return local_root + path.substr(remote_prefix.size());
+	}
+
+	LocalFileSystem backing_fs;
+	string local_root;
+	string failed_removal_path;
+	bool fail_removal = false;
+};
+
 class WindowsPathFileSystem : public LocalFileSystem {
 public:
 	string PathSeparator(const string &) override {
@@ -204,22 +298,6 @@ public:
 private:
 	string failed_path;
 	bool fail_removal = true;
-};
-
-class MissingFileRemovalFileSystem : public FileOnlyRecursiveListFileSystem {
-public:
-	explicit MissingFileRemovalFileSystem(string missing_path) : missing_path(std::move(missing_path)) {
-	}
-
-	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
-		if (path == missing_path) {
-			throw Exception({{"status_code", "404"}}, ExceptionType::HTTP, "injected missing object");
-		}
-		LocalFileSystem::RemoveFile(path, opener);
-	}
-
-private:
-	string missing_path;
 };
 
 class DelayedFileRemovalFileSystem : public FileOnlyRecursiveListFileSystem {
@@ -478,6 +556,12 @@ TEST_CASE("Distributed COPY temporary direct output preserves the canonical targ
 	REQUIRE(committed_res.value().rows_copied == 2);
 	REQUIRE(committed_res.value().files[0].final_path == worker_file);
 
+	CoordinatorHiddenWorkerFileSystem coordinator_fs(worker_file);
+	auto node_local_res = ReadCommittedDistributedCopyDirectWriteResult(coordinator_fs, output_path, run_id);
+	REQUIRE(node_local_res.is_ok());
+	REQUIRE(node_local_res.value().rows_copied == 2);
+	REQUIRE(node_local_res.value().files[0].final_path == worker_file);
+
 	const string stale_run_id = "run-tmp-stale";
 	auto stale_worker_file =
 	    BuildCopyDirectTargetFilePath(temporary_output_path, stale_run_id, "w_failed", "part.parquet");
@@ -639,6 +723,13 @@ TEST_CASE("Distributed COPY accepts a committed marker after its write response 
 	selected_info.staging_path = selected_file;
 	selected_info.row_count = 3;
 	selected_info.file_size_bytes = selected_contents.size();
+	auto expected_footer_size = Value::UBIGINT(17);
+	auto expected_column_statistics = Value::LIST({Value("column-stats")});
+	auto expected_partition_keys =
+	    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, {Value("part")}, {Value("value")});
+	selected_info.footer_size_bytes = expected_footer_size;
+	selected_info.column_statistics = expected_column_statistics;
+	selected_info.partition_keys = expected_partition_keys;
 	vector<DistributedCopyFileInfo> selected_files;
 	selected_files.push_back(std::move(selected_info));
 
@@ -648,6 +739,10 @@ TEST_CASE("Distributed COPY accepts a committed marker after its write response 
 	REQUIRE(finalize_res.value().output_committed);
 	REQUIRE_FALSE(finalize_res.value().output_outcome_unknown);
 	REQUIRE(finalize_res.value().rows_copied == 3);
+	REQUIRE(finalize_res.value().files.size() == 1);
+	REQUIRE(finalize_res.value().files[0].footer_size_bytes == expected_footer_size);
+	REQUIRE(finalize_res.value().files[0].column_statistics == expected_column_statistics);
+	REQUIRE(finalize_res.value().files[0].partition_keys == expected_partition_keys);
 	REQUIRE(local_fs.FileExists(commit_paths.committed_marker_path));
 }
 
@@ -972,12 +1067,12 @@ TEST_CASE("Direct-write cleanup requires lifecycle registration", "[distributed]
 	REQUIRE(fs.FileExists(data_file));
 }
 
-TEST_CASE("Direct-write force abort removes the commit marker before run data",
-          "[distributed][copy][lifecycle][object-storage]") {
-	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort");
+TEST_CASE("Direct-write force abort refuses node-local output without mutating the run",
+          "[distributed][copy][lifecycle]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort_node_local");
 	auto &local_fs = test_dir.fs;
 	auto base_path = local_fs.JoinPath(test_dir.path, "out");
-	const string run_id = "run-force-abort";
+	const string run_id = "run-force-abort-node-local";
 	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
 	WriteTestFile(local_fs, data_file, "discard me");
 	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(local_fs, base_path, run_id, 1).is_ok());
@@ -985,28 +1080,51 @@ TEST_CASE("Direct-write force abort removes the commit marker before run data",
 	WriteTestFile(local_fs, paths.manifest_path, "manifest");
 	REQUIRE(WriteDistributedCopyFinalizeCommittedMarker(local_fs, paths).is_ok());
 
-	FileRemovalFailureFileSystem failing_fs(paths.committed_marker_path);
-	auto failed_abort = ForceAbortDistributedCopyDirectWriteRun(failing_fs, base_path, run_id);
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(local_fs, base_path, run_id);
 
-	REQUIRE(failed_abort.is_err());
-	REQUIRE(StringUtil::Contains(failed_abort.error().what(), "injected object removal failure"));
+	REQUIRE(abort_res.is_err());
+	REQUIRE(StringUtil::Contains(abort_res.error().what(), "cannot prove node-local worker output was removed"));
 	REQUIRE(local_fs.FileExists(paths.committed_marker_path));
 	REQUIRE(local_fs.FileExists(data_file));
 	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE(local_fs.FileExists(paths.manifest_path));
+}
 
-	failing_fs.AllowRemoval();
-	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(failing_fs, base_path, run_id);
+TEST_CASE("Direct-write force abort cleans shared remote output before reporting safe retry",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort_remote");
+	MappedRemoteFileSystem fs(test_dir.fs.JoinPath(test_dir.path, "remote"));
+	const string base_path = "s3://bucket/out";
+	const string run_id = "run-force-abort-remote";
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	WriteTestFile(fs, data_file, "discard me");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id, 1).is_ok());
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+	WriteTestFile(fs, paths.manifest_path, "manifest");
+	REQUIRE(WriteDistributedCopyFinalizeCommittedMarker(fs, paths).is_ok());
+
+	fs.FailRemovalOf(paths.committed_marker_path);
+	auto failed_abort = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
+
+	REQUIRE(failed_abort.is_err());
+	REQUIRE(StringUtil::Contains(failed_abort.error().what(), "injected remote object removal failure"));
+	REQUIRE(fs.FileExists(paths.committed_marker_path));
+	REQUIRE(fs.FileExists(data_file));
+	REQUIRE(fs.FileExists(paths.lifecycle_path));
+
+	fs.AllowRemoval();
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
 
 	REQUIRE(abort_res.is_ok());
 	REQUIRE_FALSE(abort_res.value().skipped_committed);
-	REQUIRE_FALSE(local_fs.FileExists(paths.committed_marker_path));
-	REQUIRE_FALSE(local_fs.FileExists(data_file));
-	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
-	REQUIRE_FALSE(local_fs.DirectoryExists(paths.commit_dir));
+	REQUIRE_FALSE(fs.FileExists(paths.committed_marker_path));
+	REQUIRE_FALSE(fs.FileExists(data_file));
+	REQUIRE_FALSE(fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(fs.DirectoryExists(paths.commit_dir));
 }
 
-TEST_CASE("Direct-write force abort accepts an already absent commit marker",
-          "[distributed][copy][lifecycle][object-storage]") {
+TEST_CASE("Direct-write force abort preserves node-local lifecycle when the marker is absent",
+          "[distributed][copy][lifecycle]") {
 	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort_missing_marker");
 	auto &local_fs = test_dir.fs;
 	auto base_path = local_fs.JoinPath(test_dir.path, "out");
@@ -1018,14 +1136,14 @@ TEST_CASE("Direct-write force abort accepts an already absent commit marker",
 	WriteTestFile(local_fs, paths.manifest_path, "manifest");
 	REQUIRE_FALSE(local_fs.FileExists(paths.committed_marker_path));
 
-	MissingFileRemovalFileSystem missing_fs(paths.committed_marker_path);
-	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(missing_fs, base_path, run_id);
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(local_fs, base_path, run_id);
 
-	REQUIRE(abort_res.is_ok());
-	REQUIRE_FALSE(abort_res.value().skipped_committed);
-	REQUIRE_FALSE(local_fs.FileExists(data_file));
-	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
-	REQUIRE_FALSE(local_fs.DirectoryExists(paths.commit_dir));
+	REQUIRE(abort_res.is_err());
+	REQUIRE(StringUtil::Contains(abort_res.error().what(), "cannot prove node-local worker output was removed"));
+	REQUIRE_FALSE(local_fs.FileExists(paths.committed_marker_path));
+	REQUIRE(local_fs.FileExists(data_file));
+	REQUIRE(local_fs.FileExists(paths.lifecycle_path));
+	REQUIRE(local_fs.FileExists(paths.manifest_path));
 }
 
 TEST_CASE("Direct-write cleanup restores lifecycle when directory removal fails", "[distributed][copy][lifecycle]") {

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1944,7 +1944,7 @@ struct PyPhysicalPlanWrapperRunner {
 			}
 
 			auto result = std::move(res).value();
-			if (!result.output_committed) {
+			if (!result.output_committed && !result.output_outcome_unknown) {
 				rethrow_submission_error(plan.idx());
 				throw py::value_error("distributed COPY completed without a committed output marker");
 			}

--- a/src/duckdb_py/ray/native_fragment_executor.cpp
+++ b/src/duckdb_py/ray/native_fragment_executor.cpp
@@ -901,6 +901,8 @@ static void AppendDistributedCopyResultMetadata(pybind11::dict &out,
 	out["copy_output_lifecycle_path"] = result.output_lifecycle_path;
 	out["copy_output_direct_write"] = result.output_direct_write;
 	out["copy_output_committed"] = result.output_committed;
+	out["copy_output_outcome_unknown"] = result.output_outcome_unknown;
+	out["copy_output_outcome_error"] = result.output_outcome_error;
 	out["copy_staging_write_ms"] = result.staging_write_ms;
 	out["copy_finalize_ms"] = result.finalize_ms;
 	out["copy_cleanup_ms"] = result.cleanup_ms;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1570,7 +1570,7 @@ void register_ray_bindings(py::module_ &mod) {
 		    });
 	    },
 	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
-	    "Explicitly discard a direct-write COPY run and verify that it is safe to retry.");
+	    "Explicitly discard a shared-storage direct-write COPY run and verify that it is safe to retry.");
 
 	m.def(
 	    "register_copy_direct_write_run_lifecycle",

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -181,6 +181,17 @@ static string QueryConnectionSettingForTest(DuckDBPyConnection &connection, cons
 	throw std::runtime_error("connection setting query returned no rows: " + name);
 }
 
+static py::dict WithCopyRecoveryContext(py::object conn_obj,
+                                        const std::function<py::dict(duckdb::ClientContext &)> &callback) {
+	if (!conn_obj.is_none()) {
+		auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
+		return callback(*conn_wrapper.con.GetConnection().context);
+	}
+	duckdb::DuckDB db(nullptr);
+	duckdb::Connection conn(db);
+	return callback(*conn.context);
+}
+
 void register_ray_bindings(py::module_ &mod) {
 	auto m = mod.def_submodule("ray_cxx");
 	m.doc() = "C++ Ray execution bindings (experimental)";
@@ -1419,38 +1430,36 @@ void register_ray_bindings(py::module_ &mod) {
 
 	m.def(
 	    "read_committed_copy_direct_write_result",
-	    [](const std::string &base_path, const std::string &run_id) {
+	    [](const std::string &base_path, const std::string &run_id, py::object conn_obj) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    DuckDB db(nullptr);
-		    Connection conn(db);
-		    auto &context = *conn.context;
-		    auto &fs = FileSystem::GetFileSystem(context);
+		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    auto read_res = ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, run_id);
+			    if (read_res.is_err()) {
+				    throw py::value_error(read_res.error().what());
+			    }
+			    auto result = std::move(read_res).value();
 
-		    auto read_res = ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, run_id);
-		    if (read_res.is_err()) {
-			    throw py::value_error(read_res.error().what());
-		    }
-		    auto result = std::move(read_res).value();
-
-		    py::dict out;
-		    out["rows_copied"] = result.rows_copied;
-		    py::list files;
-		    for (const auto &info : result.files) {
-			    py::dict entry;
-			    entry["staging_path"] = info.staging_path;
-			    entry["worker_output_path"] = info.staging_path;
-			    entry["final_path"] = info.final_path;
-			    entry["row_count"] = info.row_count;
-			    entry["file_size_bytes"] = info.file_size_bytes;
-			    files.append(entry);
-		    }
-		    out["files"] = files;
-		    AppendDistributedCopyResultMetadata(out, result);
-		    return out;
+			    py::dict out;
+			    out["rows_copied"] = result.rows_copied;
+			    py::list files;
+			    for (const auto &info : result.files) {
+				    py::dict entry;
+				    entry["staging_path"] = info.staging_path;
+				    entry["worker_output_path"] = info.staging_path;
+				    entry["final_path"] = info.final_path;
+				    entry["row_count"] = info.row_count;
+				    entry["file_size_bytes"] = info.file_size_bytes;
+				    files.append(entry);
+			    }
+			    out["files"] = files;
+			    AppendDistributedCopyResultMetadata(out, result);
+			    return out;
+		    });
 	    },
-	    py::arg("base_path"), py::arg("run_id"),
+	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
 	    "Read a committed direct-write distributed COPY result through its committed manifest.");
 
 	m.def(
@@ -1479,6 +1488,89 @@ void register_ray_bindings(py::module_ &mod) {
 	    },
 	    py::arg("base_path"), py::arg("run_id"),
 	    "Cleanup a lifecycle-registered uncommitted direct-write distributed COPY run.");
+
+	m.def(
+	    "inspect_copy_direct_write_run",
+	    [](const std::string &base_path, const std::string &run_id, py::object conn_obj) {
+		    using namespace duckdb;
+		    using namespace duckdb::distributed;
+
+		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    auto inspection_res = InspectDistributedCopyDirectWriteRun(fs, base_path, run_id);
+			    if (inspection_res.is_err()) {
+				    throw py::value_error(inspection_res.error().what());
+			    }
+			    auto inspection = std::move(inspection_res).value();
+			    py::dict out;
+			    switch (inspection.state) {
+			    case DistributedCopyDirectWriteRunState::COMMITTED:
+				    out["state"] = "COMMITTED";
+				    break;
+			    case DistributedCopyDirectWriteRunState::UNCOMMITTED:
+				    out["state"] = "UNCOMMITTED";
+				    break;
+			    case DistributedCopyDirectWriteRunState::UNKNOWN:
+				    out["state"] = "UNKNOWN";
+				    break;
+			    }
+			    out["safe_to_retry"] = false;
+			    out["error"] = inspection.error;
+			    out["copy_output_base_path"] = inspection.base_path;
+			    out["copy_output_run_id"] = inspection.run_id;
+			    out["copy_output_commit_dir"] = inspection.paths.commit_dir;
+			    out["copy_output_manifest_path"] = inspection.paths.manifest_path;
+			    out["copy_output_committed_marker_path"] = inspection.paths.committed_marker_path;
+			    out["copy_output_lifecycle_path"] = inspection.paths.lifecycle_path;
+			    py::list files;
+			    if (inspection.state == DistributedCopyDirectWriteRunState::COMMITTED) {
+				    out["rows_copied"] = inspection.committed_result.rows_copied;
+				    for (const auto &info : inspection.committed_result.files) {
+					    py::dict entry;
+					    entry["staging_path"] = info.staging_path;
+					    entry["worker_output_path"] = info.staging_path;
+					    entry["final_path"] = info.final_path;
+					    entry["row_count"] = info.row_count;
+					    entry["file_size_bytes"] = info.file_size_bytes;
+					    files.append(entry);
+				    }
+			    } else {
+				    out["rows_copied"] = py::none();
+			    }
+			    out["files"] = files;
+			    return out;
+		    });
+	    },
+	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
+	    "Inspect a direct-write COPY run without making an uncommitted run safe to retry.");
+
+	m.def(
+	    "force_abort_copy_direct_write_run",
+	    [](const std::string &base_path, const std::string &run_id, py::object conn_obj) {
+		    using namespace duckdb;
+		    using namespace duckdb::distributed;
+
+		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    auto abort_res = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
+			    if (abort_res.is_err()) {
+				    throw py::value_error(abort_res.error().what());
+			    }
+			    auto cleanup = std::move(abort_res).value();
+			    py::dict out;
+			    out["state"] = "ABORTED";
+			    out["safe_to_retry"] = true;
+			    out["copy_output_base_path"] = base_path;
+			    out["copy_output_run_id"] = run_id;
+			    out["data_run_dir_existed"] = cleanup.data_run_dir_existed;
+			    out["data_run_dir_removed"] = cleanup.data_run_dir_removed;
+			    out["commit_dir_existed"] = cleanup.commit_dir_existed;
+			    out["commit_dir_removed"] = cleanup.commit_dir_removed;
+			    return out;
+		    });
+	    },
+	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
+	    "Explicitly discard a direct-write COPY run and verify that it is safe to retry.");
 
 	m.def(
 	    "register_copy_direct_write_run_lifecycle",

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -68,6 +68,30 @@ def test_local_runner_preloads_arrow_dataset_imports():
     _preload_arrow_dataset_imports()
 
 
+def test_local_runner_rejects_unknown_native_copy_outcome():
+    from duckdb.runners import CopyOutcomeUnknownError
+    from duckdb.runners.local.runner import _require_known_copy_outcome
+
+    result = {
+        "copy_output_committed": False,
+        "copy_output_outcome_unknown": True,
+        "copy_output_outcome_error": "marker readback unavailable",
+        "copy_output_base_path": "s3://bucket/out",
+        "copy_output_run_id": "run-local-unknown",
+        "copy_output_manifest_path": "s3://bucket/out.duckdb_commit/run-local-unknown/manifest.txt",
+        "copy_output_committed_marker_path": "s3://bucket/out.duckdb_commit/run-local-unknown/committed",
+    }
+
+    try:
+        _require_known_copy_outcome("local-copy", result)
+    except CopyOutcomeUnknownError as error:
+        assert error.operation_id == "local-copy"
+        assert error.run_id == "run-local-unknown"
+        assert error.safe_to_retry is False
+    else:
+        raise AssertionError("local runner must reject an unknown COPY outcome")
+
+
 def test_local_runner_rejects_invalid_num_workers():
     from duckdb.runners.local import _normalize_num_workers
     from duckdb.runners.local.runner import _normalize_num_workers as normalize_runner

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -92,6 +92,33 @@ def test_local_runner_rejects_unknown_native_copy_outcome():
         raise AssertionError("local runner must reject an unknown COPY outcome")
 
 
+def test_local_runner_records_cleanup_failures_on_unknown_copy_outcome():
+    from duckdb.runners import CopyOutcomeUnknownError
+    from duckdb.runners.local.runner import _record_unknown_copy_cleanup_errors
+
+    error = CopyOutcomeUnknownError(
+        "local-copy",
+        "s3://bucket/out",
+        "run-local-unknown",
+        cleanup_warnings=("native cleanup warning",),
+    )
+
+    recorded = _record_unknown_copy_cleanup_errors(
+        error,
+        "local write resource shutdown",
+        [RuntimeError("backend join timed out"), ValueError("fragment close failed")],
+    )
+
+    assert recorded is True
+    assert error.cleanup_warnings == (
+        "native cleanup warning",
+        "local write resource shutdown failed: RuntimeError: backend join timed out",
+        "local write resource shutdown failed: ValueError: fragment close failed",
+    )
+    assert "backend join timed out" in str(error)
+    assert error.safe_to_retry is False
+
+
 def test_local_runner_rejects_invalid_num_workers():
     from duckdb.runners.local import _normalize_num_workers
     from duckdb.runners.local.runner import _normalize_num_workers as normalize_runner

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -1944,7 +1944,12 @@ def test_distributed_copy_direct_write_committed_reader_requires_marker(tmp_path
     assert result["committed_file_path"].endswith("_vane_direct_write_run-reader/w_selected/part.parquet")
     assert result["committed_contains_loser"] is False
 
-    committed = duckdb.ray_cxx.read_committed_copy_direct_write_result(result["base_path"], result["run_id"])
+    conn = duckdb.connect()
+    committed = duckdb.ray_cxx.read_committed_copy_direct_write_result(
+        result["base_path"],
+        result["run_id"],
+        conn,
+    )
     assert committed["rows_copied"] == 7
     assert committed["copy_output_run_id"] == "run-reader"
     assert committed["copy_output_direct_write"] is True
@@ -2020,6 +2025,51 @@ def test_cleanup_uncommitted_copy_direct_write_run_public_api(tmp_path):
     assert committed_file.exists()
     assert committed_commit_dir.exists()
     assert (committed_commit_dir / "committed").exists()
+
+
+def test_inspect_and_force_abort_copy_direct_write_run_public_api(tmp_path):
+    from duckdb.runners.ray import (
+        force_abort_copy_direct_write_run,
+        inspect_copy_direct_write_run,
+    )
+
+    result = duckdb.ray_cxx.distributed_copy_direct_write_committed_reader_for_test(str(tmp_path))
+    base_path = result["base_path"]
+    run_id = result["run_id"]
+    run_dir = Path(base_path) / f"_vane_direct_write_{run_id}"
+    commit_dir = Path(f"{base_path}.duckdb_commit") / run_id
+    conn = duckdb.connect()
+
+    inspection = inspect_copy_direct_write_run(base_path, run_id, conn=conn)
+
+    assert inspection["state"] == "COMMITTED"
+    assert inspection["safe_to_retry"] is False
+    assert inspection["error"] == ""
+    assert inspection["rows_copied"] == 7
+    assert len(inspection["files"]) == 1
+    assert inspection["copy_output_run_id"] == run_id
+
+    aborted = force_abort_copy_direct_write_run(base_path, run_id, conn=conn)
+
+    assert aborted["state"] == "ABORTED"
+    assert aborted["safe_to_retry"] is True
+    assert aborted["copy_output_run_id"] == run_id
+    assert not run_dir.exists()
+    assert not commit_dir.exists()
+
+    after = inspect_copy_direct_write_run(base_path, run_id, conn=conn)
+    assert after["state"] == "UNCOMMITTED"
+    assert after["safe_to_retry"] is False
+
+
+def test_copy_direct_write_recovery_helpers_are_exported():
+    from duckdb.runners.ray import (
+        force_abort_copy_direct_write_run,
+        inspect_copy_direct_write_run,
+    )
+
+    assert callable(inspect_copy_direct_write_run)
+    assert callable(force_abort_copy_direct_write_run)
 
 
 def _register_direct_write_lifecycle_run(

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2027,7 +2027,7 @@ def test_cleanup_uncommitted_copy_direct_write_run_public_api(tmp_path):
     assert (committed_commit_dir / "committed").exists()
 
 
-def test_inspect_and_force_abort_copy_direct_write_run_public_api(tmp_path):
+def test_inspect_and_force_abort_copy_direct_write_run_rejects_node_local_output(tmp_path):
     from duckdb.runners.ray import (
         force_abort_copy_direct_write_run,
         inspect_copy_direct_write_run,
@@ -2049,17 +2049,14 @@ def test_inspect_and_force_abort_copy_direct_write_run_public_api(tmp_path):
     assert len(inspection["files"]) == 1
     assert inspection["copy_output_run_id"] == run_id
 
-    aborted = force_abort_copy_direct_write_run(base_path, run_id, conn=conn)
-
-    assert aborted["state"] == "ABORTED"
-    assert aborted["safe_to_retry"] is True
-    assert aborted["copy_output_run_id"] == run_id
-    assert not run_dir.exists()
-    assert not commit_dir.exists()
+    with pytest.raises(ValueError, match="cannot prove node-local worker output was removed"):
+        force_abort_copy_direct_write_run(base_path, run_id, conn=conn)
 
     after = inspect_copy_direct_write_run(base_path, run_id, conn=conn)
-    assert after["state"] == "UNCOMMITTED"
+    assert after["state"] == "COMMITTED"
     assert after["safe_to_retry"] is False
+    assert run_dir.exists()
+    assert commit_dir.exists()
 
 
 def test_copy_direct_write_recovery_helpers_are_exported():

--- a/tests/fast/test_ray_remote_exceptions.py
+++ b/tests/fast/test_ray_remote_exceptions.py
@@ -43,6 +43,32 @@ def test_remote_ray_exception_pickle_round_trip_restores_cause_chain():
     _assert_restored_chain(restored, "pickle")
 
 
+def test_remote_ray_exception_preserves_unknown_copy_recovery_context():
+    from duckdb.runners import CopyOutcomeUnknownError
+
+    original = CopyOutcomeUnknownError(
+        "copy-operation",
+        "s3://bucket/out",
+        "run-unknown",
+        "s3://bucket/out.duckdb_commit/run-unknown/manifest.txt",
+        "s3://bucket/out.duckdb_commit/run-unknown/committed",
+        "marker readback unavailable",
+        ("teardown warning",),
+    )
+
+    restored = pickle.loads(pickle.dumps(RemoteRayException.from_exception(original))).restore()
+
+    assert type(restored) is CopyOutcomeUnknownError
+    assert restored.operation_id == original.operation_id
+    assert restored.base_path == original.base_path
+    assert restored.run_id == original.run_id
+    assert restored.manifest_path == original.manifest_path
+    assert restored.committed_marker_path == original.committed_marker_path
+    assert restored.detail == original.detail
+    assert restored.cleanup_warnings == original.cleanup_warnings
+    assert restored.safe_to_retry is False
+
+
 @pytest.mark.parametrize(
     ("original", "attributes"),
     [

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -2541,8 +2541,30 @@ def test_ray_query_driver_client_copy_failure_recovers_without_cancel_or_close(m
     ]
 
 
-def test_ray_query_driver_client_maps_recovery_rpc_creation_failure_to_unknown(monkeypatch):
+@pytest.mark.parametrize(
+    "structured_operation_error",
+    (False, True),
+    ids=("plain-timeout", "structured-unknown"),
+)
+def test_ray_query_driver_client_maps_recovery_rpc_creation_failure_to_unknown(
+    monkeypatch,
+    structured_operation_error,
+):
     copy_future = object()
+    operation_id = "copy-recovery-creation-failed"
+    operation_error = (
+        driver.CopyOutcomeUnknownError(
+            operation_id,
+            base_path="s3://bucket/out",
+            run_id="run-recovery-creation-failed",
+            manifest_path="s3://bucket/out.duckdb_commit/run-recovery-creation-failed/manifest.txt",
+            committed_marker_path="s3://bucket/out.duckdb_commit/run-recovery-creation-failed/committed",
+            detail="native marker readback failed",
+            cleanup_warnings=("native cleanup failed",),
+        )
+        if structured_operation_error
+        else FutureTimeoutError("COPY response wait timed out")
+    )
 
     class _RemoteMethod:
         def __init__(self, result=None, *, error=None):
@@ -2568,29 +2590,60 @@ def test_ray_query_driver_client_maps_recovery_rpc_creation_failure_to_unknown(m
     monkeypatch.setattr(client, "_runtime_is_unavailable_or_replaced", lambda: False)
 
     monkeypatch.setattr(driver, "progress_enabled", lambda: False)
-    monkeypatch.setattr(
-        driver,
-        "resolve_object_refs_blocking",
-        lambda ref, **_kwargs: (_ for _ in ()).throw(FutureTimeoutError("COPY response wait timed out")),
-    )
+
+    def _resolve(ref, **_kwargs):
+        assert ref is copy_future
+        raise operation_error
+
+    monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
 
     with pytest.raises(driver.CopyOutcomeUnknownError) as error:
-        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-recovery-creation-failed"))
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr(operation_id))
 
-    assert error.value.operation_id == "copy-recovery-creation-failed"
+    assert error.value.operation_id == operation_id
+    if structured_operation_error:
+        assert error.value is operation_error
+        assert error.value.base_path == "s3://bucket/out"
+        assert error.value.run_id == "run-recovery-creation-failed"
+        assert error.value.manifest_path.endswith("/manifest.txt")
+        assert error.value.committed_marker_path.endswith("/committed")
+        assert error.value.detail == "native marker readback failed"
+        assert error.value.cleanup_warnings == ("native cleanup failed",)
     assert len(run_copy_plan.calls) == 1
     assert recover_copy_plan.calls == [
         (
             _TEST_RUNTIME_OWNER_ID,
             _TEST_SESSION_ID,
-            "copy-recovery-creation-failed",
+            operation_id,
         )
     ]
 
 
-def test_ray_query_driver_client_maps_recovery_resolution_failure_to_unknown(monkeypatch):
+@pytest.mark.parametrize(
+    "structured_operation_error",
+    (False, True),
+    ids=("plain-timeout", "structured-unknown"),
+)
+def test_ray_query_driver_client_maps_recovery_resolution_failure_to_unknown(
+    monkeypatch,
+    structured_operation_error,
+):
     copy_future = object()
     recovery_future = object()
+    operation_id = "copy-recovery-resolution-failed"
+    operation_error = (
+        driver.CopyOutcomeUnknownError(
+            operation_id,
+            base_path="s3://bucket/out",
+            run_id="run-recovery-resolution-failed",
+            manifest_path="s3://bucket/out.duckdb_commit/run-recovery-resolution-failed/manifest.txt",
+            committed_marker_path="s3://bucket/out.duckdb_commit/run-recovery-resolution-failed/committed",
+            detail="native marker readback failed",
+            cleanup_warnings=("native cleanup failed",),
+        )
+        if structured_operation_error
+        else FutureTimeoutError("COPY response wait timed out")
+    )
 
     class _RemoteMethod:
         def __init__(self, result):
@@ -2614,7 +2667,7 @@ def test_ray_query_driver_client_maps_recovery_resolution_failure_to_unknown(mon
 
     def _resolve(ref, **_kwargs):
         if ref is copy_future:
-            raise FutureTimeoutError("COPY response wait timed out")
+            raise operation_error
         assert ref is recovery_future
         raise PermissionError("runtime owner expired during COPY recovery")
 
@@ -2622,15 +2675,23 @@ def test_ray_query_driver_client_maps_recovery_resolution_failure_to_unknown(mon
     monkeypatch.setattr(driver, "resolve_object_refs_blocking", _resolve)
 
     with pytest.raises(driver.CopyOutcomeUnknownError) as error:
-        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr("copy-recovery-resolution-failed"))
+        client.run_copy_plan(_FakePhysicalPlanWithoutPlanAttr(operation_id))
 
-    assert error.value.operation_id == "copy-recovery-resolution-failed"
+    assert error.value.operation_id == operation_id
+    if structured_operation_error:
+        assert error.value is operation_error
+        assert error.value.base_path == "s3://bucket/out"
+        assert error.value.run_id == "run-recovery-resolution-failed"
+        assert error.value.manifest_path.endswith("/manifest.txt")
+        assert error.value.committed_marker_path.endswith("/committed")
+        assert error.value.detail == "native marker readback failed"
+        assert error.value.cleanup_warnings == ("native cleanup failed",)
     assert len(run_copy_plan.calls) == 1
     assert recover_copy_plan.calls == [
         (
             _TEST_RUNTIME_OWNER_ID,
             _TEST_SESSION_ID,
-            "copy-recovery-resolution-failed",
+            operation_id,
         )
     ]
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -917,6 +917,7 @@ def test_query_driver_concurrent_startup_failure_preserves_unknown_copy_outcome(
             asyncio.run(_run_actor_copy_plan(runner, logical_plan))
         assert error.value.run_id == "run-startup-unknown"
         assert any("injected concurrent COPY startup failure" in warning for warning in error.value.cleanup_warnings)
+        assert "injected concurrent COPY startup failure" in str(error.value)
         assert error.value.safe_to_retry is False
 
     assert plan_calls == 1

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -864,6 +864,65 @@ def test_query_driver_failure_immediately_after_commit_replays_success(monkeypat
     assert teardown_calls == [(plan_id, plan_id, True)]
 
 
+def test_query_driver_concurrent_startup_failure_preserves_unknown_copy_outcome(monkeypatch):
+    import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
+
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-startup-failure-outcome-unknown"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_finished = threading.Event()
+    plan_calls = 0
+    teardown_calls = []
+    unknown_result = {
+        "rows_copied": 5,
+        "copy_output_committed": False,
+        "copy_output_outcome_unknown": True,
+        "copy_output_outcome_error": "committed-marker readback was inconclusive",
+        "copy_output_base_path": "s3://bucket/out",
+        "copy_output_run_id": "run-startup-unknown",
+        "copy_output_manifest_path": "s3://bucket/out.duckdb_commit/run-startup-unknown/manifest.txt",
+        "copy_output_committed_marker_path": "s3://bucket/out.duckdb_commit/run-startup-unknown/committed",
+    }
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            plan_finished.set()
+            return unknown_result
+
+    def _fail_after_copy(_self, _actors):
+        assert plan_finished.wait(timeout=2.0)
+        raise RuntimeError("injected concurrent COPY startup failure")
+
+    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+        teardown_calls.append((actual_plan_id, query_id, drop_fragments))
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: ["actor-pool"])
+    monkeypatch.setattr(cls, "_wait_for_udf_actors_ready", _fail_after_copy)
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "wait_for_fte_query_progress_topology",
+        lambda *_args, **_kwargs: plan_finished.wait(timeout=2.0),
+    )
+
+    for _ in range(2):
+        with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+            asyncio.run(_run_actor_copy_plan(runner, logical_plan))
+        assert error.value.run_id == "run-startup-unknown"
+        assert any("injected concurrent COPY startup failure" in warning for warning in error.value.cleanup_warnings)
+        assert error.value.safe_to_retry is False
+
+    assert plan_calls == 1
+    assert teardown_calls == [(plan_id, plan_id, True)]
+
+
 def test_query_driver_postcommit_startup_drain_cancellation_replays_success(monkeypatch):
     import duckdb.runners.ray.fte_fragment_scheduler as scheduler_mod
 
@@ -1135,6 +1194,70 @@ def test_query_driver_copy_failure_is_replayed_without_reexecution(monkeypatch):
     assert plan_calls == 1
 
 
+def test_query_driver_unknown_native_copy_outcome_is_structured_and_never_reexecuted(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "copy-native-outcome-unknown"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    plan_calls = 0
+    unknown_result = {
+        "rows_copied": 3,
+        "copy_output_committed": False,
+        "copy_output_outcome_unknown": True,
+        "copy_output_outcome_error": "marker PUT failed and readback was inconclusive",
+        "copy_output_base_path": "s3://bucket/out",
+        "copy_output_run_id": "run-unknown",
+        "copy_output_manifest_path": "s3://bucket/out.duckdb_commit/run-unknown/manifest.txt",
+        "copy_output_committed_marker_path": "s3://bucket/out.duckdb_commit/run-unknown/committed",
+    }
+
+    class _PlanRunner:
+        def run_copy_plan(self, _plan, _conn):
+            nonlocal plan_calls
+            plan_calls += 1
+            return unknown_result
+
+    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+        assert actual_plan_id == plan_id
+        assert drop_fragments is True
+        cls._release_plan_session_state(runner, actual_plan_id)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_mark_query_actor_stages_ready", lambda *_args: None)
+    monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
+
+    for operation in (
+        lambda: _run_actor_copy_plan(runner, logical_plan),
+        lambda: _run_actor_copy_plan(runner, logical_plan),
+    ):
+        with pytest.raises(driver.CopyOutcomeUnknownError) as error:
+            asyncio.run(operation())
+        assert error.value.operation_id == plan_id
+        assert error.value.base_path == "s3://bucket/out"
+        assert error.value.run_id == "run-unknown"
+        assert error.value.manifest_path.endswith("/manifest.txt")
+        assert error.value.committed_marker_path.endswith("/committed")
+        assert error.value.safe_to_retry is False
+        assert error.value.cleanup_warnings == ()
+        assert "readback was inconclusive" in str(error.value)
+
+    recovered = asyncio.run(
+        cls.recover_copy_plan(
+            runner,
+            _TEST_RUNTIME_OWNER_ID,
+            _TEST_SESSION_ID,
+            plan_id,
+        )
+    )
+
+    assert recovered.outcome is None
+    assert isinstance(recovered.error, driver.CopyOutcomeUnknownError)
+    assert recovered.error.run_id == "run-unknown"
+    assert plan_calls == 1
+
+
 def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     first_plan_id = "copy-evicted-terminal-first"
@@ -1278,12 +1401,27 @@ def test_query_driver_copy_recovery_timeout_preserves_inflight_write(monkeypatch
 
 
 def test_copy_outcome_unknown_error_preserves_operation_id_across_serialization():
-    error = driver.CopyOutcomeUnknownError("unknown-copy-operation")
+    error = driver.CopyOutcomeUnknownError(
+        "unknown-copy-operation",
+        "s3://bucket/out",
+        "run-unknown",
+        "s3://bucket/out.duckdb_commit/run-unknown/manifest.txt",
+        "s3://bucket/out.duckdb_commit/run-unknown/committed",
+        "marker readback failed",
+        ("teardown warning",),
+    )
 
     restored = pickle.loads(pickle.dumps(error))
 
     assert type(restored) is driver.CopyOutcomeUnknownError
     assert restored.operation_id == error.operation_id
+    assert restored.base_path == error.base_path
+    assert restored.run_id == error.run_id
+    assert restored.manifest_path == error.manifest_path
+    assert restored.committed_marker_path == error.committed_marker_path
+    assert restored.detail == error.detail
+    assert restored.cleanup_warnings == error.cleanup_warnings
+    assert restored.safe_to_retry is False
     assert str(restored) == str(error)
 
 

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-import weakref
 from concurrent.futures import Future
 from types import SimpleNamespace
 
@@ -655,29 +654,24 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
 
     monkeypatch.setattr(RayStreamAdapter, "retire", blocking_retire)
 
-    def make_source():
-        def submitter(lease):
-            generator = _Generator(
-                [
-                    _Ref("large-block", is_block=True),
-                    _Ref(_metadata(lease, size_bytes=64)),
-                ]
-            )
-            generator_holder["generator"] = generator
-            return generator
-
-        source = _source(
-            fake_ray,
-            driver,
-            request_id="deterministic-retirement",
-            submitter=submitter,
+    def submitter(lease):
+        generator = _Generator(
+            [
+                _Ref("large-block", is_block=True),
+                _Ref(_metadata(lease, size_bytes=64)),
+            ]
         )
-        return source, weakref.ref(source)
+        generator_holder["generator"] = generator
+        return generator
 
-    source, source_ref = make_source()
+    source = _source(
+        fake_ray,
+        driver,
+        request_id="deterministic-retirement",
+        submitter=submitter,
+    )
     collector = AsyncResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(2, 22, source)
-    del source
     capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
     try:
         events = []
@@ -693,8 +687,9 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         # has dropped the source and deleted the Ray ObjectRef stream.
         assert [item[2] for item in events] == ["data"]
         assert collector._records
-        assert source_ref() is not None
         generator = generator_holder["generator"]
+        assert source.generator is generator
+        assert source.lease is not None
         assert generator.deleted_streams == []
 
         data = next(item for item in events if item[2] == "data")
@@ -711,7 +706,8 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
 
         assert [item[2] for item in events] == ["complete"]
         assert collector._records == {}
-        assert source_ref() is None
+        assert source.generator is None
+        assert source.lease is None
         assert generator.deleted_streams == [generator.completion_ref]
     finally:
         allow_retire.set()


### PR DESCRIPTION
## Summary

- reconcile a failed direct-write COPY commit-marker write by validating the marker, manifest, and selected files; report committed only when that readback is conclusive
- return and replay a structured `CopyOutcomeUnknownError` otherwise, including the base path, run ID, manifest, marker, native error, and cleanup warnings, without automatically resubmitting the write
- preserve that structured recovery context when the client-side reconciliation RPC cannot be created, resolved, or validated
- add operator-driven inspect and force-abort helpers so callers can accept the original committed run or explicitly choose data loss before submitting a new operation
- preserve connection-local object-store configuration in committed reads and recovery operations
- reject force-abort on node-local worker output before mutating the marker, lifecycle, manifest, or data; retry-safe force-abort is limited to shared remote storage
- make the terminal stream retirement regression test assert explicit source ownership cleanup instead of CPython weakref destruction timing, removing a recurring full-suite CI flake

This intentionally does not implement exactly-once fencing. `force_abort_copy_direct_write_run` is a manual recovery action for a terminated COPY with no concurrent writer.

## Related issue

close: #257

## Documentation impact

- [x] No user-facing documentation update is required. The low-level recovery helpers and their non-exactly-once constraint are documented in their public docstrings and this PR.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- incremental release wheel build and install with `SKBUILD_BUILD_DIR=build/python-release`
- `build/native-cxx20/test/unittest "[distributed][copy]"` (22 cases, 290 assertions)
- structured recovery fallback regression matrix (RPC creation/resolution x plain timeout/structured UNKNOWN): 4 passed
- `tests/fast/test_ray_result_contract.py`: 222 passed
- `tests/fast/test_ray_remote_exceptions.py`: 17 passed
- `scripts/run_release_tests.sh`: 467 passed, 1 skipped, 14 deselected; 10 real-Ray tests passed, 472 deselected
- earlier full `scripts/run_fast_tests.sh`: 6153 passed in the main shard; 96 passed in the shared-Ray shard; all test-owned Ray fault-injection shards passed; optional dependency/GPU tests skipped
- CI-equivalent artifact-mode non-Ray 1/2 shard after the retirement-test fix: 3077 passed, 13 skipped, 4 xfailed
- isolated rerun of `test_ray_grouping_sets_span_multiple_scan_tasks` with the CI Ray resource profile: passed
- workspace format check from the PR merge base
- full pre-commit diff from the PR merge base, including ruff, clang-format, and mypy
- two consecutive clean final code-review passes after the recovery-context fix and release validation

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.