### PR TITLE
[fix](flight) Cancel stalled remote exchange reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A worker lazily starts one process-owned plaintext `grpc://` Flight service when
 
 Workers advertise their Ray private address by default. `VANE_FLIGHT_BIND_HOST` may select a different local bind address, including `0.0.0.0` in a container with appropriate network policy, while `VANE_FLIGHT_ADVERTISE_HOST` must always be a routable non-wildcard address. The advertised-host override is worker-local: set it in each worker node's environment rather than on the driver or in a Ray Job/actor runtime environment. `DUCKDB_FLIGHT_PORT` selects a fixed worker-local port; the default `0` lets the operating system allocate one. See [SECURITY.md](SECURITY.md) for the complete trust boundary.
 
-Cross-worker reads have a one-hour call deadline and a 60-second per-read idle timeout by default. Override them with `VANE_FLIGHT_CALL_TIMEOUT_S` and `VANE_FLIGHT_READ_IDLE_TIMEOUT_S`; either value may be set to `0` to disable that timeout. Query interruption also cancels an in-flight Flight call, so stalled consumers release the producer-side stream and its shuffle-file read lease.
+Cross-worker reads have a one-hour call deadline and a 60-second maximum duration for each blocking DoGet, schema, or batch-read operation by default. Override them with `VANE_FLIGHT_CALL_TIMEOUT_S` and `VANE_FLIGHT_READ_TIMEOUT_S`; either value may be set to `0` to disable that timeout. The read timeout measures the complete Arrow operation, not byte-level network idleness. Query interruption also cancels an in-flight Flight call, so stalled consumers release the producer-side stream and its shuffle-file read lease.
 
 ### More Resources
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ A worker lazily starts one process-owned plaintext `grpc://` Flight service when
 
 Workers advertise their Ray private address by default. `VANE_FLIGHT_BIND_HOST` may select a different local bind address, including `0.0.0.0` in a container with appropriate network policy, while `VANE_FLIGHT_ADVERTISE_HOST` must always be a routable non-wildcard address. The advertised-host override is worker-local: set it in each worker node's environment rather than on the driver or in a Ray Job/actor runtime environment. `DUCKDB_FLIGHT_PORT` selects a fixed worker-local port; the default `0` lets the operating system allocate one. See [SECURITY.md](SECURITY.md) for the complete trust boundary.
 
+Cross-worker reads have a one-hour call deadline and a 60-second per-read idle timeout by default. Override them with `VANE_FLIGHT_CALL_TIMEOUT_S` and `VANE_FLIGHT_READ_IDLE_TIMEOUT_S`; either value may be set to `0` to disable that timeout. Query interruption also cancels an in-flight Flight call, so stalled consumers release the producer-side stream and its shuffle-file read lease.
+
 ### More Resources
 
 - [Examples](https://vane.astrovela.ai/docs/data/examples)

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -49,6 +49,18 @@
 #include <sstream>
 #include <thread>
 
+// Arrow 24 exports this idempotent registration hook, but does not install the
+// transport-specific header that declares it.
+namespace arrow {
+namespace flight {
+namespace transport {
+namespace grpc {
+ARROW_FLIGHT_EXPORT void InitializeFlightGrpcClient();
+} // namespace grpc
+} // namespace transport
+} // namespace flight
+} // namespace arrow
+
 namespace duckdb {
 namespace distributed {
 
@@ -281,18 +293,6 @@ DuckDBResult<void> ConvertArrowRecordBatchToChunk(ClientContext &context, const 
 	return DuckDBResult<void>::ok();
 }
 
-arrow::Status EnsureFlightExchangeClientTransportRegistered(const arrow::flight::Location &location) {
-	static std::once_flag register_once;
-	static arrow::Status register_status;
-	std::call_once(register_once, [&]() {
-		auto client_res = arrow::flight::FlightClient::Connect(location);
-		if (!client_res.ok()) {
-			register_status = client_res.status();
-		}
-	});
-	return register_status;
-}
-
 // FlightClient::DoGet reads the initial schema before returning its FlightStreamReader. Use Arrow's exported
 // transport stream directly so the watchdog can obtain a cancellation handle before the first blocking read.
 DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>
@@ -303,11 +303,7 @@ ConnectFlightExchangeTransport(const std::string &location_string) {
 		    FlightExchangeArrowToError(location_res.status(), "parse flight location"));
 	}
 	auto location = std::move(location_res).ValueOrDie();
-	auto register_status = EnsureFlightExchangeClientTransportRegistered(location);
-	if (!register_status.ok()) {
-		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
-		    FlightExchangeArrowToError(register_status, "register flight client transport"));
-	}
+	arrow::flight::transport::grpc::InitializeFlightGrpcClient();
 
 	auto uri_res = arrow::util::Uri::FromString(location.ToString());
 	if (!uri_res.ok()) {

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -372,12 +372,12 @@ private:
 
 } // namespace
 
-enum class FlightWatchdogStopReason : uint8_t { NONE = 0, INTERRUPTED = 1, IDLE_TIMEOUT = 2 };
+enum class FlightWatchdogStopReason : uint8_t { NONE = 0, INTERRUPTED = 1, READ_TIMEOUT = 2 };
 
 class FlightStreamWatchdog {
 public:
-	FlightStreamWatchdog(ClientContext &context, double idle_timeout_seconds)
-	    : context_(context), idle_timeout_seconds_(idle_timeout_seconds), watchdog_thread_([this]() { Run(); }) {
+	FlightStreamWatchdog(ClientContext &context, double read_timeout_seconds)
+	    : context_(context), read_timeout_seconds_(read_timeout_seconds), watchdog_thread_([this]() { Run(); }) {
 	}
 
 	~FlightStreamWatchdog() {
@@ -394,9 +394,9 @@ public:
 			}
 			operation_active_ = true;
 			operation_generation_++;
-			if (idle_timeout_seconds_ > 0.0) {
+			if (read_timeout_seconds_ > 0.0) {
 				deadline_ = Clock::now() + std::chrono::duration_cast<Clock::duration>(
-				                               std::chrono::duration<double>(idle_timeout_seconds_));
+				                               std::chrono::duration<double>(read_timeout_seconds_));
 			}
 			if (context_.IsInterrupted()) {
 				reason = FlightWatchdogStopReason::INTERRUPTED;
@@ -466,7 +466,7 @@ private:
 
 			const auto generation = operation_generation_;
 			auto wake_at = Clock::now() + INTERRUPT_POLL_INTERVAL;
-			if (idle_timeout_seconds_ > 0.0 && deadline_ < wake_at) {
+			if (read_timeout_seconds_ > 0.0 && deadline_ < wake_at) {
 				wake_at = deadline_;
 			}
 			condition_.wait_until(guard, wake_at);
@@ -477,8 +477,8 @@ private:
 			FlightWatchdogStopReason reason = FlightWatchdogStopReason::NONE;
 			if (context_.IsInterrupted()) {
 				reason = FlightWatchdogStopReason::INTERRUPTED;
-			} else if (idle_timeout_seconds_ > 0.0 && Clock::now() >= deadline_) {
-				reason = FlightWatchdogStopReason::IDLE_TIMEOUT;
+			} else if (read_timeout_seconds_ > 0.0 && Clock::now() >= deadline_) {
+				reason = FlightWatchdogStopReason::READ_TIMEOUT;
 			}
 			if (reason == FlightWatchdogStopReason::NONE) {
 				continue;
@@ -495,7 +495,7 @@ private:
 	}
 
 	ClientContext &context_;
-	double idle_timeout_seconds_;
+	double read_timeout_seconds_;
 	std::mutex mutex_;
 	std::condition_variable condition_;
 	Clock::time_point deadline_;
@@ -507,12 +507,12 @@ private:
 	std::thread watchdog_thread_;
 };
 
-DuckDBError FlightWatchdogError(FlightWatchdogStopReason reason, const char *operation, double idle_timeout_seconds) {
+DuckDBError FlightWatchdogError(FlightWatchdogStopReason reason, const char *operation, double read_timeout_seconds) {
 	if (reason == FlightWatchdogStopReason::INTERRUPTED) {
 		return DuckDBError::external_error(std::string(operation) + " canceled by query interruption");
 	}
 	std::ostringstream message;
-	message << operation << " idle timeout after " << idle_timeout_seconds << " seconds without progress";
+	message << operation << " timed out after " << read_timeout_seconds << " seconds";
 	return DuckDBError::external_error(message.str());
 }
 
@@ -1383,11 +1383,11 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	if (config_.flight_timeout_seconds > 0.0) {
 		call_options.timeout = arrow::flight::TimeoutDuration(config_.flight_timeout_seconds);
 	}
-	stream->flight_watchdog = make_uniq<FlightStreamWatchdog>(*context_, config_.flight_read_idle_timeout_seconds);
+	stream->flight_watchdog = make_uniq<FlightStreamWatchdog>(*context_, config_.flight_read_timeout_seconds);
 	auto watchdog_reason = stream->flight_watchdog->Arm();
 	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_idle_timeout_seconds));
+		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_timeout_seconds));
 	}
 	std::unique_ptr<arrow::flight::internal::ClientDataStream> data_stream;
 	auto do_get_status = stream->flight_transport->DoGet(call_options, flight_ticket, &data_stream);
