### PR TITLE
[fix](udf) bound pending slot cleanup

### DIFF
--- a/duckdb/execution/udf_stream_result_collector.py
+++ b/duckdb/execution/udf_stream_result_collector.py
@@ -164,6 +164,7 @@ class _CleanupTicket:
         self.wait_response: RayStreamCleanupWait | None = None
         self.retry_call: RayControlScheduledCall | None = None
         self.wait_timeout: RayControlScheduledCall | None = None
+        self.deadline_call: RayControlScheduledCall | None = None
         self._done = False
         self._error: BaseException | None = None
         self._on_complete = on_complete
@@ -248,6 +249,10 @@ class UDFStreamResultCollector:
         self._shutdown_timeout_s = float(os.environ.get("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S", "5"))
         if not math.isfinite(self._shutdown_timeout_s) or self._shutdown_timeout_s <= 0:
             raise ValueError("VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S must be positive")
+        cleanup_timeout = os.environ.get("VANE_UDF_STREAM_CLEANUP_TIMEOUT_S")
+        self._cleanup_timeout_s = self._shutdown_timeout_s if cleanup_timeout is None else float(cleanup_timeout)
+        if not math.isfinite(self._cleanup_timeout_s) or self._cleanup_timeout_s <= 0:
+            raise ValueError("VANE_UDF_STREAM_CLEANUP_TIMEOUT_S must be positive")
         # Cleanup ownership can outlive the asyncio loop, so its process-wide
         # deadline owner must exist before this collector accepts any stream.
         RAY_CONTROL_DEADLINE_SCHEDULER.ensure_started()
@@ -1175,6 +1180,10 @@ class UDFStreamResultCollector:
                 holder: list[_CleanupTicket] = ticket_holder,
             ) -> None:
                 callback_error: BaseException | None = None
+                deadline_call: RayControlScheduledCall | None = None
+                retry_call: RayControlScheduledCall | None = None
+                wait_timeout: RayControlScheduledCall | None = None
+                operation_future: Any | None = None
                 try:
                     if on_each_done is not None:
                         on_each_done(error)
@@ -1183,6 +1192,17 @@ class UDFStreamResultCollector:
                 finally:
                     ticket = holder[0]
                     with self._cv:
+                        deadline_call = ticket.deadline_call
+                        retry_call = ticket.retry_call
+                        wait_timeout = ticket.wait_timeout
+                        operation_future = ticket.operation_future
+                        ticket.deadline_call = None
+                        ticket.retry_call = None
+                        ticket.wait_timeout = None
+                        ticket.operation_future = None
+                        ticket.wait_future = None
+                        ticket.wait_response = None
+                        ticket.submitting = False
                         if store_error and error is not None:
                             self._terminal_cleanup_errors.append(error)
                         if callback_error is not None:
@@ -1198,6 +1218,11 @@ class UDFStreamResultCollector:
                                         None,
                                     )
                         self._cv.notify_all()
+                    for scheduled_call in (deadline_call, retry_call, wait_timeout):
+                        if scheduled_call is not None:
+                            scheduled_call.cancel()
+                    if operation_future is not None:
+                        operation_future.cancel()
                     self._notify_wakeup()
                     self._stop_loop_after_final_cleanup_ticket()
 
@@ -1220,8 +1245,64 @@ class UDFStreamResultCollector:
                     self._cleanup_tickets_by_slot[slot_id].update(tickets)
                 self._cv.notify_all()
             for ticket in tickets:
+                try:
+                    self._arm_cleanup_ticket_deadline(ticket)
+                except BaseException as exc:
+                    ticket.finish(exc)
+            for ticket in tickets:
                 self._drive_cleanup_ticket(ticket)
         return tuple(tickets)
