### PR TITLE
[fix](ray) Stop result poller before Python finalization

### DIFF
--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -2047,6 +2047,10 @@ void register_ray_bindings(py::module_ &mod) {
 	    py::arg("handle"),
 	    "Verify RayTaskResultHandle records the current Python handle worker_id at completion time.");
 
+	m.def("_prepare_ray_task_result_poller_shutdown_race_for_test",
+	      &duckdb::distributed::python::ray::PrepareRayTaskResultPollerShutdownRaceForTest, py::arg("handle"));
+	m.def("_shutdown_ray_task_result_poller_for_test", &duckdb::distributed::python::ray::ShutdownRayTaskResultPoller);
+
 	m.def(
 	    "_ray_task_result_poller_batch_for_test",
 	    [](py::list handles, int timeout_ms) {
@@ -4935,6 +4939,11 @@ void register_ray_bindings(py::module_ &mod) {
 	} catch (...) {
 		// swallow: package may not be importable in some contexts during build
 	}
+
+	// Stop the poller before CPython enters late finalization. The callback is
+	// registered after the other Ray cleanup hook, so it runs first at exit.
+	py::module_::import("atexit").attr("register")(
+	    py::cpp_function([]() { duckdb::distributed::python::ray::ShutdownRayTaskResultPoller(); }));
 }
 
 } // namespace duckdb

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -18,6 +18,7 @@
 #include <duckdb/common/arrow/arrow.hpp>
 #include <duckdb/common/arrow/arrow_type_extension.hpp>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <iostream>

--- a/src/duckdb_py/ray/task.cpp
+++ b/src/duckdb_py/ray/task.cpp
@@ -18,6 +18,7 @@
 #include <duckdb/common/arrow/arrow.hpp>
 #include <duckdb/common/arrow/arrow_type_extension.hpp>
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <iostream>
 #include <mutex>
@@ -549,6 +550,9 @@ public:
 
 	uint64_t Register(const std::shared_ptr<RayTaskPollState> &state) {
 		lock_guard<mutex> guard(mutex_);
+		if (shutting_down_) {
+			throw duckdb::InternalException("Ray task result poller is shut down");
+		}
 		state->id = next_id_++;
 		tasks_[state->id] = state;
 		EnsureStartedLocked();
@@ -561,9 +565,49 @@ public:
 	}
 
 	void Shutdown() {
-		stop_.store(true);
+		lock_guard<mutex> shutdown_guard(shutdown_mutex_);
+		if (shutdown_complete_) {
+			return;
+		}
+		{
+			lock_guard<mutex> guard(mutex_);
+			shutting_down_ = true;
+			stop_.store(true);
+		}
+		ReleaseBeforeGILPauseForTest();
 		if (thread_.joinable()) {
 			thread_.join();
+		}
+		shutdown_complete_ = true;
+	}
+
+	void ClearPythonReferencesUnderGIL() {
+		std::vector<std::shared_ptr<RayTaskPollState>> states;
+		{
+			lock_guard<mutex> guard(mutex_);
+			states.reserve(tasks_.size());
+			for (auto &entry : tasks_) {
+				entry.second->done_sent.store(true);
+				states.push_back(std::move(entry.second));
+			}
+			tasks_.clear();
+		}
+		for (auto &state : states) {
+			state->handle.reset_with_gil();
+		}
+	}
+
+	void PauseBeforeNextGILForTest() {
+		lock_guard<mutex> guard(test_mutex_);
+		test_reached_before_gil_ = false;
+		test_release_before_gil_ = false;
+		test_pause_before_gil_.store(true, std::memory_order_release);
+	}
+
+	void WaitUntilPausedBeforeGILForTest() {
+		unique_lock<mutex> lock(test_mutex_);
+		if (!test_cv_.wait_for(lock, std::chrono::seconds(5), [this]() { return test_reached_before_gil_; })) {
+			throw duckdb::InternalException("Timed out waiting for Ray task result poller before GIL acquisition");
 		}
 	}
 
