### PR TITLE
[fix](video) Preserve endpoint-scoped S3 identity

### DIFF
--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -29,6 +29,7 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
+from functools import lru_cache
 from itertools import repeat
 from types import ModuleType
 from typing import Any, cast
@@ -64,7 +65,7 @@ _DEFAULT_MAX_SOURCE_PATH_BYTES = 4096
 # This version covers both the structured fields and their normalization. Bump
 # it whenever either changes so a source ID never silently changes meaning.
 _S3_SOURCE_IDENTITY_VERSION = 1
-_S3_DEFAULT_ENDPOINT_NAMESPACE = "aws"
+_S3_DEFAULT_AWS_PARTITION = "aws"
 _S3_DEFAULT_TRANSPORT_SCHEME = "https"
 _SOURCE_ID_BYTES = hashlib.sha256().digest_size * 2
 _ARROW_STRING_OFFSET_BYTES = np.dtype(np.int32).itemsize
@@ -89,6 +90,8 @@ class _S3EndpointSettings:
     scheme_override: str | None
     endpoint_override: str | None
     namespace: str
+    region: str | None
+    partition: str | None
 
 
 class VideoReadError(RuntimeError):
@@ -323,11 +326,62 @@ def _wait_for_memory() -> None:
             return
 
 
+def _configured_s3_region() -> str | None:
+    """Resolve the region that will be passed explicitly to PyArrow."""
+    region = _read_optional_text_env(("AWS_REGION", "AWS_DEFAULT_REGION"))
+    if region is not None:
+        return region
+
+    # Match the standard AWS configuration chain for profile/shared-config
+    # regions, then pass the result explicitly to PyArrow so provenance and I/O
+    # cannot resolve different regions.
+    from botocore.exceptions import ProfileNotFound  # type: ignore[import-not-found]
+    from botocore.session import Session  # type: ignore[import-not-found]
+
+    try:
+        configured_region = Session().get_config_variable("region")
+    except ProfileNotFound:
+        # Preserve the existing contract that profile validation belongs to
+        # the AWS SDK during I/O; a credentials-only or missing profile does
+        # not itself define a different source namespace.
+        return None
+    if configured_region is None:
+        return None
+    region = str(configured_region).strip()
+    return region or None
+
+
+@lru_cache(maxsize=None)
+def _aws_partition_for_region(region: str) -> str:
+    """Resolve an AWS region to a partition using Botocore endpoint metadata."""
+    from botocore.exceptions import UnknownRegionError
+    from botocore.session import Session
+
+    try:
+        partition = str(Session().get_partition_for_region(region)).strip()
+    except UnknownRegionError as exc:
+        raise ValueError(
+            f"cannot determine the AWS partition for region {region!r}; "
+            "update botocore or set AWS_ENDPOINT_URL explicitly"
+        ) from exc
+    if not partition:
+        raise ValueError(f"botocore returned an empty AWS partition for region {region!r}")
+    return partition
+
+
 def _s3_endpoint_settings() -> _S3EndpointSettings:
-    """Return the pyarrow overrides and stable namespace for the effective S3 endpoint."""
+    """Return one region/endpoint snapshot and its stable source namespace."""
+    region = _configured_s3_region()
     endpoint_url = _read_optional_text_env(("AWS_ENDPOINT_URL",))
     if endpoint_url is None:
-        return _S3EndpointSettings(None, None, _S3_DEFAULT_ENDPOINT_NAMESPACE)
+        partition = _S3_DEFAULT_AWS_PARTITION if region is None else _aws_partition_for_region(region)
+        return _S3EndpointSettings(
+            scheme_override=None,
+            endpoint_override=None,
+            namespace=partition,
+            region=region,
+            partition=partition,
+        )
 
     # Treat a scheme-less value as an authority so paths are discarded
     # consistently from endpoint_override.
@@ -357,7 +411,13 @@ def _s3_endpoint_settings() -> _S3EndpointSettings:
     default_port = (effective_scheme == "http" and port == 80) or (effective_scheme == "https" and port == 443)
     namespace_authority = namespace_host if port is None or default_port else f"{namespace_host}:{port}"
     endpoint_namespace = f"{effective_scheme}://{namespace_authority}"
-    return _S3EndpointSettings(scheme_override, endpoint_override, endpoint_namespace)
+    return _S3EndpointSettings(
+        scheme_override=scheme_override,
+        endpoint_override=endpoint_override,
+        namespace=endpoint_namespace,
+        region=region,
+        partition=None,
+    )
 
 
 def _s3_filesystem_kwargs(endpoint_settings: _S3EndpointSettings | None = None) -> dict[str, str | bool]:
@@ -370,9 +430,8 @@ def _s3_filesystem_kwargs(endpoint_settings: _S3EndpointSettings | None = None) 
             kwargs["scheme"] = settings.scheme_override
         kwargs["endpoint_override"] = settings.endpoint_override
 
-    region = _read_optional_text_env(("AWS_REGION", "AWS_DEFAULT_REGION"))
-    if region is not None:
-        kwargs["region"] = region
+    if settings.region is not None:
+        kwargs["region"] = settings.region
 
     if _read_bool_env("S3FS_ANON", False):
         kwargs["anonymous"] = True

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import json
 import logging
 import os
 import tempfile
@@ -27,9 +28,11 @@ import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import dataclass
 from itertools import repeat
 from types import ModuleType
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import numpy as np
 import numpy.typing as npt