+
+    def _arm_cleanup_ticket_deadline(self, ticket: _CleanupTicket) -> None:
+        deadline_call: RayControlScheduledCall
+
+        def deadline_elapsed() -> None:
+            self._expire_cleanup_ticket(ticket, deadline_call)
+
+        deadline_call = create_ray_control_deadline(
+            f"{ticket.operation.submission_scope}:cleanup-total-timeout",
+            deadline_elapsed,
+        )
+        with self._cv:
+            if ticket not in self._cleanup_tickets:
+                arm_deadline = False
+            else:
+                ticket.deadline_call = deadline_call
+                arm_deadline = True
+        if not arm_deadline:
+            deadline_call.cancel()
+            return
+        try:
+            RAY_CONTROL_DEADLINE_SCHEDULER.schedule(
+                deadline_call,
+                self._cleanup_timeout_s,
+            )
+        except BaseException as exc:
+            with self._cv:
+                if ticket.deadline_call is deadline_call:
+                    ticket.deadline_call = None
+                    active = ticket in self._cleanup_tickets
+                else:
+                    active = False
+            deadline_call.cancel()
+            if active:
+                ticket.finish(exc)
+
+    def _expire_cleanup_ticket(
+        self,
+        ticket: _CleanupTicket,
+        deadline_call: RayControlScheduledCall,
+    ) -> None:
+        with self._cv:
+            if ticket not in self._cleanup_tickets or ticket.deadline_call is not deadline_call:
+                return
+            ticket.deadline_call = None
+        ticket.finish(
+            TimeoutError(
+                "Ray UDF remote cleanup did not terminate within "
+                f"{self._cleanup_timeout_s:g}s: scope={ticket.operation.submission_scope}"
+            )
+        )
 
     @staticmethod
     def _cleanup_retry_delay(retry_count: int) -> float:

--- a/src/duckdb_py/udf_executor.cpp
+++ b/src/duckdb_py/udf_executor.cpp
@@ -1863,10 +1863,6 @@ private:
 			// Terminal shutdown owns the process-wide collector as one unit.
 			// Per-slot cancellation would apply its full timeout once per slot.
 			CancelSlotForCleanup_WithGIL(*kv.second, false);
