### PR TITLE
[fix](python) Reject empty shared_ptr try_cast results

### DIFF
--- a/src/duckdb_py/include/duckdb_python/pybind11/pybind_wrapper.hpp
+++ b/src/duckdb_py/include/duckdb_python/pybind11/pybind_wrapper.hpp
@@ -78,13 +78,25 @@ inline bool isinstance(handle obj, handle type) {
 }
 
 template <class T>
+bool is_valid_try_cast_result(const T &) {
+	return true;
+}
+
+// Pybind11 accepts None for holder types and returns an empty holder. Callers use a successful
+// try_cast as permission to dereference the result, so an empty shared_ptr is not a valid result.
+template <class T, bool SAFE>
+bool is_valid_try_cast_result(const shared_ptr<T, SAFE> &result) {
+	return result != nullptr;
+}
+
+template <class T>
 bool try_cast(const handle &object, T &result) {
 	try {
 		result = cast<T>(object);
 	} catch (pybind11::cast_error &) {
 		return false;
 	}
-	return true;
+	return is_valid_try_cast_result(result);
 }
 
 } // namespace py

--- a/tests/fast/test_pybind_try_cast.py
+++ b/tests/fast/test_pybind_try_cast.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: MIT AND Apache-2.0
+#
+# Modified by Vane contributors.
+
+from pathlib import Path
+
+import pytest
+
+import duckdb
+from duckdb import FunctionExpression
+from duckdb.sqltypes import BIGINT
+
+
+@pytest.mark.parametrize("fields", [[None], {"a": None}])
+def test_struct_type_rejects_null_type_holder(fields):
+    with pytest.raises(duckdb.InvalidInputException, match="object has to be a list of DuckDBPyType"):
+        duckdb.struct_type(fields)
+
+
+def test_execute_rejects_null_statement_holder(duckdb_cursor):
+    with pytest.raises(
+        duckdb.InvalidInputException,
+        match="Please provide either a DuckDBPyStatement or a string representing the query",
+    ):
+        duckdb_cursor.execute(None)
+
+
+def test_value_rejects_null_type_holder(duckdb_cursor):
+    value = duckdb.Value(1, None)
+    with pytest.raises(
+        duckdb.InvalidInputException,
+        match="The 'type' of a Value should be of type DuckDBPyType",
+    ):
+        duckdb_cursor.execute("select ?", [value])
+
+
+@pytest.mark.parametrize("dtype", [[None], {"category_id": None}])
+def test_read_csv_rejects_null_type_holder(duckdb_cursor, dtype):
+    csv_path = Path(__file__).parent / "data" / "category.csv"
+    with pytest.raises(duckdb.InvalidInputException, match="can not be converted to a DuckDB Type"):
+        duckdb_cursor.read_csv(csv_path, dtype=dtype)
+
+
+def test_none_parameter_annotation_uses_explicit_udf_type(duckdb_cursor):
+    def add_one(value: None):
+        return value + 1
+
+    duckdb_cursor.create_function("issue_159_add_one", add_one, [BIGINT], BIGINT)
+    assert duckdb_cursor.sql("select issue_159_add_one(41)").fetchone() == (42,)
+
+
+def test_none_still_implicitly_converts_to_sql_null_expression(duckdb_cursor):
+    expression = FunctionExpression("greatest", None, 42)
+    assert duckdb_cursor.sql("select 1").select(expression).fetchone() == (42,)


### PR DESCRIPTION
## Summary

- Treat a pybind11 try_cast as unsuccessful when it produces an empty DuckDB shared_ptr holder, so existing invalid-input branches run before any dereference.
- Keep the generic result path unchanged, preserving false and zero-valued enums as well as None converting to a non-empty SQL NULL expression where implicit expression conversion is supported.
- Add regression coverage for statement, Value type, struct type, CSV dtype, UDF annotation, and expression conversion paths.
- Implement the result check with C++11-compatible function-template overloads; no C++20-only language feature is used.

## Related issue

close: #159

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- Native incremental Release install: `uv pip install . --no-build-isolation`
- C++11 wrapper syntax check: `/usr/bin/c++ -std=c++11 -fsyntax-only ...`
- New regression tests: 8 passed
- Affected Python tests: 249 passed, 1 skipped
- `scripts/run_release_tests.sh`: 468 passed, 1 skipped, 14 deselected; real-Ray shard 10 passed, 473 deselected
- `scripts/run_fast_tests.sh`: non-Ray shard 6216 passed, 28 skipped, 8 xfailed, 1 xpassed; shared-Ray shard 98 passed, 6 skipped; isolated Ray-cluster shards 7 passed; optional vLLM shard skipped because vLLM is unavailable
- `scripts/format root --changed`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.