### PR TITLE
[fix](ray) Preserve FTE worker command batch ownership

### DIFF
--- a/duckdb/runners/fte/fte_events.py
+++ b/duckdb/runners/fte/fte_events.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from duckdb.runners.fte import FteTaskAttemptId
+    from duckdb.runners.fte import FteTaskAttemptId, ScheduledAttempt
 
 
 @dataclass(frozen=True)
@@ -150,6 +150,22 @@ class FteCreateTaskCommand(FteWorkerCommand):
     attempt_id: FteTaskAttemptId
     partition_id: int
     request: dict[str, Any]
+    scheduled_attempt: ScheduledAttempt = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.scheduled_attempt.attempt_id != self.attempt_id:
+            raise ValueError(
+                "FTE create command scheduled attempt mismatch: "
+                f"command={self.attempt_id} scheduled={self.scheduled_attempt.attempt_id}"
+            )
+        if self.scheduled_attempt.request is not self.request:
+            raise ValueError("FTE create command must own its scheduled attempt request")
+        if str(self.scheduled_attempt.worker_id or "") != str(self.worker_id or ""):
+            raise ValueError(
+                "FTE create command scheduled worker mismatch: "
+                f"command={self.worker_id or '<unknown>'} "
+                f"scheduled={self.scheduled_attempt.worker_id or '<unknown>'}"
+            )
 
 
 @dataclass(frozen=True)

--- a/duckdb/runners/fte/fte_execution.py
+++ b/duckdb/runners/fte/fte_execution.py
@@ -1548,6 +1548,7 @@ class FteFragmentExecution:
             attempt_id=scheduled.attempt_id,
             partition_id=partition.task_id.partition_id,
             request=scheduled.request,
+            scheduled_attempt=scheduled,
         )
         self._record_worker_command(command)
         return scheduled

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import os
 import sys
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from duckdb.runners.common import QueryDeadlineExceeded
-from duckdb.runners.fte import fte_status_wait_timeout_s
+from duckdb.runners.fte import FteWorkerControlFailure, fte_status_wait_timeout_s
 from duckdb.runners.fte.fte_events import FteCreateTaskCommand, TaskStatusChanged
 from duckdb.runners.fte.fte_scheduler import (
     FteAttemptStatusWatcher,
@@ -22,6 +23,7 @@ from duckdb.runners.ray.fragment_registry import (
     _FTE_SCHEDULERS,
     _FTE_STATUS_WATCHERS,
 )
+from duckdb.runners.ray.fragment_worker_failures import quarantine_fte_worker
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _store_fte_result_handles,
     begin_fte_registry_operation,
@@ -62,26 +64,67 @@ class _FteQueryClosingEvent:
             return self._query_id in _FTE_CLOSING_QUERIES
 
 
+@dataclass(frozen=True)
+class FteWorkerCommandDispatchResult:
+    """Settled ownership of one driver-side worker-command batch."""
+
+    scheduled_attempts: tuple[Any, ...] = ()
+    recovery_handles: tuple[Any, ...] = ()
+    failures: tuple[FteWorkerControlFailure, ...] = ()
+    query_closed: bool = False
+
+    @property
+    def failed_worker_ids(self) -> frozenset[str]:
+        return frozenset(failure.worker_id for failure in self.failures if failure.worker_id)
+
+
 class FteWorkerCommandMixin:
     if TYPE_CHECKING:
         # Supplied by the other mixins on the composed Ray worker handle.
         _bind_fte_scheduler_handlers: Any
         _fte_partition_owner: Any
         _fte_task_handle_cls: Any
+        _handles_for_fte_worker_control_failure: Any
 
     def _execute_fte_fragment_execution_worker_commands(
         self,
         fragment_execution: FteFragmentExecution,
         worker_commands: list[Any] | tuple[Any, ...],
-    ) -> None:
+    ) -> FteWorkerCommandDispatchResult:
+        commands = tuple(worker_commands)
         terminal_attempts: set[str] = set()
-        for command_index, command in enumerate(worker_commands):
+        successful_create_attempts: dict[str, Any] = {}
+        failed_worker_keys: set[tuple[str, Any]] = set()
+        failures: list[FteWorkerControlFailure] = []
+        query_closed = False
+        abort_error: BaseException | None = None
+
+        for command_index, command in enumerate(commands):
             query_id = str(command.query_id)
             attempt_id = getattr(command, "attempt_id", None)
             if attempt_id is not None and str(attempt_id) in terminal_attempts:
                 continue
