### PR TITLE
[fix](relation) Match explode columns case-insensitively

### DIFF
--- a/external/duckdb/src/main/relation/unnest_relation.cpp
+++ b/external/duckdb/src/main/relation/unnest_relation.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/planner/expression/bound_unnest_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 
 namespace duckdb {
@@ -22,6 +23,21 @@ static idx_t FindUnnestColumnIndex(const vector<string> &names, const string &co
 		if (names[i] == column_name) {
 			return i;
 		}
+	}
+
+	idx_t case_insensitive_match = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < names.size(); i++) {
+		if (!StringUtil::CIEquals(names[i], column_name)) {
+			continue;
+		}
+		if (case_insensitive_match != DConstants::INVALID_INDEX) {
+			throw BinderException("Ambiguous reference to column name \"%s\" in child relation for unnest/explode",
+			                      column_name);
+		}
+		case_insensitive_match = i;
+	}
+	if (case_insensitive_match != DConstants::INVALID_INDEX) {
+		return case_insensitive_match;
 	}
 	throw BinderException("Column \"%s\" not found in child relation for unnest/explode", column_name);
 }
@@ -75,6 +91,7 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 
 	// 2. Find the column to unnest
 	auto unnest_col_idx = FindUnnestColumnIndex(child_bound.names, column_name);
+	const auto &unnest_column_name = child_bound.names[unnest_col_idx];
 
 	// 3. Determine element type from the list/array column
 	auto &list_type = child_bound.types[unnest_col_idx];
@@ -90,7 +107,7 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 
 	// 4. Create BoundUnnestExpression: unnest(col_ref) → element_type
 	unique_ptr<Expression> unnest_child =
-	    make_uniq<BoundColumnRefExpression>(column_name, list_type, child_bindings[unnest_col_idx]);
+	    make_uniq<BoundColumnRefExpression>(unnest_column_name, list_type, child_bindings[unnest_col_idx]);
 	// PhysicalUnnest consumes LIST vectors. Match the SQL UNNEST binder by
 	// casting ARRAY inputs to LIST while preserving their element type.
 	unnest_child = BoundCastExpression::AddArrayCastToList(binder.context, std::move(unnest_child));
@@ -114,9 +131,10 @@ BoundStatement UnnestRelation::Bind(Binder &binder) {
 	for (idx_t i = 0; i < child_bound.names.size(); i++) {
 		if (i == unnest_col_idx) {
 			// Replace the list column with the unnested scalar
-			auto ref = make_uniq<BoundColumnRefExpression>(column_name, element_type, ColumnBinding(unnest_index, 0));
+			auto ref =
+			    make_uniq<BoundColumnRefExpression>(unnest_column_name, element_type, ColumnBinding(unnest_index, 0));
 			proj_exprs.push_back(std::move(ref));
-			result.names.push_back(column_name);
+			result.names.push_back(unnest_column_name);
 			result.types.push_back(element_type);
 		} else {
 			// Pass-through: reference the child's original column binding

--- a/tests/fast/relational_api/test_explode.py
+++ b/tests/fast/relational_api/test_explode.py
@@ -3,6 +3,8 @@
 
 import pytest
 
+import duckdb
+
 EXPECTED_COLUMNS = ["x", "a", "y"]
 EXPECTED_ROWS = [(10, 20, 30), (10, 21, 30)]
 
@@ -27,6 +29,25 @@ def test_explode_serialized_query_matches_direct_binding(duckdb_cursor, collecti
     assert serialized.columns == EXPECTED_COLUMNS
     assert serialized.types == exploded.types
     assert serialized.fetchall() == EXPECTED_ROWS
+
+
+@pytest.mark.parametrize("collection_type", ["INTEGER[]", "INTEGER[2]"])
+def test_explode_unique_target_name_is_case_insensitive(duckdb_cursor, collection_type):
+    exploded = middle_collection_relation(duckdb_cursor, collection_type).explode("A")
+    serialized = duckdb_cursor.sql(exploded.sql_query())
+
+    assert exploded.columns == EXPECTED_COLUMNS
+    assert exploded.fetchall() == EXPECTED_ROWS
+    assert serialized.columns == EXPECTED_COLUMNS
+    assert serialized.types == exploded.types
+    assert serialized.fetchall() == EXPECTED_ROWS
+
+
+def test_explode_case_insensitive_target_requires_unique_match(duckdb_cursor):
+    relation = duckdb_cursor.sql('SELECT [20, 21]::INTEGER[] AS target, [30, 31]::INTEGER[] AS "TARGET"')
+
+    with pytest.raises(duckdb.BinderException, match="Ambiguous reference to column"):
+        relation.explode("Target")
 
 
 @pytest.mark.parametrize("duplicate_name", ["x", "X"])


### PR DESCRIPTION
## Summary

- resolve `Relation.explode()` targets with exact-name priority followed by a unique ASCII case-insensitive match, matching DuckDB identifier semantics without changing the existing exact selection of case-only duplicate names
- reject non-exact lookups that match multiple child columns as ambiguous instead of silently choosing one
- preserve the resolved child column's original spelling in direct-bound output so direct and serialized Relation schemas remain aligned
- add LIST/ARRAY regressions for case-insensitive lookup, original-name preservation, direct-versus-serialized parity, and ambiguous case-only duplicates

## Related issue

Closes #369

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This restores the documented DuckDB identifier behavior for an existing Relation API; the public API is unchanged.

## Validation

- Release incremental native install with `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `python -m pytest tests/fast/relational_api/test_explode.py -q`: 16 passed
- `python -m pytest tests/fast/relational_api -q`: 409 passed, 1 skipped
- `scripts/run_release_tests.sh`: 468 passed, 1 skipped in the non-Ray shard; 10 passed in the real-Ray shard
- `VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh "[relation_api]"`: 35 test cases and 651 assertions passed
- manual exact/case-variant/ambiguous/missing-name matrix, including serialized rebinding and connection reuse
- `scripts/format workspace --changed`
- pre-commit hooks for both changed files
- `git diff --check`
- two consecutive clean review passes after addressing the only review finding (Python import ordering)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. This changes local identifier resolution only.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
