### PR TITLE
[fix](fte) Release consumed dynamic split payloads

### DIFF
--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -335,6 +335,7 @@ class FteTaskExecution:
         self.seen_sequences: dict[str, set[int]] = {
             source_id: {split.sequence_id for split in splits} for source_id, splits in self.initial_splits.items()
         }
+        self._discard_dynamic_initial_splits()
         self.status = TaskStatus(self.task_id, FteTaskState.PLANNED)
         self._last_split_queue_status: dict[str, Any] = {}
         self.result: Any = None
@@ -388,6 +389,32 @@ class FteTaskExecution:
             queue.add_exchange_source_split(data)
         else:
             raise ValueError(f"unsupported dynamic split kind: {expected_kind}")
+
+    def _store_accepted_split(self, source_node_id: str, split: FteSplit) -> None:
+        scan_queue = self.dynamic_scan_source_queues.get(source_node_id)
+        exchange_queue = self.dynamic_exchange_source_queues.get(source_node_id)
+        if scan_queue is None and exchange_queue is None:
+            self.initial_splits.setdefault(source_node_id, []).append(split)
+            return
+        if scan_queue is not None:
+            self._add_split_to_dynamic_queue(scan_queue, split, "scan_task")
+        if exchange_queue is not None:
+            self._add_split_to_dynamic_queue(exchange_queue, split, "exchange_source_task")
+
+    def _register_static_split_source(self, source_node_id: str) -> None:
+        if (
+            source_node_id not in self.dynamic_scan_source_queues
+            and source_node_id not in self.dynamic_exchange_source_queues
+        ):
+            self.initial_splits.setdefault(source_node_id, [])
+
+    def _discard_dynamic_initial_splits(self) -> None:
+        dynamic_sources = self.dynamic_scan_source_ids | self.dynamic_exchange_source_ids
+        if not dynamic_sources:
+            return
+        for source_id in dynamic_sources:
+            self.initial_splits.pop(source_id, None)
+        self._refresh_request_splits()
 
     def _transition(
         self,
@@ -467,9 +494,7 @@ class FteTaskExecution:
             **self.dynamic_exchange_source_queues,
         }
         submitted_by_source = {
-            source_id: int(queues_by_source[source_id].submitted_splits())
-            for source_id in sorted(self.initial_splits)
-            if source_id in queues_by_source
+            source_id: int(queue.submitted_splits()) for source_id, queue in sorted(queues_by_source.items())
         }
         buffered_by_source = {
             source_id: int(queue.buffered_splits()) for source_id, queue in sorted(queues_by_source.items())
@@ -820,21 +845,15 @@ class FteTaskExecution:
             if source_node_id in self.no_more_split_sources:
                 raise RuntimeError(f"source {source_node_id} is already marked no_more_splits")
             seen = self.seen_sequences.setdefault(source_node_id, set())
-            target = self.initial_splits.setdefault(source_node_id, [])
+            self._register_static_split_source(source_node_id)
             added = False
             for payload in splits:
                 split = FteSplit.from_dict(source_node_id, payload)
                 if split.sequence_id in seen:
                     self.status.duplicate_split_count += 1
                     continue
+                self._store_accepted_split(source_node_id, split)
                 seen.add(split.sequence_id)
-                target.append(split)
-                scan_queue = self.dynamic_scan_source_queues.get(source_node_id)
-                if scan_queue is not None:
-                    self._add_split_to_dynamic_queue(scan_queue, split, "scan_task")
-                exchange_queue = self.dynamic_exchange_source_queues.get(source_node_id)
-                if exchange_queue is not None:
-                    self._add_split_to_dynamic_queue(exchange_queue, split, "exchange_source_task")
                 added = True
             if added:
                 self.status.version += 1
@@ -885,20 +904,14 @@ class FteTaskExecution:
         if source_node_id in self.no_more_split_sources and splits:
             raise RuntimeError(f"source {source_node_id} is already marked no_more_splits")
         seen = self.seen_sequences.setdefault(source_node_id, set())
-        target = self.initial_splits.setdefault(source_node_id, [])
+        self._register_static_split_source(source_node_id)
         added = False
         for split in splits:
             if split.sequence_id in seen:
                 self.status.duplicate_split_count += 1
                 continue
+            self._store_accepted_split(source_node_id, split)
             seen.add(split.sequence_id)
-            target.append(split)
-            scan_queue = self.dynamic_scan_source_queues.get(source_node_id)
-            if scan_queue is not None:
-                self._add_split_to_dynamic_queue(scan_queue, split, "scan_task")
-            exchange_queue = self.dynamic_exchange_source_queues.get(source_node_id)
-            if exchange_queue is not None:
-                self._add_split_to_dynamic_queue(exchange_queue, split, "exchange_source_task")
             added = True
         return added
 
@@ -934,12 +947,14 @@ class FteTaskExecution:
             if merged_source_node_ids != current:
                 self.request["source_node_ids"] = sorted(merged_source_node_ids)
                 changed = True
+        dynamic_sources_changed = False
         if update_request.dynamic_scan_source_node_ids:
             merged_scan_source_ids = self.dynamic_scan_source_ids | set(update_request.dynamic_scan_source_node_ids)
             if merged_scan_source_ids != self.dynamic_scan_source_ids:
                 self.dynamic_scan_source_ids = merged_scan_source_ids
                 self._add_dynamic_source_queues("scan_task", merged_scan_source_ids)
                 self.request["dynamic_scan_source_node_ids"] = sorted(merged_scan_source_ids)
+                dynamic_sources_changed = True
                 changed = True
         if update_request.dynamic_exchange_source_node_ids:
             merged_exchange_source_ids = self.dynamic_exchange_source_ids | set(
@@ -949,7 +964,11 @@ class FteTaskExecution:
                 self.dynamic_exchange_source_ids = merged_exchange_source_ids
                 self._add_dynamic_source_queues("exchange_source_task", merged_exchange_source_ids)
                 self.request["dynamic_exchange_source_node_ids"] = sorted(merged_exchange_source_ids)
+                dynamic_sources_changed = True
                 changed = True
+
+        if dynamic_sources_changed:
+            self._discard_dynamic_initial_splits()
 
         for source_id, splits in update_request.initial_splits.items():
             changed = self._append_update_splits(source_id, list(splits)) or changed

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -908,6 +908,182 @@ def test_fte_task_execution_terminal_status_refreshes_split_stats_with_fallback(
 
 
 @pytest.mark.parametrize(
+    ("dynamic_source_field", "queue_attribute", "source_node_id", "split_kind"),
+    [
+        ("dynamic_scan_source_node_ids", "dynamic_scan_source_queues", "7", "scan_task"),
+        (
+            "dynamic_exchange_source_node_ids",
+            "dynamic_exchange_source_queues",
+            "9",
+            "exchange_source_task",
+        ),
+    ],
+)
+def test_fte_task_execution_dynamic_split_payloads_are_queue_owned(
+    dynamic_source_field,
+    queue_attribute,
+    source_node_id,
+    split_kind,
+):
+    async def execute_fn(_request):
+        return None
+
+    initial_payload = b"initial-payload" * 1024
+    added_payload = b"added-payload" * 1024
+    execution = FteTaskExecution(
+        {
+            "task_id": f"q-dynamic-payload.0.{source_node_id}.0",
+            dynamic_source_field: [source_node_id],
+            "initial_splits": {
+                source_node_id: [
+                    {
+                        "sequence_id": 0,
+                        "kind": split_kind,
+                        "data": initial_payload,
+                    }
+                ],
+            },
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+
+    queue = getattr(execution, queue_attribute)[source_node_id]
+    assert execution.initial_splits == {}
+    assert execution.request["initial_splits"] == {}
+    assert execution.seen_sequences == {source_node_id: {0}}
+    assert execution.info()["initial_split_counts"] == {}
+
+    execution.add_splits(
+        source_node_id,
+        [{"sequence_id": 1, "kind": split_kind, "data": added_payload}],
+    )
+
+    assert execution.initial_splits == {}
+    assert execution.request["initial_splits"] == {}
+    assert execution.seen_sequences == {source_node_id: {0, 1}}
+    assert queue.buffered_splits() == 2
+    assert queue.buffered_bytes() == len(initial_payload) + len(added_payload)
+    status = execution.split_queue_status()
+    assert status["submitted_split_count"] == 2
+    assert status["submitted_split_count_by_source"] == {source_node_id: 2}
+
+    assert queue.try_get_next()["data"] == initial_payload
+    assert queue.try_get_next()["data"] == added_payload
+    assert queue.buffered_splits() == 0
+    assert queue.buffered_bytes() == 0
+
+    duplicate_status = execution.add_splits(
+        source_node_id,
+        [{"sequence_id": 1, "kind": split_kind, "data": b"duplicate"}],
+    )
+    assert duplicate_status.duplicate_split_count == 1
+    assert queue.try_get_next() == {"state": "BLOCKED"}
+    assert execution.initial_splits == {}
+
+
+@pytest.mark.parametrize(
+    ("dynamic_source_field", "queue_attribute", "source_node_id", "split_kind"),
+    [
+        ("dynamic_scan_source_node_ids", "dynamic_scan_source_queues", "7", "scan_task"),
+        (
+            "dynamic_exchange_source_node_ids",
+            "dynamic_exchange_source_queues",
+            "9",
+            "exchange_source_task",
+        ),
+    ],
+)
+def test_fte_task_execution_dynamic_source_update_transfers_and_releases_retained_splits(
+    dynamic_source_field,
+    queue_attribute,
+    source_node_id,
+    split_kind,
+):
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {
+            "task_id": "q-dynamic-update.0.0.0",
+            "initial_splits": {
+                source_node_id: [
+                    {
+                        "sequence_id": 0,
+                        "kind": split_kind,
+                        "data": b"retained-before-update",
+                    }
+                ],
+            },
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+    assert [split.data for split in execution.initial_splits[source_node_id]] == [b"retained-before-update"]
+
+    execution.update_task(
+        {
+            dynamic_source_field: [source_node_id],
+            "initial_splits": {
+                source_node_id: [
+                    {
+                        "sequence_id": 1,
+                        "kind": split_kind,
+                        "data": b"added-with-update",
+                    }
+                ],
+            },
+        }
+    )
+
+    queue = getattr(execution, queue_attribute)[source_node_id]
+    assert execution.initial_splits == {}
+    assert execution.request["initial_splits"] == {}
+    assert execution.seen_sequences == {source_node_id: {0, 1}}
+    assert execution.info()["initial_split_counts"] == {}
+    assert queue.buffered_splits() == 2
+    assert queue.try_get_next()["data"] == b"retained-before-update"
+    assert queue.try_get_next()["data"] == b"added-with-update"
+
+    duplicate_status = execution.update_task(
+        {
+            "initial_splits": {
+                source_node_id: [
+                    {
+                        "sequence_id": 1,
+                        "kind": split_kind,
+                        "data": b"duplicate",
+                    }
+                ],
+            },
+        }
+    )
+    assert duplicate_status.duplicate_split_count == 1
+    assert queue.try_get_next() == {"state": "BLOCKED"}
+    assert execution.initial_splits == {}
+
+
+def test_fte_task_execution_empty_split_batch_only_registers_static_source():
+    async def execute_fn(_request):
+        return None
+
+    execution = FteTaskExecution(
+        {
+            "task_id": "q-empty-splits.0.0.0",
+            "dynamic_scan_source_node_ids": ["dynamic"],
+        },
+        execute_fn,
+        default_task_memory_bytes=1,
+    )
+
+    execution.add_splits("static", [])
+    execution.add_splits("dynamic", [])
+
+    assert execution.initial_splits == {"static": []}
+    assert execution.seen_sequences == {"static": set(), "dynamic": set()}
+
+
+@pytest.mark.parametrize(
     "terminal_state",
     [
         FteTaskState.FINISHED,


### PR DESCRIPTION
## Summary

- make native dynamic split queues the sole payload owner after successful handoff
- retain only sequence IDs for worker-side duplicate detection
- discard initial dynamic payloads immediately, including sources converted to dynamic by task updates
- derive submitted split statistics from native queues instead of retained Python descriptors
- preserve empty static-source registration semantics

## Review

- fixed an empty static split-batch compatibility issue found in the first review
- added scan and exchange coverage for initial, add_splits, and update_task paths
- completed a clean review and an additional manager-level lifecycle review with no remaining findings

## Testing

- scripts/format root --changed
- pre-commit run --files duckdb/runners/fte/fte_worker_runtime.py tests/fast/test_ray_fte.py
- python -m pytest tests/fast/test_ray_fte.py (178 passed)
- scripts/run_release_tests.sh (468 passed, 1 skipped; real-Ray shard 10 passed)
- manager-level issue reproduction with a 4 MiB split payload

Fixes #349
