### PR TITLE
[fix](distributed) Preserve physical schema boundaries

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/materialized_coordinator.cpp
@@ -21,21 +21,11 @@ static std::string MakeCoordinatorExchangeId(const PipelineNodeContext &context)
 }
 
 static DuckDBResult<vector<LogicalType>> ResolveSchemaTypes(const SchemaRef &schema) {
-	vector<LogicalType> types;
 	if (!schema) {
 		return DuckDBResult<vector<LogicalType>>::err(
 		    DuckDBError::invalid_state_error("materialized coordinator requires an output schema"));
 	}
-	if (schema->id() == duckdb::LogicalTypeId::STRUCT) {
-		const auto &children = duckdb::StructType::GetChildTypes(*schema);
-		types.reserve(children.size());
-		for (const auto &child : children) {
-			types.push_back(child.second);
-		}
-	} else {
-		types.push_back(*schema);
-	}
-	return DuckDBResult<vector<LogicalType>>::ok(std::move(types));
+	return DuckDBResult<vector<LogicalType>>::ok(GetSchemaTypes(schema));
 }
 
 static vector<std::string> CollectCoordinatorSourceNodes(const std::vector<ExchangeSourceHandle> &handles) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
@@ -94,25 +94,68 @@ using ExpressionRef = std::shared_ptr<duckdb::Expression>;
 using BoundExpr = ExpressionRef;
 using BoundAggExpr = ExpressionRef;
 
