### PR TITLE
[fix](distributed) Make shuffle translation build-or-throw

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -84,19 +84,40 @@ PhysicalPlanToPipelineNodeTranslator::physical_plan_to_pipeline_node(PlanConfig 
 	return DuckDBResult<std::shared_ptr<DistributedPipelineNode>>::ok(translator.node_stack_.back());
 }
 
-DuckDBResult<std::shared_ptr<DistributedPipelineNode>>
+std::shared_ptr<DistributedPipelineNode>
 PhysicalPlanToPipelineNodeTranslator::gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec,
                                                        SchemaRef schema,
                                                        std::shared_ptr<DistributedPipelineNode> child) {
-	size_t upstream_num = child->config().clustering_spec()->num_partitions();
+	if (!repartition_spec) {
+		throw InternalException("Cannot build shuffle node without a repartition specification");
+	}
+	if (!child) {
+		throw InternalException("Cannot build shuffle node without a child");
+	}
+	auto child_clustering = child->config().clustering_spec();
+	if (!child_clustering) {
+		throw InternalException("Cannot build shuffle node without child clustering metadata");
+	}
+
+	size_t upstream_num = child_clustering->num_partitions();
 	auto clustering = repartition_spec->to_clustering_spec(upstream_num);
+	if (!clustering) {
+		throw InternalException("Cannot build shuffle node without output clustering metadata");
+	}
 	size_t num_partitions = clustering->num_partitions();
 
 	auto plan_cfg_ptr = std::make_shared<PlanConfig>(plan_config_);
-	return DuckDBResult<std::shared_ptr<DistributedPipelineNode>>::ok(
-	    RepartitionNode::create(get_next_pipeline_node_id(), plan_cfg_ptr, repartition_spec, num_partitions, schema,
-	                            child, exchange_mgr_)
-	        ->into_node());
+	auto repartition_node =
+	    RepartitionNode::create(get_next_pipeline_node_id(), plan_cfg_ptr, std::move(repartition_spec), num_partitions,
+	                            std::move(schema), std::move(child), exchange_mgr_);
+	if (!repartition_node) {
+		throw InternalException("Failed to build shuffle node");
+	}
+	auto node = repartition_node->into_node();
+	if (!node) {
+		throw InternalException("Failed to wrap shuffle node");
+	}
+	return node;
 }
 
 std::shared_ptr<DistributedPipelineNode>
@@ -106,11 +127,7 @@ PhysicalPlanToPipelineNodeTranslator::gen_gather_node(std::shared_ptr<Distribute
 	}
 
 	auto spec = RepartitionSpec::create_into_partitions(1);
-	auto res = gen_shuffle_node(spec, input_node->config().schema(), input_node);
-	if (!res) {
-		throw std::runtime_error(std::string("gen_gather_node failed: ") + res.error().what());
-	}
-	return res.value();
+	return gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
 }
 
 void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOperator &op) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_aggregate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_aggregate.cpp
@@ -37,12 +37,7 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::g
 		                             ? plan_config_.num_partitions
 		                             : input_node->config().clustering_spec()->num_partitions();
 		auto spec = RepartitionSpec::create_hash(target_partitions, std::move(by));
-		auto res = gen_shuffle_node(spec, input_node->config().schema(), input_node);
-		if (!res) {
-			throw std::runtime_error(std::string("gen_shuffle_node failed in aggregate translation: ") +
-			                         res.error().what());
-		}
-		agg_input = res.value();
+		agg_input = gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
 	}
 	if (!agg_input) {
 		throw std::runtime_error("aggregate translation produced null shuffle/gather input");
@@ -73,12 +68,7 @@ PhysicalPlanToPipelineNodeTranslator::gen_with_pre_agg(std::shared_ptr<Distribut
 			by.push_back(e);
 		}
 		auto spec = RepartitionSpec::create_hash(num_partitions, std::move(by));
-		auto res = gen_shuffle_node(spec, split_details.second_stage_schema, initial_agg);
-		if (!res) {
-			throw std::runtime_error(std::string("gen_shuffle_node failed in aggregate translation: ") +
-			                         res.error().what());
-		}
-		shuffle = res.value();
+		shuffle = gen_shuffle_node(std::move(spec), split_details.second_stage_schema, initial_agg);
 	}
 
 	auto final_aggregation =
@@ -193,11 +183,7 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::g
 	    plan_config_.num_partitions > 0 ? std::min(raw_partitions, plan_config_.num_partitions) : raw_partitions;
 	const auto target_partitions = std::max<size_t>(1, configured_partitions);
 	auto repartition_spec = RepartitionSpec::create_hash(target_partitions, std::move(partition_by));
