### PR TITLE
[fix](ray) Isolate FTE workers by manager

### DIFF
--- a/duckdb/runners/fte/fte_events.py
+++ b/duckdb/runners/fte/fte_events.py
@@ -69,6 +69,7 @@ class WorkerFailed(FteEvent):
     worker_id: str
     error: Any = None
     failed_worker_ids: frozenset[str] | None = None
+    manager_instance_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -320,6 +320,7 @@ class FteAttemptStatusWatcher:
 
     def _run(self) -> None:
         min_version = None
+        manager_instance_id = str(getattr(self.worker, "manager_instance_id", ""))
         while not self._stop.is_set():
             try:
                 status = self._wait_task_status(min_version)
@@ -335,6 +336,7 @@ class FteAttemptStatusWatcher:
                         self.scheduler.query_id,
                         str(self.worker.worker_id),
                         exc,
+                        manager_instance_id=manager_instance_id,
                     )
                 )
                 return
@@ -346,6 +348,7 @@ class FteAttemptStatusWatcher:
                         self.scheduler.query_id,
                         str(self.worker.worker_id),
                         TypeError("fte_wait_task_status must return a dict"),
+                        manager_instance_id=manager_instance_id,
                     )
                 )
                 return
@@ -357,6 +360,7 @@ class FteAttemptStatusWatcher:
                         self.scheduler.query_id,
                         str(self.worker.worker_id),
                         exc,
+                        manager_instance_id=manager_instance_id,
                     )
                 )
                 return
@@ -375,6 +379,7 @@ class FteAttemptStatusWatcher:
                         self.scheduler.query_id,
                         str(self.worker.worker_id),
                         ValueError(f"unknown FTE task state: {raw_state!r}"),
+                        manager_instance_id=manager_instance_id,
                     )
                 )
                 return
@@ -562,6 +567,31 @@ class FteQueryScheduler:
         self._queued_internal_admission_classes: set[str | None] = set()
         self._failed_worker_ids: set[str] = set()
         self._task_sources: dict[str, FteTaskSourceRegistration] = {}
+        self._manager_instance_id: str | None = None
+
+    def bind_manager_instance(
+        self,
+        manager_instance_id: str,
+        *,
+        handlers: FteEventHandlers | None = None,
+    ) -> None:
+        manager_instance_id = str(manager_instance_id or "").strip()
+        with self._lock:
+            if self._manager_instance_id is None:
+                self._manager_instance_id = manager_instance_id
+            elif self._manager_instance_id != manager_instance_id:
+                raise RuntimeError(
+                    "FTE query scheduler manager ownership mismatch: "
+                    f"query={self.query_id} owner={self._manager_instance_id or '<default>'} "
+                    f"requested={manager_instance_id or '<default>'}"
+                )
+            if handlers is not None:
+                self._handlers = handlers
+
+    def is_owned_by_manager_instance(self, manager_instance_id: str) -> bool:
+        manager_instance_id = str(manager_instance_id or "").strip()
+        with self._lock:
+            return self._manager_instance_id == manager_instance_id
 
     def set_handlers(self, handlers: FteEventHandlers) -> None:
         with self._lock:

--- a/duckdb/runners/fte/fte_scheduler.py
+++ b/duckdb/runners/fte/fte_scheduler.py
@@ -320,6 +320,8 @@ class FteAttemptStatusWatcher:
 
     def _run(self) -> None:
         min_version = None
+        # Missing metadata belongs to the explicit legacy scope. None is
+        # reserved for events whose ownership is genuinely unknown.
         manager_instance_id = str(getattr(self.worker, "manager_instance_id", ""))
         while not self._stop.is_set():
             try:
@@ -567,6 +569,7 @@ class FteQueryScheduler:
         self._queued_internal_admission_classes: set[str | None] = set()
         self._failed_worker_ids: set[str] = set()
         self._task_sources: dict[str, FteTaskSourceRegistration] = {}
+        # None means unbound; "" is the bound legacy/default manager scope.
         self._manager_instance_id: str | None = None
 
     def bind_manager_instance(

--- a/duckdb/runners/fte/fte_worker_runtime.py
+++ b/duckdb/runners/fte/fte_worker_runtime.py
@@ -298,10 +298,12 @@ class FteTaskExecution:
         status_callback: Callable[["FteTaskExecution"], object] | None = None,
         require_query_task_lease: bool = False,
         default_task_memory_bytes: int | None = None,
+        debug_fields: Mapping[str, Any] | None = None,
     ) -> None:
         self.request = dict(request)
         self.task_id = FteTaskAttemptId.coerce(self.request["task_id"])
         self.execute_fn = execute_fn
+        self._debug_fields = dict(debug_fields or {})
         self._status_callback = status_callback
         self.initial_splits = normalize_initial_splits(self.request.get("initial_splits"))
         self.no_more_split_sources = {str(source) for source in self.request.get("no_more_splits") or []}
@@ -1077,14 +1079,17 @@ class FteTaskExecution:
     def _log_result_lifecycle(self, event: str, *, result: Any = None, **fields: Any) -> None:
         if not _fte_result_debug_enabled():
             return
-        payload = {
-            "task_id": str(self.task_id),
-            "query_id": self.task_id.query_id,
-            "fragment_execution_id": self.task_id.fragment_execution_id,
-            "partition_id": self.task_id.partition_id,
-            "attempt_id": self.task_id.attempt_id,
-            "state": self.status.state.value,
-        }
+        payload = dict(self._debug_fields)
+        payload.update(
+            {
+                "task_id": str(self.task_id),
+                "query_id": self.task_id.query_id,
+                "fragment_execution_id": self.task_id.fragment_execution_id,
+                "partition_id": self.task_id.partition_id,
+                "attempt_id": self.task_id.attempt_id,
+                "state": self.status.state.value,
+            }
+        )
         payload.update(fields)
         if result is not None:
             payload.update(describe_result_payload(result))
@@ -1135,6 +1140,7 @@ class FteWorkerTaskManager:
         admission_config: FteWorkerAdmissionConfig,
         require_query_task_lease: bool = False,
         worker_label: str | None = None,
+        worker_log_fields: Mapping[str, Any] | None = None,
         sync_udf_active_fragment_tasks: bool = False,
     ) -> None:
         self.execute_fn = execute_fn
@@ -1142,6 +1148,12 @@ class FteWorkerTaskManager:
         self.query_tasks: dict[str, set[str]] = {}
         self.admission_config = admission_config
         self.worker_label = str(worker_label or os.getenv("VANE_FTE_WORKER_ID") or "-")
+        raw_worker_log_fields = worker_log_fields or {}
+        self.worker_log_fields = {
+            field: str(raw_worker_log_fields[field]).strip()
+            for field in ("manager_instance_id", "node_id", "host")
+            if raw_worker_log_fields.get(field) is not None and str(raw_worker_log_fields[field]).strip()
+        }
         self.max_running_tasks = self.admission_config.max_running_tasks
         self.require_query_task_lease = bool(require_query_task_lease)
         self.sync_udf_active_fragment_tasks = bool(sync_udf_active_fragment_tasks)
@@ -1166,6 +1178,7 @@ class FteWorkerTaskManager:
                 status_callback=self._publish_status,
                 require_query_task_lease=self.require_query_task_lease,
                 default_task_memory_bytes=self.admission_config.task_memory_bytes,
+                debug_fields={"worker_id": self.worker_label, **self.worker_log_fields},
             )
             key = str(execution.task_id)
             existing = self.tasks.get(key)
@@ -1421,6 +1434,7 @@ class FteWorkerTaskManager:
             f"memory_budget_bytes={_format_admission_field(stats.get('executor_memory_budget_bytes'))}",
             f"task_memory_bytes={_format_admission_field(stats.get('executor_task_memory_bytes'))}",
         ]
