### PR TITLE
[fix](distributed) Preserve nested-loop join output schemas

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
@@ -6,8 +6,10 @@
 #include <algorithm>
 #include <functional>
 
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
@@ -384,15 +386,16 @@ SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<Work
 		const auto &right_types = right_root.GetTypes();
 		FixHashJoinConditionTypes(nlj.conditions, left_types, right_types);
 
-		// Recompute output types: [all LHS cols, all RHS cols] for INNER join
-		duckdb::vector<LogicalType> nlj_types;
-		for (auto &t : left_types) {
-			nlj_types.push_back(t);
+		// The translated output types are the schema contract for this node. Validate
+		// that contract against the attached children, but do not replace it: doing so
+		// would make the physical plan disagree with HashJoinNode::config().schema().
+		auto child_derived_types = BuildJoinOutputTypes(join_type_, left_types, right_types);
+		if (nlj.GetTypes() != child_derived_types) {
+			throw InternalException(
+			    "HashJoinNode translated a %s nested loop join with an output schema that does not match its children "
+			    "(%llu translated columns, %llu child-derived columns)",
+			    EnumUtil::ToString(join_type_), nlj.GetTypes().size(), child_derived_types.size());
 		}
-		for (auto &t : right_types) {
-			nlj_types.push_back(t);
-		}
-		nlj.types = nlj_types;
 
 		left_plan->SetRoot(nlj);
 	} else {

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/delim_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/utils/optional.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
@@ -42,13 +43,15 @@ duckdb::vector<std::string> BuildJoinOutputNames(const PhysicalHashJoin &hj, con
 		}
 	};
 
