### PR TITLE
[fix](join) Preserve NULL semantics in partitioned MARK joins

### DIFF
--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -536,6 +536,9 @@ void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attemp
 
 void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id,
                                   int flight_port) {
+	if (instance.mark_join_build_summary.valid && !instance.mark_join_build_summary.IsValid()) {
+		throw InvalidInputException("finished Flight sink has an invalid MARK join build summary");
+	}
 	if (instance.query_id != ctx_.query_id) {
 		throw InvalidInputException("finished Flight sink query does not match its exchange");
 	}
@@ -630,6 +633,13 @@ void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, co
 		}
 		if (!instance.flight_server_epoch.empty()) {
 			attempt_metadata.flight_server_epoch = instance.flight_server_epoch;
+		}
+		if (attempt_metadata.mark_join_build_summary.valid && instance.mark_join_build_summary.valid &&
+		    !(attempt_metadata.mark_join_build_summary == instance.mark_join_build_summary)) {
+			throw InvalidInputException("finished Flight sink MARK join build summary changed for one attempt");
+		}
+		if (instance.mark_join_build_summary.valid) {
+			attempt_metadata.mark_join_build_summary = instance.mark_join_build_summary;
 		}
 
 		auto selected_entry = selected_attempts_.find(handle.task_partition_id);
@@ -768,6 +778,22 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 	if (selected_attempts.empty()) {
 		return handles;
 	}
+	MarkJoinBuildSummary mark_join_build_summary;
+	bool has_attempt_without_mark_summary = false;
+	for (const auto &entry : selected_attempts) {
+		const auto &attempt_summary = entry.second.mark_join_build_summary;
+		if (!attempt_summary.valid) {
+			has_attempt_without_mark_summary = true;
+			continue;
+		}
+		if (!attempt_summary.IsValid()) {
+			throw InvalidInputException("selected Flight sink has an invalid MARK join build summary");
+		}
+		mark_join_build_summary.Merge(attempt_summary);
+	}
+	if (mark_join_build_summary.valid && has_attempt_without_mark_summary) {
+		throw InvalidInputException("selected Flight sink attempts have inconsistent MARK join build summaries");
+	}
 
 	auto build_source_file = [&](const SinkAttemptMetadata &attempt_metadata, idx_t partition_id) {
 		ExchangeSourceFile file;
@@ -802,6 +828,7 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 			handle.source_task_partition_id = source_task_partition_id;
 			handle.attempt_id = attempt_id;
 			handle.node_id = attempt_metadata.node_id;
+			handle.mark_join_build_summary = mark_join_build_summary;
 			if (FlightExchangeUsesNetworkTransport(config_)) {
 				handle.flight_host = attempt_metadata.flight_host;
 				handle.flight_port = attempt_metadata.flight_port;

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -536,7 +536,7 @@ void FlightExchange::SinkFinished(const ExchangeSinkHandle &handle, idx_t attemp
 
 void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, const std::string &node_id,
                                   int flight_port) {
-	if (instance.mark_join_build_summary.valid && !instance.mark_join_build_summary.IsValid()) {
+	if (!instance.mark_join_build_summary.IsConsistent()) {
 		throw InvalidInputException("finished Flight sink has an invalid MARK join build summary");
 	}
 	if (instance.query_id != ctx_.query_id) {
@@ -782,12 +782,12 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 	bool has_attempt_without_mark_summary = false;
 	for (const auto &entry : selected_attempts) {
 		const auto &attempt_summary = entry.second.mark_join_build_summary;
+		if (!attempt_summary.IsConsistent()) {
+			throw InvalidInputException("selected Flight sink has an invalid MARK join build summary");
+		}
 		if (!attempt_summary.valid) {
 			has_attempt_without_mark_summary = true;
 			continue;
-		}
-		if (!attempt_summary.IsValid()) {
-			throw InvalidInputException("selected Flight sink has an invalid MARK join build summary");
 		}
 		mark_join_build_summary.Merge(attempt_summary);
 	}

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/plan/exchange_source_task.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
@@ -38,6 +39,21 @@ void MoveTaskInputsOrThrow(TaskInputs &target, TaskInputs &source) {
 		}
 	}
 	source.clear();
+}
+
+MarkJoinBuildSummary ExtractMarkJoinBuildSummary(const TaskInputs &inputs, optional_idx source_node_id) {
+	if (!source_node_id.IsValid()) {
+		return MarkJoinBuildSummary();
+	}
+	auto entry = inputs.find(static_cast<SourceNodeId>(source_node_id.GetIndex()));
+	if (entry == inputs.end() || entry->second.kind != TaskInput::Kind::ExchangeSourceTask) {
+		throw InvalidInputException("HashJoinNode is missing its MARK build exchange source input");
+	}
+	auto descriptor = ExchangeSourceTaskDescriptor::DeserializeFromBytes(entry->second.exchange_source_task_bytes);
+	if (!descriptor.mark_join_build_summary.valid || !descriptor.mark_join_build_summary.IsValid()) {
+		throw InvalidInputException("HashJoinNode received an invalid global MARK build summary");
+	}
+	return descriptor.mark_join_build_summary;
 }
 
 class HashJoinTaskFanInStream {
@@ -239,14 +255,16 @@ HashJoinNode::HashJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb
                            duckdb::vector<unique_ptr<BaseStatistics>> join_stats,
                            unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality,
                            std::shared_ptr<DistributedPipelineNode> left,
-                           std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+                           std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema,
+                           optional_idx mark_build_summary_source_node_id)
     : context_(plan_config.query_idx, plan_config.query_id, node_id, "HashJoin"), left_(std::move(left)),
       right_(std::move(right)), conditions_(std::move(conditions)), join_type_(join_type),
       output_types_(std::move(output_types)), delim_types_(std::move(delim_types)),
       condition_types_(std::move(condition_types)), payload_columns_(std::move(payload_columns)),
       lhs_output_columns_(std::move(lhs_output_columns)), rhs_output_columns_(std::move(rhs_output_columns)),
       join_stats_(std::move(join_stats)), filter_pushdown_(std::move(filter_pushdown)),
-      estimated_cardinality_(estimated_cardinality) {
+      estimated_cardinality_(estimated_cardinality),
+      mark_build_summary_source_node_id_(mark_build_summary_source_node_id) {
 	size_t num_partitions = 1;
 	if (left_ && right_) {
 		num_partitions = std::max(left_->config().clustering_spec()->num_partitions(),
@@ -399,6 +417,8 @@ SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<Work
 
 		left_plan->SetRoot(nlj);
 	} else {
+		auto mark_build_summary =
+		    ExtractMarkJoinBuildSummary(right_task.task()->inputs(), mark_build_summary_source_node_id_);
 		// Has equality conditions: use PhysicalHashJoin (normal path)
 		auto &hash_join = left_plan
 		                      ->Make<PhysicalHashJoin>(dummy_join, std::move(conditions), join_type_, delim_types_,
@@ -410,6 +430,7 @@ SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<Work
 		hash_join.lhs_output_columns = lhs_output_columns_;
 		hash_join.rhs_output_columns = rhs_output_columns_;
 		hash_join.join_stats = CopyJoinStats(join_stats_);
+		hash_join.mark_join_build_summary = mark_build_summary;
 		if (filter_pushdown_) {
 			hash_join.filter_pushdown = CopyFilterPushdownInfo(*filter_pushdown_);
 		}

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -442,13 +442,13 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 			auto source_nodes = CollectShuffleSourceNodes(handles);
 			MarkJoinBuildSummary mark_join_build_summary;
 			for (const auto &handle : handles) {
+				if (!handle.mark_join_build_summary.IsConsistent()) {
+					return DuckDBResult<void>::err(
+					    DuckDBError::invalid_state_error("shuffle source has an invalid MARK build summary"));
+				}
 				if (self_shared->collect_mark_join_build_summary_ && !handle.mark_join_build_summary.valid) {
 					return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
 					    "MARK join build shuffle source is missing its global build summary"));
-				}
-				if (handle.mark_join_build_summary.valid && !handle.mark_join_build_summary.IsValid()) {
-					return DuckDBResult<void>::err(
-					    DuckDBError::invalid_state_error("shuffle source has an invalid MARK build summary"));
 				}
 				mark_join_build_summary.Merge(handle.mark_join_build_summary);
 			}

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -45,7 +45,18 @@ std::string ExchangeSourceHandleKey(const ExchangeSourceHandle &handle) {
 	for (const auto &file : handle.files) {
 		ss << '|' << file.path << ':' << file.rows << ':' << file.file_size;
 	}
+	const auto &summary = handle.mark_join_build_summary;
+	ss << '|' << summary.valid << ':' << summary.has_rows << ':' << summary.has_null;
 	return ss.str();
+}
+
+vector<unique_ptr<Expression>> CopyExpressions(const vector<unique_ptr<Expression>> &expressions) {
+	vector<unique_ptr<Expression>> result;
+	result.reserve(expressions.size());
+	for (const auto &expression : expressions) {
+		result.push_back(expression->Copy());
+	}
+	return result;
 }
 
 vector<unique_ptr<Expression>> CopyHashPartitionByExpressions(const std::shared_ptr<RepartitionSpec> &spec) {
@@ -117,7 +128,9 @@ idx_t ResolveExchangeSourceTaskCount(idx_t num_partitions, const DuckDBExecution
 DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan, const std::shared_ptr<RepartitionSpec> &spec,
                                               idx_t num_partitions, const std::string &exchange_id,
                                               const distributed::ExchangeSinkInstanceHandle &sink_handle,
-                                              std::shared_ptr<distributed::ExchangeManager> exchange_mgr) {
+                                              std::shared_ptr<distributed::ExchangeManager> exchange_mgr,
+                                              bool collect_mark_join_build_summary,
+                                              vector<unique_ptr<Expression>> mark_join_build_expressions) {
 	if (!plan || !plan->HasRoot()) {
 		return plan;
 	}
@@ -137,9 +150,12 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan, const st
 	auto repartition_type = ResolveRepartitionType(spec);
 	auto &old_root = plan->Root();
 	auto estimated = old_root.estimated_cardinality;
-	auto &sink = plan->Make<PhysicalRemoteExchangeSink>(old_root.GetTypes(), estimated, exchange_id, num_partitions,
-	                                                    repartition_type, std::move(partition_exprs), sink_handle,
-	                                                    std::move(exchange_mgr));
+	auto &sink = static_cast<PhysicalRemoteExchangeSink &>(plan->Make<PhysicalRemoteExchangeSink>(
+	    old_root.GetTypes(), estimated, exchange_id, num_partitions, repartition_type, std::move(partition_exprs),
+	    sink_handle, std::move(exchange_mgr)));
+	if (collect_mark_join_build_summary) {
+		sink.EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
+	}
 	sink.children.push_back(old_root);
 	plan->SetRoot(sink);
 	return plan;
@@ -248,6 +264,9 @@ std::vector<std::string> RepartitionNode::multiline_display(bool verbose) const 
 	// here and provide a simplified display string. A full implementation
 	// would call into the RepartitionSpec for richer details.
 	result.push_back("Repartition");
+	if (collect_mark_join_build_summary_) {
+		result.push_back("MARK build summary: global");
+	}
 
 	return result;
 }
@@ -323,14 +342,15 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 
 		// Build sink plan builder: RemoteExchangeSink
 		auto repartition_spec = self_shared->repartition_spec_;
-		auto plan_builder = [repartition_spec, num_partitions, shuffle_stage_id, exchange, exchange_mgr,
+		auto plan_builder = [self_shared, repartition_spec, num_partitions, shuffle_stage_id, exchange, exchange_mgr,
 		                     sink_task_counter](DuckPhysicalPlanRef plan) {
 			// Each task gets its own sink handle via the Exchange SPI
 			auto task_partition_id = sink_task_counter->fetch_add(1);
 			auto sink_handle_obj = exchange->AddSink(task_partition_id);
 			auto sink_instance = exchange->InstantiateSink(sink_handle_obj, /*attempt_id=*/0);
 			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, num_partitions, shuffle_stage_id,
-			                                 sink_instance, exchange_mgr);
+			                                 sink_instance, exchange_mgr, self_shared->collect_mark_join_build_summary_,
+			                                 CopyExpressions(self_shared->mark_join_build_expressions_));
 		};
 		auto node_ref = std::static_pointer_cast<PipelineNodeImpl>(self_shared);
 		auto first_with_sink =
@@ -420,6 +440,22 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				return DuckDBResult<void>::ok();
 			}
 			auto source_nodes = CollectShuffleSourceNodes(handles);
+			MarkJoinBuildSummary mark_join_build_summary;
+			for (const auto &handle : handles) {
+				if (self_shared->collect_mark_join_build_summary_ && !handle.mark_join_build_summary.valid) {
+					return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+					    "MARK join build shuffle source is missing its global build summary"));
+				}
+				if (handle.mark_join_build_summary.valid && !handle.mark_join_build_summary.IsValid()) {
+					return DuckDBResult<void>::err(
+					    DuckDBError::invalid_state_error("shuffle source has an invalid MARK build summary"));
+				}
+				mark_join_build_summary.Merge(handle.mark_join_build_summary);
+			}
+			if (self_shared->collect_mark_join_build_summary_ && !mark_join_build_summary.valid) {
+				return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
+				    "MARK join build shuffle completed without a global build summary"));
+			}
 			for (idx_t task_idx = 0; task_idx < target_tasks; task_idx++) {
 				idx_t part_start = task_idx * num_partitions / target_tasks;
 				idx_t part_end = (task_idx + 1) * num_partitions / target_tasks;
@@ -448,6 +484,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				source_task.source_handles = std::move(task_handles);
 				source_task.source_partition_count = num_partitions;
 				source_task.source_task_count = target_tasks;
+				source_task.mark_join_build_summary = mark_join_build_summary;
 				auto plan =
 				    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, shuffle_stage_id, {}, {},
 				                                 exchange_mgr, source_nodes, optional_idx(self_shared->node_id()));
@@ -477,7 +514,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 			}
 			return make_source_update_tasks(new_handles, reason);
 		};