-	auto shuffle_res = gen_shuffle_node(repartition_spec, expanded_schema, expanded);
-	if (shuffle_res.is_err()) {
-		throw std::runtime_error(std::string("gen_shuffle_node failed in grouping sets translation: ") +
-		                         shuffle_res.error().what());
-	}
+	auto shuffle = gen_shuffle_node(std::move(repartition_spec), std::move(expanded_schema), expanded);
 
 	std::vector<BoundExpr> final_group_by;
 	final_group_by.reserve(group_by.size() + grouping_functions.size() + 1);
@@ -234,10 +220,9 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::g
 		final_aggregate_types.push_back(aggregate->return_type);
 	}
 	auto final_aggregate_schema = MakeSchemaRef(final_aggregate_types);
-	auto final_aggregation =
-	    std::make_shared<AggregateNode>(get_next_pipeline_node_id(), plan_config_, final_group_by, final_aggregations,
-	                                    final_aggregate_schema, shuffle_res.value())
-	        ->into_node();
+	auto final_aggregation = std::make_shared<AggregateNode>(get_next_pipeline_node_id(), plan_config_, final_group_by,
+	                                                         final_aggregations, final_aggregate_schema, shuffle)
+	                             ->into_node();
 
 	std::vector<BoundExpr> final_expressions;
 	final_expressions.reserve(group_by.size() + aggregations.size() + grouping_functions.size());

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -308,10 +308,7 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 			if (!receiver_keys.empty()) {
 				size_t target_partitions = plan_config_.num_partitions;
 				auto receiver_spec = RepartitionSpec::create_hash(target_partitions, receiver_keys);
-				auto shuffle_res = gen_shuffle_node(receiver_spec, receiver->config().schema(), receiver);
-				if (shuffle_res) {
-					receiver = shuffle_res.value();
-				}
+				receiver = gen_shuffle_node(std::move(receiver_spec), receiver->config().schema(), receiver);
 			}
 		}
 
@@ -340,15 +337,9 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 			size_t target_partitions =
 			    std::max(static_cast<size_t>(plan_config_.num_partitions), static_cast<size_t>(1));
 			auto left_spec = RepartitionSpec::create_hash(target_partitions, std::move(left_partition_by));
-			auto left_shuffle_res = gen_shuffle_node(left_spec, left_node->config().schema(), left_node);
-			if (left_shuffle_res) {
-				join_left = left_shuffle_res.value();
-			}
+			join_left = gen_shuffle_node(std::move(left_spec), left_node->config().schema(), left_node);
 			auto right_spec = RepartitionSpec::create_hash(target_partitions, std::move(right_partition_by));
-			auto right_shuffle_res = gen_shuffle_node(right_spec, right_node->config().schema(), right_node);
-			if (right_shuffle_res) {
-				join_right = right_shuffle_res.value();
-			}
+			join_right = gen_shuffle_node(std::move(right_spec), right_node->config().schema(), right_node);
 		}
 	}
 

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_misc_unary.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_misc_unary.cpp
@@ -215,11 +215,7 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 			    !WindowPartitionKeysMatch(input_node, window_definition->partitions, target_partitions)) {
 				auto spec =
 				    RepartitionSpec::create_hash(target_partitions, CopyWindowPartitionKeys(*window_definition));
-				auto shuffle = gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
-				if (!shuffle) {
-					throw InvalidInputException("Failed to repartition Window input: %s", shuffle.error().what());
-				}
-				input_node = shuffle.value();
+				input_node = gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
 			}
 		}
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_unary.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_unary.cpp
@@ -110,11 +110,7 @@ std::shared_ptr<DistributedPipelineNode> PhysicalPlanToPipelineNodeTranslator::T
 	if (!spec) {
 		spec = RepartitionSpec::create_random(0);
 	}