@@ -1398,7 +1398,7 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	watchdog_reason = stream->flight_watchdog->Disarm();
 	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_idle_timeout_seconds));
+		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_timeout_seconds));
 	}
 	if (!do_get_status.ok()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
@@ -1411,7 +1411,7 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	watchdog_reason = stream->flight_watchdog->Arm();
 	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_idle_timeout_seconds));
+		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_timeout_seconds));
 	}
 	auto memory_manager = call_options.memory_manager;
 	if (!memory_manager) {
@@ -1422,7 +1422,7 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	watchdog_reason = stream->flight_watchdog->Disarm();
 	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_idle_timeout_seconds));
+		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_timeout_seconds));
 	}
 	if (!reader_res.ok()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
@@ -1450,15 +1450,15 @@ DuckDBResult<bool> FlightExchangeSource::ReadStreamChunk(DataChunk &chunk) {
 		while (true) {
 			auto watchdog_reason = stream_state_->flight_watchdog->Arm();
 			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-				return DuckDBResult<bool>::err(FlightWatchdogError(watchdog_reason, "flight read batch",
-				                                                   config_.flight_read_idle_timeout_seconds));
+				return DuckDBResult<bool>::err(
+				    FlightWatchdogError(watchdog_reason, "flight read batch", config_.flight_read_timeout_seconds));
 			}
 			std::shared_ptr<arrow::RecordBatch> batch;
 			auto next_status = stream_state_->flight_reader->ReadNext(&batch);
 			watchdog_reason = stream_state_->flight_watchdog->Disarm();
 			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-				return DuckDBResult<bool>::err(FlightWatchdogError(watchdog_reason, "flight read batch",
-				                                                   config_.flight_read_idle_timeout_seconds));
+				return DuckDBResult<bool>::err(
+				    FlightWatchdogError(watchdog_reason, "flight read batch", config_.flight_read_timeout_seconds));
 			}
 			if (!next_status.ok()) {
 				return DuckDBResult<bool>::err(FlightExchangeArrowToError(next_status, "flight read batch"));

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -31,17 +31,23 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/client_data.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/config.hpp"
 
 #include <arrow/c/bridge.h>
+#include <arrow/device.h>
 #include <arrow/flight/api.h>
+#include <arrow/flight/transport.h>
 #include <arrow/ipc/api.h>
+#include <arrow/util/uri.h>
 
 #include <algorithm>
 #include <array>
+#include <condition_variable>
 #include <iostream>
 #include <mutex>
 #include <sstream>
+#include <thread>
 
 namespace duckdb {
 namespace distributed {
@@ -275,19 +281,242 @@ DuckDBResult<void> ConvertArrowRecordBatchToChunk(ClientContext &context, const 
 	return DuckDBResult<void>::ok();
 }
 
-DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>> ConnectFlightExchangeClient(const std::string &location) {
-	auto location_res = arrow::flight::Location::Parse(location);
+arrow::Status EnsureFlightExchangeClientTransportRegistered(const arrow::flight::Location &location) {
+	static std::once_flag register_once;
+	static arrow::Status register_status;
+	std::call_once(register_once, [&]() {
+		auto client_res = arrow::flight::FlightClient::Connect(location);
+		if (!client_res.ok()) {
+			register_status = client_res.status();
+		}
+	});
+	return register_status;
+}
+
+// FlightClient::DoGet reads the initial schema before returning its FlightStreamReader. Use Arrow's exported
+// transport stream directly so the watchdog can obtain a cancellation handle before the first blocking read.
+DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>
+ConnectFlightExchangeTransport(const std::string &location_string) {
+	auto location_res = arrow::flight::Location::Parse(location_string);
 	if (!location_res.ok()) {
-		return DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>>::err(
+		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
 		    FlightExchangeArrowToError(location_res.status(), "parse flight location"));
 	}
-	auto client_res = arrow::flight::FlightClient::Connect(std::move(location_res).ValueOrDie());
-	if (!client_res.ok()) {
-		return DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>>::err(
-		    FlightExchangeArrowToError(client_res.status(), "connect flight client"));
+	auto location = std::move(location_res).ValueOrDie();
+	auto register_status = EnsureFlightExchangeClientTransportRegistered(location);
+	if (!register_status.ok()) {
+		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
+		    FlightExchangeArrowToError(register_status, "register flight client transport"));
 	}
-	return DuckDBResult<std::unique_ptr<arrow::flight::FlightClient>>::ok(std::move(client_res).ValueOrDie());
+
+	auto uri_res = arrow::util::Uri::FromString(location.ToString());
+	if (!uri_res.ok()) {
+		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
+		    FlightExchangeArrowToError(uri_res.status(), "parse flight transport URI"));
+	}
+	auto transport_res = arrow::flight::internal::GetDefaultTransportRegistry()->MakeClient(location.scheme());
+	if (!transport_res.ok()) {
+		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
+		    FlightExchangeArrowToError(transport_res.status(), "create flight client transport"));
+	}
+	auto transport = std::move(transport_res).ValueOrDie();
+	auto uri = std::move(uri_res).ValueOrDie();
+	auto init_status = transport->Init(arrow::flight::FlightClientOptions::Defaults(), location, uri);
+	if (!init_status.ok()) {
+		return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::err(
+		    FlightExchangeArrowToError(init_status, "connect flight client transport"));
+	}
+	return DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>::ok(std::move(transport));
 }
+
+class FlightExchangeIpcMessageReader final : public arrow::ipc::MessageReader {
+public:
+	FlightExchangeIpcMessageReader(std::shared_ptr<arrow::flight::internal::ClientDataStream> stream,
+	                               std::shared_ptr<arrow::MemoryManager> memory_manager)
+	    : stream_(std::move(stream)), memory_manager_(std::move(memory_manager)) {
+	}
+
+	arrow::Result<std::unique_ptr<arrow::ipc::Message>> ReadNextMessage() override {
+		if (finished_) {
+			return nullptr;
+		}
+		while (true) {
+			arrow::flight::internal::FlightData data;
+			if (!stream_->ReadData(&data)) {
+				finished_ = true;
+				auto status = stream_->Finish(arrow::Status::OK());
+				if (!status.ok()) {
+					return status;
+				}
+				return nullptr;
+			}
+			if (!data.metadata) {
+				continue;
+			}
+			if (data.body) {
+				auto body_res = arrow::Buffer::ViewOrCopy(data.body, memory_manager_);
+				if (!body_res.ok()) {
+					return body_res.status();
+				}
+				data.body = std::move(body_res).ValueOrDie();
+			}
+			return data.OpenMessage();
+		}
+	}
+
+private:
+	std::shared_ptr<arrow::flight::internal::ClientDataStream> stream_;
+	std::shared_ptr<arrow::MemoryManager> memory_manager_;
+	bool finished_ = false;
+};
+
+} // namespace
+
+enum class FlightWatchdogStopReason : uint8_t { NONE = 0, INTERRUPTED = 1, IDLE_TIMEOUT = 2 };
+
+class FlightStreamWatchdog {
+public:
+	FlightStreamWatchdog(ClientContext &context, double idle_timeout_seconds)
+	    : context_(context), idle_timeout_seconds_(idle_timeout_seconds), watchdog_thread_([this]() { Run(); }) {
+	}
+
+	~FlightStreamWatchdog() {
+		Stop();
+	}
+
+	FlightWatchdogStopReason Arm() {
+		arrow::flight::internal::ClientDataStream *stream = nullptr;
+		FlightWatchdogStopReason reason = FlightWatchdogStopReason::NONE;
+		{
+			std::lock_guard<std::mutex> guard(mutex_);
+			if (stop_reason_ != FlightWatchdogStopReason::NONE || stopping_) {
+				return stop_reason_;
+			}
+			operation_active_ = true;
+			operation_generation_++;
+			if (idle_timeout_seconds_ > 0.0) {
+				deadline_ = Clock::now() + std::chrono::duration_cast<Clock::duration>(
+				                               std::chrono::duration<double>(idle_timeout_seconds_));
+			}
+			if (context_.IsInterrupted()) {
+				reason = FlightWatchdogStopReason::INTERRUPTED;
+				stop_reason_ = reason;
+				operation_active_ = false;
+				operation_generation_++;
+				stream = stream_;
+			}
+		}
+		condition_.notify_all();
+		if (reason != FlightWatchdogStopReason::NONE) {
+			RequestCancellation(stream);
+		}
+		return reason;
+	}
+
+	FlightWatchdogStopReason Disarm() {
+		std::lock_guard<std::mutex> guard(mutex_);
+		operation_active_ = false;
+		operation_generation_++;
+		condition_.notify_all();
+		return stop_reason_;
+	}
+
+	void SetStream(arrow::flight::internal::ClientDataStream *stream) {
+		bool cancel_stream = false;
+		{
+			std::lock_guard<std::mutex> guard(mutex_);
+			stream_ = stream;
+			cancel_stream = stream_ && stop_reason_ != FlightWatchdogStopReason::NONE;
+		}
+		if (cancel_stream) {
+			stream->TryCancel();
+		}
+	}
+
+	void Stop() {
+		{
+			std::lock_guard<std::mutex> guard(mutex_);
+			stopping_ = true;
+			operation_active_ = false;
+			operation_generation_++;
+		}
+		condition_.notify_all();
+		if (watchdog_thread_.joinable()) {
+			watchdog_thread_.join();
+		}
+	}
+
+private:
+	using Clock = std::chrono::steady_clock;
+	static constexpr std::chrono::milliseconds INTERRUPT_POLL_INTERVAL {25};
+
+	void RequestCancellation(arrow::flight::internal::ClientDataStream *stream) {
+		if (stream) {
+			stream->TryCancel();
+		}
+	}
+
+	void Run() {
+		std::unique_lock<std::mutex> guard(mutex_);
+		while (!stopping_) {
+			if (!operation_active_) {
+				condition_.wait(guard, [&]() { return stopping_ || operation_active_; });
+				continue;
+			}
+
+			const auto generation = operation_generation_;
+			auto wake_at = Clock::now() + INTERRUPT_POLL_INTERVAL;
+			if (idle_timeout_seconds_ > 0.0 && deadline_ < wake_at) {
+				wake_at = deadline_;
+			}
+			condition_.wait_until(guard, wake_at);
+			if (stopping_ || !operation_active_ || generation != operation_generation_) {
+				continue;
+			}
+
+			FlightWatchdogStopReason reason = FlightWatchdogStopReason::NONE;
+			if (context_.IsInterrupted()) {
+				reason = FlightWatchdogStopReason::INTERRUPTED;
+			} else if (idle_timeout_seconds_ > 0.0 && Clock::now() >= deadline_) {
+				reason = FlightWatchdogStopReason::IDLE_TIMEOUT;
+			}
+			if (reason == FlightWatchdogStopReason::NONE) {
+				continue;
+			}
+
+			stop_reason_ = reason;
+			operation_active_ = false;
+			operation_generation_++;
+			auto *stream = stream_;
+			guard.unlock();
+			RequestCancellation(stream);
+			guard.lock();
+		}
+	}
+
+	ClientContext &context_;
+	double idle_timeout_seconds_;
+	std::mutex mutex_;
+	std::condition_variable condition_;
+	Clock::time_point deadline_;
+	arrow::flight::internal::ClientDataStream *stream_ = nullptr;
+	FlightWatchdogStopReason stop_reason_ = FlightWatchdogStopReason::NONE;
+	uint64_t operation_generation_ = 0;
+	bool operation_active_ = false;
+	bool stopping_ = false;
+	std::thread watchdog_thread_;
+};
+
+DuckDBError FlightWatchdogError(FlightWatchdogStopReason reason, const char *operation, double idle_timeout_seconds) {
+	if (reason == FlightWatchdogStopReason::INTERRUPTED) {
+		return DuckDBError::external_error(std::string(operation) + " canceled by query interruption");
+	}
+	std::ostringstream message;
+	message << operation << " idle timeout after " << idle_timeout_seconds << " seconds without progress";
+	return DuckDBError::external_error(message.str());
+}
+
+namespace {
 
 DuckDBResult<void> EnsureLocalFlightServerStartedInternal(const FlightServiceConfig &config) {
 	auto advertise_host_res = ParseFlightHost(config.advertise_host);
@@ -965,6 +1194,20 @@ DuckDBResult<void> FlightExchangeSink::EnsureSchema(ClientContext &context, cons
 struct FlightExchangeSource::PartitionStreamState {
 	enum class Kind : uint8_t { LOCAL_FILES = 1, FLIGHT = 2 };
 
+	~PartitionStreamState() {
+		if (flight_watchdog) {
+			flight_watchdog->Stop();
+		}
+		if (flight_data_stream) {
+			flight_data_stream->TryCancel();
+		}
+		flight_reader.reset();
+		flight_data_stream.reset();
+		if (flight_transport) {
+			(void)flight_transport->Close();
+		}
+	}
+
 	Kind kind = Kind::LOCAL_FILES;
 	vector<LogicalType> expected_types;
 
@@ -974,8 +1217,10 @@ struct FlightExchangeSource::PartitionStreamState {
 	std::shared_ptr<arrow::io::InputStream> current_input;
 	std::shared_ptr<arrow::ipc::RecordBatchStreamReader> current_ipc_reader;
 
-	std::unique_ptr<arrow::flight::FlightClient> flight_client;
-	std::unique_ptr<arrow::flight::FlightStreamReader> flight_reader;
+	std::unique_ptr<arrow::flight::internal::ClientTransport> flight_transport;
+	std::shared_ptr<arrow::flight::internal::ClientDataStream> flight_data_stream;
+	std::shared_ptr<arrow::ipc::RecordBatchStreamReader> flight_reader;
+	unique_ptr<FlightStreamWatchdog> flight_watchdog;
 
 	unique_ptr<ArrowTableSchema> arrow_table;
 	vector<LogicalType> arrow_types;
@@ -1119,11 +1364,11 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		    ": " + files_res.error().what()));
 	}
 	auto location = BuildFlightLocation(source_flight_host, source_flight_port);
-	auto client_res = ConnectFlightExchangeClient(location);
-	if (client_res.is_err()) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(client_res.error());
+	auto transport_res = ConnectFlightExchangeTransport(location);
+	if (transport_res.is_err()) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(transport_res.error());
 	}
-	stream->flight_client = std::move(client_res.value());
+	stream->flight_transport = std::move(transport_res.value());
 
 	arrow::flight::Ticket flight_ticket;
 	FlightExchangeTicket ticket;
@@ -1138,19 +1383,53 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	if (config_.flight_timeout_seconds > 0.0) {
 		call_options.timeout = arrow::flight::TimeoutDuration(config_.flight_timeout_seconds);
 	}
-	auto reader_res = stream->flight_client->DoGet(call_options, flight_ticket);
+	stream->flight_watchdog = make_uniq<FlightStreamWatchdog>(*context_, config_.flight_read_idle_timeout_seconds);
+	auto watchdog_reason = stream->flight_watchdog->Arm();
+	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_idle_timeout_seconds));
+	}
+	std::unique_ptr<arrow::flight::internal::ClientDataStream> data_stream;
+	auto do_get_status = stream->flight_transport->DoGet(call_options, flight_ticket, &data_stream);
+	if (data_stream) {
+		stream->flight_data_stream = std::move(data_stream);
+		stream->flight_watchdog->SetStream(stream->flight_data_stream.get());
+	}
+	watchdog_reason = stream->flight_watchdog->Disarm();
+	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_idle_timeout_seconds));
+	}
+	if (!do_get_status.ok()) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    FlightExchangeArrowToError(do_get_status, "flight do_get"));
+	}
+	if (!stream->flight_data_stream) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    DuckDBError::external_error("flight do_get returned no data stream"));
+	}
+	watchdog_reason = stream->flight_watchdog->Arm();
+	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_idle_timeout_seconds));
+	}
+	auto memory_manager = call_options.memory_manager;
+	if (!memory_manager) {
+		memory_manager = arrow::CPUDevice::Instance()->default_memory_manager();
+	}
+	auto message_reader = std::make_unique<FlightExchangeIpcMessageReader>(stream->flight_data_stream, memory_manager);
+	auto reader_res = arrow::ipc::RecordBatchStreamReader::Open(std::move(message_reader), call_options.read_options);
+	watchdog_reason = stream->flight_watchdog->Disarm();
+	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
+		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_idle_timeout_seconds));
+	}
 	if (!reader_res.ok()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightExchangeArrowToError(reader_res.status(), "flight do_get"));
