### PR TITLE
[fix](udf) Allow registered table UDFs to change cardinality

### DIFF
--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -2227,7 +2227,6 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::MapBatches(
 		input_name_values.emplace_back(Value(col.Name()));
 	}
 	new_children.emplace_back("input_names", Value::LIST(LogicalType::VARCHAR, std::move(input_name_values)));
-	new_children.emplace_back("row_preserving", Value::BOOLEAN(false));
 	if (uses_subprocess_backend) {
 		new_children.emplace_back("produce_ref_bundle_output", Value::BOOLEAN(true));
 		new_children.emplace_back("streaming_output_mode", Value("local_shm_ref_bundle"));
@@ -2343,7 +2342,6 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::FlatMap(
 			input_name_values.emplace_back(Value(col.Name()));
 		}
 		new_children.emplace_back("input_names", Value::LIST(LogicalType::VARCHAR, std::move(input_name_values)));
-		new_children.emplace_back("row_preserving", Value::BOOLEAN(false));
 		if (uses_subprocess_backend) {
 			new_children.emplace_back("produce_ref_bundle_output", Value::BOOLEAN(true));
 			new_children.emplace_back("streaming_output_mode", Value("local_shm_ref_bundle"));

--- a/src/duckdb_py/python_udf_utils.cpp
+++ b/src/duckdb_py/python_udf_utils.cpp
@@ -408,6 +408,7 @@ Value BuildPythonUDFPayload(
 	auto udf_display_name = PythonCallableDisplayName(udf);
 	children.emplace_back("udf_name", Value(udf_display_name));
 	children.emplace_back("call_mode", Value(flat_map ? "flat_map" : "map_batches"));
+	children.emplace_back("row_preserving", Value::BOOLEAN(false));
 	children.emplace_back("execution_backend", Value(execution_backend));
 	children.emplace_back("function_pickle", Value::BLOB_RAW(pickled_str));
 	children.emplace_back("function_pickle_size_bytes", Value::BIGINT(NumericCast<int64_t>(pickled_str.size())));

--- a/tests/fast/test_map.py
+++ b/tests/fast/test_map.py
@@ -121,6 +121,22 @@ class TestMap:
         results = [duckdb_cursor.execute("EXECUTE prepared_streaming_udf").fetchall() for _ in range(3)]
         assert results == [expected, expected, expected]
 
+    def test_create_table_function_map_batches_can_change_cardinality(self, duckdb_cursor):
+        def keep_first_three(table):
+            import pyarrow as pa
+
+            values = table.column(0).to_pylist()
+            return pa.table({"x": [value for value in values if value < 3]})
+
+        duckdb_cursor.create_table_function(
+            "filter_batches_test",
+            keep_first_three,
+            schema={"x": duckdb.sqltypes.BIGINT},
+        )
+        result = duckdb_cursor.sql("select * from filter_batches_test((select i from range(5) tbl(i)))")
+
+        assert result.fetchall() == [(0,), (1,), (2,)]
+
     def test_create_table_function_map_batches_projects_output(self, duckdb_cursor):
         def calculate_values(table):
             import pyarrow as pa


### PR DESCRIPTION
## Summary

- declare result-only `map_batches` and `flat_map` payloads as non-row-preserving in the shared payload builder
- remove the duplicate relation-level declarations while preserving expression UDF overrides
- add a regression proving a registered table UDF can filter five input rows to three output rows

## Root cause

`create_table_function()` used `BuildPythonUDFPayload()` without adding the `row_preserving` field that relation `map_batches()` and `flat_map()` added separately. Streaming execution treats a missing field as row-preserving for compatibility, so it rejected otherwise valid row-changing output.

The shared builder now records the result-only cardinality contract explicitly. Expression batch UDF construction continues to override the field when `row_preserving=True`, and the execution-side fallback for legacy payloads remains unchanged.

## Validation

- negative control: the new regression failed before the fix with `lazy output count (3) does not match input rows (5)`
- non-editable incremental Release build with `uv pip install . --no-build-isolation`
- `scripts/format root --changed --check`
- `python -m pytest tests/fast/test_map.py tests/fast/test_expression_udf_map_batches.py tests/fast/test_expression_udf_contracts.py -q` — 100 passed
- `python -m pytest tests/fast/test_flat_map.py tests/fast/test_udf.py::test_flat_map_basic -q` — 9 passed
- `python -m pytest tests/fast/test_expression_cls_batch.py -q` — 17 passed
- `scripts/run_release_tests.sh` — 460 passed and 1 artifact-only skip; 10 real-Ray tests passed

Closes #326