+        parts.extend(f"{key}={_format_admission_field(value)}" for key, value in self.worker_log_fields.items())
         if execution is not None:
             task_id = execution.task_id
             parts.extend(

--- a/duckdb/runners/ray/fragment_worker_client.py
+++ b/duckdb/runners/ray/fragment_worker_client.py
@@ -51,6 +51,8 @@ class RayWorkerActorHandle(
         memory_capacity_bytes: int,
         node_id: str,
         worker_id: str,
+        host: str | None = None,
+        manager_instance_id: str | None = None,
     ):
         memory_capacity_bytes = int(memory_capacity_bytes)
         if memory_capacity_bytes <= 0:
@@ -61,9 +63,14 @@ class RayWorkerActorHandle(
         worker_id = str(worker_id).strip()
         if not worker_id:
             raise ValueError("worker_id must be non-empty")
+        host = str(host if host is not None else worker_id.rsplit("#", 1)[0]).strip()
+        if not host:
+            raise ValueError("host must be non-empty")
         self.actor_handle = actor_handle
         self.worker_id = worker_id
         self.node_id = node_id
+        self.host = host
+        self.manager_instance_id = str(manager_instance_id or "").strip()
         self.memory_capacity_bytes = memory_capacity_bytes
         self._registered_fragment_ids: set[str] = set()
         self._fragment_registration_refs: dict[str, Any] = {}
@@ -85,6 +92,9 @@ class RayWorkerActorHandle(
         self._fragment_drop_incomplete_queries: set[str] = set()
         self._worker_shutdown_started = False
         with _FTE_REGISTRY_LOCK:
+            current = _FTE_WORKER_HANDLES.get(worker_id)
+            if current is not None and current is not self:
+                raise RuntimeError(f"FTE worker id is already registered: {worker_id}")
             _FTE_WORKER_HANDLES[worker_id] = self
 
     def close_session(self, session_id: str) -> None:

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -85,6 +85,7 @@ class FteWorkerCommandMixin:
         _fte_partition_owner: Any
         _fte_task_handle_cls: Any
         _handles_for_fte_worker_control_failure: Any
+        manager_instance_id: str
 
     def _execute_fte_fragment_execution_worker_commands(
         self,
@@ -201,7 +202,10 @@ class FteWorkerCommandMixin:
                         # select the failed worker. The scheduler reconciliation
                         # remains deferred until this batch's healthy tail owns a
                         # terminal outcome.
-                        quarantine_fte_worker(failure.worker_id)
+                        quarantine_fte_worker(
+                            failure.worker_id,
+                            manager_instance_id=self.manager_instance_id,
+                        )
                     continue
                 try:
                     if isinstance(command, FteCreateTaskCommand):

--- a/duckdb/runners/ray/fragment_worker_commands.py
+++ b/duckdb/runners/ray/fragment_worker_commands.py
@@ -53,6 +53,16 @@ def _fte_command_debug_log(event: str, **fields: Any) -> None:
     print("[vane-fte-command] " + " ".join(parts), file=sys.stderr, flush=True)
 
 
+def _fte_worker_command_debug_fields(command: Any) -> dict[str, str]:
+    worker = getattr(command, "worker", None)
+    return {
+        "worker_id": str(getattr(command, "worker_id", None) or getattr(worker, "worker_id", "") or ""),
+        "manager_instance_id": str(getattr(worker, "manager_instance_id", "") or ""),
+        "node_id": str(getattr(worker, "node_id", "") or ""),
+        "host": str(getattr(worker, "host", "") or ""),
+    }
+
+
 class _FteQueryClosingEvent:
     """Event-compatible view of one query's registry close state."""
 
@@ -111,6 +121,7 @@ class FteWorkerCommandMixin:
                 worker_key = ("worker_id", worker_id)
             else:
                 worker_key = ("worker_handle", id(getattr(command, "worker", None)))
+            worker_debug_fields = _fte_worker_command_debug_fields(command)
             if worker_key in failed_worker_keys:
                 _fte_command_debug_log(
                     "execute_command_skipped_failed_worker",
@@ -120,7 +131,7 @@ class FteWorkerCommandMixin:
                     query_id=getattr(command, "query_id", ""),
                     fragment_id=getattr(command, "fragment_id", ""),
                     attempt_id=attempt_id,
-                    worker_id=worker_id,
+                    **worker_debug_fields,
                 )
                 continue
             if not begin_fte_registry_operation(query_id):
@@ -141,6 +152,7 @@ class FteWorkerCommandMixin:
                     fragment_id=getattr(command, "fragment_id", ""),
                     partition_id=getattr(command, "partition_id", ""),
                     attempt_id=attempt_id,
+                    **worker_debug_fields,
                 )
                 try:
                     if isinstance(command, FteCreateTaskCommand):
@@ -193,6 +205,7 @@ class FteWorkerCommandMixin:
                         elapsed_ms=int((time.monotonic() - started_at) * 1000),
                         error_type=type(exc).__name__,
                         error=exc,
+                        **worker_debug_fields,
                     )
                     failure = fragment_execution.worker_control_failure_for_command(command, exc)
                     failed_worker_keys.add(worker_key)
@@ -236,6 +249,7 @@ class FteWorkerCommandMixin:
                     partition_id=getattr(command, "partition_id", ""),
                     attempt_id=attempt_id,
                     elapsed_ms=int((time.monotonic() - started_at) * 1000),
+                    **worker_debug_fields,
                 )
             finally:
                 end_fte_registry_operation(query_id)

--- a/duckdb/runners/ray/fragment_worker_events.py
+++ b/duckdb/runners/ray/fragment_worker_events.py
@@ -49,6 +49,7 @@ class FteWorkerEventHandlingMixin:
         _submit_fte_pending_tasks: Any
         _task_input_stream_exhausted_direct: Any
         _try_reserve_fte_partition_for_node_wait: Any
+        manager_instance_id: str
 
     def _handles_for_fte_worker_control_failure(
         self,
@@ -56,7 +57,10 @@ class FteWorkerEventHandlingMixin:
     ) -> list[Any]:
         """Fence a failed worker before queued work can observe it as live."""
 
-        failed_worker_ids = quarantine_fte_worker(failure.worker_id)
+        failed_worker_ids = quarantine_fte_worker(
+            failure.worker_id,
+            manager_instance_id=self.manager_instance_id,
+        )
         query_ids = set(_FTE_SCHEDULERS.query_ids())
         query_ids.add(failure.attempt_id.task_id.query_id)
         schedulers = []
@@ -67,6 +71,8 @@ class FteWorkerEventHandlingMixin:
             scheduler = _FTE_SCHEDULERS.get(query_id)
             if scheduler is None:
                 continue
+            if not scheduler.is_owned_by_manager_instance(self.manager_instance_id):
+                continue
             self._bind_fte_scheduler_handlers(scheduler)
             scheduler.enqueue(
                 WorkerFailed(
@@ -74,6 +80,7 @@ class FteWorkerEventHandlingMixin:
                     failure.worker_id,
                     failure,
                     failed_worker_ids=failed_worker_ids,
+                    manager_instance_id=self.manager_instance_id,
                 ),
                 # Control failures happen inside an active drain.  Reconcile
                 # them before reservation completions already in that queue.
@@ -331,8 +338,9 @@ class FteWorkerEventHandlingMixin:
                 query_id_filter=scheduler.query_id,
             )
 
-        scheduler.set_handlers(
-            FteEventHandlers(
+        scheduler.bind_manager_instance(
+            self.manager_instance_id,
+            handlers=FteEventHandlers(
                 on_split_events=self._submit_fte_pending_tasks,
                 on_source_input_exhausted=on_source_input_exhausted,
                 on_task_status_changed=self._handles_for_task_status_changed_event,
@@ -349,5 +357,5 @@ class FteWorkerEventHandlingMixin:
                 on_worker_reservation_completed=self._handles_for_worker_reservation_completed_event,
                 on_retry_delay_expired=lambda _event: request_fte_pending_task_drain(),
                 on_exchange_selector_updated=self._handles_for_exchange_selector_updated_event,
-            )
+            ),
         )

--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -18,15 +18,25 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
 )
 
 
-def quarantine_fte_worker(worker_id: str) -> frozenset[str]:
+def quarantine_fte_worker(
+    worker_id: str,
+    *,
+    manager_instance_id: str | None = None,
+) -> frozenset[str]:
     """Make a failed worker ineligible before per-query reconciliation."""
 
     worker_id = str(worker_id or "")
     failed_worker_ids = frozenset({worker_id}) if worker_id else frozenset()
+    normalized_manager_instance_id = None if manager_instance_id is None else str(manager_instance_id or "").strip()
     with _FTE_REGISTRY_LOCK:
         for failed_worker_id in failed_worker_ids:
             handle = _FTE_WORKER_HANDLES.get(failed_worker_id)
             if handle is not None:
+                if (
+                    normalized_manager_instance_id is not None
+                    and str(getattr(handle, "manager_instance_id", "")) != normalized_manager_instance_id
+                ):
+                    return frozenset()
                 handle._fte_healthy = False
     return failed_worker_ids
 
@@ -39,10 +49,18 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         scheduler = _FTE_SCHEDULERS.get(event.query_id)
     if scheduler is None:
         return []
+    manager_instance_id = getattr(event, "manager_instance_id", None)
+    if manager_instance_id is not None and not scheduler.is_owned_by_manager_instance(manager_instance_id):
+        return []
     failed_worker_ids = (
         {str(item) for item in event.failed_worker_ids}
         if event.failed_worker_ids is not None
-        else set(quarantine_fte_worker(event.worker_id))
+        else set(
+            quarantine_fte_worker(
+                event.worker_id,
+                manager_instance_id=manager_instance_id,
+            )
+        )
     )
     new_failed_worker_ids = scheduler.record_worker_failure(failed_worker_ids)
     if not new_failed_worker_ids:
@@ -52,6 +70,7 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         failure,
         query_id_filter=event.query_id,
         failed_worker_ids_override=new_failed_worker_ids,
+        manager_instance_id=manager_instance_id,
     )
     delay_s = _fte_retry_remaining_delay_s(event.query_id)
     if delay_s > 0:

