### PR TITLE
[fix](video) Classify only source-boundary failures

### DIFF
--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -27,7 +27,7 @@ import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from itertools import islice, repeat
+from itertools import repeat
 from types import ModuleType
 from typing import Any, cast
 
@@ -94,6 +94,30 @@ class RemoteVideoTooLargeError(VideoReadError):
 
 class SourceFrameTooLargeError(VideoReadError):
     """A decoded source frame exceeded its configured working-set bound."""
+
+
+def _video_read_error(video_path: str, exc: Exception) -> VideoReadError:
+    return VideoReadError(video_path, f"{type(exc).__name__}: {exc}")
+
+
+def _is_decord_error(exc: Exception) -> bool:
+    """Return whether *exc* is one of Decord's direct Exception subclasses."""
+    try:
+        decord_base = importlib.import_module("decord._ffi.base")
+    except ImportError:
+        return False
+    return any(
+        isinstance(error_type, type) and isinstance(exc, error_type)
+        for error_type in (
+            getattr(decord_base, "DECORDError", None),
+            getattr(decord_base, "DECORDLimitReachedError", None),
+        )
+    )
+
+
+def _is_decord_read_error(exc: Exception) -> bool:
+    """Return whether a decoder-boundary failure means the source is unreadable."""
+    return isinstance(exc, (OSError, RuntimeError)) or _is_decord_error(exc)
 
 
 def _read_bool_env(name: str, default: bool) -> bool:
