### PR TITLE
[fix](distributed) Preserve range repartition metadata

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -48,14 +48,22 @@ std::string ExchangeSourceHandleKey(const ExchangeSourceHandle &handle) {
 	return ss.str();
 }
 
-vector<unique_ptr<Expression>> CopyPartitionByExpressions(const std::shared_ptr<RepartitionSpec> &spec) {
+vector<unique_ptr<Expression>> CopyHashPartitionByExpressions(const std::shared_ptr<RepartitionSpec> &spec) {
 	vector<unique_ptr<Expression>> result;
-	if (!spec) {
+	if (!spec || spec->type() == RepartitionSpec::Type::Random ||
+	    spec->type() == RepartitionSpec::Type::IntoPartitions) {
 		return result;
 	}
-	auto exprs = spec->repartition_by();
+	if (spec->type() != RepartitionSpec::Type::Hash) {
+		throw InternalException("Expected HashRepartitionSpec for generic exchange sink");
+	}
+	auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(spec.get());
+	if (!hash_spec) {
+		throw InternalException("Expected HashRepartitionSpec for generic exchange sink");
+	}
+	const auto &exprs = hash_spec->config()->by;
 	result.reserve(exprs.size());
-	for (auto &expr_ref : exprs) {
+	for (const auto &expr_ref : exprs) {
 		if (expr_ref) {
 			result.push_back(expr_ref->Copy());
 		} else {
@@ -113,7 +121,19 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan, const st
 	if (!plan || !plan->HasRoot()) {
 		return plan;
 	}
-	auto partition_exprs = CopyPartitionByExpressions(spec);
+	if (spec && spec->type() == RepartitionSpec::Type::Range) {
+		auto *range_spec = dynamic_cast<RangeRepartitionSpec *>(spec.get());
+		if (!range_spec) {
+			throw InternalException("Expected RangeRepartitionSpec for range exchange sink");
+		}
+		const auto &config = range_spec->config();
+		if (config.num_partitions() && config.num_partitions() != num_partitions) {
+			throw InvalidInputException("range repartition partition count does not match exchange partition count");
+		}
+		return AddRemoteRangeExchangeSinkPlan(std::move(plan), config.orders(), num_partitions, exchange_id,
+		                                      sink_handle, std::move(exchange_mgr), config.boundaries());
+	}
+	auto partition_exprs = CopyHashPartitionByExpressions(spec);
 	auto repartition_type = ResolveRepartitionType(spec);
 	auto &old_root = plan->Root();
 	auto estimated = old_root.estimated_cardinality;
@@ -133,6 +153,7 @@ DuckPhysicalPlanRef AddRemoteRangeExchangeSinkPlan(DuckPhysicalPlanRef plan, con
 	if (!plan || !plan->HasRoot()) {
 		return plan;
 	}
+	RangeRepartitionConfig::Validate(orders, num_partitions, boundary_keys);
 	vector<unique_ptr<Expression>> partition_exprs;
 	vector<string> order_modifiers;
 	partition_exprs.reserve(orders.size());

--- a/external/duckdb/src/execution/operator/exchange/physical_local_exchange.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_local_exchange.cpp
@@ -202,10 +202,14 @@ PhysicalLocalExchange::PhysicalLocalExchange(PhysicalPlan &physical_plan, Physic
                                              idx_t estimated_cardinality)
     : PhysicalOperator(physical_plan, type, std::move(types), estimated_cardinality),
       repartition_spec(std::move(repartition_spec)) {
-	if (this->repartition_spec) {
-		auto exprs = this->repartition_spec->repartition_by();
+	if (this->repartition_spec && this->repartition_spec->type() == RepartitionSpec::Type::Hash) {
+		auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(this->repartition_spec.get());
+		if (!hash_spec) {
+			throw InternalException("Expected HashRepartitionSpec for local exchange");
+		}
+		const auto &exprs = hash_spec->config()->by;
 		partition_by.reserve(exprs.size());
-		for (auto &expr_ref : exprs) {
+		for (const auto &expr_ref : exprs) {
 			if (expr_ref) {
 				partition_by.push_back(expr_ref->Copy());
 			}

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -145,9 +145,7 @@ PhysicalRemoteExchangeSink::PhysicalRemoteExchangeSink(
 				throw InvalidInputException("range repartition order expression cannot be null");
 			}
 		}
-		if (range_boundaries_.size() >= num_partitions_) {
-			throw InvalidInputException("range repartition requires fewer boundary keys than partitions");
-		}
+		RangeRepartitionConfig::ValidateBoundaries(num_partitions_, range_boundaries_);
 	}
 }
 

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -140,6 +140,11 @@ PhysicalRemoteExchangeSink::PhysicalRemoteExchangeSink(
 		if (partition_by_.size() != range_order_modifiers_.size()) {
 			throw InvalidInputException("range repartition requires one order modifier per partition expression");
 		}
+		for (const auto &expression : partition_by_) {
+			if (!expression) {
+				throw InvalidInputException("range repartition order expression cannot be null");
+			}
+		}
 		if (range_boundaries_.size() >= num_partitions_) {
 			throw InvalidInputException("range repartition requires fewer boundary keys than partitions");
 		}

--- a/external/duckdb/src/execution/operator/exchange/repartition.cpp
+++ b/external/duckdb/src/execution/operator/exchange/repartition.cpp
@@ -3,7 +3,48 @@
 
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 
+#include "duckdb/common/exception.hpp"
+
 namespace duckdb {
+
+namespace {
+
+void ValidateRangeOrders(const vector<BoundOrderByNode> &orders) {
+	if (orders.empty()) {
+		throw InvalidInputException("range repartition requires at least one order expression");
+	}
+	for (const auto &order : orders) {
+		if (!order.expression) {
+			throw InvalidInputException("range repartition order expression cannot be null");
+		}
+		if (order.type != OrderType::ASCENDING && order.type != OrderType::DESCENDING) {
+			throw InvalidInputException("range repartition requires explicit ASC or DESC order");
+		}
+		if (order.null_order != OrderByNullType::NULLS_FIRST && order.null_order != OrderByNullType::NULLS_LAST) {
+			throw InvalidInputException("range repartition requires explicit NULLS FIRST or NULLS LAST order");
+		}
+	}
+}
+
+vector<BoundOrderByNode> CopyRangeOrders(const vector<BoundOrderByNode> &orders) {
+	vector<BoundOrderByNode> result;
+	result.reserve(orders.size());
+	for (const auto &order : orders) {
+		result.push_back(order.Copy());
+	}
+	return result;
+}
+
+std::vector<ExprRef> CopyRangeExpressions(const vector<BoundOrderByNode> &orders) {
+	std::vector<ExprRef> result;
+	result.reserve(orders.size());
+	for (const auto &order : orders) {
+		result.emplace_back(order.expression->Copy().release());
+	}
+	return result;
+}
+
+} // namespace
 
 // HashRepartitionConfig 实现
 HashRepartitionConfig::HashRepartitionConfig(size_t num_partitions, std::vector<ExprRef> by)
@@ -42,34 +83,50 @@ std::shared_ptr<RandomShuffleConfig> RandomShuffleConfig::create(size_t num_part
 }
 
 // RangeRepartitionConfig 实现
-RangeRepartitionConfig::RangeRepartitionConfig(size_t num_partitions, std::shared_ptr<RecordBatch> boundaries,
-                                               std::vector<std::shared_ptr<class BoundExpr>> by,
-                                               std::vector<bool> descending)
-    : num_partitions(num_partitions), boundaries(std::move(boundaries)), by(std::move(by)),
-      descending(std::move(descending)) {
+RangeRepartitionConfig::RangeRepartitionConfig(size_t num_partitions, vector<BoundOrderByNode> orders,
+                                               vector<string> boundaries)
+    : num_partitions_(num_partitions), orders_(std::move(orders)), boundaries_(std::move(boundaries)) {
+	if (num_partitions_) {
+		Validate(orders_, num_partitions_, boundaries_);
+	} else {
+		ValidateRangeOrders(orders_);
+	}
 }
 
 std::vector<std::string> RangeRepartitionConfig::multiline_display() const {
 	std::vector<std::string> result;
-	result.push_back("Num partitions = " + (num_partitions ? std::to_string(num_partitions) : "None"));
+	result.push_back("Num partitions = " + (num_partitions_ ? std::to_string(num_partitions_) : "None"));
 
-	std::string pairs = "By = ";
-	for (size_t i = 0; i < by.size(); ++i) {
+	std::string by = "By = ";
+	for (size_t i = 0; i < orders_.size(); ++i) {
 		if (i > 0)
-			pairs += ", ";
-		pairs += "(expr, " + (descending[i] ? std::string("descending") : std::string("ascending")) + ")";
+			by += ", ";
+		by += orders_[i].ToString();
 	}
-	result.push_back(pairs);
+	result.push_back(std::move(by));
+	result.push_back("Boundaries = " + std::to_string(boundaries_.size()));
 
 	return result;
 }
 
-std::shared_ptr<RangeRepartitionConfig> RangeRepartitionConfig::create(size_t num_partitions,
-                                                                       std::shared_ptr<RecordBatch> boundaries,
-                                                                       std::vector<std::shared_ptr<class BoundExpr>> by,
-                                                                       std::vector<bool> descending) {
-	return std::make_shared<RangeRepartitionConfig>(num_partitions, std::move(boundaries), std::move(by),
-	                                                std::move(descending));
+std::shared_ptr<const RangeRepartitionConfig>
+RangeRepartitionConfig::create(size_t num_partitions, vector<BoundOrderByNode> orders, vector<string> boundaries) {
+	return std::make_shared<const RangeRepartitionConfig>(num_partitions, std::move(orders), std::move(boundaries));
+}
+
+void RangeRepartitionConfig::Validate(const vector<BoundOrderByNode> &orders, size_t num_partitions,
+                                      const vector<string> &boundaries) {
+	ValidateRangeOrders(orders);
+	if (num_partitions == 0) {
+		throw InvalidInputException("range repartition requires at least one partition");
+	}
+	if (boundaries.size() >= num_partitions) {
+		throw InvalidInputException("range repartition requires fewer boundary keys than partitions");
+	}
+}
+
+vector<BoundOrderByNode> RangeRepartitionConfig::CopyOrders() const {
+	return CopyRangeOrders(orders_);
 }
 
 // IntoPartitionsConfig 实现
@@ -100,21 +157,14 @@ std::shared_ptr<RepartitionSpec> RepartitionSpec::create_into_partitions(size_t 
 	return std::make_shared<IntoPartitionsRepartitionSpec>(config);
 }
 
-std::shared_ptr<RepartitionSpec> RepartitionSpec::create_range(size_t num_partitions,
-                                                               std::shared_ptr<RecordBatch> boundaries,
-                                                               std::vector<std::shared_ptr<class BoundExpr>> by,
-                                                               std::vector<bool> descending) {
-	auto config =
-	    RangeRepartitionConfig::create(num_partitions, std::move(boundaries), std::move(by), std::move(descending));
-	return std::make_shared<RangeRepartitionSpec>(config);
+std::shared_ptr<RepartitionSpec> RepartitionSpec::create_range(size_t num_partitions, vector<BoundOrderByNode> orders,
+                                                               vector<string> boundaries) {
+	auto config = RangeRepartitionConfig::create(num_partitions, std::move(orders), std::move(boundaries));
+	return std::make_shared<RangeRepartitionSpec>(std::move(config));
 }
 
 // HashRepartitionSpec 实现
 HashRepartitionSpec::HashRepartitionSpec(std::shared_ptr<HashRepartitionConfig> config) : config_(std::move(config)) {
-}
-
-std::vector<ExprRef> HashRepartitionSpec::repartition_by() const {
-	return config_->by;
 }
 
 std::vector<std::string> HashRepartitionSpec::multiline_display() const {
@@ -134,10 +184,6 @@ ClusteringSpecRef HashRepartitionSpec::to_clustering_spec(size_t upstream_num_pa
 RandomRepartitionSpec::RandomRepartitionSpec(std::shared_ptr<RandomShuffleConfig> config) : config_(std::move(config)) {
 }
 
-std::vector<ExprRef> RandomRepartitionSpec::repartition_by() const {
-	return {};
-}
-
 std::vector<std::string> RandomRepartitionSpec::multiline_display() const {
 	return config_->multiline_display();
 }
@@ -153,10 +199,6 @@ IntoPartitionsRepartitionSpec::IntoPartitionsRepartitionSpec(std::shared_ptr<Int
     : config_(std::move(config)) {
 }
 
-std::vector<ExprRef> IntoPartitionsRepartitionSpec::repartition_by() const {
-	return {};
-}
-
 std::vector<std::string> IntoPartitionsRepartitionSpec::multiline_display() const {
 	return config_->multiline_display();
 }
@@ -167,17 +209,11 @@ ClusteringSpecRef IntoPartitionsRepartitionSpec::to_clustering_spec(size_t /*ups
 }
 
 // RangeRepartitionSpec 实现
-RangeRepartitionSpec::RangeRepartitionSpec(std::shared_ptr<RangeRepartitionConfig> config)
+RangeRepartitionSpec::RangeRepartitionSpec(std::shared_ptr<const RangeRepartitionConfig> config)
     : config_(std::move(config)) {
-}
-
-std::vector<ExprRef> RangeRepartitionSpec::repartition_by() const {
-	// Convert BoundExpr list to ExprRef placeholders (real conversion would be more complex)
-	std::vector<ExprRef> res;
-	for (auto &b : config_->by) {
-		res.push_back(nullptr);
+	if (!config_) {
+		throw InvalidInputException("range repartition requires a non-null configuration");
 	}
-	return res;
 }
 
 std::vector<std::string> RangeRepartitionSpec::multiline_display() const {
@@ -185,31 +221,50 @@ std::vector<std::string> RangeRepartitionSpec::multiline_display() const {
 }
 
 ClusteringSpecRef RangeRepartitionSpec::to_clustering_spec(size_t upstream_num_partitions) const {
-	size_t actual = config_->num_partitions ? config_->num_partitions : upstream_num_partitions;
-	auto cfg = RangeClusteringConfig(actual, repartition_by(), std::vector<bool> {});
-	return ClusteringSpec::from_range_config(cfg);
+	size_t actual = config_->num_partitions() ? config_->num_partitions() : upstream_num_partitions;
+	RangeRepartitionConfig::Validate(config_->orders(), actual, config_->boundaries());
+	return ClusteringSpec::from_range_config(RangeClusteringConfig(actual, config_->CopyOrders()));
 }
 
 // RangeClusteringConfig 实现
-RangeClusteringConfig::RangeClusteringConfig(size_t num_partitions, std::vector<ExprRef> by,
-                                             std::vector<bool> descending)
-    : num_partitions(num_partitions), by(std::move(by)), descending(std::move(descending)) {
+RangeClusteringConfig::RangeClusteringConfig(size_t num_partitions, vector<BoundOrderByNode> orders)
+    : num_partitions_(num_partitions), orders_(std::move(orders)) {
+	ValidateRangeOrders(orders_);
+	if (num_partitions_ == 0) {
+		throw InvalidInputException("range clustering requires at least one partition");
+	}
+}
+
+RangeClusteringConfig::RangeClusteringConfig(const RangeClusteringConfig &other)
+    : num_partitions_(other.num_partitions_), orders_(CopyRangeOrders(other.orders_)) {
+}
+
+RangeClusteringConfig &RangeClusteringConfig::operator=(const RangeClusteringConfig &other) {
+	if (this != &other) {
+		auto orders = CopyRangeOrders(other.orders_);
+		num_partitions_ = other.num_partitions_;
+		orders_ = std::move(orders);
+	}
+	return *this;
 }
 
 std::vector<std::string> RangeClusteringConfig::multiline_display() const {
 	std::vector<std::string> result;
-	result.push_back("Num partitions = " + std::to_string(num_partitions));
+	result.push_back("Num partitions = " + std::to_string(num_partitions_));
 
-	std::string pairs = "By = ";
-	for (size_t i = 0; i < by.size(); ++i) {
+	std::string by = "By = ";
+	for (size_t i = 0; i < orders_.size(); ++i) {
 		if (i > 0)
-			pairs += ", ";
-		// We don't depend on Expression internals here; print a placeholder
-		pairs += "(expr, " + (descending[i] ? std::string("descending") : std::string("ascending")) + ")";
+			by += ", ";
+		by += orders_[i].ToString();
 	}
-	result.push_back(pairs);
+	result.push_back(std::move(by));
 
 	return result;
+}
+
+std::vector<ExprRef> RangeClusteringConfig::partition_by() const {
+	return CopyRangeExpressions(orders_);
 }
 
 // HashClusteringConfig 实现
@@ -300,30 +355,19 @@ std::vector<std::string> UnknownClusteringConfig::multiline_display() const {
 // The ClusteringSpec factory helpers are now implemented inline in repartition.hpp.
 
 // RangeClusteringSpec 实现
-RangeClusteringSpec::RangeClusteringSpec(const RangeClusteringConfig &config) : config_(config) {
+RangeClusteringSpec::RangeClusteringSpec(RangeClusteringConfig config) : config_(std::move(config)) {
 }
 
 size_t RangeClusteringSpec::num_partitions() const {
-	return config_.num_partitions;
+	return config_.num_partitions();
 }
 
 std::vector<ExprRef> RangeClusteringSpec::partition_by() const {
-	return config_.by;
+	return config_.partition_by();
 }
 
 std::vector<std::string> RangeClusteringSpec::multiline_display() const {
 	return config_.multiline_display();
-}
-
-// 其他 ClusteringSpec 派生类的实现类似...
-// 为简洁起见，这里省略详细实现
-
-// 聚类规范转换函数
-ClusteringSpecRef translate_clustering_spec(ClusteringSpecRef input_clustering_spec,
-                                            const std::vector<ExprRef> &projection) {
-	// 简化实现，实际需要根据输入规范类型和投影表达式进行复杂转换
-	// 这里返回一个未知聚类规范作为示例
-	return ClusteringSpec::unknown_with_num_partitions(input_clustering_spec->num_partitions());
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/repartition.cpp
+++ b/external/duckdb/src/execution/operator/exchange/repartition.cpp
@@ -5,6 +5,9 @@
 
 #include "duckdb/common/exception.hpp"
 
+#include <algorithm>
+#include <cstring>
+
 namespace duckdb {
 
 namespace {
@@ -24,6 +27,15 @@ void ValidateRangeOrders(const vector<BoundOrderByNode> &orders) {
 			throw InvalidInputException("range repartition requires explicit NULLS FIRST or NULLS LAST order");
 		}
 	}
+}
+
+bool EncodedSortKeyLess(const string &left, const string &right) {
+	const auto min_size = std::min(left.size(), right.size());
+	const auto comparison = std::memcmp(left.data(), right.data(), min_size);
+	if (comparison != 0) {
+		return comparison < 0;
+	}
+	return left.size() < right.size();
 }
 
 vector<BoundOrderByNode> CopyRangeOrders(const vector<BoundOrderByNode> &orders) {
@@ -86,11 +98,8 @@ std::shared_ptr<RandomShuffleConfig> RandomShuffleConfig::create(size_t num_part
 RangeRepartitionConfig::RangeRepartitionConfig(size_t num_partitions, vector<BoundOrderByNode> orders,
                                                vector<string> boundaries)
     : num_partitions_(num_partitions), orders_(std::move(orders)), boundaries_(std::move(boundaries)) {
-	if (num_partitions_) {
-		Validate(orders_, num_partitions_, boundaries_);
-	} else {
-		ValidateRangeOrders(orders_);
-	}
+	ValidateRangeOrders(orders_);
+	ValidateBoundaries(num_partitions_, boundaries_);
 }
 
 std::vector<std::string> RangeRepartitionConfig::multiline_display() const {
@@ -120,8 +129,17 @@ void RangeRepartitionConfig::Validate(const vector<BoundOrderByNode> &orders, si
 	if (num_partitions == 0) {
 		throw InvalidInputException("range repartition requires at least one partition");
 	}
-	if (boundaries.size() >= num_partitions) {
+	ValidateBoundaries(num_partitions, boundaries);
+}
+
+void RangeRepartitionConfig::ValidateBoundaries(size_t num_partitions, const vector<string> &boundaries) {
+	if (num_partitions && boundaries.size() >= num_partitions) {
 		throw InvalidInputException("range repartition requires fewer boundary keys than partitions");
+	}
+	for (size_t index = 1; index < boundaries.size(); index++) {
+		if (EncodedSortKeyLess(boundaries[index], boundaries[index - 1])) {
+			throw InvalidInputException("range repartition boundary keys must be sorted");
+		}
 	}
 }
 

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
@@ -73,6 +73,7 @@ public:
 	                                                            vector<string> boundaries);
 	static void Validate(const vector<BoundOrderByNode> &orders, size_t num_partitions,
 	                     const vector<string> &boundaries);
+	static void ValidateBoundaries(size_t num_partitions, const vector<string> &boundaries);
 
 	size_t num_partitions() const {
 		return num_partitions_;

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
@@ -3,16 +3,18 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-#include <string>
+#include "duckdb/planner/bound_result_modifier.hpp"
+
 #include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace duckdb {
 
 // 前置声明
 class Expression;
-class RecordBatch;
 class ClusteringSpec;
 
 using ExprRef = std::shared_ptr<Expression>;
@@ -64,19 +66,29 @@ public:
 // 范围重新分区配置
 class RangeRepartitionConfig : public BaseConfig {
 public:
-	size_t num_partitions; // 0 means auto
-	std::shared_ptr<RecordBatch> boundaries;
-	std::vector<std::shared_ptr<class BoundExpr>> by;
-	std::vector<bool> descending;
-
-	RangeRepartitionConfig(size_t num_partitions, std::shared_ptr<RecordBatch> boundaries,
-	                       std::vector<std::shared_ptr<class BoundExpr>> by, std::vector<bool> descending);
+	RangeRepartitionConfig(size_t num_partitions, vector<BoundOrderByNode> orders, vector<string> boundaries);
 	std::vector<std::string> multiline_display() const override;
 
-	static std::shared_ptr<RangeRepartitionConfig> create(size_t num_partitions,
-	                                                      std::shared_ptr<RecordBatch> boundaries,
-	                                                      std::vector<std::shared_ptr<class BoundExpr>> by,
-	                                                      std::vector<bool> descending);
+	static std::shared_ptr<const RangeRepartitionConfig> create(size_t num_partitions, vector<BoundOrderByNode> orders,
+	                                                            vector<string> boundaries);
+	static void Validate(const vector<BoundOrderByNode> &orders, size_t num_partitions,
+	                     const vector<string> &boundaries);
+
+	size_t num_partitions() const {
+		return num_partitions_;
+	}
+	const vector<BoundOrderByNode> &orders() const {
+		return orders_;
+	}
+	const vector<string> &boundaries() const {
+		return boundaries_;
+	}
+	vector<BoundOrderByNode> CopyOrders() const;
+
+private:
+	size_t num_partitions_; // 0 means auto
+	vector<BoundOrderByNode> orders_;
+	vector<string> boundaries_;
 };
 
 // 分区数配置
@@ -99,7 +111,6 @@ public:
 
 	virtual Type type() const = 0;
 	virtual std::string var_name() const = 0;
-	virtual std::vector<ExprRef> repartition_by() const = 0;
 	virtual std::vector<std::string> multiline_display() const = 0;
 	virtual ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const = 0;
 
@@ -107,9 +118,8 @@ public:
 	static std::shared_ptr<RepartitionSpec> create_hash(size_t num_partitions, std::vector<ExprRef> by);
 	static std::shared_ptr<RepartitionSpec> create_random(size_t num_partitions);
 	static std::shared_ptr<RepartitionSpec> create_into_partitions(size_t num_partitions);
-	static std::shared_ptr<RepartitionSpec> create_range(size_t num_partitions, std::shared_ptr<RecordBatch> boundaries,
-	                                                     std::vector<std::shared_ptr<class BoundExpr>> by,
-	                                                     std::vector<bool> descending);
+	static std::shared_ptr<RepartitionSpec> create_range(size_t num_partitions, vector<BoundOrderByNode> orders,
+	                                                     vector<string> boundaries);
 };
 
 // 聚类规范（ClusteringSpec）基础类
@@ -129,7 +139,7 @@ public:
 
 	static ClusteringSpecRef unknown();
 	static ClusteringSpecRef unknown_with_num_partitions(size_t num_partitions);
-	static ClusteringSpecRef from_range_config(const RangeClusteringConfig &config);
+	static ClusteringSpecRef from_range_config(RangeClusteringConfig config);
 	static ClusteringSpecRef from_hash_config(const HashClusteringConfig &config);
 	static ClusteringSpecRef from_random_config(const RandomClusteringConfig &config);
 	static ClusteringSpecRef from_unknown_config(const UnknownClusteringConfig &config);
@@ -159,7 +169,6 @@ public:
 	std::string var_name() const override {
 		return "Hash";
 	}
-	std::vector<ExprRef> repartition_by() const override;
 	std::vector<std::string> multiline_display() const override;
 	ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const override;
 
@@ -181,7 +190,6 @@ public:
 	std::string var_name() const override {
 		return "Random";
 	}
-	std::vector<ExprRef> repartition_by() const override;
 	std::vector<std::string> multiline_display() const override;
 	ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const override;
 
@@ -203,7 +211,6 @@ public:
 	std::string var_name() const override {
 		return "IntoPartitions";
 	}
-	std::vector<ExprRef> repartition_by() const override;
 	std::vector<std::string> multiline_display() const override;
 	ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const override;
 
@@ -214,10 +221,10 @@ public:
 
 class RangeRepartitionSpec : public RepartitionSpec {
 private:
-	std::shared_ptr<RangeRepartitionConfig> config_;
+	std::shared_ptr<const RangeRepartitionConfig> config_;
 
 public:
-	RangeRepartitionSpec(std::shared_ptr<RangeRepartitionConfig> config);
+	explicit RangeRepartitionSpec(std::shared_ptr<const RangeRepartitionConfig> config);
 
 	Type type() const override {
 		return Type::Range;
@@ -225,23 +232,34 @@ public:
 	std::string var_name() const override {
 		return "Range";
 	}
-	std::vector<ExprRef> repartition_by() const override;
 	std::vector<std::string> multiline_display() const override;
 	ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const override;
 
-	const std::shared_ptr<RangeRepartitionConfig> &config() const {
-		return config_;
+	const RangeRepartitionConfig &config() const {
+		return *config_;
 	}
 };
 
 class RangeClusteringConfig : public BaseConfig {
 public:
-	size_t num_partitions;
-	std::vector<ExprRef> by;
-	std::vector<bool> descending;
-
-	RangeClusteringConfig(size_t num_partitions, std::vector<ExprRef> by, std::vector<bool> descending);
+	RangeClusteringConfig(size_t num_partitions, vector<BoundOrderByNode> orders);
+	RangeClusteringConfig(const RangeClusteringConfig &other);
+	RangeClusteringConfig &operator=(const RangeClusteringConfig &other);
+	RangeClusteringConfig(RangeClusteringConfig &&other) noexcept = default;
+	RangeClusteringConfig &operator=(RangeClusteringConfig &&other) noexcept = default;
 	std::vector<std::string> multiline_display() const override;
+
+	size_t num_partitions() const {
+		return num_partitions_;
+	}
+	const vector<BoundOrderByNode> &orders() const {
+		return orders_;
+	}
+	std::vector<ExprRef> partition_by() const;
+
+private:
+	size_t num_partitions_;
+	vector<BoundOrderByNode> orders_;
 };
 
 class HashClusteringConfig : public BaseConfig {
@@ -275,7 +293,7 @@ private:
 	RangeClusteringConfig config_;
 
 public:
-	RangeClusteringSpec(const RangeClusteringConfig &config);
+	explicit RangeClusteringSpec(RangeClusteringConfig config);
 
 	Type type() const override {
 		return Type::Range;
@@ -346,10 +364,6 @@ public:
 	std::vector<std::string> multiline_display() const override;
 };
 
-// 聚类规范转换函数
-ClusteringSpecRef translate_clustering_spec(ClusteringSpecRef input_clustering_spec,
-                                            const std::vector<ExprRef> &projection);
-
 // Default implementations for ClusteringSpec that mirror the Rust `impl`.
 inline std::string ClusteringSpec::var_name() const {
 	switch (type()) {
@@ -415,8 +429,8 @@ inline ClusteringSpecRef ClusteringSpec::unknown_with_num_partitions(size_t num_
 	return std::make_shared<UnknownClusteringSpec>(UnknownClusteringConfig(num_partitions));
 }
 
-inline ClusteringSpecRef ClusteringSpec::from_range_config(const RangeClusteringConfig &config) {
-	return std::make_shared<RangeClusteringSpec>(config);
+inline ClusteringSpecRef ClusteringSpec::from_range_config(RangeClusteringConfig config) {
+	return std::make_shared<RangeClusteringSpec>(std::move(config));
 }
 
 inline ClusteringSpecRef ClusteringSpec::from_hash_config(const HashClusteringConfig &config) {

--- a/external/duckdb/src/planner/operator/logical_local_exchange.cpp
+++ b/external/duckdb/src/planner/operator/logical_local_exchange.cpp
@@ -44,9 +44,9 @@ void LogicalLocalExchange::Serialize(Serializer &serializer) const {
 			if (config->num_partitions) {
 				num_partitions = optional_idx(static_cast<idx_t>(config->num_partitions));
 			}
-			auto exprs = repartition_spec->repartition_by();
+			const auto &exprs = config->by;
 			partition_by.reserve(exprs.size());
-			for (auto &expr : exprs) {
+			for (const auto &expr : exprs) {
 				if (expr) {
 					partition_by.push_back(expr->Copy());
 				}

--- a/external/duckdb/test/execution/distributed/test_clustering_spec.cpp
+++ b/external/duckdb/test/execution/distributed/test_clustering_spec.cpp
@@ -102,6 +102,11 @@ TEST_CASE("Range repartition rejects incomplete metadata", "[execution][repartit
 	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(2, std::move(too_many_boundaries), {"a", "b"}),
 	                    Catch::Matchers::Contains("fewer boundary keys"));
 
+	auto unsorted_boundaries = TestRangeOrders();
+	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(3, std::move(unsorted_boundaries), {"z", "a"}),
+	                    Catch::Matchers::Contains("sorted"));
+	REQUIRE_NOTHROW(RepartitionSpec::create_range(3, TestRangeOrders(), {"a", "a"}));
+
 	vector<BoundOrderByNode> unresolved_order;
 	unresolved_order.emplace_back(OrderType::ORDER_DEFAULT, OrderByNullType::ORDER_DEFAULT,
 	                              make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));

--- a/external/duckdb/test/execution/distributed/test_clustering_spec.cpp
+++ b/external/duckdb/test/execution/distributed/test_clustering_spec.cpp
@@ -3,22 +3,51 @@
 
 #include "catch.hpp"
 
+#include "duckdb/execution/distributed/exchange/flight_exchange_manager.hpp"
+#include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
+#include "duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp"
 #include "duckdb/execution/operator/exchange/repartition.hpp"
+#include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 using namespace duckdb;
+using namespace duckdb::distributed;
+
+namespace {
+
+vector<BoundOrderByNode> TestRangeOrders() {
+	vector<BoundOrderByNode> orders;
+	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+	                    make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	orders.emplace_back(OrderType::DESCENDING, OrderByNullType::NULLS_FIRST,
+	                    make_uniq<BoundReferenceExpression>(LogicalType::VARCHAR, 1));
+	return orders;
+}
+
+} // namespace
 
 TEST_CASE("ClusteringSpec: basic properties and factories", "[execution][repartition]") {
 	// Range variant
 	{
-		RangeClusteringConfig cfg(3, std::vector<ExprRef> {nullptr}, std::vector<bool> {false});
+		RangeClusteringConfig cfg(3, TestRangeOrders());
 		auto spec = ClusteringSpec::from_range_config(cfg);
 		REQUIRE(spec->type() == ClusteringSpec::Type::Range);
 		REQUIRE(spec->var_name() == "Range");
 		REQUIRE(spec->num_partitions() == 3);
 		auto by = spec->partition_by();
-		REQUIRE(by.size() == 1);
+		REQUIRE(by.size() == 2);
+		REQUIRE(by[0] != nullptr);
+		REQUIRE(by[1] != nullptr);
+		auto *range = dynamic_cast<RangeClusteringSpec *>(spec.get());
+		REQUIRE(range != nullptr);
+		REQUIRE(range->config().orders()[0].type == OrderType::ASCENDING);
+		REQUIRE(range->config().orders()[0].null_order == OrderByNullType::NULLS_LAST);
+		REQUIRE(range->config().orders()[1].type == OrderType::DESCENDING);
+		REQUIRE(range->config().orders()[1].null_order == OrderByNullType::NULLS_FIRST);
 		auto md = spec->multiline_display();
-		REQUIRE(!md.empty());
+		REQUIRE(md.size() == 2);
+		REQUIRE(md[1].find("ASC NULLS LAST") != string::npos);
+		REQUIRE(md[1].find("DESC NULLS FIRST") != string::npos);
 	}
 
 	// Hash variant
@@ -58,4 +87,68 @@ TEST_CASE("ClusteringSpec: basic properties and factories", "[execution][reparti
 		auto spec2 = ClusteringSpec::unknown_with_num_partitions(5);
 		REQUIRE(spec2->num_partitions() == 5);
 	}
+}
+
+TEST_CASE("Range repartition rejects incomplete metadata", "[execution][repartition]") {
+	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(3, {}, {}),
+	                    Catch::Matchers::Contains("at least one order expression"));
+
+	vector<BoundOrderByNode> null_order;
+	null_order.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, nullptr);
+	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(3, std::move(null_order), {}),
+	                    Catch::Matchers::Contains("cannot be null"));
+
+	auto too_many_boundaries = TestRangeOrders();
+	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(2, std::move(too_many_boundaries), {"a", "b"}),
+	                    Catch::Matchers::Contains("fewer boundary keys"));
+
+	vector<BoundOrderByNode> unresolved_order;
+	unresolved_order.emplace_back(OrderType::ORDER_DEFAULT, OrderByNullType::ORDER_DEFAULT,
+	                              make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	REQUIRE_THROWS_WITH(RepartitionSpec::create_range(3, std::move(unresolved_order), {}),
+	                    Catch::Matchers::Contains("explicit ASC or DESC"));
+
+	auto automatic = RepartitionSpec::create_range(0, TestRangeOrders(), {"boundary-0"});
+	REQUIRE(automatic->to_clustering_spec(2)->num_partitions() == 2);
+	REQUIRE_THROWS_WITH(automatic->to_clustering_spec(1), Catch::Matchers::Contains("fewer boundary keys"));
+}
+
+TEST_CASE("Generic exchange builder preserves range partition metadata", "[distributed][repartition]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> types {LogicalType::INTEGER, LogicalType::VARCHAR};
+	auto &scan = plan->Make<PhysicalDummyScan>(types, 10);
+	plan->SetRoot(scan);
+
+	auto spec = RepartitionSpec::create_range(3, TestRangeOrders(), {"boundary-0", "boundary-1"});
+	auto clustering = spec->to_clustering_spec(1);
+	REQUIRE(clustering->type() == ClusteringSpec::Type::Range);
+	REQUIRE(clustering->num_partitions() == 3);
+	auto clustering_by = clustering->partition_by();
+	REQUIRE(clustering_by.size() == 2);
+	REQUIRE(clustering_by[0] != nullptr);
+	REQUIRE(clustering_by[1] != nullptr);
+
+	ExchangeSinkInstanceHandle sink_handle;
+	sink_handle.sink_handle.task_partition_id = 0;
+	sink_handle.output_partition_count = 3;
+	FlightExchangeConfig flight_config;
+	flight_config.node_id = "node-1";
+	auto exchange_mgr = std::make_shared<FlightExchangeManager>(std::move(flight_config));
+
+	REQUIRE_THROWS_WITH(AddRemoteExchangeSinkPlan(plan, spec, 4, "range-stage", sink_handle, exchange_mgr),
+	                    Catch::Matchers::Contains("does not match exchange partition count"));
+	auto result = AddRemoteExchangeSinkPlan(plan, spec, 3, "range-stage", sink_handle, std::move(exchange_mgr));
+	REQUIRE(result.get() == plan.get());
+	auto *sink = dynamic_cast<PhysicalRemoteExchangeSink *>(&result->Root());
+	REQUIRE(sink != nullptr);
+	REQUIRE(sink->RepartitionType() == RepartitionSpec::Type::Range);
+	REQUIRE(sink->PartitionBy().size() == 2);
+	REQUIRE(sink->PartitionBy()[0] != nullptr);
+	REQUIRE(sink->PartitionBy()[1] != nullptr);
+	const vector<string> expected_boundaries {"boundary-0", "boundary-1"};
+	const vector<string> expected_modifiers {"ASC NULLS LAST", "DESC NULLS FIRST"};
+	REQUIRE(sink->RangeBoundaries() == expected_boundaries);
+	REQUIRE(sink->RangeOrderModifiers() == expected_modifiers);
+	REQUIRE(sink->children.size() == 1);
 }


### PR DESCRIPTION
## Summary

- Replace the placeholder range repartition payload with owned DuckDB BoundOrderByNode orders and encoded boundary keys.
- Preserve non-null expressions, ASC/DESC direction, and NULL ordering when converting to range clustering metadata, and route the generic remote builder through the existing range exchange sink path.
- Remove the unused clustering translation stub that always returned Unknown, and reject incomplete, inconsistent, or unsorted range metadata before execution.

## Related issue

close: #293

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in AstroVela/vane-website.

This changes an internal low-level repartition API and adds no user-facing syntax or configuration.

## Validation

- scripts/format duckdb --changed
- uv pip install . --no-build-isolation with the Release incremental build directory
- build/native-cxx20/test/unittest [repartition] — 51 assertions in 3 test cases passed
- python -m pytest --import-mode=importlib -o pythonpath=tests tests/fast/test_ray_e2e.py::test_ray_order_by tests/fast/test_ray_e2e.py::test_ray_order_by_partitioned_global -q — 2 passed
- scripts/run_release_tests.sh — 467 passed, 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- pre-commit run --from-ref upstream/main --to-ref HEAD

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.