### PR TITLE
[fix](ai) Reject unsuccessful Anthropic stop reasons

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1658,6 +1658,7 @@ class TestAnthropicTokenMetrics:
         mock_response = MagicMock()
         mock_response.usage = mock_usage
         mock_response.content = [mock_text_block]
+        mock_response.stop_reason = "end_turn"
 
         mock_client = AsyncMock()
         mock_client.messages.create = AsyncMock(return_value=mock_response)
@@ -2708,6 +2709,55 @@ def test_provider_capability_error_never_stringifies_unbounded_upstream_text():
 
     assert error.original_error_summary == "UnboundedError (status_code=503)"
     assert original not in error.__dict__.values()
+
+
+@pytest.mark.parametrize("on_error", ["raise", "ignore"])
+def test_anthropic_terminal_result_obeys_prompt_error_policy(on_error):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from vane.ai.functions import _PromptBatch
+    from vane.ai.provider import _ProviderResultError
+    from vane.ai.providers.anthropic import AnthropicPrompter
+
+    prompter = AnthropicPrompter.__new__(AnthropicPrompter)
+    prompter._provider_name = "anthropic"
+    prompter._model = "claude-test"
+    prompter._system_message = None
+    prompter._return_format = None
+    prompter._return_raw_response = False
+    prompter._options = {"max_tokens": 64}
+    prompter._client = SimpleNamespace(
+        messages=SimpleNamespace(
+            create=AsyncMock(
+                return_value=SimpleNamespace(
+                    content=[],
+                    usage=None,
+                    stop_reason="refusal",
+                )
+            )
+        )
+    )
+
+    class Descriptor:
+        def instantiate(self):
+            return prompter
+
+    wrapper = _PromptBatch(
+        Descriptor(),
+        ["message"],
+        "response",
+        max_retries=3,
+        on_error=on_error,
+    )
+    table = pa.table({"message": ["hello"]})
+
+    if on_error == "raise":
+        with pytest.raises(_ProviderResultError, match="refused"):
+            _drive(wrapper, table)
+    else:
+        assert _drive(wrapper, table).column("response").to_pylist() == [None]
+    assert prompter._client.messages.create.await_count == 1
 
 
 def test_prompt_batch_retry_and_row_isolation(monkeypatch):

--- a/tests/ai/test_prompt_provider_contracts.py
+++ b/tests/ai/test_prompt_provider_contracts.py
@@ -111,6 +111,7 @@ def test_openai_compatible_endpoint_omits_strict_schema_flag(chat):
 
 
 def test_anthropic_structured_tool_and_raw_body_contracts():
+    from vane.ai.provider import _ProviderResultError
     from vane.ai.providers.anthropic import AnthropicPrompter
 
     prompter = AnthropicPrompter.__new__(AnthropicPrompter)
@@ -144,6 +145,16 @@ def test_anthropic_structured_tool_and_raw_body_contracts():
         "name": "vane_structured_output",
         "disable_parallel_tool_use": True,
     }
+
+    prompter._client.messages.create = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(type="tool_use", name="vane_structured_output", input={"answer": "ok"})],
+            usage=None,
+            stop_reason="end_turn",
+        )
+    )
+    with pytest.raises(_ProviderResultError, match="missing or unsupported stop_reason"):
+        asyncio.run(prompter.prompt(("question",)))
 
     prompter._return_raw_response = True
     prompter._client.messages.create = AsyncMock(return_value=_RawBody({"id": "message-1", "content": []}))

--- a/tests/ai/test_prompt_provider_contracts.py
+++ b/tests/ai/test_prompt_provider_contracts.py
@@ -153,7 +153,10 @@ def test_anthropic_structured_tool_and_raw_body_contracts():
             stop_reason="end_turn",
         )
     )
-    with pytest.raises(_ProviderResultError, match="missing or unsupported stop_reason"):
+    with pytest.raises(
+        _ProviderResultError,
+        match=r"stop_reason 'end_turn'.*structured Prompt output.*'tool_use'",
+    ):
         asyncio.run(prompter.prompt(("question",)))
 
     prompter._return_raw_response = True

