### PR TITLE
[fix](distributed) Close abandoned result channels

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
@@ -93,14 +93,14 @@ public:
 	}
 
 	~PlanResultStream() {
-		// Close the channel so background plan tasks
-		// detect send() failure and exit on their own. We intentionally do not
+		// Disconnect the receiver so background plan tasks detect send() failure
+		// and queued outputs are released. We intentionally do not
 		// wait here because the destructor may run on the Python asyncio event-loop
 		// thread (during coroutine-frame GC).
 		// Waiting for control tasks here would block the event loop and prevent
 		// Ray from delivering the final result back to the client. Each detached
 		// task retains the ClientContext and status until it finishes naturally.
-		receiver_ = UnboundedReceiver<MaterializedOutput>();
+		receiver_.close();
 	}
 
 	PlanResultStream(PlanResultStream &&) = default;

--- a/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
@@ -366,12 +366,26 @@ public:
 	}
 
 	/// Disconnect the receiver and release queued values that can no longer be consumed.
-	void disconnect_receiver() {
-		std::queue<T> abandoned;
-		{
-			std::lock_guard<std::mutex> lock(mutex_);
-			closed_ = true;
-			queue_.swap(abandoned);
+	void disconnect_receiver() noexcept {
+		try {
+			std::queue<T> abandoned;
+			{
+				std::lock_guard<std::mutex> lock(mutex_);
+				closed_ = true;
+				queue_.swap(abandoned);
+			}
+		} catch (...) {
+			// Receiver cleanup runs from noexcept move/destruction paths. If allocating
+			// the temporary queue fails, close and drain in place as a best effort.
+			try {
+				std::lock_guard<std::mutex> lock(mutex_);
+				closed_ = true;
+				while (!queue_.empty()) {
+					queue_.pop();
+				}
+			} catch (...) {
+				// No safe cleanup remains if locking or in-place destruction also fails.
+			}
 		}
 		not_empty_.notify_all();
 	}
@@ -488,12 +502,12 @@ public:
 		return *this;
 	}
 
-	~UnboundedReceiver() {
+	~UnboundedReceiver() noexcept {
 		close();
 	}
 
 	/// Close the receive side and discard values that no consumer can observe.
-	void close() {
+	void close() noexcept {
 		if (!state_) {
 			return;
 		}

--- a/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
@@ -358,10 +358,21 @@ public:
 		return std::make_pair(true, std::move(value));
 	}
 
-	/// Close the channel
+	/// Close the channel to new sends while preserving queued values for the receiver.
 	void close() {
 		std::lock_guard<std::mutex> lock(mutex_);
 		closed_ = true;
+		not_empty_.notify_all();
+	}
+
+	/// Disconnect the receiver and release queued values that can no longer be consumed.
+	void disconnect_receiver() {
+		std::queue<T> abandoned;
+		{
+			std::lock_guard<std::mutex> lock(mutex_);
+			closed_ = true;
+			queue_.swap(abandoned);
+		}
 		not_empty_.notify_all();
 	}
 
@@ -460,6 +471,34 @@ public:
 	UnboundedReceiver() = default;
 
 	explicit UnboundedReceiver(std::shared_ptr<UnboundedChannelState<T>> state) : state_(std::move(state)) {
+	}
+
+	// Move-only receiver semantics (tokio::mpsc-style single receiver).
+	UnboundedReceiver(const UnboundedReceiver &) = delete;
+	UnboundedReceiver &operator=(const UnboundedReceiver &) = delete;
+
+	UnboundedReceiver(UnboundedReceiver &&other) noexcept : state_(std::move(other.state_)) {
+	}
+
+	UnboundedReceiver &operator=(UnboundedReceiver &&other) noexcept {
+		if (this != &other) {
+			close();
+			state_ = std::move(other.state_);
+		}
+		return *this;
+	}
+
+	~UnboundedReceiver() {
+		close();
+	}
+
+	/// Close the receive side and discard values that no consumer can observe.
+	void close() {
+		if (!state_) {
+			return;
+		}
+		auto state = std::move(state_);
+		state->disconnect_receiver();
 	}
 
 	/// Receive a value (blocking)

--- a/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
+++ b/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
@@ -3,30 +3,35 @@
 
 /**
  * @file test_streaming_channel.cpp
- * @brief Unit tests for the T2 removal and dispatcher streaming channel changes.
+ * @brief Unit tests for distributed streaming channel lifecycle behavior.
  *
  * These tests verify that:
  * 1. Temporary senders created from UnboundedChannelState correctly manage
  *    sender counts (increment on create, decrement on destroy).
- * 2. The streaming channel state can be stored and retrieved from a
- *    WorkerManager (simulating the execute_plan → dispatcher path).
- * 3. Channel close ordering is correct: the channel only closes when ALL
- *    senders (including temporaries) are destroyed.
- * 4. Concurrent creation of temporary senders is thread-safe.
+ * 2. Sender completion preserves queued values for the receiver to drain.
+ * 3. Receiver abandonment closes the channel and releases queued values.
+ * 4. Moving a receiver transfers its single-consumer ownership.
+ * 5. Concurrent sender activity and receiver closure are thread-safe.
  */
 
 #include <atomic>
-#include <chrono>
 #include <memory>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "catch.hpp"
 #include "test_common.hpp"
+#include "duckdb/execution/distributed/plan/distributed_physical_plan.hpp"
 #include "duckdb/execution/distributed/utils/channel.hpp"
 
 using namespace duckdb::distributed;
 using namespace duckdb::distributed::testing;
+
+static_assert(!std::is_copy_constructible<UnboundedReceiver<int>>::value,
+              "unbounded channels must have exactly one receiver owner");
+static_assert(!std::is_copy_assignable<UnboundedReceiver<int>>::value,
+              "unbounded channels must have exactly one receiver owner");
 
 //==============================================================================
 // Section 1: UnboundedSender temporary lifecycle tests
@@ -153,6 +158,112 @@ TEST_CASE("Streaming channel: channel closes only when all senders drop", "[dist
 	REQUIRE(values[1] == 2);
 	REQUIRE(values[2] == 3);
 	REQUIRE(values[3] == 4);
+}
+
+//==============================================================================
+// Section 2: UnboundedReceiver lifecycle tests
+//==============================================================================
+
+TEST_CASE("Streaming channel: dropping receiver closes channel and rejects sends", "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<int>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+	auto state = sender.state();
+
+	{ auto dropped_receiver = std::move(receiver); }
+
+	REQUIRE(state->is_closed());
+	REQUIRE(state->is_empty());
+	REQUIRE(sender.send(42).is_err());
+}
+
+TEST_CASE("Streaming channel: closing receiver releases queued values", "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<std::shared_ptr<int>>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+	auto state = sender.state();
+	auto payload = std::make_shared<int>(42);
+	std::weak_ptr<int> payload_lifetime = payload;
+
+	REQUIRE(sender.send(std::move(payload)).is_ok());
+	REQUIRE_FALSE(payload_lifetime.expired());
+
+	receiver.close();
+	receiver.close();
+
+	REQUIRE(state->is_closed());
+	REQUIRE(state->is_empty());
+	REQUIRE(payload_lifetime.expired());
+	REQUIRE(sender.send(std::make_shared<int>(43)).is_err());
+}
+
+TEST_CASE("Streaming channel: moving receiver transfers channel ownership", "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<int>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+	auto moved_receiver = std::move(receiver);
+
+	REQUIRE(sender.send(42).is_ok());
+	auto item = moved_receiver.recv();
+	REQUIRE(item.first);
+	REQUIRE(item.second == 42);
+}
+
+TEST_CASE("Streaming channel: receiver move assignment closes replaced channel", "[distributed][streaming_channel]") {
+	auto old_pair = create_unbounded_channel<int>();
+	auto old_sender = std::move(old_pair.first);
+	auto old_receiver = std::move(old_pair.second);
+	auto replacement_pair = create_unbounded_channel<int>();
+	auto replacement_sender = std::move(replacement_pair.first);
+	auto replacement_receiver = std::move(replacement_pair.second);
+
+	old_receiver = std::move(replacement_receiver);
+
+	REQUIRE(old_sender.send(1).is_err());
+	REQUIRE(replacement_sender.send(2).is_ok());
+	auto item = old_receiver.recv();
+	REQUIRE(item.first);
+	REQUIRE(item.second == 2);
+}
+
+TEST_CASE("Streaming channel: dropping plan result stream disconnects result receiver",
+          "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<MaterializedOutput>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+
+	{ PlanResultStream stream(nullptr, std::move(receiver)); }
+
+	REQUIRE(sender.send(MaterializedOutput()).is_err());
+}
+
+TEST_CASE("Streaming channel: receiver close races safely with active sender", "[distributed][streaming_channel]") {
+	for (idx_t iteration = 0; iteration < 64; iteration++) {
+		auto ch_pair_ = create_unbounded_channel<int>();
+		auto sender = std::move(ch_pair_.first);
+		auto receiver = std::move(ch_pair_.second);
+		auto state = sender.state();
+		std::atomic<bool> start {false};
+
+		std::thread producer([concurrent_sender = sender.clone(), &start]() mutable {
+			while (!start.load(std::memory_order_acquire)) {
+				std::this_thread::yield();
+			}
+			for (idx_t value = 0; value < 128; value++) {
+				if (concurrent_sender.send(static_cast<int>(value)).is_err()) {
+					break;
+				}
+			}
+		});
+
+		start.store(true, std::memory_order_release);
+		receiver.close();
+		producer.join();
+
+		REQUIRE(state->is_closed());
+		REQUIRE(state->is_empty());
+		REQUIRE(sender.send(42).is_err());
+	}
 }
 
 //==============================================================================

--- a/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
+++ b/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <thread>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "catch.hpp"
@@ -32,6 +33,12 @@ static_assert(!std::is_copy_constructible<UnboundedReceiver<int>>::value,
               "unbounded channels must have exactly one receiver owner");
 static_assert(!std::is_copy_assignable<UnboundedReceiver<int>>::value,
               "unbounded channels must have exactly one receiver owner");
+static_assert(std::is_nothrow_move_assignable<UnboundedReceiver<int>>::value,
+              "replacing an unbounded receiver must not throw");
+static_assert(std::is_nothrow_destructible<UnboundedReceiver<int>>::value,
+              "destroying an unbounded receiver must not throw");
+static_assert(noexcept(std::declval<UnboundedReceiver<int> &>().close()),
+              "closing an unbounded receiver must not throw");
 
 //==============================================================================
 // Section 1: UnboundedSender temporary lifecycle tests


### PR DESCRIPTION
## Summary

- make `UnboundedReceiver` a single, move-only owner that disconnects its channel when closed, replaced, or destroyed
- reject producer sends and release queued payloads as soon as the result consumer is abandoned, while preserving normal producer-close-and-drain behavior
- make `PlanResultStream` explicitly close its receiver and add lifecycle, move, payload-release, and send/close race coverage

This fixes the core channel ownership defect without adding blocking teardown to the Python event-loop path or expanding the change into full query cancellation.

## Related issue

close: #336

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format duckdb --changed --check`
- `scripts/run_native_tests.sh "[distributed][streaming_channel]"` — 11 test cases, 3240 assertions
- `scripts/run_native_tests.sh "[distributed]"` — 166 test cases, 4722 assertions
- incremental non-editable native install with `SKBUILD_BUILD_DIR=build/python-release` and Release configuration
- focused native-backend Python lifecycle tests — 3 passed
- `scripts/run_release_tests.sh` — 468 passed / 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (No new dependencies or third-party assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (No security-sensitive surface changed.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.