-/// Schema reference type (using LogicalType for now as placeholder for Schema)
-using SchemaRef = std::shared_ptr<duckdb::LogicalType>;
+/// Logical column schema carried between distributed pipeline nodes.
+///
+/// A schema owns the top-level column boundary explicitly. In particular, a
+/// single STRUCT column is represented as one entry in `types_`, rather than
+/// overloading STRUCT as an encoding for a multi-column row.
+class PipelineSchema {
+public:
+	PipelineSchema(duckdb::vector<LogicalType> types, duckdb::vector<std::string> names)
+	    : types_(std::move(types)), names_(std::move(names)) {
+		if (types_.empty()) {
+			throw std::invalid_argument("pipeline schema requires at least one column");
+		}
+		if (!names_.empty() && names_.size() != types_.size()) {
+			throw std::invalid_argument("pipeline schema names must match its columns");
+		}
+	}
+
+	const duckdb::vector<LogicalType> &types() const {
+		return types_;
+	}
+
+	const duckdb::vector<std::string> &names() const {
+		return names_;
+	}
+
+	std::string ToString() const {
+		if (types_.size() == 1 && names_.empty()) {
+			return types_[0].ToString();
+		}
+
+		child_list_t<LogicalType> children;
+		children.reserve(types_.size());
+		for (idx_t i = 0; i < types_.size(); i++) {
+			std::string name = names_.empty() ? ("c" + std::to_string(i)) : names_[i];
+			children.emplace_back(std::move(name), types_[i]);
+		}
+		return LogicalType::STRUCT(std::move(children)).ToString();
+	}
+
+private:
+	duckdb::vector<LogicalType> types_;
+	duckdb::vector<std::string> names_;
+};
+
+using SchemaRef = std::shared_ptr<const PipelineSchema>;
 
 template <class TypeList>
 inline SchemaRef MakeSchemaRefImpl(const TypeList &types, const std::vector<std::string> *names = nullptr) {
 	if (types.empty()) {
 		return nullptr;
 	}
-	const bool use_names = names && names->size() == types.size();
-	if (types.size() == 1 && !use_names) {
-		return std::make_shared<duckdb::LogicalType>(types[0]);
+	duckdb::vector<LogicalType> schema_types(types.begin(), types.end());
+	duckdb::vector<std::string> schema_names;
+	if (names && !names->empty()) {
+		schema_names.assign(names->begin(), names->end());
+	} else if (types.size() > 1) {
+		schema_names.reserve(types.size());
+		for (idx_t i = 0; i < types.size(); i++) {
+			schema_names.push_back("c" + std::to_string(i));
+		}
 	}
-	child_list_t<LogicalType> children;
-	children.reserve(types.size());
-	for (idx_t i = 0; i < types.size(); i++) {
-		std::string name = use_names ? (*names)[i] : ("c" + std::to_string(i));
-		children.emplace_back(std::move(name), types[i]);
-	}
-	return std::make_shared<duckdb::LogicalType>(LogicalType::STRUCT(std::move(children)));
+	return std::make_shared<const PipelineSchema>(std::move(schema_types), std::move(schema_names));
 }
 
 inline SchemaRef MakeSchemaRef(const std::vector<LogicalType> &types) {
@@ -132,18 +175,17 @@ inline SchemaRef MakeSchemaRef(const duckdb::vector<LogicalType> &types, const d
 }
 
 inline duckdb::vector<std::string> GetSchemaNames(const SchemaRef &schema) {
-	duckdb::vector<std::string> names;
 	if (!schema) {
-		return names;
+		return {};
 	}
-	if (schema->id() == duckdb::LogicalTypeId::STRUCT) {
-		const auto &children = duckdb::StructType::GetChildTypes(*schema);
-		names.reserve(children.size());
-		for (const auto &child : children) {
-			names.push_back(child.first);
-		}
+	return schema->names();
+}
+
+inline duckdb::vector<LogicalType> GetSchemaTypes(const SchemaRef &schema) {
+	if (!schema) {
+		return {};
 	}
-	return names;
+	return schema->types();
 }
 
 //------------------------------------------------------------------------------

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/projection.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/projection.hpp
@@ -73,23 +73,6 @@ public:
 				    }
 			    }
 
-			    auto schema_types = [&](const SchemaRef &schema) -> duckdb::vector<duckdb::LogicalType> {
-				    duckdb::vector<duckdb::LogicalType> types;
-				    if (!schema) {
-					    return types;
-				    }
-				    if (schema->id() == duckdb::LogicalTypeId::STRUCT) {
-					    const auto &children = duckdb::StructType::GetChildTypes(*schema);
-					    types.reserve(children.size());
-					    for (const auto &child : children) {
-						    types.push_back(child.second);
-					    }
-				    } else {
-					    types.push_back(*schema);
-				    }
-				    return types;
-			    };
-
 			    std::function<void(duckdb::Expression &, const duckdb::vector<duckdb::LogicalType> &)> fix_ref_types;
 			    fix_ref_types = [&](duckdb::Expression &expr,
 			                        const duckdb::vector<duckdb::LogicalType> &types) -> void {
@@ -128,7 +111,7 @@ public:
 			    // Build select_list and output types from projection expressions
 			    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> select_list;
 			    duckdb::vector<duckdb::LogicalType> out_types;
-			    auto expected_types = schema_types(schema);
+			    auto expected_types = duckdb::distributed::GetSchemaTypes(schema);
 			    idx_t expected_count = 0;
 			    for (auto &expr_ref : projection) {
 				    if (expr_ref) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/table_inout.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/table_inout.hpp
@@ -87,10 +87,7 @@ public:
 
 private:
 	static SchemaRef BuildSchema(const vector<LogicalType> &output_types) {
-		if (output_types.empty()) {
-			return nullptr;
-		}
-		return std::make_shared<duckdb::LogicalType>(output_types[0]);
+		return MakeSchemaRef(output_types);
 	}
 
 	PipelineNodeContext ctx_;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/vllm.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/vllm.hpp
@@ -182,10 +182,7 @@ public:
 
 private:
 	static SchemaRef BuildSchema(const duckdb::vector<LogicalType> &output_types) {
-		if (output_types.empty()) {
-			return nullptr;
-		}
-		return std::make_shared<duckdb::LogicalType>(output_types[0]);
+		return MakeSchemaRef(output_types);
 	}
 
 	PipelineNodeContext ctx_;

--- a/external/duckdb/test/execution/distributed/test_execute_plan.cpp
+++ b/external/duckdb/test/execution/distributed/test_execute_plan.cpp
@@ -75,13 +75,13 @@ TEST_CASE("Pipeline produce_tasks: basic pipeline (scan->proj->filter)", "[distr
 	    empty_plan->Make<duckdb::PhysicalDummyScan>(std::vector<duckdb::LogicalType> {duckdb::LogicalType::BIGINT}, 1);
 	empty_plan->SetRoot(dummy);
 
-	SchemaRef scan_schema = std::make_shared<LogicalType>(LogicalType::BIGINT);
+	SchemaRef scan_schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT});
 	std::vector<ScanTaskDescriptor> scan_tasks;
 	auto scan_impl = std::make_shared<ScanSourceNode>(PipelineNodeContext(0, "", 1, "scan"), empty_plan, scan_tasks,
 	                                                  scan_schema, DuckDBExecutionConfigRef(), false);
 	ExpressionRef proj_expr = std::make_shared<duckdb::BoundConstantExpression>(duckdb::Value::INTEGER(42));
 	std::vector<std::string> proj_names;
-	SchemaRef proj_schema = std::make_shared<LogicalType>(LogicalType::INTEGER);
+	SchemaRef proj_schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::INTEGER});
 	auto proj_impl =
 	    std::make_shared<ProjectionNode>(2, scan_impl, std::vector<ExpressionRef> {proj_expr}, proj_names, proj_schema);
 	ExpressionRef pred_expr = std::make_shared<duckdb::BoundConstantExpression>(duckdb::Value::BOOLEAN(true));
