### PR TITLE
[fix](ray) Unify one-shot direct-write lifecycle cleanup

### DIFF
--- a/duckdb/runners/ray/__init__.py
+++ b/duckdb/runners/ray/__init__.py
@@ -14,10 +14,7 @@ from duckdb.runners.ray.committed_copy import (
     inspect_copy_direct_write_run,
     read_committed_copy_direct_write_parquet,
 )
-from duckdb.runners.ray.lifecycle import (
-    cleanup_copy_direct_write_lifecycle_once,
-    run_copy_direct_write_lifecycle_cleanup_loop,
-)
+from duckdb.runners.ray.lifecycle import cleanup_copy_direct_write_lifecycle_once
 from duckdb.runners.ray.runner import RayRunner
 
 if TYPE_CHECKING:
@@ -31,7 +28,6 @@ __all__ = [
     "force_abort_copy_direct_write_run",
     "inspect_copy_direct_write_run",
     "read_committed_copy_direct_write_parquet",
-    "run_copy_direct_write_lifecycle_cleanup_loop",
     "set_runner_ray",
 ]
 

--- a/duckdb/runners/ray/lifecycle.py
+++ b/duckdb/runners/ray/lifecycle.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import signal
 import sys
-import threading
-import time
 from dataclasses import dataclass
 from os import PathLike, fspath
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Iterable, Sequence
 
 BasePath = str | PathLike[str]
 
