### PR TITLE
[refactor](relation) Decouple order binding from plan shapes

### DIFF
--- a/external/duckdb/src/include/duckdb/main/relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation.hpp
@@ -278,6 +278,8 @@ protected:
 	                                               const ParsedExpression &expression);
 	static unique_ptr<TableRef> BindRelationInput(Binder &binder, Relation &child);
 	static BoundStatement BindSelectNodeOnChild(Binder &binder, Relation &child, unique_ptr<SelectNode> select_node);
+	//! Bind an ORDER BY through the SELECT binder without replacing the child's output bindings.
+	static BoundStatement BindOrderOnChild(Binder &binder, Relation &child, const vector<OrderByNode> &orders);
 	static unique_ptr<SelectNode> WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
 	                                            const vector<ColumnDefinition> &columns);
 	static unique_ptr<QueryNode> RestoreDuplicateColumnAliases(unique_ptr<QueryNode> query_node, const string &alias,

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -372,6 +372,11 @@ private:
 	idx_t depth;
 
 private:
+	enum class SelectPlanMode : uint8_t {
+		STANDARD,
+		PRESERVE_INPUT_BINDINGS_FOR_ORDER,
+	};
+
 	//! Determine the depth of the binder
 	idx_t GetBinderDepth() const;
 	//! Increase the depth of the binder
@@ -439,7 +444,7 @@ private:
 	BoundStatement BindNode(StatementNode &node);
 
 	unique_ptr<LogicalOperator> VisitQueryNode(BoundQueryNode &node, unique_ptr<LogicalOperator> root);
-	unique_ptr<LogicalOperator> CreatePlan(BoundSelectNode &statement);
+	unique_ptr<LogicalOperator> CreatePlan(BoundSelectNode &statement, SelectPlanMode mode = SelectPlanMode::STANDARD);
 	unique_ptr<LogicalOperator> CreatePlan(BoundSetOperationNode &node);
 	unique_ptr<LogicalOperator> CreatePlan(BoundQueryNode &node);
 
@@ -533,7 +538,10 @@ private:
 
 	LogicalType BindLogicalTypeInternal(const unique_ptr<ParsedExpression> &type_expr);
 
-	BoundStatement BindSelectNode(SelectNode &statement, BoundStatement from_table);
+	BoundStatement BindSelectNode(SelectNode &statement, BoundStatement from_table,
+	                              SelectPlanMode mode = SelectPlanMode::STANDARD);
+	//! Bind ORDER BY expressions on an already-bound input while preserving its output column bindings.
+	BoundStatement BindOrderOnInput(BoundStatement from_table, const vector<OrderByNode> &orders);
 
 	unique_ptr<LogicalOperator> BindCopyDatabaseSchema(Catalog &source_catalog, const string &target_database_name);
 	unique_ptr<LogicalOperator> BindCopyDatabaseData(Catalog &source_catalog, const string &target_database_name);

--- a/external/duckdb/src/main/relation.cpp
+++ b/external/duckdb/src/main/relation.cpp
@@ -881,6 +881,12 @@ BoundStatement Relation::BindSelectNodeOnChild(Binder &binder, Relation &child, 
 	return binder.Bind(stmt.Cast<SQLStatement>());
 }
 
+BoundStatement Relation::BindOrderOnChild(Binder &binder, Relation &child, const vector<OrderByNode> &orders) {
+	auto child_ref = BindRelationInput(binder, child);
+	auto child_bound = binder.Bind(*child_ref);
+	return binder.BindOrderOnInput(std::move(child_bound), orders);
+}
+
 unique_ptr<SelectNode> Relation::WrapQueryNode(unique_ptr<QueryNode> query_node, const string &alias,
                                                const vector<ColumnDefinition> &columns) {
 	auto statement = make_uniq<SelectStatement>();

--- a/external/duckdb/src/main/relation/order_relation.cpp
+++ b/external/duckdb/src/main/relation/order_relation.cpp
@@ -6,44 +6,12 @@
 
 #include "duckdb/main/relation/order_relation.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/parser/query_node.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression/bound_columnref_expression.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
-#include "duckdb/planner/operator/logical_order.hpp"
-#include "duckdb/planner/operator/logical_projection.hpp"
 
 namespace duckdb {
-
-static void InlineOrderProjection(unique_ptr<Expression> &expression, const LogicalProjection &projection) {
-	if (expression->type == ExpressionType::BOUND_COLUMN_REF) {
-		auto &column_ref = expression->Cast<BoundColumnRefExpression>();
-		if (column_ref.binding.table_index == projection.table_index) {
-			if (column_ref.binding.column_index >= projection.expressions.size()) {
-				throw InternalException("Order relation projection reference is out of range");
-			}
-			expression = projection.expressions[column_ref.binding.column_index]->Copy();
-			return;
-		}
-	}
-	ExpressionIterator::EnumerateChildren(
-	    *expression, [&](unique_ptr<Expression> &child) { InlineOrderProjection(child, projection); });
-}
-
-static bool TryGetOrderProjectionIndex(const Expression &expression, idx_t projection_index, idx_t &column_index) {
-	if (expression.type != ExpressionType::BOUND_COLUMN_REF) {
-		return false;
-	}
-	auto &column_ref = expression.Cast<BoundColumnRefExpression>();
-	if (column_ref.binding.table_index != projection_index) {
-		return false;
-	}
-	column_index = column_ref.binding.column_index;
-	return true;
-}
 
 OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> orders)
     : Relation(child_p->context, RelationType::ORDER_RELATION), orders(std::move(orders)), child(std::move(child_p)) {
@@ -100,61 +68,7 @@ BoundStatement OrderRelation::Bind(Binder &binder) {
 }
 
 BoundStatement OrderRelation::BindAsInput(Binder &binder) {
-	if (orders.empty()) {
-		auto child_ref = BindRelationInput(binder, *child);
-		return binder.Bind(*child_ref);
-	}
-	auto select_node = make_uniq<SelectNode>();
-	select_node->select_list.push_back(make_uniq<StarExpression>());
-	auto order_node = make_uniq<OrderModifier>();
-	for (auto &order : orders) {
-		order_node->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
-	}
-	select_node->modifiers.push_back(std::move(order_node));
-	auto result = BindSelectNodeOnChild(binder, *child, std::move(select_node));
-
-	// The SELECT binder evaluates ORDER BY-only expressions in a temporary
-	// projection. Inline those expressions into the LogicalOrder and remove the
-	// projection so the child's table bindings remain visible to later relation
-	// operators. Window, UNNEST, and subquery plan nodes below it are retained.
-	auto root = std::move(result.plan);
-	if (root->type == LogicalProjection::TYPE && root->children.size() == 1 &&
-	    root->children[0]->type == LogicalOrder::TYPE) {
-		root = std::move(root->children[0]);
-	}
-	if (root->type == LogicalProjection::TYPE) {
-		D_ASSERT(root->children.size() == 1);
-		result.plan = std::move(root->children[0]);
-		return result;
-	}
-	if (root->type != LogicalOrder::TYPE || root->children.size() != 1 ||
-	    root->children[0]->type != LogicalProjection::TYPE) {
-		throw InternalException("Unexpected logical plan for an order relation");
-	}
-
-	auto &logical_order = root->Cast<LogicalOrder>();
-	auto projection_op = std::move(root->children[0]);
-	auto &projection = projection_op->Cast<LogicalProjection>();
-	D_ASSERT(projection.children.size() == 1);
-	unordered_set<idx_t> seen_projection_columns;
-	vector<BoundOrderByNode> rewritten_orders;
-	rewritten_orders.reserve(logical_order.orders.size());
-	for (auto &order : logical_order.orders) {
-		idx_t projection_column;
-		if (TryGetOrderProjectionIndex(*order.expression, projection.table_index, projection_column) &&
-		    !seen_projection_columns.insert(projection_column).second) {
-			// The SELECT binder shares identical ORDER BY expressions through one
-			// projection slot. A repeated sort key is redundant; dropping it keeps
-			// volatile expressions at one evaluation per input row.
-			continue;
-		}
-		InlineOrderProjection(order.expression, projection);
-		rewritten_orders.push_back(std::move(order));
-	}
-	logical_order.orders = std::move(rewritten_orders);
-	root->children[0] = std::move(projection.children[0]);
-	result.plan = std::move(root);
-	return result;
+	return BindOrderOnChild(binder, *child, orders);
 }
 
 bool OrderRelation::CanSerializeToQueryNodeInternal(Binder &binder) {

--- a/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
@@ -418,7 +418,21 @@ void Binder::BindWhereStarExpression(unique_ptr<ParsedExpression> &expr) {
 	}
 }
 
-BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from_table) {
+BoundStatement Binder::BindOrderOnInput(BoundStatement from_table, const vector<OrderByNode> &orders) {
+	if (orders.empty()) {
+		return from_table;
+	}
+	SelectNode statement;
+	statement.select_list.push_back(make_uniq<StarExpression>());
+	auto order_node = make_uniq<OrderModifier>();
+	for (auto &order : orders) {
+		order_node->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
+	}
+	statement.modifiers.push_back(std::move(order_node));
+	return BindSelectNode(statement, std::move(from_table), SelectPlanMode::PRESERVE_INPUT_BINDINGS_FOR_ORDER);
+}
+
+BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from_table, SelectPlanMode mode) {
 	D_ASSERT(from_table.plan);
 	D_ASSERT(!statement.from_table);
 	auto result_ptr = make_uniq<BoundSelectNode>();
@@ -701,7 +715,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 	BoundStatement result_statement;
 	result_statement.types = result.types;
 	result_statement.names = result.names;
-	result_statement.plan = CreatePlan(result);
+	result_statement.plan = CreatePlan(result, mode);
 	result_statement.extra_info.original_expressions = std::move(result.bind_state.original_expressions);
 	return result_statement;
 }

--- a/external/duckdb/src/planner/binder/query_node/plan_select_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/plan_select_node.cpp
@@ -1,12 +1,71 @@
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/planner/bound_result_modifier.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/query_node/bound_select_node.hpp"
 
 namespace duckdb {
+
+static void InlineOrderSelectList(unique_ptr<Expression> &expression, idx_t projection_index,
+                                  const vector<unique_ptr<Expression>> &select_list) {
+	if (expression->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &column_ref = expression->Cast<BoundColumnRefExpression>();
+		if (column_ref.binding.table_index == projection_index) {
+			if (column_ref.binding.column_index >= select_list.size()) {
+				throw InternalException(
+				    "ORDER BY select-list reference is out of range while preserving input bindings");
+			}
+			expression = select_list[column_ref.binding.column_index]->Copy();
+			return;
+		}
+	}
+	ExpressionIterator::EnumerateChildren(*expression, [&](unique_ptr<Expression> &child) {
+		InlineOrderSelectList(child, projection_index, select_list);
+	});
+}
+
+static bool TryGetOrderSelectListIndex(const Expression &expression, idx_t projection_index, idx_t &column_index) {
+	if (expression.type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	auto &column_ref = expression.Cast<BoundColumnRefExpression>();
+	if (column_ref.binding.table_index != projection_index) {
+		return false;
+	}
+	column_index = column_ref.binding.column_index;
+	return true;
+}
+
+static void RewriteOrderForInputBindings(BoundSelectNode &statement) {
+	if (statement.modifiers.empty()) {
+		return;
+	}
+	if (statement.modifiers.size() != 1 || statement.modifiers[0]->type != ResultModifierType::ORDER_MODIFIER) {
+		throw InternalException("Expected only an ORDER BY modifier while preserving relation input bindings");
+	}
+	auto &bound_order = statement.modifiers[0]->Cast<BoundOrderModifier>();
+	unordered_set<idx_t> seen_projection_columns;
+	vector<BoundOrderByNode> rewritten_orders;
+	rewritten_orders.reserve(bound_order.orders.size());
+	for (auto &order : bound_order.orders) {
+		idx_t projection_column;
+		if (TryGetOrderSelectListIndex(*order.expression, statement.projection_index, projection_column) &&
+		    !seen_projection_columns.insert(projection_column).second) {
+			// The SELECT binder shares identical ORDER BY expressions through one
+			// projection slot. A repeated sort key is redundant; dropping it keeps
+			// volatile expressions at one evaluation per input row.
+			continue;
+		}
+		InlineOrderSelectList(order.expression, statement.projection_index, statement.select_list);
+		rewritten_orders.push_back(std::move(order));
+	}
+	bound_order.orders = std::move(rewritten_orders);
+}
 
 unique_ptr<LogicalOperator> Binder::PlanFilter(unique_ptr<Expression> condition, unique_ptr<LogicalOperator> root) {
 	PlanSubqueries(condition, root);
@@ -15,7 +74,7 @@ unique_ptr<LogicalOperator> Binder::PlanFilter(unique_ptr<Expression> condition,
 	return std::move(filter);
 }
 
-unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement, SelectPlanMode mode) {
 	D_ASSERT(statement.from_table.plan);
 	auto root = std::move(statement.from_table.plan);
 
@@ -104,6 +163,16 @@ unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
 
 	for (auto &expr : statement.select_list) {
 		PlanSubqueries(expr, root);
+	}
+
+	if (mode == SelectPlanMode::PRESERVE_INPUT_BINDINGS_FOR_ORDER) {
+		// ORDER BY-only expressions have been bound as hidden select-list entries.
+		// Inline those structured expressions before the SELECT projection is
+		// created, then plan the modifier directly on the input. Window, UNNEST,
+		// and subquery operators planned above remain in the tree, while the
+		// input's table bindings stay visible to subsequent Relation operators.
+		RewriteOrderForInputBindings(statement);
+		return VisitQueryNode(statement, std::move(root));
 	}
 
 	auto proj = make_uniq<LogicalProjection>(statement.projection_index, std::move(statement.select_list));

--- a/external/duckdb/test/api/test_relation_api.cpp
+++ b/external/duckdb/test/api/test_relation_api.cpp
@@ -1350,6 +1350,20 @@ TEST_CASE("Empty order is an identity and inherits child serializability", "[rel
 	REQUIRE(CHECK_COLUMN(result, 0, {42}));
 }
 
+TEST_CASE("Order remains chainable above non-SQL relation inputs", "[relation_api][local_exchange]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	duckdb::unique_ptr<QueryResult> result;
+
+	REQUIRE_NO_FAIL(con.Query("PRAGMA enable_verification"));
+	auto exchange = con.Values("(2), (1)", {"i"})->LocalExchange(2);
+	auto ordered = exchange->Order("(SELECT -i)")->Limit(1)->Project("i");
+
+	REQUIRE(ordered->GetQuery().empty());
+	REQUIRE_NOTHROW(result = ordered->Execute());
+	REQUIRE(CHECK_COLUMN(result, 0, {2}));
+}
+
 TEST_CASE("Bound local query scopes determine relation serialization", "[relation_api]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/tests/fast/relational_api/test_joins.py
+++ b/tests/fast/relational_api/test_joins.py
@@ -143,6 +143,22 @@ class TestRAPIJoins:
         assert relation.order("(SELECT -id)").fetchall() == [(2,), (1,)]
 
     @pytest.mark.parametrize(
+        ("order_expression", "limit", "expected"),
+        [
+            ("(SELECT -l.id)", 1, [(2, 20)]),
+            ("unnest(l.sort_keys) DESC", 2, [(2, 20), (2, 20)]),
+        ],
+    )
+    def test_chained_order_only_expression_preserves_qualified_inputs(self, con, order_expression, limit, expected):
+        con.execute("PRAGMA enable_verification")
+        left = con.sql("SELECT * FROM (VALUES (1, [2, 1]), (2, [4, 3])) data(id, sort_keys)").set_alias("l")
+        right = con.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("r")
+
+        result = left.join(right, "l.id = r.id").order(order_expression).limit(limit).project("l.id, r.value")
+
+        assert result.fetchall() == expected
+
+    @pytest.mark.parametrize(
         ("operation", "expected"),
         [
             ("direct", [(2, 1), (2, 1), (3, 1)]),

--- a/tests/fast/relational_api/test_repartition.py
+++ b/tests/fast/relational_api/test_repartition.py
@@ -137,6 +137,22 @@ def test_relational_operations_preserve_exchange(duckdb_cursor, exchange_method,
         assert sorted(rows) == expected
 
 
+@pytest.mark.parametrize(
+    ("exchange_method", "plan_node"),
+    [("repartition", "REPARTITION"), ("local_exchange", "LOCAL_EXCHANGE")],
+)
+def test_order_after_exchange_preserves_bindings_for_downstream_relations(duckdb_cursor, exchange_method, plan_node):
+    duckdb_cursor.execute("PRAGMA enable_verification")
+    left = duckdb_cursor.sql("SELECT * FROM (VALUES (1), (2)) data(id)").set_alias("left_data")
+    right = duckdb_cursor.sql("SELECT * FROM (VALUES (1, 10), (2, 20)) data(id, value)").set_alias("right_data")
+    exchanged = getattr(left.join(right, "left_data.id = right_data.id"), exchange_method)(2)
+
+    result = exchanged.order("(SELECT -left_data.id)").limit(1).project("left_data.id, right_data.value")
+
+    assert plan_node in result.explain()
+    assert result.fetchall() == [(2, 20)]
+
+
 @pytest.mark.parametrize("exchange_method", ["repartition", "local_exchange"])
 @pytest.mark.parametrize("outer_operation", ["project", "filter"])
 def test_distinct_preserves_collation_through_exchange(duckdb_cursor, exchange_method, outer_operation):


### PR DESCRIPTION
## Summary

- add a dedicated Binder path for applying `ORDER BY` to an already-bound relation input while preserving that input's column bindings
- rewrite bound select-list references before the SELECT projection is created, retaining required window, UNNEST, and subquery operators and the existing single-evaluation behavior for duplicate volatile sort keys
- remove `OrderRelation::BindAsInput`'s inspection and mutation of concrete `LogicalProjection`/`LogicalOrder` tree shapes
- add Python and native coverage for qualified multi-source inputs, hidden order expressions, downstream relation operators, and non-SQL exchange inputs

This is an architectural maintenance change. It preserves the intended Relation API behavior and closes the concrete-plan-shape dependency documented in the issue; it does not claim a newly reproduced user-visible wrong-result bug. There is no new public Python or C++ API.

## Related issue

Closes #335

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- non-editable incremental Release build/install with `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- focused ORDER binding regressions: 7 passed
- complete modified relational API files: 216 passed
- `scripts/run_native_tests.sh '[relation_api]'`: 36 test cases, 655 assertions passed
- `python -m pytest tests/fast/test_udf_process.py`: 7 passed
- `scripts/run_release_tests.sh`: 467 passed, 1 artifact-only skip; 10 real-Ray tests passed
- `scripts/run_fast_tests.sh` clean rerun:
  - non-Ray: 6184 passed, 28 skipped, 8 xfailed, 1 xpassed
  - shared-Ray: 96 passed, 6 environment skips
  - test-owned Ray clusters: 7 passed, 1 optional-vLLM skip
- `scripts/format workspace --changed --check`
- `pre-commit run --files tests/fast/relational_api/test_joins.py tests/fast/relational_api/test_repartition.py`
- `git diff --check`
- embedded DuckDB SourceID matches the final source tree

An initial full-fast attempt had one unrelated transient failure in the vLLM native finalizer `insert_select` case while additional local Ray checks were running concurrently. That exact case subsequently passed once and then 10 more consecutive isolated reruns; the clean full launcher rerun above also passed it.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (No new dependencies or assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (These surfaces are unchanged.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