@@ -115,13 +115,13 @@ TEST_CASE("Pipeline produce_tasks yields a task with a printable plan", "[distri
 	    empty_plan->Make<duckdb::PhysicalDummyScan>(std::vector<duckdb::LogicalType> {duckdb::LogicalType::BIGINT}, 1);
 	empty_plan->SetRoot(dummy);
 
-	SchemaRef scan_schema = std::make_shared<LogicalType>(LogicalType::BIGINT);
+	SchemaRef scan_schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT});
 	std::vector<ScanTaskDescriptor> scan_tasks;
 	auto scan_impl = std::make_shared<ScanSourceNode>(PipelineNodeContext(0, "", 1, "scan"), empty_plan, scan_tasks,
 	                                                  scan_schema, DuckDBExecutionConfigRef(), false);
 	ExpressionRef proj_expr = std::make_shared<duckdb::BoundConstantExpression>(duckdb::Value::INTEGER(42));
 	std::vector<std::string> proj_names;
-	SchemaRef proj_schema = std::make_shared<LogicalType>(LogicalType::INTEGER);
+	SchemaRef proj_schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::INTEGER});
 	auto proj_impl =
 	    std::make_shared<ProjectionNode>(2, scan_impl, std::vector<ExpressionRef> {proj_expr}, proj_names, proj_schema);
 	ExpressionRef pred_expr = std::make_shared<duckdb::BoundConstantExpression>(duckdb::Value::BOOLEAN(true));

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -203,13 +203,7 @@ static unique_ptr<ColumnDataCollection> MakeSingleValueCollection(const vector<L
 }
 
 static idx_t SchemaColumnCount(const SchemaRef &schema) {
-	if (!schema) {
-		return 0;
-	}
-	if (schema->id() == LogicalTypeId::STRUCT) {
-		return StructType::GetChildTypes(*schema).size();
-	}
-	return 1;
+	return GetSchemaTypes(schema).size();
 }
 
 static std::string SQLStringLiteral(const std::string &value) {
@@ -329,18 +323,32 @@ static bool NodeDisplayContains(const DistributedPipelineNodeRef &node, const st
 	return false;
 }
 
-TEST_CASE("Streaming UDF passthrough schema preserves all output columns", "[distributed][udf]") {
-	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::VARCHAR};
-	StreamingUDFPassthroughNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {}, vector<column_t> {},
-	                                 optional_idx(), output_types, 0);
+TEST_CASE("Streaming UDF passthrough schema preserves physical column boundaries", "[distributed][udf]") {
+	SECTION("multiple scalar columns") {
+		vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::VARCHAR};
+		StreamingUDFPassthroughNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {},
+		                                 vector<column_t> {}, optional_idx(), output_types, 0);
 