--- a/tests/fast/test_anthropic_prompter_content.py
+++ b/tests/fast/test_anthropic_prompter_content.py
@@ -114,8 +114,18 @@ def test_prompt_rejects_unsuccessful_terminal_reasons(monkeypatch, stop_reason, 
         asyncio.run(prompter.prompt(("hello",)))
 
 
-@pytest.mark.parametrize("stop_reason", [None, "future_stop_reason", "tool_use"])
-def test_plain_prompt_rejects_missing_or_unsupported_stop_reason(monkeypatch, stop_reason):
+@pytest.mark.parametrize(
+    ("stop_reason", "message"),
+    [
+        (None, r"missing stop_reason.*plain Prompt output.*'end_turn'.*'stop_sequence'"),
+        (
+            "future_stop_reason",
+            r"unsupported stop_reason.*plain Prompt output.*'end_turn'.*'stop_sequence'",
+        ),
+        ("tool_use", r"stop_reason 'tool_use'.*plain Prompt output.*'end_turn'.*'stop_sequence'"),
+    ],
+)
+def test_plain_prompt_rejects_missing_or_unsupported_stop_reason(monkeypatch, stop_reason, message):
     from vane.ai.provider import _ProviderResultError
 
     prompter = _make_prompter(
@@ -124,8 +134,11 @@ def test_plain_prompt_rejects_missing_or_unsupported_stop_reason(monkeypatch, st
         stop_reason=stop_reason,
     )
 
-    with pytest.raises(_ProviderResultError, match="missing or unsupported stop_reason"):
+    with pytest.raises(_ProviderResultError, match=message) as exc_info:
         asyncio.run(prompter.prompt(("hello",)))
+
+    if stop_reason == "future_stop_reason":
+        assert stop_reason not in str(exc_info.value)
 
 
 def test_zero_max_tokens_prewarm_remains_successful(monkeypatch):

--- a/tests/fast/test_anthropic_prompter_content.py
+++ b/tests/fast/test_anthropic_prompter_content.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""AnthropicPrompter plain-text extraction across response content blocks.
+"""AnthropicPrompter terminal-state validation and plain-text extraction.
 
 Extended-thinking models return a leading ``thinking`` block (which has
 ``.thinking`` and no ``.text``), so ``prompt`` must concatenate the
@@ -12,13 +12,15 @@ import asyncio
 import sys
 from types import SimpleNamespace
 
+import pytest
 
-def _make_prompter(monkeypatch, content):
+
+def _make_prompter(monkeypatch, content, *, stop_reason="end_turn", max_tokens=64):
     """Build an AnthropicPrompter whose SDK client returns ``content``."""
 
     class FakeMessages:
         async def create(self, **kwargs):
-            return SimpleNamespace(content=content, usage=None)
+            return SimpleNamespace(content=content, usage=None, stop_reason=stop_reason)
 
     class FakeAsyncAnthropic:
         def __init__(self, **options):
@@ -32,7 +34,7 @@ def _make_prompter(monkeypatch, content):
 
     from vane.ai.providers.anthropic import AnthropicPrompter
 
-    return AnthropicPrompter(options={"max_tokens": 64}, model="claude-test")
+    return AnthropicPrompter(options={"max_tokens": max_tokens}, model="claude-test")
 
 
 def _thinking_block(text="Let me think about this."):
@@ -76,5 +78,57 @@ def test_prompt_returns_none_for_thinking_only_content(monkeypatch):
 
 def test_prompt_returns_none_for_empty_content(monkeypatch):
     prompter = _make_prompter(monkeypatch, [])
+
+    assert asyncio.run(prompter.prompt(("hello",))) is None
+
+
+def test_prompt_accepts_configured_stop_sequence(monkeypatch):
+    prompter = _make_prompter(
+        monkeypatch,
+        [_text_block("stopped as configured")],
+        stop_reason="stop_sequence",
+    )
+
+    assert asyncio.run(prompter.prompt(("hello",))) == "stopped as configured"
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "content", "message"),
+    [
+        ("max_tokens", [_text_block("partial answer")], "max_tokens=64"),
+        (
+            "model_context_window_exceeded",
+            [_text_block("partial answer")],
+            "model context window",
+        ),
+        ("refusal", [], "refused"),
+        ("pause_turn", [_text_block("partial answer")], "paused before completion"),
+    ],
+)
+def test_prompt_rejects_unsuccessful_terminal_reasons(monkeypatch, stop_reason, content, message):
+    from vane.ai.provider import _ProviderResultError
+
+    prompter = _make_prompter(monkeypatch, content, stop_reason=stop_reason)
+
+    with pytest.raises(_ProviderResultError, match=message):
+        asyncio.run(prompter.prompt(("hello",)))
+
+
+@pytest.mark.parametrize("stop_reason", [None, "future_stop_reason", "tool_use"])
+def test_plain_prompt_rejects_missing_or_unsupported_stop_reason(monkeypatch, stop_reason):
+    from vane.ai.provider import _ProviderResultError
+
+    prompter = _make_prompter(
+        monkeypatch,
+        [_text_block("must not be accepted")],
+        stop_reason=stop_reason,
+    )
+
+    with pytest.raises(_ProviderResultError, match="missing or unsupported stop_reason"):
+        asyncio.run(prompter.prompt(("hello",)))
+
+
+def test_zero_max_tokens_prewarm_remains_successful(monkeypatch):
+    prompter = _make_prompter(monkeypatch, [], stop_reason="max_tokens", max_tokens=0)
 
     assert asyncio.run(prompter.prompt(("hello",))) is None

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -290,10 +290,23 @@ class AnthropicPrompter:
                 "Vane Prompt does not support continuing paused turns"
             )
 
-        complete_stop_reasons = {"tool_use"} if return_format is not None else {"end_turn", "stop_sequence"}
+        if return_format is not None:
+            complete_stop_reasons = ("tool_use",)
+            output_mode = "structured"
+        else:
+            complete_stop_reasons = ("end_turn", "stop_sequence")
+            output_mode = "plain"
         if stop_reason not in complete_stop_reasons:
+            if stop_reason is None:
+                received_stop_reason = "a missing stop_reason"
+            elif stop_reason in ("end_turn", "stop_sequence", "tool_use"):
+                received_stop_reason = f"stop_reason {stop_reason!r}"
+            else:
+                received_stop_reason = "an unsupported stop_reason"
+            expected_stop_reasons = " or ".join(repr(reason) for reason in complete_stop_reasons)
             raise _ProviderResultError(
-                f"Anthropic response from model {self._model!r} returned a missing or unsupported stop_reason"
+                f"Anthropic response from model {self._model!r} returned {received_stop_reason} "
+                f"for {output_mode} Prompt output; expected {expected_stop_reasons}"
             )
 
         blocks = getattr(response, "content", None) or []

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -13,7 +13,7 @@ from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import OutputValidationError, serialize_raw_response
 from vane.ai.options import validate_prompt_options
 from vane.ai.protocols import PrompterDescriptor
-from vane.ai.provider import Provider, ProviderCapabilityError
+from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -270,12 +270,30 @@ class AnthropicPrompter:
         if getattr(self, "_return_raw_response", False):
             return serialize_raw_response(response)
 
-        if getattr(response, "stop_reason", None) == "max_tokens":
+        stop_reason = getattr(response, "stop_reason", None)
+        if stop_reason == "max_tokens":
             if self._options.get("max_tokens") == 0:
                 return None
-            raise ValueError(
+            raise _ProviderResultError(
                 f"Anthropic response from model {self._model!r} was truncated at "
                 f"max_tokens={self._options.get('max_tokens')}"
+            )
+        if stop_reason == "model_context_window_exceeded":
+            raise _ProviderResultError(
+                f"Anthropic response from model {self._model!r} was truncated at the model context window"
+            )
+        if stop_reason == "refusal":
+            raise _ProviderResultError(f"Anthropic model {self._model!r} refused the Prompt request")
+        if stop_reason == "pause_turn":
+            raise _ProviderResultError(
+                f"Anthropic response from model {self._model!r} paused before completion; "
+                "Vane Prompt does not support continuing paused turns"
+            )
+
+        complete_stop_reasons = {"tool_use"} if return_format is not None else {"end_turn", "stop_sequence"}
+        if stop_reason not in complete_stop_reasons:
+            raise _ProviderResultError(
+                f"Anthropic response from model {self._model!r} returned a missing or unsupported stop_reason"
             )
 
         blocks = getattr(response, "content", None) or []


### PR DESCRIPTION
## Summary

- Validate every current Anthropic Messages API `stop_reason` before interpreting response content.
- Accept only `end_turn` and `stop_sequence` for plain Prompt output, and only `tool_use` for structured output.
- Reject token/context truncation, refusals, paused turns, missing reasons, and unknown future reasons as non-retryable provider-result errors, so `on_error="raise"` reports the terminal outcome and `on_error="ignore"` produces NULL.
- Preserve raw-response passthrough and the existing `max_tokens=0` prewarm behavior.
- Add provider, structured-output, retry, and error-policy regression coverage.

## Related issue

close: #476

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is a provider correctness fix. The compatibility change is intentional: incomplete or refused non-raw Anthropic responses no longer enter result columns as successful text or NULL. Raw responses remain unchanged.

## Validation

- `scripts/format root --changed --check`
- `ruff check tests/ai/test_ai_functions.py tests/ai/test_prompt_provider_contracts.py tests/fast/test_anthropic_prompter_content.py vane/ai/providers/anthropic.py`
- Targeted provider and Prompt contract tests: 23 passed, 1 skipped (`google-genai` not installed)
- `python -m pytest tests/ai/test_ai_functions.py -q`: 165 passed, 20 skipped (`google-genai` not installed)
- `scripts/run_release_tests.sh` non-Ray shard: 507 passed, 4 skipped, 14 deselected
- `scripts/run_release_tests.sh` real-Ray shard: 10 passed, 515 deselected
- Python 3.12.13, Linux x86-64; isolated non-editable Release installation, DuckDB SourceID `7e31688ba8`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.