+		    FlightExchangeArrowToError(reader_res.status(), "flight get schema"));
 	}
 	stream->flight_reader = std::move(reader_res).ValueOrDie();
-	auto schema_res = stream->flight_reader->GetSchema();
-	if (!schema_res.ok()) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightExchangeArrowToError(schema_res.status(), "flight get schema"));
-	}
-	auto converter_res =
-	    BuildArrowBatchConverter(*context_, std::move(schema_res).ValueOrDie(), stream->expected_types);
+	auto converter_res = BuildArrowBatchConverter(*context_, stream->flight_reader->schema(), stream->expected_types);
 	if (converter_res.is_err()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(converter_res.error());
 	}
@@ -1169,20 +1448,30 @@ DuckDBResult<bool> FlightExchangeSource::ReadStreamChunk(DataChunk &chunk) {
 	}
 	if (stream_state_->kind == PartitionStreamState::Kind::FLIGHT) {
 		while (true) {
-			auto next_res = stream_state_->flight_reader->Next();
-			if (!next_res.ok()) {
-				return DuckDBResult<bool>::err(FlightExchangeArrowToError(next_res.status(), "flight read batch"));
+			auto watchdog_reason = stream_state_->flight_watchdog->Arm();
+			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+				return DuckDBResult<bool>::err(FlightWatchdogError(watchdog_reason, "flight read batch",
+				                                                   config_.flight_read_idle_timeout_seconds));
 			}
-			auto flight_chunk = std::move(next_res).ValueOrDie();
-			if (!flight_chunk.data) {
+			std::shared_ptr<arrow::RecordBatch> batch;
+			auto next_status = stream_state_->flight_reader->ReadNext(&batch);
+			watchdog_reason = stream_state_->flight_watchdog->Disarm();
+			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
+				return DuckDBResult<bool>::err(FlightWatchdogError(watchdog_reason, "flight read batch",
+				                                                   config_.flight_read_idle_timeout_seconds));
+			}
+			if (!next_status.ok()) {
+				return DuckDBResult<bool>::err(FlightExchangeArrowToError(next_status, "flight read batch"));
+			}
+			if (!batch) {
 				return DuckDBResult<bool>::ok(false);
 			}
-			if (flight_chunk.data->num_rows() == 0) {
+			if (batch->num_rows() == 0) {
 				continue;
 			}
-			auto convert_res = ConvertArrowRecordBatchToChunk(*context_, *stream_state_->arrow_table,
-			                                                  stream_state_->arrow_types, stream_state_->output_types,
-			                                                  stream_state_->needs_cast, flight_chunk.data, chunk);
+			auto convert_res =
+			    ConvertArrowRecordBatchToChunk(*context_, *stream_state_->arrow_table, stream_state_->arrow_types,
+			                                   stream_state_->output_types, stream_state_->needs_cast, batch, chunk);
 			if (convert_res.is_err()) {
 				return DuckDBResult<bool>::err(convert_res.error());
 			}
@@ -1253,6 +1542,9 @@ DuckDBResult<bool> FlightExchangeSource::ReadStreamChunk(DataChunk &chunk) {
 
 bool FlightExchangeSource::ReadChunk(DataChunk &chunk) {
 	chunk.Reset();
+	if (context_ && context_->IsInterrupted()) {
+		throw InterruptException();
+	}
 	if (closed_ || current_handle_idx_ >= handles_.size()) {
 		return false;
 	}
@@ -1261,6 +1553,9 @@ bool FlightExchangeSource::ReadChunk(DataChunk &chunk) {
 		if (!stream_state_) {
 			auto stream_res = OpenPartitionStream(handles_[current_handle_idx_]);
 			if (stream_res.is_err()) {
+				if (context_ && context_->IsInterrupted()) {
+					throw InterruptException();
+				}
 				throw std::runtime_error(stream_res.error().what());
 			}
 			stream_state_ = std::move(stream_res.value());
@@ -1268,6 +1563,9 @@ bool FlightExchangeSource::ReadChunk(DataChunk &chunk) {
 
 		auto read_res = ReadStreamChunk(chunk);
 		if (read_res.is_err()) {
+			if (context_ && context_->IsInterrupted()) {
+				throw InterruptException();
+			}
 			throw std::runtime_error(read_res.error().what());
 		}
 		if (read_res.value() && chunk.size() > 0) {

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -353,6 +353,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
 	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
 	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_source_task_partition_ids);
+	serializer.WriteProperty(118, "flight_read_idle_timeout_seconds", flight_config.flight_read_idle_timeout_seconds);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -353,7 +353,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
 	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
 	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_source_task_partition_ids);
-	serializer.WriteProperty(118, "flight_read_idle_timeout_seconds", flight_config.flight_read_idle_timeout_seconds);
+	serializer.WriteProperty(118, "flight_read_timeout_seconds", flight_config.flight_read_timeout_seconds);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1243,10 +1243,14 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto source_handle_flight_hosts = deserializer.ReadProperty<vector<string>>(116, "source_handle_flight_hosts");
 		auto source_handle_task_partition_ids =
 		    deserializer.ReadProperty<vector<idx_t>>(117, "source_handle_task_partition_ids");
+		auto read_idle_timeout_seconds = deserializer.ReadPropertyWithExplicitDefault<double>(
+		    118, "flight_read_idle_timeout_seconds",
+		    distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
 		flight_config.flight_timeout_seconds = timeout_seconds;
+		flight_config.flight_read_idle_timeout_seconds = read_idle_timeout_seconds;
 		flight_config.expected_types = types;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1243,14 +1243,13 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto source_handle_flight_hosts = deserializer.ReadProperty<vector<string>>(116, "source_handle_flight_hosts");
 		auto source_handle_task_partition_ids =
 		    deserializer.ReadProperty<vector<idx_t>>(117, "source_handle_task_partition_ids");
-		auto read_idle_timeout_seconds = deserializer.ReadPropertyWithExplicitDefault<double>(
-		    118, "flight_read_idle_timeout_seconds",
-		    distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
+		auto read_timeout_seconds = deserializer.ReadPropertyWithExplicitDefault<double>(
+		    118, "flight_read_timeout_seconds", distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
 		flight_config.flight_timeout_seconds = timeout_seconds;
-		flight_config.flight_read_idle_timeout_seconds = read_idle_timeout_seconds;
+		flight_config.flight_read_timeout_seconds = read_timeout_seconds;
 		flight_config.expected_types = types;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <cstdlib>
 #include <chrono>
+#include <cmath>
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -41,9 +42,13 @@ class ClientContext;
 namespace distributed {
 
 struct FlightExchangeConfig {
+	static constexpr double DEFAULT_FLIGHT_TIMEOUT_SECONDS = 3600.0;
+	static constexpr double DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS = 60.0;
+
 	std::vector<std::string> local_dirs; // shuffle directories for IPC files
 	std::string node_id;
-	double flight_timeout_seconds = 0.0;
+	double flight_timeout_seconds = DEFAULT_FLIGHT_TIMEOUT_SECONDS;
+	double flight_read_idle_timeout_seconds = DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS;
 	std::vector<LogicalType> expected_types;
 };
 
@@ -66,6 +71,23 @@ inline int ResolveFlightExchangeEnvInt(const char *name, int fallback) {
 	}
 	try {
 		return std::stoi(value);
+	} catch (...) {
+		return fallback;
+	}
+}
+
+inline double ResolveFlightExchangeEnvTimeoutSeconds(const char *name, double fallback) {
+	const char *value = std::getenv(name);
+	if (!value || !*value) {
+		return fallback;
+	}
+	try {
+		size_t parsed_length = 0;
+		auto parsed = std::stod(value, &parsed_length);
+		if (parsed_length != std::string(value).size() || !std::isfinite(parsed) || parsed < 0.0) {
+			return fallback;
+		}
+		return parsed;
 	} catch (...) {
 		return fallback;
 	}
@@ -181,6 +203,10 @@ inline FlightExchangeConfig ResolveFlightExchangeConfigFromEnv() {
 	FlightExchangeConfig config;
 	config.node_id = ResolveFlightExchangeNodeIdFromEnv();
 	config.local_dirs = ResolveFlightExchangeLocalDirsFromEnv();
+	config.flight_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
+	    "VANE_FLIGHT_CALL_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
+	config.flight_read_idle_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
+	    "VANE_FLIGHT_READ_IDLE_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
 	return config;
 }
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -43,12 +43,13 @@ namespace distributed {
 
 struct FlightExchangeConfig {
 	static constexpr double DEFAULT_FLIGHT_TIMEOUT_SECONDS = 3600.0;
-	static constexpr double DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS = 60.0;
+	static constexpr double DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS = 60.0;
 
 	std::vector<std::string> local_dirs; // shuffle directories for IPC files
 	std::string node_id;
 	double flight_timeout_seconds = DEFAULT_FLIGHT_TIMEOUT_SECONDS;
-	double flight_read_idle_timeout_seconds = DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS;
+	// Maximum duration of one DoGet, schema, or batch-read operation; not a byte-idle timer.
+	double flight_read_timeout_seconds = DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS;
 	std::vector<LogicalType> expected_types;
 };
 
@@ -205,8 +206,8 @@ inline FlightExchangeConfig ResolveFlightExchangeConfigFromEnv() {
 	config.local_dirs = ResolveFlightExchangeLocalDirsFromEnv();
 	config.flight_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
 	    "VANE_FLIGHT_CALL_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
-	config.flight_read_idle_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
-	    "VANE_FLIGHT_READ_IDLE_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
+	config.flight_read_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
+	    "VANE_FLIGHT_READ_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 	return config;
 }
 

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -119,6 +119,112 @@ private:
 	string exchange_id_;
 };
 
+class BlockingFlightState {
+public:
+	void MarkStarted() {
+		std::lock_guard<std::mutex> guard(mutex_);
+		started_ = true;
+		condition_.notify_all();
+	}
+
+	bool WaitUntilStarted(std::chrono::milliseconds timeout) {
+		std::unique_lock<std::mutex> guard(mutex_);
+		return condition_.wait_for(guard, timeout, [&]() { return started_; });
+	}
+
+	void WaitUntilReleased() {
+		std::unique_lock<std::mutex> guard(mutex_);
+		condition_.wait(guard, [&]() { return released_; });
+	}
+
+	bool WaitUntilReleased(std::chrono::milliseconds timeout) {
+		std::unique_lock<std::mutex> guard(mutex_);
+		return condition_.wait_for(guard, timeout, [&]() { return released_; });
+	}
+
+	void Release() {
+		std::lock_guard<std::mutex> guard(mutex_);
+		released_ = true;
+		condition_.notify_all();
+	}
+
+private:
+	std::mutex mutex_;
+	std::condition_variable condition_;
+	bool started_ = false;
+	bool released_ = false;
+};
+
+class BlockingRecordBatchReader final : public arrow::RecordBatchReader {
+public:
+	explicit BlockingRecordBatchReader(std::shared_ptr<BlockingFlightState> state)
+	    : state_(std::move(state)), schema_(arrow::schema({arrow::field("value", arrow::int32())})) {
+	}
+
+	std::shared_ptr<arrow::Schema> schema() const override {
+		return schema_;
+	}
+
+	arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch> *batch) override {
+		state_->MarkStarted();
+		state_->WaitUntilReleased();
+		*batch = nullptr;
+		return arrow::Status::OK();
+	}
+
+	arrow::Status Close() override {
+		state_->Release();
+		return arrow::Status::OK();
+	}
+
+private:
+	std::shared_ptr<BlockingFlightState> state_;
+	std::shared_ptr<arrow::Schema> schema_;
+};
+
+class BlockingReadFlightServer final : public arrow::flight::FlightServerBase {
+public:
+	explicit BlockingReadFlightServer(std::shared_ptr<BlockingFlightState> state) : state_(std::move(state)) {
+	}
+
+	arrow::Status DoGet(const arrow::flight::ServerCallContext &, const arrow::flight::Ticket &,
+	                    std::unique_ptr<arrow::flight::FlightDataStream> *stream) override {
+		auto reader = std::make_shared<BlockingRecordBatchReader>(state_);
+		*stream = std::unique_ptr<arrow::flight::RecordBatchStream>(new arrow::flight::RecordBatchStream(reader));
+		return arrow::Status::OK();
+	}
+
+private:
+	std::shared_ptr<BlockingFlightState> state_;
+};
+
+class BlockingDoGetFlightServer final : public arrow::flight::FlightServerBase {
+public:
+	explicit BlockingDoGetFlightServer(std::shared_ptr<BlockingFlightState> state) : state_(std::move(state)) {
+	}
+
+	arrow::Status DoGet(const arrow::flight::ServerCallContext &context, const arrow::flight::Ticket &,
+	                    std::unique_ptr<arrow::flight::FlightDataStream> *) override {
+		state_->MarkStarted();
+		while (!context.is_cancelled()) {
+			if (state_->WaitUntilReleased(std::chrono::milliseconds(5))) {
+				return arrow::Status::Cancelled("blocking DoGet test released");
+			}
+		}
+		return arrow::Status::Cancelled("blocking DoGet test canceled");
+	}
+
+private:
+	std::shared_ptr<BlockingFlightState> state_;
+};
+
+void StartTestFlightServer(arrow::flight::FlightServerBase &server) {
+	auto location = arrow::flight::Location::ForGrpcTcp("127.0.0.1", 0);
+	REQUIRE(location.ok());
+	arrow::flight::FlightServerOptions options(std::move(location).ValueOrDie());
+	REQUIRE(server.Init(options).ok());
+}
+
 using MaterializedRows = vector<vector<Value>>;
 
 ExchangeSourceHandle MakeSourceHandle(const string &output_location, const string &node_id, idx_t partition_id,
@@ -128,6 +234,14 @@ ExchangeSourceHandle MakeSourceHandle(const string &output_location, const strin
 	handle.attempt_id = attempt_id;
 	handle.node_id = node_id;
 	handle.files.push_back(ExchangeSourceFile(output_location, 0));
+	return handle;
+}
+
+ExchangeSourceHandle MakeRemoteSourceHandle(int port) {
+	auto handle = MakeSourceHandle("blocking-flight-test", "producer-node", 0);
+	handle.flight_host = "127.0.0.1";
+	handle.flight_port = port;
+	handle.flight_server_epoch = "blocking-flight-epoch";
 	return handle;
 }
 
@@ -378,6 +492,33 @@ TEST_CASE("Exchange: FlightExchangeTicket parse errors", "[distributed][exchange
 	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\nnope").is_err());
 	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1x\n2").is_err());
 	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nstage\nnode\n1\n2x").is_err());
+}
+
+TEST_CASE("Exchange: Flight timeouts resolve from the worker environment", "[distributed][exchange]") {
+	SECTION("configured values") {
+		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "12.5");
+		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "3.25");
+		auto config = ResolveFlightExchangeConfigFromEnv();
+		REQUIRE(config.flight_timeout_seconds == Approx(12.5));
+		REQUIRE(config.flight_read_idle_timeout_seconds == Approx(3.25));
+	}
+
+	SECTION("zero explicitly disables a timeout") {
+		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "0");
+		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "0");
+		auto config = ResolveFlightExchangeConfigFromEnv();
+		REQUIRE(config.flight_timeout_seconds == 0.0);
+		REQUIRE(config.flight_read_idle_timeout_seconds == 0.0);
+	}
+
+	SECTION("invalid values retain safe defaults") {
+		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "not-a-timeout");
+		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "-1");
+		auto config = ResolveFlightExchangeConfigFromEnv();
+		REQUIRE(config.flight_timeout_seconds == FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
+		REQUIRE(config.flight_read_idle_timeout_seconds ==
+		        FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
+	}
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -1003,6 +1144,160 @@ TEST_CASE("Exchange: process-local Flight shutdown is bounded and releases its s
 	REQUIRE(stopped_while_reader_open);
 	registry.RemoveAndCleanupByQuery(query_id);
 	REQUIRE(registry.RetireQuery(query_id).is_ok());
+}
+
+TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled batch read", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto state = std::make_shared<BlockingFlightState>();
+	BlockingReadFlightServer server(state);
+	StartTestFlightServer(server);
+
+	FlightExchangeConfig config;
+	config.local_dirs = {TestCreatePath("flight_idle_watchdog")};
+	config.node_id = "reader-node";
+	config.expected_types = {LogicalType::INTEGER};
+	config.flight_timeout_seconds = 5.0;
+	config.flight_read_idle_timeout_seconds = 0.5;
+	auto handle = MakeRemoteSourceHandle(server.port());
+	auto read_future = std::async(std::launch::async, [&]() {
+		try {
+			ReadSourceRows(*conn.context, config, {std::move(handle)});
+			return string();
+		} catch (const std::exception &ex) {
+			return string(ex.what());
+		}
+	});
+
+	const bool read_started = state->WaitUntilStarted(std::chrono::seconds(2));
+	const bool read_stopped =
+	    read_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
+	state->Release();
+	read_future.wait();
+	auto read_error = read_future.get();
+	auto shutdown_status = server.Shutdown();
+
+	REQUIRE(read_started);
+	REQUIRE(read_stopped);
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight read batch idle timeout"));
+	REQUIRE(shutdown_status.ok());
+}
+
+TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled initial schema", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto state = std::make_shared<BlockingFlightState>();
+	BlockingDoGetFlightServer server(state);
+	StartTestFlightServer(server);
+
+	FlightExchangeConfig config;
+	config.local_dirs = {TestCreatePath("flight_schema_idle_watchdog")};
+	config.node_id = "reader-node";
+	config.expected_types = {LogicalType::INTEGER};
+	config.flight_timeout_seconds = 5.0;
+	config.flight_read_idle_timeout_seconds = 0.5;
+	auto handle = MakeRemoteSourceHandle(server.port());
+	auto read_future = std::async(std::launch::async, [&]() {
+		try {
+			ReadSourceRows(*conn.context, config, {std::move(handle)});
+			return string();
+		} catch (const std::exception &ex) {
+			return string(ex.what());
+		}
+	});
+
+	const bool do_get_started = state->WaitUntilStarted(std::chrono::seconds(2));
+	const bool read_stopped =
+	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
+	state->Release();
+	read_future.wait();
+	auto read_error = read_future.get();
+	auto shutdown_status = server.Shutdown();
+
+	REQUIRE(do_get_started);
+	REQUIRE(read_stopped);
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight get schema idle timeout"));
+	REQUIRE(shutdown_status.ok());
+}
+
+TEST_CASE("Exchange: Flight call deadline bounds a stalled initial schema", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto state = std::make_shared<BlockingFlightState>();
+	BlockingDoGetFlightServer server(state);
+	StartTestFlightServer(server);
+
+	FlightExchangeConfig config;
+	config.local_dirs = {TestCreatePath("flight_call_deadline")};
+	config.node_id = "reader-node";
+	config.expected_types = {LogicalType::INTEGER};
+	config.flight_timeout_seconds = 0.5;
+	config.flight_read_idle_timeout_seconds = 5.0;
+	auto handle = MakeRemoteSourceHandle(server.port());
+	auto read_future = std::async(std::launch::async, [&]() {
+		try {
+			ReadSourceRows(*conn.context, config, {std::move(handle)});
+			return string();
+		} catch (const std::exception &ex) {
+			return string(ex.what());
+		}
+	});
+
+	const bool do_get_started = state->WaitUntilStarted(std::chrono::seconds(2));
+	const bool read_stopped =
+	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
+	state->Release();
+	read_future.wait();
+	auto read_error = read_future.get();
+	auto shutdown_status = server.Shutdown();
+
+	REQUIRE(do_get_started);
+	REQUIRE(read_stopped);
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("Deadline Exceeded"));
+	REQUIRE(shutdown_status.ok());
+}
+
+TEST_CASE("Exchange: query interrupt cancels a stalled Flight DoGet", "[distributed][exchange]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto state = std::make_shared<BlockingFlightState>();
+	BlockingDoGetFlightServer server(state);
+	StartTestFlightServer(server);
+
+	FlightExchangeConfig config;
+	config.local_dirs = {TestCreatePath("flight_interrupt_watchdog")};
+	config.node_id = "reader-node";
+	config.expected_types = {LogicalType::INTEGER};
+	config.flight_timeout_seconds = 5.0;
+	config.flight_read_idle_timeout_seconds = 5.0;
+	auto handle = MakeRemoteSourceHandle(server.port());
+	auto read_future = std::async(std::launch::async, [&]() {
+		try {
+			ReadSourceRows(*conn.context, config, {std::move(handle)});
+			return string("completed");
+		} catch (const InterruptException &) {
+			return string("interrupted");
+		} catch (const std::exception &ex) {
+			return string(ex.what());
+		}
+	});
+
+	const bool do_get_started = state->WaitUntilStarted(std::chrono::seconds(2));
+	if (do_get_started) {
+		conn.context->Interrupt();
+	}
+	const bool read_stopped =
+	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
+	state->Release();
+	read_future.wait();
+	auto outcome = read_future.get();
+	conn.context->ClearInterrupt();
+	auto shutdown_status = server.Shutdown();
+
+	REQUIRE(do_get_started);
+	REQUIRE(read_stopped);
+	REQUIRE(outcome == "interrupted");
+	REQUIRE(shutdown_status.ok());
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -497,27 +497,26 @@ TEST_CASE("Exchange: FlightExchangeTicket parse errors", "[distributed][exchange
 TEST_CASE("Exchange: Flight timeouts resolve from the worker environment", "[distributed][exchange]") {
 	SECTION("configured values") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "12.5");
-		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "3.25");
+		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "3.25");
 		auto config = ResolveFlightExchangeConfigFromEnv();
 		REQUIRE(config.flight_timeout_seconds == Approx(12.5));
-		REQUIRE(config.flight_read_idle_timeout_seconds == Approx(3.25));
+		REQUIRE(config.flight_read_timeout_seconds == Approx(3.25));
 	}
 
 	SECTION("zero explicitly disables a timeout") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "0");
-		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "0");
+		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "0");
 		auto config = ResolveFlightExchangeConfigFromEnv();
 		REQUIRE(config.flight_timeout_seconds == 0.0);
-		REQUIRE(config.flight_read_idle_timeout_seconds == 0.0);
+		REQUIRE(config.flight_read_timeout_seconds == 0.0);
 	}
 
 	SECTION("invalid values retain safe defaults") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "not-a-timeout");