-	auto schema = node.config().schema();
-	REQUIRE(schema);
-	REQUIRE(schema->id() == LogicalTypeId::STRUCT);
-	const auto &columns = StructType::GetChildTypes(*schema);
-	REQUIRE(columns.size() == output_types.size());
-	REQUIRE(columns[0].second == output_types[0]);
-	REQUIRE(columns[1].second == output_types[1]);
+		auto schema_types = GetSchemaTypes(node.config().schema());
+		REQUIRE(schema_types == output_types);
+	}
+
+	SECTION("one struct column") {
+		child_list_t<LogicalType> fields;
+		fields.emplace_back("name", LogicalType::VARCHAR);
+		fields.emplace_back("score", LogicalType::DOUBLE);
+		auto struct_type = LogicalType::STRUCT(std::move(fields));
+		vector<LogicalType> output_types = {struct_type};
+		StreamingUDFPassthroughNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {},
+		                                 vector<column_t> {}, optional_idx(), output_types, 0);
+
+		auto schema_types = GetSchemaTypes(node.config().schema());
+		REQUIRE(schema_types.size() == 1);
+		REQUIRE(schema_types[0] == struct_type);
+		REQUIRE(GetSchemaNames(node.config().schema()).empty());
+		const auto &struct_fields = StructType::GetChildTypes(schema_types[0]);
+		REQUIRE(struct_fields.size() == 2);
+	}
 }
 
 TEST_CASE("PhysicalPlanTranslator: simple projection", "[distributed]") {

--- a/external/duckdb/test/execution/distributed/test_pipeline_nodes.cpp
+++ b/external/duckdb/test/execution/distributed/test_pipeline_nodes.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/execution/distributed/pipeline_node/projection.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/pipeline_node/table_inout.hpp"
+#include "duckdb/execution/distributed/pipeline_node/vllm.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/execution/distributed/plan/physical_plan_helpers.hpp"
@@ -15,10 +17,40 @@
 using namespace duckdb;
 using namespace duckdb::distributed;
 
+TEST_CASE("PipelineSchema preserves explicit top-level columns", "[distributed]") {
+	child_list_t<LogicalType> fields;
+	fields.emplace_back("value", LogicalType::INTEGER);
+	fields.emplace_back("label", LogicalType::VARCHAR);
+	vector<LogicalType> types = {LogicalType::STRUCT(std::move(fields))};
+	vector<std::string> names = {"feature"};
+
+	auto schema = MakeSchemaRef(types, names);
+	REQUIRE(GetSchemaTypes(schema) == types);
+	REQUIRE(GetSchemaNames(schema) == names);
+
+	vector<LogicalType> two_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+	REQUIRE_THROWS_AS(MakeSchemaRef(two_types, names), std::invalid_argument);
+}
+
+TEST_CASE("Schema-changing nodes preserve every output type", "[distributed]") {
+	vector<LogicalType> output_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+
+	SECTION("table in-out") {
+		TableInOutNode node(1, nullptr, TableFunction {}, nullptr, vector<ColumnIndex> {}, vector<column_t> {},
+		                    optional_idx(), output_types, 0);
+		REQUIRE(GetSchemaTypes(node.config().schema()) == output_types);
+	}
+
+	SECTION("vLLM projection") {
+		VLLMProjectNode node(1, nullptr, nullptr, "", Value(), "output", output_types);
+		REQUIRE(GetSchemaTypes(node.config().schema()) == output_types);
+	}
+}
+
 TEST_CASE("ProjectionNode: construction and display", "[distributed]") {
 	// Create a dummy child scan source node with no scans
 	std::vector<DuckPhysicalPlanRef> plans;
-	SchemaRef schema = std::make_shared<LogicalType>(LogicalType::INTEGER);
+	SchemaRef schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::INTEGER});
 	std::vector<ScanTaskDescriptor> scan_tasks;
 	auto child = std::make_shared<ScanSourceNode>(PipelineNodeContext(0, "", 0, "scan"), DuckPhysicalPlanRef(),
 	                                              scan_tasks, schema, DuckDBExecutionConfigRef(), false);