-			if (kv.second->py_executor) {
-				kv.second->py_executor.reset();
-			}
-			kv.second->actor_handles.reset();
 		}
 		try {
 			while (DrainOutputLeaseReleases_WithGIL()) {
@@ -1924,6 +1920,53 @@ private:
 		slot.collector_cleanup_retry_scheduled = true;
 	}
 
+	void ReleaseSlotLocalResources_WithGIL(ExecutorSlot &slot) {
+		// The process-wide collector independently owns remote stream state, and
+		// cancel_slot transfers terminal operations into its durable ticket
+		// ledger. None of the query-local executor state is needed while those
+		// tickets reach a terminal state, so release it without coupling local
+		// lifetime to a remote acknowledgement.
+		if (slot.py_executor) {
+			try {
+				slot.py_executor->obj.attr("close")();
+			} catch (const py::error_already_set &ex) {
+				SetSlotError(slot, StringUtil::Format("udf executor close failed: %s", ex.what()));
+			} catch (const std::exception &ex) {
+				SetSlotError(slot, StringUtil::Format("udf executor close failed: %s", ex.what()));
+			}
+			slot.py_executor.reset();
+			slot.py_executor_initialized = false;
+		}
+		slot.actor_handles.reset();
+		{
+			lock_guard<mutex> guard(slot.cmd_lock);
+			slot.cmd_queue.clear();
+		}
+		slot.rows_by_submit_id.clear();
+		slot.terminal_submit_ids.clear();
+		slot.ref_inputs_by_submit_id.clear();
+		{
+			lock_guard<mutex> guard(slot.task_admission_lock);
+			slot.task_admission_request_pending = false;
+			slot.task_admission_available = false;
+			slot.task_admission_reserved = false;
+			slot.task_admission_retained_input_bytes = 0;
+		}
+		{
+			lock_guard<mutex> guard(slot.consumer_lock);
+			slot.has_output_consumer = false;
+			slot.output_consumer = {};
+		}
+		{
+			lock_guard<mutex> guard(slot.wakeup_lock);
+			slot.has_interrupt_state = false;
+			slot.wakeup_callback = nullptr;
+		}
+		slot.inflight_count.store(0);
+		slot.finished_submitting_acked.store(true);
+		slot.all_tasks_finished.store(true);
+	}
+
 	bool CleanupSlot(uint64_t id) {
 		shared_ptr<ExecutorSlot> slot;
 		{
@@ -1950,10 +1993,12 @@ private:
 			PythonGILWrapper gil;
 			slot_ptr->cleanup_cancel_requested.store(true);
 			auto cancel_status = CancelUDFStreamResultCollectorSlot_WithGIL(*slot_ptr);
+			ReleaseSlotLocalResources_WithGIL(*slot_ptr);
 			if (cancel_status != UDFStreamResultCollectorSlotCancelStatus::COMPLETE) {
-				// A pending ticket owns its eventual wakeup. A synchronous
-				// ownership-handoff failure has no such event, so retain the
-				// slot and retry it on the dispatcher's bounded backoff clock.
+				// Keep only the lightweight retirement fence. A pending ticket
+				// owns its eventual wakeup; a synchronous ownership-handoff
+				// failure has no such event, so retry it on the dispatcher's
+				// bounded backoff clock.
 				if (cancel_status == UDFStreamResultCollectorSlotCancelStatus::RETRY) {
 					ScheduleCollectorCleanupRetry(*slot_ptr);
 				} else {
@@ -1962,21 +2007,7 @@ private:
 				return false;
 			}
 			ResetCollectorCleanupRetry(*slot_ptr);
-			if (slot_ptr->py_executor) {
-				try {
-					slot_ptr->py_executor->obj.attr("close")();
-				} catch (const py::error_already_set &ex) {
-					SetSlotError(*slot_ptr, StringUtil::Format("udf executor close failed: %s", ex.what()));
-				} catch (const std::exception &ex) {
-					SetSlotError(*slot_ptr, StringUtil::Format("udf executor close failed: %s", ex.what()));
-				}
-				slot_ptr->py_executor.reset();
-			}
-			slot_ptr->actor_handles.reset();
 		}
-		slot_ptr->rows_by_submit_id.clear();
-		slot_ptr->ref_inputs_by_submit_id.clear();
-		slot_ptr->inflight_count.store(0);
 		{
 			lock_guard<mutex> g(global_lock);
 			auto it = slots.find(id);
@@ -2178,23 +2209,10 @@ private:
 				ScheduleCollectorCleanupRetry(slot);
 			}
 		}
-		// Local executor close is independently idempotent and must not be
-		// skipped when process shutdown takes over a slot whose collector
-		// cancellation was already pending.
-		if (slot.py_executor) {
-			try {
-				slot.py_executor->obj.attr("close")();
-			} catch (const py::error_already_set &ex) {
-				SetSlotError(slot, StringUtil::Format("udf executor close failed: %s", ex.what()));
-			} catch (const std::exception &ex) {
-				SetSlotError(slot, StringUtil::Format("udf executor close failed: %s", ex.what()));
-			}
-		}
-		slot.rows_by_submit_id.clear();
-		slot.ref_inputs_by_submit_id.clear();
-		slot.inflight_count.store(0);
-		slot.finished_submitting_acked.store(true);
-		slot.all_tasks_finished.store(true);
+		// Local release is independently idempotent and must not be skipped
+		// when process shutdown takes over a slot whose collector cancellation
+		// was already pending.
+		ReleaseSlotLocalResources_WithGIL(slot);
 	}
 
 	bool MarkSlotAborted(ExecutorSlot &slot) {

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -312,6 +312,7 @@ def test_ray_get_uses_query_deadline_timeout(monkeypatch):
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
         "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ],
 )
@@ -325,6 +326,7 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
         "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -339,7 +341,10 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
             udf_subprocess._subprocess_control_timeout_s()
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
-        elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
+        elif env_name in {
+            "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
+            "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
+        }:
             udf_stream_result_collector.UDFStreamResultCollector(ray_module=object())
 
 
@@ -349,6 +354,7 @@ def test_timeout_env_parsers_reject_non_finite_negative_and_invalid(monkeypatch,
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
         "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ],
 )
@@ -361,6 +367,7 @@ def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
         "VANE_RAY_ACTOR_INIT_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_CONTROL_TIMEOUT_S",
         "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S",
+        "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
         "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -373,7 +380,10 @@ def test_positive_timeout_env_parsers_reject_zero(monkeypatch, env_name):
             udf_subprocess._subprocess_control_timeout_s()
         elif env_name == "VANE_UDF_SUBPROCESS_SHUTDOWN_GRACE_S":
             udf_subprocess._subprocess_shutdown_grace_s()
-        elif env_name == "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S":
+        elif env_name in {
+            "VANE_UDF_STREAM_CLEANUP_TIMEOUT_S",
+            "VANE_UDF_STREAM_SHUTDOWN_TIMEOUT_S",
+        }:
             udf_stream_result_collector.UDFStreamResultCollector(ray_module=object())
 
 

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -619,8 +619,8 @@ def test_native_dispatcher_terminal_shutdown_uses_one_aggregate_collector_deadli
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
-def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_collector_handoff():
-    """Aggregate shutdown must close local ownership after per-slot cleanup stalls."""
+def test_native_dispatcher_pending_collector_handoff_releases_local_executor():
+    """Remote cleanup ownership must not retain query-local executor state."""
     import os
     import subprocess
     import sys
@@ -629,6 +629,7 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
     script = textwrap.dedent(
         """
         import threading
+        import weakref
 
         import _duckdb
         import duckdb
@@ -639,6 +640,8 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
         tracked = threading.Event()
         cancel_started = threading.Event()
         executor_closed = threading.Event()
+        executor_released = threading.Event()
+        executor_close_calls = []
 
 
         class FakeCollector:
@@ -715,12 +718,15 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
                 return False
 
             def close(self):
+                executor_close_calls.append(None)
                 executor_closed.set()
 
 
         def build_executor(_payload, options=None):
             del options
-            return FakeExecutor()
+            executor = FakeExecutor()
+            weakref.finalize(executor, executor_released.set)
+            return executor
 
 
         def passthrough(table):
@@ -753,10 +759,12 @@ def test_native_dispatcher_terminal_shutdown_closes_executor_after_pending_colle
             assert not query_thread.is_alive(), "completed query did not reach unregister"
             assert query_errors == [], query_errors
             assert cancel_started.is_set(), "slot cleanup never transferred to the collector"
-            assert not executor_closed.is_set(), "pending per-slot cleanup unexpectedly closed the executor"
+            assert executor_closed.wait(timeout=5), "pending remote cleanup retained the local executor"
+            assert executor_released.wait(timeout=5), "pending remote cleanup retained the executor object"
+            assert len(executor_close_calls) == 1
 
             _duckdb._shutdown_udf_executor_dispatcher()
-            assert executor_closed.is_set(), "terminal shutdown skipped the pending slot's executor close"
+            assert len(executor_close_calls) == 1, "terminal shutdown closed an already released executor again"
         finally:
             query_thread.join(timeout=5)
             connection.close()

--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -931,6 +931,96 @@ def test_cleanup_tickets_retry_transient_failure_without_starving_peer():
         collector.shutdown()
 
 
+def test_cleanup_ticket_total_deadline_stops_permanent_error_retries(monkeypatch):
+    monkeypatch.setenv("VANE_UDF_STREAM_CLEANUP_TIMEOUT_S", "0.08")
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
+    attempts = 0
+    slot_id = 31
+
+    def fail_permanently():
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("planned permanent cleanup failure")
+
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                fail_permanently,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
+        store_error=False,
+        slot_ids=(slot_id,),
+    )
+    try:
+        collector.cancel_slot(slot_id)
+        assert collector.slot_has_pending(slot_id)
+
+        errors = _wait_cleanup_tickets(
+            tickets,
+            timeout_message="permanently failing cleanup ticket did not expire",
+        )
+        assert len(errors) == 1
+        assert isinstance(errors[0], TimeoutError)
+        assert "remote cleanup did not terminate within 0.08s" in str(errors[0])
+        assert attempts >= 2
+        assert collector.slot_has_pending(slot_id) is False
+        with collector._cv:
+            assert collector._cleanup_tickets == set()
+            assert collector._cleanup_tickets_by_slot.get(slot_id) is None
+
+        cleanup_error = collector.retire_slot(slot_id)
+        assert cleanup_error is not None
+        assert "TimeoutError" in cleanup_error
+        attempts_after_expiry = attempts
+        time.sleep(0.12)
+        assert attempts == attempts_after_expiry
+    finally:
+        if not collector.slot_has_pending(slot_id):
+            collector.retire_slot(slot_id)
+        collector.shutdown()
+
+
+def test_cleanup_ticket_total_deadline_expires_unresolved_future(monkeypatch):
+    monkeypatch.setenv("VANE_UDF_STREAM_CLEANUP_TIMEOUT_S", "0.08")
+    collector = UDFStreamResultCollector(ray_module=_FakeRay())
+    unresolved = Future()
+    slot_id = 32
+    tickets = collector._submit_cleanup_operations(
+        (
+            RayStreamCleanupOperation(
+                lambda: unresolved,
+                submission_scope=_CLEANUP_SUBMISSION_SCOPE,
+                retry_on_error=True,
+            ),
+        ),
+        store_error=False,
+        slot_ids=(slot_id,),
+    )
+    try:
+        collector.cancel_slot(slot_id)
+        assert collector.slot_has_pending(slot_id)
+
+        errors = _wait_cleanup_tickets(
+            tickets,
+            timeout_message="unresolved cleanup Future did not expire",
+        )
+        assert len(errors) == 1
+        assert isinstance(errors[0], TimeoutError)
+        assert collector.slot_has_pending(slot_id) is False
+        assert tickets[0].wait_future is None
+
+        cleanup_error = collector.retire_slot(slot_id)
+        assert cleanup_error is not None
+        assert "TimeoutError" in cleanup_error
+    finally:
+        unresolved.cancel()
+        if not collector.slot_has_pending(slot_id):
+            collector.retire_slot(slot_id)
+        collector.shutdown()
+
+
 def test_cleanup_tickets_progress_when_loop_notification_fails(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- release query-local Python executor, actor-handle, admission, and buffered state immediately after durable collector cleanup owns the remote teardown
- keep only a lightweight native retirement fence while the collector ticket is pending
- add a configurable total cleanup-ticket deadline through VANE_UDF_STREAM_CLEANUP_TIMEOUT_S, defaulting to the existing shutdown timeout
- terminalize retrying or unresolved cleanup operations at the deadline, clear global and per-slot ticket ledgers, and wake native retirement
- cover permanent remote errors, unresolved acknowledgements, environment validation, and native pending-slot teardown

## Why

When a query-driver actor dies or stays unreachable, the collector cleanup acknowledgement can remain pending indefinitely. The native slot then retains its Python executor and related state, while the collector retries the cleanup ticket forever. This change separates local resource lifetime from the durable remote-cleanup fence and gives every cleanup ticket a bounded terminal state.

## Testing

- rebased onto upstream/main at 3d67f350b5
- Release non-editable incremental install completed successfully after rebase
- python -m pytest tests/fast/test_udf_stream_result_collector.py: 66 passed
- python -m pytest tests/fast/test_udf_process.py: 20 passed
- python -m pytest tests/fast/test_udf_executor_lifecycle.py: 308 passed
- python -m pytest tests/fast/test_udf_task_admission.py: 36 passed
- scripts/run_release_tests.sh: 507 non-Ray passed, 4 skipped; 10 real-Ray passed
- pre-commit on the upstream/main..HEAD range passed all applicable hooks

An earlier optional full native run on the prior main built all 489 targets and reported 4602 passed with 25 failures in the untouched external/duckdb suite. Representative allowed_paths and ordinality failures reproduced in isolation.