@@ -369,7 +393,10 @@ def _materialize_video_path(
     canonical_path, _ = _video_source_identity(video_path)
     object_path = canonical_path[len("s3://") :]
     fs = _s3_filesystem()
-    file_info = fs.get_file_info(object_path)
+    try:
+        file_info = fs.get_file_info(object_path)
+    except OSError as exc:
+        raise _video_read_error(canonical_path, exc) from exc
     object_size_value = file_info.size
     object_size = None if object_size_value is None else int(object_size_value)
     if object_size is not None and object_size >= 0 and object_size > max_remote_video_bytes:
@@ -387,19 +414,27 @@ def _materialize_video_path(
     )
     local_path = temporary.name
     try:
-        with temporary, fs.open_input_file(object_path) as source:
-            copied_bytes = 0
-            while True:
-                chunk = source.read(_REMOTE_VIDEO_READ_CHUNK_BYTES)
-                if not chunk:
-                    break
-                copied_bytes += len(chunk)
-                if copied_bytes > max_remote_video_bytes:
-                    raise RemoteVideoTooLargeError(
-                        canonical_path,
-                        f"remote object exceeded limit {max_remote_video_bytes} while downloading",
-                    )
-                temporary.write(chunk)
+        with temporary:
+            try:
+                source = fs.open_input_file(object_path)
+            except OSError as exc:
+                raise _video_read_error(canonical_path, exc) from exc
+            with source:
+                copied_bytes = 0
+                while True:
+                    try:
+                        chunk = source.read(_REMOTE_VIDEO_READ_CHUNK_BYTES)
+                    except OSError as exc:
+                        raise _video_read_error(canonical_path, exc) from exc
+                    if not chunk:
+                        break
+                    copied_bytes += len(chunk)
+                    if copied_bytes > max_remote_video_bytes:
+                        raise RemoteVideoTooLargeError(
+                            canonical_path,
+                            f"remote object exceeded limit {max_remote_video_bytes} while downloading",
+                        )
+                    temporary.write(chunk)
         yield local_path
     finally:
         try:
@@ -435,14 +470,61 @@ def _constant_string_array(value: str, count: int) -> pa.Array:
     return pa.Array.from_buffers(pa.string(), count, [None, pa.py_buffer(offsets), pa.py_buffer(data)])
 
 
-def _open_decord_reader(video_path: str, *, width: int, height: int) -> Any:
+def _open_decord_reader(
+    decoder_path: str,
+    *,
+    width: int,
+    height: int,
+    source_path: str | None = None,
+) -> Any:
     VideoReader = _import_video_dependency("decord", "decord").VideoReader
-    return VideoReader(
-        video_path,
-        width=int(width),
-        height=int(height),
-        num_threads=_VIDEO_DECODE_THREADS,
-    )
+    try:
+        return VideoReader(
+            decoder_path,
+            width=int(width),
+            height=int(height),
+            num_threads=_VIDEO_DECODE_THREADS,
+        )
+    except Exception as exc:
+        if not _is_decord_read_error(exc):
+            raise
+        raise _video_read_error(source_path or decoder_path, exc) from exc
+
+
+def _iter_decord_frames(
+    reader: Any,
+    *,
+    video_path: str,
+    max_frames: int | None,
+) -> Iterator[Any]:
+    try:
+        frames = iter(reader)
+    except Exception as exc:
+        if not _is_decord_read_error(exc):
+            raise
+        raise _video_read_error(video_path, exc) from exc
+
+    frame_count = 0
+    while max_frames is None or frame_count < max_frames:
+        try:
+            frame = next(frames)
+        except StopIteration:
+            return
+        except Exception as exc:
+            if not _is_decord_read_error(exc):
+                raise
+            raise _video_read_error(video_path, exc) from exc
+        yield frame
+        frame_count += 1
+
+
+def _decord_frame_asnumpy(frame: Any, *, video_path: str) -> npt.NDArray[np.uint8]:
+    try:
+        return frame.asnumpy()
+    except Exception as exc:
+        if not _is_decord_error(exc):
+            raise
+        raise _video_read_error(video_path, exc) from exc
 
 
 def _video_decoder_dimensions(*, width: int, height: int) -> tuple[int, int]:
@@ -613,21 +695,28 @@ def _decode_video_batches(
             decoder_path,
             width=decoder_width,
             height=decoder_height,
+            source_path=source_path,
         )
         open_s = time.perf_counter() - open_start
         if _VIDEO_RESIZE_THREADS > 1:
             resize_executor = ThreadPoolExecutor(max_workers=_VIDEO_RESIZE_THREADS)
         try:
-            frames = reader if max_frames is None else islice(reader, max_frames)
-            for frame_idx, frame in enumerate(frames):
-                shape_frame_bytes = _source_frame_bytes_from_shape(frame)
+            for frame_idx, frame in enumerate(
+                _iter_decord_frames(reader, video_path=source_path, max_frames=max_frames)
+            ):
+                try:
+                    shape_frame_bytes = _source_frame_bytes_from_shape(frame)
+                except Exception as exc:
+                    if not _is_decord_error(exc):
+                        raise
+                    raise _video_read_error(source_path, exc) from exc
                 if shape_frame_bytes is not None and shape_frame_bytes > max_source_frame_bytes:
                     raise SourceFrameTooLargeError(
                         source_path,
                         f"source frame size {shape_frame_bytes} exceeds limit {max_source_frame_bytes}",
                     )
                 decode_start = time.perf_counter()
-                array = frame.asnumpy()
+                array = _decord_frame_asnumpy(frame, video_path=source_path)
                 decode_s += time.perf_counter() - decode_start
                 if array.nbytes > max_source_frame_bytes:
                     raise SourceFrameTooLargeError(
@@ -693,21 +782,6 @@ def _validate_video_error_mode(on_error: str) -> str:
     return on_error
 
 
-def _is_decord_error(exc: Exception) -> bool:
-    """Return whether *exc* is one of Decord's direct Exception subclasses."""
-    try:
-        decord_base = importlib.import_module("decord._ffi.base")
-    except ImportError:
-        return False
-    return any(
-        isinstance(error_type, type) and isinstance(exc, error_type)
-        for error_type in (
-            getattr(decord_base, "DECORDError", None),
-            getattr(decord_base, "DECORDLimitReachedError", None),
-        )
-    )
-
-
 def _decode_video_with_policy(
     video_path: str,
     *,
@@ -734,26 +808,16 @@ def _decode_video_with_policy(
             max_source_path_bytes=max_source_path_bytes,
             remote_temp_dir=remote_temp_dir,
         )
-    except Exception as exc:
-        if not isinstance(exc, (OSError, RuntimeError, ValueError)) and not _is_decord_error(exc):
-            raise
-        if isinstance(exc, VideoReadError):
-            error = exc
-        else:
-            try:
-                source_path, _ = _video_source_identity(video_path)
-            except ValueError:
-                source_path = video_path
-            error = VideoReadError(source_path, f"{type(exc).__name__}: {exc}")
+    except VideoReadError as error:
         if on_error == "raise":
-            if error is exc:
-                raise
-            raise error from exc
+            raise
+        cause = error.__cause__
+        reported_error = cause if isinstance(cause, Exception) else error
         _LOGGER.warning(
             "Skipping unreadable video source=%r error_type=%s error=%s",
             error.video_path,
-            type(exc).__name__,
-            exc,
+            type(reported_error).__name__,
+            reported_error,
         )
 
 
@@ -1323,6 +1387,8 @@ class VideoFrameSource(DataSource):
     ``on_error="skip"`` keeps frames emitted before the error, skips the
     remainder of that file, and continues with the next file. Frames that
     decord recovers without raising are considered successfully decoded.
+    Configuration, task-infrastructure, and result-construction failures
+    always fail the query instead of being classified as unreadable input.
     """
 
     def __init__(

--- a/duckdb/datasource/video_reader.py
+++ b/duckdb/datasource/video_reader.py
@@ -1384,11 +1384,11 @@ class VideoFrameSource(DataSource):
     decoding.
 
     ``on_error="raise"`` fails the query on an unreadable file.
-    ``on_error="skip"`` keeps frames emitted before the error, skips the
-    remainder of that file, and continues with the next file. Frames that
-    decord recovers without raising are considered successfully decoded.
-    Configuration, task-infrastructure, and result-construction failures
-    always fail the query instead of being classified as unreadable input.
+    ``on_error="skip"`` suppresses only failures classified as
+    :class:`VideoReadError`: it keeps frames emitted before the error, skips
+    the remainder of that file, and continues with the next file. Every other
+    exception propagates and fails the query. Frames that decord recovers
+    without raising are considered successfully decoded.
     """
 
     def __init__(

--- a/tests/fast/test_video_reader.py
+++ b/tests/fast/test_video_reader.py
@@ -221,6 +221,78 @@ def test_remote_video_materialization_allows_unknown_size_metadata(monkeypatch, 
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.parametrize("failure_point", ["metadata", "open", "read"])
+def test_remote_video_source_io_errors_are_video_read_errors(monkeypatch, tmp_path, failure_point):
+    import duckdb.datasource.video_reader as video_reader
+
+    failure = OSError(f"planned {failure_point} failure")
+    temporary_files = []
+
+    class FailingRemoteFile:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size):
+            raise failure
+
+    class FailingS3FileSystem:
+        def get_file_info(self, _path):
+            if failure_point == "metadata":
+                raise failure
+            return type("FileInfo", (), {"size": 1})()
+
+        def open_input_file(self, _path):
+            if failure_point == "open":
+                raise failure
+            return FailingRemoteFile()
+
+    real_named_temporary_file = video_reader.tempfile.NamedTemporaryFile
+
+    def recording_named_temporary_file(*args, **kwargs):
+        temporary = real_named_temporary_file(*args, **kwargs)
+        temporary_files.append(temporary)
+        return temporary
+
+    monkeypatch.setattr(video_reader, "_s3_filesystem", FailingS3FileSystem)
+    monkeypatch.setattr(video_reader.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+
+    with pytest.raises(video_reader.VideoReadError, match=f"planned {failure_point} failure") as raised:
+        with video_reader._materialize_video_path(
+            "s3://media-bucket/clips/example.mp4",
+            max_remote_video_bytes=1024,
+            remote_temp_dir=str(tmp_path),
+        ):
+            pytest.fail("a failed remote read must not yield a decoder path")
+
+    assert raised.value.__cause__ is failure
+    assert raised.value.video_path == "s3://media-bucket/clips/example.mp4"
+    assert len(temporary_files) == (0 if failure_point == "metadata" else 1)
+    assert all(temporary.closed for temporary in temporary_files)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_remote_video_tempfile_errors_are_not_classified_as_bad_input(
+    recording_s3_filesystem,
+    tmp_path,
+):
+    import duckdb.datasource.video_reader as video_reader
+
+    missing_temp_dir = tmp_path / "missing"
+
+    with pytest.raises(FileNotFoundError) as raised:
+        with video_reader._materialize_video_path(
+            "s3://media-bucket/clips/example.mp4",
+            max_remote_video_bytes=1024,
+            remote_temp_dir=str(missing_temp_dir),
+        ):
+            pytest.fail("temporary-file creation failure must not yield a decoder path")
+
+    assert not isinstance(raised.value, video_reader.VideoReadError)
+
+
 def test_video_source_identity_distinguishes_same_basename_sources():
     import duckdb.datasource.video_reader as video_reader
 
@@ -714,6 +786,95 @@ def test_video_decoder_uses_one_thread_for_bounded_native_buffering(monkeypatch)
     assert calls == [("clip.avi", 320, 180, 1)]
 
 
+@pytest.mark.parametrize("error_type", [OSError, RuntimeError])
+def test_video_decoder_open_errors_use_public_source_identity(monkeypatch, error_type):
+    import duckdb.datasource.video_reader as video_reader
+
+    failure = error_type("planned decoder open failure")
+
+    class FailingVideoReader:
+        def __init__(self, *_args, **_kwargs):
+            raise failure
+
+    class FakeDecordModule:
+        VideoReader = FailingVideoReader
+
+    monkeypatch.setattr(video_reader, "_import_video_dependency", lambda *_args: FakeDecordModule)
+
+    with pytest.raises(video_reader.VideoReadError, match="planned decoder open failure") as raised:
+        video_reader._open_decord_reader(
+            "/tmp/materialized.mp4",
+            width=320,
+            height=180,
+            source_path="s3://media-bucket/clips/example.mp4",
+        )
+
+    assert raised.value.__cause__ is failure
+    assert raised.value.video_path == "s3://media-bucket/clips/example.mp4"
+
+
+def test_video_decoder_iteration_wraps_direct_decord_errors(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeDecordError(Exception):
+        pass
+
+    class FakeDecordLimitReachedError(Exception):
+        pass
+
+    class FakeDecordBase:
+        DECORDError = FakeDecordError
+        DECORDLimitReachedError = FakeDecordLimitReachedError
+
+    failure = FakeDecordError("planned frame decode failure")
+
+    class FailingReader:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise failure
+
+    real_import_module = video_reader.importlib.import_module
+
+    def fake_import_module(module_name, *args, **kwargs):
+        if module_name == "decord._ffi.base":
+            return FakeDecordBase
+        return real_import_module(module_name, *args, **kwargs)
+
+    monkeypatch.setattr(video_reader.importlib, "import_module", fake_import_module)
+    assert video_reader._is_decord_error(FakeDecordLimitReachedError("recovery limit"))
+
+    with pytest.raises(video_reader.VideoReadError, match="planned frame decode failure") as raised:
+        list(
+            video_reader._iter_decord_frames(
+                FailingReader(),
+                video_path="clip.avi",
+                max_frames=None,
+            )
+        )
+
+    assert raised.value.__cause__ is failure
+    assert raised.value.video_path == "clip.avi"
+
+
+def test_video_frame_conversion_does_not_wrap_generic_runtime_errors(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    failure = RuntimeError("planned frame conversion invariant failure")
+
+    class FailingFrame:
+        def asnumpy(self):
+            raise failure
+
+    monkeypatch.setattr(video_reader, "_is_decord_error", lambda _exc: False)
+
+    with pytest.raises(RuntimeError, match="planned frame conversion invariant failure") as raised:
+        video_reader._decord_frame_asnumpy(FailingFrame(), video_path="clip.avi")
+
+    assert raised.value is failure
+
+
 def test_video_decode_aligns_narrow_decord_output_before_exact_resize(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 
@@ -742,7 +903,7 @@ def test_video_decode_aligns_narrow_decord_output_before_exact_resize(monkeypatc
     )
 
     source_path, _ = video_reader._video_source_identity("clip.avi")
-    assert calls == [(source_path, {"width": 32, "height": 2})]
+    assert calls == [(source_path, {"width": 32, "height": 2, "source_path": source_path})]
     assert batches[0].column("frame").type.shape == [2, 2, 3]
 
 
@@ -799,7 +960,11 @@ def test_remote_video_decode_uses_temporary_path_and_preserves_remote_identity(
     decoder_paths = []
 
     def fake_open_decoder(path, **kwargs):
-        assert kwargs == {"width": 32, "height": 2}
+        assert kwargs == {
+            "width": 32,
+            "height": 2,
+            "source_path": "s3://media-bucket/clips/example.mp4",
+        }
         decoder_path = Path(path)
         assert decoder_path.is_file()
         decoder_paths.append(decoder_path)
@@ -840,7 +1005,11 @@ def test_remote_video_decode_cleans_temporary_path_when_consumer_stops_early(
     decoder_paths = []
 
     def fake_open_decoder(path, **kwargs):
-        assert kwargs == {"width": 32, "height": 2}
+        assert kwargs == {
+            "width": 32,
+            "height": 2,
+            "source_path": "s3://media-bucket/clips/example.mp4",
+        }
         decoder_paths.append(Path(path))
         return [FakeFrame(), FakeFrame(), FakeFrame()]
 
@@ -1249,20 +1418,6 @@ def test_video_frame_source_map_batches_skips_bad_file_and_continues(
     class FakeDecordError(Exception):
         pass
 
-    class FakeDecordLimitReachedError(Exception):
-        pass
-
-    class FakeDecordBase:
-        DECORDError = FakeDecordError
-        DECORDLimitReachedError = FakeDecordLimitReachedError
-
-    real_import_module = video_reader.importlib.import_module
-
-    def fake_import_module(module_name, *args, **kwargs):
-        if module_name == "decord._ffi.base":
-            return FakeDecordBase
-        return real_import_module(module_name, *args, **kwargs)
-
     def fake_decode(video_path, **_kwargs):
         source_path, source_id = video_reader._video_source_identity(video_path)
         row_count = 1 if video_path == "bad.avi" else 2
@@ -1275,11 +1430,12 @@ def test_video_frame_source_map_batches_skips_bad_file_and_continues(
             }
         )
         if video_path == "bad.avi":
-            raise FakeDecordError("corrupt video")
+            failure = FakeDecordError("corrupt video")
+            raise video_reader.VideoReadError(
+                source_path,
+                f"{type(failure).__name__}: {failure}",
+            ) from failure
 
-    monkeypatch.setattr(video_reader.importlib, "import_module", fake_import_module)
-    assert video_reader._is_decord_error(FakeDecordError("corrupt"))
-    assert video_reader._is_decord_error(FakeDecordLimitReachedError("recovery limit"))
     monkeypatch.setattr(video_reader, "_wait_for_memory", lambda: None)
     monkeypatch.setattr(video_reader, "_decode_video_batches", fake_decode)
     manifest = pa.table(
@@ -1311,14 +1467,19 @@ def test_video_frame_source_map_batches_skips_bad_file_and_continues(
     assert f"Skipping unreadable video source={bad_path!r}" in caplog.text
 
 
-def test_video_read_error_mode_raise_wraps_file_failure(monkeypatch):
+def test_video_read_error_mode_raise_preserves_decoder_boundary_failure(monkeypatch):
     import duckdb.datasource.video_reader as video_reader
 
-    def fake_decode(_video_path, **_kwargs):
-        raise OSError("corrupt video")
-        yield
+    failure = OSError("corrupt video")
 
-    monkeypatch.setattr(video_reader, "_decode_video_batches", fake_decode)
+    class FailingVideoReader:
+        def __init__(self, *_args, **_kwargs):
+            raise failure
+
+    class FakeDecordModule:
+        VideoReader = FailingVideoReader
+
+    monkeypatch.setattr(video_reader, "_import_video_dependency", lambda *_args: FakeDecordModule)
 
     with pytest.raises(video_reader.VideoReadError, match="corrupt video") as raised:
         list(
@@ -1335,9 +1496,71 @@ def test_video_read_error_mode_raise_wraps_file_failure(monkeypatch):
             )
         )
 
-    assert isinstance(raised.value.__cause__, OSError)
+    assert raised.value.__cause__ is failure
     expected_path, _ = video_reader._video_source_identity("bad.avi")
     assert raised.value.video_path == expected_path
+
+
+@pytest.mark.parametrize("error_type", [OSError, RuntimeError, ValueError])
+def test_video_skip_mode_propagates_non_video_read_errors(monkeypatch, caplog, error_type):
+    import duckdb.datasource.video_reader as video_reader
+
+    failure = error_type("planned internal failure")
+
+    def fake_decode(*_args, **_kwargs):
+        raise failure
+        yield
+
+    monkeypatch.setattr(video_reader, "_decode_video_batches", fake_decode)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=video_reader.__name__),
+        pytest.raises(error_type, match="planned internal failure") as raised,
+    ):
+        list(
+            video_reader._decode_video_with_policy(
+                "input.mp4",
+                height=2,
+                width=2,
+                max_partition_bytes=1024,
+                max_frames=None,
+                max_remote_video_bytes=4096,
+                max_source_frame_bytes=2048,
+                remote_temp_dir=None,
+                on_error="skip",
+            )
+        )
+
+    assert raised.value is failure
+    assert "Skipping unreadable video" not in caplog.text
+
+
+def test_video_skip_mode_propagates_resize_invariant(monkeypatch):
+    import duckdb.datasource.video_reader as video_reader
+
+    class FakeFrame:
+        shape = (2, 32, 3)
+
+        def asnumpy(self):
+            return np.zeros(self.shape, dtype=np.uint8)
+
+    monkeypatch.setattr(video_reader, "_open_decord_reader", lambda *_args, **_kwargs: [FakeFrame()])
+    monkeypatch.setattr(video_reader, "_resize_frame_batch", lambda *_args, **_kwargs: [])
+
+    with pytest.raises(RuntimeError, match="video resize returned a different number of frames"):
+        list(
+            video_reader._decode_video_with_policy(
+                "input.mp4",
+                height=2,
+                width=2,
+                max_partition_bytes=1024,
+                max_frames=None,
+                max_remote_video_bytes=4096,
+                max_source_frame_bytes=2048,
+                remote_temp_dir=None,
+                on_error="skip",
+            )
+        )
 
 
 def test_resize_frame_batch_preserves_order_and_uses_configured_threads(monkeypatch):


### PR DESCRIPTION
## Summary

- translate only explicit S3 and Decord source-boundary failures into VideoReadError
- make on_error=skip consume only VideoReadError so configuration, infrastructure, and invariant failures still surface
- guarantee temporary-file cleanup on remote-open failures and add focused classification regressions

## Testing

- PYTHONDEVMODE=1 .venv/bin/python -W error -m pytest -q tests/fast/test_video_reader.py tests/fast/test_video_optional_deps.py
- .venv/bin/pre-commit run --from-ref upstream/main --to-ref HEAD
- scripts/run_release_tests.sh
- Decord 0.6.0 missing/corrupt-input smoke test

Fixes #357