### PR TITLE
[fix](udf) Rebuild failed stream result collector

### DIFF
--- a/duckdb/execution/ray_stream_adapter.py
+++ b/duckdb/execution/ray_stream_adapter.py
@@ -145,7 +145,7 @@ class TaskLeaseObjectRefGenerator:
             admission.release()
             raise
         # Stream-contract validation belongs to RayStreamAdapter, which is
-        # constructed by AsyncResultCollector under its durable cleanup-ticket
+        # constructed by UDFStreamResultCollector under its durable cleanup-ticket
         # owner.  Once remote work exists, this constructor must not discover a
         # post-submit error that has no scheduler available to retain an
         # asynchronous driver handoff.

--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -212,7 +212,7 @@ class _CleanupTicket:
             return () if self._error is None else (self._error,)
 
 
-class AsyncResultCollector:
+class UDFStreamResultCollector:
     """Capacity-aware scheduler for lease-owned Ray generator streams.
 
     ``_cv`` owns every published stream transition. Registration first starts
@@ -731,6 +731,11 @@ class AsyncResultCollector:
     def set_wakeup_callback(self, fn: Any) -> None:
         with self._cv:
             self._wakeup_fn = fn
+
+    def fatal_error(self) -> BaseException | None:
+        """Return the process-owner-visible scheduler failure, if any."""
+        with self._cv:
+            return self._thread_error
 
     def shutdown(self) -> None:
         """Stop the process-owned loop after the native submitter is quiescent."""
@@ -2310,4 +2315,4 @@ class AsyncResultCollector:
                     self._cv.notify_all()
 
 
-__all__ = ["AsyncResultCollector"]
+__all__ = ["UDFStreamResultCollector"]

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1591,9 +1591,10 @@ private:
 				}
 			}
 
-			// Drain async sources whenever there are in-flight slots or tracked ObjectRefs in the async collector.
+			// Drain async sources whenever there are in-flight slots or tracked ObjectRefs in the UDF stream result
+			// collector.
 			bool has_async_inflight = false;
-			bool pending_commands_need_async_collector = false;
+			bool pending_commands_need_udf_stream_result_collector = false;
 			for (auto *slot : active) {
 				if (!slot) {
 					continue;
@@ -1607,11 +1608,11 @@ private:
 					continue;
 				}
 				if (PayloadUsesRayStreamCollector(sc->slot->payload)) {
-					pending_commands_need_async_collector = true;
+					pending_commands_need_udf_stream_result_collector = true;
 					break;
 				}
 			}
-			bool drain_async = (bool)async_collector || has_async_inflight;
+			bool drain_async = (bool)udf_stream_result_collector || has_async_inflight;
 
 			bool needs_gil =
 			    !pending_commands.empty() || has_pending_cleanup_cancel || drain_async || has_output_lease_releases;
@@ -1645,7 +1646,7 @@ private:
 			                          has_output_lease_releases || debug_loop_tick % 200 == 0)) {
 				UDFDebugLog(StringUtil::Format(
 				    "dispatcher_loop tick=%llu active_slots=%llu inflight_slots=%llu inflight_total=%llu "
-				    "pending_shutdown_slots=%llu command_slots=%llu command_count=%llu async_collector=%s "
+				    "pending_shutdown_slots=%llu command_slots=%llu command_count=%llu udf_stream_result_collector=%s "
 				    "has_async_inflight=%s drain_async=%s needs_gil=%s work_pending=%s wakeup_fired=%s",
 				    static_cast<unsigned long long>(debug_loop_tick),
 				    static_cast<unsigned long long>(debug_active_slots),
@@ -1653,20 +1654,25 @@ private:
 				    static_cast<unsigned long long>(debug_inflight_total),
 				    static_cast<unsigned long long>(debug_pending_shutdown_slots),
 				    static_cast<unsigned long long>(pending_commands.size()),
-				    static_cast<unsigned long long>(debug_command_count), async_collector ? "true" : "false",
-				    has_async_inflight ? "true" : "false", drain_async ? "true" : "false", needs_gil ? "true" : "false",
+				    static_cast<unsigned long long>(debug_command_count),
+				    udf_stream_result_collector ? "true" : "false", has_async_inflight ? "true" : "false",
+				    drain_async ? "true" : "false", needs_gil ? "true" : "false",
 				    work_pending.load() ? "true" : "false", python_wakeup_fired ? "true" : "false"));
 			}
 			// Phase 2: single GIL acquisition for all submits + async drain
 			if (needs_gil) {
 				PythonGILWrapper gil;
+				if (RecoverFailedUDFStreamResultCollector_WithGIL(active)) {
+					did_work = true;
+				}
 
-				// Ensure async collector exists for ObjectRef-based paths.
-				if ((bool)async_collector || pending_commands_need_async_collector) {
+				// Ensure UDF stream result collector exists for ObjectRef-based paths.
+				if ((bool)udf_stream_result_collector || pending_commands_need_udf_stream_result_collector) {
 					try {
-						EnsureAsyncCollector();
+						EnsureUDFStreamResultCollector();
 					} catch (const std::exception &ex) {
-						auto msg = StringUtil::Format("udf async collector initialization failed: %s", ex.what());
+						auto msg =
+						    StringUtil::Format("udf stream result collector initialization failed: %s", ex.what());
 						for (auto &sc : pending_commands) {
 							if (sc && sc->slot && PayloadUsesRayStreamCollector(sc->slot->payload) &&
 							    !sc->slot->abort_requested.load()) {
@@ -1760,7 +1766,7 @@ private:
 					}
 				}
 
-				// Drain completed results from async collector
+				// Drain completed results from UDF stream result collector
 				if (drain_async) {
 					did_work |= DrainAsyncResults_WithGIL(active);
 				}
@@ -1825,14 +1831,16 @@ private:
 		// then destroy slots after releasing it for the same reason as
 		// Unregister(): queued Arrow/PyArrow buffers can acquire the GIL.
 		std::unordered_map<uint64_t, shared_ptr<ExecutorSlot>> cleanup_slots;
-		unique_ptr<RegisteredObject> cleanup_async_collector;
+		unique_ptr<RegisteredObject> cleanup_udf_stream_result_collector;
+		unique_ptr<RegisteredObject> cleanup_failed_udf_stream_result_collector;
 		{
 			lock_guard<mutex> g(global_lock);
-			if (slots.empty() && !async_collector) {
+			if (slots.empty() && !udf_stream_result_collector && !failed_udf_stream_result_collector) {
 				return;
 			}
 			cleanup_slots.swap(slots);
-			cleanup_async_collector = std::move(async_collector);
+			cleanup_udf_stream_result_collector = std::move(udf_stream_result_collector);
+			cleanup_failed_udf_stream_result_collector = std::move(failed_udf_stream_result_collector);
 		}
 		if (!PythonRuntimeUsableForUDFTeardown()) {
 			for (auto &kv : cleanup_slots) {
@@ -1842,8 +1850,11 @@ private:
 				kv.second->actor_handles.reset();
 				MarkSlotCleanupComplete(*kv.second);
 			}
-			if (cleanup_async_collector) {
-				cleanup_async_collector.release();
+			if (cleanup_udf_stream_result_collector) {
+				cleanup_udf_stream_result_collector.release();
+			}
+			if (cleanup_failed_udf_stream_result_collector) {
+				cleanup_failed_udf_stream_result_collector.release();
 			}
 			return;
 		}
@@ -1865,16 +1876,21 @@ private:
 		} catch (const std::exception &ex) {
 			RecordDispatcherError(StringUtil::Format("udf output lease final release failed: %s", ex.what()));
 		}
-		if (cleanup_async_collector) {
+		auto shutdown_collector = [&](unique_ptr<RegisteredObject> &collector) {
+			if (!collector) {
+				return;
+			}
 			try {
-				cleanup_async_collector->obj.attr("shutdown")();
+				collector->obj.attr("shutdown")();
 			} catch (const py::error_already_set &ex) {
 				RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
 			} catch (const std::exception &ex) {
 				RecordDispatcherError(StringUtil::Format("udf dispatcher final cleanup failed: %s", ex.what()));
 			}
-			cleanup_async_collector.reset();
-		}
+			collector.reset();
+		};
+		shutdown_collector(cleanup_udf_stream_result_collector);
+		shutdown_collector(cleanup_failed_udf_stream_result_collector);
 		for (auto &kv : cleanup_slots) {
 			MarkSlotCleanupComplete(*kv.second);
 		}
@@ -1889,7 +1905,7 @@ private:
 		slot.cleanup_cv.notify_all();
 	}
 
-	enum class AsyncCollectorSlotCancelStatus : uint8_t { COMPLETE, PENDING, RETRY };
+	enum class UDFStreamResultCollectorSlotCancelStatus : uint8_t { COMPLETE, PENDING, RETRY };
 
 	static std::chrono::milliseconds CollectorCleanupRetryDelay(idx_t retry_count) {
 		const auto exponent = MinValue<idx_t>(retry_count > 0 ? retry_count - 1 : 0, 7);
@@ -1933,12 +1949,12 @@ private:
 		{
 			PythonGILWrapper gil;
 			slot_ptr->cleanup_cancel_requested.store(true);
-			auto cancel_status = CancelAsyncCollectorSlot_WithGIL(*slot_ptr);
-			if (cancel_status != AsyncCollectorSlotCancelStatus::COMPLETE) {
+			auto cancel_status = CancelUDFStreamResultCollectorSlot_WithGIL(*slot_ptr);
+			if (cancel_status != UDFStreamResultCollectorSlotCancelStatus::COMPLETE) {
 				// A pending ticket owns its eventual wakeup. A synchronous
 				// ownership-handoff failure has no such event, so retain the
 				// slot and retry it on the dispatcher's bounded backoff clock.
-				if (cancel_status == AsyncCollectorSlotCancelStatus::RETRY) {
+				if (cancel_status == UDFStreamResultCollectorSlotCancelStatus::RETRY) {
 					ScheduleCollectorCleanupRetry(*slot_ptr);
 				} else {
 					ResetCollectorCleanupRetry(*slot_ptr);
@@ -2102,59 +2118,63 @@ private:
 		WakeupPipelineThread(slot);
 	}
 
-	AsyncCollectorSlotCancelStatus CancelAsyncCollectorSlot_WithGIL(ExecutorSlot &slot) {
+	UDFStreamResultCollectorSlotCancelStatus CancelUDFStreamResultCollectorSlot_WithGIL(ExecutorSlot &slot) {
 		if (terminal_collector_shutdown_owned.load()) {
-			return AsyncCollectorSlotCancelStatus::COMPLETE;
+			return UDFStreamResultCollectorSlotCancelStatus::COMPLETE;
 		}
-		if (!PayloadUsesRayStreamCollector(slot.payload) || !async_collector || slot.collector_retired.load()) {
-			return AsyncCollectorSlotCancelStatus::COMPLETE;
+		if (!PayloadUsesRayStreamCollector(slot.payload) || !udf_stream_result_collector ||
+		    slot.collector_retired.load()) {
+			return UDFStreamResultCollectorSlotCancelStatus::COMPLETE;
 		}
 		try {
-			async_collector->obj.attr("cancel_slot")(py::int_(slot.id));
+			udf_stream_result_collector->obj.attr("cancel_slot")(py::int_(slot.id));
 		} catch (const py::error_already_set &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot, StringUtil::Format("udf stream result collector cancel_slot failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot, StringUtil::Format("udf stream result collector cancel_slot failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		}
 		bool collector_pending;
 		try {
-			collector_pending = async_collector->obj.attr("slot_has_pending")(py::int_(slot.id)).cast<bool>();
+			collector_pending =
+			    udf_stream_result_collector->obj.attr("slot_has_pending")(py::int_(slot.id)).cast<bool>();
 		} catch (const py::error_already_set &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot,
+			                 StringUtil::Format("udf stream result collector slot_has_pending failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector slot_has_pending failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot,
+			                 StringUtil::Format("udf stream result collector slot_has_pending failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		}
 		if (collector_pending) {
-			return AsyncCollectorSlotCancelStatus::PENDING;
+			return UDFStreamResultCollectorSlotCancelStatus::PENDING;
 		}
 		try {
 			// Once the collector reports no ownership, this dispatcher generation
 			// is the last possible submitter, so its process-lifetime cancellation
 			// fence can go.
-			auto cleanup_error = async_collector->obj.attr("retire_slot")(py::int_(slot.id));
+			auto cleanup_error = udf_stream_result_collector->obj.attr("retire_slot")(py::int_(slot.id));
 			slot.collector_retired.store(true);
 			if (!cleanup_error.is_none()) {
-				PublishSlotError(slot, StringUtil::Format("udf async collector slot cleanup failed: %s",
+				PublishSlotError(slot, StringUtil::Format("udf stream result collector slot cleanup failed: %s",
 				                                          py::str(cleanup_error).cast<string>()));
 			}
 		} catch (const py::error_already_set &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot, StringUtil::Format("udf stream result collector retire_slot failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		} catch (const std::exception &ex) {
-			PublishSlotError(slot, StringUtil::Format("udf async collector retire_slot failed: %s", ex.what()));
-			return AsyncCollectorSlotCancelStatus::RETRY;
+			PublishSlotError(slot, StringUtil::Format("udf stream result collector retire_slot failed: %s", ex.what()));
+			return UDFStreamResultCollectorSlotCancelStatus::RETRY;
 		}
-		return AsyncCollectorSlotCancelStatus::COMPLETE;
+		return UDFStreamResultCollectorSlotCancelStatus::COMPLETE;
 	}
 
 	void CancelSlotForCleanup_WithGIL(ExecutorSlot &slot, bool cancel_collector = true) {
 		const bool first_cancel = !slot.cleanup_cancel_requested.exchange(true);
 		if (first_cancel && cancel_collector) {
-			if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
+			if (CancelUDFStreamResultCollectorSlot_WithGIL(slot) == UDFStreamResultCollectorSlotCancelStatus::RETRY) {
 				ScheduleCollectorCleanupRetry(slot);
 			}
 		}
@@ -2196,13 +2216,14 @@ private:
 		if (first_abort && PythonRuntimeUsableForUDFTeardown()) {
 			try {
 				PythonGILWrapper gil;
-				if (CancelAsyncCollectorSlot_WithGIL(slot) == AsyncCollectorSlotCancelStatus::RETRY) {
+				if (CancelUDFStreamResultCollectorSlot_WithGIL(slot) ==
+				    UDFStreamResultCollectorSlotCancelStatus::RETRY) {
 					ScheduleCollectorCleanupRetry(slot);
 				}
 			} catch (const py::error_already_set &ex) {
-				SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
+				SetSlotError(slot, StringUtil::Format("udf stream result collector cancel_slot failed: %s", ex.what()));
 			} catch (const std::exception &ex) {
-				SetSlotError(slot, StringUtil::Format("udf async collector cancel_slot failed: %s", ex.what()));
+				SetSlotError(slot, StringUtil::Format("udf stream result collector cancel_slot failed: %s", ex.what()));
 			}
 		}
 	}
@@ -2543,7 +2564,7 @@ private:
 			return DrainSyncResults(slot, generation) || slot.has_error.load() != old_error;
 		} catch (const py::error_already_set &ex) {
 			if (IsActiveSlotGeneration(slot, generation)) {
-				SetSlotError(slot, StringUtil::Format("udf async collector failed: %s", ex.what()));
+				SetSlotError(slot, StringUtil::Format("udf stream result collector failed: %s", ex.what()));
 			}
 			return true;
 		} catch (const std::exception &ex) {
@@ -2637,10 +2658,10 @@ private:
 		if (ref.is_none()) {
 			return;
 		}
-		if (!async_collector) {
-			throw InvalidInputException("udf async collector is unavailable for stale submitted work");
+		if (!udf_stream_result_collector) {
+			throw InvalidInputException("udf stream result collector is unavailable for stale submitted work");
 		}
-		async_collector->obj.attr("discard_generator_ref")(py::int_(slot.id), ref);
+		udf_stream_result_collector->obj.attr("discard_generator_ref")(py::int_(slot.id), ref);
 	}
 
 	void TrackSubmittedPythonRef_WithGIL(ExecutorSlot &slot, idx_t submit_id, py::object &ref,
@@ -2661,8 +2682,8 @@ private:
 			    static_cast<long long>(slot.inflight_count.load())));
 			return;
 		}
-		if (!async_collector) {
-			throw InvalidInputException("udf async collector is unavailable");
+		if (!udf_stream_result_collector) {
+			throw InvalidInputException("udf stream result collector is unavailable");
 		}
 		py::object error_context = py::none();
 		if (py::hasattr(slot.py_executor->obj, "error_context")) {
@@ -2672,7 +2693,8 @@ private:
 			DiscardSubmittedPythonRef_WithGIL(slot, ref);
 			return;
 		}
-		async_collector->obj.attr("track_generator_ref")(py::int_(slot.id), py::int_(submit_id), ref, error_context);
+		udf_stream_result_collector->obj.attr("track_generator_ref")(py::int_(slot.id), py::int_(submit_id), ref,
+		                                                             error_context);
 		if (!IsActiveSlotGeneration(slot, generation)) {
 			return;
 		}
@@ -2866,7 +2888,7 @@ private:
 			return true;
 		};
 
-		if (async_collector && has_ray_collector_slot) {
+		if (udf_stream_result_collector && has_ray_collector_slot) {
 			try {
 				py::dict capacities;
 				idx_t debug_capacity_total = 0;
@@ -2923,7 +2945,7 @@ private:
 					capacities[py::int_(slot->id)] = std::move(capacity_obj);
 				}
 
-				auto results_list = async_collector->obj.attr("drain_results")(capacities);
+				auto results_list = udf_stream_result_collector->obj.attr("drain_results")(capacities);
 				auto results = results_list.cast<py::list>();
 				auto debug_result_count = static_cast<idx_t>(py::len(results));
 				auto debug_tick = g_udf_debug_drain_tick.fetch_add(1, std::memory_order_relaxed) + 1;
@@ -2964,23 +2986,23 @@ private:
 							if (tuple_len == 6) {
 								if (event_kind != "data") {
 									throw InvalidInputException(
-									    "udf async collector returned lease identity for non-data event");
+									    "udf stream result collector returned lease identity for non-data event");
 								}
 								output_request_id = tup[4].cast<string>();
 								output_lease_id = tup[5].cast<string>();
 							}
 						} else {
-							throw InvalidInputException("udf async collector returned invalid result tuple");
+							throw InvalidInputException("udf stream result collector returned invalid result tuple");
 						}
 						std::function<void()> handoff_output_lease;
 						std::function<void()> release_output_lease;
 						if (event_kind == "data") {
 							if (tuple_len != 6 || output_request_id.empty() || output_lease_id.empty()) {
 								throw InvalidInputException(
-								    "udf async collector data event is missing output lease identity");
+								    "udf stream result collector data event is missing output lease identity");
 							}
-							auto callbacks = MakeCollectorOutputLeaseCallbacks(async_collector->obj, slot_id,
-							                                                   output_request_id, output_lease_id);
+							auto callbacks = MakeCollectorOutputLeaseCallbacks(
+							    udf_stream_result_collector->obj, slot_id, output_request_id, output_lease_id);
 							handoff_output_lease = std::move(callbacks.handoff);
 							release_output_lease = std::move(callbacks.release);
 						}
@@ -3040,8 +3062,8 @@ private:
 						} else {
 							event.kind = UDFOutputEventKind::ERROR;
 							event.submit_complete = true;
-							event.error = StringUtil::Format("udf async collector returned unknown output event '%s'",
-							                                 event_kind);
+							event.error = StringUtil::Format(
+							    "udf stream result collector returned unknown output event '%s'", event_kind);
 						}
 						if (!DeliverOutputEvent(*slot, std::move(event), slot_generation)) {
 							SetSlotError(*slot, "udf async: output consumer rejected capacity-aware delivery");
@@ -3050,14 +3072,16 @@ private:
 						continue;
 					} catch (const py::error_already_set &ex) {
 						if (slot && !slot->abort_requested.load() && IsActiveSlotGeneration(*slot, slot_generation)) {
-							SetSlotError(*slot, StringUtil::Format("udf async collector result failed: %s", ex.what()));
+							SetSlotError(
+							    *slot, StringUtil::Format("udf stream result collector result failed: %s", ex.what()));
 						} else if (!slot) {
-							fail_active_slots(StringUtil::Format("udf async collector failed: %s", ex.what()));
+							fail_active_slots(StringUtil::Format("udf stream result collector failed: %s", ex.what()));
 						}
 						did_work = true;
 					} catch (const std::exception &ex) {
 						if (slot && !slot->abort_requested.load() && IsActiveSlotGeneration(*slot, slot_generation)) {
-							SetSlotError(*slot, StringUtil::Format("udf async collector result failed: %s", ex.what()));
+							SetSlotError(
+							    *slot, StringUtil::Format("udf stream result collector result failed: %s", ex.what()));
 						} else if (!slot) {
 							fail_active_slots(StringUtil::Format("udf async result drain failed: %s", ex.what()));
 						}
@@ -3066,7 +3090,7 @@ private:
 				}
 
 			} catch (const py::error_already_set &ex) {
-				fail_active_slots(StringUtil::Format("udf async collector failed: %s", ex.what()));
+				fail_active_slots(StringUtil::Format("udf stream result collector failed: %s", ex.what()));
 			} catch (const std::exception &ex) {
 				fail_active_slots(StringUtil::Format("udf async result drain failed: %s", ex.what()));
 			}
@@ -3281,15 +3305,18 @@ private:
 		}
 	}
 
-	void EnsureAsyncCollector() {
-		if (async_collector) {
+	void EnsureUDFStreamResultCollector() {
+		if (failed_udf_stream_result_collector) {
+			throw InvalidInputException("udf stream result collector recovery failed; process restart required");
+		}
+		if (udf_stream_result_collector) {
 			return;
 		}
 		// Caller holds GIL
 		try {
 			auto module = py::module_::import("duckdb.execution.udf_stream_result_collector");
-			auto collector_obj = module.attr("AsyncResultCollector")();
-			// Wire wakeup callback: when async collector completes an await,
+			auto collector_obj = module.attr("UDFStreamResultCollector")();
+			// Wire wakeup callback: when UDF stream result collector completes an await,
 			// it calls this lambda which signals work_cv so the dispatcher
 			// wakes up immediately to drain results (no GIL spin).
 			auto wakeup_fn = py::cpp_function([this]() {
@@ -3297,12 +3324,69 @@ private:
 				work_cv.notify_one();
 			});
 			collector_obj.attr("set_wakeup_callback")(wakeup_fn);
-			async_collector = make_uniq<RegisteredObject>(std::move(collector_obj));
+			udf_stream_result_collector = make_uniq<RegisteredObject>(std::move(collector_obj));
 		} catch (const py::error_already_set &ex) {
-			throw InvalidInputException("udf async collector initialization failed: %s", ex.what());
+			throw InvalidInputException("udf stream result collector initialization failed: %s", ex.what());
 		} catch (const std::exception &ex) {
-			throw InvalidInputException("udf async collector initialization failed: %s", ex.what());
+			throw InvalidInputException("udf stream result collector initialization failed: %s", ex.what());
 		}
+	}
+
+	bool GetUDFStreamResultCollectorFatalError_WithGIL(string &failure) {
+		if (!udf_stream_result_collector) {
+			return false;
+		}
+		try {
+			auto error = udf_stream_result_collector->obj.attr("fatal_error")();
+			if (error.is_none()) {
+				return false;
+			}
+			failure = py::str(error).cast<string>();
+			return true;
+		} catch (const py::error_already_set &ex) {
+			failure = StringUtil::Format("collector health check failed: %s", ex.what());
+			return true;
+		} catch (const std::exception &ex) {
+			failure = StringUtil::Format("collector health check failed: %s", ex.what());
+			return true;
+		}
+	}
+
+	bool RecoverFailedUDFStreamResultCollector_WithGIL(vector<ExecutorSlot *> &active) {
+		string failure;
+		if (!GetUDFStreamResultCollectorFatalError_WithGIL(failure)) {
+			return false;
+		}
+		UDFDebugLog(StringUtil::Format("udf_stream_result_collector_recovery_start failure=%s", failure));
+		for (auto *slot : active) {
+			if (slot && PayloadUsesRayStreamCollector(slot->payload)) {
+				slot->collector_retired.store(true);
+			}
+		}
+		auto error = StringUtil::Format("udf stream result collector failed: %s", failure);
+		for (auto *slot : active) {
+			if (!slot || !PayloadUsesRayStreamCollector(slot->payload) || slot->abort_requested.load() ||
+			    !IsSlotActive(*slot)) {
+				continue;
+			}
+			SetSlotError(*slot, error);
+		}
+
+		auto failed_collector = std::move(udf_stream_result_collector);
+		try {
+			failed_collector->obj.attr("shutdown")();
+		} catch (const py::error_already_set &ex) {
+			failed_udf_stream_result_collector = std::move(failed_collector);
+			RecordDispatcherError(StringUtil::Format("udf stream result collector recovery failed: %s", ex.what()));
+			return true;
+		} catch (const std::exception &ex) {
+			failed_udf_stream_result_collector = std::move(failed_collector);
+			RecordDispatcherError(StringUtil::Format("udf stream result collector recovery failed: %s", ex.what()));
+			return true;
+		}
+		failed_collector.reset();
+		UDFDebugLog("udf_stream_result_collector_recovery_done");
+		return true;
 	}
 
 	// ── Members ──────────────────────────────────────────────────────────
@@ -3317,7 +3401,7 @@ private:
 	atomic<bool> stop {false};
 	atomic<bool> shutdown_requested {false};
 	atomic<bool> terminal_collector_shutdown_owned {false};
-	atomic<bool> wakeup_fired {false}; // set by async collector wakeup callback
+	atomic<bool> wakeup_fired {false}; // set by UDF stream result collector wakeup callback
 	atomic<bool> work_pending {false}; // set by all notify paths before signaling work_cv
 	mutex dispatcher_error_lock;
 	atomic<bool> has_dispatcher_error {false};
@@ -3326,7 +3410,8 @@ private:
 	bool thread_running = false;
 	mutex output_lease_release_lock;
 	std::deque<PendingCollectorOutputLeaseCallback> output_lease_releases;
-	unique_ptr<RegisteredObject> async_collector; // Python AsyncResultCollector
+	unique_ptr<RegisteredObject> udf_stream_result_collector; // Python UDFStreamResultCollector
+	unique_ptr<RegisteredObject> failed_udf_stream_result_collector;
 };
 
 struct CollectorOutputLeaseCallbackState {

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -334,7 +334,7 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
         elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
-            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
+            udf_stream_result_collector.UDFStreamResultCollector(ray_module=object())
 
 
 @pytest.mark.parametrize(
@@ -368,7 +368,7 @@ def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
         elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
-            udf_stream_result_collector.AsyncResultCollector(ray_module=object())
+            udf_stream_result_collector.UDFStreamResultCollector(ray_module=object())
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -472,6 +472,9 @@ def test_native_dispatcher_terminal_shutdown_uses_one_aggregate_collector_deadli
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
 
+            def fatal_error(self):
+                return None
+
             def track_generator_ref(self, _slot_id, _submit_id, _source, _error_context):
                 global tracked_count
                 with state_lock:
@@ -553,7 +556,7 @@ def test_native_dispatcher_terminal_shutdown_uses_one_aggregate_collector_deadli
 
 
         udf_exec.build_executor = build_executor
-        collector_mod.AsyncResultCollector = FakeCollector
+        collector_mod.UDFStreamResultCollector = FakeCollector
         connections = [duckdb.connect() for _ in range(slot_count)]
         relations = [
             connection.sql("select 1::BIGINT as x").map_batches(
@@ -647,6 +650,9 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
 
+            def fatal_error(self):
+                return None
+
             def track_generator_ref(self, slot_id, submit_id, _source, _error_context):
                 self._events.append((int(slot_id), int(submit_id), "complete", None))
                 tracked.set()
@@ -722,7 +728,7 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
 
 
         udf_exec.build_executor = build_executor
-        collector_mod.AsyncResultCollector = FakeCollector
+        collector_mod.UDFStreamResultCollector = FakeCollector
         connection = duckdb.connect()
         relation = connection.sql("select 1::BIGINT as x").map_batches(
             passthrough,
@@ -767,6 +773,195 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
             **os.environ,
             "VANE_UDF_UNREGISTER_TIMEOUT_MS": "50",
         },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_native_dispatcher_rebuilds_failed_ray_stream_collector():
+    """A fatal collector error must not poison later Ray UDF queries."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import threading
+
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import duckdb.execution.udf_stream_result_collector as collector_mod
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import make_local_shm_ref_bundle_result
+
+        collector_instances = []
+        first_collector_shutdown = threading.Event()
+
+
+        class FakeSource:
+            def __init__(self, value):
+                self.value = int(value)
+
+
+        class FakeCollector:
+            def __init__(self):
+                self._index = len(collector_instances)
+                self._wakeup = None
+                self._fatal_error = None
+                self._events = {}
+                self._cancelled = set()
+                collector_instances.append(self)
+
+            def set_wakeup_callback(self, callback):
+                self._wakeup = callback
+
+            def fatal_error(self):
+                return self._fatal_error
+
+            def track_generator_ref(self, slot_id, submit_id, source, _error_context):
+                slot_id = int(slot_id)
+                submit_id = int(submit_id)
+                if self._index == 0:
+                    self._fatal_error = RuntimeError("planned fatal collector failure")
+                else:
+                    payload = make_local_shm_ref_bundle_result(pa.table({"y": [source.value]}))
+                    self._events[slot_id] = [
+                        (
+                            slot_id,
+                            submit_id,
+                            "data",
+                            payload,
+                            "output-request:recovered",
+                            "output-lease:recovered",
+                        ),
+                        (slot_id, submit_id, "complete", None),
+                    ]
+                if self._wakeup is not None:
+                    self._wakeup()
+
+            def discard_generator_ref(self, _slot_id, _source):
+                return None
+
+            def drain_results(self, capacities):
+                if self._fatal_error is not None:
+                    raise RuntimeError(f"Ray UDF stream multiplexer failed: {self._fatal_error}")
+                results = []
+                for slot_id in list(self._events):
+                    if int(capacities.get(slot_id, {}).get("rows", 0)) <= 0:
+                        continue
+                    results.extend(self._events.pop(slot_id))
+                return results
+
+            def handoff_output_block_lease(self, _request_id, _lease_id):
+                return True
+
+            def release_output_block_lease(self, _request_id, _lease_id):
+                return True
+
+            def cancel_slot(self, slot_id):
+                slot_id = int(slot_id)
+                self._cancelled.add(slot_id)
+                self._events.pop(slot_id, None)
+
+            def slot_has_pending(self, _slot_id):
+                return False
+
+            def retire_slot(self, _slot_id):
+                return None
+
+            def shutdown(self):
+                self._events.clear()
+                if self._index == 0:
+                    first_collector_shutdown.set()
+
+
+        class FakeExecutor:
+            def __init__(self):
+                self._wakeup = None
+                self._admission_state = "idle"
+                self._retained_input_bytes = 0
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                self._retained_input_bytes = int(retained_input_bytes)
+                self._admission_state = "ready"
+                return True
+
+            def task_admission_state(self):
+                return {
+                    "state": self._admission_state,
+                    "available": self._admission_state == "ready",
+                    "retained_input_bytes": self._retained_input_bytes,
+                }
+
+            def submit_with_id(self, _submit_id, table):
+                self._admission_state = "idle"
+                return FakeSource(table.column(0).to_pylist()[0])
+
+            def take_ready_result(self):
+                return None
+
+            def finished_submitting(self):
+                return None
+
+            def all_tasks_finished(self):
+                return False
+
+            def close(self):
+                return None
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return FakeExecutor()
+
+
+        def passthrough(table):
+            return pa.table({"y": table.column(0)})
+
+
+        udf_exec.build_executor = build_executor
+        collector_mod.UDFStreamResultCollector = FakeCollector
+        failed_connection = duckdb.connect()
+        recovered_connection = duckdb.connect()
+        failed_relation = failed_connection.sql("select 1::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        recovered_relation = recovered_connection.sql("select 2::BIGINT as x").map_batches(
+            passthrough,
+            schema={"y": duckdb.sqltypes.BIGINT},
+            execution_backend="ray_task",
+        )
+        try:
+            try:
+                failed_relation.fetchall()
+            except BaseException as exc:
+                assert "planned fatal collector failure" in str(exc), exc
+            else:
+                raise AssertionError("poisoned collector query unexpectedly succeeded")
+
+            assert first_collector_shutdown.wait(timeout=5), "failed collector was not shut down"
+            assert recovered_relation.fetchall() == [(2,)]
+            assert len(collector_instances) == 2, len(collector_instances)
+        finally:
+            failed_connection.close()
+            recovered_connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ},
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
@@ -976,6 +1171,9 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
 