@@ -58,6 +61,11 @@ _DEFAULT_MAX_SOURCE_FRAME_BYTES = int(os.environ.get("VANE_VIDEO_MAX_SOURCE_FRAM
 _REMOTE_VIDEO_READ_CHUNK_BYTES = 8 * 1024**2
 _VIDEO_DECODER_MEMORY_HEADROOM_BYTES = 128 * 1024**2
 _DEFAULT_MAX_SOURCE_PATH_BYTES = 4096
+# This version covers both the structured fields and their normalization. Bump
+# it whenever either changes so a source ID never silently changes meaning.
+_S3_SOURCE_IDENTITY_VERSION = 1
+_S3_DEFAULT_ENDPOINT_NAMESPACE = "aws"
+_S3_DEFAULT_TRANSPORT_SCHEME = "https"
 _SOURCE_ID_BYTES = hashlib.sha256().digest_size * 2
 _ARROW_STRING_OFFSET_BYTES = np.dtype(np.int32).itemsize
 _FRAME_INDEX_BYTES = np.dtype(np.int64).itemsize
@@ -74,6 +82,13 @@ _VIDEO_DECODE_THREADS = 1
 _VIDEO_DECODE_WIDTH_ALIGNMENT = 32
 _VIDEO_ERROR_MODES = frozenset({"raise", "skip"})
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _S3EndpointSettings:
+    scheme_override: str | None
+    endpoint_override: str | None
+    namespace: str
 
 
 class VideoReadError(RuntimeError):
@@ -308,24 +323,52 @@ def _wait_for_memory() -> None:
             return
 
 
-def _s3_filesystem_kwargs() -> dict[str, str | bool]:
-    """Build explicit S3 overrides without bypassing the AWS SDK defaults."""
-    from urllib.parse import urlparse
+def _s3_endpoint_settings() -> _S3EndpointSettings:
+    """Return the pyarrow overrides and stable namespace for the effective S3 endpoint."""
+    endpoint_url = _read_optional_text_env(("AWS_ENDPOINT_URL",))
+    if endpoint_url is None:
+        return _S3EndpointSettings(None, None, _S3_DEFAULT_ENDPOINT_NAMESPACE)
 
+    # Treat a scheme-less value as an authority so paths are discarded
+    # consistently from endpoint_override.
+    parse_target = endpoint_url
+    if "://" not in parse_target and not parse_target.startswith("//"):
+        parse_target = f"//{parse_target}"
+    parsed = urlparse(parse_target)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("AWS_ENDPOINT_URL must not include credentials")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError(f"AWS_ENDPOINT_URL must include an endpoint host, got {endpoint_url!r}")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"invalid AWS_ENDPOINT_URL port in {endpoint_url!r}") from exc
+
+    scheme_override = parsed.scheme.lower() or None
+    effective_scheme = scheme_override or _S3_DEFAULT_TRANSPORT_SCHEME
+    if effective_scheme not in {"http", "https"}:
+        raise ValueError(f"AWS_ENDPOINT_URL scheme must be http or https, got {effective_scheme!r}")
+
+    endpoint_override = parsed.netloc
+    namespace_host = hostname.lower()
+    if ":" in namespace_host:
+        namespace_host = f"[{namespace_host}]"
+    default_port = (effective_scheme == "http" and port == 80) or (effective_scheme == "https" and port == 443)
+    namespace_authority = namespace_host if port is None or default_port else f"{namespace_host}:{port}"
+    endpoint_namespace = f"{effective_scheme}://{namespace_authority}"
+    return _S3EndpointSettings(scheme_override, endpoint_override, endpoint_namespace)
+
+
+def _s3_filesystem_kwargs(endpoint_settings: _S3EndpointSettings | None = None) -> dict[str, str | bool]:
+    """Build explicit S3 overrides without bypassing the AWS SDK defaults."""
     kwargs: dict[str, str | bool] = {}
 
-    endpoint_url = _read_optional_text_env(("AWS_ENDPOINT_URL",))
-    if endpoint_url is not None:
-        # Treat a scheme-less value as an authority so paths are discarded
-        # consistently from endpoint_override.
-        parse_target = endpoint_url
-        if "://" not in parse_target and not parse_target.startswith("//"):
-            parse_target = f"//{parse_target}"
-        parsed = urlparse(parse_target)
-        endpoint = parsed.netloc or parsed.path.rstrip("/")
-        if parsed.scheme:
-            kwargs["scheme"] = parsed.scheme
-        kwargs["endpoint_override"] = endpoint
+    settings = endpoint_settings if endpoint_settings is not None else _s3_endpoint_settings()
+    if settings.endpoint_override is not None:
+        if settings.scheme_override is not None:
+            kwargs["scheme"] = settings.scheme_override
+        kwargs["endpoint_override"] = settings.endpoint_override
 
     region = _read_optional_text_env(("AWS_REGION", "AWS_DEFAULT_REGION"))
     if region is not None:
@@ -337,26 +380,53 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool]:
     return kwargs
 
 
-def _video_source_identity(video_path: str) -> tuple[str, str]:
-    """Return a stable provenance path and collision-resistant source ID."""
+def _parse_s3_video_path(video_path: str) -> tuple[str, str, str]:
+    """Validate an S3 video locator without changing bucket or key spelling."""
+    if not video_path.startswith("s3://"):
+        raise ValueError(f"invalid S3 video path: {video_path!r}")
+    object_path = video_path[len("s3://") :]
+    bucket, separator, key = object_path.partition("/")
+    if not bucket or not separator or not key:
+        raise ValueError(f"invalid S3 video path: {video_path!r}")
+    return bucket, key, object_path
+
+
+def _video_source_path(video_path: str) -> str:
+    """Return the exact S3 locator or resolved local path used for execution."""
     if video_path.startswith("s3://"):
