### PR TITLE
[fix](ray) Preserve execute_native result order

### DIFF
--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -2311,12 +2311,14 @@ struct PyPhysicalPlanWrapperRunner {
 			} plan_guard(prepared_data->physical_plan);
 
 			PendingQueryParameters parameters;
-			// Force a parallel result collector for this query only. This enables multi-threaded pipeline
-			// execution for UDF-heavy workloads without changing the connection's collector callback.
-			parameters.get_result_collector = [](duckdb::ClientContext &,
+			// execute_native always returns a materialized result. Keep that collector contract query-local,
+			// while only allowing parallel collection when the plan does not require order preservation.
+			parameters.get_result_collector = [](duckdb::ClientContext &context,
 			                                     duckdb::PreparedStatementData &data) -> duckdb::PhysicalOperator & {
 				auto &physical_plan = *data.physical_plan;
-				return physical_plan.Make<duckdb::PhysicalMaterializedCollector>(data, true);
+				const bool preserve_order =
+				    duckdb::PhysicalPlanGenerator::PreserveInsertionOrder(context, physical_plan.Root());
+				return physical_plan.Make<duckdb::PhysicalMaterializedCollector>(data, !preserve_order);
 			};
 			std::unique_ptr<QueryResult> query_result;
 			vector<PipelineProgressSnapshot> stable_pipeline_snapshots;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -200,6 +200,39 @@ def test_execute_native_keeps_result_collector_query_local():
     assert duckdb.ray_cxx._connection_result_collector_calls_for_test(cursor) == 2
 
 
+def test_execute_native_preserves_materialized_order(tmp_path):
+    pytest.importorskip("pyarrow")
+    row_count = 200_000
+    source = tmp_path / "execute_native_order.parquet"
+    con = duckdb.connect()
+    try:
+        con.execute("SET threads=4")
+        con.execute(
+            f"""
+            COPY (
+                SELECT ({row_count - 1} - i)::BIGINT AS i
+                FROM range({row_count}) tbl(i)
+            ) TO '{source}' (FORMAT PARQUET, ROW_GROUP_SIZE 2048)
+            """
+        )
+        relation = con.sql(f"SELECT i FROM read_parquet('{source}') ORDER BY i")
+        plan = duckdb.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            str(uuid.uuid4()),
+        ).to_physical_plan(con)
+
+        result = duckdb.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            con.cursor(),
+            plan,
+        )
+
+        assert result.completion_status == "ok"
+        assert len(result.partition_payloads) == 1
+        assert result.partition_payloads[0].column(0).to_pylist() == list(range(row_count))
+    finally:
+        con.close()
+
+
 def test_physical_plan_pickle_propagates_non_serializable_operator_error():
     plan = duckdb.ray_cxx._make_non_serializable_physical_plan_for_test("query-non-serializable")
 


### PR DESCRIPTION
## Summary

- Keep `execute_native` on its query-local `PhysicalMaterializedCollector` contract instead of inheriting connection-level collector callbacks.
- Select parallel materialization only when `PhysicalPlanGenerator::PreserveInsertionOrder` says the physical root does not require ordered output; order-preserving plans use the serial materialized collector.
- Add a direct native-execution regression covering a 200,000-row Parquet `ORDER BY` with four DuckDB threads.

## Related issue

close: #403

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- Pre-fix negative control: 5/5 runs of the 200,000-row, four-thread native `ORDER BY` returned block-reordered output.
- `scripts/format root --from-ref upstream/main --check`
- Release incremental native reinstall after rebasing onto current `upstream/main`.
- Targeted collector isolation, ordered output, and the prior SIGSEGV plan-replay case: 3 passed.
- Exact failed CI non-Ray 2/2 shard: 3183 passed, 13 skipped, 5 xfailed.
- `scripts/run_release_tests.sh`: base shard 479 passed, 1 skipped, 14 deselected; real-Ray shard 10 passed, 484 deselected.
- `scripts/run_native_tests.sh "Result collector serializes ordered plans without batch indexes" -s`: 1 test case, 7 assertions passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