@@ -580,6 +624,28 @@ private:
 		}
 		stop_.store(false);
 		thread_ = std::thread([this]() { Run(); });
+	}
+
+	void PauseBeforeGILForTest() {
+		if (!test_pause_before_gil_.load(std::memory_order_acquire)) {
+			return;
+		}
+		unique_lock<mutex> lock(test_mutex_);
+		if (!test_pause_before_gil_.load(std::memory_order_relaxed)) {
+			return;
+		}
+		test_reached_before_gil_ = true;
+		test_cv_.notify_all();
+		test_cv_.wait(lock, [this]() { return test_release_before_gil_; });
+		test_pause_before_gil_.store(false, std::memory_order_release);
+	}
+
+	void ReleaseBeforeGILPauseForTest() {
+		{
+			lock_guard<mutex> guard(test_mutex_);
+			test_release_before_gil_ = true;
+		}
+		test_cv_.notify_all();
 	}
 
 	static std::string TaskFailureMessage(const std::shared_ptr<RayTaskPollState> &state, const std::string &operation,
@@ -706,6 +772,7 @@ private:
 			bool had_progress = false;
 			std::string operation = "acquire Python GIL";
 			try {
+				PauseBeforeGILForTest();
 				// Keep one GIL acquisition per cycle. The batch helper remains
 				// the fast path, while an isolated per-handle path recovers from
 				// helper and result-contract failures.
@@ -918,11 +985,19 @@ private:
 	}
 
 	mutex mutex_;
+	mutex shutdown_mutex_;
 	std::unordered_map<uint64_t, std::shared_ptr<RayTaskPollState>> tasks_;
 	std::atomic<bool> stop_ {false};
+	bool shutdown_complete_ = false;
 	std::atomic<uint64_t> next_id_ {1};
 	std::thread thread_;
 	std::string last_batch_failure_;
+	bool shutting_down_ = false;
+	mutex test_mutex_;
+	std::condition_variable test_cv_;
+	std::atomic<bool> test_pause_before_gil_ {false};
+	bool test_reached_before_gil_ = false;
+	bool test_release_before_gil_ = false;
 };
 
 } // namespace
@@ -930,6 +1005,30 @@ private:
 } // namespace python
 } // namespace distributed
 } // namespace duckdb
+
+void duckdb::distributed::python::ray::ShutdownRayTaskResultPoller() {
+	auto &poller = RayTaskResultPoller::Get();
+	{
+		// Python atexit callbacks hold the GIL, while the poller may already
+		// be waiting to acquire it. Release it before joining to avoid a
+		// circular wait.
+		py::gil_scoped_release release;
+		poller.Shutdown();
+	}
+	poller.ClearPythonReferencesUnderGIL();
+}
+
+void duckdb::distributed::python::ray::PrepareRayTaskResultPollerShutdownRaceForTest(py::object handle) {
+	auto &poller = RayTaskResultPoller::Get();
+	poller.PauseBeforeNextGILForTest();
+	auto state = std::make_shared<RayTaskPollState>();
+	state->handle = SafePyObject(std::move(handle));
+	poller.Register(state);
+	{
+		py::gil_scoped_release release;
+		poller.WaitUntilPausedBeforeGILForTest();
+	}
+}
 
 RayTaskResultHandle::RayTaskResultHandle(TaskContext task_context, py::object handle, WorkerId worker_id,
                                          std::string fte_task_id)

--- a/src/duckdb_py/ray/task.hpp
+++ b/src/duckdb_py/ray/task.hpp
@@ -34,6 +34,14 @@ namespace py = pybind11;
 
 struct RayTaskPollState;
 