-        object_path = video_path[len("s3://") :]
-        bucket, separator, key = object_path.partition("/")
-        if not bucket or not separator or not key:
-            raise ValueError(f"invalid S3 video path: {video_path!r}")
-        canonical_path = f"s3://{bucket.lower()}/{key}"
-    else:
-        # Resolve components in filesystem order.  Lexically collapsing
-        # ``link/..`` before following ``link`` can identify a different file
-        # from the one the decoder opens.
-        canonical_path = os.path.realpath(video_path)
-    source_id = hashlib.sha256(canonical_path.encode("utf-8")).hexdigest()
-    return canonical_path, source_id
+        _parse_s3_video_path(video_path)
+        return video_path
+    # Resolve components in filesystem order.  Lexically collapsing
+    # ``link/..`` before following ``link`` can identify a different file
+    # from the one the decoder opens.
+    return os.path.realpath(video_path)
+
+
+def _s3_video_source_id(bucket: str, key: str, endpoint_namespace: str) -> str:
+    """Hash a versioned, endpoint-scoped identity for an exact S3 object locator."""
+    identity = {
+        "version": _S3_SOURCE_IDENTITY_VERSION,
+        "scheme": "s3",
+        "endpoint_namespace": endpoint_namespace,
+        "bucket": bucket,
+        "key": key,
+    }
+    serialized = json.dumps(identity, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _video_source_id(source_path: str, *, endpoint_settings: _S3EndpointSettings | None = None) -> str:
+    """Return the provenance ID for an already resolved execution locator."""
+    if source_path.startswith("s3://"):
+        bucket, key, _ = _parse_s3_video_path(source_path)
+        settings = endpoint_settings if endpoint_settings is not None else _s3_endpoint_settings()
+        return _s3_video_source_id(bucket, key, settings.namespace)
+    return hashlib.sha256(source_path.encode("utf-8")).hexdigest()
 
 
 def _video_source_path_bytes(video_path: str) -> int:
-    canonical_path, _ = _video_source_identity(video_path)
-    return len(canonical_path.encode("utf-8"))
+    source_path = _video_source_path(video_path)
+    return len(source_path.encode("utf-8"))
 
 
 def _max_video_source_path_bytes(video_paths: list[str]) -> int:
@@ -370,10 +440,10 @@ def _safe_video_suffix(video_path: str) -> str:
     return suffix
 
 
-def _s3_filesystem() -> Any:
+def _s3_filesystem(endpoint_settings: _S3EndpointSettings | None = None) -> Any:
     import pyarrow.fs as pa_fs
 
-    return pa_fs.S3FileSystem(**_s3_filesystem_kwargs())
+    return pa_fs.S3FileSystem(**_s3_filesystem_kwargs(endpoint_settings))
 
 
 @contextmanager
@@ -382,6 +452,7 @@ def _materialize_video_path(
     *,
     max_remote_video_bytes: int,
     remote_temp_dir: str | None,
+    endpoint_settings: _S3EndpointSettings | None = None,
 ) -> Iterator[str]:
     """Yield a local decoder path while keeping remote heap use constant."""
     if not video_path.startswith("s3://"):
@@ -390,18 +461,17 @@ def _materialize_video_path(
     if max_remote_video_bytes <= 0:
         raise ValueError("max_remote_video_bytes must be positive")
 
-    canonical_path, _ = _video_source_identity(video_path)
-    object_path = canonical_path[len("s3://") :]
-    fs = _s3_filesystem()
+    _, _, object_path = _parse_s3_video_path(video_path)
+    fs = _s3_filesystem(endpoint_settings) if endpoint_settings is not None else _s3_filesystem()
     try:
         file_info = fs.get_file_info(object_path)
     except OSError as exc:
-        raise _video_read_error(canonical_path, exc) from exc
+        raise _video_read_error(video_path, exc) from exc
     object_size_value = file_info.size
     object_size = None if object_size_value is None else int(object_size_value)
     if object_size is not None and object_size >= 0 and object_size > max_remote_video_bytes:
         raise RemoteVideoTooLargeError(
-            canonical_path,
+            video_path,
             f"remote object size {object_size} exceeds limit {max_remote_video_bytes}",
         )
 
@@ -418,20 +488,20 @@ def _materialize_video_path(
             try:
                 source = fs.open_input_file(object_path)
             except OSError as exc:
-                raise _video_read_error(canonical_path, exc) from exc
+                raise _video_read_error(video_path, exc) from exc
             with source:
                 copied_bytes = 0
                 while True:
                     try:
                         chunk = source.read(_REMOTE_VIDEO_READ_CHUNK_BYTES)
                     except OSError as exc:
-                        raise _video_read_error(canonical_path, exc) from exc
+                        raise _video_read_error(video_path, exc) from exc
                     if not chunk:
                         break
                     copied_bytes += len(chunk)
                     if copied_bytes > max_remote_video_bytes:
                         raise RemoteVideoTooLargeError(
-                            canonical_path,
+                            video_path,
                             f"remote object exceeded limit {max_remote_video_bytes} while downloading",
                         )
                     temporary.write(chunk)
@@ -592,7 +662,9 @@ def _decode_video_batches(
     if max_source_frame_bytes <= 0:
         raise ValueError("max_source_frame_bytes must be positive")
 
-    source_path, source_id = _video_source_identity(video_path)
+    source_path = _video_source_path(video_path)
+    endpoint_settings = _s3_endpoint_settings() if source_path.startswith("s3://") else None
+    source_id = _video_source_id(source_path, endpoint_settings=endpoint_settings)
     source_path_bytes = len(source_path.encode("utf-8"))
     if max_source_path_bytes is None:
         max_source_path_bytes = source_path_bytes
@@ -600,7 +672,7 @@ def _decode_video_batches(
         max_source_path_bytes = int(max_source_path_bytes)
         if max_source_path_bytes < source_path_bytes:
             raise ValueError(
-                f"max_source_path_bytes {max_source_path_bytes} is smaller than canonical path size {source_path_bytes}"
+                f"max_source_path_bytes {max_source_path_bytes} is smaller than source path size {source_path_bytes}"
             )
 
     decoder_width, decoder_height = _video_decoder_dimensions(width=width, height=height)
@@ -686,6 +758,7 @@ def _decode_video_batches(
         source_path,
         max_remote_video_bytes=max_remote_video_bytes,
         remote_temp_dir=remote_temp_dir,
+        endpoint_settings=endpoint_settings,
     ) as decoder_path:
         # Bound Decord's materialized frame shape at reader construction rather
         # than discovering an oversized frame after iteration begins. The
@@ -847,7 +920,7 @@ def _video_max_output_rows(max_source_path_bytes: int) -> int:
         raise ValueError("max_source_path_bytes must be non-negative")
     if max_source_path_bytes > _ARROW_STRING_DATA_MAX_BYTES:
         raise ValueError(
-            f"canonical video path requires {max_source_path_bytes} bytes, "
+            f"video source path requires {max_source_path_bytes} bytes, "
             f"exceeding Arrow's {_ARROW_STRING_DATA_MAX_BYTES}-byte UTF-8 offset limit"
         )
     path_limit = (
@@ -1108,7 +1181,7 @@ def _video_frame_source_manifest_sql(source: VideoFrameSource) -> str:
     max_source_path_bytes = _max_video_source_path_bytes(source.paths)
     rows = ", ".join(
         "("
-        f"list_value({', '.join(_sql_string_literal(_video_source_identity(path)[0]) for path in paths)}), "
+        f"list_value({', '.join(_sql_string_literal(_video_source_path(path)) for path in paths)}), "
         f"{int(source.height)}, "
         f"{int(source.width)}, "
         f"{int(source.max_partition_bytes)}, "
@@ -1378,9 +1451,12 @@ class VideoFrameSource(DataSource):
     """DataSource that streams video frames from local or S3 video files.
 
     Each video file becomes an independent task. Frames are decoded using
-    decord and resized to (height, width). Output rows contain the canonical
+    decord and resized to (height, width). Output rows contain the execution
     ``video_path``, its SHA-256 ``source_id``, ``frame_index``, and the frame
-    tensor. S3 objects are copied to a bounded task-local temporary file before
+    tensor. Local paths are resolved with ``realpath``; S3 paths preserve the
+    exact bucket and key spelling supplied by the caller. S3 ``source_id``
+    values hash a versioned identity containing the endpoint namespace, bucket,
+    and key. S3 objects are copied to a bounded task-local temporary file before
     decoding.
 
     ``on_error="raise"`` fails the query on an unreadable file.

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -30,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
+from ipaddress import ip_address
 from itertools import repeat
 from types import ModuleType
 from typing import Any, cast
@@ -405,9 +406,12 @@ def _s3_endpoint_settings() -> _S3EndpointSettings:
         raise ValueError(f"AWS_ENDPOINT_URL scheme must be http or https, got {effective_scheme!r}")
 
     endpoint_override = parsed.netloc
-    # A terminal dot only makes a DNS hostname absolute; it does not identify
-    # a different endpoint. Exclude it from the stable provenance namespace.
-    namespace_host = hostname.lower().removesuffix(".")
+    try:
+        namespace_host = ip_address(hostname).compressed
+    except ValueError:
+        # A terminal dot only makes a DNS hostname absolute; it does not
+        # identify a different endpoint. Exclude it from the namespace.
+        namespace_host = hostname.lower().removesuffix(".")
     if ":" in namespace_host:
         namespace_host = f"[{namespace_host}]"
     default_port = (effective_scheme == "http" and port == 80) or (effective_scheme == "https" and port == 443)

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -405,7 +405,9 @@ def _s3_endpoint_settings() -> _S3EndpointSettings:
         raise ValueError(f"AWS_ENDPOINT_URL scheme must be http or https, got {effective_scheme!r}")
 
     endpoint_override = parsed.netloc
-    namespace_host = hostname.lower()
+    # A terminal dot only makes a DNS hostname absolute; it does not identify
+    # a different endpoint. Exclude it from the stable provenance namespace.
+    namespace_host = hostname.lower().removesuffix(".")
     if ":" in namespace_host:
         namespace_host = f"[{namespace_host}]"
     default_port = (effective_scheme == "http" and port == 80) or (effective_scheme == "https" and port == 443)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license-files = [
 keywords = ["Vane", "DuckDB", "Ray", "Distributed", "Database", "SQL", "OLAP"]
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "botocore>=1.34,<2",
+    "botocore>=1.38.0,<2",
     "cloudpickle>=3.1.2,<4",
     "numpy",
     "pyarrow>=14.0.0",

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -55,6 +55,12 @@ def test_base_distribution_requires_pyarrow_14_or_newer():
     assert pyarrow_requirement.specifier == SpecifierSet(">=14.0.0")
 
 
+def test_base_distribution_requires_botocore_1_38_or_newer():
+    botocore_requirement = _base_requirements()["botocore"]
+
+    assert botocore_requirement.specifier == SpecifierSet(">=1.38.0,<2")
+
+
 def test_artifact_mode_imports_installed_python_packages():
     if os.environ.get("VANE_FAST_TEST_ARTIFACT_MODE") != "1":
         pytest.skip("only applies to artifact-backed fast-test jobs")

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -56,7 +56,8 @@ def recording_s3_filesystem(monkeypatch):
         def __init__(self, **kwargs):
             recorded["kwargs"] = kwargs
 
-        def get_file_info(self, _path):
+        def get_file_info(self, path):
+            recorded["file_info_path"] = path
             return type("FileInfo", (), {"size": len(b"video-bytes")})()
 
         def open_input_file(self, path):
@@ -72,15 +73,27 @@ def _clear_s3_environment(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_video_s3_reader_uses_default_aws_sdk_chain(
+def _source_identity(video_reader, video_path):
+    source_path = video_reader._video_source_path(video_path)
+    return source_path, video_reader._video_source_id(source_path)
+
+
+def test_video_s3_reader_uses_default_aws_sdk_chain_and_exact_locator(
     monkeypatch,
     recording_s3_filesystem,
     tmp_path,
 ):
+    import duckdb.datasource.video_reader as video_reader
+
     _clear_s3_environment(monkeypatch)
+    monkeypatch.setattr(
+        video_reader,
+        "_video_source_id",
+        lambda _path: pytest.fail("materialization must not depend on provenance identity"),
+    )
 
     with _materialize_video_path(
-        "s3://media-bucket/clips/example.mp4",
+        "s3://MEDIA-BUCKET/clips/Example.mp4",
         max_remote_video_bytes=1024,
         remote_temp_dir=str(tmp_path),
     ) as local_path:
@@ -89,7 +102,8 @@ def test_video_s3_reader_uses_default_aws_sdk_chain(
     assert result == b"video-bytes"
     assert recording_s3_filesystem == {
         "kwargs": {},
-        "path": "media-bucket/clips/example.mp4",
+        "file_info_path": "MEDIA-BUCKET/clips/Example.mp4",
+        "path": "MEDIA-BUCKET/clips/Example.mp4",
     }
 
 
@@ -293,11 +307,12 @@ def test_remote_video_tempfile_errors_are_not_classified_as_bad_input(
     assert not isinstance(raised.value, video_reader.VideoReadError)
 
 
-def test_video_source_identity_distinguishes_same_basename_sources():
+def test_video_source_identity_distinguishes_same_basename_sources(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 
-    path_a, source_id_a = video_reader._video_source_identity("s3://bucket-a/train/clip.mp4")
-    path_b, source_id_b = video_reader._video_source_identity("s3://bucket-b/eval/clip.mp4")
+    _clear_s3_environment(monkeypatch)
+    path_a, source_id_a = _source_identity(video_reader, "s3://bucket-a/train/clip.mp4")
+    path_b, source_id_b = _source_identity(video_reader, "s3://bucket-b/eval/clip.mp4")
 
     assert path_a == "s3://bucket-a/train/clip.mp4"
     assert path_b == "s3://bucket-b/eval/clip.mp4"
@@ -306,12 +321,18 @@ def test_video_source_identity_distinguishes_same_basename_sources():
     assert source_id_a != source_id_b
 
 
-def test_video_source_identity_preserves_s3_object_key_semantics():
+def test_video_source_identity_preserves_exact_s3_locator_and_case(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 
-    path, _ = video_reader._video_source_identity("s3://MEDIA-BUCKET/a//../clip.mp4")
+    _clear_s3_environment(monkeypatch)
+    path, source_id = _source_identity(video_reader, "s3://MEDIA-BUCKET/a//../Clip.mp4")
+    _, lowercase_source_id = _source_identity(video_reader, "s3://media-bucket/a//../Clip.mp4")
+    _, lowercase_key_source_id = _source_identity(video_reader, "s3://MEDIA-BUCKET/a//../clip.mp4")
 
-    assert path == "s3://media-bucket/a//../clip.mp4"
+    assert path == "s3://MEDIA-BUCKET/a//../Clip.mp4"
+    assert source_id == "c03d65babeea00c996c154794fd9f7087c4fbd8f7dc8ec4135f291154bfa9833"
+    assert source_id != lowercase_source_id
+    assert source_id != lowercase_key_source_id
 
 
 def test_video_source_identity_resolves_symlink_before_parent_component(tmp_path):
@@ -327,8 +348,8 @@ def test_video_source_identity_resolves_symlink_before_parent_component(tmp_path
     link = tmp_path / "link"
     link.symlink_to(decoded_dir, target_is_directory=True)
 
-    canonical_path, source_id = video_reader._video_source_identity(str(link / ".." / "clip.mp4"))
-    direct_path, direct_source_id = video_reader._video_source_identity(str(direct_video))
+    canonical_path, source_id = _source_identity(video_reader, str(link / ".." / "clip.mp4"))
+    direct_path, direct_source_id = _source_identity(video_reader, str(direct_video))
 
     assert canonical_path == str(decoded_video.resolve())
     assert direct_path == str(direct_video.resolve())
@@ -496,6 +517,61 @@ def test_video_s3_reader_normalizes_endpoint_override(
     assert recording_s3_filesystem["kwargs"] == expected_kwargs
 
 
+def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    path = "s3://MEDIA-BUCKET/a//../Clip.mp4"
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "HTTPS://OBJECTS.EXAMPLE.TEST:443/prefix")
+    source_path, first_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "objects.example.test/another-prefix")
+    _, equivalent_endpoint_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://other.example.test")
+    _, other_endpoint_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://objects.example.test")
+    _, other_scheme_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test:9443")
+    _, other_port_source_id = _source_identity(video_reader, path)
+
+    assert source_path == path
+    assert first_source_id == "39874672dd4d30134572b88928574d43945bdfe2207847eabad0408b9e46debf"
+    assert equivalent_endpoint_source_id == first_source_id
+    assert other_endpoint_source_id != first_source_id
+    assert other_scheme_source_id != first_source_id
+    assert other_port_source_id != first_source_id
+
+
+def test_video_s3_source_identity_excludes_credentials_and_request_options(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    path = "s3://media-bucket/clips/example.mp4"
+    _, source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "temporary-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "temporary-secret-key")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "temporary-session-token")
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
+    monkeypatch.setenv("S3FS_ANON", "true")
+
+    assert _source_identity(video_reader, path)[1] == source_id
+
+
+def test_video_s3_endpoint_rejects_embedded_credentials(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://user:secret@objects.example.test")
+
+    with pytest.raises(ValueError, match="AWS_ENDPOINT_URL must not include credentials"):
+        _source_identity(video_reader, "s3://media-bucket/clips/example.mp4")
+
+
 def test_video_s3_reader_does_not_enable_anonymous_mode_when_explicitly_disabled(
     monkeypatch,
     recording_s3_filesystem,
@@ -593,6 +669,22 @@ def test_video_frame_source_manifest_groups_paths_like_ray_read_tasks():
     assert "max_source_frame_bytes::BIGINT" in sql
     assert "max_source_path_bytes::BIGINT" in sql
     assert "on_error::VARCHAR" in sql
+
+
+def test_video_frame_source_manifest_preserves_exact_s3_locator(monkeypatch, duckdb_cursor):
+    import duckdb.datasource.video_reader as video_reader
+
+    source_path = "s3://MEDIA-BUCKET/a//../Clip.mp4"
+    source = VideoFrameSource([source_path], height=8, width=8)
+    monkeypatch.setattr(
+        video_reader,
+        "_video_source_id",
+        lambda _path: pytest.fail("manifest construction must not depend on provenance identity"),
+    )
+
+    manifest = duckdb_cursor.sql(_video_frame_source_manifest_sql(source)).to_arrow_table()
+
+    assert manifest.column("video_paths").to_pylist() == [[source_path]]
 
 
 @pytest.mark.parametrize("on_error", ["", "ignore", "warn"])
@@ -740,7 +832,7 @@ def test_video_decode_batches_do_not_mutate_emitted_arrow_buffers(monkeypatch):
         lambda _path, **_kwargs: [FakeFrame(i) for i in range(5)],
     )
     monkeypatch.setattr(video_reader, "_VIDEO_RESIZE_THREADS", 1)
-    source_path, _ = video_reader._video_source_identity("clip.avi")
+    source_path = video_reader._video_source_path("clip.avi")
     max_partition_bytes = video_reader._video_output_batch_bytes(
         1,
         height=2,
@@ -761,7 +853,7 @@ def test_video_decode_batches_do_not_mutate_emitted_arrow_buffers(monkeypatch):
 
     values = [batch.column("frame").to_numpy_ndarray()[:, 0, 0, 0].tolist() for batch in batches]
     assert values == [[0, 1], [2, 3], [4]]
-    expected_path, expected_source_id = video_reader._video_source_identity("clip.avi")
+    expected_path, expected_source_id = _source_identity(video_reader, "clip.avi")
     assert batches[0].column("video_path").to_pylist() == [expected_path, expected_path]
     assert batches[0].column("source_id").to_pylist() == [expected_source_id, expected_source_id]
 
@@ -902,7 +994,7 @@ def test_video_decode_aligns_narrow_decord_output_before_exact_resize(monkeypatc
         )
     )
 
-    source_path, _ = video_reader._video_source_identity("clip.avi")
+    source_path = video_reader._video_source_path("clip.avi")
     assert calls == [(source_path, {"width": 32, "height": 2, "source_path": source_path})]
     assert batches[0].column("frame").type.shape == [2, 2, 3]
 
@@ -970,11 +1062,23 @@ def test_remote_video_decode_uses_temporary_path_and_preserves_remote_identity(
         decoder_paths.append(decoder_path)
         return [FakeFrame()]
 
-    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+    remote_path = "s3://media-bucket/clips/example.mp4"
+    source_path, source_id = _source_identity(video_reader, remote_path)
+    endpoint_settings = video_reader._s3_endpoint_settings()
+    endpoint_setting_calls = 0
 
+    def endpoint_settings_snapshot():
+        nonlocal endpoint_setting_calls
+        endpoint_setting_calls += 1
+        if endpoint_setting_calls > 1:
+            pytest.fail("decode must reuse one endpoint snapshot for provenance and I/O")
+        return endpoint_settings
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
+    monkeypatch.setattr(video_reader, "_s3_endpoint_settings", endpoint_settings_snapshot)
     batches = list(
         _decode_video_batches(
-            "s3://media-bucket/clips/example.mp4",
+            remote_path,
             height=2,
             width=2,
             max_partition_bytes=1024,
@@ -983,12 +1087,12 @@ def test_remote_video_decode_uses_temporary_path_and_preserves_remote_identity(
         )
     )
 
-    source_path, source_id = video_reader._video_source_identity("s3://media-bucket/clips/example.mp4")
     assert len(decoder_paths) == 1
     assert not decoder_paths[0].exists()
     assert batches[0].column("video_path").to_pylist() == [source_path]
     assert batches[0].column("source_id").to_pylist() == [source_id]
     assert recording_s3_filesystem["path"] == "media-bucket/clips/example.mp4"
+    assert endpoint_setting_calls == 1
 
 
 def test_remote_video_decode_cleans_temporary_path_when_consumer_stops_early(
@@ -1014,7 +1118,7 @@ def test_remote_video_decode_cleans_temporary_path_when_consumer_stops_early(
         return [FakeFrame(), FakeFrame(), FakeFrame()]
 
     monkeypatch.setattr(video_reader, "_open_decord_reader", fake_open_decoder)
-    source_path, _ = video_reader._video_source_identity("s3://media-bucket/clips/example.mp4")
+    source_path = video_reader._video_source_path("s3://media-bucket/clips/example.mp4")
     max_partition_bytes = video_reader._video_output_batch_bytes(
         1,
         height=2,
@@ -1063,7 +1167,7 @@ def test_video_decode_keeps_raw_resize_window_bounded(monkeypatch):
     )
     monkeypatch.setattr(video_reader, "_resize_frame_batch", fake_resize)
     monkeypatch.setattr(video_reader, "_VIDEO_RESIZE_THREADS", 3)
-    source_path, _ = video_reader._video_source_identity("clip.avi")
+    source_path = video_reader._video_source_path("clip.avi")
     max_partition_bytes = video_reader._video_output_batch_bytes(
         8,
         height=2,
@@ -1419,7 +1523,7 @@ def test_video_frame_source_map_batches_skips_bad_file_and_continues(
         pass
 
     def fake_decode(video_path, **_kwargs):
-        source_path, source_id = video_reader._video_source_identity(video_path)
+        source_path, source_id = _source_identity(video_reader, video_path)
         row_count = 1 if video_path == "bad.avi" else 2
         yield pa.record_batch(
             {
@@ -1461,8 +1565,8 @@ def test_video_frame_source_map_batches_skips_bad_file_and_continues(
     with caplog.at_level(logging.WARNING, logger=video_reader.__name__):
         tables = list(_video_frame_source_map_batches(manifest))
 
-    bad_path, _ = video_reader._video_source_identity("bad.avi")
-    good_path, _ = video_reader._video_source_identity("good.avi")
+    bad_path = video_reader._video_source_path("bad.avi")
+    good_path = video_reader._video_source_path("good.avi")
     assert [table.column("video_path").to_pylist() for table in tables] == [[bad_path, good_path, good_path]]
     assert f"Skipping unreadable video source={bad_path!r}" in caplog.text
 
@@ -1497,7 +1601,7 @@ def test_video_read_error_mode_raise_preserves_decoder_boundary_failure(monkeypa
         )
 
     assert raised.value.__cause__ is failure
-    expected_path, _ = video_reader._video_source_identity("bad.avi")
+    expected_path = video_reader._video_source_path("bad.avi")
     assert raised.value.video_path == expected_path
 
 

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -559,6 +559,24 @@ def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
     assert other_port_source_id != first_source_id
 
 
+def test_video_s3_source_identity_canonicalizes_ipv6_endpoint_literals(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    path = "s3://media-bucket/clips/example.mp4"
+
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://[2001:db8::1]")
+    _, compressed_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv(
+        "AWS_ENDPOINT_URL",
+        "https://[2001:0DB8:0000:0000:0000:0000:0000:0001]:443/prefix",
+    )
+    _, expanded_source_id = _source_identity(video_reader, path)
+
+    assert expanded_source_id == compressed_source_id
+
+
 def test_video_s3_default_source_identity_is_partition_scoped(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -534,6 +534,9 @@ def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
     monkeypatch.setenv("AWS_REGION", "future-moon-1")
     _, arbitrary_region_source_id = _source_identity(video_reader, path)
 
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://objects.example.test./another-prefix")
+    _, absolute_dns_name_source_id = _source_identity(video_reader, path)
+
     monkeypatch.setenv("AWS_ENDPOINT_URL", "objects.example.test/another-prefix")
     _, equivalent_endpoint_source_id = _source_identity(video_reader, path)
 
@@ -548,6 +551,7 @@ def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
 
     assert source_path == path
     assert first_source_id == "39874672dd4d30134572b88928574d43945bdfe2207847eabad0408b9e46debf"
+    assert absolute_dns_name_source_id == first_source_id
     assert arbitrary_region_source_id == first_source_id
     assert equivalent_endpoint_source_id == first_source_id
     assert other_endpoint_source_id != first_source_id

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -40,9 +40,12 @@ _S3_ENV_NAMES = (
     "AWS_ROLE_ARN",
     "AWS_ROLE_SESSION_NAME",
     "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_DEFAULT_PROFILE",
     "AWS_REGION",
     "AWS_DEFAULT_REGION",
     "AWS_ENDPOINT_URL",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
 )
 
 
@@ -71,6 +74,8 @@ def recording_s3_filesystem(monkeypatch):
 def _clear_s3_environment(monkeypatch):
     for name in _S3_ENV_NAMES:
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", os.devnull)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", os.devnull)
 
 
 def _source_identity(video_reader, video_path):
@@ -526,6 +531,9 @@ def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
     monkeypatch.setenv("AWS_ENDPOINT_URL", "HTTPS://OBJECTS.EXAMPLE.TEST:443/prefix")
     source_path, first_source_id = _source_identity(video_reader, path)
 
+    monkeypatch.setenv("AWS_REGION", "future-moon-1")
+    _, arbitrary_region_source_id = _source_identity(video_reader, path)
+
     monkeypatch.setenv("AWS_ENDPOINT_URL", "objects.example.test/another-prefix")
     _, equivalent_endpoint_source_id = _source_identity(video_reader, path)
 
@@ -540,10 +548,97 @@ def test_video_s3_source_identity_is_versioned_and_endpoint_scoped(monkeypatch):
 
     assert source_path == path
     assert first_source_id == "39874672dd4d30134572b88928574d43945bdfe2207847eabad0408b9e46debf"
+    assert arbitrary_region_source_id == first_source_id
     assert equivalent_endpoint_source_id == first_source_id
     assert other_endpoint_source_id != first_source_id
     assert other_scheme_source_id != first_source_id
     assert other_port_source_id != first_source_id
+
+
+def test_video_s3_default_source_identity_is_partition_scoped(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    path = "s3://shared-name/clips/example.mp4"
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _, standard_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
+    _, other_standard_region_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_REGION", "cn-north-1")
+    _, china_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_REGION", "us-gov-west-1")
+    _, govcloud_source_id = _source_identity(video_reader, path)
+
+    monkeypatch.setenv("AWS_REGION", "eusc-de-east-1")
+    _, sovereign_cloud_source_id = _source_identity(video_reader, path)
+
+    assert other_standard_region_source_id == standard_source_id
+    assert len({standard_source_id, china_source_id, govcloud_source_id, sovereign_cloud_source_id}) == 4
+
+
+def test_video_s3_profile_region_is_reused_for_identity_and_io(
+    monkeypatch,
+    recording_s3_filesystem,
+    tmp_path,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    config_path = tmp_path / "aws-config"
+    config_path.write_text("[profile sovereign]\nregion = eusc-de-east-1\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("AWS_PROFILE", "sovereign")
+
+    source_path = video_reader._video_source_path("s3://shared-name/clips/example.mp4")
+    settings = video_reader._s3_endpoint_settings()
+    profile_source_id = video_reader._video_source_id(source_path, endpoint_settings=settings)
+
+    monkeypatch.setenv("AWS_REGION", "eusc-de-east-1")
+    _, environment_source_id = _source_identity(video_reader, source_path)
+    video_reader._s3_filesystem(settings)
+
+    assert settings.region == "eusc-de-east-1"
+    assert settings.partition == "aws-eusc"
+    assert settings.namespace == "aws-eusc"
+    assert profile_source_id == environment_source_id
+    assert recording_s3_filesystem["kwargs"] == {"region": "eusc-de-east-1"}
+
+
+def test_video_s3_region_snapshot_is_reused_after_environment_changes(
+    monkeypatch,
+    recording_s3_filesystem,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    source_path = video_reader._video_source_path("s3://shared-name/clips/example.mp4")
+    monkeypatch.setenv("AWS_REGION", "cn-north-1")
+    settings = video_reader._s3_endpoint_settings()
+    china_source_id = video_reader._video_source_id(source_path, endpoint_settings=settings)
+
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    _, standard_source_id = _source_identity(video_reader, source_path)
+    video_reader._s3_filesystem(settings)
+
+    assert settings.region == "cn-north-1"
+    assert settings.partition == "aws-cn"
+    assert china_source_id != standard_source_id
+    assert video_reader._video_source_id(source_path, endpoint_settings=settings) == china_source_id
+    assert recording_s3_filesystem["kwargs"] == {"region": "cn-north-1"}
+
+
+def test_video_s3_unknown_default_region_fails_closed(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
+    monkeypatch.setenv("AWS_REGION", "future-moon-1")
+
+    with pytest.raises(ValueError, match="cannot determine the AWS partition"):
+        _source_identity(video_reader, "s3://shared-name/clips/example.mp4")
 
 
 def test_video_s3_source_identity_excludes_credentials_and_request_options(monkeypatch):
@@ -1044,6 +1139,8 @@ def test_remote_video_decode_uses_temporary_path_and_preserves_remote_identity(
     tmp_path,
 ):
     import duckdb.datasource.video_reader as video_reader
+
+    _clear_s3_environment(monkeypatch)
 
     class FakeFrame:
         def asnumpy(self):


### PR DESCRIPTION
## Summary

- Preserve the caller's exact S3 bucket and key spelling in manifests, output paths, metadata lookups, and object reads.
- Separate source locator handling, provenance hashing, and remote materialization so identity generation cannot rewrite the I/O locator.
- Derive S3 `source_id` from canonical JSON containing `version`, `scheme`, normalized endpoint namespace, exact bucket, and exact key, then hash it with SHA-256.
- Snapshot endpoint settings once per decode and reuse that snapshot for provenance and I/O; credentials, region, and anonymous/request options are excluded from identity.
- Intentionally do not retain the legacy URI-only ID or add a fallback. Existing S3 `source_id` values change to the versioned format.

## Related issue

close: #355

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The `VideoFrameSource` API docstring now documents exact S3 locator preservation and endpoint-scoped source identity.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files duckdb/datasource/video_reader.py tests/fast/test_video_reader.py`
- `python -m pytest tests/fast/test_video_reader.py` — 72 passed
- `scripts/run_release_tests.sh` — 469 passed, 1 skipped; real-Ray shard 10 passed
- `scripts/run_fast_tests.sh` — non-Ray shard 6224 passed, 28 skipped, 8 xfailed, 1 xpassed; shared-Ray shard 98 passed, 6 skipped; test-owned Ray clusters 7 passed, optional vLLM test skipped
- CPU-only Linux x86-64; matching Release native package built with embedded DuckDB SourceID `900181cbd5`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