-		ScopedEnvVar idle_timeout("VANE_FLIGHT_READ_IDLE_TIMEOUT_S", "-1");
+		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "-1");
 		auto config = ResolveFlightExchangeConfigFromEnv();
 		REQUIRE(config.flight_timeout_seconds == FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
-		REQUIRE(config.flight_read_idle_timeout_seconds ==
-		        FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
+		REQUIRE(config.flight_read_timeout_seconds == FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 	}
 }
 
@@ -1146,7 +1145,7 @@ TEST_CASE("Exchange: process-local Flight shutdown is bounded and releases its s
 	REQUIRE(registry.RetireQuery(query_id).is_ok());
 }
 
-TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled batch read", "[distributed][exchange]") {
+TEST_CASE("Exchange: Flight source read timeout cancels a stalled batch read", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 	auto state = std::make_shared<BlockingFlightState>();
@@ -1154,11 +1153,11 @@ TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled batch read", 
 	StartTestFlightServer(server);
 
 	FlightExchangeConfig config;
-	config.local_dirs = {TestCreatePath("flight_idle_watchdog")};
+	config.local_dirs = {TestCreatePath("flight_read_timeout")};
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 5.0;
-	config.flight_read_idle_timeout_seconds = 0.5;
+	config.flight_read_timeout_seconds = 0.5;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1173,17 +1172,17 @@ TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled batch read", 
 	const bool read_stopped =
 	    read_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
 	state->Release();
-	read_future.wait();
+	REQUIRE(read_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
 	auto read_error = read_future.get();
 	auto shutdown_status = server.Shutdown();
 
 	REQUIRE(read_started);
 	REQUIRE(read_stopped);
-	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight read batch idle timeout"));
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight read batch timed out"));
 	REQUIRE(shutdown_status.ok());
 }
 
-TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled initial schema", "[distributed][exchange]") {
+TEST_CASE("Exchange: Flight source read timeout cancels a stalled initial schema", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 	auto state = std::make_shared<BlockingFlightState>();
@@ -1191,11 +1190,11 @@ TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled initial schem
 	StartTestFlightServer(server);
 
 	FlightExchangeConfig config;
-	config.local_dirs = {TestCreatePath("flight_schema_idle_watchdog")};
+	config.local_dirs = {TestCreatePath("flight_schema_read_timeout")};
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 5.0;
-	config.flight_read_idle_timeout_seconds = 0.5;
+	config.flight_read_timeout_seconds = 0.5;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1210,13 +1209,13 @@ TEST_CASE("Exchange: Flight source idle watchdog cancels a stalled initial schem
 	const bool read_stopped =
 	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
 	state->Release();
-	read_future.wait();
+	REQUIRE(read_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
 	auto read_error = read_future.get();
 	auto shutdown_status = server.Shutdown();
 
 	REQUIRE(do_get_started);
 	REQUIRE(read_stopped);
-	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight get schema idle timeout"));
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight get schema timed out"));
 	REQUIRE(shutdown_status.ok());
 }
 
@@ -1232,7 +1231,7 @@ TEST_CASE("Exchange: Flight call deadline bounds a stalled initial schema", "[di
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 0.5;
-	config.flight_read_idle_timeout_seconds = 5.0;
+	config.flight_read_timeout_seconds = 5.0;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1247,7 +1246,7 @@ TEST_CASE("Exchange: Flight call deadline bounds a stalled initial schema", "[di
 	const bool read_stopped =
 	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
 	state->Release();
-	read_future.wait();
+	REQUIRE(read_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
 	auto read_error = read_future.get();
 	auto shutdown_status = server.Shutdown();
 
@@ -1269,7 +1268,7 @@ TEST_CASE("Exchange: query interrupt cancels a stalled Flight DoGet", "[distribu
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 5.0;
-	config.flight_read_idle_timeout_seconds = 5.0;
+	config.flight_read_timeout_seconds = 5.0;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1289,7 +1288,7 @@ TEST_CASE("Exchange: query interrupt cancels a stalled Flight DoGet", "[distribu
 	const bool read_stopped =
 	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
 	state->Release();
-	read_future.wait();
+	REQUIRE(read_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
 	auto outcome = read_future.get();
 	conn.context->ClearInterrupt();
 	auto shutdown_status = server.Shutdown();

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -195,7 +195,7 @@ void SerializePreStrictRemoteExchangeSource(Serializer &serializer) {
 	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
 }
 
-void SerializeRemoteExchangeSourceWithoutIdleTimeout(Serializer &serializer) {
+void SerializeRemoteExchangeSourceWithoutReadTimeout(Serializer &serializer) {
 	vector<LogicalType> types = {LogicalType::INTEGER};
 	vector<idx_t> partition_indices = {0};
 	vector<string> source_nodes = {"node-1"};
@@ -1952,7 +1952,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
 	flight_config.flight_timeout_seconds = 7.5;
-	flight_config.flight_read_idle_timeout_seconds = 3.25;
+	flight_config.flight_read_timeout_seconds = 3.25;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", partition_indices,
@@ -2009,10 +2009,10 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
 	REQUIRE(roundtrip_manager != nullptr);
 	REQUIRE(roundtrip_manager->config().flight_timeout_seconds == 7.5);
-	REQUIRE(roundtrip_manager->config().flight_read_idle_timeout_seconds == 3.25);
+	REQUIRE(roundtrip_manager->config().flight_read_timeout_seconds == 3.25);
 }
 
-TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight idle timeout",
+TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight read timeout",
           "[serialization][physical_plan][exchange]") {
 	Allocator allocator;
 	PhysicalPlan plan(allocator);
@@ -2020,7 +2020,7 @@ TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight idle timeout",
 	SerializationOptions options;
 	BinarySerializer serializer(stream, options);
 	serializer.Begin();
-	SerializeRemoteExchangeSourceWithoutIdleTimeout(serializer);
+	SerializeRemoteExchangeSourceWithoutReadTimeout(serializer);
 	serializer.End();
 
 	stream.Rewind();
@@ -2032,8 +2032,8 @@ TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight idle timeout",
 	REQUIRE(source != nullptr);
 	auto manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source->GetExchangeManager());
 	REQUIRE(manager != nullptr);
-	REQUIRE(manager->config().flight_read_idle_timeout_seconds ==
-	        distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
+	REQUIRE(manager->config().flight_read_timeout_seconds ==
+	        distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 }
 
 TEST_CASE("Remote exchange plans reject pre-strict endpoint payloads", "[serialization][physical_plan][exchange]") {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -195,6 +195,40 @@ void SerializePreStrictRemoteExchangeSource(Serializer &serializer) {
 	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
 }
 
+void SerializeRemoteExchangeSourceWithoutIdleTimeout(Serializer &serializer) {
+	vector<LogicalType> types = {LogicalType::INTEGER};
+	vector<idx_t> partition_indices = {0};
+	vector<string> source_nodes = {"node-1"};
+	vector<idx_t> handle_partition_ids = {0};
+	vector<string> handle_node_ids = {"node-1"};
+	vector<string> handle_paths = {"shuffle-stage__sink_0__attempt_0"};
+	vector<int> handle_flight_ports = {6123};
+	vector<idx_t> handle_attempt_ids = {0};
+	vector<string> local_dirs = {"/tmp/vane-shuffle"};
+	vector<string> handle_server_epochs = {"epoch-1"};
+	vector<string> handle_flight_hosts = {"flight-node-1.internal"};
+	vector<idx_t> handle_task_partition_ids = {0};
+	serializer.WriteProperty(100, "type", PhysicalOperatorType::EXCHANGE_SOURCE);
+	serializer.WriteProperty(101, "types", types);
+	serializer.WriteProperty<idx_t>(102, "estimated_cardinality", 0);
+	serializer.WriteProperty(103, "shuffle_stage_id", string("shuffle-stage"));
+	serializer.WriteProperty(104, "partition_indices", partition_indices);
+	serializer.WriteProperty(105, "source_nodes", source_nodes);
+	serializer.WriteProperty<double>(106, "flight_timeout_seconds", 7.5);
+	serializer.WriteProperty(107, "source_handle_partition_ids", handle_partition_ids);
+	serializer.WriteProperty(108, "source_handle_node_ids", handle_node_ids);
+	serializer.WriteProperty(109, "source_handle_paths", handle_paths);
+	serializer.WriteProperty(110, "source_handle_flight_ports", handle_flight_ports);
+	serializer.WritePropertyWithDefault(111, "runtime_source_node_id", optional_idx(), optional_idx());
+	serializer.WriteProperty(112, "source_handle_attempt_ids", handle_attempt_ids);
+	serializer.WriteProperty(113, "local_dirs", local_dirs);
+	serializer.WriteProperty(114, "source_handle_flight_server_epochs", handle_server_epochs);
+	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
+	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
+	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_task_partition_ids);
+	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
+}
+
 string SerializeSinkDescriptorWithoutFlightHost() {
 	MemoryStream stream(Allocator::DefaultAllocator());
 	BinarySerializer serializer(stream);
@@ -1918,6 +1952,7 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
 	flight_config.flight_timeout_seconds = 7.5;
+	flight_config.flight_read_idle_timeout_seconds = 3.25;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "shuffle_stage", partition_indices,
@@ -1974,6 +2009,31 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
 	REQUIRE(roundtrip_manager != nullptr);
 	REQUIRE(roundtrip_manager->config().flight_timeout_seconds == 7.5);
+	REQUIRE(roundtrip_manager->config().flight_read_idle_timeout_seconds == 3.25);
+}
+
+TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight idle timeout",
+          "[serialization][physical_plan][exchange]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	MemoryStream stream(allocator);
+	SerializationOptions options;
+	BinarySerializer serializer(stream, options);
+	serializer.Begin();
+	SerializeRemoteExchangeSourceWithoutIdleTimeout(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	REQUIRE(deserialized_op != nullptr);
+	auto source = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
+	REQUIRE(source != nullptr);
+	auto manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source->GetExchangeManager());
+	REQUIRE(manager != nullptr);
+	REQUIRE(manager->config().flight_read_idle_timeout_seconds ==
+	        distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_IDLE_TIMEOUT_SECONDS);
 }
 
 TEST_CASE("Remote exchange plans reject pre-strict endpoint payloads", "[serialization][physical_plan][exchange]") {


### PR DESCRIPTION
## Summary

- add a one-hour default Flight call deadline and a 60-second maximum duration for each blocking DoGet, schema, or batch-read operation, with `VANE_FLIGHT_CALL_TIMEOUT_S` and `VANE_FLIGHT_READ_TIMEOUT_S` overrides (`0` disables either timeout)
- make query interruption cancel initial-schema and record-batch waits by acquiring the transport stream before the first blocking read
- serialize the read timeout with remote exchange plans and document that it measures a complete Arrow operation, not byte-level network idleness
- register the Arrow gRPC client transport through its local idempotent hook, without a probe connection or process-wide caching of endpoint failures

## Why

Arrow Flight eagerly reads the initial schema inside the public `FlightClient::DoGet` path, before returning a cancellable reader. The source now uses the exported Arrow transport interface so the watchdog owns a `TryCancel()` handle before schema or batch reads can block. The watchdog is scoped to one active remote partition and is stopped during source teardown; it is not a background maintenance loop.

Arrow 24 exposes completion of whole FlightData messages to this layer, not partial-byte transport progress. The configurable read timeout is therefore intentionally a maximum duration for one complete DoGet, schema, or batch-read operation.

Direct transport construction requires the gRPC factory to be registered. The implementation now invokes the exported idempotent registration hook directly; connection initialization remains per stream, so a transient endpoint failure cannot poison later exchanges.

## Validation

- `[distributed][exchange]`: 58 test cases, 3823 assertions
- `[serialization][physical_plan][exchange]`: 12 test cases, 169 assertions
- exchange suite repeated 10 times without a hang or failure
- release suite after the latest review fix: 484 passed, 1 skipped; real-Ray shard: 10 passed
- incremental native and release wheel builds completed successfully
- two clean local review passes after each review-fix round

Closes #406