-	auto shuffle_result = gen_shuffle_node(spec, schema, children[0]);
-	if (!shuffle_result) {
-		throw InternalException("Failed to create RepartitionNode for REPARTITION: %s", shuffle_result.error().what());
-	}
-	return shuffle_result.value();
+	return gen_shuffle_node(std::move(spec), std::move(schema), children[0]);
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateVLLMProject(

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -86,9 +86,9 @@ private:
 	std::vector<std::shared_ptr<DistributedPipelineNode>> node_stack_;
 
 	// 生成 shuffle 节点（实现自 Rust 逻辑）
-	DuckDBResult<std::shared_ptr<DistributedPipelineNode>>
-	gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec, SchemaRef schema,
-	                 std::shared_ptr<DistributedPipelineNode> child);
+	std::shared_ptr<DistributedPipelineNode> gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec,
+	                                                          SchemaRef schema,
+	                                                          std::shared_ptr<DistributedPipelineNode> child);
 
 	// 生成无预聚合的聚合节点（GroupBy/Shuffle/Gather）
 	std::shared_ptr<DistributedPipelineNode> gen_without_pre_agg(std::shared_ptr<DistributedPipelineNode> input_node,

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -72,8 +72,8 @@
 #include "test_helpers.hpp"
 
 #include <memory>
-#include <utility>
 #include <cstdlib>
+#include <utility>
 
 using namespace duckdb;
 using namespace duckdb::distributed;
@@ -1333,6 +1333,50 @@ TEST_CASE("PhysicalPlanTranslator: window rejects incompatible partition definit
 
 	REQUIRE(res.is_err());
 	REQUIRE_THAT(res.error().what(), Catch::Matchers::Contains("incompatible partition definitions"));
+}
+
+TEST_CASE("PhysicalPlanTranslator: hash join builds both required shuffles", "[distributed][join]") {
+	ScopedTranslatorEnvironment join_strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "hash");
+	PlanConfig config;
+	config.num_partitions = 4;
+
+	auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::INNER, 1, 1));
+
+	REQUIRE(res.is_ok());
+	auto join = res.value()->inner();
+	REQUIRE(join != nullptr);
+	REQUIRE(join->name() == "HashJoin");
+	auto children = join->children();
+	REQUIRE(children.size() == 2);
+	for (const auto &child : children) {
+		auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(child);
+		REQUIRE(shuffle != nullptr);
+		REQUIRE(shuffle->config().clustering_spec() != nullptr);
+		REQUIRE(shuffle->config().clustering_spec()->type() == ClusteringSpec::Type::Hash);
+		REQUIRE(shuffle->config().clustering_spec()->num_partitions() == 4);
+	}
+}
+
+TEST_CASE("PhysicalPlanTranslator: broadcast join builds the required receiver shuffle", "[distributed][join]") {
+	ScopedTranslatorEnvironment join_strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "broadcast_left");
+	ScopedTranslatorEnvironment repartition_receiver("VANE_DISTRIBUTED_BROADCAST_JOIN_RECEIVER_REPARTITION", "true");
+	PlanConfig config;
+	config.num_partitions = 4;
+
+	auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::INNER, 1, 1));
+
+	REQUIRE(res.is_ok());
+	auto join = res.value()->inner();
+	REQUIRE(join != nullptr);
+	REQUIRE(join->name() == "BroadcastJoin");
+	auto children = join->children();
+	REQUIRE(children.size() == 2);
+	REQUIRE(std::dynamic_pointer_cast<RepartitionNode>(children[0]) == nullptr);
+	auto receiver_shuffle = std::dynamic_pointer_cast<RepartitionNode>(children[1]);
+	REQUIRE(receiver_shuffle != nullptr);
+	REQUIRE(receiver_shuffle->config().clustering_spec() != nullptr);
+	REQUIRE(receiver_shuffle->config().clustering_spec()->type() == ClusteringSpec::Type::Hash);
+	REQUIRE(receiver_shuffle->config().clustering_spec()->num_partitions() == 4);
 }
 
 TEST_CASE("PhysicalPlanTranslator: left delim join -> placeholder node", "[distributed]") {


### PR DESCRIPTION
## Summary

- Change the internal shuffle-node builder to build-or-throw while preserving the existing Result conversion at the physical-plan translation boundary.
- Update join, aggregate, grouping-set, window, gather, and repartition callers to consume the built node directly, so a mandatory shuffle can no longer fail while translation keeps an unpartitioned child.
- Add translator topology coverage for both required hash-join shuffles and the optional broadcast receiver shuffle.

## Related issue

close: #318

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change is internal to physical-plan translation and does not alter the public API.

## Validation

- `scripts/format duckdb --from-ref upstream/main --check`
- `VANE_NATIVE_BUILD_JOBS=8 VCPKG_INSTALLED_DIR=../astrovela_vane/vcpkg_installed scripts/run_native_tests.sh "[distributed]"` — 151 test cases, 4404 assertions
- `SKBUILD_BUILD_DIR=$PWD/build/python-release SKBUILD_CMAKE_BUILD_TYPE=Release CMAKE_BUILD_PARALLEL_LEVEL=8 uv pip install . --no-build-isolation`
- `scripts/run_release_tests.sh` — 460 passed, 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — all hooks skipped because the configured root hooks exclude `external/duckdb`
- Two clean post-fix code-review passes after rebasing onto `upstream/main`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.