-	if (!hj.lhs_output_columns.col_idxs.empty()) {
-		append_by_index(left_names, hj.lhs_output_columns.col_idxs);
-	} else if (!left_names.empty()) {
-		output_names.insert(output_names.end(), left_names.begin(), left_names.end());
+	if (JoinOutputsLeft(hj.join_type)) {
+		if (!hj.lhs_output_columns.col_idxs.empty()) {
+			append_by_index(left_names, hj.lhs_output_columns.col_idxs);
+		} else if (!left_names.empty()) {
+			output_names.insert(output_names.end(), left_names.begin(), left_names.end());
+		}
 	}
 
-	if (hj.join_type != JoinType::ANTI && hj.join_type != JoinType::SEMI && hj.join_type != JoinType::MARK) {
+	if (JoinOutputsRight(hj.join_type)) {
 		if (!hj.payload_columns.col_idxs.empty()) {
 			append_by_index(right_names, hj.payload_columns.col_idxs);
 		} else if (!right_names.empty()) {
@@ -403,7 +406,7 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	PhysicalHashJoin::JoinProjectionColumns payload_columns;
 	PhysicalHashJoin::JoinProjectionColumns rhs_output_columns;
 
-	if (nlj.join_type != JoinType::ANTI && nlj.join_type != JoinType::SEMI && nlj.join_type != JoinType::MARK) {
+	if (JoinOutputsRight(nlj.join_type)) {
 		for (idx_t rhs_col = 0; rhs_col < rhs_input_types.size(); rhs_col++) {
 			auto &rhs_col_type = rhs_input_types[rhs_col];
 			auto it = build_columns_in_conditions.find(rhs_col);

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "duckdb/common/vector.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -91,7 +92,7 @@ inline void FixHashJoinOutputColumnTypes(PhysicalHashJoin &join, const duckdb::v
                                          const duckdb::vector<LogicalType> &right_types) {
 	EnsureHashJoinProjectionColumns(join.lhs_output_columns, left_types);
 
-	if (join.join_type == JoinType::ANTI || join.join_type == JoinType::SEMI || join.join_type == JoinType::MARK) {
+	if (!JoinOutputsRight(join.join_type)) {
 		return;
 	}
 
@@ -125,23 +126,8 @@ inline void RepairHashJoinMetadataAfterChildAttach(PhysicalHashJoin &join,
 	FixHashJoinConditionTypes(join.conditions, left_types, right_types, join.condition_types);
 	FixHashJoinOutputColumnTypes(join, left_types, right_types);
 
-	duckdb::vector<LogicalType> join_types;
-	join_types.reserve(join.lhs_output_columns.col_idxs.size() + join.rhs_output_columns.col_idxs.size() + 1);
-	if (join.join_type != JoinType::RIGHT_SEMI && join.join_type != JoinType::RIGHT_ANTI) {
-		for (auto idx : join.lhs_output_columns.col_idxs) {
-			if (idx < left_types.size()) {
-				join_types.push_back(left_types[idx]);
-			}
-		}
-	}
-	if (join.join_type != JoinType::ANTI && join.join_type != JoinType::SEMI && join.join_type != JoinType::MARK) {
-		for (auto &col_type : join.rhs_output_columns.col_types) {
-			join_types.push_back(col_type);
-		}
-	}
-	if (join.join_type == JoinType::MARK) {
-		join_types.push_back(LogicalType::BOOLEAN);
-	}
+	auto join_types =
+	    BuildJoinOutputTypes(join.join_type, join.lhs_output_columns.col_types, join.rhs_output_columns.col_types);
 	if (!join_types.empty()) {
 		join.types = std::move(join_types);
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/common/enums/join_type.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+inline bool JoinOutputsLeft(JoinType join_type) {
+	return join_type != JoinType::RIGHT_SEMI && join_type != JoinType::RIGHT_ANTI;
+}
+
+inline bool JoinOutputsRight(JoinType join_type) {
+	return join_type != JoinType::ANTI && join_type != JoinType::SEMI && join_type != JoinType::MARK;
+}
+
+// The side inputs must already contain the projection-resolved output columns.
+// This helper applies only the join-type shape: left, right, or left plus MARK.
+inline duckdb::vector<LogicalType> BuildJoinOutputTypes(JoinType join_type,
+                                                        const duckdb::vector<LogicalType> &left_output_types,
+                                                        const duckdb::vector<LogicalType> &right_output_types) {
+	duckdb::vector<LogicalType> result;
+	result.reserve((JoinOutputsLeft(join_type) ? left_output_types.size() : 0) +
+	               (JoinOutputsRight(join_type) ? right_output_types.size() : 0) +
+	               (join_type == JoinType::MARK ? 1 : 0));
+	if (JoinOutputsLeft(join_type)) {
+		result.insert(result.end(), left_output_types.begin(), left_output_types.end());
+	}
+	if (JoinOutputsRight(join_type)) {
+		result.insert(result.end(), right_output_types.begin(), right_output_types.end());
+	}
+	if (join_type == JoinType::MARK) {
+		result.push_back(LogicalType::BOOLEAN);
+	}
+	return result;
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -13,6 +13,7 @@
 
 #include "catch.hpp"
 
+#include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
@@ -25,6 +26,7 @@
 #include "duckdb/execution/distributed/scheduling/task.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/execution/distributed/pipeline_node/translator.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
@@ -72,6 +74,27 @@ static DuckPhysicalPlanRef MakeScanPlanWithRoot() {
 	    plan->Make<PhysicalColumnDataScan>(types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0, std::move(collection));
 	plan->SetRoot(scan);
 	return plan;
+}
+
+static vector<JoinCondition> MakeNonEqualityJoinConditions() {
+	vector<JoinCondition> conditions;
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	condition.comparison = ExpressionType::COMPARE_GREATERTHAN;
+	conditions.push_back(std::move(condition));
+	return conditions;
+}
+
+static PhysicalHashJoin::JoinProjectionColumns MakeProjectionColumns(const vector<LogicalType> &types) {
+	PhysicalHashJoin::JoinProjectionColumns result;
+	result.col_idxs.reserve(types.size());
+	result.col_types.reserve(types.size());
+	for (idx_t index = 0; index < types.size(); index++) {
+		result.col_idxs.push_back(index);
+		result.col_types.push_back(types[index]);
+	}
+	return result;
 }
 
 static WorkerTask MakeWorkerTaskWithInput(NodeID node_id, const std::string &node_name, SourceNodeId source_node_id,
@@ -445,6 +468,79 @@ TEST_CASE("HashJoinNode: replacement task preserves both side inputs", "[distrib
 	    ClonePhysicalPlanOrThrow(joined_task.task()->plan(), "hash_join_owned_children_test", nullptr);
 	REQUIRE(joined_plan_clone->HasRoot());
 	REQUIRE(joined_plan_clone->Root().children.size() == 2);
+}
+
+TEST_CASE("Join output types follow join semantics", "[distributed][join]") {
+	const vector<LogicalType> left_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+	const vector<LogicalType> right_types = {LogicalType::BIGINT, LogicalType::DOUBLE};
+	const vector<LogicalType> both_types = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BIGINT,
+	                                        LogicalType::DOUBLE};
+	const vector<LogicalType> mark_types = {LogicalType::INTEGER, LogicalType::VARCHAR, LogicalType::BOOLEAN};
+
+	for (auto join_type : {JoinType::INNER, JoinType::LEFT, JoinType::RIGHT, JoinType::OUTER, JoinType::SINGLE}) {
+		CAPTURE(static_cast<int>(join_type));
+		REQUIRE(BuildJoinOutputTypes(join_type, left_types, right_types) == both_types);
+	}
+	for (auto join_type : {JoinType::SEMI, JoinType::ANTI}) {
+		CAPTURE(static_cast<int>(join_type));
+		REQUIRE(BuildJoinOutputTypes(join_type, left_types, right_types) == left_types);
+	}
+	REQUIRE(BuildJoinOutputTypes(JoinType::MARK, left_types, right_types) == mark_types);
+	for (auto join_type : {JoinType::RIGHT_SEMI, JoinType::RIGHT_ANTI}) {
+		CAPTURE(static_cast<int>(join_type));
+		REQUIRE(BuildJoinOutputTypes(join_type, left_types, right_types) == right_types);
+	}
+}
+
+TEST_CASE("HashJoinNode: non-equality simple joins preserve their output schema", "[distributed][source_id][join]") {
+	struct TestCase {
+		JoinType join_type;
+		vector<LogicalType> output_types;
+	};
+	const vector<TestCase> test_cases = {
+	    {JoinType::SEMI, {LogicalType::BIGINT}},
+	    {JoinType::ANTI, {LogicalType::BIGINT}},
+	    {JoinType::MARK, {LogicalType::BIGINT, LogicalType::BOOLEAN}},
+	};
+
+	for (const auto &test_case : test_cases) {
+		CAPTURE(static_cast<int>(test_case.join_type));
+		PlanConfig plan_cfg(1, "join-query", std::make_shared<DuckDBExecutionConfig>());
+		auto schema = MakeSchemaRef(test_case.output_types);
+		auto lhs_output_columns = MakeProjectionColumns({LogicalType::BIGINT});
+		HashJoinNode node(300, plan_cfg, MakeNonEqualityJoinConditions(), test_case.join_type, test_case.output_types,
+		                  {}, {LogicalType::BIGINT}, PhysicalHashJoin::JoinProjectionColumns(),
+		                  std::move(lhs_output_columns), PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1,
+		                  nullptr, nullptr, std::move(schema));
+
+		auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+		auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+		TaskIDCounter task_id_counter;
+		auto joined_task =
+		    node.BuildHashJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+		REQUIRE(joined_task.task()->plan()->Root().type == PhysicalOperatorType::NESTED_LOOP_JOIN);
+		REQUIRE(joined_task.task()->plan()->Root().GetTypes() == test_case.output_types);
+		auto cloned_plan = ClonePhysicalPlanOrThrow(joined_task.task()->plan(), "nlj_output_schema_test", nullptr);
+		REQUIRE(cloned_plan->Root().GetTypes() == test_case.output_types);
+	}
+}
+
+TEST_CASE("HashJoinNode: non-equality joins reject a stale output schema", "[distributed][source_id][join]") {
+	PlanConfig plan_cfg(1, "join-query", std::make_shared<DuckDBExecutionConfig>());
+	vector<LogicalType> stale_output_types = {LogicalType::INTEGER};
+	auto schema = MakeSchemaRef(stale_output_types);
+	auto lhs_output_columns = MakeProjectionColumns({LogicalType::BIGINT});
+	HashJoinNode node(300, plan_cfg, MakeNonEqualityJoinConditions(), JoinType::SEMI, stale_output_types, {},
+	                  {LogicalType::BIGINT}, PhysicalHashJoin::JoinProjectionColumns(), std::move(lhs_output_columns),
+	                  PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr, 1, nullptr, nullptr, std::move(schema));
+
+	auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+	auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+	TaskIDCounter task_id_counter;
+
+	REQUIRE_THROWS_WITH(node.BuildHashJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr),
+	                    Catch::Matchers::Contains("output schema that does not match its children"));
 }
 
 TEST_CASE("HashJoinNode: fan-in preserves child task streams", "[distributed][source_id][join]") {


### PR DESCRIPTION
## Summary

- keep the translated `HashJoinNode` output types as the schema contract when a pure non-equality join is rebuilt as a `PhysicalNestedLoopJoin`
- centralize join output-shape semantics for left-only, right-only, MARK, and two-sided joins, and reuse them in metadata repair and output-name translation
- fail fast when translated NLJ output types disagree with the attached child-derived schema instead of silently replacing the contract
- cover all join-type shapes plus the SEMI, ANTI, and MARK non-equality reconstruction paths

## Root cause

`HashJoinNode::BuildHashJoinTask` copied the correct translated output types into the replacement NLJ, then unconditionally overwrote them with all left and right child types. That shape is valid for ordinary two-sided joins, but corrupts SEMI/ANTI (left only) and MARK (left plus BOOLEAN) output schemas.

## Validation

- `scripts/format duckdb --changed`
- `scripts/run_native_tests.sh "[distributed][join]"` — 15 test cases, 153 assertions passed
- local distributed execution with physical `NESTED_LOOP_JOIN` plans for MARK, SEMI, and ANTI — expected rows and schemas passed
- `scripts/run_release_tests.sh` — 471 passed, 1 skipped; real-Ray shard 10 passed
- full native suite — 4602/4619 passed; all 17 failures were reproduced on the unmodified baseline or came from the same missing loadable demo-extension artifacts in that build configuration