+            worker_id = str(getattr(command, "worker_id", None) or "")
+            worker_key: tuple[str, Any]
+            if worker_id:
+                worker_key = ("worker_id", worker_id)
+            else:
+                worker_key = ("worker_handle", id(getattr(command, "worker", None)))
+            if worker_key in failed_worker_keys:
+                _fte_command_debug_log(
+                    "execute_command_skipped_failed_worker",
+                    command_index=command_index,
+                    command_count=len(commands),
+                    command_type=getattr(command, "command_type", type(command).__name__),
+                    query_id=getattr(command, "query_id", ""),
+                    fragment_id=getattr(command, "fragment_id", ""),
+                    attempt_id=attempt_id,
+                    worker_id=worker_id,
+                )
+                continue
             if not begin_fte_registry_operation(query_id):
-                return
+                query_closed = True
+                break
             try:
                 scheduler = _FTE_SCHEDULERS.get_or_create(query_id)
                 self._bind_fte_scheduler_handlers(scheduler)
@@ -91,7 +134,7 @@ class FteWorkerCommandMixin:
                 _fte_command_debug_log(
                     "execute_command_start",
                     command_index=command_index,
-                    command_count=len(worker_commands),
+                    command_count=len(commands),
                     command_type=command_type,
                     query_id=getattr(command, "query_id", ""),
                     fragment_id=getattr(command, "fragment_id", ""),
@@ -110,13 +153,16 @@ class FteWorkerCommandMixin:
                         command,
                         cancel_event=query_closing,
                     )
-                except FteSplitSubmissionCancelled:
+                except FteSplitSubmissionCancelled as exc:
                     if query_closing.is_set():
-                        return
-                    raise
+                        query_closed = True
+                    else:
+                        abort_error = exc
+                    break
                 except FteSplitQueueTerminal as exc:
                     if query_closing.is_set():
