### PR TITLE
[fix](parquet) Restore DuckDB row group byte default

### DIFF
--- a/external/duckdb/extension/parquet/parquet_extension.cpp
+++ b/external/duckdb/extension/parquet/parquet_extension.cpp
@@ -65,15 +65,13 @@
 
 namespace duckdb {
 
-static constexpr idx_t DEFAULT_PARQUET_ROW_GROUP_SIZE_BYTES = 128ULL * 1024ULL * 1024ULL;
-
 struct ParquetWriteBindData : public TableFunctionData {
 	vector<LogicalType> sql_types;
 	vector<string> column_names;
 	duckdb_parquet::CompressionCodec::type codec = duckdb_parquet::CompressionCodec::SNAPPY;
 	vector<pair<string, string>> kv_metadata;
 	idx_t row_group_size = DEFAULT_ROW_GROUP_SIZE;
-	idx_t row_group_size_bytes = DEFAULT_PARQUET_ROW_GROUP_SIZE_BYTES;
+	idx_t row_group_size_bytes = NumericLimits<idx_t>::Maximum();
 
 	//! Encryption configuration
 	shared_ptr<ParquetEncryptionConfig> encryption_config;


### PR DESCRIPTION
## Summary

- restore DuckDB’s NumericLimits<idx_t>::Maximum() default when ROW_GROUP_SIZE_BYTES is omitted
- remove the Vane-only implicit 128 MiB cap
- preserve explicit byte-limit handling and all other Parquet writer behavior

## Validation

- scripts/format duckdb --changed
- incremental native package build/install completed successfully
- tests not run, per requested scope

Closes #290