### PR TITLE
[fix](execution) Select pipeline data representation

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -183,6 +183,16 @@ OperatorResultType PhysicalTableInOutFunction::ExecuteBatch(ExecutionContext &co
 	return function.in_out_function_batch(context, data, input, output);
 }
 
+ExecutionBatchRequirement PhysicalTableInOutFunction::GetExecutionBatchRequirement(PipelineOperatorRole role) const {
+	if (role != PipelineOperatorRole::INTERMEDIATE || !projected_input.empty() || this->ordinality_idx.IsValid()) {
+		return ExecutionBatchRequirement::OPTIONAL;
+	}
+	if (function.in_out_function_batch || function.in_out_function_final_batch) {
+		return ExecutionBatchRequirement::REQUIRED;
+	}
+	return ExecutionBatchRequirement::OPTIONAL;
+}
+
 InsertionOrderPreservingMap<string> PhysicalTableInOutFunction::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	if (function.to_string) {

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_local_exchange.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_local_exchange.hpp
@@ -61,6 +61,11 @@ public:
 		return OrderPreservationType::NO_ORDER;
 	}
 
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override {
+		return role == PipelineOperatorRole::SOURCE ? ExecutionBatchRequirement::REQUIRED
+		                                            : ExecutionBatchRequirement::OPTIONAL;
+	}
+
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;

--- a/external/duckdb/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -75,6 +75,8 @@ public:
 		return function.order_preservation_type;
 	}
 
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override;
+
 private:
 	//! The table function
 	TableFunction function;

