### PR TITLE
[fix](distributed) Bound Flight shuffle buffer memory

### DIFF
--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -871,12 +871,12 @@ DuckDBResult<void> FlightExchangeSink::AddChunk(idx_t partition_id, DataChunk &c
 }
 
 bool FlightExchangeSink::IsBlocked() const {
-	// Disk-first: no memory backpressure needed
+	// AddChunk handles memory pressure by flushing retained buffers directly to shuffle storage.
 	return false;
 }
 
 void FlightExchangeSink::WaitUnblocked() {
-	// No-op: disk writes don't block
+	// No-op: AddChunk does not return until any required pressure flush completes.
 }
 
 DuckDBResult<void> FlightExchangeSink::Finish() {
@@ -915,6 +915,7 @@ DuckDBResult<void> FlightExchangeSink::Abort() {
 	if (finished_) {
 		return DuckDBResult<void>::ok();
 	}
+	shuffle_cache_->DiscardBufferedData();
 	ShuffleCacheRegistry::Instance().RemoveForDeferredCleanup(handle_.output_location);
 	write_lease_.reset();
 	finished_ = true;
@@ -922,7 +923,7 @@ DuckDBResult<void> FlightExchangeSink::Abort() {
 }
 
 size_t FlightExchangeSink::GetMemoryUsage() const {
-	return 0; // Disk-first: memory usage is transient buffer only
+	return shuffle_cache_->GetBufferedBytes();
 }
 
 DuckDBResult<void> FlightExchangeSink::EnsureSchema(ClientContext &context, const vector<LogicalType> &types,

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -26,7 +26,8 @@
 #include <arrow/ipc/api.h>
 #include <arrow/io/api.h>
 #include <algorithm>
-#include <cerrno>
+#include <charconv>
+#include <cstring>
 #include <cstdlib>
 #include <fstream>
 #include <limits>
@@ -126,18 +127,23 @@ bool IsArrowCompatibleType(const LogicalType &arrow_type, const LogicalType &exp
 	return false;
 }
 
+unsigned long long ParsePositiveByteCount(const char *name, const char *raw) {
+	unsigned long long value = 0;
+	auto end = raw + std::strlen(raw);
+	auto result = std::from_chars(raw, end, value, 10);
+	if (result.ec != std::errc() || result.ptr != end || value == 0) {
+		throw InvalidInputException(std::string(name) + " must be a positive integer byte count");
+	}
+	return value;
+}
+
 idx_t ResolveShuffleCacheFlushThresholdBytes() {
 	const char *raw = std::getenv("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES");
 	if (!raw || !*raw) {
 		return ShuffleCache::DEFAULT_FLUSH_THRESHOLD_BYTES;
 	}
 
-	errno = 0;
-	char *end = nullptr;
-	auto value = std::strtoull(raw, &end, 10);
-	if (raw[0] == '-' || errno != 0 || end == raw || !end || *end != '\0' || value == 0) {
-		throw InvalidInputException("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES must be a positive integer byte count");
-	}
+	auto value = ParsePositiveByteCount("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES", raw);
 	if (value > static_cast<unsigned long long>(std::numeric_limits<idx_t>::max())) {
 		throw InvalidInputException("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES exceeds idx_t max");
 	}
@@ -150,12 +156,7 @@ optional_idx ResolveShuffleCacheMaxBufferedBytes() {
 		return optional_idx();
 	}
 
-	errno = 0;
-	char *end = nullptr;
-	auto value = std::strtoull(raw, &end, 10);
-	if (raw[0] == '-' || errno != 0 || end == raw || !end || *end != '\0' || value == 0) {
-		throw InvalidInputException("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES must be a positive integer byte count");
-	}
+	auto value = ParsePositiveByteCount("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES", raw);
 	if (value >= static_cast<unsigned long long>(std::numeric_limits<idx_t>::max())) {
 		throw InvalidInputException("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES must be less than idx_t max");
 	}

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
+#include "duckdb/storage/temporary_memory_manager.hpp"
 
 #include <arrow/api.h>
 #include <arrow/c/bridge.h>
@@ -134,13 +135,31 @@ idx_t ResolveShuffleCacheFlushThresholdBytes() {
 	errno = 0;
 	char *end = nullptr;
 	auto value = std::strtoull(raw, &end, 10);
-	if (errno != 0 || end == raw || !end || *end != '\0' || value == 0) {
+	if (raw[0] == '-' || errno != 0 || end == raw || !end || *end != '\0' || value == 0) {
 		throw InvalidInputException("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES must be a positive integer byte count");
 	}
 	if (value > static_cast<unsigned long long>(std::numeric_limits<idx_t>::max())) {
 		throw InvalidInputException("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES exceeds idx_t max");
 	}
 	return static_cast<idx_t>(value);
+}
+
+optional_idx ResolveShuffleCacheMaxBufferedBytes() {
+	const char *raw = std::getenv("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES");
+	if (!raw || !*raw) {
+		return optional_idx();
+	}
+
+	errno = 0;
+	char *end = nullptr;
+	auto value = std::strtoull(raw, &end, 10);
+	if (raw[0] == '-' || errno != 0 || end == raw || !end || *end != '\0' || value == 0) {
+		throw InvalidInputException("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES must be a positive integer byte count");
+	}
+	if (value >= static_cast<unsigned long long>(std::numeric_limits<idx_t>::max())) {
+		throw InvalidInputException("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES must be less than idx_t max");
+	}
+	return optional_idx(static_cast<idx_t>(value));
 }
 
 void CastChunk(ClientContext &context, DataChunk &input, DataChunk &output, const vector<LogicalType> &target_types) {
@@ -690,8 +709,9 @@ ShuffleCache::ShuffleCache(ShuffleCacheConfig config) : ShuffleCache(std::move(c
 
 ShuffleCache::ShuffleCache(ShuffleCacheConfig config, std::shared_ptr<ShuffleStorage> storage)
     : config_(std::move(config)), partitions_(config_.num_partitions), next_file_ids_(config_.num_partitions),
-      storage_(std::move(storage)), write_buffers_(config_.num_partitions), buffer_bytes_(config_.num_partitions, 0),
-      flush_threshold_bytes_(ResolveShuffleCacheFlushThresholdBytes()) {
+      storage_(std::move(storage)), write_buffers_(config_.num_partitions), buffer_bytes_(config_.num_partitions),
+      flush_threshold_bytes_(ResolveShuffleCacheFlushThresholdBytes()),
+      configured_max_buffered_bytes_(ResolveShuffleCacheMaxBufferedBytes()) {
 	if (!storage_) {
 		throw InvalidInputException("ShuffleCache storage backend must not be null");
 	}
@@ -711,6 +731,9 @@ ShuffleCache::ShuffleCache(ShuffleCacheConfig config, std::shared_ptr<ShuffleSto
 	for (auto &entry : next_file_ids_) {
 		entry.store(0);
 	}
+	for (auto &entry : buffer_bytes_) {
+		entry.store(0);
+	}
 	buffer_mutexes_.reserve(config_.num_partitions);
 	for (idx_t i = 0; i < config_.num_partitions; i++) {
 		buffer_mutexes_.push_back(make_uniq<std::mutex>());
@@ -718,11 +741,17 @@ ShuffleCache::ShuffleCache(ShuffleCacheConfig config, std::shared_ptr<ShuffleSto
 }
 
 ShuffleCache::~ShuffleCache() {
-	// FlushAll is called explicitly via SinkFinalize; no destructor flush needed.
+	// FlushAll is called explicitly via SinkFinalize; never write from a destructor.
+	DiscardBufferedData();
 }
 
 const ShuffleCacheConfig &ShuffleCache::config() const {
 	return config_;
+}
+
+vector<string> ShuffleCache::BufferedNames() const {
+	std::lock_guard<std::mutex> lock(buffered_names_mutex_);
+	return buffered_names_;
 }
 
 DuckDBResult<void> ShuffleCache::EnsurePartitionDirectory(idx_t partition_idx) const {
@@ -1153,6 +1182,70 @@ DuckDBResult<void> ShuffleCache::EnsureSchemaFile(ClientContext &context, const 
 	return DuckDBResult<void>::ok();
 }
 
+void ShuffleCache::EnsureMemoryBudget(ClientContext &context) {
+	if (memory_budget_initialized_.load()) {
+		return;
+	}
+
+	std::lock_guard<std::mutex> guard(memory_state_mutex_);
+	if (memory_budget_initialized_.load()) {
+		return;
+	}
+	temporary_memory_state_ = TemporaryMemoryManager::Get(context).Register(context);
+	auto max_bytes = std::numeric_limits<idx_t>::max();
+	auto aggregate_target = config_.num_partitions > max_bytes / flush_threshold_bytes_
+	                            ? max_bytes
+	                            : config_.num_partitions * flush_threshold_bytes_;
+	auto desired_bytes = MinValue(temporary_memory_state_->GetRemainingSize(), aggregate_target);
+	if (configured_max_buffered_bytes_.IsValid()) {
+		desired_bytes = MinValue(desired_bytes, configured_max_buffered_bytes_.GetIndex());
+	}
+	if (desired_bytes > 0) {
+		// One target-size partition is the guaranteed floor. The manager may grant
+		// more of the default share while memory is available and shrink it under
+		// contention from other temporary operators or shuffle sinks.
+		auto minimum_reservation = MinValue(temporary_memory_state_->GetMinimumReservation(), flush_threshold_bytes_);
+		minimum_reservation = MinValue(minimum_reservation, desired_bytes);
+		temporary_memory_state_->SetMinimumReservation(minimum_reservation);
+		temporary_memory_state_->SetRemainingSizeAndUpdateReservation(context, desired_bytes);
+	}
+	auto budget = temporary_memory_state_->GetReservation();
+	if (configured_max_buffered_bytes_.IsValid()) {
+		budget = MinValue(budget, configured_max_buffered_bytes_.GetIndex());
+	}
+	buffer_budget_bytes_.store(budget);
+	memory_budget_initialized_.store(true);
+}
+
+void ShuffleCache::RefreshMemoryBudget(ClientContext &context) {
+	std::lock_guard<std::mutex> guard(memory_state_mutex_);
+	if (!temporary_memory_state_) {
+		return;
+	}
+	temporary_memory_state_->UpdateReservation(context);
+	auto budget = temporary_memory_state_->GetReservation();
+	if (configured_max_buffered_bytes_.IsValid()) {
+		budget = MinValue(budget, configured_max_buffered_bytes_.GetIndex());
+	}
+	buffer_budget_bytes_.store(budget);
+}
+
+void ShuffleCache::ReleaseMemoryReservation() {
+	std::lock_guard<std::mutex> guard(memory_state_mutex_);
+	if (temporary_memory_state_) {
+		temporary_memory_state_->SetZero();
+		temporary_memory_state_.reset();
+	}
+	buffer_budget_bytes_.store(0);
+	memory_budget_initialized_.store(false);
+}
+
+void ShuffleCache::UpdatePeakBufferedBytes(idx_t buffered_bytes) {
+	auto peak = peak_buffered_bytes_.load();
+	while (peak < buffered_bytes && !peak_buffered_bytes_.compare_exchange_weak(peak, buffered_bytes)) {
+	}
+}
+
 DuckDBResult<void> ShuffleCache::WriteChunk(ClientContext &context, DataChunk &chunk, idx_t partition_idx,
                                             const vector<string> &names) {
 	if (partition_idx >= partitions_.size()) {
@@ -1161,38 +1254,59 @@ DuckDBResult<void> ShuffleCache::WriteChunk(ClientContext &context, DataChunk &c
 	if (chunk.ColumnCount() == 0) {
 		return DuckDBResult<void>::err(DuckDBError::value_error("shuffle cache write requires at least one column"));
 	}
+	EnsureMemoryBudget(context);
 
 	// Capture column names for later FlushAll calls.
-	if (buffered_names_.empty() && !names.empty()) {
-		buffered_names_ = names;
-	}
-
-	// Lock this partition's buffer for thread-safe access.
-	std::lock_guard<std::mutex> lock(*buffer_mutexes_[partition_idx]);
-
-	// Lazily create the write buffer for this partition.
-	if (!write_buffers_[partition_idx]) {
-		write_buffers_[partition_idx] =
-		    make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), chunk.GetTypes());
-	}
-
-	// Append the chunk to the in-memory buffer.
-	write_buffers_[partition_idx]->Append(chunk);
-	buffer_bytes_[partition_idx] = write_buffers_[partition_idx]->AllocationSize();
-
-	// Flush if we exceeded the threshold.
-	if (buffer_bytes_[partition_idx] >= flush_threshold_bytes_) {
-		auto flush_res = FlushBuffer(context, partition_idx, names);
-		if (flush_res.is_err()) {
-			return DuckDBResult<void>::err(flush_res.error());
+	if (!names.empty()) {
+		std::lock_guard<std::mutex> names_guard(buffered_names_mutex_);
+		if (buffered_names_.empty()) {
+			buffered_names_ = names;
 		}
 	}
 
+	{
+		// Lock this partition's buffer for thread-safe access.
+		std::lock_guard<std::mutex> lock(*buffer_mutexes_[partition_idx]);
+
+		// Keep disk-first buffers in memory, but charge them to DuckDB's memory limit.
+		if (!write_buffers_[partition_idx]) {
+			write_buffers_[partition_idx] =
+			    make_uniq<ColumnDataCollection>(BufferAllocator::Get(context), chunk.GetTypes());
+		}
+
+		// Account allocated capacity rather than row payload size, including varlen blocks.
+		auto previous_bytes = buffer_bytes_[partition_idx].load();
+		write_buffers_[partition_idx]->Append(chunk);
+		auto current_bytes = write_buffers_[partition_idx]->AllocationSize();
+		D_ASSERT(current_bytes >= previous_bytes);
+		buffer_bytes_[partition_idx].store(current_bytes);
+		auto allocated_bytes = current_bytes - previous_bytes;
+		auto total_bytes = buffered_bytes_.fetch_add(allocated_bytes) + allocated_bytes;
+		UpdatePeakBufferedBytes(total_bytes);
+
+		// The per-partition threshold remains a target output segment size.
+		if (current_bytes >= flush_threshold_bytes_) {
+			auto flush_res = FlushBufferLocked(context, partition_idx, names);
+			if (flush_res.is_err()) {
+				return DuckDBResult<void>::err(flush_res.error());
+			}
+		}
+	}
+
+	if (buffered_bytes_.load() > buffer_budget_bytes_.load()) {
+		return FlushUnderMemoryPressure(context, names);
+	}
 	return DuckDBResult<void>::ok();
 }
 
 DuckDBResult<ShufflePartitionFile> ShuffleCache::FlushBuffer(ClientContext &context, idx_t partition_idx,
                                                              const vector<string> &names) {
+	std::lock_guard<std::mutex> lock(*buffer_mutexes_[partition_idx]);
+	return FlushBufferLocked(context, partition_idx, names);
+}
+
+DuckDBResult<ShufflePartitionFile> ShuffleCache::FlushBufferLocked(ClientContext &context, idx_t partition_idx,
+                                                                   const vector<string> &names) {
 	auto &buffer = write_buffers_[partition_idx];
 	if (!buffer || buffer->Count() == 0) {
 		ShufflePartitionFile empty;
@@ -1201,30 +1315,80 @@ DuckDBResult<ShufflePartitionFile> ShuffleCache::FlushBuffer(ClientContext &cont
 
 	auto result = WriteCollectionToFile(context, *buffer, partition_idx, names);
 
-	// Reset the buffer.
+	// Release accounting only after the synchronous write no longer needs the buffer.
+	auto released_bytes = buffer_bytes_[partition_idx].load();
 	buffer.reset();
-	buffer_bytes_[partition_idx] = 0;
+	if (released_bytes > 0) {
+		auto previous_total = buffered_bytes_.fetch_sub(released_bytes);
+		D_ASSERT(previous_total >= released_bytes);
+	}
+	buffer_bytes_[partition_idx].store(0);
 
 	return result;
 }
 
+DuckDBResult<void> ShuffleCache::FlushUnderMemoryPressure(ClientContext &context, const vector<string> &names) {
+	std::lock_guard<std::mutex> pressure_guard(pressure_mutex_);
+	RefreshMemoryBudget(context);
+
+	while (buffered_bytes_.load() > buffer_budget_bytes_.load()) {
+		optional_idx victim_partition;
+		idx_t victim_bytes = 0;
+		for (idx_t partition_idx = 0; partition_idx < buffer_bytes_.size(); partition_idx++) {
+			auto partition_bytes = buffer_bytes_[partition_idx].load();
+			if (partition_bytes > victim_bytes) {
+				victim_partition = partition_idx;
+				victim_bytes = partition_bytes;
+			}
+		}
+		if (!victim_partition.IsValid()) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::internal_error("shuffle cache memory accounting exceeded its budget without a buffer"));
+		}
+
+		auto partition_idx = victim_partition.GetIndex();
+		std::lock_guard<std::mutex> partition_guard(*buffer_mutexes_[partition_idx]);
+		if (buffer_bytes_[partition_idx].load() == 0) {
+			continue;
+		}
+		auto flush_res = FlushBufferLocked(context, partition_idx, names);
+		if (flush_res.is_err()) {
+			return DuckDBResult<void>::err(flush_res.error());
+		}
+	}
+	return DuckDBResult<void>::ok();
+}
+
 DuckDBResult<void> ShuffleCache::FlushAll(ClientContext &context, const vector<string> &names) {
+	std::lock_guard<std::mutex> pressure_guard(pressure_mutex_);
 	if (flushed_) {
 		return DuckDBResult<void>::ok();
 	}
 	flushed_ = true;
 
-	idx_t total_flushed = 0;
 	for (idx_t i = 0; i < write_buffers_.size(); i++) {
-		if (write_buffers_[i] && write_buffers_[i]->Count() > 0) {
-			auto res = FlushBuffer(context, i, names);
-			if (res.is_err()) {
-				return DuckDBResult<void>::err(res.error());
-			}
-			total_flushed++;
+		auto res = FlushBuffer(context, i, names);
+		if (res.is_err()) {
+			return DuckDBResult<void>::err(res.error());
 		}
 	}
+	ReleaseMemoryReservation();
 	return DuckDBResult<void>::ok();
+}
+
+void ShuffleCache::DiscardBufferedData() {
+	std::lock_guard<std::mutex> pressure_guard(pressure_mutex_);
+	for (idx_t partition_idx = 0; partition_idx < write_buffers_.size(); partition_idx++) {
+		std::lock_guard<std::mutex> partition_guard(*buffer_mutexes_[partition_idx]);
+		auto released_bytes = buffer_bytes_[partition_idx].load();
+		write_buffers_[partition_idx].reset();
+		if (released_bytes > 0) {
+			auto previous_total = buffered_bytes_.fetch_sub(released_bytes);
+			D_ASSERT(previous_total >= released_bytes);
+		}
+		buffer_bytes_[partition_idx].store(0);
+	}
+	ReleaseMemoryReservation();
 }
 
 DuckDBResult<ShufflePartitionFile> ShuffleCache::WriteCollectionToFile(ClientContext &context,

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -1203,8 +1203,8 @@ void ShuffleCache::EnsureMemoryBudget(ClientContext &context) {
 	}
 	if (desired_bytes > 0) {
 		// One target-size partition is the guaranteed floor. The manager may grant
-		// more of the default share while memory is available and shrink it under
-		// contention from other temporary operators or shuffle sinks.
+		// more of the default share while memory is available; that grant remains
+		// accounted for until this state refreshes or releases it.
 		auto minimum_reservation = MinValue(temporary_memory_state_->GetMinimumReservation(), flush_threshold_bytes_);
 		minimum_reservation = MinValue(minimum_reservation, desired_bytes);
 		temporary_memory_state_->SetMinimumReservation(minimum_reservation);
@@ -1254,6 +1254,9 @@ DuckDBResult<void> ShuffleCache::WriteChunk(ClientContext &context, DataChunk &c
 	}
 	if (chunk.ColumnCount() == 0) {
 		return DuckDBResult<void>::err(DuckDBError::value_error("shuffle cache write requires at least one column"));
+	}
+	if (chunk.size() == 0) {
+		return DuckDBResult<void>::ok();
 	}
 	EnsureMemoryBudget(context);
 
@@ -1309,7 +1312,20 @@ DuckDBResult<ShufflePartitionFile> ShuffleCache::FlushBuffer(ClientContext &cont
 DuckDBResult<ShufflePartitionFile> ShuffleCache::FlushBufferLocked(ClientContext &context, idx_t partition_idx,
                                                                    const vector<string> &names) {
 	auto &buffer = write_buffers_[partition_idx];
-	if (!buffer || buffer->Count() == 0) {
+	if (!buffer) {
+		ShufflePartitionFile empty;
+		return DuckDBResult<ShufflePartitionFile>::ok(std::move(empty));
+	}
+	if (buffer->Count() == 0) {
+		// InitializeAppend can allocate storage before seeing an empty chunk. Do not
+		// leave an unflushable allocation in the pressure-victim set.
+		auto released_bytes = buffer_bytes_[partition_idx].load();
+		buffer.reset();
+		if (released_bytes > 0) {
+			auto previous_total = buffered_bytes_.fetch_sub(released_bytes);
+			D_ASSERT(previous_total >= released_bytes);
+		}
+		buffer_bytes_[partition_idx].store(0);
 		ShufflePartitionFile empty;
 		return DuckDBResult<ShufflePartitionFile>::ok(std::move(empty));
 	}
@@ -1343,6 +1359,11 @@ DuckDBResult<void> ShuffleCache::FlushUnderMemoryPressure(ClientContext &context
 			}
 		}
 		if (!victim_partition.IsValid()) {
+			// A concurrent threshold flush can release the last candidate between the
+			// aggregate check and this unlocked scan.
+			if (buffered_bytes_.load() <= buffer_budget_bytes_.load()) {
+				continue;
+			}
 			return DuckDBResult<void>::err(
 			    DuckDBError::internal_error("shuffle cache memory accounting exceeded its budget without a buffer"));
 		}

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_sink.hpp
@@ -25,9 +25,9 @@ namespace distributed {
 /// Lifecycle: Created by ExchangeManager::CreateSink() → Add() data →
 ///            Finish() on success or Abort() on failure.
 ///
-/// Threading: A single ExchangeSink is used by one operator thread.
-///            Implementations must be safe for concurrent access from
-///            the backpressure mechanism.
+/// Threading: A global ExchangeSink can be used by parallel operator threads.
+///            Implementations must synchronize concurrent writes and access
+///            from the backpressure mechanism.
 class ExchangeSink {
 public:
 	virtual ~ExchangeSink() = default;

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/shuffle_cache.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/execution/distributed/common_types.hpp"
 
 #include <atomic>
@@ -26,6 +27,7 @@ class ColumnDataCollection;
 class FileOpener;
 class FileSystem;
 class LogicalType;
+class TemporaryMemoryState;
 
 namespace distributed {
 
@@ -105,14 +107,26 @@ public:
 	                                                                  const vector<LogicalType> &expected_types);
 	DuckDBResult<std::shared_ptr<arrow::io::InputStream>> OpenPartitionFile(const std::string &path) const;
 
-	//! Flush all remaining buffered data to disk. Called by the destructor and
-	//! can also be called explicitly before the cache is destroyed.
+	//! Flush all remaining buffered data to disk. This must be called explicitly
+	//! before publishing the cache; the destructor only discards buffered data.
 	DuckDBResult<void> FlushAll(ClientContext &context, const vector<string> &names);
 
 	//! Get the buffered column names.
-	const vector<string> &BufferedNames() const {
-		return buffered_names_;
+	vector<string> BufferedNames() const;
+	//! Retained partition-buffer allocations charged to DuckDB's buffer pool.
+	idx_t GetBufferedBytes() const {
+		return buffered_bytes_.load();
 	}
+	//! Current manager-provided upper bound for retained partition buffers.
+	idx_t GetBufferBudgetBytes() const {
+		return buffer_budget_bytes_.load();
+	}
+	//! Peak retained bytes, including transient overshoot by concurrent appends.
+	idx_t GetPeakBufferedBytes() const {
+		return peak_buffered_bytes_.load();
+	}
+	//! Release uncommitted in-memory buffers without writing them.
+	void DiscardBufferedData();
 
 	DuckDBResult<void> RegisterPartitionFile(idx_t partition_idx, ShufflePartitionFile file);
 	DuckDBResult<ShufflePartitionFiles> GetPartitionFiles(idx_t partition_idx) const;
@@ -143,6 +157,14 @@ private:
 	//! Flush a single partition buffer to an IPC file.
 	DuckDBResult<ShufflePartitionFile> FlushBuffer(ClientContext &context, idx_t partition_idx,
 	                                               const vector<string> &names);
+	//! Flush a partition whose buffer mutex is already held.
+	DuckDBResult<ShufflePartitionFile> FlushBufferLocked(ClientContext &context, idx_t partition_idx,
+	                                                     const vector<string> &names);
+	DuckDBResult<void> FlushUnderMemoryPressure(ClientContext &context, const vector<string> &names);
+	void EnsureMemoryBudget(ClientContext &context);
+	void RefreshMemoryBudget(ClientContext &context);
+	void ReleaseMemoryReservation();
+	void UpdatePeakBufferedBytes(idx_t buffered_bytes);
 	//! Write a ColumnDataCollection to a single IPC file (shared implementation).
 	DuckDBResult<ShufflePartitionFile> WriteCollectionToFile(ClientContext &context, ColumnDataCollection &collection,
 	                                                         idx_t partition_idx, const vector<string> &names);
@@ -164,12 +186,23 @@ private:
 	//! Per-partition write buffers.
 	std::vector<std::unique_ptr<ColumnDataCollection>> write_buffers_;
 	//! Accumulated allocated bytes per partition buffer.
-	std::vector<idx_t> buffer_bytes_;
+	std::vector<std::atomic<idx_t>> buffer_bytes_;
 	//! Flush threshold resolved when the cache is constructed.
 	idx_t flush_threshold_bytes_;
+	//! Optional configured upper bound on the manager-provided memory budget.
+	optional_idx configured_max_buffered_bytes_;
+	std::atomic<idx_t> buffered_bytes_ {0};
+	std::atomic<idx_t> peak_buffered_bytes_ {0};
+	std::atomic<idx_t> buffer_budget_bytes_ {0};
+	std::atomic<bool> memory_budget_initialized_ {false};
 	//! Per-partition mutex for thread-safe buffer access.
 	std::vector<std::unique_ptr<std::mutex>> buffer_mutexes_;
+	//! Serializes cross-partition pressure flushes without serializing normal appends.
+	std::mutex pressure_mutex_;
+	std::mutex memory_state_mutex_;
+	std::unique_ptr<TemporaryMemoryState> temporary_memory_state_;
 	//! Column names captured on first WriteChunk call.
+	mutable std::mutex buffered_names_mutex_;
 	vector<string> buffered_names_;
 	//! Whether FlushAll has already been called.
 	bool flushed_ = false;

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1142,16 +1142,29 @@ TEST_CASE("Exchange: ShuffleCache bounds aggregate buffers across partitions", "
 	REQUIRE(total_rows == PARTITION_COUNT);
 }
 
-TEST_CASE("Exchange: ShuffleCache validates aggregate buffer budget", "[distributed][exchange]") {
-	ScopedEnvVar max_buffered_bytes("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES",
-	                                std::to_string(std::numeric_limits<idx_t>::max()));
-	ShuffleCacheConfig config;
-	config.shuffle_stage_id = "stage_invalid_buffer_budget";
-	config.node_id = "node_budget";
-	config.num_partitions = 1;
-	config.local_dirs = {TestCreatePath("exchange_cache_invalid_buffer_budget")};
+TEST_CASE("Exchange: ShuffleCache validates buffer byte settings", "[distributed][exchange]") {
+	auto make_config = []() {
+		ShuffleCacheConfig config;
+		config.shuffle_stage_id = "stage_invalid_buffer_budget";
+		config.node_id = "node_budget";
+		config.num_partitions = 1;
+		config.local_dirs = {TestCreatePath("exchange_cache_invalid_buffer_budget")};
+		return config;
+	};
 
-	REQUIRE_THROWS_WITH(ShuffleCache(std::move(config)), Catch::Matchers::Contains("must be less than idx_t max"));
+	SECTION("aggregate budget cannot use the optional_idx sentinel") {
+		ScopedEnvVar max_buffered_bytes("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES",
+		                                std::to_string(std::numeric_limits<idx_t>::max()));
+		REQUIRE_THROWS_WITH(ShuffleCache(make_config()), Catch::Matchers::Contains("must be less than idx_t max"));
+	}
+	SECTION("flush threshold rejects a whitespace-prefixed negative value") {
+		ScopedEnvVar flush_threshold("VANE_SHUFFLE_CACHE_FLUSH_THRESHOLD_BYTES", " -2");
+		REQUIRE_THROWS_WITH(ShuffleCache(make_config()), Catch::Matchers::Contains("positive integer byte count"));
+	}
+	SECTION("aggregate budget rejects a whitespace-prefixed negative value") {
+		ScopedEnvVar max_buffered_bytes("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES", " -2");
+		REQUIRE_THROWS_WITH(ShuffleCache(make_config()), Catch::Matchers::Contains("positive integer byte count"));
+	}
 }
 
 TEST_CASE("Exchange: ShuffleCache committed manifest replay via object storage backend", "[distributed][exchange]") {

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1224,6 +1224,12 @@ TEST_CASE("Exchange: ShuffleCache empty partition handling", "[distributed][exch
 	ShuffleCache cache(std::move(config));
 
 	vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+	DataChunk zero_row_chunk;
+	zero_row_chunk.Initialize(Allocator::DefaultAllocator(), types);
+	REQUIRE(cache.WriteChunk(context, zero_row_chunk, 0, {"id", "name"}).is_ok());
+	REQUIRE(cache.GetBufferedBytes() == 0);
+	REQUIRE(cache.GetBufferBudgetBytes() == 0);
+
 	auto empty_res = cache.ReadPartition(context, 0, types);
 	REQUIRE(empty_res.is_ok());
 	auto empty_collection = std::move(empty_res.value());

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <future>
 #include <iterator>
+#include <limits>
 #include <utility>
 #include <cstdlib>
 #include <condition_variable>
@@ -1054,6 +1055,105 @@ TEST_CASE("Exchange: ShuffleCache flushes large BLOB buffers by actual allocatio
 	REQUIRE(collection->Count() == static_cast<idx_t>(ids.size()));
 }
 
+TEST_CASE("Exchange: ShuffleCache bounds aggregate buffers across partitions", "[distributed][exchange]") {
+	static constexpr idx_t PARTITION_COUNT = 512;
+	static constexpr idx_t WRITER_COUNT = 8;
+	static constexpr idx_t MAX_BUFFERED_BYTES = 1024 * 1024;
+	ScopedEnvVar max_buffered_bytes("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES", std::to_string(MAX_BUFFERED_BYTES));
+
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto &context = *conn.context;
+
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = "stage_aggregate_buffer_budget";
+	config.node_id = "node_budget";
+	config.num_partitions = PARTITION_COUNT;
+	config.local_dirs = {TestCreatePath("exchange_cache_aggregate_buffer_budget")};
+	ShuffleCache cache(std::move(config));
+
+	vector<LogicalType> types = {LogicalType::INTEGER};
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), types);
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+
+	REQUIRE(cache.WriteChunk(context, chunk, 0, {}).is_ok());
+	const auto single_partition_bytes = cache.GetBufferedBytes();
+	const auto buffer_budget = cache.GetBufferBudgetBytes();
+	REQUIRE(single_partition_bytes > 0);
+	REQUIRE(buffer_budget > 0);
+	REQUIRE(buffer_budget <= MAX_BUFFERED_BYTES);
+
+	std::mutex start_mutex;
+	std::condition_variable start_cv;
+	idx_t ready_writers = 0;
+	bool start_writers = false;
+	vector<std::future<bool>> writers;
+	for (idx_t writer_idx = 0; writer_idx < WRITER_COUNT; writer_idx++) {
+		writers.push_back(std::async(std::launch::async, [&, writer_idx]() {
+			DataChunk writer_chunk;
+			writer_chunk.Initialize(Allocator::DefaultAllocator(), types);
+			writer_chunk.SetCardinality(1);
+			writer_chunk.SetValue(0, 0, Value::INTEGER(static_cast<int32_t>(writer_idx)));
+			{
+				std::unique_lock<std::mutex> lock(start_mutex);
+				ready_writers++;
+				start_cv.notify_all();
+				start_cv.wait(lock, [&]() { return start_writers; });
+			}
+			for (idx_t partition_idx = writer_idx + 1; partition_idx < PARTITION_COUNT; partition_idx += WRITER_COUNT) {
+				if (cache.WriteChunk(context, writer_chunk, partition_idx, {"value"}).is_err()) {
+					return false;
+				}
+			}
+			return true;
+		}));
+	}
+	{
+		std::unique_lock<std::mutex> lock(start_mutex);
+		start_cv.wait(lock, [&]() { return ready_writers == WRITER_COUNT; });
+		start_writers = true;
+	}
+	start_cv.notify_all();
+	for (auto &writer : writers) {
+		REQUIRE(writer.get());
+	}
+	REQUIRE(cache.BufferedNames() == vector<string> {"value"});
+	REQUIRE(cache.GetBufferedBytes() <= buffer_budget);
+	REQUIRE(cache.GetPeakBufferedBytes() <= buffer_budget + WRITER_COUNT * single_partition_bytes);
+
+	idx_t pressure_flushed_files = 0;
+	for (idx_t partition_idx = 0; partition_idx < PARTITION_COUNT; partition_idx++) {
+		auto files_res = cache.GetPartitionFiles(partition_idx);
+		REQUIRE(files_res.is_ok());
+		pressure_flushed_files += files_res.value().files.size();
+	}
+	REQUIRE(pressure_flushed_files > 0);
+
+	REQUIRE(cache.FlushAll(context, {"value"}).is_ok());
+	REQUIRE(cache.GetBufferedBytes() == 0);
+	idx_t total_rows = 0;
+	for (idx_t partition_idx = 0; partition_idx < PARTITION_COUNT; partition_idx++) {
+		auto files_res = cache.GetPartitionFiles(partition_idx);
+		REQUIRE(files_res.is_ok());
+		total_rows += files_res.value().total_rows;
+	}
+	REQUIRE(total_rows == PARTITION_COUNT);
+}
+
+TEST_CASE("Exchange: ShuffleCache validates aggregate buffer budget", "[distributed][exchange]") {
+	ScopedEnvVar max_buffered_bytes("VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES",
+	                                std::to_string(std::numeric_limits<idx_t>::max()));
+	ShuffleCacheConfig config;
+	config.shuffle_stage_id = "stage_invalid_buffer_budget";
+	config.node_id = "node_budget";
+	config.num_partitions = 1;
+	config.local_dirs = {TestCreatePath("exchange_cache_invalid_buffer_budget")};
+
+	REQUIRE_THROWS_WITH(ShuffleCache(std::move(config)), Catch::Matchers::Contains("must be less than idx_t max"));
+}
+
 TEST_CASE("Exchange: ShuffleCache committed manifest replay via object storage backend", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
@@ -1869,7 +1969,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 
 	FlightExchangeSink sink(cache, handle, &context);
 
-	// Should not be blocked (disk-first, no backpressure)
+	// Synchronous pressure flushing does not expose an asynchronous blocked state.
 	REQUIRE(sink.IsBlocked() == false);
 
 	// Write data
@@ -1888,6 +1988,7 @@ TEST_CASE("Exchange: FlightExchangeSink write and flush", "[distributed][exchang
 	// Finish should flush and register in ShuffleCacheRegistry
 	auto finish_res = sink.Finish();
 	REQUIRE(finish_res.is_ok());
+	REQUIRE(sink.GetMemoryUsage() == 0);
 
 	// Verify ShuffleCacheRegistry has the cache
 	auto registered = ShuffleCacheRegistry::Instance().Get("sink_test_stage");
@@ -1935,9 +2036,16 @@ TEST_CASE("Exchange: FlightExchangeSink memory usage", "[distributed][exchange]"
 
 	FlightExchangeSink sink(cache, handle, conn.context.get());
 
-	// Memory usage should be 0 (disk-first)
-	REQUIRE(sink.GetMemoryUsage() == 0);
+	vector<LogicalType> types = {LogicalType::INTEGER};
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), types);
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::INTEGER(42));
+	REQUIRE(sink.AddChunk(0, chunk).is_ok());
+	REQUIRE(sink.GetMemoryUsage() > 0);
+	REQUIRE(sink.GetMemoryUsage() == cache->GetBufferedBytes());
 	REQUIRE(sink.Abort().is_ok());
+	REQUIRE(sink.GetMemoryUsage() == 0);
 	auto cleanup = ShuffleCacheRegistry::Instance().RemoveAndCleanupByQuery(handle.query_id);
 	REQUIRE(cleanup.cleanup_errors == 0);
 	REQUIRE(cleanup.cleanup_pending == 0);


### PR DESCRIPTION
## Summary

- charge retained shuffle partition buffers to the DuckDB buffer pool and report their aggregate allocation through FlightExchangeSink
- obtain a fair, bounded working-set budget from TemporaryMemoryManager, with VANE_SHUFFLE_CACHE_MAX_BUFFERED_BYTES as an optional upper bound
- synchronously flush the largest retained partition directly to final shuffle storage when the aggregate budget is exceeded
- discard uncommitted buffers on abort while preserving deferred cleanup ownership for already-written files
- make buffered column-name access safe for the parallel sink path

Disk-first semantics are preserved: pressure flushing writes final shuffle IPC files and does not route buffers through DuckDB temporary spill storage. IsBlocked remains false because AddChunk completes any required pressure flush before returning. Concurrent appends can transiently overshoot by their in-flight allocation, but the cache is back under budget once writers quiesce.

## Tests

- scripts/run_native_tests.sh "Exchange: ShuffleCache bounds aggregate buffers across partitions"
- scripts/run_native_tests.sh "Exchange: FlightExchangeSink memory usage"
- scripts/run_native_tests.sh "[distributed][exchange]"
- scripts/run_native_tests.sh "[distributed]" (162 cases, 5561 assertions)
- scripts/run_release_tests.sh (468 passed, 1 skipped; real-Ray shard 10 passed)

Closes #344