### PR TITLE
[fix](udf) Reset streaming state for prepared executions

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -2868,6 +2868,15 @@ void PhysicalStreamingUDF::BuildPipelines(Pipeline &current, MetaPipeline &meta_
 	if (children.size() != 1) {
 		throw InternalException("PhysicalStreamingUDF requires exactly one child");
 	}
+
+	// Prepared statements reuse physical operators. Clear the source/sink
+	// rendezvous before either side initializes state for the next execution.
+	std::shared_ptr<StreamingUDFState> previous_streaming_state;
+	{
+		lock_guard<std::mutex> guard(streaming_state_lock);
+		previous_streaming_state = std::move(streaming_state);
+	}
+	previous_streaming_state.reset();
 	auto &state = meta_pipeline.GetState();
 	state.SetPipelineSource(current, *this);
 	auto &child_meta_pipeline = meta_pipeline.CreateChildMetaPipeline(current, *this, MetaPipelineType::REGULAR, false);

--- a/tests/fast/test_map.py
+++ b/tests/fast/test_map.py
@@ -102,6 +102,25 @@ class TestMap:
         assert "INOUT_FUNCTION" not in plan
         assert result.fetchall() == [(0,), (3,), (6,)]
 
+    def test_create_table_function_prepared_statement_reuses_streaming_plan(self, duckdb_cursor):
+        def identity(table):
+            import pyarrow as pa
+
+            return pa.table({"x": table.column(0)})
+
+        duckdb_cursor.create_table_function(
+            "prepared_map_batches_test",
+            identity,
+            schema={"x": duckdb.sqltypes.BIGINT},
+        )
+        duckdb_cursor.execute(
+            "PREPARE prepared_streaming_udf AS SELECT * FROM prepared_map_batches_test((SELECT i FROM range(3) tbl(i)))"
+        )
+
+        expected = [(0,), (1,), (2,)]
+        results = [duckdb_cursor.execute("EXECUTE prepared_streaming_udf").fetchall() for _ in range(3)]
+        assert results == [expected, expected, expected]
+
     def test_create_table_function_map_batches_projects_output(self, duckdb_cursor):
         def calculate_values(table):
             import pyarrow as pa


### PR DESCRIPTION
## Summary

- clear `PhysicalStreamingUDF`'s shared source/sink rendezvous whenever its
  pipelines are rebuilt, so a cached prepared physical plan lazily creates
  fresh runtime state for every execution
- release the previous execution state outside the operator's state-pointer
  lock while preserving the existing mutex-protected lazy initialization path
- add a regression that executes the same prepared streaming table UDF three
  times and requires identical non-empty results

`PreparedStatementData` retains the physical plan. Before this change, the
first execution left `source_finished` set on the `PhysicalStreamingUDF`
member state, so subsequent executions silently returned an empty result.
This restores prepared-statement reuse without changing the public API.

## Related issue

close: #319

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change restores existing prepared-statement semantics and adds no new
configuration or API.

## Validation

- non-editable incremental Release install with
  `SKBUILD_BUILD_DIR="$PWD/build/python-release"`
  `SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- installed DuckDB SourceID matched the final source tree:
  `3b79223cd4e2989f709771f7189fa70eb19d0c6c`
- `scripts/format workspace --from-ref upstream/main --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `python -m pytest tests/fast/test_map.py::TestMap::test_create_table_function_prepared_statement_reuses_streaming_plan -q`
  — 1 passed
- `python -m pytest tests/fast/test_map.py tests/fast/test_udf_process.py -q`
  — 16 passed
- `scripts/run_native_tests.sh "[execution][udf][streaming]"`
  — 2 test cases passed
- `scripts/run_release_tests.sh`
  — 460 passed and 1 skipped in the non-Ray shard; 10 passed in the real-Ray
  shard
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. The change adds no new trust
      boundary.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
