### PR TITLE
[fix](relation) Remove unreachable repartition validation

### DIFF
--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -123,9 +123,6 @@ shared_ptr<Relation> Relation::Limit(int64_t limit, int64_t offset) {
 }
 
 shared_ptr<Relation> Relation::Repartition(idx_t num_partitions, vector<unique_ptr<ParsedExpression>> partition_by) {
-	if (num_partitions > 0 && false) {
-		throw InvalidInputException("num_partitions must be greater than zero");
-	}
 	return make_shared_ptr<RepartitionRelation>(shared_from_this(), num_partitions, std::move(partition_by));
 }
 


### PR DESCRIPTION
## Summary

- remove the permanently disabled validation branch from Relation::Repartition
- preserve the internal zero-as-auto partition contract
- leave Python argument validation unchanged

## Validation

- scripts/format duckdb --changed
- tests not run, per requested scope
- local build not run, per requested scope

Closes #330