### PR TITLE
[fix](ray) Keep maintenance loops alive on Python 3.10

### DIFF
--- a/duckdb/runners/ray/driver.py
+++ b/duckdb/runners/ray/driver.py
@@ -2008,7 +2008,7 @@ class RayQueryDriverActor:
                 self._client_lease_maintenance_error = f"{type(error).__name__}: {error}"
             try:
                 await asyncio.wait_for(stop.wait(), timeout=interval)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 continue
 
     async def stop_client_lease_maintenance(self) -> None:
@@ -2469,7 +2469,7 @@ class RayQueryDriverActor:
                 self._query_resource_maintenance_error = f"{type(exc).__name__}: {exc}"
             try:
                 await asyncio.wait_for(stop.wait(), timeout=interval)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 continue
 
     async def stop_query_resource_maintenance(self) -> None:

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -354,6 +354,58 @@ def test_client_owner_lease_settings_accept_one_third_heartbeat_interval(
     assert driver._client_owner_lease_settings() == (30.0, 10.0)
 
 
+@pytest.mark.parametrize("maintenance_kind", ["client_lease", "query_resource"])
+def test_maintenance_loops_continue_after_pre311_asyncio_timeout(
+    monkeypatch,
+    maintenance_kind,
+):
+    class _Pre311AsyncioTimeout(Exception):
+        pass
+
+    runner_cls = driver.RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    maintenance_calls = []
+
+    async def scenario():
+        stop = asyncio.Event()
+        if maintenance_kind == "client_lease":
+            runner._client_lease_maintenance_stop = stop
+            runner._client_heartbeat_interval_s = 0.25
+            runner._client_lease_maintenance_error = ""
+            runner._client_lease_maintenance_failures = 0
+            runner._schedule_expired_client_reclamations = lambda: maintenance_calls.append(None)
+            maintenance_loop = runner_cls._client_lease_maintenance_loop
+        else:
+            runner._query_resource_maintenance_stop = stop
+            runner._query_resource_maintenance_interval_s = 0.25
+            runner._query_resource_maintenance_error = ""
+            runner._query_resource_maintenance_failures = 0
+            runner._maintain_query_resources_once = lambda: maintenance_calls.append(None)
+            maintenance_loop = runner_cls._query_resource_maintenance_loop
+
+        wait_calls = 0
+
+        async def wait_for(awaitable, *, timeout):
+            nonlocal wait_calls
+            assert timeout == 0.25
+            wait_calls += 1
+            if wait_calls == 1:
+                awaitable.close()
+                raise _Pre311AsyncioTimeout
+            stop.set()
+            return await awaitable
+
+        monkeypatch.setattr(driver.asyncio, "TimeoutError", _Pre311AsyncioTimeout)
+        monkeypatch.setattr(driver.asyncio, "wait_for", wait_for)
+
+        await maintenance_loop(runner)
+        assert wait_calls == 2
+
+    asyncio.run(scenario())
+
+    assert maintenance_calls == [None, None]
+
+
 @pytest.mark.parametrize("raw", ["0", "-1", "nan", "inf", "invalid"])
 def test_copy_reconciliation_timeout_rejects_unsafe_values(monkeypatch, raw):
     monkeypatch.setenv("VANE_RAY_COPY_RECONCILIATION_TIMEOUT_S", raw)


### PR DESCRIPTION
## Summary

- Catch both built-in and asyncio timeout exceptions in the client lease maintenance loop.
- Apply the same compatibility handling to the query resource maintenance loop.
- Prevent expected `asyncio.wait_for` timer expirations from terminating these loops on Python 3.10.
- Add a parameterized regression test that simulates the distinct pre-3.11 `asyncio.TimeoutError` class for both loops.

## Related issue

close: #402

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed`
- `git diff --check`
- `python -m pytest -q tests/fast/test_ray_result_contract.py::test_maintenance_loops_continue_after_pre311_asyncio_timeout` (`2 passed`)
- `scripts/run_release_tests.sh` (`473 passed, 1 skipped` in the non-real-Ray shard; `10 passed` in the real-Ray shard)
- Verified with Python 3.10.19 that `asyncio.TimeoutError` is neither identical to nor a subclass of built-in `TimeoutError`.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.