@@ -38,7 +70,7 @@ TEST_CASE("ProjectionNode: construction and display", "[distributed]") {
 
 TEST_CASE("FilterNode: construction and display", "[distributed]") {
 	std::vector<DuckPhysicalPlanRef> plans;
-	SchemaRef schema = std::make_shared<LogicalType>(LogicalType::INTEGER);
+	SchemaRef schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::INTEGER});
 	std::vector<ScanTaskDescriptor> scan_tasks;
 	auto child = std::make_shared<ScanSourceNode>(PipelineNodeContext(0, "", 0, "scan"), DuckPhysicalPlanRef(),
 	                                              scan_tasks, schema, DuckDBExecutionConfigRef(), false);
@@ -56,7 +88,7 @@ TEST_CASE("ScanSourceNode: display", "[distributed]") {
 	// Create a simple in-memory plan and attach to ScanSourceNode
 	DuckPhysicalPlanRef p = duckdb::distributed::make_physical_plan_with_identity_projection({{1, 2, 3}});
 	std::vector<DuckPhysicalPlanRef> plans = {p};
-	SchemaRef schema = std::make_shared<LogicalType>(LogicalType::BIGINT);
+	SchemaRef schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::BIGINT});
 	std::vector<ScanTaskDescriptor> scan_tasks = {ScanTaskDescriptor {}};
 	auto node = ScanSourceNode(PipelineNodeContext(0, "", 3, "scan"), plans[0], scan_tasks, schema,
 	                           DuckDBExecutionConfigRef(), false);

