### PR TITLE
[chore](examples) Format querying images projection

### DIFF
--- a/examples/querying_images.py
+++ b/examples/querying_images.py
@@ -142,8 +142,7 @@ def relation_from_rows(conn: Any, rows: list[dict[str, Any]]) -> Any:
         *(tuple(constant(row[column]) for column in columns) for row in rows),
     )
     projections = [
-        f'{quote_ident(source)} AS {quote_ident(column)}'
-        for source, column in zip(raw.columns, columns, strict=True)
+        f"{quote_ident(source)} AS {quote_ident(column)}" for source, column in zip(raw.columns, columns, strict=True)
     ]
     return raw.query("input_rows", f"select {', '.join(projections)} from input_rows")
 


### PR DESCRIPTION
## Summary

`examples/querying_images.py` retained a list-comprehension layout and quote
style that did not match the pinned Ruff formatter, causing the full-workspace
format check to fail.

Normalize that expression to Ruff's canonical layout. The change is
AST-equivalent and does not alter behavior.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format workspace --all --check`
- `scripts/format workspace --from-ref upstream/main --check`
- `SKIP=ruff-format,clang-format,cmake-format,shfmt pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/run_release_tests.sh`
  - Non-Ray: 460 passed, 1 skipped
  - Real Ray: 10 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