@@ -111,13 +108,15 @@ def cleanup_copy_direct_write_lifecycle_once(
     min_age_ms: int,
     now_epoch_ms: int = 0,
     fail_fast: bool = False,
+    conn: Any | None = None,
 ) -> dict[str, Any]:
     """Run one direct-write COPY lifecycle cleanup scan.
 
-    This is the standalone-process entry point for stale uncommitted
-    direct-write COPY results. It delegates correctness decisions to the C++
-    manifest/marker aware scanner: committed runs are skipped, active runs are
-    kept, and only lifecycle-registered stale uncommitted runs are removed.
+    This is the one-shot entry point for stale uncommitted direct-write COPY
+    results. It delegates correctness decisions to the C++ manifest/marker
+    aware scanner: committed runs are skipped, active runs are kept, and only
+    lifecycle-registered stale uncommitted runs are removed. Pass the DuckDB
+    connection that owns any connection-scoped filesystem or secret config.
 
     The caller must ensure that no COPY is running for any supplied base path.
     Elapsed time does not prove that an uncommitted run is abandoned.
@@ -132,6 +131,7 @@ def cleanup_copy_direct_write_lifecycle_once(
                 base_path,
                 min_age_ms=int(min_age_ms),
                 now_epoch_ms=int(now_epoch_ms),
+                conn=conn,
             )
             scans.append(CopyDirectWriteLifecycleScan.from_api_result(base_path, raw))
         except Exception as exc:
@@ -139,64 +139,6 @@ def cleanup_copy_direct_write_lifecycle_once(
                 raise
             scans.append(CopyDirectWriteLifecycleScan.from_exception(base_path, exc))
     return _aggregate_scans(scans)
-
-
-def run_copy_direct_write_lifecycle_cleanup_loop(
-    base_paths: BasePath | Iterable[BasePath],
-    *,
-    min_age_ms: int,
-    interval_seconds: float = 300.0,
-    stop_event: threading.Event | None = None,
-    max_iterations: int | None = None,
-    fail_fast: bool = False,
-    now_epoch_ms_fn: Callable[[], int] | None = None,
-    sleep_fn: Callable[[float], None] | None = None,
-    on_iteration: Callable[[dict[str, Any]], None] | None = None,
-) -> dict[str, Any]:
-    """Run direct-write lifecycle cleanup periodically until stopped.
-
-    The caller must keep every supplied base path free of concurrent COPY
-    operations for the lifetime of the loop.
-    """
-    if max_iterations is not None and max_iterations <= 0:
-        raise ValueError("max_iterations must be positive when provided")
-    if interval_seconds < 0:
-        raise ValueError("interval_seconds must be non-negative")
-
-    paths = _normalize_base_paths(base_paths)
-    stop = stop_event or threading.Event()
-    sleep = sleep_fn or time.sleep
-    summaries: list[dict[str, Any]] = []
-    iteration = 0
-
-    while not stop.is_set():
-        now_epoch_ms = int(now_epoch_ms_fn()) if now_epoch_ms_fn is not None else 0
-        summary = cleanup_copy_direct_write_lifecycle_once(
-            paths,
-            min_age_ms=min_age_ms,
-            now_epoch_ms=now_epoch_ms,
-            fail_fast=fail_fast,
-        )
-        summary["iteration"] = iteration
-        summaries.append(summary)
-        if on_iteration is not None:
-            on_iteration(summary)
-
-        iteration += 1
-        if max_iterations is not None and iteration >= max_iterations:
-            break
-        if interval_seconds == 0:
-            continue
-        if stop_event is not None:
-            stop.wait(interval_seconds)
-        else:
-            sleep(interval_seconds)
-
-    return {
-        "iterations": iteration,
-        "last_summary": summaries[-1] if summaries else None,
-        "summaries": summaries,
-    }
 
 
 def _format_summary(summary: dict[str, Any]) -> str:
@@ -209,14 +151,6 @@ def _format_summary(summary: dict[str, Any]) -> str:
         f"active={summary['active_runs']} "
         f"errors={summary['errors']}"
     )
-
-
-def _install_signal_handlers(stop_event: threading.Event) -> None:
-    def _stop(_signum: int, _frame: Any) -> None:
-        stop_event.set()
-
-    signal.signal(signal.SIGTERM, _stop)
-    signal.signal(signal.SIGINT, _stop)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -239,46 +173,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Minimum uncommitted run age before cleanup. Defaults to 24h.",
     )
     parser.add_argument(
-        "--interval-seconds",
-        type=float,
-        default=300.0,
-        help="Sleep interval between scans when running as a loop.",
+        "--now-epoch-ms",
+        type=int,
+        default=0,
+        help="Override the current epoch time for deterministic maintenance runs.",
     )
-    parser.add_argument("--once", action="store_true", help="Run one cleanup scan and exit.")
-    parser.add_argument("--max-iterations", type=int, default=None)
-    parser.add_argument("--now-epoch-ms", type=int, default=0)
     parser.add_argument("--fail-fast", action="store_true")
     parser.add_argument("--json", action="store_true", dest="as_json")
     args = parser.parse_args(argv)
 
-    if args.once:
-        summary = cleanup_copy_direct_write_lifecycle_once(
-            args.base_path,
-            min_age_ms=args.min_age_ms,
-            now_epoch_ms=args.now_epoch_ms,
-            fail_fast=args.fail_fast,
-        )
-        print(json.dumps(summary, sort_keys=True) if args.as_json else _format_summary(summary))
-        return 1 if summary["errors"] else 0
-
-    stop_event = threading.Event()
-    _install_signal_handlers(stop_event)
-
-    loop_result = run_copy_direct_write_lifecycle_cleanup_loop(
+    summary = cleanup_copy_direct_write_lifecycle_once(
         args.base_path,
         min_age_ms=args.min_age_ms,
-        interval_seconds=args.interval_seconds,
-        stop_event=stop_event,
-        max_iterations=args.max_iterations,
+        now_epoch_ms=args.now_epoch_ms,
         fail_fast=args.fail_fast,
-        now_epoch_ms_fn=(lambda: args.now_epoch_ms) if args.now_epoch_ms else None,
-        on_iteration=lambda summary: print(
-            json.dumps(summary, sort_keys=True) if args.as_json else _format_summary(summary),
-            flush=True,
-        ),
     )
-    last_summary = loop_result.get("last_summary") or {}
-    return 1 if last_summary.get("errors") else 0
+    print(json.dumps(summary, sort_keys=True) if args.as_json else _format_summary(summary))
+    return 1 if summary["errors"] else 0
 
 
 if __name__ == "__main__":

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -40,6 +40,8 @@
 #include <duckdb/common/types/uuid.hpp>
 #include <duckdb/optimizer/optimizer.hpp>
 
+#include <exception>
+#include <optional>
 #include <set>
 
 static inline int DuckdbGetEnvIntMs(const char *name) {
@@ -183,12 +185,31 @@ static string QueryConnectionSettingForTest(DuckDBPyConnection &connection, cons
 	throw std::runtime_error("connection setting query returned no rows: " + name);
 }
 
-static py::dict WithCopyRecoveryContext(py::object conn_obj,
-                                        const std::function<py::dict(duckdb::ClientContext &)> &callback) {
+template <typename CALLBACK>
+static auto WithCopyRecoveryContext(py::object conn_obj, CALLBACK callback) {
 	auto run_callback = [&](duckdb::ClientContext &context) {
-		py::dict result;
-		context.RunFunctionInTransaction([&]() { result = callback(context); });
-		return result;
+		using Result = decltype(callback(context));
+		std::optional<Result> result;
+		std::exception_ptr callback_error;
+		{
+			py::gil_scoped_release release;
+			context.RunFunctionInTransaction(
+			    [&]() {
+				    // Match normal query startup after a failed query leaves a stale interrupt flag behind.
+				    context.ClearInterrupt();
+				    try {
+					    result.emplace(callback(context));
+				    } catch (...) {
+					    callback_error = std::current_exception();
+				    }
+			    },
+			    false);
+		}
+		if (callback_error) {
+			std::rethrow_exception(callback_error);
+		}
+		D_ASSERT(result.has_value());
+		return std::move(result.value());
 	};
 	if (!conn_obj.is_none()) {
 		auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
@@ -1488,30 +1509,30 @@ void register_ray_bindings(py::module_ &mod) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+		    auto read_res = WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
 			    auto &fs = FileSystem::GetFileSystem(context);
-			    auto read_res = ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, run_id);
-			    if (read_res.is_err()) {
-				    throw py::value_error(read_res.error().what());
-			    }
-			    auto result = std::move(read_res).value();
-
-			    py::dict out;
-			    out["rows_copied"] = result.rows_copied;
-			    py::list files;
-			    for (const auto &info : result.files) {
-				    py::dict entry;
-				    entry["staging_path"] = info.staging_path;
-				    entry["worker_output_path"] = info.staging_path;
-				    entry["final_path"] = info.final_path;
-				    entry["row_count"] = info.row_count;
-				    entry["file_size_bytes"] = info.file_size_bytes;
-				    files.append(entry);
-			    }
-			    out["files"] = files;
-			    AppendDistributedCopyResultMetadata(out, result);
-			    return out;
+			    return ReadCommittedDistributedCopyDirectWriteResult(fs, base_path, run_id);
 		    });
+		    if (read_res.is_err()) {
+			    throw py::value_error(read_res.error().what());
+		    }
+		    auto result = std::move(read_res).value();
+
+		    py::dict out;
+		    out["rows_copied"] = result.rows_copied;
+		    py::list files;
+		    for (const auto &info : result.files) {
+			    py::dict entry;
+			    entry["staging_path"] = info.staging_path;
+			    entry["worker_output_path"] = info.staging_path;
+			    entry["final_path"] = info.final_path;
+			    entry["row_count"] = info.row_count;
+			    entry["file_size_bytes"] = info.file_size_bytes;
+			    files.append(entry);
+		    }
+		    out["files"] = files;
+		    AppendDistributedCopyResultMetadata(out, result);
+		    return out;
 	    },
 	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
 	    "Read a committed direct-write distributed COPY result through its committed manifest.");
@@ -1549,51 +1570,51 @@ void register_ray_bindings(py::module_ &mod) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+		    auto inspection_res = WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
 			    auto &fs = FileSystem::GetFileSystem(context);
-			    auto inspection_res = InspectDistributedCopyDirectWriteRun(fs, base_path, run_id);
-			    if (inspection_res.is_err()) {
-				    throw py::value_error(inspection_res.error().what());
-			    }
-			    auto inspection = std::move(inspection_res).value();
-			    py::dict out;
-			    switch (inspection.state) {
-			    case DistributedCopyDirectWriteRunState::COMMITTED:
-				    out["state"] = "COMMITTED";
-				    break;
-			    case DistributedCopyDirectWriteRunState::UNCOMMITTED:
-				    out["state"] = "UNCOMMITTED";
-				    break;
-			    case DistributedCopyDirectWriteRunState::UNKNOWN:
-				    out["state"] = "UNKNOWN";
-				    break;
-			    }
-			    out["safe_to_retry"] = false;
-			    out["error"] = inspection.error;
-			    out["copy_output_base_path"] = inspection.base_path;
-			    out["copy_output_run_id"] = inspection.run_id;
-			    out["copy_output_commit_dir"] = inspection.paths.commit_dir;
-			    out["copy_output_manifest_path"] = inspection.paths.manifest_path;
-			    out["copy_output_committed_marker_path"] = inspection.paths.committed_marker_path;
-			    out["copy_output_lifecycle_path"] = inspection.paths.lifecycle_path;
-			    py::list files;
-			    if (inspection.state == DistributedCopyDirectWriteRunState::COMMITTED) {
-				    out["rows_copied"] = inspection.committed_result.rows_copied;
-				    for (const auto &info : inspection.committed_result.files) {
-					    py::dict entry;
-					    entry["staging_path"] = info.staging_path;
-					    entry["worker_output_path"] = info.staging_path;
-					    entry["final_path"] = info.final_path;
-					    entry["row_count"] = info.row_count;
-					    entry["file_size_bytes"] = info.file_size_bytes;
-					    files.append(entry);
-				    }
-			    } else {
-				    out["rows_copied"] = py::none();
-			    }
-			    out["files"] = files;
-			    return out;
+			    return InspectDistributedCopyDirectWriteRun(fs, base_path, run_id);
 		    });
+		    if (inspection_res.is_err()) {
+			    throw py::value_error(inspection_res.error().what());
+		    }
+		    auto inspection = std::move(inspection_res).value();
+		    py::dict out;
+		    switch (inspection.state) {
+		    case DistributedCopyDirectWriteRunState::COMMITTED:
+			    out["state"] = "COMMITTED";
+			    break;
+		    case DistributedCopyDirectWriteRunState::UNCOMMITTED:
+			    out["state"] = "UNCOMMITTED";
+			    break;
+		    case DistributedCopyDirectWriteRunState::UNKNOWN:
+			    out["state"] = "UNKNOWN";
+			    break;
+		    }
+		    out["safe_to_retry"] = false;
+		    out["error"] = inspection.error;
+		    out["copy_output_base_path"] = inspection.base_path;
+		    out["copy_output_run_id"] = inspection.run_id;
+		    out["copy_output_commit_dir"] = inspection.paths.commit_dir;
+		    out["copy_output_manifest_path"] = inspection.paths.manifest_path;
+		    out["copy_output_committed_marker_path"] = inspection.paths.committed_marker_path;
+		    out["copy_output_lifecycle_path"] = inspection.paths.lifecycle_path;
+		    py::list files;
+		    if (inspection.state == DistributedCopyDirectWriteRunState::COMMITTED) {
+			    out["rows_copied"] = inspection.committed_result.rows_copied;
+			    for (const auto &info : inspection.committed_result.files) {
+				    py::dict entry;
+				    entry["staging_path"] = info.staging_path;
+				    entry["worker_output_path"] = info.staging_path;
+				    entry["final_path"] = info.final_path;
+				    entry["row_count"] = info.row_count;
+				    entry["file_size_bytes"] = info.file_size_bytes;
+				    files.append(entry);
+			    }
+		    } else {
+			    out["rows_copied"] = py::none();
+		    }
+		    out["files"] = files;
+		    return out;
 	    },
 	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
 	    "Inspect a direct-write COPY run without making an uncommitted run safe to retry.");
@@ -1604,24 +1625,24 @@ void register_ray_bindings(py::module_ &mod) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+		    auto abort_res = WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
 			    auto &fs = FileSystem::GetFileSystem(context);
-			    auto abort_res = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
-			    if (abort_res.is_err()) {
-				    throw py::value_error(abort_res.error().what());
-			    }
-			    auto cleanup = std::move(abort_res).value();
-			    py::dict out;
-			    out["state"] = "ABORTED";
-			    out["safe_to_retry"] = true;
-			    out["copy_output_base_path"] = base_path;
-			    out["copy_output_run_id"] = run_id;
-			    out["data_run_dir_existed"] = cleanup.data_run_dir_existed;
-			    out["data_run_dir_removed"] = cleanup.data_run_dir_removed;
-			    out["commit_dir_existed"] = cleanup.commit_dir_existed;
-			    out["commit_dir_removed"] = cleanup.commit_dir_removed;
-			    return out;
+			    return ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
 		    });
+		    if (abort_res.is_err()) {
+			    throw py::value_error(abort_res.error().what());
+		    }
+		    auto cleanup = std::move(abort_res).value();
+		    py::dict out;
+		    out["state"] = "ABORTED";
+		    out["safe_to_retry"] = true;
+		    out["copy_output_base_path"] = base_path;
+		    out["copy_output_run_id"] = run_id;
+		    out["data_run_dir_existed"] = cleanup.data_run_dir_existed;
+		    out["data_run_dir_removed"] = cleanup.data_run_dir_removed;
+		    out["commit_dir_existed"] = cleanup.commit_dir_existed;
+		    out["commit_dir_removed"] = cleanup.commit_dir_removed;
+		    return out;
 	    },
 	    py::arg("base_path"), py::arg("run_id"), py::arg("conn") = py::none(),
 	    "Explicitly discard a shared-storage direct-write COPY run and verify that it is safe to retry.");
@@ -1665,35 +1686,32 @@ void register_ray_bindings(py::module_ &mod) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+		    auto cleanup_res = WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
 			    auto &fs = FileSystem::GetFileSystem(context);
-			    auto cleanup_res = [&]() {
-				    py::gil_scoped_release release;
-				    return CleanupExpiredDistributedCopyDirectWriteRuns(fs, base_path, min_age_ms, now_epoch_ms);
-			    }();
-			    if (cleanup_res.is_err()) {
-				    throw py::value_error(cleanup_res.error().what());
-			    }
-			    auto cleanup = std::move(cleanup_res).value();
-			    py::dict out;
-			    out["scanned_runs"] = cleanup.scanned_runs;
-			    out["cleaned_runs"] = cleanup.cleaned_runs;
-			    out["committed_runs"] = cleanup.committed_runs;
-			    out["active_runs"] = cleanup.active_runs;
-			    out["skipped_unregistered_runs"] = cleanup.skipped_unregistered_runs;
-			    out["errors"] = cleanup.errors;
-			    py::list cleaned_run_ids;
-			    for (const auto &run_id : cleanup.cleaned_run_ids) {
-				    cleaned_run_ids.append(run_id);
-			    }
-			    out["cleaned_run_ids"] = cleaned_run_ids;
-			    py::list error_messages;
-			    for (const auto &message : cleanup.error_messages) {
-				    error_messages.append(message);
-			    }
-			    out["error_messages"] = error_messages;
-			    return out;
+			    return CleanupExpiredDistributedCopyDirectWriteRuns(fs, base_path, min_age_ms, now_epoch_ms);
 		    });
+		    if (cleanup_res.is_err()) {
+			    throw py::value_error(cleanup_res.error().what());
+		    }
+		    auto cleanup = std::move(cleanup_res).value();
+		    py::dict out;
+		    out["scanned_runs"] = cleanup.scanned_runs;
+		    out["cleaned_runs"] = cleanup.cleaned_runs;
+		    out["committed_runs"] = cleanup.committed_runs;
+		    out["active_runs"] = cleanup.active_runs;
+		    out["skipped_unregistered_runs"] = cleanup.skipped_unregistered_runs;
+		    out["errors"] = cleanup.errors;
+		    py::list cleaned_run_ids;
+		    for (const auto &run_id : cleanup.cleaned_run_ids) {
+			    cleaned_run_ids.append(run_id);
+		    }
+		    out["cleaned_run_ids"] = cleaned_run_ids;
+		    py::list error_messages;
+		    for (const auto &message : cleanup.error_messages) {
+			    error_messages.append(message);
+		    }
+		    out["error_messages"] = error_messages;
+		    return out;
 	    },
 	    py::arg("base_path"), py::arg("min_age_ms"), py::arg("now_epoch_ms") = 0, py::arg("conn") = py::none(),
 	    "TTL cleanup scan for uncommitted direct-write distributed COPY runs.");

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -185,13 +185,18 @@ static string QueryConnectionSettingForTest(DuckDBPyConnection &connection, cons
 
 static py::dict WithCopyRecoveryContext(py::object conn_obj,
                                         const std::function<py::dict(duckdb::ClientContext &)> &callback) {
+	auto run_callback = [&](duckdb::ClientContext &context) {
+		py::dict result;
+		context.RunFunctionInTransaction([&]() { result = callback(context); });
+		return result;
+	};
 	if (!conn_obj.is_none()) {
 		auto &conn_wrapper = ExtractPyConnectionWrapper(std::move(conn_obj));
-		return callback(*conn_wrapper.con.GetConnection().context);
+		return run_callback(*conn_wrapper.con.GetConnection().context);
 	}
 	duckdb::DuckDB db(nullptr);
 	duckdb::Connection conn(db);
-	return callback(*conn.context);
+	return run_callback(*conn.context);
 }
 
 void register_ray_bindings(py::module_ &mod) {
@@ -1656,40 +1661,41 @@ void register_ray_bindings(py::module_ &mod) {
 
 	m.def(
 	    "cleanup_expired_copy_direct_write_runs",
-	    [](const std::string &base_path, idx_t min_age_ms, idx_t now_epoch_ms) {
+	    [](const std::string &base_path, idx_t min_age_ms, idx_t now_epoch_ms, py::object conn_obj) {
 		    using namespace duckdb;
 		    using namespace duckdb::distributed;
 
-		    DuckDB db(nullptr);
-		    Connection conn(db);
-		    auto &context = *conn.context;
-		    auto &fs = FileSystem::GetFileSystem(context);
-
-		    auto cleanup_res = CleanupExpiredDistributedCopyDirectWriteRuns(fs, base_path, min_age_ms, now_epoch_ms);
-		    if (cleanup_res.is_err()) {
-			    throw py::value_error(cleanup_res.error().what());
-		    }
-		    auto cleanup = std::move(cleanup_res).value();
-		    py::dict out;
-		    out["scanned_runs"] = cleanup.scanned_runs;
-		    out["cleaned_runs"] = cleanup.cleaned_runs;
-		    out["committed_runs"] = cleanup.committed_runs;
-		    out["active_runs"] = cleanup.active_runs;
-		    out["skipped_unregistered_runs"] = cleanup.skipped_unregistered_runs;
-		    out["errors"] = cleanup.errors;
-		    py::list cleaned_run_ids;
-		    for (const auto &run_id : cleanup.cleaned_run_ids) {
-			    cleaned_run_ids.append(run_id);
-		    }
-		    out["cleaned_run_ids"] = cleaned_run_ids;
-		    py::list error_messages;
-		    for (const auto &message : cleanup.error_messages) {
-			    error_messages.append(message);
-		    }
-		    out["error_messages"] = error_messages;
-		    return out;
+		    return WithCopyRecoveryContext(std::move(conn_obj), [&](ClientContext &context) {
+			    auto &fs = FileSystem::GetFileSystem(context);
+			    auto cleanup_res = [&]() {
+				    py::gil_scoped_release release;
+				    return CleanupExpiredDistributedCopyDirectWriteRuns(fs, base_path, min_age_ms, now_epoch_ms);
+			    }();
+			    if (cleanup_res.is_err()) {
+				    throw py::value_error(cleanup_res.error().what());
+			    }
+			    auto cleanup = std::move(cleanup_res).value();
+			    py::dict out;
+			    out["scanned_runs"] = cleanup.scanned_runs;
+			    out["cleaned_runs"] = cleanup.cleaned_runs;
+			    out["committed_runs"] = cleanup.committed_runs;
+			    out["active_runs"] = cleanup.active_runs;
+			    out["skipped_unregistered_runs"] = cleanup.skipped_unregistered_runs;
+			    out["errors"] = cleanup.errors;
+			    py::list cleaned_run_ids;
+			    for (const auto &run_id : cleanup.cleaned_run_ids) {
+				    cleaned_run_ids.append(run_id);
+			    }
+			    out["cleaned_run_ids"] = cleaned_run_ids;
+			    py::list error_messages;
+			    for (const auto &message : cleanup.error_messages) {
+				    error_messages.append(message);
+			    }
+			    out["error_messages"] = error_messages;
+			    return out;
+		    });
 	    },
-	    py::arg("base_path"), py::arg("min_age_ms"), py::arg("now_epoch_ms") = 0,
+	    py::arg("base_path"), py::arg("min_age_ms"), py::arg("now_epoch_ms") = 0, py::arg("conn") = py::none(),
 	    "TTL cleanup scan for uncommitted direct-write distributed COPY runs.");
 
 	m.def(

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2220,32 +2220,35 @@ def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_filesystem():
     filesystem.pseudo_dirs = [""]
 
     conn = duckdb.connect()
-    conn.register_filesystem(filesystem)
-    base_path = "memory://bucket/copy_direct_lifecycle_once"
-    run_id = "run-connection-filesystem"
-    run_dir = f"{base_path}/_vane_direct_write_{run_id}"
-    lifecycle_path = f"{base_path}.duckdb_commit/{run_id}/lifecycle.txt"
-    data_path = f"{run_dir}/w_failed/part.parquet"
-    lifecycle = textwrap.dedent(
-        f"""\
-        version=2
-        mode=direct_write
-        base_path={base_path}
-        worker_base_path={base_path}
-        run_id={run_id}
-        created_epoch_ms=1000
-        direct_write_run_dir={run_dir}
-        """
-    ).encode()
-    filesystem.pipe(lifecycle_path, lifecycle)
-    filesystem.pipe(data_path, b"stale")
+    try:
+        conn.register_filesystem(filesystem)
+        base_path = "memory://bucket/copy_direct_lifecycle_once"
+        run_id = "run-connection-filesystem"
+        run_dir = f"{base_path}/_vane_direct_write_{run_id}"
+        lifecycle_path = f"{base_path}.duckdb_commit/{run_id}/lifecycle.txt"
+        data_path = f"{run_dir}/w_failed/part.parquet"
+        lifecycle = textwrap.dedent(
+            f"""\
+            version=2
+            mode=direct_write
+            base_path={base_path}
+            worker_base_path={base_path}
+            run_id={run_id}
+            created_epoch_ms=1000
+            direct_write_run_dir={run_dir}
+            """
+        ).encode()
+        filesystem.pipe(lifecycle_path, lifecycle)
+        filesystem.pipe(data_path, b"stale")
 
-    summary = cleanup_copy_direct_write_lifecycle_once(
-        base_path,
-        min_age_ms=5_000,
-        now_epoch_ms=10_000,
-        conn=conn,
-    )
+        summary = cleanup_copy_direct_write_lifecycle_once(
+            base_path,
+            min_age_ms=5_000,
+            now_epoch_ms=10_000,
+            conn=conn,
+        )
+    finally:
+        conn.close()
 
     assert summary["scanned_runs"] == 1
     assert summary["cleaned_runs"] == 1
@@ -2255,13 +2258,143 @@ def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_filesystem():
     assert not filesystem.exists(data_path)
 
 
-def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_s3_config():
+def test_copy_direct_write_lifecycle_cleanup_releases_gil_before_connection_lock():
+    pytest.importorskip("fsspec", minversion="2022.11.0")
+    script = textwrap.dedent(
+        """
+        import threading
+        import time
+
+        import duckdb
+        import fsspec
+        from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
+
+        filesystem = fsspec.filesystem("memory", skip_instance_cache=True)
+        filesystem.store = {}
+        filesystem.pseudo_dirs = [""]
+        original_ls = filesystem.ls
+        entered_first_scan = threading.Event()
+        delayed = False
+
+        def delayed_ls(path, *args, **kwargs):
+            global delayed
+            if not delayed:
+                delayed = True
+                entered_first_scan.set()
+                time.sleep(1)
+            return original_ls(path, *args, **kwargs)
+
+        filesystem.ls = delayed_ls
+        conn = duckdb.connect()
+        conn.register_filesystem(filesystem)
+        errors = []
+
+        def first_scan():
+            try:
+                cleanup_copy_direct_write_lifecycle_once(
+                    "memory://bucket/copy",
+                    min_age_ms=1,
+                    conn=conn,
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=first_scan)
+        thread.start()
+        assert entered_first_scan.wait(timeout=2)
+        cleanup_copy_direct_write_lifecycle_once(
+            "memory://bucket/copy",
+            min_age_ms=1,
+            conn=conn,
+        )
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert not errors
+        conn.close()
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.getcwd(),
+        check=True,
+        timeout=15,
+    )
+
+
+def test_copy_direct_write_lifecycle_cleanup_error_does_not_abort_caller_transaction(monkeypatch):
+    from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
+
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+    filesystem = fsspec.filesystem("memory", skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
+
+    def fail_list(*_args, **_kwargs):
+        raise OSError("intentional lifecycle cleanup failure")
+
+    monkeypatch.setattr(filesystem, "ls", fail_list)
+    conn = duckdb.connect()
+    try:
+        conn.register_filesystem(filesystem)
+        conn.execute("BEGIN")
+        summary = cleanup_copy_direct_write_lifecycle_once(
+            "memory://bucket/copy",
+            min_age_ms=1,
+            conn=conn,
+        )
+
+        assert summary["errors"] == 1
+        assert "intentional lifecycle cleanup failure" in summary["error_messages"][0]
+        assert conn.execute("SELECT 42").fetchone() == (42,)
+        conn.execute("ROLLBACK")
+    finally:
+        conn.close()
+
+
+def test_copy_direct_write_lifecycle_cleanup_runs_in_invalidated_transaction(tmp_path):
+    from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
+
+    base = tmp_path / "copy_direct_lifecycle_invalidated_transaction"
+    run_id = "run-invalidated-transaction"
+    stale, stale_file = _register_direct_write_lifecycle_run(
+        base,
+        run_id,
+        created_epoch_ms=1,
+        worker_dir="w_failed",
+    )
+
+    conn = duckdb.connect()
+    try:
+        conn.execute("BEGIN")
+        with pytest.raises(duckdb.ConversionException):
+            conn.execute("SELECT CAST('invalid' AS INTEGER)")
+
+        summary = cleanup_copy_direct_write_lifecycle_once(
+            str(base),
+            min_age_ms=1,
+            now_epoch_ms=10,
+            conn=conn,
+        )
+
+        assert summary["errors"] == 0
+        assert summary["cleaned_runs"] == 1
+        assert not stale_file.exists()
+        assert not Path(stale["copy_output_commit_dir"]).exists()
+        conn.execute("ROLLBACK")
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("invalidate_transaction", [False, True], ids=["valid", "invalidated"])
+def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_s3_config(invalidate_transaction):
     from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
 
     server, thread, handler = _start_s3_list_ok_server()
     try:
         endpoint = f"127.0.0.1:{server.server_address[1]}"
         conn = duckdb.connect()
+        transaction_started = False
         try:
             conn.execute("LOAD httpfs")
             conn.execute(
@@ -2269,6 +2402,11 @@ def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_s3_config():
                 "TYPE S3, KEY_ID 'access-key', SECRET 'secret-key', REGION 'us-east-1', "
                 f"ENDPOINT {_sql_string_literal(endpoint)}, URL_STYLE 'path', USE_SSL false)"
             )
+            if invalidate_transaction:
+                conn.execute("BEGIN")
+                transaction_started = True
+                with pytest.raises(duckdb.ConversionException):
+                    conn.execute("SELECT CAST('invalid' AS INTEGER)")
             summary = cleanup_copy_direct_write_lifecycle_once(
                 "s3://bucket/prefix",
                 min_age_ms=5_000,
@@ -2276,6 +2414,8 @@ def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_s3_config():
                 conn=conn,
             )
         finally:
+            if transaction_started:
+                conn.execute("ROLLBACK")
             conn.close()
     finally:
         server.shutdown()

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2211,35 +2211,82 @@ def test_copy_direct_write_lifecycle_cleanup_once_public_api(tmp_path):
     assert Path(active["copy_output_lifecycle_path"]).exists()
 
 
-def test_copy_direct_write_lifecycle_cleanup_loop_public_api(tmp_path):
-    from duckdb.runners.ray import run_copy_direct_write_lifecycle_cleanup_loop
+def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_filesystem():
+    from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
 
-    base = tmp_path / "copy_direct_lifecycle_loop"
-    stale_run_id = "run-lifecycle-loop-stale"
-    stale, stale_file = _register_direct_write_lifecycle_run(
-        base,
-        stale_run_id,
-        created_epoch_ms=1_000,
-        worker_dir="w_failed",
-    )
-    seen = []
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+    filesystem = fsspec.filesystem("memory", skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
 
-    result = run_copy_direct_write_lifecycle_cleanup_loop(
-        str(base),
+    conn = duckdb.connect()
+    conn.register_filesystem(filesystem)
+    base_path = "memory://bucket/copy_direct_lifecycle_once"
+    run_id = "run-connection-filesystem"
+    run_dir = f"{base_path}/_vane_direct_write_{run_id}"
+    lifecycle_path = f"{base_path}.duckdb_commit/{run_id}/lifecycle.txt"
+    data_path = f"{run_dir}/w_failed/part.parquet"
+    lifecycle = textwrap.dedent(
+        f"""\
+        version=2
+        mode=direct_write
+        base_path={base_path}
+        worker_base_path={base_path}
+        run_id={run_id}
+        created_epoch_ms=1000
+        direct_write_run_dir={run_dir}
+        """
+    ).encode()
+    filesystem.pipe(lifecycle_path, lifecycle)
+    filesystem.pipe(data_path, b"stale")
+
+    summary = cleanup_copy_direct_write_lifecycle_once(
+        base_path,
         min_age_ms=5_000,
-        interval_seconds=0,
-        max_iterations=2,
-        now_epoch_ms_fn=lambda: 10_000,
-        on_iteration=seen.append,
+        now_epoch_ms=10_000,
+        conn=conn,
     )
 
-    assert result["iterations"] == 2
-    assert seen[0]["cleaned_runs"] == 1
-    assert result["summaries"][0]["cleaned_run_ids"] == [{"base_path": str(base), "run_id": stale_run_id}]
-    assert result["summaries"][1]["cleaned_runs"] == 0
-    assert result["last_summary"]["errors"] == 0
-    assert not stale_file.exists()
-    assert not Path(stale["copy_output_commit_dir"]).exists()
+    assert summary["scanned_runs"] == 1
+    assert summary["cleaned_runs"] == 1
+    assert summary["errors"] == 0
+    assert summary["cleaned_run_ids"] == [{"base_path": base_path, "run_id": run_id}]
+    assert not filesystem.exists(lifecycle_path)
+    assert not filesystem.exists(data_path)
+
+
+def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_s3_config():
+    from duckdb.runners.ray import cleanup_copy_direct_write_lifecycle_once
+
+    server, thread, handler = _start_s3_list_ok_server()
+    try:
+        endpoint = f"127.0.0.1:{server.server_address[1]}"
+        conn = duckdb.connect()
+        try:
+            conn.execute("LOAD httpfs")
+            conn.execute(
+                "CREATE TEMPORARY SECRET lifecycle_cleanup_s3 ("
+                "TYPE S3, KEY_ID 'access-key', SECRET 'secret-key', REGION 'us-east-1', "
+                f"ENDPOINT {_sql_string_literal(endpoint)}, URL_STYLE 'path', USE_SSL false)"
+            )
+            summary = cleanup_copy_direct_write_lifecycle_once(
+                "s3://bucket/prefix",
+                min_age_ms=5_000,
+                fail_fast=True,
+                conn=conn,
+            )
+        finally:
+            conn.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert summary["scanned_runs"] == 0
+    assert summary["cleaned_runs"] == 0
+    assert summary["errors"] == 0
+    assert handler.requests
+    assert all("list-type=2" in path and "prefix=prefix.duckdb_commit" in path for _, path in handler.requests)
 
 
 def test_copy_direct_write_lifecycle_cleanup_cli_once(tmp_path):
@@ -2263,13 +2310,13 @@ def test_copy_direct_write_lifecycle_cleanup_cli_once(tmp_path):
             "5000",
             "--now-epoch-ms",
             "10000",
-            "--once",
             "--json",
         ],
         cwd=os.getcwd(),
         capture_output=True,
         text=True,
         env=os.environ.copy(),
+        timeout=10,
     )
 
     assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
## Summary

- remove the periodic direct-write lifecycle cleanup loop and its interval/iteration CLI controls; the maintenance CLI now always performs one scan
- let the one-shot Python and native cleanup APIs reuse a caller-provided DuckDB connection so local files, registered filesystems, and S3 share one cleanup path
- run copy-recovery filesystem work inside the connection transaction needed by temporary S3 secrets, and release the Python GIL during the potentially slow native scan
- cover local cleanup, a connection-registered `memory://` filesystem, and a temporary S3 secret routed through a local S3-compatible endpoint

Fixes #375

## Validation

- non-editable incremental Release build: `uv pip install . --no-build-isolation`
- `python -m pytest tests/fast/test_ray_cpp_bindings.py -q`: 115 passed, 4 deselected
- `python -m pytest tests/fast/test_ray_result_contract.py -q`: 223 passed
- `scripts/run_release_tests.sh`: 472 passed, 1 skipped, 14 deselected; real-Ray shard 10 passed, 477 deselected
- `pre-commit run --from-ref upstream/main --to-ref HEAD`: passed