-                        return
+                        query_closed = True
+                        break
                     terminal_attempts.add(str(exc.attempt_id))
                     scheduler.enqueue(
                         TaskStatusChanged.from_status(
@@ -127,15 +173,17 @@ class FteWorkerCommandMixin:
                         priority=True,
                     )
                     continue
-                except QueryDeadlineExceeded:
-                    raise
+                except QueryDeadlineExceeded as exc:
+                    abort_error = exc
+                    break
                 except Exception as exc:
                     if query_closing.is_set():
-                        return
+                        query_closed = True
+                        break
                     _fte_command_debug_log(
                         "execute_command_error",
                         command_index=command_index,
-                        command_count=len(worker_commands),
+                        command_count=len(commands),
                         command_type=command_type,
                         query_id=getattr(command, "query_id", ""),
                         fragment_id=getattr(command, "fragment_id", ""),
@@ -145,21 +193,39 @@ class FteWorkerCommandMixin:
                         error_type=type(exc).__name__,
                         error=exc,
                     )
-                    raise fragment_execution.worker_control_failure_for_command(command, exc) from exc
+                    failure = fragment_execution.worker_control_failure_for_command(command, exc)
+                    failed_worker_keys.add(worker_key)
+                    failures.append(failure)
+                    if failure.worker_id:
+                        # Fence immediately, before another command or thread can
+                        # select the failed worker. The scheduler reconciliation
+                        # remains deferred until this batch's healthy tail owns a
+                        # terminal outcome.
+                        quarantine_fte_worker(failure.worker_id)
+                    continue
+                try:
+                    if isinstance(command, FteCreateTaskCommand):
+                        command.worker.record_fte_task_started_from_reservation(
+                            command.query_id,
+                            command.fragment_id,
+                            command.partition_id,
+                            command.attempt_id,
+                            command.request,
+                        )
+                    else:
+                        fragment_execution.handle_worker_command_success(command)
+                except Exception as exc:
+                    abort_error = exc
+                    break
+                if query_closing.is_set():
+                    query_closed = True
+                    break
                 if isinstance(command, FteCreateTaskCommand):
-                    command.worker.record_fte_task_started_from_reservation(
-                        command.query_id,
-                        command.fragment_id,
-                        command.partition_id,
-                        command.attempt_id,
-                        command.request,
-                    )
-                else:
-                    fragment_execution.handle_worker_command_success(command)
+                    successful_create_attempts[str(command.attempt_id)] = command.scheduled_attempt
                 _fte_command_debug_log(
                     "execute_command_done",
                     command_index=command_index,
-                    command_count=len(worker_commands),
+                    command_count=len(commands),
                     command_type=command_type,
                     query_id=getattr(command, "query_id", ""),
                     fragment_id=getattr(command, "fragment_id", ""),
@@ -170,18 +236,53 @@ class FteWorkerCommandMixin:
             finally:
                 end_fte_registry_operation(query_id)
 
-    def _execute_fte_fragment_execution_outbox(self, fragment_execution: FteFragmentExecution) -> None:
-        self._execute_fte_fragment_execution_worker_commands(
-            fragment_execution, fragment_execution.pop_worker_commands()
+        recovery_handles: list[Any] = []
+        unknown_worker_failure: FteWorkerControlFailure | None = None
+        for failure in failures:
+            if not failure.worker_id:
+                unknown_worker_failure = unknown_worker_failure or failure
+                continue
+            recovery_handles.extend(self._handles_for_fte_worker_control_failure(failure))
+
+        if abort_error is not None:
+            raise abort_error
+        if unknown_worker_failure is not None:
+            raise unknown_worker_failure from unknown_worker_failure.cause
+
+        failed_worker_ids = frozenset(failure.worker_id for failure in failures if failure.worker_id)
+        successful_scheduled_attempts: tuple[Any, ...] = ()
+        if not query_closed:
+            successful_scheduled_attempts = tuple(
+                scheduled_attempt
+                for scheduled_attempt in successful_create_attempts.values()
+                if str(scheduled_attempt.worker_id or "") not in failed_worker_ids
+            )
+
+        return FteWorkerCommandDispatchResult(
+            scheduled_attempts=successful_scheduled_attempts,
+            recovery_handles=tuple(recovery_handles),
+            failures=tuple(failures),
+            query_closed=query_closed,
+        )
+
+    def _execute_fte_fragment_execution_outbox(
+        self,
+        fragment_execution: FteFragmentExecution,
+    ) -> FteWorkerCommandDispatchResult:
+        return self._execute_fte_fragment_execution_worker_commands(
+            fragment_execution,
+            fragment_execution.pop_worker_commands(),
         )
 
     def _execute_fte_fragment_execution_mutation_result(
         self,
         fragment_execution: FteFragmentExecution,
         result: Any,
-    ) -> list[Any]:
-        self._execute_fte_fragment_execution_worker_commands(fragment_execution, list(result.worker_commands))
-        return list(result)
+    ) -> FteWorkerCommandDispatchResult:
+        return self._execute_fte_fragment_execution_worker_commands(
+            fragment_execution,
+            list(result.worker_commands),
+        )
 
     def _handles_for_fte_scheduled_attempts(
         self,

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -100,11 +100,9 @@ class FteWorkerEventHandlingMixin:
                     continue
                 fragment_execution = _FTE_FRAGMENT_EXECUTIONS.get((query_id, fragment_id))
             if fragment_execution is not None:
-                try:
-                    self._execute_fte_fragment_execution_outbox(fragment_execution)
-                except FteWorkerControlFailure as exc:
-                    handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    continue
+                dispatch = self._execute_fte_fragment_execution_outbox(fragment_execution)
+                handles.extend(dispatch.recovery_handles)
+                scheduled_attempts = list(dispatch.scheduled_attempts)
             handles.extend(
                 self._handles_for_fte_scheduled_attempts(
                     query_id,
@@ -200,17 +198,18 @@ class FteWorkerEventHandlingMixin:
                     finally:
                         request_fte_pending_task_drain()
                 return []
-            self._execute_fte_fragment_execution_worker_commands(
+            dispatch = self._execute_fte_fragment_execution_worker_commands(
                 fragment_execution,
                 worker_commands,
             )
-            handles = self._handles_for_fte_scheduled_attempts(
-                event.query_id,
-                str(event.fragment_id),
-                [scheduled],
+            handles = list(dispatch.recovery_handles)
+            handles.extend(
+                self._handles_for_fte_scheduled_attempts(
+                    event.query_id,
+                    str(event.fragment_id),
+                    list(dispatch.scheduled_attempts),
+                )
             )
-        except FteWorkerControlFailure as exc:
-            return self._handles_for_fte_worker_control_failure(exc)
         except FteWorkerReservationUnavailable:
             return request_fte_pending_task_drain()
         except Exception:
@@ -254,16 +253,15 @@ class FteWorkerEventHandlingMixin:
             with _FTE_REGISTRY_LOCK:
                 closing = query_id in _FTE_CLOSING_QUERIES
             if not closing and scheduled is not None:
-                self._execute_fte_fragment_execution_outbox(fragment_execution)
+                dispatch = self._execute_fte_fragment_execution_outbox(fragment_execution)
+                handles.extend(dispatch.recovery_handles)
                 handles.extend(
                     self._handles_for_fte_scheduled_attempts(
                         query_id,
                         fragment_id,
-                        [scheduled],
+                        list(dispatch.scheduled_attempts),
                     )
                 )
-        except FteWorkerControlFailure as exc:
-            handles.extend(self._handles_for_fte_worker_control_failure(exc))
         except Exception:
             with _FTE_REGISTRY_LOCK:
                 if query_id not in _FTE_CLOSING_QUERIES:
@@ -305,19 +303,21 @@ class FteWorkerEventHandlingMixin:
                 partition,
                 fragment_execution=fragment_execution,
             )
-        try:
-            scheduled_result = fragment_execution.apply_assignment_result(result)
-            with _FTE_REGISTRY_LOCK:
-                if query_id in _FTE_CLOSING_QUERIES:
-                    return []
-            scheduled = self._execute_fte_fragment_execution_mutation_result(fragment_execution, scheduled_result)
-        except FteWorkerControlFailure as exc:
-            return self._handles_for_fte_worker_control_failure(exc)
+        scheduled_result = fragment_execution.apply_assignment_result(result)
+        with _FTE_REGISTRY_LOCK:
+            if query_id in _FTE_CLOSING_QUERIES:
+                return []
+        dispatch = self._execute_fte_fragment_execution_mutation_result(fragment_execution, scheduled_result)
 
-        handles = self._handles_for_fte_scheduled_attempts(
-            query_id,
-            fragment_id,
-            scheduled,
+        handles = list(dispatch.recovery_handles)
+        if dispatch.query_closed:
+            return handles
+        handles.extend(
+            self._handles_for_fte_scheduled_attempts(
+                query_id,
+                fragment_id,
+                list(dispatch.scheduled_attempts),
+            )
         )
         if selector_snapshot.final:
             with _FTE_REGISTRY_LOCK:

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -11,7 +11,6 @@ import ray
 
 from duckdb.runners.fte import (
     FteTaskAttemptId,
-    FteWorkerControlFailure,
     validate_fte_status_identity,
 )
 from duckdb.runners.fte.fte_events import (
@@ -269,15 +268,12 @@ class FteWorkerLifecycleMixin:
                         partition,
                         fragment_execution=fragment_execution,
                     )
-                try:
-                    scheduled_result = fragment_execution.apply_assignment_result(result)
-                    scheduled = self._execute_fte_fragment_execution_mutation_result(
-                        fragment_execution, scheduled_result
-                    )
-                except FteWorkerControlFailure as exc:
-                    handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    scheduled = []
-                scheduled_attempts.extend(scheduled)
+                scheduled_result = fragment_execution.apply_assignment_result(result)
+                dispatch = self._execute_fte_fragment_execution_mutation_result(fragment_execution, scheduled_result)
+                handles.extend(dispatch.recovery_handles)
+                scheduled_attempts.extend(dispatch.scheduled_attempts)
+                if dispatch.query_closed:
+                    break
             handles.extend(
                 self._handles_for_fte_scheduled_attempts(
                     query_id,

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -13,7 +13,6 @@ from duckdb.runners.fte import (
     AssignmentResult,
     FteFragmentExecution,
     FteTaskExecutionClass,
-    FteWorkerControlFailure,
     FteWorkerReservationUnavailable,
     PartitionInfo,
 )
@@ -389,31 +388,30 @@ class FteWorkerSubmissionMixin:
             ):
                 if max_scheduled_attempts is not None and scheduled_attempt_count >= max_scheduled_attempts:
                     break
-                try:
-                    pending_reservation_done_count_before = fte_pending_worker_reservation_done_count(query_id_filter)
-                    scheduled = fragment_execution.schedule_next_pending_partition(execution_class)
-                    pending_reservation_done_count_after = fte_pending_worker_reservation_done_count(query_id_filter)
-                    if scheduled is not None:
-                        self._execute_fte_fragment_execution_outbox(fragment_execution)
-                except FteWorkerControlFailure as exc:
-                    handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    should_drain_events = True
-                    break
+                pending_reservation_done_count_before = fte_pending_worker_reservation_done_count(query_id_filter)
+                scheduled = fragment_execution.schedule_next_pending_partition(execution_class)
+                pending_reservation_done_count_after = fte_pending_worker_reservation_done_count(query_id_filter)
                 if scheduled is None:
                     if pending_reservation_done_count_after > pending_reservation_done_count_before:
                         made_progress = True
                         should_drain_events = True
                         break
                     continue
-                made_progress = True
-                scheduled_attempt_count += 1
+                dispatch = self._execute_fte_fragment_execution_outbox(fragment_execution)
+                handles.extend(dispatch.recovery_handles)
+                successful_scheduled_attempts = list(dispatch.scheduled_attempts)
+                made_progress = bool(successful_scheduled_attempts) or made_progress
+                scheduled_attempt_count += len(successful_scheduled_attempts)
                 handles.extend(
                     self._handles_for_fte_scheduled_attempts(
                         query_id,
                         fragment_id,
-                        [scheduled],
+                        successful_scheduled_attempts,
                     )
                 )
+                if dispatch.failures or dispatch.query_closed:
+                    should_drain_events = True
+                    break
             return made_progress, should_drain_events
 
         while True:
@@ -727,28 +725,25 @@ class FteWorkerSubmissionMixin:
                     partition_id=partition.task_id.partition_id,
                     elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
                 )
-                try:
-                    scheduled_result = fragment_execution.apply_assignment_result(
-                        AssignmentResult(
-                            partitions_added=[PartitionInfo(0)],
-                            sealed_partitions=[0],
-                            no_more_partitions=True,
-                        )
+                scheduled_result = fragment_execution.apply_assignment_result(
+                    AssignmentResult(
+                        partitions_added=[PartitionInfo(0)],
+                        sealed_partitions=[0],
+                        no_more_partitions=True,
                     )
-                    _fte_submission_debug_log(
-                        "pending_item_empty_source_apply_done",
-                        prepared_index=prepared_index,
-                        scheduled_count=len(scheduled_result),
-                        command_count=len(scheduled_result.worker_commands),
-                        elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
-                    )
-                    scheduled = self._execute_fte_fragment_execution_mutation_result(
-                        fragment_execution, scheduled_result
-                    )
-                except FteWorkerControlFailure as exc:
-                    handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    scheduled = []
-                scheduled_attempts.extend(scheduled)
+                )
+                _fte_submission_debug_log(
+                    "pending_item_empty_source_apply_done",
+                    prepared_index=prepared_index,
+                    scheduled_count=len(scheduled_result),
+                    command_count=len(scheduled_result.worker_commands),
+                    elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
+                )
+                dispatch = self._execute_fte_fragment_execution_mutation_result(fragment_execution, scheduled_result)
+                handles.extend(dispatch.recovery_handles)
+                scheduled_attempts.extend(dispatch.scheduled_attempts)
+                if dispatch.query_closed:
+                    return handles
 
             for source_node_id, source_splits in by_source.items():
                 _fte_submission_debug_log(
@@ -797,27 +792,24 @@ class FteWorkerSubmissionMixin:
                         partition_id=partition_info.partition_id,
                         elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
                     )
-                try:
-                    _fte_submission_debug_log(
-                        "pending_item_apply_start",
-                        prepared_index=prepared_index,
-                        elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
-                    )
-                    scheduled_result = fragment_execution.apply_assignment_result(result)
-                    _fte_submission_debug_log(
-                        "pending_item_apply_done",
-                        prepared_index=prepared_index,
-                        scheduled_count=len(scheduled_result),
-                        command_count=len(scheduled_result.worker_commands),
-                        elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
-                    )
-                    scheduled = self._execute_fte_fragment_execution_mutation_result(
-                        fragment_execution, scheduled_result
-                    )
-                except FteWorkerControlFailure as exc:
-                    handles.extend(self._handles_for_fte_worker_control_failure(exc))
-                    scheduled = []
-                scheduled_attempts.extend(scheduled)
+                _fte_submission_debug_log(
+                    "pending_item_apply_start",
+                    prepared_index=prepared_index,
+                    elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
+                )
+                scheduled_result = fragment_execution.apply_assignment_result(result)
+                _fte_submission_debug_log(
+                    "pending_item_apply_done",
+                    prepared_index=prepared_index,
+                    scheduled_count=len(scheduled_result),
+                    command_count=len(scheduled_result.worker_commands),
+                    elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
+                )
+                dispatch = self._execute_fte_fragment_execution_mutation_result(fragment_execution, scheduled_result)
+                handles.extend(dispatch.recovery_handles)
+                scheduled_attempts.extend(dispatch.scheduled_attempts)
+                if dispatch.query_closed:
+                    return handles
 
             _fte_submission_debug_log(
                 "pending_item_handles_start",

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -27,6 +27,7 @@ import duckdb.runners.ray.fte_fragment_scheduler as fte_fragment_scheduler_mod
 import duckdb.runners.ray.worker as worker_mod
 import duckdb.runners.ray.worker_handle as worker_handle_mod
 from duckdb.runners.common import QueryDeadlineExceeded
+from duckdb.runners.fte.fte_attempts import FragmentExecutionMutationResult
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
 from duckdb.runners.ray.fragment_worker_context import fragment_id_for_task
 from duckdb.runners.ray.fte import (
@@ -34,6 +35,7 @@ from duckdb.runners.ray.fte import (
     FteFragmentExecution,
     FteTaskAttemptId,
     FteTaskExecution,
+    FteTaskId,
     FteTaskState,
     FteWorkerReservationUnavailable,
     NodeRequirements,
@@ -956,6 +958,288 @@ def test_fte_split_backpressure_remote_error_is_canceled_by_query_close():
 
         assert add_called.is_set() is False
         assert query_id not in worker_handle_mod._FTE_ACTIVE_OPERATIONS_BY_QUERY
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_worker_command_dispatch_preserves_healthy_tail_and_new_outbox_commands(monkeypatch):
+    query_id = "query-command-owned-tail"
+    coordinator = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-coordinator",
+    )
+    failed_a = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-failed-a",
+    )
+    healthy = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-healthy",
+    )
+    failed_b = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-failed-b",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+
+    def add_command(worker, partition_id):
+        return FteAddSplitsCommand(
+            query_id=query_id,
+            fragment_id=stage.fragment_id,
+            worker_id=worker.worker_id,
+            worker=worker,
+            attempt_id=FteTaskAttemptId(FteTaskId(query_id, 0, partition_id), 0),
+            source_node_id="7",
+            splits=({"sequence_id": partition_id, "kind": "scan_task", "data": b"x"},),
+        )
+
+    failed_first = add_command(failed_a, 0)
+    failed_same_worker_tail = add_command(failed_a, 1)
+    healthy_first = add_command(healthy, 2)
+    failed_other_worker = add_command(failed_b, 3)
+    healthy_second = add_command(healthy, 4)
+    appended_during_dispatch = add_command(healthy, 5)
+    stage._worker_command_outbox.extend(
+        [
+            failed_first,
+            failed_same_worker_tail,
+            healthy_first,
+            failed_other_worker,
+            healthy_second,
+        ]
+    )
+
+    fte_fragment_scheduler_mod.open_fte_registry_for_query(query_id)
+    scheduler = worker_commands_mod._FTE_SCHEDULERS.get_or_create(query_id)
+    executed = []
+    appended = False
+
+    def execute(command, **_kwargs):
+        nonlocal appended
+        executed.append((command.worker_id, command.attempt_id.partition_id))
+        if command is failed_first or command is failed_other_worker:
+            raise RuntimeError(f"planned control failure for {command.worker_id}")
+        if command is healthy_first:
+            assert failed_a._fte_healthy is False
+            if not appended:
+                stage._record_worker_command(appended_during_dispatch)
+                appended = True
+        if command is healthy_second:
+            assert failed_b._fte_healthy is False
+
+    monkeypatch.setattr(scheduler.worker_command_executor, "execute", execute)
+
+    try:
+        dispatch = coordinator._execute_fte_fragment_execution_outbox(stage)
+
+        assert executed == [
+            (failed_a.worker_id, 0),
+            (healthy.worker_id, 2),
+            (failed_b.worker_id, 3),
+            (healthy.worker_id, 4),
+        ]
+        assert dispatch.failed_worker_ids == {failed_a.worker_id, failed_b.worker_id}
+        assert len(dispatch.failures) == 2
+        assert dispatch.query_closed is False
+        assert [command.attempt_id.partition_id for command in stage._worker_command_outbox] == [5]
+        assert failed_a._fte_healthy is False
+        assert failed_b._fte_healthy is False
+        assert healthy._fte_healthy is True
+        assert scheduler.stats().event_counts.get("WorkerFailed", 0) == 2
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_worker_command_dispatch_publishes_only_successful_healthy_creates(monkeypatch):
+    query_id = "query-command-create-outcomes"
+    coordinator = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-create-coordinator",
+    )
+    create_failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-create-failed",
+    )
+    failed_after_create = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-failed-after-create",
+    )
+    healthy = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-create-healthy",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        task_memory_bytes=1,
+    )
+
+    scheduled_attempts = []
+    create_commands = []
+    for partition_id, worker in enumerate((create_failed, failed_after_create, healthy)):
+        partition = stage.add_partition(partition_id)
+        scheduled = partition.start_attempt(worker_id=worker.worker_id, remote_handle=worker)
+        scheduled_attempts.append(scheduled)
+        create_commands.append(
+            FteCreateTaskCommand(
+                query_id=query_id,
+                fragment_id=stage.fragment_id,
+                worker_id=worker.worker_id,
+                worker=worker,
+                attempt_id=scheduled.attempt_id,
+                partition_id=partition_id,
+                request=scheduled.request,
+                scheduled_attempt=scheduled,
+            )
+        )
+    fail_after_create_command = FteAddSplitsCommand(
+        query_id=query_id,
+        fragment_id=stage.fragment_id,
+        worker_id=failed_after_create.worker_id,
+        worker=failed_after_create,
+        attempt_id=scheduled_attempts[1].attempt_id,
+        source_node_id="7",
+        splits=({"sequence_id": 1, "kind": "scan_task", "data": b"x"},),
+    )
+    mutation_result = FragmentExecutionMutationResult.from_attempts(
+        scheduled_attempts,
+        [
+            create_commands[0],
+            create_commands[1],
+            fail_after_create_command,
+            create_commands[2],
+        ],
+    )
+
+    fte_fragment_scheduler_mod.open_fte_registry_for_query(query_id)
+    scheduler = worker_commands_mod._FTE_SCHEDULERS.get_or_create(query_id)
+    executed = []
+
+    def execute(command, **_kwargs):
+        executed.append((command.command_type, command.worker_id))
+        if command is create_commands[0] or command is fail_after_create_command:
+            raise RuntimeError(f"planned control failure for {command.worker_id}")
+
+    monkeypatch.setattr(scheduler.worker_command_executor, "execute", execute)
+    monkeypatch.setattr(worker_commands_mod, "fte_partition_task_lease_payload", lambda *_args: {})
+
+    try:
+        dispatch = coordinator._execute_fte_fragment_execution_mutation_result(stage, mutation_result)
+
+        assert executed == [
+            ("FteCreateTaskCommand", create_failed.worker_id),
+            ("FteCreateTaskCommand", failed_after_create.worker_id),
+            ("FteAddSplitsCommand", failed_after_create.worker_id),
+            ("FteCreateTaskCommand", healthy.worker_id),
+        ]
+        assert dispatch.failed_worker_ids == {create_failed.worker_id, failed_after_create.worker_id}
+        assert dispatch.scheduled_attempts == (scheduled_attempts[2],)
+        assert str(scheduled_attempts[1].attempt_id) not in {
+            str(attempt.attempt_id) for attempt in dispatch.scheduled_attempts
+        }
+        assert healthy.fte_pressure_stats()["running_attempt_count"] == 1
+        assert scheduler.stats().event_counts.get("WorkerFailed", 0) == 2
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_worker_command_dispatch_claim_owns_all_create_publication(monkeypatch):
+    query_id = "query-command-create-claim"
+    workers = [
+        RayWorkerActorHandle(
+            _FakeActor(),
+            memory_capacity_bytes=1 << 60,
+            worker_id=f"worker-create-claim-{partition_id}",
+        )
+        for partition_id in range(2)
+    ]
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        worker_selector=lambda partition: (
+            workers[partition.task_id.partition_id].worker_id,
+            workers[partition.task_id.partition_id],
+        ),
+        task_memory_bytes=1,
+    )
+    coordinator = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-create-claim-coordinator",
+    )
+
+    fte_fragment_scheduler_mod.open_fte_registry_for_query(query_id)
+    scheduler = worker_commands_mod._FTE_SCHEDULERS.get_or_create(query_id)
+    monkeypatch.setattr(scheduler.worker_command_executor, "execute", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(worker_commands_mod, "fte_partition_task_lease_payload", lambda *_args: {})
+
+    try:
+        first = stage.start_attempt_with_worker(stage.add_partition(0))
+        second = stage.start_attempt_with_worker(stage.add_partition(1))
+
+        claimed = coordinator._execute_fte_fragment_execution_outbox(stage)
+        already_claimed = coordinator._execute_fte_fragment_execution_outbox(stage)
+
+        assert claimed.scheduled_attempts == (first, second)
+        assert already_claimed.scheduled_attempts == ()
+        assert [worker.fte_pressure_stats()["running_attempt_count"] for worker in workers] == [1, 1]
+    finally:
+        fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
+
+
+def test_fte_worker_command_dispatch_query_close_owns_successful_create(monkeypatch):
+    query_id = "query-command-close-after-create"
+    worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-close-after-create",
+    )
+    stage = FteFragmentExecution(
+        query_id,
+        0,
+        fragment_id=f"{query_id}:node:7",
+        worker=worker,
+        worker_id=worker.worker_id,
+        task_memory_bytes=1,
+    )
+    coordinator = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-command-close-coordinator",
+    )
+
+    fte_fragment_scheduler_mod.open_fte_registry_for_query(query_id)
+    scheduled = stage.start_attempt_with_worker(stage.add_partition(0))
+    scheduler = worker_commands_mod._FTE_SCHEDULERS.get_or_create(query_id)
+    monkeypatch.setattr(
+        scheduler.worker_command_executor,
+        "execute",
+        lambda *_args, **_kwargs: worker_handle_mod.close_fte_registry_for_query(query_id),
+    )
+    monkeypatch.setattr(worker_commands_mod, "fte_partition_task_lease_payload", lambda *_args: {})
+
+    try:
+        dispatch = coordinator._execute_fte_fragment_execution_outbox(stage)
+
+        assert dispatch.query_closed is True
+        assert dispatch.scheduled_attempts == ()
+        assert worker.fte_pressure_stats()["running_attempt_count"] == 1
+        assert str(scheduled.attempt_id) not in worker_handle_mod._FTE_STATUS_WATCHERS
     finally:
         fte_fragment_scheduler_mod._drop_fte_registry_for_query(query_id)
 
@@ -4126,11 +4410,9 @@ def test_fte_split_ack_before_create_ack_is_merged_into_running_pressure(monkeyp
         worker_id=handle.worker_id,
         remote_handle=handle,
     )
-    request = {
-        **scheduled.request,
-        "initial_splits": {
-            "7": ({"sequence_id": 0, "kind": "scan_task", "data": b"base"},),
-        },
+    request = scheduled.request
+    request["initial_splits"] = {
+        "7": ({"sequence_id": 0, "kind": "scan_task", "data": b"base"},),
     }
     handle.reserve_fte_partition(
         query_id,
@@ -4147,6 +4429,7 @@ def test_fte_split_ack_before_create_ack_is_merged_into_running_pressure(monkeyp
         attempt_id=scheduled.attempt_id,
         partition_id=0,
         request=request,
+        scheduled_attempt=scheduled,
     )
     add_command = FteAddSplitsCommand(
         query_id=query_id,


### PR DESCRIPTION
## Summary

- settle each claimed FTE worker-command batch instead of aborting at the first ordinary worker control failure
- quarantine failed workers immediately, skip only their remaining commands, preserve original-order execution for healthy workers, and reconcile every failed worker after the healthy tail settles
- bind each create command to its exact scheduled attempt so the dispatcher that claims the command also owns result-handle publication
- keep query teardown and deadline/cancellation ownership distinct from recoverable worker failures
- add regression coverage for healthy-tail preservation, multi-worker failures, concurrent outbox ownership, create publication, and query close

## Related issue

Closes #339

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal FTE control-plane ownership only.

## Validation

- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/format root --changed --check`
- `python -m pytest tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_fte.py` — 406 passed
- `scripts/run_release_tests.sh` — 467 passed, 1 skipped (non-real-Ray); 10 passed (real-Ray)
- `scripts/run_fast_tests.sh non-ray` — 6184 passed, 28 skipped, 8 xfailed, 1 xpassed
- `scripts/run_fast_tests.sh shared-ray` — 96 passed, 6 skipped
- `scripts/run_fast_tests.sh owner-ray` — 7 passed, 1 skipped

Release and fast tests used a non-editable Python-only build target aligned to the upstream SourceID.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.