### PR TITLE
[fix](vllm) Use a single atomic inflight counter

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -4,9 +4,10 @@
 #include "duckdb/execution/operator/projection/physical_vllm.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/vllm_executor.hpp"
-#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/execution/vllm_inflight_counter.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -193,11 +194,9 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 	std::mutex executor_call_mutex;
 	shared_ptr<VLLMExecutor> executor;
 
-	//! Global backpressure tracking (atomic for lock-free access).
-	//! Signed to avoid underflow when concurrent executors share an actor pool
-	//! and concurrent executors receive results belonging to another executor.
-	std::atomic<int64_t> submitted_prompts {0};
-	std::atomic<int64_t> completed_prompts {0};
+	//! Global backpressure tracking. A single atomic counter prevents readers
+	//! from combining submitted and completed values from different moments.
+	VLLMInflightCounter inflight_prompts;
 
 	//! Thread coordination for FinalExecute.
 	std::atomic<idx_t> active_threads {1};
@@ -208,21 +207,11 @@ struct VLLMGlobalOperatorState : public GlobalOperatorState {
 		active_threads.store(MaxValue<idx_t>(1, max_threads));
 	}
 
-	int64_t InflightPrompts() const {
-		const auto submitted = submitted_prompts.load();
-		const auto completed = completed_prompts.load();
-		if (completed > submitted) {
-			throw InternalException("vllm completed prompt count exceeded submitted prompt count");
-		}
-		return submitted - completed;
-	}
-
 	bool CanSubmitMore() const {
-		auto inflight = InflightPrompts();
 		if (config.inflight_limit == 0) {
 			return true; // No backpressure limit (shared pool mode)
 		}
-		return static_cast<idx_t>(inflight) < config.inflight_limit;
+		return inflight_prompts.Count() < config.inflight_limit;
 	}
 
 	void EnsureExecutor(ExecutionContext &context) {
@@ -382,7 +371,7 @@ static void SubmitPrompts(ExecutionContext &context, VLLMGlobalOperatorState &gs
 			// Publish after Python has installed its reservation and wait state.
 			// executor_call_mutex also prevents a result drain from racing ahead
 			// of this native accounting update.
-			gstate.submitted_prompts.fetch_add(prompts.size());
+			gstate.inflight_prompts.RecordSubmission(prompts.size());
 		});
 		return;
 	}
@@ -417,7 +406,7 @@ static void SubmitPrompts(ExecutionContext &context, VLLMGlobalOperatorState &gs
 
 		gstate.WithExecutor([&](VLLMExecutor &exec) {
 			exec.Submit(prefix, std::move(batch_prompts), batch_rows, context.client);
-			gstate.submitted_prompts.fetch_add(count);
+			gstate.inflight_prompts.RecordSubmission(count);
 		});
 	}
 }
@@ -440,7 +429,7 @@ static void TakeReadyResultOnce(ExecutionContext &context, VLLMGlobalOperatorSta
 		throw InvalidInputException("vllm executor returned %d columns, expected %d", result.second.rows->ColumnCount(),
 		                            input_column_count);
 	}
-	gstate.completed_prompts.fetch_add(result.second.rows->size());
+	gstate.inflight_prompts.RecordCompletion(result.second.rows->size());
 	auto output = BuildOutputChunk(context, *result.second.rows, result.second.outputs, result.second.outputs_validity);
 	state.pending_outputs.push_back(std::move(output));
 }

--- a/external/duckdb/src/include/duckdb/execution/vllm_inflight_counter.hpp
+++ b/external/duckdb/src/include/duckdb/execution/vllm_inflight_counter.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/vllm_inflight_counter.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+
+namespace duckdb {
+
+//! Tracks the number of submitted vLLM prompts whose results have not been consumed.
+//! A single atomic value makes each observation a consistent snapshot.
+class VLLMInflightCounter {
+public:
+	idx_t Count() const {
+		return count.load();
+	}
+
+	void RecordSubmission(idx_t amount) {
+		if (amount == 0) {
+			return;
+		}
+
+		auto current = count.load();
+		do {
+			if (amount > NumericLimits<idx_t>::Maximum() - current) {
+				throw InternalException("vllm inflight prompt count overflow");
+			}
+		} while (!count.compare_exchange_weak(current, current + amount));
+	}
+
+	void RecordCompletion(idx_t amount) {
+		if (amount == 0) {
+			return;
+		}
+
+		auto current = count.load();
+		do {
+			if (amount > current) {
+				throw InternalException("vllm completed prompt count exceeded submitted prompt count");
+			}
+		} while (!count.compare_exchange_weak(current, current - amount));
+	}
+
+private:
+	atomic<idx_t> count {0};
+};
+
+} // namespace duckdb

--- a/external/duckdb/test/execution/CMakeLists.txt
+++ b/external/duckdb/test/execution/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 option(BUILD_DISTRIBUTED "Build the distributed execution tests" ON)
 
-add_library_unity(test_execution OBJECT test_execution_batch.cpp)
+add_library_unity(test_execution OBJECT test_execution_batch.cpp
+                  test_vllm_inflight_counter.cpp)
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_execution>)
 
 if(BUILD_DISTRIBUTED)