+// Stop the process-wide Ray task result poller while Python is still usable.
+// Must be called with the GIL held; it temporarily releases the GIL while the
+// poller thread is joined.
+void ShutdownRayTaskResultPoller();
+
+// Arrange the deterministic shutdown race used by subprocess regression tests.
+void PrepareRayTaskResultPollerShutdownRaceForTest(py::object handle);
+
 // RayTaskResult mirrors the Rust enum with an extra task-level result_schema
 // carrier used by the distributed Python runner.
 struct RayTaskResult {

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -884,6 +884,41 @@ def _assert_successful_poller_outcome(outcome, worker_id):
     }
 
 
+def _run_ray_task_result_poller_shutdown_race_script(body):
+    script = textwrap.dedent(
+        f"""
+        import atexit
+        import weakref
+
+        def verify_shutdown():
+            status = "stopped" if handle_ref() is None else "reference-live"
+            print(f"poller-{{status}}", flush=True)
+
+        atexit.register(verify_shutdown)
+
+        import duckdb
+
+        class PendingHandle:
+            def done(self):
+                return False
+
+        handle = PendingHandle()
+        handle_ref = weakref.ref(handle)
+        duckdb.ray_cxx._prepare_ray_task_result_poller_shutdown_race_for_test(handle)
+        del handle
+        {body}
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "poller-stopped" in completed.stdout, completed.stdout + completed.stderr
+
+
 def test_ray_task_result_poller_isolates_handle_done_failure_and_recovers():
     healthy = _PollerTestHandle("healthy", ready_after=3)
     outcomes = _poll_with_shared_ray_task_result_poller(
@@ -980,6 +1015,26 @@ def test_ray_task_result_poller_isolates_per_handle_completion_failure():
     assert "task_id=poller-test.0" in outcomes[0]["error"]
     assert "injected completion failure" in outcomes[0]["error"]
     _assert_successful_poller_outcome(outcomes[1], "worker-healthy")
+
+
+def test_ray_task_result_poller_stops_before_python_finalization():
+    _run_ray_task_result_poller_shutdown_race_script("")
+
+
+def test_ray_task_result_poller_shutdown_is_terminal_and_idempotent():
+    _run_ray_task_result_poller_shutdown_race_script(
+        """
+        duckdb.ray_cxx._shutdown_ray_task_result_poller_for_test()
+        duckdb.ray_cxx._shutdown_ray_task_result_poller_for_test()
+        try:
+            duckdb.ray_cxx._ray_task_result_poller_batch_for_test([PendingHandle()])
+        except Exception as ex:
+            if "poller is shut down" not in str(ex):
+                raise
+        else:
+            raise AssertionError("Ray task result poller restarted after shutdown")
+        """
+    )
 
 
 def test_flight_exchange_source_reads_only_selected_retry_attempt_data(tmp_path):


### PR DESCRIPTION
## Summary

- register a mandatory Python `atexit` shutdown for the process-wide Ray task result poller
- make shutdown terminal and idempotent, release the GIL while joining the poller thread, then clear retained Python handles while the runtime is still usable
- add a deterministic before-GIL barrier regression that covers active-poller exit, reference cleanup, repeated shutdown, and rejection of post-shutdown registration

## Why

`RayTaskResultPoller` previously relied on its function-static destructor. A poll cycle could pass the finalization check and then block in `PyGILState_Ensure()` once CPython entered late finalization. The static destructor would then wait forever in `join()`.

The `atexit` hook runs before late finalization. Releasing the GIL around `join()` lets a poller already waiting for it finish its last cycle, while the terminal registration fence prevents a later exit callback from starting a new poller thread.

## Validation

- `scripts/format root --changed --check`
- `python -m pytest -q tests/fast/test_ray_cpp_bindings.py -k 'ray_task_result_poller or ray_task_result_handle_uses'` (11 passed)
- `python -m pytest -q tests/fast/test_ray_result_contract.py -k 'wait_fte_query'` (12 passed)
- deterministic shutdown regression repeated 10 times (20 subprocess cases passed)
- `scripts/run_release_tests.sh` (486 passed, 1 skipped; 10 real-Ray tests passed)

Closes #411