+            def fatal_error(self):
+                return None
+
             def discard_generator_ref(self, _slot_id, ref):
                 assert ref is submitted_ref
                 discarded.set()
@@ -1057,7 +1255,7 @@ def test_retired_ray_submit_is_discarded_before_python_ref_is_dropped(failure_ph
 
 
         udf_exec.build_executor = build_executor
-        collector_mod.AsyncResultCollector = FakeCollector
+        collector_mod.UDFStreamResultCollector = FakeCollector
         connection = duckdb.connect()
         relation = connection.sql("select i::BIGINT as x from range(2) t(i)").map_batches(
             passthrough,
@@ -1162,6 +1360,9 @@ def test_pending_ray_slot_cleanup_does_not_spin_or_block_healthy_slot():
 
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
+
+            def fatal_error(self):
+                return None
 
             def track_generator_ref(self, slot_id, submit_id, source, _error_context):
                 slot_id = int(slot_id)
@@ -1283,7 +1484,7 @@ def test_pending_ray_slot_cleanup_does_not_spin_or_block_healthy_slot():
 
 
         udf_exec.build_executor = build_executor
-        collector_mod.AsyncResultCollector = FakeCollector
+        collector_mod.UDFStreamResultCollector = FakeCollector
         slow_connection = duckdb.connect()
         healthy_connection = duckdb.connect()
         slow_relation = slow_connection.sql("select 1::BIGINT as x").map_batches(
@@ -1409,6 +1610,9 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
             def set_wakeup_callback(self, callback):
                 self._wakeup = callback
 
+            def fatal_error(self):
+                return None
+
             def track_generator_ref(self, slot_id, submit_id, source, _error_context):
                 slot_id = int(slot_id)
                 submit_id = int(submit_id)
@@ -1529,7 +1733,7 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
 
 
         udf_exec.build_executor = build_executor
-        collector_mod.AsyncResultCollector = FakeCollector
+        collector_mod.UDFStreamResultCollector = FakeCollector
         bad_connection = duckdb.connect()
         good_connection = duckdb.connect()
         bad_relation = bad_connection.sql("select 1::BIGINT as x").map_batches(

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -20,7 +20,7 @@ from duckdb.execution.ray_stream_adapter import (
     TaskLeaseObjectRefGenerator,
 )
 from duckdb.execution.udf_stream_result_collector import (
-    AsyncResultCollector,
+    UDFStreamResultCollector,
     _OutputLeaseToken,
     _ReadyEvent,
     _StreamRecord,
@@ -385,7 +385,7 @@ def _capture_thread_error(errors, operation, *args):
 
 def test_collector_requires_task_lease_stream_and_has_no_raw_generator_fallback():
     fake_ray = _FakeRay()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     try:
         with pytest.raises(TypeError, match="must return TaskLeaseObjectRefGenerator"):
             collector.track_generator_ref(1, 1, _Generator([]))
@@ -404,7 +404,7 @@ def test_event_loop_start_failure_prevents_submitted_stream_ownership(monkeypatc
 
     monkeypatch.setattr(threading.Thread, "start", fail_start)
     with pytest.raises(RuntimeError, match="planned thread start failure"):
-        AsyncResultCollector(ray_module=fake_ray)
+        UDFStreamResultCollector(ray_module=fake_ray)
 
     assert fake_ray.cancel_calls == []
 
@@ -414,7 +414,7 @@ def test_event_loop_start_timeout_rolls_back_started_thread(monkeypatch):
     monkeypatch.setenv("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "0.02")
     existing_threads = set(threading.enumerate())
 
-    class SlowStartCollector(AsyncResultCollector):
+    class SlowStartCollector(UDFStreamResultCollector):
         def _run_event_loop(self):
             # Stay blocked beyond both the startup deadline and the old
             # second bounded join. Construction must still reclaim this
@@ -432,7 +432,7 @@ def test_event_loop_start_timeout_rolls_back_started_thread(monkeypatch):
 def test_scheduler_failure_isolated_to_stream_does_not_poison_future_slots():
     fake_ray = _FailingWaitRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         1,
@@ -488,7 +488,7 @@ def test_initial_waiter_registration_failure_unpublishes_and_cleans_stream():
     driver = _Driver()
     generator = _Generator([], completed=False)
     generator.completion_ref = _FailingFutureRef(None, ready=False)
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     try:
         with pytest.raises(RuntimeError, match="planned Future registration failure"):
             collector.track_generator_ref(
@@ -527,7 +527,7 @@ def test_invalid_submitted_stream_cleanup_does_not_block_healthy_stream():
         request_id="invalid-stream-delayed-handoff",
         submitter=lambda _lease: invalid_stream,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     errors = []
     track = threading.Thread(
         target=_capture_thread_error,
@@ -606,7 +606,7 @@ def test_midstream_waiter_registration_failure_is_isolated_to_its_stream():
             [_Ref("healthy-block", is_block=True), _Ref(_metadata(lease))],
         )
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         1,
@@ -657,7 +657,7 @@ def test_midstream_waiter_registration_failure_is_isolated_to_its_stream():
 def test_registration_is_not_visible_until_track_commits_it(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector._ensure_started()
     collector.drain_results({1: {"rows": 1, "bytes": 128, "item_bytes": 128}})
     registration_paused = threading.Event()
@@ -726,7 +726,7 @@ def test_discarded_submitted_stream_enters_terminal_cleanup_ledger():
     fake_ray = _FakeRay()
     driver = _Driver()
     generator = _Generator([], completed=False)
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     try:
         collector.discard_generator_ref(
             9,
@@ -763,7 +763,7 @@ def test_slot_cancel_is_nonblocking_and_cleanup_completion_wakes_dispatcher():
         cleanup_response,
     )
     generator = _Generator([], completed=False)
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     cleanup_wakeup = threading.Event()
     collector.set_wakeup_callback(cleanup_wakeup.set)
     collector.discard_generator_ref(
@@ -812,7 +812,7 @@ def test_slot_cancel_hands_off_cleanup_before_blocking_record_future_cancel():
         ],
         completed=False,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         19,
         1,
@@ -862,7 +862,7 @@ def test_slot_cancel_hands_off_cleanup_before_blocking_record_future_cancel():
 def test_failure_wakeup_can_reenter_shutdown_after_cleanup_handoff():
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         1,
@@ -892,7 +892,7 @@ def test_failure_wakeup_can_reenter_shutdown_after_cleanup_handoff():
 
 
 def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = 0
     order = []
 
@@ -934,7 +934,7 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
 def test_cleanup_tickets_progress_when_loop_notification_fails(
     monkeypatch,
 ):
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     operation_calls = []
     original_call_soon_threadsafe = collector._loop.call_soon_threadsafe
 
@@ -980,7 +980,7 @@ def test_cleanup_tickets_progress_when_loop_notification_fails(
 
 
 def test_cleanup_tickets_progress_after_event_loop_exits():
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     operation_calls = []
     collector._request_event_loop_stop()
     collector._thread.join(timeout=1.0)
@@ -1012,7 +1012,7 @@ def test_cleanup_tickets_progress_after_event_loop_exits():
 
 
 def test_cleanup_ticket_preserves_incomplete_ownership_retry():
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = 0
 
     def transfer_owner():
@@ -1053,7 +1053,7 @@ def test_cleanup_ticket_rejects_a_broken_future_callback_contract():
         def result(self):
             raise AssertionError("broken Future must never be resolved")
 
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     tickets = collector._submit_cleanup_operations(
         (
             RayStreamCleanupOperation(
@@ -1096,7 +1096,7 @@ def test_slot_retirement_reports_async_cancellation_ticket_failure():
         assert allow_operation.wait(timeout=2)
         return _BrokenFuture()
 
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     collector._submit_cleanup_operations(
         (
             RayStreamCleanupOperation(
@@ -1129,7 +1129,7 @@ def test_cleanup_ticket_retries_a_hung_control_response(monkeypatch):
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
         0.01,
     )
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = []
 
     def transfer_owner():
@@ -1171,7 +1171,7 @@ def test_cleanup_ticket_accepts_late_ack_from_timed_out_attempt(monkeypatch):
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
         0.01,
     )
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = []
     second_attempt_started = threading.Event()
 
@@ -1216,7 +1216,7 @@ def test_cleanup_ticket_ignores_invalid_late_ack(monkeypatch):
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
         0.01,
     )
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = []
     second_attempt_started = threading.Event()
 
@@ -1263,7 +1263,7 @@ def test_cleanup_ticket_finishes_once_when_retried_acks_race(monkeypatch):
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_S",
         0.01,
     )
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = []
     second_attempt_started = threading.Event()
     completions = []
@@ -1332,7 +1332,7 @@ def test_cleanup_ticket_expands_slow_response_deadline(monkeypatch):
         "duckdb.execution.udf_stream_result_collector._CLEANUP_RESPONSE_TIMEOUT_MAX_S",
         0.04,
     )
-    collector = AsyncResultCollector(ray_module=_FakeRay())
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
     attempts = []
     response_timers = []
 
@@ -1394,7 +1394,7 @@ def test_zero_capacity_does_not_consume_block_or_metadata_objects():
         holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         10,
@@ -1426,7 +1426,7 @@ def test_ready_block_read_reserves_data_capacity_across_streams():
         generators.append(generator)
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         1,
         10,
@@ -1479,7 +1479,7 @@ def test_ready_block_read_reserves_data_capacity_across_streams():
 
 def test_data_capacity_does_not_count_interleaved_control_events():
     fake_ray = _FakeRay()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     token = _OutputLeaseToken(
         request_id="strict-consumer-request",
         lease_id="strict-consumer-lease",
@@ -1517,7 +1517,7 @@ def test_direct_block_pair_is_leased_and_large_block_is_never_fetched():
     def submitter(lease):
         return _Generator([block_ref, _Ref(_metadata(lease, size_bytes=64))])
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         20,
@@ -1581,7 +1581,7 @@ def test_output_lease_control_retries_until_driver_acknowledges_ownership(operat
         submit_id=20,
         size_bytes=64,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     key = (token.request_id, token.lease_id)
     with collector._cv:
         collector._active_output_leases[key] = token
@@ -1616,7 +1616,7 @@ def test_output_control_waits_on_one_inflight_driver_response():
         submit_id=21,
         size_bytes=64,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     key = (token.request_id, token.lease_id)
     with collector._cv:
         collector._active_output_leases[key] = token
@@ -1651,7 +1651,7 @@ def test_output_release_ticket_handoff_is_atomic_with_shutdown(monkeypatch):
         submit_id=22,
         size_bytes=64,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     key = (token.request_id, token.lease_id)
     with collector._cv:
         collector._active_output_leases[key] = token
@@ -1720,7 +1720,7 @@ def test_slot_cancel_reuses_an_already_claimed_output_release_ticket():
         submit_id=23,
         size_bytes=64,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     key = (token.request_id, token.lease_id)
     with collector._cv:
         collector._active_output_leases[key] = token
@@ -1782,7 +1782,7 @@ def test_metadata_transition_is_atomic_with_concurrent_capacity_refresh(
             ]
         )
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         23,
@@ -1833,7 +1833,7 @@ def test_inflight_block_keeps_item_capacity_from_read_admission():
         holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         24,
@@ -1926,7 +1926,7 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
         return source, weakref.ref(source)
 
     source, source_ref = make_source()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(2, 22, source)
     del source
     capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
@@ -1985,7 +1985,7 @@ def test_terminal_cleanup_handoff_failure_replans_owned_stream(monkeypatch):
         )
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         22,
@@ -2049,7 +2049,7 @@ def test_blocked_output_admission_submission_does_not_stall_healthy_stream():
     driver.acquire_query_output_block_lease = _RemoteMethod(
         blocking_acquire_output,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         24,
@@ -2139,7 +2139,7 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         "retire_operations",
         selectively_blocking_retire_operations,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         25,
@@ -2213,7 +2213,7 @@ def test_slot_cancel_observes_claimed_terminal_retirement_without_waiting(monkey
         )
 
     monkeypatch.setattr(RayStreamAdapter, "retire_operations", blocking_retire_operations)
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         4,
         41,
@@ -2258,7 +2258,7 @@ def test_completion_ready_before_final_metadata_does_not_fail_valid_pair():
         holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         21,
@@ -2304,7 +2304,7 @@ def test_completion_ready_before_final_metadata_does_not_fail_valid_pair():
 def test_output_grant_transition_is_atomic_with_slot_cancellation():
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         2,
         19,
@@ -2423,7 +2423,7 @@ def test_terminal_record_releases_completed_output_lease_with_exact_rpc_contract
         output_request_id=f"output-request:{metadata['block_id']}",
         output_lease_ref=_Ref(driver._acquire_output(output_request)),
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     record.registered = True
     record.terminal = True
     with collector._cv:
@@ -2476,7 +2476,7 @@ def test_one_slow_stream_cannot_block_a_ready_stream():
     def fast_submitter(lease):
         return _Generator([fast_block, _Ref(_metadata(lease))])
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         30,
@@ -2522,7 +2522,7 @@ def test_capacity_one_selects_ready_stream_without_prefetching_slow_stream():
         generators["fast"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         32,
@@ -2564,7 +2564,7 @@ def test_capacity_one_schedules_ready_streams_in_round_robin_order():
             ]
         )
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     for submit_id in (37, 38):
         collector.track_generator_ref(
             3,
@@ -2603,7 +2603,7 @@ def test_ready_generator_without_capacity_is_not_dequeued_or_polled():
         holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         34,
@@ -2623,7 +2623,7 @@ def test_ready_generator_without_capacity_is_not_dequeued_or_polled():
 def test_unready_generator_polling_uses_bounded_idle_backoff():
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         39,
@@ -2685,7 +2685,7 @@ def test_local_eligibility_change_interrupts_idle_readiness_backoff():
         fast_generators.append(generator)
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         35,
@@ -2734,7 +2734,7 @@ def test_readiness_probe_failure_is_reported_without_dequeuing():
         generators.append(generator)
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         3,
         42,
@@ -2779,7 +2779,7 @@ def test_batch_wait_failure_isolates_one_bad_generator_from_healthy_slots():
         healthy_holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         31,
         310,
@@ -2856,7 +2856,7 @@ def test_real_ray_generator_wait_is_non_consuming_and_preserves_pair_order():
         }
         return yield_pair.remote(metadata)
 
-    collector = AsyncResultCollector(ray_module=ray)
+    collector = UDFStreamResultCollector(ray_module=ray)
     collector.track_generator_ref(
         3,
         43,
@@ -2885,7 +2885,7 @@ def test_real_ray_generator_wait_is_non_consuming_and_preserves_pair_order():
 def test_empty_stream_completion_progresses_with_zero_data_capacity():
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         4,
         40,
@@ -2913,7 +2913,7 @@ def test_generator_terminating_mid_pair_fails_without_fetching_block():
     driver = _Driver()
     orphan_block = _Ref("remote-error-or-orphan-block", is_block=True)
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         9,
         90,
@@ -2960,7 +2960,7 @@ def test_failed_completion_retires_without_cancelling_terminal_remote_work():
     completion_future = Future()
     completion_future.set_exception(RuntimeError("planned completion failure"))
     record.completion_future = completion_future
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector._records[(record.slot_id, record.submit_id)] = record
 
     try:
@@ -3008,7 +3008,7 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
         holder["generator"] = generator
         return generator
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         10,
         100,
@@ -3038,7 +3038,7 @@ def test_malformed_metadata_fails_only_its_stream_without_output_admission():
     def submitter(_lease):
         return _Generator([_Ref("block", is_block=True), _Ref({"size_bytes": 1})])
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         5,
         50,
@@ -3070,7 +3070,7 @@ def test_stream_error_wakes_dispatcher_before_generator_cancellation():
     def submitter(_lease):
         return _Generator([_Ref("block", is_block=True), _Ref({"size_bytes": 1})])
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
 
     def notify():
         cancel_counts_at_wakeup.append(len(fake_ray.cancel_calls))
@@ -3129,7 +3129,7 @@ def test_many_cancellations_complete_on_the_cleanup_event_loop():
     fake_ray = _FakeRay()
     driver = _Driver()
     generators = []
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     for index in range(12):
         generator = _Generator([], completed=False)
         generators.append(generator)
@@ -3162,7 +3162,7 @@ def test_pending_output_control_futures_do_not_withhold_task_or_stream_cleanup()
     release_response = _Ref({"released": True}, ready=False)
     blocked_release = _DelayedAckRemoteMethod(release_response)
     driver.release_query_output_block_lease = blocked_release
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     output_tokens = [
         _OutputLeaseToken(
             request_id=f"output-request:blocked:{index}",
@@ -3226,7 +3226,7 @@ def test_block_larger_than_declared_item_capacity_fails_instead_of_stalling_queu
             ]
         )
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         7,
         70,
@@ -3257,7 +3257,7 @@ def test_slot_cancellation_recursively_cancels_stream_and_releases_output_lease(
             completed=False,
         )
 
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         6,
         60,
@@ -3283,7 +3283,7 @@ def test_slot_cancellation_recursively_cancels_stream_and_releases_output_lease(
 def test_shutdown_clears_callback_and_fully_joins_owned_thread():
     fake_ray = _FakeRay()
     driver = _Driver()
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.set_wakeup_callback(lambda: None)
     collector.track_generator_ref(
         8,
@@ -3320,7 +3320,7 @@ def test_shutdown_cleanup_handoff_failure_is_retryable(monkeypatch):
         ],
         completed=False,
     )
-    collector = AsyncResultCollector(ray_module=fake_ray)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         8,
         81,


### PR DESCRIPTION
## Summary

- expose fatal scheduler state to the native UDF dispatcher
- pause submissions, fail slots owned by a poisoned collector, and shut it down before lazily creating a replacement
- rename the collector API and native identifiers to `UDFStreamResultCollector` without a compatibility alias or fallback
- cover a failed first Ray UDF query followed by a successful query in the same process

## Tests

- `python -m pytest tests/fast/test_udf_process.py`
- `python -m pytest tests/fast/test_udf_stream_result_collector.py`
- `python -m pytest tests/fast/test_udf_executor_lifecycle.py`
- `scripts/run_release_tests.sh`
- `scripts/format root --changed`

Closes #409