--- a/external/duckdb/src/include/duckdb/execution/operator/projection/physical_udf_inout.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/projection/physical_udf_inout.hpp
@@ -54,6 +54,11 @@ public:
 		return OrderPreservationType::NO_ORDER;
 	}
 
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override {
+		return role == PipelineOperatorRole::SOURCE ? ExecutionBatchRequirement::REQUIRED
+		                                            : ExecutionBatchRequirement::OPTIONAL;
+	}
+
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
 	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	ProgressData GetSinkProgress(ClientContext &context, GlobalSinkState &gstate,

--- a/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
@@ -45,6 +45,12 @@ class Deserializer;
 
 enum class OperatorCachingMode : uint8_t { NONE, PARTITIONED, ORDERED, UNORDERED };
 
+//! The role a physical operator has in a specific execution pipeline.
+enum class PipelineOperatorRole : uint8_t { SOURCE, INTERMEDIATE, SINK };
+
+//! Whether a role needs ExecutionBatch callbacks to preserve its execution semantics.
+enum class ExecutionBatchRequirement : uint8_t { OPTIONAL, REQUIRED };
+
 //! PhysicalOperator is the base class of the physical operators present in the execution plan.
 class PhysicalOperator {
 public:
@@ -135,6 +141,12 @@ public:
 	//! The influence the operator has on order (insertion order means no influence)
 	virtual OrderPreservationType OperatorOrder() const {
 		return OrderPreservationType::INSERTION_ORDER;
+	}
+
+	//! Whether this operator needs ExecutionBatch callbacks for the role it has in a pipeline.
+	//! OPTIONAL operators remain compatible with ExecutionBatch pipelines through the default materializing wrappers.
+	virtual ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole) const {
+		return ExecutionBatchRequirement::OPTIONAL;
 	}
 
 public:

--- a/external/duckdb/src/include/duckdb/parallel/pipeline.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/pipeline.hpp
@@ -30,6 +30,8 @@ class MetaPipeline;
 class PipelineExecutor;
 class Pipeline;
 
+enum class PipelineExecutionMode : uint8_t { DATA_CHUNK, EXECUTION_BATCH };
+
 class PipelineTask : public ExecutorTask {
 	static constexpr const idx_t PARTIAL_CHUNK_COUNT = 50;
 
@@ -129,6 +131,9 @@ public:
 	//! Returns whether any of the operators in the pipeline care about preserving order
 	bool IsOrderDependent() const;
 
+	//! Returns the representation selected for data flowing through this pipeline.
+	PipelineExecutionMode GetExecutionMode() const;
+
 	//! Registers a new batch index for a pipeline executor - returns the current minimum batch index
 	idx_t RegisterNewBatchIndex();
 
@@ -156,6 +161,8 @@ private:
 	vector<reference<PhysicalOperator>> operators;
 	//! The sink (i.e. destination) for data; this is e.g. a hash table to-be-built
 	optional_ptr<PhysicalOperator> sink;
+	//! The representation selected from the requirements of the source, intermediate operators, and sink.
+	PipelineExecutionMode execution_mode = PipelineExecutionMode::DATA_CHUNK;
 
 	//! The global source state
 	unique_ptr<GlobalSourceState> source_state;
@@ -176,6 +183,7 @@ private:
 	multiset<idx_t> batch_indexes;
 
 private:
+	void ResolveExecutionMode();
 	void ScheduleSequentialTask(shared_ptr<Event> &event);
 	bool LaunchScanTasks(shared_ptr<Event> &event, idx_t max_threads);
 

--- a/external/duckdb/src/include/duckdb/parallel/pipeline_executor.hpp
+++ b/external/duckdb/src/include/duckdb/parallel/pipeline_executor.hpp
@@ -158,8 +158,8 @@ private:
 	idx_t flushing_idx;
 	//! Persist the current operator's finalization result while downstream operators drain its output
 	OperatorFlushState operator_flush_state = OperatorFlushState::NEEDS_FINALIZE;
-	//! Whether this executor should route source/operator/sink calls through ExecutionBatch callbacks
-	bool use_execution_batches = false;
+	//! The representation selected from the source/operator/sink requirements during pipeline construction.
+	PipelineExecutionMode execution_mode;
 
 private:
 	void StartOperator(PhysicalOperator &op);

--- a/external/duckdb/src/parallel/pipeline.cpp
+++ b/external/duckdb/src/parallel/pipeline.cpp
@@ -305,6 +305,31 @@ void Pipeline::Ready() {
 	}
 	ready = true;
 	std::reverse(operators.begin(), operators.end());
+	ResolveExecutionMode();
+}
+
+void Pipeline::ResolveExecutionMode() {
+	execution_mode = PipelineExecutionMode::DATA_CHUNK;
+	if (source &&
+	    source->GetExecutionBatchRequirement(PipelineOperatorRole::SOURCE) == ExecutionBatchRequirement::REQUIRED) {
+		execution_mode = PipelineExecutionMode::EXECUTION_BATCH;
+		return;
+	}
+	for (auto &op_ref : operators) {
+		if (op_ref.get().GetExecutionBatchRequirement(PipelineOperatorRole::INTERMEDIATE) ==
+		    ExecutionBatchRequirement::REQUIRED) {
+			execution_mode = PipelineExecutionMode::EXECUTION_BATCH;
+			return;
+		}
+	}
+	if (sink && sink->GetExecutionBatchRequirement(PipelineOperatorRole::SINK) == ExecutionBatchRequirement::REQUIRED) {
+		execution_mode = PipelineExecutionMode::EXECUTION_BATCH;
+	}
+}
+
+PipelineExecutionMode Pipeline::GetExecutionMode() const {
+	D_ASSERT(ready);
+	return execution_mode;
 }
 
 void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {

--- a/external/duckdb/src/parallel/pipeline_executor.cpp
+++ b/external/duckdb/src/parallel/pipeline_executor.cpp
@@ -111,7 +111,8 @@ void ReferencePipelineBatch(ExecutionBatch &target, ExecutionBatch &source) {
 } // namespace
 
 PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_p)
-    : pipeline(pipeline_p), thread(context_p), context(context_p, thread, &pipeline_p), use_execution_batches(true) {
+    : pipeline(pipeline_p), thread(context_p), context(context_p, thread, &pipeline_p),
+      execution_mode(pipeline_p.GetExecutionMode()) {
 	D_ASSERT(pipeline.source_state);
 	if (pipeline.sink) {
 		local_sink_state = pipeline.sink->GetLocalSinkState(context);
@@ -127,19 +128,23 @@ PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_
 	}
 	local_source_state = pipeline.source->GetLocalSourceState(context, *pipeline.source_state);
 
-	intermediate_chunks.reserve(pipeline.operators.size());
-	intermediate_batches.reserve(pipeline.operators.size());
+	if (execution_mode == PipelineExecutionMode::DATA_CHUNK) {
+		intermediate_chunks.reserve(pipeline.operators.size());
+	} else {
+		intermediate_batches.reserve(pipeline.operators.size());
+	}
 	intermediate_states.reserve(pipeline.operators.size());
 	for (idx_t i = 0; i < pipeline.operators.size(); i++) {
 		auto &current_operator = pipeline.operators[i].get();
 
-		if (!use_execution_batches) {
+		if (execution_mode == PipelineExecutionMode::DATA_CHUNK) {
 			auto &prev_operator = i == 0 ? *pipeline.source : pipeline.operators[i - 1].get();
 			auto chunk = make_uniq<DataChunk>();
 			chunk->Initialize(BufferAllocator::Get(context.client), prev_operator.GetTypes());
 			intermediate_chunks.push_back(std::move(chunk));
+		} else {
+			intermediate_batches.push_back(make_uniq<ExecutionBatch>());
 		}
-		intermediate_batches.push_back(make_uniq<ExecutionBatch>());
 
 		auto op_state = current_operator.GetOperatorState(context);
 		intermediate_states.push_back(std::move(op_state));
@@ -150,7 +155,7 @@ PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_
 			FinishProcessing();
 		}
 	}
-	if (!use_execution_batches) {
+	if (execution_mode == PipelineExecutionMode::DATA_CHUNK) {
 		InitializeChunk(final_chunk);
 	}
 }
@@ -441,7 +446,7 @@ SinkNextBatchType PipelineExecutor::NextBatch(ExecutionBatch &source_batch, cons
 }
 
 PipelineExecuteResult PipelineExecutor::Execute(idx_t max_chunks) {
-	if (use_execution_batches) {
+	if (execution_mode == PipelineExecutionMode::EXECUTION_BATCH) {
 		return ExecuteBatches(max_chunks);
 	}
 	D_ASSERT(pipeline.sink);

--- a/external/duckdb/test/execution/test_execution_batch.cpp
+++ b/external/duckdb/test/execution/test_execution_batch.cpp
@@ -3,11 +3,13 @@
 
 #include "catch.hpp"
 
+#include "duckdb/execution/executor.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parallel/interrupt.hpp"
+#include "duckdb/parallel/pipeline_executor.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 
 using namespace duckdb;
@@ -70,6 +72,195 @@ public:
 	mutable vector<vector<int64_t>> observed_values;
 };
 
+class MaterializedCountingSource : public PhysicalOperator {
+public:
+	explicit MaterializedCountingSource(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::TABLE_SCAN, {LogicalType::BIGINT}, 3) {
+	}
+
+	bool IsSource() const override {
+		return true;
+	}
+
+	SourceResultType GetDataBatch(ExecutionContext &context, ExecutionBatch &batch,
+	                              OperatorSourceInput &input) const override {
+		batch_calls++;
+		return PhysicalOperator::GetDataBatch(context, batch, input);
+	}
+
+	mutable idx_t data_calls = 0;
+	mutable idx_t batch_calls = 0;
+	mutable vector<const DataChunk *> output_addresses;
+
+protected:
+	SourceResultType GetDataInternal(ExecutionContext &, DataChunk &chunk, OperatorSourceInput &) const override {
+		data_calls++;
+		output_addresses.push_back(&chunk);
+		if (next_value >= 3) {
+			return SourceResultType::FINISHED;
+		}
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(NumericCast<int64_t>(next_value + 1)));
+		next_value++;
+		return SourceResultType::HAVE_MORE_OUTPUT;
+	}
+
+private:
+	mutable idx_t next_value = 0;
+};
+
+class MaterializedCountingOperator : public PhysicalOperator {
+public:
+	explicit MaterializedCountingOperator(PhysicalPlan &physical_plan, bool requires_batch_p = false)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::PROJECTION, {LogicalType::BIGINT}, 3),
+	      requires_batch(requires_batch_p) {
+	}
+
+	OperatorResultType Execute(ExecutionContext &, DataChunk &input, DataChunk &output, GlobalOperatorState &,
+	                           OperatorState &) const override {
+		execute_calls++;
+		output_addresses.push_back(&output);
+		output.Reference(input);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	OperatorResultType ExecuteBatch(ExecutionContext &context, ExecutionBatch &input, ExecutionBatch &output,
+	                                GlobalOperatorState &gstate, OperatorState &state) const override {
+		batch_calls++;
+		return PhysicalOperator::ExecuteBatch(context, input, output, gstate, state);
+	}
+
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override {
+		return requires_batch && role == PipelineOperatorRole::INTERMEDIATE ? ExecutionBatchRequirement::REQUIRED
+		                                                                    : ExecutionBatchRequirement::OPTIONAL;
+	}
+
+	mutable idx_t execute_calls = 0;
+	mutable idx_t batch_calls = 0;
+	mutable vector<const DataChunk *> output_addresses;
+
+private:
+	bool requires_batch;
+};
+
+class MaterializedCountingSink : public PhysicalOperator {
+public:
+	explicit MaterializedCountingSink(PhysicalPlan &physical_plan, bool requires_batch_p = false)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::RESULT_COLLECTOR, {}, 3),
+	      requires_batch(requires_batch_p) {
+	}
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	SinkResultType Sink(ExecutionContext &, DataChunk &chunk, OperatorSinkInput &) const override {
+		sink_calls++;
+		for (idx_t row = 0; row < chunk.size(); row++) {
+			values.push_back(chunk.GetValue(0, row).GetValue<int64_t>());
+		}
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	SinkResultType SinkBatch(ExecutionContext &context, ExecutionBatch &batch,
+	                         OperatorSinkInput &input) const override {
+		batch_calls++;
+		return PhysicalOperator::SinkBatch(context, batch, input);
+	}
+
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override {
+		return requires_batch && role == PipelineOperatorRole::SINK ? ExecutionBatchRequirement::REQUIRED
+		                                                            : ExecutionBatchRequirement::OPTIONAL;
+	}
+
+	mutable idx_t sink_calls = 0;
+	mutable idx_t batch_calls = 0;
+	mutable vector<int64_t> values;
+
+private:
+	bool requires_batch;
+};
+
+class LazyBatchSource : public PhysicalOperator {
+public:
+	explicit LazyBatchSource(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::TABLE_SCAN, {LogicalType::BIGINT}, 3) {
+	}
+
+	bool IsSource() const override {
+		return true;
+	}
+
+	ExecutionBatchRequirement GetExecutionBatchRequirement(PipelineOperatorRole role) const override {
+		return role == PipelineOperatorRole::SOURCE ? ExecutionBatchRequirement::REQUIRED
+		                                            : ExecutionBatchRequirement::OPTIONAL;
+	}
+
+	SourceResultType GetDataBatch(ExecutionContext &, ExecutionBatch &batch, OperatorSourceInput &) const override {
+		batch_calls++;
+		batch = ExecutionBatch();
+		if (emitted) {
+			return SourceResultType::FINISHED;
+		}
+
+		ExternalBlockDescriptor block;
+		block.metadata.num_rows = 3;
+		block.metadata.size_bytes = 24;
+		auto lazy = make_uniq<LazyDataChunk>();
+		lazy->logical_types = types;
+		lazy->names = {"value"};
+		lazy->blocks.push_back(std::move(block));
+		lazy->RecomputeCardinality();
+
+		batch.kind = ExecutionBatchKind::LAZY_DATA_CHUNK;
+		batch.rows = lazy->cardinality;
+		batch.estimated_bytes = lazy->EstimatedBytes();
+		batch.lazy = std::move(lazy);
+		emitted = true;
+		return SourceResultType::HAVE_MORE_OUTPUT;
+	}
+
+	mutable idx_t data_calls = 0;
+	mutable idx_t batch_calls = 0;
+
+protected:
+	SourceResultType GetDataInternal(ExecutionContext &, DataChunk &, OperatorSourceInput &) const override {
+		data_calls++;
+		throw InternalException("LazyBatchSource requires ExecutionBatch execution");
+	}
+
+private:
+	mutable bool emitted = false;
+};
+
+class LazyBatchSink : public PhysicalOperator {
+public:
+	explicit LazyBatchSink(PhysicalPlan &physical_plan)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::RESULT_COLLECTOR, {}, 3) {
+	}
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	SinkResultType Sink(ExecutionContext &, DataChunk &, OperatorSinkInput &) const override {
+		data_calls++;
+		throw InternalException("LazyBatchSink received materialized input");
+	}
+
+	SinkResultType SinkBatch(ExecutionContext &, ExecutionBatch &batch, OperatorSinkInput &) const override {
+		batch_calls++;
+		REQUIRE(batch.kind == ExecutionBatchKind::LAZY_DATA_CHUNK);
+		REQUIRE(batch.lazy);
+		accepted_rows += batch.lazy->cardinality;
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	mutable idx_t data_calls = 0;
+	mutable idx_t batch_calls = 0;
+	mutable idx_t accepted_rows = 0;
+};
+
 static void RequireRetryablePayload(const ExecutionBatch &batch, const DataChunk *expected_payload) {
 	REQUIRE(batch.kind == ExecutionBatchKind::MATERIALIZED_CHUNK);
 	REQUIRE(batch.rows == 3);
@@ -125,6 +316,105 @@ static void VerifyStreamingBackpressure(idx_t threads) {
 }
 
 } // namespace
+
+TEST_CASE("Materialized pipelines use and reuse DataChunk callbacks", "[execution_batch][pipeline]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	Executor executor(*con.context);
+	Pipeline pipeline(executor);
+	PipelineBuildState build_state;
+	PhysicalPlan physical_plan(Allocator::DefaultAllocator());
+	MaterializedCountingSource source(physical_plan);
+	MaterializedCountingOperator op(physical_plan);
+	MaterializedCountingSink sink(physical_plan);
+
+	build_state.SetPipelineSource(pipeline, source);
+	build_state.AddPipelineOperator(pipeline, op);
+	build_state.SetPipelineSink(pipeline, sink, 0);
+	pipeline.Ready();
+	REQUIRE(pipeline.GetExecutionMode() == PipelineExecutionMode::DATA_CHUNK);
+
+	pipeline.Reset();
+	PipelineExecutor pipeline_executor(*con.context, pipeline);
+	REQUIRE(pipeline_executor.Execute() == PipelineExecuteResult::FINISHED);
+
+	REQUIRE(source.data_calls == 4);
+	REQUIRE(source.batch_calls == 0);
+	REQUIRE(op.execute_calls == 3);
+	REQUIRE(op.batch_calls == 0);
+	REQUIRE(sink.sink_calls == 3);
+	REQUIRE(sink.batch_calls == 0);
+	REQUIRE(sink.values == vector<int64_t> {1, 2, 3});
+
+	REQUIRE_FALSE(source.output_addresses.empty());
+	for (auto address : source.output_addresses) {
+		REQUIRE(address == source.output_addresses.front());
+	}
+	REQUIRE_FALSE(op.output_addresses.empty());
+	for (auto address : op.output_addresses) {
+		REQUIRE(address == op.output_addresses.front());
+	}
+}
+
+TEST_CASE("Batch-required sources preserve lazy payloads through the pipeline", "[execution_batch][pipeline]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	Executor executor(*con.context);
+	Pipeline pipeline(executor);
+	PipelineBuildState build_state;
+	PhysicalPlan physical_plan(Allocator::DefaultAllocator());
+	LazyBatchSource source(physical_plan);
+	LazyBatchSink sink(physical_plan);
+
+	build_state.SetPipelineSource(pipeline, source);
+	build_state.SetPipelineSink(pipeline, sink, 0);
+	pipeline.Ready();
+	REQUIRE(pipeline.GetExecutionMode() == PipelineExecutionMode::EXECUTION_BATCH);
+
+	pipeline.Reset();
+	PipelineExecutor pipeline_executor(*con.context, pipeline);
+	REQUIRE(pipeline_executor.Execute() == PipelineExecuteResult::FINISHED);
+
+	REQUIRE(source.data_calls == 0);
+	REQUIRE(source.batch_calls == 2);
+	REQUIRE(sink.data_calls == 0);
+	REQUIRE(sink.batch_calls == 1);
+	REQUIRE(sink.accepted_rows == 3);
+}
+
+TEST_CASE("Intermediate and sink requirements select ExecutionBatch", "[execution_batch][pipeline]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	PhysicalPlan physical_plan(Allocator::DefaultAllocator());
+
+	SECTION("intermediate operator") {
+		Executor executor(*con.context);
+		Pipeline pipeline(executor);
+		PipelineBuildState build_state;
+		MaterializedCountingSource source(physical_plan);
+		MaterializedCountingOperator op(physical_plan, true);
+		MaterializedCountingSink sink(physical_plan);
+
+		build_state.SetPipelineSource(pipeline, source);
+		build_state.AddPipelineOperator(pipeline, op);
+		build_state.SetPipelineSink(pipeline, sink, 0);
+		pipeline.Ready();
+		REQUIRE(pipeline.GetExecutionMode() == PipelineExecutionMode::EXECUTION_BATCH);
+	}
+
+	SECTION("sink") {
+		Executor executor(*con.context);
+		Pipeline pipeline(executor);
+		PipelineBuildState build_state;
+		MaterializedCountingSource source(physical_plan);
+		MaterializedCountingSink sink(physical_plan, true);
+
+		build_state.SetPipelineSource(pipeline, source);
+		build_state.SetPipelineSink(pipeline, sink, 0);
+		pipeline.Ready();
+		REQUIRE(pipeline.GetExecutionMode() == PipelineExecutionMode::EXECUTION_BATCH);
+	}
+}
 
 TEST_CASE("ExecutionBatch payload remains retryable after a sink blocks", "[execution_batch][sink]") {
 	DuckDB db(nullptr);
@@ -221,7 +511,7 @@ TEST_CASE("ExecutionBatch payload remains stable while an operator has more outp
 	}
 }
 
-TEST_CASE("Native streaming preserves ExecutionBatch payload through backpressure", "[execution_batch][streaming]") {
+TEST_CASE("Native streaming preserves rows through backpressure", "[execution_batch][streaming]") {
 	SECTION("single-threaded") {
 		VerifyStreamingBackpressure(1);
 	}


### PR DESCRIPTION
## Summary

- add a role-aware `ExecutionBatchRequirement` contract and resolve each pipeline's data representation once during `Pipeline::Ready`
- run ordinary materialized pipelines through the reusable `DataChunk` path instead of allocating through default batch compatibility wrappers
- keep `ExecutionBatch` execution for lazy local-exchange and streaming-UDF sources, and for table in/out callbacks whose semantics require batch payloads
- add native coverage for callback selection, stable chunk reuse, source/operator/sink requirements, and lazy-payload preservation

## Related issue

close: #288

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes an internal execution-path selection contract and adds no public API or configuration.

## Validation

- non-editable Release wheel install with the pinned vcpkg toolchain and `SKBUILD_BUILD_DIR="$PWD/build/python-release"`
- `scripts/format duckdb --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/run_native_tests.sh '[execution_batch]'` — 6 test cases, 120149 assertions passed
- `build/native-cxx20/test/unittest '[external_block]'` — 13 test cases, 117 assertions passed
- `build/native-cxx20/test/unittest '[execution][udf][streaming]'` — 2 test cases passed
- `build/native-cxx20/test/unittest '[distributed][executor][pipeline]'` — 10 test cases, 153 assertions passed
- `python -m pytest tests/fast/test_udf_process.py` — 7 passed
- `python -m pytest tests/fast/test_map.py::TestMap::test_create_table_function_prepared_statement_reuses_streaming_plan -q` — 1 passed
- `scripts/run_release_tests.sh` — 460 passed and 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- complete native suite audit — 4571 passed; 17 baseline/environment failures remained outside the changed paths, primarily missing loadable-extension fixtures. The potentially relevant `test_15432` failure reproduced unchanged when temporarily restoring the pre-fix global `ExecutionBatch` mode.
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. The change adds no new trust boundary.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
