### PR TITLE
[fix](executor) Drain tasks before teardown

### DIFF
--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -189,6 +189,9 @@ ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
 
 ClientContext::~ClientContext() {
 	if (Exception::UncaughtException()) {
+		if (active_query && active_query->executor) {
+			active_query->executor->CancelTasks();
+		}
 		return;
 	}
 	// destroy the client context and rollback if there is an active transaction

--- a/external/duckdb/src/parallel/executor.cpp
+++ b/external/duckdb/src/parallel/executor.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <thread>
 
 namespace duckdb {
 
@@ -516,6 +517,9 @@ void Executor::InitializeInternal(PhysicalOperator &plan, bool schedule_events) 
 }
 
 void Executor::CancelTasks() {
+	if (executor_tasks > 0) {
+		context.interrupted = true;
+	}
 	task.reset();
 	// Blocked tasks have to be released before draining, otherwise their task
 	// registrations keep executor_tasks non-zero indefinitely.
@@ -532,6 +536,9 @@ void Executor::CancelTasks() {
 	// states, so those must stay alive until all tasks have completed.
 	while (executor_tasks > 0) {
 		WorkOnTasks();
+		if (executor_tasks > 0) {
+			std::this_thread::yield();
+		}
 	}
 
 	vector<shared_ptr<MetaPipeline>> recursive_pipelines_to_destroy;

--- a/external/duckdb/src/parallel/executor.cpp
+++ b/external/duckdb/src/parallel/executor.cpp
@@ -28,7 +28,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cerrno>
 
 namespace duckdb {
 
@@ -518,35 +517,41 @@ void Executor::InitializeInternal(PhysicalOperator &plan, bool schedule_events) 
 
 void Executor::CancelTasks() {
 	task.reset();
+	// Blocked tasks have to be released before draining, otherwise their task
+	// registrations keep executor_tasks non-zero indefinitely.
 	{
-		vector<shared_ptr<MetaPipeline>> recursive_pipelines_to_destroy;
-		vector<shared_ptr<Pipeline>> pipelines_to_destroy;
-		vector<shared_ptr<Pipeline>> root_pipelines_to_destroy;
 		unordered_map<Task *, shared_ptr<Task>> tasks_to_destroy;
-		vector<shared_ptr<Event>> events_to_destroy;
 		{
 			lock_guard<mutex> elock(executor_lock);
 			// mark the query as cancelled so tasks will early-out
 			cancelled = true;
-			// Detach pipelines, events and blocked tasks while holding executor_lock,
-			// then destroy them after releasing it. Pipeline state destructors can
-			// synchronously wait on external callbacks that reschedule tasks through
-			// this executor.
-			for (auto &rec_cte_ref : recursive_ctes) {
-				auto &rec_cte = rec_cte_ref.get().Cast<PhysicalRecursiveCTE>();
-				if (rec_cte.recursive_meta_pipeline) {
-					recursive_pipelines_to_destroy.push_back(std::move(rec_cte.recursive_meta_pipeline));
-				}
-			}
-			pipelines_to_destroy = std::move(pipelines);
-			root_pipelines_to_destroy = std::move(root_pipelines);
 			tasks_to_destroy = std::move(to_be_rescheduled_tasks);
-			events_to_destroy = std::move(events);
 		}
 	}
-	// Take all pending tasks and execute them until they cancel
+	// Drain all tasks first. They hold references to pipelines, events and
+	// states, so those must stay alive until all tasks have completed.
 	while (executor_tasks > 0) {
 		WorkOnTasks();
+	}
+
+	vector<shared_ptr<MetaPipeline>> recursive_pipelines_to_destroy;
+	vector<shared_ptr<Pipeline>> pipelines_to_destroy;
+	vector<shared_ptr<Pipeline>> root_pipelines_to_destroy;
+	vector<shared_ptr<Event>> events_to_destroy;
+	{
+		lock_guard<mutex> elock(executor_lock);
+		// Detach pipeline state while holding executor_lock, then destroy it
+		// after releasing the lock. State destructors can synchronously wait on
+		// external callbacks that reschedule tasks through this executor.
+		for (auto &rec_cte_ref : recursive_ctes) {
+			auto &rec_cte = rec_cte_ref.get().Cast<PhysicalRecursiveCTE>();
+			if (rec_cte.recursive_meta_pipeline) {
+				recursive_pipelines_to_destroy.push_back(std::move(rec_cte.recursive_meta_pipeline));
+			}
+		}
+		pipelines_to_destroy = std::move(pipelines);
+		root_pipelines_to_destroy = std::move(root_pipelines);
+		events_to_destroy = std::move(events);
 	}
 }
 
@@ -774,24 +779,9 @@ vector<LogicalType> Executor::GetTypes() {
 
 void Executor::PushError(ErrorData exception) {
 	// push the exception onto the stack
-	// Use try-catch to handle the case where error_manager's mutex has been destroyed
-	// This can happen during cleanup when Executor is being destroyed but TaskScheduler
-	// threads are still running and trying to push errors
-	try {
-		error_manager.PushError(std::move(exception));
-		// interrupt execution of any other pipelines that belong to this executor
-		context.interrupted = true;
-	} catch (const std::system_error &e) {
-		// Mutex has been destroyed or is in an invalid state - this can happen during cleanup
-		// Ignore the error to avoid worker crash, as the Executor is being destroyed anyway
-		// The error code "Invalid argument" (EINVAL) typically indicates the mutex is invalid
-		if (e.code().value() == EINVAL) {
-			// Mutex is invalid - Executor is being destroyed, ignore the error
-			return;
-		}
-		// Re-throw other system errors
-		throw;
-	}
+	error_manager.PushError(std::move(exception));
+	// interrupt execution of any other pipelines that belong to this executor
+	context.interrupted = true;
 }
 
 bool Executor::HasError() {

--- a/external/duckdb/test/api/test_pending_query.cpp
+++ b/external/duckdb/test/api/test_pending_query.cpp
@@ -44,6 +44,7 @@ struct BlockingExecutorTaskState {
 	std::condition_variable cv;
 	bool started = false;
 	bool release = false;
+	bool interrupted = false;
 	bool finished = false;
 };
 
@@ -62,7 +63,12 @@ public:
 		std::unique_lock<std::mutex> lock(state->lock);
 		state->started = true;
 		state->cv.notify_all();
-		state->cv.wait(lock, [&]() { return state->release; });
+		while (!state->release && !executor.context.IsInterrupted()) {
+			state->cv.wait_for(lock, std::chrono::milliseconds(1));
+		}
+		if (!state->release) {
+			state->interrupted = executor.context.IsInterrupted();
+		}
 		state->finished = true;
 		state->cv.notify_all();
 		return TaskExecutionResult::TASK_FINISHED;
@@ -82,9 +88,9 @@ TEST_CASE("ClientContext drains executor tasks during exception unwinding", "[ap
 
 	auto state = make_shared_ptr<BlockingExecutorTaskState>();
 	std::thread executor_task;
-	std::thread release_task;
 
 	bool finished_before_catch = false;
+	bool interrupted_before_catch = false;
 	string caught_message;
 	try {
 		Connection connection(db);
@@ -107,34 +113,29 @@ TEST_CASE("ClientContext drains executor tasks during exception unwinding", "[ap
 		{
 			std::unique_lock<std::mutex> lock(state->lock);
 			if (!state->cv.wait_for(lock, std::chrono::seconds(5), [&]() { return state->started; })) {
+				state->release = true;
+				state->cv.notify_all();
+				lock.unlock();
+				executor_task.join();
 				throw std::runtime_error("executor task did not start");
 			}
 		}
-		release_task = std::thread([state]() {
-			std::this_thread::sleep_for(std::chrono::milliseconds(200));
-			std::lock_guard<std::mutex> lock(state->lock);
-			state->release = true;
-			state->cv.notify_all();
-		});
 		throw std::runtime_error("trigger exception unwinding");
 	} catch (const std::exception &ex) {
 		std::lock_guard<std::mutex> lock(state->lock);
 		finished_before_catch = state->finished;
+		interrupted_before_catch = state->interrupted;
 		caught_message = ex.what();
-		if (!release_task.joinable()) {
-			state->release = true;
-			state->cv.notify_all();
-		}
+		state->release = true;
+		state->cv.notify_all();
 	}
 
-	if (release_task.joinable()) {
-		release_task.join();
-	}
 	if (executor_task.joinable()) {
 		executor_task.join();
 	}
 	REQUIRE(caught_message == "trigger exception unwinding");
 	REQUIRE(finished_before_catch);
+	REQUIRE(interrupted_before_catch);
 }
 
 TEST_CASE("Test Pending Query API", "[api][.]") {

--- a/external/duckdb/test/api/test_pending_query.cpp
+++ b/external/duckdb/test/api/test_pending_query.cpp
@@ -3,9 +3,17 @@
 
 #include <thread>
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/execution/operator/helper/physical_batch_collector.hpp"
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
 #include "duckdb/main/client_config.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+#include "duckdb/parallel/task.hpp"
+
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
 
 using namespace duckdb;
 using namespace std;
@@ -31,7 +39,103 @@ public:
 	}
 };
 
+struct BlockingExecutorTaskState {
+	std::mutex lock;
+	std::condition_variable cv;
+	bool started = false;
+	bool release = false;
+	bool finished = false;
+};
+
+class BlockingExecutorTask : public Task {
+public:
+	BlockingExecutorTask(Executor &executor_p, duckdb::shared_ptr<BlockingExecutorTaskState> state_p)
+	    : executor(executor_p), state(std::move(state_p)) {
+		executor.RegisterTask();
+	}
+
+	~BlockingExecutorTask() override {
+		executor.UnregisterTask();
+	}
+
+	TaskExecutionResult Execute(TaskExecutionMode) override {
+		std::unique_lock<std::mutex> lock(state->lock);
+		state->started = true;
+		state->cv.notify_all();
+		state->cv.wait(lock, [&]() { return state->release; });
+		state->finished = true;
+		state->cv.notify_all();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	Executor &executor;
+	duckdb::shared_ptr<BlockingExecutorTaskState> state;
+};
+
 } // namespace
+
+TEST_CASE("ClientContext drains executor tasks during exception unwinding", "[api][executor][lifecycle]") {
+	DuckDB db(nullptr);
+	Connection setup(db);
+	REQUIRE_NO_FAIL(setup.Query("SET threads = 2"));
+
+	auto state = make_shared_ptr<BlockingExecutorTaskState>();
+	std::thread executor_task;
+	std::thread release_task;
+
+	bool finished_before_catch = false;
+	string caught_message;
+	try {
+		Connection connection(db);
+		PendingQueryParameters parameters;
+		parameters.get_result_collector = [](ClientContext &, PreparedStatementData &data) -> PhysicalOperator & {
+			return data.physical_plan->Make<PhysicalBatchCollector>(data);
+		};
+		auto pending = connection.PendingQuery("SELECT 42", parameters);
+		if (pending->HasError()) {
+			pending->ThrowError();
+		}
+
+		auto &executor = connection.context->GetExecutor();
+		duckdb::shared_ptr<Task> task = make_shared_ptr<BlockingExecutorTask>(executor, state);
+		executor_task = std::thread([task = std::move(task)]() mutable {
+			task->Execute(TaskExecutionMode::PROCESS_ALL);
+			task.reset();
+		});
+
+		{
+			std::unique_lock<std::mutex> lock(state->lock);
+			if (!state->cv.wait_for(lock, std::chrono::seconds(5), [&]() { return state->started; })) {
+				throw std::runtime_error("executor task did not start");
+			}
+		}
+		release_task = std::thread([state]() {
+			std::this_thread::sleep_for(std::chrono::milliseconds(200));
+			std::lock_guard<std::mutex> lock(state->lock);
+			state->release = true;
+			state->cv.notify_all();
+		});
+		throw std::runtime_error("trigger exception unwinding");
+	} catch (const std::exception &ex) {
+		std::lock_guard<std::mutex> lock(state->lock);
+		finished_before_catch = state->finished;
+		caught_message = ex.what();
+		if (!release_task.joinable()) {
+			state->release = true;
+			state->cv.notify_all();
+		}
+	}
+
+	if (release_task.joinable()) {
+		release_task.join();
+	}
+	if (executor_task.joinable()) {
+		executor_task.join();
+	}
+	REQUIRE(caught_message == "trigger exception unwinding");
+	REQUIRE(finished_before_catch);
+}
 
 TEST_CASE("Test Pending Query API", "[api][.]") {
 	DuckDB db;


### PR DESCRIPTION
## Summary

- port DuckDB #21642 cancellation ordering so executor tasks drain before pipeline, event, and state teardown
- cancel active executor tasks when ClientContext is destroyed during exception unwinding
- remove the EINVAL error suppression in Executor::PushError now that task lifetimes are bounded
- add a regression test covering an active executor task during ClientContext exception unwinding

## Testing

- VANE_NATIVE_BUILD_JOBS=8 VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed scripts/run_native_tests.sh "ClientContext drains executor tasks during exception unwinding" -s
- scripts/format duckdb --changed
- git diff --check

Closes #291