--- a/external/duckdb/test/execution/distributed/test_repartition_node.cpp
+++ b/external/duckdb/test/execution/distributed/test_repartition_node.cpp
@@ -13,7 +13,7 @@ using namespace duckdb;
 using namespace duckdb::distributed;
 
 TEST_CASE("RepartitionNode: basic creation and properties (unittest)", "[distributed]") {
-	SchemaRef schema = std::make_shared<LogicalType>(LogicalType::INTEGER);
+	SchemaRef schema = MakeSchemaRef(std::vector<LogicalType> {LogicalType::INTEGER});
 	auto proj_impl = std::make_shared<ProjectionNode>(1, nullptr, std::vector<ExpressionRef> {},
 	                                                  std::vector<std::string> {}, schema);
 	auto child = std::make_shared<DistributedPipelineNode>(proj_impl);

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -234,13 +234,17 @@ def _rows_from_partition(part, column_names=None):
     return [], column_names
 
 
-def _collect_result_rows(parts):
+def _collect_raw_result_rows(parts):
     all_rows = []
     column_names = None
     for part in parts:
         rows, column_names = _rows_from_partition(part, column_names)
         all_rows.extend(rows)
-    return [tuple(_stringify_value(val) for val in row) for row in all_rows]
+    return all_rows
+
+
+def _collect_result_rows(parts):
+    return [tuple(_stringify_value(val) for val in row) for row in _collect_raw_result_rows(parts)]
 
 
 def _expected_result_rows(con, sql):
@@ -2837,6 +2841,70 @@ def test_ray_row_preserving_batch_udf_limit_preserves_output_schema(
     assert len(rows) == 5
     assert all(len(row) == 2 for row in rows)
     assert all(int(y) == int(x) + 1 for x, y in rows)
+
+
+def test_ray_streaming_batch_udf_limit_preserves_single_struct_column(
+    ray_runner,
+    duckdb_conn,
+    tmp_path,
+    monkeypatch,
+):
+    pa = pytest.importorskip("pyarrow")
+
+    if ray is None:
+        pytest.skip("ray not installed")
+
+    label = "test_ray_e2e: one struct UDF column across streaming limit"
+    input_path = tmp_path / "streaming_struct_udf_limit"
+    shuffle_dir = tmp_path / "streaming_struct_udf_limit_shuffle"
+    monkeypatch.setenv("VANE_SHUFFLE_LOCAL_DIRS", str(shuffle_dir))
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+
+    duckdb_conn.execute(f"""
+        COPY (
+            SELECT
+                i::INTEGER AS x,
+                floor(i / 4)::INTEGER AS file_id
+            FROM range(0, 16) AS t(i)
+        ) TO '{input_path}' (FORMAT PARQUET, PARTITION_BY (file_id))
+    """)
+
+    feature_arrow_type = pa.struct([("value", pa.int32()), ("doubled", pa.int32())])
+
+    def make_feature(table):
+        values = table.column("x").to_pylist()
+        features = [{"value": value, "doubled": value * 2} for value in values]
+        return pa.table({"feature": pa.array(features, type=feature_arrow_type)})
+
+    base = duckdb_conn.sql(f"SELECT x FROM read_parquet('{input_path}/**/*.parquet')")
+    feature_type = duckdb.sqltype('STRUCT("value" INTEGER, doubled INTEGER)')
+    relation = base.map_batches(
+        make_feature,
+        schema={"feature": feature_type},
+        execution_backend="ray_task",
+        batch_size=4,
+    ).limit(5)
+
+    ray_cxx = getattr(duckdb, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("duckdb.ray_cxx.PyLogicalPlan not available in this environment")
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"{label}-plan")
+    distributed_plan = logical_plan.to_physical_plan(duckdb_conn)
+    descriptor_counts = [len(descriptors) for descriptors in distributed_plan.scan_task_descriptor_map().values()]
+    assert descriptor_counts == [4], f"{label}: expected four scan tasks, got {descriptor_counts}"
+    assert distributed_plan.num_partitions() == 4
+    plan_text = distributed_plan.repr_ascii(False).upper()
+    assert "STREAMINGUDF" in plan_text
+    assert "STREAMINGLIMIT" in plan_text
+
+    parts = _run_iter_tables(ray_runner, relation, label, timeout_s=60.0)
+    rows = _collect_raw_result_rows(parts)
+
+    assert len(rows) == 5
+    assert all(len(row) == 1 for row in rows)
+    assert all(feature["doubled"] == feature["value"] * 2 for (feature,) in rows)
 
 
 def test_ray_python_stream_table_udf(ray_runner, duckdb_conn, parquet_path):


### PR DESCRIPTION
## Summary

- replace the overloaded `LogicalType` schema placeholder with an immutable `PipelineSchema` that carries top-level types and names separately
- make projection and materialized coordinators consume explicit top-level types so one STRUCT column cannot be mistaken for multiple columns
- preserve every declared output type for streaming UDF, table in-out, and vLLM nodes
- add native protocol coverage and a four-partition Ray E2E regression through a streaming UDF and distributed LIMIT

The schema helper now rejects a non-empty column-name list whose length does not match the type list. Empty output types retain the existing null-schema behavior.

Follow-up metadata gaps found during review are tracked separately in #473 and #474; this PR does not close them.

## Related issue

N/A — this is a self-contained regression fix.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes an internal distributed schema protocol and preserves the intended public result shape.

## Validation

- `uv pip install . --no-build-isolation` with the documented Release incremental build directory
- `build/native-cxx20/test/unittest "[distributed]"` — 184 test cases, 7,963 assertions passed
- `python -m pytest tests/fast/test_ray_e2e.py::test_ray_streaming_batch_udf_limit_preserves_single_struct_column -vv` — passed
- `scripts/run_release_tests.sh` — 498 passed and 4 skipped in the base shard; 10 passed in the real-Ray shard
- `scripts/format workspace --changed --check`
- pre-commit hooks for all changed files

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. No such artifacts are added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. The change only makes internal schema metadata explicit.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.