--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -27,6 +27,8 @@ def quarantine_fte_worker(
 
     worker_id = str(worker_id or "")
     failed_worker_ids = frozenset({worker_id}) if worker_id else frozenset()
+    # Preserve "" as the explicit legacy scope. Only None means that the
+    # caller has no ownership metadata and requires the compatibility path.
     normalized_manager_instance_id = None if manager_instance_id is None else str(manager_instance_id or "").strip()
     with _FTE_REGISTRY_LOCK:
         for failed_worker_id in failed_worker_ids:
@@ -49,6 +51,7 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         scheduler = _FTE_SCHEDULERS.get(event.query_id)
     if scheduler is None:
         return []
+    # Do not collapse "" into None: legacy schedulers are explicitly owned.
     manager_instance_id = getattr(event, "manager_instance_id", None)
     if manager_instance_id is not None and not scheduler.is_owned_by_manager_instance(manager_instance_id):
         return []

--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -296,6 +296,8 @@ class FteWorkerLifecycleMixin:
             scheduler = _FTE_SCHEDULERS.get(query_id)
             if scheduler is None:
                 continue
+            if not scheduler.is_owned_by_manager_instance(self.manager_instance_id):
+                continue
             self._bind_fte_scheduler_handlers(scheduler)
             scheduler.enqueue(SourceInputExhausted.from_source_node_ids(query_id, exhausted_sources))
             handles.extend(scheduler.drain())
@@ -335,6 +337,8 @@ class FteWorkerLifecycleMixin:
             scheduler = _FTE_SCHEDULERS.get(query_id)
             if scheduler is None:
                 continue
+            if not scheduler.is_owned_by_manager_instance(self.manager_instance_id):
+                continue
             self._bind_fte_scheduler_handlers(scheduler)
             scheduler.enqueue(
                 WorkerFailed(
@@ -342,6 +346,7 @@ class FteWorkerLifecycleMixin:
                     failed_worker_id,
                     failure,
                     failed_worker_ids=failed_worker_ids,
+                    manager_instance_id=self.manager_instance_id,
                 )
             )
             handles.extend(scheduler.drain())
@@ -453,6 +458,9 @@ class FteWorkerLifecycleMixin:
             return
         self._worker_shutdown_started = True
         if self.worker_id:
+            with _FTE_REGISTRY_LOCK:
+                if _FTE_WORKER_HANDLES.get(str(self.worker_id)) is not self:
+                    return
             try:
                 self.mark_fte_worker_failed(
                     self.worker_id,

--- a/duckdb/runners/ray/fragment_worker_selection.py
+++ b/duckdb/runners/ray/fragment_worker_selection.py
@@ -28,11 +28,15 @@ def available_fte_workers(
     exclude: set[str] | None = None,
 ) -> list[Any]:
     exclude = exclude or set()
+    manager_instance_id = str(getattr(current_worker, "manager_instance_id", ""))
     with _FTE_REGISTRY_LOCK:
         workers = [
             handle
             for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
-            if handle is not None and str(worker_id) not in exclude and handle._fte_healthy
+            if handle is not None
+            and str(worker_id) not in exclude
+            and handle._fte_healthy
+            and str(getattr(handle, "manager_instance_id", "")) == manager_instance_id
         ]
         include_current_worker = (
             current_worker not in workers

--- a/duckdb/runners/ray/fragment_worker_submission.py
+++ b/duckdb/runners/ray/fragment_worker_submission.py
@@ -264,8 +264,9 @@ class FteWorkerSubmissionMixin:
         with _FTE_REGISTRY_LOCK:
             if fte_registry_query_is_closing(query_id):
                 raise RuntimeError(f"FTE query registry is closing: {query_id}")
-            _FTE_SCHEDULERS.get_or_create(query_id)
+            scheduler = _FTE_SCHEDULERS.get_or_create(query_id)
             existing = _FTE_FRAGMENT_EXECUTIONS.get(key)
+        self._bind_fte_scheduler_handlers(scheduler)
         if existing is not None:
             return merge_existing(existing)
 

--- a/duckdb/runners/ray/fragment_worker_transitions.py
+++ b/duckdb/runners/ray/fragment_worker_transitions.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte import (
+    FteWorkerControlFailure,
+)
+from duckdb.runners.fte.fte_events import MemoryPressureDetected
 from duckdb.runners.ray.fragment_registry import (
     _FTE_FRAGMENT_EXECUTIONS,
     _FTE_REGISTRY_LOCK,
@@ -15,10 +19,6 @@ from duckdb.runners.ray.fragment_worker_state import (
     fte_fragment_execution_items,
     fte_fragment_execution_query_ids,
 )
-from duckdb.runners.fte import (
-    FteWorkerControlFailure,
-)
-from duckdb.runners.fte.fte_events import MemoryPressureDetected
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _fte_effective_worker_memory_budget_bytes,
     _fte_pressure_total_memory_bytes,
@@ -37,6 +37,15 @@ if TYPE_CHECKING:
 
 
 class FteWorkerTransitionMixin:
+    if TYPE_CHECKING:
+        # Supplied by the other mixins on the composed Ray worker handle.
+        _bind_fte_scheduler_handlers: Any
+        _drain_fte_pending_tasks: Any
+        _fte_partition_owner: Any
+        _fte_worker_placement_manager: Any
+        _handles_for_fte_worker_control_failure: Any
+        manager_instance_id: str
+
     def _release_deferred_fte_execution_partitions(
         self,
         fragment_execution_items: list[tuple[tuple[str, str], FteFragmentExecution]],
@@ -142,6 +151,8 @@ class FteWorkerTransitionMixin:
             scheduler = _FTE_SCHEDULERS.get(query_id)
             if scheduler is None:
                 continue
+            if not scheduler.is_owned_by_manager_instance(self.manager_instance_id):
+                continue
             self._bind_fte_scheduler_handlers(scheduler)
             scheduler.enqueue(MemoryPressureDetected(query_id, max_count_per_worker))
             handles.extend(scheduler.drain())
@@ -155,17 +166,18 @@ class FteWorkerTransitionMixin:
     ) -> list[Any]:
         if query_id_filter is not None:
             query_id_filter = str(query_id_filter)
+        manager_instance_id = str(getattr(self, "manager_instance_id", ""))
         with _FTE_REGISTRY_LOCK:
             workers = [
                 handle
                 for _, handle in sorted(_FTE_WORKER_HANDLES.items())
-                if handle is not None and handle._fte_healthy
+                if handle is not None
+                and handle._fte_healthy
+                and str(getattr(handle, "manager_instance_id", "")) == manager_instance_id
             ]
         revoked_any = False
         for worker in workers:
             budget_bytes = _fte_effective_worker_memory_budget_bytes(worker, None)
-            if budget_bytes is None:
-                continue
             worker_id = str(worker.worker_id)
             if not worker_id:
                 continue

--- a/duckdb/runners/ray/fragment_worker_transitions.py
+++ b/duckdb/runners/ray/fragment_worker_transitions.py
@@ -177,7 +177,9 @@ class FteWorkerTransitionMixin:
             ]
         revoked_any = False
         for worker in workers:
-            budget_bytes = _fte_effective_worker_memory_budget_bytes(worker, None)
+            budget_bytes: int | None = _fte_effective_worker_memory_budget_bytes(worker, None)
+            if budget_bytes is None:
+                continue
             worker_id = str(worker.worker_id)
             if not worker_id:
                 continue

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -2262,19 +2262,34 @@ class FteWorkerPlacementManager:
 def _worker_failure_payload(worker_id: str, error: Any) -> dict[str, Any]:
     if error is not None and not issubclass(type(error), BaseException):
         if isinstance(error, Mapping):
-            return _normalize_failure_payload(error)
-        raise TypeError("FTE worker failure must be an exception or structured failure payload")
-    memory_error_types: tuple[type[BaseException], ...] = (
-        OutOfMemoryException,
-        MemoryError,
-        ray.exceptions.OutOfMemoryError,
-    )
-    error_code = "OUT_OF_MEMORY" if _failure_exception_matches(error, memory_error_types) else "WORKER_LOST"
-    return _failure_payload(
-        error_code,
-        error if error is not None else f"FTE worker lost: {worker_id}",
-        error_type="EXTERNAL",
-    )
+            failure = _normalize_failure_payload(error)
+        else:
+            raise TypeError("FTE worker failure must be an exception or structured failure payload")
+    else:
+        memory_error_types: tuple[type[BaseException], ...] = (
+            OutOfMemoryException,
+            MemoryError,
+            ray.exceptions.OutOfMemoryError,
+        )
+        error_code = "OUT_OF_MEMORY" if _failure_exception_matches(error, memory_error_types) else "WORKER_LOST"
+        failure = _failure_payload(
+            error_code,
+            error if error is not None else f"FTE worker lost: {worker_id}",
+            error_type="EXTERNAL",
+        )
+    worker_id = str(worker_id or "")
+    failure["worker_id"] = worker_id
+    with _FTE_REGISTRY_LOCK:
+        handle = _FTE_WORKER_HANDLES.get(worker_id)
+        if handle is not None:
+            failure.update(
+                {
+                    "manager_instance_id": str(getattr(handle, "manager_instance_id", "")),
+                    "node_id": str(getattr(handle, "node_id", "")),
+                    "host": str(getattr(handle, "host", "")),
+                }
+            )
+    return failure
 
 
 def _mark_fte_worker_failed(
@@ -2899,9 +2914,20 @@ def fte_registry_stats() -> dict[str, Any]:
         }
 
     event_scheduler_stats = _FTE_SCHEDULERS.stats()
-    worker_stats = {
-        str(worker_id): handle.fte_pressure_stats() for worker_id, handle in worker_handles if handle is not None
-    }
+    worker_stats: dict[str, dict[str, Any]] = {}
+    for worker_id, handle in worker_handles:
+        if handle is None:
+            continue
+        metrics: dict[str, Any] = dict(handle.fte_pressure_stats())
+        metrics.update(
+            {
+                "worker_id": str(worker_id),
+                "manager_instance_id": str(getattr(handle, "manager_instance_id", "")),
+                "node_id": str(getattr(handle, "node_id", "")),
+                "host": str(getattr(handle, "host", "")),
+            }
+        )
+        worker_stats[str(worker_id)] = metrics
     return {
         **registry_counts,
         "submission_window": fte_submission_window_snapshot(),

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -2291,6 +2291,7 @@ def _mark_fte_worker_failed(
     failure = _normalize_failure_payload(failure)
     if query_id_filter is not None:
         query_id_filter = str(query_id_filter)
+    # Preserve "" as the explicit legacy scope; None alone is unscoped.
     normalized_manager_instance_id = None if manager_instance_id is None else str(manager_instance_id or "").strip()
     failed_worker_ids = (
         {str(item) for item in failed_worker_ids_override} if failed_worker_ids_override is not None else {worker_id}

--- a/duckdb/runners/ray/fte_fragment_scheduler.py
+++ b/duckdb/runners/ray/fte_fragment_scheduler.py
@@ -998,14 +998,6 @@ def fte_execution_query_ids_for_resource(
     return tuple(sorted(execution_query_ids))
 
 
-def _worker_id_host_and_index(worker_id: str) -> tuple[str, str]:
-    worker_id = str(worker_id or "")
-    if "#" not in worker_id:
-        return worker_id, ""
-    host_id, worker_index = worker_id.rsplit("#", 1)
-    return host_id, worker_index
-
-
 def _node_requirements_host(node_requirements: NodeRequirements | Mapping[str, Any] | None) -> str | None:
     if node_requirements is None:
         return None
@@ -1063,8 +1055,7 @@ def _worker_matches_node_requirements(
     host = _node_requirements_host(node_requirements)
     if host is None:
         return True
-    worker_host, _ = _worker_id_host_and_index(str(handle.worker_id))
-    return worker_host == host
+    return str(handle.host) == host
 
 
 def _filter_workers_for_node_requirements(
@@ -1555,6 +1546,7 @@ def _fte_worker_selection_key(
 def _select_replacement_fte_worker(
     exclude_worker_id: str | set[str],
     *,
+    manager_instance_id: str | None = None,
     memory_requirement_bytes: Any = None,
     execution_class: FteTaskExecutionClass | str | None = None,
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
@@ -1569,7 +1561,10 @@ def _select_replacement_fte_worker(
         candidates = [
             handle
             for worker_id, handle in sorted(_FTE_WORKER_HANDLES.items())
-            if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
+            if str(worker_id) not in exclude_worker_ids
+            and handle is not None
+            and handle._fte_healthy
+            and (manager_instance_id is None or str(getattr(handle, "manager_instance_id", "")) == manager_instance_id)
         ]
     if not candidates:
         return None
@@ -1605,6 +1600,7 @@ def _select_replacement_fte_worker(
 def _has_replacement_fte_worker(
     exclude_worker_id: str | set[str],
     *,
+    manager_instance_id: str | None = None,
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
     node_requirements_wait_started_at: float | None = None,
 ) -> bool:
@@ -1617,7 +1613,10 @@ def _has_replacement_fte_worker(
         candidates = [
             handle
             for worker_id, handle in _FTE_WORKER_HANDLES.items()
-            if str(worker_id) not in exclude_worker_ids and handle is not None and handle._fte_healthy
+            if str(worker_id) not in exclude_worker_ids
+            and handle is not None
+            and handle._fte_healthy
+            and (manager_instance_id is None or str(getattr(handle, "manager_instance_id", "")) == manager_instance_id)
         ]
     return bool(
         _filter_workers_for_node_requirements(
@@ -2284,6 +2283,7 @@ def _mark_fte_worker_failed(
     *,
     query_id_filter: str | None = None,
     failed_worker_ids_override: set[str] | frozenset[str] | None = None,
+    manager_instance_id: str | None = None,
 ) -> list[tuple[str, str, list[Any], list[Any]]]:
     worker_id = str(worker_id or "")
     if not worker_id:
@@ -2291,6 +2291,7 @@ def _mark_fte_worker_failed(
     failure = _normalize_failure_payload(failure)
     if query_id_filter is not None:
         query_id_filter = str(query_id_filter)
+    normalized_manager_instance_id = None if manager_instance_id is None else str(manager_instance_id or "").strip()
     failed_worker_ids = (
         {str(item) for item in failed_worker_ids_override} if failed_worker_ids_override is not None else {worker_id}
     )
@@ -2306,8 +2307,14 @@ def _mark_fte_worker_failed(
     ] = []
     with _FTE_REGISTRY_LOCK:
         for failed_worker_id in sorted(failed_worker_ids):
-            failed_handle = _FTE_WORKER_HANDLES.pop(failed_worker_id, None)
+            failed_handle = _FTE_WORKER_HANDLES.get(failed_worker_id)
             if failed_handle is not None:
+                failed_handle_manager_instance_id = str(getattr(failed_handle, "manager_instance_id", ""))
+                if normalized_manager_instance_id is None:
+                    normalized_manager_instance_id = failed_handle_manager_instance_id
+                elif failed_handle_manager_instance_id != normalized_manager_instance_id:
+                    continue
+                _FTE_WORKER_HANDLES.pop(failed_worker_id, None)
                 failed_handle._fte_healthy = False
                 if failed_worker_id != worker_id:
                     handles_to_kill.append(failed_handle)
@@ -2350,6 +2357,7 @@ def _mark_fte_worker_failed(
         wait_started_at = time.time()
         replacement = _select_replacement_fte_worker(
             failed_worker_ids,
+            manager_instance_id=normalized_manager_instance_id,
             memory_requirement_bytes=memory_requirement_bytes,
             execution_class=execution_class,
             node_requirements=node_requirements,
@@ -2357,6 +2365,7 @@ def _mark_fte_worker_failed(
         )
         retryable_by_owner_key[owner_key] = replacement is not None or _has_replacement_fte_worker(
             failed_worker_ids,
+            manager_instance_id=normalized_manager_instance_id,
             node_requirements=node_requirements,
             node_requirements_wait_started_at=wait_started_at,
         )

--- a/duckdb/runners/ray/worker.py
+++ b/duckdb/runners/ray/worker.py
@@ -30,9 +30,14 @@ from duckdb.runners.fte import (
     materialize_task_inputs,
     validate_fte_status_identity,
 )
-from duckdb.runners.fte.debug_memory import describe_result_payload, log_debug, process_memory_snapshot
+from duckdb.runners.fte.debug_memory import (
+    debug_flag_enabled,
+    describe_result_payload,
+    log_debug,
+    process_memory_snapshot,
+)
 from duckdb.runners.fte.fte_config import FteWorkerAdmissionConfig
-from duckdb.runners.fte.fte_failures import FteTaskTerminalControlError
+from duckdb.runners.fte.fte_failures import FteTaskTerminalControlError, _safe_failure_message
 from duckdb.runners.fte.memory_config import apply_duckdb_memory_limit
 from duckdb.runners.ray.admission_ledger import BoundedReplayMap
 from duckdb.runners.ray.fte_scheduler_config import _fte_control_rpc_timeout_s
@@ -145,8 +150,30 @@ def _ray_worker_memory_log(event: str, **fields: Any) -> None:
     log_debug("vane-ray-worker-memory", event, **payload)
 
 
+def _ray_worker_observability_log(event: str, **fields: Any) -> None:
+    if not debug_flag_enabled(
+        "VANE_RAY_WORKER_MEMORY_DEBUG",
+        "VANE_FTE_RESULT_DEBUG",
+        "VANE_FTE_ADMISSION_DEBUG",
+        "DUCKDB_DISTRIBUTED_DEBUG",
+    ):
+        return
+    log_debug("vane-ray-worker", event, **fields)
+
+
 def _fte_worker_label() -> str:
     return os.getenv("VANE_WORKER_ID", "").strip() or os.getenv("VANE_FTE_WORKER_ID", "").strip() or "-"
+
+
+def _ray_worker_log_fields(worker: Any) -> dict[str, str]:
+    return {
+        "worker_id": str(getattr(worker, "_worker_id", "") or _fte_worker_label()),
+        "manager_instance_id": str(
+            getattr(worker, "_manager_instance_id", "") or os.getenv("VANE_WORKER_MANAGER_INSTANCE_ID", "")
+        ).strip(),
+        "node_id": str(getattr(worker, "_node_id", "") or os.getenv("VANE_WORKER_NODE_ID", "")).strip(),
+        "host": str(getattr(worker, "_host", "") or os.getenv("VANE_WORKER_HOST", "")).strip(),
+    }
 
 
 def _ensure_python_datasource_runtime() -> None:
@@ -790,9 +817,15 @@ class RayWorkerActor:
             raise ValueError("Ray worker duckdb_memory_bytes must be positive")
         if task_heap_capacity_bytes <= 0:
             raise ValueError("Ray worker task_heap_capacity_bytes must be positive")
-        self._node_id = str(ray.get_runtime_context().get_node_id() or "").strip()
+        runtime_context = ray.get_runtime_context()
+        self._node_id = str(runtime_context.get_node_id() or "").strip()
         if not self._node_id:
             raise RuntimeError("Ray worker runtime context is missing node_id")
+        self._worker_id = _fte_worker_label()
+        self._manager_instance_id = os.getenv("VANE_WORKER_MANAGER_INSTANCE_ID", "").strip()
+        self._host = ray_node_ip_address or os.getenv("VANE_WORKER_HOST", "").strip() or self._node_id
+        get_actor_id = getattr(runtime_context, "get_actor_id", None)
+        self._actor_id = str(get_actor_id() or "").strip() if callable(get_actor_id) else ""
         self._duckdb_memory_bytes = duckdb_memory_bytes
         self._task_heap_capacity_bytes = task_heap_capacity_bytes
         try:
@@ -856,12 +889,21 @@ class RayWorkerActor:
         self._shutdown_prepared = False
         self._shutdown_complete = False
         self._get_shared_conn()  # eagerly initialize
+        _ray_worker_observability_log(
+            "worker_registered",
+            **self._worker_log_fields(),
+            actor_id=self._actor_id or "-",
+        )
         _ray_worker_memory_log(
             "actor_initialized",
             num_cpus=num_cpus,
             num_gpus=num_gpus,
-            worker_label=_fte_worker_label(),
+            worker_label=self._worker_id,
+            **self._worker_log_fields(),
         )
+
+    def _worker_log_fields(self) -> dict[str, str]:
+        return _ray_worker_log_fields(self)
 
     def _ensure_worker_runtime_running(self) -> None:
         shutdown_lock = getattr(self, "_shutdown_lock", None)
@@ -999,11 +1041,13 @@ class RayWorkerActor:
             if getattr(self, "_shutdown_started", False):
                 raise RuntimeError("Ray worker runtime is shutting down")
             if self._fte_task_manager is None:
+                worker_log_fields = self._worker_log_fields()
                 self._fte_task_manager = FteWorkerTaskManager(
                     self._execute_fte_request,
                     admission_config=self._fte_admission_config,
                     require_query_task_lease=True,
-                    worker_label=_fte_worker_label(),
+                    worker_label=worker_log_fields["worker_id"],
+                    worker_log_fields=worker_log_fields,
                 )
             return self._fte_task_manager
 
@@ -1814,11 +1858,35 @@ class RayWorkerActor:
 
     @ray.method(concurrency_group="control")
     def prepare_shutdown(self) -> None:
-        self._prepare_worker_runtime_shutdown()
+        worker_log_fields = self._worker_log_fields()
+        _ray_worker_observability_log("worker_shutdown_prepare_start", **worker_log_fields)
+        try:
+            self._prepare_worker_runtime_shutdown()
+        except BaseException as exc:
+            _ray_worker_observability_log(
+                "worker_shutdown_prepare_error",
+                **worker_log_fields,
+                error_type=type(exc).__name__,
+                error=_safe_failure_message(exc),
+            )
+            raise
+        _ray_worker_observability_log("worker_shutdown_prepare_done", **worker_log_fields)
 
     @ray.method(concurrency_group="control")
     def finish_shutdown(self) -> None:
-        self._finish_worker_runtime_shutdown()
+        worker_log_fields = self._worker_log_fields()
+        _ray_worker_observability_log("worker_shutdown_finish_start", **worker_log_fields)
+        try:
+            self._finish_worker_runtime_shutdown()
+        except BaseException as exc:
+            _ray_worker_observability_log(
+                "worker_shutdown_finish_error",
+                **worker_log_fields,
+                error_type=type(exc).__name__,
+                error=_safe_failure_message(exc),
+            )
+            raise
+        _ray_worker_observability_log("worker_shutdown_finish_done", **worker_log_fields)
 
     def _shutdown_worker_runtime(self) -> None:
         self._prepare_worker_runtime_shutdown()
@@ -1867,6 +1935,8 @@ class RayWorkerActor:
         cursor = None
         cursor_registered = False
         debug_context = dict(debug_context or {})
+        worker_log_context = dict(debug_context)
+        worker_log_context.update(_ray_worker_log_fields(self))
         start = time.monotonic()
 
         try:
@@ -1897,7 +1967,7 @@ class RayWorkerActor:
             )
             _ray_worker_memory_log(
                 "native_execute_start",
-                **debug_context,
+                **worker_log_context,
                 scan_task_map_count=len(scan_task_map or {}),
                 exchange_source_task_map_count=len(exchange_source_task_map or {}),
                 has_exchange_sink_instance=exchange_sink_instance is not None,
@@ -1921,14 +1991,14 @@ class RayWorkerActor:
             )
             _ray_worker_memory_log(
                 "native_execute_done",
-                **debug_context,
+                **worker_log_context,
                 duration_ms=int((time.monotonic() - start) * 1000),
             )
             return result
         except BaseException as exc:
             _ray_worker_memory_log(
                 "native_execute_error",
-                **debug_context,
+                **worker_log_context,
                 duration_ms=int((time.monotonic() - start) * 1000),
                 error_type=type(exc).__name__,
                 error=str(exc),
@@ -1965,11 +2035,13 @@ class RayWorkerActor:
     ) -> Any:
         """Run a plan on worker and return a Ray-serializable result tuple."""
         debug_context = dict(debug_context or {})
+        worker_log_context = dict(debug_context)
+        worker_log_context.update(_ray_worker_log_fields(self))
 
         copy_output_info = _copy_output_info_from_context(context)
         scan_task_map, exchange_source_task_map = _extract_native_task_maps_from_context(context)
         run_start = time.monotonic()
-        _ray_worker_memory_log("run_plan_return_start", **debug_context)
+        _ray_worker_memory_log("run_plan_return_start", **worker_log_context)
         # Native execution, shuffle publication, and actor teardown are owned by
         # the execution query. The resource query can differ for nested
         # executions and is only the owner of the admission lease.
@@ -2037,7 +2109,7 @@ class RayWorkerActor:
         ) = _normalize_native_task_result(result_list)
         _ray_worker_memory_log(
             "native_result_normalized",
-            **debug_context,
+            **worker_log_context,
             duration_ms=int((time.monotonic() - run_start) * 1000),
             stats_len=len(stats_payload or []),
             **describe_result_payload(
@@ -2081,7 +2153,7 @@ class RayWorkerActor:
             partition_metas_for_ray.append((metadata.num_rows, size_bytes))
         _ray_worker_memory_log(
             "ray_put_done",
-            **debug_context,
+            **worker_log_context,
             duration_ms=int((time.monotonic() - run_start) * 1000),
             ray_put_count=ray_put_count,
             **describe_result_payload(

--- a/duckdb/runners/ray/worker_handle.py
+++ b/duckdb/runners/ray/worker_handle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import Any
 
 from duckdb.runners.ray import fragment_registry as _fragment_registry
 from duckdb.runners.ray import fragment_worker_client as _fragment_worker_client
@@ -55,12 +56,12 @@ def _sync_worker_pool_overrides() -> None:
             setattr(_worker_pool, name, globals()[name])
 
 
-def start_ray_workers(existing_worker_ids):
+def start_ray_workers(existing_worker_ids: list[str], manager_instance_id: str) -> list[Any]:
     _sync_worker_pool_overrides()
-    return _worker_pool.start_ray_workers(existing_worker_ids)
+    return _worker_pool.start_ray_workers(existing_worker_ids, manager_instance_id)
 
 
-def try_autoscale(bundles):
+def try_autoscale(bundles: list[dict[str, int]]) -> None:
     _sync_worker_pool_overrides()
     return _worker_pool.try_autoscale(bundles)
 
@@ -70,7 +71,7 @@ _FACADE_TRY_AUTOSCALE = try_autoscale
 
 
 class _WorkerHandleFacadeModule(types.ModuleType):
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         super().__setattr__(name, value)
         if name == "start_ray_workers" and value is _FACADE_START_RAY_WORKERS:
             setattr(_worker_pool, name, _ORIGINAL_WORKER_POOL_START_RAY_WORKERS)

--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -91,8 +91,11 @@ def start_ray_workers(existing_worker_ids: list[str], manager_instance_id: str) 
                 if worker_id in existing_worker_ids:
                     continue
                 worker_env = dict(env_overrides)
+                worker_env["VANE_WORKER_HOST"] = worker_host
                 worker_env["VANE_WORKER_ID"] = worker_id
                 worker_env["VANE_WORKER_INDEX"] = "0"
+                worker_env["VANE_WORKER_MANAGER_INSTANCE_ID"] = manager_instance_id
+                worker_env["VANE_WORKER_NODE_ID"] = node_id
                 memory_layout = build_ray_node_memory_layout(int(node["Resources"]["memory"]))
                 # max_concurrency limits how many control/execute RPCs can queue
                 # inside the actor. FTE backpressure is handled by task
@@ -103,7 +106,7 @@ def start_ray_workers(existing_worker_ids: list[str], manager_instance_id: str) 
                 # and Ray-backed UDFs, so reserving the node's full CPU/GPU capacity
                 # here would prevent those child Ray workloads from being scheduled.
                 _actor_max_conc = int(os.environ.get("VANE_RAY_ACTOR_MAX_CONCURRENCY", "256"))
-                actor = RayWorkerActor.options(
+                actor = RayWorkerActor.options(  # type: ignore[attr-defined]
                     max_concurrency=_actor_max_conc,
                     memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
                     runtime_env=_persistent_worker_runtime_env(worker_env),

--- a/duckdb/runners/ray/worker_pool.py
+++ b/duckdb/runners/ray/worker_pool.py
@@ -65,24 +65,29 @@ def _cleanup_started_workers(
     return errors
 
 
-def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
+def start_ray_workers(existing_worker_ids: list[str], manager_instance_id: str) -> list[RayWorkerRuntime]:
     ACTOR_STARTUP_TIMEOUT = 120
+    manager_instance_id = str(manager_instance_id or "").strip()
+    if not manager_instance_id:
+        raise ValueError("manager_instance_id must be non-empty")
     env_overrides = _collect_vane_env_overrides()
     actors = []
     worker_handles = []
     try:
         for node in ray.nodes():
             node_manager_address = str(node.get("NodeManagerAddress") or "").strip()
-            base_worker_id = node_manager_address or str(node.get("NodeID") or "")
+            node_id = str(node.get("NodeID") or "").strip()
+            worker_host = node_manager_address or node_id
             if (
                 "Resources" in node
                 and "CPU" in node["Resources"]
                 and "memory" in node["Resources"]
                 and node["Resources"]["CPU"] > 0
                 and node["Resources"]["memory"] > 0
-                and base_worker_id
+                and node_id
+                and worker_host
             ):
-                worker_id = base_worker_id
+                worker_id = f"{manager_instance_id}:{node_id}:0"
                 if worker_id in existing_worker_ids:
                     continue
                 worker_env = dict(env_overrides)
@@ -98,12 +103,12 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
                 # and Ray-backed UDFs, so reserving the node's full CPU/GPU capacity
                 # here would prevent those child Ray workloads from being scheduled.
                 _actor_max_conc = int(os.environ.get("VANE_RAY_ACTOR_MAX_CONCURRENCY", "256"))
-                actor = RayWorkerActor.options(  # type: ignore[attr-defined]
+                actor = RayWorkerActor.options(
                     max_concurrency=_actor_max_conc,
                     memory=(memory_layout.worker_duckdb_memory_bytes + memory_layout.runtime_reserve_bytes),
                     runtime_env=_persistent_worker_runtime_env(worker_env),
                     scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                        node_id=node["NodeID"],
+                        node_id=node_id,
                         soft=False,
                     ),
                 ).remote(
@@ -133,7 +138,9 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RayWorkerRuntime]:
             actor_handle = RayWorkerActorHandle(
                 actor,
                 worker_id=worker_id,
-                node_id=str(node["NodeID"]),
+                node_id=str(node["NodeID"]).strip(),
+                host=str(node.get("NodeManagerAddress") or "").strip() or str(node["NodeID"]).strip(),
+                manager_instance_id=manager_instance_id,
                 memory_capacity_bytes=build_ray_node_memory_layout(
                     int(node["Resources"]["memory"])
                 ).task_heap_capacity_bytes,

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb_python/pybind11/gil_wrapper.hpp"
 
 namespace py = pybind11;
@@ -19,6 +20,10 @@ using duckdb::distributed::TaskResourceRequest;
 using duckdb::distributed::WorkerSnapshot;
 
 static constexpr auto REFRESH_INTERVAL = std::chrono::seconds(5);
+
+RayWorkerManager::RayWorkerManager()
+    : manager_instance_id_(duckdb::UUID::ToString(duckdb::UUID::GenerateRandomUUID())) {
+}
 
 static std::vector<std::string> AbortWorkers(const std::vector<std::shared_ptr<RayWorkerRuntime>> &workers) {
 	std::vector<std::string> errors;
@@ -564,7 +569,7 @@ RayWorkerManager::WorkerSnapshotResult RayWorkerManager::WorkerSnapshotsWithoutG
 		duckdb::PythonGILWrapper gil;
 		try {
 			py::module_ worker_pool_obj = py::module_::import("duckdb.runners.ray.worker_pool");
-			py::object py_workers_obj = worker_pool_obj.attr("start_ray_workers")(existing_ids);
+			py::object py_workers_obj = worker_pool_obj.attr("start_ray_workers")(existing_ids, manager_instance_id_);
 
 			py::iterable workers_iter;
 			try {

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -29,6 +29,8 @@ string SubmissionErrorOwnerQueryId(const std::vector<duckdb::distributed::Worker
 
 class RayWorkerManager : public duckdb::distributed::WorkerManager {
 public:
+	RayWorkerManager();
+
 	DuckDBResult<void> submit_fte_task_events(std::vector<duckdb::distributed::WorkerTask> tasks) override;
 
 	// WorkerManager interface implementations (one-to-one with Rust trait)
@@ -96,6 +98,7 @@ private:
 		bool active_;
 	};
 
+	const string manager_instance_id_;
 	mutable mutex mutex_;
 	mutable std::condition_variable shutdown_cv_;
 	mutable State state_;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -367,7 +367,7 @@ def test_worker_submission_preserves_worker_plan_exception_cause(monkeypatch, ma
         monkeypatch.setattr(
             ray_worker_handle,
             "start_ray_workers",
-            lambda _existing_ids: [
+            lambda _existing_ids, _manager_instance_id: [
                 duckdb.ray_cxx.RayWorkerRuntime(
                     "worker-1",
                     target,
@@ -2692,7 +2692,7 @@ def test_ray_worker_manager_integration(monkeypatch):
 
     dummy_worker_handle = DummyRayWorkerHandle()
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [duckdb.ray_cxx.RayWorkerRuntime("worker-1", dummy_worker_handle, 1.0, 0.0, 1024)]
 
     autoscale_called = {}
@@ -2728,6 +2728,44 @@ def test_ray_worker_manager_integration(monkeypatch):
     assert dummy_worker_handle.fte_cleanup_query_calls == ["query-lifecycle"]
 
 
+def test_ray_worker_manager_instances_use_distinct_worker_scopes(monkeypatch):
+    start_calls = []
+
+    class DummyRayWorkerHandle:
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            return None
+
+    def start_ray_workers(existing_ids, manager_instance_id):
+        start_calls.append((tuple(existing_ids), manager_instance_id))
+        worker_id = f"{manager_instance_id}:node-a:0"
+        return [duckdb.ray_cxx.RayWorkerRuntime(worker_id, DummyRayWorkerHandle(), 1.0, 0.0, 1024)]
+
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    first_manager = duckdb.ray_cxx.RayWorkerManager()
+    second_manager = duckdb.ray_cxx.RayWorkerManager()
+
+    first_snapshots = first_manager.worker_snapshots()
+    second_snapshots = second_manager.worker_snapshots()
+
+    assert [existing_ids for existing_ids, _manager_id in start_calls] == [(), ()]
+    assert start_calls[0][1]
+    assert start_calls[1][1]
+    assert start_calls[0][1] != start_calls[1][1]
+    assert first_snapshots[0]["worker_id"] != second_snapshots[0]["worker_id"]
+
+    first_manager.shutdown()
+    second_manager.shutdown()
+
+
 def test_ray_worker_manager_worker_snapshot_refresh_is_single_flight(monkeypatch):
     thread_count = 8
     caller_barrier = threading.Barrier(thread_count)
@@ -2745,7 +2783,7 @@ def test_ray_worker_manager_worker_snapshot_refresh_is_single_flight(monkeypatch
         def abort_shutdown(self):
             return None
 
-    def start_ray_workers(existing_ids):
+    def start_ray_workers(existing_ids, _manager_instance_id):
         with start_condition:
             start_calls.append(tuple(existing_ids))
             start_condition.notify_all()
@@ -2819,9 +2857,9 @@ def test_ray_worker_manager_failed_snapshot_refresh_is_shared_and_retryable(monk
         def abort_shutdown(self):
             return None
 
-    def start_ray_workers(existing_ids):
+    def start_ray_workers(existing_ids, manager_instance_id):
         with start_condition:
-            start_calls.append(tuple(existing_ids))
+            start_calls.append((tuple(existing_ids), manager_instance_id))
             call_number = len(start_calls)
             start_condition.notify_all()
             if call_number == 1:
@@ -2866,7 +2904,8 @@ def test_ray_worker_manager_failed_snapshot_refresh_is_shared_and_retryable(monk
 
     snapshots = manager.worker_snapshots()
     assert [snapshot["worker_id"] for snapshot in snapshots] == ["worker-retry"]
-    assert start_calls == [(), ()]
+    assert [existing_ids for existing_ids, _manager_id in start_calls] == [(), ()]
+    assert start_calls[0][1] == start_calls[1][1]
     manager.shutdown()
 
 
@@ -2889,7 +2928,7 @@ def test_ray_worker_manager_rejects_and_cleans_duplicate_refresh_workers(monkeyp
             if self.label == "first":
                 raise RuntimeError("planned first abort failure")
 
-    def start_ray_workers(existing_ids):
+    def start_ray_workers(existing_ids, _manager_instance_id):
         start_calls.append(tuple(existing_ids))
         if len(start_calls) == 1:
             return [
@@ -2946,7 +2985,7 @@ def test_ray_worker_manager_cleans_all_runtimes_after_invalid_refresh_entry(monk
         def abort_shutdown(self):
             aborted.append(self.label)
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-before-invalid",
@@ -3002,7 +3041,7 @@ def test_ray_worker_manager_snapshot_refresh_shutdown_has_no_deadlock(monkeypatc
         def abort_shutdown(self):
             aborted.append("worker-racing-shutdown")
 
-    def start_ray_workers(existing_ids):
+    def start_ray_workers(existing_ids, _manager_instance_id):
         start_calls.append(tuple(existing_ids))
         refresh_entered.set()
         assert release_refresh.wait(timeout=10)
@@ -3099,7 +3138,7 @@ def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypat
         def shutdown(self):
             pass
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-dead",
@@ -3185,7 +3224,7 @@ def test_ray_worker_manager_drop_fans_out_after_result_payload_release_failure(m
         def shutdown(self):
             pass
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-with-result",
@@ -3246,7 +3285,7 @@ def test_ray_worker_manager_shutdown_uses_global_prepare_barrier(monkeypatch):
         def abort_shutdown(self):
             raise AssertionError("successful shutdown must not force-terminate actors")
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-a",
@@ -3306,7 +3345,7 @@ def test_ray_worker_manager_concurrent_shutdown_waits_for_first_result(monkeypat
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [
+        lambda _existing_ids, _manager_instance_id: [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-a",
                 DummyRayWorkerHandle(),
@@ -3380,7 +3419,7 @@ def test_ray_worker_manager_shutdown_waits_for_entered_result_collection(monkeyp
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [
+        lambda _existing_ids, _manager_instance_id: [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-a",
                 DummyRayWorkerHandle(),
@@ -3444,7 +3483,7 @@ def test_ray_worker_manager_shutdown_aborts_all_actors_after_prepare_error(monke
         def abort_shutdown(self):
             calls.append(("abort", self.worker_id))
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-failing",
@@ -3502,7 +3541,7 @@ def test_ray_worker_manager_shutdown_finishes_all_actors_after_finish_error(monk
         def abort_shutdown(self):
             raise AssertionError("a finish error happens after the prepare barrier")
 
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-failing",
@@ -3542,7 +3581,7 @@ def test_ray_worker_manager_shutdown_finishes_all_actors_after_finish_error(monk
 
 
 def test_ray_worker_manager_worker_snapshots_fail_fast(monkeypatch):
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         raise RuntimeError("start-ray-workers boom")
 
     def try_autoscale(_bundles):
@@ -3559,7 +3598,7 @@ def test_ray_worker_manager_worker_snapshots_fail_fast(monkeypatch):
 
 
 def test_ray_worker_manager_try_autoscale_fail_fast(monkeypatch):
-    def start_ray_workers(_existing_ids):
+    def start_ray_workers(_existing_ids, _manager_instance_id):
         return []
 
     def try_autoscale(_bundles):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -19,6 +19,7 @@ ray = pytest.importorskip("ray")
 
 import duckdb.runners.fte.fte_execution as fte_execution_mod
 import duckdb.runners.ray.fragment_worker_commands as worker_commands_mod
+import duckdb.runners.ray.fragment_worker_failures as worker_failures_mod
 import duckdb.runners.ray.fragment_worker_placement as worker_placement_mod
 import duckdb.runners.ray.fragment_worker_selection as worker_selection_mod
 import duckdb.runners.ray.fragment_worker_submission as fragment_submission_mod
@@ -46,6 +47,7 @@ from duckdb.runners.ray.fte_events import (
     FteCreateTaskCommand,
     FteNoMoreSplitsCommand,
     TaskStatusChanged,
+    WorkerFailed,
     WorkerReservationCompleted,
 )
 from duckdb.runners.ray.query_execution_graph import (
@@ -78,12 +80,16 @@ class RayWorkerActorHandle(_ProductionRayWorkerActorHandle):
         memory_capacity_bytes,
         worker_id=None,
         node_id=None,
+        host=None,
+        manager_instance_id=None,
     ):
         super().__init__(
             actor_handle,
             memory_capacity_bytes=memory_capacity_bytes,
             worker_id=str(worker_id or f"test-worker-{id(actor_handle)}"),
             node_id=str(node_id or _test_ray_node_id()),
+            host=host,
+            manager_instance_id=manager_instance_id,
         )
 
     def record_fte_task_result_ready(self, attempt_id):
@@ -5661,14 +5667,196 @@ def test_fte_reservation_failure_does_not_publish_owner(monkeypatch):
 def test_fte_owner_selection_prefers_node_requirement_host(monkeypatch):
     actor0 = _FakeActor()
     actor1 = _FakeActor()
-    non_matching = RayWorkerActorHandle(actor0, memory_capacity_bytes=1 << 60, worker_id="aaa#0")
-    matching = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="zzz#0")
+    non_matching = RayWorkerActorHandle(
+        actor0,
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        host="aaa",
+    )
+    matching = RayWorkerActorHandle(
+        actor1,
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-b:0",
+        host="zzz",
+    )
 
     selected = non_matching._select_fte_worker(
         node_requirements=NodeRequirements(host="zzz"),
     )
 
     assert selected is matching
+
+
+def test_fte_worker_registry_rejects_duplicate_worker_identity():
+    first = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        host="10.0.0.1",
+    )
+
+    with pytest.raises(RuntimeError, match="FTE worker id is already registered: manager-a:node-a:0"):
+        RayWorkerActorHandle(
+            _FakeActor(),
+            memory_capacity_bytes=1 << 60,
+            worker_id="manager-a:node-a:0",
+            host="10.0.0.1",
+        )
+
+    assert worker_handle_mod._FTE_WORKER_HANDLES["manager-a:node-a:0"] is first
+    assert first._fte_healthy is True
+
+
+def test_fte_worker_selection_stays_with_manager_scope():
+    current = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-z:0",
+        manager_instance_id="manager-a",
+    )
+    RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+
+    assert current._select_fte_worker() is current
+
+
+def test_fte_worker_failure_replacement_stays_with_manager_scope():
+    same_manager = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-z:0",
+        manager_instance_id="manager-a",
+    )
+    RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+
+    replacement = fte_fragment_scheduler_mod._select_replacement_fte_worker(
+        "manager-a:failed:0",
+        manager_instance_id="manager-a",
+    )
+
+    assert replacement is same_manager
+
+
+def test_fte_worker_quarantine_rejects_cross_manager_identity():
+    other_manager = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+
+    failed_worker_ids = worker_failures_mod.quarantine_fte_worker(
+        other_manager.worker_id,
+        manager_instance_id="manager-a",
+    )
+
+    assert failed_worker_ids == frozenset()
+    assert other_manager._fte_healthy is True
+
+
+def test_fte_query_scheduler_rejects_cross_manager_rebinding():
+    first = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+    second = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-manager-scope")
+    first._bind_fte_scheduler_handlers(scheduler)
+
+    with pytest.raises(RuntimeError, match="FTE query scheduler manager ownership mismatch"):
+        second._bind_fte_scheduler_handlers(scheduler)
+
+
+def test_fte_global_worker_failure_does_not_claim_unbound_scheduler():
+    first = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+    second = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-unbound-manager-scope")
+
+    first.mark_fte_worker_failed(first.worker_id, RuntimeError("planned failure"))
+    second._bind_fte_scheduler_handlers(scheduler)
+
+    assert scheduler.is_owned_by_manager_instance("manager-b")
+
+
+def test_fte_worker_failure_event_rejects_cross_manager_scheduler():
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+    owner = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-cross-manager-failure")
+    owner._bind_fte_scheduler_handlers(scheduler)
+
+    scheduled = worker_failures_mod.mark_fte_worker_failed_for_event(
+        WorkerFailed(
+            scheduler.query_id,
+            failed.worker_id,
+            RuntimeError("planned failure"),
+            manager_instance_id="manager-a",
+        )
+    )
+
+    assert scheduled == []
+    assert scheduler.stats().failed_worker_count == 0
+    assert worker_handle_mod._FTE_WORKER_HANDLES[failed.worker_id] is failed
+    assert failed._fte_healthy is True
+
+
+def test_stale_worker_shutdown_does_not_fail_current_registry_owner(monkeypatch):
+    stale = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        host="10.0.0.1",
+    )
+    current = SimpleNamespace(_fte_healthy=True)
+    failure_calls = []
+    monkeypatch.setattr(
+        stale,
+        "mark_fte_worker_failed",
+        lambda worker_id, error: failure_calls.append((worker_id, error)),
+    )
+    with worker_handle_mod._FTE_REGISTRY_LOCK:
+        worker_handle_mod._FTE_WORKER_HANDLES[stale.worker_id] = current
+
+    stale._begin_worker_shutdown()
+
+    assert failure_calls == []
+    assert worker_handle_mod._FTE_WORKER_HANDLES[stale.worker_id] is current
+    assert current._fte_healthy is True
 
 
 def test_fte_non_remote_node_requirement_requires_matching_host(monkeypatch):
@@ -11037,16 +11225,36 @@ def test_start_ray_workers_keeps_flight_host_worker_local_and_skips_nested_warmu
         lambda **kwargs: ("node-affinity", kwargs),
     )
 
-    runtimes = worker_handle_mod.start_ray_workers(existing_worker_ids=[])
+    runtimes = worker_handle_mod.start_ray_workers(
+        existing_worker_ids=[],
+        manager_instance_id="manager-a",
+    )
+    other_manager_runtimes = worker_handle_mod.start_ray_workers(
+        existing_worker_ids=[],
+        manager_instance_id="manager-b",
+    )
+    refreshed_runtimes = worker_handle_mod.start_ray_workers(
+        existing_worker_ids=["manager-a:node-a:0", "manager-a:node-b:0"],
+        manager_instance_id="manager-a",
+    )
 
     assert len(runtimes) == 2
-    for index, address in enumerate(("10.0.0.1", "10.0.0.2")):
+    assert len(other_manager_runtimes) == 2
+    assert refreshed_runtimes == []
+    assert sorted(worker_handle_mod._FTE_WORKER_HANDLES) == [
+        "manager-a:node-a:0",
+        "manager-a:node-b:0",
+        "manager-b:node-a:0",
+        "manager-b:node-b:0",
+    ]
+    for index, (node_id, address) in enumerate((("node-a", "10.0.0.1"), ("node-b", "10.0.0.2"))):
+        worker_id = f"manager-a:{node_id}:0"
         assert option_calls[index]["memory"] == 358
         assert option_calls[index]["runtime_env"] == {
             "env_vars": {
                 "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
                 "VANE_WORKER": "1",
-                "VANE_WORKER_ID": address,
+                "VANE_WORKER_ID": worker_id,
                 "VANE_WORKER_INDEX": "0",
             },
         }
@@ -11056,6 +11264,12 @@ def test_start_ray_workers_keeps_flight_host_worker_local_and_skips_nested_warmu
         assert remote_calls[index]["duckdb_memory_bytes"] == 256
         assert remote_calls[index]["task_heap_capacity_bytes"] == 615
         assert remote_calls[index]["ray_node_ip_address"] == address
+        assert worker_handle_mod._FTE_WORKER_HANDLES[worker_id].host == address
+        assert worker_handle_mod._FTE_WORKER_HANDLES[worker_id].manager_instance_id == "manager-a"
+        other_worker_id = f"manager-b:{node_id}:0"
+        assert option_calls[index + 2]["runtime_env"]["env_vars"]["VANE_WORKER_ID"] == other_worker_id
+        assert worker_handle_mod._FTE_WORKER_HANDLES[other_worker_id].host == address
+        assert worker_handle_mod._FTE_WORKER_HANDLES[other_worker_id].manager_instance_id == "manager-b"
     assert get_calls == []
 
 
@@ -11121,7 +11335,10 @@ def test_start_ray_workers_cleans_up_actors_after_warmup_failure(monkeypatch, wa
     )
 
     with pytest.raises(RuntimeError, match=error_match):
-        worker_handle_mod.start_ray_workers(existing_worker_ids=[])
+        worker_handle_mod.start_ray_workers(
+            existing_worker_ids=[],
+            manager_instance_id="manager-a",
+        )
 
     assert sorted(killed) == [("node-a", True), ("node-b", True)]
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -24,6 +24,7 @@ import duckdb.runners.ray.fragment_worker_placement as worker_placement_mod
 import duckdb.runners.ray.fragment_worker_selection as worker_selection_mod
 import duckdb.runners.ray.fragment_worker_submission as fragment_submission_mod
 import duckdb.runners.ray.fragment_worker_task_control as task_control_mod
+import duckdb.runners.ray.fragment_worker_transitions as worker_transitions_mod
 import duckdb.runners.ray.fte_fragment_scheduler as fte_fragment_scheduler_mod
 import duckdb.runners.ray.worker as worker_mod
 import duckdb.runners.ray.worker_handle as worker_handle_mod
@@ -5763,6 +5764,58 @@ def test_fte_worker_quarantine_rejects_cross_manager_identity():
     assert other_manager._fte_healthy is True
 
 
+def test_fte_blank_manager_scope_remains_legacy_and_fail_closed():
+    legacy = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="legacy#0",
+    )
+    managed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-b:node-a:0",
+        manager_instance_id="manager-b",
+    )
+
+    failed_worker_ids = worker_failures_mod.quarantine_fte_worker(
+        managed.worker_id,
+        manager_instance_id="   ",
+    )
+    scheduled = fte_fragment_scheduler_mod._mark_fte_worker_failed(
+        managed.worker_id,
+        fte_fragment_scheduler_mod._worker_failure_payload(
+            managed.worker_id,
+            RuntimeError("planned failure"),
+        ),
+        manager_instance_id="   ",
+    )
+
+    assert failed_worker_ids == frozenset()
+    assert scheduled == []
+    assert worker_handle_mod._FTE_WORKER_HANDLES[managed.worker_id] is managed
+    assert managed._fte_healthy is True
+    assert worker_failures_mod.quarantine_fte_worker(
+        legacy.worker_id,
+        manager_instance_id="   ",
+    ) == frozenset({legacy.worker_id})
+    assert legacy._fte_healthy is False
+
+
+def test_fte_memory_pressure_skips_worker_without_budget(monkeypatch):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="legacy#0",
+    )
+    monkeypatch.setattr(
+        worker_transitions_mod,
+        "_fte_effective_worker_memory_budget_bytes",
+        lambda _worker, _execution_class: None,
+    )
+
+    assert handle._revoke_fte_speculative_tasks_for_memory_pressure_direct() == []
+
+
 def test_fte_query_scheduler_rejects_cross_manager_rebinding():
     first = RayWorkerActorHandle(
         _FakeActor(),
@@ -5804,12 +5857,13 @@ def test_fte_global_worker_failure_does_not_claim_unbound_scheduler():
     assert scheduler.is_owned_by_manager_instance("manager-b")
 
 
-def test_fte_worker_failure_event_rejects_cross_manager_scheduler():
+@pytest.mark.parametrize("failed_manager_instance_id", ["manager-a", ""])
+def test_fte_worker_failure_event_rejects_cross_manager_scheduler(failed_manager_instance_id):
     failed = RayWorkerActorHandle(
         _FakeActor(),
         memory_capacity_bytes=1 << 60,
-        worker_id="manager-a:node-a:0",
-        manager_instance_id="manager-a",
+        worker_id=f"{failed_manager_instance_id or 'legacy'}:node-a:0",
+        manager_instance_id=failed_manager_instance_id,
     )
     owner = RayWorkerActorHandle(
         _FakeActor(),
@@ -5825,7 +5879,7 @@ def test_fte_worker_failure_event_rejects_cross_manager_scheduler():
             scheduler.query_id,
             failed.worker_id,
             RuntimeError("planned failure"),
-            manager_instance_id="manager-a",
+            manager_instance_id=failed_manager_instance_id,
         )
     )
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -5725,6 +5725,64 @@ def test_fte_worker_selection_stays_with_manager_scope():
     assert current._select_fte_worker() is current
 
 
+def test_fte_registry_stats_exposes_worker_topology():
+    worker_id = "manager-a:node-a:0"
+    RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id=worker_id,
+        node_id="node-a",
+        host="10.0.0.1",
+        manager_instance_id="manager-a",
+    )
+
+    worker_stats = worker_handle_mod.fte_registry_stats()["workers"][worker_id]
+
+    assert worker_stats["worker_id"] == worker_id
+    assert worker_stats["manager_instance_id"] == "manager-a"
+    assert worker_stats["node_id"] == "node-a"
+    assert worker_stats["host"] == "10.0.0.1"
+
+
+def test_fte_worker_failure_payload_exposes_worker_topology():
+    worker_id = "manager-a:node-a:0"
+    RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id=worker_id,
+        node_id="node-a",
+        host="10.0.0.1",
+        manager_instance_id="manager-a",
+    )
+
+    failure = fte_fragment_scheduler_mod._worker_failure_payload(worker_id, RuntimeError("worker lost"))
+
+    assert failure["worker_id"] == worker_id
+    assert failure["manager_instance_id"] == "manager-a"
+    assert failure["node_id"] == "node-a"
+    assert failure["host"] == "10.0.0.1"
+
+
+def test_fte_worker_command_debug_fields_exposes_worker_topology():
+    worker_id = "manager-a:node-a:0"
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id=worker_id,
+        node_id="node-a",
+        host="10.0.0.1",
+        manager_instance_id="manager-a",
+    )
+    command = SimpleNamespace(worker=handle, worker_id=worker_id)
+
+    assert worker_commands_mod._fte_worker_command_debug_fields(command) == {
+        "worker_id": worker_id,
+        "manager_instance_id": "manager-a",
+        "node_id": "node-a",
+        "host": "10.0.0.1",
+    }
+
+
 def test_fte_worker_failure_replacement_stays_with_manager_scope():
     same_manager = RayWorkerActorHandle(
         _FakeActor(),
@@ -11015,7 +11073,7 @@ assert restored.__name__ == actor_cls.__name__
     assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_ray_worker_fte_admission_log_uses_worker_id(monkeypatch, capsys):
+def test_ray_worker_fte_debug_logs_use_worker_topology(monkeypatch, capsys):
     actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
     actor = object.__new__(actor_cls)
     actor._fte_task_manager = None
@@ -11032,7 +11090,11 @@ def test_ray_worker_fte_admission_log_uses_worker_id(monkeypatch, capsys):
 
     actor._execute_fte_request = execute_fte_request
     monkeypatch.setenv("VANE_FTE_ADMISSION_DEBUG", "1")
+    monkeypatch.setenv("VANE_FTE_RESULT_DEBUG", "1")
     monkeypatch.setenv("VANE_WORKER_ID", "ray-worker-log")
+    monkeypatch.setenv("VANE_WORKER_MANAGER_INSTANCE_ID", "manager-log")
+    monkeypatch.setenv("VANE_WORKER_NODE_ID", "node-log")
+    monkeypatch.setenv("VANE_WORKER_HOST", "10.0.0.9")
 
     async def run():
         task_id = {
@@ -11077,12 +11139,21 @@ def test_ray_worker_fte_admission_log_uses_worker_id(monkeypatch, capsys):
 
     assert "[vane-fte-admission" in captured
     assert "worker_id=ray-worker-log" in captured
+    assert "manager_instance_id=manager-log" in captured
+    assert "node_id=node-log" in captured
+    assert "host=10.0.0.9" in captured
     assert "event=manager_init" in captured
     assert "event=create_task" in captured
     assert "event=start_task" in captured
     assert "event=task_done" in captured
     assert "task_id=ray-log.0.0.0" in captured
     assert "max_running=4" in captured
+    result_lines = [line for line in captured.splitlines() if "[vane-fte-result" in line]
+    assert result_lines
+    assert all("worker_id=ray-worker-log" in line for line in result_lines)
+    assert all("manager_instance_id=manager-log" in line for line in result_lines)
+    assert all("node_id=node-log" in line for line in result_lines)
+    assert all("host=10.0.0.9" in line for line in result_lines)
 
 
 def test_drop_query_fragments_clears_local_registry():
@@ -11308,8 +11379,11 @@ def test_start_ray_workers_keeps_flight_host_worker_local_and_skips_nested_warmu
             "env_vars": {
                 "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
                 "VANE_WORKER": "1",
+                "VANE_WORKER_HOST": address,
                 "VANE_WORKER_ID": worker_id,
                 "VANE_WORKER_INDEX": "0",
+                "VANE_WORKER_MANAGER_INSTANCE_ID": "manager-a",
+                "VANE_WORKER_NODE_ID": node_id,
             },
         }
         assert "num_cpus" not in option_calls[index]

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6202,7 +6202,9 @@ def test_remote_exchange_sink_accepts_nested_query_id_without_exposing_result_co
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("node-a", worker, 4.0, 0.0, 8 << 30)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("node-a", worker, 4.0, 0.0, 8 << 30)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -6938,7 +6940,9 @@ def test_run_copy_plan_propagates_worker_task_failure_before_finalize(tmp_path, 
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-fail", failing_worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-fail", failing_worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7075,7 +7079,9 @@ def test_run_copy_plan_direct_write_failure_cleans_uncommitted_run(tmp_path, mon
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-direct-fail", failing_worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-direct-fail", failing_worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7140,7 +7146,9 @@ def test_wait_fte_query_propagates_status_errors(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-status-fail", failing_worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-status-fail", failing_worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7198,7 +7206,9 @@ def test_wait_fte_query_releases_gil_while_waiting(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-gil-wait", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-gil-wait", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7255,7 +7265,9 @@ def test_wait_fte_query_rejects_malformed_query_status(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-status-malformed", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-status-malformed", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7323,7 +7335,9 @@ def test_wait_fte_query_rejects_result_handles_without_task_id(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-handle-malformed", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-handle-malformed", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7392,7 +7406,9 @@ def test_wait_fte_query_rejects_result_handles_without_worker_id(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-coordinator", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-coordinator", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7483,7 +7499,9 @@ def test_wait_fte_query_propagates_selected_attempt_handle_errors(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-selected", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-selected", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7606,7 +7624,9 @@ def test_wait_fte_query_ignores_retry_loser_attempt_errors(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-retry", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-retry", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7711,7 +7731,7 @@ def test_wait_fte_query_release_failure_preserves_failed_handle_and_releases_res
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [
+        lambda _existing_ids, _manager_instance_id: [
             duckdb.ray_cxx.RayWorkerRuntime(
                 "worker-release-failure",
                 worker,
@@ -7845,7 +7865,9 @@ def test_wait_fte_query_does_not_drain_pending_retry_loser_attempt(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-retry-pending", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-retry-pending", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -7946,7 +7968,9 @@ def test_wait_fte_query_clears_cached_handles_after_failed_status(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-stale-failed", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-stale-failed", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -8040,7 +8064,9 @@ def test_wait_fte_query_timeout_preserves_collected_handles(monkeypatch):
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-timeout-preserve", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-timeout-preserve", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -8136,7 +8162,9 @@ def test_wait_fte_query_respects_timeout_after_finished_status_during_drain(monk
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [duckdb.ray_cxx.RayWorkerRuntime("worker-drain-timeout", worker, 1.0, 0.0, 1024)],
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime("worker-drain-timeout", worker, 1.0, 0.0, 1024)
+        ],
     )
     monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
 
@@ -8186,7 +8214,7 @@ def test_worker_manager_close_session_attempts_every_worker_before_retry(monkeyp
     monkeypatch.setattr(
         ray_worker_handle,
         "start_ray_workers",
-        lambda _existing_ids: [
+        lambda _existing_ids, _manager_instance_id: [
             duckdb.ray_cxx.RayWorkerRuntime("worker-a", first, 1.0, 0.0, 1024),
             duckdb.ray_cxx.RayWorkerRuntime("worker-b", second, 1.0, 0.0, 1024),
         ],

--- a/tests/fast/test_ray_worker_cuda_visibility.py
+++ b/tests/fast/test_ray_worker_cuda_visibility.py
@@ -18,6 +18,52 @@ class _RuntimeContext:
         return "node-a"
 
 
+def test_ray_worker_observability_log_treats_off_as_disabled(monkeypatch, capsys):
+    monkeypatch.setenv("VANE_FTE_ADMISSION_DEBUG", "off")
+    monkeypatch.delenv("VANE_RAY_WORKER_MEMORY_DEBUG", raising=False)
+    monkeypatch.delenv("VANE_FTE_RESULT_DEBUG", raising=False)
+    monkeypatch.delenv("DUCKDB_DISTRIBUTED_DEBUG", raising=False)
+
+    worker_mod._ray_worker_observability_log("worker_registered", worker_id="worker-a")
+
+    assert capsys.readouterr().err == ""
+
+
+def test_ray_worker_init_logs_worker_topology(monkeypatch, capfd):
+    class _ActorRuntimeContext(_RuntimeContext):
+        def get_actor_id(self):
+            return "actor-a"
+
+    actor_cls = worker_mod.RayWorkerActor.__ray_metadata__.modified_class
+    monkeypatch.setenv("VANE_FTE_ADMISSION_DEBUG", "1")
+    monkeypatch.setenv("VANE_WORKER_ID", "manager-a:node-a:0")
+    monkeypatch.setenv("VANE_WORKER_MANAGER_INSTANCE_ID", "manager-a")
+    monkeypatch.setenv("VANE_WORKER_NODE_ID", "node-a")
+    monkeypatch.setenv("VANE_WORKER_HOST", "10.0.0.1")
+    monkeypatch.setattr(worker_mod.ray, "get_runtime_context", _ActorRuntimeContext)
+    monkeypatch.setattr(worker_mod, "_warm_up_python_native_dependencies", lambda: None)
+    monkeypatch.setattr(worker_mod, "_ensure_python_datasource_runtime", lambda: None)
+    monkeypatch.setattr(actor_cls, "_get_shared_conn", lambda _self: None)
+
+    actor = actor_cls(
+        num_cpus=2,
+        num_gpus=0,
+        duckdb_memory_bytes=128 * 1024**2,
+        task_heap_capacity_bytes=128 * 1024**2,
+        ray_node_ip_address="10.0.0.1",
+    )
+    actor_cls.__del__(actor)
+    captured = capfd.readouterr().err
+
+    assert "[vane-ray-worker" in captured
+    assert "event=worker_registered" in captured
+    assert "worker_id=manager-a:node-a:0" in captured
+    assert "manager_instance_id=manager-a" in captured
+    assert "node_id=node-a" in captured
+    assert "host=10.0.0.1" in captured
+    assert "actor_id=actor-a" in captured
+
+
 @pytest.mark.parametrize(
     ("node_local_host", "expected_host"),
     [


### PR DESCRIPTION
## Summary

- assign each native RayWorkerManager a stable UUID scope and derive worker IDs from that scope, the Ray NodeID, and worker index
- keep topology host data separate from worker identity, reject duplicate registry ownership, and fence stale shutdowns
- scope FTE worker selection, replacement, quarantine, memory-pressure handling, and query scheduler events to the owning manager
- expose worker_id, manager_instance_id, node_id, and host in worker/task/command/result lifecycle logs, failure payloads, and FTE registry stats without changing identity or routing; startup logs also include the Ray actor ID
- add native/Python regressions for multi-manager isolation, refresh stability, duplicate registration, stale shutdown, locality, cross-manager failure isolation, topology observability, debug flag behavior, legacy-scope ownership, and missing memory budgets

Fixes #368

## Validation

- incremental release native build and reinstall for the original C++ change
- pre-commit on all changed files, including mypy and secret scanning
- affected Python suites: 857 passed, 4 deselected
- worker topology and Ray environment regressions: 46 passed
- scripts/run_release_tests.sh: 469 passed, 1 skipped, 14 deselected; real-Ray shard: 10 passed, 474 deselected
- scripts/run_fast_tests.sh shared-ray: 98 passed, 10 environment-dependent skips, 6248 deselected