-		auto on_sink_output = [exchange,
+		auto on_sink_output = [self_shared, exchange,
 		                       send_new_source_handles](const MaterializedOutput &output) -> DuckDBResult<void> {
 			if (!output.has_exchange_sink_instance()) {
 				return DuckDBResult<void>::err(DuckDBError::invalid_state_error(
@@ -491,6 +528,9 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 			const auto &sink_instance = output.exchange_sink_instance();
 			exchange->AddSink(sink_instance.sink_handle.task_partition_id);
 			exchange->SinkFinished(sink_instance, node_id, output.flight_port());
+			if (self_shared->collect_mark_join_build_summary_) {
+				return DuckDBResult<void>::ok();
+			}
 			return send_new_source_handles("sink_output");
 		};
 		auto materialize_profile_start = std::chrono::steady_clock::now();

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -237,9 +237,22 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 
 	std::vector<duckdb::ExprRef> left_partition_by;
 	std::vector<duckdb::ExprRef> right_partition_by;
+	duckdb::vector<unique_ptr<Expression>> mark_join_build_summary_expressions;
+	const bool correlated_mark_counts =
+	    hj.join_type == JoinType::MARK && !hj.delim_types.empty() && hj.delim_types.size() + 1 == conditions.size();
+	const auto partition_condition_count = correlated_mark_counts ? hj.delim_types.size() : conditions.size();
 	left_partition_by.reserve(conditions.size());
 	right_partition_by.reserve(conditions.size());
-	for (const auto &cond : conditions) {
+	for (idx_t condition_idx = 0; condition_idx < conditions.size(); condition_idx++) {
+		const auto &cond = conditions[condition_idx];
+		if (hj.join_type == JoinType::MARK && !correlated_mark_counts && cond.right &&
+		    cond.comparison != ExpressionType::COMPARE_DISTINCT_FROM &&
+		    cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			mark_join_build_summary_expressions.push_back(cond.right->Copy());
+		}
+		if (condition_idx >= partition_condition_count) {
+			continue;
+		}
 		if (cond.comparison != ExpressionType::COMPARE_EQUAL &&
 		    cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 			continue;
@@ -324,6 +337,7 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 
 	DistributedPipelineNodeRef join_left = left_node;
 	DistributedPipelineNodeRef join_right = right_node;
+	optional_idx mark_build_summary_source_node_id;
 	bool needs_join_repartition = (plan_config_.num_partitions > 1);
 	if (!needs_join_repartition && left_node && right_node) {
 		size_t left_parts = left_node->config().clustering_spec()->num_partitions();
@@ -343,13 +357,22 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 			join_left = gen_shuffle_node(std::move(left_spec), left_node->config().schema(), left_node);
 			auto right_spec = RepartitionSpec::create_hash(target_partitions, std::move(right_partition_by));
 			join_right = gen_shuffle_node(std::move(right_spec), right_node->config().schema(), right_node);
+			if (hj.join_type == JoinType::MARK && !correlated_mark_counts && target_partitions > 1) {
+				auto right_repartition = std::dynamic_pointer_cast<RepartitionNode>(join_right->inner());
+				if (!right_repartition) {
+					throw InternalException("MARK join build shuffle is not a RepartitionNode");
+				}
+				right_repartition->EnableMarkJoinBuildSummary(std::move(mark_join_build_summary_expressions));
+				mark_build_summary_source_node_id = optional_idx(right_repartition->node_id());
+			}
 		}
 	}
 
-	return std::make_shared<HashJoinNode>(
-	    get_next_pipeline_node_id(), plan_config_, std::move(conditions), hj.join_type, hj.GetTypes(), hj.delim_types,
-	    hj.condition_types, hj.payload_columns, hj.lhs_output_columns, hj.rhs_output_columns, std::move(join_stats),
-	    std::move(filter_pushdown), hj.estimated_cardinality, join_left, join_right, schema);
+	return std::make_shared<HashJoinNode>(get_next_pipeline_node_id(), plan_config_, std::move(conditions),
+	                                      hj.join_type, hj.GetTypes(), hj.delim_types, hj.condition_types,
+	                                      hj.payload_columns, hj.lhs_output_columns, hj.rhs_output_columns,
+	                                      std::move(join_stats), std::move(filter_pushdown), hj.estimated_cardinality,
+	                                      join_left, join_right, schema, mark_build_summary_source_node_id);
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateDelimJoin(

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -151,6 +151,12 @@ void ExchangeSinkInstanceTaskDescriptor::Serialize(Serializer &serializer) const
 	serializer.WriteProperty(6, "query_id", sink_instance.query_id);
 	serializer.WriteProperty(7, "flight_host", sink_instance.flight_host);
 	serializer.WriteProperty(8, "fte_task_identity", sink_instance.fte_task_identity);
+	serializer.WritePropertyWithDefault<bool>(9, "mark_join_build_summary_valid",
+	                                          sink_instance.mark_join_build_summary.valid, false);
+	serializer.WritePropertyWithDefault<bool>(10, "mark_join_build_has_rows",
+	                                          sink_instance.mark_join_build_summary.has_rows, false);
+	serializer.WritePropertyWithDefault<bool>(11, "mark_join_build_has_null",
+	                                          sink_instance.mark_join_build_summary.has_null, false);
 }
 
 ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deserialize(Deserializer &deserializer) {
@@ -165,6 +171,15 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	result.sink_instance.query_id = deserializer.ReadProperty<string>(6, "query_id");
 	result.sink_instance.flight_host = deserializer.ReadProperty<string>(7, "flight_host");
 	result.sink_instance.fte_task_identity = deserializer.ReadPropertyWithDefault<bool>(8, "fte_task_identity");
+	deserializer.ReadPropertyWithDefault<bool>(9, "mark_join_build_summary_valid",
+	                                           result.sink_instance.mark_join_build_summary.valid);
+	deserializer.ReadPropertyWithDefault<bool>(10, "mark_join_build_has_rows",
+	                                           result.sink_instance.mark_join_build_summary.has_rows);
+	deserializer.ReadPropertyWithDefault<bool>(11, "mark_join_build_has_null",
+	                                           result.sink_instance.mark_join_build_summary.has_null);
+	if (result.sink_instance.mark_join_build_summary.valid && !result.sink_instance.mark_join_build_summary.IsValid()) {
+		throw SerializationException("invalid MARK join build summary in exchange sink task");
+	}
 	return result;
 }
 

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -143,6 +143,9 @@ void ApplyRuntimeTaskIndexToOperator(PhysicalOperator &op, idx_t task_partition_
 } // namespace
 
 void ExchangeSinkInstanceTaskDescriptor::Serialize(Serializer &serializer) const {
+	if (!sink_instance.mark_join_build_summary.IsConsistent()) {
+		throw SerializationException("invalid MARK join build summary in exchange sink task");
+	}
 	serializer.WriteProperty(1, "task_partition_id", sink_instance.sink_handle.task_partition_id);
 	serializer.WriteProperty(2, "attempt_id", sink_instance.attempt_id);
 	serializer.WriteProperty(3, "output_location", sink_instance.output_location);
@@ -177,7 +180,7 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	                                           result.sink_instance.mark_join_build_summary.has_rows);
 	deserializer.ReadPropertyWithDefault<bool>(11, "mark_join_build_has_null",
 	                                           result.sink_instance.mark_join_build_summary.has_null);
-	if (result.sink_instance.mark_join_build_summary.valid && !result.sink_instance.mark_join_build_summary.IsValid()) {
+	if (!result.sink_instance.mark_join_build_summary.IsConsistent()) {
 		throw SerializationException("invalid MARK join build summary in exchange sink task");
 	}
 	return result;

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -53,6 +53,9 @@ bool ApplyExchangeSourceTasksToOperator(PhysicalOperator &op,
 } // namespace
 
 void ExchangeSourceTaskDescriptor::Serialize(Serializer &serializer) const {
+	if (!mark_join_build_summary.IsConsistent()) {
+		throw SerializationException("invalid MARK join build summary in exchange source task");
+	}
 	serializer.WriteProperty(1, "partition_indices", partition_indices);
 	serializer.WriteList(2, "source_handles", source_handles.size(), [&](Serializer::List &list, idx_t i) {
 		list.WriteObject([&](Serializer &obj) {
@@ -114,7 +117,7 @@ ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deseriali
 	                                           result.mark_join_build_summary.valid);
 	deserializer.ReadPropertyWithDefault<bool>(7, "mark_join_build_has_rows", result.mark_join_build_summary.has_rows);
 	deserializer.ReadPropertyWithDefault<bool>(8, "mark_join_build_has_null", result.mark_join_build_summary.has_null);
-	if (result.mark_join_build_summary.valid && !result.mark_join_build_summary.IsValid()) {
+	if (!result.mark_join_build_summary.IsConsistent()) {
 		throw SerializationException("invalid MARK join build summary in exchange source task");
 	}
 	if (result.source_partition_count == 0 && !result.partition_indices.empty()) {

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -77,6 +77,9 @@ void ExchangeSourceTaskDescriptor::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(3, "source_partition_count", source_partition_count);
 	serializer.WriteProperty(4, "source_task_count", source_task_count);
 	serializer.WritePropertyWithDefault<bool>(5, "replicated", replicated, false);
+	serializer.WritePropertyWithDefault<bool>(6, "mark_join_build_summary_valid", mark_join_build_summary.valid, false);
+	serializer.WritePropertyWithDefault<bool>(7, "mark_join_build_has_rows", mark_join_build_summary.has_rows, false);
+	serializer.WritePropertyWithDefault<bool>(8, "mark_join_build_has_null", mark_join_build_summary.has_null, false);
 }
 
 ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deserializer &deserializer) {
@@ -107,6 +110,13 @@ ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deseriali
 	deserializer.ReadPropertyWithDefault<idx_t>(3, "source_partition_count", result.source_partition_count);
 	deserializer.ReadPropertyWithDefault<idx_t>(4, "source_task_count", result.source_task_count);
 	deserializer.ReadPropertyWithDefault<bool>(5, "replicated", result.replicated);
+	deserializer.ReadPropertyWithDefault<bool>(6, "mark_join_build_summary_valid",
+	                                           result.mark_join_build_summary.valid);
+	deserializer.ReadPropertyWithDefault<bool>(7, "mark_join_build_has_rows", result.mark_join_build_summary.has_rows);
+	deserializer.ReadPropertyWithDefault<bool>(8, "mark_join_build_has_null", result.mark_join_build_summary.has_null);
+	if (result.mark_join_build_summary.valid && !result.mark_join_build_summary.IsValid()) {
+		throw SerializationException("invalid MARK join build summary in exchange source task");
+	}
 	if (result.source_partition_count == 0 && !result.partition_indices.empty()) {
 		for (auto partition_idx : result.partition_indices) {
 			result.source_partition_count = std::max(result.source_partition_count, partition_idx + 1);

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -16,11 +16,13 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 
 namespace duckdb {
@@ -32,11 +34,13 @@ struct RemoteSinkGlobalState : public GlobalSinkState {
 	}
 
 	std::unique_ptr<distributed::ExchangeSink> sink;
+	std::atomic<bool> mark_join_build_has_rows {false};
+	std::atomic<bool> mark_join_build_has_null {false};
 };
 
 struct RemoteSinkLocalState : public LocalSinkState {
 	explicit RemoteSinkLocalState(ClientContext &context, const PhysicalRemoteExchangeSink &op)
-	    : executor(context), hash(LogicalType::HASH), sort_key(LogicalType::BLOB) {
+	    : executor(context), mark_join_build_executor(context), hash(LogicalType::HASH), sort_key(LogicalType::BLOB) {
 		const auto &exprs = op.PartitionBy();
 		if (!exprs.empty()) {
 			vector<LogicalType> types;
@@ -57,6 +61,16 @@ struct RemoteSinkLocalState : public LocalSinkState {
 				range_modifiers.push_back(OrderModifiers::Parse(modifier));
 			}
 		}
+		if (op.CollectsMarkJoinBuildSummary()) {
+			vector<LogicalType> types;
+			for (const auto &expr : op.MarkJoinBuildExpressions()) {
+				mark_join_build_executor.AddExpression(*expr);
+				types.push_back(expr->return_type);
+			}
+			if (!types.empty()) {
+				mark_join_build_keys.InitializeEmpty(types);
+			}
+		}
 		selections.reserve(op.NumPartitions());
 		for (idx_t i = 0; i < op.NumPartitions(); i++) {
 			selections.emplace_back(STANDARD_VECTOR_SIZE);
@@ -66,6 +80,8 @@ struct RemoteSinkLocalState : public LocalSinkState {
 
 	ExpressionExecutor executor;
 	DataChunk key_chunk;
+	ExpressionExecutor mark_join_build_executor;
+	DataChunk mark_join_build_keys;
 	Vector hash;
 	Vector sort_key;
 	vector<OrderModifiers> range_modifiers;
@@ -180,6 +196,19 @@ SinkResultType PhysicalRemoteExchangeSink::Sink(ExecutionContext &context, DataC
 	auto &lstate = input.local_state.Cast<RemoteSinkLocalState>();
 	const auto count = chunk.size();
 	const auto partitions = num_partitions_;
+	if (collect_mark_join_build_summary_) {
+		gstate.mark_join_build_has_rows.store(true, std::memory_order_relaxed);
+		if (!mark_join_build_expressions_.empty() && !gstate.mark_join_build_has_null.load(std::memory_order_relaxed)) {
+			lstate.mark_join_build_keys.Reset();
+			lstate.mark_join_build_executor.Execute(chunk, lstate.mark_join_build_keys);
+			for (auto &key : lstate.mark_join_build_keys.data) {
+				if (VectorOperations::HasNull(key, count)) {
+					gstate.mark_join_build_has_null.store(true, std::memory_order_relaxed);
+					break;
+				}
+			}
+		}
+	}
 
 	std::fill(lstate.sel_counts.begin(), lstate.sel_counts.end(), 0);
 
@@ -282,6 +311,11 @@ SinkFinalizeType PhysicalRemoteExchangeSink::Finalize(Pipeline &pipeline, Event 
 		}
 		throw IOException(message);
 	}
+	if (collect_mark_join_build_summary_) {
+		sink_handle_.mark_join_build_summary =
+		    MarkJoinBuildSummary::Create(gstate.mark_join_build_has_rows.load(std::memory_order_relaxed),
+		                                 gstate.mark_join_build_has_null.load(std::memory_order_relaxed));
+	}
 	return SinkFinalizeType::READY;
 }
 
@@ -320,6 +354,11 @@ void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) c
 	serializer.WriteProperty(114, "flight_server_epoch", sink_handle_.flight_server_epoch);
 	serializer.WriteProperty(115, "query_id", sink_handle_.query_id);
 	serializer.WriteProperty(116, "fte_task_identity", sink_handle_.fte_task_identity);
+	serializer.WritePropertyWithDefault<bool>(117, "collect_mark_join_build_summary", collect_mark_join_build_summary_,
+	                                          false);
+	if (collect_mark_join_build_summary_) {
+		serializer.WriteProperty(118, "mark_join_build_expressions", mark_join_build_expressions_);
+	}
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/join/physical_hash_join.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_hash_join.cpp
@@ -273,8 +273,11 @@ public:
 };
 
 unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &context) const {
+	if (!mark_join_build_summary.IsConsistent()) {
+		throw InternalException("invalid global MARK join build summary on PhysicalHashJoin");
+	}
 	if (mark_join_build_summary.valid) {
-		if (join_type != JoinType::MARK || !mark_join_build_summary.IsValid()) {
+		if (join_type != JoinType::MARK) {
 			throw InternalException("invalid global MARK join build summary on PhysicalHashJoin");
 		}
 		if (!delim_types.empty() && delim_types.size() + 1 == conditions.size()) {
@@ -1722,6 +1725,9 @@ InsertionOrderPreservingMap<string> PhysicalHashJoin::ParamsToString() const {
 }
 
 void PhysicalHashJoin::SerializeOperatorData(Serializer &serializer) const {
+	if (!mark_join_build_summary.IsConsistent()) {
+		throw SerializationException("invalid global MARK join build summary for hash join");
+	}
 	serializer.WriteProperty(103, "join_type", join_type);
 	serializer.WriteProperty(104, "conditions", conditions);
 	serializer.WriteProperty(105, "condition_types", condition_types);

--- a/external/duckdb/src/execution/operator/join/physical_hash_join.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_hash_join.cpp
@@ -273,8 +273,19 @@ public:
 };
 
 unique_ptr<JoinHashTable> PhysicalHashJoin::InitializeHashTable(ClientContext &context) const {
+	if (mark_join_build_summary.valid) {
+		if (join_type != JoinType::MARK || !mark_join_build_summary.IsValid()) {
+			throw InternalException("invalid global MARK join build summary on PhysicalHashJoin");
+		}
+		if (!delim_types.empty() && delim_types.size() + 1 == conditions.size()) {
+			throw InternalException("global MARK join build summary cannot be used with correlated per-group counts");
+		}
+	}
 	auto result = make_uniq<JoinHashTable>(context, *this, conditions, payload_columns.col_types, join_type,
 	                                       rhs_output_columns.col_idxs);
+	if (mark_join_build_summary.valid) {
+		result->has_null = mark_join_build_summary.has_null;
+	}
 	if (!delim_types.empty() && join_type == JoinType::MARK) {
 		// correlated MARK join
 		if (delim_types.size() + 1 == conditions.size()) {
@@ -1111,6 +1122,36 @@ unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ExecutionContext &c
 	return std::move(state);
 }
 
+void PhysicalHashJoin::ConstructEmptyMarkJoinResult(DataChunk &join_keys, DataChunk &input, DataChunk &result) const {
+	D_ASSERT(join_type == JoinType::MARK);
+	D_ASSERT(mark_join_build_summary.IsValid());
+	ConstructEmptyJoinResult(join_type, mark_join_build_summary.has_null, input, result);
+	if (!mark_join_build_summary.has_rows || mark_join_build_summary.has_null) {
+		return;
+	}
+
+	auto &mask = FlatVector::Validity(result.data.back());
+	mask.SetAllValid(result.size());
+	for (idx_t condition_idx = 0; condition_idx < conditions.size(); condition_idx++) {
+		auto comparison = conditions[condition_idx].comparison;
+		if (comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
+		    comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			continue;
+		}
+		UnifiedVectorFormat key_data;
+		join_keys.data[condition_idx].ToUnifiedFormat(join_keys.size(), key_data);
+		if (key_data.validity.AllValid()) {
+			continue;
+		}
+		for (idx_t row_idx = 0; row_idx < join_keys.size(); row_idx++) {
+			auto key_idx = key_data.sel->get_index(row_idx);
+			if (!key_data.validity.RowIsValidUnsafe(key_idx)) {
+				mask.SetInvalid(row_idx);
+			}
+		}
+	}
+}
+
 OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
                                                      GlobalOperatorState &gstate, OperatorState &state_p) const {
 	auto &state = state_p.Cast<HashJoinOperatorState>();
@@ -1123,7 +1164,15 @@ OperatorResultType PhysicalHashJoin::ExecuteInternal(ExecutionContext &context, 
 			return OperatorResultType::FINISHED;
 		}
 		state.lhs_output.ReferenceColumns(input, lhs_output_columns.col_idxs);
-		ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, state.lhs_output, chunk);
+		if (join_type == JoinType::MARK && mark_join_build_summary.valid) {
+			if (mark_join_build_summary.has_rows && !mark_join_build_summary.has_null) {
+				state.lhs_join_keys.Reset();
+				state.probe_executor.Execute(input, state.lhs_join_keys);
+			}
+			ConstructEmptyMarkJoinResult(state.lhs_join_keys, state.lhs_output, chunk);
+		} else {
+			ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, state.lhs_output, chunk);
+		}
 		return OperatorResultType::NEED_MORE_INPUT;
 	}
 
@@ -1543,7 +1592,12 @@ void HashJoinLocalSourceState::ExternalProbe(HashJoinGlobalSinkState &sink, Hash
 	lhs_output.ReferenceColumns(lhs_probe_chunk, sink.op.lhs_output_columns.col_idxs);
 
 	if (sink.hash_table->Count() == 0 && !gstate.op.EmptyResultIfRHSIsEmpty()) {
-		gstate.op.ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, lhs_output, chunk);
+		if (gstate.op.join_type == JoinType::MARK && gstate.op.mark_join_build_summary.valid) {
+			gstate.op.ConstructEmptyMarkJoinResult(lhs_join_keys, lhs_output, chunk);
+		} else {
+			gstate.op.ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, lhs_output,
+			                                   chunk);
+		}
 		empty_ht_probe_in_progress = true;
 		return;
 	}
@@ -1692,6 +1746,10 @@ void PhysicalHashJoin::SerializeOperatorData(Serializer &serializer) const {
 		});
 	}
 	serializer.WritePropertyWithDefault(114, "filter_pushdown", filter_pushdown);
+	serializer.WritePropertyWithDefault<bool>(115, "mark_join_build_summary_valid", mark_join_build_summary.valid,
+	                                          false);
+	serializer.WritePropertyWithDefault<bool>(116, "mark_join_build_has_rows", mark_join_build_summary.has_rows, false);
+	serializer.WritePropertyWithDefault<bool>(117, "mark_join_build_has_null", mark_join_build_summary.has_null, false);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1055,6 +1055,14 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		});
 		auto filter_pushdown =
 		    deserializer.ReadPropertyWithDefault<unique_ptr<JoinFilterPushdownInfo>>(114, "filter_pushdown");
+		MarkJoinBuildSummary mark_join_build_summary;
+		deserializer.ReadPropertyWithDefault<bool>(115, "mark_join_build_summary_valid", mark_join_build_summary.valid);
+		deserializer.ReadPropertyWithDefault<bool>(116, "mark_join_build_has_rows", mark_join_build_summary.has_rows);
+		deserializer.ReadPropertyWithDefault<bool>(117, "mark_join_build_has_null", mark_join_build_summary.has_null);
+		if (mark_join_build_summary.valid && (join_type != JoinType::MARK || !mark_join_build_summary.IsValid() ||
+		                                      (!delim_types.empty() && delim_types.size() + 1 == conditions.size()))) {
+			throw SerializationException("invalid global MARK join build summary for hash join");
+		}
 
 		LogicalComparisonJoin dummy_join(join_type);
 		dummy_join.types = std::move(types);
@@ -1070,6 +1078,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		join->rhs_output_columns.col_types = std::move(rhs_col_types);
 		join->join_stats = std::move(join_stats);
 		join->filter_pushdown = std::move(filter_pushdown);
+		join->mark_join_build_summary = mark_join_build_summary;
 		return unique_ptr<PhysicalOperator>(std::move(join));
 	}
 	case PhysicalOperatorType::LEFT_DELIM_JOIN:
@@ -1190,15 +1199,23 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		sink_handle.flight_server_epoch = deserializer.ReadProperty<string>(114, "flight_server_epoch");
 		sink_handle.query_id = deserializer.ReadProperty<string>(115, "query_id");
 		sink_handle.fte_task_identity = deserializer.ReadPropertyWithDefault<bool>(116, "fte_task_identity");
+		auto collect_mark_join_build_summary =
+		    deserializer.ReadPropertyWithDefault<bool>(117, "collect_mark_join_build_summary");
+		auto mark_join_build_expressions =
+		    deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(118, "mark_join_build_expressions");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		flight_config.node_id = node_id;
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
-		return make_uniq<PhysicalRemoteExchangeSink>(
+		auto result = make_uniq<PhysicalRemoteExchangeSink>(
 		    physical_plan, std::move(types), estimated_cardinality, std::move(exchange_id), num_partitions,
 		    repartition_type, std::move(partition_by), std::move(sink_handle), std::move(exchange_mgr),
 		    std::move(range_boundaries), std::move(range_order_modifiers));
+		if (collect_mark_join_build_summary) {
+			result->EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
+		}
+		return unique_ptr<PhysicalOperator>(std::move(result));
 	}
 	case PhysicalOperatorType::EXCHANGE_SOURCE: {
 		auto exchange_id = deserializer.ReadProperty<string>(103, "shuffle_stage_id");

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1059,8 +1059,9 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		deserializer.ReadPropertyWithDefault<bool>(115, "mark_join_build_summary_valid", mark_join_build_summary.valid);
 		deserializer.ReadPropertyWithDefault<bool>(116, "mark_join_build_has_rows", mark_join_build_summary.has_rows);
 		deserializer.ReadPropertyWithDefault<bool>(117, "mark_join_build_has_null", mark_join_build_summary.has_null);
-		if (mark_join_build_summary.valid && (join_type != JoinType::MARK || !mark_join_build_summary.IsValid() ||
-		                                      (!delim_types.empty() && delim_types.size() + 1 == conditions.size()))) {
+		if (!mark_join_build_summary.IsConsistent() ||
+		    (mark_join_build_summary.valid &&
+		     (join_type != JoinType::MARK || (!delim_types.empty() && delim_types.size() + 1 == conditions.size())))) {
 			throw SerializationException("invalid global MARK join build summary for hash join");
 		}
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 #include "duckdb/common/types.hpp"
+#include "duckdb/execution/mark_join_build_summary.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -53,6 +54,9 @@ struct ExchangeSinkInstanceHandle {
 	std::string flight_host;
 	/// Process-local Flight service incarnation that published this attempt.
 	std::string flight_server_epoch;
+	/// Present only for a MARK-join build shuffle. This is the summary produced
+	/// by this concrete sink attempt.
+	MarkJoinBuildSummary mark_join_build_summary;
 };
 
 // ─── Source Handles ──────────────────────────────────────
@@ -83,6 +87,9 @@ struct ExchangeSourceHandle {
 	int flight_port = 0;
 	std::string flight_server_epoch;
 	std::vector<ExchangeSourceFile> files;
+	/// Global summary reduced across all selected sink attempts. When present,
+	/// every source handle for the exchange carries the same value.
+	MarkJoinBuildSummary mark_join_build_summary;
 };
 
 } // namespace distributed

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -215,6 +215,7 @@ private:
 		std::string flight_host;
 		int flight_port = 0;
 		std::string flight_server_epoch;
+		MarkJoinBuildSummary mark_join_build_summary;
 	};
 
 	ExchangeContext ctx_;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/hash_join.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/enums/join_type.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/execution/distributed/common_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/distributed/plan/plan_config.hpp"
@@ -33,7 +34,7 @@ public:
 	             duckdb::vector<unique_ptr<BaseStatistics>> join_stats,
 	             unique_ptr<JoinFilterPushdownInfo> filter_pushdown, idx_t estimated_cardinality,
 	             std::shared_ptr<DistributedPipelineNode> left, std::shared_ptr<DistributedPipelineNode> right,
-	             SchemaRef schema);
+	             SchemaRef schema, optional_idx mark_build_summary_source_node_id = optional_idx());
 
 	std::shared_ptr<DistributedPipelineNode> into_node();
 
@@ -75,6 +76,7 @@ private:
 	duckdb::vector<unique_ptr<BaseStatistics>> join_stats_;
 	unique_ptr<JoinFilterPushdownInfo> filter_pushdown_;
 	idx_t estimated_cardinality_;
+	optional_idx mark_build_summary_source_node_id_;
 };
 
 } // namespace distributed

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -30,6 +30,8 @@ private:
 	size_t num_partitions_;
 	std::shared_ptr<DistributedPipelineNode> child_;
 	std::shared_ptr<ExchangeManager> exchange_mgr_;
+	bool collect_mark_join_build_summary_ = false;
+	vector<unique_ptr<Expression>> mark_join_build_expressions_;
 
 	static constexpr const char *NODE_NAME = "Repartition";
 
@@ -52,6 +54,15 @@ public:
 	std::vector<PipelineNodeRef> children() const override;
 
 	std::vector<std::string> multiline_display(bool verbose) const override;
+
+	void EnableMarkJoinBuildSummary(vector<unique_ptr<Expression>> expressions) {
+		collect_mark_join_build_summary_ = true;
+		mark_join_build_expressions_ = std::move(expressions);
+	}
+
+	bool CollectsMarkJoinBuildSummary() const {
+		return collect_mark_join_build_summary_;
+	}
 
 	// 生成任务流（核心方法）
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
@@ -76,7 +87,9 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan,
                                               const std::shared_ptr<::duckdb::RepartitionSpec> &spec,
                                               idx_t num_partitions, const std::string &exchange_id,
                                               const ExchangeSinkInstanceHandle &sink_handle,
-                                              std::shared_ptr<ExchangeManager> exchange_mgr);
+                                              std::shared_ptr<ExchangeManager> exchange_mgr,
+                                              bool collect_mark_join_build_summary = false,
+                                              vector<unique_ptr<Expression>> mark_join_build_expressions = {});
 
 DuckPhysicalPlanRef AddRemoteRangeExchangeSinkPlan(DuckPhysicalPlanRef plan,
                                                    const vector<::duckdb::BoundOrderByNode> &orders,

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/exchange_source_task.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/exchange_source_task.hpp
@@ -31,6 +31,7 @@ struct ExchangeSourceTaskDescriptor {
 	idx_t source_partition_count = 0;
 	idx_t source_task_count = 0;
 	bool replicated = false;
+	MarkJoinBuildSummary mark_join_build_summary;
 
 	void Serialize(Serializer &serializer) const;
 	static ExchangeSourceTaskDescriptor Deserialize(Deserializer &deserializer);

--- a/external/duckdb/src/include/duckdb/execution/mark_join_build_summary.hpp
+++ b/external/duckdb/src/include/duckdb/execution/mark_join_build_summary.hpp
@@ -24,7 +24,12 @@ struct MarkJoinBuildSummary {
 	}
 
 	bool IsValid() const {
-		return valid && (!has_null || has_rows);
+		return valid && IsConsistent();
+	}
+
+	//! An absent summary must not carry payload bits, and a NULL requires at least one build row.
+	bool IsConsistent() const {
+		return valid ? (!has_null || has_rows) : (!has_rows && !has_null);
 	}
 
 	void Merge(const MarkJoinBuildSummary &other) {

--- a/external/duckdb/src/include/duckdb/execution/mark_join_build_summary.hpp
+++ b/external/duckdb/src/include/duckdb/execution/mark_join_build_summary.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace duckdb {
+
+//! Global state required to evaluate an uncorrelated partitioned MARK join.
+//! The three valid states are:
+//! - no build rows: unmatched probes, including NULL probes, are false;
+//! - build rows without NULL: unmatched probes are false and NULL probes are NULL;
+//! - build rows with NULL: every unmatched probe is NULL.
+struct MarkJoinBuildSummary {
+	bool valid = false;
+	bool has_rows = false;
+	bool has_null = false;
+
+	static MarkJoinBuildSummary Create(bool has_rows_p, bool has_null_p) {
+		MarkJoinBuildSummary result;
+		result.valid = true;
+		result.has_rows = has_rows_p;
+		result.has_null = has_null_p;
+		return result;
+	}
+
+	bool IsValid() const {
+		return valid && (!has_null || has_rows);
+	}
+
+	void Merge(const MarkJoinBuildSummary &other) {
+		if (!other.valid) {
+			return;
+		}
+		if (!valid) {
+			*this = other;
+			return;
+		}
+		has_rows = has_rows || other.has_rows;
+		has_null = has_null || other.has_null;
+	}
+
+	bool operator==(const MarkJoinBuildSummary &other) const {
+		return valid == other.valid && has_rows == other.has_rows && has_null == other.has_null;
+	}
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
@@ -84,6 +84,16 @@ public:
 	const vector<string> &RangeOrderModifiers() const {
 		return range_order_modifiers_;
 	}
+	void EnableMarkJoinBuildSummary(vector<unique_ptr<Expression>> expressions) {
+		collect_mark_join_build_summary_ = true;
+		mark_join_build_expressions_ = std::move(expressions);
+	}
+	bool CollectsMarkJoinBuildSummary() const {
+		return collect_mark_join_build_summary_;
+	}
+	const vector<unique_ptr<Expression>> &MarkJoinBuildExpressions() const {
+		return mark_join_build_expressions_;
+	}
 
 private:
 	static idx_t SelectPartitionHash(const hash_t hash, const idx_t num_partitions);
@@ -94,10 +104,12 @@ private:
 	idx_t num_partitions_;
 	RepartitionSpec::Type repartition_type_;
 	vector<unique_ptr<Expression>> partition_by_;
-	distributed::ExchangeSinkInstanceHandle sink_handle_;
+	mutable distributed::ExchangeSinkInstanceHandle sink_handle_;
 	std::shared_ptr<distributed::ExchangeManager> exchange_mgr_;
 	vector<string> range_boundaries_;
 	vector<string> range_order_modifiers_;
+	bool collect_mark_join_build_summary_ = false;
+	vector<unique_ptr<Expression>> mark_join_build_expressions_;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/join/physical_hash_join.hpp
@@ -16,6 +16,7 @@
 
 #include "duckdb/common/value_operations/value_operations.hpp"
 #include "duckdb/execution/join_hashtable.hpp"
+#include "duckdb/execution/mark_join_build_summary.hpp"
 #include "duckdb/execution/operator/join/perfect_hash_join_executor.hpp"
 #include "duckdb/execution/operator/join/physical_comparison_join.hpp"
 #include "duckdb/execution/physical_operator.hpp"
@@ -63,6 +64,10 @@ public:
 	//! Join Keys statistics (optional)
 	vector<unique_ptr<BaseStatistics>> join_stats;
 
+	//! Global RHS state for an uncorrelated partitioned MARK join. Invalid for
+	//! ordinary local, gathered, broadcast, and correlated MARK joins.
+	MarkJoinBuildSummary mark_join_build_summary;
+
 public:
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 	void SerializeOperatorData(Serializer &serializer) const override;
@@ -70,6 +75,7 @@ public:
 public:
 	// Operator Interface
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
+	void ConstructEmptyMarkJoinResult(DataChunk &join_keys, DataChunk &input, DataChunk &result) const;
 
 	bool ParallelOperator() const override {
 		return true;

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1747,6 +1747,47 @@ TEST_CASE("Exchange: FlightExchange with no sinks has no unpublished source hand
 	exchange->Close();
 }
 
+TEST_CASE("Exchange: FlightExchange reduces MARK build summaries from selected attempts only",
+          "[distributed][exchange][join]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config;
+	config.node_id = "mark-summary-coordinator";
+	config.local_dirs = {TestCreatePath("exchange_mark_build_summary")};
+	FlightExchangeManager manager(config, conn.context.get());
+
+	ExchangeContext ctx;
+	ctx.query_id = "mark-summary-query";
+	ctx.exchange_id = "mark-summary-stage";
+	auto exchange = manager.CreateExchange(ctx, 3);
+	auto first = exchange->InstantiateSink(exchange->AddSink(0), 0);
+	auto first_retry = exchange->InstantiateSink(exchange->AddSink(0), 1);
+	auto second = exchange->InstantiateSink(exchange->AddSink(1), 0);
+	first.flight_host = "mark-worker-0.internal";
+	first.flight_server_epoch = "mark-epoch-0";
+	first.mark_join_build_summary = MarkJoinBuildSummary::Create(false, false);
+	first_retry.flight_host = "mark-worker-retry.internal";
+	first_retry.flight_server_epoch = "mark-epoch-retry";
+	first_retry.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
+	second.flight_host = "mark-worker-1.internal";
+	second.flight_server_epoch = "mark-epoch-1";
+	second.mark_join_build_summary = MarkJoinBuildSummary::Create(true, false);
+
+	exchange->SinkFinished(first, "mark-worker-0", 5100);
+	exchange->SinkFinished(first_retry, "mark-worker-retry", 5102);
+	exchange->SinkFinished(second, "mark-worker-1", 5101);
+	exchange->AllRequiredSinksFinished();
+	auto handles = exchange->GetSourceHandles();
+	REQUIRE(handles.size() == 6);
+	for (const auto &handle : handles) {
+		REQUIRE(handle.mark_join_build_summary.valid);
+		REQUIRE(handle.mark_join_build_summary.has_rows);
+		REQUIRE_FALSE(handle.mark_join_build_summary.has_null);
+	}
+	exchange->Close();
+}
+
 TEST_CASE("Exchange: same logical stage has isolated exchange instances and directories", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1774,6 +1774,12 @@ TEST_CASE("Exchange: FlightExchange reduces MARK build summaries from selected a
 	second.flight_server_epoch = "mark-epoch-1";
 	second.mark_join_build_summary = MarkJoinBuildSummary::Create(true, false);
 
+	auto malformed = first;
+	malformed.mark_join_build_summary = MarkJoinBuildSummary();
+	malformed.mark_join_build_summary.has_rows = true;
+	REQUIRE_THROWS_WITH(exchange->SinkFinished(malformed, "mark-worker-0", 5100),
+	                    Catch::Matchers::Contains("invalid MARK join build summary"));
+
 	exchange->SinkFinished(first, "mark-worker-0", 5100);
 	exchange->SinkFinished(first_retry, "mark-worker-retry", 5102);
 	exchange->SinkFinished(second, "mark-worker-1", 5101);

--- a/external/duckdb/test/execution/distributed/test_executor_pipeline.cpp
+++ b/external/duckdb/test/execution/distributed/test_executor_pipeline.cpp
@@ -28,9 +28,12 @@
 #include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
+#include "duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp"
+#include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 
 #include <functional>
 
@@ -44,6 +47,209 @@ static idx_t GetRowCount(unique_ptr<QueryResult> &result) {
 // Helper function to get value from query result
 static Value GetResultValue(unique_ptr<QueryResult> &result, idx_t col, idx_t row) {
 	return result->Cast<MaterializedQueryResult>().GetValue(col, row);
+}
+
+static unique_ptr<ColumnDataCollection> MakeIntegerCollection(const vector<Value> &values) {
+	vector<LogicalType> types = {LogicalType::INTEGER};
+	auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), types);
+	if (values.empty()) {
+		return collection;
+	}
+	DataChunk chunk;
+	chunk.Initialize(Allocator::DefaultAllocator(), types);
+	for (idx_t row_idx = 0; row_idx < values.size(); row_idx++) {
+		chunk.SetValue(0, row_idx, values[row_idx]);
+	}
+	chunk.SetCardinality(values.size());
+	collection->Append(chunk);
+	return collection;
+}
+
+class MarkSummaryTestExchangeSink final : public distributed::ExchangeSink {
+public:
+	DuckDBResult<void> AddChunk(idx_t partition_id, DataChunk &chunk) override {
+		return DuckDBResult<void>::ok();
+	}
+
+	bool IsBlocked() const override {
+		return false;
+	}
+
+	void WaitUnblocked() override {
+	}
+
+	DuckDBResult<void> Finish() override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<void> Abort() override {
+		return DuckDBResult<void>::ok();
+	}
+
+	size_t GetMemoryUsage() const override {
+		return 0;
+	}
+};
+
+class MarkSummaryTestExchangeManager final : public distributed::ExchangeManager {
+public:
+	std::unique_ptr<distributed::Exchange> CreateExchange(const distributed::ExchangeContext &ctx,
+	                                                      idx_t output_partition_count) override {
+		return nullptr;
+	}
+
+	std::unique_ptr<distributed::ExchangeSink>
+	CreateSink(const distributed::ExchangeSinkInstanceHandle &handle) override {
+		return std::unique_ptr<distributed::ExchangeSink>(new MarkSummaryTestExchangeSink());
+	}
+
+	std::unique_ptr<distributed::ExchangeSource> CreateSource() override {
+		return nullptr;
+	}
+
+	void Shutdown() override {
+	}
+};
+
+static MarkJoinBuildSummary ExecuteMarkJoinSummarySink(Connection &con, const vector<Value> &right_values) {
+	auto physical_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	vector<LogicalType> input_types = {LogicalType::INTEGER};
+	auto &scan = physical_plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                         right_values.size(), MakeIntegerCollection(right_values));
+
+	vector<unique_ptr<Expression>> partition_by;
+	partition_by.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	distributed::ExchangeSinkInstanceHandle sink_handle;
+	sink_handle.output_partition_count = 2;
+	auto exchange_manager = std::make_shared<MarkSummaryTestExchangeManager>();
+	auto &sink = physical_plan
+	                 ->Make<PhysicalRemoteExchangeSink>(input_types, right_values.size(), "mark-summary-test", 2,
+	                                                    RepartitionSpec::Type::Hash, std::move(partition_by),
+	                                                    sink_handle, std::move(exchange_manager))
+	                 .Cast<PhysicalRemoteExchangeSink>();
+	vector<unique_ptr<Expression>> summary_expressions;
+	summary_expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	sink.EnableMarkJoinBuildSummary(std::move(summary_expressions));
+	sink.children.push_back(scan);
+	physical_plan->SetRoot(sink);
+
+	auto prepared = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+	prepared->names = {"value"};
+	prepared->types = input_types;
+	prepared->properties.return_type = StatementReturnType::QUERY_RESULT;
+	prepared->output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	prepared->memory_type = QueryResultMemoryType::IN_MEMORY;
+	prepared->physical_plan = std::move(physical_plan);
+
+	PendingQueryParameters parameters;
+	auto pending = con.context->PendingQueryPreparedStatementNoRebind("test:mark_summary_sink", prepared, parameters);
+	if (!pending || pending->HasError()) {
+		throw InvalidInputException(pending ? pending->GetError() : "failed to start MARK summary sink test query");
+	}
+	auto result = pending->Execute();
+	if (!result || result->HasError()) {
+		throw InvalidInputException(result ? result->GetError() : "failed to execute MARK summary sink test query");
+	}
+	return sink.SinkHandle().mark_join_build_summary;
+}
+
+TEST_CASE("Remote exchange sink: MARK build summary records empty and NULL-bearing inputs",
+          "[distributed][executor][exchange][join]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	auto empty = ExecuteMarkJoinSummarySink(con, {});
+	REQUIRE(empty.valid);
+	REQUIRE_FALSE(empty.has_rows);
+	REQUIRE_FALSE(empty.has_null);
+
+	auto with_null =
+	    ExecuteMarkJoinSummarySink(con, {Value::INTEGER(1), Value(LogicalType::INTEGER), Value::INTEGER(2)});
+	REQUIRE(with_null.valid);
+	REQUIRE(with_null.has_rows);
+	REQUIRE(with_null.has_null);
+}
+
+static unique_ptr<QueryResult> ExecuteMarkJoinFragment(Connection &con, const vector<Value> &left_values,
+                                                       const vector<Value> &local_right_values,
+                                                       MarkJoinBuildSummary summary) {
+	auto physical_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	vector<LogicalType> input_types = {LogicalType::INTEGER};
+	auto &left = physical_plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                         left_values.size(), MakeIntegerCollection(left_values));
+	auto &right = physical_plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN,
+	                                                          local_right_values.size(),
+	                                                          MakeIntegerCollection(local_right_values));
+
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.comparison = ExpressionType::COMPARE_EQUAL;
+	vector<JoinCondition> conditions;
+	conditions.push_back(std::move(condition));
+	LogicalComparisonJoin logical_join(JoinType::MARK);
+	logical_join.types = {LogicalType::INTEGER, LogicalType::BOOLEAN};
+	auto &join = physical_plan
+	                 ->Make<PhysicalHashJoin>(logical_join, left, right, std::move(conditions), JoinType::MARK,
+	                                          left_values.size())
+	                 .Cast<PhysicalHashJoin>();
+	join.mark_join_build_summary = summary;
+	physical_plan->SetRoot(join);
+
+	auto prepared = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+	prepared->names = {"value", "mark"};
+	prepared->types = logical_join.types;
+	prepared->properties.return_type = StatementReturnType::QUERY_RESULT;
+	prepared->output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	prepared->memory_type = QueryResultMemoryType::IN_MEMORY;
+	prepared->physical_plan = std::move(physical_plan);
+
+	PendingQueryParameters parameters;
+	auto pending =
+	    con.context->PendingQueryPreparedStatementNoRebind("test:partitioned_mark_join", prepared, parameters);
+	if (!pending || pending->HasError()) {
+		throw InvalidInputException(pending ? pending->GetError() : "failed to start MARK join test query");
+	}
+	return pending->Execute();
+}
+
+TEST_CASE("Hash join: global MARK build summary distinguishes an empty RHS from an empty local partition",
+          "[distributed][executor][join]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.Query("SET threads=1");
+
+	SECTION("globally empty RHS returns false even for a NULL probe") {
+		auto result = ExecuteMarkJoinFragment(con, {Value::INTEGER(7), Value(LogicalType::INTEGER)}, {},
+		                                      MarkJoinBuildSummary::Create(false, false));
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(GetResultValue(result, 1, 0) == Value::BOOLEAN(false));
+		REQUIRE(GetResultValue(result, 1, 1) == Value::BOOLEAN(false));
+	}
+
+	SECTION("globally non-empty RHS without NULL preserves a NULL probe") {
+		auto result = ExecuteMarkJoinFragment(con, {Value::INTEGER(7), Value(LogicalType::INTEGER)}, {},
+		                                      MarkJoinBuildSummary::Create(true, false));
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(GetResultValue(result, 1, 0) == Value::BOOLEAN(false));
+		REQUIRE(GetResultValue(result, 1, 1).IsNull());
+	}
+
+	SECTION("a global NULL makes every unmatched probe unknown") {
+		auto result = ExecuteMarkJoinFragment(con, {Value::INTEGER(7), Value(LogicalType::INTEGER)}, {},
+		                                      MarkJoinBuildSummary::Create(true, true));
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(GetResultValue(result, 1, 0).IsNull());
+		REQUIRE(GetResultValue(result, 1, 1).IsNull());
+	}
+
+	SECTION("a local match remains true when another partition contains NULL") {
+		auto result = ExecuteMarkJoinFragment(con, {Value::INTEGER(1), Value::INTEGER(2)}, {Value::INTEGER(1)},
+		                                      MarkJoinBuildSummary::Create(true, true));
+		REQUIRE_FALSE(result->HasError());
+		REQUIRE(GetResultValue(result, 1, 0) == Value::BOOLEAN(true));
+		REQUIRE(GetResultValue(result, 1, 1).IsNull());
+	}
 }
 
 TEST_CASE("Executor: Pipeline count for different query types", "[distributed][executor][pipeline]") {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -1114,6 +1114,49 @@ TEST_CASE("PhysicalHashJoin serialization roundtrip", "[serialization][physical_
 	std::cerr << "[test] PhysicalHashJoin serialization roundtrip PASSED" << std::endl;
 }
 
+TEST_CASE("PhysicalHashJoin serialization preserves a global MARK build summary",
+          "[serialization][physical_plan][join]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> input_types = {LogicalType::INTEGER};
+	auto &left_scan = MakeColumnDataScan(plan, input_types);
+	auto &right_scan = MakeColumnDataScan(plan, input_types);
+
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0);
+	condition.comparison = ExpressionType::COMPARE_EQUAL;
+	vector<JoinCondition> conditions;
+	conditions.push_back(std::move(condition));
+
+	LogicalComparisonJoin logical_join(JoinType::MARK);
+	logical_join.types = {LogicalType::INTEGER, LogicalType::BOOLEAN};
+	auto &hash_join =
+	    plan.Make<PhysicalHashJoin>(logical_join, left_scan, right_scan, std::move(conditions), JoinType::MARK, 100)
+	        .Cast<PhysicalHashJoin>();
+	hash_join.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
+
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	hash_join.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	auto *join_ptr = dynamic_cast<PhysicalHashJoin *>(deserialized_op.get());
+	REQUIRE(join_ptr != nullptr);
+	REQUIRE(join_ptr->join_type == JoinType::MARK);
+	REQUIRE(join_ptr->mark_join_build_summary.valid);
+	REQUIRE(join_ptr->mark_join_build_summary.has_rows);
+	REQUIRE(join_ptr->mark_join_build_summary.has_null);
+}
+
 TEST_CASE("PhysicalUngroupedAggregate serialization roundtrip", "[serialization][physical_plan]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
@@ -1625,6 +1668,9 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	vector<unique_ptr<Expression>> partition_by;
 	auto &sink = plan.Make<PhysicalRemoteExchangeSink>(types, 123, "shuffle_stage", 4, RepartitionSpec::Type::Random,
 	                                                   std::move(partition_by), sink_handle, exchange_mgr);
+	vector<unique_ptr<Expression>> mark_join_build_expressions;
+	mark_join_build_expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	sink.Cast<PhysicalRemoteExchangeSink>().EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
 
 	MemoryStream stream(allocator);
 	SerializationOptions options;
@@ -1652,6 +1698,9 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves sink instance meta
 	REQUIRE(sink_ptr->SinkHandle().flight_host.empty());
 	REQUIRE(sink_ptr->SinkHandle().flight_server_epoch == "sink-epoch");
 	REQUIRE(sink_ptr->SinkHandle().fte_task_identity);
+	REQUIRE(sink_ptr->CollectsMarkJoinBuildSummary());
+	REQUIRE(sink_ptr->MarkJoinBuildExpressions().size() == 1);
+	REQUIRE(sink_ptr->MarkJoinBuildExpressions()[0]->return_type == LogicalType::INTEGER);
 	auto roundtrip_manager =
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(sink_ptr->GetExchangeManager());
 	const std::vector<std::string> expected_local_dirs = {"/session-a/shuffle-0", "/session-a/shuffle-1"};
@@ -1783,6 +1832,7 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	descriptor.sink_instance.flight_host = "flight-worker.internal";
 	descriptor.sink_instance.flight_server_epoch = "endpoint-epoch";
 	descriptor.sink_instance.fte_task_identity = true;
+	descriptor.sink_instance.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
 
 	auto roundtrip =
 	    distributed::ExchangeSinkInstanceTaskDescriptor::DeserializeFromBytes(descriptor.SerializeToBytes());
@@ -1795,6 +1845,9 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	REQUIRE(roundtrip.sink_instance.flight_host == "flight-worker.internal");
 	REQUIRE(roundtrip.sink_instance.flight_server_epoch == "endpoint-epoch");
 	REQUIRE(roundtrip.sink_instance.fte_task_identity);
+	REQUIRE(roundtrip.sink_instance.mark_join_build_summary.valid);
+	REQUIRE(roundtrip.sink_instance.mark_join_build_summary.has_rows);
+	REQUIRE(roundtrip.sink_instance.mark_join_build_summary.has_null);
 }
 
 TEST_CASE("Exchange task descriptors reject missing advertised hosts", "[serialization][physical_plan][exchange]") {
@@ -2025,6 +2078,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	descriptor.partition_indices = {0, 1};
 	descriptor.source_partition_count = 2;
 	descriptor.source_task_count = 2;
+	descriptor.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
 
 	distributed::ExchangeSourceHandle handle0;
 	handle0.partition_id = 0;
@@ -2053,6 +2107,9 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.partition_indices == descriptor.partition_indices);
 	REQUIRE(roundtrip.source_partition_count == 2);
 	REQUIRE(roundtrip.source_task_count == 2);
+	REQUIRE(roundtrip.mark_join_build_summary.valid);
+	REQUIRE(roundtrip.mark_join_build_summary.has_rows);
+	REQUIRE(roundtrip.mark_join_build_summary.has_null);
 	REQUIRE(roundtrip.source_handles.size() == 2);
 	REQUIRE(roundtrip.source_handles[0].partition_id == 0);
 	REQUIRE(roundtrip.source_handles[0].source_task_partition_id == 21);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -1850,6 +1850,21 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	REQUIRE(roundtrip.sink_instance.mark_join_build_summary.has_null);
 }
 
+TEST_CASE("Exchange task descriptors reject MARK summary payload without validity",
+          "[serialization][physical_plan][exchange]") {
+	SECTION("sink task") {
+		distributed::ExchangeSinkInstanceTaskDescriptor descriptor;
+		descriptor.sink_instance.mark_join_build_summary.has_rows = true;
+		REQUIRE_THROWS(descriptor.SerializeToBytes());
+	}
+
+	SECTION("source task") {
+		distributed::ExchangeSourceTaskDescriptor descriptor;
+		descriptor.mark_join_build_summary.has_rows = true;
+		REQUIRE_THROWS(descriptor.SerializeToBytes());
+	}
+}
+
 TEST_CASE("Exchange task descriptors reject missing advertised hosts", "[serialization][physical_plan][exchange]") {
 	REQUIRE_THROWS(distributed::ExchangeSinkInstanceTaskDescriptor::DeserializeFromBytes(
 	    SerializeSinkDescriptorWithoutFlightHost()));

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -292,6 +292,34 @@ static DuckPhysicalPlanRef MakeHashJoinPlan(JoinType join_type, idx_t left_cardi
 	return plan;
 }
 
+static DuckPhysicalPlanRef MakeCorrelatedMarkJoinPlan() {
+	auto plan = std::make_shared<PhysicalPlan>(Allocator::DefaultAllocator());
+	vector<LogicalType> input_types = {LogicalType::INTEGER, LogicalType::INTEGER};
+	auto left_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), input_types);
+	auto &left_scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 1,
+	                                                     std::move(left_collection));
+	auto right_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), input_types);
+	auto &right_scan = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 1,
+	                                                      std::move(right_collection));
+
+	vector<JoinCondition> conditions;
+	for (idx_t column_idx = 0; column_idx < input_types.size(); column_idx++) {
+		JoinCondition condition;
+		condition.left = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, column_idx);
+		condition.right = make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, column_idx);
+		condition.comparison = ExpressionType::COMPARE_EQUAL;
+		conditions.push_back(std::move(condition));
+	}
+
+	LogicalComparisonJoin logical_join(JoinType::MARK);
+	logical_join.types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BOOLEAN};
+	auto &hash_join = plan->Make<PhysicalHashJoin>(logical_join, left_scan, right_scan, std::move(conditions),
+	                                               JoinType::MARK, vector<idx_t> {}, vector<idx_t> {},
+	                                               vector<LogicalType> {LogicalType::INTEGER}, 1, nullptr);
+	plan->SetRoot(hash_join);
+	return plan;
+}
+
 static bool NodeDisplayContains(const DistributedPipelineNodeRef &node, const std::string &needle) {
 	for (const auto &line : node->inner()->multiline_display(false)) {
 		if (line.find(needle) != std::string::npos) {
@@ -1354,6 +1382,39 @@ TEST_CASE("PhysicalPlanTranslator: hash join builds both required shuffles", "[d
 		REQUIRE(shuffle->config().clustering_spec() != nullptr);
 		REQUIRE(shuffle->config().clustering_spec()->type() == ClusteringSpec::Type::Hash);
 		REQUIRE(shuffle->config().clustering_spec()->num_partitions() == 4);
+	}
+}
+
+TEST_CASE("PhysicalPlanTranslator: partitioned MARK joins preserve global build semantics", "[distributed][join]") {
+	ScopedTranslatorEnvironment join_strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", "hash");
+	PlanConfig config;
+	config.num_partitions = 4;
+
+	SECTION("uncorrelated MARK build shuffle collects one global summary") {
+		auto res = physical_plan_to_pipeline_node(config, MakeHashJoinPlan(JoinType::MARK, 1, 1));
+		REQUIRE(res.is_ok());
+		auto children = res.value()->inner()->children();
+		REQUIRE(children.size() == 2);
+		auto left_shuffle = std::dynamic_pointer_cast<RepartitionNode>(children[0]);
+		auto right_shuffle = std::dynamic_pointer_cast<RepartitionNode>(children[1]);
+		REQUIRE(left_shuffle != nullptr);
+		REQUIRE(right_shuffle != nullptr);
+		REQUIRE_FALSE(left_shuffle->CollectsMarkJoinBuildSummary());
+		REQUIRE(right_shuffle->CollectsMarkJoinBuildSummary());
+		REQUIRE(NodeDisplayContains(right_shuffle->into_node(), "MARK build summary: global"));
+	}
+
+	SECTION("correlated MARK rows are co-located by correlation keys") {
+		auto res = physical_plan_to_pipeline_node(config, MakeCorrelatedMarkJoinPlan());
+		REQUIRE(res.is_ok());
+		auto children = res.value()->inner()->children();
+		REQUIRE(children.size() == 2);
+		for (const auto &child : children) {
+			auto shuffle = std::dynamic_pointer_cast<RepartitionNode>(child);
+			REQUIRE(shuffle != nullptr);
+			REQUIRE_FALSE(shuffle->CollectsMarkJoinBuildSummary());
+			REQUIRE(shuffle->config().clustering_spec()->partition_by().size() == 1);
+		}
 	}
 }
 

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/execution/distributed/common_types.hpp"
 #include "duckdb/execution/distributed/exchange/exchange_manager.hpp"
 #include "duckdb/execution/distributed/scheduling/task.hpp"
+#include "duckdb/execution/distributed/plan/exchange_source_task.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/execution/distributed/pipeline_node/translator.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
@@ -541,6 +542,39 @@ TEST_CASE("HashJoinNode: non-equality joins reject a stale output schema", "[dis
 
 	REQUIRE_THROWS_WITH(node.BuildHashJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr),
 	                    Catch::Matchers::Contains("output schema that does not match its children"));
+}
+
+TEST_CASE("HashJoinNode: MARK join embeds the global build summary from its right source",
+          "[distributed][source_id][join]") {
+	PlanConfig plan_cfg(1, "mark-join-query", std::make_shared<DuckDBExecutionConfig>());
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	condition.comparison = ExpressionType::COMPARE_EQUAL;
+	vector<JoinCondition> conditions;
+	conditions.push_back(std::move(condition));
+	auto schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT, LogicalType::BOOLEAN});
+
+	HashJoinNode node(301, plan_cfg, std::move(conditions), JoinType::MARK,
+	                  vector<LogicalType> {LogicalType::BIGINT, LogicalType::BOOLEAN}, {},
+	                  vector<LogicalType> {LogicalType::BIGINT}, PhysicalHashJoin::JoinProjectionColumns(),
+	                  PhysicalHashJoin::JoinProjectionColumns(), PhysicalHashJoin::JoinProjectionColumns(), {}, nullptr,
+	                  1, nullptr, nullptr, schema, optional_idx(20));
+
+	auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+	auto right_worker = MakeWorkerTaskWithInput(20, "right", 21, "right_scan");
+	ExchangeSourceTaskDescriptor right_source;
+	right_source.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
+	right_worker.mutable_inputs()[20] = TaskInput::make_exchange_source_task(right_source.SerializeToBytes());
+	auto right_task = SubmittableTask<WorkerTask>(std::move(right_worker));
+	TaskIDCounter task_id_counter;
+
+	auto joined_task = node.BuildHashJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+	auto *join = dynamic_cast<PhysicalHashJoin *>(&joined_task.task()->plan()->Root());
+	REQUIRE(join != nullptr);
+	REQUIRE(join->mark_join_build_summary.valid);
+	REQUIRE(join->mark_join_build_summary.has_rows);
+	REQUIRE(join->mark_join_build_summary.has_null);
 }
 
 TEST_CASE("HashJoinNode: fan-in preserves child task streams", "[distributed][source_id][join]") {

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -44,6 +44,18 @@ FindFlightExchangeSinkManager(const duckdb::PhysicalOperator &op) {
 	return nullptr;
 }
 
+static const duckdb::PhysicalRemoteExchangeSink *FindRemoteExchangeSinkOperator(const duckdb::PhysicalOperator &op) {
+	if (op.type == duckdb::PhysicalOperatorType::EXCHANGE_SINK) {
+		return dynamic_cast<const duckdb::PhysicalRemoteExchangeSink *>(&op);
+	}
+	for (auto &child : op.children) {
+		if (auto *sink = FindRemoteExchangeSinkOperator(child.get())) {
+			return sink;
+		}
+	}
+	return nullptr;
+}
+
 struct PyPhysicalPlanWrapper {
 	static constexpr uint64_t INIT_MAGIC = 0x445046504C414E31ULL;
 	uint64_t init_magic_;
@@ -2220,6 +2232,9 @@ struct PyPhysicalPlanWrapperRunner {
 				return py::none();
 			}
 			auto completed_task = *exchange_sink_instance_task;
+			if (auto *sink = FindRemoteExchangeSinkOperator(root_op)) {
+				completed_task.sink_instance = sink->SinkHandle();
+			}
 			completed_task.sink_instance.flight_host = task_flight_host();
 			completed_task.sink_instance.flight_server_epoch = task_flight_server_epoch();
 			return py::bytes(completed_task.SerializeToBytes());

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1364,8 +1364,7 @@ void register_ray_bindings(py::module_ &mod) {
 					        exchange_sink_instance_task.sink_instance.mark_join_build_summary.has_null =
 					            py::bool_(d["mark_join_build_has_null"]).cast<bool>();
 				        }
-				        if (exchange_sink_instance_task.sink_instance.mark_join_build_summary.valid &&
-				            !exchange_sink_instance_task.sink_instance.mark_join_build_summary.IsValid()) {
+				        if (!exchange_sink_instance_task.sink_instance.mark_join_build_summary.IsConsistent()) {
 					        throw py::value_error("exchange_sink_instance has an invalid MARK join build summary");
 				        }
 				        has_exchange_sink_instance_task = true;

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -1352,6 +1352,22 @@ void register_ray_bindings(py::module_ &mod) {
 				        if (d.contains("query_id")) {
 					        exchange_sink_instance_task.sink_instance.query_id = py::str(d["query_id"]).cast<string>();
 				        }
+				        if (d.contains("mark_join_build_summary_valid")) {
+					        exchange_sink_instance_task.sink_instance.mark_join_build_summary.valid =
+					            py::bool_(d["mark_join_build_summary_valid"]).cast<bool>();
+				        }
+				        if (d.contains("mark_join_build_has_rows")) {
+					        exchange_sink_instance_task.sink_instance.mark_join_build_summary.has_rows =
+					            py::bool_(d["mark_join_build_has_rows"]).cast<bool>();
+				        }
+				        if (d.contains("mark_join_build_has_null")) {
+					        exchange_sink_instance_task.sink_instance.mark_join_build_summary.has_null =
+					            py::bool_(d["mark_join_build_has_null"]).cast<bool>();
+				        }
+				        if (exchange_sink_instance_task.sink_instance.mark_join_build_summary.valid &&
+				            !exchange_sink_instance_task.sink_instance.mark_join_build_summary.IsValid()) {
+					        throw py::value_error("exchange_sink_instance has an invalid MARK join build summary");
+				        }
 				        has_exchange_sink_instance_task = true;
 			        } else {
 				        throw py::value_error("exchange_sink_instance must be bytes or dict");
@@ -1506,6 +1522,20 @@ void register_ray_bindings(py::module_ &mod) {
 		    return desc.replicated;
 	    },
 	    py::arg("bytes"), "Return whether a raw ExchangeSourceTaskDescriptor is replicated.");
+
+	m.def(
+	    "exchange_source_task_mark_join_build_summary_for_test",
+	    [](py::bytes bytes_obj) {
+		    using namespace duckdb::distributed;
+		    string raw(bytes_obj);
+		    auto desc = ExchangeSourceTaskDescriptor::DeserializeFromBytes(raw);
+		    py::dict out;
+		    out["valid"] = desc.mark_join_build_summary.valid;
+		    out["has_rows"] = desc.mark_join_build_summary.has_rows;
+		    out["has_null"] = desc.mark_join_build_summary.has_null;
+		    return out;
+	    },
+	    py::arg("bytes"), "Return MARK build summary metadata from an exchange source descriptor.");
 
 	m.def(
 	    "exchange_source_task_logical_identity",
@@ -1753,7 +1783,8 @@ void register_ray_bindings(py::module_ &mod) {
 	m.def(
 	    "make_exchange_source_task_descriptor_for_test",
 	    [](py::list handles, py::list partition_indices, idx_t source_partition_count, idx_t source_task_count,
-	       bool replicated) {
+	       bool replicated, bool mark_join_build_summary_valid, bool mark_join_build_has_rows,
+	       bool mark_join_build_has_null) {
 		    using namespace duckdb::distributed;
 		    ExchangeSourceTaskDescriptor desc;
 		    for (auto item : partition_indices) {
@@ -1762,6 +1793,15 @@ void register_ray_bindings(py::module_ &mod) {
 		    desc.source_partition_count = source_partition_count;
 		    desc.source_task_count = source_task_count;
 		    desc.replicated = replicated;
+		    if (mark_join_build_summary_valid) {
+			    desc.mark_join_build_summary =
+			        MarkJoinBuildSummary::Create(mark_join_build_has_rows, mark_join_build_has_null);
+			    if (!desc.mark_join_build_summary.IsValid()) {
+				    throw py::value_error("invalid MARK join build summary");
+			    }
+		    } else if (mark_join_build_has_rows || mark_join_build_has_null) {
+			    throw py::value_error("MARK join build summary values require a valid summary");
+		    }
 
 		    for (auto item : handles) {
 			    py::dict d = item.cast<py::dict>();
@@ -1807,7 +1847,8 @@ void register_ray_bindings(py::module_ &mod) {
 		    return py::bytes(bytes);
 	    },
 	    py::arg("handles"), py::arg("partition_indices"), py::arg("source_partition_count"),
-	    py::arg("source_task_count"), py::arg("replicated") = false,
+	    py::arg("source_task_count"), py::arg("replicated") = false, py::arg("mark_join_build_summary_valid") = false,
+	    py::arg("mark_join_build_has_rows") = false, py::arg("mark_join_build_has_null") = false,
 	    "Build a raw ExchangeSourceTaskDescriptor for Python fast tests.");
 
 	m.def(
@@ -4859,6 +4900,7 @@ void register_ray_bindings(py::module_ &mod) {
 			    single.source_partition_count = partition_count;
 			    single.source_task_count = desc.source_task_count;
 			    single.replicated = desc.replicated;
+			    single.mark_join_build_summary = desc.mark_join_build_summary;
 			    for (const auto &handle : desc.source_handles) {
 				    if (handle.partition_id == partition_id) {
 					    single.source_handles.push_back(handle);

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -147,7 +147,7 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	if (d.contains("mark_join_build_has_null")) {
 		out.mark_join_build_summary.has_null = py::bool_(d["mark_join_build_has_null"]).cast<bool>();
 	}
-	if (out.mark_join_build_summary.valid && !out.mark_join_build_summary.IsValid()) {
+	if (!out.mark_join_build_summary.IsConsistent()) {
 		throw py::value_error("exchange_sink_instance has an invalid MARK join build summary");
 	}
 	return true;
@@ -1264,6 +1264,9 @@ py::object RayWorkerTask::ExchangeSinkInstance() const {
 		return py::none();
 	}
 	const auto &instance = sink->SinkHandle();
+	if (!instance.mark_join_build_summary.IsConsistent()) {
+		throw py::value_error("exchange_sink_instance has an invalid MARK join build summary");
+	}
 	py::dict sink_handle;
 	sink_handle["task_partition_id"] = instance.sink_handle.task_partition_id;
 	sink_handle["partition_id"] = instance.sink_handle.task_partition_id;

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -138,6 +138,18 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	if (d.contains("query_id")) {
 		out.query_id = py::str(d["query_id"]).cast<string>();
 	}
+	if (d.contains("mark_join_build_summary_valid")) {
+		out.mark_join_build_summary.valid = py::bool_(d["mark_join_build_summary_valid"]).cast<bool>();
+	}
+	if (d.contains("mark_join_build_has_rows")) {
+		out.mark_join_build_summary.has_rows = py::bool_(d["mark_join_build_has_rows"]).cast<bool>();
+	}
+	if (d.contains("mark_join_build_has_null")) {
+		out.mark_join_build_summary.has_null = py::bool_(d["mark_join_build_has_null"]).cast<bool>();
+	}
+	if (out.mark_join_build_summary.valid && !out.mark_join_build_summary.IsValid()) {
+		throw py::value_error("exchange_sink_instance has an invalid MARK join build summary");
+	}
 	return true;
 }
 
@@ -1275,6 +1287,11 @@ py::object RayWorkerTask::ExchangeSinkInstance() const {
 	if (!instance.output_location.empty()) {
 		result["output_location"] = instance.output_location;
 		result["attempt_path"] = instance.output_location;
+	}
+	if (instance.mark_join_build_summary.valid) {
+		result["mark_join_build_summary_valid"] = true;
+		result["mark_join_build_has_rows"] = instance.mark_join_build_summary.has_rows;
+		result["mark_join_build_has_null"] = instance.mark_join_build_summary.has_null;
 	}
 	return result;
 }

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -647,6 +647,47 @@ def test_exchange_source_task_split_preserves_mark_join_build_summary():
     assert duckdb.ray_cxx.exchange_source_task_mark_join_build_summary_for_test(split[0][1]) == expected
 
 
+@pytest.mark.parametrize("payload_field", ["mark_join_build_has_rows", "mark_join_build_has_null"])
+def test_execute_native_rejects_mark_summary_payload_without_validity(payload_field):
+    con = duckdb.connect()
+    cursor = con.cursor()
+    plan = _make_test_physical_plan(con)
+    runner = duckdb.ray_cxx.DistributedPhysicalPlanRunner()
+
+    try:
+        with pytest.raises(ValueError, match="invalid MARK join build summary"):
+            runner.execute_native(
+                cursor,
+                plan,
+                exchange_sink_instance={payload_field: True},
+            )
+    finally:
+        cursor.close()
+        con.close()
+
+
+@pytest.mark.parametrize("payload_field", ["mark_join_build_has_rows", "mark_join_build_has_null"])
+def test_ray_task_result_rejects_mark_summary_payload_without_validity(payload_field):
+    class _MalformedSummaryHandle:
+        worker_id = "worker-malformed-summary"
+
+        def done(self):
+            return True
+
+        def get_result_sync(self):
+            return duckdb.ray_cxx.RayTaskResult.success(
+                [],
+                [],
+                exchange_sink_instance={payload_field: True},
+            )
+
+        def release_result_payload(self):
+            return None
+
+    with pytest.raises(RuntimeError, match="invalid MARK join build summary"):
+        duckdb.ray_cxx.ray_task_result_handle_refreshed_worker_id_for_test(_MalformedSummaryHandle())
+
+
 def test_exchange_source_task_descriptor_preserves_replicated_distribution():
     handles = [
         {

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -620,6 +620,33 @@ def test_exchange_source_task_descriptor_preserves_attempt_ids():
     assert duckdb.ray_cxx.exchange_source_task_source_handles_for_test(split[1][1]) == [handles[1]]
 
 
+def test_exchange_source_task_split_preserves_mark_join_build_summary():
+    raw = duckdb.ray_cxx.make_exchange_source_task_descriptor_for_test(
+        [
+            {
+                "partition_id": 0,
+                "source_task_partition_id": 17,
+                "attempt_id": 0,
+                "node_id": "node-a",
+                "flight_port": 5010,
+                "files": [{"path": "mark-shuffle", "file_size": 11}],
+            }
+        ],
+        [0],
+        1,
+        1,
+        mark_join_build_summary_valid=True,
+        mark_join_build_has_rows=True,
+        mark_join_build_has_null=True,
+    )
+    expected = {"valid": True, "has_rows": True, "has_null": True}
+
+    assert duckdb.ray_cxx.exchange_source_task_mark_join_build_summary_for_test(raw) == expected
+    split = duckdb.ray_cxx.split_exchange_source_task_by_partition(raw)
+    assert len(split) == 1
+    assert duckdb.ray_cxx.exchange_source_task_mark_join_build_summary_for_test(split[0][1]) == expected
+
+
 def test_exchange_source_task_descriptor_preserves_replicated_distribution():
     handles = [
         {


### PR DESCRIPTION
## Summary

- compute a retry-safe global `{has_rows, has_null}` summary for partitioned uncorrelated MARK build exchanges
- carry the summary through sink completion, selected-attempt reduction, source descriptors, and physical hash join execution
- preserve empty-RHS versus empty-local-partition semantics, including NULL probe keys
- co-locate correlated MARK rows by correlation keys so per-group counts remain complete
- reject missing or inconsistent summary metadata instead of silently degrading results

## Testing

- `scripts/run_native_tests.sh "[distributed]"` (173 cases, 5831 assertions)
- `scripts/run_native_tests.sh "*MARK*"` (16 cases, 704 assertions; 2 existing skips)
- `scripts/run_native_tests.sh "[serialization][physical_plan]"` (39 cases, 10774 assertions)
- `python -m pytest -q tests/fast/test_ray_cpp_bindings.py` (115 passed, 4 deselected)
- `scripts/run_release_tests.sh` (472 passed, 1 skipped; 10 real-Ray passed)

Fixes #396