### PR TITLE
[fix](execution) Preserve materialized result order

### DIFF
--- a/external/duckdb/src/execution/operator/helper/physical_result_collector.cpp
+++ b/external/duckdb/src/execution/operator/helper/physical_result_collector.cpp
@@ -45,7 +45,7 @@ PhysicalOperator &PhysicalResultCollector::GetResultCollector(ClientContext &con
 		if (data.output_type == QueryResultOutputType::ALLOW_STREAMING) {
 			return physical_plan.Make<PhysicalBufferedCollector>(data, false);
 		}
-		return physical_plan.Make<PhysicalMaterializedCollector>(data, true);
+		return physical_plan.Make<PhysicalMaterializedCollector>(data, false);
 	}
 
 	// Order-preserving plan, and we can use the batch index: use a batch collector.

--- a/external/duckdb/test/execution/distributed/test_executor_initialize.cpp
+++ b/external/duckdb/test/execution/distributed/test_executor_initialize.cpp
@@ -6,12 +6,26 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/execution/executor.hpp"
 #include "duckdb/execution/physical_plan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 
 using namespace duckdb;
+
+namespace {
+
+class ParallelUnpartitionedDummyScan : public PhysicalDummyScan {
+public:
+	using PhysicalDummyScan::PhysicalDummyScan;
+
+	bool ParallelSource() const override {
+		return true;
+	}
+};
+
+} // namespace
 
 TEST_CASE("Executor: Initialize with dummy plan builds pipelines", "[distributed][executor]") {
 	DuckDB db(nullptr);
@@ -86,4 +100,33 @@ TEST_CASE("Executor: progress topology plans pipelines without scheduling tasks"
 	}
 	REQUIRE(found_source_role);
 	REQUIRE(found_sink_role);
+}
+
+TEST_CASE("Result collector serializes ordered plans without batch indexes",
+          "[distributed][executor][result_collector]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+	REQUIRE_NO_FAIL(con.Query("SET threads=4"));
+
+	auto prepared = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+	prepared->names = {"value"};
+	prepared->types = {LogicalType::INTEGER};
+	prepared->properties.return_type = StatementReturnType::QUERY_RESULT;
+	prepared->output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	prepared->memory_type = QueryResultMemoryType::IN_MEMORY;
+
+	auto plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	auto &scan = plan->Make<ParallelUnpartitionedDummyScan>(prepared->types, 1);
+	REQUIRE(TaskScheduler::GetScheduler(context).NumberOfThreads() > 1);
+	REQUIRE(scan.ParallelSource());
+	REQUIRE_FALSE(scan.SupportsPartitioning(OperatorPartitionInfo::BatchIndex()));
+	REQUIRE(PhysicalPlanGenerator::PreserveInsertionOrder(context, scan));
+	REQUIRE_FALSE(PhysicalPlanGenerator::UseBatchIndex(context, scan));
+
+	plan->SetRoot(scan);
+	prepared->physical_plan = std::move(plan);
+	auto &collector = PhysicalResultCollector::GetResultCollector(context, *prepared);
+
+	REQUIRE_FALSE(collector.ParallelSink());
 }


### PR DESCRIPTION
## Summary

- serialize materialized result collection when insertion order must be preserved but the plan cannot provide batch indexes
- leave unordered parallel collection and ordered batch collection unchanged
- add a deterministic native regression covering a multi-threaded, parallel, order-preserving source without batch-index partitioning

## Validation

- `scripts/format duckdb --changed --check`
- `scripts/run_native_tests.sh "Result collector serializes ordered plans without batch indexes" -s` (1 case, 7 assertions)
- negative control with the old constructor flag fails the regression at `collector.ParallelSink()`
- `scripts/run_native_tests.sh "[distributed][executor]"` (13 cases, 182 assertions)
- `scripts/run_native_tests.sh "[distributed]"` (150 cases, 4390 assertions)
- delayed datasource reproduction with 4 threads returned `[0, 1, 2, 3]` in 5 consecutive runs
- `scripts/run_release_tests.sh` (460 base tests and 10 real-Ray tests passed; 1 artifact-only test skipped)

Closes #320