--- a/external/duckdb/test/execution/test_vllm_inflight_counter.cpp
+++ b/external/duckdb/test/execution/test_vllm_inflight_counter.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/execution/vllm_inflight_counter.hpp"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace duckdb;
+
+TEST_CASE("vLLM inflight counter tracks submissions and completions", "[execution][vllm][concurrency]") {
+	VLLMInflightCounter counter;
+
+	REQUIRE(counter.Count() == 0);
+	counter.RecordSubmission(5);
+	REQUIRE(counter.Count() == 5);
+	counter.RecordCompletion(2);
+	REQUIRE(counter.Count() == 3);
+	counter.RecordCompletion(3);
+	REQUIRE(counter.Count() == 0);
+}
+
+TEST_CASE("vLLM inflight counter rejects invalid transitions", "[execution][vllm][concurrency]") {
+	VLLMInflightCounter counter;
+
+	counter.RecordSubmission(2);
+	REQUIRE_THROWS_AS(counter.RecordCompletion(3), InternalException);
+	REQUIRE(counter.Count() == 2);
+
+	counter.RecordCompletion(2);
+	counter.RecordSubmission(NumericLimits<idx_t>::Maximum());
+	REQUIRE_THROWS_AS(counter.RecordSubmission(1), InternalException);
+	REQUIRE(counter.Count() == NumericLimits<idx_t>::Maximum());
+	counter.RecordCompletion(NumericLimits<idx_t>::Maximum());
+	REQUIRE(counter.Count() == 0);
+}
+
+TEST_CASE("vLLM inflight counter atomically rejects concurrent over-completion", "[execution][vllm][concurrency]") {
+	VLLMInflightCounter counter;
+	counter.RecordSubmission(1);
+
+	std::atomic<idx_t> successful_completions {0};
+	std::atomic<idx_t> rejected_completions {0};
+	auto complete = [&]() {
+		try {
+			counter.RecordCompletion(1);
+			successful_completions.fetch_add(1);
+		} catch (const InternalException &) {
+			rejected_completions.fetch_add(1);
+		}
+	};
+
+	std::thread first(complete);
+	std::thread second(complete);
+	first.join();
+	second.join();
+
+	REQUIRE(successful_completions.load() == 1);
+	REQUIRE(rejected_completions.load() == 1);
+	REQUIRE(counter.Count() == 0);
+}
+
+TEST_CASE("vLLM inflight counter remains consistent under concurrent updates", "[execution][vllm][concurrency]") {
+	VLLMInflightCounter counter;
+	constexpr idx_t thread_count = 8;
+	constexpr idx_t iterations = 10000;
+	std::atomic<bool> start {false};
+	std::atomic<bool> first_observation_done {false};
+	std::atomic<idx_t> first_submissions {0};
+	std::atomic<idx_t> active_workers {thread_count};
+	std::atomic<idx_t> failures {0};
+	std::atomic<idx_t> observations {0};
+	std::vector<std::thread> threads;
+
+	for (idx_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {
+		threads.emplace_back([&]() {
+			while (!start.load()) {
+			}
+			try {
+				counter.RecordSubmission(1);
+			} catch (const InternalException &) {
+				failures.fetch_add(1);
+			}
+			first_submissions.fetch_add(1);
+			while (!first_observation_done.load()) {
+			}
+			try {
+				counter.RecordCompletion(1);
+			} catch (const InternalException &) {
+				failures.fetch_add(1);
+			}
+			for (idx_t iteration = 1; iteration < iterations; iteration++) {
+				try {
+					counter.RecordSubmission(1);
+					counter.RecordCompletion(1);
+				} catch (const InternalException &) {
+					failures.fetch_add(1);
+				}
+			}
+			active_workers.fetch_sub(1);
+		});
+	}
+
+	std::thread observer([&]() {
+		while (!start.load()) {
+		}
+		while (first_submissions.load() < thread_count) {
+		}
+		try {
+			if (counter.Count() != thread_count) {
+				failures.fetch_add(1);
+			}
+		} catch (const InternalException &) {
+			failures.fetch_add(1);
+		}
+		observations.fetch_add(1);
+		first_observation_done.store(true);
+		while (active_workers.load() > 0) {
+			try {
+				if (counter.Count() > thread_count) {
+					failures.fetch_add(1);
+				}
+			} catch (const InternalException &) {
+				failures.fetch_add(1);
+			}
+			observations.fetch_add(1);
+		}
+	});
+
+	start.store(true);
+	for (auto &thread : threads) {
+		thread.join();
+	}
+	observer.join();
+
+	REQUIRE(failures.load() == 0);
+	REQUIRE(observations.load() > 0);
+	REQUIRE(counter.Count() == 0);
+}


### PR DESCRIPTION
## Summary

- replace the independently sampled submitted/completed totals with one authoritative atomic inflight count
- update the count through checked CAS transitions so valid concurrent work cannot form a mixed snapshot, while real over-completion and overflow still fail without corrupting state
- bypass inflight accounting entirely when backpressure is disabled
- add deterministic native tests for normal transitions, invalid transitions, competing completions, and concurrent readers/writers

## Why

`PhysicalVLLM` is parallel, but its old inflight calculation loaded two separately updated atomics. A submission and completion between those loads could make a reader combine an older submitted total with a newer completed total and raise an internal invariant error even though the live state was valid.

A single inflight value gives every reader one linearizable snapshot and removes that class of failure rather than relying on a particular two-load ordering.

## Validation

- Release incremental package build and install
- `python -m pytest tests/fast/test_vllm_native_regressions.py` (26 passed)
- vLLM fast regressions (82 passed, 1 optional vLLM dependency skip)
- `scripts/run_native_tests.sh "[vllm]" -s` (4 cases, 15 assertions)
- focused concurrency test repeated 50 times normally and 20 times on one CPU
- `scripts/run_native_tests.sh "[distributed]"` (150 cases, 4390 assertions)
- `scripts/run_release_tests.sh` (460 passed/1 skipped, then 10 passed)
- DuckDB formatter check and diff checks

Closes #324
